### PR TITLE
The Continue message wears a light-blue box: your gesture, standardized words

### DIFF
--- a/ui/webview/continue-bubble.test.ts
+++ b/ui/webview/continue-bubble.test.ts
@@ -36,7 +36,9 @@ test("the canned Continue wears the Follow-up grammar: caret, → Continue, the 
 
 test("the row sheds the bubble, keeps the header when expanded, and the caret flips in CSS", () => {
   assert.match(CSS, /\.user-bubble\.nudge-collapsible \{ cursor: pointer; \}/);
-  assert.match(CSS, /\.user-bubble\.cont-row \{ max-width: none; background: none; border: none;/);
+  // the LIGHT BLUE box (the user 2026-08-18, superseding the bare row): blue = "from you", gray =
+  // "from romp" — pale blue says "your gesture, standardized words", never posing as typed prose
+  assert.match(CSS, /\.user-bubble\.cont-row \{\s*\n\s*max-width: 72%;\s*\n\s*background: rgba\(43, 108, 239, 0\.16\); border: 1px solid rgba\(43, 108, 239, 0\.42\);/);
   assert.match(CSS, /\.user-bubble\.cont-row \.cont-tri::before \{ content: "▸"; \}/);
   assert.match(CSS, /\.user-bubble\.cont-row\.expanded \.cont-tri::before \{ content: "▾"; \}/,
     "the same .expanded class the fold delegate flips also turns the caret");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1277,12 +1277,17 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .user-bubble.cmd-row .nudge-gist, .user-bubble.cmd-row .nudge-caret { color: var(--dim); }
 .user-bubble.cmd-row .nudge-gist { margin-left: 8px; }
 .user-bubble.cmd-row .nudge-full { color: var(--dim); margin-top: 4px; max-width: 640px; }
-/* The Continue button's turn wears the FOLLOW-UP grammar (render.ts canned === "continue", the user
-   2026-08-17, superseding the 2026-08-15 ✦ + boxed-chip dress — one gesture grammar, fewer elements):
-   caret, "→ Continue" in the accent (the same dress "↩ Follow-up" wears), the sent text's own first
-   line dimmed beside it, the full words unfolding in place under the row. The caret glyph lives in CSS
-   so the same .expanded class the fold delegate flips also turns it. */
-.user-bubble.cont-row { max-width: none; background: none; border: none; border-radius: 0; padding: 2px 0; }
+/* The Continue button keeps the FOLLOW-UP grammar inside (caret, "→ Continue" in the accent, the
+   sent text's own first line dimmed beside it, the full words unfolding in place) but wears a LIGHT
+   BLUE box around it (the user 2026-08-18, superseding the 2026-08-17 bare row): in the transcript's
+   color grammar blue means "from you" and gray means "from romp", so a pale blue box says "your
+   gesture, standardized words" — user-side, but never posing as typed prose. Same right-aligned
+   spot and width cap as the bubbles it sits among; the ↩ Follow-up header itself is unchanged. */
+.user-bubble.cont-row {
+  max-width: 72%;
+  background: rgba(43, 108, 239, 0.16); border: 1px solid rgba(43, 108, 239, 0.42);
+  border-radius: 14px; padding: 7px 14px;
+}
 .user-bubble.cont-row .followup-tag { max-width: none; }
 .user-bubble.cont-row .cont-tri::before { content: "▸"; }
 .user-bubble.cont-row.expanded .cont-tri::before { content: "▾"; }


### PR DESCRIPTION
User-requested 2026-08-18: the Continue button's canned message rendered as a bare unboxed row, with nothing marking it as an auto message. It now wears a pale blue box, completing the transcript's color grammar: solid blue = your typed words, pale blue = your gesture with standardized words, gray = from romp.

Same right-aligned position and 72% width cap as its bubble neighbors; the inner grammar (caret, "→ Continue" in the accent, the sent text's own first line dimmed, expand-in-place with keyed fold) is unchanged, and the ↩ Follow-up header keeps its current dress untouched, as requested.

Verified headless against the real stylesheet (right edge on the user bubble's, boxed, capped); the continue-bubble test pins the new box and the suite passes (2,106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)