### PR TITLE
The nudge fires only where and when it is needed: five gates from the eagerness audit

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1865,6 +1865,14 @@ def _nudge_text(count, stalled=False):
 _autonudge_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 
+# ONE lock for the nudge ledger's read-modify-write spans (2026-08-19 audit: a live episode
+# record vanished with no state-visible writer — the ledger's writers run on the producer tick,
+# judge callbacks, and WS handlers concurrently, and two overlapping dict(read)…write() spans
+# silently drop whichever landed first). The four EPISODE-record writers hold it across their
+# span; remaining writers (debt, settings) migrate as touched.
+_NUDGE_LOCK = threading.RLock()
+
+
 def _auto_nudge_data():
     p = jd.STATE / "auto-nudge.json"
     try:
@@ -2488,32 +2496,46 @@ def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
     fire time — the failed-stamp's parse-lag guard measures its 6h backstop from it (the user 2026-07-24:
     a stamp raced the parse of a second, still-landing nudge turn and blocked two goals whose response
     resolved them; the guard waits for the response segment to become VISIBLE, bounded by the backstop)."""
-    d = dict(_auto_nudge_data())
-    nudged = dict(d.get("nudged", {}))
-    nudged.pop(gid, None)
-    rec = {"count": count, "lastTurnId": turn_id}
-    if isinstance(arm_atoms, int):
-        rec["armAtoms"] = arm_atoms
-    if at is not None:
-        rec["at"] = int(at)
-    nudged[gid] = rec                                       # reinsert → most-recent
-    if len(nudged) > 3000:                                  # bounded; drop the oldest
-        nudged = dict(list(nudged.items())[-3000:])
-    d["nudged"] = nudged
-    _write_auto_nudge(d)
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        nudged = dict(d.get("nudged", {}))
+        nudged.pop(gid, None)
+        rec = {"count": count, "lastTurnId": turn_id}
+        if isinstance(arm_atoms, int):
+            rec["armAtoms"] = arm_atoms
+        if at is not None:
+            rec["at"] = int(at)
+        nudged[gid] = rec                                       # reinsert → most-recent
+        if len(nudged) > 3000:                                  # bounded; drop the oldest
+            nudged = dict(list(nudged.items())[-3000:])
+        d["nudged"] = nudged
+        _write_auto_nudge(d)
 
 
 def _drop_auto_nudge_rec(gid):
-    """Erase `gid`'s ledger record outright — called when NEW INFORMATION voids the episode the record
+    """Erase `gid`'s SPENT ledger record — called when NEW INFORMATION voids the episode the record
     tracks (today: an awaiting-stamp LIFT in _lift_spent_awaiting — the wait the episode ended on has
-    returned). The record's arm-key dedup and its failed/moot latches all assume the world the episode
-    saw; once a later event supersedes that world, keeping them latched leaves an IDLE session (which
-    never produces the genuine turn a re-arm needs) in Working forever with no reviver (2026-08-16)."""
-    d = dict(_auto_nudge_data())
-    nudged = dict(d.get("nudged", {}))
-    if nudged.pop(gid, None) is not None:
-        d["nudged"] = nudged
-        _write_auto_nudge(d)
+    returned). A spent record's failed/moot/answered latches assume the world the episode saw; once a
+    later event supersedes that world, keeping them latched leaves an IDLE session (which never
+    produces the genuine turn a re-arm needs) in Working forever with no reviver (2026-08-16).
+
+    A LIVE record — mid-count, no latch — is NOT the episode's residue; it IS the once-per-stall
+    invariant and the escalation ladder's memory. Dropping those too (the original form) reset the
+    counter on every stamp↔lift flap, so the same arm turn drew fresh first-nudges minutes apart and
+    _mark_nudge_failed never engaged (the 2026-08-19 audit: three count-1 nudges in 21 minutes, each
+    answered "the suite is still running"). A live record keeps itself honest without our help: a
+    genuine new turn re-arms it through the arm-key dedup, and answering marks it answered."""
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        nudged = dict(d.get("nudged", {}))
+        rec = nudged.get(gid)
+        if not isinstance(rec, dict):
+            return
+        if not (rec.get("failed") or rec.get("moot") or rec.get("answeredAt")):
+            return                                        # live mid-episode → the ladder's memory, keep it
+        if nudged.pop(gid, None) is not None:
+            d["nudged"] = nudged
+            _write_auto_nudge(d)
 
 
 def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
@@ -2559,7 +2581,12 @@ def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
             # A KINDLESS stamp keeps the old behavior: it may well be a peer wait (the enum predates
             # it), and a false lift there is the known, tested legacy trade.
             kind = nd.get("awaitingKind")
-            if not (at and answered_at and at < answered_at and kind in (None, "peer")):
+            # keyed on the stamp's WRITE time, not the anchor (2026-08-19 audit): awaitingAt is the
+            # audited turn's TRIGGER, which predates the reply that turn solicited — so a fresh
+            # re-stamp was superseded the instant it was filed, contradicting this machinery's own
+            # "a stamp filed AFTER the reply survives" contract. The write time is the closer's
+            # epistemic moment; a reply older than it was already in the audited world.
+            if not (at and answered_at and _stamp_written_at(nd) < answered_at and kind in (None, "peer")):
                 cand = (at, nd["awaitingWhy"], kind or "")   # "" keeps max() comparable
                 best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
@@ -2602,91 +2629,92 @@ def _mark_nudge_failed(gid, ev_t=None, wake=False):
         except Exception:
             pass
     now = int(time.time())
-    d = dict(_auto_nudge_data())
-    nudged = dict(d.get("nudged", {}))
-    rec = nudged.get(gid)
-    if not rec or rec.get("failed") or rec.get("moot"):
-        return None
-    # MOOT, NOT FAILED (the user 2026-07-29): if a real judge FILED a verdict on this node after the
-    # response turn — an unblock ("answered in passing"), a completion — then the judges have already
-    # ruled on evidence at least as new as ours, and "the response didn't resolve this" is a stale
-    # claim. Filing our procedural block anyway would overwrite that ruling AND resurface the node's
-    # LAST decision brief, which the later verdict may have just answered — the audited card sat in
-    # Needs-you presenting a question the user had answered and the unblocker had ruled answered, five
-    # minutes after the fact. Retire the record instead (`moot`, no `failed`, no block): the anti-loop
-    # gate keeps this arm from ever re-firing, and a genuinely still-stalled goal re-arms on the next
-    # GENUINE ended turn, judged against the post-verdict world. The verdict's FILING time (`at`; ev_t
-    # for legacy rows) is the event — same discipline as _nudge_fire_list's arm-time guard, applied at
-    # the eval end of the race. Rows the nudge pipeline itself wrote never count (jd.nudge_pipeline_row,
-    # the user 2026-07-30): placing the reply always files its own "reopened (nudge)" row after the
-    # response turn, and reading that as a fresh ruling mooted EVERY placed-but-unresolved reply — the
-    # ladder's escalation rung went dead and cards parked in Working with no chip, no block, and no
-    # reviver.
-    #
-    # TWO row shapes never moot (2026-08-09, a card wedged in Working on an idle, finished session —
-    # both matched the bare filed-after test and together silenced the escalation with no reviver left):
-    # - a BLOCK row: it AGREES with the escalation ("the goal needs the user"), so it cannot mean stand
-    #   down. It only coexists with a still-'working' goal when a LATER unblock lifted it — judge that
-    #   unblock on its own merits — and a slow pass filing a block about pre-response evidence after the
-    #   response is not "a judge looked after the reply" (filing time as a proxy for a newer world — the
-    #   same-trigger lesson from the fire-side guard, met again at the eval end).
-    # - an UNBLOCK evidenced by the RESPONSE TURN ITSELF (ev_t == _ev): the unblocker judged the very
-    #   reply this evaluator is scoring and moved laterally — it lifted a block and resolved nothing, so
-    #   the stall stands and the escalation must proceed. The card's session had answered the status
-    #   check with a wrong claim that nothing was owed; the unblock believed it, the planner's nudge
-    #   unit declined to resolve, and moot then retired the one rung left — Working forever. An unblock
-    #   evidenced ELSEWHERE (the audited 2026-07-29 shape: the user's own earlier answer) still moots:
-    #   re-blocking there would re-present an answered brief.
-    _ev = int(ev_t or now)
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        nudged = dict(d.get("nudged", {}))
+        rec = nudged.get(gid)
+        if not rec or rec.get("failed") or rec.get("moot"):
+            return None
+        # MOOT, NOT FAILED (the user 2026-07-29): if a real judge FILED a verdict on this node after the
+        # response turn — an unblock ("answered in passing"), a completion — then the judges have already
+        # ruled on evidence at least as new as ours, and "the response didn't resolve this" is a stale
+        # claim. Filing our procedural block anyway would overwrite that ruling AND resurface the node's
+        # LAST decision brief, which the later verdict may have just answered — the audited card sat in
+        # Needs-you presenting a question the user had answered and the unblocker had ruled answered, five
+        # minutes after the fact. Retire the record instead (`moot`, no `failed`, no block): the anti-loop
+        # gate keeps this arm from ever re-firing, and a genuinely still-stalled goal re-arms on the next
+        # GENUINE ended turn, judged against the post-verdict world. The verdict's FILING time (`at`; ev_t
+        # for legacy rows) is the event — same discipline as _nudge_fire_list's arm-time guard, applied at
+        # the eval end of the race. Rows the nudge pipeline itself wrote never count (jd.nudge_pipeline_row,
+        # the user 2026-07-30): placing the reply always files its own "reopened (nudge)" row after the
+        # response turn, and reading that as a fresh ruling mooted EVERY placed-but-unresolved reply — the
+        # ladder's escalation rung went dead and cards parked in Working with no chip, no block, and no
+        # reviver.
+        #
+        # TWO row shapes never moot (2026-08-09, a card wedged in Working on an idle, finished session —
+        # both matched the bare filed-after test and together silenced the escalation with no reviver left):
+        # - a BLOCK row: it AGREES with the escalation ("the goal needs the user"), so it cannot mean stand
+        #   down. It only coexists with a still-'working' goal when a LATER unblock lifted it — judge that
+        #   unblock on its own merits — and a slow pass filing a block about pre-response evidence after the
+        #   response is not "a judge looked after the reply" (filing time as a proxy for a newer world — the
+        #   same-trigger lesson from the fire-side guard, met again at the eval end).
+        # - an UNBLOCK evidenced by the RESPONSE TURN ITSELF (ev_t == _ev): the unblocker judged the very
+        #   reply this evaluator is scoring and moved laterally — it lifted a block and resolved nothing, so
+        #   the stall stands and the escalation must proceed. The card's session had answered the status
+        #   check with a wrong claim that nothing was owed; the unblock believed it, the planner's nudge
+        #   unit declined to resolve, and moot then retired the one rung left — Working forever. An unblock
+        #   evidenced ELSEWHERE (the audited 2026-07-29 shape: the user's own earlier answer) still moots:
+        #   re-blocking there would re-present an answered brief.
+        _ev = int(ev_t or now)
 
-    def _supersedes(e):
-        if (e.get("at") or e.get("ev_t") or 0) <= _ev or jd.nudge_pipeline_row(e):
-            return False               # predates the reply, or the machinery talking to itself
-        if e.get("kind") == "block":
-            return False               # agrees with the escalation — never a stand-down (see above)
-        if e.get("kind") == "unblock" and (e.get("ev_t") or 0) == _ev:
-            return False               # a lateral move off the reply itself — the stall stands
-        return True
+        def _supersedes(e):
+            if (e.get("at") or e.get("ev_t") or 0) <= _ev or jd.nudge_pipeline_row(e):
+                return False               # predates the reply, or the machinery talking to itself
+            if e.get("kind") == "block":
+                return False               # agrees with the escalation — never a stand-down (see above)
+            if e.get("kind") == "unblock" and (e.get("ev_t") or 0) == _ev:
+                return False               # a lateral move off the reply itself — the stall stands
+            return True
 
-    try:
-        _nd0 = jd.load_goals(gid.rsplit(":", 1)[0]).get("nodes", {}).get(gid)
-        if _nd0 is not None and any(_supersedes(e) for e in _nd0.get("log") or []):
-            nudged[gid] = dict(rec, moot=True)
-            d["nudged"] = nudged
-            _write_auto_nudge(d)
-            return "moot"
-    except Exception:
-        pass
-    # failedAt: the build_feed chip's retire fallback when the block row below goes missing — the two
-    # writes land in different files and only this one is guaranteed (g52, 2026-07-16: a planner pass's
-    # stale save erased the row, and the row-keyed retire left the chip saying "waiting on you" through
-    # the user's own follow-up).
-    nudged[gid] = dict(rec, failed=True, failedAt=now)
-    d["nudged"] = nudged
-    _write_auto_nudge(d)
-    try:
-        sid = gid.rsplit(":", 1)[0]
-        store = jd.load_goals(sid)
-        nd = store.get("nodes", {}).get(gid)
-        why = jd.WAKE_BLOCK_WHY if wake else jd.NUDGE_BLOCK_WHY   # shared constants: the briefer recognizes
-        #                                   these as PROCEDURAL and writes no decision brief, rather than
-        #                                   inventing one from <work>
-        # EVIDENCE TIME (_ev, hoisted above for the moot check) = the nudge RESPONSE turn, not wall-clock
-        # `now` (the user 2026-07-22). The block's evidence IS that response; claiming `now` made the stamp
-        # structurally outrank the user's own reply floor (_block_is_stale voids a block only when
-        # ev_t <= followupAt), so a reply could NEVER void a nudge block — the one mechanism built to stop
-        # a judge re-blocking a just-answered card.
-        if nd is not None and jd.record_verdict(store, nd, "nudge", "block", _ev, why=why):
-            nd["mt"] = _ev                            # the event materialized blocked + blockWhy
-            jd.append_block(sid, gid, "nudge", why, _ev)  # journal before the save it protects: a judge
-            #                                           pass holding this store across its model call
-            #                                           erases the row on save; replay re-records it
-            jd.rollup_status(store, False)
-            jd.save_goals(sid, store)
-            _mark_views_dirty()
-    except Exception:
-        sys.stderr.write("nudge-failed block: %s\n" % traceback.format_exc())
-    return "failed"
+        try:
+            _nd0 = jd.load_goals(gid.rsplit(":", 1)[0]).get("nodes", {}).get(gid)
+            if _nd0 is not None and any(_supersedes(e) for e in _nd0.get("log") or []):
+                nudged[gid] = dict(rec, moot=True)
+                d["nudged"] = nudged
+                _write_auto_nudge(d)
+                return "moot"
+        except Exception:
+            pass
+        # failedAt: the build_feed chip's retire fallback when the block row below goes missing — the two
+        # writes land in different files and only this one is guaranteed (g52, 2026-07-16: a planner pass's
+        # stale save erased the row, and the row-keyed retire left the chip saying "waiting on you" through
+        # the user's own follow-up).
+        nudged[gid] = dict(rec, failed=True, failedAt=now)
+        d["nudged"] = nudged
+        _write_auto_nudge(d)
+        try:
+            sid = gid.rsplit(":", 1)[0]
+            store = jd.load_goals(sid)
+            nd = store.get("nodes", {}).get(gid)
+            why = jd.WAKE_BLOCK_WHY if wake else jd.NUDGE_BLOCK_WHY   # shared constants: the briefer recognizes
+            #                                   these as PROCEDURAL and writes no decision brief, rather than
+            #                                   inventing one from <work>
+            # EVIDENCE TIME (_ev, hoisted above for the moot check) = the nudge RESPONSE turn, not wall-clock
+            # `now` (the user 2026-07-22). The block's evidence IS that response; claiming `now` made the stamp
+            # structurally outrank the user's own reply floor (_block_is_stale voids a block only when
+            # ev_t <= followupAt), so a reply could NEVER void a nudge block — the one mechanism built to stop
+            # a judge re-blocking a just-answered card.
+            if nd is not None and jd.record_verdict(store, nd, "nudge", "block", _ev, why=why):
+                nd["mt"] = _ev                            # the event materialized blocked + blockWhy
+                jd.append_block(sid, gid, "nudge", why, _ev)  # journal before the save it protects: a judge
+                #                                           pass holding this store across its model call
+                #                                           erases the row on save; replay re-records it
+                jd.rollup_status(store, False)
+                jd.save_goals(sid, store)
+                _mark_views_dirty()
+        except Exception:
+            sys.stderr.write("nudge-failed block: %s\n" % traceback.format_exc())
+        return "failed"
 
 
 def _interrupt_focus_top(store):
@@ -3143,11 +3171,12 @@ AWAITING_BACKSTOP_TEXT = (
 def _put_nudged(gid, rec):
     """Persist ONE nudge/wake record into auto-nudge.json's `nudged` ledger — the read-modify-write the
     failed stamp already does inline, shared so the wake's answered/fired records take the same shape."""
-    d = dict(_auto_nudge_data())
-    nudged = dict(d.get("nudged", {}))
-    nudged[gid] = rec
-    d["nudged"] = nudged
-    _write_auto_nudge(d)
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        nudged = dict(d.get("nudged", {}))
+        nudged[gid] = rec
+        d["nudged"] = nudged
+        _write_auto_nudge(d)
 
 
 def _last_awaiting_is_lift(nd):
@@ -3313,6 +3342,22 @@ def _lift_spent_awaiting(now, tmux):
                     return ((t.get("endT") or 0) > _anchor or (t.get("t") or 0) > _anchor
                             or (t.get("status") == "running" and (t.get("deadline") or 0) > _anchor))
                 if not any(_returned_after(t) for t in own):
+                    continue
+                # THE STAND-DOWN RULE, joined (the 2026-08-19 audit): a writer whose evidence
+                # predates the diary yields — but only on a RE-ASSERT. The flap's signature is the
+                # closer re-affirming the wait AFTER a prior lift of this same stamp: everything
+                # this lift can cite (returns that preceded that lift) was already ruled on once,
+                # so lifting again off it produced the observed 2-3 second stamp↔lift flaps that
+                # reset the nudge ladder (fires 5s after a lift, three first-nudges in 21 minutes —
+                # the session had re-armed a watcher the ownership window cannot see). A FIRST
+                # stamp keeps the designed audit-lag lift: the write postdates the whole audited
+                # turn, and returns the judge never saw must still lift (the suite pins those).
+                _aw = [e for e in (nd.get("log") or []) if e.get("kind") == "awaiting"]
+                _last_lift = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if e.get("lift")), default=0)
+                _last_assert = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if not e.get("lift")), default=0)
+                _evidence = max((max(t.get("endT") or 0, t.get("t") or 0, t.get("deadline") or 0)
+                                 for t in own), default=0)
+                if _last_lift and _last_assert > _last_lift and _stamp_written_at(nd) > _evidence:
                     continue
                 if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
@@ -4206,6 +4251,17 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
                 and any(e.get("kind") == "unblock" for e in judge_rows[:-1]):
             if held is not None:                     # a REPEAT unblock mid-oscillation: the unblocker spoke
                 held.append((f, jd.WHY_UNBLOCK_UNSETTLED, 0))   # again, the closer hasn't answered (see docstring)
+            continue
+        if nd.get("awaitingWhy") and nd.get("awaitingAt"):
+            # A LIVE awaiting stamp holds the fire — the judges have ruled "this goal is waiting,
+            # nothing owed", and a status ask over that ruling is exactly the wrong-reason nudge
+            # (the 2026-08-19 audit: one fired 43s AFTER the closer filed "awaiting: the full test
+            # suite it kicked off" — its ev_t equals the seen turn's, so the offending-rows check
+            # above can never catch it). Parity with the other two writers: _wake_goal re-keys on
+            # the store as written and _mark_nudge_failed re-checks the stamp at the write moment;
+            # this was the only fire path without the re-check. The walk's own stamp screening
+            # handles the SNAPSHOT's stamps; this catches one filed since. No `held` record: the
+            # stamp itself is the visible why, and its own wake is the backstop.
             continue
         keep.append(f)
     return keep

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -402,3 +402,78 @@ class AwaitingLift(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LiftStandsDown(unittest.TestCase):
+    """The lift joins the stand-down rule (the 2026-08-19 nudge audit): a writer whose evidence
+    predates the diary yields. The lift's evidence is the newest RETURN it can cite; a closer
+    assert filed AFTER every citable return means the judge ruled on a fresher world (the session
+    re-armed something the ownership window can't see), and lifting anyway produced 2-3 second
+    stamp↔lift flaps that reset the nudge ladder (fires 5s after a lift; three first-nudges in 21
+    minutes, each answered "still running")."""
+
+    def setUp(self):
+        AwaitingLift.setUp(self)
+
+    def tearDown(self):
+        AwaitingLift.tearDown(self)
+
+    _transcript = AwaitingLift._transcript
+    _seed = AwaitingLift._seed
+    _tick = AwaitingLift._tick
+    _stamp = AwaitingLift._stamp
+
+    def test_a_reassert_after_a_lift_stands_the_next_lift_down(self):
+        # the FLAP: assert → lift → the closer re-asserts AFTER the lift, citing a fresher world —
+        # every return this lift could cite preceded the prior lift, so lifting again just flaps
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(written=BACK + 60)
+        import json as _json
+        gp = km.jd.GOALDIR / (SID + ".json")
+        store = _json.loads(gp.read_text())
+        nd = store["nodes"][self.gid]
+        nd["log"] = [
+            {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": "w", "at": STAMP},
+            {"ev_t": BACK + 10, "src": "romp", "kind": "awaiting", "lift": True, "at": BACK + 10},
+            {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": nd["awaitingWhy"], "at": BACK + 60},
+        ]
+        gp.write_text(_json.dumps(store))
+        self._tick(now=BACK + 120)
+        self.assertIsNotNone(self._stamp(), "a re-assert after a lift means a fresher ruling — yield")
+
+    def test_a_first_stamp_still_lifts_on_audit_lag_returns(self):
+        # NO prior lift: the original design holds — a return the judge never saw still lifts,
+        # even when the stamp's write time postdates it (the same-turn suite pins depend on this)
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(written=BACK + 60)                    # written after the return, but never lifted before
+        self._tick(now=BACK + 120)
+        self.assertIsNone(self._stamp(), "first-stamp audit-lag lift preserved")
+
+
+class LiftKeepsLiveLedgerRecords(unittest.TestCase):
+    """A lift drops only SPENT ledger records (failed/moot/answered latches — the 2026-08-16
+    idle-in-Working fix). A LIVE mid-count record is the once-per-stall invariant itself: dropping
+    it reset the counter on every stamp↔lift flap and the same arm turn drew fresh first-nudges
+    minutes apart while the escalation ladder never engaged."""
+
+    def test_live_records_survive_the_drop(self):
+        import tempfile as _tf
+        from pathlib import Path as _P
+        with _tf.TemporaryDirectory() as td:
+            saved = km.jd.STATE
+            try:
+                km.jd.STATE = _P(td)
+                km._write_auto_nudge({"enabled": True, "nudged": {
+                    "g-live": {"count": 2, "lastTurnId": "u9"},
+                    "g-failed": {"count": 1, "lastTurnId": "u1", "failed": True},
+                    "g-moot": {"count": 1, "lastTurnId": "u2", "moot": True},
+                    "g-answered": {"count": 1, "lastTurnId": "u3", "answeredAt": 5}}})
+                for gid in ("g-live", "g-failed", "g-moot", "g-answered"):
+                    km._drop_auto_nudge_rec(gid)
+                left = km._auto_nudge_data().get("nudged", {})
+                self.assertIn("g-live", left, "mid-episode memory survives — the ladder can escalate")
+                self.assertEqual(left["g-live"].get("count"), 2, "…with its count intact")
+                for gid in ("g-failed", "g-moot", "g-answered"):
+                    self.assertNotIn(gid, left, "spent latches still drop (the 2026-08-16 fix)")
+            finally:
+                km.jd.STATE = saved

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -738,3 +738,29 @@ class WakeBodyKeepsItsCopy(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SupersedeKeysOnWriteTime(unittest.TestCase):
+    """The peer-answer supersede keys on the stamp's WRITE time, not its anchor (2026-08-19 audit):
+    awaitingAt is the audited turn's TRIGGER, which predates the very replies that turn solicited —
+    so a fresh re-stamp was superseded the instant it was filed, contradicting the machinery's own
+    'a stamp filed AFTER the reply survives' contract."""
+
+    def _nodes(self, anchor, written, kind="peer"):
+        return {"g1": {"id": "g1", "parentId": None, "awaitingWhy": "waiting on the peer's report",
+                       "awaitingAt": anchor, "awaitingKind": kind,
+                       "log": [{"ev_t": anchor, "at": written, "src": "closer", "kind": "awaiting",
+                                "why": "waiting on the peer's report", "awaitKind": kind}]}}
+
+    def test_a_stamp_written_after_the_reply_survives(self):
+        # anchor 100 (trigger), reply 150, stamp WRITTEN 200: the closer knew the reply — stamp stands
+        got = km._goal_awaiting_stamp_full(self._nodes(100, 200), "g1", answered_at=150)
+        self.assertIsNotNone(got, "written after the reply → the ruling already weighed it")
+
+    def test_a_stamp_written_before_the_reply_is_superseded(self):
+        got = km._goal_awaiting_stamp_full(self._nodes(100, 120), "g1", answered_at=150)
+        self.assertIsNone(got, "the reply IS the awaited event — the stamp yields")
+
+    def test_job_stamps_never_yield_to_mail(self):
+        got = km._goal_awaiting_stamp_full(self._nodes(100, 120, kind="job"), "g1", answered_at=150)
+        self.assertIsNotNone(got, "peer-scoped: a slurm wait keeps standing through unrelated mail")

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -373,3 +373,21 @@ class PromptPins(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class NudgeFireListAwaitingHold(unittest.TestCase):
+    """A LIVE awaiting stamp holds the fire (the 2026-08-19 audit): a status ask over a judge's own
+    'this goal is waiting, nothing owed' ruling is the wrong-reason nudge — one fired 43 seconds
+    AFTER the closer filed 'awaiting: the full test suite it kicked off', because the stamp's ev_t
+    equals the seen turn's and the offending-rows check can never catch it. Parity with the other
+    two writers (_wake_goal, _mark_nudge_failed), which both re-check the stamp at the write moment."""
+
+    def test_a_live_awaiting_stamp_holds_the_fire(self):
+        nd = _node(G1, "waiting on the suite")
+        nd["awaitingWhy"] = "the full test suite it kicked off"
+        nd["awaitingAt"] = 100
+        fresh = _store({G1: nd, G2: _node(G2, "genuinely stalled")},
+                       status={G1: "working", G2: "working"})
+        out = km._nudge_fire_list(fresh, [(G1, 1, False), (G2, 1, False)])
+        self.assertEqual([f[0] for f in out], [G2],
+                         "the stamped goal is the judges' ruled wait; the unstamped one still fires")


### PR DESCRIPTION
The user saw nudges landing right after sessions answered. The audit proved the judges DO get their full time (every examined fire followed the closer's settle) — the over-eagerness was filed verdicts being voided immediately afterward. Five fixes, **replay-validated against the recorded 24 hours: of 62 real fires, 43 keep firing, 19 are suppressed (13 held by the stamp re-check, 6 flap re-fires that escalate through the ladder instead of re-asking), and the stuck-check found zero suppressions left without a reviver** — every one leaves a live stamp with its 6h wake or a kept ledger that escalates to needs-you.

1. **A lift drops only SPENT ledger records** — dropping live mid-count records reset the once-per-stall counter on every stamp↔lift flap (three first-nudges in 21 minutes, each answered "still running") and the escalation ladder never engaged.
2. **The lift joins the stand-down rule, keyed on the RE-ASSERT** — a closer re-affirming a wait after a prior lift means everything a new lift can cite was already ruled on; first stamps keep the designed audit-lag lift (the pinned same-turn suite behavior is untouched).
3. **The fire path re-checks the awaiting stamp at send time** (parity with the wake and fail-marker): one status ask went out 43s after the closer filed "awaiting: the full test suite".
4. **The supersede keys on the stamp's WRITE time**, honoring its own "a stamp filed AFTER the reply survives" contract (the trigger anchor predates the very replies the turn solicited).
5. **One lock across the ledger's episode-record read-modify-writes** (a live record vanished with no state-visible writer).

Tests: 2 new stand-down cases + live-vs-spent ledger drops (awaiting-lift suite, all 30 green incl. every pre-existing pin), the fire-path stamp hold, and 3 write-time supersede cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)