### PR TITLE
A restart landing mid-retry is a machine cut: stamp it, resume it, never blame the user

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3001,7 +3001,16 @@ class SdkBackend:
                     if r.get("effortPending") or r.get("modelPending"):
                         self._update_reg(sid, effortPending=False, modelPending=False)
                     queued = [t for t in (r.get("queue") or []) if isinstance(t, str) and t]
-                    cut = last_state_value(self.state_dir, sid) == "working"
+                    # A cut turn is any MACHINE-ACTIVE last state, not just "working" (the user
+                    # 2026-08-19, whose figure session sat blocked-on-you after every restart that
+                    # landed mid-API-retry): "retrying" is a long-lived open-turn state — the CLI is
+                    # mid-turn waiting out an API error — and "compacting" likewise. A restart
+                    # during either cut the turn exactly as a working cut does, but the == "working"
+                    # test skipped the machineCut stamp AND the resume nudge, so the bare stop
+                    # record read as the user's Esc (INTERRUPT_BLOCK_WHY) and nothing ever resumed
+                    # the session. "permission"/"picker" stay excluded: those turns were already
+                    # waiting on the user, so blocked-on-you is the truth there.
+                    cut = last_state_value(self.state_dir, sid) in ("working", "retrying", "compacting")
                     # bg tasks the dead kernel's CLI took with it (the reg mirror, _on_task_event):
                     # the session must HEAR about them or it waits forever on a dead timer/watcher.
                     dead_tasks = [t for t in (r.get("bgTasks") or []) if isinstance(t, dict)]

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -655,3 +655,26 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RetryingCutIsAMachineCut(unittest.TestCase):
+    """A restart landing mid-API-retry (or mid-compaction) cuts the turn exactly as a working cut
+    does (the user 2026-08-19, whose figure session sat blocked-on-you — "you stopped this session
+    mid-turn" — after every restart that landed in its retry loop, with no machineCut stamp ever
+    written and no resume nudge queued). The boot reconcile's cut discriminator now reads every
+    MACHINE-ACTIVE last state; "permission"/"picker" stay excluded — those turns were already
+    waiting on the user, so blocked-on-you is the truth there."""
+
+    def test_machine_active_states_read_as_cut_and_user_wait_states_do_not(self):
+        import inspect
+        src = inspect.getsource(sb.SdkBackend)
+        self.assertIn('last_state_value(self.state_dir, sid) in ("working", "retrying", "compacting")', src)
+        self.assertNotIn('last_state_value(self.state_dir, sid) == "working"', src,
+                         "the narrow test is gone — a retrying cut got no stamp and no resume")
+
+    def test_last_state_value_reports_retrying(self):
+        with tempfile.TemporaryDirectory() as td:
+            sb.append_state(Path(td), SID, "working", T0)
+            sb.append_state(Path(td), SID, "retrying", T0 + 5)
+            self.assertEqual(sb.last_state_value(Path(td), SID), "retrying",
+                             "the discriminator sees the retry loop the restart landed in")


### PR DESCRIPTION
Sessions cut by kernel restarts sat dead wearing "you stopped this session mid-turn — waiting on your next instruction" (live case: a figure-heavy session cycling working↔retrying through an API-error window, blocked-on-you after every restart, zero machineCut stamps in its states file all day). The boot reconcile's cut discriminator tested the last state against exactly `"working"` — but `retrying` is a long-lived OPEN-TURN state and `compacting` likewise. A restart landing in either cut the turn exactly as a working cut does, yet got **no machineCut stamp** (the interrupt classifier's authoritative leg stayed empty, so the bare stop record read as the user's Esc → a false blocked-on-you card that stands the nudge ladder down) and **no resume nudge** (nothing ever continued the turn).

The discriminator now reads every machine-active last state: `working`, `retrying`, `compacting`. `permission`/`picker` stay excluded — those turns were already waiting on the user, so blocked-on-you is the truth there. Tests: the widened discriminator pinned at source + last_state_value reporting the retry loop; all 73 machine-cut/lifecycle tests green, full suite 4914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)