### PR TITLE
The Stack toggle says so when narrow width already forces stacking

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -57,3 +57,18 @@ test("both controls live on the build-once header — click-safe across re-rende
   assert.ok(build.includes('el("button", "fcol-fold")') && build.includes("wireColDrag(name, col, key)"),
     "wired inside ensureCols' one-time scaffold, never in a render loop");
 });
+
+test("the Stack toggle says so when narrow width already forces stacking (2026-08-19)", () => {
+  // at or under the container query's 540px the layout stacks regardless of the pref, so the
+  // toggle is a no-op there: faded (aria-disabled), click no-ops, tooltip names the way out.
+  // The width constant must match the CSS query — the two stacking owners cannot drift.
+  assert.match(FEED, /const STACK_FORCED_W = 540;/);
+  assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\)/);
+  assert.match(FEED, /b\.classList\.toggle\("forced", forced\);/);
+  assert.match(FEED, /widen the feed to unstack into three columns/);
+  assert.match(FEED, /if \(b\.classList\.contains\("forced"\)\) return;/,
+    "keyboard activation bypasses pointer-events, so the handler itself no-ops");
+  assert.match(FEED, /new ResizeObserver\(\(\) => refreshStackForced\(b\)\)/,
+    "width changes are the event — never a poll");
+  assert.match(CSS, /#feed-stacked\.forced \{ opacity: 0\.4; cursor: default; \}/);
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1154,3 +1154,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   rgba(255, 255, 255, 0.18); background: #333; color: inherit; cursor: pointer; font-size: 0.95em; }
 .judge-limit-banner .jl-switch:hover { background: #3c3c3c; }
 .judge-limit-banner .jl-switch:disabled { opacity: 0.6; cursor: default; }
+
+/* the Stack toggle while the narrow container query FORCES stacking (2026-08-19): faded and inert —
+   unclicking it would change nothing at this width, and the tooltip names the way out (more width).
+   pointer-events stays on so the tooltip still shows on hover; the click handler no-ops instead. */
+#feed-stacked.forced { opacity: 0.4; cursor: default; }
+#feed-stacked.forced:hover { color: inherit; background: inherit; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3064,6 +3064,7 @@ function makeFeedToggle(id: string, label: string, get: () => boolean, key: stri
   b.id = id; b.textContent = label;
   b.onclick = (ev) => {
     ev.stopPropagation();
+    if (b.classList.contains("forced")) return;   // stacking is automatic at this width — a no-op toggle lies
     const on = !get();
     try {
       const s = JSON.parse(localStorage.getItem("romp:settings") || "{}");
@@ -3102,11 +3103,31 @@ function ensureNewestFirst(): HTMLElement {
 function applyStacked(on: boolean) {
   document.getElementById("feed-list")?.style.setProperty("--romp-stack", on ? "on" : "off");
 }
+// FORCED stacking (the user 2026-08-19): at or under the container query's own 540px the layout
+// stacks regardless of the pref, so the toggle is a no-op there — unclicking it would change
+// nothing. The button says so instead of lying: faded, unclickable, tooltip naming the way out
+// (more width). Width changes are the event — a ResizeObserver on #feed-list, installed once.
+const STACK_FORCED_W = 540;   // MUST match feed.css's @container (max-width: 540px) stack query
+let stackResizeWatch: ResizeObserver | null = null;
+function refreshStackForced(b: HTMLElement): void {
+  const list = document.getElementById("feed-list");
+  const forced = !!list && list.clientWidth > 0 && list.clientWidth <= STACK_FORCED_W;
+  b.classList.toggle("forced", forced);
+  b.setAttribute("aria-disabled", forced ? "true" : "false");
+  if (forced) b.title = "stacked automatically at this width — widen the feed to unstack into three columns";
+}
 function ensureStackToggle(): HTMLElement {
-  return ensureFeedToggle("feed-stacked", "Stack", () => feedPrefs().stacked, "stacked",
+  const b = ensureFeedToggle("feed-stacked", "Stack", () => feedPrefs().stacked, "stacked",
     "one-column layout at any width — click for side-by-side columns when the feed is wide",
     "stack the columns into one, whatever the width",
     (on) => applyStacked(on));
+  refreshStackForced(b);                      // per render: the ensure title above just overwrote ours
+  const list = document.getElementById("feed-list");
+  if (!stackResizeWatch && list && typeof ResizeObserver !== "undefined") {
+    stackResizeWatch = new ResizeObserver(() => refreshStackForced(b));
+    stackResizeWatch.observe(list);
+  }
+  return b;
 }
 // (The "Collapsed" default-section toggle moved into the settings modal, 2026-08-18 — a set-and-forget
 // preference, not a per-glance view action. The pref and its behavior are unchanged; the gear writes


### PR DESCRIPTION
At or under the container query's own 540px the feed stacks regardless of the pref, so the toggle is a no-op there — unclicking it changed nothing and read as broken. While the width forces stacking, the button fades (aria-disabled), its click no-ops (the handler gates — keyboard activation bypasses pointer-events), and the tooltip names the way out: *widen the feed to unstack into three columns*. Width changes are the event (a ResizeObserver on the feed list, installed once), and `STACK_FORCED_W` is pinned against the CSS query so the two stacking owners cannot drift. Pins in feed-col-fold.test.ts; suite 2136 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)