### PR TITLE
Math radicals render again: the sanitizer allows DOMPurify's svg profile

### DIFF
--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -159,7 +159,7 @@ test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML u
   assert.match(VIEW, /if \(isMd\) \{\s*\n\s*for \(const mode of \["rendered", "raw"\] as const\)/);
   assert.match(VIEW, /const rendered = isMd && fmt\.md === "rendered";/, "non-md never renders as prose");
   assert.match(VIEW, /import DOMPurify from "dompurify";/);
-  assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true \}, ADD_DATA_URI_TAGS: \["img"\] \}\);/);
+  assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\] \}\);/);
   // a README's links open a NEW tab rather than navigating the chat pane's document away
   assert.match(VIEW, /target = "_blank"/);
   assert.match(VIEW, /rel = "noopener"/);

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -555,7 +555,9 @@ function mdBlock(text: string): HTMLElement {
   const box = el("div", "fileview-md");
   try {
     const dirty = marked.parse(text) as string;
-    box.innerHTML = DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true }, ADD_DATA_URI_TAGS: ["img"] });
+    // html + svg, in lockstep with the chat's md(): KaTeX draws stretchy glyphs (\sqrt radicals,
+    // wide accents) as inline <svg> even in html output, and the html-only profile ate them.
+    box.innerHTML = DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"] });
   } catch {
     box.textContent = text;                            // a marked bug must never cost the content
   }

--- a/ui/webview/render-math.test.ts
+++ b/ui/webview/render-math.test.ts
@@ -98,8 +98,19 @@ test("render.ts wires the math extensions into marked", () => {
 });
 
 test("math.ts renders html-only output so md()'s DOMPurify profile passes it", () => {
-  // output: "html" means no MathML twin; the sanitizer keeps its narrow html profile.
+  // output: "html" means no MathML twin — but stretchy glyphs (\sqrt radicals, wide accents,
+  // extensible arrows) are still inline <svg> even in html mode, so the sanitizer allows
+  // DOMPurify's svg profile alongside html (the user 2026-08-19: $\sqrt{d}$ rendered as a bare
+  // serif "d" — the radical was sanitized away while its radicand survived).
   assert.match(UI("math.ts"), /output: "html"/);
+  assert.match(UI("render.ts"), /USE_PROFILES: \{ html: true, svg: true \}/);
+});
+
+test("executed: \\sqrt really does emit inline svg — the glyph the sanitizer must keep", () => {
+  const out = html("norm grows like $\\sqrt{d}$ here.");
+  assert.ok(hasMath(out));
+  assert.ok(out.includes("<svg"), "the radical is an inline svg even with output:html");
+  assert.ok(out.includes("sqrt"), "KaTeX marks the construct");
 });
 
 test("styles.css imports the KaTeX layout css", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -566,7 +566,11 @@ function md(src: string): string {
   // on <img> (the CSP allows them and inline transcript images rely on them).
   try {
     const dirty = marked.parse(src) as string;
-    return DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true }, ADD_DATA_URI_TAGS: ["img"] });
+    // svg profile too (the user 2026-08-19): KaTeX's html output still draws STRETCHY glyphs —
+    // \sqrt radicals, wide accents, extensible arrows — as inline <svg><path>, and the html-only
+    // profile silently ate them: $\sqrt{d}$ rendered as a bare serif "d", the radical gone.
+    // DOMPurify's svg profile is still sanitized (no scripts, handlers, or foreignObject).
+    return DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"] });
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
 }
 


### PR DESCRIPTION
User report 2026-08-19 with a screenshot: `$\sqrt{depth}$` rendered as a bare serif "depth" — the radicand survived, the radical vanished.

**Root cause**: KaTeX's `output: "html"` mode still draws stretchy glyphs (sqrt radicals, wide accents, extensible arrows) as inline `<svg><path>`, and the sanitizer's html-only DOMPurify profile silently stripped them while passing the glyph spans through.

**Fix**: both sanitize sites — the chat's `md()` and the file viewer's `mdBlock`, which share the same marked singleton and math extensions — now use `USE_PROFILES: { html: true, svg: true }`. DOMPurify's svg profile is still sanitized (no scripts, handlers, or `foreignObject`), asserted in the headless repro.

**Verification**: a headless page running the real pipeline reproduces the exact reported symptom under the old profile and renders `√depth` correctly under the new one (screenshot in the session). New executed test proves `\sqrt` emits inline svg even in html output mode; profile pins on both sites. Suite passes (2,137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)