### PR TITLE
The upload gate dialog resolves itself the moment the upload finishes

### DIFF
--- a/ui/webview/composer-ship-gate.test.ts
+++ b/ui/webview/composer-ship-gate.test.ts
@@ -26,14 +26,29 @@ test("a send with ships in flight is gated by the confirm: send-without is expli
 });
 
 test("the held send fires on the LAST ack — event-based — and a nack cancels it loudly", () => {
-  assert.match(RENDER, /if \(owner && sendOnShip\.has\(owner\) && !\(pendingShips\.get\(owner\) \|\| \[\]\)\.length\) \{/,
-    "the deciding event is the last pending ship retiring");
+  assert.match(RENDER, /if \(owner && \(sendOnShip\.has\(owner\) \|\| gateOpen\) && !\(pendingShips\.get\(owner\) \|\| \[\]\)\.length\) \{/,
+    "the deciding event is the last pending ship retiring — for a held send AND an open gate dialog");
   assert.match(RENDER, /if \(owner === activeId\) fireHeldSend\(\);/);
   assert.match(RENDER, /the held message was not sent; review it there/,
     "a mid-hold tab switch surfaces instead of sending a background composer");
   assert.match(RENDER, /const held = !!owner && sendOnShip\.delete\(owner\);/,
     "a failed save cancels the hold — it must not fire without the file it waited for");
-  assert.match(RENDER, /\+ \(held \? " Your message was NOT sent\." : ""\)/);
+  assert.match(RENDER, /\+ \(held \|\| gateWasOpen \? " Your message was NOT sent\." : ""\)/);
+});
+
+test("the OPEN gate dialog resolves itself on the last ack: closes and sends, no click needed", () => {
+  // the user 2026-08-19: pressing Enter mid-upload popped the dialog, the upload finished, and the
+  // dialog just sat there. The upload finishing IS the answer to the question the dialog asks.
+  assert.match(RENDER, /let shipGateSid: string \| null = null;/);
+  assert.match(RENDER, /shipGateSid = sid;\s*\/\/ the last-ship ack resolves the open dialog itself/);
+  assert.match(RENDER, /const gateOpen = shipGateSid === owner;/);
+  assert.match(RENDER, /if \(gateOpen\) \{ shipGateSid = null; closeConfirm\(null\); \}/,
+    "the dialog dismisses itself the moment the last ship lands, then the send fires");
+  assert.match(RENDER, /shipGateSid = null;\n\s*if \(v === "now"\)/,
+    "any button (or cancel) un-registers the gate — the ack path can never resolve a closed dialog");
+  // a FAILED save also moots the dialog — it closes, but never auto-sends without the file
+  assert.match(RENDER, /const gateWasOpen = shipGateSid === owner;/);
+  assert.match(RENDER, /if \(gateWasOpen\) \{ shipGateSid = null; closeConfirm\(null\); \}/);
 });
 
 test("any successful send supersedes a hold, so a spent hold can never double-send", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9006,6 +9006,10 @@ function retirePendingShip(key: string): string | null {
 // "wait" pick in sendComposer's gate; fired by the LAST droppedPath ack (event-based), cancelled by
 // a dropSaveFailed nack or by any successful send for the sid.
 const sendOnShip = new Set<string>();
+// The ship-gate confirm currently open, by owning sid (the user 2026-08-19): while the "still
+// uploading" dialog is up, the upload FINISHING answers the question itself — the dialog closes and
+// the send fires, no click needed. The deciding event is the same last-ship ack a held send waits on.
+let shipGateSid: string | null = null;
 // Assigned by setupComposer (sendComposer lives in its closure); the WS ack handler fires a held
 // send through it when the last pending ship lands.
 let fireHeldSend: () => void = () => {};
@@ -10291,9 +10295,13 @@ window.addEventListener("message", (e: MessageEvent) => {
     }
     const owner = retirePendingShip(m.path) || activeId;               // the chip this ack answers names the OWNING composer (no-op for pickFile, which never ships)
     addComposerFile(owner, m.path);
-    if (owner && sendOnShip.has(owner) && !(pendingShips.get(owner) || []).length) {
+    // an OPEN ship-gate dialog counts as a held send (the user 2026-08-19): the upload finishing is
+    // the answer to the question it asks, so it closes itself and the send fires — no click needed
+    const gateOpen = shipGateSid === owner;
+    if (owner && (sendOnShip.has(owner) || gateOpen) && !(pendingShips.get(owner) || []).length) {
       // the LAST ship landed — the event the held send was waiting for (the user 2026-08-16)
       sendOnShip.delete(owner);
+      if (gateOpen) { shipGateSid = null; closeConfirm(null); }
       if (owner === activeId) fireHeldSend();
       else warnToast("attachments finished uploading on another tab — the held message was not sent; review it there.");
     }
@@ -10302,8 +10310,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     // never leave dots pulsing over a file that is not coming (fail loudly, don't degrade silently)
     const owner = retirePendingShip(m.name) || activeId;
     const held = !!owner && sendOnShip.delete(owner);    // a held send must not fire without the file it waited for
+    const gateWasOpen = shipGateSid === owner;
+    if (gateWasOpen) { shipGateSid = null; closeConfirm(null); }   // the question is moot — but a failed save never auto-sends
     warnToast(m.name + " couldn't be saved on the kernel, so it was not attached — try again."
-              + (held ? " Your message was NOT sent." : ""));
+              + (held || gateWasOpen ? " Your message was NOT sent." : ""));
     if (owner && owner === activeId) renderComposerFiles(owner);   // the held-send button state clears with the hold
   }
   // an EDITOR highlight (VS Code host, onDidChangeTextEditorSelection — the user 2026-07-13) seeds the
@@ -10464,12 +10474,14 @@ function setupComposer() {
       const sid = activeId;
       const what = shipping === 1 ? "An attachment is" : shipping + " attachments are";
       const them = shipping === 1 ? "it" : "them";
+      shipGateSid = sid;                       // the last-ship ack resolves the open dialog itself
       showConfirm(what + " still uploading",
-                  "Send now and your message goes without " + them + ". Wait, and it sends itself "
-                  + "the moment the upload finishes.",
+                  "Send now and your message goes without " + them + ". Or just wait — it sends "
+                  + "itself the moment the upload finishes.",
                   [{ label: "Wait for the upload", value: "wait" },
                    { label: "Send without " + them, value: "now", danger: true }],
                   (v) => {
+                    shipGateSid = null;
                     if (v === "now") sendComposer({ pastShipGate: true });
                     else if (v === "wait") { sendOnShip.add(sid); renderComposerFiles(sid); }
                   });


### PR DESCRIPTION
User report 2026-08-19: pressing Enter with an attachment mid-upload pops the ship-gate confirm ("Wait for the upload" / "Send without it") — and the dialog then sat there after the upload finished, waiting for a click whose question no longer existed.

The upload finishing is the answer to the question the dialog asks, so the open dialog now subscribes to the same last-ship ack a held send waits on: it closes itself and the send fires, no click needed (event-based — the same deciding event, not a timer). Any button press or cancel un-registers the gate first, so the ack path can never resolve a dialog the user already answered. A failed save also moots the dialog: it closes, the failure toast gains "Your message was NOT sent.", and nothing auto-sends without the file it waited for. Dialog copy updated to say the wait is automatic.

Tests: the gate test file gains an executed-pin test for the self-resolution (registration, ack-close-then-send, button un-registration, and the failed-save moot), and the two existing pins that changed shape were updated. Suite passes (2,137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)