### PR TITLE
CI: the bats install survives a hung apt mirror — 90s per call, two retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install bats + tmux (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y bats tmux
+        # A hung apt mirror used to eat the whole job's 35-minute box — three PRs stalled that way
+        # on 2026-08-19 alone, each needing a manual rerun. Cap every apt call at 90s and retry
+        # twice, with a step-level box as the backstop, so a bad mirror costs seconds, not the job.
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            sudo timeout 90 apt-get update && sudo timeout 90 apt-get install -y bats tmux && exit 0
+            echo "apt attempt $i timed out or failed; retrying"; sleep 5
+          done
+          exit 1
       - name: Install bats + tmux (macOS)
         if: runner.os == 'macOS'
         run: brew install bats-core tmux


### PR DESCRIPTION
A hung apt mirror eats the bats job's entire 35-minute time-box: the job sits on "Install bats + tmux (Linux)" until the box cancels it, and the PR needs a manual rerun. It happened to three PRs on 2026-08-19 alone.

Every apt call now runs under `timeout 90` with two retries (a fresh attempt usually lands on a healthy mirror) and a 6-minute step-level box as the backstop. A bad mirror now costs seconds and self-heals; a genuinely broken runner fails fast instead of silently burning 35 minutes.

This PR's own bats job exercises the changed step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)