### PR TITLE
The default view is the default GROUP: born a member, hiding means leaving it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19076,19 +19076,28 @@ def _reveal_chat_for(client, focus_msg):
     revealSelfPane) — which covers every kernel, local included, and makes the shell line a harmless
     duplicate rather than the only mover."""
     wid = (client or {}).get("wid") or ""
-    # The reveal rule (the user 2026-08-18): every gesture that focuses a session's chat — create,
-    # open, revive, a deep link, a feed chip — REVEALS it in the session views first, or the focus
-    # would land on a tab the strip doesn't show (a session created under an active group view was
-    # born invisible, with the focus yanked away by the strip's re-point). Drop its hidden bit; when
-    # the active group excludes it, fall back to All — the same one rule the chat picker applies.
+    # The reveal rule (the user 2026-08-18; reshaped 2026-08-19 with the DEFAULT-GROUP model): every
+    # gesture that focuses a session's chat — create, open, revive, a deep link, a feed chip — must
+    # land on a visible tab. Focusing now SWITCHES the active view to one that shows the session and
+    # never mutates membership: peeking at a pool worker must not permanently drag it back into the
+    # default group. Preference order: the default group (active "all" — "everything not removed"),
+    # else the first named group holding it; a session in NO view at all (removed from default,
+    # member of nothing) is re-added to the default group — the one case where visibility requires
+    # a membership edit.
     sid = focus_msg.get("id") if isinstance(focus_msg, dict) else None
     if sid:
         v = _timeline_views()
         if not _view_visible(v, sid):
             v = json.loads(json.dumps(v))
-            v["hidden"] = [x for x in v["hidden"] if x != sid]
-            if v["active"] != "all" and not any(g["id"] == v["active"] and sid in g["members"] for g in v["groups"]):
+            if sid not in v["hidden"]:
                 v["active"] = "all"
+            else:
+                holder = next((g["id"] for g in v["groups"] if sid in g["members"]), None)
+                if holder:
+                    v["active"] = holder
+                else:
+                    v["hidden"] = [x for x in v["hidden"] if x != sid]
+                    v["active"] = "all"
             _set_timeline_views(v)
             _mark_views_dirty()
     _send_to_view("chat", focus_msg, wid)

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -116,17 +116,25 @@ class TimelineViews(unittest.TestCase):
         self.assertIn("window.__rompTimelineSetViews=function(views)", src)
         self.assertIn('post({type:"setTimelineViews",views:views});', src)
 
-    def test_focus_reveals_a_hidden_session(self):
-        # the reveal rule: every gesture that focuses a session's chat (create/open/revive/deep link,
-        # all through _reveal_chat_for) reveals it first — a session created under an active group
-        # view must not be born invisible with its focus yanked away
-        km._set_timeline_views({"active": "g1", "hidden": ["s9"],
-                                "groups": [{"id": "g1", "name": "pool", "members": ["s2"]}]})
+    def test_focus_switches_to_a_view_that_shows_the_session(self):
+        # the reveal rule, default-group model (the user 2026-08-19): focusing switches the active
+        # view and never mutates membership — peeking at a pool worker must not drag it back into
+        # the default group. Order: the default group, else the first named group holding it, else
+        # (in no view at all) re-add to the default group.
+        G = {"id": "g1", "name": "pool", "members": ["s2"]}
+        km._set_timeline_views({"active": "g1", "hidden": [], "groups": [G]})
         km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s9"})
         v = km._timeline_views()
-        self.assertNotIn("s9", v["hidden"], "the hidden bit drops")
-        self.assertEqual(v["active"], "all", "the excluding group yields to All")
-        km._set_timeline_views({"active": "g1", "hidden": [],
-                                "groups": [{"id": "g1", "name": "pool", "members": ["s2"]}]})
+        self.assertEqual(v["active"], "all", "still in the default group → switch to it")
+        km._set_timeline_views({"active": "all", "hidden": ["s2"], "groups": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
+        v = km._timeline_views()
+        self.assertEqual(v["active"], "g1", "out of default but in a group → switch to that group")
+        self.assertEqual(v["hidden"], ["s2"], "membership untouched — the peek is temporary")
+        km._set_timeline_views({"active": "all", "hidden": ["sX"], "groups": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "sX"})
+        v = km._timeline_views()
+        self.assertEqual(v["hidden"], [], "in NO view at all → re-added to the default group")
+        km._set_timeline_views({"active": "g1", "hidden": [], "groups": [G]})
         km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
         self.assertEqual(km._timeline_views()["active"], "g1", "a member's focus changes nothing")

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -26,9 +26,13 @@ function _rompOnlyTag() {
 // on-camera prefix (the user 2026-07-16). Mirrors ui/webview/only-filter.ts's matchesOnly.
 // ── session VIEWS (the user 2026-08-18): which sessions the lanes — and the chat tab strip — show.
 // {active:"all"|gid, hidden:[id...], groups:[{id,name,color,members:[id...]}]}, kernel-persisted
-// (timeline-views.json) and echoed on every payload as data.views. "all" shows everything except the
-// hidden set (a hidden session is a BACKGROUND session: still judged and carded, surfaced by the feed
-// and the pickers); a named group shows exactly its members — membership beats the hidden bit. The
+// (timeline-views.json) and echoed on every payload as data.views. The DEFAULT-GROUP model (the user
+// 2026-08-19): every session is in the default group at birth; `hidden` stores the sessions REMOVED
+// from it ("all" minus hidden IS the default group, so the wire shape is unchanged). A session out of
+// the default group is a BACKGROUND session — still judged and carded, surfaced by the feed and the
+// pickers. Named groups are independent member lists (multi-membership by construction: put a manager
+// in the default group AND its workers' group; remove the workers from default and they live only in
+// their group). A named group shows exactly its members — membership beats the hidden bit. The
 // kernel's _view_visible is the decision of record; this is its three-line mirror for the lanes.
 function viewVisible(views, id) {
   if (!views || !views.active || views.active === 'all')
@@ -37,9 +41,9 @@ function viewVisible(views, id) {
   return g ? (g.members || []).indexOf(id) >= 0 : true;
 }
 function viewLabel(views) {
-  if (!views || !views.active || views.active === 'all') return 'All';
+  if (!views || !views.active || views.active === 'all') return 'default';
   const g = (views.groups || []).find((x) => x.id === views.active);
-  return g ? (g.name || 'group') : 'All';
+  return g ? (g.name || 'group') : 'default';
 }
 // live sessions the current view is NOT showing — the "N more" cue that keeps a hidden session
 // exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
@@ -2422,7 +2426,7 @@ class TimelinePanel {
     };
     const v = this._curViews();
     const pick = (active) => { const nv = JSON.parse(JSON.stringify(v)); nv.active = active; this._setViews(nv); this._closeViewsMenu(); };
-    item('All sessions', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
+    item('default', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
     for (const gr of v.groups || [])
       item(gr.name, { dot: gr.color || MODEL_FG, current: v.active === gr.id }).addEventListener('click', () => pick(gr.id));
     sep();
@@ -2523,8 +2527,8 @@ class TimelinePanel {
           });
         }
       }
-      const sub = card.createDiv({ text: gr ? 'Checked sessions are in this group.'
-        : 'Unchecked sessions are hidden from the timeline and the chat tabs.' });
+      const sub = card.createDiv({ text: gr ? 'Checked sessions are in this group. A session can be in several groups.'
+        : 'Every session joins the default group at birth. Unchecked sessions leave it — out of the timeline and the chat tabs until you view a group that has them.' });
       sub.setAttribute('style', 'opacity:0.6;font-size:0.82em;margin:0 0 6px;');
       for (const s of (this.data && this.data.sessions) || []) {
         const row = card.createDiv();

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -1,6 +1,6 @@
 // The timeline's corner control panel (the user 2026-08-18): "Show: <view> ▾ · N more" in the
 // bottom-left corner — the strip under the lane gutter, left of the time labels. The dropdown picks
-// the active VIEW (All sessions / named groups), holds New group… / Edit sessions…, and carries the
+// the active VIEW (the default group / named groups), holds New group… / Edit sessions…, and carries the
 // two timeline display toggles (collapse idle gaps, active only) so they finally work in every host.
 // The dialog is one checkbox per session: unchecked in the all-view = hidden from the timeline AND
 // the chat strip (a background session); checked in a group = member. House pattern: execute the
@@ -29,7 +29,9 @@ test("executed: the all-view hides the hidden set; a group shows exactly its mem
 });
 
 test("executed: the trigger label and the N-more cue (live sessions outside the view)", () => {
-  assert.equal(viewLabel(null), "All");
+  // the built-in view is the DEFAULT GROUP (the user 2026-08-19), not "All": every session joins it
+  // at birth, and hiding means leaving it
+  assert.equal(viewLabel(null), "default");
   assert.equal(viewLabel(V("g1")), "pool");
   const sessions = [{ id: "s1", live: true }, { id: "s2", live: true }, { id: "s4", live: false }];
   assert.equal(viewMoreCount(V("g1"), sessions), 1, "s1 is live and outside; dead s4 never counts");

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -21,21 +21,28 @@ test("executed: the all-view minus hidden; a group exactly; membership beats hid
   assert.equal(viewVisible({ active: "gone", groups: [] }, "s1"), true, "an orphaned active fails open");
 });
 
-test("executed: hide adds the bit; reveal drops it and falls back to All when the group excludes it", () => {
+test("executed: hide leaves the default group (and the active group); reveal SWITCHES views", () => {
   const hid = hideIn({ active: "all", hidden: [] }, "s1");
-  assert.deepEqual(hid.hidden, ["s1"]);
+  assert.deepEqual(hid.hidden, ["s1"], "hiding = leaving the default group");
   assert.deepEqual(hideIn(hid, "s1").hidden, ["s1"], "idempotent");
   // hiding while a group that CONTAINS the session is active must also leave that group — membership
   // beats hidden, so without this the gesture is a silent no-op
   const g = hideIn({ active: "g1", hidden: [], groups: [{ id: "g1", members: ["s2", "s3"] }, { id: "g2", members: ["s2"] }] }, "s2");
   assert.deepEqual(g.hidden, ["s2"]);
   assert.deepEqual(g.groups![0].members, ["s3"], "dropped from the ACTIVE group");
-  assert.deepEqual(g.groups![1].members, ["s2"], "other groups keep it");
-  const rev = revealIn({ active: "g1", hidden: ["s1"], groups: [G] }, "s1");
-  assert.deepEqual(rev.hidden, []);
-  assert.equal(rev.active, "all", "the active group excludes it → fall back to All");
-  const rev2 = revealIn({ active: "g1", hidden: ["s2"], groups: [G] }, "s2");
-  assert.equal(rev2.active, "g1", "a member reveals in place — no view switch");
+  assert.deepEqual(g.groups![1].members, ["s2"], "other groups keep it — multi-membership");
+  // reveal never mutates membership (the user 2026-08-19: peeking at a pool worker must not drag it
+  // back into the default group) — it switches the active view to one that shows the session
+  const rev = revealIn({ active: "g1", hidden: [], groups: [G] }, "s1");
+  assert.equal(rev.active, "all", "still in the default group → switch to it");
+  assert.deepEqual(rev.hidden, [], "…and nothing edited");
+  const rev2 = revealIn({ active: "all", hidden: ["s2"], groups: [G] }, "s2");
+  assert.equal(rev2.active, "g1", "out of default but in a group → switch to that group");
+  assert.deepEqual(rev2.hidden, ["s2"], "membership untouched — the peek is temporary");
+  const rev3 = revealIn({ active: "all", hidden: ["sX"], groups: [G] }, "sX");
+  assert.deepEqual(rev3.hidden, [], "in NO view at all → re-added to the default group (the one edit)");
+  const rev4 = revealIn({ active: "g1", hidden: ["s2"], groups: [G] }, "s2");
+  assert.equal(rev4.active, "g1", "already visible in the active group → nothing changes");
 });
 
 test("executed: the canonical key ignores list order — the kernel normalizer re-sorts", () => {

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -1,6 +1,8 @@
 // Session views (the user 2026-08-18): the kernel's timeline-views blob, echoed on every tabOrder
 // push — which sessions the chat TAB STRIP (and the timeline lanes) show. "all" shows everything
-// except the hidden set (a hidden session is a BACKGROUND session: still running, judged and carded;
+// except the hidden set — which reads as "removed from the DEFAULT GROUP": every session is in the
+// default group at birth, and leaving it is what hiding means (the user 2026-08-19). A session out
+// of the default group is a BACKGROUND session: still running, judged and carded;
 // the feed and the + picker keep surfacing it, so nothing runs in secret — the 2026-08-11 rule); a
 // named group shows exactly its members, membership beating the hidden bit. The kernel's
 // _view_visible is the decision of record; this is its client mirror (the timeline carries its own
@@ -39,14 +41,18 @@ export function hideIn(views: SessionViews | null | undefined, id: string): Sess
   return v;
 }
 
-// the reveal gesture: explicitly opening a hidden session always shows it — drop its hidden bit,
-// and when the active group excludes it, fall back to All. One predictable rule.
+// the reveal gesture (reshaped 2026-08-19 with the DEFAULT-GROUP model): explicitly opening a
+// session SWITCHES the active view to one that shows it and never mutates membership — peeking at
+// a pool worker must not drag it back into the default group. Prefer the default group ("all" =
+// everything not removed from it), else the first named group holding it; a session in NO view at
+// all is re-added to the default group, the one case where visibility requires a membership edit.
 export function revealIn(views: SessionViews | null | undefined, id: string): SessionViews {
   const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
+  if (viewVisible(v, id)) return v;
+  if (!(v.hidden || []).includes(id)) { v.active = "all"; return v; }
+  const holder = (v.groups || []).find((g) => (g.members || []).includes(id));
+  if (holder) { v.active = holder.id; return v; }
   v.hidden = (v.hidden || []).filter((x) => x !== id);
-  if (v.active && v.active !== "all") {
-    const g = (v.groups || []).find((x) => x.id === v.active);
-    if (!g || !(g.members || []).includes(id)) v.active = "all";
-  }
+  v.active = "all";
   return v;
 }


### PR DESCRIPTION
Reshapes the views model per user direction (2026-08-19), with the wire shape unchanged — "all minus hidden" already is a default group with exclusions:

- Every session is in the **default group** at birth; `hidden` now reads as "removed from the default group". The trigger and dropdown say **default** instead of "All sessions", and the dialog speaks membership: unchecked sessions leave the default group, out of the timeline and chat until you view a group that has them.
- Named groups are independent member lists, so **multi-membership** works by construction. The pool workflow: put a manager in the default group and its workers' group; remove the workers from default — they live only in their group, the manager shows in both views.
- The **reveal rule switches views instead of mutating membership**: focusing a session (create, open, revive, deep link, picker) activates the default group when it's a member, else the first named group holding it. Peeking at a pool worker never drags it back into the default group. Only a session in no view at all is re-added to default.

Tests updated on all three surfaces (kernel reveal rule, client revealIn/hideIn, timeline labels); both suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)