### PR TITLE
The forced Stack toggle stays visibly ON and hover stays responsive

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -70,5 +70,7 @@ test("the Stack toggle says so when narrow width already forces stacking (2026-0
     "keyboard activation bypasses pointer-events, so the handler itself no-ops");
   assert.match(FEED, /new ResizeObserver\(\(\) => refreshStackForced\(b\)\)/,
     "width changes are the event — never a poll");
-  assert.match(CSS, /#feed-stacked\.forced \{ opacity: 0\.4; cursor: default; \}/);
+  assert.match(CSS, /#feed-stacked\.forced \{ opacity: 0\.5; cursor: default;\s*\n\s*color: var\(--accent\); border-color: var\(--accent\); \}/,
+    "grayed but still wearing the on-accent — stacking IS active (the user 2026-08-19)");
+  assert.match(CSS, /#feed-stacked\.forced:hover \{ opacity: 0\.75; \}/, "hover stays responsive");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1155,8 +1155,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .judge-limit-banner .jl-switch:hover { background: #3c3c3c; }
 .judge-limit-banner .jl-switch:disabled { opacity: 0.6; cursor: default; }
 
-/* the Stack toggle while the narrow container query FORCES stacking (2026-08-19): faded and inert —
-   unclicking it would change nothing at this width, and the tooltip names the way out (more width).
-   pointer-events stays on so the tooltip still shows on hover; the click handler no-ops instead. */
-#feed-stacked.forced { opacity: 0.4; cursor: default; }
-#feed-stacked.forced:hover { color: inherit; background: inherit; }
+/* the Stack toggle while the narrow container query FORCES stacking (2026-08-19): stacking IS on,
+   so the button keeps the pressed accent — grayed by opacity, never stripped of its on-state (the
+   user 2026-08-19: "grayed out but still blue to show that it's on"). Hover stays responsive (a
+   gentle brighten, not the action-blue that promises a click); the tooltip names the way out. */
+#feed-stacked.forced { opacity: 0.5; cursor: default;
+  color: var(--accent); border-color: var(--accent); }
+#feed-stacked.forced:hover { opacity: 0.75; }


### PR DESCRIPTION
Refinement from live use: the first cut faded the forced Stack toggle to neutral and killed its hover, which read as broken — stacking IS active at that width, so the button now keeps its pressed accent (grayed by opacity, never stripped of the on-state) and hover brightens gently instead of promising a click. The tooltip is unchanged. Pins updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)