### PR TITLE
Doc-review submit routes by the reviewed session and never destroys comments on failure

### DIFF
--- a/ui/webview/docreview.test.ts
+++ b/ui/webview/docreview.test.ts
@@ -122,3 +122,30 @@ test("comments are keyed per session AND per file, so two open docs keep separat
   assert.notEqual(docKey("s1", "a.md"), docKey("s1", "b.md"));
   assert.notEqual(docKey("s1", "a.md"), docKey("s2", "a.md"));
 });
+
+// ── the submit handoff (2026-08-19): two user-data-loss bugs from one root, pinned at source ──
+import * as fs from "node:fs";
+import * as path from "node:path";
+const FV = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "file-view.ts"), "utf8");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("submit routes by the REVIEWED session's sid, never activeId-at-submit", () => {
+  assert.match(FV, /let commentSink: \(\(sid: string, text: string\) => boolean\) \| null = null;/,
+    "the sink contract carries the sid and reports whether the draft landed");
+  assert.match(FV, /const landed = commentSink!\(sid \|\| "",/, "the viewer passes ITS OWN sid");
+  assert.match(RENDER, /setCommentSink\(\(sid, text\) => \{/);
+  assert.match(RENDER, /if \(sid === activeId\) \{/, "active tab → the live textarea");
+  assert.match(RENDER, /const prev = drafts\.get\(sid\) \|\| "";/,
+    "any other sid → straight into that session's persisted draft");
+});
+
+test("a failed handoff PRESERVES the comments and says so — never a silent erase", () => {
+  assert.match(FV, /if \(!landed\) \{/);
+  assert.match(FV, /submitBtn\.textContent = "Couldn't draft it — comments kept, try again";/,
+    "visible, and the button re-arms for a retry");
+  const at = FV.indexOf("if (!landed) {");
+  const del = FV.indexOf("comments.delete(key);", at);
+  const ret = FV.indexOf("return;", at);
+  assert.ok(ret > 0 && (del < 0 || ret < del), "comments.delete is gated BEHIND the landed return");
+  assert.match(RENDER, /if \(!sid\) return false;/, "a sid-less viewer cannot land a draft — say so, keep the work");
+});

--- a/ui/webview/file-view-comments.test.ts
+++ b/ui/webview/file-view-comments.test.ts
@@ -51,8 +51,9 @@ test("Submit DRAFTS one assembled message — it never sends, and never clobbers
   assert.match(body, /buildReviewMessage\(path, list\)/);
   assert.match(body, /commentSink!\(/);
   assert.doesNotMatch(body, /sendMessage/, "Submit drafts; the person sends");
-  // the composer side appends and remembers the draft
-  const sink = RENDER.slice(RENDER.indexOf("setCommentSink((text) => {"));
+  // the composer side appends and remembers the draft (sid-routed since 2026-08-19 —
+  // docreview.test.ts pins the routing + the preserve-on-failure contract)
+  const sink = RENDER.slice(RENDER.indexOf("setCommentSink((sid, text) => {"));
   const sinkBody = sink.slice(0, sink.indexOf("\n});"));
   assert.match(sinkBody, /ta\.value = ta\.value \+ sep \+ text;/);
   assert.match(sinkBody, /drafts\.set\(sid, ta\.value\);/);

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -136,8 +136,12 @@ function saveComments(): void {
 
 // render.ts owns the composer, and it imports THIS module — so the finished message is handed back
 // through a sink it registers at startup rather than importing render.ts here (which would be a cycle).
-let commentSink: ((text: string) => void) | null = null;
-export function setCommentSink(fn: (text: string) => void): void { commentSink = fn; }
+// The sink takes THE REVIEWED SESSION'S sid and reports whether the draft LANDED (2026-08-19, two
+// user-data-loss bugs from one root): the old void sink read activeId at submit time, so switching
+// tabs drafted session A's review into session B — and Submit deleted the comments unconditionally,
+// so a closed tab or missing composer erased the whole review from memory and localStorage silently.
+let commentSink: ((sid: string, text: string) => boolean) | null = null;
+export function setCommentSink(fn: (sid: string, text: string) => boolean): void { commentSink = fn; }
 
 export function closeFileView(): void {
   const wrap = document.getElementById("romp-fileview");
@@ -409,10 +413,17 @@ export function openFileView(path: string, sid?: string | null): void {
       .catch(() => false)                                       // can't re-read → claim no staleness we didn't see
       .then((stale) => {
         const msg = buildReviewMessage(path, list);
-        if (!msg) return;
-        commentSink!(stale
+        if (!msg) { submitBtn.disabled = false; submitBtn.textContent = "Submit"; return; }
+        const landed = commentSink!(sid || "", stale
           ? msg + "\n(Heads up: the file changed while I was reading it, so the line numbers may have moved.)\n"
           : msg);
+        if (!landed) {
+          // the review is the user's WORK — never erased on a failed handoff. Say so, visibly,
+          // and keep every comment (memory + localStorage) for the next attempt.
+          submitBtn.disabled = false;
+          submitBtn.textContent = "Couldn't draft it — comments kept, try again";
+          return;
+        }
         comments.delete(key);
         saveComments();
         closeFileView();

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11363,17 +11363,29 @@ document.getElementById("content")?.addEventListener("contextmenu", showSelectio
 // The file viewer's review comments come back here as ONE assembled message (the user 2026-08-14).
 // It is DRAFTED into the composer, never sent: you read what the session will get, add a line if you
 // want, and send it yourself. Appended, so it never clobbers a half-typed draft.
-setCommentSink((text) => {
-  const sid = activeId;
-  if (!sid) return;
-  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-  if (!ta) return;
-  const sep = !ta.value ? "" : ta.value.endsWith("\n\n") ? "" : ta.value.endsWith("\n") ? "\n" : "\n\n";
-  ta.value = ta.value + sep + text;
-  ta.selectionStart = ta.selectionEnd = ta.value.length;
-  growComposer(ta);
-  ta.focus();
-  drafts.set(sid, ta.value);
+setCommentSink((sid, text) => {
+  // Routed by the REVIEWED session's sid, never activeId-at-submit (2026-08-19: switching tabs
+  // while the viewer was open drafted session A's review into session B's composer). Active tab →
+  // the live textarea; any other sid → straight into that session's persisted draft, where the
+  // composer restores it on the next visit (or on revival — drafts outlive the tab).
+  if (!sid) return false;
+  if (sid === activeId) {
+    const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+    if (ta) {
+      const sep = !ta.value ? "" : ta.value.endsWith("\n\n") ? "" : ta.value.endsWith("\n") ? "\n" : "\n\n";
+      ta.value = ta.value + sep + text;
+      ta.selectionStart = ta.selectionEnd = ta.value.length;
+      growComposer(ta);
+      ta.focus();
+      drafts.set(sid, ta.value);
+      persistDrafts();
+      return true;
+    }
+  }
+  const prev = drafts.get(sid) || "";
+  const sep = !prev ? "" : prev.endsWith("\n\n") ? "" : prev.endsWith("\n") ? "\n" : "\n\n";
+  drafts.set(sid, prev + sep + text);
   persistDrafts();
+  return true;
 });
 if (vscodeApi) vscodeApi.postMessage({ type: "ready" });


### PR DESCRIPTION
Two user-data-loss bugs from one root (found by the PR's adversarial security review; user-routed here). The comment sink read `activeId` at submit time, so switching tabs while the viewer was open drafted session A's review into session B's composer — and Submit deleted the file's whole comment set unconditionally after the void sink, so a closed tab or missing composer erased the entire review from memory and localStorage with no error.

The sink contract is now `(sid, text) => boolean`: the viewer passes ITS OWN sid; the sink appends to the live textarea when that session is the active tab, and otherwise lands the review straight in that session's persisted draft (restored on the next visit, or on revival — drafts outlive the tab). `comments.delete` gates on a landed draft: a failed handoff re-arms Submit with a visible "comments kept" message and preserves every comment. Tests: sid routing + preserve-on-failure pins (docreview.test.ts), the stale sink-shape pin updated; suite 2138 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)