### PR TITLE
romp mail send --from: a non-session script sends under an explicit label, never anonymously

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2697,25 +2697,40 @@ def mcp():
 # ───────────────────────── CLI client modes ─────────────────────────
 
 def cli_send(argv):
-    kind = ""
-    if argv and argv[0] == "--kind":
-        kind = (argv[1].strip().lower() if len(argv) > 1 else "")
-        argv = argv[2:]
-        if kind not in ("delegate", "coordinate", "question"):
-            sys.stderr.write("[romp mail] --kind must be delegate, coordinate, or question\n"); return 2
+    kind = frm_label = ""
+    while argv and argv[0] in ("--kind", "--from"):
+        if argv[0] == "--kind":
+            kind = (argv[1].strip().lower() if len(argv) > 1 else "")
+            argv = argv[2:]
+            if kind not in ("delegate", "coordinate", "question"):
+                sys.stderr.write("[romp mail] --kind must be delegate, coordinate, or question\n"); return 2
+        else:
+            # --from <label>: an EXPLICIT identity for a non-session caller (a launchd/cron script, a
+            # bare shell — 2026-08-19, after the anonymous-send refusal broke a morning script that
+            # had been mailing as "unknown"). Not anonymity restored: the mail arrives placeable,
+            # from <label> with a stable synthetic id, and recipients can tell scripts apart.
+            frm_label = (argv[1].strip() if len(argv) > 1 else "")
+            argv = argv[2:]
+            if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,31}", frm_label or ""):
+                sys.stderr.write("[romp mail] --from must be one word (letters/digits/dash/underscore, <=32 chars)\n"); return 2
     if len(argv) < 2:
-        sys.stderr.write('usage: romp mail send [--kind delegate|coordinate|question] <session> <text>\n'); return 2
+        sys.stderr.write('usage: romp mail send [--kind delegate|coordinate|question] [--from <label>] <session> <text>\n'); return 2
     to, body = argv[0], " ".join(argv[1:])
     if not body.strip():
         sys.stderr.write("[romp mail] refusing to send an empty message\n"); return 2
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     me, mid = my_name(), my_id()
+    if frm_label:
+        me, mid = frm_label, "ext:" + frm_label
     if not mid:
-        # the bus refuses anonymous sends; say it here with the actionable half
-        sys.stderr.write("[romp mail] cannot send: this session's own identity did not resolve "
-                         "(no session id), so the mail would arrive anonymously. Surface this to "
-                         "the user as a session-identity bug.\n")
+        # the bus refuses anonymous sends; say it here with BOTH actionable halves: a broken
+        # session identity is a bug to surface, and a deliberate non-session caller has a door
+        sys.stderr.write("[romp mail] cannot send: no session identity resolved, and anonymous "
+                         "mail is refused (it arrives as an unplaceable ghost). Inside a romp "
+                         "session, surface this to the user as a session-identity bug. From a "
+                         "script or bare shell, pass --from <label> to send under an explicit "
+                         "name.\n")
         return 1
     try:
         resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid, "body": body,

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -105,7 +105,7 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     # the CLI: with no resolvable self, it refuses with the actionable half and posts nothing
     CLAUDE_CODE_SESSION_ID= ROMP_SID= run "$POSTAL" send beta "How is it going?"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"identity did not resolve"* ]]
+    [[ "$output" == *"no session identity resolved"* ]]
     [ "$(cnt "$(mb uuid-b)/new")" = "0" ]
 }
 

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -109,6 +109,23 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     [ "$(cnt "$(mb uuid-b)/new")" = "0" ]
 }
 
+@test "a non-session caller sends with --from, and the refusal names the flag" {
+    # a launchd/cron script has no session identity; --from gives it an explicit, placeable one
+    CLAUDE_CODE_SESSION_ID= ROMP_SID= run "$POSTAL" send --from morning-brief beta "the morning summary"
+    [ "$status" -eq 0 ]
+    [ "$(cnt "$(mb uuid-b)/new")" = "1" ]
+    grep -q "From: morning-brief" "$(mb uuid-b)/new/"*
+    grep -q "ext:morning-brief" "$(mb uuid-b)/new/"*
+    # without --from the refusal is loud AND names the door
+    CLAUDE_CODE_SESSION_ID= ROMP_SID= run "$POSTAL" send beta "anonymous attempt"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"pass --from"* ]]
+    # a garbage label exits 2
+    CLAUDE_CODE_SESSION_ID= ROMP_SID= run "$POSTAL" send --from "two words" beta "x"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--from must be one word"* ]]
+}
+
 @test "send to an unknown session errors" {
     run "$POSTAL" send ghost "x"
     [ "$status" -ne 0 ]

--- a/tests/test_postal_sender_identity.py
+++ b/tests/test_postal_sender_identity.py
@@ -57,7 +57,12 @@ class SendRefusal(unittest.TestCase):
 
     def test_mcp_and_cli_guards_precede_the_post(self):
         src = open(os.path.join(BIN, "romp-postal-service")).read()
-        self.assertEqual(src.count("identity did not resolve"), 2, "both sender surfaces guard")
+        self.assertIn("identity did not resolve", src, "the MCP surface guards (always in-session)")
+        self.assertIn("pass --from <label>", src,
+                      "the CLI surface guards AND names the non-session door (2026-08-19: the "
+                      "refusal broke launchd scripts that had been mailing as 'unknown')")
+        self.assertIn('mid = frm_label, "ext:" + frm_label', src,
+                      "--from mails placeable under a stable synthetic id, never anonymously")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The anonymous-send refusal (merged 08-18) caught a legitimate caller class: launchd/cron scripts with no session identity, which had been mailing as `unknown` — the exact unplaceable ghost the refusal exists to kill, so restoring anonymity would be wrong. Instead the CLI gains `--from <label>` (one word): the mail arrives placeable, from that label with a stable synthetic id (`ext:<label>`), and recipients can tell scripts apart. The refusal message now carries both actionable halves — inside a session it's a session-identity bug to surface; from a script or bare shell, pass `--from`. The MCP surface is unchanged (always in-session). Bats: --from delivers with the ext id; the refusal names the flag; garbage labels exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)