### PR TITLE
A bare 429 names both account-wide causes — a key's per-minute limits are not 'quota'

### DIFF
--- a/ui/webview/api-error-reason.test.ts
+++ b/ui/webview/api-error-reason.test.ts
@@ -37,6 +37,15 @@ test("a dead network and a busy API are told apart", () => {
   assert.doesNotMatch(apiErrorReason({ status: 529, networkDown: true }), /overloaded/i);
 });
 
+test("a bare 429 names BOTH account-wide causes — a key's per-minute limits are not 'quota'", () => {
+  // the user 2026-08-19, on key billing, went hunting for a spent quota that wasn't the cause: keys
+  // are never unlimited (per-minute org limits by tier), subscriptions have usage windows — say both
+  const s = apiErrorReason({ status: 429 });
+  assert.match(s, /per-minute limits or the plan's usage window/);
+  assert.match(s, /not this session/);
+  assert.match(s, /retries clear it/);
+});
+
 test("a quota 429 names which limit it hit", () => {
   assert.match(apiErrorReason({ status: 429, rateLimitType: "output_tokens" }), /output_tokens/);
   assert.match(apiErrorReason({ status: 429 }), /rate limited/i);

--- a/ui/webview/api-error-reason.ts
+++ b/ui/webview/api-error-reason.ts
@@ -37,7 +37,11 @@ export function apiErrorReason(f: ApiErrorFacts): string {
   // session-specific fault from the outside, and it is far likelier to hit a LONG thread — a big request
   // needs more capacity at once, so a fresh session sails through the same minute a full one keeps bouncing.
   if (s === 529) return "the API was overloaded — server-side and temporary, not this session";
-  if (s === 429) return "rate limited — the account's quota, not this session";
+  // Account-WIDE, but not necessarily "quota": an API key hits per-minute org rate limits (keys are
+  // never unlimited — RPM/TPM by usage tier), a subscription hits its usage window. Both clear on
+  // their own; naming "quota" alone sent a key-billed user hunting for a cap that wasn't the cause
+  // (the user 2026-08-19). Parallel sessions sharing one key make the per-minute case the common one.
+  if (s === 429) return "rate limited account-wide (per-minute limits or the plan's usage window) — not this session, retries clear it";
   if (s === 401 || s === 403) return "the API rejected our credentials";
   if (s === 404) return "the API says that model does not exist";
   if (s >= 500) return "server-side and temporary";


### PR DESCRIPTION
User report 2026-08-19: on API-key billing, the retry card's "rate limited — the account's quota, not this session" reads wrong — the key has no monthly cap to spend. The 429s are real, though: API keys carry per-minute org rate limits by usage tier, and many parallel sessions sharing one key make that the common cause. A subscription's 429 is its usage window.

The gloss now names both causes and the resolution: "rate limited account-wide (per-minute limits or the plan's usage window) — not this session, retries clear it". The specific-limit path (`rateLimitType`) and the model-allowance path are unchanged. New test pins the wording; suite passes (2,139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)