### PR TITLE
Fork button moves below the response it branches from

### DIFF
--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -1,5 +1,7 @@
-// Fork a session (the user 2026-08-13): a NEW parallel session branches from just before a chosen user
-// message (the bubble's hover "fork") or from the tip (the palette's "Fork this session…"); the parent
+// Fork a session (the user 2026-08-13): a NEW parallel session branches from a chosen point — the
+// hover "fork" BELOW each response run (the user 2026-08-19: forking conceptually cuts under the
+// response, so the button left the prompt's msg-acts row) or from the tip (the palette's "Fork this
+// session…", and the tip run's own spot); the parent
 // is untouched and both continue as separate threads. The modal asks the new name — default
 // "<session>-fork", editable — and the provisional tab is the instant acknowledgement, joined by NAME
 // exactly like a picker create. Source-level pins (no jsdom for the chat renderer), plus the kernel
@@ -15,11 +17,22 @@ const PALETTE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const BACKEND = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
 
-test("a fork button rides each editable bubble — non-destructive, accent hover, single click to the modal", () => {
-  assert.match(RENDER, /const fk = el\("button", "msg-fork"\) as HTMLButtonElement;/);
-  assert.match(RENDER, /fk\.addEventListener\("click", \(e\) => \{ e\.stopPropagation\(\); showForkPrompt\(editSid, uuid\); \}\);/);
-  assert.match(RENDER, /acts\.appendChild\(fk\);/);
-  // fork is not a rewind: no two-click arm (the modal is the confirmation), and never the destructive red
+test("the fork affordance rides BELOW each response run — delegated, with the cut the old bubble button passed", () => {
+  // the spot map: the FIRST genuine editable prompt after a run is its cut; the tip run forks everything
+  assert.match(RENDER, /function applyForkSpots\(sid: string, v: View\): void \{/);
+  assert.match(RENDER, /&& senderKind\(ev\) === "user" && editable\?\.has\(ev\.uuid\)/);
+  assert.match(RENDER, /if \(run && !spots\.has\(run\)\) spots\.set\(run, ""\);/);
+  assert.match(RENDER, /\.turn-assistant\[data-uuid="\$\{cssEscape\(anchor\)\}"\]/);
+  // …applied on the marks' hooks, like the branch chips (the transcript DOM rebuilds constantly)
+  assert.match(RENDER, /applyForkSpots\(sid, v\);/);
+  // the OLD home is gone: the prompt's msg-acts row no longer carries a fork (the user 2026-08-19)
+  assert.doesNotMatch(RENDER, /acts\.appendChild\(fk\);/);
+  // click-safe: the button is DELEGATED (data-act), landing in the shared modal with the spot's own cut
+  assert.match(RENDER, /fk\.dataset\.act = "forkspot";/);
+  assert.match(RENDER, /forkspot: \(elx\) => \{/);
+  assert.match(RENDER, /showForkPrompt\(activeId, cut\);/);
+  // hover the RESPONSE to reveal it; not a rewind: no two-click arm, and never the destructive red
+  assert.match(CSS, /\.turn-assistant:hover \.msg-fork, \.msg-fork:focus-visible \{ opacity: 0\.9; \}/);
   assert.match(CSS, /\.msg-fork:hover \{ color: var\(--fg\); border-color: var\(--accent\); \}/);
   assert.doesNotMatch(CSS, /\.msg-fork\.armed/);
 });
@@ -32,7 +45,7 @@ test("the modal defaults to <session>-fork and posts forkSession {id, uuid, name
   // the instant acknowledgement is the provisional tab, name-joined like a picker create
   assert.match(RENDER, /openProvisional\(\{ name, backend: "sdk", dir: "", host: hostOf\(sid\) \}\);/);
   // both cut semantics are said in the dialog itself
-  assert.match(RENDER, /continues from just before this message/);
+  assert.match(RENDER, /continues the conversation to just below this response/);
   assert.match(RENDER, /continues this whole conversation/);
   assert.match(CSS, /\.fork-name \{ display: block; width: 100%;/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2238,20 +2238,13 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         });
         rf.addEventListener("blur", rfDisarm);
         rf.addEventListener("pointerleave", rfDisarm);
-        // FORK affordance (the user 2026-08-13): branch a NEW parallel session from just before this
-        // message — old and new then run as separate threads (the rewind family above edits THIS
-        // session; fork leaves it untouched). Non-destructive, so no two-click arm: the name modal is
-        // the confirmation.
-        const fk = el("button", "msg-fork") as HTMLButtonElement;
-        fk.type = "button";
-        fk.textContent = "fork";
-        fk.title = "Fork the session from just before this message — a new parallel session carries the conversation up to here; this one is untouched";
-        fk.addEventListener("click", (e) => { e.stopPropagation(); showForkPrompt(editSid, uuid); });
+        // (The FORK affordance no longer rides this row: forking conceptually cuts BELOW the previous
+        // response, so its button lives there now — applyForkSpots — while the rewind family above
+        // stays here, acting on THIS message. The user 2026-08-19.)
         const acts = el("div", "msg-acts");   // one row under the bubble (the turn is a column flex)
         acts.appendChild(edit);
         acts.appendChild(del);
         acts.appendChild(rf);
-        acts.appendChild(fk);
         turn.appendChild(acts);
       }
     }
@@ -5529,7 +5522,7 @@ function showForkPrompt(sid: string, uuid: string): void {
   const h = el("div", "confirm-title"); h.textContent = "Fork session";
   const d = el("div", "confirm-detail");
   d.textContent = uuid
-    ? "A new session continues from just before this message; this one is untouched."
+    ? "A new session continues the conversation to just below this response; this one is untouched."
     : "A new session continues this whole conversation; this one is untouched.";
   const input = document.createElement("input");
   input.type = "text"; input.className = "fork-name"; input.value = base + "-fork";
@@ -5615,6 +5608,7 @@ function applyCommentMarks(sid: string): void {
   const v = views.get(sid);
   if (!v) return;
   applyBranchChips(sid, v);   // same driver, same hooks: branch chips re-anchor with the marks
+  applyForkSpots(sid, v);     // and the below-response fork spots (same reason: this DOM rebuilds constantly)
   if (sid === activeId) updateCommentRail();   // and the scroll-rail ticks follow the active view
   const threads = commentThreads.get(sid) || [];
   const have = new Set(threads.map((t) => t.tid));
@@ -5655,6 +5649,49 @@ function applyBranchChips(sid: string, v: View): void {
     chip.textContent = "↳ " + (k.name || "fork");
     chip.title = "A session branched from this message: " + (k.name || k.sid) + ". Click to open it there.";
     box.appendChild(chip);
+  }
+}
+
+/** The FORK affordance lives BELOW the response it branches from (the user 2026-08-19: forking
+ *  conceptually cuts under the response — the old button rode the NEXT prompt's msg-acts row, where
+ *  it read as acting on that message). A hover-revealed "fork" under the LAST assistant bubble of
+ *  each response run. The CUT is unchanged: the first genuine editable prompt after the run — exactly
+ *  the uuid the old bubble button passed, so _rewind_target resolves it the same way — and the tip
+ *  run, with no prompt after it, forks the whole conversation (uuid "", the palette's fork-from-tip).
+ *  Idempotent and applied on the marks' hooks, like the branch chips (this DOM rebuilds constantly);
+ *  a windowed-out anchor turn simply has no spot until it returns. */
+function applyForkSpots(sid: string, v: View): void {
+  const s = sessions.get(sid);
+  const evs = (s?.events || []) as ChatEvent[];
+  const editable = (s as any)?._editable as Set<string> | undefined;
+  const spots = new Map<string, string>();   // last-assistant-of-run uuid -> cut uuid ("" = whole conversation)
+  let run: string | null = null;             // the newest assistant uuid whose run has no cut yet
+  for (const ev of evs) {
+    if (ev.kind === "assistant" && ev.uuid) run = ev.uuid;
+    else if (ev.kind === "user" && ev.uuid && run && !spots.has(run)
+             && senderKind(ev) === "user" && editable?.has(ev.uuid)) {
+      spots.set(run, ev.uuid);   // the FIRST prompt after the run = the cut just below its response
+    }
+  }
+  if (run && !spots.has(run)) spots.set(run, "");   // the tip run: nothing follows -> whole conversation
+  for (const old of Array.from(v.el.querySelectorAll(".fork-spot")) as HTMLElement[]) {
+    const anchor = (old.parentElement as HTMLElement | null)?.dataset.uuid || "";
+    if (spots.get(anchor) !== old.dataset.cut) old.remove();   // gone, or its cut moved
+  }
+  for (const [anchor, cut] of spots) {
+    const turn = v.el.querySelector(`.turn-assistant[data-uuid="${cssEscape(anchor)}"]`) as HTMLElement | null;
+    if (!turn || turn.querySelector(":scope > .fork-spot")) continue;
+    const row = el("div", "fork-spot");
+    row.dataset.cut = cut;
+    const fk = el("button", "msg-fork") as HTMLButtonElement;
+    fk.type = "button";
+    fk.textContent = "fork";
+    fk.dataset.act = "forkspot";   // delegated (click-safe): the transcript rebuilds on every push
+    fk.title = cut
+      ? "Fork the session from just below this response — a new parallel session carries the conversation to here; this one is untouched"
+      : "Fork the session — a new parallel session continues this whole conversation; this one is untouched";
+    row.appendChild(fk);
+    turn.appendChild(row);
   }
 }
 
@@ -11290,6 +11327,11 @@ setupSettings();
       if (!sid) return;
       if (!sessions.get(sid)) { warnToast("That session isn't on this dashboard right now."); return; }
       setActive(sid, elx.dataset.cut || undefined);
+    },
+    // a below-response fork spot: the row carries its own cut ("" = whole conversation)
+    forkspot: (elx) => {
+      const cut = (elx.closest(".fork-spot") as HTMLElement | null)?.dataset.cut || "";
+      if (activeId && !isProvisionalId(activeId) && sessions.get(activeId)) showForkPrompt(activeId, cut);
     },
     // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
     // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the

--- a/ui/webview/rewind-delete.test.ts
+++ b/ui/webview/rewind-delete.test.ts
@@ -47,7 +47,7 @@ test("the bare overlay dims the deleted bubble itself, not just the tail", () =>
 test("the delete button dresses like edit, with a destructive armed state", () => {
   assert.match(CSS, /\.msg-acts \{ display: flex; gap: 4px; align-self: flex-end; \}/);
   // restore-files shares delete's dress (same reveal, same destructive armed red — the user 2026-08-04)
-  assert.match(CSS, /\.turn-user:hover \.msg-del, \.msg-del:focus-visible,\s*\n\.turn-user:hover \.msg-restorefiles, \.msg-restorefiles:focus-visible,\s*\n\.turn-user:hover \.msg-fork, \.msg-fork:focus-visible \{ opacity: 0\.9; \}/);
+  assert.match(CSS, /\.turn-user:hover \.msg-del, \.msg-del:focus-visible,\s*\n\.turn-user:hover \.msg-restorefiles, \.msg-restorefiles:focus-visible \{ opacity: 0\.9; \}/);
   assert.match(CSS, /\.msg-del\.armed, \.msg-restorefiles\.armed \{ color: #ff6a6a; border-color: #ff6a6a;/);
 });
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1232,9 +1232,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 .turn-user:hover .msg-del, .msg-del:focus-visible,
-.turn-user:hover .msg-restorefiles, .msg-restorefiles:focus-visible,
-.turn-user:hover .msg-fork, .msg-fork:focus-visible { opacity: 0.9; }
+.turn-user:hover .msg-restorefiles, .msg-restorefiles:focus-visible { opacity: 0.9; }
 .msg-del:hover, .msg-restorefiles:hover { color: var(--fg); border-color: #ff6a6a; }
+/* fork lives BELOW the response it branches from (the user 2026-08-19) — .fork-spot rides the run's
+   LAST assistant turn (applyForkSpots), revealed by hovering that turn, left with the response column */
+.fork-spot { display: flex; margin-top: 3px; }
+.turn-assistant:hover .msg-fork, .msg-fork:focus-visible { opacity: 0.9; }
 .msg-fork:hover { color: var(--fg); border-color: var(--accent); }   /* non-destructive: accent, never the rewind red */
 /* armed = one click from rolling back: destructive red, holds until blur/pointerleave/re-render */
 .msg-del.armed, .msg-restorefiles.armed { color: #ff6a6a; border-color: #ff6a6a; opacity: 0.95; }


### PR DESCRIPTION
The fork button lived in the user bubble's action row (edit / delete / restore files / fork), but conceptually a fork cuts **below the previous response** — attached to the prompt it read as acting on that message (the user's report, 2026-08-19).

## What changes
- The fork affordance now rides the **last assistant bubble of each response run**: hover the response to reveal a small `fork` button under it (same clothes as the other message affordances, accent hover, no two-click arm — the name modal is the confirmation).
- The **cut is unchanged**: the button passes the uuid of the first genuine editable prompt after the run — exactly what the old bubble button passed, so `_rewind_target` resolution, guards, and the kernel op are untouched. The newest response (nothing after it) forks the whole conversation (uuid "", the palette's fork-from-tip semantics), so the tip is now forkable by hover too.
- Implemented as `applyForkSpots`, an idempotent DOM post-pass riding the comment-marks hooks (the same idiom as the branch chips), with the click **delegated** (`data-act=forkspot`) so the constantly-rebuilding transcript DOM can't eat a mid-press click.
- The modal wording follows the placement ("continues the conversation to just below this response").

## Tests
`fork-session.test.ts` rewritten for the new home (spot map, tip rule, delegation, hover reveal, and a does-not-match pin that the old msg-acts home is gone); the `rewind-delete.test.ts` reveal-CSS pin updated to the remaining two buttons. UI suite: 2138/2138 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)