### PR TITLE
The lightbox download icon is an inline tray SVG, not an uncovered codepoint

### DIFF
--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -73,6 +73,10 @@ test("the lightbox offers a download beside the close, saving the same bytes it 
   assert.ok(body.indexOf("dl.onclick = (ev) => ev.stopPropagation()") > 0,
     "saving must not also dismiss the lightbox");
   assert.ok(body.indexOf('bar.append(name, dl, close)') > 0, "between the filename and the ✕");
+  // an inline TRAY SVG, not a codepoint: "⭳" (U+2B73) has no coverage in the mac system fonts and
+  // rendered as a tofu box (the user 2026-08-19). Same stroke family as the composer's buttons.
+  assert.ok(body.indexOf('<polyline points="7 10 12 15 17 10"/>') > 0, "the arrow-into-tray glyph");
+  assert.ok(body.indexOf("\u2b73") < 0 && body.indexOf("⭳") < 0, "the uncovered codepoint is gone");
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   assert.match(CSS, /\.romp-lightbox-dl \{ font: inherit; font-size: 0\.86em;/,
     "one control vocabulary — the same chip dress as the close beside it");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -147,8 +147,15 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   dl.className = "romp-lightbox-dl";
   dl.href = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
   dl.download = path.slice(path.lastIndexOf("/") + 1) || "image";
-  dl.textContent = "⭳";
+  // the tray icon every download control should wear (the composer buttons' stroke family) as an
+  // inline SVG: the old text glyph (U+2B73, arrow-to-bar) has no coverage in the mac system fonts
+  // and rendered as a tofu box instead of an icon (the user 2026-08-19). A literal — no sanitize.
+  dl.innerHTML = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"'
+    + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>'
+    + '<polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
   dl.title = "download";
+  dl.setAttribute("aria-label", "download");
   dl.onclick = (ev) => ev.stopPropagation();               // saving must not also dismiss
   const close = document.createElement("button");
   close.className = "romp-lightbox-close";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2409,7 +2409,8 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* download: an anchor dressed exactly like the close button beside it (one control vocabulary —
    same chip, same hover cue), sitting between the filename and the ✕ */
 .romp-lightbox-dl { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
-  padding: 2px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.1); color: var(--fg);
+  display: inline-flex; align-items: center;   /* centers the inline tray SVG in the chip */
+  padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.1); color: var(--fg);
   border: 1px solid rgba(255, 255, 255, 0.18); text-decoration: none; line-height: normal; }
 .romp-lightbox-dl:hover { border-color: var(--accent); }
 


### PR DESCRIPTION
User report 2026-08-19: the download button in the figure lightbox shows a broken/tofu glyph. It was drawing U+2B73 (downwards triangle-headed arrow to bar) as text — a codepoint with effectively no coverage in the macOS system font stack.

It now draws the standard arrow-into-tray as an inline SVG in the same stroke family as the composer's buttons (feather idiom), vertically centered in the same chip dress as the close button beside it, with an aria-label carrying the word. Test pins the SVG and fails if the uncovered codepoint ever returns. Suite passes (2,138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)