### PR TITLE
The sessions dialog is the pool builder: each live row carries the feed toggle

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2544,6 +2544,31 @@ class TimelinePanel {
         nm.setAttribute('style', 'min-width:0;overflow:hidden;text-overflow:ellipsis;' + (s.live ? '' : 'opacity:0.55;'));
         const st = row.createSpan({ text: s.live ? (s.model || '') : 'gone' });
         st.setAttribute('style', 'margin-left:auto;flex:0 0 auto;opacity:0.5;font-size:0.82em;');
+        // The pool-builder's second switch (the user 2026-08-19, from the manager/worker experiment):
+        // a background worker usually wants BOTH edits — out of the default group AND off the feed —
+        // so the same row carries the lane gear's feed toggle. Reused machinery end to end (icon,
+        // optimistic _pendingFlags, _setSessionFlag); deliberately NOT auto-coupled to membership:
+        // hideFromFeed seals goals and gates the planner, an edit the user makes knowingly.
+        const ft = LANE_TOGGLES.find((t) => t.flag === 'hideFromFeed');
+        if (ft && s.live) {
+          const on = ft.enabled(s);
+          const fic = el('svg', { viewBox: '0 0 17 17', width: 14, height: 14 });
+          fic.setAttribute('style', 'flex:0 0 auto;cursor:pointer;' + (on ? '' : 'opacity:0.55;'));
+          fic.appendChild(ft.icon(!on, 8.5, 8.5, on ? ROMP_BLUE : MODEL_FG));
+          fic.addEventListener('click', (e) => {
+            e.stopPropagation();                       // the row toggle is membership; this is the feed
+            const next = ft.value(!on);
+            s.hideFromFeed = next;
+            (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).hideFromFeed = next;
+            this._setSessionFlag(s, 'hideFromFeed', next);
+            this._reconcilePendingFlags();
+            build();
+          });
+          const tip = on ? 'its prompts make feed cards — click to mute (a pool worker usually wants this off)'
+                         : 'feed-muted: new prompts mint no cards — click to restore';
+          fic.addEventListener('mouseenter', () => { fic.setAttribute('title', tip); });
+          row.appendChild(fic);
+        }
         const toggle = () => {
           this._setViews(gr ? viewToggleMember(this._curViews(), gid, s.id)
                             : viewToggleHidden(this._curViews(), s.id));

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -78,6 +78,17 @@ test("the dropdown and dialog wear the shared menu vocabulary and adopt into the
   assert.match(SRC, /const h = this\._menuHost\(anchorEl\.getBoundingClientRect\(\)\);[\s\S]{0,400}this\._viewsMenu = menu;/);
 });
 
+test("the sessions dialog is the pool builder: each live row carries the lane gear's feed toggle", () => {
+  // the user 2026-08-19, from the manager/worker experiment: a background worker wants BOTH edits —
+  // out of the default group AND off the feed — in one visit. Reused machinery, never a new one;
+  // and deliberately NOT auto-coupled to membership (hideFromFeed seals goals + gates the planner).
+  assert.match(SRC, /const ft = LANE_TOGGLES\.find\(\(t\) => t\.flag === 'hideFromFeed'\);/);
+  assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.hideFromFeed = next;/,
+    "the same optimistic sticky flags the lane gear uses");
+  assert.match(SRC, /this\._setSessionFlag\(s, 'hideFromFeed', next\);\s*\n\s*this\._reconcilePendingFlags\(\);/);
+  assert.match(SRC, /e\.stopPropagation\(\);\s*\/\/ the row toggle is membership; this is the feed/);
+});
+
 test("the two display toggles write the host's own romp:settings — reachable in every host now", () => {
   assert.match(SRC, /item\('Collapse idle gaps', \{ current: !!this\._collapseGaps, dim: true \}\)/);
   assert.match(SRC, /item\('Active sessions only', \{ current: !!this\._activeOnly, dim: true \}\)/);


### PR DESCRIPTION
Follow-up to the default-group model, from the manager/worker-pool experiment (2026-08-19): the architecture works as hoped — the manager's card narrates which worker did what, report-backs advance it silently, and clicking the card opens the manager — but each feed-visible worker mints its own completed card per delegated task, redundant attention when the manager's card tells the story.

The recipe for a background worker is therefore both edits: out of the default group (no tab, no lane in the default view) and feed-muted (no cards). The timeline's sessions dialog now carries the lane gear's feed toggle on every live row, so building a pool is one visit to one surface. Reused machinery end to end — the same icon, optimistic sticky flags, and setSessionFlag path the gear uses — and deliberately not auto-coupled to membership: hideFromFeed seals goals and gates the planner, an edit the user makes knowingly.

Test pins the reuse (LANE_TOGGLES lookup, pendingFlags stickiness, the stopPropagation separating the feed toggle from the membership row). Suite passes (2,140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)