### PR TITLE
Awaited background-task boxes wear the chip's await-green outline

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11207,6 +11207,15 @@ def _awaiting_task_descs(sid, path):
     return [t["desc"] or "background task" for t in awaited]
 
 
+def _awaiting_task_ids(sid, path):
+    """The AWAITED live background-task launch IDS — the same _bg_split set as _awaiting_task_descs,
+    as tool_use ids, so the chat's #bg-tasks box can outline exactly the rows the await-green chip is
+    waiting on (the user 2026-08-19). The box rows carry the same launching id (_bg_tasks "id" / the
+    lifecycle set's toolUseId), so the match is exact — never a description-string guess."""
+    awaited, _ = _bg_split(sid, path, _bg_live_norm(sid, path))
+    return [t["tid"] for t in awaited if t.get("tid")]
+
+
 def _bg_service_descs(sid, path):
     """The live background-task descriptions the judge classified as SERVICES (_bg_split) — persistent
     processes the session keeps around, surfaced as the feed's neutral per-session chip (bgServices in
@@ -15009,6 +15018,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   "awaitingWhy": awaiting_why or None,
                   "awaitingKind": awaiting_kind,   # WHAT the wait is on (jd.AWAIT_KINDS; None = kindless)
                   "awaitingTasks": (_awaiting_task_descs(sid, sess["path"]) if awaiting_why else []),
+                  # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
+                  # rows in the chip's await-green (the user 2026-08-19)
+                  "awaitingTaskIds": (_awaiting_task_ids(sid, sess["path"]) if awaiting_why else []),
                   "apiTooLong": bool(aerr and aerr.get("tooLong")),
                   # a spend cap is on-you like tooLong (red tab, "raise your cap") AND never auto-retried:
                   # the client's apiRetryTick skips it, and the global pause it engages stops the loop too

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -520,6 +520,30 @@ class AgentTasksAreNeverServices(unittest.TestCase):
         self.assertEqual(rows[0]["type"], "local_agent", "the lifecycle set's type survives normalization")
 
 
+class AwaitedTaskIdsMirrorTheDescs(unittest.TestCase):
+    """_awaiting_task_ids (the user 2026-08-19): the chat's #bg-tasks box outlines exactly the rows the
+    await-green chip waits on, matched by the LAUNCH id both payloads carry. The ids come from the same
+    _bg_split set as _awaiting_task_descs, so the outline and the chip can never disagree about which
+    tasks are awaited — and a service row (placed, unstamped shell task) keeps its plain border."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def test_ids_track_the_awaited_split_and_skip_services(self):
+        saved = (km._tmux_sessions, km._bg_placed_tops, km._session_stamped_tops)
+        km._tmux_sessions = lambda: {self.SID: {"bgTasks": [
+            {"toolUseId": "t1", "desc": "suite run", "since": 5, "type": "local_shell"},
+            {"toolUseId": "t2", "desc": "mkdocs serve", "since": 6, "type": "local_shell"},
+        ]}}
+        km._bg_placed_tops = lambda sid, path, tids: {"t2": self.SID + ":g1"}  # placed, no stamp -> service
+        km._session_stamped_tops = lambda sid: frozenset()
+        try:
+            ids = km._awaiting_task_ids(self.SID, "/p")
+            descs = km._awaiting_task_descs(self.SID, "/p")
+        finally:
+            km._tmux_sessions, km._bg_placed_tops, km._session_stamped_tops = saved
+        self.assertEqual(ids, ["t1"], "pending t1 is awaited; the placed-unstamped service t2 is not")
+        self.assertEqual(descs, ["suite run"], "ids and descriptions describe the same awaited set")
+
+
 class TaskOutputsForCard(unittest.TestCase):
     """_task_outputs_for joins a completed background command's notification to its shell command (from the
     launch scan) and its output-file tail, so the inline completion card can EXPAND to real detail instead of

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -90,6 +90,25 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   assert.match(STYLES, /\.bg-fold-head\.bg-await \{ --bgt: var\(--st-awaitbg-bg\); \}/);
 });
 
+test("the awaited tasks wear the chip's green outline — exact launch-id match; dots keep status meaning", () => {
+  // kernel: the awaited LAUNCH IDS ride the status payload beside the descriptions (the user
+  // 2026-08-19), from the same _bg_split set, so outline and chip can never disagree
+  assert.match(KERNEL, /"awaitingTaskIds": \(_awaiting_task_ids\(sid, sess\["path"\]\) if awaiting_why else \[\]\),/);
+  assert.match(KERNEL, /def _awaiting_task_ids\(sid, path\):/);
+  assert.match(KERNEL, /return \[t\["tid"\] for t in awaited if t\.get\("tid"\)\]/);
+  // client: rows are marked from awaitingTaskIds only while the chip is awaitingBg…
+  assert.match(RENDER, /awaitingTaskIds\?: string\[\];/);
+  assert.match(RENDER, /const awaited = new Set<string>\(\(s!\.status\.state === "awaitingBg" && s!\.status\.awaitingTaskIds\) \|\| \[\]\);/);
+  assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
+  assert.match(RENDER, /\(awaited\.has\(t\.id\) \? " bg-awaited" : ""\)/);
+  // …the untracked-wait box (renderAwaitWhy) IS the awaited thing, so it wears the border whole
+  assert.match(RENDER, /host\.classList\.add\("bg-awaited"\);/);
+  // the outline is the chip's await-green — the border/outline only; the status DOT rules are untouched
+  assert.match(STYLES, /#bg-tasks\.bg-awaited \{ border-color: var\(--st-awaitbg-bg\); \}/);
+  assert.match(STYLES, /\.bg-task\.bg-awaited \{ box-shadow: inset 0 0 0 1px var\(--st-awaitbg-bg\); border-radius: 5px; \}/);
+  assert.match(STYLES, /\.bg-task \{ --bgt: var\(--st-working-bg\); \}/);
+});
+
 test("the timeline lane's awaitingBg why reads the SAME working signal as its badge (same input, 2026-07-03 rule)", () => {
   // the skeleton build's raw-snapshot open_now fed _session_awaiting while the chip read the event
   // model — a lane badge could say Awaiting with a null why beside it (audited live 2026-08-13)

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -217,7 +217,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -7880,8 +7880,14 @@ function renderBgTasks() {
   const box = s && s.bgTasks;
   const tasks = (box && box.tasks) || [];
   const count = box ? box.count : 0;
+  host.classList.remove("bg-awaited");   // re-derived below from THIS payload (renderAwaitWhy adds its own)
   if (!count || !tasks.length) { renderAwaitWhy(host, s || null); return; }
   host.style.display = "";
+  // the AWAITED rows (the user 2026-08-19): when the await-green chip waits on specific tasks, those
+  // rows — and the box holding them — wear a thin outline in the chip's green (awaitingTaskIds, the
+  // kernel's exact launch-id match); the status DOT keeps its meaning (yellow = the task is running)
+  const awaited = new Set<string>((s!.status.state === "awaitingBg" && s!.status.awaitingTaskIds) || []);
+  host.classList.toggle("bg-awaited", tasks.some((t) => awaited.has(t.id)));
   const sid = activeId as string;
   const open = bgFoldOpen.has(sid);
   // worst status among the shown tasks → the header dot color (so a failure shows even while collapsed)
@@ -7899,7 +7905,7 @@ function renderBgTasks() {
   const list = el("div", "bg-list");
   for (const t of tasks) {
     const tOpen = bgExpanded.has(t.id);
-    const row = el("div", "bg-task bg-" + (t.status || "running") + (tOpen ? " open" : ""));
+    const row = el("div", "bg-task bg-" + (t.status || "running") + (awaited.has(t.id) ? " bg-awaited" : "") + (tOpen ? " open" : ""));
     const rh = el("div", "bg-head");
     rh.dataset.act = "bg-toggle"; rh.dataset.id = t.id;   // the row header toggles; clicks in the detail body don't collapse it
     rh.appendChild(el("span", "bg-dot"));
@@ -7939,6 +7945,7 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
   const why = (s && s.status.state === "awaitingBg" && (s.status.awaitingWhy || "").trim()) || "";
   if (!why || !activeId) { host.style.display = "none"; return; }
   host.style.display = "";
+  host.classList.add("bg-awaited");   // this whole box IS the awaited thing — the chip's green border
   const sid = activeId;
   const open = bgFoldOpen.has(sid);
   const head = el("div", "bg-fold-head bg-await" + (open ? " open" : ""));

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -485,6 +485,10 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .bg-task { --bgt: var(--st-working-bg); }
 .bg-task.bg-failed { --bgt: var(--st-blocked-bg); }
 .bg-task.bg-completed { --bgt: var(--st-ready-bg); }
+/* AWAITED (the user 2026-08-19): the session's await-green chip is waiting on THIS task — the box
+   border + the row's thin outline take the chip's green; the dot keeps meaning the task's own status */
+#bg-tasks.bg-awaited { border-color: var(--st-awaitbg-bg); }
+.bg-task.bg-awaited { box-shadow: inset 0 0 0 1px var(--st-awaitbg-bg); border-radius: 5px; }
 .bg-head { display: flex; align-items: center; gap: 8px; padding: 5px 9px; cursor: pointer; user-select: none; border-radius: 5px; }
 .bg-head:hover { background: rgba(255, 255, 255, 0.04); }
 /* SOLID status dot — no pulse (the user 2026-07-07: the pulsating yellow was distracting; a running dot is


### PR DESCRIPTION
When a session is **Awaiting** on background tasks, the chat's tasks box gave no cue which rows the wait was on — the header showed a working-yellow dot and the rows looked like any other running task (the user's report, 2026-08-19: don't recolor the dot, yellow rightly means running; outline the boxes in the awaiting chip's color).

## What changes
- **Kernel**: the chat status payload ships `awaitingTaskIds` beside `awaitingTasks` — the same `_bg_split` awaited set as the descriptions, as launch `tool_use` ids. The box rows already carry that id, so the match is exact, never a description-string guess, and the outline can never disagree with the chip.
- **UI**: while the chip is `awaitingBg`, the `#bg-tasks` box border and each awaited row take a thin outline in the chip's green (`--st-awaitbg-bg`); status dots keep their meaning (yellow = running, red = failed, ready-blue = completed). A judged **service** row (a dev server the session keeps around) stays plain. The untracked-wait box (`renderAwaitWhy`) wears the border whole — that box is the awaited thing itself.

## Tests
- `tests/test_kernel_bg_tasks.py`: `_awaiting_task_ids` tracks the awaited split (pending task in, placed-unstamped service out) and mirrors the descriptions exactly.
- `ui/webview/awaiting-state.test.ts`: pins the payload line, the exact-id match in `renderBgTasks`, the renderAwaitWhy border, and the CSS (outline in the chip's green; dot rules untouched).

Suites: python 4920 passed, UI 2139 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)