### PR TITLE
Forced stack fade wins the cascade it was losing to the on-state

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -70,7 +70,16 @@ test("the Stack toggle says so when narrow width already forces stacking (2026-0
     "keyboard activation bypasses pointer-events, so the handler itself no-ops");
   assert.match(FEED, /new ResizeObserver\(\(\) => refreshStackForced\(b\)\)/,
     "width changes are the event — never a poll");
-  assert.match(CSS, /#feed-stacked\.forced \{ opacity: 0\.5; cursor: default;\s*\n\s*color: var\(--accent\); border-color: var\(--accent\); \}/,
+  assert.match(CSS, /#feed-foot \.feed-modetoggle\.forced \{ opacity: 0\.5; cursor: default;\s*\n\s*color: var\(--accent\); border-color: var\(--accent\); \}/,
     "grayed but still wearing the on-accent — stacking IS active (the user 2026-08-19)");
-  assert.match(CSS, /#feed-stacked\.forced:hover \{ opacity: 0\.75; \}/, "hover stays responsive");
+  assert.match(CSS, /#feed-foot \.feed-modetoggle\.forced:hover \{ opacity: 0\.75;/, "hover stays responsive");
+  // THE CASCADE, not just the rule (the user's third report, 2026-08-19): `.on { opacity: 1 }` ties
+  // the forced fade's specificity, so the fade only paints if its rule comes LATER in the file. The
+  // first two cuts pinned the rule's existence while `.on` silently won — pin the tiebreak itself.
+  const onAt = CSS.indexOf("#feed-foot .feed-modetoggle.on");
+  const forcedAt = CSS.indexOf("#feed-foot .feed-modetoggle.forced");
+  assert.ok(onAt >= 0 && forcedAt > onAt,
+    "the forced rule must follow the .on rule at equal specificity, or opacity: 1 wins and the fade never shows");
+  assert.doesNotMatch(CSS, /#feed-stacked\.forced/,
+    "no (1,1,0) leftovers — every forced rule must tie the .on rule's specificity");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1157,8 +1157,13 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 
 /* the Stack toggle while the narrow container query FORCES stacking (2026-08-19): stacking IS on,
    so the button keeps the pressed accent — grayed by opacity, never stripped of its on-state (the
-   user 2026-08-19: "grayed out but still blue to show that it's on"). Hover stays responsive (a
-   gentle brighten, not the action-blue that promises a click); the tooltip names the way out. */
-#feed-stacked.forced { opacity: 0.5; cursor: default;
+   user 2026-08-19, who wanted it grayed but still blue). Hover stays responsive (a gentle brighten,
+   not the action-blue that promises a click); the tooltip names the way out. The selector MUST tie
+   the .on rule's (1,2,0) specificity and sit LATER in this file: the first two cuts keyed the
+   rule on the button id alone at (1,1,0), so `.on { opacity: 1 }` silently won the cascade and the
+   fade never painted while the button was pressed — which forced stacking always implies (the user's
+   third report, 2026-08-19). */
+#feed-foot .feed-modetoggle.forced { opacity: 0.5; cursor: default;
   color: var(--accent); border-color: var(--accent); }
-#feed-stacked.forced:hover { opacity: 0.75; }
+#feed-foot .feed-modetoggle.forced:hover { opacity: 0.75;
+  background: rgba(156, 210, 255, 0.12); }   /* keep the pressed wash — never the action hover's promise */


### PR DESCRIPTION
Third report from the user: the forced Stack toggle still showed no visible change when narrow width forces stacking — even after the restyle landed.

## Root cause
The fade rule existed but **never painted**: `#feed-foot .feed-modetoggle.on { … opacity: 1 }` has specificity (1,2,0), which beats the forced rule's old `#feed-stacked.forced { opacity: 0.5 }` at (1,1,0) — and the forced state always implies the pressed `.on` state, so `opacity: 1` silently won every time. Both prior test pins passed because they asserted the rule's *existence*, not that it *wins the cascade*.

## Fix
- The forced rule is now `#feed-foot .feed-modetoggle.forced` — it ties the `.on` rule's specificity and sits later in the file, so the order tiebreak makes the alpha fade (0.5, hover 0.75) actually paint. Hover also keeps the pressed accent wash instead of falling to the action hover.
- The test now pins the **cascade**: the forced rule must follow the `.on` rule at equal specificity (source-order assertion), plus a does-not-match ban on the old weaker selector so a (1,1,0) rule can't sneak back.

UI suite: 2140/2140 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)