### PR TITLE
romp fork: split a session from the terminal, no WS surgery

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -655,6 +655,7 @@ For scripts / agents:
 EOF
     _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
+    _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> <text>" -            "Hand a session a message (kernel API, either backend)"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -792,6 +793,47 @@ for r in rows:
                                      r.get("backend") or "", r.get("dir") or ""))
 '
     exit 0
+fi
+
+# Fork a session into a NEW parallel one (the user 2026-08-19, via the lab workflow: per-stage
+# experiment splits were hand-driving the kernel's WS forkSession op — websocket surgery nobody
+# should repeat). Rides the kernel's POST /fork, the WS op as a one-shot route beside /new and
+# /send: parent untouched, explicit new name, tip fork by default, --at <record-uuid> for a cut
+# point, and the fork is discoverable in `romp sessions` the moment this acks.
+if [[ "${1:-}" == "fork" ]]; then
+    shift
+    _fork_usage="usage: romp fork <parent> <new-name> [--at <record-uuid>]"
+    parent_arg=""; newname_arg=""; at_arg=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --at) shift
+                  if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_fork_usage" >&2; exit 2; fi
+                  at_arg="$1"; shift ;;
+            -*)   echo "$_fork_usage" >&2; exit 2 ;;
+            *)    if [[ -z "$parent_arg" ]]; then parent_arg="$1"
+                  elif [[ -z "$newname_arg" ]]; then newname_arg="$1"
+                  else echo "$_fork_usage" >&2; exit 2; fi
+                  shift ;;
+        esac
+    done
+    if [[ -z "$parent_arg" || -z "$newname_arg" ]]; then echo "$_fork_usage" >&2; exit 2; fi
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp fork: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
+        exit 1
+    fi
+    _payload="$(python3 -c 'import json,sys; print(json.dumps({"parent": sys.argv[1], "name": sys.argv[2], "at": sys.argv[3]}))' "$parent_arg" "$newname_arg" "$at_arg")"
+    _resp="$(_romp_token_cfg | curl -sf -m 30 --config - -X POST "http://127.0.0.1:$_kport/fork" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp fork: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        echo "romp fork: \"$newname_arg\" branched from \"$parent_arg\" — both continue as separate sessions (see: romp sessions)"
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp fork: refused — $_err" >&2
+    exit 1
 fi
 
 # Bare `romp` — THE front door (the user 2026-07-25: the shortest command does the most common

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25136,6 +25136,45 @@ class Handler(BaseHTTPRequestHandler):
                 threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
                 return self._send(200, json.dumps({"ok": True, "pending": True, "dir": cwd}),
                                   "application/json")
+            if u.path == "/fork":
+                # Headless session fork (`romp fork`, the user 2026-08-19 via lab_manager): the WS
+                # forkSession op as a one-shot POST beside /new and /send, so a terminal or another
+                # machine's plugin can split a session — the first per-stage experiment split had to
+                # hand-drive the WS op with the dashboard token, which nobody should repeat. Body:
+                # {"parent": <live name or sid>, "name": <new-name>, "at": <record-uuid, optional>}
+                # ("at" empty = the whole conversation, the tip fork). Same contract as the op:
+                # parent untouched, explicit new name, and the fork discoverable the moment we ack
+                # (be.fork writes names/ synchronously inside _fork_session). Loud on refusal.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                parent = str((b or {}).get("parent") or "").strip()
+                nm = str((b or {}).get("name") or "").strip()
+                if not parent or not nm:
+                    return self._send(400, json.dumps({"ok": False, "error": "parent and name required"}),
+                                      "application/json")
+                live = _live_names(_tmux_sessions())
+                if nm in live:
+                    # a second session under one name would poison every by-name surface (postal,
+                    # romp send, this very route's post-fork lookup) — refuse, never overload
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'a session named "%s" is already running — pick another name' % nm}),
+                                      "application/json")
+                psid = live.get(parent) or ""
+                if not psid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", parent):
+                    psid = parent                 # a sid: _fork_session validates it owns a transcript
+                if not psid:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'no live session named "%s" (a dormant one can be forked by sid)' % parent}),
+                                      "application/json")
+                err = _fork_session(psid, str((b or {}).get("at") or ""), nm)
+                if err:
+                    return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
+                # be.fork registered the name synchronously above, so the live store answers by ack time
+                fsid = _live_names(_tmux_sessions()).get(nm) or ""
+                return self._send(200, json.dumps({"ok": True, "id": fsid, "name": nm}),
+                                  "application/json")
             if u.path == "/working":
                 # Publish/clear a session's working-note in the backend-agnostic store, so the postal bus's
                 # set_working goes through the kernel (no tmux @romp-working) and an SDK session can publish a

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -167,6 +167,39 @@ MOCK
     grep '/send' "$MOCK_LOG" | grep 'ideabox' | grep -q 'look into the flaky test'
 }
 
+@test "fork: POST /fork with parent, new name and optional --at cut" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp fork exp-web exp-web-stage2
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"branched from"* ]]
+    grep '/fork' "$MOCK_LOG" | grep -q '"parent": *"exp-web"'
+    grep '/fork' "$MOCK_LOG" | grep -q '"name": *"exp-web-stage2"'
+    # --at rides through as the cut record
+    run run_romp fork --at aaaabbbb-1111-2222-3333-444455556666 exp-web exp-web-fig
+    [ "$status" -eq 0 ]
+    grep '/fork' "$MOCK_LOG" | grep -q '"at": *"aaaabbbb-1111-2222-3333-444455556666"'
+}
+
+@test "fork: usage errors exit 2; no kernel token is a loud exit 1" {
+    touch "$MOCK_LOG"
+    run run_romp fork
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp fork"* ]]
+    run run_romp fork only-parent
+    [ "$status" -eq 2 ]
+    run run_romp fork exp-web new-name extra-arg
+    [ "$status" -eq 2 ]
+    run run_romp fork --at "" exp-web new-name
+    [ "$status" -eq 2 ]
+    # hermetic env has no serve token: the failure names the kernel, and no API call is made
+    run run_romp fork exp-web new-name
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel isn't running"* ]]
+    [ "$(grep -c '/fork' "$MOCK_LOG")" -eq 0 ]
+}
+
 @test "new --tag rides the /send tag field; needs -m; bad labels exit 2" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_fork_route.py
+++ b/tests/test_fork_route.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""POST /fork (the user 2026-08-19, via the lab workflow's delegate): the WS forkSession op as a
+one-shot token-gated route beside /new and /send, so a terminal or another machine's plugin can
+split a session without a WS client. Contract: parent resolved by LIVE NAME (or raw sid for a
+dormant parent), explicit new name refused on collision, "at" rides through as the cut, refusals
+loud, and the ack carries the fork's id from the live store (be.fork registers the name
+synchronously inside _fork_session).
+
+Drives the REAL Handler over HTTP (the test_new_route_prefs.py pattern). Synthetic only.
+"""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+PARENT_SID = "11111111-2222-3333-4444-555555555555"
+FORK_SID = "66666666-7777-8888-9999-000000000000"
+
+
+class ForkRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.calls = []
+        self.names = {"exp-web": PARENT_SID}      # the live-name store the route consults
+        self._saved = (km._tmux_sessions, km._live_names, km._fork_session)
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: dict(self.names)
+
+        def fake_fork(psid, at, nm, now=None, client=None):
+            self.calls.append((psid, at, nm))
+            self.names[nm] = FORK_SID             # be.fork registers the name synchronously
+            return None
+        km._fork_session = fake_fork
+
+    def tearDown(self):
+        km._tmux_sessions, km._live_names, km._fork_session = self._saved
+
+    def _post(self, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/fork" % self.port, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_live_name_forks_and_acks_with_the_new_id(self):
+        st, r = self._post({"parent": "exp-web", "name": "exp-web-stage2"})
+        self.assertEqual(st, 200)
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r.get("id"), FORK_SID, "the ack carries the fork's id from the live store")
+        self.assertEqual(r.get("name"), "exp-web-stage2")
+        self.assertEqual(self.calls, [(PARENT_SID, "", "exp-web-stage2")], "tip fork: empty cut by default")
+
+    def test_at_rides_through_as_the_cut(self):
+        self._post({"parent": "exp-web", "name": "exp-web-fig", "at": "aaaabbbb-1111-2222-3333-444455556666"})
+        self.assertEqual(self.calls[0][1], "aaaabbbb-1111-2222-3333-444455556666")
+
+    def test_a_sid_parent_reaches_the_fork_directly(self):
+        st, r = self._post({"parent": PARENT_SID, "name": "by-sid-fork"})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(self.calls[0][0], PARENT_SID)
+
+    def test_unknown_parent_name_is_refused_loudly(self):
+        st, r = self._post({"parent": "nope", "name": "x2"})
+        self.assertEqual(st, 200)
+        self.assertFalse(r.get("ok"))
+        self.assertIn("no live session named", r.get("error") or "")
+        self.assertEqual(self.calls, [], "nothing forked")
+
+    def test_name_collision_is_refused_never_overloaded(self):
+        st, r = self._post({"parent": "exp-web", "name": "exp-web"})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("already running", r.get("error") or "")
+        self.assertEqual(self.calls, [])
+
+    def test_missing_fields_are_a_400(self):
+        st, r = self._post({"parent": "exp-web"})
+        self.assertEqual(st, 400)
+        st, r = self._post({"name": "only-name"})
+        self.assertEqual(st, 400)
+
+    def test_a_fork_refusal_rides_out_verbatim(self):
+        km._fork_session = lambda psid, at, nm, now=None, client=None: "fork needs the SDK backend"
+        st, r = self._post({"parent": "exp-web", "name": "x3"})
+        self.assertEqual(st, 200)
+        self.assertFalse(r.get("ok"))
+        self.assertIn("SDK backend", r.get("error") or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
User-approved ask (2026-08-19, via the lab workflow's delegate): splitting an experiment session into a per-stage sibling required hand-driving the kernel's WS `forkSession` op with the dashboard token — websocket surgery nobody should repeat. The kernel mechanics all existed (`_fork_session`, `be.fork`, empty uuid = tip fork); this adds the missing doors.

## What's new
- **`POST /fork`** — token-gated, beside `/new` and `/send`, so terminals and other machines' plugins (e.g. an editor's experiment-create flow) can fork without a WS client. Body `{parent, name, at?}`: parent resolves by **live name** (or a raw sid for a dormant parent), the new name is explicit and **refused on collision** (a second session under one name would poison every by-name surface), `at` is the optional cut record (absent = tip fork, the whole conversation). The parent is untouched, refusals are loud, and the ack carries the fork's id read back from the live store — `be.fork` registers the name synchronously inside `_fork_session`, so the fork is discoverable in `romp sessions` the moment the call returns.
- **`romp fork <parent> <new-name> [--at <record-uuid>]`** — the CLI verb on that route, mirroring `romp new`'s token/report conventions, plus a help line in the scripts/agents section.

## Tests
- `tests/test_fork_route.py`: the route end-to-end over the real Handler — live-name resolution, sid parents, `at` pass-through, tip-fork default, name collision, unknown parent, missing-field 400s, and refusal pass-through.
- `tests/romp.bats`: the CLI payload (`parent`/`name`/`at`), usage errors exit 2, and the loud no-kernel path.

Suites: python 4927 passed, UI 2140 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)