### PR TITLE
CI: bats from the pinned release tarball, apt off the critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,23 @@ jobs:
         os: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["ubuntu-latest","macos-latest"]' || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install bats + tmux (Linux)
+      # bats comes from the pinned release tarball, NOT apt: an Azure apt-mirror outage hung
+      # `apt-get update` to the job timeout three runs in a row (2026-08-19, ~35 wasted minutes
+      # each). GitHub itself is already on the critical path (checkout), so this adds no new
+      # dependency — and no bats test needs a real tmux (every suite PATH-prepends its own mock),
+      # so nothing else is installed at all. The step timeout kills any residual network hang in
+      # minutes instead of letting it eat the job's budget.
+      - name: Install bats (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y bats tmux
+        timeout-minutes: 5
+        run: |
+          curl -fsSL --retry 3 -o /tmp/bats.tar.gz \
+            https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz
+          tar -xzf /tmp/bats.tar.gz -C /tmp
+          sudo /tmp/bats-core-1.11.1/install.sh /usr/local
       - name: Install bats + tmux (macOS)
         if: runner.os == 'macOS'
+        timeout-minutes: 15
         run: brew install bats-core tmux
       - name: Run bats
         run: bats --print-output-on-failure tests/*.bats


### PR DESCRIPTION
Today's Azure apt-mirror outage hung `sudo apt-get update` to the 35-minute job timeout on **three runs in a row**, stalling every open PR (the shell job is a required check).

## What changes
- Linux installs bats from the **pinned bats-core release tarball** (v1.11.1) with `curl --retry` — GitHub is already on the job's critical path via checkout, so this removes the apt mirrors as a dependency rather than trading one for another.
- **Nothing else is installed on Linux.** No bats test needs a real tmux: every suite that touches tmux PATH-prepends its own mock binary (verified across all 12 bats files).
- Both install steps get their own `timeout-minutes` so any residual network hang dies in minutes instead of eating the job's 35-minute budget (sized for the ~16-minute macOS suite).

The PR's own green shell job is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)