### PR TITLE
Re-completed cards present only the new work; a replied-past takeaway says so

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16464,7 +16464,7 @@ def build_feed(now, tmux=None):
             _bcmemo[nid] = res
             return res
 
-        def flatten(nid, out, ancestor_done=False):  # AskTreeNode flat list, root first; nest via children ids
+        def flatten(nid, out, ancestor_done=False, boundary=None):  # AskTreeNode flat list, root first; nest via children ids
             nd = nodes[nid]
             kids = sorted(children.get(nid, []), key=_fsubmax, reverse=True)   # most-recent-first (matches the ledger)
             explicit = bool(nd.get("nodeComplete"))
@@ -16494,6 +16494,14 @@ def build_feed(now, tmux=None):
                         # user-cleared sub (nodeOverride op:clear) → renders struck-through + faded with a
                         # "cleared" chip; `status` above stays honest (box = done, the user 2026-07-26)
                         "cleared": bool(nd.get("cleared")),
+                        # this DONE sub's outcome was already REVIEWED: its done predates the top's
+                        # review boundary (jd.review_boundary — the same boundary the distiller scopes
+                        # the takeaway with, so the fold and the summary can never disagree). The card
+                        # collapses these behind one "N reviewed earlier" row instead of re-presenting
+                        # them on every re-completion (the user 2026-08-19). `out` is empty only for
+                        # the ROOT row, which is the card head, never a checklist row.
+                        "reviewedEarlier": bool(boundary and out and done
+                                                and jd._done_since(nd) <= boundary) or None,
                         # a rolled-UP question (the block lives in a descendant, not here) — the client's
                         # mark tooltip says "blocked inside", and the actual ask keeps its own ⏸ below
                         "qderived": st == "question" and not nd.get("blocked"),
@@ -16524,7 +16532,7 @@ def build_feed(now, tmux=None):
                         "log": _node_log_rows(nd, seg_uuid) if st != "done" else None,
                         "children": kids})
             for c in kids:
-                flatten(c, out, ancestor_done=done)
+                flatten(c, out, ancestor_done=done, boundary=boundary)
             return out
         # HARD blocked floor: a session stopped RIGHT NOW on a live permission prompt (tmux state)
         # floors its ACTIVE-FOCUS card under BLOCKED — the strongest signal, beats the goal's planner
@@ -16960,7 +16968,13 @@ def build_feed(now, tmux=None):
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
                 "blockSummary": nodes[nid].get("blockSummary"),    # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18
                 "briefParts": nodes[nid].get("briefParts") or None,   # MULTI-item brief: [{id, since}] one per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null for single-item briefs, whose stamp is the card header's age (the user 2026-07-24)
-                "summaryParts": nodes[nid].get("summaryParts") or None,   # the DONE twin: [{id, since}] per takeaway paragraph when the distiller split by <completed-items>; done-event times (the user 2026-07-24)
+                "summaryParts": nodes[nid].get("summaryParts") or None,
+                # the user FOLLOWED UP after the takeaway they read (followupAt postdates what the
+                # summary covers) → the summary section says so instead of presenting the old takeaway
+                # as current; self-clears when the re-distill stamps a newer distilledMt (16 live cards
+                # measured reading stale, the user 2026-08-19)
+                "summaryStale": bool((nodes[nid].get("followupAt") or 0) > (nodes[nid].get("distilledMt") or 0)
+                                     and (nodes[nid].get("summary") or "").strip()) or None,   # the DONE twin: [{id, since}] per takeaway paragraph when the distiller split by <completed-items>; done-event times (the user 2026-07-24)
                 "background": nodes[nid].get("background"),    # the distiller's BACKGROUND section: re-orientation for a reader who forgot the thread — collapsed by default on the card (the user 2026-07-02)
                 "summaryAnchorUuid": _sa_u,    # click the summary line → the completion turn's wrap-up (completed pin), else the cited/latest prose (the user 2026-07-14)
                 "warns": nodes[nid].get("warns") or None,   # judge-stamped anomalies (judge _node_warn) → yellow "warning" chip; click shows each warn's what/why detail (the user 2026-07-02)
@@ -17017,7 +17031,7 @@ def build_feed(now, tmux=None):
                 "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
                                              store.get("placements") or {}) or None)
                             if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section
-                "tree": flatten(nid, [])})
+                "tree": flatten(nid, [], boundary=jd.review_boundary(nodes[nid]))})
         # A session actively working a brand-new ask shows NO card until the planner classifies the held
         # segment at turn-end — surface a live-prompt placeholder so it isn't invisible. Only when nothing
         # already covers it (no working card); replaced by the real card once the planner places it.

--- a/ui/webview/card-subgoals.test.ts
+++ b/ui/webview/card-subgoals.test.ts
@@ -18,7 +18,10 @@ test("ask cards render the goal's WHOLE sub-goal tree (the 'subgoals' section), 
   assert.match(FEED, /if \(choice !== "subgoals" \|\| !root\) \{ cl\.style\.display = "none"; return; \}/);
   // a RECURSIVE walk from the root's children, descending every level (was root.children only)
   assert.match(FEED, /const walk = \(nid: string, depth: number\) =>/);
-  assert.match(FEED, /for \(const c of root\.children \|\| \[\]\) walk\(c, 0\)/);
+  assert.match(FEED, /for \(const c of freshKids\) walk\(c, 0\);/);
+  // …and the reviewed-earlier kids still walk the SAME whole-tree recursion when expanded
+  // (the user 2026-08-19: collapsed behind one row, never dropped)
+  assert.match(FEED, /if \(revOpen\) for \(const c of revKids\) walk\(c, 0\);/);
   assert.match(FEED, /for \(const c of n\.children \|\| \[\]\) walk\(c, depth \+ 1\)/);
   assert.doesNotMatch(FEED, /root\.children\.map/, "no longer capped at the direct children");
   assert.match(FEED, /s\.status === "done" \? "✓"/);         // ✓ done / ⏸ question(blocked) / empty-ring open mark

--- a/ui/webview/distiller-line.ts
+++ b/ui/webview/distiller-line.ts
@@ -92,3 +92,13 @@ export function applyDistillLine(
   el.style.display = t ? "" : "none";   // hidden until the distiller produces — no stuck placeholder
   return t;
 }
+
+/** The STALE-takeaway note (the user 2026-08-19): shown above a COMPLETED card's takeaway when the user
+ *  followed up AFTER the summary they read (kernel summaryStale: followupAt postdates what distilledMt
+ *  covers) — an old takeaway must never present as current beside a newer reply. "" when there is
+ *  nothing to say: not stale, not completed, or no takeaway shown to annotate. Self-clearing by
+ *  construction: the re-distill stamps a newer distilledMt and the kernel stops sending the flag. */
+export function distillStaleNote(summaryStale: boolean, completed: boolean, shownText: string): string {
+  if (!summaryStale || !completed || !shownText.trim()) return "";
+  return "You followed up since this — it updates when the new work lands.";
+}

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -24,7 +24,7 @@ test("the swirl is driven by spinFor's caption — shown when there is one, else
   assert.match(FEED, /import \{ spinFor, KIND_WORD \} from "\.\/spin-caption";/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
-  assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending \} from "\.\/distiller-line";/);
+  assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
   assert.match(FEED, /a\._awaitSpin\.style\.display = spinCaption \? "" : "none";/);
   assert.match(FEED, /a\._awaitWhy\.textContent = spinCaption; a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });

--- a/ui/webview/feed-card-prefs.test.ts
+++ b/ui/webview/feed-card-prefs.test.ts
@@ -33,7 +33,7 @@ test("the card shows the DISTILLER's line (summary/blockSummary) but NO why/gene
   // distiller-line.test.ts (completed→summary, blocked→blockSummary, hidden when empty). These pins just
   // confirm the card creates the element and routes through that single rule.
   assert.match(FEED, /const distill = el\("div", "fask-distill"\)/);
-  assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending \} from "\.\/distiller-line"/);
+  assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line"/);
   // keyed on the GENUINE state (dCompleted/dBlocked from distillInputs), not the transient column, so a
   // still-blocked card keeps its brief through the recheck/rejudging Working flip (the user 2026-07-21)
   assert.match(FEED, /applyDistillLine\(a\._distill as HTMLElement, dCompleted, dBlocked,\s*\n?\s*it\.summary, it\.blockSummary\)/);

--- a/ui/webview/feed-distill-state.test.ts
+++ b/ui/webview/feed-distill-state.test.ts
@@ -11,7 +11,7 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("the card routes the distiller line through distillInputs(distillState, column), not column directly", () => {
-  assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending \}/);
+  assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \}/);
   // the card computes (completed, blocked) from the genuine state via the shared helper
   assert.match(FEED, /const \{ completed: dCompleted, blocked: dBlocked \} = distillInputs\(it\.distillState, it\.column\);/);
   // both the shown line AND the pending swirl read those, so the two can never disagree about the state

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -936,6 +936,12 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* a card sub-goal is clickable just like the modal tree node (the user 2026-06-17): the checkbox + text are
    separate links. Per-ZONE hover highlight (.lz-hl, JS-toggled) — a halo on the mark, a fill on the text. */
 .fcheck .lz-nav { cursor: pointer; }
+/* the REVIEWED-EARLIER fold row (the user 2026-08-19): sub-goals already reviewed before the follow-up
+   collapse behind this one dimmer row; whole-row click toggles (state in cardTreeExpanded) */
+.fcheck.freviewed { opacity: 0.6; cursor: pointer; }
+.fcheck.freviewed:hover { opacity: 0.85; }
+/* the STALE-takeaway note above a completed card's summary: the user followed up after reading it */
+.fsum-stale { font-style: italic; opacity: 0.62; font-size: 0.92em; margin-bottom: 3px; }
 .fcheck-text.lz-hl { background: rgba(255, 255, 255, 0.12); border-radius: 3px; box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12); }
 .fcheck-mark.lz-hl { box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16); }
 /* standalone-completion modal: same tree vocabulary as ask cards; pending

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -6,7 +6,7 @@
 // Rendering is KEYED + INCREMENTAL: cards are kept alive across the host's live
 // pushes and updated in place — never torn down — so hovering one doesn't flicker
 // when the fleet streams new deliverables in.
-import { distillText, distillInputs, applyDistillLine, distillPending } from "./distiller-line";
+import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { spinFor, KIND_WORD } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
@@ -47,6 +47,7 @@ interface AskTreeNode {
   blockSummary?: string | null;                                  // the BLOCK-distiller's decision brief for a blocked goal → the modal's auto-line for a BLOCKED node (kernel 466393c); null until produced
   trgb?: [number, number, number];                               // last-activity recency tint (timestamp)
   cleared?: boolean;                                             // user-cleared sub (nodeOverride op:clear) → struck-through faded row + "cleared" chip; the mark stays tied to status (box = done, the user 2026-07-26)
+  reviewedEarlier?: boolean;                                     // this done sub predates the top's review boundary (kernel flatten ↔ jd.review_boundary, the distiller's own scoping) → collapsed behind one "N reviewed earlier" row (the user 2026-08-19)
   log?: NodeLogRow[] | null;                                     // the node's newest verdict rows (kernel _node_log_rows, non-done only) → the modal's per-item story (the user 2026-07-20)
   children: string[];
 }
@@ -88,6 +89,7 @@ interface AskItem {
   blockSummary?: string | null;                    // block-distiller's decision brief for a BLOCKED goal → the blocked card's one auto-written line (kernel 466393c); null until produced
   briefParts?: { id?: string; since: number }[] | null;   // MULTI-item brief: one {id, since} per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null/absent = single ask, the card header's age is the stamp (the user 2026-07-24)
   summaryParts?: { id?: string; since: number }[] | null;   // the DONE twin: per-paragraph done-event stamps for a takeaway the distiller split by <completed-items> (the user 2026-07-24)
+  summaryStale?: boolean;                          // the user followed up AFTER the shown takeaway (kernel: followupAt > distilledMt) → the summary section carries the stale note until the re-distill lands (the user 2026-08-19)
   background?: string | null;                      // distiller's BACKGROUND section: re-orientation for a reader who forgot the thread → the card's collapsed-by-default section above the takeaway (the user 2026-07-02)
   summaryAnchorUuid?: string | null;               // click the summary line → the completion turn's wrap-up block (kernel build_feed completed pin; cited/latest-prose fallbacks — the user 2026-07-14)
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
@@ -1393,8 +1395,17 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
       seen.add(n.id);
       for (const c of n.children || []) walk(c, depth + 1);
     };
-    for (const c of root.children || []) walk(c, 0);
-    for (const { node: s, depth, repeat, expandable, collapsed } of rows) {
+    // REVIEWED-EARLIER fold (the user 2026-08-19): direct children whose outcomes the user already
+    // reviewed (kernel reviewedEarlier, from the SAME boundary the distiller scopes the takeaway with)
+    // collapse behind one row, so a re-completed card presents only the new work — the old material is
+    // one click away, never gone. Fresh rows first; the fold row sits below them.
+    const revKids = (root.children || []).filter((c) => !!byId.get(c)?.reviewedEarlier);
+    const freshKids = (root.children || []).filter((c) => !byId.get(c)?.reviewedEarlier);
+    const revOpen = cardTreeExpanded.has(id + ":reviewed");
+    for (const c of freshKids) walk(c, 0);
+    const freshEnd = rows.length;
+    if (revOpen) for (const c of revKids) walk(c, 0);
+    const paintRow = ({ node: s, depth, repeat, expandable, collapsed }: typeof rows[number]) => {
       const row = el("div", "fcheck " + nodeStatusClass(s) + (s.auth ? " auth-" + s.auth : "") + (repeat ? " repeat" : ""));
       if (depth) row.style.paddingLeft = (depth * TREE_INDENT_EM) + "em";   // same per-level indent as the modal outline
       // disclosure triangle: ▶ collapsed / ▼ expanded; a non-expandable node gets a blank same-width spacer so
@@ -1423,7 +1434,27 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
       // SAME wireNodeZones; a dim repeat is display-only (wire=false).
       wireNodeZones(it, s, mark, txt, null, !repeat);
       cl.appendChild(row);
+    };
+    rows.slice(0, freshEnd).forEach(paintRow);
+    if (revKids.length) {
+      // the fold row: same gesture grammar as a branch triangle — click toggles, state survives
+      // re-renders via cardTreeExpanded (keyed per card), and the label carries the count
+      const row = el("div", "fcheck freviewed" + (revOpen ? " open" : ""));
+      const tri = el("span", "fcheck-tri nav"); tri.textContent = revOpen ? "▼" : "▶";
+      const mark = el("span", "fcheck-mark"); mark.textContent = "✓";
+      const txt = el("span", "fcheck-text");
+      txt.textContent = revKids.length + " reviewed earlier";
+      row.title = "sub-goals you reviewed before your follow-up — the update above doesn't re-present them";
+      row.onclick = (ev: Event) => {
+        ev.stopPropagation();
+        const k = id + ":reviewed";
+        if (cardTreeExpanded.has(k)) cardTreeExpanded.delete(k); else cardTreeExpanded.add(k);
+        renderTree();
+      };
+      row.append(tri, mark, txt);
+      cl.appendChild(row);
     }
+    rows.slice(freshEnd).forEach(paintRow);
     cl.style.display = cl.children.length ? "" : "none";
   };
   renderTree();
@@ -1692,6 +1723,14 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // _seg_best_text). This was lost when the line was restored via applyDistillLine (which only sets text), so
   // the summary read like plain text with no affordance (the user 2026-06-29). stopPropagation so it doesn't
   // also open the modal (the card-body click). Falls back to non-clickable when there's no anchor.
+  // STALE-takeaway note (the user 2026-08-19): the rule lives in ./distiller-line so the test EXECUTES
+  // it. Prepended after the parts-split (which rewrites the element), so it survives either rendering.
+  const staleNote = distillStaleNote(!!it.summaryStale, dCompleted, distillShown);
+  if (staleNote) {
+    const sn = el("div", "fsum-stale");
+    sn.textContent = staleNote;
+    (a._distill as HTMLElement).prepend(sn);
+  }
   const dl = a._distill as HTMLElement;
   if (distillShown && it.summaryAnchorUuid) {
     dl.classList.add("fask-distill-link");

--- a/ui/webview/reviewed-fold.test.ts
+++ b/ui/webview/reviewed-fold.test.ts
@@ -1,0 +1,50 @@
+// Re-review churn on multi-goal cards (the user 2026-08-19): a re-completed card presents only the NEW
+// work — sub-goals reviewed before the follow-up collapse behind one "N reviewed earlier" row, and a
+// takeaway the user has replied past says so instead of posing as current. The boundary is the SAME
+// jd.review_boundary the distiller scopes with, so the fold and the summary can never disagree.
+// The stale-note rule is EXECUTED (distiller-line's design); the wiring is source-pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { distillStaleNote } from "../../ui/webview/distiller-line";
+
+const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const FEED = W("feed.ts");
+const FEEDCSS = W("feed.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-judge"), "utf8");
+
+test("the stale-takeaway note: EXECUTED rule — completed + stale + shown text, nothing otherwise", () => {
+  assert.equal(distillStaleNote(true, true, "the takeaway"),
+    "You followed up since this — it updates when the new work lands.");
+  assert.equal(distillStaleNote(false, true, "the takeaway"), "", "not stale → silent");
+  assert.equal(distillStaleNote(true, false, "the takeaway"), "", "not completed → the brief owns blocked");
+  assert.equal(distillStaleNote(true, true, "  "), "", "no shown takeaway → nothing to annotate");
+});
+
+test("kernel: summaryStale = followupAt postdates the read summary; self-clears on re-distill", () => {
+  assert.match(KERNEL, /"summaryStale": bool\(\(nodes\[nid\]\.get\("followupAt"\) or 0\) > \(nodes\[nid\]\.get\("distilledMt"\) or 0\)/);
+  assert.match(FEED, /summaryStale\?: boolean;/);
+  assert.match(FEED, /distillStaleNote\(!!it\.summaryStale, dCompleted, distillShown\)/);
+  assert.match(FEEDCSS, /\.fsum-stale \{ font-style: italic;/);
+});
+
+test("kernel: reviewedEarlier keys on the SHARED review boundary, never a second derivation", () => {
+  assert.match(KERNEL, /"tree": flatten\(nid, \[\], boundary=jd\.review_boundary\(nodes\[nid\]\)\)\}\)/);
+  assert.match(KERNEL, /"reviewedEarlier": bool\(boundary and out and done\s*\n\s*and jd\._done_since\(nd\) <= boundary\) or None,/);
+  // the shared helper: settle boundary advanced to the summary watermark on a reopen past it
+  assert.match(JUDGE, /def review_boundary\(nd\):/);
+  assert.match(JUDGE, /and \(b is None or dm > b\):/);
+});
+
+test("feed: reviewed-earlier sub-goals collapse behind ONE toggle row, fresh rows first", () => {
+  assert.match(FEED, /reviewedEarlier\?: boolean;/);
+  assert.match(FEED, /const revKids = \(root\.children \|\| \[\]\)\.filter\(\(c\) => !!byId\.get\(c\)\?\.reviewedEarlier\);/);
+  assert.match(FEED, /const revOpen = cardTreeExpanded\.has\(id \+ ":reviewed"\);/);
+  assert.match(FEED, /rows\.slice\(0, freshEnd\)\.forEach\(paintRow\);/);
+  assert.match(FEED, /txt\.textContent = revKids\.length \+ " reviewed earlier";/);
+  // the fold expands in place (state survives re-renders) and never dead-ends: progressive disclosure
+  assert.match(FEED, /if \(revOpen\) for \(const c of revKids\) walk\(c, 0\);/);
+  assert.match(FEEDCSS, /\.fcheck\.freviewed \{ opacity: 0\.6; cursor: pointer; \}/);
+});


### PR DESCRIPTION
The feed half of today's re-review-churn package (kernel half: the delta re-distill scoping PR, which this builds on — its commit rides along until that merges).

## What changes
- **Reviewed-earlier fold.** On a re-completed card, sub-goals whose completion predates the review boundary collapse behind one dimmer `N reviewed earlier` row — one click expands, nothing is dropped, the grouping stays whole. The flag is stamped per tree node by kernel flatten from `jd.review_boundary`, the **same** boundary the distiller scopes takeaways with, so the checklist and the summary can never disagree about what counts as reviewed. (The worst live card was re-presenting 30 reviewed sub-goals every cycle.)
- **Stale-takeaway note.** When you've followed up after the summary you read (`followupAt` postdates `distilledMt` — 16 live cards were in that window), the summary section says "You followed up since this — it updates when the new work lands" instead of presenting the old takeaway as current. Self-clearing: the re-distill stamps a newer `distilledMt` and the kernel stops sending the flag. The rule is an **executed** `distiller-line` export per that module's design (regex pins once let the captions die silently).

## Tests
`reviewed-fold.test.ts`: the stale-note rule executed across its four states, kernel payload pins (shared-boundary wiring, the self-clearing stale flag), and the fold's structure (fresh rows first, one toggle row, expanded rows walk the same whole-tree recursion). Four sibling test files' pins updated for the changed import/walk lines. Suites: python 4934 passed, UI 2147 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)