### PR TITLE
The transcript cache survives its cross-thread callers: a lock around the LRU's dict ops

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -26,7 +26,7 @@ Auxiliary inputs the file adapter may read (same category as the transcript):
                                transcript lost to an API-errored try; judge parse only)
   timeline/messages.jsonl   -> peer rompUuid for a postal atom (join on the msg id)
 """
-import json, os, re, sys, time, hashlib
+import json, os, re, sys, time, hashlib, threading
 from datetime import datetime
 from pathlib import Path
 
@@ -439,6 +439,11 @@ _JSONL_CACHE_MAX = 256            # bounds MEMORY only — past the cap, evict t
                                   # background burn (recurred 2026-08-15, kernel pinned at ~30-60% CPU; the survival
                                   # guarantee is pinned by tests/test_kernel_jsonl_cache.py).
 _JSONL_TAIL_GUARD = 64            # bytes of pre-offset content re-verified before an incremental read
+_JSONL_CACHE_LOCK = threading.Lock()   # the cache has cross-thread callers (the judge tiers' worker pools,
+                                       # the pusher, the warm threads) and HITS mutate (LRU reinsert): the
+                                       # lock covers only the cheap dict ops — the parse runs outside it —
+                                       # and pops stay guarded so a lost race degrades to a re-parse, never
+                                       # a raise
 
 
 def _scan_jsonl_bytes(data, base_offset):
@@ -466,13 +471,15 @@ def _read_jsonl_incremental(path):
     try:
         st = os.stat(path)
     except OSError:
-        _JSONL_CACHE.pop(path, None)
+        with _JSONL_CACHE_LOCK:
+            _JSONL_CACHE.pop(path, None)
         return []
-    hit = _JSONL_CACHE.get(path)
-    if hit is not None and hit[0] == st.st_mtime and hit[1] == st.st_size:
-        _JSONL_CACHE.pop(path)            # reinsert at the LRU tail: a served entry is a USED entry
-        _JSONL_CACHE[path] = hit
-        return hit[4]
+    with _JSONL_CACHE_LOCK:
+        hit = _JSONL_CACHE.get(path)
+        if hit is not None and hit[0] == st.st_mtime and hit[1] == st.st_size:
+            _JSONL_CACHE.pop(path, None)  # reinsert at the LRU tail: a served entry is a USED entry
+            _JSONL_CACHE[path] = hit
+            return hit[4]
     try:
         with open(path, "rb") as fh:
             if hit is not None and st.st_size > hit[1]:
@@ -490,12 +497,14 @@ def _read_jsonl_incremental(path):
             fh.seek(tail_from)
             tail = fh.read(offset - tail_from)
     except OSError:
-        _JSONL_CACHE.pop(path, None)
+        with _JSONL_CACHE_LOCK:
+            _JSONL_CACHE.pop(path, None)
         return []
-    _JSONL_CACHE.pop(path, None)
-    while len(_JSONL_CACHE) >= _JSONL_CACHE_MAX:
-        _JSONL_CACHE.pop(next(iter(_JSONL_CACHE)))   # oldest-used first; hot entries survive any cold flood
-    _JSONL_CACHE[path] = (st.st_mtime, st.st_size, offset, tail, records)
+    with _JSONL_CACHE_LOCK:
+        _JSONL_CACHE.pop(path, None)
+        while len(_JSONL_CACHE) >= _JSONL_CACHE_MAX:
+            _JSONL_CACHE.pop(next(iter(_JSONL_CACHE)))   # oldest-used first; hot entries survive any cold flood
+        _JSONL_CACHE[path] = (st.st_mtime, st.st_size, offset, tail, records)
     return records
 
 

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -14,7 +14,10 @@ through, (2) an append costs only its delta, (3) the cap still bounds the cache.
 """
 import json
 import os
+import sys
 import tempfile
+import threading
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -93,6 +96,73 @@ class JsonlCacheEviction(unittest.TestCase):
             _write_jsonl(p, 1)
             em._read_jsonl_incremental(p)
         self.assertLessEqual(len(em._JSONL_CACHE), em._JSONL_CACHE_MAX)
+
+
+class JsonlCacheThreadSafety(unittest.TestCase):
+    """The LRU made cache HITS mutate (pop + reinsert) and evictions iterate, while the
+    cache has cross-thread callers: the index and triage judge tiers run as parallel
+    threads each producer pass, each parsing via worker pools, alongside the pusher's
+    per-cycle parse and the parse-warm/boot-warm threads. One thread's eviction can pop
+    the entry another just matched — KeyError from an unconditional pop, RuntimeError
+    from next(iter()) over a dict resizing under it — and the callers catch-and-degrade
+    (the tier runner's per-session futures swallow + log), so the raise surfaces as
+    silently missing judge output for that pass, not a crash. So the cache must never
+    raise cross-thread, and a lost race must degrade to a re-parse, never to wrong
+    records."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="jsonl-cache-mt-")
+        em._JSONL_CACHE.clear()
+        self._max = em._JSONL_CACHE_MAX
+        self._switch = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)   # the race windows are a few bytecodes wide — preempt often
+
+    def tearDown(self):
+        sys.setswitchinterval(self._switch)
+        em._JSONL_CACHE_MAX = self._max
+        em._JSONL_CACHE.clear()
+
+    def test_hit_survives_concurrent_eviction(self):
+        em._JSONL_CACHE_MAX = 2       # at-cap from the third file on: every miss evicts
+        paths, expected = [], {}
+        for i in range(8):
+            p = os.path.join(self.dir, f"t{i}.jsonl")
+            _write_jsonl(p, 2, start=i * 10)
+            paths.append(p)
+            expected[p] = [f"u{i * 10}", f"u{i * 10 + 1}"]
+        stop = time.monotonic() + 3.0   # unfixed, the first raise lands in ≤~1s across trials
+        errors = []
+
+        def hammer(k):
+            # Half the threads hammer two SHARED hot files (the mutating hit path), half
+            # rotate cold ones (constant eviction of exactly those entries) — the collision
+            # the judge tier workers + pusher produce over a live transcript set.
+            i = 0
+            try:
+                while time.monotonic() < stop and not errors:
+                    p = paths[k % 2] if k < 4 else paths[2 + (i % 6)]
+                    recs = em._read_jsonl_incremental(p)
+                    if [r["uuid"] for r in recs] != expected[p]:
+                        raise AssertionError(f"wrong records served for {os.path.basename(p)}")
+                    i += 1
+            except Exception as e:   # noqa: BLE001 — the raise IS the defect under test
+                errors.append(e)
+
+        threads = [threading.Thread(target=hammer, args=(k,)) for k in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [], f"cache raised or served wrong records cross-thread: {errors[:3]!r}")
+
+    def test_hit_serves_the_same_records_as_a_cold_read(self):
+        # The locked lookup+move path must serve exactly what a cold parse produces.
+        p = os.path.join(self.dir, "hit.jsonl")
+        _write_jsonl(p, 4)
+        em._read_jsonl_incremental(p)               # warm
+        served = em._read_jsonl_incremental(p)      # the hit path
+        em._JSONL_CACHE.clear()
+        self.assertEqual(served, em._read_jsonl_incremental(p))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What breaks**

`_read_jsonl_incremental`'s LRU (`kernel/event_model.py`) makes cache **hits** mutate — `get`, then an unconditional `pop(path)`, then reinsert at the tail — and eviction iterate — `pop(next(iter(_JSONL_CACHE)))` — with no lock, while the cache has concurrent callers:

- the `index` and `triage` judge tiers run as parallel threads each producer pass (`kernel/kernel.py`), deliberately overlapping, and their stages parse via `ThreadPoolExecutor` worker pools (`kernel/judge.py`);
- the pusher parses on every 0.5s push cycle;
- the parse-warm and boot-warm daemon threads.

With more distinct transcript files in flight than cache slots (every subagent writes its own file), one thread's eviction pops the entry another thread just matched: `KeyError` from the unconditional `pop(path)` on the hit path, or `RuntimeError` from `next(iter())` over a dict resizing underneath. The GIL doesn't close these windows — each spans several bytecodes.

The function's docstring promises "[] on any error", but only `OSError` is caught, so the raise escapes into callers that swallow per-session errors (the tier runner's per-session futures swallow + log). The failure therefore surfaces as intermittent, silently missing judge output for that pass — not a crash.

**The fix**

A module-level `threading.Lock` held for the cheap dict operations only: the hit's lookup + move-to-tail, the two failure-path pops, and evict + insert. The stat/open/read/parse all stay outside the lock, so the hot path never queues behind a large parse. The hit-path pop is default-guarded (`pop(path, None)`), so a lost race degrades to one redundant re-parse — never a raise, never wrong records. Same LRU order, same cap, same cache contract.

**Reproduction / tests**

`tests/test_kernel_jsonl_cache.py` gains `JsonlCacheThreadSafety`:

- `test_hit_survives_concurrent_eviction` — 8 threads hammer a 2-slot cache for a bounded 3s (half on two shared hot files exercising the mutating hit path, half rotating through six cold files so every miss evicts exactly those hot entries), with `sys.setswitchinterval(1e-6)` (restored in tearDown) to force preemption inside the narrow windows. Against the unfixed code it fails within about a second; with the fix it only fails on an actual raise or wrong served records, and it asserts every served record set matches the file's real contents.
- `test_hit_serves_the_same_records_as_a_cold_read` — pins that the locked hit path serves exactly what a cold parse produces (deterministic, no timing dependence).

The existing eviction / append-delta / size-bound tests in the same file run unchanged over the locked code, as the no-regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)