### PR TITLE
Manual compacts get their "Context compacted" card: the detached boundary is adopted

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -666,7 +666,10 @@ class FileAdapter:
                     # parentUuid normally; compact_boundary carries parentUuid:null +
                     # logicalParentUuid:<pre-compaction leaf> — follow that so the active
                     # path survives compaction instead of orphaning every pre-compaction turn.
-                    self.parent_of[u] = r.get("parentUuid") or r.get("logicalParentUuid")
+                    # A SELF-referential link (corrupt record) becomes a root: kept as-is it
+                    # 1-cycles every walk that starts or passes there.
+                    p = r.get("parentUuid") or r.get("logicalParentUuid")
+                    self.parent_of[u] = None if p == u else p
                     if is_leaf:
                         self.leaf_uuid = u
                 if t == "attachment":
@@ -684,8 +687,14 @@ class FileAdapter:
         # stale override (wrong file, raced clear) falls back to the true file leaf, never an empty parse.
         if leaf_override and leaf_override in self.by_uuid:
             self.leaf_uuid = leaf_override
+        self._adopted = {}       # boundary uuid -> its episode's splice record (the /compact stdout),
+        #                          filled by _adopt_detached_compactions. Downstream consumers key on
+        #                          membership: an ADOPTED boundary is a LIVE manual compact, so the
+        #                          replay dedup must not arm on it (nothing after it is a replayed
+        #                          tail) and its atom must sort AFTER the episode's stdout.
         self._repair_compaction_stitches()
         self._stitch_resume_forks()
+        self._adopt_detached_compactions()
 
     def _stitch_resume_forks(self):
         """Some CLI resumes of a machine-cut turn FORK the transcript with a FRESH head (parentUuid
@@ -732,6 +741,166 @@ class FileAdapter:
                 if cand and cand in self.by_uuid:
                     self.parent_of[u] = cand
                     break
+
+    def _adopt_detached_compactions(self):
+        """A LIVE manual /compact writes its compact_boundary + summary as a DETACHED side
+        branch: the boundary carries parentUuid:null + logicalParentUuid:<pre-compact leaf>,
+        the summary record is its only child, and NOTHING chains through them — the visible
+        conversation parents through the /compact invocation records (caveat/wrapper/stdout)
+        instead. The backward walk never visits the side branch, so the compaction atom — the
+        chat's "Context compacted" card — was silently never emitted for a live manual
+        compact, while auto-compactions (whose continuation chains THROUGH boundary+summary)
+        kept theirs (the user 2026-08-19).
+
+        Adopt the orphaned pair by splicing it in AFTER its own invocation episode's stdout
+        record: …anchor ← caveat ← wrapper ← stdout ← boundary ← summary ← former child. Two
+        deliberate choices there, both corrections of the first cut (2026-08-19 review):
+
+        * The boundary's own EPISODE — not its bare anchor — is both the gate and the splice
+          point. The designed link is the summary record's promptId, which the CLI stamps
+          with the invoking /compact's promptId (13/13 manual boundaries in the live corpus;
+          file-order adjacency is the fallback for summaries carrying NO promptId at all, and
+          is genuinely a fallback: one corpus episode is appended BEFORE its boundary). Gating
+          on the bare anchor resurrected compactions the user had REWOUND AWAY (next prompt
+          re-parents at the pre-compact leaf: wrappers off-path, anchor still on it), and two
+          compactions sharing one anchor threaded through each other. Episode off the active
+          path → its /compact was undone → the boundary stays hidden with it; no episode →
+          nothing witnesses the invocation on the visible history → stays hidden — and a
+          promptId that names NOTHING on record stays hidden the same way, never handed to
+          adjacency: that is the crash-truncated write this module models mid-write, and
+          adjacency in its place stole a later same-anchor /compact's episode.
+        * Splicing BEFORE the stdout pulled that stdout atom out of its /compact command
+          segment into the boundary's fresh triggerless turn, minting a brand-new
+          judge-visible WORK unit ("Compacted (ctrl+o…)") for every manual compact in every
+          existing session. After the stdout, the command segment keeps its output and the
+          boundary's turn holds nothing — no assistant work, no unit.
+
+        Keyed on the SHAPE (boundary off the active path, its episode on it), never on
+        trigger=manual: an attached boundary of either kind (auto, or the resume re-splice a
+        manual pair arrives back in) no-ops here. When the stdout IS the leaf (the user
+        compacted and has not typed since), the pair becomes the chain's new tail — the card
+        must not wait for the next prompt. Runs after the stitch repair and the resume
+        stitching (the active path must already cross files). parent_of/leaf_uuid only —
+        records are never mutated, so the shared _read_jsonl_incremental cache lists stay
+        pristine. Adopted boundaries are recorded in self._adopted for the two downstream
+        consumers that must NOT treat them as attached: the replay dedup (a live manual
+        compact replays no tail — arming it ate the user's next genuine prompt whenever its
+        text repeated an earlier one) and the emit-order override (the boundary record is
+        appended BEFORE the stdout, so raw (t, seq) order would put the card inside the
+        command exchange it belongs after).
+
+        Placement note (re-derived 2026-08-19 against the golden scenario AND every
+        boundary-bearing live-corpus transcript, plan_units pre vs post — the first cut
+        asserted no-bump from intention and was wrong, so only measurements are recorded
+        here; tests/test_placements_canary.py pins the class): the added boundary atom's
+        turn holds no user ask and no assistant work of its own, so on the golden scenario
+        and 11 of 12 corpus transcripts the unit sets are byte-identical pre/post — no
+        recorded placement key shifts, no unit appears or disappears. The residue: when
+        assistant work FOLLOWS the manual compact with no new opener (a queued prompt
+        spliced through it — 1 of 12), that continuation moves from the /compact command
+        segment (where the old parse misfiled it as a human-triggered "/compact worked"
+        unit) into the boundary's own turn — the same non-human continuation unit an
+        attached auto-compact has always produced. One re-attributed unit per such
+        transcript. DECIDED no-bump (2026-08-19, from traced evidence): the orphaned row
+        is inert — every placements consumer queries only units the CURRENT parse yields,
+        and _migrate_placements never removes old rows, so orphans are the normal
+        post-bump state of every store since v2; the fuzzy _placed_key path reads them
+        only in the dedup direction (prevents replay, never causes one). The one NEW unit
+        costs a single planner call. A bump would be strictly worse: it seals every
+        store's currently-ready unplaced units — measured ~29 across the live corpus,
+        including genuinely pending work — the silent drop of a real ask this repo calls
+        its one fatal error."""
+        active = self.active_path()
+        if not any(r.get("type") == "system" and r.get("subtype") == "compact_boundary"
+                   and u not in active for u, r in self.by_uuid.items()):
+            return                        # nothing detached — skip the episode scan entirely
+        # the active CHILD of each on-path uuid — the chain has at most one per node
+        child_of, u = {}, self.leaf_uuid
+        while u is not None:
+            p = self.parent_of.get(u)
+            if p is None or p in child_of:
+                break
+            child_of[p] = u
+            u = p
+        # /compact invocation EPISODES, keyed by promptId: head = first record in file order
+        # (the caveat/raw twin, parented on the pre-compact leaf); splice = the FIRST stdout
+        # record — a restore burst can replay the episode verbatim with the promptId preserved,
+        # and a later copy must never re-seat the card off the original splice (the copy
+        # seq-nearest the boundary+summary pair; the replayed copy's atoms fall to the dedup) —
+        # else the last record seen: a MID-WRITE episode, one parse wide, never hidden, each
+        # phase self-correcting at the next record. Boundary- or summary-as-leaf the pair is ON
+        # the active path (attached by shape, emits natively; the dedup arms there on an empty
+        # window — the file ends at the pair); caveat- or wrapper-as-leaf it adopts AT the
+        # episode's last landed record — adopted, so unarmed — and re-seats once the stdout lands.
+        episodes = {}
+        for eu, er in self.by_uuid.items():          # insertion order = file read order
+            pid = er.get("promptId")
+            if not pid or er.get("type") != "user" or er.get("isCompactSummary"):
+                continue
+            blocks = _content(er.get("message"))
+            btext = (_text_of(blocks) if blocks else "") or ""
+            g = episodes.setdefault(pid, {"head_parent": self.parent_of.get(eu),
+                                          "head_seq": self.seq_of.get(eu, 0),
+                                          "splice": eu, "stdout": None, "compact": False})
+            m = COMMAND_NAME_ANY_RE.search(btext)
+            if m:
+                name = m.group(1).strip()
+                if (name if name.startswith("/") else "/" + name) == "/compact":
+                    g["compact"] = True              # the episode invokes /compact, not some other command
+            if LOCAL_STDOUT_RE.match(btext) and g["stdout"] is None:
+                g["stdout"] = eu                     # first stdout wins — see the splice rule above
+            g["splice"] = g["stdout"] or eu
+        boundaries = sorted((self.seq_of.get(u, 0), u) for u, r in self.by_uuid.items()
+                            if r.get("type") == "system" and r.get("subtype") == "compact_boundary")
+        for _, b in boundaries:
+            if b in active:
+                continue                  # attached (auto / resume re-splice) — never double-emit
+            summary = next((s for s, sr in self.by_uuid.items()
+                            if sr.get("isCompactSummary") is True and self.parent_of.get(s) == b),
+                           None)
+            pid = (self.by_uuid.get(summary) or {}).get("promptId") if summary else None
+            if pid:
+                # the designed link, and the ONLY one honored when present: a promptId that
+                # names no on-record /compact episode (a crash-truncated compaction —
+                # boundary+summary landed, the episode records never did) keeps its boundary
+                # HIDDEN. Degrading to adjacency stole a later same-anchor /compact's episode:
+                # the stale summary rendered at the live splice, and the already-claimed guard
+                # below then hid the real compact's card (2026-08-19 second review).
+                ep = episodes.get(pid)
+                if ep is not None and not ep["compact"]:
+                    ep = None             # the summary's promptId names some OTHER exchange — not a witness
+            else:
+                # fallback ONLY for summaries carrying no promptId at all (older writes,
+                # synthetic shapes): b's own episode is the nearest /compact invoked from b's
+                # anchor and appended after b — the CLI writes boundary+summary first, then
+                # the episode records
+                anchor = self.parent_of.get(b)
+                cands = [g for g in episodes.values()
+                         if g["compact"] and g["head_parent"] == anchor
+                         and g["head_seq"] > self.seq_of.get(b, 0)]
+                ep = min(cands, key=lambda g: g["head_seq"]) if cands else None
+            if ep is None:
+                continue                  # no on-record /compact invocation owns this boundary — stays hidden
+            sp = ep["splice"]
+            if sp not in active or sp == b or sp in self._adopted.values():
+                continue                  # the episode was rewound/cleared away (or already claimed) — hidden
+            c = child_of.get(sp)
+            tail = summary if summary is not None else b
+            self.parent_of[b] = sp        # …stdout <- b (<- summary) <- former child
+            if c is not None:
+                self.parent_of[c] = tail
+            else:
+                self.leaf_uuid = tail     # the stdout was the leaf: the adopted pair is the new tail
+            active.add(b)
+            child_of[sp] = b
+            if summary is not None:
+                active.add(summary)
+                child_of[b] = summary
+                if c is not None:
+                    child_of[summary] = c
+            elif c is not None:
+                child_of[b] = c
+            self._adopted[b] = sp
 
     def active_path(self):
         """The set of uuids on the leaf->root chain (directed walk, O(chain length))."""
@@ -877,7 +1046,14 @@ class FileAdapter:
                 continue
             if r.get("type") == "system" and r.get("subtype") == "compact_boundary":
                 _compacted = True
-                _restoring = True          # the restore burst starts here and ends at the next assistant
+                if u not in self._adopted:
+                    # the restore burst starts here and ends at the next assistant. An ADOPTED
+                    # boundary (a LIVE manual compact) never arms it: its transcript replays NO
+                    # tail — the records after it are the user's genuine next actions, and the
+                    # armed window silently ate the next typed prompt whenever its text repeated
+                    # any earlier message ("continue", a nudge) — a dropped real ask (2026-08-19).
+                    # Attached boundaries (auto, and the resume re-splice, which DOES replay) keep it.
+                    _restoring = True
                 last_boundary = u
             elif r.get("type") == "assistant":
                 _restoring = False         # work resumed → anything later is new, not restored context
@@ -1062,10 +1238,25 @@ class FileAdapter:
                     atom["rompAuto"] = True
                 out.append(atom)
             elif t == "system" and r.get("subtype") == "compact_boundary":
+                if (r.get("parentUuid") or r.get("logicalParentUuid")) == u:
+                    continue   # self-anchored (corrupt): a boundary claiming to compact itself
+                               # anchors nothing — no card, and no cycle for the turn builder
+                sp = self._adopted.get(u)
+                if sp is not None:
+                    # an ADOPTED boundary's record is appended BEFORE its episode's stdout, so raw
+                    # (t, seq) order would drop the card into the middle of the /compact exchange —
+                    # and the stdout atom would then fold into the boundary's fresh turn as
+                    # "assistant work", minting a phantom WORK unit (2026-08-19). Sort it right
+                    # after the stdout instead: the moment the compaction visibly completed.
+                    spt = parse_z((self.by_uuid.get(sp) or {}).get("timestamp"))
+                    if spt is not None and (ts is None or spt > ts):
+                        ts = spt
+                    seq = self.seq_of.get(sp, seq) + 0.5
                 cm = r.get("compactMetadata") or r.get("compact_metadata") or {}
                 out.append({"type": "system", "subtype": "compact_boundary", "uuid": u,
                             "session_id": rompuuid, "t": ts, "fsid": fsid,
-                            "parentUuid": self.parent_of.get(u),   # the repaired stitch (see _repair_compaction_stitches)
+                            "parentUuid": self.parent_of.get(u),   # the repaired stitch (see _repair_compaction_stitches);
+                            #                                        for an ADOPTED boundary, its episode's stdout record
                             "compact_metadata": {"trigger": cm.get("trigger"),
                                                  "pre_tokens": cm.get("preTokens") or cm.get("pre_tokens"),
                                                  "post_tokens": cm.get("postTokens") or cm.get("post_tokens")},

--- a/tests/fixtures/event-model-golden/manual_compact_detached.json
+++ b/tests/fixtures/event-model-golden/manual_compact_detached.json
@@ -1,0 +1,182 @@
+{
+ "color": "#888888",
+ "dir": "/TESTDIR",
+ "landedTextUuids": [
+  "a1",
+  "a2"
+ ],
+ "leafFsid": "11111111-2222-3333-4444-555555555555",
+ "name": "impl",
+ "rompUuid": "11111111-2222-3333-4444-555555555555",
+ "turns": [
+  {
+   "atoms": [
+    {
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "start the long build",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": null,
+     "promptSource": "typed",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096400,
+     "type": "user",
+     "uuid": "u1"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "Working on it.",
+        "type": "text"
+       }
+      ],
+      "role": "assistant",
+      "stop_reason": "end_turn"
+     },
+     "parentUuid": "u1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096430,
+     "type": "assistant",
+     "uuid": "a1"
+    }
+   ],
+   "end": 1781096430,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096400:a3503980",
+   "t": 1781096400,
+   "trigger": {
+    "uuid": "u1"
+   }
+  },
+  {
+   "atoms": [
+    {
+     "author": "human",
+     "command": "/compact",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "/compact",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "rt1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096790,
+     "type": "user",
+     "uuid": "cw1"
+    },
+    {
+     "command": true,
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "Compacted (ctrl+o to see full summary)",
+        "type": "text"
+       }
+      ],
+      "role": "assistant",
+      "stop_reason": "end_turn"
+     },
+     "parentUuid": "cw1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096800,
+     "type": "assistant",
+     "uuid": "so1"
+    }
+   ],
+   "end": 1781096800,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096790:9b15c581",
+   "t": 1781096790,
+   "trigger": {
+    "uuid": "cw1"
+   }
+  },
+  {
+   "atoms": [
+    {
+     "compact_metadata": {
+      "post_tokens": 6514,
+      "pre_tokens": 263239,
+      "trigger": "manual"
+     },
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "parentUuid": "so1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "subtype": "compact_boundary",
+     "summary": "summary of the conversation so far",
+     "t": 1781096800,
+     "type": "system",
+     "uuid": "cb1"
+    }
+   ],
+   "end": 1781096800,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096800:da39a3ee",
+   "t": 1781096800,
+   "trigger": null
+  },
+  {
+   "atoms": [
+    {
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "carry on with the build",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "so1",
+     "promptSource": "typed",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096900,
+     "type": "user",
+     "uuid": "u2"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "Continuing.",
+        "type": "text"
+       }
+      ],
+      "role": "assistant",
+      "stop_reason": "end_turn"
+     },
+     "parentUuid": "u2",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096930,
+     "type": "assistant",
+     "uuid": "a2"
+    }
+   ],
+   "end": 1781096930,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096900:b249da83",
+   "t": 1781096900,
+   "trigger": {
+    "uuid": "u2"
+   }
+  }
+ ]
+}

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -97,10 +97,47 @@ def compact_line_broken(t, uuid, dangling_logical, preserved_tail, trigger="auto
                                                      "tailUuid": preserved_tail}}}
 
 
-def compact_summary_line(t, uuid, parent):
+def compact_summary_line(t, uuid, parent, text="summary of the conversation so far"):
     return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
             "isCompactSummary": True, "isVisibleInTranscriptOnly": True,
-            "message": {"role": "user", "content": "summary of the conversation so far"}}
+            "message": {"role": "user", "content": text}}
+
+
+def manual_compact_lines(t_issue, t_done, tag, parent, summary_text="summary of the conversation so far",
+                         summary_pid=True):
+    """The on-disk tail of a LIVE manual /compact, exactly as the CLI writes it (shape verified
+    against the live corpus 2026-08-19; all content here synthetic): the boundary + summary are
+    appended FIRST, at COMPLETION time, as a DETACHED side branch — the boundary carries
+    parentUuid:null + logicalParentUuid:<the pre-compact leaf>, and the summary is its only
+    child. THEN come the command-wrapper records (the raw-text twin and the <command-name>
+    wrapper, stamped with the earlier ISSUE time), then the stdout at completion time. The
+    conversation chains through the wrappers — NOTHING on the active path visits the side
+    branch, which is why the walk dropped the boundary and the chat lost its card.
+    The summary record carries the invoking /compact's promptId (13/13 manual compacts in the
+    live corpus) — the designed link the adoption repair keys on; summary_pid=False models a
+    write without it, which the repair must still adopt via the file-order fallback.
+    Returns (records, stdout_uuid); chain the next prompt off the stdout, as the CLI does."""
+    cb, cs, rt, cw, so = ("cb" + tag, "cs" + tag, "rt" + tag, "cw" + tag, "so" + tag)
+    summary = compact_summary_line(t_done, cs, parent=cb, text=summary_text)
+    if summary_pid:
+        summary["promptId"] = "p" + tag
+    recs = [
+        compact_line(t_done, cb, logical_parent=parent, trigger="manual"),
+        summary,
+        {"type": "user", "timestamp": iso(t_issue), "uuid": rt, "parentUuid": parent,
+         "isMeta": True, "promptId": "p" + tag,
+         "message": {"role": "user", "content": "/compact"}},
+        {"type": "user", "timestamp": iso(t_issue), "uuid": cw, "parentUuid": rt,
+         "promptId": "p" + tag,
+         "message": {"role": "user", "content": "<command-name>/compact</command-name>\n"
+                                                "<command-message>compact</command-message>\n"
+                                                "<command-args></command-args>"}},
+        {"type": "user", "timestamp": iso(t_done), "uuid": so, "parentUuid": cw,
+         "promptId": "p" + tag,
+         "message": {"role": "user", "content": "<local-command-stdout>Compacted "
+                                                "(ctrl+o to see full summary)</local-command-stdout>"}},
+    ]
+    return recs, so
 
 
 def tasknote_line(t, uuid, parent):
@@ -187,6 +224,23 @@ def scenario_compaction_broken_stitch():
                             preserved_tail="a1", trigger="auto", pre=99999),
         uline(T0 + 520, "post-compaction ask", "u2", parent="c1", ps="sdk"),
         aline(T0 + 530, "post-compaction reply", "a2", "u2", stop="end_turn"),
+    ]
+
+
+def scenario_manual_compact_detached():
+    """A LIVE manual /compact (the user 2026-08-19): the boundary + summary land as a DETACHED
+    side branch (10/13 manual boundaries in the live corpus; the other 3 are resume re-splices
+    that arrive attached) while the conversation chains through the /compact command wrappers.
+    The walk never visited the branch, so no compact atom was emitted and the chat showed no
+    "Context compacted" card — while auto-compactions, which chain THROUGH their boundary,
+    kept theirs. The adoption repair splices the pair back in at its anchor."""
+    side, so = manual_compact_lines(T0 + 390, T0 + 400, "1", parent="a1")
+    return [
+        uline(T0, "start the long build", "u1", ps="typed"),
+        aline(T0 + 30, "Working on it.", "a1", "u1", stop="end_turn"),
+    ] + side + [
+        uline(T0 + 500, "carry on with the build", "u2", so, ps="typed"),
+        aline(T0 + 530, "Continuing.", "a2", "u2", stop="end_turn"),
     ]
 
 
@@ -294,6 +348,7 @@ SINGLE_FILE = {
     "queued_new_turn": (scenario_queued_new_turn, None),
     "compaction_atom": (scenario_compaction_atom, None),
     "compaction_broken_stitch": (scenario_compaction_broken_stitch, None),
+    "manual_compact_detached": (scenario_manual_compact_detached, None),
     "idle_atom": (scenario_idle_atom, IDLE_STATES),
     "popall": (scenario_popall, None),
     "clear_breaks_lineage": (scenario_clear_breaks_lineage, None),
@@ -666,6 +721,341 @@ class Compaction(unittest.TestCase):
         self.assertIn("u2", uuids)
         comp = [a for t in out["turns"] for a in t["atoms"] if a.get("subtype") == "compact_boundary"]
         self.assertEqual(comp[0]["parentUuid"], "a1", "the compaction atom's parent is the repaired stitch")
+
+
+class DetachedManualCompaction(unittest.TestCase):
+    """A LIVE manual /compact writes its boundary + summary as a DETACHED side branch — the
+    boundary has parentUuid:null + logicalParentUuid:<pre-compact leaf>, the summary is its only
+    child, and the conversation chains through the /compact command wrappers instead, so the
+    leaf->root walk never visits the pair and the compact atom (the chat's "Context compacted"
+    card) was silently never emitted (the user 2026-08-19; 10/13 manual boundaries in the live
+    corpus). The adoption repair (FileAdapter._adopt_detached_compactions) splices the pair in
+    at its anchor — keyed on the SHAPE (boundary off the active path, its anchor on it), never
+    on trigger=manual: an attached manual must no-op, a detached auto must be adopted."""
+
+    def _flat(self, out):
+        return [a for t in out["turns"] for a in t["atoms"]]
+
+    def _cards(self, out):
+        return [a for a in self._flat(out) if a.get("subtype") == "compact_boundary"]
+
+    def test_detached_manual_boundary_is_adopted_and_emits_the_card_atom(self):
+        out = run_scenario("manual_compact_detached")
+        comp = self._cards(out)
+        self.assertEqual(len(comp), 1, "the detached boundary is adopted — the card exists")
+        self.assertEqual(comp[0]["uuid"], "cb1")
+        self.assertEqual(comp[0]["compact_metadata"]["trigger"], "manual")
+        self.assertEqual(comp[0].get("summary"), "summary of the conversation so far",
+                         "the side-branch summary rides the adopted atom, same as an attached one")
+        self.assertEqual(comp[0]["parentUuid"], "so1",
+                         "the adopted atom chains from its episode's stdout — the /compact exchange "
+                         "stays intact on the path, with the pre-compact leaf reachable through it")
+
+    def test_adopted_card_sits_where_the_compact_completed(self):
+        out = run_scenario("manual_compact_detached")
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        self.assertLess(uuids.index("cw1"), uuids.index("cb1"),
+                        "the card follows the /compact invocation")
+        self.assertLess(uuids.index("so1"), uuids.index("cb1"),
+                        "…AFTER the whole command exchange: splicing before the stdout pulled that "
+                        "atom into the boundary's fresh turn as assistant work, minting a phantom "
+                        "WORK unit per manual compact (2026-08-19 review)")
+        self.assertLess(uuids.index("cb1"), uuids.index("u2"),
+                        "…and precedes the next prompt — the moment the compaction happened")
+
+    def test_adopted_boundary_opens_a_fresh_turn(self):
+        out = run_scenario("manual_compact_detached")
+        bturn = next(t for t in out["turns"] if any(a.get("uuid") == "cb1" for a in t["atoms"]))
+        self.assertEqual(bturn["atoms"][0].get("uuid"), "cb1",
+                         "the boundary anchors its own turn, exactly as an attached one does")
+        self.assertIsNone(bturn["trigger"])
+        u2turn = next(t for t in out["turns"] if any(a.get("uuid") == "u2" for a in t["atoms"]))
+        self.assertEqual(u2turn["trigger"], {"uuid": "u2"},
+                         "the genuine post-compact prompt still opens its own turn")
+
+    def test_adoption_splices_in_and_never_reroutes_around(self):
+        # everything that was already kept stays kept: the pre-compact history, the /compact
+        # command atom, its stdout output, the post-compact conversation
+        out = run_scenario("manual_compact_detached")
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        for u in ("u1", "a1", "cw1", "so1", "u2", "a2"):
+            self.assertIn(u, uuids)
+        self.assertNotIn("cs1", uuids, "the summary is captured, never its own atom")
+
+    def test_attached_auto_boundary_is_not_double_emitted(self):
+        # the no-op leg, keyed on shape: an ATTACHED boundary (an auto-compaction's normal
+        # shape — the continuation chains through boundary+summary) emits exactly once
+        recs = [uline(T0, "do the long task", "u1", ps="typed"),
+                aline(T0 + 30, "on it", "a1", "u1", stop="end_turn"),
+                compact_line(T0 + 500, "cb1", logical_parent="a1", trigger="auto"),
+                compact_summary_line(T0 + 505, "cs1", parent="cb1"),
+                uline(T0 + 520, "carry on please", "u2", "cs1", ps="sdk"),
+                aline(T0 + 530, "done", "a2", "u2", stop="end_turn")]
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual(len(comp), 1, "an attached boundary emits exactly once — the repair stands down")
+
+    def test_attached_manual_resume_resplice_is_not_double_emitted(self):
+        # the corpus's other manual shape: a RESUME rebuild re-splices the boundary into the
+        # chain, arriving attached (the compaction_atom scenario IS that shape). The repair
+        # must not fight the resume shape — same no-op leg, still exactly one atom.
+        out = run_scenario("compaction_atom")
+        self.assertEqual(len(self._cards(out)), 1)
+
+    def test_two_sequential_manual_compacts_each_get_their_card_in_order(self):
+        side1, so1 = manual_compact_lines(T0 + 90, T0 + 100, "1", parent="a1",
+                                          summary_text="first compact summary")
+        side2, so2 = manual_compact_lines(T0 + 290, T0 + 300, "2", parent="a2",
+                                          summary_text="second compact summary")
+        recs = ([uline(T0, "kick off phase one", "u1", ps="typed"),
+                 aline(T0 + 30, "phase one done", "a1", "u1", stop="end_turn")]
+                + side1
+                + [uline(T0 + 150, "kick off phase two", "u2", so1, ps="typed"),
+                   aline(T0 + 180, "phase two done", "a2", "u2", stop="end_turn")]
+                + side2
+                + [uline(T0 + 350, "kick off phase three", "u3", so2, ps="typed"),
+                   aline(T0 + 380, "phase three done", "a3", "u3", stop="end_turn")])
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([a["uuid"] for a in comp], ["cb1", "cb2"],
+                         "each compaction adopts at its own anchor — two cards, in order")
+        self.assertEqual([a.get("summary") for a in comp],
+                         ["first compact summary", "second compact summary"])
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        self.assertLess(uuids.index("cb1"), uuids.index("u2"))
+        self.assertLess(uuids.index("u2"), uuids.index("cb2"))
+        self.assertLess(uuids.index("cb2"), uuids.index("u3"))
+        # BOTH stdouts render, identical text and all: an adopted boundary never arms the
+        # restore-burst dedup (a live manual compact replays no tail), so nothing after it is
+        # "restored context". The first cut pinned so2 as eaten — that pin was the bug's own
+        # signature, not a goal (2026-08-19 review).
+        self.assertIn("so1", uuids)
+        self.assertIn("so2", uuids)
+
+    def test_boundary_whose_anchor_was_rewound_away_stays_hidden(self):
+        # a detached boundary whose OWN anchor is off the active path — its pre-compact context
+        # was rewound away, so the compaction is not part of visible history. No card. Pinned.
+        side, _so = manual_compact_lines(T0 + 190, T0 + 200, "1", parent="ax")
+        recs = ([uline(T0, "main line ask", "u1", ps="typed"),
+                 aline(T0 + 30, "main reply", "a1", "u1", stop="end_turn"),
+                 uline(T0 + 100, "abandoned tangent", "ux", "a1", ps="typed"),
+                 aline(T0 + 130, "tangent reply", "ax", "ux", stop="end_turn")]
+                + side
+                + [uline(T0 + 300, "back on the main line", "u2", "a1", ps="typed"),
+                   aline(T0 + 330, "continuing main", "a2", "u2", stop="end_turn")])
+        out = run_recs(recs)
+        self.assertEqual(self._cards(out), [],
+                         "a compaction whose context was rewound away stays hidden")
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        self.assertNotIn("ux", uuids, "…and the rewound branch stays dropped")
+
+    def test_repeated_typed_prompt_after_manual_compact_renders(self):
+        # The fatal shape (2026-08-19 review): the user's GENUINE next prompt after a live
+        # manual compact repeats an earlier message's text ("continue", "retry", a nudge).
+        # Arming the restore-burst dedup on the adopted boundary read it as replayed context
+        # and silently dropped a real ask — the one loss class this file exists to prevent.
+        side, so = manual_compact_lines(T0 + 390, T0 + 400, "1", parent="a1")
+        recs = ([uline(T0, "run the full test suite", "u1", ps="typed"),
+                 aline(T0 + 30, "all green", "a1", "u1", stop="end_turn")]
+                + side
+                + [uline(T0 + 500, "run the full test suite", "u2", so, ps="typed"),
+                   aline(T0 + 530, "running now", "a2", "u2", stop="end_turn")])
+        out = run_recs(recs)
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        self.assertIn("u2", uuids, "the repeated-text prompt is the user's real ask, not a replay")
+        self.assertEqual([c["uuid"] for c in self._cards(out)], ["cb1"])
+
+    def test_rewound_manual_compact_is_not_resurrected(self):
+        # The user rewinds PAST the /compact: the next prompt re-parents at the pre-compact
+        # leaf, so the episode (wrappers + stdout) is off-path but the ANCHOR is still on it.
+        # Gating on the bare anchor resurrected the undone compaction's card (2026-08-19
+        # review); the episode gate keeps it hidden with the history it belonged to.
+        side, _so = manual_compact_lines(T0 + 90, T0 + 100, "1", parent="a1")
+        recs = ([uline(T0, "kick off the refactor", "u1", ps="typed"),
+                 aline(T0 + 30, "refactor staged", "a1", "u1", stop="end_turn")]
+                + side
+                + [uline(T0 + 200, "different direction instead", "u2", "a1", ps="typed"),
+                   aline(T0 + 230, "sure", "a2", "u2", stop="end_turn")])
+        out = run_recs(recs)
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        self.assertNotIn("cw1", uuids, "the rewound /compact exchange stays dropped")
+        self.assertNotIn("so1", uuids)
+        self.assertEqual(self._cards(out), [], "an undone compaction gets no card")
+
+    def test_same_anchor_double_compact_only_the_live_one_renders(self):
+        # Compact, rewind to the anchor, compact again: two detached boundaries share ONE
+        # anchor. Splicing both at the anchor threaded them through each other — boundary #1's
+        # parent became boundary #2's summary, and the rewound one rendered (2026-08-19
+        # review). Each boundary belongs to its OWN episode; only the live episode is on-path.
+        side1, _so1 = manual_compact_lines(T0 + 90, T0 + 100, "1", parent="a1",
+                                           summary_text="first summary")
+        side2, so2 = manual_compact_lines(T0 + 290, T0 + 300, "2", parent="a1",
+                                          summary_text="second summary")
+        recs = ([uline(T0, "start it", "u1", ps="typed"),
+                 aline(T0 + 30, "started", "a1", "u1", stop="end_turn")]
+                + side1 + side2
+                + [uline(T0 + 400, "go on", "u2", so2, ps="typed"),
+                   aline(T0 + 430, "going", "a2", "u2", stop="end_turn")])
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([c["uuid"] for c in comp], ["cb2"],
+                         "only the live compaction renders; the rewound one stays hidden")
+        self.assertEqual(comp[0]["parentUuid"], "so2",
+                         "…chained from its OWN episode's stdout, never through the other pair")
+        self.assertEqual(comp[0].get("summary"), "second summary")
+
+    def test_summary_without_promptid_adopts_via_the_file_order_fallback(self):
+        # An older write whose summary lacks the promptId link: the episode is still
+        # identified — the nearest /compact invoked from the boundary's anchor and appended
+        # after it (the CLI writes boundary+summary first, then the episode records).
+        side, so = manual_compact_lines(T0 + 390, T0 + 400, "1", parent="a1",
+                                        summary_pid=False)
+        recs = ([uline(T0, "start the long build", "u1", ps="typed"),
+                 aline(T0 + 30, "Working on it.", "a1", "u1", stop="end_turn")]
+                + side
+                + [uline(T0 + 500, "carry on with the build", "u2", so, ps="typed"),
+                   aline(T0 + 530, "Continuing.", "a2", "u2", stop="end_turn")])
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([c["uuid"] for c in comp], ["cb1"])
+        self.assertEqual(comp[0].get("summary"), "summary of the conversation so far")
+
+    def test_self_anchored_boundary_is_skipped(self):
+        # a corrupt boundary whose logicalParentUuid is its own uuid: no card, no crash —
+        # and no 1-cycle handed to any walk (the parent link is dropped at load)
+        recs = [uline(T0, "only ask", "u1", ps="typed"),
+                aline(T0 + 30, "only answer", "a1", "u1", stop="end_turn"),
+                compact_line(T0 + 50, "cbS", logical_parent="cbS", trigger="manual")]
+        out = run_recs(recs)
+        self.assertEqual(self._cards(out), [])
+
+    def test_stdout_stays_in_the_command_turn_and_the_boundary_turn_holds_no_work(self):
+        # Defect 2's event-model contract (2026-08-19 review): the /compact stdout is the
+        # command exchange's output — it must never migrate into the boundary's fresh turn,
+        # where it reads as assistant work and mints a judge-visible unit.
+        out = run_scenario("manual_compact_detached")
+        cmd_turn = next(t for t in out["turns"] if any(a.get("uuid") == "cw1" for a in t["atoms"]))
+        self.assertIn("so1", [a.get("uuid") for a in cmd_turn["atoms"]])
+        bturn = next(t for t in out["turns"] if any(a.get("uuid") == "cb1" for a in t["atoms"]))
+        self.assertEqual([a.get("uuid") for a in bturn["atoms"]], ["cb1"],
+                         "the boundary's turn holds the boundary alone")
+
+    def test_crash_truncated_compact_never_steals_a_same_anchor_retrys_episode(self):
+        # The mid-write window's worst case: boundary+summary landed, the CLI died before the
+        # episode records, then the user compacted AGAIN from the same anchor. The stale
+        # summary's promptId names nothing on record — the designed link failed, so the stale
+        # boundary stays hidden. Degrading to the file-order fallback handed it the RETRY's
+        # episode: the stale summary rendered at the live splice, and the already-claimed
+        # guard then hid the real compact's card (2026-08-19 second review).
+        stale = compact_summary_line(T0 + 100, "cs1", parent="cb1",
+                                     text="stale interrupted summary")
+        stale["promptId"] = "p1"
+        side2, so2 = manual_compact_lines(T0 + 290, T0 + 300, "2", parent="a1",
+                                          summary_text="second live summary")
+        recs = ([uline(T0, "kick off the sweep", "u1", ps="typed"),
+                 aline(T0 + 30, "sweep done", "a1", "u1", stop="end_turn"),
+                 compact_line(T0 + 100, "cb1", logical_parent="a1", trigger="manual"),
+                 stale]
+                + side2
+                + [uline(T0 + 400, "keep going", "u2", so2, ps="typed"),
+                   aline(T0 + 430, "going", "a2", "u2", stop="end_turn")])
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([c["uuid"] for c in comp], ["cb2"],
+                         "only the retry renders — a promptId that names no on-record episode "
+                         "keeps its boundary hidden, never falls to adjacency")
+        self.assertEqual(comp[0]["parentUuid"], "so2")
+        self.assertEqual(comp[0].get("summary"), "second live summary")
+
+    def test_replayed_episode_copy_never_reseats_the_card(self):
+        # A later auto compaction's restore burst can replay the manual /compact episode
+        # records VERBATIM — new uuids, promptId preserved (the documented replay shape).
+        # The card's splice is the ORIGINAL episode, the copy seq-nearest its own
+        # boundary+summary pair: last-copy-wins re-seated the card after the auto card, on
+        # a parent atom the replay dedup drops (2026-08-19 second review).
+        side1, so1 = manual_compact_lines(T0 + 90, T0 + 100, "1", parent="a1",
+                                          summary_text="manual compact summary")
+        auto_summary = compact_summary_line(T0 + 500, "csA", parent="cbA",
+                                            text="auto compact summary")
+        auto_summary["promptId"] = "pA"
+        replay = [
+            {"type": "user", "timestamp": iso(T0 + 501), "uuid": "rt1r", "parentUuid": "csA",
+             "isMeta": True, "promptId": "p1",
+             "message": {"role": "user", "content": "/compact"}},
+            {"type": "user", "timestamp": iso(T0 + 501), "uuid": "cw1r", "parentUuid": "rt1r",
+             "promptId": "p1",
+             "message": {"role": "user", "content": "<command-name>/compact</command-name>\n"
+                                                    "<command-message>compact</command-message>\n"
+                                                    "<command-args></command-args>"}},
+            {"type": "user", "timestamp": iso(T0 + 501), "uuid": "so1r", "parentUuid": "cw1r",
+             "promptId": "p1",
+             "message": {"role": "user", "content": "<local-command-stdout>Compacted "
+                                                    "(ctrl+o to see full summary)"
+                                                    "</local-command-stdout>"}},
+            uline(T0 + 501, "step two of the migration", "u2r", "so1r", ps="typed"),
+        ]
+        recs = ([uline(T0, "start the migration", "u1", ps="typed"),
+                 aline(T0 + 30, "migration started", "a1", "u1", stop="end_turn")]
+                + side1
+                + [uline(T0 + 200, "step two of the migration", "u2", so1, ps="typed"),
+                   aline(T0 + 230, "step two done", "a2", "u2", stop="end_turn"),
+                   compact_line(T0 + 500, "cbA", logical_parent="a2", trigger="auto"),
+                   auto_summary]
+                + replay
+                + [aline(T0 + 540, "resuming after the auto compact", "a3", "u2r",
+                         stop="end_turn"),
+                   uline(T0 + 600, "now step three", "u3", "a3", ps="typed"),
+                   aline(T0 + 630, "step three done", "a4", "u3", stop="end_turn")])
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([c["uuid"] for c in comp], ["cb1", "cbA"])
+        self.assertEqual(comp[0]["parentUuid"], "so1",
+                         "the card seats at the ORIGINAL episode's stdout, never a replayed copy")
+        self.assertEqual(comp[0].get("summary"), "manual compact summary")
+        uuids = [a.get("uuid") for a in self._flat(out)]
+        self.assertLess(uuids.index("cb1"), uuids.index("cbA"),
+                        "…so it stays where the manual compact happened, before the auto card")
+        self.assertLess(uuids.index("so1"), uuids.index("cb1"))
+        self.assertLess(uuids.index("cb1"), uuids.index("u2"))
+
+    def test_mid_write_wrapper_leaf_build_adopts_at_the_wrapper(self):
+        # The mid-write phase the episode-scan comment describes: the wrapper is the file
+        # leaf, the stdout not yet written. The pair is NOT hidden — it adopts at the
+        # episode's last landed record for this one build (parent = the wrapper) and
+        # re-seats at the stdout next parse (the full-shape tests above ARE that parse).
+        side, _so = manual_compact_lines(T0 + 390, T0 + 400, "1", parent="a1")
+        cut = side[:-1]           # boundary, summary, caveat twin, wrapper — no stdout yet
+        recs = ([uline(T0, "start the long build", "u1", ps="typed"),
+                 aline(T0 + 30, "build started", "a1", "u1", stop="end_turn")]
+                + cut)
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([c["uuid"] for c in comp], ["cb1"])
+        self.assertEqual(comp[0]["parentUuid"], "cw1",
+                         "mid-write, the card seats at the episode's last landed record")
+        # ADOPTED is also the dedup's off-switch (the emit loop keys on _adopted membership).
+        # Nothing can follow the wrapper in this phase, so no atoms-level probe exists —
+        # pin the switch itself on the adapter.
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / (SID + ".jsonl")
+            p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+            adapter = em.FileAdapter([str(p)], p)
+            self.assertIn("cb1", adapter._adopted,
+                          "mid-write adoption keeps the restore dedup unarmed")
+
+    def test_mid_write_summary_leaf_build_is_attached_by_shape(self):
+        # One write earlier — boundary+summary are the whole tail. The pair IS the active
+        # path: attached by shape, native emit, no adoption needed (and the dedup's armed
+        # window is empty — the file ends there).
+        side, _so = manual_compact_lines(T0 + 390, T0 + 400, "1", parent="a1")
+        recs = ([uline(T0, "start the long build", "u1", ps="typed"),
+                 aline(T0 + 30, "build started", "a1", "u1", stop="end_turn")]
+                + side[:2])       # boundary + summary only
+        out = run_recs(recs)
+        comp = self._cards(out)
+        self.assertEqual([c["uuid"] for c in comp], ["cb1"])
+        self.assertEqual(comp[0]["parentUuid"], "a1",
+                         "the leaf-anchored pair emits natively off its pre-compact anchor")
 
 
 class Lineage(unittest.TestCase):

--- a/tests/test_event_model_incremental.py
+++ b/tests/test_event_model_incremental.py
@@ -163,5 +163,78 @@ class ParseSessionEquivalence(unittest.TestCase):
             em._read_jsonl_incremental(self.p)                # warm the cache at this prefix
 
 
+def _manual_compact_recs():
+    """A transcript containing a LIVE manual /compact's on-disk shape (synthetic content;
+    shape mirrors the live corpus): the DETACHED boundary + summary side branch appended
+    first at completion time, then the command wrappers, then the stdout — plus the
+    post-compact growth appended separately. Returns (prefix, growth)."""
+    b = lambda i: "11111111-2222-3333-4444-%012d" % i
+    ts = lambda s: "2026-07-05T10:%02d:%02dZ" % (s // 60, s % 60)
+    prefix = [
+        {"type": "user", "uuid": b(0), "parentUuid": None, "timestamp": ts(0),
+         "promptSource": "typed", "message": {"role": "user", "content": "start the refactor"}},
+        {"type": "assistant", "uuid": b(1), "parentUuid": b(0), "timestamp": ts(10),
+         "message": {"role": "assistant", "content": [{"type": "text", "text": "refactor done"}],
+                     "stop_reason": "end_turn"}},
+        {"type": "system", "subtype": "compact_boundary", "uuid": b(2), "parentUuid": None,
+         "logicalParentUuid": b(1), "timestamp": ts(40),
+         "compactMetadata": {"trigger": "manual", "preTokens": 120000, "postTokens": 5000}},
+        {"type": "user", "uuid": b(3), "parentUuid": b(2), "timestamp": ts(40),
+         "isCompactSummary": True,
+         "message": {"role": "user", "content": "synthetic compact summary"}},
+        {"type": "user", "uuid": b(4), "parentUuid": b(1), "timestamp": ts(30),
+         "isMeta": True, "promptId": "p1", "message": {"role": "user", "content": "/compact"}},
+        {"type": "user", "uuid": b(5), "parentUuid": b(4), "timestamp": ts(30), "promptId": "p1",
+         "message": {"role": "user", "content": "<command-name>/compact</command-name>"}},
+        {"type": "user", "uuid": b(6), "parentUuid": b(5), "timestamp": ts(40), "promptId": "p1",
+         "message": {"role": "user",
+                     "content": "<local-command-stdout>Compacted</local-command-stdout>"}},
+    ]
+    growth = [
+        {"type": "user", "uuid": b(7), "parentUuid": b(6), "timestamp": ts(60),
+         "promptSource": "typed",
+         "message": {"role": "user", "content": "carry on after the compact"}},
+        {"type": "assistant", "uuid": b(8), "parentUuid": b(7), "timestamp": ts(70),
+         "message": {"role": "assistant", "content": [{"type": "text", "text": "carried on"}],
+                     "stop_reason": "end_turn"}},
+    ]
+    return prefix, growth
+
+
+class ManualCompactAdoptionEquivalence(unittest.TestCase):
+    """A transcript that grows PAST a live manual /compact must produce the same adopted
+    compact atom incrementally as cold: the adoption repair (_adopt_detached_compactions)
+    reads only the assembled graph and must never mutate the cache's shared record lists,
+    so the grew-branch reuse stays intact across parses that ran the repair."""
+
+    def setUp(self):
+        em._JSONL_CACHE.clear()
+        fd, self.p = tempfile.mkstemp(suffix=".jsonl")
+        os.close(fd)
+
+    def tearDown(self):
+        em._JSONL_CACHE.clear()
+        os.unlink(self.p)
+
+    def _cards(self, out):
+        return [a for t in out["turns"] for a in t["atoms"]
+                if a.get("subtype") == "compact_boundary"]
+
+    def test_growth_past_a_manual_compact_adopts_identically_warm_and_cold(self):
+        prefix, growth = _manual_compact_recs()
+        _write(self.p, prefix)
+        first = em.parse_session(self.p)                  # cold; primes the cache
+        self.assertEqual(len(self._cards(first)), 1,
+                         "the detached boundary is adopted before any growth")
+        _append(self.p, growth)
+        warm = em.parse_session(self.p)                   # rides the grew-branch reuse
+        self.assertEqual(em.parse_session(self.p), warm,
+                         "a re-parse from the warm cache is stable — the repair mutated no cached record")
+        em._JSONL_CACHE.clear()
+        cold = em.parse_session(self.p)
+        self.assertEqual(warm, cold, "grown past the compact: warm == cold, adoption included")
+        self.assertEqual(len(self._cards(cold)), 1, "exactly one adopted card either way")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -81,27 +81,87 @@ RECORDS = [
      "parentUuid": None, "logicalParentUuid": "a4",
      "compactMetadata": {"trigger": "manual", "preTokens": 90000}},
     aline(T0 + 4020, "Resuming after compaction.", "a5", "cb1"),
+    # a DETACHED live manual /compact (2026-08-19): boundary+summary land as a side branch
+    # (parentUuid null + logicalParentUuid; the conversation chains through the /compact
+    # caveat/wrapper/stdout records) and the adoption repair splices them back in AFTER the
+    # stdout. Pinned here because this class changes BOTH identity dimensions when it drifts:
+    # the splice position decides whether the stdout atom mints a phantom triggerless WORK
+    # unit, and the replay-dedup arming decides whether the user's next typed prompt — u7
+    # deliberately repeats u3's text — survives in the atom set at all.
+    uline(T0 + 5000, "now wire the audit log into the export page", "u6", "a5"),
+    aline(T0 + 5060, "Wired the audit log through.", "a6", "u6"),
+    {"type": "system", "subtype": "compact_boundary", "timestamp": iso(T0 + 5400), "uuid": "cb2",
+     "parentUuid": None, "logicalParentUuid": "a6",
+     "compactMetadata": {"trigger": "manual", "preTokens": 90000, "postTokens": 4000}},
+    {"type": "user", "timestamp": iso(T0 + 5400), "uuid": "cs2", "parentUuid": "cb2",
+     "isCompactSummary": True, "isVisibleInTranscriptOnly": True, "promptId": "pc2",
+     "message": {"role": "user", "content": "synthetic summary of the audit-log work"}},
+    {"type": "user", "timestamp": iso(T0 + 5300), "uuid": "rt2", "parentUuid": "a6",
+     "isMeta": True, "promptId": "pc2", "message": {"role": "user", "content": "/compact"}},
+    {"type": "user", "timestamp": iso(T0 + 5300), "uuid": "cw2", "parentUuid": "rt2", "promptId": "pc2",
+     "message": {"role": "user", "content": "<command-name>/compact</command-name>\n"
+                                            "<command-message>compact</command-message>\n"
+                                            "<command-args></command-args>"}},
+    {"type": "user", "timestamp": iso(T0 + 5400), "uuid": "so2", "parentUuid": "cw2", "promptId": "pc2",
+     "message": {"role": "user", "content": "<local-command-stdout>Compacted "
+                                            "(ctrl+o to see full summary)</local-command-stdout>"}},
+    uline(T0 + 5500, "now rename the exported CSV columns to snake_case", "u7", "so2"),
+    aline(T0 + 5560, "Renamed them again on the new export page.", "a7", "u7"),
 ]
 
 # The pinned derivation, recorded under PLACEMENTS_V = 7 (2026-08-01; the derivation itself is unchanged
-# since v6 — v7 seals for a GROWN atom set, the replay-guard scoping. The LAST id — a text-less segment
-# — moved off the shared sha1('') hash da39a3ee onto its anchor atom's uuid, so text-less seams no longer
-# alias each other; the four text-bearing ids above are unchanged, they still key on content).
+# since v6 — v7 seals for a GROWN atom set, the replay-guard scoping. The LAST id of the first five — a
+# text-less segment — moved off the shared sha1('') hash da39a3ee onto its anchor atom's uuid, so text-less
+# seams no longer alias each other; the four text-bearing ids above it are unchanged, they still key on
+# content). The last four ids pin the detached manual-compact block (2026-08-19, no bump — additions only):
+# u6's ask, the /compact command segment, the adopted boundary's own text-less segment, and u7's
+# repeated-text ask (same text hash as u3's id, its own t — present at all only because the adopted
+# boundary does not arm the replay dedup).
 EXPECTED_SEG_IDS = [
     SID + ":1780000000:ca8d36fd",
     SID + ":1780000120:f03c5f4f",
     SID + ":1780000240:686c9d66",
     SID + ":1780000330:f3320ed1",
     SID + ":1780004000:d780b71b",
+    SID + ":1780005000:d105998b",
+    SID + ":1780005300:9b15c581",
+    SID + ":1780005400:06676388",
+    SID + ":1780005500:686c9d66",
 ]
+
+# Dimension 2 pinned EXPLICITLY (WHICH atoms parse, in rendered order): seg ids alone cannot see an
+# atom that changes segments without changing any id — the detached compact's stdout (so2) belongs to
+# the /compact COMMAND turn (cb2 sorts after it), and u7 must be in the set at all.
+EXPECTED_ATOM_UUIDS = [
+    "u1", "a1", "u2", "a2", "u3", "a3", "att1", "a4", "cb1", "a5",
+    "u6", "a6", "cw2", "so2", "cb2", "u7", "a7",
+]
+
+# The judge-visible units (seg id, kind, human): the /compact command segment and the adopted
+# boundary's work-less segment yield NONE — a drift that mints a unit here replays as a fresh card
+# in every dormant session that ever compacted manually. (cb1's unit is the ATTACHED shape's
+# continuation work — a5 chains through the boundary — and predates this block.)
+EXPECTED_UNITS = [
+    (SID + ":1780000000:ca8d36fd", "work", True),
+    (SID + ":1780000120:f03c5f4f", "nudge", False),
+    (SID + ":1780000240:686c9d66", "work", True),
+    (SID + ":1780000330:f3320ed1", "work", True),
+    (SID + ":1780004000:d780b71b", "work", False),
+    (SID + ":1780005000:d105998b", "work", True),
+    (SID + ":1780005500:686c9d66", "work", True),
+]
+
+
+def _parse_fixture():
+    with tempfile.TemporaryDirectory() as td:
+        tp = Path(td) / (SID + ".jsonl")
+        tp.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+        return jd.parsed_session(SID, [str(tp)], T0 + 4000)
 
 
 class PlacementIdentityCanary(unittest.TestCase):
     def test_seg_id_derivation_is_pinned_to_placements_v(self):
-        with tempfile.TemporaryDirectory() as td:
-            tp = Path(td) / (SID + ".jsonl")
-            tp.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
-            sess = jd.parsed_session(SID, [str(tp)], T0 + 4000)
+        sess = _parse_fixture()
         ids = [seg["id"] for turn in sess["turns"] for seg in em.segments(turn)]
         self.assertEqual(
             ids, EXPECTED_SEG_IDS,
@@ -110,6 +170,23 @@ class PlacementIdentityCanary(unittest.TestCase):
             "\nIn THIS commit: bump jd.PLACEMENTS_V (seals v(n-1) stores' ready-unplaced units at the"
             "\nnext pass) and re-pin EXPECTED_SEG_IDS to the new derivation. Current PLACEMENTS_V=%d."
             % jd.PLACEMENTS_V)
+
+    def test_atom_set_is_pinned(self):
+        # Dimension 2 of placement identity: WHICH atoms parse, and in what order. A change here
+        # without a bump replays dormant history (the 2026-07-10 absorbed-atom incident) or — worse —
+        # silently DROPS a real message (the 2026-08-19 manual-compact replay-dedup incident, which
+        # ate u7's shape while every pinned seg id of the day still matched).
+        sess = _parse_fixture()
+        self.assertEqual([a.get("uuid") for t in sess["turns"] for a in t["atoms"]],
+                         EXPECTED_ATOM_UUIDS)
+
+    def test_plan_units_are_pinned(self):
+        # The judge-visible face of the same identity: a unit minted from a segment that never
+        # yielded one before (the 2026-08-19 phantom "Compacted (ctrl+o…)" WORK unit) files fresh
+        # cards for every manual compact in every existing session at the next kernel restart.
+        sess = _parse_fixture()
+        units = jd.plan_units({"turns": sess["turns"], "rompUuid": sess["rompUuid"]})
+        self.assertEqual([(u[0], u[1], u[4]) for u in units], EXPECTED_UNITS)
 
     def test_placements_v_is_current(self):
         # The pins above were recorded under this version; a bump without re-pinning (or re-pinning


### PR DESCRIPTION
## What breaks

A live manual `/compact` never shows a "Context compacted" card in the chat — only auto-compactions get one.

**Cause:** on a live manual compact, the Claude Code CLI writes the `compact_boundary` + its `isCompactSummary` record as a **detached side branch** — the boundary carries `parentUuid: null` + `logicalParentUuid: <pre-compact leaf>`, and the summary is its only child — while the visible conversation chains through the `/compact` command-wrapper records onto the same leaf. The event model's leaf-to-root walk never visits the pair, so the compact atom is never emitted. Auto-compactions chain *through* their boundary and keep their card.

In a corpus of real transcripts, 10 of 13 manual boundaries were dark; the other 3 arrived attached via resume re-splices and were fine.

## Reproduction

Run `/compact` manually in a live session and look for the card — there is none. Or run the new `manual_compact_detached` golden scenario against the base: no `compact_boundary` atom is emitted (16 of the new tests fail on the unfixed base, including one where the post-compaction replay dedup silently swallows the user's next typed prompt).

## The fix

`_adopt_detached_compactions` in `kernel/event_model.py`, running after the existing stitch repairs: a boundary off the active path is spliced back in **after its own `/compact` invocation episode's stdout record**. The episode is found via the summary record's `promptId` — the CLI stamps it with the invoking `/compact`'s (13/13 in the corpus) — with file-order adjacency only for summaries carrying no `promptId` at all.

Keyed on the detached **shape**, never on `trigger=manual`:

- attached boundaries (auto, resume re-splices) no-op;
- a rewound-away compaction stays hidden with its history (the episode, not the bare anchor, is the gate);
- a `promptId` naming nothing on record keeps its boundary hidden — a crash-truncated compaction must not steal a same-anchor retry's episode;
- first-stdout-wins, so a replayed episode copy cannot re-seat the card;
- only the in-memory parent map is rewired — cached records are never mutated.

Two deliberate consequences:

- an **adopted boundary never arms the post-compaction replay dedup**: a live manual compact replays no tail, and armed, the dedup silently dropped the user's next typed prompt whenever its text repeated an earlier message — the worst defect this fixes;
- the adopted atom **sorts just after the episode's stdout** (the boundary record is appended before it in the file), so the stdout stays in its command segment and no phantom work unit is minted.

## Tests

~24 new tests: a golden scenario + fixture (`manual_compact_detached`) covering adoption, no-double-emit, rewind, same-anchor double compact, crash truncation, replayed copies, and mid-write phases; a warm/cold incremental-cache equivalence test; and the placements canary extended with the detached-manual shape plus explicit atom-set and plan-units pins.

## Judgment call to flag: no PLACEMENTS_V bump

This change **grows the emitted atom set for existing transcripts**, which normally argues for a bump. I deliberately shipped without one — the traced rationale is in the method docstring and the canary comments:

- the only new atoms are triggerless system boundaries yielding no replayed human unit;
- unit sets are byte-identical pre/post on the golden scenario and 11 of 12 boundary-bearing corpus transcripts — the twelfth re-attributes one continuation unit to the exact shape attached auto-compacts have always produced;
- a bump would seal every store's currently-ready unplaced units, silently dropping genuinely pending work.

If you'd rather have the bump anyway, say so and I'll add it to this PR.

## Rollout note

This is an event-model change, so on the next restart every **past** manual compact in existing sessions retroactively gains its card — an expected one-time appearance, not churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)