### PR TITLE
Model refusals become a fifth on-you API-error class: never auto-retried

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5981,10 +5981,16 @@ def _fire_api_retry(sid, be, manual=False):
             return                                        # not api-blocked right now → nothing to retry
         # ON-YOU classes are never auto-retried (server-side twin of the client tick's skip, and the
         # kernel driver's own guard): a retry cannot compact a too-long prompt, raise a spend cap, refill
-        # a model allowance, or mend a credential — the card names the real fix. Manual keeps firing:
-        # the button is only rendered where a retry can work, and an explicit click is the user's call.
+        # a model allowance, or mend a credential — the card names the real fix. A safeguards REFUSAL is
+        # the starkest of them (the user 2026-08-15): it's deterministic on the same input, so a retry
+        # re-sends the same prompt and manufactures the same refusal — measured 12/12 in one ~6-minute
+        # storm, where each refusal's NEW error record minted a new episode and the once-per-episode
+        # gate below never terminated — and in fallback configurations each retry manufactures another
+        # model downgrade. Manual keeps firing: the button is only rendered where a retry can work, and
+        # an explicit click is the user's call (they may have rewritten or dropped the thread since).
         if _rerr and (_rerr.get("tooLong") or _rerr.get("spendLimit")
-                      or _rerr.get("modelLimit") or _rerr.get("authErr")):
+                      or _rerr.get("modelLimit") or _rerr.get("authErr")
+                      or _rerr.get("refusal")):
             return
         if _auto_retried.get(sid) == _rk:
             return                                        # this episode already got its retry
@@ -11821,6 +11827,21 @@ def _is_auth_error(text):
             or "authentication_error" in low)
 
 
+# A safeguards REFUSAL — the model's classifier refused the prompt itself ("<Model>'s safeguards
+# flagged this message (https://www.anthropic.com/legal/aup)…"). DETERMINISTIC on the same input, so
+# it's on YOU like the limit classes, only more so: a retry re-sends the same prompt and manufactures
+# the same refusal (measured 12/12 in one storm — each refusal wrote a NEW error record, new uuid →
+# new episode, so the once-per-episode gate never terminated), and in a fallback configuration each
+# retry manufactures another model downgrade. The real fix is rewriting the ask or dropping the
+# thread. This wording check is CO-EQUAL with the event path in _api_error (the system
+# model_refusal_* record), not a legacy fallback: the CLI omits the system record for some refusal
+# errors (observed in the same storm that produced linked ones), and at a transcript's tail the error
+# record can land a beat before its system record — the signature rides the error record itself.
+def _is_refusal_text(text):
+    low = (text or "").lower()
+    return "safeguards flagged" in low or "anthropic.com/legal/aup" in low
+
+
 def _spend_dialog_showing(pane):
     """Is the CLI's spend-cap MODAL currently up in this pane capture? When a tmux session hits the
     monthly cap MID-TURN the CLI drops into an interactive menu ("What do you want to do? / Adjust
@@ -11885,7 +11906,15 @@ def _api_error(path):
                                "modelLimit": _is_model_limit(text),
                                # a dead credential (no login / refused key) — on YOU, never auto-retried;
                                # see _is_auth_error (per-session auth, the user 2026-08-08)
-                               "authErr": _is_auth_error(text)}
+                               "authErr": _is_auth_error(text),
+                               # the error's parent = the refused/failed USER message — kept so the
+                               # system model_refusal_* record below can link itself to THIS episode
+                               "parentUuid": o.get("parentUuid"),
+                               # a safeguards refusal is deterministic on the same input — on YOU
+                               # (rewrite the ask or drop the thread), never auto-retried; see
+                               # _is_refusal_text, and the system-record event path below (the user
+                               # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
+                               "refusal": _is_refusal_text(text)}
                     elif (isinstance(c, list) and any(isinstance(b, dict)
                             and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
                             or (isinstance(c, str) and c.strip()):
@@ -11896,6 +11925,19 @@ def _api_error(path):
                         isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
                     if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears it
                         err = None
+                elif t == "system" and o.get("subtype") in ("model_refusal_no_fallback",
+                                                            "model_refusal_fallback"):
+                    # The CLI's structured refusal record — the EXACT event behind _is_refusal_text's
+                    # wording check (so a future CLI rephrase still classifies). It lands a few records
+                    # AFTER the assistant error it explains (queue-operation / file-history-snapshot
+                    # lines sit between; none of those clears err), linked by parentUuid: the refusal
+                    # record and the error BOTH carry the refused user message's uuid as parentUuid.
+                    # Deliberately NOT refusedUserMessageUuid — observed diverging from the episode's
+                    # parent in 2 of 13 refusal records of one storm — and deliberately not
+                    # record-alone: the CLI also omits this record for some refusal errors, which is
+                    # why the text signature above stays co-equal rather than a legacy fallback.
+                    if err is not None and o.get("parentUuid") == err.get("parentUuid"):
+                        err["refusal"] = True
     except OSError:
         return None
     if key is not None:
@@ -15034,6 +15076,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # service.env) — and with per-session auth it's how a session that landed on a broken
                   # side gets seen at all instead of idling as an invisible transient (the user 2026-08-08)
                   "apiAuthErr": bool(aerr and aerr.get("authErr")),
+                  # the model's safeguards refused the prompt itself — on-you like the four above (red
+                  # tab), and never auto-retried: a refusal is deterministic on the same input, so a
+                  # retry re-sends the same prompt and manufactures the same refusal (12/12 in the
+                  # audited storm) — rewrite the ask or drop the thread (the user 2026-08-15)
+                  "apiRefusal": bool(aerr and aerr.get("refusal")),
                   # user interrupted this thread's retry/API-error storm → romp's auto-retry stays OFF for it
                   # until a successful turn re-arms (the user 2026-07-06); the card + retry loop read this
                   "retrySuppressed": _session_retry_suppressed(sid),
@@ -16795,8 +16842,12 @@ def build_feed(now, tmux=None):
             # turn until you switch model or top up, so leaving the card in Working left a working card on
             # a session nothing could move — not nudged (the api-error gate suppresses it), not blocked,
             # not awaiting, for 80 minutes.
+            # A safeguards REFUSAL joins them (the user 2026-08-15): deterministic on the same input,
+            # never auto-retried, so a Working card would sit on a session nothing can move — the
+            # human rewriting or dropping the ask IS the only unblock.
             api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")
-                                                          or aerr.get("modelLimit") or aerr.get("authErr"))))
+                                                          or aerr.get("modelLimit")
+                                                          or aerr.get("authErr") or aerr.get("refusal"))))
             # NUDGE FAILED (plans/stalled-open-todos-nudge.md, the user 2026-07-01): the tick stamped
             # `failed` on this goal's nudge record — the nudge-response turn completed (judged) and the goal
             # was still working-stalled; per the anti-loop rule it is never re-nudged, so the card carries
@@ -16987,6 +17038,7 @@ def build_feed(now, tmux=None):
                              "spendLimit": bool(aerr.get("spendLimit")),
                              "modelLimit": bool(aerr.get("modelLimit")),
                              "authErr": bool(aerr.get("authErr")),
+                             "refusal": bool(aerr.get("refusal")),
                              "what": ("this account hit its monthly spend limit — raise it at claude.ai/settings/usage to continue" if aerr.get("spendLimit")
                                       else "this session's prompt is too long — compact it to continue" if aerr.get("tooLong")
                                       # the CLI's own text names the model and the two remedies; the card
@@ -16995,6 +17047,9 @@ def build_feed(now, tmux=None):
                                       # a dead credential: retrying re-presents it forever — name the fix
                                       # (per-session auth, the user 2026-08-08)
                                       else "this session's sign-in or API key isn't working — fix the login (claude /login) or the key, or switch which one it bills" if aerr.get("authErr")
+                                      # a refusal is deterministic: retrying re-sends the same prompt and
+                                      # collects the same refusal — name the real fix (the user 2026-08-15)
+                                      else "the model's safeguards refused this prompt — rewrite it or drop this thread" if aerr.get("refusal")
                                       else "this session stopped on an API error — Retry to resume")} if nid == api_top
                             # the session itself is fine — it's romp's ANALYSIS of it whose credential is
                             # refused, so the copy blames the judges, not the session (the user 2026-08-12)

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -29,10 +29,12 @@ class ApiErrorWorking(unittest.TestCase):
     def test_only_on_you_errors_floor_the_card_to_needs_input(self):
         src = inspect.getsource(km.build_feed)
         # api_block fires for an ON-YOU api_top — "prompt too long" (compact), a monthly spend cap (raise
-        # it, the user 2026-07-14), a spent model allowance, or a dead credential (per-session auth, the
-        # user 2026-08-08); a transient error does NOT move the card (it auto-retries in Working).
+        # it, the user 2026-07-14), a spent model allowance, a dead credential (per-session auth, the
+        # user 2026-08-08), or a safeguards refusal (the user 2026-08-15); a transient error does NOT
+        # move the card (it auto-retries in Working).
         self.assertIn('api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")', src)
-        self.assertIn('or aerr.get("modelLimit") or aerr.get("authErr"))))', src)
+        self.assertIn('or aerr.get("modelLimit")', src)
+        self.assertIn('or aerr.get("authErr") or aerr.get("refusal"))))', src)
         self.assertIn('column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top', src)   # stalled_floor retired 2026-07-07; jauth_top = the judge-auth floor (2026-08-12)
         self.assertIn('or (col == "blocked" and not recheck and not rejudging))', src)
 

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -135,9 +135,10 @@ class SurfacesPinTheOnYouTreatment(unittest.TestCase):
 
     def test_the_card_floors_to_needs_you(self):
         src = inspect.getsource(km.build_feed)
-        self.assertIn('or aerr.get("modelLimit") or aerr.get("authErr"))))', src,
+        self.assertIn('or aerr.get("modelLimit")', src,
                       "api_block must include the model limit — otherwise the card sits in Working "
                       "with the nudge suppressed and nothing able to move it")
+        self.assertIn('or aerr.get("authErr") or aerr.get("refusal"))))', src)
 
     def test_the_card_names_the_real_remedy(self):
         src = inspect.getsource(km.build_feed)

--- a/tests/test_kernel_refusal_retry.py
+++ b/tests/test_kernel_refusal_retry.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""A classifier REFUSAL is deterministic on the same input — never auto-retried (the user 2026-08-15).
+
+The incident, all fixtures SYNTHETIC: the `api` session sent a prompt the model's safeguards refused.
+The CLI wrote an assistant API-error record (isApiErrorMessage:true, error:"invalid_request") whose
+text reads "API Error: <Model>'s safeguards flagged this message (https://www.anthropic.com/legal/aup)…",
+plus, a few records later, a structured system record (subtype model_refusal_no_fallback) carrying the
+refusal category and explanation. romp classified the error as TRANSIENT, so the auto-retry re-sent the
+same prompt — which manufactured the same refusal, verbatim, TWELVE times in ~6 minutes: each refusal
+wrote a NEW error record (new uuid → new episode), so the once-per-episode gate never terminated, and
+in a fallback configuration each attempt would also manufacture another model downgrade.
+
+Detection is event-based FIRST with the CLI's own wording as a co-equal signature, because neither
+alone covers the evidence:
+- the system refusal record (subtype model_refusal_no_fallback / model_refusal_fallback) is the exact
+  event, linked to its episode by parentUuid — the refusal record and the assistant error BOTH carry
+  the refused user message's uuid as parentUuid. (refusedUserMessageUuid is NOT the link: it was
+  observed diverging from the episode's parent in 2 of 13 refusal records of one storm.)
+- the text signature ("safeguards flagged" / the aup URL) is REQUIRED, not a legacy nicety: the same
+  storm contained refusal-text errors with NO system record at all, and at a transcript's tail the
+  error record can be flushed a beat before its system record — the signature rides the error record
+  itself, so the very first read classifies right.
+"""
+import inspect
+import json
+import os
+import tempfile
+import types
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_refusal", os.path.join(BIN, "romp-kernel")).load_module()
+
+T0 = 1786600000
+RETRY = "retry\n\n<!-- romp-injected -->"
+# The CLI's own boilerplate for a safeguards refusal, model name neutralised.
+REFUSAL_TEXT = ("API Error: Opus 5's safeguards flagged this message "
+                "(https://www.anthropic.com/legal/aup). Our intentionally broad safeguards allow us "
+                "to deliver more capabilities faster, but can sometimes flag legitimate coding, "
+                "cybersecurity, and biology tasks. Claude Code can't respond to this message with "
+                "Opus 5.")
+# An invalid_request whose wording carries NO refusal signature — isolates the event path.
+GENERIC_TEXT = "API Error: the request was rejected by the server."
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def _apierr(t, uuid, parent, text, status=None, category="invalid_request"):
+    o = {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+         "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                     "stop_reason": "stop_sequence"},
+         "isApiErrorMessage": True, "error": category}
+    if status is not None:
+        o["apiErrorStatus"] = status
+    return o
+
+
+def _sysrefusal(t, uuid, parent, subtype="model_refusal_no_fallback", refused=None):
+    return {"type": "system", "subtype": subtype, "timestamp": _iso(t), "uuid": uuid,
+            "parentUuid": parent, "refusedUserMessageUuid": refused or parent,
+            "apiRefusalCategory": "synthetic", "apiRefusalExplanation": "synthetic refusal",
+            "originalModel": "opus-5"}
+
+
+# The non-productive records the CLI interleaves between the error and its system record — they must
+# neither clear the blocking error nor break the correlation (observed shape: error, queue-operations
+# and/or a file-history-snapshot, THEN the system refusal record).
+def _queueop():
+    return {"type": "queue-operation", "operation": "synthetic"}
+
+
+def _snapshot():
+    return {"type": "file-history-snapshot", "messageId": "11111111-2222-3333-4444-000000000099"}
+
+
+class IsRefusalTextPredicate(unittest.TestCase):
+    def test_the_clis_own_phrasing_classifies(self):
+        for t in (REFUSAL_TEXT,
+                  "API Error: Fable 5's safeguards flagged this message.",
+                  "API Error: blocked (https://www.anthropic.com/legal/aup)."):
+            self.assertTrue(km._is_refusal_text(t), t)
+
+    def test_other_failures_do_not(self):
+        for t in ("API Error: 500 Internal server error.",
+                  "Request timed out",
+                  "You've hit your monthly spend limit. Raise it at claude.ai/settings/usage.",
+                  "You've reached your Opus 5 limit. Run /usage-credits to continue or switch "
+                  "models with /model",
+                  GENERIC_TEXT):
+            self.assertFalse(km._is_refusal_text(t), t)
+
+
+class ApiErrorCarriesTheRefusalFlag(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.p = os.path.join(self.td.name, "s.jsonl")
+        km._api_err_cache.clear()
+
+    def tearDown(self):
+        km._api_err_cache.clear()
+        self.td.cleanup()
+
+    def _write(self, *rows):
+        with open(self.p, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+        km._api_err_cache.clear()
+
+    def test_the_text_signature_flags_without_the_system_record(self):
+        # the CLI omits the system record for SOME refusal errors (observed in the audited storm), and
+        # at the transcript tail the error can land a beat before its system record — the signature on
+        # the error record itself covers both.
+        self._write(_uline(T0, "synthetic refused ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001", REFUSAL_TEXT))
+        e = km._api_error(self.p)
+        self.assertTrue(e["refusal"], "the CLI's refusal wording classifies on its own")
+        self.assertFalse(e["tooLong"] or e["spendLimit"] or e["modelLimit"] or e["authErr"])
+
+    def test_the_system_record_flags_the_episode_event_based(self):
+        # the EXACT event: a system model_refusal record whose parentUuid equals the blocking error's
+        # parentUuid (both point at the refused user message) — wording-independent, so a future CLI
+        # rephrase of the error text still classifies.
+        self._write(_uline(T0, "synthetic refused ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001", GENERIC_TEXT),
+                    _queueop(), _snapshot(),
+                    _sysrefusal(T0 + 2, "11111111-2222-3333-4444-000000000003",
+                                "11111111-2222-3333-4444-000000000001"))
+        self.assertTrue(km._api_error(self.p)["refusal"],
+                        "the linked system record marks the episode regardless of wording")
+
+    def test_the_fallback_subtype_marks_too(self):
+        # model_refusal_fallback with a still-BLOCKING error: each retry would also manufacture
+        # another model downgrade, so it is every bit as non-retryable.
+        self._write(_uline(T0, "synthetic refused ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001", GENERIC_TEXT),
+                    _sysrefusal(T0 + 2, "11111111-2222-3333-4444-000000000003",
+                                "11111111-2222-3333-4444-000000000001",
+                                subtype="model_refusal_fallback"))
+        self.assertTrue(km._api_error(self.p)["refusal"])
+
+    def test_a_plain_invalid_request_is_not_flagged(self):
+        self._write(_uline(T0, "synthetic ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001", GENERIC_TEXT))
+        self.assertFalse(km._api_error(self.p)["refusal"],
+                         "an invalid_request without refusal evidence stays transient")
+
+    def test_a_transient_500_is_not_flagged(self):
+        self._write(_uline(T0, "synthetic ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001",
+                            "API Error: 500 Internal server error.",
+                            status=500, category="server_error"))
+        self.assertFalse(km._api_error(self.p)["refusal"],
+                         "a 500 still auto-retries in Working — this must not widen")
+
+    def test_a_system_record_from_another_turn_does_not_mark(self):
+        # an UNLINKED refusal record (parentUuid points at a different user message) belongs to some
+        # other turn's story — it must not paint the current blocking error as a refusal.
+        self._write(_uline(T0, "synthetic ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001", GENERIC_TEXT),
+                    _sysrefusal(T0 + 2, "11111111-2222-3333-4444-000000000003",
+                                "11111111-2222-3333-4444-000000000042"))
+        self.assertFalse(km._api_error(self.p)["refusal"])
+
+    def test_the_flag_survives_the_cache(self):
+        self._write(_uline(T0, "synthetic refused ask", "11111111-2222-3333-4444-000000000001"),
+                    _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                            "11111111-2222-3333-4444-000000000001", REFUSAL_TEXT))
+        self.assertTrue(km._api_error(self.p)["refusal"])
+        self.assertIn(self.p, km._api_err_cache, "the first read populated the (mtime,size) cache")
+        self.assertTrue(km._api_error(self.p)["refusal"], "the flag rides the cached record")
+
+    def test_the_storm_shape_keeps_the_flag_per_episode(self):
+        # the audited shape: each injected retry clears the error (a genuine user prompt), the next
+        # refusal writes a NEW error record with a NEW uuid, and ITS system record must re-mark it.
+        rows = [_uline(T0, "synthetic refused ask", "11111111-2222-3333-4444-000000000001"),
+                _apierr(T0 + 1, "11111111-2222-3333-4444-000000000002",
+                        "11111111-2222-3333-4444-000000000001", GENERIC_TEXT),
+                _queueop(),
+                _sysrefusal(T0 + 2, "11111111-2222-3333-4444-000000000003",
+                            "11111111-2222-3333-4444-000000000001"),
+                _uline(T0 + 10, RETRY, "11111111-2222-3333-4444-000000000004",
+                       parent="11111111-2222-3333-4444-000000000003"),
+                _apierr(T0 + 11, "11111111-2222-3333-4444-000000000005",
+                        "11111111-2222-3333-4444-000000000004", GENERIC_TEXT),
+                _snapshot(),
+                _sysrefusal(T0 + 12, "11111111-2222-3333-4444-000000000006",
+                            "11111111-2222-3333-4444-000000000004")]
+        self._write(*rows)
+        e = km._api_error(self.p)
+        self.assertTrue(e["refusal"], "episode two is marked by ITS OWN system record")
+        self.assertEqual(e["uuid"], "11111111-2222-3333-4444-000000000005",
+                         "the latest episode's record stands")
+
+
+class FakeBackend:
+    """A minimal backend: a controllable pending queue + a record of what got sent."""
+    def __init__(self, pending=()):
+        self._pending = list(pending)
+        self.sent = []
+
+    def pending_queued(self, sid):
+        return list(self._pending)
+
+    def send(self, sid, text):
+        self.sent.append(text)
+        return True
+
+
+class RefusalNeverAutoRetried(unittest.TestCase):
+    """The retry gate: a refusal-flagged error never collects an auto-retry — not once per episode,
+    not once at all — because a retry re-sends the same prompt and manufactures the same refusal
+    (measured 12/12 in the audited storm). Manual Retry-now keeps the existing override contract."""
+
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self._saved = (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
+                       km._api_error, km._path_of, km._alive_sessions)
+        km._retry_paused_on = lambda: False
+        km._session_retry_suppressed = lambda sid: False
+        km._alive_sessions = lambda now, tmux: [{"sid": self.SID, "path": "/TESTDIR/x.jsonl"}]
+        km._path_of = lambda sid, now=None: "/TESTDIR/x.jsonl"
+        self.aerr = {"text": REFUSAL_TEXT, "status": None, "category": "invalid_request",
+                     "uuid": "11111111-2222-3333-4444-000000000101",
+                     "parentUuid": "11111111-2222-3333-4444-000000000100",
+                     "tooLong": False, "spendLimit": False, "modelLimit": False,
+                     "authErr": False, "refusal": True}
+        km._api_error = lambda path: self.aerr
+        self.be = FakeBackend()
+        km.Sessions = types.SimpleNamespace(backend_for=lambda sid: self.be)
+        km._auto_retried.clear()
+        km._auto_retry_state.clear()
+
+    def tearDown(self):
+        (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
+         km._api_error, km._path_of, km._alive_sessions) = self._saved
+        km._auto_retried.clear()
+        km._auto_retry_state.clear()
+
+    def _tick(self):
+        km._auto_retry_tick(1_000_000, {self.SID: {"state": ""}})
+
+    def test_two_successive_refusal_episodes_never_fire(self):
+        # THE storm shape: every refusal writes a new error record (new uuid → new episode), which is
+        # exactly why the once-per-episode gate alone could never terminate the loop.
+        self._tick()
+        self.assertEqual(self.be.sent, [], "episode one: a refusal is never auto-retried")
+        self.aerr = dict(self.aerr, uuid="11111111-2222-3333-4444-000000000102")
+        self._tick()
+        self.assertEqual(self.be.sent, [], "episode two (fresh uuid): still never — the storm is dead")
+
+    def test_manual_retry_still_fires(self):
+        # the existing manual-override contract: an explicit click is the user's call — they may have
+        # rewritten or dropped the offending thread since.
+        km._fire_api_retry(self.SID, self.be, manual=True)
+        self.assertEqual(self.be.sent, [RETRY])
+
+    def test_a_transient_server_error_still_auto_retries(self):
+        # the guard must not over-block: a 500 keeps the recovery path it always had.
+        self.aerr = {"text": "API Error: 500 Internal server error.", "status": 500,
+                     "category": "server_error", "uuid": "11111111-2222-3333-4444-000000000103",
+                     "tooLong": False, "spendLimit": False, "modelLimit": False,
+                     "authErr": False, "refusal": False}
+        self._tick()
+        self.assertEqual(self.be.sent, [RETRY])
+
+
+class SurfacesPinTheOnYouTreatment(unittest.TestCase):
+    """The flag has to reach every surface that already distinguishes on-you from transient, or the
+    tab keeps saying romp is handling a storm romp is deliberately not retrying."""
+
+    def test_the_auto_retry_skip_names_refusal(self):
+        fn = inspect.getsource(km._fire_api_retry)
+        self.assertIn('or _rerr.get("refusal")', fn,
+                      "the on-you skip must include the refusal — the kernel driver and every "
+                      "client ask share this one decision")
+
+    def test_the_card_floors_to_needs_you(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('or aerr.get("authErr") or aerr.get("refusal"))))', src,
+                      "api_block must include the refusal — otherwise the card sits in Working "
+                      "with the nudge suppressed and nothing able to move it")
+
+    def test_the_card_names_the_real_remedy(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('"refusal": bool(aerr.get("refusal"))', src)
+        self.assertIn("the model's safeguards refused this prompt — rewrite it or drop this thread",
+                      src)
+        self.assertIn("this session stopped on an API error — Retry to resume", src,
+                      "the transient wording stays for genuinely transient errors")
+
+    def test_the_status_flag_reaches_the_tab(self):
+        self.assertIn('"apiRefusal": bool(aerr and aerr.get("refusal"))',
+                      inspect.getsource(km.build_session))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -395,7 +395,7 @@ class AuthErrorClass(unittest.TestCase):
         self.assertIn('"authErr": _is_auth_error(text)', inspect.getsource(km._api_error))
         self.assertIn('"apiAuthErr": bool(aerr and aerr.get("authErr"))', inspect.getsource(km.build_session))
         feed = inspect.getsource(km.build_feed)
-        self.assertIn('aerr.get("authErr"))))', feed, "the card floors to needs-you")
+        self.assertIn('aerr.get("authErr") or aerr.get("refusal"))))', feed, "the card floors to needs-you")
         self.assertIn("sign-in or API key isn't working", feed, "the card names the real remedy")
 
 

--- a/ui/webview/api-error-reason.test.ts
+++ b/ui/webview/api-error-reason.test.ts
@@ -32,6 +32,15 @@ test("a spent MODEL allowance names the fix, not a wait (the user 2026-08-01)", 
   assert.doesNotMatch(s, /rate limited/i);
 });
 
+test("a safeguards refusal names the real fix, and outranks the status code (the user 2026-08-15)", () => {
+  // a refusal is deterministic on the same input — by status alone a 400 would read as an ordinary
+  // rejection, sending the user to retry the one class that can never succeed on a retry
+  const s = apiErrorReason({ status: 400, refusal: true });
+  assert.match(s, /safeguards refused this prompt/);
+  assert.match(s, /rewrite it or drop this thread/);
+  assert.equal(apiErrorReason({ refusal: true }), s, "with or without a status, the same words");
+});
+
 test("a dead network and a busy API are told apart", () => {
   assert.match(apiErrorReason({ status: 529, networkDown: true }), /offline/i);
   assert.doesNotMatch(apiErrorReason({ status: 529, networkDown: true }), /overloaded/i);

--- a/ui/webview/api-error-reason.ts
+++ b/ui/webview/api-error-reason.ts
@@ -15,6 +15,7 @@ export interface ApiErrorFacts {
   spendLimit?: boolean | null;
   tooLong?: boolean | null;
   modelLimit?: boolean | null;
+  refusal?: boolean | null;
 }
 
 // The plain-words reason, or "" when the facts don't identify one (callers then fall back to the bare
@@ -29,6 +30,10 @@ export function apiErrorReason(f: ApiErrorFacts): string {
   // A MODEL's own allowance, not the account's: "rate limited" would send the user off to wait when the
   // fix is one model switch away (the user 2026-08-01).
   if (f.modelLimit) return "this model is out of allowance — switch model or add credits";
+  // A safeguards refusal is deterministic on the same input — no retry or wait fixes it, only the prompt
+  // does (the user 2026-08-15). Same words as the chat card's remedy line, so the surfaces can't diverge.
+  // It outranks the status ladder: a refusal riding a 4xx would otherwise read as a plain rejection.
+  if (f.refusal) return "the model's safeguards refused this prompt — rewrite it or drop this thread";
   if (f.networkDown) return "this machine is offline";
   if (f.rateLimitType) return `rate limited (${f.rateLimitType})`;
   const s = Number(f.status);

--- a/ui/webview/apierror-refusal.test.ts
+++ b/ui/webview/apierror-refusal.test.ts
@@ -1,0 +1,63 @@
+// Safeguards-refusal handling (the user 2026-08-15): a classifier refusal ("<Model>'s safeguards
+// flagged this message…") is DETERMINISTIC on the same input — a retry re-sends the same prompt and
+// manufactures the same refusal (one refused prompt drew twelve auto-retries in ~6 minutes before this),
+// and in fallback configurations each retry manufactures another model downgrade. The kernel classifies
+// it (_api_error.refusal — the system model_refusal_* record linked by parentUuid, plus the CLI's own
+// wording as a co-equal signature) and never auto-retries it; the client skips it in the retry tick,
+// renders it red/on-you, and names the real fix: rewrite the prompt or drop the thread. The chat/feed
+// renderers have no jsdom harness, so pin the wiring at source. (Kernel side:
+// tests/test_kernel_refusal_retry.py.)
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const R = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const F = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+test("Status carries the per-session apiRefusal flag", () => {
+  assert.match(R, /apiRefusal\?: boolean/);
+});
+
+test("the auto-retry tick SKIPS a refused thread (a retry manufactures the same refusal)", () => {
+  assert.match(R, /!s\.status\.retrySuppressed && !s\.status\.apiSpendLimit && !s\.status\.apiModelLimit && !s\.status\.apiAuthErr && !s\.status\.apiRefusal/);
+});
+
+test("a refusal paints the tab alarm-red (on-you), not amber retrying", () => {
+  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit \|\| s\.status\.apiModelLimit \|\| s\.status\.apiAuthErr \|\| s\.status\.apiRefusal\) \? "tab-blocked" : "tab-retrying"/);
+});
+
+test("the chat error card drops Retry on a refusal and names the real fix in plain terms", () => {
+  const apiErr = R.slice(R.indexOf("function renderApiError"), R.indexOf("// ── API-error auto-retry"));
+  // the refusal joins the no-Retry gate (the button cannot work — same contract as the other on-you classes)
+  assert.match(apiErr, /const refusal = !!st\?\.apiRefusal;/);
+  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit \|\| !!st\?\.apiModelLimit \|\| !!st\?\.apiAuthErr \|\| refusal;/);
+  // …and the countdown line says what happened + the fix, never "retrying soon…" — via the ONE shared
+  // remedy string, so this write and the tick's re-assert below cannot drift into different words
+  assert.match(R, /const REFUSAL_REMEDY = "the model's safeguards refused this prompt — rewrite it or drop this thread";/);
+  assert.match(apiErr, /if \(refusal\) countdown\.textContent = REFUSAL_REMEDY;/);
+  // no Dismiss-dialog dead button either: the Esc-sender is for the CLI's spend-limit menu, which a
+  // refusal never parks
+  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{/);
+});
+
+test("the 1s countdown tick RE-ASSERTS the refusal remedy — it must never write \"retrying soon…\" over it", () => {
+  // apiRetryTick's countdown writer runs every second; without its own branch it fell through to the
+  // else arm (a refusal session is out of the retry set, so `at` is always undefined) and overwrote the
+  // remedy with "retrying soon…" one second after render — promising a retry the kernel never fires.
+  // The branch leads the ladder (the global pause is about auto-retry, which a refusal never gets), and
+  // WRITING each tick, rather than skipping, also heals the Stop/Resume-all handler's blanket rewrite.
+  const tick = R.slice(R.indexOf("function apiRetryTick"), R.indexOf("function renderTool"));
+  assert.match(tick, /if \(active\?\.status\.apiRefusal\) \{/);
+  assert.match(tick, /cd\.textContent = REFUSAL_REMEDY;\s*\} else if \(globalRetryPaused\) \{/,
+    "the remedy branch sits ABOVE the paused/suppressed/countdown chain");
+});
+
+test("the feed card badges a refusal and HIDES Retry (a useless click there)", () => {
+  assert.match(F, /const refusal = !!\(it\.blocked && it\.blocked\.refusal\)/);
+  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none"/);
+  assert.match(F, /refusal \? "⚠ Safeguards refused"/);
+  assert.match(F, /refusal\?: boolean/);
+  // the badge tooltip carries the kernel's plain-terms remedy, not the CLI's boilerplate
+  assert.match(F, /\(spendLimit \|\| refusal\) \? it\.blocked\.what/);
+});

--- a/ui/webview/apierror-spend-limit.test.ts
+++ b/ui/webview/apierror-spend-limit.test.ts
@@ -24,7 +24,8 @@ test("the auto-retry tick SKIPS a spend-capped thread (retrying can't fix a bill
 });
 
 test("a spend cap paints the tab alarm-red (on-you), not amber retrying", () => {
-  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit \|\| s\.status\.apiModelLimit \|\| s\.status\.apiAuthErr\) \? "tab-blocked" : "tab-retrying"/);
+  // a safeguards refusal is the fifth on-you class (the user 2026-08-15) — see apierror-refusal.test.ts
+  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit \|\| s\.status\.apiModelLimit \|\| s\.status\.apiAuthErr \|\| s\.status\.apiRefusal\) \? "tab-blocked" : "tab-retrying"/);
 });
 
 test("the paused line names the spend cap and points at the settings page (no fake countdown)", () => {
@@ -38,7 +39,7 @@ test("the globalRetryPaused push reason is threaded into the client", () => {
 
 test("the feed card badges a spend cap and HIDES Retry (a useless click there)", () => {
   assert.match(F, /const spendLimit = !!\(it\.blocked && it\.blocked\.spendLimit\)/);
-  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit\) \? "" : "none"/);
+  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none"/);
   assert.match(F, /spendLimit \? "⚠ Spend limit"/);
   assert.match(F, /spendLimit\?: boolean/);
 });

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -66,6 +66,28 @@ test("spend-limit and prompt-too-long blocks say what they are", () => {
   assert.match(tl.text, /prompt too long/);
 });
 
+test("a refusal block names the refusal and the remedy — never a bare \"API error\"", () => {
+  // the fifth on-you class (the user 2026-08-15): a refusal ships state:"apiError" + refusal:true with
+  // no status, which fell through to the generic label while the card itself said "Safeguards refused"
+  const rf = badgeNotices([base({ blocked: { state: "apiError", refusal: true } })], new Set()).notices[0];
+  assert.equal(rf.kind, "apierror");
+  assert.match(rf.text, /safeguards refused this prompt — rewrite it or drop this thread/);
+  assert.doesNotMatch(rf.text, /API error/);
+  // a refusal that rides a 4xx must still read as the refusal, not "the request itself was rejected"
+  const rf400 = badgeNotices([base({ blocked: { state: "apiError", status: 400, refusal: true } })], new Set()).notices[0];
+  assert.match(rf400.text, /safeguards refused/);
+  assert.doesNotMatch(rf400.text, /API error 400/);
+});
+
+test("a refusal after a plain error on the same card is a NEW episode — its own bell entry", () => {
+  // the signature's class slot must discriminate the refusal, or a refusal arriving while a status-less
+  // transient episode is still in the seen set (error → auto-retry → refusal) mints no entry at all
+  const plain = badgeNotices([base({ blocked: { state: "apiError" } })], new Set());
+  const after = badgeNotices([base({ blocked: { state: "apiError", refusal: true } })], new Set(plain.active));
+  assert.equal(after.notices.length, 1, "the refusal logs afresh under its own signature");
+  assert.match(after.notices[0].text, /safeguards refused/);
+});
+
 test("a /clear boundary that dropped cards logs once, naming them and the way back", () => {
   // the user 2026-07-27: the boundary settle was fully silent — cards left the board with one
   // stderr line. The bell entry is the durable "you saw it happen" record.

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -24,7 +24,7 @@ export interface BadgeItem {
   nudgeFailed?: boolean;
   retrying?: { since?: number | null; count?: number; max?: number | null; status?: number | string | null; networkDown?: boolean | null; rateLimitType?: string | null } | null;
   warns?: { kind: string; t: number; msg: string }[] | null;
-  blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean; modelLimit?: boolean } | null;
+  blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean; modelLimit?: boolean; refusal?: boolean } | null;
 }
 // sid + itemId ride along so a bell entry can JUMP back to the card it was minted from (the user
 // 2026-07-28): the shell posts them back as {romp:'revealCard'} and the feed scrolls + pulses the card.
@@ -58,11 +58,13 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
     // only the API-error block is an ERROR; a permission ask / picker is ordinary Needs-you traffic
     if (it.blocked && it.blocked.state === "apiError") {
       const b = it.blocked;
-      // spendLimit / tooLong / modelLimit already read as plain words; apiErrorReason covers them too, so the
-      // whole verdict comes from one place and the bell can't describe a failure differently than the chat does.
-      const onYou = b.spendLimit || b.tooLong || b.modelLimit;
+      // spendLimit / tooLong / modelLimit / refusal already read as plain words; apiErrorReason covers them too,
+      // so the whole verdict comes from one place and the bell can't describe a failure differently than the chat
+      // does. The signature's class slot keeps each on-you class a distinct EPISODE from a plain error on the
+      // same card (a refusal often replaces a transient error mid-storm and must still mint its own entry).
+      const onYou = b.spendLimit || b.tooLong || b.modelLimit || b.refusal;
       const what = apiErrorReason(b) || "API error" + (b.status ? " " + b.status : "");
-      add("e|" + it.itemId + "|" + (b.status || "") + "|" + (b.spendLimit ? "sl" : b.tooLong ? "tl" : b.modelLimit ? "ml" : ""),
+      add("e|" + it.itemId + "|" + (b.status || "") + "|" + (b.spendLimit ? "sl" : b.tooLong ? "tl" : b.modelLimit ? "ml" : b.refusal ? "rf" : ""),
         "apierror", it.name + " — " + (b.status && !onYou ? "API error " + b.status + ": " : "") + what);
     }
   }

--- a/ui/webview/dismiss-dialog.test.ts
+++ b/ui/webview/dismiss-dialog.test.ts
@@ -15,12 +15,14 @@ const K = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py
 const apiErr = R.slice(R.indexOf("function renderApiError"), R.indexOf("// ── API-error auto-retry"));
 
 test("a spend cap suppresses the Retry button entirely", () => {
-  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit \|\| !!st\?\.apiModelLimit \|\| !!st\?\.apiAuthErr;/);
+  // a safeguards refusal joins the no-Retry classes (the user 2026-08-15) — see apierror-refusal.test.ts
+  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit \|\| !!st\?\.apiModelLimit \|\| !!st\?\.apiAuthErr \|\| refusal;/);
   assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?retry\.textContent = "Retry now";/);
 });
 
 test("a tmux spend cap offers Dismiss dialog, posting the dismissDialog op", () => {
-  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux"\) \{/);
+  // refusal-gated: the Esc-sender is for the CLI's spend-limit dialog — a refusal parks no menu
+  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{/);
   assert.match(apiErr, /dismiss\.textContent = "Dismiss dialog";/);
   assert.match(apiErr, /vscodeApi\.postMessage\(\{ type: "dismissDialog", id: activeId \}\)/);
   // acknowledges the click at once (disable + "Dismissing…"), like every other card control
@@ -29,11 +31,11 @@ test("a tmux spend cap offers Dismiss dialog, posting the dismissDialog op", () 
 
 test("an SDK spend cap shows neither Retry nor a Dismiss button (raise-the-cap line only)", () => {
   // the Dismiss branch is tmux-gated, so an SDK spend cap falls through with no button appended
-  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux"\) \{[\s\S]*?head\.appendChild\(dismiss\);\s*\}/);
+  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{[\s\S]*?head\.appendChild\(dismiss\);\s*\}/);
 });
 
 test("the countdown reads the spend-cap message, never a fake retry countdown", () => {
-  assert.match(apiErr, /if \(spendCap\) countdown\.textContent = "spend limit reached — raise it at claude\.ai\/settings\/usage";/);
+  assert.match(apiErr, /else if \(spendCap\) countdown\.textContent = "spend limit reached — raise it at claude\.ai\/settings\/usage";/);
 });
 
 // kernel contract this card codes against (node-tests-pin-kernel-source precedent)

--- a/ui/webview/feed-apierror-working.test.ts
+++ b/ui/webview/feed-apierror-working.test.ts
@@ -20,7 +20,8 @@ test("the apiError chip + Retry still show (they key on blocked.state, not the c
   assert.match(FEED, /const isApiErr = it\.blocked\?\.state === "apiError";/);
   assert.match(FEED, /a\._apiBadge\.style\.display = isApiErr \? "" : "none";/);
   // Retry shows for a transient/on-you-compactable error but is HIDDEN for a spend cap (retrying can't lift a
-  // billing limit) — the user 2026-07-14; the spend-cap wiring is pinned in apierror-spend-limit.test.ts.
-  assert.match(FEED, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit\) \? "" : "none";/);
+  // billing limit) — the user 2026-07-14; the spend-cap wiring is pinned in apierror-spend-limit.test.ts,
+  // and a safeguards refusal joins the hide (the user 2026-08-15) — pinned in apierror-refusal.test.ts.
+  assert.match(FEED, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none";/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -81,6 +81,7 @@ interface AskItem {
               tooLong?: boolean;   // apiError: a "prompt is too long" error (on you → compact) vs a transient API error
               spendLimit?: boolean;   // apiError: a monthly spend cap (on you → raise it, never auto-retried; the user 2026-07-14)
               modelLimit?: boolean;   // apiError: this session's MODEL is out of allowance (on you → switch model or add credits; the user 2026-08-01)
+              refusal?: boolean;   // apiError: the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — deterministic on the same input, the user 2026-08-15)
               mode?: string; since?: number;   // judgeAuth adds these: which billing its judges ride ('key'|'login') + the first refusal time — romp can't analyze the session until the credential is fixed (the user 2026-08-12)
               toName?: string; toSid?: string;    // parkedHandoff adds to*
               mid?: string; frm?: string; to?: string; origin?: string; body?: string; gist?: string };   // quarantine (held peer mail) adds these; gist = the bus's 90-char collapse for the compact card line
@@ -1768,12 +1769,15 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // a transient stall, not a block — so this badge + Retry are the only API-error cue; no column move.
   const spendLimit = !!(it.blocked && it.blocked.spendLimit);
   const modelLimit = !!(it.blocked && it.blocked.modelLimit);
+  const refusal = !!(it.blocked && it.blocked.refusal);
   a._apiBadge.style.display = isApiErr ? "" : "none";
   // Retry pastes "retry" to resume a stalled turn — useless against a monthly spend cap (retrying can't lift a
   // billing limit), so hide it there and let the badge tell you to raise the cap (the user 2026-07-14).
   // A spent MODEL allowance is the same shape: Retry re-fails until you switch model or top up, and the
   // badge says so (the user 2026-08-01). Its window does reset on its own, which the badge title carries.
-  a._apiRetry.style.display = (isApiErr && !spendLimit && !modelLimit) ? "" : "none";
+  // A safeguards REFUSAL is the same shape again (the user 2026-08-15): deterministic on the same input,
+  // so Retry re-collects the same refusal — the badge names the real fix (rewrite it or drop the thread).
+  a._apiRetry.style.display = (isApiErr && !spendLimit && !modelLimit && !refusal) ? "" : "none";
   // "Continue" shows on a LIVE needs-you card with no live ask attached: the gesture claims "you're not
   // waiting on me", which means nothing in Working/Completed, can't answer a real permission prompt or
   // picker (it.blocked — text sent there would just queue behind the ask), and has no one to tell on a
@@ -1791,8 +1795,10 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     a._apiBadge.textContent = spendLimit ? "⚠ Spend limit"
       : it.blocked.tooLong ? "⚠ Prompt too long"
       : modelLimit ? "⚠ Model limit"
+      : refusal ? "⚠ Safeguards refused"
       : it.blocked.status ? `⚠ API error · ${it.blocked.status}` : "⚠ API error";
-    a._apiBadge.title = spendLimit ? it.blocked.what : (it.blocked.text || it.blocked.what);
+    // a refusal's raw CLI text buries the remedy — the kernel's `what` states it plainly, so title with that
+    a._apiBadge.title = (spendLimit || refusal) ? it.blocked.what : (it.blocked.text || it.blocked.what);
     a._apiRetry.disabled = false; a._apiRetry.textContent = "Retry";
     a._apiRetry.onclick = (ev: Event) => {
       ev.stopPropagation();

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -217,7 +217,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -3148,6 +3148,10 @@ function restoreToComposer(text: string) {
 // never touched — the toast alone covers it.
 const pendingCancelRestores = new Map<string, { before: string; after: string }>();
 
+// The refusal card's remedy line, ONE string: renderApiError's initial write and apiRetryTick's
+// per-second re-assert both read it, so the card and the tick can never drift into different words.
+const REFUSAL_REMEDY = "the model's safeguards refused this prompt — rewrite it or drop this thread";
+
 // The turn stopped on an API error — the session is BLOCKED until retried. A red-dot card at the bottom
 // (so it stands out, the user 2026-06-16) carrying the error text + a red "API error" badge and a Retry
 // button that pastes "retry" into the session to resume the stalled turn.
@@ -3174,7 +3178,11 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
   // changes or its own window resets, so the card names the fix instead of offering a button that cannot work.
   // A dead CREDENTIAL is the same shape (the user 2026-08-08, per-session auth): retrying re-presents the
   // broken login/key forever — the fix is /login, the key, or switching which one the session bills.
-  const spendCap = !!st?.apiSpendLimit || !!st?.apiModelLimit || !!st?.apiAuthErr;
+  // A safeguards REFUSAL too (the user 2026-08-15): a refusal is deterministic on the same input — a
+  // retry re-sends the same prompt and manufactures the same refusal — so no button; the line below
+  // names the real fix (rewrite the ask, or drop this thread).
+  const refusal = !!st?.apiRefusal;
+  const spendCap = !!st?.apiSpendLimit || !!st?.apiModelLimit || !!st?.apiAuthErr || refusal;
   if (!spendCap) {
     const retry = el("button", "apierror-retry") as HTMLButtonElement;
     retry.textContent = "Retry now";
@@ -3191,7 +3199,8 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
       setTimeout(() => { if (retry.isConnected) { retry.disabled = false; retry.textContent = "Retry now"; } }, 2500);
     });
     head.appendChild(retry);
-  } else if (st?.backend === "tmux") {
+  } else if (st?.backend === "tmux" && !refusal) {
+    // (a refusal parks no menu — the Esc-sender below is for the CLI's spend-limit dialog only)
     const dismiss = el("button", "apierror-retry") as HTMLButtonElement;   // same button chrome, different verb
     dismiss.textContent = "Dismiss dialog";
     dismiss.title = "the terminal is showing the spend-limit menu — send Esc to close it (cancels; changes no billing setting)";
@@ -3208,7 +3217,8 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
   // Per-thread suppression (the user 2026-07-06): the user interrupted THIS thread's storm → its auto-retry is
   // held off until a successful turn re-arms it. Distinct from the global pause; "Retry now" + a message still work.
   const suppressed = activeId ? !!sessions.get(activeId)?.status.retrySuppressed : false;
-  if (spendCap) countdown.textContent = "spend limit reached — raise it at claude.ai/settings/usage";   // never "retrying soon…": the tick skips spend-capped threads
+  if (refusal) countdown.textContent = REFUSAL_REMEDY;   // never "retrying soon…": a refusal is deterministic, and the tick RE-ASSERTS this line every second
+  else if (spendCap) countdown.textContent = "spend limit reached — raise it at claude.ai/settings/usage";   // never "retrying soon…": the tick skips spend-capped threads
   else if (paused) countdown.textContent = retryPausedText();   // a usage-limit pause counts down to the window reset
   else if (suppressed) countdown.textContent = "auto-retry stopped for this session — send a message to resume";
   const stop = el("button", "apierror-stop") as HTMLButtonElement;
@@ -3270,7 +3280,9 @@ function apiRetryTick(): void {
     // never auto-retried — the card asks you to raise it instead (the global pause it engages also gates this).
     // A spent MODEL allowance (apiModelLimit) is out for the same reason: every retry re-fails until the
     // user switches model or tops up, and the card says exactly that (the user 2026-08-01).
-    sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit && !s.status.apiModelLimit && !s.status.apiAuthErr) blocked.add(id); });
+    // A safeguards REFUSAL (apiRefusal) is out too (the user 2026-08-15): a refusal is deterministic on
+    // the same input, so every retry re-sends the same prompt and manufactures the same refusal.
+    sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit && !s.status.apiModelLimit && !s.status.apiAuthErr && !s.status.apiRefusal) blocked.add(id); });
     apiRetryNext.forEach((_, id) => { if (!blocked.has(id)) apiRetryNext.delete(id); });   // recovered / suppressed → stop
     blocked.forEach((id) => {
       // The kernel owns the cadence now (the user 2026-07-29): it backs each outage's attempts off up to
@@ -3299,7 +3311,13 @@ function apiRetryTick(): void {
   const cd = cds.length ? (cds[cds.length - 1] as HTMLElement) : null;
   if (cd) {
     const active = activeId ? sessions.get(activeId) : null;
-    if (globalRetryPaused) {
+    if (active?.status.apiRefusal) {
+      // A refusal is never auto-retried, so there is no countdown to show — hold the remedy line.
+      // FIRST in the ladder: the global pause is about auto-retry, which a refusal never gets. Writing
+      // (not skipping) each tick also heals the Stop/Resume-all handler's blanket countdown rewrite
+      // within a second, without that handler needing per-session context.
+      cd.textContent = REFUSAL_REMEDY;
+    } else if (globalRetryPaused) {
       cd.textContent = retryPausedText();
     } else if (active?.status.retrySuppressed) {
       cd.textContent = "auto-retry stopped for this session — send a message to resume";
@@ -4070,9 +4088,10 @@ function renderTabs() {
     const st = s.status.state;
     if (st === "working") tab.classList.add("tab-working");
     // "blocked" is an API error. An on-YOU one — "prompt is too long" (compact), a monthly spend cap (raise it,
-    // the user 2026-07-14), or a spent model allowance (switch model, the user 2026-08-01) — is alarm-red dashed; a TRANSIENT API error is auto-retrying and needs no attention → the
+    // the user 2026-07-14), a spent model allowance (switch model, the user 2026-08-01), or a safeguards
+    // refusal (rewrite the ask, the user 2026-08-15) — is alarm-red dashed; a TRANSIENT API error is auto-retrying and needs no attention → the
     // amber retrying treatment, not red (the user 2026-06-29).
-    else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit || s.status.apiModelLimit || s.status.apiAuthErr) ? "tab-blocked" : "tab-retrying");
+    else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit || s.status.apiModelLimit || s.status.apiAuthErr || s.status.apiRefusal) ? "tab-blocked" : "tab-retrying");
     else if (st === "needsInput" || st === "awaiting") tab.classList.add("tab-awaiting");   // legacy name = an older remote kernel
     else if (st === "retrying") tab.classList.add("tab-retrying");       // amber: soft-blocked on an API auto-retry
     else if (st === "compacting" || st === "clearing") tab.classList.add("tab-compacting");   // both: a context op in flight


### PR DESCRIPTION
## What breaks

When the model's safeguards refuse a prompt, the CLI records it as an assistant API-error record (`isApiErrorMessage: true`, error `invalid_request`, text carrying the refusal notice), usually followed a few records later by a system record (subtype `model_refusal_no_fallback` or `model_refusal_fallback`). `_api_error` classifies that record as transient, so the auto-retry re-sends the identical prompt — but a refusal is deterministic on the same input: every attempt fails the same way and writes a NEW error record. A new record means a new uuid, hence a new retry episode, so the once-per-episode gate can never terminate the loop. In one observed window a single refused prompt drew 12 injected retries in about 6 minutes, each burning a full turn on a guaranteed failure; in configurations with model fallback enabled, each retry can additionally trigger another fallback switch.

## Reproduction

Transcript shape (full synthetic fixtures in `tests/test_kernel_refusal_retry.py`): a user record, then an assistant record with `isApiErrorMessage: true` whose text carries the refusal wording, then usually a `system` record with a `model_refusal_*` subtype sharing the error's `parentUuid` (queue-operation / file-history-snapshot records interleave between them). On the current base, `_api_error` returns that error with no on-you flag, `_fire_api_retry` treats it as transient, and `_auto_retry_tick` drives a retry each pusher cycle with no client open; each refusal writes a fresh error record with a fresh uuid, so the storm never ends.

## The fix

Refusal joins tooLong / spendLimit / modelLimit / authErr as a fifth on-you, never-auto-retried class, following the existing groove end to end.

Detection is two-signal, and both signals are required by the observed evidence:

1. **Event path** — the system `model_refusal_*` record, linked to the blocking error by shared `parentUuid` (the record and the assistant error both carry the refused user message's uuid; the record's `refusedUserMessageUuid` field was observed diverging from that linkage in 2 of 13 records, so it is deliberately not the link). This half survives any future rewording of the CLI text.
2. **The error text's own signature** ("safeguards flagged" / the aup URL) — co-equal rather than a fallback, because the CLI omits the system record entirely for some refusal errors (observed in the same storm that produced linked ones), and at a transcript's tail the error record can be flushed a beat before its system record, so the very first read must classify right.

The flag rides the same (mtime,size) cache as its siblings. `_fire_api_retry` adds refusal to the auto-path skip — one gate shared by the kernel's own `_auto_retry_tick` and every client ask — while manual Retry-now keeps the existing explicit-override contract (the user may have rewritten or dropped the thread). `build_session` ships `apiRefusal` beside the other four flags; `build_feed` floors the card to needs-input and names the actionable fix ("rewrite it or drop this thread") instead of leaving a working card on a session nothing can move.

The second commit is the dashboard mirror, at every site `apiModelLimit` already touches, and is separately droppable (the kernel commit alone kills the storm — the client tick's redundant asks hit `_fire_api_retry`'s non-manual guard):

- the tab paints alarm-red (blocked), never amber (retrying);
- the chat error card drops the Retry and tmux Dismiss-dialog buttons (neither can act on a refusal — it parks no spend menu) and holds the remedy line, which the 1s countdown tick re-asserts first in its ladder so "retrying soon…" never overwrites it;
- the feed card hides Retry and badges "⚠ Safeguards refused", with the kernel's plain-terms remedy as the tooltip instead of the CLI boilerplate that buries it;
- the notification bell names the refusal in the same words via `apiErrorReason` — ahead of the status ladder, so a refusal riding a 4xx doesn't read as a generic rejection — and the bell's episode signature gains a refusal class slot, so a refusal replacing a transient error on the same card still mints its own entry.

## Tests

- `tests/test_kernel_refusal_retry.py` — 17 new cases, fully synthetic fixtures: the text predicate, the parentUuid event linkage (interleaved queue-operation / file-history-snapshot records, a system record from another turn not marking, the fallback subtype), the (mtime,size) cache, the storm shape re-marking per episode, never-auto-fired across successive episodes, manual retry still firing, a transient 500 still auto-retrying, and source pins on every surface.
- `ui/webview/apierror-refusal.test.ts` — pins the client wiring at source in the existing style; `badge-mirror.test.ts` and `api-error-reason.test.ts` gain behavioral bell tests.
- Six existing test files get their widened-expression pins updated in place; transient-error auto-retry behavior is unchanged and pinned.
- Red-first: against the unfixed base the new/updated tests fail (18 pytest failures, 16 node failures); with the fix, full suites are green (pytest 4945 passed / 40 skipped; node 2156/2156; tsc clean; build clean; bats 336/336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)