### PR TITLE
Idle SDK sessions hear their own alarms: stranded queued notifications now drive a turn

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -175,6 +175,29 @@ can show its login's windows and its key's spend together. Only turns whose
 session billed the key count toward the API numbers — a login turn's computed
 cost is dollars nobody pays.
 
+### Self-scheduled work wakes an idle session
+
+A session's own scheduled work (a recurring Monitor, a cron firing, a
+background task's completion notice) arrives as a queued notification even
+while the session is idle. The Claude Code CLI usually delivers it on its
+own, starting the turn within a fraction of a second; but a session can fall
+into a stuck state where the CLI only queues, nothing ever starts the turn
+that reads the queue, and the backlog waits silently until your next message.
+Romp watches for that: once a queued notification has sat undelivered for a
+minute (well past the CLI's own delivery window) with no turn running, one
+driven turn delivers every text that has waited out that minute, verbatim and
+with no words of Romp's own, and logs one kernel-log line per wake; a newer
+arrival waits out its own minute rather than delaying the rest. A
+notification that arrives mid-turn is delivered once the turn settles, and
+one whose delivery a kernel restart interrupted is re-driven on the next
+boot rather than dropped. Notifications
+the CLI delivers itself in either state (a background agent finishing) are
+left to it, and sessions that are mid-turn, compacting, blocked on an API
+error, retry-paused, or that you interrupted or ended are left alone. On the
+first run after an upgrade, a session holding a genuinely old queued backlog
+may get one catch-up turn delivering it; that is this feature doing its job
+once.
+
 ### Install-time switches
 
 For `./install.sh`:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3515,14 +3515,16 @@ def _launch_error(sid):
 
 
 def _backend_queued(sid):
-    """True if the session's backend holds queued-but-unstarted user turns (the SDK keeps them in _pending;
+    """True if the session's backend holds queued-but-unstarted USER turns (the SDK keeps them in _pending;
     tmux folds them from the transcript's queue-op records). Composer sends now go straight to that queue
     while a turn runs (_send_or_park), so 'the user has messages waiting' — the nudge-suppression guard —
-    must consult it, not just the kernel FIFO. Guarded: a backend hiccup reads as 'nothing queued' rather
-    than crashing the nudge check."""
+    must consult it, not just the kernel FIFO. Genuine entries only: the idle-queue drive parks harness
+    wrappers in the same SDK _pending, and a wrapper is not the user having said something (the tmux fold
+    already filters via _pending_queued). Guarded: a backend hiccup reads as 'nothing queued' rather than
+    crashing the nudge check."""
     try:
         be = Sessions.backend_for(str(sid))
-        return bool(be and be.pending_queued(str(sid)))
+        return bool(be) and any(_genuine_queued(t) for t in be.pending_queued(str(sid)))
     except Exception:
         return False
 
@@ -6027,6 +6029,72 @@ def _auto_retry_tick(now, tmux):
                 _fire_api_retry(sid, be)
         except Exception:
             sys.stderr.write("auto-retry (session %s): %s\n" % (sid or "?", traceback.format_exc()))
+
+
+def _idle_queue_drive_tick(now, tmux):
+    """KERNEL-side driver for self-scheduled wake signals stuck in an idle SDK session's CLI queue
+    (the user 2026-08-18 — the full story on _undelivered_wake_tail). In the CLI's STUCK regime it
+    only enqueues; romp drives the turn that delivers, the way boot reconcile already does for its
+    own persisted queues — the same recovery for a queue that lives in the CLI instead of the reg.
+    In the CLI's DELIVERING regime (most sessions — see the measurement on the comment block above
+    _undelivered_wake_tail) the CLI starts that turn itself within milliseconds, and romp must stay
+    out of its way. Kernel-side gates:
+      * the AGE FLOOR, PER ENTRY: an entry qualifies once IT is _WAKE_DRIVE_FLOOR_S old, and only
+        the aged subset drives — a younger entry may still be racing the CLI's own delivery, so it
+        waits out its own floor and drives on a later parse. (Keyed on the NEWEST entry, the floor
+        never expired under any sub-floor wake cadence — a 30s monitor reset the clock on every
+        enqueue, and two simulated hours stranded 240 pending entries with zero drives, silently:
+        the exact pathology this drive exists to end.) No aged wake signal → stand down WITHOUT
+        latching, the next parse re-checks. The floor is a documented exception to the
+        no-time-windows rule (the armStale shape): the event it approximates — the CLI deciding
+        NOT to deliver — emits no record, so only its delivery window passing proves the stuck
+        regime, and a drive-time re-parse alone cannot close the race (the CLI can deliver between
+        the re-check and romp's enqueue landing). The delivering regime's own user record clears an
+        entry long before its floor expires; the stuck regime's entries age past it and drive.
+      * the GLOBAL retry pause stands everything down (the user paused romp's self-driving);
+      * a retry-SUPPRESSED session stands down (the user interrupted that thread's storm — a clean
+        user turn re-arms it, _auto_resume_session_retry);
+      * an API-error-BLOCKED session stands down (the auto-retry tick owns that recovery; driving
+        into the error would just burn the wake on a turn that cannot run);
+      * a tail with no wake signal in it does not drive — a bare queued user message (and a
+        background-agent completion notice, which the CLI delivers itself in EVERY regime) is the
+        CLI's own to deliver, and romp re-sending it would double-deliver.
+    The backend owns the rest (open turn, compaction, ended/cut sessions, the per-watermark latch,
+    the dormant-spawn stagger) — see SdkBackend.drive_idle_queue. tmux sessions are skipped by
+    ownership: their CLI is interactive and delivers its own queue."""
+    be = _sdk()
+    if be is None or not hasattr(be, "drive_idle_queue"):
+        return
+    if _retry_paused_on():
+        return
+    cands = []
+    for s in _alive_sessions(now, tmux):
+        sid = str(s.get("sid") or "")
+        path = s.get("path")
+        try:
+            if not sid or not path or not be.owns(sid):
+                continue
+            entries, mark = _undelivered_wake_tail(path)
+            if mark is None or not any(e["wrapper"] for e in entries):
+                continue
+            aged = [e for e in entries if now - _wake_ts_epoch(e["ts"]) >= _WAKE_DRIVE_FLOOR_S]
+            wa = [e for e in aged if e["wrapper"]]
+            if not wa:
+                continue                   # no wake signal past its own delivery window — stand down
+            #                                WITHOUT latching; the next parse re-checks (see docstring)
+            if _session_retry_suppressed(sid):
+                continue
+            if _api_error(path):
+                continue
+            cands.append({"sid": sid, "path": str(path), "entries": aged,
+                          "mark": (wa[-1]["pos"], wa[-1]["ts"])})
+            #              ^ the newest DRIVEN wrapper, never the newest pending entry: latching past
+            #                the still-young entries would make the backend's prev-filter skip them
+            #                forever once they age — they must exceed the mark on a later parse
+        except Exception:
+            sys.stderr.write("idle-queue-drive (%s): %s\n" % (sid or "?", traceback.format_exc()))
+    if cands:
+        be.drive_idle_queue(cands)
 
 
 def _predict_working(flavor, ids=None, sid=None):
@@ -10901,6 +10969,159 @@ def _pending_queued(path):
     return out
 
 
+# ── Idle-queue drive: wake signals stuck in an idle SDK CLI's queue (the user 2026-08-18) ──
+# Under the SDK backend a session's own scheduled work — a recurring Monitor, a cron firing, a
+# background task's completion notice — lands as a queue-operation enqueue in the CLI's queue. What
+# happens next has TWO regimes (measured across this machine's live SDK transcripts, 2026-08-18: of
+# 1311 monitor/cron/bash-class task-notification enqueues, 602 were delivered by the CLI itself
+# straight from idle at median 46ms, p90 126ms, across 25 sessions — the delivery writes NO dequeue
+# record; the non-meta user record carrying the text IS the evidence — and the rest were discarded
+# by content-addressed removes or stranded):
+#   * the DELIVERING regime — most sessions, most of the time: the CLI auto-starts the turn itself
+#     within milliseconds, and romp must stay out of its way or the model hears the same
+#     notification twice and acts on it twice;
+#   * the STUCK regime — the pathology this drive exists for: the CLI never starts that turn and the
+#     backlog only grows. Hit twice in one day: an overnight 15-minute Monitor stacked 33 on-time
+#     <task-notification> enqueues with ZERO turns for eight hours, and a recurring cron behaved the
+#     same with the CLI process alive (that transcript: 123 enqueues, 0 delivered, 66 removes =
+#     discards). There, the driven turn must carry the queued texts itself.
+# The CLI writes no record of DECIDING not to deliver, so the regimes are indistinguishable at
+# enqueue time — only the delivery window passing proves the stuck one. Hence _WAKE_DRIVE_FLOOR_S in
+# _idle_queue_drive_tick, applied PER ENTRY — each enqueue waits out its own floor, so a fast-cadence
+# stream cannot keep resetting the clock (a documented exception to the no-time-windows rule;
+# rationale on the tick's docstring). Background-AGENT completion notices (a-prefixed 17-hex task
+# ids) are the CLI's own to deliver in EVERY regime — verified even in the stuck session — so they
+# are never wake signals
+# (carve-out below). Event-based otherwise, no new polling: these records are the same
+# queue-operations _pending_queued folds for the chat's queued chip (whose _genuine_queued filter the
+# SDK queued-bubble build now applies too, so a driven wrapper never shows as the USER'S queued
+# input); the parse below rides the normal push cadence, and the parse IS the event.
+_WAKE_DRIVE_FLOOR_S = 60.0    # ~400x the delivering regime's p90 (0.126s); a rounding error against
+#                               the 8-hour stuck-regime pathology it exists to end
+_AGENT_TASK_ID_RE = re.compile(r"<task-id>([^<]*)</task-id>")
+_AGENT_ID_SHAPE_RE = re.compile(r"a[0-9a-f]{16}")   # background-agent ids; monitor/cron/bash ids are
+#                                                     9-char base36, so the classes cannot collide
+_wake_tail_cache = {}         # path -> ((mtime, size), (entries, mark))
+
+
+def _wake_ts_epoch(ts):
+    """A queue-operation timestamp as epoch seconds, for the drive's age floor. Unparseable reads as
+    ANCIENT (0.0): failing toward driving matches the bug being fixed — a silent strand — while the
+    floor's only job is to not race a CLI that stamps its records correctly."""
+    try:
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _undelivered_wake_tail(path):
+    """The transcript's still-pending queue-operation enqueues, resolved PER ENTRY on the evidence the
+    CLI actually writes (measured live 2026-08-18 — the comment block above):
+      * a `remove` carrying content discards exactly the entry with that text (the CLI's removes are
+        content-addressed single-item discards, routinely of a NON-oldest entry while others stay
+        pending); a content-less remove discards the oldest, matching _pending_queued's FIFO fold;
+      * a `dequeue` alone clears NOTHING — the CLI's idle deliveries write no dequeue at all, and an
+        agent notification's instant dequeue must not wipe an older undriven signal; the delivery
+        evidence is the user record it produces;
+      * a later non-isMeta USER record clears exactly the entries whose text it CONTAINS — the CLI's
+        idle auto-delivery, its bare-message delivery at a turn start, and romp's own driven turn
+        (whose user record carries the wrapper texts verbatim) all resolve this way. ONE entry per
+        carried occurrence, oldest first: a varianceless recurring monitor enqueues byte-identical
+        firings (live census: 6 of 1373 enqueues are exact repeats), and a record carrying that
+        text once delivered exactly one of them — an identical firing enqueued mid-flight is a
+        distinct signal still owed a turn, not already-heard news. The driven turn joins k
+        delivered copies "\\n\\n"-separated, k non-overlapping occurrences, so it still clears
+        exactly what it carried and no re-drive loop opens;
+      * assistant records and isMeta user records clear NOTHING: a turn merely running is not
+        evidence any particular queued signal was delivered — in the stuck regime, mid-turn arrivals
+        are never folded into the open turn, and the old whole-tail clear silently dropped them.
+    Returns ([{pos, ts, text, wrapper}], (pos, ts) of the newest one) or ([], None). `wrapper` marks
+    the wake-signal class — harness system wrappers (<task-notification>/<system-reminder>) EXCEPT
+    background-agent completion notices (a-prefixed 17-hex <task-id>), which the CLI delivers itself
+    in every regime and which therefore behave like bare user/postal enqueues: they ride along for
+    the drive's log count only, never qualify candidacy, and are never re-sent. A missing or
+    otherwise-shaped id keeps wrapper=True — under-delivering is the original bug; the carve-out is
+    only for the one class the CLI provably owns. Cached by (mtime, size) like _pending_queued,
+    since the drive tick asks every push cycle."""
+    try:
+        st = os.stat(path)
+        key = (st.st_mtime, st.st_size)
+    except OSError:
+        return [], None
+    hit = _wake_tail_cache.get(path)
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    tail = []
+    try:
+        with open(path, errors="replace") as f:
+            for pos, line in enumerate(f):
+                if '"queue-operation"' in line:              # cheap prefilter; the parse verifies
+                    try:
+                        o = json.loads(line)
+                    except Exception:
+                        continue
+                    if o.get("type") != "queue-operation":
+                        continue
+                    op = o.get("operation")
+                    if op == "enqueue":
+                        text = o.get("content") if isinstance(o.get("content"), str) else ""
+                        w = bool(em.SYSTEM_WRAPPER_RE.match(text))
+                        if w:
+                            m = _AGENT_TASK_ID_RE.search(text)
+                            if m and _AGENT_ID_SHAPE_RE.fullmatch(m.group(1)):
+                                w = False                    # an agent completion notice — the CLI's own
+                        #                                      to deliver, in every regime (see docstring)
+                        tail.append({"pos": pos, "ts": str(o.get("timestamp") or ""), "text": text,
+                                     "wrapper": w})
+                    elif op == "remove":
+                        c = o.get("content") if isinstance(o.get("content"), str) else None
+                        if c is not None:
+                            i = next((i for i, e in enumerate(tail) if e["text"] == c), None)
+                            if i is not None:                # content-addressed single-item discard —
+                                del tail[i]                  # the CLI's call on THAT entry only
+                        elif tail:
+                            del tail[0]                      # content-less: the oldest, as _pending_queued folds
+                    #      a `dequeue` clears nothing — its delivery evidence is the user record it produces
+                    continue
+                if not tail:
+                    continue                                 # nothing pending → nothing to resolve (fast path)
+                if '"user"' not in line:
+                    continue                                 # cheap prefilter for delivery-evidence records
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                if o.get("type") == "user" and not o.get("isMeta"):
+                    mc = (o.get("message") or {}).get("content")
+                    if isinstance(mc, str):
+                        utext = mc
+                    elif isinstance(mc, list):
+                        utext = "\n".join(str(b.get("text") or "") for b in mc
+                                          if isinstance(b, dict) and b.get("type") == "text")
+                    else:
+                        utext = ""
+                    if utext:                                # delivered = the record CARRIES the text
+                        budget = {}
+                        kept = []
+                        for e in tail:
+                            t = e["text"]
+                            if t and t in utext:
+                                if t not in budget:
+                                    budget[t] = utext.count(t)
+                                if budget[t] > 0:
+                                    budget[t] -= 1
+                                    continue                 # cleared: one entry per carried copy
+                            kept.append(e)
+                        tail = kept
+    except OSError:
+        return [], None
+    out = (tail, (tail[-1]["pos"], tail[-1]["ts"]) if tail else None)
+    if len(_wake_tail_cache) > 256:                          # bounded by the session count; never unbounded
+        _wake_tail_cache.clear()
+    _wake_tail_cache[path] = (key, out)
+    return out
+
+
 _api_err_cache = {}           # path -> ((mtime, size), err|None)
 
 
@@ -14732,6 +14953,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         cancelable = hasattr(_cbe, "unqueue") and _queue_recallable(_cbe, sid)
         qmsgs = []
         for i, t in enumerate(queued):
+            if not _genuine_queued(t):
+                # A harness wrapper in the SDK queue — the idle-queue drive enqueues <task-notification>
+                # texts through the same _pending the user's messages ride — must not render as the
+                # user's queued input (the 2026-06-30 regression, till now guarded only on the tmux
+                # transcript fold at _pending_queued). Skipped, not filtered upstream: `queued` doubles
+                # as shown_texts for echo suppression, and a surviving bubble's idx must keep naming its
+                # backend _pending position for cancelQueued.
+                continue
             goal, body, fu, ctx = _split_followup(t)
             m = {"md": body, "idx": i, "cancelable": cancelable}   # idx ↔ the backend's _pending position (cancelQueued)
             if fu:
@@ -21123,6 +21352,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _auto_retry_tick(now, tmux)       # the dashboard tick is just the countdown + a redundant asker)
     except Exception:
         sys.stderr.write("auto-retry-tick: %s\n" % traceback.format_exc())
+    try:                                  # self-scheduled wake signals queued in an idle SDK CLI get their
+        _idle_queue_drive_tick(now, tmux)  # turn driven (crons/monitors/task notices — see the tick)
+    except Exception:
+        sys.stderr.write("idle-queue-drive: %s\n" % traceback.format_exc())
     try:                                  # expire stale set_working notes once a session goes idle + done (cheap when no notes)
         _clear_done_working_notes(now, tmux)
     except Exception:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2902,6 +2902,20 @@ class SdkBackend:
         self._heal_attempts: dict[str, int] = {}  # sid -> crash-resume attempts since its last COMPLETED turn
         #                                           (bounds _heal_cut_session to one resume per cut; a completed
         #                                           turn resets it, so a crash LOOP can't respawn forever)
+        self._drive_marks: dict[str, tuple] = {}  # sid -> (path, pos, ts) of the last idle-queue drive's newest
+        #                                           DRIVEN wrapper — the in-memory face of the reg's driveMark
+        #                                           (the per-watermark latch; see drive_idle_queue)
+        self._drive_inflight: set[str] = set()    # sids a drive worker currently carries: acceptance stands
+        #                                           down on these WITHOUT latching, so two workers can never
+        #                                           overlap on one sid — an overlap let a stand-down's mark
+        #                                           restore clobber the newer worker's watermark and the model
+        #                                           heard the same notifications twice (2026-08-18 review)
+        self._spawn_sem = threading.Semaphore(BOOT_RESUME_CONCURRENCY)   # the ONE machine-wide spawn-stagger
+        #                                           budget: boot reconcile's resume sweep AND the idle-queue
+        #                                           drive's dormant spawns draw slots from this same semaphore
+        #                                           (as two same-sized budgets they burst to 2x the cap after
+        #                                           a restart — 2026-08-18 review); a spawn holds its slot
+        #                                           until the CLI proves up or its thread dies
         # Kernel-restart heal: nothing is running yet, so any alive session still reading awaiting:true is stale
         # — its background tasks (and the Stop hook that clears the overlay) died with the previous kernel. Left
         # uncleared it reads working/awaiting forever, climbing a ghost work-timer (reorder_bug 2026-06-24).
@@ -3049,9 +3063,13 @@ class SdkBackend:
                 self._poke()
             # STAGGERED spawn (see BOOT_RESUME_CONCURRENCY): every reg above is already fixed —
             # queues persisted, heals applied — so even a death mid-stagger loses nothing (the next
-            # boot's sweep picks the rest up). Spawns hold a semaphore slot until the session's CLI
-            # is past its catch-up burst (init message) or its thread dies (_fire_boot_settled);
-            # the acquire timeout is a loud BACKSTOP for a pre-init wedge, never the pacing itself.
+            # boot's sweep picks the rest up). Spawns hold a slot on the backend-wide _spawn_sem —
+            # SHARED with the idle-queue drive, whose first ticks run inside this very stagger
+            # window, so the two together never exceed the one machine-wide budget — until the
+            # session's CLI is past its catch-up burst (init message) or its thread dies
+            # (_fire_boot_settled); the acquire timeout is a loud BACKSTOP for a pre-init wedge,
+            # never the pacing itself (and an expired backstop holds NO slot, so nothing releases —
+            # a stray release would permanently inflate the process-lifetime budget).
             # NO resume gate (the user 2026-07-22). The high-context hold used to divert these sessions
             # behind a Proceed / Compact on resume / Skip card; that card is cut. It went stale the moment
             # anything else resumed the session (nothing ever retired it), and its premise did not hold
@@ -3059,19 +3077,196 @@ class SdkBackend:
             # Compact each paid in full the reload the gate existed to avoid, leaving Skip as the only
             # option that did what the card said. Context is managed by hand for now. Every cut/queued
             # session resumes here, exactly as it did before the gate.
-            sem = threading.Semaphore(BOOT_RESUME_CONCURRENCY)
             for sid in to_start:
-                if not sem.acquire(timeout=BOOT_RESUME_SLOT_S):
+                slot = self._spawn_sem.acquire(timeout=BOOT_RESUME_SLOT_S)
+                if not slot:
                     self._log("boot reconcile: resume slot backstop expired (a CLI is wedged "
                               "pre-init?) — continuing the sweep anyway")
                 try:   # same per-session isolation as above: one bad spawn must not strand the rest
-                    self._ensure(sid, on_boot_settled=sem.release)
+                    self._ensure(sid, on_boot_settled=(self._spawn_sem.release if slot else None))
                 except Exception:
-                    sem.release()   # the parked release never got attached — free the slot here
+                    if slot:
+                        self._spawn_sem.release()   # the parked release never got attached — free the slot here
                     self._log("boot reconcile: spawn %s failed (sweep continues): %s"
                               % (sid, traceback.format_exc()))
         except Exception:
             self._log("boot reconcile failed: %s" % traceback.format_exc())
+
+    def drive_idle_queue(self, cands, wait: bool = False) -> None:
+        """Deliver wake signals stuck in a STUCK-regime session's CLI queue (the user 2026-08-18; the
+        two-regime story — in MOST sessions the CLI delivers this class itself from idle, and the
+        kernel tick's age floor keeps those out of here — lives on kernel._undelivered_wake_tail's
+        comment block). Each candidate is {sid, path, entries, mark} from the kernel's tick: the
+        transcript's still-pending enqueues and the newest one's (pos, ts) watermark. The same
+        recovery boot reconcile performs for romp's persisted queues, for the queue that lives in the
+        CLI: reconnect if dormant, then deliver — via enqueue(), the exact channel restored queues
+        ride, carrying the CLI's OWN queued texts verbatim (joined in queue order), never a synthetic
+        prompt. Gates, each an exact event, checked at acceptance AND re-checked at the send moment
+        in _drive_deliver (acceptance alone was a TOCTOU hole — a turn could open while earlier
+        candidates in the batch spawned their CLIs):
+          * an OPEN turn / compaction / clearing / a pending rewind stands down WITHOUT latching —
+            the next parse re-checks once the operation settles. Mid-turn arrivals SURVIVE the parse
+            (a turn's records clear only the entries whose text they carry — see
+            _undelivered_wake_tail) and drive once the turn settles;
+          * an ENDED session (reg alive=False) never revives for housekeeping, and a CUT turn (any
+            machine-active state tail — 'working'/'retrying'/'compacting', boot reconcile's own cut
+            discriminator) belongs to the boot/crash resume machinery;
+          * a recorded launchError stands down (the usage-limit queue hold owns that session until a
+            connect proves the CLI up again);
+          * ONE DRIVE PER WATERMARK: the newest driven wrapper's (path, pos, ts) — the tick marks
+            the aged subset it hands over, so a still-young entry stays past the mark and drives
+            once aged — is latched IN MEMORY the moment a drive is accepted — that alone stops the
+            next tick's re-parse re-firing while the worker is in flight — and persisted to the reg
+            (driveMark) only AFTER the enqueue lands, in _drive_deliver: a kernel death between
+            acceptance and delivery leaves the reg unlatched, so the next boot's tick re-produces
+            the candidate and drives it, instead of a persisted-at-acceptance mark silently
+            discarding the never-delivered backlog forever. Only a NEWER enqueue re-arms, and a
+            re-armed drive delivers only the entries past the previous mark. A drive that fails
+            AFTER the enqueue stays latched on purpose — the failure is problem-ring loud, and a
+            recurring signal's next enqueue re-arms — never a silent retry storm.
+          * ONE WORKER PER SID (_drive_inflight): while a worker carries a sid, acceptance stands
+            down WITHOUT latching even for a strictly newer enqueue — the next parse re-checks,
+            like every other gate. Overlapping workers double-delivered: the first one's send-moment
+            stand-down restored its pre-acceptance mark over the second's newer latch, the restored
+            mark re-drove the whole backlog, and the second worker then delivered its slice again.
+            Acceptance runs only on the pusher tick thread, so check-then-add cannot race another
+            acceptor; a worker's discard racing the check at worst defers one tick.
+        Delivery runs on a worker thread (`wait=True` runs it inline, the test seam); see
+        _drive_deliver for the send-moment re-resolve/re-check and the spawn stagger, which draws on
+        the SAME _spawn_sem budget as boot reconcile — one machine-wide BOOT_RESUME_CONCURRENCY cap,
+        not two."""
+        todo = []
+        for c in cands:
+            sid = str(c.get("sid") or "")
+            try:
+                if sid in self._drive_inflight:
+                    continue               # a worker already carries this sid — stand down WITHOUT
+                #                            latching (even for a newer enqueue); the next parse
+                #                            re-checks, and overlap is double delivery (docstring)
+                path = str(c.get("path") or "")
+                pos, ts = c["mark"]
+                prev = self._drive_marks.get(sid)
+                if prev is None:
+                    pm = (read_reg(self.state_dir, sid) or {}).get("driveMark")
+                    prev = ((str(pm.get("path") or ""), pm.get("pos", -1), str(pm.get("ts") or ""))
+                            if isinstance(pm, dict) else ("", -1, ""))
+                    self._drive_marks[sid] = prev
+                fresh = prev[0] != path or pos > prev[1] or ts > prev[2]
+                if not fresh:
+                    continue                       # this backlog was already driven; a newer enqueue re-arms
+                with self._lock:
+                    s = self.sessions.get(sid)
+                s = s if (s and s.thread.is_alive()) else None
+                if s is not None:
+                    if s.ended or s.inflight > 0 or s._compacting or s._clearing \
+                            or (s._rewind_to and not s._rewind_armed):
+                        continue                   # mid-operation → stand down, no latch: re-check next parse
+                else:
+                    reg = read_reg(self.state_dir, sid)
+                    if not reg or not reg.get("alive"):
+                        continue                   # the user ended this session — never revive it for housekeeping
+                    if reg.get("launchError"):
+                        continue                   # can't even start (usage limit etc.) — that hold owns it
+                    if last_state_value(self.state_dir, sid) in ("working", "retrying", "compacting"):
+                        continue                   # a CUT turn — any MACHINE-ACTIVE last state, the same
+                    #                                discriminator boot reconcile uses (a restart mid-retry or
+                    #                                mid-compact cuts the turn exactly as a working cut does) —
+                    #                                is the boot/crash resume machinery's recovery, not the drive's
+                texts = [e["text"] for e in c["entries"]
+                         if e.get("wrapper") and e.get("text")
+                         and (prev[0] != path or e["pos"] > prev[1] or e["ts"] > prev[2])]
+                if not texts:
+                    continue                       # every wake signal here was already driven
+                others = sum(1 for e in c["entries"] if e.get("text") and not e.get("wrapper"))
+                # LATCH in memory only: one drive per watermark within this process. The reg's
+                # driveMark is written by _drive_deliver AFTER the enqueue lands — persisting here
+                # made a kernel death in the latch→delivery window (seconds to minutes behind the
+                # spawn stagger) discard the backlog forever, silently (2026-08-18 review).
+                self._drive_marks[sid] = (path, pos, ts)
+                self._drive_inflight.add(sid)     # released in _drive_deliver's finally, whatever path
+                todo.append((sid, texts, others, (path, pos, ts), prev))
+            except Exception:
+                self._log("idle-queue drive (%s): %s" % (sid[:8] or "?", traceback.format_exc()))
+        if not todo:
+            return
+        if wait:
+            self._drive_deliver(todo)
+        else:
+            threading.Thread(target=self._drive_deliver, args=(todo,),
+                             name="sdk-idle-queue-drive", daemon=True).start()
+
+    def _drive_deliver(self, todo) -> None:
+        """The idle-queue drive's delivery half (worker thread): re-resolve each session and re-check
+        the stand-down gates at the SEND moment, reconnect dormant candidates under the shared spawn
+        stagger, then enqueue each backlog as one turn and persist its watermark. Loud both ways:
+        every drive logs one kernel-log line naming the session and the queued count (normal
+        operation, not a problem); every failure — a refused reconnect, a failed send — lands in the
+        problem ring, never silent."""
+        for sid, texts, others, mark, prev in todo:
+            try:
+                # Re-resolve at the send moment, never the acceptance-time snapshot: earlier
+                # candidates' spawns can hold this delivery back for minutes, and a session that died
+                # and respawned in that window must get its LIVE object — enqueueing into the stale
+                # one mirrored the dead queue over reg['queue'] and the texts evaporated with the
+                # object, latched against any re-drive (2026-08-18 review, repro-verified).
+                with self._lock:
+                    s = self.sessions.get(sid)
+                s = s if (s and s.thread.is_alive()) else None
+                if s is not None:
+                    if s.ended or s.inflight > 0 or s._compacting or s._clearing \
+                            or (s._rewind_to and not s._rewind_armed):
+                        # The acceptance gates, re-checked at the send moment: a turn that opened
+                        # while earlier candidates spawned must not have stale pings injected into
+                        # it. Stand down WITHOUT latching — restore the pre-acceptance mark (the reg
+                        # was never written); the next parse re-checks once the operation settles,
+                        # and the surviving tail re-drives then. Unconditional restore is safe ONLY
+                        # because _drive_inflight bars a second worker for this sid: with overlap,
+                        # this write clobbered a newer drive's watermark and double-delivered.
+                        self._drive_marks[sid] = prev
+                        self._log("idle-queue drive (%s): a turn opened between acceptance and "
+                                  "delivery — standing down; the next parse re-checks" % sid[:8])
+                        continue
+                else:
+                    slot = self._spawn_sem.acquire(timeout=BOOT_RESUME_SLOT_S)
+                    if not slot:
+                        self._log("idle-queue drive: stagger slot backstop expired (a CLI is wedged "
+                                  "pre-init?) — driving %s anyway" % sid[:8], problem=True)
+                    try:
+                        s = self._ensure(sid, on_boot_settled=(self._spawn_sem.release if slot else None))
+                    except Exception:
+                        if slot:
+                            self._spawn_sem.release()   # the parked release never got attached (or can
+                            #                             never fire: an unstarted thread runs no finally)
+                            #                             — free the slot, then fail loud below
+                        raise
+                    if s is None:
+                        self._log("idle-queue drive (%s): the session could not be started (reconnect "
+                                  "refused) — %d queued notification(s) stay undelivered"
+                                  % (sid[:8], len(texts)), problem=True)
+                        continue
+                    # No gate re-check on this arm: a just-spawned session's only possible open turn
+                    # is its persisted-queue seed, and riding behind that in queue order IS correct
+                    # delivery — standing down here would strand the backlog instead.
+                s.enqueue("\n\n".join(texts))
+                try:
+                    # Persist the watermark only now the texts are in the queue (and its reg mirror,
+                    # via enqueue's _persist_queue): a death BEFORE this line re-drives on the next
+                    # boot; a death after enqueue but before this write means at worst one re-drive —
+                    # the same degraded semantics the except below already accepts.
+                    self._update_reg(sid, driveMark={"path": mark[0], "pos": mark[1], "ts": mark[2]})
+                except Exception:
+                    self._log("idle-queue drive (%s): drive mark not persisted (a kernel restart may "
+                              "re-drive this backlog once): %s" % (sid[:8], traceback.format_exc()))
+                self._log("idle-queue drive (%s): waking the session for %d queued notification(s)%s"
+                          % (s.name, len(texts),
+                             " (+%d other queued item(s))" % others if others else ""))
+                self._poke()
+            except Exception:
+                self._log("idle-queue drive (%s): delivery failed: %s" % (sid[:8], traceback.format_exc()))
+            finally:
+                self._drive_inflight.discard(sid)   # every exit — delivery, stand-down, refused
+                #                                     reconnect, raise — frees the sid for the next
+                #                                     parse's acceptance
 
     def drain(self, timeout: float = 2.0, kill=os.kill) -> dict:
         """Graceful-shutdown drain (the kernel's SIGTERM handler): stop every running session cleanly

--- a/tests/test_idle_queue_drive.py
+++ b/tests/test_idle_queue_drive.py
@@ -1,0 +1,863 @@
+#!/usr/bin/env python3
+"""Idle-queue drive — self-scheduled work must wake an idle SDK session (the user 2026-08-18).
+
+The bug, hit twice in one day: under the SDK backend, a session's own scheduled work — a recurring
+Monitor, a cron firing, a background task's completion notice — lands as a queue-operation enqueue,
+and in the CLI's STUCK regime nothing ever drives that queue into a turn: an overnight 15-minute
+Monitor stacked 33 on-time <task-notification> enqueues with no delivery while the session ran zero
+turns, until the next human message hours later. The stuck regime is NOT the population's behavior
+(the 2026-08-18 review measurement over this machine's live transcripts): in MOST sessions the CLI
+delivers this class itself, straight from idle, at median 46ms (p90 126ms) — writing no dequeue
+record; the non-meta user record carrying the text is the delivery — so the drive must stay out of
+the delivering regime's way or the model hears the same notification twice. Background-AGENT
+completion notices (a-prefixed 17-hex task ids) are delivered by the CLI in EVERY regime, the stuck
+one included, so they are never wake signals at all.
+
+The fix under test, in three parts:
+  * kernel._undelivered_wake_tail: the transcript's still-pending enqueues, resolved PER ENTRY on
+    the CLI's own evidence — a content-addressed remove discards its one entry, a dequeue alone
+    clears nothing, a non-isMeta user record clears entries whose text it CONTAINS (one entry per
+    carried occurrence, oldest first — a varianceless recurring monitor's identical firings are
+    distinct signals), and turn records alone clear nothing (a mid-turn arrival in the stuck regime
+    is never folded into the open turn, so the turn must not eat it). The parse rides the normal
+    push cadence.
+  * kernel._idle_queue_drive_tick: the pusher-cycle job that finds idle SDK sessions with a wake
+    signal in that tail and hands them to the backend. Kernel-side gates: the age floor, PER ENTRY
+    (an entry drives only once IT is _WAKE_DRIVE_FLOOR_S old, and only the aged subset drives — the
+    documented time-window exception; the CLI's decision not to deliver emits no record, so only
+    its window passing proves the stuck regime; keyed on the NEWEST entry, a sub-floor wake cadence
+    reset the clock forever and re-opened the silent strand), the global retry pause, per-session
+    retry suppression, an API-error block.
+  * SdkBackend.drive_idle_queue: gates (open turn, compaction, ended/cut sessions) re-checked at
+    delivery time, a per-watermark latch (one drive per newest-driven-wrapper, held in memory at
+    acceptance and persisted to the reg only after the enqueue lands, so a kernel death in between
+    re-drives instead of silently discarding), a per-sid in-flight exclusion (overlapping workers
+    for one sid double-delivered), and delivery — reconnect-if-dormant via _ensure drawing on the
+    SAME spawn-stagger budget as boot reconcile, then enqueue() of the CLI's OWN queued texts
+    verbatim (no synthetic prompt), the exact channel boot-reconcile's restored queues ride.
+
+Synthetic transcripts only: placeholder uuids, invented notification text, TESTHOST.
+"""
+import inspect
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_idledrain", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_idledrain", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+SRC = open(os.path.join(BIN, "romp-kernel")).read()
+
+SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "11111111-2222-3333-4444-666666666666"
+TS = "2026-08-18T06:%02d:%02d.000Z"
+
+
+def _iso(epoch):
+    """An ISO-Z timestamp for an epoch second — the cadence tests span hours, past TS's minute field."""
+    return datetime.fromtimestamp(epoch, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _wrap(n=0, tid="b1111111a"):
+    """A synthetic Monitor task-notification, the shape the CLI enqueues (invented text)."""
+    return ("<task-notification>\n<task-id>%s</task-id>\n<summary>Monitor event: \"nightly check\"</summary>"
+            "\n<event>[tick %d] heartbeat</event>\n</task-notification>" % (tid, n))
+
+
+def _qop(op, content=None, ts=TS % (14, 0)):
+    o = {"type": "queue-operation", "operation": op, "sessionId": SID, "timestamp": ts}
+    if content is not None:
+        o["content"] = content
+    return o
+
+
+def _urec(text="status?", meta=False, ts=TS % (7, 0)):
+    o = {"type": "user", "uuid": "22222222-2222-3333-4444-555555555555", "timestamp": ts,
+         "message": {"role": "user", "content": text}}
+    if meta:
+        o["isMeta"] = True
+    return o
+
+
+def _arec(text="done.", ts=TS % (7, 30), api_error=False):
+    o = {"type": "assistant", "uuid": "33333333-2222-3333-4444-555555555555", "timestamp": ts,
+         "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+    if api_error:
+        o["isApiErrorMessage"] = True
+        o["apiErrorStatus"] = 500
+        o["error"] = "server_error"
+    return o
+
+
+def _write_tx(path, recs):
+    with open(path, "w") as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+
+
+def _turn(ts_u=TS % (7, 0), ts_a=TS % (7, 30)):
+    """One completed turn: a user record and its assistant reply."""
+    return [_urec(ts=ts_u), _arec(ts=ts_a)]
+
+
+def _backlog(count=3, minute0=14):
+    """`count` Monitor enqueues, the overnight shape (enqueue records, no dequeue)."""
+    return [_qop("enqueue", _wrap(i), ts=TS % (minute0 + i, 9)) for i in range(count)]
+
+
+class WakeTail(unittest.TestCase):
+    """kernel._undelivered_wake_tail — the trailing unconsumed enqueues, from the transcript's own
+    queue-operation records (the authoritative queue; the display fold _pending_queued is untouched)."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.tx = os.path.join(self.dir, SID + ".jsonl")
+
+    def _tail(self, recs):
+        _write_tx(self.tx, recs)
+        return km._undelivered_wake_tail(self.tx)
+
+    def test_overnight_backlog_is_the_tail(self):
+        entries, mark = self._tail(_turn() + _backlog(33))
+        self.assertEqual(len(entries), 33, "every undelivered enqueue after the last turn is the tail")
+        self.assertTrue(all(e["wrapper"] for e in entries), "task-notifications are wake signals")
+        self.assertEqual([e["text"] for e in entries], [_wrap(i) for i in range(33)], "texts verbatim, in order")
+        self.assertIsNotNone(mark, "the newest enqueue is the watermark")
+        self.assertEqual(mark[0], entries[-1]["pos"], "watermark = the newest enqueue's position")
+
+    def test_a_content_matched_remove_clears_only_its_entry(self):
+        # the CLI's removes are content-addressed single-item discards, routinely of a NON-oldest
+        # entry while others stay pending (46/76 in the live evidence transcript) — the old
+        # whole-tail clear let one supersede-remove erase every other still-pending wake signal
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap(0)),
+                                              _qop("enqueue", _wrap(1), ts=TS % (15, 0)),
+                                              _qop("remove", _wrap(1))])
+        self.assertEqual([e["text"] for e in entries], [_wrap(0)],
+                         "the remove discards ITS entry; the older signal is still owed a turn")
+        self.assertIsNotNone(mark, "the survivor still marks the session a candidate")
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap()), _qop("remove", _wrap())])
+        self.assertEqual((entries, mark), ([], None), "a remove means the CLI discarded it — its call")
+
+    def test_a_contentless_remove_resolves_the_oldest(self):
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap(0)),
+                                           _qop("enqueue", _wrap(1), ts=TS % (15, 0)), _qop("remove")])
+        self.assertEqual([e["text"] for e in entries], [_wrap(1)],
+                         "no content → FIFO, exactly as _pending_queued folds the same records")
+
+    def test_a_remove_matching_nothing_drops_nothing(self):
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap(0)), _qop("remove", _wrap(7))])
+        self.assertEqual([e["text"] for e in entries], [_wrap(0)],
+                         "the removed item predates this tail — nothing here resolved")
+
+    def test_a_dequeue_alone_clears_nothing(self):
+        # the CLI's idle deliveries write NO dequeue record at all; where a dequeue does appear
+        # (agent notices), the delivery evidence is the user record it produces, pinned below
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap()), _qop("dequeue")])
+        self.assertEqual([e["text"] for e in entries], [_wrap()],
+                         "a dequeue is not delivery evidence — the user record it produces is")
+
+    def test_a_user_record_containing_the_text_clears_it(self):
+        # the delivering regime's shape: enqueue → non-meta user record carrying the text (median
+        # 46ms, no dequeue record) — and romp's own driven turn resolves the same way, since its
+        # user record carries the joined wrapper texts verbatim
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap())]
+                                   + [_urec(text=_wrap(), ts=TS % (15, 0))])
+        self.assertEqual((entries, mark), ([], None), "the CLI delivered it — romp stays out of the way")
+        joined = _wrap(0) + "\n\n" + _wrap(1)
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap(0)), _qop("enqueue", _wrap(1))]
+                                   + [_urec(text=joined, ts=TS % (15, 0))])
+        self.assertEqual((entries, mark), ([], None), "a driven turn's joined texts clear every entry it carried")
+        blocks = dict(_urec(ts=TS % (15, 0)))
+        blocks["message"] = {"role": "user", "content": [{"type": "text", "text": _wrap()}]}
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap())] + [blocks])
+        self.assertEqual((entries, mark), ([], None), "block-list user content is delivery evidence too")
+
+    def test_one_delivery_record_clears_one_identical_entry(self):
+        # varianceless recurring monitors enqueue byte-identical firings (live census: 6 of 1373
+        # enqueues are exact repeats); a record carrying the text ONCE delivered exactly one of
+        # them — an identical firing enqueued mid-flight is a distinct signal still owed a turn,
+        # and the whole-tail containment clear silently dropped it
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap()),
+                                              _qop("enqueue", _wrap(), ts=TS % (15, 0)),
+                                              _urec(text=_wrap(), ts=TS % (15, 1))])
+        self.assertEqual(len(entries), 1, "one carried copy clears ONE entry, not every look-alike")
+        self.assertEqual(entries[0]["ts"], TS % (15, 0),
+                         "oldest first — the delivered copy was the one that had been waiting")
+        self.assertIsNotNone(mark, "the surviving firing still marks the session a candidate")
+
+    def test_a_record_carrying_the_text_twice_clears_both_identical_entries(self):
+        # the driven turn joins k delivered copies "\n\n"-separated — k non-overlapping
+        # occurrences — so its own user record clears exactly what it carried: no re-drive loop
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap()),
+                                              _qop("enqueue", _wrap(), ts=TS % (15, 0)),
+                                              _urec(text=_wrap() + "\n\n" + _wrap(), ts=TS % (15, 1))])
+        self.assertEqual((entries, mark), ([], None),
+                         "two carried copies are two deliveries — the driven turn settles its own batch")
+
+    def test_a_midturn_arrival_survives_the_turns_own_records(self):
+        # stuck regime, measured live: a wrapper landing during an open turn is NEVER folded into it
+        # (zero in-turn appearances) — so the turn's records must not eat the signal; it drives once
+        # the turn settles. The old rule ("a turn ran after the signal → it had its shot") silently
+        # dropped ~18% of the exact payload class of the overnight incident.
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap())]
+                                   + _turn(ts_u=TS % (15, 0), ts_a=TS % (15, 30)))
+        self.assertEqual([e["text"] for e in entries], [_wrap()],
+                         "a turn that does not CARRY the text is not its delivery")
+        self.assertIsNotNone(mark)
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap())] + [_arec(ts=TS % (15, 0))])
+        self.assertEqual(len(entries), 1, "assistant records clear nothing")
+
+    def test_an_agent_dequeue_does_not_wipe_an_older_watchdog_entry(self):
+        # the live 19:14:17 → 19:15:00 shape: watchdog enqueued, then an agent notice's instant
+        # enqueue → dequeue → user record; only the agent entry resolves, the watchdog stays owed
+        agent = _wrap(5, tid="a0123456789abcdef")
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap(0)),
+                                              _qop("enqueue", agent, ts=TS % (15, 0)), _qop("dequeue"),
+                                              _urec(text=agent, ts=TS % (15, 1))])
+        self.assertEqual([e["text"] for e in entries], [_wrap(0)],
+                         "the agent's own delivery resolves the agent entry and nothing else")
+        self.assertIsNotNone(mark)
+
+    def test_agent_completion_notices_are_not_wake_signals(self):
+        # the CLI delivers a-prefixed 17-hex agent notices itself in EVERY regime (verified live,
+        # stuck session included) — re-sending one would double-deliver a subagent completion
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap(0, tid="a0123456789abcdef"))])
+        self.assertEqual(len(entries), 1)
+        self.assertFalse(entries[0]["wrapper"], "an agent notice rides along like a bare queued message")
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap(0))])
+        self.assertTrue(entries[0]["wrapper"],
+                        "monitor/cron/bash ids (9-char base36) keep the wake-signal class")
+        entries, _ = self._tail(_turn() + [_qop("enqueue", "<task-notification>\nno id at all\n"
+                                                           "</task-notification>")])
+        self.assertTrue(entries[0]["wrapper"],
+                        "a missing id fails toward delivering — under-delivering is the original bug")
+
+    def test_meta_records_do_not_eat_wake_signals(self):
+        entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap())] + [_urec(meta=True, ts=TS % (15, 0))])
+        self.assertEqual(len(entries), 1, "an isMeta record is CLI bookkeeping, not the session being awake")
+
+    def test_non_wrapper_content_is_in_the_tail_but_not_a_wake_signal(self):
+        entries, mark = self._tail(_turn() + [_qop("enqueue", "a queued plain message")])
+        self.assertEqual(len(entries), 1)
+        self.assertFalse(entries[0]["wrapper"], "a plain queued message is the CLI's own to deliver")
+        self.assertIsNotNone(mark)
+
+    def test_contentless_enqueues_are_not_wake_signals(self):
+        entries, _ = self._tail(_turn() + [_qop("enqueue")])
+        self.assertTrue(all(not e["wrapper"] for e in entries), "no content, nothing to deliver")
+
+
+class FakeDriveBackend:
+    """Records what the tick hands over; owns() by a fixed sid set."""
+
+    def __init__(self, owned):
+        self.owned = set(owned)
+        self.calls = []
+
+    def owns(self, sid):
+        return sid in self.owned
+
+    def drive_idle_queue(self, cands):
+        self.calls.append(cands)
+
+
+class DriveTick(unittest.TestCase):
+    """kernel._idle_queue_drive_tick — kernel-side gates, then hand off to the backend."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.tx = os.path.join(self.dir, SID + ".jsonl")
+        _write_tx(self.tx, _turn() + _backlog(3))
+        self.fb = FakeDriveBackend({SID})
+        self.alive = [{"sid": SID, "path": self.tx, "name": "web"}]
+
+    def tearDown(self):
+        km._set_retry_paused(False)
+        km._clear_session_retry_suppress(SID)
+
+    def _tick(self, now=None):
+        with mock.patch.object(km, "_sdk", lambda: self.fb), \
+             mock.patch.object(km, "_alive_sessions", lambda now, tmux: self.alive):
+            km._idle_queue_drive_tick(int(time.time()) if now is None else now, {SID: {}})
+
+    def test_wake_signals_reach_the_backend(self):
+        self._tick()
+        self.assertEqual(len(self.fb.calls), 1, "one batch per tick")
+        (cand,) = self.fb.calls[0]
+        self.assertEqual(cand["sid"], SID)
+        self.assertEqual(len(cand["entries"]), 3)
+        self.assertIsNotNone(cand["mark"])
+
+    def test_the_global_pause_stands_down(self):
+        km._set_retry_paused(True)
+        self._tick()
+        self.assertEqual(self.fb.calls, [], "the global pause stops all self-driving")
+
+    def test_a_retry_suppressed_session_stands_down(self):
+        km._suppress_session_retry(SID)
+        self._tick()
+        self.assertEqual(self.fb.calls, [], "the user interrupted this thread's storm — hands off")
+
+    def test_an_api_error_blocked_session_stands_down(self):
+        _write_tx(self.tx, _turn() + [_arec(ts=TS % (8, 0), api_error=True)] + _backlog(3))
+        self._tick()
+        self.assertEqual(self.fb.calls, [], "an API-error block is the auto-retry tick's to clear")
+
+    def test_a_tail_without_wake_signals_does_not_drive(self):
+        _write_tx(self.tx, _turn() + [_qop("enqueue", "a queued plain message")])
+        self._tick()
+        self.assertEqual(self.fb.calls, [], "a bare queued message is the CLI's own to deliver")
+
+    def test_an_agent_only_tail_is_not_a_candidate(self):
+        _write_tx(self.tx, _turn() + [_qop("enqueue", _wrap(0, tid="a0123456789abcdef"))])
+        self._tick()
+        self.assertEqual(self.fb.calls, [], "an agent notice is the CLI's own to deliver, in every regime")
+
+    def test_a_young_wake_enqueue_stands_down_without_latching(self):
+        """The delivering regime starts the turn itself within milliseconds (p90 0.126s measured), so
+        a parse landing in the enqueue→delivery gap must not race it. The floor is the documented
+        exception to the no-time-windows rule: the CLI's decision NOT to deliver writes no record, so
+        only the window passing proves the stuck regime. Stand-down is latch-free — the same tail
+        past the floor drives on a later parse."""
+        ts = TS % (14, 9)
+        epoch = int(km._wake_ts_epoch(ts))
+        _write_tx(self.tx, _turn() + [_qop("enqueue", _wrap(), ts=ts)])
+        self._tick(now=epoch + 10)
+        self.assertEqual(self.fb.calls, [], "younger than the floor → not a candidate yet")
+        self._tick(now=epoch + int(km._WAKE_DRIVE_FLOOR_S) + 60)
+        self.assertEqual(len(self.fb.calls), 1, "no latch: the aged tail drives on the next parse")
+
+    def test_the_floor_is_per_entry_the_aged_drive_the_fresh_wait(self):
+        # an old backlog with one fresh arrival: the AGED entries drive now — each waited out its
+        # own floor — while the fresh one, which may still be racing the CLI's own delivery, waits
+        # for its own floor and drives on a later parse. (Keyed on the newest enqueue, the whole
+        # batch waited — and a sub-floor cadence made it wait forever; see the cadence test below.)
+        old, young = TS % (14, 9), TS % (30, 0)
+        _write_tx(self.tx, _turn() + [_qop("enqueue", _wrap(0), ts=old),
+                                      _qop("enqueue", _wrap(1), ts=young)])
+        self._tick(now=int(km._wake_ts_epoch(young)) + 10)
+        self.assertEqual(len(self.fb.calls), 1, "the aged entry is not held hostage by a fresh arrival")
+        (cand,) = self.fb.calls[0]
+        self.assertEqual([e["text"] for e in cand["entries"]], [_wrap(0)],
+                         "only the aged subset drives — the fresh one may still be racing the CLI")
+        self.assertEqual(cand["mark"], (cand["entries"][-1]["pos"], cand["entries"][-1]["ts"]),
+                         "the watermark is the newest DRIVEN wrapper, never the newest pending entry")
+        self._tick(now=int(km._wake_ts_epoch(young)) + int(km._WAKE_DRIVE_FLOOR_S) + 10)
+        self.assertEqual(len(self.fb.calls), 2, "the fresh entry drives once IT ages past the floor")
+        (cand,) = self.fb.calls[1]
+        self.assertIn(_wrap(1), [e["text"] for e in cand["entries"]],
+                      "the once-young entry is in the aged subset now")
+        self.assertEqual(cand["mark"], (cand["entries"][-1]["pos"], cand["entries"][-1]["ts"]))
+
+    def test_a_sustained_sub_floor_cadence_still_drives(self):
+        """The starvation regression: a 30s-cadence monitor in a stuck session, ticked between
+        enqueues for two simulated hours. Keyed on the NEWEST enqueue, the floor's clock reset on
+        every arrival before the previous one aged past it — 240 pending entries, ZERO drives, and
+        nothing logged: the exact silent strand this feature exists to end, back again for any
+        wake stream firing faster than the floor. Per entry, the first firing qualifies once IT
+        ages past the floor, whatever keeps arriving after it. Synthetic throughout."""
+        base = int(km._wake_ts_epoch(TS % (14, 0)))
+        cadence = 30
+        recs = list(_turn())
+        drives = []
+        for step in range(240):                     # two simulated hours of a 30s monitor
+            enq_t = base + step * cadence
+            recs.append(_qop("enqueue", _wrap(step), ts=_iso(enq_t)))
+            _write_tx(self.tx, recs)
+            now = enq_t + cadence - 1               # just before the next firing: newest is never
+            before = len(self.fb.calls)             # older than 29s, so the old floor never expired
+            self._tick(now=now)
+            if len(self.fb.calls) > before:
+                drives.append((now, self.fb.calls[-1]))
+        self.assertTrue(drives, "a sub-floor cadence starved candidacy forever — 240 pending, 0 drives")
+        self.assertLessEqual(drives[0][0] - base, km._WAKE_DRIVE_FLOOR_S + 2 * cadence,
+                             "the first firing drives as soon as it has waited out its own floor")
+        for now, cands in drives:
+            for cand in cands:
+                for e in cand["entries"]:
+                    self.assertGreaterEqual(now - km._wake_ts_epoch(e["ts"]), km._WAKE_DRIVE_FLOOR_S,
+                                            "only the aged subset ever drives")
+
+    def test_sessions_of_other_backends_are_skipped(self):
+        self.fb.owned = set()
+        self._tick()
+        self.assertEqual(self.fb.calls, [], "tmux CLIs are interactive — they deliver their own queue")
+
+    def test_the_pusher_cycle_runs_the_tick(self):
+        # (now, tmux) — the cycle's ONE liveness snapshot, not a per-job fresh read (2026-08-10 CPU fix).
+        # Scoped to the CYCLE's body: the whole-file pin also matched the tick's own def line, so
+        # deleting the wiring kept every test green (2026-08-18 review, mutation-verified).
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_idle_queue_drive_tick(now, tmux)", src,
+                      "the pusher cycle drives queued wake signals server-side — unattended, no client needed")
+
+
+class FakeLive:
+    """A live, connected, idle SdkSession as drive_idle_queue sees one (duck-typed)."""
+
+    def __init__(self, name="web"):
+        self.name = name
+        self.sid = SID
+        self.ended = False
+        self.inflight = 0
+        self._compacting = False
+        self._clearing = False
+        self._rewind_to = ""
+        self._rewind_armed = False
+        self.sent = []
+        self._stop = threading.Event()
+        self.thread = threading.Thread(target=self._stop.wait, daemon=True)
+        self.thread.start()
+
+    def enqueue(self, text):
+        self.sent.append(text)
+
+    def close(self):
+        self._stop.set()
+
+
+def _ent(pos, text, wrapper=True, ts=TS % (14, 0)):
+    return {"pos": pos, "ts": ts, "text": text, "wrapper": wrapper}
+
+
+class DriveDelivery(unittest.TestCase):
+    """SdkBackend.drive_idle_queue — gates, the watermark latch, delivery, loudness."""
+
+    def setUp(self):
+        self.state = Path(tempfile.mkdtemp())
+        self.logs = []
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None,
+                                log=self.logs.append)
+        sb.write_reg(self.state, SID, {"sid": SID, "name": "web", "alive": True})
+        self.tx = str(self.state / (SID + ".jsonl"))
+        self.fakes = []
+
+    def tearDown(self):
+        for f in self.fakes:
+            f.close()
+
+    def _live(self, **kw):
+        s = FakeLive()
+        for k, v in kw.items():
+            setattr(s, k, v)
+        self.fakes.append(s)
+        self.be.sessions[SID] = s
+        return s
+
+    def _cand(self, entries=None, mark=None, sid=SID):
+        entries = entries if entries is not None else [_ent(10, _wrap(0)), _ent(11, _wrap(1))]
+        return {"sid": sid, "path": self.tx, "entries": entries,
+                "mark": mark or (entries[-1]["pos"], entries[-1]["ts"])}
+
+    def _problems(self):
+        return [p["text"] for p in self.be.problems()]
+
+    def test_cron_shape_live_idle_session_gets_the_backlog(self):
+        s = self._live()
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(s.sent, [_wrap(0) + "\n\n" + _wrap(1)],
+                         "one driven turn carrying the CLI's own queued texts verbatim, in order")
+        self.assertTrue(any("idle-queue drive" in str(m) and "web" in str(m) for m in self.logs),
+                        "each drive logs one kernel-log line naming the session")
+        self.assertFalse(any("idle-queue drive" in p for p in self._problems()),
+                         "a normal drive is not a problem")
+
+    def test_an_open_turn_stands_down_without_burning_the_watermark(self):
+        s = self._live(inflight=1)
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(s.sent, [], "never mid-turn")
+        s.inflight = 0
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(len(s.sent), 1, "the stand-down did not latch — the backlog still delivers")
+
+    def test_compacting_and_clearing_stand_down(self):
+        s = self._live(_compacting=True)
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(s.sent, [])
+        s._compacting, s._clearing = False, True
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(s.sent, [])
+
+    def test_an_ended_session_never_revives(self):
+        sb.write_reg(self.state, SID, {"sid": SID, "name": "web", "alive": False})
+        ensured = []
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: ensured.append(sid)):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(ensured, [], "the user ended this session — housekeeping must not revive it")
+
+    def test_a_cut_turn_stands_down(self):
+        sb.append_state(self.state, SID, "working")   # the tail a kernel-death cut leaves
+        ensured = []
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: ensured.append(sid)):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(ensured, [], "a cut turn is the boot/crash resume machinery's recovery")
+
+    def test_a_turn_cut_mid_retry_stands_down(self):
+        # 'retrying' is a machine-active open-turn state (the CLI mid-turn, waiting out an API
+        # error): a restart there cuts the turn exactly as a working cut does, and boot reconcile's
+        # widened cut discriminator claims it — the drive must yield, not deliver into the resume.
+        sb.append_state(self.state, SID, "retrying")
+        ensured = []
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: ensured.append(sid)):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(ensured, [], "a mid-retry cut is boot reconcile's recovery, not the drive's")
+
+    def test_a_turn_cut_mid_compact_stands_down(self):
+        sb.append_state(self.state, SID, "compacting")   # machine-active, same as retrying
+        ensured = []
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: ensured.append(sid)):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(ensured, [], "a mid-compact cut is boot reconcile's recovery, not the drive's")
+
+    def test_one_drive_per_watermark(self):
+        s = self._live()
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(len(s.sent), 1, "the same watermark never drives twice")
+
+    def test_a_newer_enqueue_rearms_and_delivers_only_the_new(self):
+        s = self._live()
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        entries = [_ent(10, _wrap(0)), _ent(11, _wrap(1)), _ent(12, _wrap(2), ts=TS % (15, 0))]
+        self.be.drive_idle_queue([self._cand(entries=entries)], wait=True)
+        self.assertEqual(len(s.sent), 2, "a newer enqueue is new information — one more drive")
+        self.assertEqual(s.sent[1], _wrap(2), "already-driven texts are not re-sent")
+
+    def test_the_watermark_survives_a_kernel_restart(self):
+        s = self._live()
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        be2 = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        s2 = FakeLive()
+        self.fakes.append(s2)
+        be2.sessions[SID] = s2
+        be2.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(s2.sent, [], "the latch is persisted — a restart cannot re-fire a driven backlog")
+
+    def test_a_dormant_session_is_reconnected_and_delivered(self):
+        cbs = []
+
+        def fake_ensure(sid, on_boot_settled=None):
+            cbs.append(on_boot_settled)
+            if on_boot_settled:
+                on_boot_settled()
+            return self._live()
+
+        with mock.patch.object(self.be, "_ensure", fake_ensure):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(len(self.fakes), 1)
+        self.assertEqual(len(self.fakes[0].sent), 1, "reconnect-if-dormant, then deliver")
+        self.assertTrue(cbs and cbs[0] is not None, "the spawn holds a stagger slot until the CLI proves up")
+
+    def test_dormant_spawns_are_staggered_like_boot_resume(self):
+        sb.write_reg(self.state, SID2, {"sid": SID2, "name": "api", "alive": True})
+        self.be._spawn_sem = threading.Semaphore(1)
+        old_slot = sb.BOOT_RESUME_SLOT_S
+        sb.BOOT_RESUME_SLOT_S = 0.05
+        try:
+            def fake_ensure(sid, on_boot_settled=None):
+                return self._live()          # never fires the callback: the CLI never proves up
+
+            with mock.patch.object(self.be, "_ensure", fake_ensure):
+                self.be.drive_idle_queue(
+                    [self._cand(), self._cand(entries=[_ent(10, _wrap(9))], sid=SID2)], wait=True)
+        finally:
+            sb.BOOT_RESUME_SLOT_S = old_slot
+        self.assertEqual(len(self.fakes), 2, "the backstop is loud but the sweep continues")
+        self.assertTrue(any("backstop" in p for p in self._problems()),
+                        "an expired stagger slot says so where the user looks")
+
+    def test_a_refused_reconnect_is_problem_ring_loud(self):
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: None):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertTrue(any("idle-queue drive" in p for p in self._problems()),
+                        "a drive failure is never silent")
+
+    def test_a_failed_send_is_problem_ring_loud(self):
+        s = self._live()
+        s.enqueue = mock.Mock(side_effect=RuntimeError("stream gone"))
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertTrue(any("idle-queue drive" in p for p in self._problems()))
+
+    def test_boot_parity_the_drive_rides_the_persisted_queue_channel(self):
+        """The drive delivers via enqueue() — the same channel boot-reconcile restores through — so a
+        kernel death between the drive and the CLI taking the turn loses nothing: the text is in the
+        reg's persisted queue and the next boot re-delivers it, exactly as for any queued message."""
+        reg = sb.read_reg(self.state, SID)
+        real = sb.SdkSession(self.be, reg)            # never started: enqueue works, nothing spawns
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: real):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        q = (sb.read_reg(self.state, SID) or {}).get("queue") or []
+        self.assertEqual(q, [_wrap(0) + "\n\n" + _wrap(1)],
+                         "the driven text persists like any queued message until the CLI takes it")
+
+    def test_a_bare_queued_message_rides_along_but_is_never_resent(self):
+        """The CLI delivers its own queued plain messages at its next turn; the drive re-sending one
+        would double-deliver it. Only wake-signal texts go into the driven turn; the bare entry is
+        counted, not sent."""
+        s = self._live()
+        entries = [_ent(10, _wrap(0)), _ent(11, "a queued plain message", wrapper=False),
+                   _ent(12, _wrap(1), ts=TS % (15, 0))]
+        self.be.drive_idle_queue([self._cand(entries=entries)], wait=True)
+        self.assertEqual(s.sent, [_wrap(0) + "\n\n" + _wrap(1)],
+                         "a bare queued message is the CLI's own to deliver — never re-sent")
+        self.assertTrue(any("+1 other queued item" in str(m) for m in self.logs),
+                        "the ride-along is counted in the drive's log line")
+
+    def test_an_agent_notice_rides_along_but_is_never_resent(self):
+        # the parser demotes agent completion notices to wrapper=False (the CLI delivers that class
+        # itself in every regime); delivery must honor it the same way it honors a bare message
+        s = self._live()
+        entries = [_ent(10, _wrap(0)),
+                   _ent(11, _wrap(5, tid="a0123456789abcdef"), wrapper=False),
+                   _ent(12, _wrap(1), ts=TS % (15, 0))]
+        self.be.drive_idle_queue([self._cand(entries=entries)], wait=True)
+        self.assertEqual(s.sent, [_wrap(0) + "\n\n" + _wrap(1)],
+                         "re-sending an agent notice would double-deliver a subagent completion")
+        self.assertTrue(any("+1 other queued item" in str(m) for m in self.logs))
+
+    def test_a_kernel_death_between_latch_and_delivery_is_not_a_discard(self):
+        """The reg's driveMark is written AFTER the enqueue lands: a kernel death between acceptance
+        and delivery (a real window — dormant candidates ahead in the batch each hold delivery back
+        for a CLI spawn, and romp is self-hosting, so deploys restart the kernel) must re-drive on
+        the next boot, never silently discard the backlog forever."""
+        s = self._live()
+        with mock.patch.object(self.be, "_drive_deliver", lambda todo: None):   # death before delivery
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(s.sent, [], "delivery never ran")
+        self.assertIsNone((sb.read_reg(self.state, SID) or {}).get("driveMark"),
+                          "acceptance alone persists nothing — the reg latch is delivery's to write")
+        be2 = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        s2 = FakeLive()
+        self.fakes.append(s2)
+        be2.sessions[SID] = s2
+        be2.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(len(s2.sent), 1, "the next kernel re-produces the candidate and drives it")
+
+    def test_a_turn_opening_between_acceptance_and_delivery_stands_down(self):
+        """Gates are re-checked at the SEND moment: with a dormant candidate ahead in the batch, a
+        turn can open on a live candidate while the dormant one spawns — its delivery must stand
+        down (without latching), not inject stale pings mid-turn."""
+        sb.write_reg(self.state, SID2, {"sid": SID2, "name": "api", "alive": True})
+        s = self._live()
+
+        def fake_ensure(sid, on_boot_settled=None):
+            if on_boot_settled:
+                on_boot_settled()
+            s.inflight = 1                       # the live candidate's turn opens during this spawn
+            d = FakeLive()
+            self.fakes.append(d)
+            return d
+
+        with mock.patch.object(self.be, "_ensure", fake_ensure):
+            self.be.drive_idle_queue([self._cand(sid=SID2, entries=[_ent(10, _wrap(9))]),
+                                      self._cand()], wait=True)
+        self.assertEqual(s.sent, [], "never mid-turn — the acceptance-time check alone was a TOCTOU hole")
+        s.inflight = 0
+        self.be.drive_idle_queue([self._cand()], wait=True)
+        self.assertEqual(len(s.sent), 1, "the stand-down did not latch — the backlog still delivers")
+
+    def test_overlapping_workers_for_one_sid_cannot_double_deliver(self):
+        """One worker per sid: W1 accepts a backlog and stalls (a dormant candidate ahead in its
+        batch can hold it for minutes); a newer enqueue lands and ages, and the next tick would
+        dispatch W2 for the same sid; a turn opens; W1 stands down, restoring its pre-acceptance
+        mark OVER W2's newer latch — the restored mark re-drives the whole backlog, and W2 then
+        delivers its slice a second time. The in-flight exclusion refuses the second acceptance
+        while a worker carries the sid; the deferred backlog still delivers, once, on a later
+        tick, and every wake text is heard exactly once."""
+        s = self._live()
+        captured = []
+        with mock.patch.object(self.be, "_drive_deliver", captured.append):
+            self.be.drive_idle_queue([self._cand()], wait=True)           # W1 accepted, in flight
+        self.assertEqual(len(captured), 1)
+        entries = [_ent(10, _wrap(0)), _ent(11, _wrap(1)), _ent(12, _wrap(2), ts=TS % (15, 0))]
+        with mock.patch.object(self.be, "_drive_deliver", captured.append):
+            self.be.drive_idle_queue([self._cand(entries=entries)], wait=True)   # a newer enqueue…
+        self.assertEqual(len(captured), 1, "…does not dispatch a second worker while one is in flight")
+        s.inflight = 1                             # a turn opens while W1 is stalled…
+        self.be._drive_deliver(captured[0])        # …so W1 stands down at the send moment
+        self.assertEqual(s.sent, [], "W1 stood down — never mid-turn")
+        s.inflight = 0                             # the turn settles
+        self.be.drive_idle_queue([self._cand(entries=entries)], wait=True)
+        for batch in captured[1:]:                 # any second worker would deliver its slice NOW
+            self.be._drive_deliver(batch)
+        self.assertEqual(len(s.sent), 1, "the deferred backlog delivers once, on the next tick")
+        for i in range(3):
+            self.assertEqual(sum(t.count(_wrap(i)) for t in s.sent), 1,
+                             "each wake text is heard exactly once across all driven turns")
+
+    def test_a_died_and_respawned_session_gets_the_backlog_not_its_ghost(self):
+        """Delivery re-resolves the session object: enqueueing into a dead snapshot would mirror the
+        dead queue over reg['queue'] and the texts would evaporate with the object, latched against
+        any re-drive."""
+        stale = self._live()
+        captured = []
+        with mock.patch.object(self.be, "_drive_deliver", captured.append):
+            self.be.drive_idle_queue([self._cand()], wait=True)
+        stale.close()                             # the CLI dies in the latch→delivery window...
+        stale.thread.join(timeout=2)
+        fresh = FakeLive()                        # ...and something respawns the session
+        self.fakes.append(fresh)
+        self.be.sessions[SID] = fresh
+        self.be._drive_deliver(captured[0])
+        self.assertEqual(fresh.sent, [_wrap(0) + "\n\n" + _wrap(1)],
+                         "the LIVE object receives the backlog")
+        self.assertEqual(stale.sent, [], "the ghost gets nothing — its queue mirror is a clobber")
+
+    def test_a_raising_ensure_returns_its_stagger_slot(self):
+        """Boot reconcile frees its slot when _ensure raises; the drive must too — _spawn_sem lives
+        for the process, so each leaked slot permanently shrinks every future spawn's budget into
+        180s-backstop purgatory."""
+        self.be._spawn_sem = threading.Semaphore(1)
+        old_slot = sb.BOOT_RESUME_SLOT_S
+        sb.BOOT_RESUME_SLOT_S = 0.05
+        try:
+            with mock.patch.object(self.be, "_ensure",
+                                   mock.Mock(side_effect=OSError("reg write failed"))):
+                self.be.drive_idle_queue([self._cand()], wait=True)
+            got = self.be._spawn_sem.acquire(timeout=1)
+        finally:
+            sb.BOOT_RESUME_SLOT_S = old_slot
+        self.assertTrue(got, "the slot came back — the parked release never got attached")
+        self.be._spawn_sem.release()
+        self.assertTrue(any("idle-queue drive" in p for p in self._problems()),
+                        "the failed spawn is problem-ring loud")
+
+    def test_boot_reconcile_and_the_drive_share_one_spawn_budget(self):
+        """Boot reconcile used to mint its own same-sized semaphore, so post-restart boot resumes and
+        drive spawns could burst to 2x BOOT_RESUME_CONCURRENCY. Pre-holding the backend's only slot
+        (a drive spawn in flight) must make boot reconcile's stagger wait on it — one shared budget."""
+        self.be._spawn_sem = threading.Semaphore(1)
+        self.assertTrue(self.be._spawn_sem.acquire(timeout=1))    # a drive spawn holds the slot
+        old_slot = sb.BOOT_RESUME_SLOT_S
+        sb.BOOT_RESUME_SLOT_S = 0.05
+        try:
+            reg = {"sid": SID, "name": "web", "alive": True, "queue": ["a queued plain message"]}
+            sb.write_reg(self.state, SID, reg)
+            with mock.patch.object(self.be, "_ensure", lambda sid, on_boot_settled=None: None):
+                self.be._boot_reconcile([reg])
+        finally:
+            sb.BOOT_RESUME_SLOT_S = old_slot
+            self.be._spawn_sem.release()
+        self.assertTrue(any("resume slot backstop expired" in str(m) for m in self.logs),
+                        "boot reconcile drew on the drive-held budget — the same semaphore instance")
+
+
+class QueuedBubbleDisplay(unittest.TestCase):
+    """A driven wrapper parked in the SDK pending queue must never render as the user's queued
+    message (the 2026-06-30 regression: a raw <task-notification> shown as '1 queued message'). The
+    _genuine_queued filter used to exist only on the tmux transcript fold; the drive now routes
+    wrappers through the SDK's _pending/reg queue, which build_session reads raw — so the bubble
+    build filters too, keeping idx aligned with the backend position for cancelQueued."""
+
+    class _Be:
+        """An SDK-shaped backend double: owns the sid, serves a fixed queue, exposes unqueue."""
+
+        def __init__(self, queued):
+            self._q = list(queued)
+
+        def owns(self, sid):
+            return True
+
+        def pending_queued(self, sid):
+            return list(self._q)
+
+        def unqueue(self, sid, idx, expect=None):
+            return None
+
+        def live_atoms(self, sid):
+            return []
+
+        def busy(self, sid):
+            return None
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.tx = os.path.join(self.dir, SID + ".jsonl")
+        _write_tx(self.tx, _turn())
+        self.now = int(time.time())
+        self.sess = [{"sid": SID, "name": "web", "path": self.tx, "mtime": self.now}]
+
+    def _events(self, queued):
+        be = self._Be(queued)
+        with mock.patch.object(km, "_sessions", lambda now: list(self.sess)), \
+             mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: be)), \
+             mock.patch.object(km, "_captions", lambda sid: {}), \
+             mock.patch.object(km, "_limit_hold", lambda sid: None):
+            m = km.build_session(SID, self.now, tmux={})
+        self.assertIsNotNone(m, "the session must build")
+        return m["events"]
+
+    def test_a_driven_wrapper_never_renders_as_the_users_queued_message(self):
+        evs = self._events([_wrap(0), "please rerun the failing test"])
+        q = next((e for e in evs if e.get("kind") == "queued"), None)
+        self.assertIsNotNone(q, "the user's own queued message still shows")
+        self.assertEqual([t["md"] for t in q["texts"]], ["please rerun the failing test"],
+                         "the wrapper is delivery plumbing, not the user's pending input")
+        self.assertEqual(q["texts"][0]["idx"], 1,
+                         "a surviving bubble's idx still names its backend _pending position")
+
+    def test_an_all_wrapper_queue_emits_no_queued_event(self):
+        evs = self._events([_wrap(0)])
+        self.assertIsNone(next((e for e in evs if e.get("kind") == "queued"), None),
+                          "nothing of the user's is pending — no empty queued group either")
+
+    def test_the_nudge_guard_reads_only_genuine_queued(self):
+        # _backend_queued means "the user has messages waiting" — a parked wrapper must not
+        # suppress nudges as if the user had spoken
+        with mock.patch.object(km.Sessions, "backend_for",
+                               staticmethod(lambda sid: self._Be([_wrap(0)]))):
+            self.assertFalse(km._backend_queued(SID), "a parked wrapper is not the user speaking")
+        with mock.patch.object(km.Sessions, "backend_for",
+                               staticmethod(lambda sid: self._Be([_wrap(0), "hold on"]))):
+            self.assertTrue(km._backend_queued(SID))
+
+
+class OvernightShape(unittest.TestCase):
+    """The exact bug, end to end through the kernel tick and a real backend: an idle session, a
+    Monitor's overnight enqueue backlog, no external input — a turn is driven, once, with the backlog."""
+
+    def setUp(self):
+        self.state = Path(tempfile.mkdtemp())
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None, log=lambda m: None)
+        sb.write_reg(self.state, SID, {"sid": SID, "name": "web", "alive": True})
+        self.tx = str(self.state / (SID + ".jsonl"))
+        _write_tx(self.tx, _turn() + _backlog(33))
+        self.alive = [{"sid": SID, "path": self.tx, "name": "web"}]
+        self.fake = FakeLive()
+
+    def tearDown(self):
+        self.fake.close()
+
+    def test_the_overnight_backlog_drives_one_turn(self):
+        with mock.patch.object(self.be, "_ensure", lambda sid, **kw: self.fake), \
+             mock.patch.object(km, "_sdk", lambda: self.be), \
+             mock.patch.object(km, "_alive_sessions", lambda now, tmux: self.alive):
+            km._idle_queue_drive_tick(int(time.time()), {SID: {}})
+            # the drive runs on a worker thread from the tick — wait for it (bounded)
+            for _ in range(100):
+                if self.fake.sent:
+                    break
+                time.sleep(0.02)
+            km._idle_queue_drive_tick(int(time.time()), {SID: {}})   # the same parse again: latched
+            time.sleep(0.1)
+        self.assertEqual(len(self.fake.sent), 1, "one driven turn, not one per notification, not zero")
+        for i in range(33):
+            self.assertIn(_wrap(i), self.fake.sent[0], "the whole backlog is delivered")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An idle SDK session's own scheduled work (a recurring Monitor, a cron firing, a background task's completion notice) can strand in the Claude Code CLI's queue: the CLI records the enqueue but never starts the turn that would deliver it, and the backlog waits silently until the user's next message. This PR watches for that state and drives one turn that delivers the queued texts verbatim.

## What breaks

Under the SDK backend, a session's self-scheduled notification lands as a `queue-operation` enqueue in the CLI's queue. What happens next has two regimes (measured over one machine's live SDK transcripts; all evidence here is counts and latencies, no session content):

- **The delivering regime**, most sessions most of the time: the CLI starts the turn itself straight from idle. Of 1311 monitor/cron/bash-class task-notification enqueues across 25 sessions, 602 were delivered this way, at median 46 ms and p90 126 ms. The delivery writes no dequeue record; the non-isMeta user record carrying the text is the only evidence it happened.
- **The stuck regime**: the CLI only enqueues, and nothing ever starts the turn. In one observed session an overnight 15-minute Monitor stacked 33 undelivered notifications across more than eight turnless hours until the next human message drained them; that transcript held 123 enqueues, 0 deliveries, and 66 content-addressed removes (discards).

The CLI writes no record of deciding not to deliver, so the two regimes are indistinguishable at enqueue time. Background-agent completion notices are delivered in every regime, the stuck one included, so the fix excludes them by id class (a-prefixed 17-hex agent ids; monitor/cron/bash ids are 9-character base36).

## Reproduction

A session in the stuck regime shows the shape directly: with any recurring Monitor, `queue-operation` enqueue records accumulate in its transcript with no turn between them, until the next user message delivers the whole backlog at once. We found no switch that forces a session into the stuck regime on demand; the test suite reconstructs both regimes synthetically from the transcript shapes above.

## The fix

Three parts, all riding existing machinery.

**Kernel tick.** `_idle_queue_drive_tick`, a new pusher-cycle job, folds the transcript's still-pending enqueues per entry from the same queue-operation records `_pending_queued` already reads (no new polling): a content-addressed remove resolves exactly its entry, a dequeue alone clears nothing, and a non-isMeta user record clears one entry per carried text occurrence, so a varianceless monitor's identical firings resolve one at a time. An entry qualifies for driving only once it is 60 seconds old, per entry, so only the aged subset drives and a fast cadence cannot reset the clock (rationale below). The global retry pause, per-session retry suppression, and an API-error block each stand the tick down.

**Backend delivery.** `SdkBackend.drive_idle_queue` delivers by `enqueue()` of the CLI's own queued texts verbatim, joined in queue order, never a synthetic prompt. One drive per watermark: the newest driven entry's position is latched in memory at acceptance and persisted only after the enqueue lands, so a kernel death in between re-drives instead of discarding. One worker per sid (overlapping workers double-delivered under test). Every gate is re-checked at the send moment against a re-resolved session object: an open turn, compaction, clearing, or a pending rewind stands down without latching; an ended session never revives; a recorded launch error yields to the hold that owns it. Dormant sessions reconnect under the same spawn-stagger budget boot reconcile uses (one shared semaphore rather than two same-sized budgets, which could burst to twice the cap after a restart). The dormant-cut yield uses the machine-active discriminator recently widened on main (8cd065d9: `working`/`retrying`/`compacting`), so a turn cut mid-retry or mid-compact stays the boot/crash resume machinery's recovery. Failures log loudly to the problem ring.

**Display.** A driven harness wrapper never renders as the user's queued input, and the nudge-suppression guard (`_backend_queued`) counts only genuine user messages.

### Why a 60-second age floor in an event-keyed design

The event the floor approximates, the CLI deciding not to deliver, writes no record, so no exact event exists to key on: only the delivery window passing proves the stuck regime. A drive-time re-parse alone cannot close the race either, because the CLI can deliver between the re-check and the driven enqueue landing. The floor is about 400x the delivering regime's p90 (0.126 s) and a rounding error against the eight-hour pathology it ends; in the delivering regime a user record clears each entry long before its floor expires, so the drive never races a working CLI.

### If the CLI's behavior changes

If a future CLI delivers in the stuck regime too, the floor makes the drive a no-op. If a future CLI starts writing dequeue records for idle deliveries, the per-entry user-record clearing still resolves entries, so the failure mode degrades to an occasional redundant re-send, not silence.

## Tests

`tests/test_idle_queue_drive.py` (52 cases, all synthetic transcripts: placeholder UUIDs, invented notification text) covers:

- the per-entry tail fold: content-addressed removes, dequeues clearing nothing, one identical entry cleared per carried copy, mid-turn arrivals surviving the turn's own records, the agent-notice carve-out;
- the tick's gates: the per-entry floor (including a sub-floor-cadence regression in which 240 firings over two simulated hours stranded with zero drives when the floor keyed on the newest entry), the retry pause, retry suppression, the API-error block;
- delivery: both regimes, every stand-down gate at acceptance and at the send moment, the watermark latch across kernel restarts, one worker per sid, the spawn budget shared with boot reconcile, stand-downs for turns cut mid-working, mid-retry, and mid-compact, loud failure paths;
- display: a driven wrapper never rendering as the user's queued message, and the nudge guard reading only genuine entries.

All 52 cases fail against the unfixed base, and the two cut-mid-retry/mid-compact cases fail against a drive gated on `working` alone. Full local runs: the Python suite (4980 passed, 40 skipped) and bats (336 passed).

One reviewer note: on the first restart after this merges, a session holding an already-old queued backlog gets one catch-up turn delivering it. That is the feature doing its job once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)