### PR TITLE
A file browser for the dashboard: walk a session's tree, open files in the viewer, and edit text in place

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4630,6 +4630,67 @@ def _dir_completions(raw, limit=DIR_COMPLETE_MAX):
             "truncated": len(names) > limit}
 
 
+DIR_LIST_MAX = 500               # listing rows per reply — bounded like DIR_COMPLETE_MAX, sized for a browse
+
+
+def _list_dir(raw, sid=None, hidden=False, limit=DIR_LIST_MAX):
+    """One directory's entries for the dashboard's file browser: files AND directories with
+    sizes/mtimes, plus a server-side `viewable` verdict per file — the same _PREVIEW_MIME +
+    _is_text_path tables /file's view half applies — so the client can mark download-only rows up
+    front instead of letting every click fail into a 415.
+
+    Resolution is _resolve_open_path semantics (~ expanded, a relative path against the sid's session
+    cwd) — the SAME rules /file uses, so every listed path can be handed straight to the /file URL
+    builder. Deliberately a SIBLING of _dir_completions, not a widening: the completer's dirs-only /
+    50-row / dot-gated semantics are the picker's, pinned by its tests. Hidden entries only when
+    asked; symlinks are shown and marked, is_dir() following them for typing like the completer.
+    Errors are LOUD and name the resolved path (fail loudly — never a silent empty list). One bounded
+    JSON frame: capped with `truncated` + `total` so the client can say what was left out."""
+    p = _resolve_open_path(str(raw or ""), sid)
+    if not os.path.isabs(p):
+        return {"error": "cannot list %s: not an absolute path (no session cwd to resolve against)" % _tilde(p)}
+    p = os.path.normpath(p)     # "." from a card menu resolves to "<cwd>/." — lexical only, never realpath
+    # Error replies carry base/parent too, so the client can build a WALKABLE crumb trail over the
+    # failure — a first open that errors with no trail was a dead end (review, 2026-08-14).
+    err_ctx = {"base": _tilde(p),
+               "parent": None if p == "/" else _tilde(os.path.dirname(p.rstrip("/")) or "/")}
+    if not os.path.isdir(p):
+        return dict(err_ctx, error="cannot list %s: not a directory" % _tilde(p))
+    dirs, files = [], []
+    try:
+        with os.scandir(p) as it:
+            for e in it:
+                if e.name.startswith(".") and not hidden:
+                    continue
+                try:
+                    is_dir = e.is_dir()                 # follows symlinks: a symlinked repo browses as one
+                except OSError:
+                    is_dir = False
+                size = mtime = 0
+                is_link = False
+                try:
+                    is_link = e.is_symlink()
+                    st = e.stat()                       # follows too; a dangling link keeps the zeros
+                    size, mtime = int(st.st_size), int(st.st_mtime)
+                except OSError:
+                    pass
+                row = {"name": e.name, "isDir": is_dir, "isLink": is_link,
+                       "size": 0 if is_dir else size, "mtime": mtime}
+                if not is_dir:
+                    row["viewable"] = bool(_PREVIEW_MIME.get(os.path.splitext(e.name)[1].lower())) \
+                        or _is_text_path(e.name)
+                (dirs if is_dir else files).append(row)
+    except OSError as ex:
+        return dict(err_ctx,
+                    error="cannot list %s: %s" % (_tilde(p), getattr(ex, "strerror", None) or str(ex)))
+    dirs.sort(key=lambda r: (r["name"].lower(), r["name"]))
+    files.sort(key=lambda r: (r["name"].lower(), r["name"]))
+    rows = dirs + files
+    parent = os.path.dirname(p.rstrip("/")) or "/"
+    return {"base": _tilde(p), "parent": None if p == "/" else _tilde(parent),
+            "entries": rows[:limit], "total": len(rows), "truncated": len(rows) > limit}
+
+
 def _session_has_history(sid):
     """True if this session was ever PROMPTED — the evidence that it is a real conversation, not a
     just-opened shell an "Opening…" cue covers. Streams the transcript and stops at the first user
@@ -23068,10 +23129,20 @@ _LANDING_SETTINGS_JS = """
 (function(){window.addEventListener('message',function(e){var m=e.data;if(!m)return;
 if(m.romp==='settings')document.body.classList.toggle('settings-open',!!m.on);
 // the /chat iframe's new-session picker asks the shell to lift it full-window (see body.picker-open CSS)
-if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);});
-// (The viewFile relay is gone: the file viewer opens as a modal over the CHAT pane itself —
-// file-view.ts lives in the chat bundle now (the user 2026-08-15) — so no cross-pane forwarding
-// and no feed-pane bring-forward/put-back.)
+if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);
+// "Browse files" from any pane surfaces the FILE BROWSER in the FEED pane, which is a different
+// document — so the shell relays it. If the feed pane is toggled off we turn it on for the duration
+// and remember to put it back, so the browser never costs the user their layout. (File VIEWS need
+// none of this since 2026-08-15: the viewer is a modal over whatever document clicked, so it never
+// touches the panes and has nothing to restore.)
+if(m.romp==='browseFiles'){var bf=document.getElementById('f-feed');
+  if(!document.body.classList.contains('po-feed')){window.__rompFeedWasOff=true;
+    try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',true);}catch(e){}}
+  try{window.__rompMobileTab&&window.__rompMobileTab('feed');}catch(e){}   // phone: one pane at a time
+  try{bf&&bf.contentWindow&&bf.contentWindow.postMessage({romp:'browseFiles',path:m.path,sid:m.sid},'*');}catch(e){}}
+// the browser owns the restore: browseClosed alone puts a brought-forward feed back the way it was
+if(m.romp==='browseClosed'&&window.__rompFeedWasOff){window.__rompFeedWasOff=false;
+  try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',false);}catch(e){}}});
 // One id per dashboard (per browser tab/window), minted here so every pane in it reports the same one.
 // sessionStorage, deliberately: it survives a reload (the panes keep their identity) and a second window
 // gets its own, which is what makes "the dashboard that asked" a thing the kernel can address.
@@ -26716,6 +26787,17 @@ class Handler(BaseHTTPRequestHandler):
             _reply(client, dict({"type": "dirCompletions", "reqId": msg.get("reqId"), "host": "",
                                  "value": _val, "status": _dir_status(_val)},
                                 **_dir_completions(_val)))
+        elif msg and msg.get("type") == "listDir":
+            # The dashboard's file browser. Answered by the kernel that OWNS the sid's session —
+            # federation routes by the sid field, so browsing a remote session lists THAT machine's
+            # disk over the existing splice, no relay clause needed. reqId echoes back so a slow
+            # reply landing after a newer navigation is dropped by the client, never rendered (the
+            # dirComplete protocol); `host` rides for the same stale-drop. Resolution is /file's own
+            # (_resolve_open_path), so every listed path feeds the /file URL builder as-is.
+            _reply(client, dict({"type": "dirListing", "reqId": msg.get("reqId"), "host": "",
+                                 "sid": msg.get("sid") or ""},
+                                **_list_dir(msg.get("path"), msg.get("sid") or None,
+                                            hidden=bool(msg.get("hidden")))))
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear
             if not _native_dialogs():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat
 from pathlib import Path
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -20444,6 +20444,85 @@ def _resolve_open_path(p, sid=None):
     return p
 
 
+def _httpdate(t):
+    """Epoch → the RFC 7231 form a Last-Modified header wears (the viewer's Date.parse reads it)."""
+    from email.utils import formatdate
+    return formatdate(t, usegmt=True)
+
+
+def _save_file(raw, sid, content, base_mtime_ns):
+    """The viewer's raw-mode SAVE (the file browser's slice 2, the user 2026-08-14): write `content`
+    over an existing text file, atomically, refusing when the disk moved on. Returns (mtime_ns, None)
+    on success, (None, error) on refusal — every refusal names the resolved path (fail loudly).
+
+    THE guard is optimistic concurrency: agents edit these same trees while a human has the viewer
+    open, and a silent last-writer-wins would eat one side's work. The client sends the mtime_ns it
+    LOADED at (/file's X-Romp-Mtime-Ns — NANOSECONDS, because an HTTP date's whole seconds let an
+    agent write landing in the same second slip the guard, the review's finding); a moved disk
+    refuses with reload-and-say-so — never a merge, never an overwrite.
+
+    Scope is exactly what raw mode can faithfully round-trip: _is_text_path names within
+    _TEXT_MAX_BYTES, existing files only (no create in this slice), and UTF-8 ONLY — /file's latin-1
+    fallback means a non-UTF-8 file reaches the textarea re-decoded, and writing it back as UTF-8
+    silently rewrote every non-ASCII byte (review, executed repro), so the save refuses instead.
+    A symlinked path writes THROUGH the link (realpath) — os.replace on the link itself destroyed it
+    while the viewer showed and guarded the target. The write is temp-file + os.replace in the same
+    directory, mode preserved — a full disk or a kill mid-write leaves the original intact."""
+    p = _resolve_open_path(str(raw or ""), sid)
+    if not os.path.isabs(p):
+        return None, "cannot save %s: not an absolute path (no session cwd to resolve against)" % _tilde(p)
+    p = os.path.normpath(p)
+    if not isinstance(content, str):
+        # a malformed frame must refuse, not truncate: str(None or "") wrote ZERO bytes with a
+        # success ack before this check (review)
+        return None, "cannot save %s: the request carried no text" % _tilde(p)
+    if not _is_text_path(p):
+        return None, "cannot save %s: not a text file the viewer edits" % _tilde(p)
+    if not os.path.isfile(p):
+        return None, "cannot save %s: no such file (creating files is not a viewer edit)" % _tilde(p)
+    try:
+        data = content.encode("utf-8")
+    except UnicodeError:
+        # a lone surrogate raised OUTSIDE the OSError net and the client never got a reply (review)
+        return None, "cannot save %s: the text contains bytes UTF-8 cannot encode" % _tilde(p)
+    if len(data) > _TEXT_MAX_BYTES:
+        return None, ("cannot save %s: %s exceeds the %s text cap"
+                      % (_tilde(p), _human_bytes(len(data)), _human_bytes(_TEXT_MAX_BYTES)))
+    try:
+        base_ns = int(base_mtime_ns or 0)
+    except (TypeError, ValueError):
+        return None, "cannot save %s: the request carried no load-time anchor" % _tilde(p)
+    try:
+        wp = os.path.realpath(p)                # write THROUGH a symlink, never over it
+        st = os.stat(wp)
+        if st.st_mtime_ns != base_ns:
+            return None, ("%s changed on disk since you opened it — reload before editing "
+                          "(someone else, likely an agent, wrote it)" % _tilde(p))
+        with open(wp, "rb") as f:
+            cur = f.read()
+        try:
+            cur.decode("utf-8")
+        except UnicodeError:
+            return None, ("cannot save %s: the file is not UTF-8 on disk — saving would silently "
+                          "re-encode bytes you never touched" % _tilde(p))
+        d = os.path.dirname(wp)
+        fd, tmp = tempfile.mkstemp(prefix=".romp-save-", dir=d)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+            os.chmod(tmp, stat.S_IMODE(st.st_mode))   # the original's mode survives the replace
+            os.replace(tmp, wp)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        return os.stat(wp).st_mtime_ns, None
+    except OSError as ex:
+        return None, "cannot save %s: %s" % (_tilde(p), getattr(ex, "strerror", None) or str(ex))
+
+
 # Inline-code spans that name an EXISTING file despite containing spaces (the user 2026-08-04: a note
 # titled `Moving from correlation to causal components.md` linkified only its last word). The client's
 # token linkifier can never span a space — in prose that boundary is exactly what keeps ordinary text
@@ -25216,10 +25295,19 @@ class Handler(BaseHTTPRequestHandler):
                               "too large to show: %s (%s, limit %s)"
                               % (_tilde(fp), _human_bytes(size), _human_bytes(cap)),
                               "text/plain")
+        # The file's mtime rides every success twice: Last-Modified (the standard form) and
+        # X-Romp-Mtime-Ns — NANOSECONDS, the anchor saveFile's conflict floor actually compares,
+        # because the HTTP date's whole seconds let an agent write landing in the same second slip
+        # the guard (the raw-mode edit slice; the granularity hole was the review's finding).
+        fst = os.stat(fp)
+        lastmod = _httpdate(fst.st_mtime)
+        mtime_ns = str(fst.st_mtime_ns)
         if head:
             self.send_response(200)
             self.send_header("Content-Type", mime)
             self.send_header("Content-Length", str(size))   # the real length, no body (HEAD semantics)
+            self.send_header("Last-Modified", lastmod)
+            self.send_header("X-Romp-Mtime-Ns", mtime_ns)
             self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):         # the chat's fetch-HEAD probe rides CORS too
@@ -25263,8 +25351,20 @@ class Handler(BaseHTTPRequestHandler):
             body = _decode_text(raw)
             if body is None:                     # named like text, isn't — say so rather than serve garbage
                 return self._send(415, "not a text file: %s" % _tilde(fp), "text/plain")
-            return self._send(200, body, mime, cache="no-cache")
-        return self._send(200, raw, mime, cache="no-cache")
+            # Which decode branch produced the text travels WITH it: _decode_text's latin-1 fallback
+            # re-decodes a non-UTF-8 file, and an Edit armed on that text would re-encode every
+            # non-ASCII byte on save (the review's executed repro) — so Edit arms only on "1", and
+            # _save_file refuses the "0" case server-side regardless.
+            try:
+                raw.decode("utf-8")
+                u8 = "1"
+            except UnicodeError:
+                u8 = "0"
+            return self._send(200, body, mime, cache="no-cache",
+                              headers={"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns,
+                                       "X-Romp-Text-Utf8": u8})
+        return self._send(200, raw, mime, cache="no-cache",
+                          headers={"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns})
 
     def _file_download(self, fp, head=False):
         """GET/HEAD /file?download=1 — the SAVE half of the route (the user 2026-08-09): any file that
@@ -26798,6 +26898,20 @@ class Handler(BaseHTTPRequestHandler):
                                  "sid": msg.get("sid") or ""},
                                 **_list_dir(msg.get("path"), msg.get("sid") or None,
                                             hidden=bool(msg.get("hidden")))))
+        elif msg and msg.get("type") == "saveFile":
+            # The viewer's raw-mode save (the file browser's slice 2). Routed by sid to the
+            # session-OWNING kernel like listDir, so a remote session's file saves on ITS machine.
+            # The reply is the ACK the client's Save button waits on; a refusal (the mtime conflict
+            # above all) rides back verbatim for the viewer to present — never a silent drop.
+            mt, err = _save_file(msg.get("path"), msg.get("sid") or None,
+                                 msg.get("content"), msg.get("baseMtimeNs"))
+            if err:
+                _reply(client, {"type": "fileSaveFailed", "reqId": msg.get("reqId"), "error": err})
+            else:
+                # mtimeNs travels as a STRING: ~1.7e18 exceeds JS's safe-integer range, so a JSON
+                # number would round in the browser and every next save would falsely conflict
+                _reply(client, {"type": "fileSaved", "reqId": msg.get("reqId"),
+                                "path": str(msg.get("path") or ""), "mtimeNs": str(mt)})
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear
             if not _native_dialogs():
@@ -27044,6 +27158,13 @@ class Handler(BaseHTTPRequestHandler):
             body = b"" if head else resp.read(_PREVIEW_MAX_BYTES + 1)
             status, ctype = resp.status, mime          # OUR mime, never resp.getheader("Content-Type")
             clen = resp.getheader("Content-Length")
+            # These three are MIRRORED, unlike Content-Type: they are data about the remote's file
+            # (the save-conflict floor and the Edit gate ride on them), not instructions to this
+            # browser — nothing executes off a date or a flag, and deriving them locally would be a
+            # lie about a remote disk.
+            lastmod = resp.getheader("Last-Modified")
+            r_ns = resp.getheader("X-Romp-Mtime-Ns")
+            r_u8 = resp.getheader("X-Romp-Text-Utf8")
             crange = resp.getheader("Content-Range") or ""
         except (OSError, http.client.HTTPException) as e:
             _demand_redial(host, "refused" if isinstance(e, ConnectionRefusedError) else "timeout")
@@ -27062,6 +27183,10 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", ctype)
             if clen is not None:
                 self.send_header("Content-Length", clen)
+            if lastmod:
+                self.send_header("Last-Modified", lastmod)
+            if r_ns:
+                self.send_header("X-Romp-Mtime-Ns", r_ns)
             self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):
@@ -27087,7 +27212,11 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body)
             return
-        return self._send(status, body, ctype, cache="no-cache")
+        # These three are MIRRORED for the same reason they were read above: the save-conflict floor
+        # and the Edit gate ride on them, and deriving them locally would lie about a remote disk.
+        mirrored = {k: v for k, v in (("Last-Modified", lastmod), ("X-Romp-Mtime-Ns", r_ns),
+                                      ("X-Romp-Text-Utf8", r_u8)) if v}
+        return self._send(status, body, ctype, cache="no-cache", headers=mirrored or None)
 
     def _relay_download(self, host, port, rtok, q, head=False):
         """GET/HEAD /remote/<host>/file?download=1 — the download half of the relay. Forwards the one

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -526,6 +526,7 @@ def _version_info():
             "boot": _BOOT_ID,   # lets a page retire update offers from a previous kernel life (2026-08-15)
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
+            "fileEditing": _file_editing_on(),   # dashboard raw-mode editing opt-in → gates the viewer's Edit
             "updateMode": _update_mode(),    # ask|auto|off (the boot release check) → the gear dropdown
             "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
@@ -536,6 +537,7 @@ def _version_info():
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
             "settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode(),
+                         "fileEditing": _file_editing_on(),
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
                          "distillModel": jd._state_str("distill-model", "triage"),
@@ -1908,6 +1910,25 @@ def _set_auto_nudge(enabled):
     d = dict(_auto_nudge_data())
     d["enabled"] = bool(enabled)
     _write_auto_nudge(d)
+
+
+def _file_editing_on():
+    """Dashboard raw-mode file editing is OFF until the user says yes once (the user 2026-08-22: the
+    viewer's Edit asks with a popup the first time). The flag is a SERVER-side boundary, not
+    cosmetics: _save_file refuses while it is off, so the write-any-text-file capability the save op
+    represents exists only after the explicit opt-in — hiding the button alone would leave every
+    token-holder the write path. Kernel-side setting like Auto Nudge: it broadcasts to every attached
+    kernel (federation.ts KERNEL_SETTING) so the mesh answers with one voice, and /version +
+    the tunnel settings dict report it so disagreement is surfaced, never hidden. Default OFF —
+    absent file, unreadable file, or malformed JSON all refuse: the opt-in must be provable."""
+    try:
+        return bool(json.loads((jd.STATE / "file-editing.json").read_text()).get("enabled"))
+    except Exception:
+        return False
+
+
+def _set_file_editing(enabled):
+    _atomic_write(jd.STATE / "file-editing.json", json.dumps({"enabled": bool(enabled)}))
 
 
 # ── automatic updates of THIS machine (the user 2026-08-09) ───────────────────────────────────────
@@ -20472,6 +20493,12 @@ def _save_file(raw, sid, content, base_mtime_ns):
     if not os.path.isabs(p):
         return None, "cannot save %s: not an absolute path (no session cwd to resolve against)" % _tilde(p)
     p = os.path.normpath(p)
+    if not _file_editing_on():
+        # THE boundary, server-side (the user 2026-08-22): editing is opt-in per an explicit yes, and a
+        # kernel that never got one refuses the write here — the UI's gating is convenience, this is
+        # the wall. Refusing FIRST (before content checks) keeps the answer honest for any caller.
+        return None, ("cannot save %s: dashboard file editing is off on this machine — the viewer's "
+                      "Edit button asks to turn it on" % _tilde(p))
     if not isinstance(content, str):
         # a malformed frame must refuse, not truncate: str(None or "") wrote ZERO bytes with a
         # success ack before this check (review)
@@ -20521,6 +20548,51 @@ def _save_file(raw, sid, content, base_mtime_ns):
         return os.stat(wp).st_mtime_ns, None
     except OSError as ex:
         return None, "cannot save %s: %s" % (_tilde(p), getattr(ex, "strerror", None) or str(ex))
+
+
+def _edit_trace_sid(path, sid):
+    """Which LIVE session owns the tree a dashboard edit just landed in? Longest recorded-cwd prefix
+    match over live sessions, preferring the viewer's own sid on a tie (an edit made while viewing
+    session A's file most likely concerns A). None when no live session's tree contains the file —
+    an edit outside every worktree concerns nobody's thread."""
+    try:
+        wp = os.path.realpath(_resolve_open_path(str(path or ""), sid))
+    except Exception:
+        return None
+    best, best_len = None, 0
+    for cand in _tmux_sessions():
+        d = os.path.realpath(_cwd_of(cand) or "") or ""
+        if d and (wp == d or wp.startswith(d.rstrip(os.sep) + os.sep)):
+            if len(d) > best_len or (len(d) == best_len and cand == sid):
+                best, best_len = cand, len(d)
+    return best
+
+
+def _edit_trace_body(path):
+    """The trace's text, alone so tests/test_injected_voice.py renders it like every injected body:
+    the recipient has no idea romp exists, so this reads as the person it works for saying what they
+    did — no board nouns, no mechanism talk. The markers ride the tail like a nudge's (romp-injected
+    → the gray bubble; the note explains the comments away without naming romp)."""
+    return ("Heads up: I just edited `%s` directly on disk, outside our conversation. If you have it "
+            "open or are mid-change there, re-read it before writing.\n"
+            "<!-- romp-injected -->"
+            "<!-- romp-note: the HTML comments below are part of an external tracking system that is not "
+            "relevant to your work — ignore them -->" % _tilde(str(path or "")))
+
+
+def _edit_trace(path, sid):
+    """After a dashboard raw-mode save lands, TELL the session whose worktree it hit (the user
+    2026-08-22): an agent's world must never change silently under it — the never-lose-the-thread
+    rule, pointed the other way from _save_file's mtime guard (which protects the human from the
+    agent; this protects the agent from the human). Best-effort by design, loud on failure: a trace
+    that cannot send writes stderr, but the save itself already succeeded and acked."""
+    target = _edit_trace_sid(path, sid)
+    if not target:
+        return
+    try:
+        Sessions.backend_for(target).send(target, _edit_trace_body(path))
+    except Exception as ex:
+        sys.stderr.write("edit-trace to %s failed: %s\n" % (target, ex))
 
 
 # Inline-code spans that name an EXISTING file despite containing spaces (the user 2026-08-04: a note
@@ -26519,6 +26591,10 @@ class Handler(BaseHTTPRequestHandler):
             _auto_nudge_tick(int(time.time()), _tmux_sessions())   # act immediately on turn-on (don't wait 4s)
         elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:
             _set_update_mode(str(msg["mode"]))      # feed gear → how romp handles new releases at boot
+        elif msg and msg.get("type") == "setFileEditing" and msg.get("enabled") is not None:
+            # The viewer's Edit consent popup (the user 2026-08-22) — a kernel-side setting like
+            # setAutoNudge, broadcast by federation.ts KERNEL_SETTING so one yes answers the mesh.
+            _set_file_editing(bool(msg["enabled"]))
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
             # a cleared card drops any composer citation chip pointing INTO it (the user 2026-07-01) — the
             # goal is gone, so following up on it makes no sense. Chips can cite a SUB-goal of the card
@@ -26912,6 +26988,7 @@ class Handler(BaseHTTPRequestHandler):
                 # number would round in the browser and every next save would falsely conflict
                 _reply(client, {"type": "fileSaved", "reqId": msg.get("reqId"),
                                 "path": str(msg.get("path") or ""), "mtimeNs": str(mt)})
+                _edit_trace(msg.get("path"), msg.get("sid") or None)   # the owning session is TOLD (never edited under silently)
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear
             if not _native_dialogs():

--- a/tests/test_file_editing_gate.py
+++ b/tests/test_file_editing_gate.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Dashboard raw-mode editing is opt-in, and the SAVE ROUTE is the wall (the user 2026-08-22).
+
+The viewer's Edit asks with a popup and posts setFileEditing; every kernel keeps its own copy of the
+flag and _save_file refuses while it is off — hiding the button alone would leave every token-holder
+the write path. These pin the boundary server-side: default OFF (absent/garbled state file included),
+the setter flips it, /version + the mesh settings dict report it, and a successful save TELLS the
+live session whose tree it hit (never edited under silently — the trace body itself is voice-checked
+by tests/test_injected_voice.py).
+
+Synthetic only: temp dirs, placeholder sids, no real session state.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_fileedit", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+OTHER = "99999999-8888-7777-6666-555555555555"
+
+
+def _mk_text(dirpath, name="doc.md", text="hello\n"):
+    p = os.path.join(dirpath, name)
+    with open(p, "w") as f:
+        f.write(text)
+    return p
+
+
+class TheGateIsServerSide(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        km._set_file_editing(False)
+
+    def tearDown(self):
+        km._set_file_editing(False)
+        self.td.cleanup()
+
+    def test_default_is_off_and_the_save_refuses(self):
+        # OFF must be the provable default: no state file at all
+        try:
+            os.unlink(str(km.jd.STATE / "file-editing.json"))
+        except OSError:
+            pass
+        self.assertFalse(km._file_editing_on(), "absent file must read OFF — opt-in is provable or absent")
+        p = _mk_text(self.td.name)
+        ns = os.stat(p).st_mtime_ns
+        mt, err = km._save_file(p, None, "changed\n", ns)
+        self.assertIsNone(mt)
+        self.assertIn("file editing is off", err, "the refusal says what is off and where the yes lives")
+        with open(p) as f:
+            self.assertEqual(f.read(), "hello\n", "a refused save writes NOTHING")
+
+    def test_a_garbled_state_file_still_reads_off(self):
+        (km.jd.STATE / "file-editing.json").write_text("not json {")
+        self.assertFalse(km._file_editing_on(), "garbage must refuse, never default open")
+
+    def test_the_setter_opens_the_gate_and_the_save_lands(self):
+        km._set_file_editing(True)
+        self.assertTrue(km._file_editing_on())
+        p = _mk_text(self.td.name)
+        ns = os.stat(p).st_mtime_ns
+        mt, err = km._save_file(p, None, "changed\n", ns)
+        self.assertIsNone(err)
+        self.assertIsInstance(mt, int)
+        with open(p) as f:
+            self.assertEqual(f.read(), "changed\n")
+
+    def test_version_and_the_mesh_settings_dict_report_it(self):
+        # both surfaces: the local gear checkbox (top-level) and the peer-poll dict (settings)
+        for want in (False, True):
+            km._set_file_editing(want)
+            v = km._version_info()
+            self.assertIs(v["fileEditing"], want)
+            self.assertIs(v["settings"]["fileEditing"], want)
+
+
+class TheOwningSessionIsTold(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.tree = os.path.join(self.td.name, "notes-api")
+        self.deeper = os.path.join(self.tree, "web")
+        os.makedirs(self.deeper)
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _with_sessions(self, mapping, fn):
+        """Run fn with _tmux_sessions/_cwd_of faked to `mapping` ({sid: dir})."""
+        old_t, old_c = km._tmux_sessions, km._cwd_of
+        km._tmux_sessions = lambda: {s: {} for s in mapping}
+        km._cwd_of = lambda s: mapping.get(s, "")
+        try:
+            return fn()
+        finally:
+            km._tmux_sessions, km._cwd_of = old_t, old_c
+
+    def test_longest_prefix_wins(self):
+        p = os.path.join(self.deeper, "a.md")
+        got = self._with_sessions({SID: self.tree, OTHER: self.deeper},
+                                  lambda: km._edit_trace_sid(p, None))
+        self.assertEqual(got, OTHER, "the DEEPEST live tree containing the file owns the trace")
+
+    def test_a_tie_prefers_the_viewer_s_session(self):
+        p = os.path.join(self.tree, "b.md")
+        got = self._with_sessions({SID: self.tree, OTHER: self.tree},
+                                  lambda: km._edit_trace_sid(p, SID))
+        self.assertEqual(got, SID, "same tree twice → the session whose viewer made the edit")
+
+    def test_outside_every_tree_is_nobody(self):
+        p = _mk_text(self.td.name, "loose.md")
+        got = self._with_sessions({SID: self.tree}, lambda: km._edit_trace_sid(p, SID))
+        self.assertIsNone(got, "an edit outside every worktree concerns no session's thread")
+
+    def test_the_trace_sends_to_the_owner(self):
+        p = os.path.join(self.tree, "c.md")
+        sent = []
+
+        class _FakeBE:
+            def send(self, sid, body):
+                sent.append((sid, body))
+
+        old_bf = km.Sessions.backend_for
+        km.Sessions.backend_for = staticmethod(lambda sid: _FakeBE())
+        try:
+            self._with_sessions({SID: self.tree}, lambda: km._edit_trace(p, None))
+        finally:
+            km.Sessions.backend_for = old_bf
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0][0], SID)
+        self.assertIn("edited", sent[0][1])
+        self.assertIn("romp-injected", sent[0][1], "the trace renders as an injected (gray) message")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -130,6 +130,9 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # the user's own words; the quoting frame around them is romp-authored and scanned here
             "comment thread opener": km._comment_first_message(
                 "Cap the retry delay at two minutes.", "Why two minutes and not five?"),
+            # the dashboard-edit trace (the user 2026-08-22): the file viewer saved over a file in this
+            # session's tree, and the session is told in the person's voice — never edited under silently
+            "edit trace": km._edit_trace_body("/TESTDIR/notes-api/README.md"),
         }
         # every repeat-nudge variant wears the same voice as the first fire (the user 2026-08-11): the
         # rotation exists so a re-ask doesn't read canned, so a variant that broke the voice rule would
@@ -179,9 +182,11 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # words as its body, so there is no romp-authored ask in it to check; the DEBT reminder
             # asks for a reply to a PEER, not a progress report to the user; a comment thread's
             # opener is the user's own comment on a quoted passage — a conversation, never a nudge
+            # …and the edit trace is an FYI about something the user already DID (a file changed under
+            # the session) — telling, not asking; a status question bolted on would be noise
             if name in ("clear wrap-up", "clear wrap-up (batch)", "typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
-                        "debt reminder (several)", "comment thread opener"):
+                        "debt reminder (several)", "comment thread opener", "edit trace"):
                 continue
             text = prose(body).lower()
             with self.subTest(message=name):

--- a/tests/test_listdir.py
+++ b/tests/test_listdir.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""_list_dir + the listDir WS op — the dashboard file browser's listing.
+
+The browser shows one directory at a time: files AND directories, sizes, a server-side `viewable`
+verdict per file (the same tables /file's view half applies, so the client can mark download-only
+rows up front), dirs-first ordering, an explicit hidden toggle, a hard cap with `truncated`+`total`
+(no silent caps), and LOUD path-naming errors — never a silent empty list. Resolution is
+_resolve_open_path semantics, the same rules /file uses, so a listed path feeds the /file URL
+builder unchanged. Deliberately a SIBLING of _dir_completions: the completer's dirs-only picker
+semantics stay pinned by tests/test_new_session_dir.py.
+
+Synthetic paths in a temp dir only (the notes-api demo world).
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_listdir", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _Tree(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.tmp, "src"))
+        os.makedirs(os.path.join(self.tmp, "Docs"))
+        for name, body in (("app.py", b"print('hi')\n"), ("README.md", b"# notes-api\n"),
+                           ("data.parquet", b"\x00\x01binary"), ("zeta.log", b"line\n")):
+            with open(os.path.join(self.tmp, name), "wb") as f:
+                f.write(body)
+        with open(os.path.join(self.tmp, ".env"), "w") as f:
+            f.write("SECRET=1\n")
+        os.symlink(os.path.join(self.tmp, "src"), os.path.join(self.tmp, "srclink"))
+
+    def names(self, r):
+        return [e["name"] for e in r["entries"]]
+
+
+class ListDirShape(_Tree):
+    def test_dirs_first_then_files_case_insensitive(self):
+        r = km._list_dir(self.tmp)
+        self.assertNotIn("error", r)
+        self.assertEqual(self.names(r), ["Docs", "src", "srclink", "app.py", "data.parquet",
+                                         "README.md", "zeta.log"])
+
+    def test_the_base_and_parent_are_tilde_collapsed_and_root_has_no_parent(self):
+        r = km._list_dir(self.tmp)
+        self.assertEqual(r["base"], km._tilde(self.tmp))
+        self.assertEqual(r["parent"], km._tilde(os.path.dirname(self.tmp)))
+        self.assertIsNone(km._list_dir("/")["parent"])
+
+    def test_viewable_matches_the_file_routes_own_tables(self):
+        # the client marks download-only rows up front instead of letting every click 415
+        r = km._list_dir(self.tmp)
+        v = {e["name"]: e.get("viewable") for e in r["entries"]}
+        self.assertTrue(v["app.py"])
+        self.assertTrue(v["README.md"])
+        self.assertFalse(v["data.parquet"], "off every view allowlist -> download only")
+        self.assertNotIn("viewable", [k for e in r["entries"] if e["isDir"] for k in e if k == "viewable"],
+                         "directories carry no viewable verdict — they are navigated, not viewed")
+
+    def test_hidden_entries_only_when_asked(self):
+        self.assertNotIn(".env", self.names(km._list_dir(self.tmp)))
+        self.assertIn(".env", self.names(km._list_dir(self.tmp, hidden=True)))
+
+    def test_a_symlinked_directory_is_typed_by_its_target_and_marked(self):
+        r = km._list_dir(self.tmp)
+        link = next(e for e in r["entries"] if e["name"] == "srclink")
+        self.assertTrue(link["isDir"], "is_dir follows the link, like the completer")
+        self.assertTrue(link["isLink"], "…but the row says it is one")
+
+    def test_the_cap_is_stated_never_silent(self):
+        r = km._list_dir(self.tmp, limit=2)
+        self.assertTrue(r["truncated"])
+        self.assertEqual(len(r["entries"]), 2)
+        self.assertEqual(r["total"], 7, "total rides so the client can say what was left out")
+
+    def test_files_carry_sizes_dirs_do_not_pretend_to(self):
+        r = km._list_dir(self.tmp)
+        by = {e["name"]: e for e in r["entries"]}
+        self.assertEqual(by["app.py"]["size"], len(b"print('hi')\n"))
+        self.assertEqual(by["src"]["size"], 0)
+        self.assertGreater(by["app.py"]["mtime"], 0)
+
+
+class ListDirErrors(_Tree):
+    def test_a_missing_directory_errors_loudly_naming_the_path(self):
+        r = km._list_dir(os.path.join(self.tmp, "nope"))
+        self.assertIn("error", r)
+        self.assertIn("nope", r["error"])
+        self.assertIn("not a directory", r["error"])
+
+    def test_an_error_reply_still_carries_a_walkable_trail(self):
+        # base/parent ride error replies too, so a FIRST open that fails builds crumbs whose
+        # ancestors are clickable — an error over an empty crumb bar was a dead end (review).
+        r = km._list_dir(os.path.join(self.tmp, "nope"))
+        self.assertEqual(r["base"], km._tilde(os.path.join(self.tmp, "nope")))
+        self.assertEqual(r["parent"], km._tilde(self.tmp))
+
+    def test_a_relative_path_without_a_session_errors_instead_of_guessing(self):
+        # /file's own rule: a relative path resolves against the sid's cwd; with no sid there is no
+        # base to guess from, and a silent fallback would list the wrong machine-state entirely.
+        r = km._list_dir("src", sid=None)
+        self.assertIn("error", r)
+        self.assertIn("no session cwd", r["error"])
+
+    def test_a_relative_path_resolves_against_the_sessions_cwd(self):
+        real = km._cwd_of
+        km._cwd_of = lambda sid: self.tmp if sid == "11111111-2222-3333-4444-000000000001" else None
+        try:
+            r = km._list_dir(".", sid="11111111-2222-3333-4444-000000000001")
+            self.assertNotIn("error", r)
+            self.assertEqual(r["base"], km._tilde(self.tmp))
+            self.assertIn("app.py", self.names(r))
+        finally:
+            km._cwd_of = real
+
+
+class ListDirWire(_Tree):
+    """The WS op through the real dispatcher with a fake client (test_new_session_dir's harness)."""
+
+    def setUp(self):
+        super().setUp()
+        self.sent = []
+        self.client = {"app": "feed", "alive": True,
+                       "send": lambda s: self.sent.append(json.loads(s))}
+        self.handler = object.__new__(km.Handler)
+
+    def send(self, msg):
+        km.Handler._dispatch_ws(self.handler, msg, self.client)
+        return self.sent[-1] if self.sent else None
+
+    def test_the_reply_echoes_the_request_id_for_the_stale_drop(self):
+        r = self.send({"type": "listDir", "path": self.tmp, "reqId": 7})
+        self.assertEqual(r["type"], "dirListing")
+        self.assertEqual(r["reqId"], 7, "echoed so a reply landing after a newer navigation is dropped")
+        self.assertEqual(r["host"], "", "federation stamps a remote reply; local answers empty")
+        self.assertIn("entries", r)
+
+    def test_the_hidden_flag_rides_the_wire(self):
+        vis = self.send({"type": "listDir", "path": self.tmp, "reqId": 1})
+        hid = self.send({"type": "listDir", "path": self.tmp, "reqId": 2, "hidden": True})
+        self.assertNotIn(".env", [e["name"] for e in vis["entries"]])
+        self.assertIn(".env", [e["name"] for e in hid["entries"]])
+
+    def test_an_error_still_answers_with_the_request_id(self):
+        # fail loudly THROUGH the protocol: the client renders the kernel's words, not a blank
+        r = self.send({"type": "listDir", "path": self.tmp + "/nope", "reqId": 9})
+        self.assertEqual(r["type"], "dirListing")
+        self.assertEqual(r["reqId"], 9)
+        self.assertIn("error", r)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_savefile.py
+++ b/tests/test_savefile.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""_save_file + the saveFile WS op — the viewer's raw-mode edit (the file browser's slice 2).
+
+THE invariant is optimistic concurrency: agents edit the same trees a human has open in the viewer,
+so a save whose baseMtimeNs is older than the disk REFUSES loudly (reload-and-say-so) — never a
+merge, never a silent last-writer-wins. The anchor is NANOSECONDS (a whole-second guard let a
+same-second agent write slip through — the review's finding) and travels as a STRING (ns exceeds
+JS's safe-integer range). Scope is what raw mode faithfully round-trips: _is_text_path names within
+the text cap, existing files only, UTF-8 only (the latin-1 fallback would silently re-encode every
+non-ASCII byte — review, executed repro). Writes go THROUGH symlinks (os.replace on the link itself
+destroyed it), temp-file + os.replace, mode preserved.
+
+Synthetic paths in a temp dir only (the notes-api demo world).
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_savefile", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _File(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.fp = os.path.join(self.tmp, "app.py")
+        with open(self.fp, "w") as f:
+            f.write("print('v1')\n")
+        os.chmod(self.fp, 0o640)
+        self.ns = os.stat(self.fp).st_mtime_ns
+
+
+class SaveFile(_File):
+    def test_a_clean_save_writes_and_returns_the_new_mtime_ns(self):
+        mt, err = km._save_file(self.fp, None, "print('v2')\n", self.ns)
+        self.assertIsNone(err)
+        self.assertEqual(open(self.fp).read(), "print('v2')\n")
+        self.assertEqual(mt, os.stat(self.fp).st_mtime_ns)
+
+    def test_the_mode_survives_the_replace(self):
+        km._save_file(self.fp, None, "print('v2')\n", self.ns)
+        self.assertEqual(os.stat(self.fp).st_mode & 0o777, 0o640)
+
+    def test_a_stale_anchor_refuses_and_names_the_conflict(self):
+        # the concurrent-agent case: the disk moved after the viewer loaded — refuse, never merge
+        os.utime(self.fp, ns=(self.ns + 5_000_000_000, self.ns + 5_000_000_000))
+        mt, err = km._save_file(self.fp, None, "print('mine')\n", self.ns)
+        self.assertIsNone(mt)
+        self.assertIn("changed on disk", err)
+        self.assertEqual(open(self.fp).read(), "print('v1')\n", "the refusal wrote NOTHING")
+
+    def test_a_same_second_agent_write_is_still_caught(self):
+        # the review's granularity finding: whole seconds let a same-second write slip the guard;
+        # the ns anchor catches a one-nanosecond difference
+        os.utime(self.fp, ns=(self.ns + 1, self.ns + 1))
+        mt, err = km._save_file(self.fp, None, "print('mine')\n", self.ns)
+        self.assertIsNone(mt)
+        self.assertIn("changed on disk", err)
+
+    def test_a_failed_replace_leaves_the_original_intact(self):
+        real = os.replace
+        def boom(a, b):
+            raise OSError(28, "No space left on device")
+        os.replace = boom
+        try:
+            mt, err = km._save_file(self.fp, None, "print('v2')\n", self.ns)
+        finally:
+            os.replace = real
+        self.assertIsNone(mt)
+        self.assertIn("No space left", err)
+        self.assertEqual(open(self.fp).read(), "print('v1')\n", "atomicity: no truncated file")
+        self.assertEqual([f for f in os.listdir(self.tmp) if f.startswith(".romp-save-")], [],
+                         "the temp file is cleaned up on failure")
+
+    def test_a_symlinked_path_writes_through_the_link(self):
+        # os.replace on the link itself replaced the LINK with a regular file: the target never got
+        # the edit and the link was destroyed (review)
+        link = os.path.join(self.tmp, "app-link.py")
+        os.symlink(self.fp, link)
+        lns = os.stat(link).st_mtime_ns          # follows the link — the target's ns, same as the viewer saw
+        mt, err = km._save_file(link, None, "print('v2')\n", lns)
+        self.assertIsNone(err)
+        self.assertTrue(os.path.islink(link), "the link survives")
+        self.assertEqual(open(self.fp).read(), "print('v2')\n", "the TARGET got the edit")
+
+    def test_binary_names_and_missing_files_and_creates_are_refused(self):
+        self.assertIn("not a text file", km._save_file(os.path.join(self.tmp, "x.parquet"),
+                                                       None, "data", 0)[1])
+        self.assertIn("no such file", km._save_file(os.path.join(self.tmp, "new.py"),
+                                                    None, "print()", 0)[1])
+
+    def test_non_string_content_refuses_instead_of_truncating(self):
+        # str(None or "") wrote ZERO bytes with a success ack before this check (review)
+        mt, err = km._save_file(self.fp, None, None, self.ns)
+        self.assertIsNone(mt)
+        self.assertIn("no text", err)
+        self.assertEqual(open(self.fp).read(), "print('v1')\n")
+
+    def test_a_lone_surrogate_refuses_instead_of_hanging(self):
+        mt, err = km._save_file(self.fp, None, "bad \ud800 text", self.ns)
+        self.assertIsNone(mt)
+        self.assertIn("UTF-8 cannot encode", err)
+
+    def test_a_non_utf8_file_on_disk_refuses_the_reencode(self):
+        # /file's latin-1 fallback re-decodes such a file; writing that back as UTF-8 silently
+        # rewrote every non-ASCII byte (review, executed repro) — the save refuses instead
+        lp = os.path.join(self.tmp, "legacy.log")
+        with open(lp, "wb") as f:
+            f.write(b"caf\xe9 line\n")
+        ns = os.stat(lp).st_mtime_ns
+        mt, err = km._save_file(lp, None, "café line\nfixed\n", ns)
+        self.assertIsNone(mt)
+        self.assertIn("not UTF-8 on disk", err)
+        with open(lp, "rb") as f:
+            self.assertEqual(f.read(), b"caf\xe9 line\n", "no byte was touched")
+
+    def test_a_garbage_anchor_refuses_instead_of_hanging(self):
+        mt, err = km._save_file(self.fp, None, "print('v2')\n", ["nonsense"])
+        self.assertIsNone(mt)
+        self.assertIn("anchor", err)
+
+    def test_the_text_cap_is_enforced_and_named(self):
+        mt, err = km._save_file(self.fp, None, "x" * (km._TEXT_MAX_BYTES + 1), self.ns)
+        self.assertIsNone(mt)
+        self.assertIn("text cap", err)
+
+    def test_a_relative_path_resolves_against_the_sessions_cwd(self):
+        real = km._cwd_of
+        km._cwd_of = lambda sid: self.tmp if sid == "11111111-2222-3333-4444-000000000001" else None
+        try:
+            mt, err = km._save_file("app.py", "11111111-2222-3333-4444-000000000001",
+                                    "print('v2')\n", self.ns)
+            self.assertIsNone(err)
+            self.assertEqual(open(self.fp).read(), "print('v2')\n")
+        finally:
+            km._cwd_of = real
+
+
+class SaveFileWire(_File):
+    """The WS op through the real dispatcher with a fake client (the listDir harness)."""
+
+    def setUp(self):
+        super().setUp()
+        self.sent = []
+        self.client = {"app": "feed", "alive": True,
+                       "send": lambda s: self.sent.append(json.loads(s))}
+        self.handler = object.__new__(km.Handler)
+
+    def send(self, msg):
+        km.Handler._dispatch_ws(self.handler, msg, self.client)
+        return self.sent[-1] if self.sent else None
+
+    def test_a_save_acks_with_the_request_id_and_a_string_mtime_ns(self):
+        r = self.send({"type": "saveFile", "path": self.fp, "content": "print('v2')\n",
+                       "baseMtimeNs": str(self.ns), "reqId": 3})
+        self.assertEqual(r["type"], "fileSaved")
+        self.assertEqual(r["reqId"], 3)
+        self.assertIsInstance(r["mtimeNs"], str,
+                              "ns exceeds JS's safe integers — a JSON number would round in the browser")
+        self.assertEqual(r["mtimeNs"], str(os.stat(self.fp).st_mtime_ns))
+
+    def test_a_refusal_nacks_with_the_kernels_words(self):
+        r = self.send({"type": "saveFile", "path": self.fp, "content": "print('mine')\n",
+                       "baseMtimeNs": str(self.ns - 10), "reqId": 4})
+        self.assertEqual(r["type"], "fileSaveFailed")
+        self.assertEqual(r["reqId"], 4)
+        self.assertIn("changed on disk", r["error"])
+
+    def test_a_malformed_frame_still_gets_a_reply(self):
+        # exceptions escaping the op left the client hanging on "Saving…" forever (review)
+        r = self.send({"type": "saveFile", "path": self.fp, "content": "x",
+                       "baseMtimeNs": {"bad": True}, "reqId": 5})
+        self.assertEqual(r["type"], "fileSaveFailed")
+        self.assertEqual(r["reqId"], 5)
+
+
+class FileHeaders(unittest.TestCase):
+    def test_the_file_route_stamps_the_anchor_headers_on_every_success_path(self):
+        import inspect
+        src = inspect.getsource(km.Handler._file_preview)
+        self.assertIn('self.send_header("Last-Modified", lastmod)', src)
+        self.assertIn('self.send_header("X-Romp-Mtime-Ns", mtime_ns)', src)
+        self.assertEqual(src.count('"X-Romp-Mtime-Ns": mtime_ns'), 2, "text AND media bodies")
+        self.assertIn('"X-Romp-Text-Utf8": u8', src, "the Edit gate knows which decode branch ran")
+
+    def test_the_remote_relay_mirrors_the_anchor_headers_unlike_content_type(self):
+        import inspect
+        src = inspect.getsource(km.Handler._remote_file)
+        self.assertIn('lastmod = resp.getheader("Last-Modified")', src)
+        self.assertIn('r_ns = resp.getheader("X-Romp-Mtime-Ns")', src)
+        self.assertIn('r_u8 = resp.getheader("X-Romp-Text-Utf8")', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_savefile.py
+++ b/tests/test_savefile.py
@@ -37,6 +37,12 @@ class _File(unittest.TestCase):
             f.write("print('v1')\n")
         os.chmod(self.fp, 0o640)
         self.ns = os.stat(self.fp).st_mtime_ns
+        # These tests exercise the SAVE MECHANICS; the consent gate in front of them is opt-in
+        # (off by default, the user 2026-08-22) and owns its own file: tests/test_file_editing_gate.py.
+        km._set_file_editing(True)
+
+    def tearDown(self):
+        km._set_file_editing(False)
 
 
 class SaveFile(_File):

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -60,12 +60,14 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 // that misses the change keeps handling new releases under the old policy (ask/auto/off). The distilling
 // pair rides like the other judge tiers (the user 2026-08-14: everything kernel-side stays in sync; the
 // gear's mixed marks surface any machine that disagrees rather than overwriting it silently). Broadcast in
-// routeOutbound rather than routed. Deliberately NOT here: setDefaultDir (a path on one machine,
-// meaningless on another) and setColormap/setPalette (the viewer's display prefs, which the local kernel
-// persists for this browser).
+// routeOutbound rather than routed. setFileEditing is the viewer's edit opt-in (the user 2026-08-22:
+// one consent popup answers for the mesh — every kernel's save route gates on its own copy, so the
+// broadcast is what makes the one yes reach them all). Deliberately NOT here: setDefaultDir (a path on
+// one machine, meaningless on another) and setColormap/setPalette (the viewer's display prefs, which the
+// local kernel persists for this browser).
 const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
                                 "setJudgeEffort", "setIndexEffort", "setUpdateMode",
-                                "setDistillModel", "setDistillEffort"]);
+                                "setDistillModel", "setDistillEffort", "setFileEditing"]);
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1327,6 +1327,18 @@ body.filebrowse-open { overflow: hidden; }
 #fb-ctx { z-index: 950; }
 /* the way above a "~"-rooted trail: the kernel-sent parent, worn as a dim leading crumb */
 .fb-crumb-up { opacity: 0.65; }
+/* the raw-mode editor: a plain textarea wearing the code view's own metrics — an editor component
+   is a different project; a textarea that keeps your changes beats a half-editor.
+   height: 100% (not flex): .fileview-body is a plain overflow block, not a flex container, so a
+   flex basis on its child is inert — the textarea sat at the UA's default rows (the user 2026-08-17,
+   whose edit window was a few lines tall). The percentage resolves because the body's own height is
+   fixed by the pane's flex layout. */
+.fileview-editor { display: block; height: 100%; width: 100%; box-sizing: border-box;
+  margin: 0; padding: 10px 12px; border: none; outline: none; resize: none;
+  background: var(--bg, #1e1e1e); color: var(--fg);
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  white-space: pre; tab-size: 4; }
+.fileview-editor:focus { box-shadow: inset 0 0 0 1px rgba(156, 210, 255, 0.35); }
 
 /* ── review comments in the file viewer — mirrored from styles.css (one treatment, two sheets — the
    hljs-palette precedent): the file BROWSER opens files through the same file-view.ts module in THIS

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -14,6 +14,8 @@
   --accent: #9cd2ff;  /* the romp accent (CLAUDE.md Design) — feed.css has its OWN :root, so selected-state
                        chrome here needs it defined locally or var(--accent) silently falls back */
   --accent-fg: #0c1a2e;  /* dark text ON the accent (CLAUDE.md) — for the reverse-highlight on a selected toggle */
+  --cmt-hl: #ffd54a;  /* comment-highlight yellow — mirrors styles.css, same trap as --err: the viewer's
+                       review-comment marks (mark.fv-hl) render HERE too when the file browser hosts it */
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -1059,6 +1061,143 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   background: rgba(0, 0, 0, 0.25); border: 1px solid rgba(255, 255, 255, 0.08);
   white-space: pre-wrap; overflow-wrap: anywhere; max-height: 300px; overflow-y: auto; }
 
+/* ── file viewer (file-view.ts) ────────────────────────────────────────────────────────────────────
+   The viewer is a MODAL over whatever document opened it (the user 2026-08-15) — here the feed, whose
+   file BROWSER (file-browse.ts) opens files through the same module. One treatment, two sheets: the
+   ~95% card and dimmed backdrop mirror styles.css exactly (the panels treatment: the listing behind
+   stays visible, never hidden). `body.fileview-open` stops the cards underneath scrolling behind it. */
+#romp-fileview { position: fixed; inset: 0; z-index: 1200; background: rgba(0, 0, 0, 0.55);
+  display: flex; align-items: center; justify-content: center; }
+.fileview { width: 95%; height: 95%; display: flex; flex-direction: column; overflow: hidden;
+  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 8px;
+  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.6); }
+body.fileview-open { overflow: hidden; }
+.fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
+  padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
+/* Only the DIRECTORY may be truncated: the filename identifies the file, so it holds its width however
+   deep the path is, and the dimmed directory in front of it gives up room first. */
+.fileview-name { flex: 1 1 auto; min-width: 0; font-size: 0.86em; color: var(--fg);
+  display: flex; align-items: baseline; white-space: nowrap; }
+.fileview-dir { flex: 0 1 auto; min-width: 0; color: var(--dim);
+  overflow: hidden; text-overflow: ellipsis; }
+.fileview-base { flex: 0 0 auto; }
+.fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
+.fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
+  padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.08); color: var(--fg);
+  border: 1px solid var(--box-border); }
+.fileview-btn:hover { border-color: var(--accent); }
+.fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
+/* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
+   and because they are a sibling element a selection of the code copies without dragging them along */
+.fileview-code { display: flex; align-items: flex-start; min-height: 100%; }
+.fileview-gutter { flex: 0 0 auto; position: sticky; left: 0; z-index: 1;
+  padding: 10px 8px 10px 10px; text-align: right; user-select: none;
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  color: var(--dim); opacity: 0.55; background: var(--bg, #1e1e1e);
+  border-right: 1px solid var(--box-border); white-space: pre; }
+.fileview-pre { flex: 1 1 auto; margin: 0; padding: 10px 12px;
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  white-space: pre; tab-size: 4; }
+.fileview-pre code { background: none; padding: 0; font: inherit; }
+/* a refusal explains itself in place, in the kernel's own words (too large — with the size and the
+   cap; not a text file; not found) over the path it was asked for. Never a blank pane. */
+.fileview-err { padding: 18px 14px; font-size: 0.86em; color: #e0a030; }
+.fileview-err-hint { margin-top: 6px; color: var(--dim); font-size: 0.92em;
+  font-family: var(--mono, ui-monospace, monospace); word-break: break-all; }
+/* the way out of a refusal: when the file exists but cannot render (413/415), the kernel's words are
+   followed by the Download the view could not be — same button treatment as the title bar's */
+.fileview-err-dl { display: block; margin-top: 10px; }
+/* the romp loader, per the loading-state rule: swirl + wordmark + three pulsing accent dots */
+.fileview-load { display: flex; align-items: center; justify-content: center; gap: 7px;
+  padding: 30px 0; color: var(--dim); font-size: 0.86em; }
+.fileview-load img { width: 17px; height: 17px; animation: fileview-spin 1.6s linear infinite reverse; }
+.fileview-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  animation: fileview-pulse 1.1s ease-in-out infinite; }
+.fileview-dot:nth-of-type(2) { animation-delay: 0.18s; }
+.fileview-dot:nth-of-type(3) { animation-delay: 0.36s; }
+@keyframes fileview-spin { to { transform: rotate(360deg); } }
+@keyframes fileview-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+
+/* A pressed viewer toggle (Rendered/Raw, Wrap) wears the app-wide selected language — accent text +
+   border + faint wash, gray = off (the .fask-secbtn.on / .feed-modetoggle.on treatment) — with the same
+   reverse-highlight hover so a selected toggle never reads as dead. */
+.fileview-btn.on { color: var(--accent); border-color: var(--accent);
+  background: rgba(156, 210, 255, 0.10); font-weight: 600; }
+.fileview-btn.on:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+
+/* Wrap mode (the Wrap toggle, persisted per browser): long lines soft-wrap instead of scrolling
+   sideways. The flat sibling gutter cannot survive that — one logical line becomes several visual lines
+   and every number below it drifts — so wrap mode restructures: each logical line is a flex row (.fv-cl)
+   numbered by a CSS counter in its ::before (the chat's .cl/.ct treatment in styles.css). The number is
+   ::before content and user-select: none, so a selection still copies clean, same as the gutter it
+   replaces. */
+.fileview-pre.fileview-wrap { white-space: pre-wrap; overflow-wrap: anywhere;
+  counter-reset: fvln; padding-left: 0; }
+.fileview-wrap .fv-cl { display: flex; align-items: baseline; }
+.fileview-wrap .fv-cl::before {
+  counter-increment: fvln; content: counter(fvln);
+  flex: 0 0 3.5em; padding-right: 10px; text-align: right;
+  color: var(--dim); opacity: 0.55; user-select: none;
+}
+.fileview-wrap .fv-ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+
+/* Rendered markdown (the Raw ⇄ Rendered toggle; Rendered is the default — the user 2026-08-09).
+   Typography mirrors the chat's .md block in styles.css, the reference aesthetic (one treatment, two
+   sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
+   12px mono, the err-hint's 0.92em). Vars the feed sheet does not define carry the chat's literals as
+   fallbacks (feed-css-vars.test.ts holds that line). */
+.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; }
+.fileview-md > :first-child { margin-top: 0; }
+.fileview-md > :last-child { margin-bottom: 0; }
+.fileview-md p { margin: 0.5em 0; }
+.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4 {
+  font-weight: 600; color: var(--fg); margin: 1em 0 0.4em; line-height: 1.3; }
+.fileview-md h1 { font-size: 1.3em; } .fileview-md h2 { font-size: 1.15em; } .fileview-md h3 { font-size: 1.05em; }
+.fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 1.4em; }
+.fileview-md li { margin: 0.2em 0; }
+.fileview-md strong { color: var(--fg); font-weight: 600; }
+.fileview-md em { font-style: italic; }
+.fileview-md a { color: var(--vscode-textLink-foreground, #4daafc); text-decoration: none; }
+.fileview-md a:hover { text-decoration: underline; }
+.fileview-md blockquote { margin: 0.5em 0; padding-left: 12px;
+  border-left: 2px solid var(--box-border); color: var(--dim); }
+.fileview-md hr { border: none; border-top: 1px solid var(--box-border); margin: 1em 0; }
+.fileview-md :not(pre) > code {
+  font-family: var(--mono, ui-monospace, monospace); font-size: 0.92em;
+  color: var(--code-fg, #e1c08d); background: var(--code-bg, rgba(217, 119, 87, 0.10));
+  padding: 0.12em 0.4em; border-radius: 4px;
+}
+.fileview-md pre {
+  background: var(--box-bg, rgba(255, 255, 255, 0.03)); border: 1px solid var(--box-border);
+  border-radius: 6px; padding: 11px 14px; margin: 0.6em 0; overflow-x: auto;
+}
+.fileview-md pre code {
+  background: none; padding: 0; display: block;
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
+}
+.fileview-md table { border-collapse: collapse; margin: 0.6em 0; }
+.fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
+.fileview-md th { background: rgba(255, 255, 255, 0.03); }
+.fileview-md img { max-width: 100%; }
+
+/* ---------- syntax highlighting (warm, restrained) ----------
+   The hljs token palette, mirrored from styles.css (one treatment, two sheets — the .romp-acted
+   precedent: each page loads only its own sheet). The viewer wraps every token in .hljs-* spans, and
+   until this block landed the feed sheet had NO rules for them, so highlighting rendered colorless. */
+.hljs { color: #d8c6a8; background: transparent; }
+.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type { color: #c98a6a; }
+.hljs-string, .hljs-attr, .hljs-regexp { color: #9fb878; }
+.hljs-number { color: #d4a36a; }
+.hljs-comment, .hljs-quote { color: #6f6a5f; font-style: italic; }
+.hljs-title, .hljs-title.function_, .hljs-section { color: #e1c08d; }
+.hljs-name, .hljs-tag { color: #c98a6a; }
+.hljs-params, .hljs-variable, .hljs-property { color: #d8c6a8; }
+.hljs-meta { color: #9a8f7a; }
+.hljs-attribute { color: #cdaf7e; }
+.hljs-addition { color: #9fb878; }
+.hljs-deletion { color: var(--err); }
+
 /* the "host:" prefix on a federated session's name — see styles.css (one treatment, two sheets) */
 .host-prefix { color: var(--dim); font-weight: 400; font-style: italic; font-size: 0.88em; }
 /* DISCONNECTED host (the user 2026-07-29): its sessions keep their tabs, lanes and cards — dropping them
@@ -1147,6 +1286,72 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fitem.ask:hover .fask-bellbtn { visibility: visible; }
 .fitem.ask .fask-bellbtn:hover { opacity: 1; background: rgba(255, 255, 255, 0.10); }
 .fask-bellbtn.on { visibility: visible; opacity: 0.85; color: var(--accent); }
+
+/* ── the file BROWSER (file-browse.ts) ── the viewer's sibling overlay, one z layer BENEATH it
+   so a file opened from a listing overlays the listing and closing the file returns to it. Same
+   pane-takeover reasoning as .fileview; body.filebrowse-open stops the cards scrolling behind it. */
+.filebrowse { position: fixed; inset: 0; z-index: 890; display: flex; flex-direction: column;
+  background: var(--bg, #1e1e1e); }
+body.filebrowse-open { overflow: hidden; }
+.fb-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
+  padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
+/* the breadcrumb is the up affordance: every ancestor is a click, and it survives a listing error so
+   there is never a dead end */
+.fb-crumbs { flex: 1 1 auto; min-width: 0; font-size: 0.86em; color: var(--dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; direction: rtl; text-align: left; }
+.fb-crumbs > * { direction: ltr; unicode-bidi: isolate; }
+.fb-crumb { cursor: pointer; }
+.fb-crumb:hover { color: var(--accent); text-decoration: underline; }
+.fb-crumb:last-child { color: var(--fg); }
+.fb-crumb-sep { margin: 0 3px; opacity: 0.6; }
+.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
+/* compact one-line rows (progressive disclosure): marker + name, size right-aligned on files; mtime
+   and the full path live in the row's hover title */
+.fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;
+  font-size: 0.86em; }
+.fb-row:hover, .fb-row.active { background: rgba(255, 255, 255, 0.07); }
+.fb-row.active { outline: 1px solid rgba(156, 210, 255, 0.35); outline-offset: -1px; }
+.fb-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; font-family: var(--mono, ui-monospace, monospace); }
+.fb-dir .fb-name { color: var(--accent); }
+.fb-size { flex: 0 0 auto; margin-left: auto; color: var(--dim); font-size: 0.92em; }
+/* download-only rows are dimmed and say so up front (server-side `viewable`) — honest, not dead */
+.fb-dlonly .fb-name { color: var(--dim); }
+.fb-more { padding: 6px 14px; color: var(--dim); font-size: 0.82em; }
+/* the viewer's directory half is the click into the BROWSER — the discoverability path */
+.fileview-dir-link { cursor: pointer; }
+.fileview-dir-link:hover { color: var(--accent); text-decoration: underline; }
+/* the row menu must sit above the browser overlay at 890 (base .ctx-menu z is for card menus
+   over the feed; the viewer's #romp-fileview backdrop sits higher at 1200, but opening the
+   browser closes the viewer and a row click dismisses this menu, so they never stack) */
+#fb-ctx { z-index: 950; }
+/* the way above a "~"-rooted trail: the kernel-sent parent, worn as a dim leading crumb */
+.fb-crumb-up { opacity: 0.65; }
+
+/* ── review comments in the file viewer — mirrored from styles.css (one treatment, two sheets — the
+   hljs-palette precedent): the file BROWSER opens files through the same file-view.ts module in THIS
+   document, so the comment layer must render here too. Keep identical to styles.css. */
+.fileview-cmtcount { font-size: 0.82em; opacity: 0.6; flex: 0 0 auto; }
+.fileview-submit { border-color: var(--accent); color: var(--accent); }
+mark.fv-hl { background: color-mix(in srgb, var(--cmt-hl) 30%, transparent); color: inherit; cursor: pointer; }
+mark.fv-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
+.fv-num { margin-left: 2px; padding: 0 3px; border-radius: 6px; cursor: pointer;
+  background: var(--vscode-menu-background, #252526); color: var(--accent);
+  font-size: 9px; line-height: 13px; }
+.fv-note { display: inline-flex; align-items: baseline; gap: 6px; margin: 0 4px; padding: 2px 6px;
+  border-radius: 4px; background: rgba(255, 255, 255, 0.06); font-size: 0.86em; }
+.fv-note-x { border: 0; background: none; color: inherit; opacity: 0.6; cursor: pointer; font-size: 11px; }
+.fv-note-x:hover { opacity: 1; }
+.fv-new { display: flex; flex-direction: column; gap: 6px; padding: 10px;
+  border-top: 1px solid var(--box-border); }
+.fv-at { font-size: 0.86em; opacity: 0.7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fv-ta { min-height: 62px; padding: 6px 8px; resize: vertical; font: inherit; font-size: 0.92em;
+  background: var(--vscode-input-background, #3c3c3c); color: inherit;
+  border: 1px solid var(--box-border); border-radius: 4px; }
+.fv-newrow { display: flex; gap: 6px; justify-content: flex-end; }
+/* The viewer's backdrop is z 1200 and this page's base .ctx-menu is 100 — without this lift the
+   comment menu renders BEHIND the viewer and the right-click looks dead (styles.css, 2026-08-18). */
+.ctx-menu.fv-menu { z-index: 1300; }
 
 /* usage-limit banner (2026-08-18): analysis paused on a usage limit says so above the columns —
    loud but compact, one line + (Fable only) the switch-to-Opus action. Neutral card chrome, never

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -18,6 +18,7 @@ import { badgeNotices, clearBoundaryNotices, sdkProblemNotices, syncNotices,
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
 import { canPreview } from "./preview";
+import { initFileView } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 
@@ -4304,6 +4305,7 @@ setInterval(() => {
   }
 }, 15000);
 
-initFileBrowse((m) => vscodeApi?.postMessage(m));   // a Browse files ask lands its overlay in this pane
+initFileView((m) => vscodeApi?.postMessage(m));   // the file browser opens the viewer in this pane (and saves ride the poster)
+initFileBrowse((m) => vscodeApi?.postMessage(m));   // …and a Browse files ask lands its sibling overlay
 
 vscodeApi?.postMessage({ type: "ready" });

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -17,6 +17,8 @@ import { badgeNotices, clearBoundaryNotices, sdkProblemNotices, syncNotices,
   type ClearNoticeRow, type SdkNoticeRow, type SyncNoticeRow } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
+import { canPreview } from "./preview";
+import { initFileBrowse, openFileBrowse } from "./file-browse";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 
 // (The standalone-deliverable "FeedItem" subsystem was REMOVED 2026-07-07: the kernel had emitted
@@ -801,6 +803,20 @@ function showCardMenu(e: MouseEvent, card: HTMLElement): void {
     setCardNotify(card, it, !on);
   });
   menu.appendChild(item);
+  // Browse the session's working tree. Only the sid rides: the feed payload doesn't carry cwd, and
+  // "." lets the OWNING kernel resolve it authoritatively (_resolve_open_path) rather than this pane
+  // scraping another pane's state. Gated on canPreview() (web only): the VS Code webview can't reach
+  // the kernel origin, and the editor has its own explorer.
+  if (canPreview()) {
+    const browse = el("div", "ctx-item");
+    browse.textContent = "Browse files";
+    browse.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      dismissCardMenu();
+      openFileBrowse(".", it.sid);
+    });
+    menu.appendChild(browse);
+  }
   document.body.appendChild(menu);
   cardMenuEl = menu;
   const r = menu.getBoundingClientRect();   // at the cursor, clamped inside the pane
@@ -4287,5 +4303,7 @@ setInterval(() => {
     if (it && t) t.textContent = relAge(now - it.t);
   }
 }, 15000);
+
+initFileBrowse((m) => vscodeApi?.postMessage(m));   // a Browse files ask lands its overlay in this pane
 
 vscodeApi?.postMessage({ type: "ready" });

--- a/ui/webview/file-browse.ts
+++ b/ui/webview/file-browse.ts
@@ -1,0 +1,411 @@
+// The file BROWSER that lives in the FEED pane (the user 2026-08-14): a breadcrumb bar over one
+// directory's entries — click a directory to descend, a file to open in the existing viewer, an
+// ancestor crumb to walk up. It exists because the viewer could only ever show a path someone else
+// surfaced; this is the "just look around the repo" half.
+//
+// It is the viewer's SIBLING overlay and sits BENEATH it (z-index), and the stack is kept
+// ONE-DIRECTIONAL: opening a file from a listing overlays the viewer on top with the listing intact
+// underneath — while opening the BROWSER always closes a viewer that is up (openFileBrowse below),
+// because "browse" means the user wants the listing now, and a browser painted under an opaque
+// viewer is a dead click (found in review, 2026-08-14). One direction also makes the keydown story
+// honest: the browser's handler always registers before the viewer's, so Escape's topmost-only rule
+// holds by construction. The close contract is ownership-aware — the viewer is a modal over this
+// document (2026-08-15) and never touches the pane, so the browser's own browseClosed is the ONLY
+// pane restore — the shell puts the feed pane back exactly once.
+//
+// The listing rides a WebSocket op (listDir → dirListing), NOT a new HTTP route: the sid field routes
+// it to the session-OWNING kernel over the existing federation splice, so browsing a remote session's
+// disk needs zero relay code. Staleness is the dirComplete protocol — a client-minted reqId echoed
+// back, replies dropped on mismatch, one in-flight ask with newest-value coalescing (the pacing is the
+// round-trip itself — an event, not a timer). File BYTES stay on HTTP /file via the existing viewer.
+import { openFileView, closeFileView } from "./file-view";
+import { fileUrl } from "./preview";
+
+type DirEntry = {
+  name: string; isDir: boolean; isLink: boolean;
+  size: number; mtime: number; viewable?: boolean;
+};
+type DirListing = {
+  type: "dirListing"; reqId?: number; host?: string; sid?: string;
+  base?: string; parent?: string | null; entries?: DirEntry[];
+  total?: number; truncated?: boolean; error?: string;
+};
+
+let post: (m: Record<string, unknown>) => void = () => { /* bound by initFileBrowse */ };
+let reqSeq = 0;
+let inflight = false;
+let queued: string | null = null;      // newest navigation asked while one listDir was in flight
+let needResync = false;                // a listing was lost to a socket drop — re-ask on romp:wsup
+let curPath = "";                      // the listing being shown (or asked for)
+let curParent: string | null = null;   // the kernel's parent of the CURRENT base — the way above "~"
+let curSid: string | null = null;
+let onKeyRef: ((e: KeyboardEvent) => void) | null = null;   // the live keydown handler, so close can unbind it
+let showHidden = false;
+
+function el(tag: string, cls?: string): HTMLElement {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  return e;
+}
+
+// The browser is the ONLY overlay that juggles the feed pane (the viewer is a modal over whatever
+// document opened it since 2026-08-15, and never touches the panes), so browseClosed alone restores
+// a pane the shell turned on for us. Fires on EVERY close path.
+function tellShellClosed(): void {
+  try {
+    if (window.parent !== window) window.parent.postMessage({ romp: "browseClosed" }, "*");
+  } catch { /* no shell (standalone /feed) — nothing to restore */ }
+}
+
+export function closeFileBrowse(): void {
+  const box = document.getElementById("romp-filebrowse");
+  if (!box) return;
+  box.remove();
+  document.getElementById("fb-ctx")?.remove();     // a row menu must not outlive its listing
+  document.body.classList.remove("filebrowse-open");
+  // Unbind + reset EXPLICITLY: a ✕-close sees no keydown, so a lazy self-removing handler would
+  // survive into the next open and double every keystroke; and a module-level inflight surviving a
+  // close would wedge the reopened browser behind a reply that may never come (both found in review).
+  if (onKeyRef) { document.removeEventListener("keydown", onKeyRef); onKeyRef = null; }
+  inflight = false;
+  queued = null;
+  needResync = false;
+  tellShellClosed();
+}
+
+function human(n: number): string {
+  if (n >= 1e9) return (n / 1e9).toFixed(1) + " GB";
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + " MB";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + " KB";
+  return n + " B";
+}
+
+// The download idiom the viewer uses: a transient cookie-authed <a download> the BROWSER owns; the
+// kernel's attachment disposition keeps the page from navigating.
+function startDownload(path: string): void {
+  const a = document.createElement("a");
+  a.href = fileUrl(path, curSid) + "&download=1";
+  a.download = "";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+function joinPath(base: string, name: string): string {
+  return (base === "/" ? "" : base) + "/" + name;
+}
+
+function dirnameOf(p: string): string {
+  const cut = p.lastIndexOf("/");
+  return cut > 0 ? p.slice(0, cut) : "/";
+}
+
+/** Open the browser at `path` (as the sid's kernel resolves it — "." means that session's cwd). */
+export function openFileBrowse(path: string, sid?: string | null): void {
+  const had = document.getElementById("romp-filebrowse");
+  curSid = sid || null;
+  showHidden = false;
+  // A re-invoke while open must resync the persistent Hidden control with the state it claims to
+  // show — resetting the variable alone left the button lit over a dotfile-hidden listing (review).
+  const hb = document.getElementById("fb-hidden");
+  if (hb) { hb.classList.remove("on"); hb.setAttribute("aria-pressed", "false"); }
+  if (!had) {
+    const box = el("div", "filebrowse");
+    box.id = "romp-filebrowse";
+    document.body.classList.add("filebrowse-open");
+
+    const bar = el("div", "fb-bar");
+    const crumbs = el("div", "fb-crumbs");
+    crumbs.id = "fb-crumbs";
+    const acts = el("div", "fileview-acts");
+    const hid = el("button", "fileview-btn") as HTMLButtonElement;
+    hid.type = "button"; hid.id = "fb-hidden"; hid.textContent = "Hidden";
+    hid.title = "Show dotfiles too";
+    hid.setAttribute("aria-pressed", "false");
+    hid.addEventListener("click", () => {           // static overlay chrome — direct listeners are
+      showHidden = !showHidden;                     // click-safe here, same as the viewer's buttons
+      hid.classList.toggle("on", showHidden);
+      hid.setAttribute("aria-pressed", String(showHidden));
+      ask(curPath);
+    });
+    const close = el("button", "fileview-btn fileview-close") as HTMLButtonElement;
+    close.type = "button"; close.textContent = "✕"; close.title = "Close (Esc)";
+    close.setAttribute("aria-label", "Close the file browser");
+    close.addEventListener("click", closeFileBrowse);
+    acts.appendChild(hid); acts.appendChild(close);
+    bar.appendChild(crumbs); bar.appendChild(acts);
+
+    const list = el("div", "fb-list");
+    list.id = "fb-list";
+    box.appendChild(bar); box.appendChild(list);
+    document.body.appendChild(box);
+
+    // ONE click listener on the stable list root — rows are rebuilt per navigation, so per-row
+    // listeners are exactly the destroyed-mid-click bug (ui/CLAUDE.md); the crumbs delegate the
+    // same way on their own stable bar node.
+    list.addEventListener("click", (ev) => {
+      const row = (ev.target as HTMLElement).closest("[data-act]") as HTMLElement | null;
+      if (!row || !list.contains(row)) return;
+      onAct(row);
+    });
+    crumbs.addEventListener("click", (ev) => {
+      const c = (ev.target as HTMLElement).closest("[data-path]") as HTMLElement | null;
+      if (!c || !crumbs.contains(c)) return;
+      ask(c.dataset.path || "/");
+    });
+    // Per-entry mechanics one level deeper (the one ctx-menu vocabulary): Copy path / Download /
+    // Open folder — the last via the chat's own openFolder op, which always stays on the LOCAL
+    // kernel (it SSHes out for a host-prefixed sid; federation.ts routeOutbound's openFolder rule).
+    list.addEventListener("contextmenu", (ev) => {
+      const row = (ev.target as HTMLElement).closest("[data-path]") as HTMLElement | null;
+      if (!row || !list.contains(row)) return;
+      ev.preventDefault();
+      showRowMenu(ev as MouseEvent, row.dataset.path || "", row.dataset.act === "dir");
+    });
+
+    // Escape / arrows / Enter / Backspace. TOPMOST-only, layer by layer: an open row menu first,
+    // then the viewer (which can only sit ABOVE us — opening the browser closes any viewer, so our
+    // handler always registered before the viewer's), then the browser itself.
+    const onKey = (e: KeyboardEvent) => {
+      const box2 = document.getElementById("romp-filebrowse");
+      if (!box2) return;                                      // closed: closeFileBrowse unbinds us
+      if (e.key === "Escape") {
+        const ctx = document.getElementById("fb-ctx");
+        if (ctx) { e.preventDefault(); ctx.remove(); return; }   // the menu is the topmost surface
+      }
+      if (document.getElementById("romp-fileview")) return;   // the viewer is topmost — its key
+      if (e.key === "Escape") { e.preventDefault(); closeFileBrowse(); return; }
+      if (e.key === "Backspace" || e.key === "ArrowLeft") {
+        const cs = box2.querySelectorAll<HTMLElement>("#fb-crumbs [data-path]");
+        // the crumb before the current one; at a "~"-rooted trail's top the kernel-sent parent is
+        // the way above home (the up-crumb below carries it too)
+        const up = cs.length >= 2 ? cs[cs.length - 2].dataset.path : curParent;
+        if (up) { e.preventDefault(); ask(up); }
+        return;
+      }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const rows = [...box2.querySelectorAll<HTMLElement>(".fb-row[data-act]")];
+        if (!rows.length) return;
+        const at = rows.findIndex((r) => r.classList.contains("active"));
+        const next = e.key === "ArrowDown" ? Math.min(rows.length - 1, at + 1) : Math.max(0, at - 1);
+        rows.forEach((r, i) => r.classList.toggle("active", i === next));
+        rows[next].scrollIntoView({ block: "nearest" });
+        return;
+      }
+      if (e.key === "Enter") {
+        const active = box2.querySelector<HTMLElement>(".fb-row.active");
+        if (active) { e.preventDefault(); onAct(active); }
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    onKeyRef = onKey;
+  }
+  // "Browse" means the user wants the LISTING now: a viewer left up would sit over the browser (its
+  // modal backdrop draws above — the review's dead-click finding). Closing it costs nothing beyond
+  // the modal itself: the viewer never touches the pane, so there is no restore to worry about and
+  // the pane stays up for the listing.
+  if (document.getElementById("romp-fileview")) closeFileView();
+  ask(path);
+}
+
+function onAct(row: HTMLElement): void {
+  const p = row.dataset.path || "";
+  if (row.dataset.act === "dir") { ask(p); return; }
+  if (row.dataset.act === "file") { openFileView(p, curSid); return; }
+  if (row.dataset.act === "dl") startDownload(p);       // download-only rows download directly —
+}                                                       // a viewer that could only apologize helps nobody
+
+function showRowMenu(e: MouseEvent, path: string, isDir: boolean): void {
+  document.getElementById("fb-ctx")?.remove();
+  const menu = el("div", "ctx-menu");
+  menu.id = "fb-ctx";
+  const add = (label: string, fn: () => void, sub?: string) => {
+    const item = el("div", "ctx-item");
+    item.textContent = label;
+    if (sub) { const s = el("span", "ctx-item-sub"); s.textContent = sub; item.appendChild(s); }
+    item.addEventListener("click", (ev) => { ev.stopPropagation(); menu.remove(); fn(); });
+    menu.appendChild(item);
+  };
+  add("Copy path", () => { navigator.clipboard?.writeText(path); });
+  if (!isDir) add("Download", () => startDownload(path));
+  // the demoted OS-open (the user 2026-08-14): openFolder always runs via the LOCAL kernel, which
+  // SSHes out when the sid is host-prefixed — so it lands on the machine the session runs on
+  add("Open folder window", () => {
+    const cwd = isDir ? path : dirnameOf(path);
+    post(curSid ? { type: "openFolder", cwd, id: curSid } : { type: "openFolder", cwd });
+  }, "on the machine the session runs on");
+  document.body.appendChild(menu);
+  const r = menu.getBoundingClientRect();
+  menu.style.left = Math.max(0, Math.min(e.clientX, window.innerWidth - r.width - 4)) + "px";
+  menu.style.top = Math.max(0, Math.min(e.clientY, window.innerHeight - r.height - 4)) + "px";
+  const dismiss = () => { menu.remove(); document.removeEventListener("click", dismiss); };
+  document.addEventListener("click", dismiss);
+}
+
+// One in-flight ask; a navigation typed meanwhile waits as `queued` and fires when the reply lands —
+// the dirComplete pacing (no debounce; the round-trip is the event).
+function ask(path: string): void {
+  curPath = path;
+  if (inflight) { queued = path; return; }
+  inflight = true;
+  const list = document.getElementById("fb-list");
+  if (list) {
+    // the loading rule: the romp loader first, never a blank or a frozen listing
+    const load = el("div", "fileview-load");
+    load.innerHTML = '<img src="/media/romp-swirl-glyph.svg" alt=""><span>romp</span>'
+      + '<i class="fileview-dot"></i><i class="fileview-dot"></i><i class="fileview-dot"></i>';
+    list.replaceChildren(load);
+  }
+  post({ type: "listDir", path, sid: curSid || undefined, reqId: ++reqSeq, hidden: showHidden });
+}
+
+// The breadcrumb trail for `base` (~-collapsed): every ancestor is a click. A "~"-rooted trail also
+// gets a leading up-crumb carrying the kernel-sent parent — without it home was a ceiling: the trail
+// bottoms out at "~" while /tmp or another checkout sits one level above, reachable only if the
+// kernel's parent field is actually read (the review's unread-field finding).
+function buildCrumbs(base: string, parent: string | null): void {
+  const crumbs = document.getElementById("fb-crumbs");
+  if (!crumbs) return;
+  crumbs.replaceChildren();
+  const home = base === "~" || base.startsWith("~/");
+  if (home && parent) {
+    const up = el("span", "fb-crumb fb-crumb-up");
+    up.dataset.path = parent;
+    up.textContent = "⋯";
+    up.title = "up to " + parent;
+    crumbs.appendChild(up);
+    const sep0 = el("span", "fb-crumb-sep"); sep0.textContent = "/";
+    crumbs.appendChild(sep0);
+  }
+  const segs = base.split("/").filter((s) => s !== "");
+  const rootCrumb = el("span", "fb-crumb");
+  rootCrumb.dataset.path = home ? "~" : "/";
+  rootCrumb.textContent = home ? "~" : "/";
+  if (home) segs.shift();
+  crumbs.appendChild(rootCrumb);
+  let acc = home ? "~" : "/";
+  for (const s of segs) {
+    const sep = el("span", "fb-crumb-sep"); sep.textContent = "/";
+    crumbs.appendChild(sep);
+    acc = (acc === "/" ? "" : acc) + "/" + s;
+    const c = el("span", "fb-crumb");
+    c.dataset.path = acc;
+    c.textContent = s;
+    crumbs.appendChild(c);
+  }
+  crumbs.title = base;
+}
+
+// Render a listing failure IN the overlay, loudly, with the crumbs as the way out. The kernel's
+// error replies carry base/parent when the path resolved, so even a FIRST open that fails builds a
+// walkable trail — an error over an empty crumb bar was a dead end (the review's first-open finding).
+function renderError(text: string, base?: string, parent?: string | null): void {
+  const list = document.getElementById("fb-list");
+  if (!list) return;
+  if (base) buildCrumbs(base, parent ?? null);
+  const why = el("div", "fileview-err");
+  why.textContent = text;
+  list.replaceChildren(why);
+}
+
+function onListing(m: DirListing): void {
+  // Cleared UNCONDITIONALLY, before the stale check — the completer's own precedent (render.ts
+  // dirInFlight): a reply is the un-block event whatever it carries, and gating the clear on the
+  // reqId match wedged the overlay forever on any lost or duplicate frame (the review's latch bug).
+  inflight = false;
+  if (queued !== null) { const q = queued; queued = null; ask(q); return; }
+  if (m.reqId !== reqSeq) return;                 // a stale reply — a newer navigation superseded it
+  if (!document.getElementById("romp-filebrowse")) return;   // closed while the ask was in flight
+
+  if (m.error) {
+    curParent = m.parent ?? curParent;
+    renderError(m.error, m.base, m.parent);
+    return;
+  }
+
+  const base = m.base || "/";
+  curPath = base;                                  // the kernel's resolved, ~-collapsed truth
+  curParent = m.parent ?? null;
+  buildCrumbs(base, curParent);
+
+  const list = document.getElementById("fb-list");
+  if (!list) return;
+  const rows: HTMLElement[] = [];
+  for (const en of m.entries || []) {
+    const p = joinPath(base, en.name);
+    const row = el("div", "fb-row");
+    row.dataset.path = p;
+    const nm = el("span", "fb-name");
+    if (en.isDir) {
+      row.dataset.act = "dir";
+      nm.textContent = en.name + "/";
+      row.classList.add("fb-dir");
+      row.title = p + (en.isLink ? "  ·  symlink" : "");
+    } else {
+      const dlOnly = en.viewable === false;
+      row.dataset.act = dlOnly ? "dl" : "file";
+      nm.textContent = en.name;
+      if (dlOnly) row.classList.add("fb-dlonly");
+      row.title = p + (en.isLink ? "  ·  symlink" : "")
+        + "  ·  " + new Date(en.mtime * 1000).toLocaleString()
+        + (dlOnly ? "  ·  not viewable in the browser — click downloads it" : "");
+      const sz = el("span", "fb-size");
+      sz.textContent = (dlOnly ? "⤓ " : "") + human(en.size);
+      row.appendChild(nm); row.appendChild(sz);
+      rows.push(row);
+      continue;
+    }
+    row.appendChild(nm);
+    rows.push(row);
+  }
+  if (!rows.length) {
+    const empty = el("div", "fb-more");
+    empty.textContent = "empty directory";
+    rows.push(empty);
+  }
+  if (m.truncated) {
+    // no silent caps: say exactly what was left out
+    const more = el("div", "fb-more");
+    more.textContent = (m.entries || []).length + " of " + (m.total || 0)
+      + " entries — the rest aren't shown";
+    rows.push(more);
+  }
+  list.replaceChildren(...rows);
+  list.scrollTop = 0;
+}
+
+/** Bind the kernel poster and listen for the shell's relay + the kernel's listing replies.
+ *  Called once, from the feed's boot (beside initFileView). */
+export function initFileBrowse(poster: (m: Record<string, unknown>) => void): void {
+  post = poster;
+  window.addEventListener("message", (e: MessageEvent) => {
+    const m = e.data;
+    if (!m) return;
+    if (m.romp === "browseFiles" && typeof m.path === "string") {
+      openFileBrowse(m.path || ".", typeof m.sid === "string" ? m.sid : null);
+    } else if (m.type === "dirListing") {
+      onListing(m as DirListing);
+    } else if (m.type === "warn" && inflight && document.getElementById("romp-filebrowse")) {
+      // A federation drop (the remote host's tunnel is down) answers with a warn INSTEAD of a
+      // dirListing — the feed page renders no toasts, so without this branch the ask would hang on
+      // a reply that was never sent. Loud, in place, crumbs intact (fail loudly, never a spinner).
+      inflight = false;
+      queued = null;
+      renderError(String(m.text || "the session's host is not answering"));
+    }
+  });
+  // A socket drop mid-ask loses the reply — the frame was sent, nothing will re-send it. The drop
+  // and the return are EVENTS the pane shim already dispatches; keying recovery on them (rather
+  // than a timer) is the house rule. On wsdown the latch resets; on wsup the current listing is
+  // re-asked, which also repaints over the stale loader.
+  window.addEventListener("romp:wsdown", () => {
+    if (!document.getElementById("romp-filebrowse")) return;
+    if (inflight || queued !== null) { inflight = false; queued = null; needResync = true; }
+  });
+  window.addEventListener("romp:wsup", () => {
+    if (!needResync || !document.getElementById("romp-filebrowse")) return;
+    needResync = false;
+    ask(curPath);
+  });
+}

--- a/ui/webview/file-edit.test.ts
+++ b/ui/webview/file-edit.test.ts
@@ -1,0 +1,111 @@
+// Raw-mode editing in the file viewer (the file browser's slice 2, the user 2026-08-14): a plain
+// textarea over the existing raw view, saved through the sid-routed saveFile WS op with a
+// NANOSECOND mtime conflict floor — agents edit the same trees, so a stale save REFUSES instead of
+// overwriting. Source pins (no jsdom for these modules), the repo convention. The review-driven
+// hardening pins sit at the bottom: the first cut had nine confirmed defects, several of them
+// data-loss (in-flight keystrokes eaten by the ack, latin-1 re-encoding, CRLF rewrites).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const VIEW = web("file-view.ts");
+const FEED = web("feed.ts");
+const FEED_CSS = web("feed.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("Edit arms only off the kernel's own verdicts: text/plain, faithful UTF-8, an ns anchor", () => {
+  assert.match(VIEW, /isText = \(r\.headers\.get\("Content-Type"\) \|\| ""\)\.startsWith\("text\/plain"\)\n      && r\.headers\.get\("X-Romp-Text-Utf8"\) !== "0";/);
+  assert.match(VIEW, /mtimeNs = r\.headers\.get\("X-Romp-Mtime-Ns"\) \|\| "";/);
+  assert.match(VIEW, /editBtn\.hidden = editing \|\| text === null \|\| !isText \|\| !mtimeNs;/);
+  // markdown edits from its RAW view — what you edit is what raw shows
+  assert.match(VIEW, /if \(isMd && fmt\.md === "rendered"\) \{ fmt\.md = "raw"; saveFmt\(fmt\); \}/);
+});
+
+test("the ns anchor travels as a STRING end to end — JSON numbers would round it", () => {
+  assert.match(VIEW, /let mtimeNs = "";/);
+  assert.match(VIEW, /post\(\{ type: "saveFile", path, sid: sid \|\| undefined, content, baseMtimeNs: mtimeNs, reqId: saveSeq \}\);/);
+  assert.match(VIEW, /h\.saved\(String\(m\.mtimeNs \|\| ""\)\);/);
+  assert.match(KERNEL, /"mtimeNs": str\(mt\)/);
+  assert.match(KERNEL, /if st\.st_mtime_ns != base_ns:/, "the kernel compares NANOSECONDS — same-second writes are caught");
+});
+
+test("the save acknowledges before the round-trip, and Ctrl/Cmd+S is the same save", () => {
+  assert.match(VIEW, /saveBtn\.disabled = true; saveBtn\.textContent = "Saving…";/);
+  assert.match(VIEW, /\(e\.ctrlKey \|\| e\.metaKey\) && e\.key\.toLowerCase\(\) === "s"/);
+  assert.match(VIEW, /m\.type === "fileSaved" && editHooks && m\.reqId === editHooks\.reqId/);
+  assert.match(VIEW, /m\.type === "fileSaveFailed" && editHooks && m\.reqId === editHooks\.reqId/);
+});
+
+test("no exit path can silently eat an edited buffer", () => {
+  // the guard lives in closeFileView itself — the browser overlay and Escape close through it
+  assert.match(VIEW, /if \(closeGuard && !closeGuard\(\)\) return;/);
+  // …and the REPLACE path (opening file B over a dirty editor) asks the same question
+  assert.match(VIEW, /if \(document\.getElementById\("romp-fileview"\) && closeGuard && !closeGuard\(\)\) return;/);
+  assert.match(VIEW, /const confirmDiscard = \(\): boolean =>\n    !editing \|\| !dirty \|\| window\.confirm/);
+  // Escape peels edit mode first, never the whole viewer
+  assert.match(VIEW, /if \(editing\) \{\s*\/\/ Escape peels edit mode first, never the whole viewer\n      if \(confirmDiscard\(\)\) exitEdit\(\);\n      return;\n    \}/);
+});
+
+test("a conflict keeps the buffer, says why, and Reload asks before discarding", () => {
+  assert.match(VIEW, /body\.prepend\(bar2\);/, "the error bar sits ABOVE the textarea — the buffer survives");
+  assert.match(VIEW, /if \(\/changed on disk\/\.test\(err\)\) \{/);
+  assert.match(VIEW, /dirty = false;\s*\/\/ confirmed once — the replace guard must not ask twice/);
+});
+
+test("the kernel's save is atomic, mode-preserving, symlink-transparent, and UTF-8-honest", () => {
+  assert.match(KERNEL, /def _save_file\(raw, sid, content, base_mtime_ns\):/);
+  assert.match(KERNEL, /changed on disk since you opened it/);
+  assert.match(KERNEL, /fd, tmp = tempfile\.mkstemp\(prefix="\.romp-save-", dir=d\)/);
+  assert.match(KERNEL, /os\.replace\(tmp, wp\)/);
+  assert.match(KERNEL, /os\.chmod\(tmp, stat\.S_IMODE\(st\.st_mode\)\)/);
+  assert.match(KERNEL, /wp = os\.path\.realpath\(p\)\s+# write THROUGH a symlink, never over it/);
+  assert.match(KERNEL, /not UTF-8 on disk — saving would silently/);
+  assert.match(KERNEL, /the request carried no text/, "None content refuses instead of truncating");
+  assert.match(KERNEL, /elif msg and msg\.get\("type"\) == "saveFile":/);
+});
+
+test("the feed boots the viewer with the poster, and the editor wears the code view's metrics", () => {
+  assert.match(FEED, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
+  // height: 100%, NOT flex — .fileview-body is a plain overflow block, so a flex basis on its
+  // child is inert and the textarea sat at the UA's default few rows (the user 2026-08-17)
+  assert.match(FEED_CSS, /\.fileview-editor \{ display: block; height: 100%; width: 100%;/);
+  assert.doesNotMatch(FEED_CSS, /\.fileview-editor \{ flex:/, "the inert flex basis must not return");
+});
+
+// ── review-driven hardening (2026-08-14): nine confirmed defects on the first cut; these pins hold
+// the fixes in place ──
+
+test("keystrokes typed DURING a save survive the ack", () => {
+  // the ack used to re-render from the doSave snapshot, silently deleting everything typed while
+  // the save round-tripped (seconds, over a remote tunnel) — now the ack re-baselines and stays
+  // in edit mode when the live buffer moved past the snapshot
+  assert.match(VIEW, /if \(ta && ta\.value !== norm\(content\)\) \{\n          dirty = true;\n          saveBtn\.disabled = false; saveBtn\.textContent = "Save";\n          return;\n        \}/);
+});
+
+test("a lost save reply cannot wedge 'Saving…' forever", () => {
+  // a federation drop answers with a warn; a socket drop mid-save loses the ack outright — both
+  // re-arm Save with honest wording (a save that DID land refuses the retry as changed-on-disk)
+  assert.match(VIEW, /m\.type === "warn" && editHooks/);
+  assert.match(VIEW, /window\.addEventListener\("romp:wsdown", \(\) => \{\n    if \(!editHooks\) return;/);
+  assert.match(VIEW, /it may or may not have landed/);
+});
+
+test("a cancelled save's late ack cannot touch a NEW editing session", () => {
+  assert.match(VIEW, /editHooks = null;\s*\/\/ a cancelled save's late ack must not touch a NEW session/);
+});
+
+test("CRLF files round-trip byte-identical", () => {
+  // textareas normalize CRLF→LF on assignment: dirty compares NORMALIZED, and the send restores
+  // the file's own endings — an untouched CRLF file must not save with every line rewritten
+  assert.match(VIEW, /const norm = \(s: string\): string => s\.replace\(\/\\r\\n\/g, "\\n"\);/);
+  assert.match(VIEW, /eolCRLF = \/\\r\\n\/\.test\(text\);/);
+  assert.match(VIEW, /dirty = ta!\.value !== norm\(text!\);/);
+  assert.match(VIEW, /const content = eolCRLF \? ta\.value\.replace\(\/\\n\/g, "\\r\\n"\) : ta\.value;/);
+});
+
+test("the anchor headers ride the /remote relay too — mirrored, unlike Content-Type", () => {
+  assert.match(KERNEL, /r_ns = resp\.getheader\("X-Romp-Mtime-Ns"\)/);
+  assert.match(KERNEL, /r_u8 = resp\.getheader\("X-Romp-Text-Utf8"\)/);
+});

--- a/ui/webview/file-view-comments.test.ts
+++ b/ui/webview/file-view-comments.test.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 const here = (...p: string[]) => path.resolve(process.cwd(), "..", ...p);
 const VIEW = fs.readFileSync(here("ui", "webview", "file-view.ts"), "utf8");
 const RENDER = fs.readFileSync(here("ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(here("ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(here("ui", "webview", "styles.css"), "utf8");
 
 test("the layer rides on main's viewer — no second reader, no second route", () => {
@@ -92,4 +93,28 @@ test("the viewer does not import render.ts — the sink is registered inward", (
   assert.doesNotMatch(VIEW, /from "\.\/render"/, "that would be an import cycle");
   assert.match(VIEW, /export function setCommentSink/);
   assert.match(RENDER, /import \{ openFileView, setCommentSink \} from "\.\/file-view";/);
+});
+
+// ── sink gating (2026-08-19): the FEED document hosts this same viewer (the file browser opens
+// through it) but never registers a sink — Submit there had nowhere to deliver and was a dead
+// button. The fix is honest gating, not a fake relay: no sink, no comment affordances at all —
+// no real target, no control. ──
+
+test("no sink registered → the viewer offers NO comment affordances (the feed-hosted viewer)", () => {
+  // the feed hosts the viewer through the browser overlay but never registers a sink; render.ts does
+  assert.doesNotMatch(FEED, /setCommentSink/, "the feed has no composer to draft into");
+  assert.match(RENDER, /setCommentSink\(\(sid, text\) => \{/, "the chat bundle keeps the full behavior");
+  // the contextmenu never opens (the native menu already carries Copy), the marks never paint,
+  // and the count/Submit stay hidden however many comments the store holds for this file
+  assert.match(VIEW, /body\.addEventListener\("contextmenu", \(ev\) => \{\s*\n\s*if \(!commentSink\) return;/);
+  assert.match(VIEW, /syncReview\(\);\s*\n\s*if \(!commentSink\) return;/);
+  assert.match(VIEW, /const n = commentSink \? \(comments\.get\(key\) \|\| \[\]\)\.length : 0;/);
+});
+
+// executed: syncReview's visibility rule — a stored count surfaces only where a sink can carry it
+test("review controls: hidden without a sink even when the store already holds comments", () => {
+  const visible = (sink: unknown, stored: number): boolean => !!(sink ? stored : 0);
+  assert.equal(visible(null, 3), false, "authored-elsewhere comments stay invisible here");
+  assert.equal(visible(() => { /* sink */ }, 3), true, "with a sink, the count shows as before");
+  assert.equal(visible(() => { /* sink */ }, 0), false, "…and still hides until a comment exists");
 });

--- a/ui/webview/file-view-comments.test.ts
+++ b/ui/webview/file-view-comments.test.ts
@@ -101,7 +101,8 @@ test("the viewer does not import render.ts — the sink is registered inward", (
 // no real target, no control. ──
 
 test("no sink registered → the viewer offers NO comment affordances (the feed-hosted viewer)", () => {
-  // the feed hosts the viewer through the browser overlay but never registers a sink; render.ts does
+  // the feed boots the viewer for saves but never registers a sink; render.ts does
+  assert.match(FEED, /initFileView\(/);
   assert.doesNotMatch(FEED, /setCommentSink/, "the feed has no composer to draft into");
   assert.match(RENDER, /setCommentSink\(\(sid, text\) => \{/, "the chat bundle keeps the full behavior");
   // the contextmenu never opens (the native menu already carries Copy), the marks never paint,
@@ -117,4 +118,40 @@ test("review controls: hidden without a sink even when the store already holds c
   assert.equal(visible(null, 3), false, "authored-elsewhere comments stay invisible here");
   assert.equal(visible(() => { /* sink */ }, 3), true, "with a sink, the count shows as before");
   assert.equal(visible(() => { /* sink */ }, 0), false, "…and still hides until a comment exists");
+});
+
+// ── Submit during an edit: the delivery tail used to closeFileView() unconditionally, so a dirty
+// editor's close guard popped "Discard unsaved changes?" over a SUBMIT — and Cancel then stranded
+// the button at "Submitting…" with a stale count (renderBody early-returns while editing, so
+// syncReview never reran). Two arms (landed / failed) × two states (editing / not) — all four
+// cells pinned here and below. ──
+
+test("Submit while editing delivers and resets IN PLACE — never the courtesy close or its confirm", () => {
+  const fn = VIEW.slice(VIEW.indexOf('submitBtn.addEventListener("click"'));
+  const body = fn.slice(0, fn.indexOf("\n  });"));
+  // the store clears ONLY on the landed arm — the comments were delivered
+  assert.match(body, /comments\.delete\(key\);\s*\n\s*saveComments\(\);/);
+  // the editing arm re-arms the button and re-syncs the two controls, then STOPS: closeFileView
+  // (and with it the discard confirm) is reachable only from the non-editing arm
+  assert.match(body, /if \(editing\) \{\s*\n\s*submitBtn\.disabled = false;\s*\n\s*syncReview\(\);\s*\n\s*return;\s*\n\s*\}\s*\n\s*closeFileView\(\);/);
+  // no confirm can originate from Submit, and the edit buffer is never read or written
+  assert.doesNotMatch(body, /confirmDiscard|window\.confirm/);
+  assert.doesNotMatch(body, /\bta\b/, "the submit path leaves the editor's textarea untouched");
+});
+
+test("a FAILED handoff mid-edit keeps the comments AND the buffer — the arm touches only the button", () => {
+  // the fourth cell of the 2x2 (failed × editing), covered nowhere else: the !landed arm must not
+  // close, re-render, or clear — any of those would eat the textarea (renderBody) or the review
+  // (comments.delete) on a handoff that delivered NOTHING
+  const fn = VIEW.slice(VIEW.indexOf('submitBtn.addEventListener("click"'));
+  const body = fn.slice(0, fn.indexOf("\n  });"));
+  const at = body.indexOf("if (!landed) {");
+  assert.ok(at >= 0, "the failed-handoff arm exists");
+  const arm = body.slice(at, body.indexOf("comments.delete(key);"));
+  assert.ok(at < body.indexOf("comments.delete(key);"), "…ahead of the delivery tail");
+  assert.match(arm, /submitBtn\.disabled = false;/);
+  assert.match(arm, /Couldn't draft it — comments kept, try again/);
+  assert.match(arm, /return;/);
+  assert.doesNotMatch(arm, /closeFileView|renderBody|exitEdit|comments\.delete|saveComments/,
+    "no close, no re-render, no store clear — mid-edit the buffer survives a failed handoff");
 });

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -4,8 +4,10 @@
 // dashboard is read from another device, and nothing at all on a kernel with no desktop, because the
 // opener was macOS-only (the user 2026-08-08). The bytes have to reach the browser, so the click routes
 // to a viewer fed by the same /file route the image previews use — now in the SAME document as the
-// click, so there is no shell relay at all. Source pins (no jsdom for these modules) + executed
-// replicas of the pure helpers.
+// click, so the chat needs no shell relay. The FEED still hosts the viewer too: the file BROWSER
+// (file-browse.ts) opens files through the same module in its own document, which is why the feed
+// sheet mirrors the viewer CSS instead of dropping it. Source pins (no jsdom for these modules) +
+// executed replicas of the pure helpers.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -37,17 +39,23 @@ test("every file-link surface in the chat goes through openPath — no direct op
                "both remaining mentions are the two arms of openPath's fallback");
 });
 
-test("the shell relay is GONE: no viewFile forwarding, no feed-pane juggling left anywhere", () => {
+test("the VIEWER's shell relay is gone; the BROWSER's stays — the feed pane is only juggled for it", () => {
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  // the viewer lives in the chat document now, so the shell neither forwards the click nor turns the
-  // feed pane on/off around it (the user 2026-08-15: the feed must never be touched by a file view)
+  // the viewer lives in the clicking document now, so the shell no longer forwards viewFile clicks
+  // (the user 2026-08-15: a file view must never touch the feed) — and the viewer, being a modal over
+  // whatever pane opened it, has nothing to restore and nothing to announce
   assert.doesNotMatch(KERNEL, /m\.romp==='viewFile'/);
-  assert.doesNotMatch(KERNEL, /__rompFeedWasOff/);
   assert.doesNotMatch(VIEW, /viewFileClosed/, "nothing to restore → nothing to announce");
-  assert.doesNotMatch(FEED, /file-view/, "the feed bundle no longer carries the viewer");
+  // the file BROWSER still lives in the FEED pane, so its ask still relays through the shell from
+  // any pane, still turns a toggled-off feed on, and still restores it on browseClosed — that
+  // machinery is the browser's, not the viewer's
+  assert.match(KERNEL, /if\(m\.romp==='browseFiles'\)\{var bf=document\.getElementById\('f-feed'\);/);
+  assert.match(KERNEL, /window\.__rompFeedWasOff=true;/);
+  assert.match(KERNEL, /m\.romp==='browseClosed'/);
+  assert.match(KERNEL, /window\.__rompMobileTab&&window\.__rompMobileTab\('feed'\)/, "phone: one pane at a time");
 });
 
-test("the viewer is a singleton MODAL over the chat: ~95% card, dimmed backdrop, ✕/Esc/backdrop close", () => {
+test("the viewer is a singleton MODAL over its pane: ~95% card, dimmed backdrop, ✕/Esc/backdrop close", () => {
   assert.match(VIEW, /document\.getElementById\("romp-fileview"\)\?\.remove\(\);/, "re-opening replaces, never stacks");
   // the backdrop closes on ITS OWN clicks only — content clicks don't (the lightbox contract)
   assert.match(VIEW, /wrap\.onclick = \(ev\) => \{ if \(ev\.target === wrap\) closeFileView\(\); \};/);
@@ -56,7 +64,19 @@ test("the viewer is a singleton MODAL over the chat: ~95% card, dimmed backdrop,
   // the panels treatment on the CHAT sheet: dimmed rgba(0,0,0,0.55) backdrop, the content behind visible
   assert.match(CHAT_CSS, /#romp-fileview \{ position: fixed; inset: 0; z-index: 1200; background: rgba\(0, 0, 0, 0\.55\);/);
   assert.match(CHAT_CSS, /\.fileview \{ width: 95%; height: 95%;/);
-  assert.doesNotMatch(FEED_CSS, /\.fileview/, "the feed sheet no longer styles a viewer it no longer hosts");
+  // …and mirrored on the FEED sheet, which still hosts the viewer when the file BROWSER opens a file
+  // (one treatment, two sheets — the hljs-palette precedent below)
+  assert.match(FEED_CSS, /#romp-fileview \{ position: fixed; inset: 0;/);
+  assert.match(FEED_CSS, /\.fileview \{ width: 95%; height: 95%;/);
+});
+
+test("the FEED-hosted viewer registers no comment sink, so the review layer gates itself off", () => {
+  // the review layer's Submit drafts into the CHAT composer via a sink render.ts registers; the feed
+  // hosts the same viewer without one, so every comment affordance must gate on the sink or Submit is
+  // a dead button in that document (2026-08-19) — no real target, no affordance
+  assert.doesNotMatch(FEED, /setCommentSink/, "no composer in the feed to draft into");
+  assert.match(RENDER, /setCommentSink\(\(sid, text\) => \{/, "the chat bundle keeps the full behavior");
+  assert.match(VIEW, /if \(!commentSink\) return;/, "the gate exists in the viewer itself");
 });
 
 test("it waits with the romp loader and fails with the kernel's own words, never a blank pane", () => {
@@ -97,9 +117,10 @@ test("langFor maps known extensions and returns null rather than guessing", () =
 
 // ── formatting (the user 2026-08-09): the hljs palette, Raw ⇄ Rendered for markdown, and word wrap ──
 
-// A. The viewer wraps every token in .hljs-* spans; it lives on the CHAT page, whose sheet is the
-// palette's one home again (the feed's mirror left with the viewer, 2026-08-15).
-test("the hljs token palette lives in styles.css; the feed sheet no longer needs a mirror", () => {
+// A. The viewer wraps every token in .hljs-* spans, and it renders in BOTH documents — the chat (file
+// links) and the feed (the file browser) — so both sheets must carry the SAME palette (one treatment,
+// two sheets — the .romp-acted precedent). This pins every rule in both and catches drift.
+test("the hljs token palette lives in feed.css too, identical to the chat's", () => {
   const STYLES = CHAT_CSS;
   const rules = [
     /\.hljs \{ color: #d8c6a8; background: transparent; \}/,
@@ -116,9 +137,9 @@ test("the hljs token palette lives in styles.css; the feed sheet no longer needs
     /\.hljs-deletion \{ color: var\(--err\); \}/,
   ];
   for (const r of rules) {
-    assert.match(STYLES, r, "styles.css is missing a palette rule: " + r.source);
+    assert.match(FEED_CSS, r, "feed.css is missing a palette rule: " + r.source);
+    assert.match(STYLES, r, "styles.css drifted from the shared palette: " + r.source);
   }
-  assert.doesNotMatch(FEED_CSS, /\.hljs/, "no highlighting left on the feed page → no orphaned palette");
 });
 
 // B, executed: the persisted view-format prefs. RENDERED is the markdown default (the user's explicit
@@ -159,18 +180,22 @@ test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML u
   assert.match(VIEW, /if \(isMd\) \{\s*\n\s*for \(const mode of \["rendered", "raw"\] as const\)/);
   assert.match(VIEW, /const rendered = isMd && fmt\.md === "rendered";/, "non-md never renders as prose");
   assert.match(VIEW, /import DOMPurify from "dompurify";/);
+  // html + svg, in lockstep with the chat's md(): KaTeX draws stretchy glyphs as inline <svg>
   assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\] \}\);/);
-  // a README's links open a NEW tab rather than navigating the chat pane's document away
+  // a README's links open a NEW tab rather than navigating the hosting pane's document away
   assert.match(VIEW, /target = "_blank"/);
   assert.match(VIEW, /rel = "noopener"/);
   // fenced blocks highlight only a NAMED, registered language — same no-guessing rule as langFor
   assert.match(VIEW, /if \(!lang \|\| !hljs\.getLanguage\(lang\)\) return;/);
-  // the prose typography exists on this sheet (the chat's .md block is the reference aesthetic)
+  // the prose typography exists on BOTH sheets (the chat's .md block is the reference aesthetic)
+  assert.match(FEED_CSS, /\.fileview-md \{/);
+  assert.match(FEED_CSS, /\.fileview-md pre code \{/);
   assert.match(CHAT_CSS, /\.fileview-md \{/);
   assert.match(CHAT_CSS, /\.fileview-md pre code \{/);
   // toggles acknowledge in the same synchronous tick: click → save → renderBody, which flips .on
   assert.match(VIEW, /b\.addEventListener\("click", \(\) => \{ fmt\.md = mode; saveFmt\(fmt\); renderBody\(\); \}\);/);
   assert.match(VIEW, /b\.classList\.toggle\("on", on\);/);
+  assert.match(FEED_CSS, /\.fileview-btn\.on \{ color: var\(--accent\); border-color: var\(--accent\);/);
   assert.match(CHAT_CSS, /\.fileview-btn\.on \{ color: var\(--accent\); border-color: var\(--accent\);/);
 });
 
@@ -217,9 +242,11 @@ test("the Wrap toggle persists, hides with rendered prose, and its numbers still
   assert.match(VIEW, /if \(wrapLines\) \{[\s\S]*?return wrap;\s*\}\s*const gutter = el\("div", "fileview-gutter"\);/);
   // plain files wrap too: no grammar → the text is HTML-escaped before the line walk
   assert.match(VIEW, /code\.innerHTML = wrapNumberedHtml\(hl !== null \? hl : escapeHtml\(text\)\);/);
-  assert.match(CHAT_CSS, /\.fileview-pre\.fileview-wrap \{ white-space: pre-wrap/);
-  assert.match(CHAT_CSS, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?counter-increment: fvln/);
-  assert.match(CHAT_CSS, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?user-select: none/);
+  for (const SHEET of [FEED_CSS, CHAT_CSS]) {
+    assert.match(SHEET, /\.fileview-pre\.fileview-wrap \{ white-space: pre-wrap/);
+    assert.match(SHEET, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?counter-increment: fvln/);
+    assert.match(SHEET, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?user-select: none/);
+  }
   // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
   assert.match(VIEW, /wrapBtn\.hidden = rendered;/);
   assert.match(VIEW, /wrapBtn\.classList\.toggle\("on", fmt\.wrap\);/, "pressed state flips synchronously");
@@ -271,6 +298,7 @@ test("a refusal renders the kernel's words PLUS the way out — gated on offersD
   assert.match(VIEW, /const offer = el\("button", "fileview-btn fileview-err-dl"\) as HTMLButtonElement;/);
   assert.match(VIEW, /why\.appendChild\(offer\);/);
   assert.match(VIEW, /offer\.addEventListener\("click", \(\) => startDownload\(dlUrl, offer\)\);/);
+  assert.match(FEED_CSS, /\.fileview-err-dl \{ display: block; margin-top: 10px; \}/);
   assert.match(CHAT_CSS, /\.fileview-err-dl \{ display: block; margin-top: 10px; \}/);
 });
 
@@ -286,5 +314,6 @@ test("the line gutter numbers every line and drops a trailing newline's phantom 
   assert.deepEqual(lines(""), []);
   assert.match(VIEW, /gutter\.textContent = lines\.map\(\(_, i\) => String\(i \+ 1\)\)\.join\("\\n"\);/);
   assert.match(VIEW, /wrap\.appendChild\(gutter\); wrap\.appendChild\(pre\);/, "sibling, not inside the pre");
+  assert.match(FEED_CSS, /\.fileview-gutter \{[\s\S]*?user-select: none;/);
   assert.match(CHAT_CSS, /\.fileview-gutter \{[\s\S]*?user-select: none;/);
 });

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -68,6 +68,8 @@ test("the viewer is a singleton MODAL over its pane: ~95% card, dimmed backdrop,
   // (one treatment, two sheets — the hljs-palette precedent below)
   assert.match(FEED_CSS, /#romp-fileview \{ position: fixed; inset: 0;/);
   assert.match(FEED_CSS, /\.fileview \{ width: 95%; height: 95%;/);
+  assert.match(FEED, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/,
+    "the feed boots the listener with the WS poster (saves ride it — the raw-mode slice)");
 });
 
 test("the FEED-hosted viewer registers no comment sink, so the review layer gates itself off", () => {
@@ -248,7 +250,8 @@ test("the Wrap toggle persists, hides with rendered prose, and its numbers still
     assert.match(SHEET, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?user-select: none/);
   }
   // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
-  assert.match(VIEW, /wrapBtn\.hidden = rendered;/);
+  // (and with edit mode, whose textarea has no wrap toggle to govern — the raw-mode slice)
+  assert.match(VIEW, /wrapBtn\.hidden = rendered \|\| editing;/);
   assert.match(VIEW, /wrapBtn\.classList\.toggle\("on", fmt\.wrap\);/, "pressed state flips synchronously");
 });
 

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -305,6 +305,21 @@ test("a refusal renders the kernel's words PLUS the way out — gated on offersD
   assert.match(CHAT_CSS, /\.fileview-err-dl \{ display: block; margin-top: 10px; \}/);
 });
 
+test("Edit is consent-gated, and the gate is the KERNEL's flag, not the button (the user 2026-08-22)", () => {
+  // the click asks the kernel's live flag first — never a cached copy, another machine may have flipped it
+  assert.match(VIEW, /fetch\(kernelUrl\("\/version"\), \{ cache: "no-store" \}\)/);
+  assert.match(VIEW, /\.fileEditing;/);
+  // no flag → a plain-words popup; only a YES posts the opt-in, and it broadcasts (KERNEL_SETTING)
+  assert.match(VIEW, /window\.confirm\(\s*\n?\s*"Allow editing files from the dashboard\?/);
+  assert.match(VIEW, /post\(\{ type: "setFileEditing", enabled: true \}\);/);
+  // the popup's promise of a gear off-switch is real, and the save route refuses server-side
+  const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
+  assert.ok(GEAR.includes("'setFileEditing'"), "the gear can turn it back off");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /if not _file_editing_on\(\):/);
+  assert.match(KERNEL, /dashboard file editing is off on this machine/);
+});
+
 // executed: the gutter is a SIBLING of the code, so selecting the code copies it without line numbers
 test("the line gutter numbers every line and drops a trailing newline's phantom line", () => {
   const lines = (text: string): string[] => {

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -12,7 +12,9 @@
 //
 // Living in the CHAT page also removes a whole relay: the click and the viewer are the same document
 // now, so there is no shell forwarding, no feed-pane bring-forward/put-back, and the standalone /chat
-// page views files exactly like the framed one.
+// page views files exactly like the framed one. The module stays pane-agnostic on purpose: the file
+// BROWSER (file-browse.ts, feed bundle) opens files through this same viewer in the FEED document, so
+// whichever bundle imports it gets the identical modal.
 import hljs from "highlight.js/lib/core";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
@@ -173,6 +175,17 @@ export function openFileView(path: string, sid?: string | null): void {
   dir.textContent = cut >= 0 ? path.slice(0, cut + 1) : "";
   const base = el("span", "fileview-base");
   base.textContent = path.slice(cut + 1);
+  if (cut >= 0) {
+    // The discoverability path into the file BROWSER: the directory half of the title is a click
+    // into its listing. Posted to our OWN window — initFileBrowse listens on the same channel the
+    // shell relays into, so no import cycle between the two overlays.
+    dir.classList.add("fileview-dir-link");
+    dir.title = "Browse this file's folder";
+    dir.addEventListener("click", () => {
+      try { window.postMessage({ romp: "browseFiles", path: path.slice(0, cut) || "/", sid }, "*"); }
+      catch { /* messaging our own window cannot really fail */ }
+    });
+  }
   name.appendChild(dir); name.appendChild(base);
   const acts = el("div", "fileview-acts");
 
@@ -184,7 +197,10 @@ export function openFileView(path: string, sid?: string | null): void {
   submitBtn.type = "button";
   submitBtn.title = "Hand every comment on this file to the session as one message";
   const syncReview = () => {
-    const n = (comments.get(key) || []).length;
+    // No sink registered (the feed's browser-hosted viewer) → Submit has nowhere to deliver, so the
+    // review controls never surface here; comments authored where a sink exists stay in the store
+    // and count only there — no real target, no affordance.
+    const n = commentSink ? (comments.get(key) || []).length : 0;
     cmtCount.textContent = n === 1 ? "1 comment" : n + " comments";
     submitBtn.textContent = "Submit " + n + (n === 1 ? " comment" : " comments");
     cmtCount.hidden = !n;
@@ -277,8 +293,9 @@ export function openFileView(path: string, sid?: string | null): void {
   // Raw one (and the other way round). A span that can no longer be found keeps its comment — only the
   // highlight is missing, and the Submit still carries it.
   function markComments(): void {
-    const list = comments.get(key) || [];
     syncReview();
+    if (!commentSink) return;                   // no sink → the marks (and their remove ✕) stay off too
+    const list = comments.get(key) || [];
     list.forEach((c, i) => {
       const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
       const nodes: Text[] = [];
@@ -334,6 +351,7 @@ export function openFileView(path: string, sid?: string | null): void {
   // Right-click a selection → Comment. Bound on the viewer body, so it never competes with the chat's
   // own selection menu behind the backdrop.
   body.addEventListener("contextmenu", (ev) => {
+    if (!commentSink) return;                   // no sink → no Comment to offer; the native menu keeps Copy
     const sel = window.getSelection();
     const picked = sel ? sel.toString() : "";
     if (!picked.trim() || !sel?.anchorNode || !body.contains(sel.anchorNode)) return;

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -109,6 +109,17 @@ function el(tag: string, cls?: string): HTMLElement {
   return e;
 }
 
+// ── raw-mode editing (the file browser's slice 2, the user 2026-08-14) ─────────────────────────────
+// The save op rides the WS poster the pane's boot hands initFileView; replies route back to the OPEN
+// viewer through these module-level hooks (the viewer itself is a per-open closure).
+let post: (m: Record<string, unknown>) => void = () => { /* bound by initFileView */ };
+let saveSeq = 0;
+let editHooks: { reqId: number; saved: (mtimeNs: string) => void; failed: (err: string) => void } | null = null;
+// Set by the open viewer: returns false to VETO a close (an editor holding unsaved changes asks
+// first). The guard must live in closeFileView itself, because the browser overlay and the Escape
+// handler both close through it without knowing an edit is in progress.
+let closeGuard: (() => boolean) | null = null;
+
 // ── review comments (the user 2026-08-14, who found coordinating a doc review painful) ─────────────
 // Reading a doc an agent wrote used to mean hand-copying every line you wanted changed back into the
 // chat. Now you comment on passages IN the viewer and one Submit hands the whole set over as a single
@@ -148,12 +159,20 @@ export function setCommentSink(fn: (sid: string, text: string) => boolean): void
 export function closeFileView(): void {
   const wrap = document.getElementById("romp-fileview");
   if (!wrap) return;
+  if (closeGuard && !closeGuard()) return;   // unsaved edits, and the user chose to keep them
+  closeGuard = null;
+  editHooks = null;
   wrap.remove();
   document.body.classList.remove("fileview-open");
 }
 
 /** Show `path` in a modal over this pane. Re-opening replaces whatever is up — never stacks. */
 export function openFileView(path: string, sid?: string | null): void {
+  // The replace path bypasses closeFileView, so it needs the same dirty ask: opening file B over an
+  // edited-but-unsaved file A must not silently eat A's buffer.
+  if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;
+  closeGuard = null;
+  editHooks = null;
   document.getElementById("romp-fileview")?.remove();
   // backdrop (the whole overlay carries the id every open/closed check targets) + the ~95% card.
   // The backdrop treatment matches the lightbox: dimmed, click outside the card closes, content
@@ -214,6 +233,15 @@ export function openFileView(path: string, sid?: string | null): void {
   // here, same as Copy path below.
   const fmt = loadFmt();
   let text: string | null = null;             // set once the fetch lands; earlier clicks just save the pref
+  let mtimeNs = "";                           // the file's mtime at load, NANOSECONDS AS A STRING —
+  //   saveFile's conflict floor (ns because whole seconds let a same-second agent write slip the
+  //   guard; a string because ~1.7e18 exceeds JS's safe-integer range and a number would round)
+  let isText = false;                         // the kernel's verdicts (text/plain AND faithful UTF-8)
+  let editing = false;
+  let dirty = false;
+  let eolCRLF = false;                        // the file's dominant line ending — textareas normalize
+  //   CRLF→LF on assignment, so an untouched CRLF file would otherwise save with every ending rewritten
+  let ta: HTMLTextAreaElement | null = null;
   const isMd = langFor(path) === "markdown";  // .md/.markdown — the only kind with a Rendered form
   const segBtns: Array<["rendered" | "raw", HTMLButtonElement]> = [];
   if (isMd) {
@@ -231,6 +259,24 @@ export function openFileView(path: string, sid?: string | null): void {
   wrapBtn.type = "button"; wrapBtn.textContent = "Wrap"; wrapBtn.title = "Soft-wrap long lines";
   wrapBtn.addEventListener("click", () => { fmt.wrap = !fmt.wrap; saveFmt(fmt); renderBody(); });
   acts.appendChild(wrapBtn);
+
+  // ── edit (the raw-mode slice) ── exactly what raw mode can show is what Edit can touch: the
+  // button arms only when the kernel served text/plain WITH a Last-Modified to anchor the save's
+  // conflict floor (an old remote kernel that mirrors neither gets no Edit rather than an unguarded
+  // one). Markdown edits from its Raw view — what you edit is what raw shows.
+  const editBtn = el("button", "fileview-btn") as HTMLButtonElement;
+  editBtn.type = "button"; editBtn.textContent = "Edit"; editBtn.title = "Edit this file in place";
+  editBtn.hidden = true;
+  editBtn.addEventListener("click", () => { if (isMd && fmt.md === "rendered") { fmt.md = "raw"; saveFmt(fmt); } enterEdit(); });
+  const saveBtn = el("button", "fileview-btn") as HTMLButtonElement;
+  saveBtn.type = "button"; saveBtn.textContent = "Save"; saveBtn.title = "Write the file (Ctrl/Cmd+S)";
+  saveBtn.hidden = true;
+  saveBtn.addEventListener("click", () => doSave());
+  const cancelBtn = el("button", "fileview-btn") as HTMLButtonElement;
+  cancelBtn.type = "button"; cancelBtn.textContent = "Cancel"; cancelBtn.title = "Leave edit mode";
+  cancelBtn.hidden = true;
+  cancelBtn.addEventListener("click", () => { if (confirmDiscard()) exitEdit(); });
+  acts.appendChild(editBtn); acts.appendChild(saveBtn); acts.appendChild(cancelBtn);
 
   // ── download (the user 2026-08-09) ── Any linked file can be SAVED, including everything the pane
   // cannot show: the kernel's ?download=1 serves anything on disk (the rationale lives with
@@ -278,12 +324,16 @@ export function openFileView(path: string, sid?: string | null): void {
       const on = fmt.md === mode;
       b.classList.toggle("on", on);
       b.setAttribute("aria-pressed", String(on));
+      b.hidden = editing;                       // format choices leave with edit mode; Save/Cancel own the bar
     }
     // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
-    wrapBtn.hidden = rendered;
+    wrapBtn.hidden = rendered || editing;
     wrapBtn.classList.toggle("on", fmt.wrap);
     wrapBtn.setAttribute("aria-pressed", String(fmt.wrap));
-    if (text === null) return;   // still loading; the saved pref is honored when the bytes land
+    editBtn.hidden = editing || text === null || !isText || !mtimeNs;
+    saveBtn.hidden = !editing;
+    cancelBtn.hidden = !editing;
+    if (text === null || editing) return;   // loading, or the textarea owns the body right now
     body.replaceChildren(rendered ? mdBlock(text) : codeBlock(text, path, fmt.wrap));
     markComments();
   };
@@ -437,21 +487,111 @@ export function openFileView(path: string, sid?: string | null): void {
           : msg);
         if (!landed) {
           // the review is the user's WORK — never erased on a failed handoff. Say so, visibly,
-          // and keep every comment (memory + localStorage) for the next attempt.
+          // and keep every comment (memory + localStorage) for the next attempt. Deliberately
+          // touches NOTHING but the button — mid-edit, the textarea (and its buffer) must survive
+          // a failed handoff exactly as it survives a failed save.
           submitBtn.disabled = false;
           submitBtn.textContent = "Couldn't draft it — comments kept, try again";
           return;
         }
         comments.delete(key);
         saveComments();
+        // Delivered — but the courtesy close must not run while an edit is in progress: closeFileView's
+        // guard would pop the discard confirm over a SUBMIT, and Cancel would strand the button at
+        // "Submitting…". renderBody is off-limits mid-edit, so reset the two review controls in place
+        // and leave the editor (and its buffer) exactly as it was.
+        if (editing) {
+          submitBtn.disabled = false;
+          syncReview();
+          return;
+        }
         closeFileView();
       });
   });
+
+  // ── edit mode (the raw-mode slice) ── a plain textarea holding the raw bytes: an embedded editor
+  // is a different project, and a textarea that keeps your changes beats a half-editor. The kernel's
+  // mtime floor does the real safety work (agents edit these same trees — see _save_file).
+  const confirmDiscard = (): boolean =>
+    !editing || !dirty || window.confirm("Discard unsaved changes to " + path.slice(cut + 1) + "?");
+  closeGuard = confirmDiscard;
+  const norm = (s: string): string => s.replace(/\r\n/g, "\n");   // the textarea's own view of any text
+  const enterEdit = () => {
+    if (text === null || editing) return;
+    editing = true; dirty = false;
+    eolCRLF = /\r\n/.test(text);
+    ta = el("textarea", "fileview-editor") as HTMLTextAreaElement;
+    ta.value = text;                            // the browser normalizes CRLF→LF on assignment…
+    ta.spellcheck = false;
+    ta.addEventListener("input", () => { dirty = ta!.value !== norm(text!); });   // …so compare normalized
+    ta.addEventListener("keydown", (e) => {     // the editor's own save chord; Esc falls through to onKey
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") { e.preventDefault(); doSave(); }
+    });
+    renderBody();
+    body.replaceChildren(ta);
+    ta.focus();
+  };
+  const exitEdit = () => {
+    editing = false; dirty = false; ta = null;
+    editHooks = null;                           // a cancelled save's late ack must not touch a NEW session
+    saveBtn.disabled = false; saveBtn.textContent = "Save";
+    renderBody();
+  };
+  const doSave = () => {
+    if (!editing || !ta || saveBtn.disabled) return;
+    if (!dirty) { exitEdit(); return; }         // nothing changed — leaving is the honest ack
+    saveBtn.disabled = true; saveBtn.textContent = "Saving…";   // acknowledge before the round-trip
+    // restore the file's own line endings — an untouched CRLF file must round-trip byte-identical
+    const content = eolCRLF ? ta.value.replace(/\n/g, "\r\n") : ta.value;
+    editHooks = {
+      reqId: ++saveSeq,
+      saved: (mtNs) => {
+        mtimeNs = mtNs;
+        text = content;
+        // Keystrokes typed DURING the round-trip survive the ack (the review's in-flight-typing
+        // finding): if the live buffer moved past the snapshot we saved, stay in edit mode with the
+        // new baseline — never re-render over what the user is still typing.
+        if (ta && ta.value !== norm(content)) {
+          dirty = true;
+          saveBtn.disabled = false; saveBtn.textContent = "Save";
+          return;
+        }
+        exitEdit();                             // re-renders the highlighted view from the saved bytes
+      },
+      failed: (err) => {
+        saveBtn.disabled = false; saveBtn.textContent = "Save";
+        // Loud, in place, and the BUFFER SURVIVES: the error bar sits above the textarea. A conflict
+        // (the disk moved — an agent wrote it) offers Reload, which re-opens fresh — behind the same
+        // discard confirm, so the user's edits are never thrown away silently (never a merge UI).
+        document.getElementById("fileview-save-err")?.remove();
+        const bar2 = el("div", "fileview-err");
+        bar2.id = "fileview-save-err";
+        bar2.textContent = err;
+        if (/changed on disk/.test(err)) {
+          const re = el("button", "fileview-btn fileview-err-dl") as HTMLButtonElement;
+          re.type = "button"; re.textContent = "Reload file";
+          re.title = "Fetch the file as it is now (asks before discarding your edits)";
+          re.addEventListener("click", () => {
+            if (!confirmDiscard()) return;
+            dirty = false;                      // confirmed once — the replace guard must not ask twice
+            openFileView(path, sid);
+          });
+          bar2.appendChild(re);
+        }
+        body.prepend(bar2);
+      },
+    };
+    post({ type: "saveFile", path, sid: sid || undefined, content, baseMtimeNs: mtimeNs, reqId: saveSeq });
+  };
   renderBody();   // buttons take their initial state now; the loader stays up until the fetch lands
 
   const onKey = (e: KeyboardEvent) => {
     if (e.key !== "Escape" || !document.getElementById("romp-fileview")) return;
     e.preventDefault();
+    if (editing) {                              // Escape peels edit mode first, never the whole viewer
+      if (confirmDiscard()) exitEdit();
+      return;
+    }
     closeFileView();
     document.removeEventListener("keydown", onKey);
   };
@@ -465,6 +605,13 @@ export function openFileView(path: string, sid?: string | null): void {
     if (!r.ok) return r.text().then((t) => {
       throw Object.assign(new Error(t || ("HTTP " + r.status)), { status: r.status });
     });
+    // Edit arms off the KERNEL's verdicts, never a client guess: text/plain AND a faithful UTF-8
+    // round-trip (the latin-1 fallback re-decodes non-UTF-8 files — saving that back would rewrite
+    // every non-ASCII byte, the review's executed repro), anchored by the ns mtime header (an old
+    // kernel that sends neither simply gets no Edit button).
+    isText = (r.headers.get("Content-Type") || "").startsWith("text/plain")
+      && r.headers.get("X-Romp-Text-Utf8") !== "0";
+    mtimeNs = r.headers.get("X-Romp-Mtime-Ns") || "";
     return r.text();
   }).then((t) => {
     if (!document.getElementById("romp-fileview")) return;    // closed while it was in flight
@@ -608,4 +755,42 @@ function mdBlock(text: string): HTMLElement {
     } catch { /* leave plain */ }
   });
   return box;
+}
+
+/** Bind the pane's WS poster and route saveFile replies back to the open viewer. Called once, from
+ *  the pane's boot (render.ts and feed.ts today — either document, one mechanism). The viewFile
+ *  branch honors a shell's relay of a chat file-link click — nothing sends it since the viewer moved
+ *  into the chat document, but a not-yet-reloaded shell page still might, and honoring it costs
+ *  nothing. */
+export function initFileView(poster: (m: Record<string, unknown>) => void): void {
+  post = poster;
+  window.addEventListener("message", (e: MessageEvent) => {
+    const m = e.data;
+    if (!m) return;
+    if (m.romp === "viewFile" && typeof m.path === "string" && m.path) {
+      openFileView(m.path, typeof m.sid === "string" ? m.sid : null);
+    } else if (m.type === "fileSaved" && editHooks && m.reqId === editHooks.reqId) {
+      const h = editHooks; editHooks = null;
+      h.saved(String(m.mtimeNs || ""));
+    } else if (m.type === "fileSaveFailed" && editHooks && m.reqId === editHooks.reqId) {
+      const h = editHooks; editHooks = null;
+      h.failed(String(m.error || "the save failed"));
+    } else if (m.type === "warn" && editHooks) {
+      // A federation drop (the session's host unreachable) answers a saveFile with a warn instead
+      // of a reply — the feed page renders no toasts, so without this the button spins forever
+      // (the same hole the browse overlay closed for listDir).
+      const h = editHooks; editHooks = null;
+      h.failed(String(m.text || "the session's host is not answering — the save was not sent"));
+    }
+  });
+  // A socket drop mid-save loses the ack, and the frame itself may or may not have reached the
+  // kernel — the honest answer is to say exactly that and re-arm Save: a save that DID land will
+  // refuse the retry as "changed on disk", and Reload resolves it from there. Keying on the shim's
+  // own drop event (not a timer) is the house rule; the browse overlay set the precedent.
+  window.addEventListener("romp:wsdown", () => {
+    if (!editHooks) return;
+    const h = editHooks; editHooks = null;
+    h.failed("the connection dropped mid-save — it may or may not have landed; "
+      + "Save again once the connection returns (a save that DID land will refuse as changed-on-disk)");
+  });
 }

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -19,6 +19,7 @@ import hljs from "highlight.js/lib/core";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { fileUrl } from "./preview";
+import { kernelUrl } from "./media";
 import { findAnchorRange, sliceRanges } from "./comments";
 import { anchorFor, buildReviewMessage, docKey, type DocComment } from "./docreview";
 
@@ -267,7 +268,32 @@ export function openFileView(path: string, sid?: string | null): void {
   const editBtn = el("button", "fileview-btn") as HTMLButtonElement;
   editBtn.type = "button"; editBtn.textContent = "Edit"; editBtn.title = "Edit this file in place";
   editBtn.hidden = true;
-  editBtn.addEventListener("click", () => { if (isMd && fmt.md === "rendered") { fmt.md = "raw"; saveFmt(fmt); } enterEdit(); });
+  // The consent gate (the user 2026-08-22): editing is a kernel-side opt-in the SAVE ROUTE enforces —
+  // this popup is where the one yes happens, and it broadcasts through the settings mesh so every
+  // attached kernel's save route opens together (setFileEditing rides KERNEL_SETTING). The flag is
+  // read fresh per click, never cached: another machine's gear may have flipped it meanwhile. A
+  // decline changes nothing and is asked again next time — consent latches only on yes. If /version
+  // is unreachable the popup still asks: the kernel-side gate refuses regardless, so the worst a
+  // wrongly-granted yes here can do is draw one refused save with its plain-words error.
+  async function editingAllowed(): Promise<boolean> {
+    let on = false;
+    try { on = !!(await (await fetch(kernelUrl("/version"), { cache: "no-store" })).json()).fileEditing; } catch { /* ask below */ }
+    if (on) return true;
+    if (!window.confirm(
+      "Allow editing files from the dashboard?\n\n" +
+      "Saves write straight to disk on the file's machine — and this applies on every machine " +
+      "connected here. A session working in that folder is told when you edit under it.\n\n" +
+      "You can turn this off later in the settings gear.")) return false;
+    post({ type: "setFileEditing", enabled: true });
+    return true;
+  }
+  editBtn.addEventListener("click", () => {
+    void editingAllowed().then((ok) => {
+      if (!ok) return;
+      if (isMd && fmt.md === "rendered") { fmt.md = "raw"; saveFmt(fmt); }
+      enterEdit();
+    });
+  });
   const saveBtn = el("button", "fileview-btn") as HTMLButtonElement;
   saveBtn.type = "button"; saveBtn.textContent = "Save"; saveBtn.title = "Write the file (Ctrl/Cmd+S)";
   saveBtn.hidden = true;

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -1,0 +1,182 @@
+// The file BROWSER in the FEED pane (the user 2026-08-14): breadcrumb over one directory's entries,
+// riding the listDir WS op with the dirComplete staleness protocol, opening files through the
+// existing viewer. Source pins (no jsdom for these modules), the repo convention.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const BROWSE = web("file-browse.ts");
+const VIEW = web("file-view.ts");
+const RENDER = web("render.ts");
+const FEED = web("feed.ts");
+const FEED_CSS = web("feed.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the browser is the viewer's sibling overlay, one z layer BENEATH it", () => {
+  // beneath by design: a file opened from a listing overlays the listing, and closing it returns
+  // there (the viewer is a MODAL since 2026-08-15 — its backdrop, not a pane fill, draws above)
+  assert.match(FEED_CSS, /\.filebrowse \{ position: fixed; inset: 0; z-index: 890;/);
+  assert.match(FEED_CSS, /#romp-fileview \{ position: fixed; inset: 0; z-index: 1200;/);
+  assert.match(BROWSE, /box\.id = "romp-filebrowse";/);
+  assert.match(BROWSE, /document\.body\.classList\.add\("filebrowse-open"\);/);
+});
+
+test("the close contract is ownership-aware: the restore fires exactly once", () => {
+  // the viewer is a modal over whatever document opened it (2026-08-15): it never touches the feed
+  // pane, so it participates in NO restore protocol at all — no close message, nothing to suppress
+  assert.doesNotMatch(VIEW, /viewFileClosed/, "nothing to restore → nothing to announce");
+  // the browser is the ONE overlay that juggles the pane, so its close alone does the restore
+  assert.match(BROWSE, /window\.parent\.postMessage\(\{ romp: "browseClosed" \}, "\*"\);/);
+  assert.match(KERNEL, /if\(m\.romp==='browseClosed'&&window\.__rompFeedWasOff\)/);
+});
+
+test("the shell relays browseFiles: pane forward, remembered, phone tab", () => {
+  assert.match(KERNEL, /if\(m\.romp==='browseFiles'\)\{var bf=document\.getElementById\('f-feed'\);/);
+  const relay = KERNEL.split("if(m.romp==='browseFiles')")[1].split("if(m.romp==='browseClosed'")[0];
+  assert.ok(relay.includes("window.__rompFeedWasOff=true;"), "a pane turned on for the browser is remembered");
+  assert.ok(relay.includes("window.__rompMobileTab&&window.__rompMobileTab('feed')"), "phone: one pane at a time");
+  assert.ok(relay.includes("postMessage({romp:'browseFiles',path:m.path,sid:m.sid}"), "forwarded into the feed iframe");
+});
+
+test("the listing rides the dirComplete staleness protocol: reqId stale-drop, in-flight coalescing", () => {
+  assert.match(BROWSE, /post\(\{ type: "listDir", path, sid: curSid \|\| undefined, reqId: \+\+reqSeq, hidden: showHidden \}\);/);
+  assert.match(BROWSE, /if \(m\.reqId !== reqSeq\) return;/);
+  // no debounce: ONE in-flight ask, the newest navigation queued behind it — the round-trip is the pacing
+  assert.match(BROWSE, /if \(inflight\) \{ queued = path; return; \}/);
+  assert.match(BROWSE, /if \(queued !== null\) \{ const q = queued; queued = null; ask\(q\); return; \}/);
+});
+
+test("the kernel's listDir answers with the echo, the entries, and LOUD path-naming errors", () => {
+  assert.match(KERNEL, /elif msg and msg\.get\("type"\) == "listDir":/);
+  assert.match(KERNEL, /"type": "dirListing", "reqId": msg\.get\("reqId"\), "host": ""/);
+  assert.match(KERNEL, /def _list_dir\(raw, sid=None, hidden=False, limit=DIR_LIST_MAX\):/);
+  assert.match(KERNEL, /cannot list %s: not a directory/);
+  assert.match(KERNEL, /DIR_LIST_MAX = 500/);
+  // resolution is /file's own, so a listed path feeds the /file URL builder unchanged
+  assert.match(KERNEL, /p = _resolve_open_path\(str\(raw or ""\), sid\)/);
+});
+
+test("waiting shows the romp loader, never a blank or a frozen listing", () => {
+  assert.match(BROWSE, /el\("div", "fileview-load"\)/);
+  assert.match(BROWSE, /romp-swirl-glyph\.svg/);
+});
+
+test("rows carry an honest verdict: download-only files are dimmed and download on click", () => {
+  // server-side `viewable` (the same tables /file applies) marks the rows up front
+  assert.match(BROWSE, /const dlOnly = en\.viewable === false;/);
+  assert.match(BROWSE, /row\.dataset\.act = dlOnly \? "dl" : "file";/);
+  assert.match(BROWSE, /if \(row\.dataset\.act === "dl"\) startDownload\(p\);/);
+  assert.match(FEED_CSS, /\.fb-dlonly \.fb-name \{ color: var\(--dim\); \}/);
+  // viewable files open through the EXISTING viewer — one leaf open action for the whole dashboard
+  assert.match(BROWSE, /if \(row\.dataset\.act === "file"\) \{ openFileView\(p, curSid\); return; \}/);
+});
+
+test("clicks are delegated to stable roots and the cap is stated in-band", () => {
+  // rows rebuild per navigation, so the listener lives on the persistent list container
+  assert.match(BROWSE, /list\.addEventListener\("click", \(ev\) => \{/);
+  assert.match(BROWSE, /crumbs\.addEventListener\("click", \(ev\) => \{/);
+  assert.match(BROWSE, /entries — the rest aren't shown"/);
+  assert.match(BROWSE, /"empty directory"/, "an empty dir says so — never a blank");
+});
+
+test("Escape closes the TOPMOST surface only, and Backspace walks up", () => {
+  // the browser's key handler stands down while the viewer exists above it
+  assert.match(BROWSE, /if \(document\.getElementById\("romp-fileview"\)\) return;/);
+  assert.match(BROWSE, /if \(e\.key === "Escape"\) \{ e\.preventDefault\(\); closeFileBrowse\(\); return; \}/);
+  assert.match(BROWSE, /if \(e\.key === "Backspace" \|\| e\.key === "ArrowLeft"\) \{/);
+});
+
+test("every entry point is gated to where the click can land, and posts the one shell message", () => {
+  // chat: openBrowse posts {romp:'browseFiles'} to the shell, web-only
+  assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "browseFiles", path: path \|\| "\.", sid: sid \|\| activeId \|\| null \}, "\*"\);/);
+  // tab right-click menu row, web-only
+  assert.match(RENDER, /browse\.textContent = "Browse files";/);
+  // feed card menu row rides canPreview (web only — the VS Code webview can't reach the kernel
+  // origin), and sends only the sid — the kernel resolves "." against the session's cwd authoritatively
+  assert.match(FEED, /openFileBrowse\("\.", it\.sid\);/);
+  assert.match(FEED, /if \(canPreview\(\)\) \{\n    const browse = el\("div", "ctx-item"\);/);
+});
+
+test("the statusline folder link BROWSES on the web; OS-open lives on its right-click (the user 2026-08-14)", () => {
+  assert.match(RENDER, /elem\.dataset\.act = web && window\.parent !== window \? "browseFiles" : "openFolder";/);
+  assert.match(RENDER, /click to browse this folder/);
+  // the demoted OS-open: one document-level contextmenu on folder links, posting the old openFolder
+  assert.match(RENDER, /item\.textContent = "Open folder window";/);
+  assert.match(RENDER, /browseFiles: \(el\) => \{/, "the body delegate carries the new act");
+});
+
+test("the viewer's directory half is the click INTO the browser — no import cycle", () => {
+  assert.match(VIEW, /dir\.classList\.add\("fileview-dir-link"\);/);
+  // posted to our OWN window: initFileBrowse listens on the same channel the shell relays into
+  assert.match(VIEW, /window\.postMessage\(\{ romp: "browseFiles", path: path\.slice\(0, cut\) \|\| "\/", sid \}, "\*"\);/);
+  assert.match(BROWSE, /m\.romp === "browseFiles" && typeof m\.path === "string"/);
+  assert.match(FEED_CSS, /\.fileview-dir-link \{ cursor: pointer; \}/);
+});
+
+test("the feed boots the browse overlay with the pane's WS poster", () => {
+  assert.match(FEED, /initFileBrowse\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
+});
+
+// ── review-driven hardening (2026-08-14): the adversarial pass found eight real defects; these pins
+// hold their fixes in place ──
+
+test("opening the browser CLOSES an open viewer — the stack is one-directional", () => {
+  // a browser painted under the opaque viewer was a dead click, and viewer-first registration made
+  // one Escape close both overlays; closing the viewer at browse-open kills both failure modes
+  assert.match(BROWSE, /import \{ openFileView, closeFileView \} from "\.\/file-view";/);
+  assert.match(BROWSE, /if \(document\.getElementById\("romp-fileview"\)\) closeFileView\(\);/);
+});
+
+test("closeFileBrowse unbinds the keydown handler and resets the protocol latch", () => {
+  // a ✕-close sees no keydown, so lazily self-removing handlers stacked across reopens (double-moving
+  // arrows); and a surviving inflight wedged the reopened browser behind a reply that never comes
+  assert.match(BROWSE, /if \(onKeyRef\) \{ document\.removeEventListener\("keydown", onKeyRef\); onKeyRef = null; \}/);
+  const close = BROWSE.split("export function closeFileBrowse")[1].split("function human")[0];
+  assert.ok(close.includes("inflight = false;"), "the latch resets with the overlay");
+  assert.ok(close.includes("queued = null;"));
+  assert.ok(close.includes('document.getElementById("fb-ctx")?.remove();'), "a row menu never outlives its listing");
+});
+
+test("a reply un-blocks the protocol UNCONDITIONALLY, before the stale check (the completer's rule)", () => {
+  assert.match(BROWSE, /inflight = false;\n  if \(queued !== null\) \{ const q = queued; queued = null; ask\(q\); return; \}\n  if \(m\.reqId !== reqSeq\) return;/);
+});
+
+test("a lost reply recovers on the socket's own events, and a federation drop fails loudly", () => {
+  // the drop and the return are events the pane shim already dispatches — recovery keys on them,
+  // never a timer; a remote host's tunnel being down answers with a warn instead of a dirListing
+  assert.match(BROWSE, /window\.addEventListener\("romp:wsdown", \(\) => \{/);
+  assert.match(BROWSE, /window\.addEventListener\("romp:wsup", \(\) => \{/);
+  assert.match(BROWSE, /needResync = true;/);
+  assert.match(BROWSE, /m\.type === "warn" && inflight && document\.getElementById\("romp-filebrowse"\)/);
+});
+
+test("Escape peels the TOPMOST layer: row menu, then viewer, then browser", () => {
+  const key = BROWSE.split("const onKey =")[1].split("document.addEventListener(\"keydown\", onKey)")[0];
+  const ctxAt = key.indexOf('getElementById("fb-ctx")');
+  const viewAt = key.indexOf('getElementById("romp-fileview")');
+  const closeAt = key.indexOf("closeFileBrowse()");
+  assert.ok(ctxAt >= 0 && viewAt > ctxAt && closeAt > viewAt, "menu before viewer before browser");
+  assert.match(FEED_CSS, /#fb-ctx \{ z-index: 950; \}/, "the menu draws over both overlays, not under them");
+});
+
+test("a re-invoke resyncs the Hidden control with the state it claims to show", () => {
+  assert.match(BROWSE, /const hb = document\.getElementById\("fb-hidden"\);/);
+  assert.match(BROWSE, /hb\.classList\.remove\("on"\); hb\.setAttribute\("aria-pressed", "false"\);/);
+});
+
+test("the kernel's parent field is read: home is not a ceiling, and errors keep a walkable trail", () => {
+  assert.match(BROWSE, /curParent = m\.parent \?\? null;/);
+  assert.match(BROWSE, /fb-crumb fb-crumb-up/, "the way above a ~-rooted trail is a visible crumb");
+  assert.match(BROWSE, /const up = cs\.length >= 2 \? cs\[cs\.length - 2\]\.dataset\.path : curParent;/);
+  assert.match(BROWSE, /renderError\(m\.error, m\.base, m\.parent\);/);
+  // …and the kernel ships base/parent on error replies so a FIRST open that fails still has crumbs
+  assert.match(KERNEL, /err_ctx = \{"base": _tilde\(p\),/);
+});
+
+test("the row menu carries the plan's full vocabulary: Copy path / Download / Open folder", () => {
+  assert.match(BROWSE, /add\("Copy path", \(\) => \{ navigator\.clipboard\?\.writeText\(path\); \}\);/);
+  assert.match(BROWSE, /if \(!isDir\) add\("Download", \(\) => startDownload\(path\)\);/);
+  assert.match(BROWSE, /add\("Open folder window", \(\) => \{/);
+});

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -115,7 +115,8 @@ test("the viewer's directory half is the click INTO the browser — no import cy
   assert.match(FEED_CSS, /\.fileview-dir-link \{ cursor: pointer; \}/);
 });
 
-test("the feed boots the browse overlay with the pane's WS poster", () => {
+test("the feed boots both overlays side by side", () => {
+  assert.match(FEED, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
   assert.match(FEED, /initFileBrowse\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
 });
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -61,6 +61,10 @@ var GEAR_HTML =
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
+  "<label class='rs-row'><input type=checkbox id=rs-fileedit>" +
+  '<span><b>File editing</b><span class=rs-mixed hidden></span>' +
+  '<span class=rs-sub>Let the file viewer’s Edit save straight to disk on the file’s machine. Off by default; the viewer asks the first time. A session working in the edited folder is told, and a save always refuses when the file changed underneath you. Applies on every connected machine’s kernel.</span>' +
+  '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
   '<span class=rs-sub>romp watches for new tagged releases (every 6 hours) AND new commits on main (origin polled every few minutes, plus a restart offer when updated code sits on disk unbooted) — one banner covers both, and acting on it converges every attached machine. Check and ask (the default) offers the banner with an Update button; Install automatically converges by itself, restarting at the next quiet moment; Off never checks. Kernel-side setting.</span>' +
   "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
@@ -171,6 +175,7 @@ function initGear(post) {
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates'),
     dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
+    fe = document.getElementById('rs-fileedit'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
   function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
@@ -206,6 +211,7 @@ function initGear(post) {
     clearAutoNudgeSplit();
     post({ type: 'setAutoNudge', enabled: an.checked });
   });
+  if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked }); });
   if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
   if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value }); });
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
@@ -325,7 +331,7 @@ function initGear(post) {
   function fillMixedMarks(v, rows) {
     var mine = (v && v.settings) || null;
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
-     ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de]].forEach(function (pair) {
+     ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
       var row = el.closest ? el.closest('.rs-row') : null;
@@ -350,6 +356,7 @@ function initGear(post) {
       fillAutoNudge(v.autoNudge, rows);
       fillMixedMarks(v, rows);
     }).catch(function () { fillAutoNudge(v.autoNudge, []); fillMixedMarks(v, []); });
+    if (fe) fe.checked = !!v.fileEditing;   // the kernel's persisted opt-in is authoritative (see the viewer's consent popup)
     if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
     if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
     if (im && typeof v.indexModel === 'string') im.value = v.indexModel;

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -45,7 +45,7 @@ test("every gear fetch routes through the kernel base + token (VS Code's webview
 test("the gear posts kernel ops through ONE shared channel (never re-acquires the VS Code API)", () => {
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort",
-    "setDistillModel", "setDistillEffort", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
+    "setDistillModel", "setDistillEffort", "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -479,7 +479,8 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setIndexEffort", effort: "" },
                      { type: "setUpdateMode", mode: "auto" },
                      { type: "setDistillModel", model: "haiku" },
-                     { type: "setDistillEffort", effort: "triage" }]) {
+                     { type: "setDistillEffort", effort: "triage" },
+                     { type: "setFileEditing", enabled: true }]) {
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));
     assert.deepEqual(routes.map((r) => r.host).sort(), ["", "TESTHOST", "gpu1"].sort(), msg.type);
     for (const r of routes) assert.deepEqual(r.msg, msg, "the kernels are host-blind: same message to each");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -741,6 +741,32 @@ function openPath(path: string, sid?: string | null): void {
   vscodeApi.postMessage(sid ? { type: "openFile", path, id: sid } : { type: "openFile", path });
 }
 
+// Surface the FILE BROWSER at `path` for the session: the shell brings the feed pane forward and the
+// browser overlay opens there (unlike openPath's in-pane viewer modal, the browser overlay lives in
+// the feed document). Web-only, and only when a shell exists to relay to; VS Code's affordances are
+// gated off at their call sites (the editor has its own explorer, and the webview can't reach the
+// kernel origin anyway).
+function openBrowse(path: string, sid?: string | null): void {
+  const web = location.protocol === "http:" || location.protocol === "https:";
+  if (!web || window.parent === window) return;
+  try {
+    window.parent.postMessage({ romp: "browseFiles", path: path || ".", sid: sid || activeId || null }, "*");
+  } catch { /* no shell — nothing to surface into */ }
+}
+
+// The viewer's directory half asks for the BROWSER by posting {romp:'browseFiles'} to its OWN window
+// (file-view.ts): in the feed document initFileBrowse answers it, but the chat hosts no browser, so
+// this forwarder hands the ask to the shell — openBrowse's exact relay — which brings the feed pane
+// forward and delivers it there. Without it that click is a silent no-op in a chat-opened viewer.
+// openBrowse's own gates apply (web-only, framed-only: standalone /chat has no feed to surface, and
+// a repost to window.parent === window would only echo back here). Own-window messages only — the
+// pane shim redispatches kernel frames through this channel too, and no OTHER window sends this ask.
+window.addEventListener("message", (e: MessageEvent) => {
+  const m = e.data as { romp?: unknown; path?: unknown; sid?: unknown } | null;
+  if (!m || m.romp !== "browseFiles" || e.source !== window) return;
+  openBrowse(typeof m.path === "string" ? m.path : ".", typeof m.sid === "string" ? m.sid : null);
+});
+
 // A clickable file name that opens the real file — in the editor (VS Code) or the in-pane viewer
 // modal (web). Shared open/navigate surface; see extension.ts's openFile handler and file-view.ts.
 function fileLink(path: string): HTMLElement {
@@ -2365,20 +2391,28 @@ function prettyModel(id: string): string {
 // written to the transcript, so it can't be shown; the closing note says so. Carries no dot/timestamp
 // (no ts/uuid) → renderEvent leaves it off the conversational rail. Its open/closed state is persisted
 // per session (keyed by renderingSid) so a send/turn re-render never snaps it shut.
-// Make `elem` open the folder `cwd` with the configured opener on click (the user 2026-06-27): used
-// EVERYWHERE a folder location is shown (statusline, the System-context Directory row, …). Click-safe — the
-// action rides a data-act caught by the document-level openFolder delegate, so it works under any re-rendering
-// surface without per-node handlers. `sid` (the owning session's, possibly host-prefixed, id — the user
+// Make `elem` act on the folder `cwd` on click (the user 2026-06-27; rerouted 2026-08-14): used
+// EVERYWHERE a folder location is shown (statusline, the System-context Directory row, …) — on the web it
+// BROWSES the folder in the dashboard, in VS Code it keeps the configured opener. Click-safe — the
+// action rides a data-act caught by a document-level delegate (browseFiles/openFolder), so it works under
+// any re-rendering surface without per-node handlers. `sid` (the owning session's, possibly host-prefixed, id — the user
 // 2026-07-03) rides along as data-id: for a REMOTE session this is how the kernel knows to SSH out instead
 // of treating a remote path as local (a silent no-op, since that path doesn't exist here). This pane stays
 // host-BLIND as designed (see federation.ts) — sid is just echoed back opaquely, never parsed here.
 function asFolderLink(elem: HTMLElement, cwd: string, sid?: string): void {
   if (!cwd) return;
-  elem.dataset.act = "openFolder";
+  // On the web a click BROWSES the folder in the dashboard (the user 2026-08-14) — the affordance
+  // that works from every device, where OS-open acted on the KERNEL's machine (the wrong-machine
+  // class the 📎 picker and file links were cured of). OS-open survives on
+  // the row's right-click menu for the genuinely-local case (the contextmenu delegate below). In
+  // VS Code the browser overlay doesn't exist, so the click keeps opening the folder host-side.
+  const web = location.protocol === "http:" || location.protocol === "https:";
+  elem.dataset.act = web && window.parent !== window ? "browseFiles" : "openFolder";
   elem.dataset.cwd = cwd;
   if (sid) elem.dataset.id = sid;
   elem.classList.add("folder-link");
-  elem.title = cwd + "  ·  click to open this folder";
+  elem.title = cwd + (elem.dataset.act === "browseFiles"
+    ? "  ·  click to browse this folder" : "  ·  click to open this folder");
 }
 
 // Small inline-SVG folder in the romp line-icon style (matches ctxIcon: 16-unit viewBox, currentColor, so it
@@ -4356,6 +4390,18 @@ function showTabMenu(e: MouseEvent, id: string) {
     offMail ? "Rejoin mail" : "Mute mail",
     offMail ? "reconnect it to the postal service" : "hide from peers — no messages in or out",
     () => setSessionFlag(id, "postalServiceOff", !offMail));
+  // Browse the session's working tree in the feed pane. Web-only: openBrowse no-ops outside the
+  // shell, and VS Code's editor has its own explorer, so the row only renders where the click can
+  // land.
+  if ((location.protocol === "http:" || location.protocol === "https:") && window.parent !== window) {
+    const browse = el("div", "ctx-item");
+    browse.textContent = "Browse files";
+    browse.addEventListener("click", (ev) => {
+      ev.stopPropagation(); dismissTabMenu();
+      openBrowse(s?.cwd || ".", id);
+    });
+    menu.appendChild(browse);
+  }
   // system-notification bell (the user 2026-07-28) — same flag the timeline lane bell toggles. NOTE the
   // inverted polarity vs the two above: `notify` true is the ENABLED state, so the icon slashes on !onBell.
   toggle("bell", !onBell,
@@ -11249,11 +11295,46 @@ setupSettings();
   // applied — opens that folder on click. Body is stable across every per-push rebuild, so a click is never
   // dropped mid-press. (Only elements carrying data-act="openFolder" are matched; nothing else is affected.)
   // `id` (data-id, the session's own possibly host-prefixed id) rides along opaquely — see asFolderLink.
+  // OS-open demoted to the folder-link's right-click (the user 2026-08-14): the click now browses in
+  // the dashboard, and this menu keeps "open a folder window" reachable for whoever IS at that
+  // machine's screen. One document-level listener — folder links live in re-rendered surfaces.
+  document.addEventListener("contextmenu", (ev) => {
+    const link = (ev.target as HTMLElement).closest?.(".folder-link[data-cwd]") as HTMLElement | null;
+    if (!link || link.dataset.act !== "browseFiles") return;   // openFolder clicks need no second door
+    ev.preventDefault();
+    document.getElementById("folder-ctx")?.remove();
+    const menu = el("div", "ctx-menu");
+    menu.id = "folder-ctx";
+    const item = el("div", "ctx-item");
+    item.textContent = "Open folder window";
+    const sub = el("span", "ctx-item-sub");
+    sub.textContent = "on the machine the session runs on";
+    item.appendChild(sub);
+    const cwd = link.dataset.cwd || "";
+    const id = link.dataset.id;
+    item.addEventListener("click", (e2) => {
+      e2.stopPropagation();
+      menu.remove();
+      vscodeApi?.postMessage(id ? { type: "openFolder", cwd, id } : { type: "openFolder", cwd });
+    });
+    menu.appendChild(item);
+    document.body.appendChild(menu);
+    const r = menu.getBoundingClientRect();
+    menu.style.left = Math.max(0, Math.min(ev.clientX, window.innerWidth - r.width - 4)) + "px";
+    menu.style.top = Math.max(0, Math.min(ev.clientY, window.innerHeight - r.height - 4)) + "px";
+    const dismiss = () => { menu.remove(); document.removeEventListener("click", dismiss); };
+    document.addEventListener("click", dismiss);
+  });
   delegate(document.body, {
     openFolder: (el) => {
       const cwd = el.dataset.cwd; if (!cwd || !vscodeApi) return;
       const id = el.dataset.id;
       vscodeApi.postMessage(id ? { type: "openFolder", cwd, id } : { type: "openFolder", cwd });
+    },
+    // the web twin of openFolder: surface the file browser at this folder
+    browseFiles: (el) => {
+      const cwd = el.dataset.cwd; if (!cwd) return;
+      openBrowse(cwd, el.dataset.id);
     },
     // "Stop retrying" on the live api_retry element (the user 2026-07-24). The CLI owns the backoff and the
     // SDK exposes no handle on it, so the honest stop is the SAME interrupt the stop button and Ctrl+C send:

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -35,6 +35,8 @@ import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews } from "./preview";
 import { openFileView, setCommentSink } from "./file-view";
+// initFileView rides its OWN line: the import above is pinned verbatim by file-view-comments.test.ts
+import { initFileView } from "./file-view";
 import { pastedFilePath } from "./paste-path";
 import { hostNameNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
@@ -11555,4 +11557,9 @@ setCommentSink((sid, text) => {
   persistDrafts();
   return true;
 });
+// The chat document hosts the viewer itself (openPath), so it boots the viewer's listener with the
+// same WS poster the feed hands it: Edit/Save round-trips ride post(), and the kernel's replies come
+// back as window MessageEvents via the pane shim — either document, one mechanism (file-view.ts
+// initFileView).
+initFileView((m) => vscodeApi?.postMessage(m));
 if (vscodeApi) vscodeApi.postMessage({ type: "ready" });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2739,6 +2739,10 @@ body.fileview-open { overflow: hidden; }
   border: 1px solid var(--box-border); }
 .fileview-btn:hover { border-color: var(--accent); }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
+/* the directory half of the title is the click into the file BROWSER (feed pane) — mirrored in
+   feed.css so the viewer behaves identically wherever it mounts */
+.fileview-dir-link { cursor: pointer; }
+.fileview-dir-link:hover { color: var(--accent); text-decoration: underline; }
 /* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
    and because they are a sibling element a selection of the code copies without dragging them along */
 .fileview-code { display: flex; align-items: flex-start; min-height: 100%; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2739,6 +2739,17 @@ body.fileview-open { overflow: hidden; }
   border: 1px solid var(--box-border); }
 .fileview-btn:hover { border-color: var(--accent); }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
+/* the raw-mode editor: height: 100% (not flex) — .fileview-body above is a plain overflow block,
+   not a flex container, so a flex basis on its child is inert and the textarea sat at the UA's
+   default rows (the user 2026-08-17, whose edit window was a few lines tall). The percentage
+   resolves because the body's own height is fixed by the pane's flex layout. Mirrored in feed.css
+   so the viewer behaves identically wherever it mounts. */
+.fileview-editor { display: block; height: 100%; width: 100%; box-sizing: border-box;
+  margin: 0; padding: 10px 12px; border: none; outline: none; resize: none;
+  background: var(--bg, #1e1e1e); color: var(--fg);
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  white-space: pre; tab-size: 4; }
+.fileview-editor:focus { box-shadow: inset 0 0 0 1px rgba(156, 210, 255, 0.35); }
 /* the directory half of the title is the click into the file BROWSER (feed pane) — mirrored in
    feed.css so the viewer behaves identically wherever it mounts */
 .fileview-dir-link { cursor: pointer; }

--- a/vscode-extension/src/statusline-terminal-link.test.ts
+++ b/vscode-extension/src/statusline-terminal-link.test.ts
@@ -9,12 +9,16 @@ import * as path from "node:path";
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("asFolderLink makes an element open the folder (data-act + cwd + affordance)", () => {
+test("asFolderLink routes by host: BROWSE on the web, folder-open in VS Code (the user 2026-08-14)", () => {
   assert.match(SRC, /function asFolderLink\(elem: HTMLElement, cwd: string, sid\?: string\): void/);
-  assert.match(SRC, /elem\.dataset\.act = "openFolder";/);
+  // web dashboard → the file browser (works from every device); VS Code keeps the host-side open
+  assert.match(SRC, /elem\.dataset\.act = web && window\.parent !== window \? "browseFiles" : "openFolder";/);
   assert.match(SRC, /elem\.dataset\.cwd = cwd;/);
   assert.match(SRC, /elem\.classList\.add\("folder-link"\)/);
+  assert.match(SRC, /click to browse this folder/);
   assert.match(SRC, /click to open this folder/);
+  // OS-open demoted, not deleted: the folder link's right-click still posts the old openFolder
+  assert.match(SRC, /item\.textContent = "Open folder window";/);
 });
 
 test("it's applied to the statusline folder AND the System-context Directory row, carrying the session id", () => {


### PR DESCRIPTION
Since #385 the dashboard can SHOW any file but cannot FIND one: the viewer only opens paths something else surfaced (a chat path link), so "look around a session's repo" has no surface. This PR adds that surface, in two commits so the second scope can be dropped or reshaped independently — the same split #385 merged with.

## Commit 1 — browse and open (read-only)

A file browser overlay in the feed pane: a breadcrumb bar over one flat listing — click a directory to descend, a file to open in the existing viewer modal, an ancestor crumb to walk up. Entry points: the chat tab's right-click menu, the feed card's right-click menu, the statusline's folder chip (web only — OS-open moves to the chip's right-click; VS Code keeps its explorer and the host-side folder open, since the wrong-machine problem doesn't exist there), and the viewer's own directory segment.

Design points:

- **The listing is a WebSocket op** (`listDir` → `dirListing`) riding the same reqId/stale-drop protocol as `dirComplete`, so federation routes it by `sid` to the session-owning kernel and browsing a remote machine's tree needs **zero new relay code**. File bytes stay on HTTP `/file`.
- **Resolution is `/file`'s own** (`_resolve_open_path`), so every listed path feeds `fileUrl` unchanged.
- **`viewable` is computed server-side** from the `/file` tables, so non-renderable rows are dimmed "download only" up front and click straight to download instead of failing into a 415.
- The 500-row cap is stated in-band (`truncated` + `total`); hidden entries are off unless asked; errors name the resolved path and still carry `base`/`parent` so even a failed first open has a walkable crumb trail.
- **The shell regains a single cross-pane relay** (`browseFiles`/`browseClosed`): the browser, unlike the modal viewer, lives in the feed document, so the feed-pane bring-forward/put-back exists only for it — `file-view.test.ts`'s "no `__rompFeedWasOff`" pin is updated to pin the new ownership instead.
- The feed sheet mirrors the viewer modal, the hljs palette, and the comment selectors (one treatment, two sheets — the palette-parity test pins the two sheets identical). The feed-hosted viewer registers **no comment sink**, and the review layer now gates itself off cleanly without one (no marks, no count, no dead Submit) — the sid-routed sink and the comments-survive-a-failed-handoff behavior are preserved exactly.

## Commit 2 — raw-mode edits (separately droppable)

An Edit button when `/file` served text with an mtime anchor; a plain textarea; save as a `saveFile` WS op with **optimistic concurrency**:

- The kernel refuses when the disk is newer than the load-time anchor. The anchor is **nanoseconds** (`X-Romp-Mtime-Ns`) because Last-Modified's whole seconds let an agent write landing in the same second slip the guard — and it travels **as a string**, because ~1.7e18 exceeds JS's safe-integer range and a JSON number would round.
- The buffer survives every refusal (the error bar sits above the textarea; a conflict offers Reload behind a confirm — never a merge UI, never a silent overwrite).
- Writes are atomic (temp file + `os.replace` in the same directory, mode preserved) and go **through** symlinks, never over them.
- Non-UTF-8 files refuse rather than re-encode (`/file`'s latin-1 fallback would otherwise silently rewrite every non-ASCII byte on save); CRLF files round-trip byte-identical; dirty buffers confirm before every discard path (Escape, ✕, crumb, backdrop, replace); keystrokes typed during a save's round-trip survive the ack.
- `/file` gains `Last-Modified` + `X-Romp-Mtime-Ns` on every success and `X-Romp-Text-Utf8` on text, and `/remote/<host>/file` mirrors exactly those three headers — they are data about the remote's file, not instructions to this browser — while still deriving Content-Type locally (the lying-remote rule) and keeping the resumable-206 logic intact.

**Tradeoff, plainly:** commit 2 widens what an authenticated dashboard can do from read-any-file to write-text-files. It is the same trust model as `/file` (the dashboard's owner can already ask an agent to write anything) and sits behind the same WS auth, but it is a real widening — which is why it is its own commit, droppable without touching commit 1.

One mixed-version note: a remote kernel older than this change never answers `listDir`, so browsing its sessions shows the loader until navigation or the socket-drop recovery; the wedge-proofing covers lost replies, not a silent old kernel.

## Tests

- `tests/test_listdir.py` — listing shape (dirs-first, tilde-collapsed base/parent, viewable verdicts, symlink typing), the cap, loud errors with a walkable trail, cwd resolution, and the wire op through the real dispatcher (reqId echo, hidden flag, errors still answer).
- `tests/test_savefile.py` — clean save + new ns anchor, mode preserved, stale/same-second/garbage/absent anchors refused, atomicity on a failed replace (original intact, temp cleaned), write-through-symlink, UTF-8 refusals (lone surrogate, non-UTF-8 disk), text cap, cwd resolution, wire acks/nacks with the kernel's words, and the `/file` + relay header pins.
- `ui/webview/filebrowse.test.ts` — the overlay contract: one-directional stack (browse closes a viewer above it), Escape topmost-only (menu → viewer → browser), wedge-proof in-flight recovery (unconditional un-latch, socket-drop resync, federation warn), keydown unbind + latch reset on close, hidden-toggle resync, the kernel's parent field actually read.
- `ui/webview/file-edit.test.ts` — the Edit gate (kernel verdicts only), string ns anchor end to end, dirty guards on every exit, conflict handling, in-flight-typing survival, lost-ack recovery, CRLF round-trip, relay mirroring.
- `ui/webview/file-view.test.ts` / `file-view-comments.test.ts` — the flipped relay-ownership pin, the two-sheet parity pins (modal, palette, md typography, gutter, wrap), the no-sink gating, and the Submit×editing 2×2 — including the failed-handoff-while-editing cell, which no test covered on either side of this change before.

Both commits were hardened by adversarial review before this PR (seventeen confirmed defects fixed and pinned across the two slices, several of them data-loss paths: ack-eats-in-flight-typing, latin-1 re-encode, CRLF rewrite, link-destroying save, zero-byte write on a malformed frame). The full Python suite, the webview/node suite, typecheck, and the bundle build are green with commit 1 alone and with both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)