### PR TITLE
The file viewer links a tracked file to its GitHub page

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20595,6 +20595,72 @@ def _edit_trace(path, sid):
         sys.stderr.write("edit-trace to %s failed: %s\n" % (target, ex))
 
 
+def _git_out(args, cwd, timeout=5):
+    """One read-only git query → stripped stdout, or None on any failure (no repo, no git, timeout).
+    List argv, never a shell; quiet — an absent repo is a normal answer here, not an error."""
+    try:
+        r = subprocess.run(["git", "-C", cwd] + args, capture_output=True, text=True, timeout=timeout)
+        return r.stdout.strip() if r.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+# origin remote → the https://github.com/<owner>/<repo> base, for the spellings git actually writes:
+# scp-like ssh, ssh:// (with an optional port, and GitHub's own documented SSH-over-HTTPS host
+# ssh.github.com), https (with an explicit :443), .git suffix and all. Anchored, so
+# github.example.com and github.com.evil.io lookalikes never match.
+_GITHUB_REMOTE = re.compile(
+    r"^(?:git@github\.com:|ssh://git@(?:ssh\.)?github\.com(?::\d+)?/|https://github\.com(?::443)?/)"
+    r"([\w.-]+)/([\w.-]+?)(?:\.git)?/?$")
+
+
+def _file_github_url(raw, sid):
+    """The GitHub web URL for a viewed file, or "" when there is none to give (the user 2026-08-15:
+    the viewer links to the file on GitHub when it is tracked there). Answered by the kernel that
+    OWNS the file — git on ITS disk is the authoritative source — and lazily, per viewer open, never
+    on the /file byte path (thumbnails must not pay three subprocesses each).
+
+    "" is a VERDICT, not an error: an untracked file, a non-repo path, or a non-GitHub origin all
+    honestly have no link, and the viewer simply never shows the button. The ref is the current
+    branch (what a human expects to read on GitHub), or the commit sha when HEAD is detached; a
+    branch that was never pushed 404s on GitHub's end, which is the truthful outcome for a file
+    that is not there yet."""
+    p = _resolve_open_path(str(raw or ""), sid)
+    if not os.path.isabs(p):
+        return ""
+    # realpath, not normpath (two executed repros): a lexical '..' collapse built a URL for a
+    # DIFFERENT file than the bytes the viewer shows when the '..' followed a symlink — a wrong link,
+    # strictly worse than none — and a symlinked path PREFIX made relpath escape the PHYSICAL toplevel
+    # git reports, silently un-linking every tracked file behind a symlink (macOS /tmp, a linked ~/code).
+    p = os.path.realpath(p)
+    d = os.path.dirname(p)
+    top = _git_out(["rev-parse", "--show-toplevel"], d)
+    if not top:
+        return ""
+    rel = os.path.relpath(p, top)
+    if rel == ".." or rel.startswith(".." + os.sep):
+        return ""                                   # escaped the repo — NOT a name-prefix test: a root
+    #                                                 file literally named ..cfg is inside and links fine
+    if _git_out(["ls-files", "--error-unmatch", "--", rel], top) is None:
+        return ""                                   # exists but untracked — no link to a thing not there
+    remote = _git_out(["remote", "get-url", "origin"], top)
+    m = _GITHUB_REMOTE.match(remote or "")
+    if not m:
+        return ""
+    ref = _git_out(["rev-parse", "--abbrev-ref", "HEAD"], top)
+    if not ref:
+        return ""
+    if ref == "HEAD":                               # detached — the sha is the only honest ref
+        ref = _git_out(["rev-parse", "HEAD"], top) or ""
+        if not ref:
+            return ""
+    return "https://github.com/%s/%s/blob/%s/%s" % (
+        # safe="/" keeps a slashed branch name (feat/x) literal — the form GitHub's own UI writes;
+        # GitHub resolves the ref/path ambiguity by longest match, exactly as it does for its users
+        m.group(1), m.group(2), quote(ref, safe="/"),
+        "/".join(quote(seg) for seg in rel.split(os.sep)))
+
+
 # Inline-code spans that name an EXISTING file despite containing spaces (the user 2026-08-04: a note
 # titled `Moving from correlation to causal components.md` linkified only its last word). The client's
 # token linkifier can never span a space — in prose that boundary is exactly what keeps ordinary text
@@ -26989,6 +27055,19 @@ class Handler(BaseHTTPRequestHandler):
                 _reply(client, {"type": "fileSaved", "reqId": msg.get("reqId"),
                                 "path": str(msg.get("path") or ""), "mtimeNs": str(mt)})
                 _edit_trace(msg.get("path"), msg.get("sid") or None)   # the owning session is TOLD (never edited under silently)
+
+
+        elif msg and msg.get("type") == "fileGitLink":
+            # The viewer's GitHub link (the user 2026-08-15), asked lazily per open. Answered by the
+            # kernel that OWNS the file — git on ITS disk is the authority, and a remote page's WS
+            # already terminates on the owning kernel (the /remote/<host>/ws splice), so no relay
+            # clause is needed; sid only resolves a relative path against that session's cwd. reqId
+            # is echoed for the stale-drop; an empty url is the no-link verdict and the viewer just
+            # never shows the button. Threaded: three git subprocesses must not block the recv loop.
+            def _gl(c=client, m=msg):
+                _reply(c, {"type": "fileGitLink", "reqId": m.get("reqId"),
+                           "url": _file_github_url(m.get("path"), m.get("sid") or None)})
+            threading.Thread(target=_gl, daemon=True).start()
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear
             if not _native_dialogs():

--- a/tests/test_file_github.py
+++ b/tests/test_file_github.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""_file_github_url + the fileGitLink WS op — the viewer's GitHub link (the user 2026-08-15).
+
+An empty url is a VERDICT, not an error: untracked files, non-repo paths, and non-GitHub origins
+honestly have no link, and the viewer never shows the button. The ref is the current branch (what a
+human expects to read), or the sha when HEAD is detached. Real temp git repos, synthetic names only
+(TESTORG / notes-api — the demo world).
+"""
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_github", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", "-c", "user.email=t@testhost", "-c", "user.name=t"] + list(args),
+                   cwd=cwd, check=True, capture_output=True)
+
+
+class _Repo(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        _git("init", "-q", "-b", "main", cwd=self.tmp)
+        os.makedirs(os.path.join(self.tmp, "src", "deep dir"))
+        self.fp = os.path.join(self.tmp, "src", "app.py")
+        with open(self.fp, "w") as f:
+            f.write("print('hi')\n")
+        self.spaced = os.path.join(self.tmp, "src", "deep dir", "notes file.md")
+        with open(self.spaced, "w") as f:
+            f.write("# notes\n")
+        with open(os.path.join(self.tmp, "loose.txt"), "w") as f:
+            f.write("untracked\n")
+        _git("add", "src", cwd=self.tmp)
+        _git("commit", "-q", "-m", "init", cwd=self.tmp)
+
+
+class GitHubUrl(_Repo):
+    def test_the_ssh_remote_spelling_builds_the_blob_url(self):
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+
+    def test_the_https_remote_spelling_builds_the_same_url(self):
+        _git("remote", "add", "origin", "https://github.com/TESTORG/notes-api.git", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+
+    def test_path_segments_are_quoted_but_slashes_survive(self):
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.spaced, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/deep%20dir/notes%20file.md")
+
+    def test_a_slashed_branch_name_stays_literal_like_githubs_own_urls(self):
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        _git("checkout", "-q", "-b", "feat/deep-work", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/feat/deep-work/src/app.py")
+
+    def test_a_detached_head_links_the_sha(self):
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,
+                             capture_output=True, text=True).stdout.strip()
+        _git("checkout", "-q", sha, cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/%s/src/app.py" % sha)
+
+    def test_a_symlinked_path_prefix_still_links(self):
+        # executed repro: git reports the PHYSICAL toplevel, so a logical path through a symlink
+        # escaped relpath and silently un-linked every tracked file behind one
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        outer = tempfile.mkdtemp()
+        link = os.path.join(outer, "via-link")
+        os.symlink(self.tmp, link)
+        self.assertEqual(km._file_github_url(os.path.join(link, "src", "app.py"), None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+
+    def test_dotdot_through_a_symlink_never_links_the_wrong_file(self):
+        # executed repro: a LEXICAL '..' collapse linked a different file than the bytes the viewer
+        # shows; realpath resolves the symlink first, and the escape gets the honest no-link
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        os.symlink(tempfile.mkdtemp(), os.path.join(self.tmp, "ext"))
+        self.assertEqual(
+            km._file_github_url(os.path.join(self.tmp, "ext", "..", "src", "app.py"), None), "",
+            "the OS would read outside the repo — a wrong link is worse than none")
+
+    def test_port_bearing_and_ssh_over_https_origins_link(self):
+        # GitHub's own SSH-over-HTTPS doc writes ssh://git@ssh.github.com:443/OWNER/REPO.git
+        for url in ("ssh://git@ssh.github.com:443/TESTORG/notes-api.git",
+                    "ssh://git@github.com:22/TESTORG/notes-api.git",
+                    "https://github.com:443/TESTORG/notes-api.git"):
+            m = km._GITHUB_REMOTE.match(url)
+            self.assertIsNotNone(m, url)
+            self.assertEqual((m.group(1), m.group(2)), ("TESTORG", "notes-api"), url)
+        for url in ("git@github.example.com:TESTORG/notes-api.git",
+                    "https://github.com.evil.io/TESTORG/notes-api.git"):
+            self.assertIsNone(km._GITHUB_REMOTE.match(url), url)
+
+    def test_a_root_file_named_with_leading_dots_still_links(self):
+        # the escape guard tests the path relation, never a name prefix
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        dd = os.path.join(self.tmp, "..cfg")
+        with open(dd, "w") as f:
+            f.write("k=v\n")
+        _git("add", "--", "..cfg", cwd=self.tmp)
+        _git("commit", "-q", "-m", "cfg", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(dd, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/..cfg")
+
+    def test_no_link_verdicts_untracked_nonrepo_and_nongithub(self):
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(os.path.join(self.tmp, "loose.txt"), None), "",
+                         "untracked file — no link to a thing not there")
+        self.assertEqual(km._file_github_url("/tmp", None), "", "not a repo")
+        _git("remote", "set-url", "origin", "git@gitlab.example.com:TESTORG/notes-api.git", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None), "", "origin is not GitHub")
+
+    def test_a_relative_path_resolves_against_the_sessions_cwd(self):
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        real = km._cwd_of
+        km._cwd_of = lambda sid: self.tmp if sid == "11111111-2222-3333-4444-000000000001" else None
+        try:
+            self.assertEqual(km._file_github_url("src/app.py", "11111111-2222-3333-4444-000000000001"),
+                             "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+            self.assertEqual(km._file_github_url("src/app.py", None), "", "no sid, no base — no guess")
+        finally:
+            km._cwd_of = real
+
+
+class GitLinkWire(_Repo):
+    """The WS op through the real dispatcher. The op answers on a THREAD (three git subprocesses must
+    not block the recv loop), so the harness waits for the reply instead of reading it synchronously."""
+
+    def setUp(self):
+        super().setUp()
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        self.sent = []
+        self.client = {"app": "feed", "alive": True,
+                       "send": lambda s: self.sent.append(json.loads(s))}
+        self.handler = object.__new__(km.Handler)
+
+    def send_and_wait(self, msg, timeout=10):
+        km.Handler._dispatch_ws(self.handler, msg, self.client)
+        deadline = time.time() + timeout
+        while not self.sent and time.time() < deadline:
+            time.sleep(0.02)
+        return self.sent[-1] if self.sent else None
+
+    def test_the_reply_echoes_the_request_id_with_the_url(self):
+        r = self.send_and_wait({"type": "fileGitLink", "path": self.fp, "reqId": 6})
+        self.assertIsNotNone(r, "the threaded op must still always reply")
+        self.assertEqual(r["type"], "fileGitLink")
+        self.assertEqual(r["reqId"], 6, "echoed so a reply landing after a newer open is dropped")
+        self.assertEqual(r["url"], "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+
+    def test_the_no_link_verdict_still_replies(self):
+        r = self.send_and_wait({"type": "fileGitLink", "path": os.path.join(self.tmp, "loose.txt"),
+                                "reqId": 7})
+        self.assertEqual(r["url"], "", "an empty url is the verdict, never a dropped reply")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -121,6 +121,46 @@ let editHooks: { reqId: number; saved: (mtimeNs: string) => void; failed: (err: 
 // handler both close through it without knowing an edit is in progress.
 let closeGuard: (() => boolean) | null = null;
 
+// ── viewer action registry (the user 2026-08-22) ── INTERNAL SEAM, no compatibility promise:
+// reshape freely. Anything acting on the OPEN file declares itself here instead of hand-wiring into
+// openFileView's action row, where every file-viewer change used to collide. mount() runs once per
+// open and returns the action's element for the row (or null to sit this file out); an action that
+// answers asynchronously (the GitHub link's kernel ask) mounts hidden and reveals itself when its
+// reply lands. Ordering is registration order, after the built-ins.
+export interface FileViewActionCtx { path: string; sid: string | null; }
+export interface FileViewAction { id: string; mount: (ctx: FileViewActionCtx) => HTMLElement | null; }
+const fileViewActions: FileViewAction[] = [];
+export function registerFileViewAction(a: FileViewAction): void {
+  if (!fileViewActions.some((x) => x.id === a.id)) fileViewActions.push(a);
+}
+
+// ── the GitHub link (the user 2026-08-15) — the registry's first entry ─────────────────────────────
+// An anchor, not a button: the browser owns opening a new tab. Hidden until the OWNING kernel answers
+// the lazy fileGitLink ask with a real URL — an untracked file, a non-repo path, or a non-GitHub
+// origin all honestly have no link, and it simply never appears. One question per open, reqId-guarded.
+let gitSeq = 0;
+let gitHooks: { reqId: number; apply: (url: string) => void } | null = null;
+registerFileViewAction({
+  id: "github-link",
+  mount({ path, sid }) {
+    const gh = el("a", "fileview-btn fileview-gh") as HTMLAnchorElement;
+    gh.textContent = "GitHub ↗";
+    gh.target = "_blank"; gh.rel = "noopener";
+    gh.hidden = true;
+    gitHooks = {
+      reqId: ++gitSeq,
+      apply: (url) => {
+        if (!url) return;
+        gh.href = url;
+        gh.title = url;                            // the full URL one hover away
+        gh.hidden = false;
+      },
+    };
+    post({ type: "fileGitLink", path, sid: sid || undefined, reqId: gitSeq });
+    return gh;
+  },
+});
+
 // ── review comments (the user 2026-08-14, who found coordinating a doc review painful) ─────────────
 // Reading a doc an agent wrote used to mean hand-copying every line you wanted changed back into the
 // chat. Now you comment on passages IN the viewer and one Submit hands the whole set over as a single
@@ -163,6 +203,7 @@ export function closeFileView(): void {
   if (closeGuard && !closeGuard()) return;   // unsaved edits, and the user chose to keep them
   closeGuard = null;
   editHooks = null;
+  gitHooks = null;                                     // a reply landing after the close decorates nothing
   wrap.remove();
   document.body.classList.remove("fileview-open");
 }
@@ -174,6 +215,7 @@ export function openFileView(path: string, sid?: string | null): void {
   if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;
   closeGuard = null;
   editHooks = null;
+  gitHooks = null;                                     // the replace path skips closeFileView — same drop
   document.getElementById("romp-fileview")?.remove();
   // backdrop (the whole overlay carries the id every open/closed check targets) + the ~95% card.
   // The backdrop treatment matches the lightbox: dimmed, click outside the card closes, content
@@ -303,6 +345,12 @@ export function openFileView(path: string, sid?: string | null): void {
   cancelBtn.hidden = true;
   cancelBtn.addEventListener("click", () => { if (confirmDiscard()) exitEdit(); });
   acts.appendChild(editBtn); acts.appendChild(saveBtn); acts.appendChild(cancelBtn);
+  // Registered actions render after the built-ins — the registry walk is the ONE place row
+  // conventions live (see registerFileViewAction above). The GitHub link mounts here.
+  for (const a of fileViewActions) {
+    const n = a.mount({ path, sid: sid || null });
+    if (n) acts.appendChild(n);
+  }
 
   // ── download (the user 2026-08-09) ── Any linked file can be SAVED, including everything the pane
   // cannot show: the kernel's ?download=1 serves anything on disk (the rationale lives with
@@ -783,11 +831,12 @@ function mdBlock(text: string): HTMLElement {
   return box;
 }
 
-/** Bind the pane's WS poster and route saveFile replies back to the open viewer. Called once, from
- *  the pane's boot (render.ts and feed.ts today — either document, one mechanism). The viewFile
- *  branch honors a shell's relay of a chat file-link click — nothing sends it since the viewer moved
- *  into the chat document, but a not-yet-reloaded shell page still might, and honoring it costs
- *  nothing. */
+/** Bind the pane's WS poster and route saveFile + fileGitLink replies back to the open viewer.
+ *  Called once, from the pane's boot (render.ts and feed.ts today — either document, one mechanism);
+ *  every reply is reqId-guarded so one landing after a close or a replace-open touches nothing. The
+ *  viewFile branch honors a shell's relay of a chat file-link click — nothing sends it since the
+ *  viewer moved into the chat document, but a not-yet-reloaded shell page still might, and honoring
+ *  it costs nothing. */
 export function initFileView(poster: (m: Record<string, unknown>) => void): void {
   post = poster;
   window.addEventListener("message", (e: MessageEvent) => {
@@ -795,6 +844,9 @@ export function initFileView(poster: (m: Record<string, unknown>) => void): void
     if (!m) return;
     if (m.romp === "viewFile" && typeof m.path === "string" && m.path) {
       openFileView(m.path, typeof m.sid === "string" ? m.sid : null);
+    } else if (m.type === "fileGitLink" && gitHooks && m.reqId === gitHooks.reqId) {
+      const h = gitHooks; gitHooks = null;
+      h.apply(String(m.url || ""));
     } else if (m.type === "fileSaved" && editHooks && m.reqId === editHooks.reqId) {
       const h = editHooks; editHooks = null;
       h.saved(String(m.mtimeNs || ""));

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -1,0 +1,54 @@
+// The viewer's GitHub link (the user 2026-08-15): a lazy fileGitLink ask per open, answered by the
+// file-OWNING kernel (git on ITS disk is the authority), an anchor that appears only when a real
+// URL comes back. Source pins (no jsdom for these modules), the repo convention.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const VIEW = web("file-view.ts");
+const RENDER = web("render.ts");
+const CHAT_CSS = web("styles.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the ask is lazy, per open, and sid-routed — never on the /file byte path", () => {
+  assert.match(VIEW, /post\(\{ type: "fileGitLink", path, sid: sid \|\| undefined, reqId: gitSeq \}\);/);
+  // thumbnails must not pay three git subprocesses each: /file itself is untouched
+  assert.doesNotMatch(KERNEL, /_file_github_url\(fp/);
+});
+
+test("the poster is bound at the boot of the document that hosts the viewer", () => {
+  assert.match(RENDER, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
+});
+
+test("the anchor appears only on a real URL, opens a new tab, and shows where it goes", () => {
+  assert.match(VIEW, /const gh = el\("a", "fileview-btn fileview-gh"\) as HTMLAnchorElement;/);
+  assert.match(VIEW, /gh\.target = "_blank"; gh\.rel = "noopener";/);
+  assert.match(VIEW, /gh\.hidden = true;/);
+  assert.match(VIEW, /if \(!url\) return;/, "an empty url is the no-link verdict — the button never appears");
+  assert.match(VIEW, /gh\.title = url;/, "the full URL one hover away");
+  assert.match(CHAT_CSS, /a\.fileview-btn \{ text-decoration: none;/);
+});
+
+test("replies are reqId-guarded and cannot touch a later open", () => {
+  assert.match(VIEW, /m\.type === "fileGitLink" && gitHooks && m\.reqId === gitHooks\.reqId/);
+  // both the close and the replace path drop the hooks, so a late reply lands nowhere
+  const closes = VIEW.match(/gitHooks = null;/g) || [];
+  assert.ok(closes.length >= 2, "cleared on close AND on replace-open");
+});
+
+test("the kernel's answer is a verdict from git itself, threaded off the recv loop", () => {
+  assert.match(KERNEL, /def _file_github_url\(raw, sid\):/);
+  assert.match(KERNEL, /elif msg and msg\.get\("type"\) == "fileGitLink":/);
+  assert.match(KERNEL, /threading\.Thread\(target=_gl, daemon=True\)\.start\(\)/);
+  // the spellings git actually writes for a GitHub origin — incl. ports and ssh.github.com
+  assert.match(KERNEL, /ssh:\/\/git@\(\?:ssh\\\.\)\?github\\\.com\(\?::\\d\+\)\?/);
+  assert.match(KERNEL, /ls-files", "--error-unmatch"/, "tracked files only — no link to a thing not there");
+  // realpath, not normpath: a lexical '..' collapse linked a DIFFERENT file than the viewer shows
+  assert.match(KERNEL, /p = os\.path\.realpath\(p\)\n    d = os\.path\.dirname\(p\)/);
+});
+
+test("the hidden anchor stays hidden — an author display must not beat [hidden]", () => {
+  assert.match(CHAT_CSS, /a\.fileview-btn\[hidden\] \{ display: none; \}/);
+});

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -52,3 +52,13 @@ test("the kernel's answer is a verdict from git itself, threaded off the recv lo
 test("the hidden anchor stays hidden — an author display must not beat [hidden]", () => {
   assert.match(CHAT_CSS, /a\.fileview-btn\[hidden\] \{ display: none; \}/);
 });
+
+test("the GitHub link is the action REGISTRY's first entry, not another hand-wired button", () => {
+  // the registry (the user 2026-08-22): internal seam, no compatibility promise — actions on the
+  // open file declare a mount() instead of editing openFileView, so viewer PRs stop colliding there
+  assert.match(VIEW, /export function registerFileViewAction\(a: FileViewAction\): void \{/);
+  assert.match(VIEW, /if \(!fileViewActions\.some\(\(x\) => x\.id === a\.id\)\) fileViewActions\.push\(a\);/, "same id registered twice mounts once");
+  assert.match(VIEW, /registerFileViewAction\(\{\n  id: "github-link",/);
+  // openFileView renders registered actions by WALKING THE TABLE, after the built-ins
+  assert.match(VIEW, /for \(const a of fileViewActions\) \{\n    const n = a\.mount\(\{ path, sid: sid \|\| null \}\);\n    if \(n\) acts\.appendChild\(n\);\n  \}/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11576,8 +11576,8 @@ setCommentSink((sid, text) => {
   return true;
 });
 // The chat document hosts the viewer itself (openPath), so it boots the viewer's listener with the
-// same WS poster the feed hands it: Edit/Save round-trips ride post(), and the kernel's replies come
-// back as window MessageEvents via the pane shim — either document, one mechanism (file-view.ts
-// initFileView).
+// same WS poster the feed hands it: Edit/Save round-trips and the GitHub-link ask ride post(), and
+// the kernel's replies come back as window MessageEvents via the pane shim — either document, one
+// mechanism (file-view.ts initFileView).
 initFileView((m) => vscodeApi?.postMessage(m));
 if (vscodeApi) vscodeApi.postMessage({ type: "ready" });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2741,6 +2741,11 @@ body.fileview-open { overflow: hidden; }
   padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.08); color: var(--fg);
   border: 1px solid var(--box-border); }
 .fileview-btn:hover { border-color: var(--accent); }
+/* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
+a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
+/* an author `display` beats the UA's [hidden] rule — without this the anchor shows hrefless
+   before the kernel ever answers */
+a.fileview-btn[hidden] { display: none; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* the raw-mode editor: height: 100% (not flex) — .fileview-body above is a plain overflow block,
    not a flex container, so a flex basis on its child is inert and the textarea sat at the UA's


### PR DESCRIPTION
Follow-up in the viewer family (#385): a "GitHub ↗" anchor in the file viewer's title bar, shown only when the viewed file is tracked in a repo whose origin is GitHub — one click from reading a file in the dashboard to its canonical page.

## Design

The kernel that owns the file answers, because git on its own disk is the only authoritative source — a new `fileGitLink` WS op, asked lazily once per viewer open and answered on a thread (three git subprocesses must never ride the `/file` byte path or block the recv loop; thumbnails pay nothing). An empty `url` is a verdict, not an error: untracked files, non-repo paths, and non-GitHub origins honestly have no link, and the anchor never appears — no dead button. Replies are reqId-guarded so a late answer cannot decorate a different file, and the hooks clear on close and on replace-open. For a remote session's file the page's own spliced WebSocket already terminates at the owning kernel, so the op needs no relay clause; the `sid` only resolves relative paths against that session's cwd.

## URL construction

The ref is the current branch (what a reader expects on GitHub), the commit sha when HEAD is detached; a slashed branch name (`feat/x`) stays literal, the form GitHub's own UI writes; path segments are percent-quoted. The origin matcher takes the spellings git actually writes — scp-like ssh, `ssh://` with an optional port, GitHub's documented SSH-over-HTTPS host (`ssh://git@ssh.github.com:443/...`), https with an explicit `:443` — and is anchored so `github.example.com` / `github.com.evil.io` lookalikes never match. The href scheme is hardcoded https, so no remote string can smuggle a `javascript:` URL.

Paths go through realpath before the repo-relative computation: a symlinked path prefix must not silently un-link tracked files (git reports the physical toplevel), and a lexical `..` collapse through a symlink must never link a DIFFERENT file than the bytes shown — a wrong link is worse than none. The escape guard tests the path relation, not a name prefix, so a root file literally named `..cfg` still links. The anchor wears the button treatment but is a real `<a>` (the browser owns the new tab), with an explicit `[hidden]` display rule so it cannot flash hrefless before the kernel answers.

## Tests

- `tests/test_file_github.py` — 13 cases on real temp repos with synthetic remotes, covering every verdict, both symlink repros, the origin-spelling matrix, and the threaded op end-to-end through the real dispatcher.
- `ui/webview/github-link.test.ts` — source pins for the lazy sid-carrying ask, the reqId guard, the hidden-until-real-URL behavior, and the kernel-side regex/realpath/tracked-only properties.

Full pytest, `npm test`, `tsc --noEmit`, and the bats suite all pass; the new tests were demonstrated failing against the unpatched tree first. Existing pinned source spans in `file-view.test.ts` / `file-view-comments.test.ts` / `docreview.test.ts` are untouched (the `initFileView` import rides its own line so the pinned import stays verbatim).

A sibling PR touching the same viewer seams (a file browser) may be open around the same time — happy to rebase whichever of the two lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)