### PR TITLE
Goals minted from rewound-away turns survive cleanup: chain identity replaces the one-shot timestamp sweep

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -936,15 +936,22 @@ class FileAdapter:
                 out.add(u)
         return out
 
-    def kept_uuids(self, active):
-        """The active leaf-ancestors PLUS any line on a BROKEN chain (its parentUuid points
-        at a uuid that exists in NO transcript — corruption / a partial write). The two
-        kinds of off-path line we DO drop are both intentional: a rewind fork (its chain
-        rejoins the active spine) and a clear branch (its chain reaches a clean null root
-        the leaf does not share — `/clear` breaks the parent link, spec-mandated drop). A
-        dangling chain is the one thing we cannot prove dead, and silently dropping a real
-        ask is this repo's one fatal error, so we keep it. (Verified 0 dangling cases
-        across the live corpus: this is a safety net, not a behavior change.)"""
+    def chain_verdicts(self, active=None):
+        """THE chain-membership identity, one verdict per uuid in the graph — the single
+        implementation every consumer must share (the goal-store rewind cleanup grew four
+        hand-rolled partial twins of this walk before it was exported, and they disagreed
+        on exactly the cases that matter — resume forks, pending cuts, broken chains):
+          "active" — on the leaf->root spine (what the chat shows).
+          "rewind" — the chain rejoins the active spine: this line was REWOUND AWAY. The
+                     only verdict that ever justifies dropping/sweeping content.
+          "clear"  — the chain reaches a clean null root the leaf does not share: `/clear`
+                     jurisdiction (the episode machinery settles those) — never swept as
+                     a rewind.
+          "broken" — parentUuid points at a uuid in NO transcript, or a cycle: unprovable,
+                     KEPT (silently dropping a real ask is this repo's one fatal error).
+        `active` defaults to active_path(); pass it when already computed."""
+        if active is None:
+            active = self.active_path()
         verdict = {}
         def classify(start):
             path, u = [], start
@@ -965,11 +972,25 @@ class FileAdapter:
             for x in path:
                 verdict[x] = res
             return res
-        kept = set(active)
+        out = {}
         for u in self.by_uuid:
-            if u not in active and classify(u) == "broken":
-                kept.add(u)
-        return kept
+            out[u] = "active" if u in active else classify(u)
+        return out
+
+    def kept_uuids(self, active):
+        """The active leaf-ancestors PLUS any line on a BROKEN chain (its parentUuid points
+        at a uuid that exists in NO transcript — corruption / a partial write). The two
+        kinds of off-path line we DO drop are both intentional: a rewind fork (its chain
+        rejoins the active spine) and a clear branch (its chain reaches a clean null root
+        the leaf does not share — `/clear` breaks the parent link, spec-mandated drop). A
+        dangling chain is the one thing we cannot prove dead, and silently dropping a real
+        ask is this repo's one fatal error, so we keep it. (Verified 0 dangling cases
+        across the live corpus: this is a safety net, not a behavior change.)
+        Derived from chain_verdicts — one implementation, so the exported membership
+        predicate (chain_membership) can never diverge from what the parse keeps.
+        set(active) is unioned as-is: the walk can record a dangling FINAL ancestor that is
+        in no file's index, and it has always been kept."""
+        return set(active) | {u for u, v in self.chain_verdicts(active).items() if v == "broken"}
 
     def _absorbed_atom(self, full, t, seq, auid, rompuuid, postal_index):
         """One synthesized user atom for a mid-turn splice. The atom carries the FULL text — any
@@ -1673,6 +1694,62 @@ def resume_fork_links(srows):
     return links
 
 
+def _lineage_closure(leaf_path, candidate_files, links):
+    """The candidate-file set CLOSED over the recorded resume lineage: a fork chain across several
+    restarts needs every resumed-from file present for the stitched walk to cross (a caller's anchor
+    covers only one hop). Shared by parse_session AND chain_membership so the exported membership
+    predicate reads the exact same file set the display parse does. From-files are frozen after
+    their fork (the CLI writes only the new file), so callers' cache keys stay honest."""
+    if not links:
+        return list(candidate_files)
+    have = {Path(f).stem for f in candidate_files}
+    stem, hops = Path(leaf_path).stem, 0
+    candidate_files = list(candidate_files)
+    while stem in links and hops < 16:
+        stem = links[stem]
+        hops += 1
+        fp = Path(leaf_path).with_name(stem + ".jsonl")
+        if stem not in have and fp.exists():
+            candidate_files.append(str(fp))
+            have.add(stem)
+    return candidate_files
+
+
+def chain_membership(leaf_path, candidate_files=None, states=None, leaf_override=None):
+    """THE exported chain-membership fact — {"kept", "rewind", "clear", "broken"} uuid sets, built
+    from the DISPLAY parse's exact inputs (resume links + lineage closure + leaf_override = the
+    kernel's pending bare-rollback cut) so it can never disagree with what the user sees. This is
+    the one predicate every rewind-cleanup consumer must use (goal sweeps, mint-time stand-downs,
+    the dead-branch reconciliation): before it was exported, four partial hand-rolled twins of this
+    walk disagreed on resume forks, pending cuts and broken chains (2026-08-17).
+
+    "rewind" is the ONLY set that ever justifies sweeping a goal: "clear" branches are /clear
+    jurisdiction (the episode machinery settles those cards), "broken" chains are kept by design,
+    and a uuid in NO set is unprovable (a synthetic orphan:<t> salvage id, a cross-file uuid whose
+    file is outside the lineage, a legacy None) — callers must treat unknown as NOT abandoned.
+    Caveat (resume-fork stitch shape): a recorded fork's fresh head is re-pointed at the from-file's
+    LAST record — if that tip was itself an abandoned tail, the stitch makes it active again; this
+    predicate follows the stitch exactly as the display parse does (kept semantics, by design)."""
+    leaf_path = Path(leaf_path)
+    if candidate_files is None:
+        candidate_files = [str(leaf_path)]
+    links = resume_fork_links(_load_states(states))
+    candidate_files = _lineage_closure(leaf_path, candidate_files, links)
+    adapter = FileAdapter(candidate_files, leaf_path, leaf_override=leaf_override, resume_links=links)
+    active = adapter.active_path()
+    verdicts = adapter.chain_verdicts(active)
+    # kept, derived from the verdicts already in hand — BY DEFINITION the same set kept_uuids
+    # computes (active ∪ broken; see its docstring: "derived from chain_verdicts — one
+    # implementation"), without paying the graph walk a second time inside it. The hold view
+    # re-asks this on every build of a held session, so the walk count matters there.
+    out = {"kept": set(active) | {u for u, v in verdicts.items() if v == "broken"},
+           "rewind": set(), "clear": set(), "broken": set()}
+    for u, v in verdicts.items():
+        if v != "active":
+            out[v].add(u)
+    return out
+
+
 def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None,
                   candidate_files=None, states=None, postal_log=None, now=None, sdk_human=False,
                   leaf_override=None):
@@ -1702,23 +1779,13 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     postal_index = _load_postal_index(postal_log)
     _srows = _load_states(states)
     links = resume_fork_links(_srows)
-    if links:
-        # The lineage closure joins the candidate set: a fork chain across several restarts needs
-        # every resumed-from file present for the stitched walk to cross (the caller's anchor covers
-        # only one hop). Resolved HERE so both parses (the judge's and the kernel's) inherit it from
-        # the one states plumbing they already share. From-files are frozen after their fork (the CLI
-        # writes only the new file), so the callers' cache keys — candidate files + the states file,
-        # whose mtime moves when a lineage row lands — stay honest without knowing about these.
-        have = {Path(f).stem for f in candidate_files}
-        stem, hops = leaf_path.stem, 0
-        candidate_files = list(candidate_files)
-        while stem in links and hops < 16:
-            stem = links[stem]
-            hops += 1
-            fp = leaf_path.with_name(stem + ".jsonl")
-            if stem not in have and fp.exists():
-                candidate_files.append(str(fp))
-                have.add(stem)
+    # The lineage closure joins the candidate set: a fork chain across several restarts needs
+    # every resumed-from file present for the stitched walk to cross (the caller's anchor covers
+    # only one hop). Resolved HERE so both parses (the judge's and the kernel's) inherit it from
+    # the one states plumbing they already share; chain_membership shares the same helper. The
+    # callers' cache keys — candidate files + the states file, whose mtime moves when a lineage
+    # row lands — stay honest without knowing about these.
+    candidate_files = _lineage_closure(leaf_path, candidate_files, links)
     adapter = FileAdapter(candidate_files, leaf_path, leaf_override=leaf_override, resume_links=links)
     adapter.sdk_human = sdk_human            # SDK-backed session → unmarked promptSource "sdk" is the human
     atoms = adapter.atoms(rompuuid, postal_index)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1473,6 +1473,98 @@ def _fileset_key(files):
 
 _PARSE_CACHE = {}          # fsid -> (fileset_key, parsed_session)
 
+# ── the pending-cut wire (the rewind goal-cleanup fix, 2026-08-17) ──
+# A PENDING bare rollback (chat delete) writes NOTHING to the transcript, so for its whole armed
+# window — unbounded; the user's next message may never come — the file leaf IS the abandoned tail.
+# The kernel's display parse has honored the cut since 2026-07-16 (leaf_override=pending_cut), but
+# the judge parse never did: every judge pass walked the deleted tail as the ACTIVE chain and the
+# planner's hard mint floors ("a user message never silently vanishes") GUARANTEED orphan goals from
+# it, which the one-shot t>=cut_t sweep — already run at gesture time — never re-caught, and the
+# auto-nudge then quoted back into a conversation with no memory of the ask (the g44 shape, proven
+# live 2026-08-16). The cut lives on the backend (sdk pending_cut); the kernel wires it in here so
+# parsed_session can pass the same leaf_override the display parse uses. No provider (standalone
+# romp-judge runs, tests that don't care) → "" — the pre-fix behavior.
+_PENDING_CUT_FN = None
+
+
+def set_pending_cut_provider(fn):
+    """Kernel wiring: fn(fsid) -> the armed bare rollback's cut uuid, or ''. See the note above."""
+    global _PENDING_CUT_FN
+    _PENDING_CUT_FN = fn
+
+
+def _pending_cut(fsid):
+    if _PENDING_CUT_FN is None:
+        return ""
+    try:
+        return str(_PENDING_CUT_FN(fsid) or "")
+    except Exception as e:
+        # fail LOUDLY, then degrade to the pre-fix behavior (parse the un-cut world) — a broken
+        # provider must not silently hide the conversation, but it must be visible in the log
+        _log_judge_error("romp", fsid, "pending-cut",
+                         note="pending-cut provider failed: %r — judging the un-cut world this pass" % e)
+        return ""
+
+
+def _judge_candidates(fsid, files):
+    """The judge parse's candidate transcript set: the leaf plus the session's anchor <fsid>.jsonl
+    when the leaf is a fork (SDK /clear: discover hands the lastSid file under the stable romp sid).
+    Shared by parsed_session and the write-moment chain checks so both walk the same graph."""
+    leaf = Path(files[0])
+    anchor = leaf.with_name(fsid + ".jsonl")
+    if anchor.name != leaf.name and anchor.exists():
+        return list(files) + [str(anchor)]
+    return list(files)
+
+
+def _rewound_away(fsid, path, uuid):
+    """WRITE-MOMENT chain check: does `uuid` PROVABLY sit on a rewound-away branch RIGHT NOW?
+
+    Deliberately frame-independent: inside a producer pass parsed_session returns the frame-pinned
+    parse — precisely the stale world in which a mid-pass rewind's dead branch still reads active —
+    so this builds a FRESH FileAdapter (cheap: the jsonl reads are append-incremental) over the same
+    inputs the display parse uses, including the backend's pending cut. The one-shot t>=cut_t sweep
+    runs at gesture time and never again; a mint applied after it from a pass framed before it was
+    the primary observed leak (the g44 shape), and this is the stand-down that closes it
+    (CLAUDE.md: a writer whose evidence predates the diary stands down).
+
+    Only "rewind" answers non-False. None/unknown uuids (umbrellas, legacy nodes, synthetic
+    orphan:<t> salvage ids, cross-file uuids outside the lineage) answer False — abandonment can't
+    be proven, and a false stand-down silently drops a real ask. "clear" is /clear jurisdiction;
+    "broken" is kept by design. A check that itself fails logs loudly and answers False (the
+    pre-fix behavior), never silently blocks a mint.
+
+    The verdict is TWO-VALUED because the evidence comes in two strengths (2026-08-17):
+    "durable" — the branch-take is ON DISK; the rewind happened and can never un-happen, so a
+                caller may act irreversibly (retire the placement key).
+    "pending" — the uuid is abandoned only under the backend's ARMED, unconsumed cut (a bare
+                rollback's window). That rewind can still fail or dissolve, and a placements[key]
+                = None retirement is permanent (_placed_key reads bare membership; nothing ever
+                pops a None key) — so callers must DEFER (skip without writing) and let the next
+                pass re-decide from whichever world the cut resolves into. Retiring here silently
+                dropped a live ask forever when the rollback dissolved: the restore leg brings
+                back hidden CARDS, but an ask retired before its card existed had nothing to
+                restore."""
+    if not uuid:
+        return False
+    try:
+        states = STATESDIR / (fsid + ".jsonl")
+        cut = _pending_cut(fsid)
+        mem = em.chain_membership(path, candidate_files=_judge_candidates(fsid, [str(path)]),
+                                  states=str(states) if states.exists() else None,
+                                  leaf_override=cut or None)
+        if uuid not in mem["rewind"]:
+            return False
+        if not cut:
+            return "durable"                           # proven from the on-disk graph alone
+        on_disk = em.chain_membership(path, candidate_files=_judge_candidates(fsid, [str(path)]),
+                                      states=str(states) if states.exists() else None)
+        return "durable" if uuid in on_disk["rewind"] else "pending"
+    except Exception as e:
+        _log_judge_error("romp", fsid, "chain-check",
+                         note="write-moment chain check failed: %r — minting anyway (pre-fix behavior)" % e)
+        return False
+
 
 def _sdk_owned(fsid):
     """True if FSID is an SDK-backed session — mirrors the SDK backend's owns() (a registry file under
@@ -1566,13 +1658,19 @@ def parsed_session(fsid, files, now):
     # the session's anchor transcript among the candidates, so a fork whose chain back-links across files
     # (a resume-style fork) keeps its history — the FileAdapter walk crosses files by design, and a /clear
     # fork (parentUuid null at the head) still drops pre-clear history naturally.
-    leaf = Path(files[0])
-    anchor = leaf.with_name(fsid + ".jsonl")
-    if anchor.name != leaf.name and anchor.exists():
-        files = list(files) + [str(anchor)]
+    files = _judge_candidates(fsid, files)
+    # A PENDING bare rollback truncates the judge's world exactly as it truncates the display parse
+    # (leaf_override — the wire note at _PENDING_CUT_FN): during the armed window plan_units never
+    # yields the abandoned turns at all, so the orphan-goal source is closed where it opens instead of
+    # being caught mint-by-mint. The cut rides the CACHE KEY (the kernel _parse's own lesson): arming
+    # and clearing both change the parse with NO file change. No PLACEMENTS_V bump: the override only
+    # SHRINKS the atom set, transiently, while a cut is armed — segment identity for everything kept is
+    # unchanged, and no previously-invisible atom ever becomes a fresh plannable segment (the two drift
+    # shapes the version exists for).
+    cut = _pending_cut(fsid)
     key_files = list(files) + ([str(states)] if states.exists() else [])
     try:
-        key = _fileset_key(key_files)
+        key = (_fileset_key(key_files), cut)
     except OSError:
         key = None
     hit = _PARSE_CACHE.get(fsid)
@@ -1580,7 +1678,8 @@ def parsed_session(fsid, files, now):
         return hit[1]
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
-                               sdk_human=_sdk_owned(fsid))   # SDK session → composer input is promptSource "sdk" = the human (mirrors the kernel)
+                               sdk_human=_sdk_owned(fsid),   # SDK session → composer input is promptSource "sdk" = the human (mirrors the kernel)
+                               leaf_override=cut or None)
     if key is not None:
         if len(_PARSE_CACHE) > 256:        # bounded by fleet size; a wholesale clear on overflow is fine
             _PARSE_CACHE.clear()
@@ -2261,6 +2360,43 @@ def _rebase_onto_disk(fsid, store):
             for rec in (snd.get("mergedFrom") or []):
                 if rec.get("id"):
                     tomb[rec["id"]] = sid_
+    # REWIND TOMBSTONES (2026-08-17): same presence-is-not-truth rule for rewind-swept nodes, which
+    # have no surviving twin to hang a mergedFrom on — the sweep records store-level rewindSwept
+    # markers instead. An id named there on EITHER side is deleted (its archive copy is the durable
+    # record; unseen diary rows on a stale twin drop with it — the pre-sweep archive copy is the
+    # kept truth). Both orderings need this: a pre-sweep loader saving post-sweep reads the marker
+    # from DISK; the sweep's own save rebasing over a mid-flight publish reads its OWN. The union
+    # is folded back so the marker itself survives the rebase.
+    #
+    # A user restore does NOT merely pop the marker (a pop is not durable: a writer whose snapshot
+    # predates the restore re-unions its stale marker right back and re-kills the node the user just
+    # brought back — proven by the review). Both restore sites pop AND stamp store-level
+    # rewindRestored[nid]; both maps union max-per-nid here, and a marker whose restore stamp is
+    # at/after its sweep stamp is NEUTRALIZED (restore wins ties: the user gesture outranks a
+    # same-second sweep). Both maps persist — ordered durable events — and because a pop can always
+    # be re-unioned back by a stale writer, every superseding event STAMPS PAST the marker it pops
+    # so the max-union converges on the right winner regardless of writer order: a re-sweep that
+    # popped a restore stamps its tombstone strictly after it (archive_goal_nodes, +1 — a bare
+    # equal second would hand its own tombstone to this tie rule), and a restore that popped a
+    # marker stamps at-or-above it (max(rt, marker) — winning the tie is the designed outcome).
+    # The one tie left is a sweep that never OBSERVED the restore it collided with (a pre-cycle
+    # snapshot: nothing to pop, no bump); the restore wins it here, and archive_goal_nodes'
+    # post-save backstop un-archives whatever this rebase hands back, so the node is never
+    # live and archived at once.
+    swept = dict(disk.get("rewindSwept") or {})
+    for k, v in (store.get("rewindSwept") or {}).items():
+        swept[k] = max(int(v or 0), int(swept.get(k) or 0))
+    restored = dict(disk.get("rewindRestored") or {})
+    for k, v in (store.get("rewindRestored") or {}).items():
+        restored[k] = max(int(v or 0), int(restored.get(k) or 0))
+    eff = {k for k, v in swept.items() if int(restored.get(k) or -1) < int(v)}   # the markers in force
+    if swept:
+        store["rewindSwept"] = swept
+    if restored:
+        store["rewindRestored"] = restored
+    for nid in [n for n in list(m_nodes) if n in eff]:
+        m_nodes.pop(nid)
+        store.get("status", {}).pop(nid, None)
 
     def _fold_log(dead, surv):
         seen = {(e.get("ev_t"), e.get("src"), e.get("kind")) for e in (surv.get("log") or [])}
@@ -2278,6 +2414,8 @@ def _rebase_onto_disk(fsid, store):
             _fold_log(dead, surv)
         store.get("status", {}).pop(nid, None)
     for nid, dnd in d_nodes.items():
+        if nid in eff:                               # rewind-swept (and not since restored) → never re-adopted
+            continue
         mnd = m_nodes.get(nid)
         if mnd is None:
             if nid in tomb:                          # deleted by a merge, not minted by the other writer
@@ -2315,6 +2453,11 @@ def _rebase_onto_disk(fsid, store):
         store["lastNode"] = tomb[store["lastNode"]]
     if store.get("lastNode") not in (store.get("nodes") or {}):
         store["lastNode"] = disk.get("lastNode") or store.get("lastNode")
+    if store.get("lastNode") not in (store.get("nodes") or {}):
+        # both writers' focus was rewind-swept → re-point at the newest survivor, exactly as the
+        # sweep itself does (a dangling focus would prematurely settle the pre-cut focus card)
+        nn = store.get("nodes") or {}
+        store["lastNode"] = (max(nn, key=lambda n: int(nn[n].get("t") or 0)) if nn else None)
     rollup_status(store, session_closed=False)       # re-derive every flag + the status map from the merged logs
 
 
@@ -2416,6 +2559,20 @@ def _replay_overrides(fsid, store):
                 if nid in store.get("nodes", {}) or nid in arch_nodes:
                     continue                           # alive, or re-cleared into the archive → nothing lost
                 store.setdefault("nodes", {})[nid] = GuardedNode(dict(nddata))
+                sv = (store.get("rewindSwept") or {}).pop(nid, None)
+                if sv is not None:
+                    # a user restore outranks the rewind tombstone — pop AND stamp: the pop keeps the
+                    # next save-rebase from re-deleting what the journal just re-inserted, and the
+                    # stamp makes the restore durable against a stale writer re-unioning its old
+                    # marker, and stands the node down from the identity-keyed reconciliation for
+                    # good (its branch's death can never be new information again). Stamped at or
+                    # ABOVE the popped marker (a superseding re-sweep stamps strictly past the
+                    # restore it popped, so the marker can lead wall clock by a second): the rebase
+                    # gives ties to the restore, so max(t, marker) is exactly "this restore wins
+                    # against the marker it popped" — and it is derived from the row's t plus the
+                    # store's own popped value, so every replay of the same row over the same store
+                    # state derives the same stamp.
+                    store.setdefault("rewindRestored", {})[nid] = max(t, int(sv))
                 applied = True
                 st = (ev.get("status") or {}).get(nid)
                 if st is not None:
@@ -2615,7 +2772,68 @@ def save_goal_archive(fsid, store):
     tmp.rename(GOALARCHDIR / (fsid + ".json"))        # atomic publish
 
 
-def drop_goals_after(fsid, cut_t):
+# The goals-archive has NONE of save_goals' rev/rebase discipline — save_goal_archive is a blind
+# overwrite — so every load→mutate→save of it must hold this lock (2026-08-17). The rewind work made
+# concurrent same-fsid archivers ROUTINE (the triage-tier reconciler, the backend settle thread's
+# drop_goals_after, the two boot daemons, the WS-thread undo-restore and the compaction sweep), with
+# systematically DIFFERENT move sets — and a lost archive write is no longer a mere live-store
+# resurrection: the rewindSwept tombstone union keeps the dropped node out of the live store too, so
+# the clobber became silent PERMANENT loss (node in NEITHER file), reproduced by the review. All
+# archive mutators live in this one kernel process, so an in-process lock is sufficient; the second
+# writer reloads a base that already holds the first writer's nodes, making its re-archive an
+# idempotent overwrite. Deliberately NOT a save_goals-style union-rebase: undo-clear restores REMOVE
+# nodes from the archive, and a union would resurrect them (the exact node-in-both-files state the
+# audit proved five times).
+_GOAL_ARCH_LOCK = threading.Lock()
+
+
+def swept_ids(store, cut_t, kept=None):
+    """The node ids a rewind at cut_t sweeps: every node BORN at/after cut_t plus its whole subtree
+    (node[\"t\"] is frozen at birth and a child is always born after its parent). ONE definition,
+    shared by drop_goals_after and the kernel's gesture-time card hide, so what the user sees
+    disappear at the delete gesture is exactly what the branch-take archives.
+
+    `kept` (optional): chain_membership's kept-chain uuid set. A node whose promptUuid is provably
+    on the KEPT chain is never selected — not as a seed, and the subtree drag neither adds nor
+    descends through it (its subtree survives unless independently in range) — because the judge's
+    prompt-run mints the replacement ask's card DURING the open rewind turn, with t > cut_t: a bare
+    t-key hid that fresh live-branch card all turn and archived it at the take (2026-08-17). A node
+    with no promptUuid keeps the t-keyed fate (the sweep's whole purpose for unprovable orphans),
+    and kept=None (the caller's lookup failed, loudly) degrades to the pure t-keyed selection.
+
+    A node carrying a rewindRestored stamp is never selected either — the kept exemption's shape,
+    on USER authority instead of chain identity: the user already pulled that card back out of a
+    rewind sweep's archive, its minting branch's death strictly predates the restore gesture, and
+    a LATER rewind whose cut range merely time-overlaps it proves nothing about it — re-archiving
+    would move a card on zero new information, silently overriding an explicit user gesture (and
+    the take's archive would pop the durable stamp, erasing even the reconciler's shield). Only
+    the user's own gesture re-kills a restored card. Mirrors _dead_branch_ids' USER-RESTORED
+    exemption, and holds on the degraded kept=None path too."""
+    cut_t = int(cut_t)
+    nodes = store.get("nodes") or {}
+    kept = kept or frozenset()
+    restored = store.get("rewindRestored") or {}
+
+    def _spared(nid):
+        if nid in restored:                             # user-restored: only their gesture re-kills
+            return True
+        pu = (nodes.get(nid) or {}).get("promptUuid")
+        return bool(pu) and pu in kept
+    children = {}
+    for nid, nd in nodes.items():
+        children.setdefault(nd.get("parentId"), []).append(nid)
+    move, stack = set(), [nid for nid, nd in nodes.items()
+                          if int(nd.get("t") or 0) >= cut_t and not _spared(nid)]
+    while stack:                                        # a born-in-range node drags its whole subtree
+        x = stack.pop()
+        if x in move:
+            continue
+        move.add(x)
+        stack.extend(c for c in children.get(x, []) if not _spared(c))
+    return move
+
+
+def drop_goals_after(fsid, cut_t, kept=None):
     """Roll a session's GOAL STORE back to just before cut_t: archive every goal node BORN at/after cut_t
     (node["t"] >= cut_t), whole subtrees, to goals-archive/. A chat delete/edit abandons every turn at/after
     cut_t, so a card MINTED from one of those now-gone turns is an orphan and goes with them (the user
@@ -2626,7 +2844,9 @@ def drop_goals_after(fsid, cut_t):
     those would mean surgically truncating the append-only diary AND the durable override journal that
     re-applies user actions on every load — far more machinery than the case is worth (the user chose this
     simpler shape over a full verdict revert). node["t"] is frozen at birth and a child is always born after
-    its parent, so a born-in-range top drags its whole subtree.
+    its parent, so a born-in-range top drags its whole subtree. `kept` threads through to swept_ids
+    (the kept-chain exemption — the replacement ask's own fresh card is minted DURING the rewind
+    turn and must survive the take).
 
     Returns the number of nodes archived. No-op-safe (absent/empty store, or nothing in range → 0)."""
     cut_t = int(cut_t)
@@ -2634,37 +2854,305 @@ def drop_goals_after(fsid, cut_t):
     nodes = store.get("nodes") or {}
     if not nodes:
         return 0
-    children = {}
-    for nid, nd in nodes.items():
-        children.setdefault(nd.get("parentId"), []).append(nid)
-    move, stack = set(), [nid for nid, nd in nodes.items() if int(nd.get("t") or 0) >= cut_t]
-    while stack:                                        # a born-in-range node drags its whole subtree
-        x = stack.pop()
-        if x in move:
-            continue
-        move.add(x)
-        stack.extend(children.get(x, []))
+    move = swept_ids(store, cut_t, kept=kept)
     if not move:
         return 0
-    status = store.get("status") or {}
-    arch = load_goal_archive(fsid)
-    a_nodes = arch.setdefault("nodes", {}); a_status = arch.setdefault("status", {})
-    for nid in move:
-        if nid in nodes:
-            a_nodes[nid] = nodes.pop(nid)              # a whole-node dict delete is UNGUARDED (not a PROTECTED key)
-        if nid in status:
-            a_status[nid] = status.pop(nid)
-    arch["rompUuid"] = store.get("rompUuid", fsid)
-    save_goal_archive(fsid, arch)
-    # a dangling lastNode is tolerated (focus→None), but that would prematurely settle the pre-cut focus card;
-    # re-point it at the newest SURVIVING node so rollup_status keeps a sane focus.
-    if store.get("lastNode") not in nodes:
-        store["lastNode"] = (max(nodes, key=lambda n: int(nodes[n].get("t") or 0)) if nodes else None)
-    # removing a born-in-range SUB can change its surviving parent's rolled-up status (a blocked child now
-    # gone), so re-roll the status map from the (unchanged) surviving logs.
-    rollup_status(store, session_closed=False)
-    save_goals(fsid, store)
+    archive_goal_nodes(fsid, store, move, int(time.time()))   # stamp = the SWEEP event's time, never
+    #                                       cut_t: the tombstone-vs-restore ordering compares event
+    #                                       stamps, and the cut record's time predates everything
     return len(move)
+
+
+def archive_goal_nodes(fsid, store, move, tomb_t):
+    """Move `move` (node ids) + their status rows out of the LIVE store into goals-archive/, leaving a
+    rewindSwept tombstone per id so no concurrent save-rebase republishes them (the mergedFrom lesson,
+    2026-08-13, applied to rewinds 2026-08-17: presence-in-a-snapshot is not truth — proven five times
+    in live stores, nodes resident in live AND archive at once). `tomb_t` is the SWEEP EVENT's time
+    (the rebase orders it against rewindRestored stamps — a user restore neutralizes an older-or-tied
+    marker; a sweep superseding a restore pops the stamp and tombstones STRICTLY after it, so no
+    stale re-union of the popped stamp can neutralize the fresh tombstone). Tombstones
+    are never pruned: entries are rare and an undo-clear restore pops its own. Re-points lastNode at
+    the newest survivor (a dangling focus would prematurely settle the pre-cut focus card), re-rolls
+    status (removing a
+    blocked SUB changes its surviving parent's rollup), re-parents any spared child of an archived
+    node at its nearest unmoved ancestor (both selections spare provably live-branch children now,
+    and a dangling parentId loses the node from every walk that starts at the roots), saves both
+    files. The shared primitive of drop_goals_after (t-keyed, at the branch-take) and
+    reconcile_rewound_goals (identity-keyed, when the abandoned-branch set changes). The whole
+    read-modify-write — archive load through both saves — holds _GOAL_ARCH_LOCK so a concurrent
+    sweep pair serializes entirely (see the lock's note: a lost archive write under the tombstones
+    is permanent loss, not resurrection)."""
+    with _GOAL_ARCH_LOCK:
+        nodes = store.get("nodes") or {}
+        status = store.get("status") or {}
+        parent0 = {nid: nd.get("parentId") for nid, nd in nodes.items()}   # pre-pop parents, for the re-parent
+        arch = load_goal_archive(fsid)
+        a_nodes = arch.setdefault("nodes", {}); a_status = arch.setdefault("status", {})
+        swept = store.setdefault("rewindSwept", {})
+        for nid in move:
+            if nid in nodes:
+                a_nodes[nid] = nodes.pop(nid)          # a whole-node dict delete is UNGUARDED (not a PROTECTED key)
+            if nid in status:
+                a_status[nid] = status.pop(nid)
+            # A sweep that OBSERVED a restore stamp supersedes it — pop the stamp and order the
+            # tombstone STRICTLY after it. The rebase gives same-second ties to the restore, and
+            # both stamps are whole seconds, so a bare equal stamp let any stale writer max-union
+            # the popped restore stamp back from disk and neutralize the tombstone this sweep just
+            # wrote (its own save-rebase included, under a mid-flight publish); the +1 encodes the
+            # restore-then-sweep order actually witnessed here under _GOAL_ARCH_LOCK. Both sweep
+            # selections (swept_ids, _dead_branch_ids) spare restored-stamped nodes now, so a
+            # stamped id reaches this pop only in a move set the selections did not vet: a caller
+            # whose snapshot predates the restore (the blind-writer shape the post-save backstop
+            # below resolves) or an explicit user gesture — the one authority above a restore.
+            prev_rt = (store.get("rewindRestored") or {}).pop(nid, None)
+            swept[nid] = max(int(tomb_t), int(prev_rt) + 1) if prev_rt is not None else int(tomb_t)
+        arch["rompUuid"] = store.get("rompUuid", fsid)
+        save_goal_archive(fsid, arch)
+        for nid, nd in nodes.items():                  # spared survivors of archived parents stay reachable
+            p = nd.get("parentId")
+            if p in move:
+                while p is not None and p in move:
+                    p = parent0.get(p)
+                nd["parentId"] = p                     # nearest unmoved ancestor; None → it becomes a top
+        if store.get("lastNode") not in nodes:
+            store["lastNode"] = (max(nodes, key=lambda n: int(nodes[n].get("t") or 0)) if nodes else None)
+        rollup_status(store, session_closed=False)
+        save_goals(fsid, store)
+        # SINGLE-RESIDENCY BACKSTOP: the save's rebase can hand a moved id BACK — a restore this
+        # sweep never observed (its snapshot was loaded before the sweep/restore cycle, so it holds
+        # the node live with no stamp to pop and bump past) can out-stamp the tombstone written
+        # above, and the adopt-wholesale branch then re-adopts the node from disk while its fresh
+        # archive copy sits here — the exact live+archive dual residency the audit named. An id
+        # that came back is provably the restore-won set (re-adoption requires the tombstone this
+        # sweep just stamped to be out of force), so finish what the restore itself would have done
+        # had the copy existed then: un-archive it. Still inside _GOAL_ARCH_LOCK, so the corrective
+        # RMW is race-free against every other archiver.
+        back = [nid for nid in move if nid in (store.get("nodes") or {})]
+        if back:
+            arch = load_goal_archive(fsid)
+            for nid in back:
+                arch.get("nodes", {}).pop(nid, None)
+                arch.get("status", {}).pop(nid, None)
+            save_goal_archive(fsid, arch)
+
+
+def _dead_branch_ids(store, rewind_set, kept_set=frozenset()):
+    """The node ids the reconciliation archives, given the predicate's `rewind` uuid set:
+    - DIRECT: promptUuid provably rewound away — except a node carrying mergedFrom, whose promptUuid
+      may be a merge TRANSPLANT from a dead twin onto a kept-origin survivor (_merge_nodes grafts the
+      dupe's uuid onto a survivor lacking one): mixed provenance proves nothing, keep.
+    - SUBTREE DRAG downward, as drop_goals_after has always done — but NEVER through a child whose
+      OWN promptUuid is in `kept_set` (the active chain): the reconciliation fires days after the
+      rewind, when a zombie top has accumulated real live-branch descendants (the grouper files new
+      work under existing tops — ~90 live goals, 8 open, sat under one dead top on live data). A
+      spared child's subtree survives with it unless independently picked; archive_goal_nodes
+      re-parents survivors at their nearest unmoved ancestor so they stay reachable.
+    - UMBRELLA DRAG upward: a container with NO promptUuid of its own whose every child is going is
+      an empty shell over dead work (the inverted subtree-drag direction a pu-keyed pick misses).
+    - AUTHORITATIVE-OPEN EXEMPTION: a node whose agentTask is open — and its ancestors, so nothing
+      dangles — stays: the live task store pins that card working (Path E is left as-is by decision;
+      the agent may genuinely still hold the to-do, and archiving it would just re-mint a fresh
+      mirror next pass while losing the diary).
+    - USER-RESTORED EXEMPTION: a node carrying a rewindRestored stamp (the user pulled it back out
+      of a rewind sweep's archive) is never re-taken — not directly, not by the drag, not as an
+      umbrella. Its branch's death strictly predates the restore gesture, so re-archiving it moves
+      a card on ZERO new information (the boot memo reset and any later sig change both replayed
+      exactly that, per the review). The t-keyed sweep (swept_ids) spares the stamp the same way,
+      so a restored card is re-killed only by the user's own gesture — a re-clear parks it back in
+      the archive through the compaction path, and the journal replay defers to that."""
+    nodes = store.get("nodes") or {}
+    restored = store.get("rewindRestored") or {}
+    kids = {}
+    for nid, nd in nodes.items():
+        kids.setdefault(nd.get("parentId"), []).append(nid)
+    move = set()
+    for nid, nd in nodes.items():
+        pu = nd.get("promptUuid")
+        if pu and pu in rewind_set and not nd.get("mergedFrom") and nid not in restored:
+            move.add(nid)
+    stack = list(move)
+    while stack:                                       # subtree drag, stopping at kept/restored children
+        for c in kids.get(stack.pop(), []):
+            cpu = (nodes.get(c) or {}).get("promptUuid")
+            if (cpu and cpu in kept_set) or c in restored:
+                continue                               # provably live / user-restored → survives the drag
+            if c not in move:
+                move.add(c)
+                stack.append(c)
+    changed = True
+    while changed:                                     # umbrella drag, to a fixpoint (nested shells)
+        changed = False
+        for nid, nd in nodes.items():
+            if nid in move or nd.get("promptUuid") or nd.get("mergedFrom") or nid in restored:
+                continue
+            ch = kids.get(nid) or []
+            if ch and all(c in move for c in ch):
+                move.add(nid)
+                changed = True
+    protected = set()
+    for nid, nd in nodes.items():
+        if (nd.get("agentTask") or {}).get("status") == "open":
+            x = nid
+            while x is not None and x not in protected:
+                protected.add(x)
+                x = (nodes.get(x) or {}).get("parentId")
+    return move - protected
+
+
+_RECON_MEMO = {}   # fsid -> (fileset key, rewound frozenset, kept frozenset, goal-store key) — the
+#                    reconciliation's event gate, watching BOTH sides of the join: the transcripts
+#                    (the abandoned set can only change with them) AND the goal store (a mint that
+#                    slips past a fail-open guard onto an already-known-dead branch changes only the
+#                    store — the write IS the new information, or the orphan is never re-caught)
+
+
+def _per_file_rewound(fsid, files):
+    """Uuids provably rewound away inside ONE transcript file's OWN walk — the incident scan's
+    per-file discriminator. A rewind that happened before a /clear lives entirely in a dead
+    episode's file: the CURRENT graph classifies that whole file "clear" (or unknown, when the file
+    sits outside the lineage closure), so the whole-graph walk can never call its interior dead
+    branch "rewind" — yet those goals were exactly the audited residue (10 of the 28 live orphans,
+    all 5 live+archive dual-residents). Within one file, a branch that rejoins the file's own
+    active spine is a rewind no matter where the graph later went. Scans the candidate files plus
+    every episode-log-recorded transcript (EPIDIR rows are the durable enumeration of dead episode
+    files); dead files are frozen, so the incremental reader keeps this cheap.
+
+    Returns (rewound uuid set, failure count). A per-file failure is a loud row — its own
+    "rewound-reconcile-file" category, distinguishable from a counted whole-session failure —
+    never a stalled scan, and it is COUNTED: the returned set is PARTIAL on any failure, and the
+    caller must not let a partial set become a memoized baseline or a zero-failure migration pass
+    (dead files never change, so a swallowed miss here would never re-open)."""
+    out, seen, fails = set(), set(), 0
+    leaf = Path(files[0])
+    cands = [Path(f) for f in files]
+    for row in episode_rows(fsid):
+        fs = str(row.get("fsid") or "")
+        if fs:
+            cands.append(leaf.with_name(fs + ".jsonl"))
+    for fp in cands:
+        if fp.name in seen:
+            continue
+        seen.add(fp.name)
+        if not fp.exists():
+            continue
+        try:
+            ad = em.FileAdapter([str(fp)], str(fp))
+            if not ad.by_uuid and fp.stat().st_size > 0:
+                # the incremental reader swallows OSError into an empty record list with no row of
+                # its own (a permissions break, say) — a non-empty transcript that yields ZERO
+                # records is a failed read, not an empty file, and must count like one
+                raise OSError("transcript read yielded no records")
+            for u, v in ad.chain_verdicts().items():
+                if v == "rewind":
+                    out.add(u)
+        except Exception as e:
+            fails += 1
+            _log_judge_error("romp", fsid, "rewound-reconcile-file",
+                             note="per-file rewind scan failed on one transcript: %r" % e)
+    return out, fails
+
+
+def reconcile_rewound_goals(fsid, path, now):
+    """EVENT-KEYED dead-branch reconciliation, riding the triage cadence: when a parse-relevant file
+    changes AND the transcript's abandoned-branch set actually CHANGED, archive live goals whose
+    anchor lies on a dead branch. The predicate is em.chain_membership's "rewind" UNIONED with the
+    per-file discriminator (_per_file_rewound, minus the current graph's kept set — a resume-stitched
+    survivor is never swept): "rewind" is the only sweepable verdict, "clear" is /clear jurisdiction
+    and "broken"/unknown prove nothing — and a dead branch INSIDE a pre-/clear episode file, which
+    the whole-graph walk can only ever call "clear", is caught by its own file's walk, exactly the
+    incident scan's dead-episode-vs-dead-branch discriminator. This is the only cover for the
+    rewinds romp never sees: CLI-native Esc-Esc in a tmux terminal, the SDK forkAt resume, a cut the
+    gesture path could not resolve, and a crash between arm and take — every one applies
+    --resume-session-at with no sweep, and 28 live orphans existed when this shipped (one still
+    being actively judged a day after its conversation stopped existing). Cards ARCHIVE
+    (recoverable, and the override journal stays safe because node-keyed ops skip absent ids and
+    restore defers to the archive) — never delete.
+
+    Deliberately blind to a PENDING (unconsumed) cut: the two-phase hold owns that window (hide at
+    gesture, archive at take, restore on failure) — reconciling it would archive cards for a rewind
+    that can still fail. Only branches dead ON DISK count, so no leaf_override here.
+
+    The gate watches both sides of the join (the memo's note): on a store-only event the memoized
+    sig is REUSED (the abandoned set cannot change without a transcript change), so the adapter-walk
+    economy holds — the store-side check (_dead_branch_ids) is pure dict work and runs whenever
+    either side moved, archiving only on a hit (one-way, identity-keyed, tombstone-idempotent: no
+    flap, no store re-publish on a miss)."""
+    files = _judge_candidates(fsid, [str(path)])
+    states = STATESDIR / (fsid + ".jsonl")
+    epi = EPIDIR / (fsid + ".jsonl")
+    key_files = (list(files) + ([str(states)] if states.exists() else [])
+                 + ([str(epi)] if epi.exists() else []))
+    try:
+        key = _fileset_key(key_files)
+    except OSError:
+        key = None
+    gpath = GOALDIR / (fsid + ".json")
+
+    def _store_key():
+        try:
+            return _fileset_key([str(gpath)]) if gpath.exists() else None
+        except OSError:
+            return None
+
+    skey = _store_key()
+    memo = _RECON_MEMO.get(fsid)
+    if key is not None and memo and memo[0] == key and memo[3] == skey:
+        return 0                       # neither the transcripts nor the goal store moved → not an event
+    pf_fails = 0
+    if key is not None and memo and memo[0] == key:
+        sig, kept = memo[1], memo[2]   # store-only event → reuse the memoized abandoned set, no walk
+    else:
+        mem = em.chain_membership(path, candidate_files=files,
+                                  states=str(states) if states.exists() else None)
+        kept = frozenset(mem["kept"])
+        pf, pf_fails = _per_file_rewound(fsid, files)
+        sig = frozenset(mem["rewind"] | (pf - kept))
+    n = 0
+    if sig:
+        store = load_goals(fsid)
+        move = _dead_branch_ids(store, sig, kept_set=kept)
+        if move:
+            archive_goal_nodes(fsid, store, move, now)
+            _log_judge_error("romp", fsid, "rewound-archived", goal=sorted(move),
+                             note="%d goal node(s) anchored on a rewound-away branch archived by "
+                                  "the reconciliation (recoverable in goals-archive)" % len(move))
+            n = len(move)
+            skey = _store_key()        # our own write moved the store — never self-trigger next pass
+    if pf_fails:
+        # AFTER the archive block on purpose (archiving a partial set is idempotent and safe —
+        # every proven hit lands), BEFORE the memo on purpose: a partial sig must never become the
+        # event gate's baseline (the EPIDIR-enumerated dead files it missed are excluded from the
+        # fileset key and never change, so the memo would seal the miss for the process lifetime).
+        # The raise makes run_rewound_reconcile count this session FAILED, which blocks the
+        # migration's zero-failure marker (kernel _rewind_migration_bg) and retries next boot —
+        # the marker's own contract: "returned" is not "succeeded".
+        raise RuntimeError("%d per-file rewind scan(s) failed — abandoned set is partial" % pf_fails)
+    _RECON_MEMO[fsid] = (key, sig, kept, skey)
+    return n
+
+
+def run_rewound_reconcile(now=None, sessions_cap=PLAN_SESSIONS, window=None, verbose=False):
+    """One reconciliation pass over the discovered sessions (run_triage runs it first, so the same
+    pass's planner/closer/nudge see a store already clean of dead-branch orphans). `window` widens
+    discovery for the one-time boot migration (the kernel passes years; the 85-node residue spans
+    sessions long outside the 48h caption horizon). Per-session failures are loud rows, never a
+    stalled pass — and they are COUNTED: returns (archived, failures), because the migration's
+    done-marker written over a swallowed failure permanently skips that session (dormant sessions
+    are exactly the ones steady-state discovery never revisits)."""
+    if now is None:
+        now = int(time.time())
+    sessions = discover(now, window=window) if window else discover(now)
+    n, fails = 0, 0
+    for fsid, path, anchor, name in sessions[:sessions_cap]:
+        try:
+            n += reconcile_rewound_goals(fsid, str(path), now)
+        except Exception as e:
+            fails += 1
+            _log_judge_error("romp", fsid, "rewound-reconcile",
+                             note="dead-branch reconciliation failed: %r" % e)
+    if verbose:
+        sys.stderr.write("romp-judge: reconciliation archived %d dead-branch goal node(s)\n" % n)
+    return n, fails
 
 
 def open_menu(store, cap=20):
@@ -3340,6 +3828,44 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
     placements[place_key] = focus if focus is not None else touched   # key presence marks the phase processed
     if focus is not None:
         store["lastNode"] = focus                     # the active focus = top-goal of the latest placement
+
+
+def apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu, place_key=None,
+                       prompt_uuid=None, quote=None, clear_wrap=False):
+    """apply_plan behind the write-moment rewind stand-down (_rewound_away). Every planner mint site
+    routes through here: a unit whose prompt PROVABLY sits on a rewound-away branch at the write
+    moment is RETIRED — placements[key]=None, the seeder/pre-episode idiom — and nothing is applied.
+    Retire, never skip: a bare skip leaves the key ABSENT, and auto-nudge's `_unplanned` gate asks
+    _placed_key of every unit plan_units yields, so an un-retired unit silences nudges for the whole
+    session forever (the documented 2026-07-27 failure). A None prompt_uuid mints unguarded —
+    abandonment can't be proven, and the hard floor ("a user message never silently vanishes")
+    outranks an unprovable suspicion. Returns True when the plan applied, False when it stood down
+    (callers skip their placed-count/regroup on False, and still save — the retirement must
+    persist). If the branch is later stitched active again by a recorded resume fork (a hypothesis
+    shape, no corpus instance), the retired key stays retired — acceptable, and the loud row below
+    is the trail.
+
+    A "pending" verdict — abandoned only under an ARMED, unconsumed cut — DEFERS instead (no
+    placements write, nothing applied): the rewind can still fail/dissolve, and a retirement here
+    was permanent while the dissolve restored only already-minted cards — the ask itself could
+    never mint again (_rewound_away's docstring has the full shape). The key stays absent, so the
+    next pass re-collects the unit and re-decides from the resolved world; during the armed window
+    fresh parses carry the leaf_override, so the deferred unit never reaches the nudge gate."""
+    away = _rewound_away(fsid, path, prompt_uuid) if prompt_uuid else False
+    if away == "pending":
+        _log_judge_error("planner", fsid, "rewind-stand-down-pending", seg=seg_id,
+                         note="the unit's prompt is abandoned only under a still-pending cut — "
+                              "deferred, not retired (the rewind can still fail)")
+        return False
+    if away:
+        key = place_key if place_key is not None else seg_id
+        store["placements"][key] = None
+        _log_judge_error("planner", fsid, "rewind-stand-down", seg=seg_id,
+                         note="the unit's prompt sits on a rewound-away branch — retired, nothing minted")
+        return False
+    apply_plan(store, seg_id, seg_t, ops, menu, place_key=place_key,
+               prompt_uuid=prompt_uuid, quote=quote, clear_wrap=clear_wrap)
+    return True
 
 
 SEAM_CAP = 32                             # live seam points kept per store (oldest drop; a seam only
@@ -6159,6 +6685,27 @@ def _plan_session(fsid, path, now):
             continue                                  # placed while THIS pass applied an earlier unit — the
         #                                               apply loop must uphold the same idempotence the
         #                                               collection loop checked at pass START (2026-07-06)
+        away = _rewound_away(fsid, path, trig) if trig else False
+        if away == "pending":
+            # abandoned only under an ARMED, unconsumed cut: DEFER without writing — a retirement
+            # is permanent, and this rewind can still fail/dissolve (the apply_plan_guarded
+            # contract's pending leg). The next pass re-decides from the resolved world.
+            _log_judge_error("planner", fsid, "rewind-stand-down-pending", seg=seg_id,
+                             note="the unit's prompt is abandoned only under a still-pending cut — "
+                                  "deferred, not retired (the rewind can still fail)")
+            continue
+        if away:
+            # WRITE-MOMENT stand-down, checked BEFORE any model call: this pass's frame pinned a
+            # world in which the unit's prompt still looked active, but a rewind has since abandoned
+            # its branch — planning it would mint an orphan (and the nudge/followup/pivot branches
+            # would file verdicts from evidence the user just deleted). RETIRE (the apply_plan_guarded
+            # contract), never skip. The apply sites below re-check through apply_plan_guarded for a
+            # rewind landing DURING this unit's own model call.
+            store["placements"][_unit_key(seg_id, phase)] = None
+            _log_judge_error("planner", fsid, "rewind-stand-down", seg=seg_id,
+                             note="the unit's prompt sits on a rewound-away branch — retired before planning")
+            save_goals(fsid, store)
+            continue
         menu = open_menu(store)
         if phase == "prompt":                         # PROMPT-run: place the ask NOW (mint-or-amend), before the work
             sib = _queued_sibling(store, seg_by_id, seg_id)   # a rapid-fire fragment may EXTEND the node the
@@ -6177,9 +6724,10 @@ def _plan_session(fsid, path, now):
                 #                                       prompted goal never stays unplaced
             ops = _card_route_subs(store, ops, menu, placer=False)   # card-level only: placing the ask is
             #                                           latency-sensitive; the work-run refines depth later
-            apply_plan(store, seg_id, seg_t, ops, menu, place_key=seg_id + "#p", prompt_uuid=trig, quote=vq)
-            placed += 1
-            _group_store(store, fsid, now)
+            if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu,
+                                  place_key=seg_id + "#p", prompt_uuid=trig, quote=vq):
+                placed += 1
+                _group_store(store, fsid, now)
             save_goals(fsid, store)
             continue
         if phase == "live":                           # LIVE re-plan: the user cleared this OPEN segment's card
@@ -6199,9 +6747,10 @@ def _plan_session(fsid, path, now):
                 ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)   # invariant: a
                 #                                       WORKING session always shows a card
             ops = _card_route_subs(store, ops, menu, placer=False)   # card-level only, like the prompt-run
-            apply_plan(store, seg_id, seg_t, ops, menu, place_key=seg_id + "#live", prompt_uuid=trig, quote=vq)
-            placed += 1
-            _group_store(store, fsid, now)
+            if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu,
+                                  place_key=seg_id + "#live", prompt_uuid=trig, quote=vq):
+                placed += 1
+                _group_store(store, fsid, now)
             save_goals(fsid, store)
             continue
         if phase == "delegation":                     # POSTAL delegation → file the recipient's work UNDER the courier's goal G
@@ -6234,9 +6783,10 @@ def _plan_session(fsid, path, now):
             ops = _restrict_retitle(ops, 1)              # goal_num=1 above → retitle is only valid on #1
             if not ops:
                 ops = [{"do": "sub", "under": 1, "text": _seg_label(text), "why": "work handed off from a peer"}]
-            apply_plan(store, seg_id, seg_t, ops, sub, place_key=seg_id + "#d", prompt_uuid=trig, quote=vq)
-            placed += 1
-            _group_store(store, fsid, now)
+            if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, sub,
+                                  place_key=seg_id + "#d", prompt_uuid=trig, quote=vq):
+                placed += 1
+                _group_store(store, fsid, now)
             save_goals(fsid, store)
             continue
         if phase == "nudge":                          # romp NUDGE → RESOLVE the goal (done/block over a plain step)
@@ -6315,9 +6865,10 @@ def _plan_session(fsid, path, now):
                 ops = _strip_unevidenced_dones(ops, _tseg, fsid, seg_id)   # a nudge spliced mid-turn reads the
                 #                                           interrupted turn's work as its reply — resolve
                 #                                           nothing; the goal stays open and re-nudgeable
-                apply_plan(store, seg_id, seg_t, ops, sub, place_key=_pkey, prompt_uuid=trig, quote=vq)
-                placed += 1
-                _group_store(store, fsid, now)
+                if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, sub,
+                                      place_key=_pkey, prompt_uuid=trig, quote=vq):
+                    placed += 1
+                    _group_store(store, fsid, now)
                 save_goals(fsid, store)
             continue
         if followup and followup in store["nodes"]:   # tagged follow-up: file under the target — a STRONG
@@ -6368,24 +6919,25 @@ def _plan_session(fsid, path, now):
                                        why="the reply started its own thread — this goal is unchanged")
                     ops = _restrict_retitle([o for o in ops if o["do"] != "skip"], gi)
                     ops = _card_route_subs(store, ops, menu)
-                    apply_plan(store, seg_id, seg_t, ops, menu, prompt_uuid=trig, quote=vq)
-                    if any(o.get("do") == "done" for o in ops):   # same post-closure re-look as the main work-run
-                        _invalidate_closure(store, session, seg_t)
-                    pv = store["placements"].get(seg_id)
-                    if isinstance(pv, str) and pv in store["nodes"]:   # provenance: the minted top remembers
-                        ytop = _top_ancestor(store["nodes"], pv)
-                        store["nodes"][ytop]["pivotFrom"] = followup
-                        _tie_pivot(store, ytop, followup, seg_t)   # ...and stays GROUPED with the cited card
-                    # a PIVOT rules the reply answered NOTHING on this card — mechanically restore the
-                    # blocks THIS gesture's send just lifted ("this goal is unchanged" must include its
-                    # pending asks, the user 2026-07-20). Older gestures' leftovers stay for a reply
-                    # that actually engages the card to rule on.
-                    floor_now = store["nodes"].get(followup, {}).get("followupAt") or 0
-                    _reassert_blocks(store, seg_id, seg_t,
-                                     [(nid, ask) for (nid, ask, lt) in lifted
-                                      if lt and floor_now and lt >= floor_now])
-                    placed += 1
-                    _group_store(store, fsid, now)
+                    if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu,
+                                          prompt_uuid=trig, quote=vq):
+                        if any(o.get("do") == "done" for o in ops):   # same post-closure re-look as the main work-run
+                            _invalidate_closure(store, session, seg_t)
+                        pv = store["placements"].get(seg_id)
+                        if isinstance(pv, str) and pv in store["nodes"]:   # provenance: the minted top remembers
+                            ytop = _top_ancestor(store["nodes"], pv)
+                            store["nodes"][ytop]["pivotFrom"] = followup
+                            _tie_pivot(store, ytop, followup, seg_t)   # ...and stays GROUPED with the cited card
+                        # a PIVOT rules the reply answered NOTHING on this card — mechanically restore the
+                        # blocks THIS gesture's send just lifted ("this goal is unchanged" must include its
+                        # pending asks, the user 2026-07-20). Older gestures' leftovers stay for a reply
+                        # that actually engages the card to rule on.
+                        floor_now = store["nodes"].get(followup, {}).get("followupAt") or 0
+                        _reassert_blocks(store, seg_id, seg_t,
+                                         [(nid, ask) for (nid, ask, lt) in lifted
+                                          if lt and floor_now and lt >= floor_now])
+                        placed += 1
+                        _group_store(store, fsid, now)
                     save_goals(fsid, store)
                     continue
                 # CONTINUATION (the strong default): reopen the target, force the work UNDER it,
@@ -6419,16 +6971,17 @@ def _plan_session(fsid, path, now):
                     if retitle:
                         forced.append(dict(retitle, goal=gi2))   # the model may ALSO retitle the target itself
                         #                                          (re-pointed at the rebuilt menu's index)
-                    apply_plan(store, seg_id, seg_t, forced, menu, prompt_uuid=trig, quote=vq)
-                    # the model's per-lifted-ask rulings (the leak, the user 2026-07-20): a block op
-                    # aimed at a lifted item's OLD menu number re-asserts that ask — the reply did not
-                    # answer it — with the reply segment as its fresh evidence. Applied by node id, so
-                    # the post-reopen menu rebuild can't misroute it.
-                    _reassert_blocks(store, seg_id, seg_t,
-                                     [(lifted_by_num[o["goal"]][0], (o.get("why") or lifted_by_num[o["goal"]][1]))
-                                      for o in ops if o.get("do") == "block" and o.get("goal") in lifted_by_num])
-                    placed += 1
-                    _group_store(store, fsid, now)
+                    if apply_plan_guarded(fsid, path, store, seg_id, seg_t, forced, menu,
+                                          prompt_uuid=trig, quote=vq):
+                        # the model's per-lifted-ask rulings (the leak, the user 2026-07-20): a block op
+                        # aimed at a lifted item's OLD menu number re-asserts that ask — the reply did not
+                        # answer it — with the reply segment as its fresh evidence. Applied by node id, so
+                        # the post-reopen menu rebuild can't misroute it.
+                        _reassert_blocks(store, seg_id, seg_t,
+                                         [(lifted_by_num[o["goal"]][0], (o.get("why") or lifted_by_num[o["goal"]][1]))
+                                          for o in ops if o.get("do") == "block" and o.get("goal") in lifted_by_num])
+                        placed += 1
+                        _group_store(store, fsid, now)
                     save_goals(fsid, store)
                     continue                           # forced placement done; skip the free-placement path
         # The WORK-run may correct its OWN earlier PROMPT-run guess (the user 2026-07-01): if this exact
@@ -6484,20 +7037,30 @@ def _plan_session(fsid, path, now):
             ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)
         ops = _restrict_retitle(ops, pgi)              # only the segment's own prompt-run node is retitle-eligible
         ops = _card_route_subs(store, ops, menu)       # card-first: route subs to the card, then the placer
-        apply_plan(store, seg_id, seg_t, ops, menu, prompt_uuid=trig, quote=vq,
-                   clear_wrap=_seg_clearwrap(seg_by_id.get(seg_id) or {}))   # a wrap-up's decision card is terminal (2026-07-24)
-        if any(o.get("do") == "done" for o in ops):    # a post-closure done → the closer re-looks before any nudge
-            _invalidate_closure(store, session, seg_t)
-        placed += 1
-        _group_store(store, fsid, now)                # regroup the forest after this placement (event-gated, no-op if tops unchanged)
+        if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu, prompt_uuid=trig, quote=vq,
+                              clear_wrap=_seg_clearwrap(seg_by_id.get(seg_id) or {})):   # a wrap-up's decision card is terminal (2026-07-24)
+            if any(o.get("do") == "done" for o in ops):    # a post-closure done → the closer re-looks before any nudge
+                _invalidate_closure(store, session, seg_t)
+            placed += 1
+            _group_store(store, fsid, now)            # regroup the forest after this placement (event-gated, no-op if tops unchanged)
         save_goals(fsid, store)                       # crash-safe: persist plan + group together
     # AUTHORITATIVE plan-sync (the user 2026-07-01): mirror the agent's live to-do list into the graph as
     # agentTask nodes BEFORE the roll-up, so an open to-do item holds its goal 'working' and a crossed-off
     # one reads authoritative-done. Deterministic (no LLM); regroup if it minted/changed anything so a
     # freshly-minted to-do top gets placed/merged this pass instead of lingering as a bare top.
     latest_seg = max(seg_by_id.values(), key=lambda s: s.get("t") or 0, default=None)
-    if _sync_declared_plan(store, session, (latest_seg or {}).get("id"), (latest_seg or {}).get("t") or now,
-                           prompt_uuid=(latest_seg or {}).get("trigger")):
+    _ls_trig = (latest_seg or {}).get("trigger")
+    if _ls_trig and _rewound_away(fsid, path, _ls_trig):
+        # This pass's frame pinned a pre-rewind world: the "latest" segment was just rewound away, so
+        # a mirror minted now would carry a provably-dead anchor and a dead trail. Skip the sync THIS
+        # pass — it is deterministic and runs every pass, so the next pass re-mints from the fresh
+        # parse with an on-chain anchor. (Task-store mirrors of abandoned-turn to-dos are otherwise
+        # LEFT AS-IS by decision: the task store is the authoritative source and a rewind does not
+        # roll it back — the agent may genuinely still hold those to-dos.)
+        _log_judge_error("planner", fsid, "rewind-stand-down",
+                         note="plan-sync skipped this pass: the latest segment was rewound away mid-pass")
+    elif _sync_declared_plan(store, session, (latest_seg or {}).get("id"), (latest_seg or {}).get("t") or now,
+                             prompt_uuid=_ls_trig):
         _group_store(store, fsid, now)
         save_goals(fsid, store)
     rollup_status(store, _session_settled(fsid, path, session, store))
@@ -9697,6 +10260,11 @@ def run_triage(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ve
         now = int(time.time())
     own = begin_pass_frame()
     try:
+        # dead-branch reconciliation FIRST: when a rewind romp never saw (native Esc-Esc, forkAt, a
+        # missed sweep) changed the abandoned-branch set, its orphans leave the store before this
+        # same pass's planner reads the menu and the nudge tick walks the tops. Event-keyed inside
+        # (fileset + abandoned-set change), so an idle pass costs stats, not adapter walks.
+        run_rewound_reconcile(now=now, sessions_cap=sessions_cap, verbose=verbose)
         placed = run_plan(now=now, sessions_cap=sessions_cap, concurrency=concurrency, verbose=verbose)
         if CLOSER_ON:
             run_close(now=now, sessions_cap=sessions_cap, concurrency=concurrency, verbose=verbose)
@@ -10127,10 +10695,10 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                     #                                    wedges auto-nudge's placement gate, 2026-08-16).
                     continue
                 pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
-                                _seg_peer_kind(seg), _seg_anchor(seg)))
+                                _seg_peer_kind(seg), _seg_anchor(seg), str(path)))
     pending.sort(key=lambda x: x[0])                  # global cross-session oldest-first
     placed = 0
-    for seg_t, fsid, seg_id, text, mid, sender, declared, anchor_uuid in pending:
+    for seg_t, fsid, seg_id, text, mid, sender, declared, anchor_uuid, path in pending:
         store = load_goals(fsid)
         if _placed_key(store["placements"], seg_id):  # drift-safe: never re-plant a t-shifted duplicate
             continue
@@ -10202,6 +10770,26 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             store.get("courierFails", {}).pop(seg_id, None)   # a clean reply clears the strike count
         store.get("courierDeferred", {}).pop(seg_id, None)    # landed (clean reply or parse give-up) → deferral over
         if edit["delegating"]:
+            away = _rewound_away(fsid, path, anchor_uuid) if anchor_uuid else False
+            if away == "pending":
+                # abandoned only under an ARMED, unconsumed cut: DEFER (no placements write) — the
+                # rewind can still fail, and a None retirement is permanent (the apply_plan_guarded
+                # contract's pending leg). The next courier pass re-judges from the resolved world.
+                _log_judge_error("courier", fsid, "rewind-stand-down-pending", seg=seg_id,
+                                 note="the peer segment is abandoned only under a still-pending cut — "
+                                      "deferred, not retired (the rewind can still fail)")
+                continue
+            if away:
+                # WRITE-MOMENT stand-down (same contract as apply_plan_guarded): the peer segment's
+                # branch was rewound away while this pass held it — planting now mints an orphan the
+                # one-shot sweep already ran past. RETIRE (None reads as courier-final downstream, so
+                # the #d delegation phase retires with it); the loud row is the trail.
+                store["placements"][seg_id] = None
+                _log_judge_error("courier", fsid, "rewind-stand-down", seg=seg_id,
+                                 note="the peer segment sits on a rewound-away branch — retired, nothing planted")
+                rollup_status(store, closed.get(fsid, False))
+                save_goals(fsid, store)
+                continue
             link_id = menu[edit["n"] - 1]["id"] if edit["n"] else None   # sender's related open goal (or None)
             # Mint the sender's precise '↪ delegated to <recipient>' tracking node (the user 2026-06-22) and
             # point B's goal at IT — so run_propagate checks off only the handed-off piece, never the sender's

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5669,6 +5669,13 @@ def _sdk_locked():
             # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
             # only as good as that file); the backend picks any live login session to ask
             jd._USAGE_REFRESH_FN = getattr(_sdk_backend, "refresh_usage", None)   # best-effort hook (judge guards None)
+            # The judge parses the SAME cut world the display parse does (jd._PENDING_CUT_FN): during
+            # an armed bare rollback the planner must not see — and mint from — the deleted tail.
+            # getattr-guarded like every other backend probe (a test fake without the affordance
+            # must still construct — the singleton contract outranks the wire).
+            _cut_fn = getattr(_sdk_backend, "pending_cut", None)
+            if _cut_fn:
+                jd.set_pending_cut_provider(_cut_fn)
         except Exception:
             sys.stderr.write("sdk-backend unavailable: %s\n" % traceback.format_exc())
             _sdk_problem("the SDK backend could not be built: %s" % traceback.format_exc())

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5676,6 +5676,9 @@ def _sdk_locked():
             _cut_fn = getattr(_sdk_backend, "pending_cut", None)
             if _cut_fn:
                 jd.set_pending_cut_provider(_cut_fn)
+            # The backend's flag-consumption events resolve held rewinds (two-phase goal cleanup:
+            # archive at the branch-take, restore on failure — _on_rewind_resolved).
+            _sdk_backend.rewind_resolved_cb = _on_rewind_resolved
         except Exception:
             sys.stderr.write("sdk-backend unavailable: %s\n" % traceback.format_exc())
             _sdk_problem("the SDK backend could not be built: %s" % traceback.format_exc())
@@ -12853,8 +12856,9 @@ def _feed_goals(sid):
                     #                                    card for the whole pass (the user 2026-07-23)
                 except Exception:
                     sys.stderr.write("feed-goals: user-override replay: %s\n" % traceback.format_exc())
-            return store
-    return jd.load_goals(sid)                          # no pass in flight → live read, outside the lock
+            return _apply_rewind_hold(sid, store)      # a pending rewind's cards are hidden NOW (latched
+            #                                            at the gesture; archive lands at the branch-take)
+    return _apply_rewind_hold(sid, jd.load_goals(sid))   # no pass in flight → live read, outside the lock
 
 # Delta-send (the user 2026-06-25, who wanted to stop re-sending what didn't change): the chat pusher used to send the
 # FULL events array (~8MB for a 34MB transcript) on every change, even when one event was appended. Keep the
@@ -13053,13 +13057,16 @@ def _rewind_send(sid, user_uuid, text, now=None):
     if err:
         return err
     # Same as delete: the edited message + its tail are abandoned; read its time before be.rewind arms the
-    # cut, then archive the cards those now-gone turns spawned. The edited text lands as a NEW turn (a later
-    # timestamp), minted AFTER this runs, so its fresh card is never caught by the cut.
+    # cut. The gesture HIDES the cards those turns spawned (a latched hold); the ARCHIVE waits for the
+    # branch-take event and a refused rewind restores them — see _on_rewind_resolved. The edited text lands
+    # as a NEW turn with a LATER timestamp, and the judge's prompt-run mints its card DURING that open turn
+    # (by design, before the take settles) — so the sweep is NOT bare t-keyed: both the hide and the take
+    # thread the kept-chain exemption (_rewind_kept_uuids → jd.swept_ids), which spares any node whose
+    # promptUuid is provably on the live chain. Identity, not time, is what saves the fresh card.
     cut_t = _atom_epoch(sess["path"], sid, str(user_uuid), now)
     ok, berr = be.rewind(sid, target, str(text))
-    if ok and cut_t is not None:
-        _drop_goals_after(sid, cut_t)
-        _mark_views_dirty()
+    if ok:
+        _arm_rewind_hold(be, sid, cut_t)
     return None if ok else (berr or "the rewind could not be applied")
 
 
@@ -13096,22 +13103,350 @@ def _rewind_rollback(sid, user_uuid, now=None):
         return err
     # The DELETED message is user_uuid (target is its surviving ancestor); everything at/after it is
     # abandoned. Read its time NOW, before be.rollback arms the pending_cut that would hide it from _parse.
+    # The gesture HIDES the affected cards; the archive waits for the branch-take (_on_rewind_resolved).
     cut_t = _atom_epoch(sess["path"], sid, str(user_uuid), now)
     ok, berr = be.rollback(sid, target)
-    if ok and cut_t is not None:
-        _drop_goals_after(sid, cut_t)                    # archive cards minted from the now-abandoned turn(s)
-        _mark_views_dirty()
+    if ok:
+        _arm_rewind_hold(be, sid, cut_t)
     return None if ok else (berr or "the rollback could not be applied")
 
 
-def _drop_goals_after(sid, cut_t):
-    """Archive goal cards born in a rewind/delete's abandoned range (jd.drop_goals_after). Best-effort: a
-    failure here must never undo the cut the user already got, so log and move on (fail loud, not silent)."""
+def _arm_rewind_hold(be, sid, cut_t):
+    """The gesture half of the two-phase rewind cleanup: latch the card hold (hide now, archive at
+    the take). cut_t=None — the edited/deleted record's time could not be resolved from the parse —
+    is LOUD, never a silent no-cleanup (the repo rule): the rewind itself already succeeded, the
+    dead-branch reconciliation will still catch any orphans, but the user must be able to see why
+    nothing hid."""
+    if cut_t is None:
+        jd._log_judge_error("romp", sid, "revert-skipped",
+                            note="rewind cut time unresolved (the record is not among the parsed "
+                                 "atoms) — no cards hidden or archived for this rewind; the "
+                                 "dead-branch reconciliation will catch any orphans")
+        return
+    leaf = ""
     try:
-        jd.drop_goals_after(sid, cut_t)
+        fn = getattr(be, "rewind_flags", None)
+        if fn:
+            leaf = (fn(sid) or ("", "", False))[1]     # the transcript leaf recorded at arm time —
+            #                                            the spent discriminator's graph anchor
+    except Exception as e:
+        sys.stderr.write("rewind-hold: could not read the armed leaf: %s\n" % e)
+    _rewind_hold_set(sid, cut_t, leaf)
+    _mark_views_dirty()
+
+
+def _drop_goals_after(sid, cut_t, kept=None):
+    """Archive goal cards born in a rewind/delete's abandoned range (jd.drop_goals_after). `kept` is the
+    kept-chain exemption (see _rewind_kept_uuids). Best-effort: a failure here must never undo the cut
+    the user already got, so log and move on (fail loud, not silent)."""
+    try:
+        jd.drop_goals_after(sid, cut_t, kept=kept)
     except Exception as e:
         jd._log_judge_error("romp", sid, "revert-failed",
                             note="goal cleanup after a rewind/delete failed: %r" % e)
+
+
+# ── two-phase rewind timing (2026-08-17): HIDE at the gesture, ARCHIVE at the branch-take ──
+# The old shape archived at ARM time, which is wrong in both directions: the arm is not the rewind
+# (apply is async and conditional — a CLI refusal or a spent flag leaves the conversation intact,
+# yet its goals were already archived), and archiving once at arm misses every mint that lands in
+# the window after it. The user's gesture IS new information — their cards should vanish at once —
+# so the gesture latches a HOLD (cards hide from the feed, nothing moves in the store) and the
+# store-side archive waits for the event that makes "abandoned" true: the branch-take (the backend's
+# flag-consumption sites). A failed/refused rewind RESTORES the hidden cards loudly. The hold is
+# latched until exactly one of those events — never re-derived per build — and file-backed so a
+# kernel restart mid-window neither drops the hide nor forgets to resolve it (the boot pass below).
+_rewind_holds = [None]                             # lazily loaded {sid: {"cutT": int, "leaf": str, "at": int}}
+_rewind_holds_lock = threading.Lock()
+
+
+def _rewind_holds_file():
+    return jd.STATE / "rewind-holds.json"
+
+
+def _rewind_holds_map():
+    with _rewind_holds_lock:
+        if _rewind_holds[0] is None:
+            try:
+                _rewind_holds[0] = {str(k): v for k, v in
+                                    json.loads(_rewind_holds_file().read_text()).items()
+                                    if isinstance(v, dict)}
+            except Exception:
+                _rewind_holds[0] = {}
+        return _rewind_holds[0]
+
+
+def _rewind_holds_save():
+    try:
+        tmp = _rewind_holds_file().with_suffix(".json.tmp.%d" % os.getpid())
+        tmp.write_text(json.dumps(_rewind_holds[0] or {}))
+        tmp.rename(_rewind_holds_file())
+    except Exception as e:
+        sys.stderr.write("rewind-hold: persist failed: %s\n" % e)
+
+
+def _rewind_hold_set(sid, cut_t, leaf):
+    m = _rewind_holds_map()
+    with _rewind_holds_lock:
+        m[str(sid)] = {"cutT": int(cut_t), "leaf": str(leaf or ""), "at": int(time.time())}
+        _rewind_holds_save()
+
+
+def _rewind_hold_get(sid):
+    return _rewind_holds_map().get(str(sid))
+
+
+def _rewind_hold_clear(sid):
+    m = _rewind_holds_map()
+    _rewind_kept_memo.pop(str(sid), None)              # the memo and the once-per-hold error latch
+    _rewind_kept_err.pop(str(sid), None)               # live exactly as long as the hold does
+    with _rewind_holds_lock:
+        if m.pop(str(sid), None) is not None:
+            _rewind_holds_save()
+
+
+_rewind_kept_memo = {}   # sid -> (input key, kept set) — see _rewind_kept_uuids
+_rewind_kept_err = {}    # sid -> the armed hold's `at` already complained about: the loud degrade
+#                          is once per HOLD, not once per build (a >48h bare hold used to append
+#                          one judge-errors row per ~5s feed rebuild, unbounded, with no dedup)
+_REWIND_ERR_MISS = object()
+
+
+def _rewind_kept_complain(sid, note):
+    """One 'rewind-kept' row per armed hold: the view rebuilds every few seconds for the whole
+    armed window (unbounded on a bare delete), and a lookup that fails once fails every build —
+    the degrade must stay LOUD without judge-errors.jsonl growing by ~17k rows/day. Keyed on the
+    hold's arm time so a NEW hold complains anew; no hold (the one-shot take path) always logs."""
+    hold = _rewind_hold_get(sid)
+    at = (hold or {}).get("at")
+    if hold is not None and _rewind_kept_err.get(str(sid), _REWIND_ERR_MISS) == at:
+        return
+    _rewind_kept_err[str(sid)] = at
+    jd._log_judge_error("romp", sid, "rewind-kept", note=note)
+
+
+def _rewind_kept_uuids(sid):
+    """The session's KEPT-chain uuid set (em.chain_membership over the same inputs the display parse
+    uses, including the backend's pending cut) — the identity exemption threaded through the rewind
+    sweep (jd.swept_ids / jd.drop_goals_after) so the replacement ask's own fresh card, minted by the
+    judge's prompt-run DURING the open rewind turn, is never hidden or archived as if it were part of
+    the abandoned tail. Returns None on ANY failure, LOUDLY: the sweep then degrades to the pure
+    t-keyed selection (the pre-fix behavior) — visible in the log (once per armed hold, see
+    _rewind_kept_complain), never a silent widening.
+
+    The session resolves through the 48h set first, then discover's cached wide walk — the exact
+    fallback _alive_sessions uses: liveness owns visibility, age owns nothing (2026-08-13). A hold
+    outlives the caption window on any bare delete left sitting (its defining property is that NO
+    record lands, freezing the transcript's mtime at arm time), and the 48h miss used to fail this
+    lookup on every build of a still-live session: a deterministic, silent widening to the bare
+    t-keyed hide, plus one error row per rebuild.
+
+    Memoized per sid on the exact inputs that can change the answer — each candidate file's
+    (mtime, size), the states file's stat (a resumeFork row lands there), and the pending cut —
+    because the hold view re-asks on EVERY feed/chat build for the whole armed window, re-walking
+    a provably unchanged transcript (~0.1s warm at tens of MB, partly inside _goals_snap_lock on
+    the mid-pass path). The branch-take busts it by construction: the take's own record moves the
+    transcript stat and consumes the cut, so the archive never sweeps against a stale kept set.
+    A FAILURE is never memoized — the loud degrade retries next build. The memo dies with the
+    hold (_rewind_hold_clear).
+
+    EDIT-REWIND CAVEAT (accepted residual): pending_cut is bare-only, so for the first seconds of
+    an EDIT rewind — until the fork record lands on disk — the kept set here is the full OLD
+    chain: promptUuid-carrying doomed cards are spared by the hold for that window (consistent
+    with the chat, which renders the same doomed tail from the same bare-only cut), and only
+    promptUuid-less mints take the t-keyed hide. The fork record landing self-heals both, and the
+    take-time archive always runs post-fork."""
+    try:
+        sess = next((s for s in _sessions(time.time()) if s["sid"] == sid), None)
+        if not sess:
+            ent = next((f for f in jd.discover(time.time(), window=jd.DEATH_BACKFILL_WINDOW)
+                        if f[0] == sid), None)         # the same cached wide walk _alive_sessions pays for
+            sess = {"sid": ent[0], "path": str(ent[1])} if ent else None
+        if not sess:
+            _rewind_kept_complain(sid, "no transcript to read the kept chain from — the rewind sweep "
+                                       "degrades to the pure t-keyed selection (pre-fix behavior)")
+            return None
+        cands = [sess["path"]]
+        anchor = os.path.join(os.path.dirname(sess["path"]), sid + ".jsonl")
+        if os.path.basename(sess["path"]) != sid + ".jsonl" and os.path.exists(anchor):
+            cands.append(anchor)
+        states = jd.STATESDIR / (sid + ".jsonl")
+        cut = ""
+        be = _sdk()
+        if be:
+            fn = getattr(be, "pending_cut", None)
+            if fn:
+                cut = fn(sid) or ""
+        key = None
+        try:
+            fstats = []
+            for f in cands:
+                st = os.stat(f)
+                fstats.append((f, st.st_mtime, st.st_size))
+            try:
+                sst = os.stat(states)
+                skey = (sst.st_mtime, sst.st_size)
+            except OSError:
+                skey = None
+            key = (tuple(fstats), skey, cut)
+        except OSError:
+            key = None                                 # unstat-able inputs → compute, never cache
+        memo = _rewind_kept_memo.get(str(sid))
+        if key is not None and memo and memo[0] == key:
+            return memo[1]
+        mem = em.chain_membership(sess["path"], candidate_files=cands,
+                                  states=str(states) if states.exists() else None,
+                                  leaf_override=cut or None)
+        if key is not None:
+            _rewind_kept_memo[str(sid)] = (key, mem["kept"])
+        return mem["kept"]
+    except Exception as e:
+        _rewind_kept_complain(sid, "kept-chain lookup failed: %r — the rewind sweep degrades to the "
+                                   "pure t-keyed selection (pre-fix behavior) this time" % e)
+        return None
+
+
+def _apply_rewind_hold(sid, store):
+    """The feed's view of a held session's store: the nodes the pending rewind will archive are
+    hidden NOW (the gesture is the new information; jd.swept_ids is the sweep's own selection —
+    including the kept-chain exemption — so what hides is exactly what the take archives). The
+    live store is never mutated (a filtered shallow copy; re-parents are copy-on-write and the
+    column re-roll runs on a throwaway deep copy), so a failed rewind restores by simply dropping
+    the hold. The view mirrors the world the take will produce, not just its node set:
+    - lastNode re-points at the newest survivor (archive_goal_nodes' own move) — build_feed's
+      perm/api-error/judge-auth floors walk from the focus and silently no-op on a hidden id,
+      the exact frozen-board shape the jauth floor exists to prevent;
+    - spared children of hidden parents re-parent at the nearest surviving ancestor, or the
+      walks that start at the roots would lose them;
+    - the columns RE-ROLL: a pre-cut top whose only blocker is a hidden post-cut sub must not
+      sit in needs-you — presenting an ask the user just deleted — for the whole window
+      (unbounded on a bare delete). The take re-rolls for exactly this reason; the view must too."""
+    hold = _rewind_hold_get(sid)
+    if not hold:
+        return store
+    try:
+        hide = jd.swept_ids(store, hold["cutT"], kept=_rewind_kept_uuids(sid))
+    except Exception:
+        return store
+    if not hide:
+        return store
+    nodes0 = store.get("nodes") or {}
+    out = dict(store)
+    out["nodes"] = {k: v for k, v in nodes0.items() if k not in hide}
+    out["status"] = {k: v for k, v in (store.get("status") or {}).items() if k not in hide}
+    for nid, nd in list(out["nodes"].items()):         # spared survivors of hidden parents stay
+        p = nd.get("parentId")                         # reachable (copy-on-write — never mutate
+        if p in hide:                                  # the live store's node dicts)
+            while p is not None and p in hide:
+                p = (nodes0.get(p) or {}).get("parentId")
+            out["nodes"][nid] = dict(nd, parentId=p)
+    if out.get("lastNode") in hide:
+        nn = out["nodes"]
+        out["lastNode"] = (max(nn, key=lambda n: int(nn[n].get("t") or 0)) if nn else None)
+    try:
+        # rollup_status mutates node dicts and appends diary events, so it runs on a throwaway
+        # DEEP copy and only its derived maps are served. A re-roll failure serves the filtered
+        # columns unchanged — degraded, never no view.
+        tmp = json.loads(json.dumps({"rompUuid": store.get("rompUuid", sid),
+                                     "nodes": out["nodes"], "status": {},
+                                     "lastNode": out.get("lastNode")}))
+        jd.rollup_status(tmp, session_closed=False)
+        out["status"] = tmp["status"]
+        out["confirming"] = tmp.get("confirming") or []
+    except Exception:
+        pass
+    return out
+
+
+def _hold_leaf_still_active(sid, leaf):
+    """The spent-flag discriminator: is the leaf recorded at gesture time still on the active
+    chain? A consumed rewind abandons it (the new branch's ancestry bypasses it), so provably
+    REWOUND means the branch took — archive; provably KEPT means the conversation moved past the
+    arm on the OLD branch (the rewind dissolved without applying) — restore. Discriminated via
+    em.chain_membership — the one exported predicate — so recorded resume-fork lineage (states/
+    resumeFork rows) and multi-hop file lineages read exactly as the display parse does: a
+    lineage-blind hand-rolled walk here read an unreachable-but-live leaf as \"taken\" and archived
+    live cards on a guess (2026-08-17). Anything unprovable (clear/broken/unknown) is None —
+    the caller restores, because a card move needs proof. Resolves the session through the 48h
+    set, then discover's cached wide walk (as _rewind_kept_uuids does): a hold outliving the
+    caption window — a bare delete's freezing of the mtime guarantees exactly that — must not
+    turn 'the transcript exists but is old' into 'unprovable'."""
+    sess = next((s for s in _sessions(time.time()) if s["sid"] == sid), None)
+    if not sess:
+        ent = next((f for f in jd.discover(time.time(), window=jd.DEATH_BACKFILL_WINDOW)
+                    if f[0] == sid), None)
+        sess = {"sid": ent[0], "path": str(ent[1])} if ent else None
+    if not sess or not leaf:
+        return None                                    # no transcript to consult → unprovable
+    try:
+        cands = [sess["path"]]
+        anchor = os.path.join(os.path.dirname(sess["path"]), sid + ".jsonl")
+        if os.path.basename(sess["path"]) != sid + ".jsonl" and os.path.exists(anchor):
+            cands.append(anchor)
+        states = jd.STATESDIR / (sid + ".jsonl")
+        mem = em.chain_membership(sess["path"], candidate_files=cands,
+                                  states=str(states) if states.exists() else None)
+        if leaf in mem["rewind"]:
+            return False                               # provably rewound away → the branch took
+        if leaf in mem["kept"]:
+            return True                                # provably live → the rollback dissolved
+        return None                                    # clear/broken/unknown → unprovable
+    except Exception:
+        return None
+
+
+def _on_rewind_resolved(sid, outcome):
+    """The backend's flag-consumption events, resolving a held rewind (wired in _sdk_locked):
+    "taken"  — the branch took (the rewind/rollback turn's ResultMessage settled) → ARCHIVE the
+               held cards at the recorded cut (drop_goals_after now runs at the event that makes
+               "abandoned" true, and catches any mint that landed during the window).
+    "failed" — the CLI refused the rewind; the conversation is unchanged → RESTORE loudly.
+    "spent"  — the flag was dropped at connect because the leaf moved: either the take already
+               landed (a crash-heal resume mid-rewind-turn) or the conversation moved on the OLD
+               branch without applying — the recorded leaf's chain membership discriminates.
+               Unprovable (no transcript) restores: a card move needs proof, not a guess."""
+    hold = _rewind_hold_get(sid)
+    if not hold:
+        return
+    if outcome == "spent":
+        on_chain = _hold_leaf_still_active(sid, hold.get("leaf"))
+        outcome = "taken" if on_chain is False else "failed"
+        if on_chain is None:
+            jd._log_judge_error("romp", sid, "rewind-restore",
+                                note="spent rewind flag with no transcript to discriminate — "
+                                     "restoring the held cards (never archive on a guess)")
+    if outcome == "taken":
+        _drop_goals_after(sid, hold["cutT"], kept=_rewind_kept_uuids(sid))
+    else:
+        jd._log_judge_error("romp", sid, "rewind-restore",
+                            note="the rewind did not happen — the cards it hid are back on the feed")
+    _rewind_hold_clear(sid)
+    _mark_views_dirty()
+    _pusher_wake.set()
+
+
+def _rewind_holds_boot():
+    """Boot pass over persisted holds: a kernel restart mid-window must neither drop a hide (the
+    file survives; reads keep filtering) nor leave one latched forever after its resolving event
+    fired while no kernel was up. A hold stays latched only while the backend's LEAF-VERIFIED
+    probe (rewind_pending — rewind_disposition against the transcript's current leaf, the same
+    verification pending_cut and the connect path use) still reads the rewind as applicable; raw
+    flag presence is not that: an out-of-band CLI-native continuation grows the transcript past
+    the recorded leaf without ever consuming the reg flag, and the raw check kept the cards hidden
+    with NO future resolving event while the chat rendered the full un-cut tail. Anything not
+    verified-pending resolves through the same spent discriminator (restore on-chain/unprovable,
+    archive off-chain)."""
+    be = _sdk()
+    for sid in list(_rewind_holds_map()):
+        try:
+            reg_pending = False
+            if be:
+                fn = getattr(be, "rewind_pending", None)
+                reg_pending = bool(fn(sid)) if fn else False
+            if not reg_pending:
+                _on_rewind_resolved(sid, "spent")
+        except Exception:
+            sys.stderr.write("rewind-hold boot: %s\n" % traceback.format_exc())
 
 
 def _parse_cached(path):
@@ -15116,7 +15451,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # LEAF: its descendants are hidden even if open. Skip cleared nodes. `current` marks the focus node
     # being worked on (the graph's lastNode) so render can point a line at it; done nodes carry their
     # time for a recency-coloured "(Xm ago)" on the right.
-    gstore = jd.load_goals(sid)
+    gstore = _apply_rewind_hold(sid, jd.load_goals(sid))   # a pending rewind's cards hide on EVERY
+    #                                            surface — this ledger tree (and the tab-hover
+    #                                            recents derived from it) used to keep showing the
+    #                                            doomed asks for the whole armed window while the
+    #                                            feed hid them (the "one chokepoint" premise was
+    #                                            false; the window is unbounded on a bare delete)
     gnodes, gstatus, gcleared = gstore.get("nodes", {}), gstore.get("status", {}), _cleared_ids()
     gkids = {}
     for _gid, _gn in gnodes.items():
@@ -15914,16 +16254,17 @@ def _compact_goal_store(fsid):
                 stack.extend(children.get(x, []))
     if not move:
         return 0
-    arch = jd.load_goal_archive(fsid)
-    a_nodes = arch.setdefault("nodes", {})
-    a_status = arch.setdefault("status", {})
-    for nid in move:
-        a_nodes[nid] = nodes.pop(nid)
-        if nid in status:
-            a_status[nid] = status.pop(nid)
-    arch["rompUuid"] = store.get("rompUuid", fsid)
-    jd.save_goal_archive(fsid, arch)
-    jd.save_goals(fsid, store)                          # placements/seq/lastNode stay → judge dedup intact
+    with jd._GOAL_ARCH_LOCK:                            # the archive is a blind RMW — see the lock's note
+        arch = jd.load_goal_archive(fsid)
+        a_nodes = arch.setdefault("nodes", {})
+        a_status = arch.setdefault("status", {})
+        for nid in move:
+            a_nodes[nid] = nodes.pop(nid)
+            if nid in status:
+                a_status[nid] = status.pop(nid)
+        arch["rompUuid"] = store.get("rompUuid", fsid)
+        jd.save_goal_archive(fsid, arch)
+        jd.save_goals(fsid, store)                      # placements/seq/lastNode stay → judge dedup intact
     return len(move)
 
 
@@ -15963,43 +16304,59 @@ def _restore_goal_archive(item_ids):
     for iid in item_ids:
         by_sid.setdefault(iid.rsplit(":", 1)[0], []).append(iid)
     for sid, ids in by_sid.items():
-        arch = jd.load_goal_archive(sid)
-        a_nodes = arch.get("nodes", {})
-        if not a_nodes:
-            continue
-        a_status = arch.get("status", {})
-        a_children = {}
-        for nid, nd in a_nodes.items():
-            a_children.setdefault(nd.get("parentId"), []).append(nid)
-        move = []
-        for iid in ids:
-            if iid in a_nodes:
-                stack = [iid]
-                while stack:
-                    x = stack.pop()
-                    if x in a_nodes:
-                        move.append(x)
-                        stack.extend(a_children.get(x, []))
-        if not move:
-            continue
-        store = jd.load_goals(sid)
-        nodes = store.setdefault("nodes", {})
-        status = store.setdefault("status", {})
-        # Journal the payload FIRST (the user 2026-07-10): once the archive save below lands, these nodes
-        # exist only in the live store's save — a stale triage-pass save racing it would drop them from
-        # BOTH files, permanently. The journal carries the node payloads; jd.load_goals re-inserts any
-        # that end up in neither file (and defers to the archive if the user re-clears later).
-        jd.append_restore(sid, {nid: a_nodes[nid] for nid in move},
-                          {nid: a_status[nid] for nid in move if nid in a_status}, int(time.time()))
-        for nid in move:
-            nodes[nid] = a_nodes.pop(nid)
-            if nid in a_status:
-                status[nid] = a_status.pop(nid)
-        # (Sticky completion restore lives in _mark_nodes_cleared now — 2026-07-07: the settle event must
-        # land AFTER the undo reopen it records, or the fold consumes it and the card returns to Working.)
-        jd.save_goals(sid, store)
-        jd.save_goal_archive(sid, arch)
-        _compact_seen.pop(sid, None)                   # force a re-stat next sweep (we just changed the live file)
+        with jd._GOAL_ARCH_LOCK:                       # the archive is a blind RMW — see the lock's note
+            arch = jd.load_goal_archive(sid)
+            a_nodes = arch.get("nodes", {})
+            if not a_nodes:
+                continue
+            a_status = arch.get("status", {})
+            a_children = {}
+            for nid, nd in a_nodes.items():
+                a_children.setdefault(nd.get("parentId"), []).append(nid)
+            move = []
+            for iid in ids:
+                if iid in a_nodes:
+                    stack = [iid]
+                    while stack:
+                        x = stack.pop()
+                        if x in a_nodes:
+                            move.append(x)
+                            stack.extend(a_children.get(x, []))
+            if not move:
+                continue
+            store = jd.load_goals(sid)
+            nodes = store.setdefault("nodes", {})
+            status = store.setdefault("status", {})
+            # Journal the payload FIRST (the user 2026-07-10): once the archive save below lands, these nodes
+            # exist only in the live store's save — a stale triage-pass save racing it would drop them from
+            # BOTH files, permanently. The journal carries the node payloads; jd.load_goals re-inserts any
+            # that end up in neither file (and defers to the archive if the user re-clears later).
+            rt = int(time.time())
+            jd.append_restore(sid, {nid: a_nodes[nid] for nid in move},
+                              {nid: a_status[nid] for nid in move if nid in a_status}, rt)
+            for nid in move:
+                nodes[nid] = a_nodes.pop(nid)
+                if nid in a_status:
+                    status[nid] = a_status.pop(nid)
+                sv = (store.get("rewindSwept") or {}).pop(nid, None)
+                if sv is not None:
+                    # the user's restore outranks a rewind tombstone — pop AND stamp: the pop keeps
+                    # jd._rebase_onto_disk from re-deleting the node on the next rebase, the durable
+                    # stamp survives a stale writer re-unioning its old marker AND stands the node
+                    # down from the identity-keyed reconciliation (boot memo resets, later sig
+                    # changes) for good — the branch's death can never be new information again.
+                    # Stamped max(rt, marker), never bare rt: a superseding re-sweep stamps its
+                    # tombstone STRICTLY past the restore it popped (jd.archive_goal_nodes), so the
+                    # marker this restore pops can lead wall clock by a second — and the rebase
+                    # gives ties to the restore, so at-or-above the popped value is exactly "this
+                    # restore wins against the marker it popped". The journal row still carries the
+                    # gesture's own rt; its replay derives the same stamp from the same popped value.
+                    store.setdefault("rewindRestored", {})[nid] = max(rt, int(sv))
+            # (Sticky completion restore lives in _mark_nodes_cleared now — 2026-07-07: the settle event must
+            # land AFTER the undo reopen it records, or the fold consumes it and the card returns to Working.)
+            jd.save_goals(sid, store)
+            jd.save_goal_archive(sid, arch)
+            _compact_seen.pop(sid, None)               # force a re-stat next sweep (we just changed the live file)
 
 
 def _resolve_node(sid, node_id):
@@ -26817,6 +27174,9 @@ def main():
     threading.Thread(target=_sdk, daemon=True).start()        # construct the SDK backend NOW so its boot
     #                                                           reconcile (cut turns, queues, orphans) runs at
     #                                                           boot, not on the first lazy touch
+    threading.Thread(target=_rewind_holds_boot, daemon=True).start()   # resolve holds whose take/fail
+    #                                                           event fired while no kernel was up (it
+    #                                                           builds the backend itself if it wins the race)
     threading.Thread(target=_producer, daemon=True).start()
     threading.Thread(target=_pusher, daemon=True).start()
     threading.Thread(target=_heartbeat, daemon=True).start()  # WS keepalive on its own thread (see _heartbeat)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13425,6 +13425,35 @@ def _on_rewind_resolved(sid, outcome):
     _pusher_wake.set()
 
 
+def _rewind_migration_bg():
+    """ONE-TIME boot migration (marker-gated): the ongoing dead-branch reconciliation only rides the
+    triage cadence over recently-touched sessions, so the residue that accumulated BEFORE it shipped
+    (85 dead-branch nodes across 8 sessions at audit time, 28 in live stores, 5 resident in live and
+    archive at once) would sit forever on dormant sessions. Run the same check once over every
+    discoverable session regardless of age, then write the marker — only on a ZERO-FAILURE pass:
+    "returned" is not "succeeded" (per-session errors are swallowed loudly inside the pass), and a
+    marker written over a failed dormant session skips its orphans forever. A crash or a dirty pass
+    retries next boot (reconciliation is idempotent: archive-by-identity re-run is a no-op). The
+    marker name is v2: the v1 predicate was blind to dead branches inside pre-/clear episode files
+    (10 of the 28 audited live orphans, all 5 dual-residents), so the widened pass must run once
+    even where a v1 marker exists. Cards archive (recoverable), never delete."""
+    marker = jd.STATE / "rewind-reconcile-migration-v2.done"
+    if marker.exists():
+        return
+    try:
+        n, fails = jd.run_rewound_reconcile(now=int(time.time()), sessions_cap=100000,
+                                            window=10 * 365 * 86400)
+        if fails:
+            sys.stderr.write("romp-kernel: rewind migration left %d session(s) unreconciled — "
+                             "no marker written, retrying next boot\n" % fails)
+        else:
+            marker.write_text(json.dumps({"t": int(time.time()), "archived": n}))
+        if n:
+            sys.stderr.write("romp-kernel: rewind migration archived %d dead-branch goal node(s)\n" % n)
+    except Exception:
+        sys.stderr.write("rewind migration: %s\n" % traceback.format_exc())
+
+
 def _rewind_holds_boot():
     """Boot pass over persisted holds: a kernel restart mid-window must neither drop a hide (the
     file survives; reads keep filtering) nor leave one latched forever after its resolving event
@@ -27177,6 +27206,8 @@ def main():
     threading.Thread(target=_rewind_holds_boot, daemon=True).start()   # resolve holds whose take/fail
     #                                                           event fired while no kernel was up (it
     #                                                           builds the backend itself if it wins the race)
+    threading.Thread(target=_rewind_migration_bg, daemon=True).start()   # one-time dead-branch cleanup
+    #                                                           of pre-fix residue, marker-gated
     threading.Thread(target=_producer, daemon=True).start()
     threading.Thread(target=_pusher, daemon=True).start()
     threading.Thread(target=_heartbeat, daemon=True).start()  # WS keepalive on its own thread (see _heartbeat)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2135,6 +2135,8 @@ class SdkSession:
                  % ((": " + dropped) if dropped else ""))})
         except Exception as e:
             self.backend._log("rewind (%s): could not tell the chat the rewind failed: %s" % (self.name, e))
+        # the conversation is unchanged → the kernel RESTORES the cards its gesture-time hold hid
+        self.backend._rewind_resolved(self.sid, "failed")
         self.backend._poke()
 
     def _learn_model(self, pm):
@@ -2430,6 +2432,9 @@ class SdkSession:
                     self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False)
                 except Exception as e:
                     self.backend._log("rewind (%s): registry clear failed after the turn landed: %s" % (self.name, e))
+                # the BRANCH-TAKE event: the settled turn is the new branch's first landed record —
+                # the kernel's held goal cleanup archives on exactly this (two-phase rewind timing)
+                self.backend._rewind_resolved(self.sid, "taken")
             self.backend._turn_completed(self.sid)   # a landed result re-arms the crash-resume budget
             self._mark("waiting")
             self.backend.retire_live_work(self.sid)   # turn over → a work atom that never landed never will
@@ -3784,6 +3789,10 @@ class SdkBackend:
                 self._log("rewind (%s): registry clear failed: %s" % (sess.name, e))
             self._log("rewind (%s): conversation moved since the request — flag spent, resuming plainly"
                       % sess.name)
+            # ambiguous consumption: the leaf moved either because the take landed pre-crash or
+            # because the old branch grew — the kernel discriminates by the recorded leaf's chain
+            # membership and archives or restores the held cards accordingly
+            self._rewind_resolved(sess.sid, "spent")
         if self.mcp_config:
             kw["mcp_servers"] = self.mcp_config
         # The flag-settings layer carries the two keys the SDK has no typed field for — ultracode
@@ -4238,6 +4247,54 @@ class SdkBackend:
         s.request_reconnect()   # idle → reconnects now; a fresh thread's FIRST connect applies the flag
         self._poke()
         return True, ""
+
+    def rewind_flags(self, sid: str) -> "tuple[str, str, bool]":
+        """The session's armed rewind flags (rewindTo, rewindLeaf, rewindBare) — live session first,
+        registry fallback (a kernel restart mid-window). ("", "", False) when nothing is armed. The
+        kernel's two-phase goal cleanup reads the recorded LEAF here at gesture time: it is the graph
+        anchor its spent-flag discriminator later checks chain membership of."""
+        s = self.sessions.get(sid)
+        if s is not None and not s.ended:
+            return (s._rewind_to or "", s._rewind_leaf or "", bool(getattr(s, "_rewind_bare", False)))
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
+            return ("", "", False)
+        return (reg.get("rewindTo") or "", reg.get("rewindLeaf") or "", bool(reg.get("rewindBare")))
+
+    def rewind_pending(self, sid: str) -> bool:
+        """A rewind flag still APPLICABLE — leaf-verified like the connect path (rewind_disposition
+        against the transcript's CURRENT leaf), never raw flag presence. The kernel's boot pass
+        latches a hold only on this: a flag the transcript already moved past is spent, and its
+        consumption event may never fire (an out-of-band CLI-native continuation while no kernel
+        was up leaves the reg armed indefinitely) — raw presence kept those cards hidden with no
+        resolving event while the leaf-verified pending_cut let the chat render the full tail."""
+        s = self.sessions.get(sid)
+        if s is not None and not s.ended:
+            to, leaf = s._rewind_to or "", s._rewind_leaf or ""
+            cwd, fsid = s.cwd, s.resume_sid or s.sid
+        else:
+            reg = read_reg(self.state_dir, sid)
+            if not reg:
+                return False
+            to, leaf = reg.get("rewindTo") or "", reg.get("rewindLeaf") or ""
+            cwd, fsid = reg.get("cwd") or "~", reg.get("lastSid") or sid
+        if not to:
+            return False
+        return rewind_disposition(to, leaf, last_record_uuid(transcript_path(cwd, fsid))) == "apply"
+
+    def _rewind_resolved(self, sid: str, outcome: str):
+        """Tell the kernel a pending rewind RESOLVED (outcome: "taken" — the branch took; "failed" —
+        the CLI refused, conversation intact; "spent" — the flag was dropped at connect because the
+        leaf moved, ambiguous between a crash-heal take and a dissolved rollback). These are the
+        exact flag-consumption events the kernel's two-phase goal cleanup keys its archive/restore
+        on (rewind-holds); no callback wired (tests, standalone) → no-op."""
+        cb = getattr(self, "rewind_resolved_cb", None)
+        if not cb:
+            return
+        try:
+            cb(sid, outcome)
+        except Exception as e:
+            self._log("rewind (%s): resolve callback failed: %s" % (sid, e))
 
     def pending_cut(self, sid: str) -> str:
         """The uuid a PENDING bare rollback (rollback(), no replacement turn) truncates the conversation

--- a/tests/test_judge_revert.py
+++ b/tests/test_judge_revert.py
@@ -5,8 +5,11 @@ live store — whole subtrees. Deliberately narrow: verdicts an abandoned turn a
 are left alone (the user chose this simpler shape over surgically reverting the append-only diary + the
 durable override journal). All fixtures are SYNTHETIC (placeholder UUIDs, invented text).
 """
+import json
 import os
 import tempfile
+import threading
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -108,6 +111,318 @@ class DropGoalsAfter(RevertBase):
     def test_empty_store_is_a_noop(self):
         jd.save_goals(SID, self._store())
         self.assertEqual(jd.drop_goals_after(SID, CUT), 0)
+
+    def test_a_user_restored_card_is_never_re_swept_by_a_later_overlapping_rewind(self):
+        # A card the user restored out of an EARLIER rewind's sweep (durable rewindRestored stamp)
+        # merely time-overlaps a LATER rewind's cut range: that rewind's evidence is about the
+        # current chain's tail, not the restored card's long-dead minting branch, so re-archiving
+        # it — and popping the stamp, erasing even the reconciler's shield — moved a card on zero
+        # new information, silently overriding an explicit user gesture. The t-keyed selection
+        # spares the stamp like the reconciler does; only the user's own gesture re-kills a
+        # restored card. Exercised with kept=None on purpose: the exemption must hold on the
+        # degraded no-kept-set path too.
+        s = self._store()
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "Survivor"}], [])
+        jd.apply_plan(s, "s2", T0 + 100, [{"do": "mint", "why": "x", "text": "Restored earlier"}],
+                      jd.open_menu(s))
+        jd.apply_plan(s, "s3", T0 + 110, [{"do": "mint", "why": "x", "text": "Doomed"}],
+                      jd.open_menu(s))
+        jd.rollup_status(s, session_closed=False)
+        s["rewindRestored"] = {self._nid(2): NOW - 50}   # the earlier restore's durable stamp
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.drop_goals_after(SID, CUT), 1,
+                         "only the unrestored in-range card is swept")
+        live = jd.load_goals(SID)
+        self.assertIn(self._nid(2), live["nodes"], "the restored card survives the overlapping take")
+        self.assertEqual(live.get("rewindRestored", {}).get(self._nid(2)), NOW - 50,
+                         "…with its durable stamp intact — the reconciler's shield is not popped")
+        self.assertNotIn(self._nid(3), live["nodes"], "the genuinely in-range card is still swept")
+        self.assertIn(self._nid(3), jd.load_goal_archive(SID)["nodes"])
+        self.assertNotIn(self._nid(2), jd.load_goal_archive(SID)["nodes"])
+
+
+class RebaseTombstones(RevertBase):
+    """The sweep leaves a DURABLE deletion marker (store rewindSwept) that _rebase_onto_disk honors —
+    the mergedFrom lesson applied to rewinds. Without it any one-shot sweep, however keyed, loses to
+    the next concurrent save: presence-in-a-snapshot is not truth, and the adopt-wholesale branch
+    republished swept nodes (proven five times in live stores — nodes resident in live AND archive
+    at once, live twins gathering diary rows on a conversation that no longer exists)."""
+
+    def _seed(self):
+        s = self._store()
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "Survivor"}], [])
+        jd.apply_plan(s, "s2", T0 + 100, [{"do": "mint", "why": "x", "text": "Doomed"}], jd.open_menu(s))
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        return self._nid(2)
+
+    def test_a_pre_sweep_loader_saving_post_sweep_does_not_republish(self):
+        # ordering (i): writer A loads, the sweep archives + saves, A saves — A's rebase must read
+        # the tombstone from DISK and drop its stale copy instead of adopting it back
+        doomed = self._seed()
+        a = jd.load_goals(SID)                        # writer A's pre-sweep snapshot (holds `doomed`)
+        self.assertEqual(jd.drop_goals_after(SID, CUT), 1)
+        a["nodes"][self._nid(1)]["mt"] = T0 + 5       # A did unrelated work, then publishes
+        jd.save_goals(SID, a)
+        live = jd.load_goals(SID)
+        self.assertNotIn(doomed, live["nodes"], "the swept node stays swept through A's rebase")
+        self.assertIn(doomed, jd.load_goal_archive(SID)["nodes"], "…and lives on in the archive only")
+        self.assertIn(doomed, live.get("rewindSwept", {}), "the tombstone itself survived the rebase")
+
+    def test_the_sweeps_own_save_rebasing_over_a_midflight_publish_does_not_readopt(self):
+        # ordering (ii): a concurrent pass publishes between the sweep's load and its save — the
+        # sweep's rebase must not adopt back from disk the very node it just popped
+        doomed = self._seed()
+        orig = jd.save_goal_archive
+        def hijack(fsid, arch):                       # runs INSIDE drop_goals_after, between its load
+            orig(fsid, arch)                          # and its save — the mid-flight window
+            w = jd.load_goals(SID)                    # the concurrent writer still sees `doomed` live
+            w["nodes"][doomed]["mt"] = T0 + 200
+            jd.save_goals(SID, w)                     # …and publishes it (disk rev moves)
+        jd.save_goal_archive = hijack
+        try:
+            self.assertEqual(jd.drop_goals_after(SID, CUT), 1)
+        finally:
+            jd.save_goal_archive = orig
+        live = jd.load_goals(SID)
+        self.assertNotIn(doomed, live["nodes"], "the sweep's rebase did not re-adopt its own pop")
+        self.assertIn(doomed, jd.load_goal_archive(SID)["nodes"])
+
+    def test_a_concurrent_archiver_cannot_drop_the_other_writers_payloads(self):
+        """goals-archive is a blind RMW (save_goal_archive has none of save_goals' rev discipline),
+        and the rewind work made concurrent same-fsid archivers routine with systematically
+        DIFFERENT move sets (t-keyed sweep vs identity-keyed reconcile). Un-serialized, the writer
+        holding a stale archive base dropped the other writer's nodes from the archive while the
+        rewindSwept union kept them out of the live store — in NEITHER file, silent permanent loss.
+        The whole RMW now holds jd._GOAL_ARCH_LOCK, so the second writer reloads a base that
+        already carries the first writer's nodes. Orchestration: writer B starts first and its
+        archive save stalls mid-window; writer A (the full t-keyed sweep) runs against it."""
+        s = self._store()
+        jd.apply_plan(s, "s1", T0 + 100, [{"do": "mint", "why": "x", "text": "Doomed one"}], [])
+        jd.apply_plan(s, "s2", T0 + 110, [{"do": "mint", "why": "x", "text": "Doomed two"}], jd.open_menu(s))
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        n1, n2 = self._nid(1), self._nid(2)
+        orig = jd.save_goal_archive
+        main = threading.current_thread()
+        b_at_save, a_done = threading.Event(), threading.Event()
+        def stalling_save(fsid, arch):
+            if threading.current_thread() is not main:
+                b_at_save.set()          # B is mid-RMW: its base predates A's sweep
+                a_done.wait(0.5)         # un-serialized, A's whole sweep lands inside this window
+            orig(fsid, arch)
+        b = threading.Thread(target=lambda: jd.archive_goal_nodes(
+            SID, jd.load_goals(SID), {n2}, T0 + 200))
+        jd.save_goal_archive = stalling_save
+        try:
+            b.start()
+            b_at_save.wait(5)
+            jd.drop_goals_after(SID, T0 + 90)          # writer A: the t-keyed sweep takes BOTH nodes
+            a_done.set()
+            b.join(10)
+        finally:
+            jd.save_goal_archive = orig
+        self.assertFalse(b.is_alive(), "writer B finished")
+        arch = jd.load_goal_archive(SID)["nodes"]
+        live = jd.load_goals(SID)["nodes"]
+        for nid in (n1, n2):
+            self.assertIn(nid, arch, "every swept payload survives in the archive: %s" % nid)
+            self.assertNotIn(nid, live)
+
+    def test_an_undo_clear_journal_restore_pops_the_tombstone(self):
+        # a user restore outranks the marker: the journal re-inserts the node AND clears its
+        # tombstone — and STAMPS rewindRestored, so the next rebase (which re-unions the stale
+        # disk marker) orders the two events and lets the restore win instead of re-deleting
+        # what the user brought back. The row's t postdates the sweep, as any real restore does
+        # (both are wall-clock event times; the ordering is exactly what the stamps encode).
+        doomed = self._seed()
+        jd.drop_goals_after(SID, CUT)
+        arch = jd.load_goal_archive(SID)
+        payload = dict(arch["nodes"].pop(doomed))     # the undo pulled it OUT of the archive…
+        jd.save_goal_archive(SID, arch)
+        rt = int(time.time()) + 10                    # …after the sweep, as restores always are
+        jd.append_restore(SID, {doomed: payload}, {}, rt)   # …and journaled the payload
+        live = jd.load_goals(SID)                     # replay re-inserts (in neither store nor archive)
+        self.assertIn(doomed, live["nodes"])
+        self.assertNotIn(doomed, live.get("rewindSwept", {}), "the restore popped the tombstone")
+        self.assertEqual(live.get("rewindRestored", {}).get(doomed), rt,
+                         "…and left the durable restore stamp in its place")
+        jd.save_goals(SID, live)                      # a follow-on rebase cycle must not re-delete it
+        again = jd.load_goals(SID)
+        self.assertIn(doomed, again["nodes"])
+
+    def test_a_stale_writer_cannot_resurrect_a_popped_tombstone_after_a_restore(self):
+        # a pass holds a pre-restore snapshot (marker present, node swept) across a 30-80s model
+        # call; the user restores; the pass publishes. Its stale marker re-unions — the restore
+        # stamp must neutralize it, or the just-restored node is re-killed and ends in NEITHER
+        # file (the review reproduced exactly that: marker back, node gone, archive empty).
+        doomed = self._seed()
+        jd.drop_goals_after(SID, CUT)
+        stale = jd.load_goals(SID)                    # the pass's snapshot: marker present, node gone
+        arch = jd.load_goal_archive(SID)              # the user restores via the journal (the
+        payload = dict(arch["nodes"].pop(doomed))     # kernel undo-clear's exact moves)
+        jd.save_goal_archive(SID, arch)
+        jd.append_restore(SID, {doomed: payload}, {}, int(time.time()) + 10)
+        live = jd.load_goals(SID)
+        self.assertIn(doomed, live["nodes"], "premise: the restore landed")
+        jd.save_goals(SID, live)                      # restored state published
+        stale["nodes"][self._nid(1)]["mt"] = T0 + 5   # the stale pass did unrelated work…
+        jd.save_goals(SID, stale)                     # …and publishes across the restore
+        # the raw published file is the assertion that actually pins the rebase's restore-wins
+        # ordering: load_goals' journal replay re-inserts the node in memory on every load, so a
+        # file-level re-kill was healed before the load-based asserts below ever ran — this test
+        # passed on the pre-fix kernel and under an eff-ignores-restores mutant (the review
+        # proved both), while feed/raw-snapshot readers lost the node until the next healed load
+        raw = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+        self.assertIn(doomed, raw["nodes"],
+                      "…in the RAW published file itself — load_goals' journal replay heals "
+                      "in memory and must not be what keeps this test green")
+        after = jd.load_goals(SID)
+        self.assertIn(doomed, after["nodes"], "the stale marker lost to the restore stamp")
+        # and the node is in exactly one place — never resident in live AND archive at once
+        self.assertNotIn(doomed, jd.load_goal_archive(SID)["nodes"])
+
+
+class SameSecondTieOrdering(RevertBase):
+    """Sweep and restore stamps are whole seconds and the rebase gives ties to the restore — so a
+    restore and a superseding event in ONE wall-clock second used to collapse into the wrong
+    winner (or into both at once). The converged ordering: every superseding event stamps PAST the
+    marker it pops (a re-sweep tombstones strictly after the restore it observed; a restore stamps
+    at-or-above the marker it popped, winning its designed tie), and archive_goal_nodes un-archives
+    whatever its own save-rebase hands back — so after ANY interleaving of sweeps, restores and
+    stale writers, a node id is live or archived, never both. All raw-file asserts on purpose:
+    load_goals' journal replay heals some of these shapes in memory and must not be what keeps a
+    test green (the lesson of the hollow stale-writer test this suite used to carry)."""
+
+    S = NOW              # the shared wall-clock second every collision in this class lands in
+    RT = NOW + 10        # the restore gesture's second, when it is NOT the colliding event
+
+    def _seed(self):
+        s = self._store()
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "Survivor"}], [])
+        jd.apply_plan(s, "s2", T0 + 100, [{"do": "mint", "why": "x", "text": "Doomed"}], jd.open_menu(s))
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        return self._nid(2)
+
+    def _sweep_then_restore(self, doomed, tomb_t, rt):
+        """Sweep the doomed card at tomb_t, then user-restore it at rt (the undo-clear's exact
+        moves: pop the archive copy, journal the payload, let the replay re-insert), and publish
+        the restored world."""
+        jd.archive_goal_nodes(SID, jd.load_goals(SID), {doomed}, tomb_t)
+        arch = jd.load_goal_archive(SID)
+        payload = dict(arch["nodes"].pop(doomed))
+        jd.save_goal_archive(SID, arch)
+        jd.append_restore(SID, {doomed: payload}, {}, rt)
+        live = jd.load_goals(SID)
+        self.assertIn(doomed, live["nodes"], "premise: the restore landed")
+        jd.save_goals(SID, live)
+
+    def _raw(self):
+        return json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+
+    def test_a_same_second_re_sweep_outlasts_a_stale_post_restore_snapshots_rebase(self):
+        # sweep@S-10 → restore@RT → a genuinely NEW sweep re-takes the card in the RESTORE'S OWN
+        # second (an undo-restore on the WS thread and a branch-take on the settle thread are
+        # concurrent — one second apart is routine). The re-sweep observed the stamp, so its
+        # tombstone orders strictly after it; a judge pass whose snapshot still carries the popped
+        # restore stamp then publishes, re-unioning it — pre-fix the S==S tie read as restore-wins
+        # and resurrected the node into the live store while its payload sat in the archive.
+        doomed = self._seed()
+        self._sweep_then_restore(doomed, self.S - 10, self.RT)
+        stale = jd.load_goals(SID)                    # the pass's snapshot: node live, restored=RT
+        jd.archive_goal_nodes(SID, jd.load_goals(SID), {doomed}, self.RT)   # the re-take, same second
+        raw = self._raw()
+        self.assertGreater(raw["rewindSwept"][doomed], self.RT,
+                           "the tombstone stamps strictly after the restore it popped")
+        self.assertNotIn(doomed, raw["nodes"], "the re-sweep's own save held its tombstone")
+        stale["nodes"][self._nid(1)]["mt"] = T0 + 7   # the stale writer did unrelated work…
+        jd.save_goals(SID, stale)                     # …and publishes the popped stamp back
+        raw = self._raw()
+        self.assertNotIn(doomed, raw["nodes"], "the re-union of the popped restore stamp lost")
+        self.assertIn(doomed, jd.load_goal_archive(SID)["nodes"], "…and the node is archive-only")
+
+    def test_a_same_second_re_sweep_survives_its_own_save_rebase_over_a_midflight_publish(self):
+        # the same tie, hit by the sweep ITSELF: any concurrent publish between the re-sweep's load
+        # and its save bumps the rev, so its save_goals rebases — and pre-fix its rebase re-adopted
+        # the very node it had just archived (its own fresh tombstone neutralized by the equal
+        # restore stamp coming back off the mid-flight writer's snapshot).
+        doomed = self._seed()
+        self._sweep_then_restore(doomed, self.S - 10, self.RT)
+        mid = jd.load_goals(SID)                      # the mid-flight writer: node live, restored=RT
+        orig = jd.save_goal_archive
+        fired = []
+        def hijack(fsid, arch):                       # runs INSIDE archive_goal_nodes, between its
+            orig(fsid, arch)                          # archive save and its goals save
+            if not fired:
+                fired.append(1)
+                mid["nodes"][self._nid(1)]["mt"] = T0 + 9
+                jd.save_goals(SID, mid)               # …and publishes (disk rev moves)
+        jd.save_goal_archive = hijack
+        try:
+            jd.archive_goal_nodes(SID, jd.load_goals(SID), {doomed}, self.RT)
+        finally:
+            jd.save_goal_archive = orig
+        raw = self._raw()
+        self.assertNotIn(doomed, raw["nodes"], "the sweep's rebase did not re-adopt its own pop")
+        self.assertGreater(raw["rewindSwept"][doomed], self.RT)
+        self.assertIn(doomed, jd.load_goal_archive(SID)["nodes"], "archive-only — never dual-resident")
+
+    def test_a_restore_in_the_same_second_as_the_sweep_it_pops_still_wins(self):
+        # the DESIGNED tie is untouched: sweep@S, user restore in the same second — the restore
+        # stamps at the popped marker's value and the rebase gives it the tie, so a stale writer
+        # re-unioning the old marker still loses.
+        doomed = self._seed()
+        jd.archive_goal_nodes(SID, jd.load_goals(SID), {doomed}, self.S)
+        stale = jd.load_goals(SID)                    # pre-restore snapshot: marker present, node gone
+        arch = jd.load_goal_archive(SID)
+        payload = dict(arch["nodes"].pop(doomed))
+        jd.save_goal_archive(SID, arch)
+        jd.append_restore(SID, {doomed: payload}, {}, self.S)   # the same-second undo
+        live = jd.load_goals(SID)
+        self.assertIn(doomed, live["nodes"], "premise: the journal replay re-inserted it")
+        self.assertEqual(live["rewindRestored"][doomed], self.S,
+                         "stamped at the popped marker — the tie the restore is designed to win")
+        jd.save_goals(SID, live)
+        stale["nodes"][self._nid(1)]["mt"] = T0 + 7
+        jd.save_goals(SID, stale)
+        raw = self._raw()
+        self.assertIn(doomed, raw["nodes"], "the restore won its tie in the raw published file")
+        self.assertNotIn(doomed, jd.load_goal_archive(SID)["nodes"], "…live-only, never dual-resident")
+
+    def test_a_sweep_blind_to_the_restore_never_leaves_a_dual_resident(self):
+        # the ONE tie strict stamping cannot break: the sweeping writer's snapshot predates the
+        # whole sweep/restore cycle (the node is live in it with NO stamp to pop and bump past), so
+        # its tombstone lands bare-equal against the restore stamp on disk. The restore wins the
+        # tie — by design — and the rebase re-adopts the node; pre-fix the sweep's fresh archive
+        # copy stayed behind: live AND archived at once, permanently (the reconciler exempts
+        # restored ids and nothing ever removed the copy). The post-save backstop un-archives
+        # exactly what the rebase handed back.
+        doomed = self._seed()
+        snap = jd.load_goals(SID)                     # the blind writer's snapshot, loaded first
+        self._sweep_then_restore(doomed, self.S - 10, self.RT)
+        jd.archive_goal_nodes(SID, snap, {doomed}, self.RT)   # blind re-take, tied with the restore
+        raw = self._raw()
+        self.assertIn(doomed, raw["nodes"], "the restore won the tie — the node is live")
+        self.assertNotIn(doomed, jd.load_goal_archive(SID)["nodes"],
+                         "…and the blind sweep's archive copy is gone: never resident in both")
+        again = jd.load_goals(SID)                    # the state is stable, not a one-publish fluke
+        again["nodes"][self._nid(1)]["mt"] = T0 + 9
+        jd.save_goals(SID, again)
+        raw = self._raw()
+        self.assertIn(doomed, raw["nodes"])
+        self.assertNotIn(doomed, jd.load_goal_archive(SID)["nodes"])
+
+    def test_a_blind_sweep_strictly_after_the_restore_still_deletes(self):
+        # control for the backstop: fresh evidence one second later beats the restore — the node
+        # archives cleanly and the backstop touches nothing (back is empty).
+        doomed = self._seed()
+        snap = jd.load_goals(SID)
+        self._sweep_then_restore(doomed, self.S - 10, self.RT)
+        jd.archive_goal_nodes(SID, snap, {doomed}, self.RT + 1)
+        raw = self._raw()
+        self.assertNotIn(doomed, raw["nodes"], "a strictly newer sweep still deletes")
+        self.assertIn(doomed, jd.load_goal_archive(SID)["nodes"], "archive-only")
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_rewind_cleanup.py
+++ b/tests/test_judge_rewind_cleanup.py
@@ -1,0 +1,812 @@
+#!/usr/bin/env python3
+"""Rewound-turn goals: the chain-membership predicate + the two mint seams (2026-08-17).
+
+A conversation rewind abandons a transcript branch, but the goal cleanup was a one-shot t>=cut_t
+sweep at gesture time while the judges kept parsing — and minting from — the abandoned tail:
+during a bare rollback's armed window the judge parse had no leaf_override (unbounded re-mint),
+and a producer pass framed before the rewind published its mints after the sweep (the late-mint
+shape, proven live). The fix, pinned here:
+  - em.chain_membership: THE exported membership predicate, built from the display parse's exact
+    inputs (resume links + lineage closure + pending cut). "rewind" is the only sweepable verdict;
+    "clear" is /clear jurisdiction, "broken" chains are kept, unknown uuids prove nothing.
+  - jd.parsed_session honors the backend's pending cut (leaf_override), so an armed bare rollback
+    stops yielding abandoned units at the source.
+  - jd.apply_plan_guarded: the write-moment stand-down at every planner mint site — fresh,
+    frame-independent inputs; RETIRES (placements[key]=None), never skips, so auto-nudge's
+    placement gate can't wedge.
+  - Task-store mirrors of abandoned-turn to-dos are LEFT AS-IS by decision (the task store is
+    authoritative and a rewind does not roll it back) — pinned, not fixed.
+SYNTHETIC fixtures only (placeholder uuids, TESTHOST-style invented text)."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_rwclean", os.path.join(BIN, "romp-judge")).load_module()
+em = jd.em
+
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = 1781100000
+CUT = T0 + 20            # u2's time: the edited/deleted record — everything at/after is abandoned
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def attline(t, uuid, parent, prompt="queued synthetic note"):
+    return {"type": "attachment", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "attachment": {"type": "queued_command", "prompt": prompt}}
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        self._saved_state = jd.STATE
+        (self.td / "state").mkdir()      # judge-errors.jsonl appends into it without mkdir -p
+        jd._rebind_state(self.td / "state")
+        jd.set_pending_cut_provider(None)
+        jd.end_pass_frame(True)          # belt: never inherit a frame a crashed test left open
+        self.path = self.td / (SID + ".jsonl")
+
+    def tearDown(self):
+        jd.set_pending_cut_provider(None)
+        jd.end_pass_frame(True)
+        jd._PARSE_CACHE.clear()
+        jd._rebind_state(self._saved_state)
+
+    def write(self, recs):
+        self.path.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def append(self, recs):
+        with open(self.path, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+
+    def base_recs(self):
+        """u1 -> a1 -> u2 -> a2: the tail (u2, a2) is what a rewind at u2 abandons."""
+        return [uline(T0, "first synthetic ask", "u1"),
+                aline(T0 + 10, "First synthetic reply, fully settled here.", "a1", "u1"),
+                uline(CUT, "second synthetic ask", "u2", "a1"),
+                aline(T0 + 30, "Second synthetic reply, also settled.", "a2", "u2")]
+
+    def fork_recs(self):
+        """The consumed rewind: u3 branches from a1, abandoning u2/a2."""
+        return [uline(T0 + 60, "second ask, rewritten", "u3", "a1"),
+                aline(T0 + 70, "Reply on the new branch, settled.", "a3", "u3")]
+
+
+class ChainMembershipPredicate(Base):
+    """em.chain_membership — the ONE exported membership fact (identity-key hazards, per verdict)."""
+
+    def test_a_rewound_fork_classifies_rewind(self):
+        self.write(self.base_recs() + self.fork_recs())
+        mem = em.chain_membership(self.path)
+        self.assertEqual(mem["rewind"], {"u2", "a2"}, "the abandoned tail is the rewind set")
+        self.assertTrue({"u1", "a1", "u3", "a3"} <= mem["kept"])
+
+    def test_an_attachment_uuid_on_the_dead_branch_is_rewind(self):
+        # hazard (a): an absorbed prompt's atom t is its ENQUEUE time (can predate cut_t), so the
+        # t-keyed sweep misses it — but its uuid is a real spine node and the predicate catches it
+        self.write(self.base_recs() + [attline(T0 + 5, "att1", "a2")] + self.fork_recs())
+        mem = em.chain_membership(self.path)
+        self.assertIn("att1", mem["rewind"], "a dead-branch attachment record is provably abandoned")
+
+    def test_a_clear_branch_is_clear_jurisdiction_never_rewind(self):
+        # hazard (d): /clear leaves a fresh null-parent head; the old chain reaches its own clean
+        # null root — the episode machinery's turf, and sweeping it as a rewind would archive a
+        # whole healthy prior conversation's cards
+        self.write(self.base_recs() + [uline(T0 + 60, "fresh start after clear", "u3", None),
+                                       aline(T0 + 70, "New conversation reply.", "a3", "u3")])
+        mem = em.chain_membership(self.path)
+        self.assertEqual(mem["rewind"], set())
+        self.assertEqual(mem["clear"], {"u1", "a1", "u2", "a2"})
+
+    def test_a_broken_chain_is_kept(self):
+        # hazard (e): a parentUuid pointing at a uuid in NO transcript is unprovable — kept.
+        # (Interleaved mid-file: the file's LAST record is the leaf, and the broken line must not
+        # usurp that or the whole real chain would read pre-clear.)
+        recs = self.base_recs()
+        self.write(recs[:2] + [uline(T0 + 15, "stray line", "u9",
+                                     "99999999-aaaa-bbbb-cccc-dddddddddddd")] + recs[2:])
+        mem = em.chain_membership(self.path)
+        self.assertIn("u9", mem["broken"])
+        self.assertIn("u9", mem["kept"])
+        self.assertNotIn("u9", mem["rewind"])
+
+    def test_resume_fork_stitched_history_is_kept(self):
+        # hazard (f): a recorded resume fork's fresh head is stitched to the from-file's last
+        # record, so pre-fork history stays active — never "clear", never "rewind"
+        frm = "22222222-3333-4444-5555-666666666666"
+        fp_from = self.td / (frm + ".jsonl")
+        fp_from.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, "ask in the first file", "u1"),
+            aline(T0 + 10, "Reply in the first file.", "a1", "u1")]) + "\n")
+        self.write([uline(T0 + 60, "continues after the machine cut", "u3", None),
+                    aline(T0 + 70, "Reply on the stitched chain.", "a3", "u3")])
+        rows = [{"resumeFork": {"from": frm, "to": SID}, "t": T0 + 55}]
+        mem = em.chain_membership(self.path, candidate_files=[str(self.path), str(fp_from)],
+                                  states=rows)
+        self.assertTrue({"u1", "a1", "u3", "a3"} <= mem["kept"], "stitched history stays kept")
+        self.assertEqual(mem["rewind"], set())
+        self.assertEqual(mem["clear"], set())
+
+    def test_an_unknown_uuid_is_in_no_set(self):
+        self.write(self.base_recs())
+        mem = em.chain_membership(self.path)
+        for k in ("kept", "rewind", "clear", "broken"):
+            self.assertNotIn("orphan:12345", mem[k], "a synthetic salvage id proves nothing")
+
+    def test_a_pending_cut_moves_the_tail_into_rewind(self):
+        # the armed bare-rollback window: nothing on disk yet, but the cut is the ground truth
+        self.write(self.base_recs())
+        full = em.chain_membership(self.path)
+        self.assertEqual(full["rewind"], set())
+        cut = em.chain_membership(self.path, leaf_override="a1")
+        self.assertEqual(cut["rewind"], {"u2", "a2"})
+
+
+class PredicateParityGolden(Base):
+    """Item 10: the exported helper vs the display parse's own adapter — byte-identical kept sets
+    on every branching shape. Guards the four-divergent-helpers problem: any future second
+    implementation of 'is this uuid on the chain' must fail here."""
+
+    def _parse_side_kept(self, leaf, cands=None, states=None, leaf_override=None):
+        """kept as parse_session computes it, via the SAME public pieces it now shares."""
+        links = em.resume_fork_links(em._load_states(states))
+        cands = em._lineage_closure(leaf, cands or [str(leaf)], links)
+        ad = em.FileAdapter(cands, leaf, leaf_override=leaf_override, resume_links=links)
+        return ad.kept_uuids(ad.active_path())
+
+    def assert_parity(self, leaf, cands=None, states=None, leaf_override=None):
+        mem = em.chain_membership(leaf, candidate_files=cands, states=states,
+                                  leaf_override=leaf_override)
+        self.assertEqual(mem["kept"], self._parse_side_kept(leaf, cands, states, leaf_override))
+
+    def test_parity_on_a_plain_rewind_fork(self):
+        self.write(self.base_recs() + self.fork_recs())
+        self.assert_parity(self.path)
+
+    def test_parity_under_a_pending_cut(self):
+        self.write(self.base_recs())
+        self.assert_parity(self.path, leaf_override="a1")
+
+    def test_parity_across_a_recorded_resume_fork_with_lineage(self):
+        frm = "22222222-3333-4444-5555-666666666666"
+        fp_from = self.td / (frm + ".jsonl")
+        fp_from.write_text("\n".join(json.dumps(r) for r in self.base_recs()) + "\n")
+        self.write([uline(T0 + 60, "continues after the machine cut", "u5", None),
+                    aline(T0 + 70, "Stitched reply.", "a5", "u5")])
+        rows = [{"resumeFork": {"from": frm, "to": SID}, "t": T0 + 55}]
+        # the lineage closure must pull the from-file in even when the caller passes only the leaf
+        self.assert_parity(self.path, cands=[str(self.path)], states=rows)
+        mem = em.chain_membership(self.path, candidate_files=[str(self.path)], states=rows)
+        self.assertIn("u1", mem["kept"], "the closure joined the resumed-from file")
+
+    def test_parity_across_a_compaction_stitch(self):
+        recs = self.base_recs() + [
+            {"type": "system", "subtype": "compact_boundary", "timestamp": iso(T0 + 40),
+             "uuid": "cb1", "parentUuid": None, "logicalParentUuid": "gone-never-written",
+             "compactMetadata": {"preservedSegment": {"tailUuid": "a2"}}},
+            uline(T0 + 50, "post-compaction ask", "u3", "cb1"),
+            aline(T0 + 60, "Post-compaction reply.", "a3", "u3")]
+        self.write(recs)
+        self.assert_parity(self.path)
+        mem = em.chain_membership(self.path)
+        self.assertIn("u1", mem["kept"], "the repaired stitch keeps pre-compaction history")
+
+
+class JudgeParseHonorsPendingCut(Base):
+    """Item 2 (first half): during an armed bare rollback the judge's parse is the CUT world, so
+    plan_units never yields the abandoned turns at all — the orphan source closes where it opens.
+    Fails on the pre-fix judge (parsed_session had no leaf_override; nothing lands on disk during
+    the window, so every pass re-collected the deleted turn as live)."""
+
+    def test_the_armed_window_hides_the_abandoned_tail_from_the_judges(self):
+        self.write(self.base_recs())
+        jd.set_pending_cut_provider(lambda sid: "a1" if sid == SID else "")
+        sess = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        texts = json.dumps([a.get("message") for t in sess["turns"] for a in t["atoms"]])
+        self.assertNotIn("second synthetic ask", texts, "the judge sees the cut world")
+        store = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+                 "placementsV": jd.PLACEMENTS_V}
+        trigs = [u[6] for u in jd.plan_units(sess, store)]
+        self.assertNotIn("u2", trigs, "no unit is ever collected from the abandoned tail")
+
+    def test_the_cut_rides_the_parse_cache_key(self):
+        # arming changes the parse with NO file change — a stale cache hit here would serve the
+        # un-cut world for the whole window (the kernel _parse learned this on 2026-07-16)
+        self.write(self.base_recs())
+        full = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        jd.set_pending_cut_provider(lambda sid: "a1")
+        cut = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIsNot(cut, full)
+        texts = json.dumps([a.get("message") for t in cut["turns"] for a in t["atoms"]])
+        self.assertNotIn("second synthetic ask", texts)
+        jd.set_pending_cut_provider(None)
+        back = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        texts = json.dumps([a.get("message") for t in back["turns"] for a in t["atoms"]])
+        self.assertIn("second synthetic ask", texts, "clearing the cut busts the cache too")
+
+    def test_a_broken_provider_is_loud_and_degrades_to_the_uncut_world(self):
+        self.write(self.base_recs())
+        def boom(sid):
+            raise RuntimeError("synthetic provider failure")
+        jd.set_pending_cut_provider(boom)
+        sess = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        texts = json.dumps([a.get("message") for t in sess["turns"] for a in t["atoms"]])
+        self.assertIn("second synthetic ask", texts, "degrades to pre-fix behavior, never blank")
+        errs = jd.ERRORS.read_text()
+        self.assertIn("pending-cut", errs, "…but never silently")
+
+
+class WriteMomentStandDown(Base):
+    """Items 1 + 2 (pinned-frame variant) + 7: apply_plan_guarded at the mint moment."""
+
+    def _store(self):
+        return {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+                "placementsV": jd.PLACEMENTS_V}
+
+    def test_late_mint_after_the_sweep_stands_down(self):
+        # Item 1, the g44 shape: the sweep ran at cut_t, THEN a pass framed pre-rewind applies a
+        # unit whose prompt is on the (now consumed) abandoned branch. Pre-fix: the node mints,
+        # survives forever, and the auto-nudge quotes it into the new conversation.
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        jd.save_goals(SID, s)
+        jd.drop_goals_after(SID, CUT)                  # the one-shot sweep already ran (empty here)
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-dead", CUT,
+                                        [{"do": "mint", "why": "x", "text": "orphan ask"}], [],
+                                        prompt_uuid="u2")
+        self.assertFalse(applied, "the guard stood down")
+        self.assertEqual(s["nodes"], {}, "no orphan node exists")
+        self.assertIn("seg-dead", s["placements"])
+        self.assertIsNone(s["placements"]["seg-dead"], "RETIRED, not skipped")
+
+    def test_pinned_frame_is_no_defense_the_guard_reads_fresh_inputs(self):
+        # the pass frame pins the pre-rewind parse for the WHOLE pass; the guard must not consult it
+        self.write(self.base_recs())
+        self.assertTrue(jd.begin_pass_frame())
+        jd.parsed_session(SID, [str(self.path)], T0 + 100)   # frame pins the un-cut world
+        self.append(self.fork_recs())                        # the rewind lands mid-pass
+        s = self._store()
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-dead", CUT,
+                                        [{"do": "mint", "why": "x", "text": "orphan ask"}], [],
+                                        prompt_uuid="u2")
+        jd.end_pass_frame(True)
+        self.assertFalse(applied, "fresh adapter walk sees the branch-take the frame hides")
+        self.assertEqual(s["nodes"], {})
+
+    def test_bare_rollback_window_stands_down_via_the_pending_cut(self):
+        # during the armed window even a FRESH parse shows the dead tail as active — the guard
+        # must fold in backend.pending_cut (item 2's second half). But PENDING-cut evidence is
+        # not durable (the rewind can still fail/dissolve), so the stand-down DEFERS — the key
+        # stays absent, never a permanent None retirement made on a rewind that never happened.
+        self.write(self.base_recs())
+        jd.set_pending_cut_provider(lambda sid: "a1")
+        s = self._store()
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-dead", CUT,
+                                        [{"do": "mint", "why": "x", "text": "orphan ask"}], [],
+                                        prompt_uuid="u2")
+        self.assertFalse(applied)
+        self.assertEqual(s["nodes"], {})
+        self.assertNotIn("seg-dead", s["placements"], "deferred, NOT retired — pending evidence")
+        self.assertIn("rewind-stand-down-pending", jd.ERRORS.read_text(), "the deferral is loud")
+        # the rollback dissolves (transcript unchanged, cut gone) → the same unit now mints
+        jd.set_pending_cut_provider(None)
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-dead", CUT,
+                                        [{"do": "mint", "why": "x", "text": "restored ask"}], [],
+                                        prompt_uuid="u2")
+        self.assertTrue(applied, "the dissolved rollback's ask still gets its card")
+        self.assertEqual(len(s["nodes"]), 1)
+
+    def test_a_consumed_rewind_on_disk_still_retires_durably(self):
+        # the counterpart: once the branch-take is ON DISK the evidence can never un-happen, so
+        # the guard retires exactly as before — even while a (new) cut is armed on the same session
+        self.write(self.base_recs() + self.fork_recs())
+        jd.set_pending_cut_provider(lambda sid: "a1")
+        s = self._store()
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-dead", CUT,
+                                        [{"do": "mint", "why": "x", "text": "orphan ask"}], [],
+                                        prompt_uuid="u2")
+        self.assertFalse(applied)
+        self.assertIn("seg-dead", s["placements"], "durable on-disk evidence → retired")
+        self.assertIsNone(s["placements"]["seg-dead"])
+
+    def test_a_none_prompt_uuid_mints_unguarded(self):
+        # abandonment can't be proven for an anchorless unit — the hard mint floor outranks suspicion
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-x", T0 + 60,
+                                        [{"do": "mint", "why": "x", "text": "anchorless ask"}], [],
+                                        prompt_uuid=None)
+        self.assertTrue(applied)
+        self.assertEqual(len(s["nodes"]), 1)
+
+    def test_a_kept_prompt_mints_normally(self):
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        applied = jd.apply_plan_guarded(SID, str(self.path), s, "seg-new", T0 + 60,
+                                        [{"do": "mint", "why": "x", "text": "new-branch ask"}], [],
+                                        prompt_uuid="u3")
+        self.assertTrue(applied)
+        self.assertEqual(len(s["nodes"]), 1)
+
+    def test_a_pending_cut_defers_the_unit_and_a_dissolved_rollback_mints_it(self):
+        # Through _plan_session itself: a stand-down retirement made on PENDING-cut evidence was
+        # permanent, but the cut is not — the CLI can refuse, the old branch can grow. The restore
+        # leg brings back hidden CARDS, but an ask retired before its card existed had nothing to
+        # restore: silently dropped forever (the repo's one fatal error). Pending evidence must
+        # DEFER; the resolved world re-decides — dissolve → the ask mints, take → the tail stops
+        # yielding units at all.
+        self.write(self.base_recs())
+        saved = (jd.plan_llm, jd.opener_llm)
+        jd.plan_llm = jd.opener_llm = (
+            lambda *a, **k: '{"ops":[{"why":"x","do":"mint","text":"Synthetic card"}]}')
+        try:
+            self.assertTrue(jd.begin_pass_frame())
+            pinned = jd.parsed_session(SID, [str(self.path)], T0 + 100)   # framed BEFORE the gesture
+            dead_keys = [jd._unit_key(u[0], u[1]) for u in jd.plan_units(pinned, self._store())
+                         if u[6] == "u2"]
+            self.assertTrue(dead_keys, "premise: the pinned world yields the doomed unit")
+            jd.set_pending_cut_provider(lambda sid: "a1")   # the bare rollback arms MID-PASS
+            jd._plan_session(SID, str(self.path), T0 + 100)
+            jd.end_pass_frame(True)
+            s = jd.load_goals(SID)
+            for k in dead_keys:
+                self.assertNotIn(k, s["placements"], "pending evidence defers — no permanent retirement")
+            self.assertFalse(any(nd.get("promptUuid") == "u2" for nd in s["nodes"].values()),
+                             "…and nothing minted from the maybe-dead branch")
+            self.assertIn("rewind-stand-down-pending", jd.ERRORS.read_text(), "the deferral is loud")
+            # the rollback DISSOLVES: transcript unchanged, cut gone — the next pass mints the ask
+            jd.set_pending_cut_provider(None)
+            jd._plan_session(SID, str(self.path), T0 + 200)
+        finally:
+            jd.plan_llm, jd.opener_llm = saved
+        s = jd.load_goals(SID)
+        self.assertTrue(any(nd.get("promptUuid") == "u2" for nd in s["nodes"].values()),
+                        "the restored world's ask got its card after all")
+
+    def test_retire_not_skip_keeps_the_nudge_gate_open(self):
+        # Item 7: the kernel's _unplanned gate asks _placed_key of EVERY unit — a stood-down unit
+        # left ABSENT reads pending forever and silences nudges for the whole session (the
+        # documented 2026-07-27 wedge). The retired key must read placed.
+        self.write(self.base_recs())
+        self.assertTrue(jd.begin_pass_frame())
+        pinned = jd.parsed_session(SID, [str(self.path)], T0 + 100)   # yields the doomed unit
+        self.append(self.fork_recs())
+        s = self._store()
+        units = list(jd.plan_units(pinned, s))
+        dead = [u for u in units if u[6] == "u2"]
+        self.assertTrue(dead, "premise: the pinned world still yields the abandoned unit")
+        for u in dead:
+            key = jd._unit_key(u[0], u[1])
+            self.assertFalse(jd.apply_plan_guarded(SID, str(self.path), s, u[0], u[2],
+                                                   [{"do": "mint", "why": "x", "text": "t"}], [],
+                                                   place_key=key, prompt_uuid=u[6]))
+        jd.end_pass_frame(True)
+        live = {sg["id"] for t in pinned["turns"] for sg in jd._segs(t, s)}
+        unplanned = [u for u in dead
+                     if not jd._placed_key(s["placements"], jd._unit_key(u[0], u[1]), live)]
+        self.assertEqual(unplanned, [], "every stood-down unit reads placed — the gate is open")
+
+
+class PlanSessionIntegration(Base):
+    """The guards through _plan_session itself: a pass framed pre-rewind retires the dead units
+    before any model call, and skips the plan-sync whose anchor died mid-pass; the next pass
+    (fresh world) syncs normally. Also pins Path E (item 9): the task-store mirror re-mints with
+    ON-CHAIN identity after a sweep — the task store is authoritative and a rewind does not roll
+    it back (left as-is by decision)."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+        self.cfg = self.td / "claude-cfg"
+        (self.cfg / "tasks" / SID).mkdir(parents=True)
+        (self.cfg / "tasks" / SID / "1.json").write_text(json.dumps(
+            {"id": "1", "subject": "synthetic open step", "status": "in_progress"}))
+        os.environ["CLAUDE_CONFIG_DIR"] = str(self.cfg)
+
+    def tearDown(self):
+        if self._saved_cfg is None:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        else:
+            os.environ["CLAUDE_CONFIG_DIR"] = self._saved_cfg
+        super().tearDown()
+
+    def test_a_pass_framed_pre_rewind_retires_dead_units_and_defers_the_sync(self):
+        self.write(self.base_recs())
+        self.assertTrue(jd.begin_pass_frame())
+        pinned = jd.parsed_session(SID, [str(self.path)], T0 + 100)   # frame pins the pre-rewind world
+        dead_keys = [jd._unit_key(u[0], u[1]) for u in jd.plan_units(pinned, {
+            "rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+            "placementsV": jd.PLACEMENTS_V}) if u[6] == "u2"]
+        self.assertTrue(dead_keys, "premise: the pinned world yields the doomed unit")
+        self.append(self.fork_recs())                                 # the rewind lands mid-pass
+        jd._plan_session(SID, str(self.path), T0 + 100)
+        jd.end_pass_frame(True)
+        s = jd.load_goals(SID)
+        for k in dead_keys:
+            self.assertIn(k, s["placements"], "the dead unit was RETIRED (key present)")
+            self.assertIsNone(s["placements"][k], "…as processed-no-goal")
+        self.assertFalse(any(nd.get("promptUuid") == "u2" for nd in s["nodes"].values()),
+                         "nothing minted from the abandoned branch")
+        self.assertFalse(any(nd.get("agentTask") for nd in s["nodes"].values()),
+                         "the plan-sync whose anchor died mid-pass deferred to the next pass")
+        errs = jd.ERRORS.read_text()
+        self.assertIn("rewind-stand-down", errs, "the stand-down is loud")
+        # next pass, fresh world: the mirror mints with ON-CHAIN identity (Path E pinned as-is)
+        jd._plan_session(SID, str(self.path), T0 + 200)
+        s = jd.load_goals(SID)
+        mirrors = [nd for nd in s["nodes"].values() if nd.get("agentTask")]
+        self.assertEqual(len(mirrors), 1, "the open to-do re-mints — the task store is authoritative")
+        self.assertEqual(mirrors[0].get("promptUuid"), "u3", "…anchored on the NEW branch")
+
+    def test_path_e_pinned_a_swept_mirror_of_a_still_open_todo_remints(self):
+        # Item 9 (assert-current): sweep the mirror, task store still holds the item open → the
+        # next sync re-mints it. This is the decided behavior, not a bug being fixed.
+        self.write(self.base_recs() + self.fork_recs())
+        store = jd.load_goals(SID)
+        session = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertTrue(jd._sync_declared_plan(store, session, "seg-sync", CUT, prompt_uuid="u2"))
+        jd.save_goals(SID, store)
+        self.assertEqual(jd.drop_goals_after(SID, CUT), 1, "the sweep archives the mirror")
+        store = jd.load_goals(SID)
+        self.assertTrue(jd._sync_declared_plan(store, session, "seg-sync2", T0 + 60,
+                                               prompt_uuid="u3"))
+        mirrors = [nd for nd in store["nodes"].values() if nd.get("agentTask")]
+        self.assertEqual(len(mirrors), 1, "the mirror re-minted — the task store is authoritative")
+        self.assertEqual(mirrors[0].get("promptUuid"), "u3", "…with post-rewind on-chain identity")
+
+
+class ReconcileRewoundGoals(Base):
+    """The state-keyed reconciliation (rides the triage cadence, event-gated on the abandoned-branch
+    set changing): the ONLY cover for rewinds romp never sees — CLI-native Esc-Esc, the SDK forkAt
+    resume, an unresolvable cut, a crash between arm and take. 28 live orphans existed when this
+    shipped; one had been actively judged for a day after its conversation stopped existing."""
+
+    def setUp(self):
+        super().setUp()
+        jd._RECON_MEMO.clear()
+
+    def _store(self):
+        return {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+                "placementsV": jd.PLACEMENTS_V}
+
+    def _mint(self, s, seg, t, text, pu, parent_ops=None):
+        jd.apply_plan(s, seg, t, parent_ops or [{"do": "mint", "why": "x", "text": text}],
+                      jd.open_menu(s), prompt_uuid=pu)
+
+    def test_the_g44_zombie_is_archived_so_no_nudge_precondition_survives(self):
+        # Item 8, the end-to-end shape: a working top minted from a rewound-away turn + an idle
+        # session on the new branch. Pre-fix every auto-nudge gate passed and _followup_body quoted
+        # the orphan ("Still open on this:") into a conversation with no memory of the ask — twice,
+        # live. The fire's precondition is a live still-'working' top; the reconciliation removes it.
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-dead", CUT, "Zombie ask from the deleted turn", "u2")
+        self._mint(s, "seg-live", T0 + 60, "Real ask on the new branch", "u3")
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        zombie, kept = "%s:g1" % SID, "%s:g2" % SID
+        self.assertEqual(jd.load_goals(SID)["status"].get(zombie, "working"), "working",
+                         "premise: the zombie is a nudgeable working top today")
+        n = jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200)
+        self.assertEqual(n, 1)
+        live = jd.load_goals(SID)
+        self.assertNotIn(zombie, live["nodes"], "the zombie left the live store — nothing to nudge")
+        self.assertIn(kept, live["nodes"], "the new branch's card is untouched")
+        self.assertIn(zombie, jd.load_goal_archive(SID)["nodes"], "archived, recoverable — not deleted")
+        self.assertIn(zombie, live.get("rewindSwept", {}), "tombstoned against rebase resurrection")
+        self.assertIn("rewound-archived", jd.ERRORS.read_text(), "the move is loud")
+
+    def test_reconciliation_is_event_keyed_not_a_timer(self):
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-dead", CUT, "Zombie", "u2")
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 1)
+        rev = jd.load_goals(SID).get("rev")
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 201), 0,
+                         "unchanged fileset → not an event, no adapter walk archives anything")
+        self.append([uline(T0 + 90, "more work on the new branch", "u4", "a3"),
+                     aline(T0 + 95, "More new-branch work, settled.", "a4", "u4")])
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 202), 0,
+                         "fileset moved but the abandoned set did not → no new information")
+        self.assertEqual(jd.load_goals(SID).get("rev"), rev, "…and the store was never re-published")
+        self.append([uline(T0 + 120, "rewriting that", "u5", "a3"),
+                     aline(T0 + 125, "Reply after the second rewind.", "a5", "u5")])
+        s = jd.load_goals(SID)
+        self._mint(s, "seg-dead2", T0 + 95, "Second zombie", "u4")
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 300), 1,
+                         "a NEW abandoned branch (u4's) is the event that re-arms the check")
+
+    def test_a_kept_anchored_child_under_a_dead_top_survives_the_drag_and_reparents(self):
+        # The reconciliation fires days after the rewind, when a zombie top has accumulated REAL
+        # live-branch descendants (the grouper files new work under existing tops — ~90 live goals,
+        # 8 open, sat under one dead top on live data). The drag must stop at a child whose own
+        # anchor is provably kept, and the survivor must stay reachable (re-parented, in open_menu).
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-dead", CUT, "Zombie top from the deleted turn", "u2")
+        top = "%s:g1" % SID
+        jd.apply_plan(s, "seg-live", T0 + 60,
+                      [{"do": "sub", "why": "x", "under": 1, "text": "Live work filed under it"}],
+                      jd.open_menu(s), prompt_uuid="u3")
+        child = "%s:g2" % SID
+        self.assertEqual(s["nodes"][child]["parentId"], top, "premise: the live child sits under the zombie")
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 1,
+                         "only the dead top moves — the kept-anchored child is spared")
+        live = jd.load_goals(SID)
+        self.assertNotIn(top, live["nodes"], "the zombie top archived")
+        self.assertIn(child, live["nodes"], "the live-branch child stays")
+        self.assertIsNone(live["nodes"][child].get("parentId"), "…re-parented at the nearest survivor (a top)")
+        self.assertIn(child, [nd["id"] for nd in jd.open_menu(live)], "…and still reachable by the planner")
+
+    def test_a_store_write_reopens_the_gate_for_an_already_known_dead_branch(self):
+        # the escape the review named: reconcile memoizes the sig, then a mint slips past the
+        # write-moment guard's fail-open onto that ALREADY-swept branch (a transient chain-check
+        # error mid-pass mints anyway, loudly, by design). The transcript never changes again — so
+        # a transcript-only gate could never re-catch it while the kernel stayed up: the g44 zombie
+        # back, behind one transient fault. The mint's own store write IS the new information; the
+        # gate watches both sides of the join.
+        self.write(self.base_recs() + self.fork_recs())
+        jd.save_goals(SID, self._store())
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 0,
+                         "premise: the abandoned set is memoized, nothing to move yet")
+        s = jd.load_goals(SID)
+        self._mint(s, "seg-escape", CUT, "Escaped orphan", "u2")   # the fail-open mint: store-only
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 300), 1,
+                         "the next pass archives it — no restart, no second rewind needed")
+        self.assertNotIn("%s:g1" % SID, jd.load_goals(SID)["nodes"])
+        self.assertIn("%s:g1" % SID, jd.load_goal_archive(SID)["nodes"])
+
+    def test_a_merge_transplanted_dead_anchor_on_a_kept_survivor_is_not_swept(self):
+        # hazard (b): _merge_nodes grafts the dupe's promptUuid onto a survivor lacking one — mixed
+        # provenance proves nothing about the NODE, so it stays
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-x", T0, "Kept-origin survivor", "u2")
+        nid = "%s:g1" % SID
+        s["nodes"][nid]["mergedFrom"] = [{"id": "%s:g9" % SID, "text": "dead twin", "at": CUT}]
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 0)
+        self.assertIn(nid, jd.load_goals(SID)["nodes"])
+
+    def test_an_umbrella_parent_over_orphan_children_is_swept_with_them(self):
+        # hazard (c): the umbrella has no promptUuid — the inverted subtree-drag direction
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-a", CUT, "Orphan child one", "u2")
+        self._mint(s, "seg-b", CUT + 5, "Orphan child two", "u2")
+        s["nodes"]["%s:umb" % SID] = jd.GuardedNode({
+            "id": "%s:umb" % SID, "text": "Umbrella over dead work", "parentId": None,
+            "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+            "t": CUT + 10, "mt": CUT + 10, "umbrella": True, "log": []})
+        for gid in ("%s:g1" % SID, "%s:g2" % SID):
+            s["nodes"][gid]["parentId"] = "%s:umb" % SID
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 3)
+        live = jd.load_goals(SID)["nodes"]
+        self.assertNotIn("%s:umb" % SID, live, "the empty shell went with its children")
+
+    def test_an_enqueue_time_anchor_below_cut_t_is_still_swept(self):
+        # hazard (a): an absorbed prompt's atom t is its ENQUEUE time — a dead-branch node can carry
+        # t < cut_t and escape any t-keyed sweep forever; the identity key catches it
+        self.write(self.base_recs() + [attline(T0 + 5, "att1", "a2")] + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-abs", T0 + 5, "Born from an absorbed prompt", "att1")
+        jd.save_goals(SID, s)
+        self.assertLess(s["nodes"]["%s:g1" % SID]["t"], CUT, "premise: t-keyed sweeps miss this node")
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 1)
+        self.assertNotIn("%s:g1" % SID, jd.load_goals(SID)["nodes"])
+
+    def test_clear_branch_and_broken_chain_nodes_are_untouched(self):
+        # hazards (d) + (e): pre-/clear history is the episode machinery's jurisdiction; a broken
+        # chain is unprovable — neither is ever swept as a rewind
+        recs = self.base_recs()
+        self.write(recs[:2] + [uline(T0 + 15, "dangling line", "u9",
+                                     "99999999-aaaa-bbbb-cccc-dddddddddddd")] + recs[2:] +
+                   [uline(T0 + 60, "fresh start after clear", "u3", None),
+                    aline(T0 + 70, "New conversation reply.", "a3", "u3")])
+        s = self._store()
+        self._mint(s, "seg-pre", T0, "Pre-clear card", "u2")     # u2 is now pre-/clear, not rewound
+        self._mint(s, "seg-brk", T0 + 15, "Broken-chain card", "u9")
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 0)
+        self.assertEqual(len(jd.load_goals(SID)["nodes"]), 2, "both cards stay")
+
+    def test_an_open_agent_task_pins_its_card_against_the_sweep(self):
+        # Path E stays as-is: the live task store is authoritative — the agent may genuinely still
+        # hold the to-do, and archiving would just re-mint a fresh mirror while losing the diary
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-dead", CUT, "Mirror of a still-open to-do", "u2")
+        nid = "%s:g1" % SID
+        s["nodes"][nid]["agentTask"] = {"key": "1", "status": "open", "raw": "in_progress"}
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 0)
+        self.assertIn(nid, jd.load_goals(SID)["nodes"])
+
+    def test_a_dead_branch_inside_a_pre_clear_episode_file_is_still_reconciled(self):
+        # The whole-graph walk can only ever call a pre-/clear file's interior branches "clear"
+        # (their chains reach the old episode's null root; the current spine never sees them), so
+        # 10 of the 28 audited live orphans — including ALL 5 live+archive dual-residents — were
+        # invisible to it. The per-file discriminator walks each dead file by itself: a branch
+        # that rejoins the file's OWN spine is a rewind wherever the graph later went. Benign
+        # pre-clear spine nodes stay (they are "clear" in the whole graph AND on their own file's
+        # spine), and so does the current branch's card.
+        anchor = self.td / (SID + ".jsonl")            # the dead episode: a rewind INSIDE it, then /clear
+        anchor.write_text("\n".join(json.dumps(r) for r in
+                                    self.base_recs() + self.fork_recs()) + "\n")
+        epfsid = "44444444-5555-6666-7777-888888888888"   # a second dead episode, enumerated only
+        epfile = self.td / (epfsid + ".jsonl")            # by the episode log (u6b/a6b rewound away
+        eprecs = [uline(T0 + 200, "old-episode ask", "u6"),  # inside it, u7 taking the branch)
+                  aline(T0 + 210, "Old-episode reply, settled.", "a6", "u6"),
+                  uline(T0 + 215, "follow-up on the old episode", "u6b", "a6"),
+                  aline(T0 + 218, "Follow-up reply.", "a6b", "u6b"),
+                  uline(T0 + 220, "follow-up, rewritten", "u7", "a6"),
+                  aline(T0 + 230, "Branch reply.", "a7", "u7")]
+        epfile.write_text("\n".join(json.dumps(r) for r in eprecs) + "\n")
+        jd.append_episode(SID, "u6", epfsid, T0 + 200)
+        leaf = self.td / ("99999999-aaaa-bbbb-cccc-dddddddddddd.jsonl")   # the CURRENT episode
+        leaf.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 + 300, "fresh start after clear", "u9"),
+            aline(T0 + 310, "New conversation reply.", "a9", "u9")]) + "\n")
+        s = self._store()
+        self._mint(s, "seg-a", CUT, "Orphan from the anchor's dead branch", "u2")
+        self._mint(s, "seg-b", T0 + 215, "Orphan from the old episode's dead branch", "u6b")
+        self._mint(s, "seg-c", T0, "Benign pre-clear card", "u1")
+        self._mint(s, "seg-d", T0 + 300, "Current branch's card", "u9")
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(leaf), T0 + 400), 2,
+                         "both interior dead branches are caught — nothing else")
+        live = jd.load_goals(SID)["nodes"]
+        self.assertNotIn("%s:g1" % SID, live, "the anchor's dead-branch orphan archived")
+        self.assertNotIn("%s:g2" % SID, live, "the episode-log-enumerated file's orphan archived")
+        self.assertIn("%s:g3" % SID, live, "a benign pre-clear spine card is untouched")
+        self.assertIn("%s:g4" % SID, live, "the current branch's card is untouched")
+
+    def test_a_user_restored_card_survives_boot_and_later_rewind_re_reconciles(self):
+        # The restore pops the tombstone, but the branch stays "rewind" in the graph forever and
+        # _RECON_MEMO is process memory: every kernel restart (memo reset) and any later unrelated
+        # rewind (sig change) re-ran the full sweep and re-archived the card the user deliberately
+        # brought back — a card move on ZERO new information. The restore's durable stamp stands
+        # the node down from the identity-keyed sweep for good.
+        self.write(self.base_recs() + self.fork_recs())
+        s = self._store()
+        self._mint(s, "seg-dead", CUT, "Zombie the user wants kept", "u2")
+        jd.save_goals(SID, s)
+        nid = "%s:g1" % SID
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 1)
+        arch = jd.load_goal_archive(SID)               # the user restores it (the undo-clear moves:
+        payload = dict(arch["nodes"].pop(nid))         # out of the archive, journaled, replayed)
+        jd.save_goal_archive(SID, arch)
+        jd.append_restore(SID, {nid: payload}, {}, T0 + 300)
+        live = jd.load_goals(SID)
+        self.assertIn(nid, live["nodes"], "premise: the restore landed")
+        jd.save_goals(SID, live)
+        jd._RECON_MEMO.clear()                         # a kernel restart resets the event gate
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 400), 0,
+                         "the boot re-check moves nothing — the restore is durable")
+        self.assertIn(nid, jd.load_goals(SID)["nodes"])
+        self.append([uline(T0 + 90, "more work on the new branch", "u4", "a3"),
+                     aline(T0 + 95, "More new-branch work, settled.", "a4", "u4"),
+                     uline(T0 + 120, "rewriting that", "u5", "a3"),
+                     aline(T0 + 125, "Reply after the second rewind.", "a5", "u5")])
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 500), 0,
+                         "an unrelated later rewind's sig change does not re-take it either")
+        self.assertIn(nid, jd.load_goals(SID)["nodes"])
+
+    def _broken_episode_world(self, corrupt_head=False, unreadable=False):
+        """The pre-/clear episode fixture with the EPIDIR-enumerated dead episode file BROKEN: a
+        valid-JSON-but-non-dict head line (FileAdapter raises on it naturally), or chmod 000 (the
+        incremental reader swallows the OSError into zero records with no row of its own). One
+        orphan minted from the anchor's dead branch (provable without the broken file) and one
+        from the broken file's own dead branch. Returns (leaf, epfile, eprecs)."""
+        anchor = self.td / (SID + ".jsonl")
+        anchor.write_text("\n".join(json.dumps(r) for r in
+                                    self.base_recs() + self.fork_recs()) + "\n")
+        epfsid = "44444444-5555-6666-7777-888888888888"
+        epfile = self.td / (epfsid + ".jsonl")
+        eprecs = [uline(T0 + 200, "old-episode ask", "u6"),
+                  aline(T0 + 210, "Old-episode reply, settled.", "a6", "u6"),
+                  uline(T0 + 215, "follow-up on the old episode", "u6b", "a6"),
+                  aline(T0 + 218, "Follow-up reply.", "a6b", "u6b"),
+                  uline(T0 + 220, "follow-up, rewritten", "u7", "a6"),
+                  aline(T0 + 230, "Branch reply.", "a7", "u7")]
+        body = "\n".join(json.dumps(r) for r in eprecs) + "\n"
+        epfile.write_text(("[]\n" if corrupt_head else "") + body)
+        if unreadable:
+            os.chmod(epfile, 0)
+            self.addCleanup(os.chmod, epfile, 0o600)
+        jd.append_episode(SID, "u6", epfsid, T0 + 200)
+        leaf = self.td / ("99999999-aaaa-bbbb-cccc-dddddddddddd.jsonl")
+        leaf.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 + 300, "fresh start after clear", "u9"),
+            aline(T0 + 310, "New conversation reply.", "a9", "u9")]) + "\n")
+        s = self._store()
+        self._mint(s, "seg-a", CUT, "Orphan from the anchor's dead branch", "u2")
+        self._mint(s, "seg-b", T0 + 215, "Orphan from the old episode's dead branch", "u6b")
+        jd.save_goals(SID, s)
+        return leaf, epfile, eprecs
+
+    def test_a_failed_per_file_scan_blocks_the_marker_never_the_proven_archives(self):
+        # The one-time -v2 migration writes its done-marker only on a ZERO-FAILURE pass — but a
+        # per-file scan failure was logged-and-swallowed inside _per_file_rewound, so the pass
+        # returned a PARTIAL abandoned set with fails=0: the marker landed over the miss and
+        # steady-state discovery (48h-windowed) never revisits a dormant session, permanently
+        # skipping exactly the pre-/clear orphan class the widening targets. A per-file failure
+        # now raises AFTER the proven archives land (partial archiving is idempotent and safe)
+        # and BEFORE the memo (a partial sig must never become the event gate's baseline), so
+        # run_rewound_reconcile counts the session failed and the marker waits.
+        leaf, epfile, eprecs = self._broken_episode_world(corrupt_head=True)
+        with self.assertRaises(RuntimeError):
+            jd.reconcile_rewound_goals(SID, str(leaf), T0 + 400)
+        live = jd.load_goals(SID)["nodes"]
+        self.assertNotIn("%s:g1" % SID, live, "the PROVEN orphan still archived — partial is safe")
+        self.assertIn("%s:g1" % SID, jd.load_goal_archive(SID)["nodes"])
+        self.assertIn("%s:g2" % SID, live, "the broken file's orphan untouched — never guessed at")
+        self.assertNotIn(SID, jd._RECON_MEMO, "a partial sig never becomes the gate's baseline")
+        self.assertIn("rewound-reconcile-file", jd.ERRORS.read_text(),
+                      "…and the row has its own category, distinguishable from a session failure")
+        # the block heals where the failure does: with the file fixed, the retry pass (the next
+        # boot's migration re-run) takes the rest and only then memoizes
+        epfile.write_text("\n".join(json.dumps(r) for r in eprecs) + "\n")
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(leaf), T0 + 500), 1)
+        self.assertNotIn("%s:g2" % SID, jd.load_goals(SID)["nodes"])
+        self.assertIn(SID, jd._RECON_MEMO, "a clean pass memoizes")
+
+    def test_a_silently_unreadable_episode_file_still_counts_as_a_failure(self):
+        # The sneakier trigger: the incremental reader swallows an OSError into an EMPTY record
+        # list with no log row, so the per-file except never fired yet the sig was still partial —
+        # even quieter than the claim said. A non-empty transcript that yields zero records now
+        # counts as the read failure it is.
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            self.skipTest("chmod 000 does not block reads for root")
+        leaf, epfile, eprecs = self._broken_episode_world(unreadable=True)
+        with self.assertRaises(RuntimeError):
+            jd.reconcile_rewound_goals(SID, str(leaf), T0 + 400)
+        self.assertIn("%s:g2" % SID, jd.load_goals(SID)["nodes"],
+                      "the unreadable file's orphan is untouched, not silently skipped for good")
+        self.assertNotIn(SID, jd._RECON_MEMO)
+        self.assertIn("yielded no records", jd.ERRORS.read_text(), "the zero-record read is loud")
+
+    def test_a_pending_unconsumed_cut_is_not_reconciled(self):
+        # the two-phase hold owns the armed window (hide now, archive at take, RESTORE on failure) —
+        # reconciling it would archive cards for a rewind that can still fail
+        self.write(self.base_recs())                   # no fork on disk: the rollback is only armed
+        jd.set_pending_cut_provider(lambda sid: "a1")
+        s = self._store()
+        self._mint(s, "seg-dead", CUT, "Card the pending delete would drop", "u2")
+        jd.save_goals(SID, s)
+        self.assertEqual(jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200), 0)
+        self.assertIn("%s:g1" % SID, jd.load_goals(SID)["nodes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -14,6 +14,7 @@ import os
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -279,29 +280,457 @@ class RevertOnDelete(unittest.TestCase):
         self.assertEqual(km._atom_epoch(p, SID, "u2", now), want, "resolves the atom's epoch time")
         self.assertIsNone(km._atom_epoch(p, SID, "no-such-uuid", now), "a uuid not in the transcript → None")
 
-    def test_delete_drops_born_in_range_goals_after_a_successful_cut(self):
+    def test_delete_hides_born_in_range_goals_at_the_gesture(self):
         # the deleted message's time is read BEFORE be.rollback arms the pending_cut (which would hide it
-        # from _parse), then the cards those now-abandoned turns spawned are archived on success.
+        # from _parse); the gesture then latches the card HOLD — the archive waits for the branch-take
+        # (two-phase timing: archiving at ARM both missed late mints and archived goals for rewinds that
+        # never happened).
         src = inspect.getsource(km._rewind_rollback)
         self.assertIn("cut_t = _atom_epoch(", src)                   # resolved before be.rollback
         self.assertIn("ok, berr = be.rollback(sid, target)", src)
-        self.assertIn("_drop_goals_after(sid, cut_t)", src)          # archive born-in-range cards on success
+        self.assertIn("_arm_rewind_hold(be, sid, cut_t)", src)       # hide on success; archive at the take
         self.assertLess(src.index("cut_t = _atom_epoch("), src.index("be.rollback(sid, target)"),
                         "the deleted message's time is read BEFORE the cut is armed")
 
-    def test_edit_drops_born_in_range_goals_too(self):
-        # an edit abandons the old tail the same way a delete does → same cleanup
+    def test_edit_hides_born_in_range_goals_too(self):
+        # an edit abandons the old tail the same way a delete does → same two-phase cleanup
         src = inspect.getsource(km._rewind_send)
         self.assertIn("cut_t = _atom_epoch(", src)
-        self.assertIn("_drop_goals_after(sid, cut_t)", src)
+        self.assertIn("_arm_rewind_hold(be, sid, cut_t)", src)
         self.assertLess(src.index("cut_t = _atom_epoch("), src.index("be.rewind(sid, target"),
                         "the edited message's time is read BEFORE the cut is armed")
 
     def test_drop_goals_after_is_best_effort(self):
         # a cleanup failure must never undo the cut the user already got
         src = inspect.getsource(km._drop_goals_after)
-        self.assertIn("jd.drop_goals_after(sid, cut_t)", src)
+        self.assertIn("jd.drop_goals_after(sid, cut_t, kept=kept)", src)   # kept-chain exemption threads through
         self.assertIn("except Exception", src)                       # swallow-and-log, never raise past the delete
+
+
+class TwoPhaseRewindTiming(unittest.TestCase):
+    """Items 4 + 5 of the rewind-cleanup plan: the gesture HIDES the affected cards (latched hold),
+    the ARCHIVE lands only at the branch-take, a failed/refused/dissolved rewind RESTORES loudly,
+    and an unresolvable cut time is an error row — never a silent no-cleanup. Pre-fix the archive
+    fired at ARM time: a CLI refusal or a spent flag left the conversation intact with its goals
+    already archived (the inverse bug), and every mint landing after the arm escaped forever."""
+
+    T0 = 1781100000
+    CUT = T0 + 50
+
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        self._saved_state = km.jd.STATE
+        (self.td / "state").mkdir()
+        km.jd._rebind_state(self.td / "state")
+        km._rewind_holds[0] = None                     # drop the cached map from any earlier test
+        self._saved_sessions = km._sessions
+        jd = km.jd
+        s = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+             "placementsV": jd.PLACEMENTS_V}
+        jd.apply_plan(s, "s1", self.T0, [{"do": "mint", "why": "x", "text": "Pre-cut survivor"}], [])
+        jd.apply_plan(s, "s2", self.T0 + 100, [{"do": "mint", "why": "x", "text": "Doomed ask"}],
+                      jd.open_menu(s))
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        self.survivor, self.doomed = "%s:g1" % SID, "%s:g2" % SID
+
+    def tearDown(self):
+        km._sessions = self._saved_sessions
+        km._rewind_holds[0] = None
+        km.jd._rebind_state(self._saved_state)
+
+    def _transcript(self, recs):
+        p = self.td / (SID + ".jsonl")
+        with open(p, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        km._sessions = lambda now: [{"sid": SID, "path": str(p)}]
+        return str(p)
+
+    def test_the_gesture_hides_and_the_take_archives(self):
+        km._rewind_hold_set(SID, self.CUT, "leaf-at-arm")
+        feed = km._feed_goals(SID)
+        self.assertNotIn(self.doomed, feed["nodes"], "the gesture hid the doomed card at once")
+        self.assertIn(self.survivor, feed["nodes"], "…and only the doomed card")
+        self.assertIn(self.doomed, km.jd.load_goals(SID)["nodes"],
+                      "the STORE is untouched while the rewind is pending (hide, not archive)")
+        km._on_rewind_resolved(SID, "taken")           # the branch-take event
+        self.assertNotIn(self.doomed, km.jd.load_goals(SID)["nodes"], "the take archives")
+        self.assertIn(self.doomed, km.jd.load_goal_archive(SID)["nodes"])
+        self.assertIsNone(km._rewind_hold_get(SID), "the hold is spent — latched until this event only")
+
+    def test_a_refused_rewind_restores_the_hidden_cards_loudly(self):
+        km._rewind_hold_set(SID, self.CUT, "leaf-at-arm")
+        km._on_rewind_resolved(SID, "failed")          # the CLI refused; conversation unchanged
+        self.assertIn(self.doomed, km.jd.load_goals(SID)["nodes"], "nothing was archived")
+        self.assertIn(self.doomed, km._feed_goals(SID)["nodes"], "the card is back on the feed")
+        self.assertIsNone(km._rewind_hold_get(SID))
+        self.assertIn("rewind-restore", km.jd.ERRORS.read_text(), "the restore is loud")
+
+    def test_a_kept_chain_card_born_after_the_cut_survives_the_hide_and_the_take(self):
+        # The replacement ask's card is minted DURING the open rewind turn (the judge's prompt-run,
+        # by design) with t > cut_t — a bare t-keyed sweep hid it all turn and archived it at the
+        # take. The sweep threads the kept-chain exemption: identity, not time, decides its fate.
+        self._transcript([_rec("user", "u1", None, "first ask"),
+                          _rec("assistant", "a1", "u1", "first reply"),
+                          _rec("user", "u2", "a1", "second ask"),
+                          _rec("assistant", "a2", "u2", "second reply"),
+                          _rec("user", "u3", "a1", "second ask, rewritten"),
+                          _rec("assistant", "a3", "u3", "new-branch reply")])
+        jd = km.jd
+        s = jd.load_goals(SID)
+        jd.apply_plan(s, "s3", self.CUT + 30, [{"do": "mint", "why": "x", "text": "Fresh ask"}],
+                      jd.open_menu(s), prompt_uuid="u3")   # kept-chain anchor, born INSIDE the window
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        fresh = "%s:g3" % SID
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        feed = km._feed_goals(SID)
+        self.assertIn(fresh, feed["nodes"], "the live-branch card stays visible during the hold")
+        self.assertNotIn(self.doomed, feed["nodes"], "…while the doomed card still hides")
+        km._on_rewind_resolved(SID, "taken")
+        live = jd.load_goals(SID)
+        self.assertIn(fresh, live["nodes"], "the take spares the kept-chain card")
+        self.assertNotIn(fresh, jd.load_goal_archive(SID)["nodes"])
+        self.assertNotIn(fresh, live.get("rewindSwept", {}), "no bogus permanent tombstone")
+        self.assertNotIn(self.doomed, live["nodes"], "the doomed card still archives")
+        self.assertIn(self.doomed, jd.load_goal_archive(SID)["nodes"])
+
+    def test_a_user_restored_card_survives_the_hold_hide_and_the_take(self):
+        # A card restored out of an EARLIER rewind's sweep carries a durable rewindRestored stamp;
+        # a LATER rewind whose cut range merely time-overlaps it used to hide it at the gesture
+        # (kernel.py's hold view) and re-archive it at the take (drop_goals_after) — popping the
+        # stamp, so even the reconciler's shield was gone. Both surfaces route through
+        # jd.swept_ids, so one exemption gives hide==take parity: the restored card never hides,
+        # never re-archives, and keeps its stamp. Only the user's own gesture re-kills it.
+        jd = km.jd
+        s = jd.load_goals(SID)
+        jd.apply_plan(s, "s3", self.T0 + 90, [{"do": "mint", "why": "x", "text": "Restored earlier"}],
+                      jd.open_menu(s))
+        restored_nid = "%s:g3" % SID
+        s["rewindRestored"] = {restored_nid: self.T0 + 95}   # the earlier restore's durable stamp
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        km._rewind_hold_set(SID, self.CUT, "leaf-at-arm")
+        feed = km._feed_goals(SID)
+        self.assertIn(restored_nid, feed["nodes"], "the restored card never hides at the gesture")
+        self.assertNotIn(self.doomed, feed["nodes"], "…while the unrestored in-range card does")
+        km._on_rewind_resolved(SID, "taken")
+        live = jd.load_goals(SID)
+        self.assertIn(restored_nid, live["nodes"], "the take spares it too — hide==take parity")
+        self.assertEqual(live["rewindRestored"][restored_nid], self.T0 + 95,
+                         "…with the durable stamp intact")
+        self.assertNotIn(restored_nid, jd.load_goal_archive(SID)["nodes"])
+        self.assertNotIn(self.doomed, live["nodes"], "the unrestored card still archives")
+
+    def test_a_spent_flag_discriminates_through_recorded_resume_lineage(self):
+        # crash-heal shape: a recorded fresh-head resume fork (states resumeFork row) means the
+        # armed leaf is reachable only through the STITCHED walk — a lineage-blind walk read it as
+        # off-chain and archived live cards on a guess. The exported predicate must restore here.
+        frm = SID
+        fork = "22222222-3333-4444-5555-666666666666"
+        anchor = self.td / (frm + ".jsonl")
+        with open(anchor, "w") as f:
+            for r in [_rec("user", "u1", None, "first ask"),
+                      _rec("assistant", "a1", "u1", "first reply"),
+                      _rec("user", "u2", "a1", "second ask"),
+                      _rec("assistant", "a2", "u2", "second reply")]:
+                f.write(json.dumps(r) + "\n")
+        fp = self.td / (fork + ".jsonl")
+        with open(fp, "w") as f:
+            for r in [_rec("user", "u3", None, "continues after the machine cut"),
+                      _rec("assistant", "a3", "u3", "stitched reply")]:
+                f.write(json.dumps(r) + "\n")
+        km.jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.STATESDIR / (SID + ".jsonl")).write_text(
+            json.dumps({"resumeFork": {"from": frm, "to": fork}, "t": self.T0 + 40}) + "\n")
+        km._sessions = lambda now: [{"sid": SID, "path": str(fp)}]
+        km._rewind_hold_set(SID, self.CUT, "a2")       # armed pre-fork; the rollback then dissolved
+        km._on_rewind_resolved(SID, "spent")
+        self.assertIn(self.doomed, km.jd.load_goals(SID)["nodes"],
+                      "the stitched walk keeps a2 → restored, never archived on a guess")
+        self.assertNotIn(self.doomed, km.jd.load_goal_archive(SID)["nodes"])
+
+    def test_a_spent_flag_with_the_old_branch_still_active_restores(self):
+        # the rollback dissolved: a record landed on the OLD branch, so the recorded leaf is still
+        # on the active chain — archiving here would archive cards for turns that still exist
+        self._transcript([_rec("user", "u1", None, "first ask"),
+                          _rec("assistant", "a1", "u1", "first reply"),
+                          _rec("user", "u2", "a1", "second ask"),
+                          _rec("assistant", "a2", "u2", "second reply")])
+        km._rewind_hold_set(SID, self.CUT, "a2")       # the leaf recorded at arm — still the leaf
+        km._on_rewind_resolved(SID, "spent")
+        self.assertIn(self.doomed, km.jd.load_goals(SID)["nodes"], "restored, not archived")
+        self.assertIsNone(km._rewind_hold_get(SID))
+
+    def test_a_spent_flag_whose_branch_took_archives(self):
+        # crash-heal shape: the take landed (u3 branches from a1) before the flag could be tidied —
+        # the recorded leaf a2 is off the active chain, so the rewind DID happen
+        self._transcript([_rec("user", "u1", None, "first ask"),
+                          _rec("assistant", "a1", "u1", "first reply"),
+                          _rec("user", "u2", "a1", "second ask"),
+                          _rec("assistant", "a2", "u2", "second reply"),
+                          _rec("user", "u3", "a1", "second ask, rewritten"),
+                          _rec("assistant", "a3", "u3", "new-branch reply")])
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        km._on_rewind_resolved(SID, "spent")
+        self.assertNotIn(self.doomed, km.jd.load_goals(SID)["nodes"], "the take archives")
+        self.assertIn(self.doomed, km.jd.load_goal_archive(SID)["nodes"])
+
+    def test_the_hold_view_re_points_a_hidden_focus_so_needs_you_floors_still_land(self):
+        # build_feed's perm/api-error/judge-auth floors walk from lastNode and require it to land
+        # in nodes — a focus hidden by the hold made every floor silently no-op for the whole
+        # window (the frozen-board shape the jauth floor exists to prevent). The view re-points at
+        # the newest survivor, the same move the take itself makes.
+        self.assertEqual(km.jd.load_goals(SID).get("lastNode"), self.doomed,
+                         "premise: the latest placement's top is the doomed card")
+        km._rewind_hold_set(SID, self.CUT, "leaf-at-arm")
+        view = km._feed_goals(SID)
+        self.assertEqual(view.get("lastNode"), self.survivor, "the view's focus re-points")
+        self.assertIn(view["lastNode"], view["nodes"], "…so a floor walk lands on a visible card")
+        self.assertEqual(km.jd.load_goals(SID).get("lastNode"), self.doomed,
+                         "the LIVE store's focus is untouched while the rewind is pending")
+
+    def test_the_hold_view_re_rolls_a_parents_column_when_its_blocker_hides(self):
+        # a pre-cut top whose ONLY blocker is a post-cut sub must not sit in needs-you — presenting
+        # an ask the user just deleted — for the whole pending window (unbounded on a bare delete).
+        # The take re-rolls for exactly this reason (archive_goal_nodes); the view must serve the
+        # same columns. Conversely a top blocked by a PRE-cut sub keeps its column.
+        jd = km.jd
+        s = jd.load_goals(SID)
+        jd.apply_plan(s, "s3", self.T0 + 5, [{"do": "mint", "why": "x", "text": "Second survivor"}],
+                      jd.open_menu(s))                                    # g3, pre-cut top
+        jd.apply_plan(s, "s4", self.T0 + 8, [{"do": "sub", "why": "x", "under": 2,
+                                              "text": "early sub"}], jd.open_menu(s))   # g4 under g3
+        jd.apply_plan(s, "s5", self.T0 + 120, [{"do": "sub", "why": "x", "under": 1,
+                                                "text": "late sub"}], jd.open_menu(s))  # g5 under g1
+        menu = jd.open_menu(s)                          # tree order: g1, g5(sub), g3, g4(sub), g2
+        jd.apply_plan(s, "s6", self.T0 + 130, [{"do": "block", "why": "owed", "goal": 2},
+                                               {"do": "block", "why": "owed", "goal": 4}], menu)
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        second = "%s:g3" % SID
+        self.assertEqual(jd.load_goals(SID)["status"][self.survivor], "blocked", "premise")
+        self.assertEqual(jd.load_goals(SID)["status"][second], "blocked", "premise")
+        km._rewind_hold_set(SID, self.CUT, "leaf-at-arm")
+        view = km._feed_goals(SID)
+        self.assertNotIn("%s:g5" % SID, view["nodes"], "the post-cut blocker hides")
+        self.assertEqual(view["status"].get(self.survivor), "working",
+                         "…and its parent's column re-rolls to what the take will produce")
+        self.assertEqual(view["status"].get(second), "blocked",
+                         "a top blocked by a PRE-cut sub keeps its column")
+        self.assertEqual(jd.load_goals(SID)["status"][self.survivor], "blocked",
+                         "the LIVE store is untouched while the rewind is pending")
+
+    def test_build_session_serves_the_hold_filtered_store(self):
+        # the feed was NOT the only goal-store surface: the session pane's ledger tree (and the
+        # tab-hover recents derived from it) read jd.load_goals raw and kept showing the doomed
+        # asks for the whole armed window — unbounded on a bare delete
+        src = inspect.getsource(km.build_session)
+        self.assertIn("gstore = _apply_rewind_hold(sid, jd.load_goals(sid))", src)
+
+    def test_the_boot_pass_resolves_a_hold_the_transcript_moved_past_out_of_band(self):
+        # bare rollback armed, kernel dies, the user continues the session CLI-natively: the OLD
+        # branch grows past the recorded leaf and nothing ever consumes the reg flag. Raw flag
+        # presence kept the hold latched forever — cards hidden with NO future resolving event
+        # while the leaf-verified pending_cut let the chat render the full tail. The boot pass
+        # keys on the backend's leaf-verified probe and resolves through the spent discriminator.
+        self._transcript([_rec("user", "u1", None, "first ask"),
+                          _rec("assistant", "a1", "u1", "first reply"),
+                          _rec("user", "u2", "a1", "second ask"),
+                          _rec("assistant", "a2", "u2", "second reply"),
+                          _rec("user", "u3", "a2", "continues in a terminal"),
+                          _rec("assistant", "a3", "u3", "out-of-band reply")])
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        class ArmedButSpent:                            # the reg still carries the flag…
+            def rewind_flags(self, sid):
+                return ("a1", "a2", True)
+            def rewind_pending(self, sid):              # …but the transcript moved past the leaf
+                return False
+        saved_sdk = km._sdk
+        km._sdk = lambda: ArmedButSpent()
+        try:
+            km._rewind_holds_boot()
+        finally:
+            km._sdk = saved_sdk
+        self.assertIn(self.doomed, km.jd.load_goals(SID)["nodes"],
+                      "the old branch grew past the arm — restored, never latched forever")
+        self.assertIsNone(km._rewind_hold_get(SID), "the hold resolved at boot")
+        # while a GENUINELY pending rewind (leaf unchanged — disposition "apply") stays latched
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        class StillPending:
+            def rewind_pending(self, sid):
+                return True
+        km._sdk = lambda: StillPending()
+        try:
+            km._rewind_holds_boot()
+        finally:
+            km._sdk = saved_sdk
+        self.assertIsNotNone(km._rewind_hold_get(SID), "a verified-pending hold stays latched")
+        km._rewind_hold_clear(SID)
+
+    def test_an_unresolvable_cut_time_is_loud_never_a_silent_no_sweep(self):
+        # item 5: cut_t=None used to skip the sweep with NO log — contra the fail-loudly rule
+        km._arm_rewind_hold(object(), SID, None)
+        self.assertIn("revert-skipped", km.jd.ERRORS.read_text(), "an error row names the skip")
+        self.assertIsNone(km._rewind_hold_get(SID), "no hold is latched on an unknowable cut")
+
+    def test_the_boot_pass_resolves_a_hold_whose_event_fired_while_down(self):
+        # kernel restart mid-window: the take landed, no kernel was up to hear the event — boot
+        # resolves through the same discriminator instead of leaving the hold latched forever
+        self._transcript([_rec("user", "u1", None, "first ask"),
+                          _rec("assistant", "a1", "u1", "first reply"),
+                          _rec("user", "u2", "a1", "second ask"),
+                          _rec("assistant", "a2", "u2", "second reply"),
+                          _rec("user", "u3", "a1", "second ask, rewritten"),
+                          _rec("assistant", "a3", "u3", "new-branch reply")])
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        saved_sdk = km._sdk
+        km._sdk = lambda: None                         # no backend → nothing reports the rewind pending
+        try:
+            km._rewind_holds_boot()
+        finally:
+            km._sdk = saved_sdk
+        self.assertNotIn(self.doomed, km.jd.load_goals(SID)["nodes"])
+        self.assertIsNone(km._rewind_hold_get(SID))
+
+
+class RewindKeptLookupEconomy(unittest.TestCase):
+    """_rewind_kept_uuids runs on EVERY feed/chat build of a held session, for the whole armed
+    window — unbounded on a bare delete. Three properties pinned here: the kept walk memoizes on
+    the exact inputs that can change its answer (candidate-file stats, states stat, pending cut)
+    and re-walks the moment any of them moves; a still-LIVE session older than the 48h caption
+    window resolves through discover's cached wide walk instead of failing every build (a bare
+    delete freezes the transcript mtime at arm time, so a long-armed hold guarantees the 48h
+    miss); and a lookup that does fail is loud once per armed hold, never once per build (the
+    pre-fix shape appended one undeduplicated judge-errors row per ~5s rebuild, ~17k rows/day,
+    while the view silently widened to the bare-t hide)."""
+
+    T0 = 1781100000
+    CUT = T0 + 50
+
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        self._saved_state = km.jd.STATE
+        (self.td / "state").mkdir()
+        km.jd._rebind_state(self.td / "state")
+        km._rewind_holds[0] = None
+        self._saved_sessions = km._sessions
+        self._saved_discover = km.jd.discover
+        self._saved_cm = km.em.chain_membership
+        self._saved_sdk = km._sdk
+        km._rewind_kept_memo.clear()
+        km._rewind_kept_err.clear()
+        jd = km.jd
+        s = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+             "placementsV": jd.PLACEMENTS_V}
+        jd.apply_plan(s, "s1", self.T0, [{"do": "mint", "why": "x", "text": "Pre-cut survivor"}], [])
+        jd.apply_plan(s, "s2", self.T0 + 100, [{"do": "mint", "why": "x", "text": "Doomed ask"}],
+                      jd.open_menu(s))
+        jd.apply_plan(s, "s3", self.CUT + 30, [{"do": "mint", "why": "x", "text": "Fresh ask"}],
+                      jd.open_menu(s), prompt_uuid="u3")   # kept-chain anchor, born in range
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        self.survivor, self.doomed, self.fresh = ("%s:g1" % SID, "%s:g2" % SID, "%s:g3" % SID)
+
+    def tearDown(self):
+        km._sdk = self._saved_sdk
+        km.em.chain_membership = self._saved_cm
+        km.jd.discover = self._saved_discover
+        km._sessions = self._saved_sessions
+        km._rewind_holds[0] = None
+        km._rewind_kept_memo.clear()
+        km._rewind_kept_err.clear()
+        km.jd._rebind_state(self._saved_state)
+
+    def _transcript(self, register=True):
+        """u2/a2 rewound away (u3 branches from a1): kept = u1,a1,u3,a3."""
+        p = self.td / (SID + ".jsonl")
+        with open(p, "w") as f:
+            for r in [_rec("user", "u1", None, "first ask"),
+                      _rec("assistant", "a1", "u1", "first reply"),
+                      _rec("user", "u2", "a1", "second ask"),
+                      _rec("assistant", "a2", "u2", "second reply"),
+                      _rec("user", "u3", "a1", "second ask, rewritten"),
+                      _rec("assistant", "a3", "u3", "new-branch reply")]:
+                f.write(json.dumps(r) + "\n")
+        if register:
+            km._sessions = lambda now: [{"sid": SID, "path": str(p)}]
+        return str(p)
+
+    def _count_walks(self):
+        calls, real = [], self._saved_cm
+        def counting(*a, **k):
+            calls.append(1)
+            return real(*a, **k)
+        km.em.chain_membership = counting
+        return calls
+
+    def test_the_kept_walk_memoizes_on_the_fileset_and_busts_on_change(self):
+        p = self._transcript()
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        calls = self._count_walks()
+        feed = km._feed_goals(SID)
+        self.assertIn(self.fresh, feed["nodes"], "premise: the kept exemption is live")
+        self.assertNotIn(self.doomed, feed["nodes"])
+        km._feed_goals(SID)
+        self.assertEqual(len(calls), 1, "an unchanged transcript is walked once, not once per build")
+        with open(p, "a") as f:                        # a record lands → the stat moves
+            f.write(json.dumps(_rec("user", "u4", "a3", "more work")) + "\n")
+        km._feed_goals(SID)
+        self.assertEqual(len(calls), 2, "a transcript change is a new world — re-walk")
+        km._feed_goals(SID)
+        self.assertEqual(len(calls), 2, "…and the new answer memoizes in turn")
+        km._rewind_hold_clear(SID)
+        self.assertNotIn(str(SID), km._rewind_kept_memo, "the memo dies with the hold")
+
+    def test_a_changed_pending_cut_busts_the_memo(self):
+        self._transcript()
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        cut = [""]
+        class Cutter:
+            def pending_cut(self, sid):
+                return cut[0]
+        km._sdk = lambda: Cutter()
+        calls = self._count_walks()
+        km._feed_goals(SID)
+        km._feed_goals(SID)
+        self.assertEqual(len(calls), 1)
+        cut[0] = "a1"                                  # the cut changes the parse with NO file change
+        km._feed_goals(SID)
+        self.assertEqual(len(calls), 2, "arming/clearing the cut must bust the memo (the _parse lesson)")
+
+    def test_a_failing_lookup_is_loud_once_per_hold_and_never_cached(self):
+        km._sessions = lambda now: []                  # no transcript anywhere:
+        km.jd.discover = lambda now, window=None, forks=True: []   # 48h set AND wide walk miss
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        feed = km._feed_goals(SID)
+        self.assertNotIn(self.doomed, feed["nodes"], "the hide degrades to t-keyed, never to nothing")
+        km._feed_goals(SID)
+        km._feed_goals(SID)
+        self.assertEqual(km.jd.ERRORS.read_text().count("rewind-kept"), 1,
+                         "three builds, one row — loud once per armed hold, not per build")
+        self.assertNotIn(str(SID), km._rewind_kept_memo, "a failure is never memoized")
+        km._rewind_hold_clear(SID)
+        km._rewind_hold_set(SID, self.CUT, "a2")       # a NEW hold is a fresh complaint
+        km._feed_goals(SID)
+        self.assertEqual(km.jd.ERRORS.read_text().count("rewind-kept"), 2)
+
+    def test_a_live_session_older_than_the_caption_window_keeps_its_kept_exemption(self):
+        # the 48h set misses the sid while it is still live on every surface (DEATH_BACKFILL wide
+        # walk keeps it visible there) — pre-fix the kept lookup failed on EVERY build of such a
+        # session: a deterministic silent widening to the bare-t hide (the fresh kept-chain card
+        # vanished) plus unbounded log growth. Liveness owns visibility; age owns nothing.
+        p = self._transcript(register=False)
+        km._sessions = lambda now: []                  # idle past the caption window
+        km.jd.discover = (lambda now, window=None, forks=True:
+                          [(SID, Path(p), SID, "web")] if window else [])
+        km._rewind_hold_set(SID, self.CUT, "a2")
+        feed = km._feed_goals(SID)
+        self.assertIn(self.fresh, feed["nodes"], "the kept-chain card stays visible past 48h")
+        self.assertNotIn(self.doomed, feed["nodes"], "…while the doomed card still hides")
+        errs = km.jd.ERRORS.read_text() if km.jd.ERRORS.exists() else ""
+        self.assertNotIn("rewind-kept", errs, "no degrade row — the lookup simply succeeds")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -575,6 +575,41 @@ class TwoPhaseRewindTiming(unittest.TestCase):
         self.assertIn("revert-skipped", km.jd.ERRORS.read_text(), "an error row names the skip")
         self.assertIsNone(km._rewind_hold_get(SID), "no hold is latched on an unknowable cut")
 
+    def test_the_one_time_migration_runs_once_and_marks_itself_done(self):
+        # the boot migration cleans the pre-fix residue (dead-branch orphans on dormant sessions the
+        # cadence-riding reconciliation never revisits) exactly once, marker-gated in state
+        calls = []
+        saved = km.jd.run_rewound_reconcile
+        km.jd.run_rewound_reconcile = lambda **kw: calls.append(kw) or (3, 0)
+        try:
+            km._rewind_migration_bg()
+            km._rewind_migration_bg()
+        finally:
+            km.jd.run_rewound_reconcile = saved
+        self.assertEqual(len(calls), 1, "the second boot found the marker and did nothing")
+        self.assertGreater(calls[0].get("window") or 0, 86400 * 365,
+                           "migration discovery reaches far past the 48h caption horizon")
+        marker = km.jd.STATE / "rewind-reconcile-migration-v2.done"
+        self.assertTrue(marker.exists())
+        self.assertEqual(json.loads(marker.read_text()).get("archived"), 3)
+
+    def test_the_migration_marker_waits_for_a_zero_failure_pass(self):
+        # "returned" is not "succeeded": per-session errors are swallowed loudly inside the pass,
+        # and a marker written over a failed DORMANT session skips its orphans forever (steady-state
+        # discovery never reaches it, and the marker blocks the wide re-run). A dirty pass leaves
+        # the marker unwritten; the clean retry writes it.
+        saved = km.jd.run_rewound_reconcile
+        marker = km.jd.STATE / "rewind-reconcile-migration-v2.done"
+        try:
+            km.jd.run_rewound_reconcile = lambda **kw: (2, 1)      # one session failed this boot
+            km._rewind_migration_bg()
+            self.assertFalse(marker.exists(), "a dirty pass writes no marker — retry next boot")
+            km.jd.run_rewound_reconcile = lambda **kw: (1, 0)      # the retry comes back clean
+            km._rewind_migration_bg()
+            self.assertTrue(marker.exists(), "the clean pass marks itself done")
+        finally:
+            km.jd.run_rewound_reconcile = saved
+
     def test_the_boot_pass_resolves_a_hold_whose_event_fired_while_down(self):
         # kernel restart mid-window: the take landed, no kernel was up to hear the event — boot
         # resolves through the same discriminator instead of leaving the hold latched forever

--- a/tests/test_sdk_rewind.py
+++ b/tests/test_sdk_rewind.py
@@ -244,6 +244,65 @@ class RollbackAndPendingCut(unittest.TestCase):
             be = _StubBackend(os.path.join(tmp, "sdk"))
             self.assertEqual(sb.SdkBackend.pending_cut(be, SID), "")
 
+    # ── rewind_pending, EXECUTED (same stub world) ────────────────────────────────────────────
+    # The boot pass keeps a hold latched only on this probe (D8: raw flag presence latched holds
+    # forever after an out-of-band continuation), but the kernel-side tests stub the backend —
+    # nothing ran the real leaf-verified join, so a regression here (a wrong fsid for a
+    # resume-forked transcript, say) would silently re-open the forever-latched-hold hole with
+    # every kernel test still green.
+
+    def test_rewind_pending_while_the_leaf_is_unmoved(self):
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HOME": tmp}):
+            be = self._fixture(tmp)
+            self.assertTrue(sb.SdkBackend.rewind_pending(be, SID),
+                            "an unconsumed rewind against an unmoved leaf is still applicable")
+
+    def test_rewind_pending_goes_false_once_the_transcript_moves(self):
+        # THE regression test for the D8 fix: raw flag presence would return True here — the flag
+        # is still armed in the session — but the leaf moved, so the rewind is spent and a boot
+        # hold keyed on it must resolve instead of latching forever
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HOME": tmp}):
+            be = self._fixture(tmp, leaf_moved=True)
+            self.assertFalse(sb.SdkBackend.rewind_pending(be, SID))
+
+    def test_rewind_pending_reads_the_reg_for_a_dead_session(self):
+        # kernel restart mid-pending: no live SdkSession, the reg carries the flag + cwd/lastSid
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HOME": tmp}):
+            be = self._fixture(tmp)
+            reg = {"cwd": be.sessions[SID].cwd, "lastSid": "", "rewindTo": "t1",
+                   "rewindLeaf": "l1", "rewindBare": True}
+            del be.sessions[SID]
+            sb.write_reg(be.state_dir, SID, reg)
+            self.assertTrue(sb.SdkBackend.rewind_pending(be, SID))
+
+    def test_rewind_pending_follows_a_resume_fork(self):
+        # pins the fsid = resume_sid-or-sid join: the forked session's CURRENT transcript is the
+        # fork file, and it moved past the recorded leaf — reading the pre-fork file instead
+        # would call the rewind still pending and re-latch a spent hold
+        from unittest import mock
+        fork = "22222222-3333-4444-5555-666666666666"
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HOME": tmp}):
+            be = self._fixture(tmp)                    # SID's own transcript leaf is UNMOVED
+            fp = sb.transcript_path(be.sessions[SID].cwd, fork)
+            os.makedirs(os.path.dirname(fp), exist_ok=True)
+            with open(fp, "w") as f:
+                f.write(json.dumps({"type": "user", "uuid": "l1"}) + "\n")
+                f.write(json.dumps({"type": "assistant", "uuid": "l2"}) + "\n")
+            be.sessions[SID].resume_sid = fork
+            self.assertFalse(sb.SdkBackend.rewind_pending(be, SID),
+                             "the fork transcript moved past the leaf — spent, not pending")
+
+    def test_rewind_pending_is_bare_agnostic(self):
+        # unlike pending_cut (bare-only by design), the probe answers for EDIT rewinds too — a
+        # boot hold from an edit gesture must stay latched while its rewind is genuinely pending
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"HOME": tmp}):
+            be = self._fixture(tmp, bare=False)
+            self.assertTrue(sb.SdkBackend.rewind_pending(be, SID))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Goals minted from turns that a rewind later abandons survive `drop_goals_after`'s one-shot `t >= cut_t` sweep by five independent routes. The orphan then behaves like a live card: it holds a column, it blocks rollups, and the auto-nudge eventually quotes it ("Still open on this:", `kernel/kernel.py:921`) into a conversation that has no memory of the turn that spawned it. This PR replaces bare-timestamp reasoning with one exported chain-identity predicate, makes the sweep fire on the branch-take instead of the arm, and adds a reconciliation for the rewinds the kernel never drives. Four commits that drop cleanly from the tail; all tests were written to fail on the unfixed code.

## What breaks

Each route is reproducible on the current tip:

1. **The judge parses the world the user already deleted.** During an armed bare rollback the kernel's display parse passes `leaf_override` so every surface renders the cut conversation now (`kernel/kernel.py:12712`), but the judge's `parsed_session` passes none (`kernel/judge.py:1581`), and the pass frame pins the first parse for the whole pass. So a judge pass framed before (or during) the armed window mints from the abandoned tail after the sweep already ran. Repro: arm a bare rollback, let a planner pass run before the next message lands; the deleted ask comes back as a fresh card.
2. **A concurrent save resurrects a swept node.** `save_goals`' rebase honors only `mergedFrom` tombstones (`kernel/judge.py:2247`). A writer holding a pre-sweep snapshot republishes the swept node, which then sits in the live store and in goals-archive at once. Dual-resident node ids are the fingerprint: any deployment store that has seen rewinds can be audited for ids present in both files.
3. **Rewinds the kernel never sees clean up nothing.** The CLI's native Esc-Esc rewind and `forkAt` resumes apply `--resume-session-at` with no sweep ever, and a cut whose message time cannot be resolved (`cut_t=None`) skips the sweep silently (`kernel/kernel.py:12790`).
4. **The sweep fires at the wrong event.** `_rewind_send`/`_rewind_rollback` archive at ARM time (`kernel/kernel.py:12791`, `12832`). A refused or dissolved rewind leaves the conversation intact with its goals already archived (the inverse bug), and a mint landing between arm and take escapes the one-shot sweep forever.
5. **Task-store mirrors re-mint.** A rewind deliberately does not roll back the agent's own task list, so plan-sync re-mints mirrors of to-dos declared in abandoned turns. This PR pins that as intended behavior (the task store is authoritative) with a test and a comment, so it reads as a decision rather than an omission.

## The fix

- `0202b97` **Transcript-tail LRU cache takes a lock.** Cache hits mutate (LRU pop+reinsert) and evictions iterate; the predicate below adds cross-thread callers (judge workers, the SDK loop's resolution callback). A lost race would make the rewind guard fail open. Standalone and safe on its own.
- `dee2943` **Chain identity replaces the timestamp sweep in the judge.** `em.chain_membership` is the one exported predicate, built from the display parse's exact inputs (resume-fork links, lineage closure, pending cut), so no consumer can disagree with what the user sees. The judge honors the backend's pending cut (`set_pending_cut_provider`, `leaf_override`); every planner mint site gets a write-moment stand-down that retires the unit by filing its placement key (a skipped key would wedge the nudge's placement gate) and defers on merely-pending evidence; swept nodes leave `rewindSwept` tombstones the rebase honors, with deterministic same-second sweep/restore ordering and a serialized goals-archive read-modify-write (the tombstones turn a lost archive write from resurrection into permanent loss, so the blind overwrite had to go); an event-keyed reconciliation rides the triage cadence and archives goals anchored on branches that are dead on disk, covering route 3's unseen rewinds, including dead branches inside pre-`/clear` episode files.
- `7a6285c` **Two-phase rewind timing in the kernel.** The gesture latches a persisted hold that hides exactly what the take will archive, on every surface; the archive lands only at the branch-take (the backend's flag-consumption events: taken / failed / spent); a failed rewind restores by dropping the hold; a spent flag is discriminated by the recorded leaf's chain membership, and anything unprovable restores, because a card move needs proof. `cut_t=None` is now a loud error row. The existing source-pin assertions in `tests/test_kernel_rewind.py` (lines 285-303 at the base) assert the arm-time call and are revised in the same commit.
- `c6a1ff6` **One-time boot migration**, marker-gated, archive-only, and the marker waits for a zero-failure pass. This is the PR's only behavior change for deployments that never touch the rewind UI, and it is kept last so you can defer or drop it: without it the reconciliation still cleans every session the cadence reaches, just not the dormant backlog. Archived cards remain recoverable from goals-archive.

Timestamps remain only as the fate of legacy nodes whose chain membership is unprovable, and user-restored cards (`rewindRestored`) outrank any later time-overlapping sweep.

## Interaction with the nudge-gate rework (3a13f798)

Checked explicitly against the reworked gates: a held (gesture-hidden) card cannot be nudge-quoted anywhere in the arm-to-take window. The fire path's session gates run before `_nudge_fire_list`: an armed bare rollback is gated by `pending_cut` (leaf-verified, with a registry fallback covering restarts), an edit rewind by its queued replacement text, and the in-turn window by the working check. Once the take resolves, the swept nodes are out of the live store; a failed rewind restores them, and nudging a restored live card is correct. The write-moment stand-down retires by filing placements, so the new gates' ledger sees every unit filed.

## Tests

75 tests fail on the unfixed base and pass with the fix: `tests/test_judge_rewind_cleanup.py` (new, 38 tests: predicate parity with the display parse, pending-cut honor, both mint seams, reconciliation selection and event gates), `tests/test_kernel_rewind.py` (+22, two-phase timing, hold view, boot pass, kept-lookup economy, migration gate), `tests/test_judge_revert.py` (+9 failing of 11 added, tombstones, serialization, tie ordering), `tests/test_sdk_rewind.py` (+5, the leaf-verified pending probe against real transcript graphs), and the cache thread-safety class. Full pytest (5003 passed), bats, and the vscode-extension typecheck/test/build pass locally. All fixtures are synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)