### PR TITLE
Keep per-session worktrees inside the repo under worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 # path and private strings, none of which mean anything on anyone else's clone.
 # Untracked on purpose so a contributor's test run never trips over it.
 tests/test_no_personal_identifiers.py
+
+# Per-session worktrees live inside the repo (see CLAUDE.md "Worktrees")
+/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,16 @@ This repo may go public; assume every commit is permanent and world-readable.
 Do ALL non-trivial work on its own git worktree, not the shared main tree — concurrent
 peer sessions clobber/commit each other's uncommitted edits in the shared tree (a peer's
 broad `git add` will sweep up your work). Conventions:
-- **One worktree per session, named after the session.** Branch + directory take the
-  session's name, e.g. session `bugsdk2` → branch `bugsdk2`, dir `../romp-bugsdk2`
-  (`git worktree add -b <session> ../romp-<session> HEAD`). So a glance at
-  `git worktree list` says who owns what.
+- **One worktree per session, named after the session, inside the repo** (user rule,
+  2026-08-21 — previously sibling `../romp-<session>` dirs). Branch takes the session's
+  name and the tree lives under `worktrees/`, e.g. session `bugsdk2` → branch `bugsdk2`,
+  dir `worktrees/bugsdk2` (`git worktree add -b <session> worktrees/<session> HEAD`). So
+  a glance at `git worktree list` says who owns what, and the parent directory stays one
+  folder per project. `/worktrees/` is gitignored, and the root `conftest.py` keeps a
+  bare `pytest` run at the repo root from collecting the nested trees' test suites. A
+  leftover sibling `../romp-<session>` dir from before the change migrates with
+  `git worktree move ../romp-<x> worktrees/<x>` whenever its owner next touches it —
+  never move one that isn't yours.
 - **Never commit on the shared `main` checkout** (user rule, 2026-07-24). Branches and
   worktrees are how work happens here, with no "quick one in main" exception. A commit
   that lands on the local `main` branch and is not pushed immediately makes local `main`
@@ -97,7 +103,7 @@ broad `git add` will sweep up your work). Conventions:
      `gh pr merge --auto --merge` — it lands itself when the six required Linux
      checks pass. There is no way to move `main` except a green PR.
 - **Clean up when finished.** After publishing, remove the worktree
-  (`git worktree remove ../romp-<session>`) and delete its branch — don't leave stale
+  (`git worktree remove worktrees/<session>`) and delete its branch — don't leave stale
   worktrees lying around.
 - **When you do touch the shared tree** (reading, or an explicit "do this in main"), use
   a focused `git add <paths>` — never `git add -A`, which sweeps peers' edits — and never

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+# Per-session worktrees live at worktrees/<session> (see CLAUDE.md "Worktrees");
+# keep a bare `pytest` at the repo root from collecting the nested checkouts.
+collect_ignore = ["worktrees"]


### PR DESCRIPTION
One project = one top-level folder: per-session worktrees now live at `worktrees/<session>` instead of sibling `../romp-<session>` dirs (maintainer rule, 2026-08-21).

- `CLAUDE.md`: the Worktrees convention now prescribes `git worktree add -b <session> worktrees/<session> HEAD`, with a migration note for leftover sibling dirs (move only your own).
- `.gitignore`: ignore `/worktrees/` so nested checkouts never show as untracked in the shared tree.
- `conftest.py` (new, root): `collect_ignore = ["worktrees"]` so a bare `pytest` at the repo root doesn't collect nested checkouts' test suites. CI is unaffected (fresh checkouts have no `worktrees/`); this guards local runs.

Docs/config only — no behavior change. Full local suite: 4934 passed, 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)