### PR TITLE
A held send looks staged: the files strip says it, counts it, and offers Cancel

### DIFF
--- a/ui/webview/composer-ship-gate.test.ts
+++ b/ui/webview/composer-ship-gate.test.ts
@@ -51,6 +51,20 @@ test("the OPEN gate dialog resolves itself on the last ack: closes and sends, no
   assert.match(RENDER, /if \(gateWasOpen\) \{ shipGateSid = null; closeConfirm\(null\); \}/);
 });
 
+test("a held send LOOKS staged: the files strip wears the staged head with a live count and a Cancel", () => {
+  // the user 2026-08-22: after "Wait for the upload" the only cue was the dimmed send button, which
+  // read as nothing happening. The head rides renderComposerFiles — the renderer that already runs
+  // on the wait click, every ack, and every tab switch, so the line tracks exactly those events.
+  assert.match(RENDER, /if \(id && sendOnShip\.has\(id\)\) \{\s*\n\s*const head = el\("div", "staged-head held-head"\);/);
+  assert.match(RENDER, /"staged — sends when the upload finishes"/);
+  assert.match(RENDER, /pending\.length > 1 \? " \(" \+ pending\.length \+ " still uploading\)" : ""/,
+    "the live count rides each ack's re-render");
+  assert.match(RENDER, /cancel\.addEventListener\("click", \(\) => \{ sendOnShip\.delete\(id\); renderComposerFiles\(id\); \}\);/,
+    "Cancel un-holds — message and attachments stay, nothing sends");
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.held-head \{ flex: 1 1 100%; \}/, "full-width: it owns the strip's top line");
+});
+
 test("any successful send supersedes a hold, so a spent hold can never double-send", () => {
   const hits = RENDER.match(/sendOnShip\.delete\(sid\);\s+\/\/ a send happened — any held one is superseded/g) || [];
   assert.equal(hits.length, 2, "both delivery paths (provisional queue and live route) clear it");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9334,6 +9334,24 @@ function renderComposerFiles(id: string | null): void {
   const pending = (id ? pendingShips.get(id) : undefined) || [];
   if (!paths.length && !pending.length) { strip.style.display = "none"; return; }
   strip.style.display = "flex";
+  // A held send IS a staged message and must LOOK like one (the user 2026-08-22): the same head line
+  // the staged strip wears — what will happen, live count, and the way out. Before this, the only
+  // cue after "Wait for the upload" was the dimmed send button, which read as nothing happening.
+  // Re-rendered here because this renderer already runs on the wait click, every ack, and every tab
+  // switch — the exact events the line must track.
+  if (id && sendOnShip.has(id)) {
+    const head = el("div", "staged-head held-head");
+    const lbl = el("span");
+    lbl.textContent = "staged — sends when the upload finishes"
+      + (pending.length > 1 ? " (" + pending.length + " still uploading)" : "");
+    lbl.title = "You chose to wait. The message sends itself the moment the last attachment lands.";
+    const cancel = el("button", "staged-go");
+    cancel.textContent = "Cancel";
+    cancel.title = "keep the message and attachments — just stop the automatic send";
+    cancel.addEventListener("click", () => { sendOnShip.delete(id); renderComposerFiles(id); });
+    head.append(lbl, cancel);
+    strip.appendChild(head);
+  }
   paths.forEach((p, i) => {
     const box = el("span", "composer-file");
     box.title = p + " — click opens it · ✕ removes";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -599,6 +599,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 #composer-files, #composer-staged, #composer-chips { flex: 1 1 100%; min-width: 0; max-width: 100%; }
 #composer-staged { flex-direction: column; gap: 3px; padding: 5px 8px 0; }
 .staged-head { display: flex; align-items: center; gap: 8px; font-size: 0.78em; color: var(--dim); letter-spacing: 0.02em; }
+/* the held-send head rides the FILES strip (a wrapping row): full-width so it owns the top line,
+   wearing the staged strip's exact dress — a held send IS a staged message (the user 2026-08-22) */
+.held-head { flex: 1 1 100%; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
 .staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }


### PR DESCRIPTION
User request 2026-08-22: choosing "Wait for the upload" (picture + message) gave no visual feedback that the message was queued — the only cue was the dimmed send button.

A held send is a **staged** send in the repo's vocabulary, so it now wears the staged strip's exact head dress at the top of the attachment strip: "staged — sends when the upload finishes", a live "(N still uploading)" count that updates on every ack, a hover explanation, and a **Cancel** that un-holds (message and attachments stay put, nothing sends). Rendered in `renderComposerFiles`, which already runs on the wait click, every ack, and every tab switch — exactly the events the line must track. One new CSS line (`.held-head` full-width); everything else reuses the staged classes.

Verified visually against the real stylesheet; test pins the head, the live count, and the Cancel un-hold. Suite passes (2,157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)