### PR TITLE
A dead session's stamped card converts to blocked instead of pausing forever

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9404,13 +9404,28 @@ def debt_block_why(peer):
             "Ping them again, take the work back, or drop the wait." % (DEBT_BLOCK_WHY_PREFIX, peer))
 
 
+DEAD_WAIT_WHY_PREFIX = "This session ended while still waiting on "
+
+
+def dead_wait_block_why(why):
+    """The block why for a judged wait whose OWNING session died with the stamp standing (the user
+    2026-08-22): nothing that could answer the wait is running, so more patience is a lie — the card
+    needs the user's call (revive, or drop the wait). The tail quotes the stamp's own why (what the
+    wait was on), a wait description, never user-question text — the same exact-shape rationale as
+    the debt block above."""
+    tail = (why or "").strip().rstrip(".")
+    return ("%s%s. Reviving the session picks the thread back up; replying here or clearing the "
+            "card drops the wait." % (DEAD_WAIT_WHY_PREFIX, tail or "background work"))
+
+
 def procedural_block_why(why):
     """True if `why` is romp's own procedural block bookkeeping rather than a decision the user was asked
-    for. EXACT match on the kernel-authored constants — plus the ONE prefix-recognized shape above (its
-    tail is a peer name, not question text): a real question that merely resembles one of these is still
-    a real question, so nothing fuzzy belongs here."""
+    for. EXACT match on the kernel-authored constants — plus the TWO prefix-recognized shapes above (their
+    tails are a peer name / a wait description, not question text): a real question that merely resembles
+    one of these is still a real question, so nothing fuzzy belongs here."""
     w = (why or "").strip()
-    return w in _PROCEDURAL_BLOCK_WHYS or w.startswith(DEBT_BLOCK_WHY_PREFIX)
+    return (w in _PROCEDURAL_BLOCK_WHYS or w.startswith(DEBT_BLOCK_WHY_PREFIX)
+            or w.startswith(DEAD_WAIT_WHY_PREFIX))
 
 
 # The BLOCK-DISTILLER (the user 2026-06-18, via business): the done-distiller's twin for a BLOCKED top.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3146,6 +3146,7 @@ def _auto_nudge_tick(now, tmux):
                              % (s.get("sid") or "?", traceback.format_exc()))
     try:
         _debt_backstop_tick(now)                       # reminder outcomes for debtors the walk can't reach
+        _dead_wait_sweep(alive_ids, nudged, now)       # dormant owners' stamped cards → procedural block
     except Exception:
         sys.stderr.write("debt-backstop: %s\n" % traceback.format_exc())
     try:
@@ -3397,6 +3398,89 @@ def _lift_spent_awaiting(now, tmux):
             sys.stderr.write("awaiting-lift (session %s): %s\n" % (sid or "?", traceback.format_exc()))
 
 
+_PREV_ALIVE = None                       # last tick's alive sids — a sid LEAVING is the death event
+
+
+def _dead_wait_sweep(alive_ids, nudged, now):
+    """Find DORMANT sessions whose Working cards still hold a judged awaiting stamp and convert each to
+    a procedural block (_dead_wait_block). Event-triggered, never a per-tick poll of every store: the
+    trigger is the DEATH TRANSITION (a sid leaving the alive set between ticks), plus one catch-up
+    sweep of all dormant stores on the first tick after boot — the same boot-re-audit pattern the
+    awaiting stamps already use — for sessions that died under a previous kernel (the two measured
+    cards had been dead 79 hours across many restarts)."""
+    global _PREV_ALIVE
+    prev, _PREV_ALIVE = _PREV_ALIVE, set(alive_ids)
+    if prev is None:
+        try:
+            cands = {f.stem for f in (jd.STATE / "goals").glob("*.json")} - set(alive_ids)
+        except OSError:
+            return
+    else:
+        cands = prev - set(alive_ids)
+    for sid in cands:
+        try:
+            store = jd.load_goals(sid)
+            nodes = store.get("nodes", {})
+            kids = {}
+            for nid, nd in nodes.items():
+                if nd.get("parentId"):
+                    kids.setdefault(nd["parentId"], []).append(nid)
+            answered = _peer_answered_at(sid)
+            for gid, st in (store.get("status") or {}).items():
+                if st != "working":
+                    continue
+                stamp = _goal_awaiting_stamp_full(nodes, gid, kids, answered_at=answered)
+                if stamp:
+                    _dead_wait_block(sid, gid, stamp[0], stamp[1], nudged, now)
+        except Exception:
+            sys.stderr.write("dead-wait sweep (%s): %s\n" % (sid, traceback.format_exc()))
+
+
+def _dead_wait_block(sid, gid, at, why, nudged, now):
+    """Convert a DORMANT session's stamped-awaiting Working card to a procedural block, once per stamp
+    episode (the user 2026-08-22, who expected every Working card nudged until it lands in Completed or
+    Blocked). Once-only rides the shared nudge ledger ({deadWait, anchor}; a genuinely NEW stamp episode
+    — newer anchor — re-arms, exactly the wake's own rule). Two stand-downs before writing, both keyed
+    on recorded events, never the clock:
+      - the session's last recorded STATE must be a genuine stop: an open-turn state (working/retrying/
+        compacting) means a restart CUT, and the resume machinery owns that card — blocking it would
+        race the resume nudge it is about to get;
+      - the stamp must still stand on a FRESH store read with the card still Working (the judges run
+        concurrently; record_verdict's own gate then refuses anything a newer user floor outranks).
+    The block's evidence time is the newest of the stamp anchor and the last state transition — the
+    settle the session actually recorded — never wall-clock (the diary is an evidence-time ledger).
+    Returns True when the block landed (the tick pushes once at the end)."""
+    rec = nudged.get(gid) or {}
+    if rec.get("deadWait") and (rec.get("anchor") or 0) >= at:
+        return False                                  # this stamp episode already converted
+    last, last_t = _last_state(sid)
+    if last in _PROGRESSING_STATES:
+        return False                                  # a cut mid-turn, not a settled death — resume owns it
+    try:
+        store = jd.load_goals(sid)
+        nd = store.get("nodes", {}).get(gid)
+        if (not nd or store.get("status", {}).get(gid, "working") != "working"
+                or not _goal_awaiting_stamp(store.get("nodes", {}), gid,
+                                            answered_at=_peer_answered_at(sid))):
+            return False                              # lifted or resolved since the walk read its snapshot
+        blkwhy = jd.dead_wait_block_why(nd.get("awaitingWhy") or why or "")
+        _ev = int(max(at or 0, last_t or 0) or now)
+        if jd.record_verdict(store, nd, "nudge", "block", _ev, why=blkwhy):
+            nd["mt"] = _ev                            # the event materialized blocked + blockWhy
+            jd.append_block(sid, gid, "nudge", blkwhy, _ev)   # journal before the save it protects (a judge
+            #                                           pass holding this store across its model call erases
+            #                                           the row on save; replay re-records it)
+            jd.rollup_status(store, False)
+            jd.save_goals(sid, store)
+            _mark_views_dirty()
+            nudged[gid] = {"deadWait": True, "anchor": at, "at": int(now)}
+            _put_nudged(gid, nudged[gid])
+            return True
+    except Exception:
+        sys.stderr.write("dead-wait block: %s\n" % traceback.format_exc())
+    return False
+
+
 def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
     """The AWAITING branch of _auto_nudge_session's goal walk — one stamped top goal. The stamp is a
     judged wait, so the plain status nudge stays off; but a wait is not an exemption from the ladder
@@ -3417,8 +3501,14 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
                 genuinely NEW stamp episode (anchor newer than the one that failed)."""
     at, why = stamp[0], stamp[1]
     if tmux.get(sid) is None:
-        return False                                 # dormant CLI → its work died with it; the death notice
-        #                                              owns that story, not a wake (same rule as the lifts)
+        # DORMANT owner (the user 2026-08-22): the CLI died while this judged wait still stood — and a
+        # stamped Working card on a dead session was exempt from the WHOLE ladder (this wake, the plain
+        # nudge, the staller), so it sat "paused" forever (two live cards measured at 79 hours). The
+        # death notice tells the CHAT what happened; nothing ever moved the CARD. Nothing that could
+        # answer the wait is running, so convert ONCE per stamp episode to a procedural block naming
+        # the dead wait — the same terminal an unanswered wake reaches — and let a revival's reply
+        # lift it like any block.
+        return _dead_wait_block(sid, gid, at, why, nudged, now)
     rec = nudged.get(gid) or {}
     if not rec.get("wake"):
         rec = {}                                     # a REGULAR nudge record (predates the stamp): the wake

--- a/tests/test_dead_wait_block.py
+++ b/tests/test_dead_wait_block.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""A DORMANT session's stamped-awaiting Working card converts to a procedural block (the user
+2026-08-22): the CLI died while a judged wait still stood, so nothing that could answer it is
+running — yet a live awaiting stamp exempted the card from the whole ladder (wake, nudge, staller)
+and it sat "paused" in Working forever (two live cards measured at 79 hours). The conversion is
+event-triggered (the death transition; a boot catch-up sweep), once per stamp episode, stands down
+for restart cuts (the resume machinery owns those), and its why is a recognized procedural block.
+SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+STAMP_T = 1781100000
+_N = [0]
+
+
+def _fresh_sid():
+    """A distinct sid per test: the goals-store cache is mtime-keyed, and same-second reseeds of one
+    sid would hand a later test the previous test's mutated store object."""
+    _N[0] += 1
+    return "11111111-2222-3333-4444-5555555555%02d" % _N[0]
+
+
+SID = ""
+GID = ""
+
+
+def _seed_store(awaiting=True):
+    store = jd.load_goals(SID)
+    nd = {"id": GID, "text": "delegate the batch and report", "parentId": None,
+          "nodeComplete": False, "blocked": False, "cleared": False, "t": STAMP_T - 100,
+          "mt": STAMP_T, "trail": [], "doneWhy": "",
+          "log": [{"ev_t": STAMP_T, "src": "closer", "kind": "awaiting",
+                   "why": "both workers' report-backs", "at": STAMP_T}]}
+    if awaiting:
+        nd["awaitingWhy"] = "both workers' report-backs"
+        nd["awaitingAt"] = STAMP_T
+        nd["awaitingKind"] = "peer"
+    store["nodes"][GID] = jd.GuardedNode(nd)
+    store["status"] = {GID: "working"}
+    jd.save_goals(SID, store)
+    return store
+
+
+def _write_state(state, t):
+    d = jd.STATE / "states"
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / (SID + ".jsonl"), "w") as f:
+        f.write(json.dumps({"state": state, "t": t}) + "\n")
+
+
+class DeadWaitBlock(unittest.TestCase):
+    def setUp(self):
+        global SID, GID
+        SID = _fresh_sid()
+        GID = SID + ":g1"
+        km._PREV_ALIVE = None
+        self.nudged = {}
+
+    def tearDown(self):
+        for d in (jd.GOALDIR, jd.STATE / "states"):
+            for f in d.glob("*"):
+                f.unlink()
+        p = jd.STATE / "auto-nudge.json"
+        if p.exists():
+            p.unlink()
+
+    def test_dormant_stamped_card_converts_to_a_recognized_procedural_block(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        fired = km._dead_wait_block(SID, GID, STAMP_T, "both workers' report-backs", self.nudged, STAMP_T + 900)
+        self.assertTrue(fired)
+        store = jd.load_goals(SID)
+        nd = store["nodes"][GID]
+        self.assertTrue(nd.get("blocked"), "the card lands in the terminal the ladder promises: blocked")
+        self.assertTrue(str(nd.get("blockWhy") or "").startswith(jd.DEAD_WAIT_WHY_PREFIX))
+        self.assertIn("both workers' report-backs", nd.get("blockWhy") or "",
+                      "the brief names WHAT died with the session")
+        self.assertTrue(jd.procedural_block_why(nd.get("blockWhy")),
+                        "a dead wait is romp bookkeeping — the briefer must not invent a decision")
+        # the evidence time is the newest recorded event (the settle), never wall-clock now
+        blk = [e for e in nd.get("log", []) if e.get("kind") == "block"][-1]
+        self.assertEqual(blk.get("ev_t"), STAMP_T + 50)
+
+    def test_an_open_turn_last_state_stands_down_for_the_resume_machinery(self):
+        _seed_store()
+        _write_state("working", STAMP_T + 50)   # a restart CUT — the resume nudge owns this card
+        self.assertFalse(km._dead_wait_block(SID, GID, STAMP_T, "w", self.nudged, STAMP_T + 900))
+        self.assertFalse(jd.load_goals(SID)["nodes"][GID].get("blocked"))
+
+    def test_once_per_stamp_episode_and_a_new_anchor_rearms(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        self.assertTrue(km._dead_wait_block(SID, GID, STAMP_T, "w", self.nudged, STAMP_T + 900))
+        self.assertFalse(km._dead_wait_block(SID, GID, STAMP_T, "w", self.nudged, STAMP_T + 950),
+                         "same episode never converts twice")
+        # a genuinely NEW stamp episode (newer anchor) re-arms — but the fresh-store guard still
+        # refuses while the card sits blocked, so no double-block either
+        self.assertFalse(km._dead_wait_block(SID, GID, STAMP_T + 100, "w", self.nudged, STAMP_T + 990))
+
+    def test_a_lifted_stamp_or_resolved_card_stands_down(self):
+        _seed_store(awaiting=False)             # no live stamp on the fresh read
+        _write_state("idle", STAMP_T + 50)
+        self.assertFalse(km._dead_wait_block(SID, GID, STAMP_T, "w", self.nudged, STAMP_T + 900))
+
+    def test_boot_catchup_sweep_converts_dormant_stores_and_spares_alive_ones(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = None                   # first tick after boot
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        self.assertTrue(jd.load_goals(SID)["nodes"][GID].get("blocked"), "boot catch-up found the dead wait")
+        # …and an ALIVE session is never swept: reseed and list it as alive
+        self.tearDown(); self.setUp()
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = None
+        km._dead_wait_sweep({SID}, self.nudged, STAMP_T + 900)
+        self.assertFalse(jd.load_goals(SID)["nodes"][GID].get("blocked"))
+
+    def test_death_transition_triggers_between_ticks(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = {SID}                  # was alive last tick…
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)   # …gone this tick: the death event
+        self.assertTrue(jd.load_goals(SID)["nodes"][GID].get("blocked"))
+
+    def test_wake_goal_routes_its_dormant_branch_here(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("return _dead_wait_block(sid, gid, at, why, nudged, now)", src)
+        self.assertIn("_dead_wait_sweep(alive_ids, nudged, now)", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -585,11 +585,20 @@ class AwaitingWake(unittest.TestCase):
         self._seed(at=now - 7 * 3600)                # the closer filed a genuinely NEW wait
         self.assertTrue(self._wake(now, rec=rec), "a fresh anchor re-arms the wake")
 
-    def test_dormant_session_is_not_woken(self):
+    def test_dormant_session_is_not_woken_but_converts_to_the_dead_wait_block(self):
+        # (the user 2026-08-22) a dormant CLI still gets no WAKE — its dispatched work is gone, not
+        # asleep — but the branch no longer dead-ends: the stamped Working card converts once to the
+        # dead-wait procedural block, so it reaches a terminal column instead of pausing forever.
         now = 1_000_000
         self._seed(at=now - 7 * 3600)
-        self.assertFalse(self._wake(now, tmux={}))   # SID not in the live set → not a live CLI
-        self.assertEqual(self.fb.sent, [], "a dormant session's dispatched work is gone, not asleep")
+        (km.jd.STATE / "states").mkdir(parents=True, exist_ok=True)
+        (km.jd.STATE / "states" / (SID + ".jsonl")).write_text(
+            json.dumps({"state": "idle", "t": now - 6 * 3600}) + "\n")
+        self.assertTrue(self._wake(now, tmux={}), "the conversion fired (the tick pushes once)")
+        self.assertEqual(self.fb.sent, [], "no wake message: nothing that could answer is running")
+        nd = km.jd.load_goals(SID)["nodes"][self.gid]
+        self.assertTrue(nd.get("blocked"), "the card lands in Blocked, the ladder's promised terminal")
+        self.assertTrue(str(nd.get("blockWhy") or "").startswith(km.jd.DEAD_WAIT_WHY_PREFIX))
 
     def test_wake_that_judges_resolved_mid_tick_stands_down(self):
         now = 1_000_000


### PR DESCRIPTION
User-approved fix for the 'paused tasks in Working' report (2026-08-22): the ladder promises every Working card a terminal — nudged or woken until it lands in Completed or Blocked — but a **dormant owner** broke the promise. The wake exempts dead CLIs entirely (correctly: their dispatched work is gone, not asleep), the plain nudge is stamp-exempted, and nothing ever moved the *card*: two live cards sat in Working for 79 hours holding `kind: peer` awaiting stamps for peers that had gone idle without ever replying.

## What changes
- **The conversion**: when a session dies while a judged awaiting stamp still stands on a Working card, the card converts once per stamp episode to a procedural block — "This session ended while still waiting on <the stamp's own why>. Reviving the session picks the thread back up; replying here or clearing the card drops the wait." The why is prefix-recognized by `procedural_block_why`, so the briefer's procedural path applies and no decision brief is invented (the same shape as the debt block).
- **Event-triggered, never a poll**: the trigger is the death transition (a sid leaving the alive set between ticks) plus one boot catch-up sweep for sessions that died under a previous kernel — the same boot-re-audit pattern the awaiting stamps already use. The two measured stuck cards get healed by the catch-up on the first restart after this lands.
- **Two event-keyed stand-downs**: an open-turn last state (working/retrying/compacting) is a restart *cut* — the resume machinery owns that card, and blocking it would race the resume nudge; and the stamp must still stand on a fresh store read with the card still Working (`record_verdict`'s own gate then refuses anything a newer user floor outranks). The block's evidence time is the newest recorded event (stamp anchor / last state transition), never wall-clock.
- The wake's dormant branch routes here instead of dead-ending; a live session's dead *peer* was already covered (the wake fires past the 6-hour backstop and escalates unanswered — unchanged).

## Tests
`tests/test_dead_wait_block.py`: the conversion end-to-end (block lands, recognized why, evidence time = the settle), the restart-cut stand-down, once-per-episode, lifted-stamp stand-down, the boot catch-up, the death-transition trigger, and alive sessions spared. The dormant-wake test updated to the new contract (no wake message still, but the card reaches its terminal). Suites: python 5147 passed, UI 2196 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)