### PR TITLE
Comment ants ride on top of the solid highlight, at a third of the speed

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -329,11 +329,14 @@ test("ticks and message notches share ONE scrollbar frame, so they can never dis
   assert.match(UI, /kids\[i\]\.style\.top = t\.y \+ "px";/);
 });
 
-test("while the thread is WRITING the region wears marching ants; the fill lands with the reply", () => {
+test("while the thread is WRITING the region wears marching ants ON TOP of the solid fill", () => {
   assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
   // a dashed outline whose dashes crawl around the box — four gradient strips, animated offsets,
-  // no fill, never a border (it would shift the inline text); solid returns when busy drops
-  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: transparent;\s*\n\s*background-image:\s*\n\s*repeating-linear-gradient/);
+  // the solid tint STAYS under the ants (the user 2026-08-23: no more mixed half-dashed phase, the
+  // only state change is the ants appearing); never a border (it would shift the inline text)
+  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--cmt-hl\) 30%, transparent\);\s*\n\s*background-image:\s*\n\s*repeating-linear-gradient/);
+  assert.match(CSS, /animation: cmt-ants 3\.6s linear infinite;/, "3× slower than the original 1.2s march");
+  assert.doesNotMatch(CSS, /cmt-ants 1\.2s/, "no fast march survives anywhere");
   // each no-repeat strip is oversized by one 12px dash period along its travel axis and starts a
   // period back, and the keyframe travels exactly that period — a strip sized to its edge slid open
   // a gap that snapped shut every cycle, a visible lurch on text-height vertical edges (2026-08-19)

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2521,13 +2521,17 @@ mark.cmt-hl {
 mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
 mark.cmt-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
 mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
-/* WRITING (the user 2026-08-17): while the thread is mid-reply the region wears MARCHING ANTS —
-   a dashed outline whose dashes crawl slowly around the box — and turns into the solid highlight
-   the moment the reply lands (the busy class drops with the thread's working state). Four gradient
-   strips with an animated offset, never a border: an inline border would shift the text it wraps.
-   This rule must stay AFTER :hover — its shorthand would otherwise wipe the strips mid-hover. */
+/* WRITING (the user 2026-08-17; reshaped 2026-08-23): while the thread is mid-reply the region
+   wears MARCHING ANTS — a dashed outline whose dashes crawl slowly around the box — ON TOP of the
+   solid highlight, which never turns off. (It used to: the busy state blanked the tint and showed
+   only the ants, and the equation host flipped on a different rule than the text marks, so a
+   comment spanning text + math passed through a mixed phase — half dashed, half highlighted —
+   before settling. Keeping the tint underneath removes the phase by construction: the only state
+   change is the ants appearing.) Four gradient strips with an animated offset, never a border: an
+   inline border would shift the text it wraps. This rule must stay AFTER :hover — its shorthand
+   would otherwise wipe the strips mid-hover. */
 mark.cmt-hl.busy {
-  background-color: transparent;
+  background-color: color-mix(in srgb, var(--cmt-hl) 30%, transparent);
   background-image:
     repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
     repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
@@ -2536,7 +2540,7 @@ mark.cmt-hl.busy {
   background-size: calc(100% + 12px) 1.5px, calc(100% + 12px) 1.5px, 1.5px calc(100% + 12px), 1.5px calc(100% + 12px);
   background-position: -12px 0, 0 100%, 0 0, 100% -12px;
   background-repeat: no-repeat;
-  animation: cmt-ants 1.2s linear infinite;
+  animation: cmt-ants 3.6s linear infinite;   /* 3× slower (the user 2026-08-23) */
 }
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
@@ -2552,7 +2556,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    stay solid and defeat the outline-then-fill cue */
 .md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),
 .md .katex.cmt-hl-host:has(mark.cmt-hl.busy) {
-  background-color: transparent;
+  background-color: color-mix(in srgb, var(--cmt-hl) 30%, transparent);
   background-image:
     repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
     repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
@@ -2561,9 +2565,9 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   background-size: calc(100% + 12px) 1.5px, calc(100% + 12px) 1.5px, 1.5px calc(100% + 12px), 1.5px calc(100% + 12px);
   background-position: -12px 0, 0 100%, 0 0, 100% -12px;
   background-repeat: no-repeat;
-  animation: cmt-ants 1.2s linear infinite;
+  animation: cmt-ants 3.6s linear infinite;   /* 3× slower (the user 2026-08-23) */
 }
-.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: var(--code-bg); }
+.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host > mark.cmt-hl { background: transparent; }
 .md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }


### PR DESCRIPTION
User report 2026-08-23: commenting on a passage spanning text and an equation showed a mixed phase — the equation wearing a dashed outline while the text stayed highlighted, then the whole region dropping its highlight for dashes-only. Root cause: the busy (mid-reply) state blanks the solid tint to show the marching ants, and the KaTeX host flips on a different rule (`:has`) than the text marks, so the two switch at different moments.

Per the user's design: the solid highlight now never turns off — the ants march on top of it while the thread is writing (background-color kept under the gradient strips, on marks, inline-code hosts, and math hosts alike), so the only state change is the ants appearing and disappearing. The march also slows from 1.2s to 3.6s per dash cycle (three times slower, as requested).

Verified headless: tint on, ants on, 3.6s period, screenshot of text+equation both highlighted with ants. Pins updated (tint-under-ants, the 3.6s period, no fast march anywhere). Suite passes (2,212).

🤖 Generated with [Claude Code](https://claude.com/claude-code)