### PR TITLE
The comment popover sheds the transcript-coupled hover chrome

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -80,6 +80,20 @@ test("threadsByAnchor groups threads per turn", () => {
   assert.equal(by.get("a1")!.length, 2);
 });
 
+test("the popover keeps the chat renderer but sheds its transcript-coupled hover chrome", () => {
+  // the user 2026-08-23, with a recording: hovering inside the comment box appended glow bands into
+  // .cmt-msgs (the band math expects the transcript's host), posted dotHover/dotOpen with the MAIN
+  // session's id and the THREAD's uuids (cross-lighting the timeline wrongly), and rail time-markers
+  // painted 45px left of gutterless turns — a clipped sliver at the popover edge.
+  assert.match(UI, /let renderingIntoThread = false;/);
+  assert.match(UI, /renderingIntoThread = true;\s*\/\/ same renderer, minus the transcript-coupled hover chrome/);
+  assert.match(UI, /renderingIntoThread = false;\s*\n\s*renderingSid = saved;/, "cleared before the fill returns");
+  assert.match(UI, /if \(\(anchorUuid \|\| epoch != null\) && !renderingIntoThread\) wireTurnHover/,
+    "no glow bands, no cross-pane posts, no dot-nav promises inside the thread");
+  assert.match(UI, /epoch != null && !renderingIntoThread && turn\.querySelector/,
+    "no rail time-markers on gutterless popover turns");
+});
+
 test("busy and stuck are disjoint state families", () => {
   for (const s of ["working", "retrying", "compacting"]) assert.ok(threadBusy(s) && !threadStuck(s));
   for (const s of ["permission", "picker"]) assert.ok(threadStuck(s) && !threadBusy(s));

--- a/ui/webview/render-postal-time.test.ts
+++ b/ui/webview/render-postal-time.test.ts
@@ -17,5 +17,5 @@ test("postal cards no longer render an in-card time", () => {
 
 test("the rail time-marker is applied to postal turns too (the postal exclusion is gone)", () => {
   assert.doesNotMatch(RENDER, /kind !== "postal-service"/, "the rail marker must not exclude postal cards");
-  assert.match(RENDER, /if \(epoch != null && turn\.querySelector\(".dot"\)\) turn\.insertBefore\(timeMarker/);
+  assert.match(RENDER, /if \(epoch != null && !renderingIntoThread && turn\.querySelector\(".dot"\)\) turn\.insertBefore\(timeMarker/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -477,6 +477,13 @@ fetch(kernelUrl("/palette"), { cache: "no-store" }).then((r) => r.json())
 const mru: string[] = [];             // recency stack, front = most-recently-active (close → return to previous)
 let activeId: string | null = null;
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
+// TRUE while fillCommentMsgs renders into the comment popover (the user 2026-08-23): the thread uses
+// the chat's own renderer deliberately — but the transcript-COUPLED hover machinery must stay out.
+// wireTurnHover's glow band appends to turn.parentElement (the .cmt-msgs list, positioned nowhere the
+// band math expects), its dotHover/dotOpen posts carry the MAIN session's id with the THREAD's uuids
+// (cross-lighting the timeline wrongly, and a dot click "jumps" somewhere false), and the rail
+// time-markers paint 45px left of a turn that has no gutter — a clipped sliver at the popover edge.
+let renderingIntoThread = false;
 // restore the last-active tab on refresh (persisted via setState); one-shot, applied when its session arrives
 let wantActive: string | null = (() => { try { return ((vscodeApi?.getState?.() || {}) as any).activeId || null; } catch { return null; } })();
 let pendingAnchor: string | null = null; // deep-link target waiting to be scrolled to
@@ -1227,14 +1234,14 @@ function renderEvent(ev: ChatEvent, prevEpoch?: number | null, worked?: number |
   // event instead of stamping the time inside its own card). Prompts ride this rail too instead
   // of an in-bubble stamp (the human via debugger, 2026-06-12). The date shows only on the first
   // turn of a new (non-today) day.
-  if (epoch != null && turn.querySelector(".dot")) turn.insertBefore(timeMarker(epoch, prevEpoch ?? null), turn.firstChild);
+  if (epoch != null && !renderingIntoThread && turn.querySelector(".dot")) turn.insertBefore(timeMarker(epoch, prevEpoch ?? null), turn.firstChild);
   // rail-dot fleet links: hover anywhere on the turn → white-highlight this turn's
   // event on the timeline AND outline its feed card(s); click the DOT → open that
   // card's modal in the feed (the host resolves turn → event → cards). The whole
   // turn is the hover target (the user 2026-06-12) — hovering the MESSAGE bubble or
   // the WORK/reply body must light the timeline, not only the rail dot.
   const railDot = turn.querySelector(".dot") as HTMLElement | null;
-  if (anchorUuid || epoch != null) wireTurnHover(turn, railDot, anchorUuid ?? null, epoch ?? 0, ev.tlId ?? null);
+  if ((anchorUuid || epoch != null) && !renderingIntoThread) wireTurnHover(turn, railDot, anchorUuid ?? null, epoch ?? 0, ev.tlId ?? null);
   // a finished prompt's last reply carries a small "worked 2m 14s" tick in the rail
   // gutter (left, by the time-markers) — how long the session ran on that prompt.
   if (worked != null) turn.appendChild(elapsedFooter(worked));
@@ -5977,12 +5984,14 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     // the folds per thread, exactly as a chat tab would.
     const saved = renderingSid;
     renderingSid = th.tid;
+    renderingIntoThread = true;   // same renderer, minus the transcript-coupled hover chrome (see the flag)
     let prev: number | null = null;
     for (const ev of evs) {
       list.appendChild(renderEvent(ev, prev, null));
       const ep = eventEpoch(ev);
       if (ep != null) prev = ep;
     }
+    renderingIntoThread = false;
     renderingSid = saved;
   } else for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
   for (const p of pend) {


### PR DESCRIPTION
User report 2026-08-23 with a recording: hovering inside the comment box produced a batch of rendering faults.

The popover deliberately renders its thread with the chat's own renderer (rail dots, markdown, tool folds — never a simplified twin), but three transcript-coupled pieces came along uninvited: the hover glow band appends to `turn.parentElement`, which in the popover is the `.cmt-msgs` list, nowhere the band math expects (stray bands on hover); the `dotHover`/`dotOpen` posts carry the main session's id with the thread's uuids, cross-lighting the timeline wrongly and promising dot-clicks that jump somewhere false; the rail hit-strip repeats both; and rail time-markers painted 45px left of gutterless popover turns — the clipped sliver visible at the popover's left edge in the recording.

A `renderingIntoThread` flag, set only while `fillCommentMsgs` renders the thread, gates `wireTurnHover` and marker insertion. Everything else the popover reuses is untouched. Pins in the comments test cover the flag lifecycle and both gates; two pre-existing marker pins updated to the gated line. Suite passes (2,213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)