### PR TITLE
An unread comment wears a NEW-here dot and a shouting rail tick

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -94,6 +94,18 @@ test("the popover keeps the chat renderer but sheds its transcript-coupled hover
     "no rail time-markers on gutterless popover turns");
 });
 
+test("an unread thread wears a NEW-here dot on its last segment and a shouting rail tick", () => {
+  // the user 2026-08-23: the 45% unread tint alone was too subtle — a thread that replied while the
+  // box was closed needs a visible element. One dot per thread (the run's hl-last segment), ringed
+  // in the page bg; the rail tick grows and double-rings. Both clear with the unread flag on open.
+  assert.match(CSS, /mark\.cmt-hl\.unread\.hl-last::after \{\s*\n\s*content: ""; position: absolute; top: -4px; right: -4px; width: 7px; height: 7px;/);
+  assert.match(CSS, /border-radius: 50%; background: var\(--cmt-hl\); box-shadow: 0 0 0 1\.5px var\(--bg\);/);
+  assert.match(CSS, /mark\.cmt-hl \{[^}]*position: relative;/s, "the mark anchors its own dot");
+  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1;/);
+  // the clearing story is the existing machinery, untouched: optimistic on open + kernel watermark
+  assert.match(UI, /if \(th\) th\.unread = false;\s*\/\/ optimistic; the kernel's watermark reconciles/);
+});
+
 test("busy and stuck are disjoint state families", () => {
   for (const s of ["working", "retrying", "compacting"]) assert.ok(threadBusy(s) && !threadStuck(s));
   for (const s of ["permission", "picker"]) assert.ok(threadStuck(s) && !threadBusy(s));

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2517,8 +2517,18 @@ mark.cmt-hl {
   color: inherit;
   border-radius: 0;
   cursor: pointer;
+  position: relative;   /* anchors the unread dot on the run's last segment */
 }
 mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
+/* NEW-here dot (the user 2026-08-23): the 45% unread tint alone was too subtle to read as "something
+   new since you last looked". A thread with messages you haven't seen — it replied while the box was
+   closed, and you haven't opened it since — wears a solid full-strength dot on the top-right corner
+   of its run's LAST segment (one dot per thread), ringed in the page bg so it reads over any text.
+   It clears with the unread flag the moment the popover opens (optimistic + kernel watermark). */
+mark.cmt-hl.unread.hl-last::after {
+  content: ""; position: absolute; top: -4px; right: -4px; width: 7px; height: 7px;
+  border-radius: 50%; background: var(--cmt-hl); box-shadow: 0 0 0 1.5px var(--bg);
+}
 mark.cmt-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
 mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
 /* WRITING (the user 2026-08-17; reshaped 2026-08-23): while the thread is mid-reply the region
@@ -2711,7 +2721,10 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 }
 .cmt-tick:hover { opacity: 1; }
 .cmt-tick.resolved { opacity: 0.3; }
-.cmt-tick.unread { box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--cmt-hl) 60%, transparent); opacity: 1; }
+/* an UNREAD thread's tick shouts (the user 2026-08-23): full width, taller, double-ringed — the old
+   faint glow read as a rendering artifact, not as "new here" */
+.cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1;
+  box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl) 85%, transparent); }
 
 /* a fully-covered KaTeX block tints at the ELEMENT (cmt-hl-host, same contract as inline code):
    a mark inside it cannot paint the glyph boxes' spacing, which punched gaps through highlighted


### PR DESCRIPTION
User request 2026-08-23: a comment thread that received a reply while its box was closed (and hasn't been opened since) needs a visible "something new here" element — the existing cue was only a 45% vs 30% tint difference on the highlight.

Two elements now, both riding the existing unread flag (kernel `lastSeenT` watermark, optimistic clear on open — that machinery is untouched): the highlight run's last segment wears a solid full-strength dot on its top-right corner, ringed in the page background so it reads over any text (one dot per thread, cleared the moment the popover opens); and the comment rail's unread tick grows to full width with a double ring, replacing the faint glow that read as an artifact.

Verified visually (unread vs read passage, unread vs plain vs resolved ticks); pins cover both elements and the untouched clearing story; the tint-ladder test still passes. Suite green (2,214).

🤖 Generated with [Claude Code](https://claude.com/claude-code)