### PR TITLE
Comment threads mail their parent under their own postal identity

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10389,6 +10389,33 @@ def _session_rows():
     return out
 
 
+def _thread_rows():
+    """Comment-thread sessions as /sessions rows, served ONLY behind ?threads=1 (the user 2026-08-22:
+    a thread is a real forked session and should mail its parent under its own name — but it stays a
+    minor player, hidden from every default listing until promotion). The name comes from the parent's
+    comments store, the one place a thread's editable name lives; rows carry thread:true + the parent
+    sid so the bus can mark them and resolve replies."""
+    be = _sdk()
+    if not be or not hasattr(be, "thread_sessions"):
+        return []
+    out = []
+    for tsid, meta in be.thread_sessions().items():
+        parent = str(meta.get("threadOf") or "")
+        nm = ""
+        try:
+            for t in (_load_comments(parent).get("threads") or []):
+                if t.get("tid") == tsid:
+                    nm = str(t.get("name") or "")
+                    break
+        except Exception:
+            pass
+        out.append({"id": tsid, "name": nm or tsid[:8], "state": meta.get("state", ""),
+                    "dir": _cwd_of(tsid), "thread": True, "parent": parent,
+                    "lastSid": jd._sdk_last_sid(tsid) or tsid,
+                    "working": "", "backend": "sdk"})
+    return out
+
+
 # ── inbox-socket delivery (Claude Code ≥ 2.1.224) ──
 # The CLI binds a per-session Unix inbox socket and registers it — with its own session id and pid —
 # in ~/.claude/sessions/<pid>.json. One JSON line {"type":"user","message":{"role":"user","content":…}}
@@ -25748,7 +25775,10 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, json.dumps(_token_analytics(int(time.time()), w)),
                                   "application/json", cache="no-cache")
             if p == "/sessions":                              # unified romp session list (tmux + SDK) for external tools (the Obsidian plugin, the postal bus)
-                return self._send(200, json.dumps(_session_rows()), "application/json", cache="no-cache")
+                rows = _session_rows()
+                if (q.get("threads") or [""])[0] == "1":       # opt-in: comment-thread rows for the postal
+                    rows = rows + _thread_rows()               # bus (the user 2026-08-22); every existing
+                return self._send(200, json.dumps(rows), "application/json", cache="no-cache")   # consumer unchanged
             if p == "/commands":                              # slash-command list for the composer's "/" autocomplete (SDK get_server_info, per-cwd cached)
                 sid = (q.get("sid") or [""])[0]
                 cmds, warming = _commands_for_cwd(_cwd_of(sid) if sid else "")

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4388,6 +4388,22 @@ class SdkBackend:
         self._poke()
         return True
 
+    def thread_sessions(self) -> dict[str, dict]:
+        """{sid: {state, threadOf}} for every alive COMMENT-THREAD session — exactly the rows
+        live_sessions deliberately hides (a thread's surface is the parent chat's comment UI, never a
+        tab). Served only to callers that ask (kernel /sessions?threads=1 → the postal bus), so a
+        thread can mail its PARENT under its own name (the user 2026-08-22) without ever gaining a
+        tab, a lane, or a feed card."""
+        out = {}
+        for reg in list_regs(self.state_dir):
+            if not reg.get("alive") or not reg.get("threadOf"):
+                continue
+            sid = reg["sid"]
+            s = self.sessions.get(sid)
+            st = (s.snapshot() if s and s.thread.is_alive() else {"state": "waiting", "backend": "sdk"})
+            out[sid] = {"state": st.get("state", "waiting"), "threadOf": str(reg.get("threadOf") or "")}
+        return out
+
     def fork_children(self) -> dict:
         """{parent sid: [{sid, name, cut, t}, …]} for every session carrying a durable forkedFrom —
         the parent chat's branch chips. Comment threads are skipped (their anchor is the comment

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -150,7 +150,7 @@ def _self_row():
     sid = _self_id()
     if not sid:
         return None
-    agents = local_agents()
+    agents = local_agents(threads=True)   # a comment thread resolves to its OWN row/name (2026-08-22)
     return (next((a for a in agents if a.get("id") == sid), None)
             or next((a for a in agents if a.get("lastSid") == sid), None))
 
@@ -465,6 +465,11 @@ def format_agents(agents, me, me_id=""):
         # the reader most needs to know which row is theirs (see resolve_recipient).
         mine = (a.get("id") == me_id) if me_id else (a["name"] == me)
         tag = " (you)" if mine else (" [remote]" if a.get("remote") else "")
+        if a.get("thread") and not mine:
+            # a comment thread of one of these sessions: addressable for replies, but a minor player —
+            # say whose it is so nobody mistakes it for a full peer (the user 2026-08-22)
+            pn = next((x.get("name") for x in agents if x.get("id") == a.get("parent")), "")
+            tag = " (thread of %s)" % (pn or "a session here")
         br = ("  [%s]" % a["branch"]) if a.get("branch") else ""
         wk = ""
         if a.get("working"):
@@ -509,7 +514,7 @@ HEARTBEATS = {}        # id -> (name, last_seen_epoch)   (remote presence)
 STREAKS = {}           # id -> (count, last_epoch)        (loop guard)
 _lock = threading.Lock()
 
-def _kernel_sessions():
+def _kernel_sessions(threads=False):
     """LIVE romp sessions (tmux + SDK) from the kernel's unified GET /sessions — the kernel owns the backend
     query (TmuxBackend for tmux liveness + the SDK registry), so the bus enumerates sessions WITHOUT shelling
     tmux and WITHOUT reading the SDK registry directly: ONE source. Loopback, authorized with X-Romp-Token
@@ -523,12 +528,16 @@ def _kernel_sessions():
     if seam:
         try:
             data = json.loads(Path(seam).read_text())
-            return data if isinstance(data, list) else []
+            if not isinstance(data, list):
+                return []
+            # the seam mirrors the route: thread rows ride only when asked (the user 2026-08-22)
+            return data if threads else [r for r in data if not (isinstance(r, dict) and r.get("thread"))]
         except Exception:
             return []
     import urllib.request
     try:
-        req = urllib.request.Request(KERNEL_BASE + "/sessions", headers={"X-Romp-Token": SERVE_TOKEN})
+        req = urllib.request.Request(KERNEL_BASE + "/sessions" + ("?threads=1" if threads else ""),
+                                     headers={"X-Romp-Token": SERVE_TOKEN})
         with urllib.request.urlopen(req, timeout=2) as r:
             data = json.loads(r.read().decode("utf-8"))
         return data if isinstance(data, list) else []
@@ -536,19 +545,29 @@ def _kernel_sessions():
         return []
 
 
-def local_agents():
+def local_agents(threads=False):
     """LIVE local sessions (tmux + SDK) as postal agent rows, read from the kernel's unified GET /sessions.
     The kernel merges both backends, so an SDK session is a live agent here too — a send to an open SDK
-    session delivers instead of parking as dead (the user via ui, 2026-06-26)."""
+    session delivers instead of parking as dead (the user via ui, 2026-06-26).
+
+    `threads` (the user 2026-08-22): also include COMMENT-THREAD sessions — real forked sessions the
+    kernel hides from tabs/lanes/cards until promotion. Opt-in per consumer so the default listing and
+    every other reader stay exactly as they were: self-identity, recipient resolution, and the agents
+    listing pass True (a thread mails its parent under its OWN name and is addressable for replies);
+    everything else never sees them."""
     res = []
-    for s in _kernel_sessions():
+    for s in _kernel_sessions(threads=threads):
         sid = s.get("id")
         if not sid:
             continue
-        res.append({"name": s.get("name") or sid[:8], "id": sid, "remote": False,
-                    "working": s.get("working", ""), "dir": s.get("dir", ""),
-                    "lastSid": s.get("lastSid", ""),   # the session's CURRENT transcript fsid (self-identity join)
-                    "state": s.get("state", "")})   # state: working/idle/waiting/... → working-note freshness
+        row = {"name": s.get("name") or sid[:8], "id": sid, "remote": False,
+               "working": s.get("working", ""), "dir": s.get("dir", ""),
+               "lastSid": s.get("lastSid", ""),   # the session's CURRENT transcript fsid (self-identity join)
+               "state": s.get("state", "")}   # state: working/idle/waiting/... → working-note freshness
+        if s.get("thread"):
+            row["thread"] = True
+            row["parent"] = s.get("parent") or ""
+        res.append(row)
     return res
 
 
@@ -598,8 +617,8 @@ def _publish_working(sid, text):
     so an SDK session can publish a note too."""
     return _kernel_post("/working", {"id": str(sid), "text": text}) is not None if sid else False
 
-def all_agents():
-    agents = local_agents()
+def all_agents(threads=False):
+    agents = local_agents(threads=threads)
     local_ids = {a["id"] for a in agents}
     now = time.time()
     for sid, (name, ts) in list(HEARTBEATS.items()):
@@ -690,7 +709,7 @@ def resolve_recipient(to, frm_id=""):
     # Everything this bus can deliver to itself: local sessions plus heartbeating remotes. A
     # host qualifier naming somebody ELSE takes them all out of the running.
     direct_all = ([] if (want_host and want_host != here)
-                  else [a for a in all_agents() if a["name"] == bare])
+                  else [a for a in all_agents(threads=True) if a["name"] == bare])   # threads addressable for replies
 
     if frm_id and any(a["id"] == frm_id for a in direct_all):
         return {"kind": "error", "status": 409,
@@ -1134,7 +1153,7 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(peers_snapshot())
         if u.path == "/agents":
             me = (q.get("me") or [""])[0]
-            agents = [a for a in all_agents() if not _postal_off(a["id"])]   # isolated sessions are invisible to peers
+            agents = [a for a in all_agents(threads=True) if not _postal_off(a["id"])]   # isolated sessions are invisible to peers
             for a in agents:                       # enrich with branch for display only
                 a["branch"] = _git_branch(a.get("dir", ""))
             if peers_on():

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -84,6 +84,41 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     [[ "$output" == *"beta"* ]]
 }
 
+# ── comment threads (the user 2026-08-22): a thread is a real forked session hidden until promotion;
+# it mails its PARENT under its own name, is addressable for replies, and stays a marked minor player ──
+addthread() {
+    python3 - "$ROMP_SESSIONS_FILE" <<'PY'
+import json, sys
+rows = json.load(open(sys.argv[1]))
+rows.append({"id": "uuid-t", "name": "alpha-comment-1", "state": "working", "dir": "", "working": "",
+             "backend": "sdk", "thread": True, "parent": "uuid-a", "lastSid": "uuid-t"})
+json.dump(rows, open(sys.argv[1], "w"))
+PY
+}
+
+@test "a comment thread mails its parent under its own name; its own name still self-refuses" {
+    addthread
+    CLAUDE_CODE_SESSION_ID=uuid-t run "$POSTAL" send --kind coordinate alpha "the anchor section needs a second pass"
+    [ "$status" -eq 0 ]
+    [ "$(cnt "$(mb uuid-a)/new")" = "1" ]
+    grep -q "From: alpha-comment-1" "$(mb uuid-a)/new/"*
+    # the self-send refusal keys on the THREAD's own identity now, not the parent's
+    CLAUDE_CODE_SESSION_ID=uuid-t run "$POSTAL" send --kind coordinate alpha-comment-1 "note to self"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"own name"* ]]
+}
+
+@test "the parent replies to a thread by name, and agents marks the thread row" {
+    addthread
+    run "$POSTAL" send --kind coordinate alpha-comment-1 "good catch, apply it"
+    [ "$status" -eq 0 ]
+    [ "$(cnt "$(mb uuid-t)/new")" = "1" ]
+    grep -q "From: alpha" "$(mb uuid-t)/new/"*
+    run "$POSTAL" agents
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"(thread of alpha)"* ]]
+}
+
 @test "send delivers into the recipient's maildir" {
     run "$POSTAL" send beta "hello there"
     [ "$status" -eq 0 ]

--- a/tests/test_postal_freshness.py
+++ b/tests/test_postal_freshness.py
@@ -61,7 +61,7 @@ class WorkingNoteFreshness(unittest.TestCase):
         # state / working / dir carry straight into the agent row used for working-note freshness.
         saved = pm._kernel_sessions
         try:
-            pm._kernel_sessions = lambda: [
+            pm._kernel_sessions = lambda threads=False: [
                 {"id": "sid-1", "name": "bugs", "state": "working", "dir": "/dir", "working": "feed.ts", "backend": "tmux"},
                 {"id": "sid-2", "name": "ui", "state": "idle", "dir": "/dir", "working": "render.ts", "backend": "sdk"}]
             agents = {a["name"]: a for a in pm.local_agents()}

--- a/tests/test_postal_sdk_agents.py
+++ b/tests/test_postal_sdk_agents.py
@@ -23,7 +23,7 @@ class SdkAgentsVisibleToPostal(unittest.TestCase):
     def setUp(self):
         # stub the kernel fetch: the kernel reports the OPEN SDK session (alive) in its unified /sessions.
         self._saved = pm._kernel_sessions
-        pm._kernel_sessions = lambda: [
+        pm._kernel_sessions = lambda threads=False: [
             {"id": SID, "name": "sdksess", "state": "waiting", "dir": "/work/dir",
              "bg": "", "fg": "", "working": "", "backend": "sdk"}]
 
@@ -44,13 +44,13 @@ class SdkAgentsVisibleToPostal(unittest.TestCase):
         self.assertEqual(pm._recip_id_for("sdksess"), SID)
 
     def test_session_absent_from_kernel_is_not_a_live_agent(self):
-        pm._kernel_sessions = lambda: []            # the kernel reports nothing live (dead/ended) → not an agent
+        pm._kernel_sessions = lambda threads=False: []            # the kernel reports nothing live (dead/ended) → not an agent
         self.assertNotIn(SID, {x["id"] for x in pm.local_agents()})
 
     def test_unreachable_kernel_yields_no_local_agents(self):
         # _kernel_sessions returns [] on any failure (the real impl swallows the urlopen error); the bus then
         # shows no local agents rather than shelling tmux behind the abstraction.
-        pm._kernel_sessions = lambda: []
+        pm._kernel_sessions = lambda threads=False: []
         self.assertEqual(pm.local_agents(), [])
 
 

--- a/tests/test_postal_self_send.py
+++ b/tests/test_postal_self_send.py
@@ -38,7 +38,7 @@ class ResolverBase(unittest.TestCase):
                        ("all_agents", "self_host", "peers_on", "_postal_off")}
         self._agents = []
         self._isolated = set()
-        pm.all_agents = lambda: list(self._agents)
+        pm.all_agents = lambda threads=False: list(self._agents)
         pm.self_host = lambda: "TESTHOST"
         pm.peers_on = lambda: True
         pm._postal_off = lambda sid: sid in self._isolated

--- a/tests/test_postal_via_dedupe.py
+++ b/tests/test_postal_via_dedupe.py
@@ -96,7 +96,7 @@ class PeerRoutePrefersDirect(_Seeded):
         self.assertEqual(agent.get("id"), FAR_ID)
 
     def test_resolve_recipient_lands_direct_with_no_ambiguity_error(self):
-        pm.local_agents, saved = (lambda: []), pm.local_agents
+        pm.local_agents, saved = (lambda threads=False: []), pm.local_agents
         try:
             r = pm.resolve_recipient("web", frm_id=HUB_ID)
         finally:
@@ -107,7 +107,7 @@ class PeerRoutePrefersDirect(_Seeded):
 
 class GossipCarriesIdentity(_Seeded):
     def test_fleet_presence_rides_the_far_bus_id_on_via_rows(self):
-        pm.local_agents, saved = (lambda: []), pm.local_agents
+        pm.local_agents, saved = (lambda threads=False: []), pm.local_agents
         try:
             rows = pm.fleet_presence("asker")
         finally:

--- a/tests/test_thread_rows.py
+++ b/tests/test_thread_rows.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""GET /sessions?threads=1 (the user 2026-08-22): comment-thread sessions ride the unified session
+list ONLY when asked — the postal bus asks, so a thread can mail its parent under its own name;
+every existing consumer (Obsidian picker, romp sessions, the default bus listing) is unchanged.
+Drives the REAL Handler over HTTP (the test_new_route_prefs.py pattern). Synthetic only."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+TSID = "66666666-7777-8888-9999-000000000000"
+
+
+class ThreadRowsRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer = __import__("http.server", fromlist=["ThreadingHTTPServer"]).ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self._saved = (km._session_rows, km._thread_rows)
+        km._session_rows = lambda: [{"id": PARENT, "name": "web", "state": "working"}]
+        km._thread_rows = lambda: [{"id": TSID, "name": "web-comment-1", "state": "working",
+                                    "thread": True, "parent": PARENT}]
+
+    def tearDown(self):
+        km._session_rows, km._thread_rows = self._saved
+
+    def _get(self, path):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path),
+                                     headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode())
+
+    def test_default_listing_hides_threads(self):
+        rows = self._get("/sessions")
+        self.assertEqual([r["id"] for r in rows], [PARENT], "every existing consumer sees exactly what it saw")
+
+    def test_threads_param_appends_flagged_rows(self):
+        rows = self._get("/sessions?threads=1")
+        self.assertEqual([r["id"] for r in rows], [PARENT, TSID])
+        t = rows[1]
+        self.assertTrue(t.get("thread"), "flagged so the bus can mark it as a minor player")
+        self.assertEqual(t.get("parent"), PARENT, "the parent sid rides for reply resolution")
+
+
+class ThreadRowsBuilder(unittest.TestCase):
+    def test_thread_rows_join_the_name_from_the_parents_comments_store(self):
+        class FakeBE:
+            def thread_sessions(self):
+                return {TSID: {"state": "waiting", "threadOf": PARENT}}
+        saved = (km._sdk, km._load_comments, km._cwd_of)
+        km._sdk = lambda: FakeBE()
+        km._load_comments = lambda sid: ({"threads": [{"tid": TSID, "name": "web-comment-1"}]}
+                                         if sid == PARENT else {})
+        km._cwd_of = lambda sid: ""
+        try:
+            rows = km._thread_rows()
+        finally:
+            km._sdk, km._load_comments, km._cwd_of = saved
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "web-comment-1",
+                         "the comments store is where a thread's editable name lives")
+        self.assertEqual(rows[0]["parent"], PARENT)
+        self.assertTrue(rows[0]["thread"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A comment thread is already a real forked session hidden until promotion (`threadOf` reg, no names/ entry) — but postal resolved caller identity through the live listing and names registry, both of which deliberately exclude threads. So a thread mailing its parent fell through to the parent's identity and hit the self-send refusal (reported by a thread 2026-08-22; the user approved the feedback mechanism the same day: threads should be able to feed back on the main session).

## What changes
- **Kernel**: `GET /sessions?threads=1` appends comment-thread rows — flagged `thread:true` with the parent sid, name joined from the parent's comments store (the one place a thread's editable name lives). The default listing is byte-identical, so the Obsidian picker, `romp sessions`, and every other consumer are untouched. A new `thread_sessions()` backend seam exposes exactly the rows `live_sessions` deliberately hides.
- **Postal**: threads ride in at exactly three opt-in seams — self-identity (a thread resolves to its OWN row, so the parent receives `From: <parent>-comment-N`, placeable and clearly a thread), recipient resolution (parents reply to threads by name; the self-send refusal now correctly guards the thread's own name), and the agents listing (threads marked `(thread of <parent>)`). Everything else keeps the thread-free default view — heartbeats, exchanges, working-note sweeps see nothing new.
- Delivery needs no changes: the thread's maildir keys on its sid and its CLI already exists, so mail into a thread renders in the comment popover like any turn.

The timeline arc (postal connector out of the comment's anchor square) is deliberately a separate polish PR.

## Tests
Bats: thread→parent mail carries the thread's own From; the thread's own name still self-refuses; parent→thread replies land in the thread's maildir; `agents` marks the thread row. Python: the route serves thread rows only behind the param (default byte-identical), and the name-join reads the comments store. Six pre-existing stub seams updated to the new `threads=` signature. Suites: python 5163 passed, UI 2213 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)