### PR TITLE
Quote is the chip; context stages alone behind a visible Stage button; every send echoes

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -58,7 +58,7 @@ test("sending with a GOAL citation routes as an askFollowUp (reopen) and consume
   // owner for the live send and the staged release; deliver feeds it activeId as the sid
   assert.match(RENDER, /const cites = composerCitations\.get\(activeId\);/);
   assert.match(RENDER, /routeUserMessage\(activeId, text, cites\);/);
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text\); \}/);
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text\); \}/);
   assert.match(RENDER, /if \(cites\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
 });
@@ -71,7 +71,7 @@ test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches 
   // sid from the itemId, owns no such session, and hands it to tmux by uuid — dropped in silence. The card
   // still flashed to Working (the kernel's cardPredict fires before any of that) and snapped back on the
   // ok:false ack, so the only visible trace was a bounce.
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text\); \}/);
   assert.match(RENDER, /routeUserMessage\(activeId, text, cites\);/);   // deliver's sid IS the active session
   // every OTHER card-addressed op already routes this way — the citation follow-up was the lone omission
   assert.match(FEED, /type: "askClear", itemId: it\.itemId, sid: it\.sid/);
@@ -197,11 +197,15 @@ test("closing a session clears its composer reply context — chip, draft, and e
 });
 
 test("quote chips send a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\);/);
-  assert.match(RENDER, /else if \(quoteCites\.length\) vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text: quoteReplyBody\(quoteCites, text\) \}\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text\); \}/);
+  // the quote branch echoes the COMPOSED body — byte-identical to what lands, so the reconcile's
+  // includes() match is exact (the user 2026-08-23, whose quoted sends painted nothing until the
+  // kernel round-tripped while plain sends painted instantly)
+  assert.match(RENDER, /else if \(quoteCites\.length\) \{ const body = quoteReplyBody\(quoteCites, text\); vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text: body \}\); registerOptimistic\(sid, body\); \}/);
   // the wrap: one section per stacked chip (lead-in + the highlighted text as a markdown quote block), in
   // strip order, then the typed message — a single chip composes byte-identically to the pre-stack form
-  assert.match(RENDER, /return sections\.join\("\\n\\n"\) \+ "\\n\\n" \+ text;/);
+  // a context-only body (staged with an empty box) carries no dangling blank tail
+  assert.match(RENDER, /return text \? sections\.join\("\\n\\n"\) \+ "\\n\\n" \+ text : sections\.join\("\\n\\n"\);/);
   // the chip's audit preview shows the SAME composed body — the whole outgoing message, every stacked
   // quote, whichever chip was clicked — client-side (no /followup-preview fetch)
   assert.match(RENDER, /body\.textContent = quoteReplyBody\(cites\.filter\(\(c\) => c\.quote\), draft \|\| "\(your message\)"\);/);
@@ -209,11 +213,27 @@ test("quote chips send a plain message wrapped by quoteReplyBody — never askFo
   assert.match(RENDER, /mark\.textContent = cite\.quote \? "“" : "↩";/);
 });
 
-test("right-click Reply drops the auto-seeded quote chip — the quote is in the composer now, never sent twice", () => {
-  // the selection that opened the context menu also seeded a chip (selectionchange); quoting it into the
-  // composer text must consume THAT chip — the newest, the one this gesture made — or the send would wrap
-  // an already-quoted message again. Earlier stacked contexts stay.
-  assert.match(RENDER, /if \(list\?\.length && list\[list\.length - 1\]\.quote\) \{\s*\n\s*list\.pop\(\);/);
+test("context stages ALONE, and the chips strip carries the visible Stage button", () => {
+  // the user 2026-08-23: nobody discovers ⌘⏎ on their own. Select a passage → the chip appears with
+  // a Stage button pinned at its right; press it (or ⌘⏎) with an EMPTY box and just the context
+  // stages — repeat, then one typed message flushes the whole run. The button lives in the chips
+  // strip, so it exists exactly while context is held and vanishes with it.
+  assert.match(RENDER, /if \(!typed && !\(composerCitations\.get\(activeId\) \|\| \[\]\)\.some\(\(c\) => c\.quote\)\) return;/,
+    "empty box + a quote chip is stageable; empty box + nothing is not");
+  assert.match(RENDER, /fireStage = \(\) => stageComposer\(\);/, "the strip's door into the composer closure");
+  assert.match(RENDER, /const st = el\("button", "staged-go composer-stage-btn"\) as HTMLButtonElement;/);
+  assert.match(RENDER, /st\.title = "hold this context \(and anything typed\) for one combined send later — ⌘⏎ does the same";/);
+  assert.match(CSS, /\.composer-stage-btn \{ position: absolute; right: 2px; top: 0;/,
+    "pinned to the RIGHT of the blue context chips");
+  assert.match(RENDER, /label\.textContent = s\.text \|\| "\(context only — sends with your message\)";/,
+    "a context-only staged row says what it is");
+});
+
+test("Quote is the chip, and only the chip — the in-box blockquote form is gone", () => {
+  // the user 2026-08-23, consolidating the three verbs by removal: selecting already seeds the chip,
+  // so the menu item just focuses the composer. No inserter, no chip dedup, nothing to double-send.
+  assert.doesNotMatch(RENDER, /quoteSelectionIntoComposer/);
+  assert.match(RENDER, /mk\("Quote", \(\) => \{ \(document\.getElementById\("composer-input"\) as HTMLTextAreaElement \| null\)\?\.focus\(\); \}\);/);
 });
 
 test("a VS Code EDITOR highlight seeds the same chip, labeled + wrapped with its file:lines origin (the user 2026-07-13)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -12,7 +12,6 @@ import markdown from "highlight.js/lib/languages/markdown";
 import diff from "highlight.js/lib/languages/diff";
 import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
-import { quoteReply } from "../quote";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
 import { SessionViews, viewVisible, viewsKey, hideIn, revealIn } from "./session-views";
 import { markerLabel, dayContext } from "./time-marker";
@@ -4281,41 +4280,16 @@ function showSelectionMenu(e: MouseEvent) {
     const sid = activeId, uuid = q.uuid, qtext = q.text;
     mk("Comment", () => openCommentComposer(sid, uuid, qtext, e.clientX, e.clientY));
   }
-  // "Quote" (renamed from "Quote in message", the user 2026-08-23): drops the passage INTO the box
-  // as an editable markdown blockquote — the automatic selection chip already covers select-and-type,
-  // and the handler below de-duplicates the chip the same selection seeded.
-  mk("Quote", () => quoteSelectionIntoComposer(text));
+  // "Quote" is the CHIP, and only the chip (the user 2026-08-23, consolidating the three verbs —
+  // Comment / Quote / Stage — by removal): the selection already seeded it (selectionchange), so
+  // the item just puts the caret where the reply goes. The in-box editable-blockquote form is gone.
+  mk("Quote", () => { (document.getElementById("composer-input") as HTMLTextAreaElement | null)?.focus(); });
   mk("Copy", () => copyToClipboard(text));
   document.body.appendChild(menu);
   ctxMenuEl = menu;
   const r = menu.getBoundingClientRect();
   menu.style.left = Math.max(0, Math.min(e.clientX, window.innerWidth - r.width - 4)) + "px";
   menu.style.top = Math.max(0, Math.min(e.clientY, window.innerHeight - r.height - 4)) + "px";
-}
-
-// Drop the selection into the composer as a markdown blockquote (quote.ts does the
-// formatting), cursor on the blank line below it, and remember it as the draft.
-function quoteSelectionIntoComposer(text: string) {
-  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-  if (!ta) return;
-  const { value, caret } = quoteReply(text, ta.value);
-  ta.value = value;
-  ta.selectionStart = ta.selectionEnd = caret;
-  growComposer(ta);
-  ta.focus();
-  if (activeId) {
-    drafts.set(activeId, ta.value);
-    // the selection that opened this menu ALSO seeded the auto quote-chip (selectionchange, the user
-    // 2026-07-13) — the quote now lives IN the composer text, so drop that chip or the send would quote it
-    // twice. Only the NEWEST chip (the one this selection's gesture made) — earlier stacked contexts stay.
-    const list = composerCitations.get(activeId);
-    if (list?.length && list[list.length - 1].quote) {
-      list.pop();
-      if (!list.length) composerCitations.delete(activeId);
-      renderComposerChips(activeId);
-    }
-    persistDrafts();
-  }
 }
 
 function copyToClipboard(text: string) {
@@ -9075,6 +9049,7 @@ const drafts = new Map<string, string>();
 // quotes. Each chip keeps its own ✕; Backspace-at-start eats the newest first.
 interface Citation { itemId?: string; title: string; quote?: string; uuid?: string | null; src?: string }   // src = a VS Code editor highlight's origin, workspace-relative file:lines (the user 2026-07-13)
 const composerCitations = new Map<string, Citation[]>();
+let fireStage: () => void = () => { /* assigned by the composer closure */ };
 
 // FILE ATTACHMENTS for the composer (the user 2026-08-04): a file dragged, pasted, or picked into the
 // chat box becomes a little THUMBNAIL in a strip above the textarea — not a raw path string dumped into
@@ -9206,8 +9181,13 @@ function routeUserMessage(sid: string, text: string, cites: Citation[] | undefin
   if (!vscodeApi) return;
   const goalCite = cites?.find((c) => c.itemId);
   const quoteCites = cites ? cites.filter((c) => c.quote) : [];
-  if (goalCite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid });
-  else if (quoteCites.length) vscodeApi.postMessage({ type: "sendMessage", id: sid, text: quoteReplyBody(quoteCites, text) });
+  // EVERY branch echoes optimistically (the user 2026-08-23: quoted and follow-up sends showed
+  // nothing until the kernel round-tripped, while plain sends painted instantly — the exact
+  // inconsistency reported). The quote branch echoes the COMPOSED body, which is byte-identical to
+  // what lands (quoteReplyBody IS the send path), so the reconcile's includes() match is exact; the
+  // follow-up echoes the typed words, a substring of the goal-wrapped landing.
+  if (goalCite?.itemId) { vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid }); registerOptimistic(sid, text); }
+  else if (quoteCites.length) { const body = quoteReplyBody(quoteCites, text); vscodeApi.postMessage({ type: "sendMessage", id: sid, text: body }); registerOptimistic(sid, body); }
   else { vscodeApi.postMessage({ type: "sendMessage", id: sid, text }); registerOptimistic(sid, text); }
 }
 
@@ -9272,7 +9252,7 @@ function renderStagedStrip(id: string | null): void {
     const mark = el("span", "composer-chip-mark");
     mark.textContent = "•";
     const label = el("span", "composer-chip-label");
-    label.textContent = s.text;
+    label.textContent = s.text || "(context only — sends with your message)";
     // one line, ellipsized IN BOUNDS, with a colored "(expand)" that is visibly chrome, not message
     // text; click toggles the full text — the context-fold idiom (the user 2026-08-15, whose staged
     // line ran off the right edge with no ellipsis and no way to read the rest)
@@ -9354,6 +9334,17 @@ function renderComposerChips(id: string | null): void {
   const cites = id ? composerCitations.get(id) : undefined;
   if (!cites || !cites.length) { strip.style.display = "none"; return; }
   strip.style.display = "flex";
+  // The STAGE button (the user 2026-08-23): nobody discovers ⌘⏎ on their own, so whenever quote
+  // context is held the strip carries its visible face — right of the blue chips, gone with them.
+  // Same action as the shortcut: stage the context (and any typed text) and keep going.
+  {
+    const st = el("button", "staged-go composer-stage-btn") as HTMLButtonElement;
+    st.type = "button";
+    st.textContent = "Stage";
+    st.title = "hold this context (and anything typed) for one combined send later — ⌘⏎ does the same";
+    st.addEventListener("click", (e) => { e.stopPropagation(); fireStage(); });
+    strip.appendChild(st);
+  }
   // one chip per held context, in the order they were added — the strip stacks them (flex column)
   cites.forEach((cite, i) => {
     const chip = el("div", "composer-chip");
@@ -9571,7 +9562,7 @@ function quoteReplyBody(cites: { quote?: string; src?: string | null }[], text: 
     const lead = c.src ? "Replying to this highlighted code (" + c.src + "):" : "Replying to this part of the conversation:";
     return lead + "\n" + q;
   });
-  return sections.join("\n\n") + "\n\n" + text;
+  return text ? sections.join("\n\n") + "\n\n" + text : sections.join("\n\n");
 }
 
 // HIGHLIGHT-TO-REPLY (the user 2026-07-13): selecting text in the chat transcript seeds the composer chip
@@ -10589,7 +10580,9 @@ function setupComposer() {
   const stageComposer = () => {
     if (!activeId) return;
     const typed = ta.value.trim();
-    if (!typed) return;
+    // context stages ALONE (the user 2026-08-23): select a passage, ⌘⏎ with an empty box, repeat —
+    // then one typed message flushes the whole run. Nothing at all → nothing to stage.
+    if (!typed && !(composerCitations.get(activeId) || []).some((c) => c.quote)) return;
     if (composerAnswersAsk()) { warnToast("A picker is waiting on this box — answer it, or send normally."); return; }
     if (composerEdits.has(activeId)) { warnToast("An edit replaces a past message — send it normally."); return; }
     if ((composerFiles.get(activeId) || []).length) { warnToast("Attachments can't be staged — send them with a normal message."); return; }
@@ -10770,6 +10763,7 @@ function setupComposer() {
   const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
   sendBtn?.addEventListener("mousedown", (e) => { e.preventDefault(); sendComposer(); if (isCoarsePointer()) ta.blur(); else ta.focus(); });
   fireHeldSend = () => sendComposer();   // the ack handler's door into this closure (see sendOnShip)
+  fireStage = () => stageComposer();     // the chips strip's Stage button's door (renderComposerChips)
 
   // ── drag-to-resize the message box (the user 2026-07-07) ── the #composer-resize handle straddles the
   // top-edge divider; dragging it UP grows the composer (to see a long message in full), DOWN shrinks it.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -547,7 +547,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* ── citation chip strip (the user 2026-07-01) ── a click on a feed card summary / sub-goal seeds a
    dismissible pill here, ABOVE the textarea: "you're following up on THIS". Accent-blue, with an ✕ to
    dismiss (Backspace-at-start dismisses too). Reads as attached context, not typed text. */
-#composer-chips { flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding: 0 0 6px 2px; }
+#composer-chips { flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding: 0 0 6px 2px; position: relative; }   /* anchors the Stage button at its top-right */
 /* attachment thumbnails (the user 2026-08-04): dropped/pasted/picked files sit as little previews above
    the box until send — a row that wraps, unlike the stacked context chips below it */
 #composer-files { flex: 1 1 100%; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 0 0 6px 2px; }
@@ -605,6 +605,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
 .staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }
+/* the chips strip's Stage button (the user 2026-08-23): the staged strip's own button dress, pinned
+   to the RIGHT of the blue context chips; it exists exactly while context is held (the strip
+   renders it, and the strip hides with the chips) */
+.composer-stage-btn { position: absolute; right: 2px; top: 0; background: none; border: 1px solid var(--accent);
+  color: var(--accent); border-radius: 5px; font-size: 0.78em; padding: 1px 8px; cursor: pointer; }
+.composer-stage-btn:hover { background: var(--accent); color: var(--accent-fg); }
 .staged-chip { display: flex; flex-direction: column; gap: 2px; border: 1px dashed rgba(156, 210, 255, 0.45);
   border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg);
   cursor: pointer; }


### PR DESCRIPTION
Three pieces of the approved verb consolidation (Comment / Quote / Stage, by removal), plus the reported echo inconsistency:

- **Quote = the chip, only.** The in-box editable-blockquote form is removed (inserter and chip-dedup deleted); the selection menu's Quote now just focuses the composer, since selecting already seeded the chip. One quote representation everywhere.
- **Context stages alone.** Select a passage, ⌘⏎ with an empty box, repeat — then one typed message flushes the whole run. Context-only staged rows are labeled, and a context-only body composes without a dangling tail.
- **A visible Stage button.** Nobody discovers ⌘⏎ unaided: while quote context is held, the chips strip pins a Stage button at its right (the staged strip's own dress) with the shortcut named in its tooltip; it vanishes with the context.
- **Every send echoes optimistically.** Quoted and follow-up sends never registered the instant local echo — only plain sends did — which is exactly the "message doesn't appear until it lands" inconsistency reported. The quote branch echoes the composed body (byte-identical to what lands, so reconciliation is exact); follow-ups echo the typed words (a substring of the goal-wrapped landing).

The file-viewer half of the consolidation (replacing its separate review-comment store with chips + staging) follows as its own PR. Suite passes (2,214) with pins updated for all four behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)