### PR TITLE
Thread mail draws from the comment's anchor square on the timeline

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18445,11 +18445,15 @@ def _postal_messages(now, alive_sids, id2name):
             execd.pop(o["id"], None)                     # (postal restore) — it never reached the recipient
     cutoff, out = now - TL_HORIZON, []
     msgsum = _msg_summaries()                           # {id: Haiku caption} → the timeline shows it over the raw body
+    tanchors = _thread_anchors(alive_sids)              # {tid: (parent sid, anchorT, name)} — thread mail's home
     for mid, e in sent.items():
         f, t, st = e.get("from_id"), e.get("to_id"), e.get("t")
         # both endpoints must EXIST (bus-origin mail — bounces from the Romp Postal Service itself —
-        # has no sender sid and can never draw), and at least one must be a local lane.
-        if not f or not t or (f not in alive_sids and t not in alive_sids) or f == t or not st or st < cutoff:
+        # has no sender sid and can never draw), and at least one must be a local lane. A comment-THREAD
+        # endpoint counts through its parent's lane (rewritten below) — the raw f == t self-check runs
+        # FIRST, so thread↔parent mail (different raw sids, one lane) survives it by design.
+        local = (f in alive_sids or t in alive_sids or f in tanchors or t in tanchors)
+        if not f or not t or not local or f == t or not st or st < cutoff:
             continue
         ex = execd.get(mid)
         ex_t, ex_dmid = (ex if isinstance(ex, tuple) else (ex, None))
@@ -18461,8 +18465,38 @@ def _postal_messages(now, alive_sids, id2name):
                "text": (e.get("body", "") or "").strip()[:240], "summary": msgsum.get(mid)}
         if ex_dmid:
             row["dmid"] = ex_dmid   # lets the MERGED view join a relayed connector to the remote turn's mids
+        # A thread has NO lane of its own; its visual home is the comment's anchor square on the
+        # parent's lane (the user 2026-08-23: the connector comes out of the square and lands back in
+        # the lane where the mail arrives — and a reply arcs back into the square). Rewrite the
+        # endpoint to the parent's lane and pin its x to the square via fromThreadT/toThreadT; the
+        # name stays the THREAD's, so the tooltip says who really spoke.
+        if f in tanchors:
+            _p, _at, _nm = tanchors[f]
+            row["fromId"], row["fromThreadT"] = _p, _at
+            row["from"] = _nm or row["from"]
+        if t in tanchors:
+            _p, _at, _nm = tanchors[t]
+            row["toId"], row["toThreadT"] = _p, _at
+            row["to"] = _nm or row["to"]
         out.append(row)
     out.sort(key=lambda m: m["sent"])
+    return out
+
+
+def _thread_anchors(alive_sids):
+    """{thread sid: (parent sid, anchorT, thread name)} across the alive sessions' comment stores —
+    where a comment thread LIVES on the timeline (its anchor square's x on the parent's lane). Only
+    open/live rows matter; a promoted thread has its own lane and never resolves here (its sid left
+    the comments store's live view when it gained a names/ entry)."""
+    out = {}
+    for sid in alive_sids:
+        try:
+            for t in (_load_comments(sid).get("threads") or []):
+                tid, at = t.get("tid"), t.get("anchorT")
+                if tid and at and t.get("status") != "promoted":
+                    out[tid] = (sid, int(at), str(t.get("name") or ""))
+        except Exception:
+            continue
     return out
 
 

--- a/tests/test_thread_arc.py
+++ b/tests/test_thread_arc.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Thread mail on the timeline (the user 2026-08-23): a comment thread has no lane — its visual home
+is the comment's anchor square on the parent's lane. _postal_messages rewrites a thread endpoint to
+the parent's lane with fromThreadT/toThreadT pinned to the square's x, keeps the THREAD's name for
+the tooltip, and the raw self-send check runs before the rewrite so thread↔parent mail (one lane,
+two identities) survives. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+TSID = "66666666-7777-8888-9999-000000000000"
+NOW = 1_787_500_000
+ANCHOR_T = NOW - 3600
+
+
+def _seed_mail(rows):
+    d = jd.STATE / "timeline"
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / "messages.jsonl", "w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+class ThreadArc(unittest.TestCase):
+    def setUp(self):
+        self._saved = (km._load_comments, km._msg_summaries)
+        km._load_comments = lambda sid: ({"threads": [{"tid": TSID, "anchorT": ANCHOR_T,
+                                                       "name": "web-comment-1", "status": "open"}]}
+                                         if sid == PARENT else {})
+        km._msg_summaries = lambda: {}
+
+    def tearDown(self):
+        km._load_comments, km._msg_summaries = self._saved
+        p = jd.STATE / "timeline" / "messages.jsonl"
+        if p.exists():
+            p.unlink()
+
+    def test_thread_to_parent_mail_rides_the_parents_lane_from_the_square(self):
+        _seed_mail([{"ev": "sent", "id": "m1", "from_id": TSID, "to_id": PARENT,
+                     "from": "web-comment-1", "t": NOW - 600, "body": "the anchor section needs a pass"},
+                    {"ev": "exec", "id": "m1", "t": NOW - 590}])
+        rows = km._postal_messages(NOW, {PARENT}, {PARENT: "web"})
+        self.assertEqual(len(rows), 1, "thread↔parent mail survives the raw self-check by design")
+        m = rows[0]
+        self.assertEqual(m["fromId"], PARENT, "the endpoint is the parent's LANE")
+        self.assertEqual(m["fromThreadT"], ANCHOR_T, "…pinned to the comment square's x")
+        self.assertEqual(m["from"], "web-comment-1", "…but the tooltip says who really spoke")
+        self.assertEqual(m["toId"], PARENT)
+        self.assertNotIn("toThreadT", m, "the landing end is ordinary parent mail")
+
+    def test_parent_reply_arcs_back_into_the_square(self):
+        _seed_mail([{"ev": "sent", "id": "m2", "from_id": PARENT, "to_id": TSID,
+                     "from": "web", "t": NOW - 300, "body": "good catch, apply it"},
+                    {"ev": "exec", "id": "m2", "t": NOW - 295}])
+        rows = km._postal_messages(NOW, {PARENT}, {PARENT: "web"})
+        self.assertEqual(len(rows), 1)
+        m = rows[0]
+        self.assertEqual(m["toId"], PARENT)
+        self.assertEqual(m["toThreadT"], ANCHOR_T, "the reply lands AT the square")
+        self.assertEqual(m["to"], "web-comment-1")
+
+    def test_promoted_threads_resolve_nowhere_here(self):
+        km._load_comments = lambda sid: ({"threads": [{"tid": TSID, "anchorT": ANCHOR_T,
+                                                       "name": "web-comment-1", "status": "promoted"}]}
+                                         if sid == PARENT else {})
+        self.assertEqual(km._thread_anchors({PARENT}), {},
+                         "a promoted thread has its own lane — the square is no longer its home")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3430,7 +3430,11 @@ class TimelinePanel {
 
     // obstacles for routing — at each event's process-start (a pending event rides `now` via execAt/startAt)
     const obstacles = [];
-    data.messages.forEach((mm) => { if (inWin(execAt(mm)) && vidx[mm.toId] != null) obstacles.push({ x: x(execAt(mm)), lane: vidx[mm.toId] }); });
+    // a THREAD endpoint draws at its comment square's x, not the mail time (fromThreadT/toThreadT,
+    // the user 2026-08-23) — sendX/landX are the drawn positions everywhere below
+    const sendXT = (mm) => mm.fromThreadT || mm.sent;
+    const landXT = (mm) => mm.toThreadT || execAt(mm);
+    data.messages.forEach((mm) => { if (inWin(landXT(mm)) && vidx[mm.toId] != null) obstacles.push({ x: x(landXT(mm)), lane: vidx[mm.toId] }); });
     vis.forEach((s, i) => turnsOf(s.id).forEach((t) => { if (inWin(startAt(t))) obstacles.push({ x: x(startAt(t)), lane: i }); }));
 
     // one connector per directed FLOW (A→B): a single line spanning the flow's first
@@ -3452,7 +3456,7 @@ class TimelinePanel {
     Object.keys(flows).forEach((k) => {
       const f = flows[k];
       const sLane = vidx[f.from], rLane = vidx[f.to];
-      const xs = x(Math.max(f.sent, t0)), ys = laneY(sLane), xe = x(f.exec), ye = laneY(rLane), col = colorOf(f.from);
+      const xs = x(Math.max(f.sent, t0)), ys = laneY(sLane), xe = x(f.exec), ye = laneY(rLane), col = colorOf(f.from);   // flows keep mail times: bands aggregate, squares are per-message
       const dir = (ys < ye) ? 1 : -1;
       const track = ye - dir * MSG_DROP;
       const xc = crossX(sLane, rLane, xs, xe, obstacles);
@@ -3471,10 +3475,10 @@ class TimelinePanel {
     // PASS 1: connector line + highlight (drawn first so the dots sit on top).
     data.messages.forEach((mm, i) => {
       if (vidx[mm.fromId] == null || vidx[mm.toId] == null) return;
-      if (execAt(mm) < t0 || mm.sent > t1) return;
+      if (landXT(mm) < t0 || sendXT(mm) > t1) return;
       const sLane = vidx[mm.fromId], rLane = vidx[mm.toId];
-      const offL = mm.sent < t0;   // sent BEFORE the visible window — only the delivery is in view
-      const xs = x(offL ? t0 : mm.sent), ys = laneY(sLane), xe = x(execAt(mm)), ye = laneY(rLane), col = colorOf(mm.fromId);
+      const offL = sendXT(mm) < t0;   // sent BEFORE the visible window — only the delivery is in view
+      const xs = x(offL ? t0 : sendXT(mm)), ys = laneY(sLane), xe = x(landXT(mm)), ye = laneY(rLane), col = colorOf(mm.fromId);
       const dir = (ys < ye) ? 1 : -1, track = ye - dir * MSG_DROP;
       const xc = crossX(sLane, rLane, xs, xe, obstacles);
       // An off-window send used to CLAMP to the left edge and hug the sender's lane all the way to the
@@ -3532,10 +3536,10 @@ class TimelinePanel {
     // co-highlight and share the click. A dot whose sender lane is off-screen has no connector but
     // is still its own hoverable/clickable target.
     data.messages.forEach((mm, i) => {
-      if (vidx[mm.toId] == null || !inWin(execAt(mm))) return;
+      if (vidx[mm.toId] == null || !inWin(landXT(mm))) return;
       const col = colorOf(mm.fromId), cy = laneY(vidx[mm.toId]);
       const u = msgUI[i];
-      const c = dot(x(execAt(mm)), cy, col, msgHtml(mm), msgNav(mm), u && u.hl, dagOrHoverMsg(mm.id));
+      const c = dot(x(landXT(mm)), cy, col, msgHtml(mm), msgNav(mm), u && u.hl, dagOrHoverMsg(mm.id));
       if (u) u.dot = c;
     });
 

--- a/ui/timeline-threadarc.test.ts
+++ b/ui/timeline-threadarc.test.ts
@@ -1,0 +1,22 @@
+// Thread mail draws from the comment's anchor square (the user 2026-08-23): a thread endpoint's x is
+// the square's anchorT (fromThreadT/toThreadT from the kernel), not the mail time, on the PARENT's
+// lane — the existing same-lane path then bridges out of the square and back into the lane where the
+// mail lands. Source pins (the view is a big canvas module; the kernel side is executed in
+// tests/test_thread_arc.py).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const VIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+
+test("send and land positions honor the thread square everywhere a message draws", () => {
+  assert.match(VIEW, /const sendXT = \(mm\) => mm\.fromThreadT \|\| mm\.sent;/);
+  assert.match(VIEW, /const landXT = \(mm\) => mm\.toThreadT \|\| execAt\(mm\);/);
+  // the per-message connector, its windowing, the obstacles pass, and the arrival dot all draw
+  // from the same two accessors — one frame, never a mix of square-x and mail-x
+  assert.match(VIEW, /const xs = x\(offL \? t0 : sendXT\(mm\)\), ys = laneY\(sLane\), xe = x\(landXT\(mm\)\)/);
+  assert.match(VIEW, /if \(landXT\(mm\) < t0 \|\| sendXT\(mm\) > t1\) return;/);
+  assert.match(VIEW, /if \(inWin\(landXT\(mm\)\) && vidx\[mm\.toId\] != null\) obstacles\.push\(\{ x: x\(landXT\(mm\)\)/);
+  assert.match(VIEW, /const c = dot\(x\(landXT\(mm\)\), cy, col/);
+});

--- a/ui/webview/timeline-hover-consistent.test.ts
+++ b/ui/webview/timeline-hover-consistent.test.ts
@@ -32,6 +32,6 @@ test("cross-lit dots are drawn grown via dot()'s lit param — arrival and promp
   assert.match(SRC, /const dot = \(cx, cy, color, html, onClick, linkedHl, lit\) =>/);
   assert.match(SRC, /r: lit \? DOT_R \+ 2 : DOT_R/, "lit → the same +2 growth the native hover applies");
   assert.match(SRC, /c\.setAttribute\('r', lit \? DOT_R \+ 2 : DOT_R\)/, "mouseleave restores the lit radius");
-  assert.match(SRC, /dot\(x\(execAt\(mm\)\), cy, col, msgHtml\(mm\), msgNav\(mm\), u && u\.hl, dagOrHoverMsg\(mm\.id\)\)/);
+  assert.match(SRC, /dot\(x\(landXT\(mm\)\), cy, col, msgHtml\(mm\), msgNav\(mm\), u && u\.hl, dagOrHoverMsg\(mm\.id\)\)/);
   assert.match(SRC, /, null, dotLit\(t, dagOrHover\)\);/, "the prompt dot passes its lit state through");
 });


### PR DESCRIPTION
The polish half of thread-to-parent mail (the identity half merged earlier): a comment thread has no timeline lane — its visual home is the comment's **anchor square** on the parent's lane.

## What changes
- **Kernel** (`_postal_messages`): a thread endpoint rewrites to the parent's lane with `fromThreadT`/`toThreadT` pinned to the square's x, joined from the alive sessions' comment stores (`_thread_anchors`; promoted threads resolve nowhere — they have their own lane). The tooltip keeps the THREAD's name, so it still says who really spoke, and the raw self-send check runs before the rewrite so thread↔parent mail (one lane, two identities) survives by design.
- **View**: send position, landing position, windowing, the obstacle pass, and the arrival dot all draw from the same two accessors (`sendXT`/`landXT`) — one coordinate frame, never a mix of square-x and mail-x. The existing same-lane path geometry already bridges out of the square, across, and back into the lane where the mail lands (and a parent's reply arcs back INTO the square).

## Tests
`tests/test_thread_arc.py` executes the rewrite end-to-end (thread→parent from the square, reply landing at the square, promoted threads excluded); `ui/timeline-threadarc.test.ts` pins the one-frame accessor discipline; one stale hover-consistency pin updated. Suites: python green, UI 2215/2215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)