### PR TITLE
Unread tints the turn's rail segment; the crawl moves from the prose to the tick

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -106,6 +106,19 @@ test("an unread thread wears a NEW-here dot on its last segment and a shouting r
   assert.match(UI, /if \(th\) th\.unread = false;\s*\/\/ optimistic; the kernel's watermark reconciles/);
 });
 
+test("an unread thread tints its turn's RAIL segment yellow; clicking the rail opens the thread", () => {
+  // the user 2026-08-23: the corner dot is easy to miss — the identity line's own segment is the
+  // prominent cue. Cleared on this same pass the moment the thread is viewed (openCommentPopover
+  // drops the flag and re-runs applyCommentMarks); the clear sweep runs BEFORE the re-apply so a
+  // resolved/removed thread can never leave a stale tint.
+  assert.match(UI, /for \(const t of Array\.from\(v\.el\.querySelectorAll\("\.turn\.cmt-rail-unread"\)\)\) t\.classList\.remove\("cmt-rail-unread"\);/);
+  assert.match(UI, /turn\.classList\.toggle\("cmt-rail-unread", list\.some\(\(t\) => !!t\.unread && t\.status === "open"\)\);/);
+  assert.match(CSS, /\.turn\.cmt-rail-unread::before \{ background: var\(--cmt-hl\); opacity: 1; width: 3px; left: 10px; \}/);
+  // the rail-hit click checks at CLICK time, so the strip reverts to timeline navigation once read
+  assert.match(UI, /const um = turn\.querySelector\("mark\.cmt-hl\.unread"\) as HTMLElement \| null;/);
+  assert.match(UI, /if \(um\?\.dataset\.tid && activeId\) \{ openCommentPopover\(activeId, um\.dataset\.tid, e\.clientX, e\.clientY\); return; \}/);
+});
+
 test("busy and stuck are disjoint state families", () => {
   for (const s of ["working", "retrying", "compacting"]) assert.ok(threadBusy(s) && !threadStuck(s));
   for (const s of ["permission", "picker"]) assert.ok(threadStuck(s) && !threadBusy(s));
@@ -355,24 +368,22 @@ test("ticks and message notches share ONE scrollbar frame, so they can never dis
   assert.match(UI, /kids\[i\]\.style\.top = t\.y \+ "px";/);
 });
 
-test("while the thread is WRITING the region wears marching ants ON TOP of the solid fill", () => {
+test("while the thread is WRITING the passage pales and the CRAWL rides the scroll-rail tick", () => {
+  // the user 2026-08-23 (superseding the same-day ants-on-top design): a crawl around the passage
+  // read as distraction, not progress. The passage now holds a PALER solid tint — visibly not the
+  // final color — and the four-strip march lives in miniature on the thread's scroll-rail tick.
   assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
-  // a dashed outline whose dashes crawl around the box — four gradient strips, animated offsets,
-  // the solid tint STAYS under the ants (the user 2026-08-23: no more mixed half-dashed phase, the
-  // only state change is the ants appearing); never a border (it would shift the inline text)
-  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--cmt-hl\) 30%, transparent\);\s*\n\s*background-image:\s*\n\s*repeating-linear-gradient/);
-  assert.match(CSS, /animation: cmt-ants 3\.6s linear infinite;/, "3× slower than the original 1.2s march");
-  assert.doesNotMatch(CSS, /cmt-ants 1\.2s/, "no fast march survives anywhere");
-  // each no-repeat strip is oversized by one 12px dash period along its travel axis and starts a
-  // period back, and the keyframe travels exactly that period — a strip sized to its edge slid open
-  // a gap that snapped shut every cycle, a visible lurch on text-height vertical edges (2026-08-19)
-  assert.match(CSS, /background-size: calc\(100% \+ 12px\) 1\.5px, calc\(100% \+ 12px\) 1\.5px, 1\.5px calc\(100% \+ 12px\), 1\.5px calc\(100% \+ 12px\);/);
-  assert.match(CSS, /background-position: -12px 0, 0 100%, 0 0, 100% -12px;/);
-  assert.match(CSS, /@keyframes cmt-ants \{\s*\n\s*to \{ background-position: 0 0, -12px 100%, 0 -12px, 100% 0; \}/);
-  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\)/, "hosts march too, or their tint defeats the cue");
-  // both ants blocks (mark + host) carry the oversize — a lone fixed block leaves the other lurching
-  assert.strictEqual((CSS.match(/background-size: calc\(100% \+ 12px\) 1\.5px/g) || []).length, 2);
-  assert.match(KERNEL, /state = be\.session_state\(tsid\)/);
+  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--cmt-hl\) 16%, transparent\);\s*\n\}/);
+  assert.doesNotMatch(CSS, /mark\.cmt-hl\.busy \{[^}]*repeating-linear-gradient/s, "no strips on prose");
+  assert.doesNotMatch(CSS, /@keyframes cmt-ants /, "the passage keyframes are gone with them");
+  // the tick's miniature march: 6px dash cycle, strips oversized by one period (the 2026-08-19
+  // loop-point lesson, scaled down), and the tick class rides threadBusy with the sig tracking it
+  assert.match(CSS, /\.cmt-tick\.busy::after \{[\s\S]*?animation: cmt-tick-ants 1\.8s linear infinite;/);
+  assert.match(CSS, /@keyframes cmt-tick-ants \{\s*\n\s*to \{ background-position: 0 0, -6px 100%, 0 -6px, 100% 0; \}/);
+  assert.match(UI, /\+ \(threadBusy\(th\.state\) && th\.status === "open" \? " busy" : ""\);/);
+  assert.match(UI, /\+ ":" \+ \(threadBusy\(t\.th\.state\) \? 1 : 0\)\)/, "a state flip re-renders the tick");
+  // the code/math hosts pale the same way — no strips there either
+  assert.match(CSS, /\.md \.katex\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{\s*\n\s*background-color: color-mix\(in srgb, var\(--cmt-hl\) 16%, transparent\);\s*\n\}/);
 });
 
 test("the popover renders the thread with the CHAT's own renderer from the branch point", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1313,6 +1313,10 @@ function wireTurnHover(turn: HTMLElement, dot: HTMLElement | null, uuid: string 
   // dotOpen payload, so the line and the dot that begins its turn navigate to exactly the same place.
   rail.addEventListener("click", (e) => {
     e.stopPropagation();
+    // a tinted (unread-comment) rail opens THAT thread (the user 2026-08-23) — checked at click
+    // time, so the same strip goes back to timeline navigation the moment the thread is read
+    const um = turn.querySelector("mark.cmt-hl.unread") as HTMLElement | null;
+    if (um?.dataset.tid && activeId) { openCommentPopover(activeId, um.dataset.tid, e.clientX, e.clientY); return; }
     if (activeId) vscodeApi?.postMessage({ type: "dotOpen", sid: activeId, uuid, t, tlId });
   });
   let railTimer: ReturnType<typeof setTimeout> | undefined;
@@ -5669,11 +5673,19 @@ function applyCommentMarks(sid: string): void {
   for (const old of Array.from(v.el.querySelectorAll("mark.cmt-hl"))) {
     if (!have.has((old as HTMLElement).dataset.tid || "")) unwrapCommentMark(old as HTMLElement);
   }
+  // the rail cue clears first (idempotent re-apply): a thread viewed, resolved, or removed must
+  // drop its turn's tint on this very pass, not linger until the next anchor match
+  for (const t of Array.from(v.el.querySelectorAll(".turn.cmt-rail-unread"))) t.classList.remove("cmt-rail-unread");
   if (!threads.length) return;
   for (const [uuid, list] of threadsByAnchor(threads)) {
     const turn = v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`) as HTMLElement | null;
     if (!turn) continue;                       // windowed out — the mark returns when the turn does
     for (const th of list) ensureCommentMark(turn, th);
+    // the turn's RAIL segment shouts the new-here state too (the user 2026-08-23: the corner dot is
+    // easy to miss — the identity line's own segment tints comment-yellow while any thread on this
+    // turn is unread, and clicking the rail opens it). Cleared above the moment it's viewed —
+    // openCommentPopover drops the unread flag and re-runs this pass.
+    turn.classList.toggle("cmt-rail-unread", list.some((t) => !!t.unread && t.status === "open"));
   }
 }
 
@@ -5781,7 +5793,8 @@ function updateCommentRail(): void {
     ticks.push({ th, y: Math.min(r.height - 6, Math.round((off / frame.sh) * (r.height - 4))) });
   }
   const sig = activeId + "|" + Math.round(r.top) + "," + Math.round(r.right) + "," + Math.round(r.height)
-    + "|" + ticks.map((t) => t.th.tid + ":" + t.y + ":" + t.th.status + ":" + (t.th.unread ? 1 : 0)).join(",");
+    + "|" + ticks.map((t) => t.th.tid + ":" + t.y + ":" + t.th.status + ":" + (t.th.unread ? 1 : 0)
+                            + ":" + (threadBusy(t.th.state) ? 1 : 0)).join(",");
   if (sig === cmtRailSig && rail) return;
   cmtRailSig = sig;
   if (!rail) { rail = el("div", "cmt-rail"); rail.id = "cmt-rail"; document.body.appendChild(rail); }
@@ -5789,7 +5802,8 @@ function updateCommentRail(): void {
   rail.style.top = r.top + "px";
   rail.style.height = r.height + "px";
   const cls = (th: CommentThread) => "cmt-tick" + (th.status === "resolved" ? " resolved" : "")
-    + (th.unread && th.status === "open" ? " unread" : "");
+    + (th.unread && th.status === "open" ? " unread" : "")
+    + (threadBusy(th.state) && th.status === "open" ? " busy" : "");   // the crawl rides the tick (2026-08-23)
   const kids = Array.from(rail.children) as HTMLElement[];
   if (kids.length === ticks.length && kids.every((k, i) => k.dataset.tid === ticks[i].th.tid)) {
     ticks.forEach((t, i) => { kids[i].style.top = t.y + "px"; kids[i].className = cls(t.th); });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2535,55 +2535,32 @@ mark.cmt-hl.unread.hl-last::after {
   content: ""; position: absolute; top: -4px; right: -4px; width: 7px; height: 7px;
   border-radius: 50%; background: var(--cmt-hl); box-shadow: 0 0 0 1.5px var(--bg);
 }
+/* the turn's rail segment shouts an unread thread (the user 2026-08-23): the identity line's own
+   segment tints the comment yellow — wider and fully opaque so it reads from across the pane — and
+   the rail-hit strip over it opens the thread on click. applyCommentMarks clears the class the
+   moment the thread is viewed. */
+.turn.cmt-rail-unread::before { background: var(--cmt-hl); opacity: 1; width: 3px; left: 10px; }
 mark.cmt-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
 mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
-/* WRITING (the user 2026-08-17; reshaped 2026-08-23): while the thread is mid-reply the region
-   wears MARCHING ANTS — a dashed outline whose dashes crawl slowly around the box — ON TOP of the
-   solid highlight, which never turns off. (It used to: the busy state blanked the tint and showed
-   only the ants, and the equation host flipped on a different rule than the text marks, so a
-   comment spanning text + math passed through a mixed phase — half dashed, half highlighted —
-   before settling. Keeping the tint underneath removes the phase by construction: the only state
-   change is the ants appearing.) Four gradient strips with an animated offset, never a border: an
-   inline border would shift the text it wraps. This rule must stay AFTER :hover — its shorthand
-   would otherwise wipe the strips mid-hover. */
+/* WRITING (the user 2026-08-17; re-reshaped 2026-08-23 — the marching ants left the PROSE: a crawl
+   around the passage read as distraction, not progress): while the thread is mid-reply the region
+   keeps its solid highlight in a PALER blend — visibly "not the final color yet", settling into the
+   full yellow the moment the reply lands. The crawl itself lives on the scroll-rail tick now (see
+   .cmt-tick.busy), where motion informs without sitting inside the text you're reading. */
 mark.cmt-hl.busy {
-  background-color: color-mix(in srgb, var(--cmt-hl) 30%, transparent);
-  background-image:
-    repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
-    repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
-    repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
-    repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px);
-  background-size: calc(100% + 12px) 1.5px, calc(100% + 12px) 1.5px, 1.5px calc(100% + 12px), 1.5px calc(100% + 12px);
-  background-position: -12px 0, 0 100%, 0 0, 100% -12px;
-  background-repeat: no-repeat;
-  animation: cmt-ants 3.6s linear infinite;   /* 3× slower (the user 2026-08-23) */
+  background-color: color-mix(in srgb, var(--cmt-hl) 16%, transparent);
 }
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
-/* the ants march clockwise: top strip right, bottom left, left edge up, right edge down — exactly
-   one 12px dash cycle per period, so the loop point is invisible. Each no-repeat strip is oversized
-   by that same 12px along its travel axis and starts one period back: a strip sized exactly to its
-   edge slid open a growing gap at its trailing end and snapped shut every cycle — a lurch that on a
-   text-height vertical edge swallowed most of the edge (the user 2026-08-19). */
-@keyframes cmt-ants {
-  to { background-position: 0 0, -12px 100%, 0 -12px, 100% 0; }
+
 }
-/* a code/math HOST whose mark is mid-reply wears the ants too — its element tint would otherwise
-   stay solid and defeat the outline-then-fill cue */
+/* a code/math HOST whose mark is mid-reply pales the same way — its element tint would otherwise
+   stay full-strength and hide the writing state */
 .md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),
 .md .katex.cmt-hl-host:has(mark.cmt-hl.busy) {
-  background-color: color-mix(in srgb, var(--cmt-hl) 30%, transparent);
-  background-image:
-    repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
-    repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
-    repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
-    repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px);
-  background-size: calc(100% + 12px) 1.5px, calc(100% + 12px) 1.5px, 1.5px calc(100% + 12px), 1.5px calc(100% + 12px);
-  background-position: -12px 0, 0 100%, 0 0, 100% -12px;
-  background-repeat: no-repeat;
-  animation: cmt-ants 3.6s linear infinite;   /* 3× slower (the user 2026-08-23) */
+  background-color: color-mix(in srgb, var(--cmt-hl) 16%, transparent);
 }
-.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
+.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: color-mix(in srgb, var(--cmt-hl) 16%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host > mark.cmt-hl { background: transparent; }
 .md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }
@@ -2731,6 +2708,25 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    faint glow read as a rendering artifact, not as "new here" */
 .cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1;
   box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl) 85%, transparent); }
+/* a WRITING thread's tick carries the crawl (the user 2026-08-23, moving the ants off the prose):
+   the same four-strip march in miniature — 6px dash cycle, strips oversized by one period so the
+   loop point is invisible (the passage ants' 2026-08-19 lesson, scaled down) — around the tick */
+.cmt-tick.busy { overflow: visible; }
+.cmt-tick.busy::after {
+  content: ""; position: absolute; inset: -3px;
+  background-image:
+    repeating-linear-gradient(90deg, var(--cmt-hl) 0 3px, transparent 3px 6px),
+    repeating-linear-gradient(90deg, var(--cmt-hl) 0 3px, transparent 3px 6px),
+    repeating-linear-gradient(0deg,  var(--cmt-hl) 0 3px, transparent 3px 6px),
+    repeating-linear-gradient(0deg,  var(--cmt-hl) 0 3px, transparent 3px 6px);
+  background-size: calc(100% + 6px) 1.5px, calc(100% + 6px) 1.5px, 1.5px calc(100% + 6px), 1.5px calc(100% + 6px);
+  background-position: -6px 0, 0 100%, 0 0, 100% -6px;
+  background-repeat: no-repeat;
+  animation: cmt-tick-ants 1.8s linear infinite;
+}
+@keyframes cmt-tick-ants {
+  to { background-position: 0 0, -6px 100%, 0 -6px, 100% 0; }
+}
 
 /* a fully-covered KaTeX block tints at the ELEMENT (cmt-hl-host, same contract as inline code):
    a mark inside it cannot paint the glyph boxes' spacing, which punched gaps through highlighted


### PR DESCRIPTION
Two comment-visual reshapes per the user (2026-08-23):

- **Unread, prominently**: the chat rail's identity line tints comment-yellow on the segment of any turn holding an unread thread — readable from across the pane where the corner dot is easy to miss — and clicking the tinted rail opens that thread. The tint clears the moment the thread is viewed (the clear sweep runs before the re-apply, so resolved/removed threads can't leave stale segments), and the rail click checks at click time, so the strip reverts to timeline navigation once read.
- **Writing, quietly**: the marching ants leave the prose (a crawl around the passage read as distraction). The passage holds a paler solid tint — visibly "not the final color yet" — and the march lives on in miniature around the thread's scroll-rail tick (6px cycle, oversized strips per the loop-point lesson, 1.8s). The tick learns the busy state and its signature tracks it, so state flips repaint.

Verified visually across the full matrix (read / unread / writing passages, three tick states, the tinted rail segment); pins cover the clear-first sweep, the click-time check, the paler tints on marks and math/code hosts, the tick march, and the removed prose keyframes. Suite passes (2,217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)