### PR TITLE
Merge: a comment thread's third exit folds it back into the session

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5196,6 +5196,10 @@ def _comment_status_refusal(prior):
         return "this thread is now its own session; end it like any session."
     if prior == "promoting":
         return "this thread is becoming its own session; give it a moment."
+    if prior == "merging":
+        return "this thread is merging back into the session; give it a moment."
+    if prior == "merged":
+        return "this thread was already merged back into the session."
     return "that thread is gone."
 
 
@@ -5625,6 +5629,67 @@ def _comment_reply(parent_sid, tid, text):
         be.resume(reg.get("name") or ("thread-" + tsid[:8]), tsid)   # alive again; names/ untouched
     if not be.send(tsid, str(text)):
         return "couldn't reach this thread's session; it may have been removed."
+    _push_soon()
+    return None
+
+
+MERGE_BODY_CAP = 6000   # the thread exchange fed back on a merge — keep the most recent tail
+
+
+def _merge_body(exact, msgs):
+    """The MERGE handoff (the user 2026-08-23): fold a side discussion's outcome back into the main
+    conversation. Injected-voice rules apply (repo CLAUDE.md): the agent reading this has never heard
+    of romp, so it reads as the person it works for handing over the record of a discussion they had
+    elsewhere, grounded by the passage it was about. No machinery named, no reply slots."""
+    quote = (exact or "").strip()
+    lines = []
+    for m in msgs or []:
+        t = (m.get("text") or "").strip()
+        if not t:
+            continue
+        lines.append(("Me: " if m.get("who") == "user" else "Them: ") + t)
+    convo = "\n\n".join(lines)
+    if len(convo) > MERGE_BODY_CAP:
+        convo = "… (earlier discussion trimmed)\n\n" + convo[-MERGE_BODY_CAP:]
+    parts = ["I took a side discussion with another assistant about this passage of your earlier work:"]
+    if quote:
+        parts.append("\n".join("> " + ln for ln in quote.splitlines()[:6]))
+    parts.append("Here is how it went:")
+    parts.append(convo)
+    parts.append("Treat what we settled there as my direction: fold it into your understanding and "
+                 "account for it in everything you do on this from here on.")
+    return "\n\n".join(parts)
+
+
+def _comment_merge(parent_sid, tid):
+    """Fold a thread's outcome back into the PARENT session (the user 2026-08-23): the thread's
+    exchange lands in the parent as the person's own handoff (_merge_body), the thread settles to
+    'merged', and its CLI shuts down like a resolve (the reg stays; history intact). With this a
+    thread has its three exits: delete (discard), break out (own session), merge (feed back in).
+    The CAS latch ('merging') keeps a racing resolve/delete from killing the CLI mid-read, exactly
+    the promote latch's rationale."""
+    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved"), status="merging")
+    if th is None:
+        return _comment_status_refusal(prior)
+
+    def _revert(msg):
+        _comment_update(parent_sid, tid, status=prior)
+        return msg
+    msgs = _thread_messages(th["sid"], th.get("cutUuid") or "", th.get("createdT") or 0)
+    if not any((m.get("text") or "").strip() for m in msgs):
+        return _revert("this thread has no discussion to merge yet.")
+    body = _merge_body(th.get("exact"), msgs)
+    be = Sessions.backend_for(parent_sid)
+    try:
+        be.send(parent_sid, body)
+    except Exception as e:
+        return _revert("the merge message could not be delivered: %s" % e)
+    _comment_update(parent_sid, tid, status="merged")
+    if hasattr(be, "kill"):
+        try:
+            be.kill(th["sid"])                      # its work is folded back; the CLI has nothing left
+        except Exception:
+            pass
     _push_soon()
     return None
 
@@ -6437,7 +6502,8 @@ def _drive(msg, client):
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
               "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction", "forkSession",
-              "commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote")
+              "commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote",
+              "commentMerge")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -6722,6 +6788,12 @@ def _drive(msg, client):
             # names no thread, and an unspent pending row reads as 'still thinking' forever
             client["send"](json.dumps({"type": "warn", "text": err}))
             client["send"](json.dumps({"type": "commentSendFailed", "id": sid, "tid": str(msg["tid"])}))
+    elif t == "commentMerge" and msg.get("tid"):
+        # Fold the thread back into the session (the user 2026-08-23). LOUD on refusal; the comments
+        # frame rides the next push and the popover adopts the merged title from it.
+        err = _comment_merge(sid, str(msg["tid"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "commentResolve" and msg.get("tid"):
         err = _comment_resolve(sid, str(msg["tid"]))
         if err:

--- a/tests/test_comment_merge.py
+++ b/tests/test_comment_merge.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""The comment thread's third exit (the user 2026-08-23): MERGE folds the discussion back into the
+parent session — the exchange lands as the person's own handoff (_merge_body), the thread settles to
+'merged', and its CLI shuts down like a resolve. Once per thread (the CAS refuses a re-merge), loud
+when there is nothing to merge, and the latch reverts on a failed delivery. SYNTHETIC fixtures."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+TSID = "66666666-7777-8888-9999-000000000000"
+
+
+class FakeBE:
+    def __init__(self):
+        self.sent, self.killed = [], []
+
+    def send(self, sid, text):
+        self.sent.append((sid, text))
+
+    def kill(self, sid):
+        self.killed.append(sid)
+
+
+class CommentMerge(unittest.TestCase):
+    def setUp(self):
+        self.be = FakeBE()
+        self._saved = (km.Sessions.backend_for, km._thread_messages, km._push_soon)
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._thread_messages = lambda tsid, cut, floor_t=0: [
+            {"who": "user", "text": "should the cache be write-through?", "t": 1},
+            {"who": "assistant", "text": "Yes; it removes the stale-read window.", "t": 2}]
+        km._push_soon = lambda: None
+        with km._comments_lock:
+            km._save_comments(PARENT, {"threads": [{
+                "tid": TSID, "sid": TSID, "name": "web-comment-1", "status": "open",
+                "anchorUuid": "aaaabbbb-1111-2222-3333-444455556666", "anchorT": 100,
+                "cutUuid": "aaaabbbb-1111-2222-3333-444455556666",
+                "exact": "the caching layer", "createdT": 100, "lastSeenT": 100}]})
+
+    def tearDown(self):
+        km.Sessions.backend_for, km._thread_messages, km._push_soon = self._saved
+        with km._comments_lock:
+            km._save_comments(PARENT, {"threads": []})
+
+    def _row(self):
+        return km._comment_thread(PARENT, TSID)
+
+    def test_merge_delivers_the_handoff_and_settles_the_thread(self):
+        self.assertIsNone(km._comment_merge(PARENT, TSID))
+        self.assertEqual(len(self.be.sent), 1)
+        sid, body = self.be.sent[0]
+        self.assertEqual(sid, PARENT, "the handoff lands in the PARENT session")
+        self.assertIn("> the caching layer", body, "grounded by the quoted passage")
+        self.assertIn("Me: should the cache be write-through?", body)
+        self.assertIn("Them: Yes; it removes the stale-read window.", body)
+        self.assertIn("account for it", body, "the going-forward direction rides the handoff")
+        self.assertEqual(self._row().get("status"), "merged")
+        self.assertEqual(self.be.killed, [TSID], "the CLI has nothing left; its work is folded back")
+
+    def test_nothing_to_merge_reverts_the_latch_loudly(self):
+        km._thread_messages = lambda tsid, cut, floor_t=0: []
+        err = km._comment_merge(PARENT, TSID)
+        self.assertIn("no discussion to merge", err or "")
+        self.assertEqual(self._row().get("status"), "open", "the latch never sticks on a refusal")
+        self.assertEqual(self.be.sent, [])
+
+    def test_failed_delivery_reverts_the_latch(self):
+        self.be.send = lambda sid, text: (_ for _ in ()).throw(RuntimeError("backend down"))
+        err = km._comment_merge(PARENT, TSID)
+        self.assertIn("could not be delivered", err or "")
+        self.assertEqual(self._row().get("status"), "open")
+
+    def test_a_merged_thread_refuses_a_second_merge_and_replies(self):
+        self.assertIsNone(km._comment_merge(PARENT, TSID))
+        err = km._comment_merge(PARENT, TSID)
+        self.assertIn("already merged", err or "")
+        self.assertEqual(len(self.be.sent), 1, "once per thread")
+
+    def test_the_transcript_cap_keeps_the_recent_tail(self):
+        body = km._merge_body("q", [{"who": "user", "text": "x" * 9000}])
+        self.assertIn("earlier discussion trimmed", body)
+        self.assertLess(len(body), 9000, "capped — a huge thread never floods the parent's turn")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -113,6 +113,15 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             "continue button": km._followup_body(TOP, None, km.CONTINUE_TEXT),
             "multi-goal bundle": km._nudge_bundle_body([TOP, TOP2], nodes, set()),
             "multi-goal bundle (fork)": km._nudge_bundle_body([TOP, TOP2], nodes, {TOP}),
+            # the Merge handoff (the user 2026-08-23): a comment thread's discussion folded back into
+            # the parent session — the reader has never heard of romp; it must read as the person's
+            # own record of a side discussion
+            "comment-thread merge": km._merge_body(
+                "the caching layer should be write-through",
+                [{"who": "user", "text": "should we make the cache write-through instead?"},
+                 {"who": "assistant", "text": "Yes: write-through avoids the stale-read window and "
+                                              "the extra invalidation pass; the cost is one write "
+                                              "per update, which this workload absorbs."}]),
             "debt reminder (question)": km._debt_reminder_body(
                 [("web", T0, "question", "Which port should the staging server use?")]),
             "debt reminder (handoff)": km._debt_reminder_body(
@@ -181,9 +190,12 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # opener is the user's own comment on a quoted passage — a conversation, never a nudge
             # …and the edit trace is an FYI about something the user already DID (a file changed under
             # the session) — telling, not asking; a status question bolted on would be noise
+            # …and the MERGE handoff is a record handed over with direction ("account for it"),
+            # never a status ask — bolting a progress question onto it would be noise
             if name in ("typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
-                        "debt reminder (several)", "comment thread opener", "edit trace"):
+                        "debt reminder (several)", "comment thread opener", "edit trace",
+                        "comment-thread merge"):
                 continue
             text = prose(body).lower()
             with self.subTest(message=name):

--- a/ui/webview/comment-merge.test.ts
+++ b/ui/webview/comment-merge.test.ts
@@ -1,0 +1,38 @@
+// The comment thread's third exit (the user 2026-08-23): MERGE folds the discussion back into the
+// parent session. The kernel executes the flow (tests/test_comment_merge.py + the injected-voice
+// sweep); these are the UI's source pins: the button, the delegated click-safe handler with its
+// instant ack, and the merged status wearing resolved's dim everywhere it renders.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const TYPES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "comments.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+
+test("the Merge button rides the actions row, delegated, acknowledging before the round-trip", () => {
+  assert.match(RENDER, /mg\.textContent = "Merge";/);
+  assert.match(RENDER, /mg\.dataset\.act = "cmtmerge";/);
+  assert.match(RENDER, /cmtmerge: \(elx\) => \{/);
+  assert.match(RENDER, /elx\.textContent = "Merging…";/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "commentMerge", id: cur\.sid, tid: cur\.th\.tid \}\);/);
+});
+
+test("merged is a first-class status: title, dim, rail, and a closed composer", () => {
+  assert.match(TYPES, /"merging" \| "merged"/);
+  assert.match(RENDER, /: th!\.status === "merged" \? nm \+ " \(merged into the session\)"/);
+  assert.match(RENDER, /t\.status === "open" \|\| t\.status === "resolved" \|\| t\.status === "merged"/);
+  assert.match(RENDER, /th\.status === "resolved" \|\| th\.status === "merged" \? " resolved" : ""/);
+  assert.match(RENDER, /Merged — its outcome lives in the session now/);
+});
+
+test("kernel: the op is registered, latched like promote, and the handoff is voice-ruled", () => {
+  assert.match(KERNEL, /"commentMerge"\)/);
+  assert.match(KERNEL, /elif t == "commentMerge" and msg\.get\("tid"\):/);
+  assert.match(KERNEL, /def _comment_merge\(parent_sid, tid\):/);
+  assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "resolved"\), status="merging"\)/);
+  assert.match(KERNEL, /MERGE_BODY_CAP = 6000/);
+  // the reply CAS never accepts a merged thread, so a merged discussion cannot silently reopen
+  assert.match(KERNEL, /this thread was already merged back into the session\./);
+});

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -309,7 +309,7 @@ test("the highlight is highlighter-YELLOW — never the selection blue — and o
   assert.match(CSS, /mark\.cmt-hl\.hl-first \{ border-top-left-radius: 2px/);
   // a fully-covered inline-code span tints at the ELEMENT: a mark inside it can't paint the code's
   // padded background, which left an untinted sliver around every code word (the word-island look)
-  assert.match(UI, /host\.classList\.toggle\("cmt-hl-host", th\.status !== "resolved"\)/);
+  assert.match(UI, /host\.classList\.toggle\("cmt-hl-host", th\.status !== "resolved" && th\.status !== "merged"\)/);
   assert.match(UI, /p\.classList\.remove\("cmt-hl-host"\)/);
   assert.match(CSS, /code\.cmt-hl-host \{ background: color-mix\(in srgb, var\(--cmt-hl\) 30%, var\(--code-bg\)\)/);
   assert.match(CSS, /code\.cmt-hl-host > mark\.cmt-hl \{ background: transparent/);

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -13,7 +13,7 @@ export type CommentThread = {
   color?: string;             // the comment's identity color — picked distinct from its parent's
   anchorUuid: string;
   exact: string;
-  status: "open" | "resolved" | "promoting" | "promoted";
+  status: "open" | "resolved" | "promoting" | "promoted" | "merging" | "merged";   // merging/merged: folded back into the parent (the user 2026-08-23)
   createdT: number;
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
   error?: string;             // the thread CLI's launch error, when it could not start

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5776,7 +5776,7 @@ function updateCommentRail(): void {
   const v = activeId ? views.get(activeId) : null;
   const s = activeId ? sessions.get(activeId) : null;
   const threads = ((activeId && commentThreads.get(activeId)) || [])
-    .filter((t) => t.status === "open" || t.status === "resolved");
+    .filter((t) => t.status === "open" || t.status === "resolved" || t.status === "merged");
   if (!content || !v || !s || !threads.length || v.el.style.display === "none") { rail?.remove(); cmtRailSig = ""; return; }
   const r = content.getBoundingClientRect();
   if (!r.height) { rail?.remove(); cmtRailSig = ""; return; }              // hidden pane
@@ -5801,7 +5801,7 @@ function updateCommentRail(): void {
   rail.style.left = (r.right - 10) + "px";
   rail.style.top = r.top + "px";
   rail.style.height = r.height + "px";
-  const cls = (th: CommentThread) => "cmt-tick" + (th.status === "resolved" ? " resolved" : "")
+  const cls = (th: CommentThread) => "cmt-tick" + (th.status === "resolved" || th.status === "merged" ? " resolved" : "")
     + (th.unread && th.status === "open" ? " unread" : "")
     + (threadBusy(th.state) && th.status === "open" ? " busy" : "");   // the crawl rides the tick (2026-08-23)
   const kids = Array.from(rail.children) as HTMLElement[];
@@ -5879,18 +5879,19 @@ function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
     const host = segs[i].parentElement;
     if (host && host.tagName === "CODE" && host.parentElement?.tagName !== "PRE"
         && host.childNodes.length === 1) {
-      host.classList.toggle("cmt-hl-host", th.status !== "resolved");
+      host.classList.toggle("cmt-hl-host", th.status !== "resolved" && th.status !== "merged");
     }
     const kat = segs[i].parentElement?.closest(".katex") as HTMLElement | null;
-    if (kat) kat.classList.toggle("cmt-hl-host", th.status !== "resolved");
+    if (kat) kat.classList.toggle("cmt-hl-host", th.status !== "resolved" && th.status !== "merged");
   }
 }
 
 function styleCommentMark(m: HTMLElement, th: CommentThread): void {
-  m.classList.toggle("resolved", th.status === "resolved");
+  m.classList.toggle("resolved", th.status === "resolved" || th.status === "merged");
   m.classList.toggle("unread", !!th.unread && th.status === "open");
   m.classList.toggle("busy", threadBusy(th.state) && th.status === "open");
   m.title = th.status === "promoted" ? "thread, now the session '" + th.promotedName + "'"
+    : th.status === "merged" ? "merged thread: its outcome was folded back into the session"
     : th.status === "resolved" ? "resolved thread: click to read or reopen"
     : "thread: click to open";
 }
@@ -6011,6 +6012,8 @@ function commentPopTitle(create: boolean, th: CommentThread | null | undefined):
   return create ? "New comment:"
     : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
     : th!.status === "promoting" ? "Breaking out…"
+    : th!.status === "merging" ? "Merging back in…"
+    : th!.status === "merged" ? nm + " (merged into the session)"
     : th!.status === "resolved" ? nm + " (resolved)" : nm;
 }
 
@@ -6235,6 +6238,7 @@ function renderCommentPopover(): void {
     box.className = "cmt-input";
     box.rows = 2;
     box.placeholder = create ? "Comment on this passage…"
+      : th!.status === "merged" ? "Merged — its outcome lives in the session now"
       : th!.status === "resolved" ? "Reply to reopen…" : "Reply…";
     box.value = commentDrafts.get(dk) || "";
     box.addEventListener("input", () => commentDrafts.set(dk, box.value));
@@ -6308,6 +6312,18 @@ function renderCommentPopover(): void {
       br.title = "Continue this thread as its own session; it keeps everything it knows";
       br.dataset.act = "cmtbreak";
       row.appendChild(br);
+      // MERGE (the user 2026-08-23): the third exit — fold the thread's outcome back into the
+      // session. The kernel sends the parent the discussion as the person's own handoff and the
+      // thread settles to 'merged'; only a thread with something to say can merge (kernel-refused
+      // otherwise, loudly).
+      if (th.status === "open" || th.status === "resolved") {
+        const mg = el("button", "cmt-act") as HTMLButtonElement;
+        mg.type = "button";
+        mg.textContent = "Merge";
+        mg.title = "Send this discussion back into the session as direction going forward; the thread closes as merged";
+        mg.dataset.act = "cmtmerge";
+        row.appendChild(mg);
+      }
       // Resolve is GONE (the user 2026-08-17): an idle thread draws no usage and its transcript
       // is on disk either way, so the real verbs are Break out and Delete. Legacy resolved rows
       // still render dimmed and reopen on reply; they just can't be minted anymore. Never for
@@ -11450,6 +11466,13 @@ setupSettings();
     cmtbreak: () => {
       const cur = openCommentThread();
       if (cur) showBreakoutPrompt(cur.sid, cur.th.tid);
+    },
+    cmtmerge: (elx) => {
+      const cur = openCommentThread();
+      if (!cur) return;
+      (elx as HTMLButtonElement).disabled = true;   // acknowledge before the round-trip
+      elx.textContent = "Merging…";
+      vscodeApi?.postMessage({ type: "commentMerge", id: cur.sid, tid: cur.th.tid });
     },
     cmtresolve: (elx) => {
       const cur = openCommentThread();


### PR DESCRIPTION
Threads had two exits — delete (discard) and break out (own session). The user asked for the third (2026-08-23): **merge**, which sends the parent session everything that happened on the branch so it can account for it going forward.

## What changes
- **Kernel** `commentMerge` op + `_comment_merge`: latches `open/resolved → merging` with the same CAS promote uses (a racing resolve/delete can never kill the CLI mid-read), builds the handoff from the thread's own exchange (`_thread_messages`), delivers it to the parent, settles the thread to `merged`, and shuts the CLI down like a resolve (reg kept, history on disk). Nothing to merge or a failed delivery reverts the latch loudly. A merged thread refuses replies and a second merge through the same CAS.
- **The handoff message** is written under the injected-voice rules — the parent agent has never heard of romp, so it reads as the person's own record of a side discussion: the quoted passage, the exchange as "Me:/Them:" lines (capped at the recent tail, trim noted), and "treat what we settled there as my direction." It rides the vocabulary sweep in `test_injected_voice.py` with the same not-an-ask exemption as the clear wrap-up.
- **UI**: Merge button between Break out and Delete (delegated, instant "Merging…" ack); `merged` is a first-class status — popover title "(merged into the session)", highlight dims like resolved, rail tick dims, composer closed with a plain-words placeholder.

## Tests
`tests/test_comment_merge.py` executes the flow (delivery + grounding + direction line, latch reverts, once-only, transcript cap); the voice sweep renders the handoff; `comment-merge.test.ts` pins the button/handler/status plumbing. Suites: python green, UI 2217/2217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)