### PR TITLE
Retire the E6 eager-done sampler: P4 closed without consolidation

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3784,7 +3784,6 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
                     # prompt-run's optimistic-echo key it can never orphan (the user 2026-07-10: a goal
                     # whose only trail entry drifted distilled to '' — real work, no summary).
                     nodes[t].setdefault("trail", []).append(seg_id)
-                _eager_done_sample(store, t, seg_t)   # E6: was this eager done on the FOCUS top? (gates P4)
         elif do == "block":
             t = _target(o)
             if t and record_verdict(store, nodes[t], "planner", "block", seg_t, why=o["why"], seg=seg_id):
@@ -3904,27 +3903,11 @@ def _stamp_seam(store, top, now):
     del seams[:-SEAM_CAP]
 
 
-def _eager_done_sample(store, nid, seg_t):
-    """E6 sampler (gates P4, the user 2026-07-06): for each PLANNER-set eager done, record whether the
-    resolved goal's top was the session's ACTIVE FOCUS at verdict time. If it was, the settled gate
-    would have held the card out of Completed until the turn ended anyway — the closer would have
-    delivered identical UX, so the planner's eagerness bought nothing visible. A high focus-held rate
-    over a few weeks green-lights consolidating resolution into the closer (P4); a low one keeps both
-    resolvers. Best-effort; never raises."""
-    try:
-        nodes = store.get("nodes", {})
-        def top(x):
-            seen = set()
-            while x in nodes and nodes[x].get("parentId") is not None and x not in seen:
-                seen.add(x); x = nodes[x]["parentId"]
-            return x
-        focus = store.get("lastNode")
-        with (STATE / "eager-done-samples.jsonl").open("a") as f:
-            f.write(json.dumps({"t": seg_t, "sid": store.get("rompUuid"), "nid": nid,
-                                "focusHeld": bool(focus and top(focus) == top(nid))}) + "\n")
-    except Exception:
-        pass
-
+# (The E6 eager-done sampler lived here 2026-06-10..2026-08-23 — it gated P4, "consolidate goal
+# resolution into the closer". CLOSED without consolidation on the final record: 597 samples, 75%
+# focus-held — high enough that eagerness rarely buys visible UX, but the dual-resolver design costs
+# nothing and keeps the planner's same-turn resolution for the cases where it does. The hook and its
+# state file (~/.local/state/romp/eager-done-samples.jsonl) are retired; the user 2026-08-23.)
 
 
 def rollup_status(store, session_closed, now=None):

--- a/tests/test_judge_verdict_log.py
+++ b/tests/test_judge_verdict_log.py
@@ -196,16 +196,16 @@ class DualWriteThroughTheSites(unittest.TestCase):
         self.td = tempfile.mkdtemp()
         jd._rebind_state(Path(self.td))
 
-    def test_planner_done_records_event_and_e6_sample(self):
+    def test_planner_done_records_event_and_writes_no_sampler_file(self):
         store = {"rompUuid": SID, "nodes": {G1: node()}, "placements": {}, "status": {}, "lastNode": G1}
         menu = [{"id": G1, "text": "Ship it"}]
         jd.apply_plan(store, "seg-x", T, [{"do": "done", "goal": 1, "why": "shipped"}], menu, place_key="seg-x")
         log = store["nodes"][G1]["log"]
         self.assertEqual([(e["src"], e["kind"]) for e in log], [("planner", "done")])
         self.assertEqual(log[0]["seg"], "seg-x")
-        samples = [json.loads(l) for l in (jd.STATE / "eager-done-samples.jsonl").read_text().splitlines()]
-        self.assertEqual(len(samples), 1)
-        self.assertTrue(samples[0]["focusHeld"], "G1 was the focus top at verdict time")
+        # the E6 sampler retired 2026-08-23 (P4 closed without consolidation: 597 samples, 75%
+        # focus-held) — a planner done writes NO side file anymore
+        self.assertFalse((jd.STATE / "eager-done-samples.jsonl").exists())
 
     def test_followup_reopen_records_a_user_reopen(self):
         # (user_move was removed 2026-07-25; the card reply is the surviving user-reopen producer)


### PR DESCRIPTION
The optimizer relay closed the loose end (user decision, 2026-08-23): the P4 question — consolidate goal resolution into the closer — is answered **without consolidation**. Final record: 597 samples over 06-10..08-22, 75% focus-held.

The sampling hook in `apply_plan`'s done arm is removed, with a dated tombstone comment where the function lived so the design record survives. The per-host state file (`~/.local/state/romp/eager-done-samples.jsonl`) simply stops growing; it can be deleted at leisure (nothing reads it). The verdict-log test that asserted the sample write now asserts the file is NOT written.

I checked for ongoing consumers before removing: the only reader outside the hook was that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)