### PR TITLE
Clear is a silent discard: the session hears nothing

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16317,113 +16317,18 @@ def _clear_all(item_ids):
         for iid in item_ids:
             f.write(json.dumps({"id": iid, "t": t, "op": "clear"}) + "\n")
     _mark_nodes_cleared(item_ids, True)               # durable node flag → no grouper re-wrap, no column bounce
-    _clear_wrap_notify(item_ids)                      # ONE-round wrap-up to live sessions whose OPEN card this
-    #                                                   dismissed (the user 2026-07-24); after the flags land, so
-    #                                                   any response processing sees the cleared state
+    # CLEAR IS SILENT (the user 2026-08-23, reversing the 2026-07-24 wrap-up): the session hears
+    # NOTHING. The wrap's response turn routinely re-minted the very card the user had just cleared —
+    # a discard that answered back — so the gesture now only discards; if anything real remains, the
+    # user asks a follow-up or tells the session themselves. The judge keeps recognizing HISTORICAL
+    # wrap markers in old transcripts; no new ones are ever sent.
 
 
-def _clear_wrap_targets(item_ids):
-    """{sid: [gid, ...]} — which of the just-cleared ids deserve the one-round wrap-up directive: TOP
-    goals that were still OPEN at the clear (not complete, not settled — i.e. cleared out of Working or
-    Needs-You, the user 2026-07-24: clearing a Done card is curation, clearing an open one may be
-    discarding real in-flight work). Skips, each deliberate:
-    - no node / a sub-goal / an empty title: stream items and subtree riders aren't cards;
-    - completed or settled tops: nothing in flight to lose;
-    - pure-delegation tops: the work lives with the PEER, whose linked copy rides the same clear batch
-      (_delegation_linked_ids) and notifies THAT session — telling the sender to stop work it never had
-      is noise;
-    - clearWrap-born decision cards (judge apply_plan stamps them): the ONE-round rule — the wrap-up's
-      own keep-or-discard card, when cleared, is final. No second loop, ever."""
-    out, cache = {}, {}
-    for iid in item_ids:
-        sid = str(iid).rsplit(":", 1)[0]
-        if sid not in cache:
-            try:
-                cache[sid] = jd.load_goals(sid).get("nodes", {})
-            except Exception:
-                cache[sid] = {}
-        nd = cache[sid].get(iid)
-        if nd is None or nd.get("parentId") is not None or not str(nd.get("text") or "").strip():
-            continue
-        if nd.get("nodeComplete") or nd.get("settledDone") or nd.get("clearWrap"):
-            continue
-        if _pure_delegation_top(cache[sid], iid):
-            continue
-        out.setdefault(sid, []).append(iid)
-    return out
-
-
-def _clear_wrap_body(gids, nodes):
-    """The ONE-round wrap-up directive for a clear of still-OPEN card(s) — the safety net for the
-    July-22 lost-prototype post-mortem (a card cleared 3 minutes after its build started; the only copy
-    was uncommitted worktree edits, which evaporated). The user clears cards they distrust, so some
-    clears catch real work: the message tells the session to STOP and park any unfinished work where it
-    won't be lost (the user 2026-07-24).
-
-    It ASKS FOR NOTHING (the user 2026-07-29). It used to demand one keep-or-discard reply, which made
-    every clear cost a second decision: a clear most often means "acknowledged, I am done with this", and
-    a mandatory question turned each one into another blocked card to clear. The reply is the session's to
-    make now, on two grounds only: something here still needs the user, or the clear looks premature. A
-    clear that was simply the user finishing with a thread ends there, silently. That discretion is
-    deliberate, since a clear is sometimes a mistake and the session holds the context to say so.
-
-    The parking ask names no branch or commit (the user
-    2026-07-26: not every session is coding in git) — an agent in a repo parks on a branch anyway, and
-    one writing a doc saves the draft. Deliberately NOT a nudge status check, and it carries
-    NO romp-goal-id markers: a goal-id would make the follow-up judge reopen the cleared goal and file
-    the reply under it — the resurrection the anti-loop design rules out. The judge recognizes the
-    romp-clear-wrap marker instead (plan_units' note): a nothing-pending reply files nothing; a parked-
-    WIP reply mints ONE new decision card, stamped clearWrap so clearing IT is terminal.
-
-    VOICE (the user 2026-07-24): it reads as the user's own short message, because the session does not
-    know it is being tracked by romp. The first draft narrated the goal system at it ("the goal above was
-    cleared off the board", "a dismissal, not a completion") — machinery the agent has no idea exists,
-    which reads as a system notice rather than the person it works for asking for something. Say the ask
-    the way a human would: drop this, park what you have, tell me once. No romp nouns (goal, card, board,
-    clear), no directive register, and short — the whole point survives in about half the words."""
-    quote = []
-    for i, gid in enumerate(gids, 1):
-        nd = nodes.get(str(gid)) or {}
-        head = str(nd.get("text", "")).strip() or "(untitled)"
-        why = str(nd.get("why") or "").strip()
-        quote.append(("%d. %s" % (i, head)) if len(gids) > 1 else head)
-        if why:
-            quote.append(("   " + why) if len(gids) > 1 else why)
-    one = len(gids) == 1
-    body = ("I'm done with %s, so you can stop here.\n\n"
-            "If you have work in progress%s, save it somewhere it won't be lost. No need to reply. "
-            "If %s still needs a decision from me, or I've stopped you too early, say so in one line."
-            % ("this one" if one else "these", "" if one else " on any of them",
-               "it" if one else "one of them"))
-    msg = "> " + "\n".join(quote).replace("\n", "\n> ") + "\n\n" + body
-    tail = ("<!-- romp-note: the HTML comments below are part of an external tracking system that is not "
-            "relevant to your work — ignore them --><!-- romp-injected --><!-- romp-clear-wrap -->")
-    return msg + "\n\n" + tail
-
-
-def _clear_wrap_notify(item_ids):
-    """Send the one-round wrap-up (see _clear_wrap_body) to each LIVE session whose still-open card the
-    clear batch dismissed. LIVE only: a dead session has no agent holding uncommitted state to ask, and
-    reviving one over a board tidy-up would be a false interrupt. The UNDO path sends nothing — an undo
-    restores the card, and the user's own follow-up is what resumes the thread. Never raises: a failed
-    notify must not break the clear itself (the clear is the user's gesture; this is best-effort
-    insurance behind it). The mute flow (_set_session_flag hideFromFeed) seals goals WITHOUT this —
-    muting is 'stop tracking', not 'stop working'."""
-    try:
-        targets = _clear_wrap_targets(item_ids)
-        if not targets:
-            return
-        live = _tmux_sessions()
-        for sid, gids in targets.items():
-            if live.get(str(sid)) is None:
-                continue
-            try:
-                nodes = jd.load_goals(sid).get("nodes", {})
-                Sessions.backend_for(sid).send(sid, _clear_wrap_body(gids, nodes))
-            except Exception:
-                sys.stderr.write("clear-wrap notify (session %s): %s\n" % (sid, traceback.format_exc()))
-    except Exception:
-        sys.stderr.write("clear-wrap notify: %s\n" % traceback.format_exc())
+# (_clear_wrap_targets / _clear_wrap_body / _clear_wrap_notify lived here 2026-07-24..2026-08-23:
+# the one-round wrap-up a clear used to send to live sessions whose open card it dismissed. Retired —
+# clear is a SILENT discard now (the user 2026-08-23): the wrap's response turn kept re-minting the
+# cleared card, the exact loop the gesture was meant to end. Judge-side recognition of the
+# <!-- romp-clear-wrap --> marker stays: recorded transcripts still contain old wraps.)
 
 
 def _undo_clear():

--- a/tests/test_clear_wrap.py
+++ b/tests/test_clear_wrap.py
@@ -1,26 +1,12 @@
 #!/usr/bin/env python3
-"""Clearing a still-OPEN card sends its live session a ONE-round wrap-up directive (the user 2026-07-24).
+"""Clear is a SILENT discard (the user 2026-08-23, reversing the 2026-07-24 one-round wrap-up).
 
-The July-22 post-mortem this encodes (all fixtures SYNTHETIC): a card was cleared from the feed three
-minutes after its build started; the only copy of the work was uncommitted worktree edits, which
-evaporated with no signal. The user clears cards they distrust — some clears catch real work — so the
-clear of a working/blocked card now tells the owning session ONCE: stop, park any unfinished work
-where it won't be lost, and surface at most one final keep-or-discard decision. Like a file-delete
-confirm, routed one time through the agent. The ask names no branch or commit (the user 2026-07-26):
-not every session is coding in git.
-
-The invariants:
-- Only still-OPEN top goals notify (completed/settled tops, sub-goals, and stream items don't).
-- A pure-delegation top notifies nobody (the peer's linked copy rides the same batch and notifies THAT
-  session).
-- ONE round only: the decision card the wrap-up reply mints carries clearWrap (judge apply_plan), and
-  clearing a clearWrap card is terminal — no second message, no loop.
-- The message carries romp-clear-wrap + romp-injected and NO romp-goal-id: a goal-id would make the
-  follow-up judge reopen the cleared goal, the resurrection the clear must rule out.
-- Dead sessions get nothing; a failed send never breaks the clear; the undo path sends nothing.
-- It reads as the user's own short message. The session does not know romp is tracking it, so the prose
-  carries none of romp's vocabulary (goal, card, board, clear) and none of its directive register.
-"""
+The wrap-up told the owning session its open card was being dismissed; the response turn then
+routinely re-minted the very card the user had just cleared — a discard that answered back. The
+gesture now only discards: the session hears NOTHING, and if anything real remains it is on the
+user to ask a follow-up or say so themselves. Judge-side recognition of the historical
+<!-- romp-clear-wrap --> marker STAYS: recorded transcripts still contain old wraps, and re-parsing
+them must keep classifying those turns correctly. SYNTHETIC fixtures only."""
 import json
 import os
 import tempfile
@@ -40,234 +26,50 @@ km = SourceFileLoader("romp_kernel_clearwrap", os.path.join(BIN, "romp-kernel"))
 jd = km.jd
 
 SID = "11111111-2222-3333-4444-555555555555"
-PEER = "66666666-7777-8888-9999-000000000000"
-G_OPEN, G_DONE, G_SUB, G_WRAP, G_DELEG = (SID + ":g1", SID + ":g2", SID + ":g3",
-                                          SID + ":g4", SID + ":g5")
+G_OPEN = SID + ":g1"
 NOW = 1781100000
-T0 = NOW - 3600
 
 
-def _node(nid, text, parent=None, **kw):
-    d = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
-         "blocked": False, "cleared": False, "t": T0, "mt": T0, "log": []}
-    d.update(kw)
-    return d
-
-
-def _nodes():
-    return {G_OPEN: _node(G_OPEN, "Build the sticky timestamp", why="Prototype the floating stamp."),
-            G_DONE: _node(G_DONE, "Ship the release", nodeComplete=True),
-            G_SUB: _node(G_SUB, "A step inside", parent=G_OPEN),
-            G_WRAP: _node(G_WRAP, "Parked WIP: keep or discard?", clearWrap=True),
-            G_DELEG: _node(G_DELEG, "Peer is porting the client",
-                           handoff={"peer": PEER, "msgId": "m1"})}
-
-
-class ClearWrapTargets(unittest.TestCase):
-    def setUp(self):
-        self._orig_load = jd.load_goals
-        nodes = _nodes()
-        jd.load_goals = lambda sid: {"rompUuid": SID, "nodes": nodes, "placements": {}, "status": {}}
-
-    def tearDown(self):
-        jd.load_goals = self._orig_load
-
-    def test_only_the_open_top_notifies(self):
-        out = km._clear_wrap_targets([G_OPEN, G_DONE, G_SUB, G_WRAP, G_DELEG, SID + ":stream-item"])
-        self.assertEqual(out, {SID: [G_OPEN]},
-                         "done tops, sub-goals, wrap-decision cards, pure delegations and non-goal "
-                         "items all skip; only the still-open own-work top gets the wrap-up")
-
-    def test_a_blocked_top_is_open_too(self):
-        # "cleared from working or blocked" (the user 2026-07-24): a blocked card holds an unanswered
-        # ask — clearing it dismisses that ask, and the session should hear about it once.
-        nodes = _nodes()
-        nodes[G_OPEN]["blocked"] = True
-        jd.load_goals = lambda sid: {"nodes": nodes}
-        self.assertEqual(km._clear_wrap_targets([G_OPEN]), {SID: [G_OPEN]})
-
-    def test_a_clearwrap_card_is_terminal(self):
-        # the one-and-only-one-loop rule: clearing the wrap-up's own decision card must NOT trigger
-        # another wrap-up — that would be the infinite confirm regress.
-        self.assertEqual(km._clear_wrap_targets([G_WRAP]), {})
-
-    def test_an_unreadable_store_notifies_nobody(self):
-        def boom(sid):
-            raise OSError("store unreadable")
-        jd.load_goals = boom
-        self.assertEqual(km._clear_wrap_targets([G_OPEN]), {})
-
-
-class ClearWrapBody(unittest.TestCase):
-    def test_single_goal_form(self):
-        out = km._clear_wrap_body([G_OPEN], _nodes())
-        self.assertIn("> Build the sticky timestamp", out)
-        self.assertIn("> Prototype the floating stamp.", out, "the planner's why rides as context")
-        # It reads as DONE, not as an abandonment order (the user 2026-07-29): a clear most often means
-        # "acknowledged, I am finished with this", and the old "stop work, don't pick it back up" framing
-        # made an ordinary acknowledgement sound like a rebuke.
-        self.assertIn("I'm done with this one", out)
-        self.assertIn("you can stop here", out)
-        self.assertIn("save it somewhere it won't be lost", out,
-                      "loss-proofing without naming git — not every session is coding (the user "
-                      "2026-07-26); an agent in a repo still reads this as 'commit to a branch'")
-        # …and it ASKS FOR NOTHING. A mandatory reply made every clear cost a second decision, which is
-        # the loop this removes: silence is the expected answer.
-        self.assertIn("No need to reply", out)
-        self.assertNotIn("reply once", out)
-        self.assertNotIn("Just the one reply", out)
-        # the session keeps the discretion to speak up, on two grounds only
-        self.assertIn("still needs a decision from me", out)
-        self.assertIn("stopped you too early", out)
-
-    def test_bundle_numbers_the_goals(self):
-        nodes = _nodes()
-        nodes[SID + ":g9"] = _node(SID + ":g9", "Write the migration guide")
-        out = km._clear_wrap_body([G_OPEN, SID + ":g9"], nodes)
-        self.assertIn("> 1. Build the sticky timestamp", out)
-        self.assertIn("> 2. Write the migration guide", out)
-        self.assertIn("I'm done with these", out)
-        self.assertIn("you can stop here", out)
-        self.assertIn("work in progress on any of them", out)
-        self.assertIn("If one of them still needs a decision", out)
-
-    def test_it_reads_as_a_human_ask_not_a_system_notice(self):
-        # the user 2026-07-24: the session has no idea romp is tracking it, so the message must not
-        # narrate the goal machinery at it ("the goal above was cleared off the board — a dismissal,
-        # not a completion"). It is the person it works for asking for something, in their words.
-        # Prose only: the marker tail is a hidden HTML comment and names romp on purpose.
-        prose = km._clear_wrap_body([G_OPEN], _nodes()).split("<!--")[0].lower()
-        for jargon in ("goal", "board", "card", "clear", "dismiss", "romp"):
-            self.assertNotIn(jargon, prose,
-                             "%r is romp's vocabulary, not the user's — the session doesn't know the "
-                             "tracking system exists" % jargon)
-
-    def test_it_stays_short(self):
-        # succinctness is the point, not a nicety: a long directive reads as a system notice however
-        # it is worded. The first draft ran ~110 words; hold the rewrite near half that.
-        body = km._clear_wrap_body([G_OPEN], _nodes()).split("<!--")[0].split("\n\n", 1)[1]
-        self.assertLess(len(body.split()), 75, "the ask fits in a short human message")
-
-    def test_markers_wrap_but_never_goal_id(self):
-        out = km._clear_wrap_body([G_OPEN], _nodes())
-        self.assertIn("<!-- romp-injected -->", out, "gray romp bubble")
-        self.assertIn("<!-- romp-clear-wrap -->", out, "the judge keys the wrap-up note off this")
-        self.assertNotIn("romp-goal-id", out,
-                         "a goal-id would reopen the cleared goal and file the reply under it — the "
-                         "resurrection the clear must rule out")
-        self.assertNotIn("romp-auto", out, "not an auto-nudge; no nudge logo, no nudge re-arm semantics")
-
-
-class ClearWrapNotify(unittest.TestCase):
-    """The glue: _clear_all → targets → live-only send; failures never break the clear."""
-
-    def setUp(self):
-        self.td = tempfile.TemporaryDirectory()
-        self.saved_state = jd.STATE
-        jd.STATE = Path(self.td.name)
-        self._orig = {n: getattr(km, n) for n in ("_tmux_sessions", "_sessions", "_mark_nodes_cleared")}
-        self._orig_load = jd.load_goals
-        self._orig_backend = km.Sessions.backend_for
-        km._sessions = lambda now: []
-        km._mark_nodes_cleared = lambda ids, v: None   # exercised by its own tests; here we test the notify
-        nodes = _nodes()
-        jd.load_goals = lambda sid: {"nodes": nodes}
+class SentNothing:
+    def __init__(self):
         self.sent = []
-        test = self
 
-        class FakeBackend:
-            def send(self, sid, body):
-                test.sent.append((sid, body))
-        km.Sessions.backend_for = staticmethod(lambda sid: FakeBackend())
-        km._tmux_sessions = lambda: {SID: {"state": "waiting"}}
-
-    def tearDown(self):
-        for n, v in self._orig.items():
-            setattr(km, n, v)
-        jd.load_goals = self._orig_load
-        km.Sessions.backend_for = self._orig_backend
-        jd.STATE = self.saved_state
-        self.td.cleanup()
-
-    def test_clearing_an_open_card_sends_one_wrap_up(self):
-        km._clear_all([G_OPEN])
-        self.assertEqual(len(self.sent), 1)
-        sid, body = self.sent[0]
-        self.assertEqual(sid, SID)
-        self.assertIn("<!-- romp-clear-wrap -->", body)
-
-    def test_a_batch_clear_bundles_into_one_message(self):
-        nodes = _nodes()
-        nodes[SID + ":g9"] = _node(SID + ":g9", "Write the migration guide")
-        jd.load_goals = lambda sid: {"nodes": nodes}
-        km._clear_all([G_OPEN, SID + ":g9", G_DONE])
-        self.assertEqual(len(self.sent), 1, "one session, one message — never one per card")
-        self.assertIn("> 1.", self.sent[0][1])
-
-    def test_clearing_a_done_card_sends_nothing(self):
-        km._clear_all([G_DONE])
-        self.assertEqual(self.sent, [])
-
-    def test_clearing_the_decision_card_sends_nothing(self):
-        km._clear_all([G_WRAP])
-        self.assertEqual(self.sent, [], "one round only — the confirm card's clear is final")
-
-    def test_a_dead_session_gets_nothing(self):
-        km._tmux_sessions = lambda: {}
-        km._clear_all([G_OPEN])
-        self.assertEqual(self.sent, [], "no live CLI → no agent holding WIP to ask")
-
-    def test_a_send_failure_never_breaks_the_clear(self):
-        class Boom:
-            def send(self, sid, body):
-                raise RuntimeError("pane gone")
-        km.Sessions.backend_for = staticmethod(lambda sid: Boom())
-        km._clear_all([G_OPEN])                        # must not raise
-        cleared = (jd.STATE / "cleared.jsonl").read_text()
-        self.assertIn(G_OPEN, cleared, "the clear itself landed despite the notify failure")
-
-    def test_undo_sends_nothing(self):
-        km._clear_all([G_OPEN])
-        self.sent.clear()
-        km._undo_clear()
-        self.assertEqual(self.sent, [], "an undo is the user re-raising the thread themselves")
+    def send(self, sid, text):
+        self.sent.append((sid, text))
 
 
-class JudgeSide(unittest.TestCase):
-    def _seg(self, text):
-        return {"id": "s1", "t": T0, "trigger": "u1",
-                "atoms": [{"uuid": "u1", "type": "user", "t": T0,
-                           "message": {"content": [{"type": "text", "text": text}]}}]}
+class ClearIsSilent(unittest.TestCase):
+    def test_clearing_an_open_card_sends_the_session_nothing(self):
+        store = jd.load_goals(SID)
+        store["nodes"][G_OPEN] = jd.GuardedNode({"id": G_OPEN, "text": "build the exporter",
+                                                 "parentId": None, "nodeComplete": False,
+                                                 "blocked": False, "cleared": False,
+                                                 "t": NOW - 600, "mt": NOW - 60, "log": []})
+        store["status"] = {G_OPEN: "working"}
+        jd.save_goals(SID, store)
+        be = SentNothing()
+        saved = (km.Sessions.backend_for, km._tmux_sessions)
+        km.Sessions.backend_for = staticmethod(lambda sid: be)
+        km._tmux_sessions = lambda: {SID: {"state": "idle"}}
+        try:
+            km._clear_all([G_OPEN])
+        finally:
+            km.Sessions.backend_for, km._tmux_sessions = saved
+        self.assertEqual(be.sent, [], "a discard that answers back is the loop this retirement ends")
+        rows = [json.loads(l) for l in (jd.STATE / "cleared.jsonl").read_text().splitlines()]
+        self.assertTrue(any(r.get("id") == G_OPEN and r.get("op") == "clear" for r in rows),
+                        "the discard itself still lands")
 
-    def test_seg_clearwrap_keys_on_the_marker(self):
-        self.assertTrue(jd._seg_clearwrap(self._seg("wrap up\n<!-- romp-clear-wrap -->")))
-        self.assertFalse(jd._seg_clearwrap(self._seg("plain nudge\n<!-- romp-injected -->")))
-        self.assertFalse(jd._seg_clearwrap({"id": "s0", "atoms": [], "trigger": None}))
+    def test_the_sender_machinery_is_gone_and_the_tombstone_stands(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertNotIn("def _clear_wrap_notify", src)
+        self.assertNotIn("def _clear_wrap_body", src)
+        self.assertIn("CLEAR IS SILENT", src)
 
-    def test_apply_plan_stamps_clearwrap_on_minted_nodes(self):
-        store = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
-        jd.apply_plan(store, "seg1", T0, [{"do": "mint", "text": "Parked WIP: keep or discard?",
-                                           "why": "draft committed to a branch"}], [], clear_wrap=True)
-        nd = next(iter(store["nodes"].values()))
-        self.assertTrue(nd.get("clearWrap"), "the decision card is marked terminal")
-        store2 = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
-        jd.apply_plan(store2, "seg1", T0, [{"do": "mint", "text": "ordinary goal", "why": "w"}], [])
-        nd2 = next(iter(store2["nodes"].values()))
-        self.assertNotIn("clearWrap", nd2, "ordinary mints stay lean — no stray flag")
-
-    def test_plan_units_note_pin(self):
-        import inspect
-        src = inspect.getsource(jd.plan_units)
-        self.assertIn("one-time wrap-up of goals the user just", src)
-        self.assertIn("re-create or reopen the cleared goals themselves", src)
-        # the DEFAULT is now to file nothing, matching a wrap-up that asks for no reply (2026-07-29):
-        # a session that merely stops, or reports what it parked, must not mint anything
-        self.assertIn("the DEFAULT is to **skip**", src)
-        self.assertIn("or reports what", src)
-        # …and a card is minted only when the session raises something that genuinely needs the user
-        self.assertIn("**one** new top-level goal, blocked on the user", src)
-        self.assertIn("an explicit question it is", src)
-        self.assertIn("the dismissal looks premature", src)
+    def test_the_judge_still_recognizes_historical_wrap_markers(self):
+        src = open(os.path.join(BIN, "romp-judge")).read()
+        self.assertIn("romp-clear-wrap", src,
+                      "recorded transcripts contain old wraps; re-parsing must keep classifying them")
 
 
 if __name__ == "__main__":

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -6,7 +6,7 @@ The recipient is an agent with NO idea it is being tracked. It has never seen th
 of a card, a goal, a board or a column, and cannot act on any of it. A message that narrates that
 machinery reads as a system notice rather than the person it works for asking for something. The
 2026-07-24 sweep found five: the two feed status asks, the multi-goal bundle, the nudge quote header,
-and the fork/stalled nudge, plus the clear wrap-up that started it.
+and the fork/stalled nudge. (The clear wrap-up retired 2026-08-23: clear is a silent discard.)
 
 This test renders each injected body from SYNTHETIC fixtures and fails on romp vocabulary in the PROSE.
 It is the guardrail behind the CLAUDE.md rule, so the rule holds without anyone remembering it.
@@ -113,8 +113,6 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             "continue button": km._followup_body(TOP, None, km.CONTINUE_TEXT),
             "multi-goal bundle": km._nudge_bundle_body([TOP, TOP2], nodes, set()),
             "multi-goal bundle (fork)": km._nudge_bundle_body([TOP, TOP2], nodes, {TOP}),
-            "clear wrap-up": km._clear_wrap_body([TOP], nodes),
-            "clear wrap-up (batch)": km._clear_wrap_body([TOP, TOP2], nodes),
             "debt reminder (question)": km._debt_reminder_body(
                 [("web", T0, "question", "Which port should the staging server use?")]),
             "debt reminder (handoff)": km._debt_reminder_body(
@@ -157,8 +155,7 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
         # a node with no text still renders SOMETHING; that placeholder must not smuggle in "goal"
         nodes = _nodes()
         nodes[TOP]["text"] = ""
-        for name, body in (("bundle", km._nudge_bundle_body([TOP], nodes, set())),
-                           ("clear wrap-up", km._clear_wrap_body([TOP], nodes))):
+        for name, body in (("bundle", km._nudge_bundle_body([TOP], nodes, set())),):
             self.assertIn("(untitled)", prose(body), name)
             self.assertNotIn("goal", prose(body).lower(), name)
 
@@ -184,7 +181,7 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # opener is the user's own comment on a quoted passage — a conversation, never a nudge
             # …and the edit trace is an FYI about something the user already DID (a file changed under
             # the session) — telling, not asking; a status question bolted on would be noise
-            if name in ("clear wrap-up", "clear wrap-up (batch)", "typed follow-up on a summary",
+            if name in ("typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
                         "debt reminder (several)", "comment thread opener", "edit trace"):
                 continue


### PR DESCRIPTION
Optimizer-relayed user decision (2026-08-23): pressing Clear on a card currently sends the owning session a one-round wrap-up, whose response turn routinely re-mints the very card that was just cleared — a discard that answers back. Clear now only discards.

## What changes
- The clear batch writes `cleared.jsonl` + the durable node flags exactly as before, and sends the session **nothing**. Follow-ups are the user's explicit act.
- The wrap-up sender machinery (`_clear_wrap_targets`/`_clear_wrap_body`/`_clear_wrap_notify`) is retired with a dated tombstone recording why (and why the 2026-07-24 design existed).
- **Judge-side recognition of the historical `romp-clear-wrap` marker stays**: recorded transcripts contain old wraps, and re-parsing them must keep classifying those turns correctly. Only the send side is gone.
- The injected-voice sweep drops its wrap entries (nothing renders them anymore).

## Tests
`test_clear_wrap.py` rewritten to the new contract: clearing an open card sends the backend nothing while the discard rows still land; the sender machinery is pinned gone with the tombstone standing; the judge's historical-marker recognition is pinned present. Suites: python green, UI 2216/2216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)