### PR TITLE
Poll the login account's usage meters on a standing interval

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2323,6 +2323,26 @@ def _retry_resume_at():
     return min(outs) if outs else None
 
 
+USAGE_POLL_SECS = 900                 # the meters are EXTERNAL state with no event feed — polling is
+_usage_poll_last = [0.0]              # the designed read (the same exception as CI watchers); 15 min
+#                                       keeps history current at ~100 calls/day, far under any budget
+
+
+def _usage_poll_tick(now):
+    """Poll the login account's rate-limit meters on a standing interval (the user 2026-08-23, the
+    standalone-poll variant: "no harm in just checking it"). get_usage rides turn ENDS, so a fleet
+    whose traffic is all API-key ends no login turns and usage.json/usage-history.json froze (stale
+    since 08-19 in the optimizer's audit) — the judge quota gate went blind and the launcher's
+    headroom line lied. The poke reuses the /usage click path (any live login-auth session answers;
+    key-billed sessions are never candidates); when none exists the backend already logs loudly."""
+    if now - _usage_poll_last[0] < USAGE_POLL_SECS:
+        return
+    _usage_poll_last[0] = now
+    be = _sdk()
+    if be and hasattr(be, "refresh_usage"):
+        be.refresh_usage()
+
+
 def _auto_pause_on_limit():
     """Hitting an ACCOUNT-WIDE usage limit (5h Session or 7d Weekly at 100%) auto-engages the global retry-pause
     (the user 2026-07-01): retrying into a rate-limited account just burns failed requests, so stop the
@@ -22213,6 +22233,11 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _auto_pause_on_limit()
     except Exception:
         sys.stderr.write("auto-pause-on-limit: %s\n" % traceback.format_exc())
+    try:                                  # the login account's rate-limit meters, polled on a standing
+        _usage_poll_tick(now)             # interval (the user 2026-08-23): all-key traffic ends no login
+    except Exception:                     # turns, so the turn-end refresh never fired and usage-history
+        sys.stderr.write("usage-poll: %s\n" % traceback.format_exc())   # sat stale — blinding the judge
+    #                                       quota gate and the headroom line
     try:                                  # a monthly spend cap (no readable reset) also engages it — else it storms forever
         _auto_pause_on_spend_limit(now, tmux)
     except Exception:

--- a/tests/test_usage_poll.py
+++ b/tests/test_usage_poll.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""The standing usage poll (the user 2026-08-23): the login account's rate-limit meters are polled on
+an interval, because all-key traffic ends no login turns — the turn-end refresh never fired and the
+meters file froze, blinding the judge quota gate and the headroom line. The poll reuses the /usage
+click path (refresh_usage: any live login-auth session answers; key-billed sessions are never
+candidates, and an empty candidate set already logs loudly). SYNTHETIC fixtures."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class UsagePoll(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+        self._saved = km._sdk
+        poked = self.calls
+
+        class BE:
+            def refresh_usage(self):
+                poked.append(1)
+        km._sdk = lambda: BE()
+        km._usage_poll_last[0] = 0.0
+
+    def tearDown(self):
+        km._sdk = self._saved
+        km._usage_poll_last[0] = 0.0
+
+    def test_polls_on_the_interval_and_not_inside_it(self):
+        t0 = 1_787_500_000
+        km._usage_poll_tick(t0)
+        self.assertEqual(len(self.calls), 1, "the first tick past the interval pokes")
+        km._usage_poll_tick(t0 + 60)
+        self.assertEqual(len(self.calls), 1, "inside the interval: no extra poke")
+        km._usage_poll_tick(t0 + km.USAGE_POLL_SECS + 1)
+        self.assertEqual(len(self.calls), 2, "the next interval pokes again")
+
+    def test_no_backend_is_a_quiet_no_op(self):
+        km._sdk = lambda: None
+        km._usage_poll_tick(1_787_500_000)
+        self.assertEqual(self.calls, [])
+
+    def test_the_tick_rides_the_push_loop(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("_usage_poll_tick(now)", src)
+        self.assertIn("USAGE_POLL_SECS = 900", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Optimizer-relayed user approval (2026-08-23, the standalone-poll variant): keep `usage-history.json` current even when the whole board is key-billed ("no harm in just checking it, it's just gonna be zero").

## The gap
`get_usage` rides turn ends. All-key traffic ends no login turns, so the meters files froze (stale since 08-19), which left the judge quota gate blind and the optimizer launcher's headroom line reading old numbers.

## What changes
A 15-minute tick (`_usage_poll_tick`, riding the push loop's tick-jobs block) pokes the same `refresh_usage` path the `/usage` click uses: any live login-auth session answers the exact `get_usage` control request, key-billed sessions are never candidates, and when no candidate exists the backend already logs loudly. The meters are external state with no event feed, so the interval is the designed read — the same exception CI watchers use.

## Tests
Interval discipline (fires on the boundary, never inside it, re-fires next window), the no-backend no-op, and the tick's registration in the push loop. Suites: python green, UI 2217/2217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)