### PR TITLE
Postal recipients accept the stable session id

### DIFF
--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -12,7 +12,7 @@ Only applies inside a romp session (a tmux session tagged `@romp`, or an SDK-bac
 
 Message sibling sessions with the postal MCP tools (each tool's own description carries the specifics): `send_message(to, body)`, `check_inbox()`, `list_agents()`, `set_working(text)`, `check_sent()`, `recall_message(to, id?)`. Inbox is also delivered automatically at each turn's end, so you rarely call `check_inbox` yourself.
 
-Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving.
+Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving. A session's stable id (the uuid `list_agents` shows) also works as the recipient — rename-proof, unique by construction, so it never hits the shared-name ambiguity refusal.
 
 Role-named recipients go stale: a role handed to a new session keeps the OLD name in your memory of it, and the retired name just bounces. Before sending to a role-style name (a router, a watcher, a manager), confirm it against `list_agents` and address whoever holds the role now.
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -708,8 +708,14 @@ def resolve_recipient(to, frm_id=""):
     here = self_host()
     # Everything this bus can deliver to itself: local sessions plus heartbeating remotes. A
     # host qualifier naming somebody ELSE takes them all out of the running.
+    # a uuid-shaped `to` addresses the STABLE session id (the user 2026-08-23, via the experiment
+    # machinery's cost-out: names are labels that renames retire; the sid survives them). An id is
+    # unique by construction, so the ambiguity arm below never fires for it; the self-send check
+    # still does — mailing your own sid is the same loopback as mailing your own name.
+    by_id = bool(re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", bare))
     direct_all = ([] if (want_host and want_host != here)
-                  else [a for a in all_agents(threads=True) if a["name"] == bare])   # threads addressable for replies
+                  else [a for a in all_agents(threads=True)
+                        if (a.get("id") == bare if by_id else a["name"] == bare)])   # threads addressable for replies
 
     if frm_id and any(a["id"] == frm_id for a in direct_all):
         return {"kind": "error", "status": 409,
@@ -2543,7 +2549,7 @@ Write so the recipient can act from your first line:
 
 Before editing a shared repo, run list_agents and read peers' branches + working-notes (overlap only collides on the SAME branch), and publish yours with set_working. Resolve ownership by reading that state, never by messaging "do you still own this?": an idle peer's note may be stale, and a peer with no note holds nothing. Declare what you own in your first line. Never wake an idle session just to coordinate.
 
-Addressing is live-only: you can message only currently-live sessions (list_agents). Dead names error, with no parked mail or reviving.
+Addressing is live-only: you can message only currently-live sessions (list_agents). Dead names error, with no parked mail or reviving. A session's stable id (the uuid in list_agents) also works as the recipient — rename-proof, unique by construction.
 
 A name is not guaranteed unique. When more than one live session answers to it the send is refused and the candidates are listed as `host:name`: pick one and resend rather than assuming the first. Your OWN name is refused outright, because a message there lands in your own inbox looking exactly like a reply from someone else. Your row in list_agents is the one marked `(you)`.
 

--- a/tests/test_postal_self_send.py
+++ b/tests/test_postal_self_send.py
@@ -266,3 +266,38 @@ class DeliveredMeansDelivered(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UuidRecipients(unittest.TestCase):
+    """A uuid-shaped `to` addresses the STABLE session id (the user 2026-08-23): names are labels
+    renames retire; the sid survives them. Unique by construction, so no ambiguity arm; the
+    self-send refusal still applies to your own sid."""
+    A = "11111111-2222-3333-4444-555555555555"
+    B = "66666666-7777-8888-9999-000000000000"
+
+    def setUp(self):
+        self._agents = [{"name": "web", "id": self.A, "remote": False},
+                        {"name": "web", "id": self.B, "remote": False}]   # a shared NAME, distinct ids
+        self._saved = (pm.all_agents, pm.peers_on, pm._postal_off)
+        pm.all_agents = lambda threads=False: list(self._agents)
+        pm.peers_on = lambda: False
+        pm._postal_off = lambda sid: False
+
+    def tearDown(self):
+        pm.all_agents, pm.peers_on, pm._postal_off = self._saved
+
+    def test_an_id_resolves_where_the_shared_name_is_ambiguous(self):
+        res = pm.resolve_recipient(self.B, frm_id=self.A)
+        self.assertEqual(res["kind"], "direct")
+        self.assertEqual(res["agent"]["id"], self.B, "the sid picks exactly one session")
+        by_name = pm.resolve_recipient("web", frm_id="")
+        self.assertEqual(by_name["kind"], "error", "…where the name alone is refused as ambiguous")
+
+    def test_your_own_id_is_still_a_self_send(self):
+        res = pm.resolve_recipient(self.A, frm_id=self.A)
+        self.assertEqual(res["kind"], "error")
+        self.assertEqual(res["status"], 409, "mailing your own sid is the same loopback")
+
+    def test_an_unknown_id_errors_live_only(self):
+        res = pm.resolve_recipient("99999999-8888-7777-6666-555544443333", frm_id=self.A)
+        self.assertEqual(res["kind"], "error")


### PR DESCRIPTION
Approved via the experiment machinery's cost-out (2026-08-23): uuid keying won, so `resolve_recipient` now accepts a uuid-shaped `to` matched against the live row's stable sid — rename-proof addressing for stored references.

- An id is unique by construction, so the shared-name ambiguity refusal never fires for it (test: two sessions sharing a name resolve exactly by id where the bare name refuses).
- Your **own** sid still refuses as a self-send — same loopback, same 409.
- Unknown ids error live-only like unknown names; `romp sessions --json`'s id/name/lastSid mapping (their resolver) is untouched.
- The MCP instructions and the postal skill advertise the id form.

Tests ride the resolution suite (3 new). Suites: python green, UI 2199/2199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)