### PR TITLE
A restart re-delivers the typed sends its dead CLI was holding

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4177,12 +4177,70 @@ class SdkBackend:
                  and a["_echo_text"] not in qs]
         if not newly:
             return
+        # RE-DELIVER, don't just flag (the user 2026-08-23, their strongest point in the restart
+        # audit: "it would be very, very bad if we ever lost stuff because of restarts" — a typed
+        # prompt queued at 11:20 was silently discarded by the 11:25 restart). A HUMAN send whose
+        # loss is proven — and whose text a direct transcript scan confirms never landed as a user
+        # record (the flag path self-corrects on a wrong guess; a re-delivery would DUPLICATE, so it
+        # verifies first) — goes back into the persisted queue in send order: the next spawn feeds
+        # it to the fresh CLI exactly like the surviving queue, recreating the pre-restart state.
+        # romp-authored echoes (nudges) keep the flag path: re-delivering one could double-nudge,
+        # and its content is regenerable machinery, not the user's words.
+        redeliver = []
+        for a in sorted(newly, key=lambda x: x.get("t") or 0):
+            if a.get("author") == "human" and not self._text_landed(sid, a["_echo_text"]):
+                redeliver.append(a)
+        if redeliver:
+            with self._reg_lock:
+                reg = read_reg(self.state_dir, sid)
+                if reg is not None:
+                    have = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+                    add = [a["_echo_text"] for a in redeliver if a["_echo_text"] not in have]
+                    if add:
+                        reg["queue"] = have + add          # behind the surviving queue: original send order
+                        write_reg(self.state_dir, sid, reg)
+                        for a in redeliver:
+                            self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
+                                      % (sid[:8], a["_echo_text"]))
+        rekeyed = {a["_echo_text"] for a in redeliver}
         for a in newly:
+            if a["_echo_text"] in rekeyed:
+                continue                                   # now in the queue → renders as queued, prunes on landing
             a["dropped"] = True
             self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
                       "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
         self._persist_echoes(sid)
         self._wake_push()
+
+    def _text_landed(self, sid: str, text: str) -> bool:
+        """Did `text` land as a USER record in the sid's transcript? The re-delivery guard: the echo
+        prune is lazy (a landed echo may still be un-pruned at boot), so a queue re-add without this
+        scan would duplicate a delivered message. Reads the transcript TAIL (the loss window is recent
+        by construction — the send predates the death that orphaned it); unreadable → True, the safe
+        side: never re-deliver on doubt, the flag path still surfaces the loss for a human call."""
+        try:
+            reg = read_reg(self.state_dir, sid) or {}
+            path = transcript_path(reg.get("cwd") or "", reg.get("lastSid") or sid)
+            want = " ".join(text.split())
+            with open(path, "rb") as f:
+                f.seek(max(0, os.path.getsize(path) - 2_000_000))
+                for line in f.read().decode(errors="replace").splitlines():
+                    if '"user"' not in line or want[:60] not in " ".join(line.split()):
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except ValueError:
+                        continue
+                    if rec.get("type") != "user":
+                        continue
+                    c = ((rec.get("message") or {}).get("content"))
+                    txt = c if isinstance(c, str) else " ".join(
+                        b.get("text", "") for b in c if isinstance(b, dict)) if isinstance(c, list) else ""
+                    if want in " ".join(txt.split()):
+                        return True
+            return False
+        except Exception:
+            return True
 
     def dismiss_echo(self, sid: str, uuid: str | None = None, t: int | None = None) -> str | None:
         """✕ on a never-delivered bubble: retire a DROPPED echo the user has acknowledged. Matched by the

--- a/tests/test_restart_redelivery.py
+++ b/tests/test_restart_redelivery.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Restarts never lose typed input (the user 2026-08-23, their strongest point in the restart audit):
+a HUMAN send whose CLI died holding it — provably lost (not in the surviving queue) and verified
+never-landed by a direct transcript scan — is RE-DELIVERED through the persisted queue in send
+order, recreating the pre-restart state, instead of parking as a never-delivered bubble waiting on
+a manual restore. romp-authored echoes keep the flag path (re-delivering a nudge double-nudges),
+and a landed-but-unpruned echo never re-delivers (the scan is the duplicate guard). SYNTHETIC."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_redeliver", os.path.join(BIN, "romp-event-model")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_redeliver2", os.path.join(HERE, "..", "kernel", "sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class Redelivery(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.state = self.td
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.td, "claude")
+        self.cwd = os.path.join(self.td, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        self.tpath = tp
+        open(tp, "w").close()
+
+        class BE:
+            state_dir = None
+            _live = {}
+            _reg_lock = __import__("threading").RLock()
+            _persisted = []
+            _logs = []
+
+            def _log(self, msg, problem=False):
+                self._logs.append(msg)
+
+            def _persist_echoes(self, sid):
+                self._persisted.append(sid)
+
+            def _wake_push(self):
+                pass
+            _text_landed = sb.SdkBackend._text_landed if hasattr(sb, "SdkBackend") else None
+        self.be = BE()
+        # bind the real methods under test onto the stub
+        import pathlib
+        self.be.state_dir = pathlib.Path(self.td)
+        self.be._mark_dropped_echoes = sb.SdkBackend._mark_dropped_echoes.__get__(self.be)
+        self.be._text_landed = sb.SdkBackend._text_landed.__get__(self.be)
+        sb.write_reg(self.be.state_dir, SID, {"sid": SID, "alive": True, "cwd": self.cwd,
+                                              "lastSid": SID, "queue": []})
+
+    def _echo(self, text, author="human", t=100):
+        self.be._live.setdefault(SID, {})["echo:" + text[:8]] = {
+            "_echo_text": text, "author": author, "t": t}
+
+    def _reg_queue(self):
+        return (sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or []
+
+    def tearDown(self):
+        self.be._live.clear()
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def test_lost_human_send_re_enters_the_queue_in_send_order(self):
+        self._echo("first typed message", t=100)
+        self._echo("second typed message", t=200)
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(self._reg_queue(), ["first typed message", "second typed message"])
+        for a in self.be._live[SID].values():
+            self.assertNotIn("dropped", a, "a re-queued send renders as queued, never as lost")
+
+    def test_landed_but_unpruned_echo_never_redelivers(self):
+        with open(self.tpath, "w") as f:
+            f.write(json.dumps({"type": "user", "uuid": "u1",
+                                "message": {"role": "user",
+                                            "content": [{"type": "text", "text": "already landed words"}]}}) + "\n")
+        self._echo("already landed words")
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(self._reg_queue(), [], "the transcript scan is the duplicate guard")
+        self.assertTrue(any(a.get("dropped") for a in self.be._live[SID].values()),
+                        "…so it takes the flag path (self-correcting on the next build)")
+
+    def test_romp_authored_echoes_keep_the_flag_path(self):
+        self._echo("a nudge body", author="romp")
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(self._reg_queue(), [], "re-delivering a nudge would double-nudge")
+        self.assertTrue(any(a.get("dropped") for a in self.be._live[SID].values()))
+
+    def test_surviving_queue_texts_stay_ahead_and_undropped(self):
+        self._echo("still queued text")
+        self._echo("lost text", t=300)
+        sb.write_reg(self.be.state_dir, SID, {"sid": SID, "alive": True, "cwd": self.cwd,
+                                              "lastSid": SID, "queue": ["still queued text"]})
+        self.be._mark_dropped_echoes(SID, ["still queued text"])
+        self.assertEqual(self._reg_queue(), ["still queued text", "lost text"],
+                         "the surviving queue keeps its place; the re-delivery lands behind it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The restart audit's strongest point (user, 2026-08-23): a typed prompt queued at 11:20 PT was silently discarded by the 11:25 mesh-update restart — never delivered as a turn. Design guidance: **not** a drain/defer system; restarts land fast, then the pre-restart state is recreated.

## What changes
The loss proof already existed — `_mark_dropped_echoes` identifies an input echo that is neither in the surviving persisted queue nor landed — but it only *flagged* the send as a never-delivered bubble waiting on a manual restore click. Now:

- A **human** send in that proven-lost set, whose text a direct transcript-tail scan confirms never landed as a user record, is **re-delivered**: appended to the persisted queue in original send order, behind the surviving queue, so the next spawn feeds it to the fresh CLI exactly like any queued message. Loud log line per re-delivery.
- The transcript scan is the duplicate guard: the echo prune is lazy (a landed echo can be un-pruned at boot), and the flag path self-corrects where a re-delivery would duplicate — so on any doubt (unreadable transcript included) the flag path stands.
- **romp-authored** echoes (nudges) keep the flag path: re-delivering one could double-nudge, and machinery is regenerable — the user's words are not.

The UI-only-builds-shouldn't-restart-the-kernel investigation continues under the same work item; this PR is the typed-input half.

## Tests
Send-order re-queue behind the surviving queue; the landed-but-unpruned duplicate guard; romp-authored echoes flag instead; surviving queue precedence. Suites: python green (5150+ line), UI 2217/2217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)