### PR TITLE
The no-kernel row's link-reset button says Re-dial

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23695,7 +23695,7 @@ var TIP={up:'Connected: the ssh tunnel is open and that machine\\u2019s romp ker
 authorizing:'Opening an ssh connection and reading that machine\\u2019s access token. Needs `ssh <host>` to work without a prompt.',
 connecting:'The ssh tunnel is up; waiting for the remote kernel to answer on its port.',
 starting:'The ssh tunnel is up; waiting for the remote kernel to answer on its port.',
-'no-kernel':'The tunnel is open but no romp kernel is answering on that machine. Start pushes this machine\\u2019s romp there and boots it.',
+'no-kernel':'The tunnel is open but no romp kernel is answering on that machine. Re-dial re-opens the link in case it is only wedged; Start pushes this machine\\u2019s romp there and boots it.',
 down:'The ssh tunnel is not up. romp keeps retrying on its own, waiting longer between tries the longer it stays down, so a machine that comes back is picked up without you doing anything. Try now dials immediately.',
 error:'The connection failed. Hover the status text for the reason romp got back. romp keeps retrying in the background.'};
 var _timer;function schedule(ms){clearTimeout(_timer);_timer=setTimeout(refresh,ms);}
@@ -23947,7 +23947,12 @@ var again=(t.status==='down'||t.status==='error')?'<span class=rnet-retry title=
 // to carry only Start — "this pushes this machine's romp there and boots its kernel" — so a link that had
 // quietly stopped carrying traffic read as a dead remote, and the only button on offer told you to go
 // restart the far end. That is the path that cost a morning of restarting kernels that were never down.
-var retry=(t.status!=='up'&&t.status!=='starting')?'<button data-ra=\"'+t.host+'\" title=\"Dial '+t.host+' now: drop the current ssh and open a fresh one. Use this when the link looks connected but nothing is coming through.\">Try now</button>':'';
+// The NAME is per state (the user 2026-08-23): on down/error it sits beside the visible countdown and
+// reads as "skip the wait", so it stays Try now there; a no-kernel row has no countdown (the ssh link
+// is up — no backoff is running), where the same name beside Start read as a redundant second attempt
+// button, distinguished only by tooltips. There it is named for what it does: Re-dial.
+var wedged=(t.status==='no-kernel');
+var retry=(t.status!=='up'&&t.status!=='starting')?'<button data-ra=\"'+t.host+'\" title=\"'+(wedged?'Drop the ssh link to '+t.host+' and dial a fresh one. The link reports connected while nothing answers through it \u2014 a wedged tunnel can make a running kernel look absent, so re-dial before restarting anything.':'Dial '+t.host+' now: drop the current ssh and open a fresh one, instead of waiting out the automatic retry.')+'\">'+(wedged?'Re-dial':'Try now')+'</button>':'';
 // The check-in publishes THIS machine TO that host, which is the opposite direction from everything else
 // in the row. Its old label, "keep connected", read as the reconnect setting so plainly that the tooltip
 // had to spend a sentence saying what it was NOT. Name it for what it does instead.

--- a/ui/webview/net-popover-known.test.ts
+++ b/ui/webview/net-popover-known.test.ts
@@ -81,8 +81,12 @@ test("a down row says romp is still dialing, when next, and offers to try now", 
   }
   assert.match(KERNEL, /next try in /, "the row counts down to the next dial");
   assert.match(KERNEL, /romp keeps dialing '\+t\.host\+' on its own/, "and says it is unconditional");
-  assert.match(KERNEL, /data-ra=\\"'\+t\.host\+'\\" title=\\"Dial /, "the web row offers Try now");
-  assert.match(KERNEL, /Try now<\/button>/, "named for what it does");
+  assert.match(KERNEL, /data-ra=\\"'\+t\.host\+'\\" title=/, "the web row offers the re-dial action");
+  // per-state name (the user 2026-08-23): beside the countdown it reads as skip-the-wait (Try now);
+  // on a no-kernel row there is no countdown and it sat beside Start as a lookalike — there it is
+  // named for what it does (Re-dial). Same button, same action, one wording rule.
+  assert.match(KERNEL, /\(wedged\?'Re-dial':'Try now'\)\+'<\/button>'/, "named for what it does, per state");
+  assert.match(KERNEL, /var wedged=\(t\.status==='no-kernel'\);/);
   assert.match(KERNEL, /s!=='no-kernel';/, "web busyStatus no longer knows the state");
   assert.match(STRIP, /s !== "no-kernel";/, "strip busy() no longer knows it");
   assert.match(KERNEL, /t\.status==='down'\)\?'background:#8a8a8a'/, "web dot is gray");


### PR DESCRIPTION
## What

On a **no-kernel** row of the remote-kernels panel, the link-reset button is now labeled **Re-dial** instead of "Try now". Down/error rows keep "Try now". Same button, same action (`POST /tunnels` — drop the current ssh and dial fresh); only the name is per-state.

## Why

On down/error rows, "Try now" sits beside the visible countdown ("next try in 4m"), so it reads as what it is: skip the wait. A no-kernel row has no countdown — the ssh link is up, nothing is backing off — and there the same name sat beside **Start** looking like a redundant second attempt button, distinguished only by tooltips. The two are not redundant (one re-dials this machine's link; Start pushes romp and boots the far kernel), so the fix is legibility, not removal: name the light verb for what it does.

The tooltip and the status gloss now say why the light verb comes first — a wedged tunnel can make a running kernel look absent, so re-dial before restarting anything (the 2026-07-29 lost morning documented at the button).

The VS Code strip is untouched: its no-kernel row carries only Start, so the pairing never arises there.

## Tests

- `tests/test_remotes_panel_render.py`: a rendered no-kernel row offers Re-dial beside Start with no "Try now" and no countdown; the existing down-row test keeps pinning "Try now" beside its countdown.
- `ui/webview/net-popover-known.test.ts`: repinned to the per-state name rule.
- Full suites green: 5162 python tests (+281 subtests), 2202 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)