### PR TITLE
The under-bubble buttons stop borrowing the code tint that read as a red wash

### DIFF
--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -35,6 +35,16 @@ test("the fork affordance rides BELOW each response run — delegated, with the 
   assert.match(CSS, /\.turn-assistant:hover \.msg-fork, \.msg-fork:focus-visible \{ opacity: 0\.9; \}/);
   assert.match(CSS, /\.msg-fork:hover \{ color: var\(--fg\); border-color: var\(--accent\); \}/);
   assert.doesNotMatch(CSS, /\.msg-fork\.armed/);
+  // the under-bubble button family wears NEUTRAL chrome (the user 2026-08-23): it sits on the page
+  // ground, where the terracotta code tint (--code-bg) read as a faint red button. Only .code-copy
+  // keeps the tint — it sits ON the tinted code block and blends there.
+  for (const block of [".msg-edit {", ".msg-del, .msg-restorefiles, .msg-fork {", ".undelivered-act {"]) {
+    const body = CSS.slice(CSS.indexOf(block), CSS.indexOf("}", CSS.indexOf(block)));
+    assert.ok(body.includes("background: rgba(255, 255, 255, 0.06)"), block + " wears the neutral ground");
+    assert.ok(!body.includes("--code-bg"), block + " must not borrow the code tint");
+  }
+  const copy = CSS.slice(CSS.indexOf(".code-copy {"), CSS.indexOf("}", CSS.indexOf(".code-copy {")));
+  assert.ok(copy.includes("var(--code-bg)"), ".code-copy stays tinted — it lives on the code block");
 });
 
 test("the modal defaults to <session>-fork and posts forkSession {id, uuid, name}", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1230,7 +1230,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .msg-edit {
   align-self: flex-end; margin-top: 3px;
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
-  border: 1px solid var(--box-border); background: var(--code-bg); color: var(--dim);
+  /* neutral ground, neutral chrome (the user 2026-08-23): these sit on the page, not on a code
+     block, so the code tint .code-copy blends with read here as a faint red button */
+  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--dim);
   cursor: pointer; opacity: 0; user-select: none;
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
@@ -1243,7 +1245,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .msg-del, .msg-restorefiles, .msg-fork {
   align-self: flex-end; margin-top: 3px;
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
-  border: 1px solid var(--box-border); background: var(--code-bg); color: var(--dim);
+  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--dim);
   cursor: pointer; opacity: 0; user-select: none;
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
@@ -1387,7 +1389,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 .undelivered-act {
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
-  border: 1px solid var(--box-border); background: var(--code-bg); color: var(--dim);
+  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--dim);
   cursor: pointer; user-select: none;
   transition: color 0.12s ease, border-color 0.12s ease;
 }


### PR DESCRIPTION
## What

The fork button under an assistant response (and its siblings: edit, delete, restore-files, and the undelivered-message actions) no longer wears `--code-bg` — the 10% terracotta tint that belongs to inline code — as its background. The family now uses the chat's existing neutral ground, `rgba(255,255,255,0.06)`; size, border, and reveal-on-hover are unchanged.

## Why

On a code block the terracotta tint blends in, which is why `.code-copy` keeps it — it sits ON the tinted block and matching is the point. But the under-bubble buttons sit on the neutral page ground, where the borrowed tint read as a slight red wash nothing else in the UI has (the user 2026-08-23). The hover/armed reds on delete and restore are untouched: those are status colors saying "destructive", not chrome.

## Tests

`ui/webview/fork-session.test.ts` pins the rule: each block in the family wears the neutral ground and never `--code-bg`, while `.code-copy` stays tinted. Suites green: 2202 JS tests; the three styles-adjacent python files pass (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)