### PR TITLE
romp rename: sessions rename from the terminal, no WS surgery

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -656,6 +656,7 @@ EOF
     _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
+    _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> <text>" -            "Hand a session a message (kernel API, either backend)"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -833,6 +834,32 @@ if [[ "${1:-}" == "fork" ]]; then
     fi
     _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
     echo "romp fork: refused — $_err" >&2
+    exit 1
+fi
+
+# Rename a session (the user 2026-08-23, via the SynthProbe fleet restructuring): the kernel's
+# POST /rename, the exact sibling of `romp fork` — sessions are uuid-keyed with the name as a
+# label, so a rename never breaks mailboxes, goals, or history; every surface resyncs.
+if [[ "${1:-}" == "rename" ]]; then
+    shift
+    _rn_usage="usage: romp rename <session> <new-name>"
+    if [[ $# -ne 2 || "$1" == -* || "$2" == -* ]]; then echo "$_rn_usage" >&2; exit 2; fi
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp rename: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
+        exit 1
+    fi
+    _payload="$(python3 -c 'import json,sys; print(json.dumps({"target": sys.argv[1], "name": sys.argv[2]}))' "$1" "$2")"
+    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/rename" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp rename: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        echo "romp rename: \"$1\" is now \"$2\""
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp rename: refused — $_err" >&2
     exit 1
 fi
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26372,6 +26372,46 @@ class Handler(BaseHTTPRequestHandler):
                 fsid = _live_names(_tmux_sessions()).get(nm) or ""
                 return self._send(200, json.dumps({"ok": True, "id": fsid, "name": nm}),
                                   "application/json")
+            if u.path == "/rename":
+                # Headless rename (`romp rename`, the user 2026-08-23 via the SynthProbe fleet
+                # restructuring): the renameSession WS op as a one-shot POST, the exact sibling of
+                # /fork — which exists precisely because hand-driving a WS op with the dashboard
+                # token is surgery nobody should repeat. Body: {"target": <live name or sid>,
+                # "name": <new-name>}. Sessions are uuid-keyed with the name as a label, so a rename
+                # never breaks mailboxes/goals/history; the by-name POISONING guard mirrors /fork's
+                # (a second session under one live name breaks every by-name surface). Loud errors.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                target = str((b or {}).get("target") or "").strip()
+                nm = str((b or {}).get("name") or "").strip()
+                if not target or not nm:
+                    return self._send(400, json.dumps({"ok": False, "error": "target and name required"}),
+                                      "application/json")
+                if not NAME_RE.match(nm):
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        "session names use letters, digits, . _ - only"}), "application/json")
+                live = _live_names(_tmux_sessions())
+                if nm in live:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'a session named "%s" is already running — pick another name' % nm}),
+                                      "application/json")
+                tsid = live.get(target) or ""
+                if not tsid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", target):
+                    tsid = target
+                if not tsid:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'no live session named "%s" (a dormant one can be renamed by sid)' % target}),
+                                      "application/json")
+                be = Sessions.backend_for(tsid)
+                if not (be and be.rename(tsid, nm)):      # live → backend reg; dead → names file
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        "the rename did not take — is that session known to this kernel?"}),
+                                      "application/json")
+                _mark_views_dirty()
+                return self._send(200, json.dumps({"ok": True, "id": tsid, "name": nm}),
+                                  "application/json")
             if u.path == "/working":
                 # Publish/clear a session's working-note in the backend-agnostic store, so the postal bus's
                 # set_working goes through the kernel (no tmux @romp-working) and an SDK session can publish a

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -182,6 +182,24 @@ MOCK
     grep '/fork' "$MOCK_LOG" | grep -q '"at": *"aaaabbbb-1111-2222-3333-444455556666"'
 }
 
+@test "rename: POST /rename with target and new name; usage and no-token are loud" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp rename exp-web cross_model
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'is now "cross_model"'* ]]
+    grep '/rename' "$MOCK_LOG" | grep -q '"target": *"exp-web"'
+    grep '/rename' "$MOCK_LOG" | grep -q '"name": *"cross_model"'
+    run run_romp rename only-one-arg
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp rename"* ]]
+    unset ROMP_SERVE_TOKEN
+    run run_romp rename exp-web cross_model
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel isn't running"* ]]
+}
+
 @test "fork: usage errors exit 2; no kernel token is a loud exit 1" {
     touch "$MOCK_LOG"
     run run_romp fork

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -610,10 +610,11 @@ MOCK
 
 # ─── No attach/rename subcommands (use tmux a / tmux rename) ─────────
 
-@test "'a', 'attach', 'rename' are unknown commands, never sessions" {
-    # There is no attach/rename command (plain tmux does both), and round 3 made
-    # every non-command bare word a loud error pointing at `romp new`.
-    for word in a attach rename; do
+@test "'a' and 'attach' are unknown commands, never sessions" {
+    # There is no attach command (plain tmux does that), and round 3 made every
+    # non-command bare word a loud error pointing at `romp new`. (`rename` left
+    # this list when it became a real verb — see the rename tests above.)
+    for word in a attach; do
         : > "$MOCK_LOG"
         run run_romp "$word"
         [ "$status" -eq 2 ]

--- a/tests/test_rename_route.py
+++ b/tests/test_rename_route.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""POST /rename (the user 2026-08-23): the renameSession WS op as a one-shot token-gated route, the
+exact sibling of /fork — agents rename sessions without WS surgery. Sessions are uuid-keyed with the
+name as a label, so nothing breaks; the by-name poisoning guard mirrors /fork's. Drives the REAL
+Handler over HTTP (the test_new_route_prefs.py pattern). Synthetic only."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class RenameRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.renames = []
+        renames = self.renames
+
+        class BE:
+            def rename(self, sid, name):
+                renames.append((sid, name))
+                return True
+        self._saved = (km.Sessions.backend_for, km._tmux_sessions, km._live_names, km._mark_views_dirty)
+        km.Sessions.backend_for = staticmethod(lambda sid: BE())
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": SID}
+        km._mark_views_dirty = lambda: None
+
+    def tearDown(self):
+        (km.Sessions.backend_for, km._tmux_sessions, km._live_names, km._mark_views_dirty) = self._saved
+
+    def _post(self, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/rename" % self.port, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_live_name_renames_through_the_backend(self):
+        st, r = self._post({"target": "web", "name": "cross_model"})
+        self.assertEqual(st, 200)
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r.get("id"), SID)
+        self.assertEqual(self.renames, [(SID, "cross_model")],
+                         "routed through be.rename so every surface resyncs")
+
+    def test_a_sid_target_reaches_the_backend_directly(self):
+        st, r = self._post({"target": SID, "name": "intuition_building"})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(self.renames[0][0], SID)
+
+    def test_the_poisoning_guard_refuses_a_live_new_name(self):
+        st, r = self._post({"target": SID, "name": "web"})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("already running", r.get("error") or "")
+        self.assertEqual(self.renames, [])
+
+    def test_bad_names_and_unknown_targets_are_loud(self):
+        st, r = self._post({"target": "web", "name": "bad name!"})
+        self.assertIn("letters, digits", r.get("error") or "")
+        st, r = self._post({"target": "nope", "name": "fine-name"})
+        self.assertIn("no live session named", r.get("error") or "")
+        st, r = self._post({"target": "web"})
+        self.assertEqual(st, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
User-driven (2026-08-23, via the SynthProbe fleet restructuring into thread-named agents): renames required clicking through the dashboard per session while agents chased the name joins. The kernel already owned rename (`renameSession` WS op; sessions are uuid-keyed with the name as a label, so mailboxes, goals, and history all follow a rename) — this adds the missing doors, the exact sibling of `/fork`:

- **`POST /rename`** — token-gated, `{target: <live name or sid>, name: <new-name>}`, `NAME_RE` validation, refused when the new name is already live (the same by-name poisoning guard as `/fork`), routed through `be.rename` so the names file and every surface resync. Loud errors; a dormant session renames by sid.
- **`romp rename <session> <new-name>`** — the CLI verb on that route, plus a help line beside `romp fork`.

Pairs with the just-merged uuid-recipient addressing: agents can now rename freely and address by stable id.

## Tests
Route end-to-end over the real Handler (live-name and sid targets, the poisoning guard, bad names, unknown targets, 400s); bats for the CLI payload, usage errors, and the loud no-kernel path. Suites: python green (line above), UI 2202/2202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)