### PR TITLE
A silent mid-turn model swap mints a completed card

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9390,6 +9390,36 @@ def debt_block_why(peer):
 DEAD_WAIT_WHY_PREFIX = "This session ended while still waiting on "
 
 
+def mint_fallback_card(sid, from_model, to_model, ev_t=None):
+    """A COMPLETED card recording a silent mid-turn model swap (the user 2026-08-23, approved
+    08-19 and revived: "it'd be nice to get a model fallback card pop up and just go to
+    completed"). The API swapped the session's model without anyone asking — the card makes the
+    swap visible on the board (it pops into Completed; the distiller writes its takeaway like any
+    completed top). Kernel-authored bookkeeping: minted done, never a question."""
+    try:
+        store = load_goals(sid)
+        nodes = store.setdefault("nodes", {})
+        n = store.get("seq", 0) + 1
+        store["seq"] = n
+        gid = "%s:g%d" % (sid, n)
+        t = int(ev_t or time.time())
+        why = ("The model was swapped mid-turn without a request: %s fell back to %s. Work continued "
+               "on the fallback; switch back from the statusline if that isn't what you want."
+               % (from_model or "the pinned model", to_model))
+        nd = GuardedNode({"id": gid, "text": "Model fallback: %s → %s" % (from_model or "?", to_model),
+                          "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
+                          "trail": [], "promptUuid": "", "quote": "", "t": t, "mt": t,
+                          "why": "kernel-observed API model fallback", "log": []})
+        nodes[gid] = nd
+        record_verdict(store, nd, "romp", "done", t, why=why)
+        rollup_status(store, True)                 # the fold materializes nodeComplete/doneWhy from the diary
+        save_goals(sid, store)
+        return gid
+    except Exception as e:
+        sys.stderr.write("fallback-card mint (%s): %r\n" % (sid[:8], e))
+        return None
+
+
 def dead_wait_block_why(why):
     """The block why for a judged wait whose OWNING session died with the stamp standing (the user
     2026-08-22): nothing that could answer the wait is running, so more patience is a lie — the card

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5926,6 +5926,10 @@ def _sdk_locked():
             # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
             # only as good as that file); the backend picks any live login session to ask
             jd._USAGE_REFRESH_FN = getattr(_sdk_backend, "refresh_usage", None)   # best-effort hook (judge guards None)
+            # silent mid-turn model swaps mint a completed card (the user 2026-08-23) — the backend
+            # observes the transition; the judge store owns the card; the kernel wires the two
+            type(_sdk_backend).on_model_fallback = staticmethod(
+                lambda sid, frm, to: (jd.mint_fallback_card(sid, frm, to), _push_soon()))
             # The judge parses the SAME cut world the display parse does (jd._PENDING_CUT_FN): during
             # an armed bare rollback the planner must not see — and mint from — the deleted tail.
             # getattr-guarded like every other backend probe (a test fake without the affordance

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2155,6 +2155,16 @@ class SdkSession:
             if cleared:
                 self.backend._poke()
             return
+        if self.model and not self._model_pending and not cleared:
+            # A model TRANSITION nobody asked for (no /model pick pending): the API fell back
+            # mid-turn. Surface it as a completed card via the kernel-wired hook (the user
+            # 2026-08-23) — never silently (the swap was invisible before this).
+            fb = getattr(type(self.backend), "on_model_fallback", None)
+            if fb:
+                try:
+                    fb(self.sid, self.model, pm)
+                except Exception as e:
+                    self.backend._log("model-fallback card (%s): %s" % (self.name, e), problem=True)
         self.model = pm
         try:
             self.backend._update_reg(self.sid, liveModel=pm, modelPending=bool(self._model_pending))

--- a/tests/test_model_fallback_card.py
+++ b/tests/test_model_fallback_card.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""A silent mid-turn model swap mints a COMPLETED card (the user 2026-08-23, approved 08-19 and
+revived): the API fell back without a request, and the swap was invisible before this. The card
+pops into Completed with a done why naming the swap; a user-driven /model pick (pending marker) or
+the first learn never mints. SYNTHETIC fixtures."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class FallbackCard(unittest.TestCase):
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+
+    def test_mints_a_completed_top_naming_the_swap(self):
+        gid = jd.mint_fallback_card(SID, "claude-fable-5", "claude-sonnet-5", ev_t=1_787_500_000)
+        self.assertTrue(gid)
+        store = jd.load_goals(SID)
+        nd = store["nodes"][gid]
+        self.assertTrue(nd["nodeComplete"])
+        self.assertIn("fell back to claude-sonnet-5", nd["doneWhy"])
+        self.assertIn("Model fallback: claude-fable-5 → claude-sonnet-5", nd["text"])
+        self.assertEqual(store["status"].get(gid), "completed", "pops straight into Completed")
+        dones = [e for e in nd["log"] if e.get("kind") == "done"]
+        self.assertEqual(len(dones), 1)
+        self.assertEqual(dones[0]["src"], "romp", "kernel-authored bookkeeping, never a question")
+
+    def test_the_backend_transition_gates_are_pinned(self):
+        src = open(os.path.join(HERE, "..", "kernel", "sdk_backend.py")).read()
+        self.assertIn("if self.model and not self._model_pending and not cleared:", src,
+                      "first learns and user-driven picks never mint")
+        self.assertIn('on_model_fallback', src)
+        ksrc = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("jd.mint_fallback_card(sid, frm, to)", ksrc, "the kernel wires the hook at boot")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Approved 08-19, revived in the optimizer relay (2026-08-23): "it'd be nice to get a model fallback card pop up and just go to completed." Before this, an API model fallback mid-turn was invisible.

## What changes
- The backend's model-learn handler already observes every live-model transition. A transition with **no `/model` pick pending** and a **prior model known** is by definition a swap nobody asked for — it now calls a kernel-wired hook (`on_model_fallback`, the `_USAGE_REFRESH_FN` wiring precedent).
- The hook mints a completed card through the diary layer: a romp-authored `done` verdict naming the swap ("claude-fable-5 fell back to claude-sonnet-5; work continued on the fallback; switch back from the statusline if that isn't what you want"), the card pops straight into Completed, and the distiller writes its takeaway like any completed top.
- First learns (a fresh session reporting its model) and user-driven picks (pending marker present, or the pick resolving) never mint.

## Tests
The mint end-to-end (completed top, romp-authored done, the swap named in text and why); the transition gates and hook wiring pinned. Suites: python green, UI 2202/2202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)