### PR TITLE
The redundancy gate caps its skips: two, then the nudge fires anyway

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4284,13 +4284,23 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             still = []
             for f in to_fire:
                 gtxt = (_nodes.get(f[0]) or {}).get("text") or ""
+                rec0 = nudged.get(f[0]) or {}
+                skips = rec0.get("redundantSkips") or 0
                 try:
-                    if gtxt and jd.nudge_redundant(gtxt, recent):
-                        nudged[f[0]] = dict(nudged.get(f[0]) or {}, answeredAt=int(now))
+                    # CAPPED at two consecutive skips (the user 2026-08-23, the same day the gate
+                    # shipped: on a status-heavy session every due nudge can read as redundant, and
+                    # each skip restarting the patience window is a forever-pause with no reviver —
+                    # the exact suppressed-without-reviver class the ladder exists to prevent). Past
+                    # the cap the nudge fires regardless; any real fire or answer resets the count.
+                    if skips < 2 and gtxt and jd.nudge_redundant(gtxt, recent):
+                        nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1)
                         _put_nudged(f[0], nudged[f[0]])
                         continue
                 except Exception:
                     pass
+                if skips:
+                    nudged[f[0]] = dict(rec0, redundantSkips=0)   # firing (or an unjudgeable check) resets
+                    _put_nudged(f[0], nudged[f[0]])
                 still.append(f)
             to_fire = still
     if len(to_fire) == 1:

--- a/tests/test_nudge_redundancy.py
+++ b/tests/test_nudge_redundancy.py
@@ -69,11 +69,15 @@ class NudgeRedundancy(unittest.TestCase):
         self.assertEqual(km._last_assistant_text(p), "the exporter shipped; nothing is blocked")
         self.assertEqual(km._last_assistant_text(os.path.join(td, "missing.jsonl")), "")
 
-    def test_the_fire_path_carries_the_gate(self):
+    def test_the_fire_path_carries_the_gate_with_the_skip_cap(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("jd.nudge_redundant(gtxt, recent)", src)
         self.assertIn('recent = _last_assistant_text(s["path"])', src)
-        self.assertIn('answeredAt=int(now)', src)
+        self.assertIn("redundantSkips=skips + 1", src)
+        self.assertIn("if skips < 2 and gtxt", src,
+                      "two consecutive skips max — past that the nudge fires regardless, so the "
+                      "gate can never become a forever-pause with no reviver")
+        self.assertIn("redundantSkips=0", src, "a real fire resets the count")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Same-day catch on this morning's redundancy gate, surfaced by the user's paused-state question: on a status-heavy session, every due nudge can be judged redundant against the latest message, and each skip records `answeredAt` — restarting the patience window indefinitely. That's a forever-pause with no reviver, the exact class the ladder exists to prevent.

**Fix:** two consecutive redundant-skips maximum per goal (`redundantSkips` on the ledger record); past the cap the nudge fires regardless of the check, and any real fire — or an unjudgeable check — resets the count. Live data confirms the gate hasn't yet mass-skipped anywhere (2 checks total, 0 recent skips), so this lands before the failure mode ever occurs.

Tests pin the cap, the reset, and the fire-regardless path. Suites: python green, UI 2202/2202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)