### PR TITLE
The dead-wait writers corroborate a death before filing the block

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3137,7 +3137,7 @@ def _closer_pending(sid, path, now, store):
     return not _closer_settled(store, lt.get("id"), len(lt.get("atoms") or []))
 
 
-def _auto_nudge_tick(now, tmux):
+def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     """One Auto-Nudge pass (from the periodic pusher). For each ALIVE, IDLE session (its turn ended) that
     isn't awaiting/compacting/api-error, isn't WAITING ON A LIVE PEER (a wait isn't a stall — the human's
     "waiting on a peer isn't needs-you"; a mutual-wait cycle is surfaced by the deadlock chip, not nudged),
@@ -3166,7 +3166,16 @@ def _auto_nudge_tick(now, tmux):
                              % (s.get("sid") or "?", traceback.format_exc()))
     try:
         _debt_backstop_tick(now)                       # reminder outcomes for debtors the walk can't reach
-        _dead_wait_sweep(alive_ids, nudged, now)       # dormant owners' stamped cards → procedural block
+        if run_dead_wait:
+            # THE DEATH TRANSITION HAS ONE OBSERVER: _dead_wait_sweep's prev-swap (_PREV_ALIVE)
+            # is a lock-free read-modify-write, safe only because exactly one caller — the
+            # pusher's periodic tick — ever runs it. setAutoNudge's WS-handler tick passes
+            # run_dead_wait=False: racing the pusher (an unlucky interleave during a listing
+            # collapse), its swap could spend a death transition mid-pass without corroboration,
+            # losing the re-arm until the boot catch-up. That tick exists to re-arm NUDGING
+            # without waiting a cycle; the pusher re-runs the sweep on its own cadence anyway,
+            # so skipping loses nothing.
+            _dead_wait_sweep(alive_ids, nudged, now)   # dormant owners' stamped cards → procedural block
     except Exception:
         sys.stderr.write("debt-backstop: %s\n" % traceback.format_exc())
     try:
@@ -3421,13 +3430,85 @@ def _lift_spent_awaiting(now, tmux):
 _PREV_ALIVE = None                       # last tick's alive sids — a sid LEAVING is the death event
 
 
+def _dead_wait_corroborated(sid, scan=None, stats=None):
+    """May the dead-wait writers (_dead_wait_sweep, _wake_goal's dormant branch) treat this sid as
+    actually DEAD? Their trigger — absence from a raw liveness listing — inherits every collapse
+    that listing has (list_lines' error/timeout→[] empties the tmux half for a cycle; a swallowed
+    SDK live_sessions merge exception empties the other), and the block they file is irreversible
+    bookkeeping the user acts on, with nothing lifting it when the listing returns. So absence
+    alone NEVER files: corroborate with the liveness OWNER first — the same doctrine as
+    _death_sweep_tick / _death_boot_pass (a death is certified only by an affirmative answer,
+    never by silence). Tri-state:
+      True  — corroborated dead: the SDK reg's alive bit is False (the death sweep's partition —
+              alive:True is live/revivable/crash-looped and must never convert; the resume
+              contract owns it), a standing death record postdates the session's last recorded
+              state, or the owner scan answers without the sid.
+      False — the owner says ALIVE: the raw listing blinked, not the session.
+      None  — cannot confirm: a real probe failure, an unreadable reg, or a reg-less sid with no
+              names-registry entry — a session launched by NEITHER backend (both write names/<sid>
+              at creation), whose existence is transcript-derived (the same file walk
+              _alive_sessions falls back to on a tmux-less box) and which no owner here can
+              answer for. The caller stands down for the cycle — the stamp stays, and the sweep
+              keeps the death transition armed so the next tick re-asks.
+    `scan` is a zero-arg owner-scan supplier for a batch pass sharing ONE scan across its probes
+    (_death_sweep_tick's idiom); the default takes its own. `stats` is a batch pass's stand-down
+    tally ({reason: count}): with it, the loud stand-downs increment their tally instead of
+    writing stderr per candidate, and the pass reports ONE line per reason (_death_sweep_tick's
+    idiom — the per-candidate line multiplied by the candidate count under exactly the wedge it
+    reports); without it (a single-probe caller like _wake_goal), the line names the sid inline."""
+    sid = str(sid)
+    reg = jd.SDKDIR / (sid + ".json")
+    if reg.exists():
+        try:
+            return not bool(json.loads(reg.read_text()).get("alive"))
+        except Exception:
+            # unreadable reg — stand down, retried next tick, but LOUDLY (the fail-loudly rule):
+            # a silent stand-down would wedge the conversion behind a corrupt reg forever,
+            # with no trace to act on
+            if stats is not None:
+                stats["reg"] = stats.get("reg", 0) + 1
+            else:
+                sys.stderr.write("dead-wait: unreadable SDK reg for %s — standing down this cycle\n" % sid)
+            return None
+    try:                                         # a corroborated death some writer already stamped,
+        m = json.loads((jd.STATE / "gone" / (sid + ".json")).read_text())   # still standing —
+        if isinstance(m, dict) and int(m.get("t") or 0) >= int((_last_states_row(sid) or {}).get("t") or 0):
+            return True                          # answers without a probe, even under a wedged server
+    except (OSError, ValueError):
+        pass
+    # AUTHORITY FOLLOWS OWNERSHIP (2026-08-23): the owner scan below settles only sids tmux could
+    # have RUN. A reg-less sid with no names-registry entry was launched by neither backend — its
+    # existence is transcript-derived — so no owner here can answer for it, whatever the box has
+    # installed. Keying the stand-down on _TMUX.available() alone would tie authority to the BOX:
+    # the availability probe is live (shutil.which), so tmux APPEARING mid-flight would hand a
+    # fresh, EMPTY server's scan authority over a live file-derived session's death and convert
+    # its card. The tmux-less box falls out of the same rule: a registered sid still stands down
+    # below when there is no server to ask.
+    if not (jd.NAMES / sid).is_file():
+        return None                              # transcript-derived: no owner here — stand down
+    if not _TMUX.available():
+        return None                              # tmux-launched, but no server on this box to ask
+    scan = scan() if scan is not None else _TMUX.alive_sids()
+    if scan is None:
+        if stats is not None:
+            stats["probe"] = stats.get("probe", 0) + 1
+        else:
+            sys.stderr.write("dead-wait: liveness probe failed for %s — standing down this cycle\n" % sid)
+        return None
+    return sid not in scan
+
+
 def _dead_wait_sweep(alive_ids, nudged, now):
     """Find DORMANT sessions whose Working cards still hold a judged awaiting stamp and convert each to
     a procedural block (_dead_wait_block). Event-triggered, never a per-tick poll of every store: the
     trigger is the DEATH TRANSITION (a sid leaving the alive set between ticks), plus one catch-up
     sweep of all dormant stores on the first tick after boot — the same boot-re-audit pattern the
     awaiting stamps already use — for sessions that died under a previous kernel (the two measured
-    cards had been dead 79 hours across many restarts)."""
+    cards had been dead 79 hours across many restarts). The transition is a RAW-listing diff, so
+    every candidate's death is corroborated with the liveness owner (_dead_wait_corroborated)
+    before its store is even walked; a stood-down candidate (owner says alive, or unconfirmable)
+    is kept in _PREV_ALIVE so the transition stays armed and the next tick re-asks — an
+    unconfirmed absence must never spend the one event that triggers this sweep."""
     global _PREV_ALIVE
     prev, _PREV_ALIVE = _PREV_ALIVE, set(alive_ids)
     if prev is None:
@@ -3437,8 +3518,19 @@ def _dead_wait_sweep(alive_ids, nudged, now):
             return
     else:
         cands = prev - set(alive_ids)
+    scan_memo = []                               # one owner scan per pass (_death_sweep_tick's idiom):
+
+    def _pass_scan():                            # under the exact collapse this guard exists for, EVERY
+        if not scan_memo:                        # alive sid is a candidate, and a per-sid probe would
+            scan_memo.append(_TMUX.alive_sids())  # fork a subprocess per session per tick
+        return scan_memo[0]
+
+    stats = {}                                   # loud stand-down tallies → ONE line per reason per pass
     for sid in cands:
         try:
+            if _dead_wait_corroborated(sid, scan=_pass_scan, stats=stats) is not True:
+                _PREV_ALIVE.add(sid)             # not corroborated dead: nothing files, and the death
+                continue                         # transition stays armed for the next tick's re-ask
             store = jd.load_goals(sid)
             nodes = store.get("nodes", {})
             kids = {}
@@ -3454,6 +3546,15 @@ def _dead_wait_sweep(alive_ids, nudged, now):
                     _dead_wait_block(sid, gid, stamp[0], stamp[1], nudged, now)
         except Exception:
             sys.stderr.write("dead-wait sweep (%s): %s\n" % (sid, traceback.format_exc()))
+    # The pass's loud stand-downs, collapsed to one line per reason (_death_sweep_tick's idiom):
+    # per-candidate lines multiply by the candidate count under exactly the wedge they report
+    # (a 20-session listing collapse would log every candidate every tick), drowning the signal.
+    if stats.get("probe"):
+        sys.stderr.write("dead-wait: probe failed; %d candidate(s) stood down this pass\n"
+                         % stats["probe"])
+    if stats.get("reg"):
+        sys.stderr.write("dead-wait: unreadable SDK reg; %d candidate(s) stood down this pass\n"
+                         % stats["reg"])
 
 
 def _dead_wait_block(sid, gid, at, why, nudged, now):
@@ -3527,7 +3628,12 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
         # death notice tells the CHAT what happened; nothing ever moved the CARD. Nothing that could
         # answer the wait is running, so convert ONCE per stamp episode to a procedural block naming
         # the dead wait — the same terminal an unanswered wake reaches — and let a revival's reply
-        # lift it like any block.
+        # lift it like any block. But the map's absence is a RAW read (on a tmux-less box this branch
+        # takes every file-derived session _alive_sessions falls back to, alive included), so the
+        # death is corroborated with the liveness owner first; unconfirmable stands down — the stamp
+        # stays and the next walk re-asks.
+        if _dead_wait_corroborated(sid) is not True:
+            return False
         return _dead_wait_block(sid, gid, at, why, nudged, now)
     rec = nudged.get(gid) or {}
     if not rec.get("wake"):
@@ -26841,7 +26947,10 @@ class Handler(BaseHTTPRequestHandler):
                 _mark_views_dirty()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             _set_auto_nudge(bool(msg["enabled"]))   # feed gear → server-side Auto Nudge on/off
-            _auto_nudge_tick(int(time.time()), _tmux_sessions())   # act immediately on turn-on (don't wait 4s)
+            # act immediately on turn-on (don't wait 4s) — but skip the dead-wait sweep: the
+            # death transition has ONE observer (the pusher's tick; see _auto_nudge_tick), and
+            # this WS thread racing its prev-swap could spend a transition uncorroborated
+            _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
         elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:
             _set_update_mode(str(msg["mode"]))      # feed gear → how romp handles new releases at boot
         elif msg and msg.get("type") == "setFileEditing" and msg.get("enabled") is not None:

--- a/tests/test_dead_wait_block.py
+++ b/tests/test_dead_wait_block.py
@@ -6,10 +6,13 @@ and it sat "paused" in Working forever (two live cards measured at 79 hours). Th
 event-triggered (the death transition; a boot catch-up sweep), once per stamp episode, stands down
 for restart cuts (the resume machinery owns those), and its why is a recognized procedural block.
 SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import contextlib
+import io
 import json
 import os
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -40,7 +43,19 @@ SID = ""
 GID = ""
 
 
-def _seed_store(awaiting=True):
+def _register_name(sid):
+    """A names-registry entry — the launch record BOTH backends write at creation. It is what marks
+    a reg-less sid as one tmux could have run; a sid with no reg and no names entry exists only as
+    a transcript (the file fallback's world), and no liveness owner here can answer for it."""
+    jd.NAMES.mkdir(parents=True, exist_ok=True)
+    (jd.NAMES / sid).write_text("web\t~/notes-api\t#3355aa\t#ffffff\n")
+
+
+def _seed_store(awaiting=True, named=True):
+    # named=True: the fixture models a romp-LAUNCHED session (the usual world), so the owner scan
+    # is entitled to settle it; named=False models a transcript-derived one (no launch record).
+    if named:
+        _register_name(SID)
     store = jd.load_goals(SID)
     nd = {"id": GID, "text": "delegate the batch and report", "parentId": None,
           "nodeComplete": False, "blocked": False, "cleared": False, "t": STAMP_T - 100,
@@ -64,22 +79,32 @@ def _write_state(state, t):
         f.write(json.dumps({"state": state, "t": t}) + "\n")
 
 
-class DeadWaitBlock(unittest.TestCase):
+class _HermeticDeadWait(unittest.TestCase):
     def setUp(self):
         global SID, GID
         SID = _fresh_sid()
         GID = SID + ":g1"
         km._PREV_ALIVE = None
         self.nudged = {}
+        # hermetic liveness: never read whether THIS box has tmux (the corroboration the sweep now
+        # does before converting would otherwise shell out); an authoritative empty owner scan is
+        # the corroborated-dead world these tests were written in
+        km._TMUX.available = lambda: True
+        km._TMUX.alive_sids = lambda t=3: set()
 
     def tearDown(self):
-        for d in (jd.GOALDIR, jd.STATE / "states"):
-            for f in d.glob("*"):
-                f.unlink()
+        for nm in ("available", "alive_sids"):
+            km._TMUX.__dict__.pop(nm, None)   # instance attrs shadow the class methods; drop them
+        for d in (jd.GOALDIR, jd.STATE / "states", jd.SDKDIR, jd.STATE / "gone", jd.NAMES):
+            if d.is_dir():
+                for f in d.glob("*"):
+                    f.unlink()
         p = jd.STATE / "auto-nudge.json"
         if p.exists():
             p.unlink()
 
+
+class DeadWaitBlock(_HermeticDeadWait):
     def test_dormant_stamped_card_converts_to_a_recognized_procedural_block(self):
         _seed_store()
         _write_state("idle", STAMP_T + 50)
@@ -143,6 +168,238 @@ class DeadWaitBlock(unittest.TestCase):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("return _dead_wait_block(sid, gid, at, why, nudged, now)", src)
         self.assertIn("_dead_wait_sweep(alive_ids, nudged, now)", src)
+
+
+class DeadWaitCorroboration(_HermeticDeadWait):
+    """The sweep's trigger — absence from a RAW liveness listing — inherits every collapse that
+    listing has (tmux list error/timeout empties the map for a cycle; a swallowed SDK live-merge
+    exception does the same to the merged half), and the block it files is irreversible bookkeeping
+    on the user's board with nothing to lift it when the listing returns. So absence alone NEVER
+    files: the death is corroborated with the liveness OWNER first (the SDK reg's alive bit / a
+    standing death record / the owner scan), and an unconfirmable candidate stands down for the
+    cycle with its transition kept armed — the doctrine _death_sweep_tick and _death_boot_pass follow."""
+
+    def _blocked(self):
+        return bool(jd.load_goals(SID)["nodes"][GID].get("blocked"))
+
+    def test_a_raw_listing_collapse_alone_never_files(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._TMUX.alive_sids = lambda t=3: {SID}   # the OWNER answers alive — the raw listing blinked
+        km._PREV_ALIVE = {SID}
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)   # empty alive set: the collapse shape
+        self.assertFalse(self._blocked(), "an owner-corroborated ALIVE session must never convert")
+        self.assertIn(SID, km._PREV_ALIVE, "the death transition stays armed for a genuine later death")
+
+    def test_probe_failure_stands_down_and_the_next_tick_retries(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._TMUX.alive_sids = lambda t=3: None    # a REAL probe failure — cannot confirm either way
+        km._PREV_ALIVE = {SID}
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        self.assertFalse(self._blocked(), "unconfirmed is never dead — nothing files")
+        self.assertIn(SID, km._PREV_ALIVE, "the candidate is kept, not spent")
+        km._TMUX.alive_sids = lambda t=3: set()   # the probe recovers and corroborates the death…
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 950)
+        self.assertTrue(self._blocked(), "…and the retried tick converts")
+
+    def test_sdk_reg_alive_bit_outranks_the_merged_maps_absence(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"alive": True}))
+        km._PREV_ALIVE = {SID}
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)   # the swallowed SDK-merge shape
+        self.assertFalse(self._blocked(),
+                         "alive:True is live/revivable/crash-looped — the resume contract owns it")
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"alive": False}))
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 950)
+        self.assertTrue(self._blocked(), "alive:False is the owner's durable answer — it converts")
+
+    def test_a_standing_death_record_corroborates_without_a_probe(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        gone = jd.STATE / "gone"
+        gone.mkdir(parents=True, exist_ok=True)
+        (gone / (SID + ".json")).write_text(json.dumps({"t": STAMP_T + 60, "by": "gone"}))
+        km._TMUX.alive_sids = lambda t=3: None    # even with the probe down…
+        km._PREV_ALIVE = {SID}
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        self.assertTrue(self._blocked(), "…a death a corroborated writer already stamped answers")
+
+    def test_wake_goal_headless_branch_stands_down_for_file_derived_sessions(self):
+        # a no-tmux box's _alive_sessions falls back to FILE-derived sessions, which reach
+        # _wake_goal absent from the merged map while genuinely ALIVE — no owner here can answer
+        # for a reg-less one, so nothing may file
+        _seed_store(named=False)                  # transcript-derived: no launch record
+        _write_state("idle", STAMP_T + 50)
+        km._TMUX.available = lambda: False
+        store = jd.load_goals(SID)
+        fired = km._wake_goal(SID, GID, (STAMP_T, "w"), self.nudged, [], store,
+                              STAMP_T + 900, {}, {})
+        self.assertFalse(fired)
+        self.assertFalse(self._blocked(), "a reg-less file-derived session has no owner to ask")
+        # …but a genuinely ENDED SDK session still converts on the same box: the reg answers
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"alive": False}))
+        fired = km._wake_goal(SID, GID, (STAMP_T, "w"), self.nudged, [], store,
+                              STAMP_T + 950, {}, {})
+        self.assertTrue(fired)
+        self.assertTrue(self._blocked())
+
+    def test_tmux_appearing_mid_flight_cannot_settle_a_sid_it_never_owned(self):
+        # AUTHORITY FOLLOWS OWNERSHIP: a headless box's file fallback lists a LIVE
+        # transcript-derived session (no reg, no names entry — launched by neither backend); it
+        # drops out of the file-derived alive set, arming its death transition… and THEN tmux is
+        # installed. The availability probe is live (shutil.which), so keying the stand-down on
+        # the BOX's tmux availability would let the fresh, EMPTY server — which never ran this
+        # sid — answer as its liveness owner: a false conversion of a live session's card. An
+        # owner scan settles only sids the owner could have run; this one stands down REGARDLESS
+        # of tmux availability.
+        _seed_store(named=False)                  # transcript-derived: no launch record
+        _write_state("idle", STAMP_T + 50)
+        km._TMUX.available = lambda: True         # tmux just appeared mid-flight…
+        km._TMUX.alive_sids = lambda t=3: set()   # …and its fresh server owns nothing
+        self.assertIsNone(km._dead_wait_corroborated(SID),
+                          "an owner scan settles only sids the owner could have run")
+        km._PREV_ALIVE = {SID}
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        self.assertFalse(self._blocked(), "a sid tmux never ran must not convert on tmux's word")
+        self.assertIn(SID, km._PREV_ALIVE, "stood down and kept armed, never spent")
+        # …while the SAME sid WITH a launch record is the owner's to settle: it converts
+        _register_name(SID)
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 950)
+        self.assertTrue(self._blocked())
+
+
+class DeadWaitStandDownLogging(_HermeticDeadWait):
+    """Wedge-time log ergonomics: a stand-down is LOUD (the fail-loudly rule — a silent one wedges
+    a candidate forever with no trace to act on) but collapsed to ONE line per sweep pass
+    (_death_sweep_tick's idiom) — the per-candidate line multiplies by the candidate count under
+    exactly the wedge it reports (a 20-session listing collapse would log every candidate every
+    tick at the pusher cadence)."""
+
+    def _blocked(self):
+        return bool(jd.load_goals(SID)["nodes"][GID].get("blocked"))
+
+    def test_probe_failure_logs_one_line_per_pass_not_per_candidate(self):
+        sid2 = _fresh_sid()
+        _register_name(SID)
+        _register_name(sid2)
+        km._TMUX.alive_sids = lambda t=3: None    # a REAL probe failure, shared by the whole pass
+        km._PREV_ALIVE = {SID, sid2}
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._dead_wait_sweep(set(), {}, STAMP_T + 900)
+        lines = [ln for ln in buf.getvalue().splitlines() if "dead-wait" in ln and "probe" in ln]
+        self.assertEqual(len(lines), 1, "one line per pass, not per candidate: %r" % lines)
+        self.assertIn("2 candidate(s) stood down this pass", lines[0])
+        self.assertEqual({SID, sid2} & km._PREV_ALIVE, {SID, sid2}, "both kept armed")
+
+    def test_unreadable_reg_stand_down_is_loud_and_per_pass_deduped(self):
+        sid2 = _fresh_sid()
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text("{not json")     # an unreadable owner reg
+        (jd.SDKDIR / (sid2 + ".json")).write_text("{not json")
+        km._PREV_ALIVE = {SID, sid2}
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._dead_wait_sweep(set(), {}, STAMP_T + 900)
+        lines = [ln for ln in buf.getvalue().splitlines()
+                 if "dead-wait" in ln and "unreadable" in ln]
+        self.assertEqual(len(lines), 1,
+                         "silent forever is a wedge with no trace; per-candidate is a flood: %r" % lines)
+        self.assertIn("2 candidate(s) stood down this pass", lines[0])
+        self.assertEqual({SID, sid2} & km._PREV_ALIVE, {SID, sid2}, "both kept armed")
+
+    def test_single_probe_callers_still_name_the_sid(self):
+        # _wake_goal's dormant branch corroborates ONE sid per call — there its line IS the pass,
+        # and naming the sid is what makes the trace actionable
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text("{not json")
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self.assertIsNone(km._dead_wait_corroborated(SID))
+        out = buf.getvalue()
+        self.assertIn(SID, out, "the unreadable-reg stand-down must be loud (fail-loudly rule)")
+        self.assertIn("unreadable", out)
+
+
+class DeadWaitOneObserver(_HermeticDeadWait):
+    """The death transition has ONE observer. _dead_wait_sweep's prev-swap (_PREV_ALIVE) is a
+    lock-free read-modify-write, safe only because exactly one caller — the pusher's periodic
+    tick — ever runs it. setAutoNudge's WS handler also fires _auto_nudge_tick (to re-arm nudging
+    immediately on turn-on); racing the pusher, its swap could spend a death transition
+    mid-pass without corroboration, losing the re-arm until the boot catch-up. So the
+    WS-triggered tick SKIPS the sweep (run_dead_wait=False): its purpose is nudge re-arming,
+    and the pusher re-runs the sweep on its own cadence anyway."""
+
+    def _blocked(self):
+        return bool(jd.load_goals(SID)["nodes"][GID].get("blocked"))
+
+    @contextlib.contextmanager
+    def _tick_stubs(self):
+        """Stub the tick's OTHER legs (session walk, peer-wait graph, debt sweep, wake outcomes)
+        so a tick-level call exercises only the sweep — the leg under test — hermetically."""
+        saved = {nm: getattr(km, nm) for nm in
+                 ("_alive_sessions", "_wait_for_graph", "_debt_backstop_tick",
+                  "_awaiting_wake_outcomes")}
+        km._alive_sessions = lambda now, tmux: []
+        km._wait_for_graph = lambda now, alive_sids: {}
+        km._debt_backstop_tick = lambda now: None
+        km._awaiting_wake_outcomes = lambda now: False
+        try:
+            yield
+        finally:
+            for nm, fn in saved.items():
+                setattr(km, nm, fn)
+
+    def test_ws_shaped_tick_skips_the_sweep_and_the_pusher_shape_runs_it(self):
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = {SID}                    # a pending death transition
+        with self._tick_stubs():
+            km._auto_nudge_tick(STAMP_T + 900, {}, run_dead_wait=False)   # setAutoNudge's tick
+            self.assertEqual(km._PREV_ALIVE, {SID},
+                             "the WS-triggered tick must not observe (or spend) the transition")
+            self.assertFalse(self._blocked())
+            km._auto_nudge_tick(STAMP_T + 950, {})                        # the pusher's tick
+        self.assertTrue(self._blocked(), "the one observer still converts, on its own cadence")
+
+    def test_a_mid_pass_ws_tick_leaves_the_transition_alone(self):
+        # the racing interleave, deterministically: the pusher is MID-PASS (inside a candidate's
+        # corroboration) when the WS handler's tick fires. The transition set must be exactly
+        # what the pusher's pass installed — untouched by the nested tick.
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = {SID}
+        real = km._dead_wait_corroborated
+        seen = {}
+
+        def hooked(sid, scan=None, stats=None):
+            if "ran" not in seen:
+                seen["ran"] = True
+                before = set(km._PREV_ALIVE)
+                km._auto_nudge_tick(STAMP_T + 901, {}, run_dead_wait=False)   # WS fires mid-pass
+                seen["moved"] = set(km._PREV_ALIVE) != before
+            return real(sid, scan=scan, stats=stats)
+
+        km._dead_wait_corroborated = hooked
+        try:
+            with self._tick_stubs():
+                km._auto_nudge_tick(STAMP_T + 900, {})                        # the pusher's tick
+        finally:
+            km._dead_wait_corroborated = real
+        self.assertTrue(seen.get("ran"), "the pusher's pass reached its corroboration")
+        self.assertFalse(seen.get("moved"), "the nested WS tick swapped the transition mid-pass")
+        self.assertTrue(self._blocked(), "the pusher's own pass still completed its conversion")
+
+    def test_the_setautonudge_call_site_skips_the_sweep(self):
+        # the ownership rule holds at the ONE other call site, pinned the way
+        # test_wake_goal_routes_its_dormant_branch_here pins its wiring
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)",
+                      src)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -589,6 +589,16 @@ class AwaitingWake(unittest.TestCase):
         # (the user 2026-08-22) a dormant CLI still gets no WAKE — its dispatched work is gone, not
         # asleep — but the branch no longer dead-ends: the stamped Working card converts once to the
         # dead-wait procedural block, so it reaches a terminal column instead of pausing forever.
+        # The conversion is owner-corroborated: the session carries its launch record (the names
+        # entry both backends write — without it no owner here could answer for the sid), and the
+        # owner scan is pinned to an authoritative empty answer rather than this box's real tmux.
+        km.jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (km.jd.NAMES / SID).write_text("web\t~/notes-api\t#3355aa\t#ffffff\n")
+        self.addCleanup(lambda: (km.jd.NAMES / SID).unlink())
+        km._TMUX.available = lambda: True
+        km._TMUX.alive_sids = lambda t=3: set()
+        self.addCleanup(lambda: [km._TMUX.__dict__.pop(nm, None)
+                                 for nm in ("available", "alive_sids")])
         now = 1_000_000
         self._seed(at=now - 7 * 3600)
         (km.jd.STATE / "states").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Follow-up hardening of #550: the two dead-wait writers now corroborate a death with the liveness owner before filing the irreversible "session ended while still waiting" block, the same doctrine `_death_sweep_tick` and `_death_boot_pass` already follow before stamping a death.

## What breaks today

Both writers trust one raw liveness listing:

- `_dead_wait_sweep`'s death transition is a set-diff of raw alive ids (`prev - alive_ids`), and every candidate's store converts unconditionally.
- `_wake_goal`'s dormant branch converts on bare absence from the merged map (`tmux.get(sid) is None`).

That listing inherits every collapse its sources have. `TmuxBackend.list_lines` returns `[]` on an exec error or timeout, which empties the tmux half of the map for a cycle; `Sessions.live` logs and swallows an SDK `live_sessions` merge exception, which empties the other half. One bad cycle converts every stamped Working card to blocked with "session ended while waiting", and nothing lifts the block when the listing returns next tick. On a tmux-less box the failure is standing, not transient: `_alive_sessions` falls back to file-derived sessions, which are never in the merged map, so the dormant branch converts genuinely live sessions.

Reproduction (synthetic): auto-nudge on, one session holding a judged awaiting stamp on a Working card; let a single `tmux list-sessions` call time out (or one SDK merge raise) for one pusher cycle. The card converts to the dead-wait block and stays there while the session keeps working. `DeadWaitCorroboration::test_a_raw_listing_collapse_alone_never_files` is that scenario as a test; it fails on main.

## The fix

A tri-state `_dead_wait_corroborated(sid)`, threaded through both writers:

- **True** (corroborated dead): the SDK reg's alive bit is False (alive:True is revivable or crash-looped and must never convert; the resume contract owns it), a standing death record postdates the session's last recorded state (answers without a probe, even under a wedged server), or the owner scan (`TmuxBackend.alive_sids`) answers without the sid.
- **False**: the owner says alive. The raw listing blinked, not the session.
- **None** (cannot confirm): a real probe failure, an unreadable reg, or a sid with no names-registry launch record. The last is an ownership rule: a session launched by neither backend is transcript-derived, and no owner on this box can answer for it, so a tmux server appearing mid-flight cannot settle a session it never ran.

A non-True answer stands down for the cycle and keeps the candidate in `_PREV_ALIVE`: the death transition stays armed, and a genuine death still converts on the next tick.

Three supporting changes:

- The sweep takes one owner scan per pass; a per-sid probe would fork a subprocess per session under exactly the collapse being guarded.
- Stand-downs are loud (a silent one would wedge a candidate forever with no trace to act on) but collapse to one stderr line per reason per pass.
- The death transition gets a single observer. The `_PREV_ALIVE` prev-swap is a lock-free read-modify-write with two callers today: the pusher's tick and the setAutoNudge handler's immediate tick. The handler now passes `run_dead_wait=False`; its job is re-arming nudging without waiting a cycle, the pusher re-runs the sweep on its own cadence, and a racing swap can no longer spend a death transition mid-pass without corroboration.

One behavior change to weigh: an unconfirmable candidate never converts. A reg-less sid on a box whose probe fails every tick stays Working until the probe recovers or a death record lands. That is the designed trade (never file irreversible bookkeeping on silence), with the boot catch-up and the re-armed transition covering recovery.

## Tests

`tests/test_dead_wait_block.py` grows three hermetic classes (`_TMUX.available` / `alive_sids` stubbed as instance attributes; no real tmux touched):

- `DeadWaitCorroboration`: a raw listing collapse alone never files; a failed probe stands down and the retried tick converts; the reg's alive bit outranks map absence; a standing death record corroborates without a probe; a headless box's file-derived session stands down in `_wake_goal` while a dead SDK reg still converts; tmux appearing mid-flight cannot settle a sid it never owned.
- `DeadWaitStandDownLogging`: one stderr line per reason per pass; single-probe callers still name the sid.
- `DeadWaitOneObserver`: a `run_dead_wait=False` tick neither observes nor spends the transition; a nested tick fired mid-pass leaves it untouched; the setAutoNudge call site is pinned.

`tests/test_kernel_awaiting_stamp.py`'s dormant-conversion test is pinned hermetic (a names entry plus a stubbed empty owner scan) so it exercises the corroborated path instead of shelling out to the box's real tmux.

Red-first: without the kernel changes, 11 of the 12 new tests fail (the standing-death-record case converts either way, so it passes on both). The full suite passes with them.

## Out of scope

`_end_on_idle_sweep` retires self-close requests on the same raw `tmux.get(sid) is None` read. That miss is milder (a spent request, not an irreversible block), so it is left alone here; the same corroboration would fit as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)