### PR TITLE
AskUserQuestion answers: fill from the record's structured answers map instead of regex-scraping the output string

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -41,6 +41,12 @@ MESSAGES_LOG = STATE / "timeline" / "messages.jsonl"
 # A turn ends when the model hands the floor back: stream `end_turn` / `stop_sequence`.
 # Mid-turn the model stops with `tool_use` (a tool cycle) — that does NOT end the turn.
 END_STOPS = ("end_turn", "stop_sequence")
+# The toolUseResult keys a consumer actually reads (Edit's structuredPatch → diffRows,
+# AskUserQuestion's answers map → the answered box). The atom carry is GATED on one of these
+# being present: an unconditional dict carry held every Read result's full file bytes in the
+# parse cache by reference — ~a fifth of transcript bytes on read-heavy sessions — for shapes
+# nothing reads. Widen this set when a new consumer appears; never revert to carry-all.
+TUR_CONSUMED_KEYS = frozenset(("answers", "structuredPatch"))
 # romp's own postal marker, injected into a delivered message body. It is the ONLY
 # postal signal — never the generic "Stop hook feedback:" prefix (any blocking Stop
 # hook produces that). The sender rompUuid is resolved from timeline/messages.jsonl
@@ -1259,13 +1265,18 @@ class FileAdapter:
                 atom = {"type": "user", "uuid": u, "session_id": rompuuid, "t": ts,
                         "fsid": fsid, "parentUuid": r.get("parentUuid"),
                         "message": _norm_message(r.get("message")), "_seq": seq}
-                if has_tool_result and isinstance(r.get("toolUseResult"), dict):
+                if has_tool_result and isinstance(r.get("toolUseResult"), dict) \
+                        and (set(r["toolUseResult"]) & TUR_CONSUMED_KEYS):
                     # The record's top-level toolUseResult — Claude Code's STRUCTURED result (Edit's
                     # structuredPatch, AskUserQuestion's answers map). The kernel's chat build reads it
                     # at tool_result attach time; the atom used to drop it, so every consumer silently
                     # fell to its lossy fallback (regex-scraping the flat output string — which is how
                     # quote-bearing AskUserQuestion answers vanished from the answered box). Dict form
-                    # only: an errored result records a plain string, which no consumer reads.
+                    # only: an errored result records a plain string, which no consumer reads. Carried
+                    # ONLY when a consumed key is present (_TUR_CONSUMED_KEYS): an unconditional carry
+                    # held every Read result's full file bytes in the parse cache by reference —
+                    # roughly a fifth of transcript bytes on read-heavy sessions — for shapes nothing
+                    # reads. Widen the key set when a new consumer appears; never back to carry-all.
                     atom["toolUseResult"] = r["toolUseResult"]
                 if ps:
                     atom["promptSource"] = ps

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1259,6 +1259,14 @@ class FileAdapter:
                 atom = {"type": "user", "uuid": u, "session_id": rompuuid, "t": ts,
                         "fsid": fsid, "parentUuid": r.get("parentUuid"),
                         "message": _norm_message(r.get("message")), "_seq": seq}
+                if has_tool_result and isinstance(r.get("toolUseResult"), dict):
+                    # The record's top-level toolUseResult — Claude Code's STRUCTURED result (Edit's
+                    # structuredPatch, AskUserQuestion's answers map). The kernel's chat build reads it
+                    # at tool_result attach time; the atom used to drop it, so every consumer silently
+                    # fell to its lossy fallback (regex-scraping the flat output string — which is how
+                    # quote-bearing AskUserQuestion answers vanished from the answered box). Dict form
+                    # only: an errored result records a plain string, which no consumer reads.
+                    atom["toolUseResult"] = r["toolUseResult"]
                 if ps:
                     atom["promptSource"] = ps
                 author = author_of(blocks, ps, postal_index, getattr(self, "sdk_human", False))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13892,16 +13892,26 @@ def _ask_fill_answers(blocks, answers):
     parsing, so quotes/equals/commas in questions and answers survive verbatim; the regex scrape below
     (_ask_fill_chosen, now the old-record fallback) garbled all of those — a double-quote inside a
     question's text stopped its capture, and the typed answer silently vanished from the answered box
-    (13 of 95 real answers dropped, 1 garbled; the user 2026-08-20)."""
+    (13 of 95 real answers dropped, 1 garbled; the user 2026-08-20).
+
+    Returns the number of blocks ACTUALLY filled — the caller latches askAnswerFilled (which stands
+    the regex fallback down) on it being nonzero, never on the map merely existing: a keying mismatch
+    (a future harness renaming, an empty map) fills nothing, and latching anyway would disarm the
+    safety net while recoverable pairs sit in the flat string."""
     amap = {str(k).strip(): v for k, v in answers.items()}
+    filled = 0
     for blk in blocks:
         ans = amap.get((blk.get("question") or "").strip())
         if ans is None and blk.get("header"):
             ans = amap.get(str(blk["header"]).strip())
         if isinstance(ans, list):
-            blk["chosen"] = [str(v) for v in ans]
+            if ans:                                   # an empty pick-list fills nothing
+                blk["chosen"] = [str(v) for v in ans]
+                filled += 1
         elif ans not in (None, ""):
             blk["chosen"] = [str(ans)]
+            filled += 1
+    return filled
 
 
 def _ask_fill_chosen(blocks, output):
@@ -13921,8 +13931,21 @@ def _ask_fill_chosen(blocks, output):
         ans = (vals[0] if len(blocks) == 1 and vals
                else pairs.get((blk.get("question") or "").strip())
                or pairs.get((blk.get("header") or "").strip()) or "")
-        if ans:
-            blk["chosen"] = [s.strip() for s in ans.split(", ")] if blk.get("multiSelect") else [ans]
+        if not ans:
+            continue
+        # The multiSelect split must be EARNED (parseAskRaw's rule in ui/webview/render.ts, ported):
+        # the flat string joins picked labels as 'A, B, C', but a SINGLE picked label may itself
+        # contain ', ' ("Boston, MA") and a free-typed 'Other' answer may carry any commas — split
+        # unconditionally and either one shreds into bogus fragments (wrong Other rows, lost
+        # highlight). So: an answer that IS an option label stays whole; otherwise split, and keep
+        # the split only when at least one part names a label (some(), not every() — a joined pick
+        # can include a free-typed Other alongside real labels); else keep the value whole.
+        labels = {str(o.get("label") or "") for o in (blk.get("options") or [])} - {""}
+        if blk.get("multiSelect") and ans not in labels:
+            parts = [s.strip() for s in re.split(r",\s*", ans) if s.strip()]
+            blk["chosen"] = parts if any(p in labels for p in parts) else [ans]
+        else:
+            blk["chosen"] = [ans]
 
 
 _compact_clicked = {}         # sid -> ts of a compact WE initiated → optimistic cross-surface "compacting"
@@ -15443,12 +15466,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             # no parsing (see _ask_fill_answers). askAnswerFilled makes the regex
                             # fallback at the bottom of this build stand down: run on top of this it
                             # could overwrite the real answer with a garbled scrape (the single-
-                            # question vals[0] rescue). A DISMISSED picker records toolUseResult as a
-                            # plain string (tur is None here) → blocks stay unanswered, exactly as a
-                            # pending ask renders.
+                            # question vals[0] rescue). It latches only when the fill FILLED something
+                            # — a map whose keys match nothing must leave the fallback armed, or the
+                            # whole ask renders pending despite recoverable pairs in the flat string.
+                            # A DISMISSED picker records toolUseResult as a plain string (tur is None
+                            # here) → blocks stay unanswered, exactly as a pending ask renders.
                             if ev.get("askAnswer") and tur and isinstance(tur.get("answers"), dict):
-                                _ask_fill_answers(ev["askAnswer"], tur["answers"])
-                                ev["askAnswerFilled"] = True
+                                if _ask_fill_answers(ev["askAnswer"], tur["answers"]):
+                                    ev["askAnswerFilled"] = True
                 else:                                            # a genuine prompt OR a delivered peer message
                     text = " ".join(b.get("text", "") for b in blocks if b.get("type") == "text").strip() \
                            if blocks else (msg.get("content") if isinstance(msg.get("content"), str) else "")
@@ -15608,9 +15633,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             # this instead of regex-parsing the output). chosen is filled below once the
                             # tool_result (the answer) is in. Built from the UNTRUNCATED input.
                             # multiSelect rides the block: it documents the LIST-valued answers the
-                            # authoritative fill records, and it arms the fallback's ', ' label split
+                            # authoritative fill records, and it arms the fallback's label split
                             # (dead before it was copied — old-record multiSelect picks rendered as
-                            # ONE joined quoted "Other" row instead of highlighted options).
+                            # ONE joined quoted "Other" row instead of highlighted options; the
+                            # split itself is label-guarded, see _ask_fill_chosen).
                             ev["askAnswer"] = [{"question": str(q.get("question") or ""),
                                                 "header": str(q.get("header")) if q.get("header") else None,
                                                 "multiSelect": bool(q.get("multiSelect")),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13884,12 +13884,35 @@ def _boot_warm():
     threading.Thread(target=go, daemon=True, name="boot-warm").start()
 
 
+def _ask_fill_answers(blocks, answers):
+    """Fill each AskUserQuestion block's `chosen` from the record's STRUCTURED toolUseResult.answers
+    map — the authoritative source (CLAUDE.md: a designed record over a lossy reconstruction). Keys are
+    the EXACT question text; a value is the answer string (an option label, or the free-typed 'Other'
+    text) or, for multiSelect, the LIST of picked labels — taken as-is, never re-joined or split. No
+    parsing, so quotes/equals/commas in questions and answers survive verbatim; the regex scrape below
+    (_ask_fill_chosen, now the old-record fallback) garbled all of those — a double-quote inside a
+    question's text stopped its capture, and the typed answer silently vanished from the answered box
+    (13 of 95 real answers dropped, 1 garbled; the user 2026-08-20)."""
+    amap = {str(k).strip(): v for k, v in answers.items()}
+    for blk in blocks:
+        ans = amap.get((blk.get("question") or "").strip())
+        if ans is None and blk.get("header"):
+            ans = amap.get(str(blk["header"]).strip())
+        if isinstance(ans, list):
+            blk["chosen"] = [str(v) for v in ans]
+        elif ans not in (None, ""):
+            blk["chosen"] = [str(ans)]
+
+
 def _ask_fill_chosen(blocks, output):
-    """Fill each AskUserQuestion block's `chosen` from the tool_result string, which records the answers
-    as `"<question>"="<answer>"` pairs (a multiSelect answer joins the picked labels as 'A, B, C'; a
-    free-text 'Other' answer is the user's verbatim text and matches NO option label). Single-question
-    calls map the lone pair; multi-question calls match by question (then header). Render highlights a
-    `chosen` value that equals an option label and shows the rest verbatim."""
+    """FALLBACK for old records whose transcript carries no dict toolUseResult (see _ask_fill_answers,
+    the authoritative path): fill each block's `chosen` from the tool_result string, which records the
+    answers as `"<question>"="<answer>"` pairs (a multiSelect answer joins the picked labels as
+    'A, B, C'; a free-text 'Other' answer is the user's verbatim text and matches NO option label).
+    Single-question calls map the lone pair; multi-question calls match by question (then header).
+    Render highlights a `chosen` value that equals an option label and shows the rest verbatim.
+    Known-lossy: a double-quote inside a question or answer breaks the scrape — which is why the
+    authoritative path exists and must never run both."""
     pairs = {}
     for m in re.finditer(r'[“"]([^”"]*)[”"]\s*=\s*[“"]([^”"]*)[”"]', output or ""):
         pairs[m.group(1).strip()] = m.group(2)
@@ -15414,6 +15437,18 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                                 pr = _patch_rows(tur["structuredPatch"])
                                 if pr:
                                     ev["diffRows"] = pr
+                            # AskUserQuestion: the SAME record carries the STRUCTURED answers at top
+                            # level — toolUseResult = {"questions": [...], "answers": {question-text:
+                            # answer}} — the authoritative source; fill chosen from it by exact key,
+                            # no parsing (see _ask_fill_answers). askAnswerFilled makes the regex
+                            # fallback at the bottom of this build stand down: run on top of this it
+                            # could overwrite the real answer with a garbled scrape (the single-
+                            # question vals[0] rescue). A DISMISSED picker records toolUseResult as a
+                            # plain string (tur is None here) → blocks stay unanswered, exactly as a
+                            # pending ask renders.
+                            if ev.get("askAnswer") and tur and isinstance(tur.get("answers"), dict):
+                                _ask_fill_answers(ev["askAnswer"], tur["answers"])
+                                ev["askAnswerFilled"] = True
                 else:                                            # a genuine prompt OR a delivered peer message
                     text = " ".join(b.get("text", "") for b in blocks if b.get("type") == "text").strip() \
                            if blocks else (msg.get("content") if isinstance(msg.get("content"), str) else "")
@@ -15572,8 +15607,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             # structured Q+A for the chat's "answered Claude's question" box (render reads
                             # this instead of regex-parsing the output). chosen is filled below once the
                             # tool_result (the answer) is in. Built from the UNTRUNCATED input.
+                            # multiSelect rides the block: it documents the LIST-valued answers the
+                            # authoritative fill records, and it arms the fallback's ', ' label split
+                            # (dead before it was copied — old-record multiSelect picks rendered as
+                            # ONE joined quoted "Other" row instead of highlighted options).
                             ev["askAnswer"] = [{"question": str(q.get("question") or ""),
                                                 "header": str(q.get("header")) if q.get("header") else None,
+                                                "multiSelect": bool(q.get("multiSelect")),
                                                 "options": [{"label": str(o.get("label") or ""),
                                                              "description": str(o.get("description") or "")}
                                                             for o in (q.get("options") or [])],
@@ -15607,7 +15647,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         anchors = seg_anchors.get(seg)
         is_prompt = ev.get("kind") in ("user", "teammate") or (ev.get("kind") == "postal-service" and ev.get("direction") == "in")
         ev["tlId"] = ((anchors[0] if is_prompt else anchors[1]) or seg) if anchors else seg
-        if ev.get("askAnswer"):                       # AskUserQuestion → fill chosen now the answer's in
+        if ev.get("askAnswer") and not ev.get("askAnswerFilled"):
+            # AskUserQuestion whose record carried NO structured answers map (an old transcript) →
+            # the lossy output-string scrape is all there is. The attach loop's authoritative fill
+            # (askAnswerFilled) already handled every record that has one — never run both.
             _ask_fill_chosen(ev["askAnswer"], ev.get("output") or "")
     if path_override:
         # Historical episode render: the transcript events only — none of the LIVE overlays below (todo,

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -351,8 +351,20 @@ def msg_to_atom(msg, sid, fsid, t, skill_tool_ids=()):
                     "skillMd": text[:_SKILL_MD_CAP] + ("\n\n…(skill content truncated)"
                                                        if len(text) > _SKILL_MD_CAP else ""),
                     "message": {"role": "assistant", "content": [], "stop_reason": None}}
-        return {"type": "user", "uuid": u, "session_id": sid, "t": t, "fsid": fsid, "parentUuid": None,
+        atom = {"type": "user", "uuid": u, "session_id": sid, "t": t, "fsid": fsid, "parentUuid": None,
                 "message": {"role": "user", "content": content}}
+        # The record-level STRUCTURED result rides the stream too: the CLI emits the transcript
+        # record's toolUseResult on the wire as `tool_use_result`, and the SDK parser maps it onto
+        # UserMessage.tool_use_result (verified in claude-agent-sdk 0.2.132 / CLI 2.1.224). Carry it
+        # onto the live atom under the SAME key and gates as the file adapter (a tool_result-bearing
+        # atom, dict form only — a dismissed picker records a plain string no consumer reads), or the
+        # live-tail window structurally bypasses the authoritative consumers: a JUST-answered
+        # AskUserQuestion rendered via the lossy regex scrape until the disk record was parsed, and
+        # Edit's diffRows lagged a parse behind the stream.
+        tur = getattr(msg, "tool_use_result", None)
+        if has_tool_result and isinstance(tur, dict):
+            atom["toolUseResult"] = tur
+        return atom
     return None
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -362,11 +362,18 @@ def msg_to_atom(msg, sid, fsid, t, skill_tool_ids=()):
         # AskUserQuestion rendered via the lossy regex scrape until the disk record was parsed, and
         # Edit's diffRows lagged a parse behind the stream.
         tur = getattr(msg, "tool_use_result", None)
-        if has_tool_result and isinstance(tur, dict):
+        if has_tool_result and isinstance(tur, dict) and (set(tur) & TUR_CONSUMED_KEYS):
+            # same consumed-keys gate as the file adapter: a Read result's dict holds the whole
+            # file — carrying shapes nothing reads only bloats the live tail
             atom["toolUseResult"] = tur
         return atom
     return None
 
+
+# The toolUseResult keys a consumer actually reads — MIRRORS event_model.TUR_CONSUMED_KEYS (this
+# module loads standalone, so it cannot import the event model; a drift pin in test_sdk_backend.py
+# holds the two sets equal). Widen both together when a new consumer appears; never carry-all.
+TUR_CONSUMED_KEYS = frozenset(("answers", "structuredPatch"))
 
 TYPE_SOMETHING = "Type something"   # meta-option label the webview turns into the inline "add your own" field
 

--- a/tests/test_kernel_askanswer.py
+++ b/tests/test_kernel_askanswer.py
@@ -32,8 +32,9 @@ km = SourceFileLoader("romp_kernel_aa", os.path.join(BIN, "romp-kernel")).load_m
 jd = km.jd
 
 
-def _blk(q, multi=False, header=None):
-    return {"question": q, "header": header, "multiSelect": multi, "options": [], "chosen": []}
+def _blk(q, multi=False, header=None, labels=()):
+    return {"question": q, "header": header, "multiSelect": multi,
+            "options": [{"label": l, "description": ""} for l in labels], "chosen": []}
 
 
 def test_single_question_picked_option():
@@ -49,9 +50,36 @@ def test_free_text_other_is_kept_verbatim_not_split():
 
 
 def test_multiselect_splits_joined_labels():
-    b = [_blk("Pick features", multi=True)]
+    # The split must be EARNED: it survives only because the parts name option labels (parseAskRaw's
+    # rule, ported) — a real picker block always carries its options, so the fixture does too.
+    b = [_blk("Pick features", multi=True, labels=("Alpha", "Beta", "Gamma"))]
     km._ask_fill_chosen(b, '"Pick features"="Alpha, Beta, Gamma"')
     assert b[0]["chosen"] == ["Alpha", "Beta", "Gamma"]
+
+
+def test_multiselect_single_comma_bearing_label_is_not_shredded():
+    # A ONE-label pick whose label itself contains ", " arrives as that exact string. Unguarded, the
+    # fallback's split shredded it into bogus fragments (two wrong "Other" rows, lost highlight). An
+    # answer that IS an option label is that label, whole — the split is only for genuinely joined picks.
+    b = [_blk("Pick a city", multi=True, labels=("Boston, MA", "Denver"))]
+    km._ask_fill_chosen(b, '"Pick a city"="Boston, MA"')
+    assert b[0]["chosen"] == ["Boston, MA"]
+
+
+def test_multiselect_comma_bearing_free_text_stays_whole():
+    # A free-typed "Other" answer with commas names no label even after splitting — keep it verbatim
+    # (parseAskRaw's rule: keep the split only when a part actually names an option label).
+    b = [_blk("Pick features", multi=True, labels=("Alpha", "Beta"))]
+    km._ask_fill_chosen(b, '"Pick features"="reads, writes, and nothing else"')
+    assert b[0]["chosen"] == ["reads, writes, and nothing else"]
+
+
+def test_multiselect_split_kept_when_a_part_names_a_label():
+    # Joined picks that include a free-typed "Other": at least ONE part naming a label keeps the split
+    # (parseAskRaw's exact rule — some(), not every(): label parts highlight, the rest render as Other).
+    b = [_blk("Pick features", multi=True, labels=("Alpha", "Beta"))]
+    km._ask_fill_chosen(b, '"Pick features"="Alpha, my own idea"')
+    assert b[0]["chosen"] == ["Alpha", "my own idea"]
 
 
 def test_multi_question_matches_by_question():
@@ -94,6 +122,23 @@ def test_answers_map_quotes_equals_commas_survive_verbatim():
     b = [_blk(q)]
     km._ask_fill_answers(b, {q: ans})
     assert b[0]["chosen"] == [ans], "exact-key fill: no parsing, nothing garbled"
+
+
+def test_answers_map_fill_count_is_returned():
+    # (#2) The caller latches askAnswerFilled on this return: it must count blocks ACTUALLY filled,
+    # not merely that a dict arrived — a keying mismatch fills nothing and must not disarm the
+    # regex safety net.
+    b = [_blk("Pick a color"), _blk("Second?")]
+    assert km._ask_fill_answers(b, {"Pick a color": "Blue"}) == 1
+    assert km._ask_fill_answers(b, {"Pick a color": "Blue", "Second?": "no"}) == 2
+
+
+def test_answers_map_zero_fills_reports_zero():
+    b = [_blk("Pending?")]
+    assert km._ask_fill_answers(b, {"A different question": "yes"}) == 0
+    assert km._ask_fill_answers(b, {}) == 0
+    assert km._ask_fill_answers(b, {"Pending?": []}) == 0, "an empty multiSelect list fills nothing"
+    assert b[0]["chosen"] == []
 
 
 NOW = 1781100000
@@ -233,6 +278,31 @@ class BuildSessionAskAnswer(unittest.TestCase):
                "options": [{"label": "Alpha"}, {"label": "Beta"}, {"label": "Gamma"}]}]
         self._write(qs, '"Pick features"="Alpha, Gamma"', tool_use_result=None)
         self.assertEqual(self._ask_event()["askAnswer"][0]["chosen"], ["Alpha", "Gamma"])
+
+    def test_old_record_single_comma_bearing_label_not_shredded(self):
+        # (#1, e2e) The fallback path with a ONE-label pick whose label contains ", ": it must render
+        # as that label (highlighted), never shredded into two bogus "Other" rows — the label-match
+        # guard, through the whole build.
+        qs = [{"question": "Pick a city", "multiSelect": True,
+               "options": [{"label": "Boston, MA"}, {"label": "Denver"}]}]
+        self._write(qs, '"Pick a city"="Boston, MA"', tool_use_result=None)
+        self.assertEqual(self._ask_event()["askAnswer"][0]["chosen"], ["Boston, MA"])
+
+    def test_mismatched_answers_map_does_not_disarm_the_fallback(self):
+        # (#2, e2e) askAnswerFilled must latch only on an ACTUAL fill: a keying mismatch (a future
+        # harness renaming) fills nothing, and latching anyway disarmed the regex safety net — the
+        # whole ask rendered pending despite recoverable pairs in the flat string.
+        qs = [{"question": "Pick a color", "multiSelect": False, "options": [{"label": "Blue"}]}]
+        self._write(qs, '"Pick a color"="Blue"',
+                    {"questions": [], "answers": {"A renamed question key": "Blue"}})
+        self.assertEqual(self._ask_event()["askAnswer"][0]["chosen"], ["Blue"],
+                         "zero fills -> the output-string scrape still recovers the answer")
+
+    def test_empty_answers_map_does_not_disarm_the_fallback(self):
+        # (#2, e2e) Same latch, the empty-map shape.
+        qs = [{"question": "Pick a color", "multiSelect": False, "options": [{"label": "Blue"}]}]
+        self._write(qs, '"Pick a color"="Blue"', {"questions": [], "answers": {}})
+        self.assertEqual(self._ask_event()["askAnswer"][0]["chosen"], ["Blue"])
 
     def test_dismissed_picker_stays_unanswered(self):
         # (f) A dismissed picker: is_error tool_result, toolUseResult a plain STRING — no crash,

--- a/tests/test_kernel_askanswer.py
+++ b/tests/test_kernel_askanswer.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python3
-"""_ask_fill_chosen: structured AskUserQuestion answers for the chat's "answered Claude's question"
-box. The tool_result records answers as `"<q>"="<a>"` pairs; we fill each block's `chosen` from them,
-handling single/multi question, multiSelect (joined 'A, B, C'), and free-text 'Other'. Synthetic only."""
+"""AskUserQuestion answers for the chat's "answered Claude's question" box, TWO paths:
+
+- AUTHORITATIVE (_ask_fill_answers, via the build_session attach loop): the tool_result's user
+  record carries the STRUCTURED answers at top level — toolUseResult = {"questions": [...],
+  "answers": {exact-question-text: answer}} (string per question; a LIST of picked labels for
+  multiSelect). Filled by exact key, no parsing, so quotes/equals/commas in questions and answers
+  survive verbatim.
+- FALLBACK (_ask_fill_chosen, old records without a dict toolUseResult): regex-scrape the flat
+  output string's `"<q>"="<a>"` pairs. A double-quote inside a question's text breaks that scrape
+  (the capture stops at the quote), which is the bug the authoritative path fixes — 13 of 95 real
+  answers silently vanished from the answered box before it.
+
+Synthetic fixtures only: placeholder UUIDs, invented questions/answers."""
+import json
 import os
+import unittest
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
@@ -15,6 +29,7 @@ SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_aa", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
 
 
 def _blk(q, multi=False, header=None):
@@ -49,3 +64,201 @@ def test_unanswered_stays_empty():
     b = [_blk("Pending?")]
     km._ask_fill_chosen(b, "")
     assert b[0]["chosen"] == []
+
+
+# ---------------------------------------------------------------------------
+# The AUTHORITATIVE path: _ask_fill_answers fills from toolUseResult's answers map.
+# ---------------------------------------------------------------------------
+
+def test_answers_map_string_value_becomes_single_chosen():
+    b = [_blk("Pick a color")]
+    km._ask_fill_answers(b, {"Pick a color": "Blue"})
+    assert b[0]["chosen"] == ["Blue"]
+
+
+def test_answers_map_list_value_is_the_multiselect_list():
+    b = [_blk("Pick features", multi=True)]
+    km._ask_fill_answers(b, {"Pick features": ["Alpha", "Gamma"]})
+    assert b[0]["chosen"] == ["Alpha", "Gamma"], "a LIST answer (multiSelect) is taken as-is, never re-joined/split"
+
+
+def test_answers_map_unknown_question_left_empty():
+    b = [_blk("Pending?")]
+    km._ask_fill_answers(b, {"A different question": "yes"})
+    assert b[0]["chosen"] == []
+
+
+def test_answers_map_quotes_equals_commas_survive_verbatim():
+    q = 'Use the "fast" path?'
+    ans = 'only "reads", and A="B" stays, commas too'
+    b = [_blk(q)]
+    km._ask_fill_answers(b, {q: ans})
+    assert b[0]["chosen"] == [ans], "exact-key fill: no parsing, nothing garbled"
+
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+
+
+class BuildSessionAskAnswer(unittest.TestCase):
+    """End-to-end through build_session: the attach loop fills chosen from the record's structured
+    toolUseResult (authoritative), and only records WITHOUT it fall back to the output-string regex.
+    Fixture mirrors test_teammate_message's discover setup (names + transcript in the munged dir)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
+                      km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD)
+        jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE = names, proj, td / "goals", td
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = td / "no-global.md"           # keep a real ~/.claude/CLAUDE.md out of the fixture
+        km._read_task_store = lambda fsid, fold=None: []                # no to-do card in the way
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+                                           "effort": "", "context": None, "compactPct": None, "color": None}}
+        jd.GOALDIR.mkdir(parents=True)
+        km._parse_cache.clear()
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
+         km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
+        km._parse_cache.clear()
+        self.td.cleanup()
+
+    def _iso(self, t):
+        return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    def _write(self, questions, output, tool_use_result=None, is_error=False):
+        """A minimal ask exchange: prompt → AskUserQuestion tool_use → its tool_result (optionally
+        carrying the top-level structured toolUseResult) → a closing reply."""
+        tr = {"type": "tool_result", "tool_use_id": "toolu_ask1", "content": output}
+        if is_error:
+            tr["is_error"] = True
+        result_rec = {"type": "user", "timestamp": self._iso(T0 + 20), "uuid": "u2", "parentUuid": "a1",
+                      "message": {"role": "user", "content": [tr]}}
+        if tool_use_result is not None:
+            result_rec["toolUseResult"] = tool_use_result
+        recs = [
+            {"type": "user", "timestamp": self._iso(T0), "uuid": "u1", "parentUuid": None,
+             "promptSource": "typed", "message": {"role": "user", "content": "kick things off"}},
+            {"type": "assistant", "timestamp": self._iso(T0 + 10), "uuid": "a1", "parentUuid": "u1",
+             "message": {"role": "assistant", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "toolu_ask1", "name": "AskUserQuestion",
+                                      "input": {"questions": questions}}]}},
+            result_rec,
+            {"type": "assistant", "timestamp": self._iso(T0 + 30), "uuid": "a2", "parentUuid": "u2",
+             "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}],
+                         "stop_reason": "end_turn"}},
+        ]
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def _ask_event(self):
+        events = km.build_session(SID, NOW)["events"]
+        asks = [e for e in events if e.get("kind") == "tool" and e.get("name") == "AskUserQuestion"]
+        self.assertEqual(len(asks), 1)
+        return asks[0]
+
+    QUOTED_Q = 'Use the "fast" path?'
+
+    def _two_questions(self):
+        return [{"question": self.QUOTED_Q, "header": "Path", "multiSelect": False,
+                 "options": [{"label": "Yes", "description": ""}, {"label": "No", "description": ""}]},
+                {"question": "Deploy target?", "header": "Target", "multiSelect": False,
+                 "options": [{"label": "staging", "description": ""}, {"label": "prod", "description": ""}]}]
+
+    def test_quote_bearing_question_custom_answer_fills(self):
+        # (a) A double-quote inside the question breaks the output-string scrape (the capture stops at
+        # the quote), and in a MULTI-question ask there is no vals[0] rescue — the typed answer vanished.
+        custom = "only for reads, not writes"
+        self._write(self._two_questions(),
+                    'User has responded with the following answers: "%s"="%s" "Deploy target?"="staging"'
+                    % (self.QUOTED_Q, custom),
+                    {"questions": [q["question"] for q in self._two_questions()],
+                     "answers": {self.QUOTED_Q: custom, "Deploy target?": "staging"}})
+        blocks = self._ask_event()["askAnswer"]
+        self.assertEqual(blocks[0]["chosen"], [custom], "the free-typed answer must not vanish")
+        self.assertEqual(blocks[1]["chosen"], ["staging"])
+
+    def test_quote_bearing_question_listed_pick_fills(self):
+        # (b) Same break, picked option instead of free text.
+        self._write(self._two_questions(),
+                    '"%s"="Yes" "Deploy target?"="prod"' % self.QUOTED_Q,
+                    {"questions": [], "answers": {self.QUOTED_Q: "Yes", "Deploy target?": "prod"}})
+        blocks = self._ask_event()["askAnswer"]
+        self.assertEqual(blocks[0]["chosen"], ["Yes"])
+        self.assertEqual(blocks[1]["chosen"], ["prod"])
+
+    def test_multiselect_list_answer_is_the_list(self):
+        # (c) multiSelect answers arrive as a LIST in the structured record; chosen is that list
+        # (render highlights each), never one joined "Alpha, Gamma" string that reads as an Other row.
+        qs = [{"question": "Pick features", "header": "Features", "multiSelect": True,
+               "options": [{"label": "Alpha"}, {"label": "Beta"}, {"label": "Gamma"}]}]
+        self._write(qs, '"Pick features"="Alpha, Gamma"',
+                    {"questions": [], "answers": {"Pick features": ["Alpha", "Gamma"]}})
+        blocks = self._ask_event()["askAnswer"]
+        self.assertEqual(blocks[0]["chosen"], ["Alpha", "Gamma"])
+        self.assertIs(blocks[0]["multiSelect"], True,
+                      "the block carries multiSelect (documents the list-valued answer; render may want it)")
+
+    def test_plain_prose_matches_what_the_regex_produced(self):
+        # (d) No-regression: plain questions answer identically through the authoritative path.
+        qs = [{"question": "Pick a color", "multiSelect": False, "options": [{"label": "Blue"}]},
+              {"question": "Second?", "multiSelect": False, "options": [{"label": "yes"}, {"label": "no"}]}]
+        self._write(qs, '"Pick a color"="Blue" "Second?"="no"',
+                    {"questions": [], "answers": {"Pick a color": "Blue", "Second?": "no"}})
+        blocks = self._ask_event()["askAnswer"]
+        self.assertEqual([b["chosen"] for b in blocks], [["Blue"], ["no"]])
+
+    def test_old_record_without_tooluseresult_falls_back_to_regex(self):
+        # (e) Old transcripts carry no structured record — the output-string scrape still fills.
+        qs = [{"question": "Pick a color", "multiSelect": False, "options": [{"label": "Blue"}]},
+              {"question": "Second?", "multiSelect": False, "options": [{"label": "yes"}, {"label": "no"}]}]
+        self._write(qs, '"Pick a color"="Blue" "Second?"="no"', tool_use_result=None)
+        blocks = self._ask_event()["askAnswer"]
+        self.assertEqual([b["chosen"] for b in blocks], [["Blue"], ["no"]])
+
+    def test_old_record_multiselect_splits_joined_labels(self):
+        # (e, multiSelect) The fallback's ", " split needs the block to KNOW it's multiSelect — before
+        # the flag was copied onto the block, the split was dead and the picks rendered as one joined
+        # quoted "Other" row.
+        qs = [{"question": "Pick features", "multiSelect": True,
+               "options": [{"label": "Alpha"}, {"label": "Beta"}, {"label": "Gamma"}]}]
+        self._write(qs, '"Pick features"="Alpha, Gamma"', tool_use_result=None)
+        self.assertEqual(self._ask_event()["askAnswer"][0]["chosen"], ["Alpha", "Gamma"])
+
+    def test_dismissed_picker_stays_unanswered(self):
+        # (f) A dismissed picker: is_error tool_result, toolUseResult a plain STRING — no crash,
+        # blocks stay unanswered (the pending look), exactly as before.
+        self._write(self._two_questions(), "User dismissed the questions.",
+                    tool_use_result="User dismissed the questions.", is_error=True)
+        ev = self._ask_event()
+        self.assertTrue(ev["isError"])
+        self.assertEqual([b["chosen"] for b in ev["askAnswer"]], [[], []])
+
+    def test_answer_with_quotes_and_equals_survives_verbatim(self):
+        # (g) The scrape garbles an answer containing quotes/equals; the exact-key fill must not.
+        tricky = 'use "romp: fix"; keep A="B" as-is'
+        qs = [{"question": "Commit message?", "multiSelect": False, "options": [{"label": "default"}]},
+              {"question": "Second?", "multiSelect": False, "options": [{"label": "yes"}]}]
+        self._write(qs, '"Commit message?"="%s" "Second?"="yes"' % tricky,
+                    {"questions": [], "answers": {"Commit message?": tricky, "Second?": "yes"}})
+        blocks = self._ask_event()["askAnswer"]
+        self.assertEqual(blocks[0]["chosen"], [tricky])
+        self.assertEqual(blocks[1]["chosen"], ["yes"])
+
+    def test_authoritative_fill_skips_the_regex(self):
+        # (#2) When the structured record filled chosen, the output-string scrape must STAND DOWN:
+        # a single-question ask's vals[0] rescue would otherwise overwrite the real answer with
+        # whatever fragment the scrape extracted.
+        qs = [{"question": "Pick a color", "multiSelect": False, "options": [{"label": "Blue"}]}]
+        self._write(qs, '"Pick a color"="scraped wrong"',
+                    {"questions": [], "answers": {"Pick a color": "the real answer"}})
+        self.assertEqual(self._ask_event()["askAnswer"][0]["chosen"], ["the real answer"])

--- a/tests/test_kernel_patch_rows.py
+++ b/tests/test_kernel_patch_rows.py
@@ -1,8 +1,15 @@
 """_patch_rows: Claude Code's structuredPatch (toolUseResult) → numbered diff rows with REAL file line numbers
-+ context, used for the chat's Edit/MultiEdit diff gutter (the user 2026-06-29). SYNTHETIC fixtures only."""
++ context, used for the chat's Edit/MultiEdit diff gutter (the user 2026-06-29). Unit tests on the row
+builder, plus END-TO-END through build_session — the whole parse path must deliver the record's
+toolUseResult to the attach loop, which it silently failed to do from birth to 2026-08-20 (the event model
+dropped the top-level field, so this consumer was dead while every unit test here stayed green).
+SYNTHETIC fixtures only: placeholder UUIDs, invented file paths and diffs."""
+import json
 import os
 import unittest
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -14,6 +21,7 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
 
 
 class PatchRows(unittest.TestCase):
@@ -53,6 +61,107 @@ class PatchRows(unittest.TestCase):
         big = [{"oldStart": 1, "newStart": 1, "lines": ["+l%d" % i for i in range(2000)]}]
         rows = km._patch_rows(big)
         self.assertLessEqual(len(rows), 601)
+
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+FILE = "/tmp/notes-api/app.py"
+
+
+class BuildSessionDiffRows(unittest.TestCase):
+    """END-TO-END: an Edit tool_use + its tool_result record carrying toolUseResult.structuredPatch →
+    the built event carries diffRows. This pins the whole chain — the event model must CARRY the
+    record's top-level toolUseResult onto the atom, and the attach loop's filePath match must feed the
+    right result to the right tool — not just the row shaping the unit tests above cover. Fixture
+    mirrors test_kernel_askanswer's discover setup (names + transcript in the munged projects dir)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
+                      km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD)
+        jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE = names, proj, td / "goals", td
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = td / "no-global.md"           # keep a real ~/.claude/CLAUDE.md out of the fixture
+        km._read_task_store = lambda fsid, fold=None: []                # no to-do card in the way
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+                                           "effort": "", "context": None, "compactPct": None, "color": None}}
+        jd.GOALDIR.mkdir(parents=True)
+        km._parse_cache.clear()
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
+         km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
+        km._parse_cache.clear()
+        self.td.cleanup()
+
+    def _iso(self, t):
+        return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    def _write(self, tool_use_result):
+        """A minimal Edit exchange: prompt → Edit tool_use → its tool_result user record (optionally
+        carrying the top-level structured toolUseResult) → a closing reply."""
+        result_rec = {"type": "user", "timestamp": self._iso(T0 + 20), "uuid": "u2", "parentUuid": "a1",
+                      "message": {"role": "user", "content": [
+                          {"type": "tool_result", "tool_use_id": "toolu_ed1", "content": "Applied 1 edit"}]}}
+        if tool_use_result is not None:
+            result_rec["toolUseResult"] = tool_use_result
+        recs = [
+            {"type": "user", "timestamp": self._iso(T0), "uuid": "u1", "parentUuid": None,
+             "promptSource": "typed", "message": {"role": "user", "content": "kick things off"}},
+            {"type": "assistant", "timestamp": self._iso(T0 + 10), "uuid": "a1", "parentUuid": "u1",
+             "message": {"role": "assistant", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "toolu_ed1", "name": "Edit",
+                                      "input": {"file_path": FILE, "old_string": "old_line",
+                                                "new_string": "new_line"}}]}},
+            result_rec,
+            {"type": "assistant", "timestamp": self._iso(T0 + 30), "uuid": "a2", "parentUuid": "u2",
+             "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}],
+                         "stop_reason": "end_turn"}},
+        ]
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def _edit_event(self):
+        events = km.build_session(SID, NOW)["events"]
+        edits = [e for e in events if e.get("kind") == "tool" and e.get("name") == "Edit"]
+        self.assertEqual(len(edits), 1)
+        return edits[0]
+
+    PATCH = [{"oldStart": 3, "oldLines": 1, "newStart": 3, "newLines": 1,
+              "lines": ["-old_line", "+new_line"]}]
+
+    def test_structured_patch_arrives_as_diffrows(self):
+        self._write({"filePath": FILE, "structuredPatch": self.PATCH})
+        ev = self._edit_event()
+        self.assertEqual(ev.get("diffRows"), [
+            {"sign": "@", "text": "@@ -3 +3 @@", "oldNo": None, "newNo": None},
+            {"sign": "-", "text": "old_line", "oldNo": 3, "newNo": None},
+            {"sign": "+", "text": "new_line", "oldNo": None, "newNo": 3},
+        ], "the record's structuredPatch must reach the event as REAL-line-number rows")
+
+    def test_mismatched_filepath_attaches_no_diffrows(self):
+        # The attach guard: a result whose filePath names a DIFFERENT file must not feed this tool —
+        # the client falls back to numberDiff's relative gutter instead of showing wrong line numbers.
+        self._write({"filePath": "/tmp/notes-api/other.py", "structuredPatch": self.PATCH})
+        self.assertNotIn("diffRows", self._edit_event())
+
+    def test_no_structured_patch_attaches_no_diffrows(self):
+        # A dict toolUseResult WITHOUT a structuredPatch (some tool results carry other shapes).
+        self._write({"filePath": FILE})
+        self.assertNotIn("diffRows", self._edit_event())
+
+    def test_no_tooluseresult_attaches_no_diffrows(self):
+        # An old record with no top-level toolUseResult at all — the pre-2026-08-20 world.
+        self._write(None)
+        self.assertNotIn("diffRows", self._edit_event())
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -247,6 +247,21 @@ class LiveTail(unittest.TestCase):
         a = sb.msg_to_atom(m, "s", "f", 5)
         self.assertNotIn("toolUseResult", a)
 
+    def test_an_unconsumed_shape_is_not_carried(self):
+        # The consumed-keys gate: a Read result's dict embeds the WHOLE read file, and nothing
+        # reads it off the atom — carrying every dict held ~a fifth of transcript bytes in the
+        # parse cache by reference. Only the consumed shapes ride (answers, structuredPatch).
+        m = _UserMessage([_ToolResultBlock("t9", "file contents…")],
+                         tool_use_result={"type": "text", "file": {"content": "x" * 512}})
+        a = sb.msg_to_atom(m, "s", "f", 5)
+        self.assertNotIn("toolUseResult", a)
+
+    def test_the_consumed_key_set_cannot_drift_from_the_file_adapter_s(self):
+        # sdk_backend loads standalone (no event-model import), so the set is MIRRORED — this pin
+        # is what keeps the two halves widening together.
+        em2 = SourceFileLoader("romp_event_model_drift", os.path.join(BIN, "romp-event-model")).load_module()
+        self.assertEqual(sb.TUR_CONSUMED_KEYS, em2.TUR_CONSUMED_KEYS)
+
     def test_command_stdout_stream_becomes_a_turn_ENDING_assistant_atom(self):
         # the user 2026-07-02: client.set_model() makes the CLI stream its feedback as a UserMessage
         # wrapped in <local-command-stdout>. As a raw USER atom it opened a turn no reply would ever

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -183,12 +183,17 @@ class _ToolUseBlock:
 class _AssistantMessage:
     def __init__(self, content, model="claude-x", uuid="a1", stop_reason="end_turn"):
         self.content, self.model, self.uuid, self.stop_reason = content, model, uuid, stop_reason
+class _ToolResultBlock:
+    def __init__(self, tool_use_id, content="", is_error=False):
+        self.tool_use_id, self.content, self.is_error = tool_use_id, content, is_error
 class _UserMessage:
-    def __init__(self, content, uuid="u1"): self.content, self.uuid = content, uuid
+    def __init__(self, content, uuid="u1", tool_use_result=None):
+        self.content, self.uuid, self.tool_use_result = content, uuid, tool_use_result
 class _ResultMessage:
     uuid = "r1"
 # rename so type(...).__name__ matches what msg_to_atom checks
 _TextBlock.__name__ = "TextBlock"; _ToolUseBlock.__name__ = "ToolUseBlock"
+_ToolResultBlock.__name__ = "ToolResultBlock"
 _AssistantMessage.__name__ = "AssistantMessage"; _UserMessage.__name__ = "UserMessage"
 _ResultMessage.__name__ = "ResultMessage"
 
@@ -212,6 +217,35 @@ class LiveTail(unittest.TestCase):
         self.assertEqual(a["message"]["content"], [{"type": "text", "text": "hello"}])
         self.assertIsNone(sb.msg_to_atom(_ResultMessage(), "s", "f", 5))   # result has no renderable content
         self.assertIsNone(sb.msg_to_atom(_AssistantMessage([]), "s", "f", 5))  # empty content → None
+
+    def test_tool_result_atom_carries_the_structured_tooluseresult(self):
+        # The SDK's UserMessage exposes the record-level structured result (the CLI streams the
+        # transcript record's toolUseResult on the wire as `tool_use_result`; the SDK parser maps it
+        # onto UserMessage.tool_use_result — verified against claude-agent-sdk 0.2.132 / CLI 2.1.224).
+        # The live atom must carry it exactly like the file adapter's atom does, or a JUST-answered
+        # AskUserQuestion renders via the lossy regex scrape until the disk record is parsed, and
+        # Edit's diffRows lag a parse behind the stream.
+        tur = {"questions": ["Pick a color"], "answers": {"Pick a color": "Blue"}}
+        m = _UserMessage([_ToolResultBlock("t1", "answered")], tool_use_result=tur)
+        a = sb.msg_to_atom(m, "s", "f", 5)
+        self.assertEqual(a["type"], "user")
+        self.assertEqual(a["toolUseResult"], tur)
+        self.assertEqual(a["message"]["content"][0]["type"], "tool_result")
+
+    def test_string_tooluseresult_is_not_carried(self):
+        # A dismissed picker records toolUseResult as a plain STRING — dict form only, the same gate
+        # as the file adapter (no consumer reads the string form).
+        m = _UserMessage([_ToolResultBlock("t1", "dismissed", is_error=True)],
+                         tool_use_result="dismissed the questions")
+        a = sb.msg_to_atom(m, "s", "f", 5)
+        self.assertNotIn("toolUseResult", a)
+
+    def test_tooluseresult_without_a_tool_result_block_is_not_carried(self):
+        # The file adapter's other gate: only an atom that carries a tool_result block may carry the
+        # record-level dict — a text-only message never does.
+        m = _UserMessage([_TextBlock("hello")], tool_use_result={"x": 1})
+        a = sb.msg_to_atom(m, "s", "f", 5)
+        self.assertNotIn("toolUseResult", a)
 
     def test_command_stdout_stream_becomes_a_turn_ENDING_assistant_atom(self):
         # the user 2026-07-02: client.set_model() makes the CLI stream its feedback as a UserMessage

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -75,8 +75,10 @@ marked.use({ extensions: [mathBlock, mathInline] });
 
 // One answered (or pending) question on an AskUserQuestion turn: the prompt + its options, plus the
 // user's answer TEXT per question (`chosen`). Answer text may name an option label OR be free-text
-// ("Other"), and is empty while the question is still pending (multi-select answers arrive pre-split).
-type AskAnswerBlock = { question: string; header?: string; options: { label: string; description?: string }[]; chosen: string[] };
+// ("Other"), and is empty while the question is still pending (multi-select answers arrive pre-split:
+// the kernel fills chosen from the record's structured answers map — a LIST of picked labels when
+// multiSelect, which renderAsk highlights per value; the flag itself rides along for reference).
+type AskAnswerBlock = { question: string; header?: string; options: { label: string; description?: string }[]; chosen: string[]; multiSelect?: boolean };
 
 // A completed background command's detail, keyed by its tool-use-id — the shell it ran + its output tail,
 // joined in by the kernel (build_session's taskOutputs) so the inline completion card can expand into it.
@@ -2567,6 +2569,9 @@ function renderAsk(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement | null
 // renderAsk consumes. The answer text may name an option label OR be free-text ("Other"); multi-select
 // joins labels as "A, B, C". Comma-split only when a label actually matches, so a free-text answer that
 // happens to contain commas isn't shredded.
+// NOTE: effectively unreachable — the kernel always attaches askAnswer to AskUserQuestion events, filled
+// from the record's structured answers map (authoritative; this scrape garbles quote-bearing questions).
+// Kept as the belt-and-suspenders raw parse only; don't extend it.
 function parseAskRaw(ev: Extract<ChatEvent, { kind: "tool" }>): AskAnswerBlock[] | null {
   let data: any;
   try { data = JSON.parse(ev.input); } catch { return null; }


### PR DESCRIPTION
## What breaks

Ask a question through AskUserQuestion whose wording contains a double quote, and the user's answer vanishes from the chat's answered box. The kernel joins answers to their questions by regex-scraping the tool_result's human-readable output, which records pairs as `"<question>"="<answer>"`: a quote inside the question stops the capture early, the truncated key matches nothing, and the answer drops with no error. A dropped listed pick only loses its highlight; a dropped "write your own" answer disappears outright, which is why the bug reads as "custom answers are unreliable". On a private corpus of 95 real answered questions, 13 answers dropped and 1 rendered wrong, and every failure involved a quote.

The structured result sits in the same transcript record: `toolUseResult = {"questions": [...], "answers": {<question text>: <answer>}}`, keyed by exact question text. It never reached the join because the event model drops the record's top-level `toolUseResult` when building atoms. The same drop means `build_session`'s existing `tur = a.get("toolUseResult")` read is always `None`, so the Edit/MultiEdit `structuredPatch` → `diffRows` consumer has been dead through the parse path since it was written.

## Reproduction

1. Have a session call AskUserQuestion with a quote in the question text, e.g. `Keep the name "verbose", or rename it?`, and answer with free text.
2. The answered box renders the question as still pending; the typed answer is gone.
3. MultiSelect shows a second failure on any question: the picks render as one joined, quoted "Other" row instead of highlighted options, because the fallback's `", "` split is gated on a `multiSelect` key the askAnswer block builder never sets.

## The fix

Commit 1, the authoritative join:

- `kernel/event_model.py`: a user atom carrying a tool_result now carries the record's dict `toolUseResult`. Dict form only: a dismissed picker records a plain string no consumer reads, so it still renders as pending.
- `kernel/kernel.py`: new `_ask_fill_answers` fills each question's `chosen` by exact key from `toolUseResult.answers` at attach time (string value → one answer, list → the multiSelect picks), with no parsing, so quotes, equals signs and commas survive verbatim. The regex join survives only as the fallback for old transcripts, and stands down (`askAnswerFilled`) once the authoritative fill filled something. `multiSelect` now rides the askAnswer blocks.
- `ui/webview/render.ts`: the optional `multiSelect` field on the block type plus comment updates. `renderAsk` needs no behavior change; it already highlights chosen labels and gives non-label values their own "Other" row.

Commit 2, review-round hardening:

- The fallback's comma split must be earned by an option-label match (the rule `parseAskRaw` already applies client-side): a picked "Boston, MA" or a comma-bearing typed answer stays whole.
- The latch counts actual fills, so a keying mismatch or an empty map leaves the regex safety net armed instead of rendering the whole ask pending.
- `kernel/sdk_backend.py`: the live tail carries the same field under the same gates. The CLI streams the record's `toolUseResult` on the wire as `tool_use_result` and the SDK maps it onto `UserMessage.tool_use_result` (verified at claude-agent-sdk 0.2.132 / CLI 2.1.224), so a just-answered question renders correctly before the disk record is parsed. If the wire name ever changes, the carry degrades softly: `getattr` returns `None` and the disk-record path fills one parse later.

## Two side effects to review as behavior changes

- Edit folds gain real line-number gutters: carrying `toolUseResult` onto atoms revives the dead `diffRows` consumer. New end-to-end tests cover the revival and its guards (mismatched filePath, missing patch, missing toolUseResult each attach nothing).
- Atoms now hold the record's `toolUseResult` dicts by reference, structuredPatch bodies included. Measured on a live corpus this is bounded, roughly a fifth of transcript bytes, and read-only; the dict gate can be narrowed if that budget is a concern.

## Tests

28 new cases across three existing files, written red-first: 16 fail on the unpatched code (the quote-bearing fills, the multiSelect list, the label-guarded splits, the diffRows arrival, the live-tail carry) and the other 12 pin behavior the fix must preserve (the old-record fallback, the attach guards, the dismissed picker staying unanswered).

- `tests/test_kernel_askanswer.py` (+21): unit coverage of both fill functions, plus end-to-end `build_session` coverage including "authoritative fill skips the regex overwrite" and "mismatched or empty answers map leaves the fallback armed".
- `tests/test_kernel_patch_rows.py` (+4): `structuredPatch` → `diffRows` end to end, plus the three attach-nothing guards.
- `tests/test_sdk_backend.py` (+3): `msg_to_atom` carries the dict, drops the string form, drops it without a tool_result block.

`ui/webview/ask-answer.test.ts` passes unchanged; the render side keeps its per-value chosen matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)