### PR TITLE
The dead-wait sweep reads the raw stamp: an ack must not hide the wait

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3445,11 +3445,16 @@ def _dead_wait_sweep(alive_ids, nudged, now):
             for nid, nd in nodes.items():
                 if nd.get("parentId"):
                     kids.setdefault(nd["parentId"], []).append(nid)
-            answered = _peer_answered_at(sid)
             for gid, st in (store.get("status") or {}).items():
                 if st != "working":
                     continue
-                stamp = _goal_awaiting_stamp_full(nodes, gid, kids, answered_at=answered)
+                # RAW stamp, answered_at=0 (the fix for the 100-hour survivors, 2026-08-23): the
+                # peer-answered supersede reads ANY inbound mail after the ask as the wait being met —
+                # a worker's "starting now" ack 110s after the stamp made the sweep see no wait at all,
+                # while the card's chip kept showing awaiting and nothing ever closed it. For a DORMANT
+                # owner the distinction is moot either way: an answer that landed in a dead session's
+                # mailbox moved nothing, so a recorded wait on a still-Working card converts regardless.
+                stamp = _goal_awaiting_stamp_full(nodes, gid, kids)
                 if stamp:
                     _dead_wait_block(sid, gid, stamp[0], stamp[1], nudged, now)
         except Exception:
@@ -3480,8 +3485,7 @@ def _dead_wait_block(sid, gid, at, why, nudged, now):
         store = jd.load_goals(sid)
         nd = store.get("nodes", {}).get(gid)
         if (not nd or store.get("status", {}).get(gid, "working") != "working"
-                or not _goal_awaiting_stamp(store.get("nodes", {}), gid,
-                                            answered_at=_peer_answered_at(sid))):
+                or not _goal_awaiting_stamp(store.get("nodes", {}), gid)):   # raw: see the sweep's note
             return False                              # lifted or resolved since the walk read its snapshot
         blkwhy = jd.dead_wait_block_why(nd.get("awaitingWhy") or why or "")
         _ev = int(max(at or 0, last_t or 0) or now)

--- a/tests/test_dead_wait_block.py
+++ b/tests/test_dead_wait_block.py
@@ -132,6 +132,23 @@ class DeadWaitBlock(unittest.TestCase):
         km._dead_wait_sweep({SID}, self.nudged, STAMP_T + 900)
         self.assertFalse(jd.load_goals(SID)["nodes"][GID].get("blocked"))
 
+    def test_a_post_stamp_peer_ack_does_not_hide_the_wait_from_the_sweep(self):
+        # the 100-hour survivors (2026-08-23): a worker's "starting now" mail seconds after the stamp
+        # made the peer-answered supersede read the wait as met, so the sweep stood down forever while
+        # the chip kept showing awaiting. The sweep reads the RAW stamp: a dormant owner can't process
+        # an answer anyway, so a recorded wait on a Working card converts regardless.
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        saved = km._peer_answered_at
+        km._peer_answered_at = lambda sid: STAMP_T + 110   # an ack landed just after the stamp
+        try:
+            km._PREV_ALIVE = None
+            km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        finally:
+            km._peer_answered_at = saved
+        self.assertTrue(jd.load_goals(SID)["nodes"][GID].get("blocked"),
+                        "the supersede must not hide a dormant owner's wait from the sweep")
+
     def test_death_transition_triggers_between_ticks(self):
         _seed_store()
         _write_state("idle", STAMP_T + 50)


### PR DESCRIPTION
The two 100-hour stuck cards the dead-wait conversion was built for **survived it** (surfaced by the user's stuck-card audit, 2026-08-23). Reproduced against a copy of the real store:

- In isolation the conversion works — block lands, card goes to Needs-you.
- Live, the sweep read the stamp **through the peer-answered supersede**, and a worker's "starting now" acknowledgment 110 seconds after the stamp made the wait read as met — so the sweep stood down forever, while the card's chip kept showing awaiting and nothing ever closed the goal.

## Fix
The sweep and the block's fresh re-check read the **raw** stamp (`answered_at` unset). For a dormant owner the supersede's distinction is moot: an answer that landed in a dead session's mailbox moved nothing, so a recorded wait on a still-Working card converts regardless. The supersede keeps its role everywhere else (live sessions, display floors, nudge gates).

## Tests
A regression reproducing the exact shape (stamp, then a peer ack 110s later, owner dormant → the block still lands), plus the existing 7. Suites: python green, UI 2202/2202. On deploy, the two live stuck cards convert at the first kernel boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)