### PR TITLE
Placed delegates still get their courier link, and dead handoffs convert

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10630,6 +10630,45 @@ def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None):
     return nid
 
 
+def _attach_courier_link(store, seg_id, mid):
+    """Attach the courier's completion link to the TOP of the goal a peer-delegate segment was PLACED
+    under (the user 2026-08-23): the courier only minted links for segments it placed itself, so a
+    planner-first placement orphaned the sender's handoff forever. The link rides `links[]` — never
+    `origin`, which means "this goal was BORN from that delegation" and stays truthful — and
+    run_propagate completes the sender's tracking node from either. Idempotent by msgId; a store
+    already carrying the msgId anywhere (origin or links) is left alone. Saves only on change."""
+    nodes = store.get("nodes", {})
+    for nd in nodes.values():
+        o = nd.get("origin")
+        if isinstance(o, dict) and o.get("msgId") == mid:
+            return False
+        if any(isinstance(l, dict) and l.get("msgId") == mid for l in (nd.get("links") or [])):
+            return False
+    tgt = store.get("placements", {}).get(seg_id)
+    if not tgt or tgt not in nodes:
+        return False
+    top = _top_ancestor(nodes, tgt)
+    peer_sid, peer_gid = _handoff_backref(mid)
+    if not (peer_sid and peer_gid):
+        return False
+    nodes[top].setdefault("links", []).append({"peer": peer_sid, "goalId": peer_gid, "msgId": mid})
+    save_goals(store["rompUuid"], store)
+    return True
+
+
+def _handoff_backref(mid):
+    """(sender sid, sender tracking-node id) for a delegate message id — read from the SENDER boards'
+    own handoff nodes (the durable record _plant_handoff_track wrote at send time). '' pair when no
+    sender tracks this message (a delegate from a non-romp source, or the sender's store is gone)."""
+    for fsid, path, anchor, name in discover(int(time.time())):
+        st = load_goals(fsid)
+        for nid, nd in st.get("nodes", {}).items():
+            h = nd.get("handoff")
+            if isinstance(h, dict) and h.get("msgId") == mid and not nd.get("nodeComplete"):
+                return fsid, nid
+    return "", ""
+
+
 def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid):
     """Mint a precise '↪ delegated to <peer>' TRACKING node in the SENDER's own tree (the user 2026-06-22):
     the exact item B's completion checks off, so a PARTIAL handoff doesn't over-complete the sender's broader
@@ -10664,10 +10703,14 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     for fsid, path, anchor, name in discover(now)[:sessions_cap]:
         store = load_goals(fsid)
         for nid, nd in list(store.get("nodes", {}).items()):
+            if not nd.get("nodeComplete"):
+                continue                                # B hasn't finished it yet
             o = nd.get("origin")
-            if not (isinstance(o, dict) and o.get("peer") and o.get("goalId") and nd.get("nodeComplete")):
-                continue                                # not a delegated goal, or B hasn't finished it yet
-            a_sid, a_gid = o["peer"], o["goalId"]
+            refs = ([o] if (isinstance(o, dict) and o.get("peer") and o.get("goalId")) else [])
+            refs += [l for l in (nd.get("links") or [])
+                     if isinstance(l, dict) and l.get("peer") and l.get("goalId")]
+            for ref in refs:
+                a_sid, a_gid = ref["peer"], ref["goalId"]
             a_store = load_goals(a_sid)
             a_node = a_store.get("nodes", {}).get(a_gid)
             if not a_node or a_node.get("nodeComplete"):
@@ -10707,6 +10750,18 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         for turn in session["turns"]:
             for seg in _segs(turn, cstore):
                 if seg["id"] in placed_ids:
+                    # LINK-ONLY repair (the user 2026-08-23): the planner placed this peer segment
+                    # before the courier saw it, so no courier goal was minted and the SENDER's
+                    # handoff waits on a completion event that can never fire (12 live handoffs, up
+                    # to 240h old). A placed DELEGATE with no courier link gets the link attached to
+                    # the placement's TOP — run_propagate completes the sender's tracking node when
+                    # that goal lands. No model call; idempotent by msgId.
+                    try:
+                        pm0 = _seg_peer(seg)
+                        if pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate":
+                            _attach_courier_link(cstore, seg["id"], pm0[1])
+                    except Exception:
+                        pass
                     continue
                 if floor and seg["t"] < floor:
                     # pre-episode: conversation the agent can no longer see. The planner retires these

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3452,8 +3452,52 @@ def _dead_wait_sweep(alive_ids, nudged, now):
                 stamp = _goal_awaiting_stamp_full(nodes, gid, kids, answered_at=answered)
                 if stamp:
                     _dead_wait_block(sid, gid, stamp[0], stamp[1], nudged, now)
+            # …and incomplete DELEGATION handoffs (the user 2026-08-23: a dead sender's "↪ delegated
+            # to X" item waits on run_propagate, and if the courier link never landed — or the peer
+            # folded the work without one — nothing can ever check it off; five were 240h old). The
+            # same terminal as a stamped wait: the card needs the user, not more patience.
+            for nid, nd in nodes.items():
+                h = nd.get("handoff") if isinstance(nd, dict) else None
+                if isinstance(h, dict) and not nd.get("nodeComplete") and not nd.get("blocked"):
+                    _dead_handoff_block(sid, nid, h, nd, nudged, now)
         except Exception:
             sys.stderr.write("dead-wait sweep (%s): %s\n" % (sid, traceback.format_exc()))
+
+
+def _dead_handoff_block(sid, nid, h, nd, nudged, now):
+    """A DORMANT sender's incomplete '↪ delegated to <peer>' tracking node converts to a procedural
+    block (the user 2026-08-23) — the sibling of _dead_wait_block for the delegation graph: the
+    completion event is run_propagate following the courier link, and a dead sender can neither chase
+    the peer nor act on the result. Same discipline: once per node (ledger), open-turn stand-down,
+    fresh re-read, evidence-time from recorded events."""
+    rec = nudged.get(nid) or {}
+    anchor = int(nd.get("t") or 0)
+    if rec.get("deadWait") and (rec.get("anchor") or 0) >= anchor:
+        return False
+    last, last_t = _last_state(sid)
+    if last in _PROGRESSING_STATES:
+        return False
+    try:
+        store = jd.load_goals(sid)
+        cur = store.get("nodes", {}).get(nid)
+        if not cur or cur.get("nodeComplete") or cur.get("blocked"):
+            return False
+        peer = _name_of(h.get("peer") or "") or (h.get("peer") or "")[:8] or "a peer"
+        blkwhy = jd.dead_wait_block_why("the delegation to %s (%s)"
+                                        % (peer, (cur.get("text") or "").replace("↪ ", "")[:80]))
+        _ev = int(max(anchor, last_t or 0) or now)
+        if jd.record_verdict(store, cur, "nudge", "block", _ev, why=blkwhy):
+            cur["mt"] = _ev
+            jd.append_block(sid, nid, "nudge", blkwhy, _ev)
+            jd.rollup_status(store, False)
+            jd.save_goals(sid, store)
+            _mark_views_dirty()
+            nudged[nid] = {"deadWait": True, "anchor": anchor, "at": int(now)}
+            _put_nudged(nid, nudged[nid])
+            return True
+    except Exception:
+        sys.stderr.write("dead-handoff block: %s\n" % traceback.format_exc())
+    return False
 
 
 def _dead_wait_block(sid, gid, at, why, nudged, now):

--- a/tests/test_courier_link.py
+++ b/tests/test_courier_link.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""The courier link survives planner-first placement (the user 2026-08-23): a peer-delegate segment
+the planner placed before the courier saw it minted no courier goal, so the SENDER's handoff waited
+on a completion event that could never fire (12 live handoffs, five ~240h old). Three fixes, all
+executed here: (1) the courier's link-only repair attaches links[] to the placed goal's TOP —
+never origin, which keeps its born-from meaning; (2) run_propagate completes the sender's tracking
+node from links[] exactly as from origin; (3) a DORMANT sender's incomplete handoff converts to the
+dead-wait procedural block. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+SENDER = "11111111-2222-3333-4444-555555555555"
+RECIP = "66666666-7777-8888-9999-000000000000"
+MID = "msg-aaaa-1111"
+T = 1_787_500_000
+
+
+def _seed_sender():
+    st = jd.load_goals(SENDER)
+    st["nodes"][SENDER + ":g1"] = jd.GuardedNode({
+        "id": SENDER + ":g1", "text": "↪ delegated to api: build the exporter", "parentId": None,
+        "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": T, "mt": T,
+        "handoff": {"peer": RECIP, "msgId": MID}, "log": []})
+    jd.save_goals(SENDER, st)
+
+
+def _seed_recipient(placed_under_existing=True):
+    st = jd.load_goals(RECIP)
+    st["nodes"][RECIP + ":g5"] = jd.GuardedNode({
+        "id": RECIP + ":g5", "text": "Ship the data layer", "parentId": None,
+        "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": T, "mt": T, "log": []})
+    if placed_under_existing:
+        st["placements"]["seg-d1"] = RECIP + ":g5"
+    jd.save_goals(RECIP, st)
+
+
+class CourierLinkRepair(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.discover
+        jd.discover = lambda now, window=None, forks=True: [
+            (SENDER, "/dev/null", None, "web"), (RECIP, "/dev/null", None, "api")]
+        _seed_sender()
+        _seed_recipient()
+
+    def tearDown(self):
+        jd.discover = self._saved
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+
+    def test_link_attaches_to_the_placed_top_and_is_idempotent(self):
+        st = jd.load_goals(RECIP)
+        self.assertTrue(jd._attach_courier_link(st, "seg-d1", MID))
+        st = jd.load_goals(RECIP)
+        links = st["nodes"][RECIP + ":g5"].get("links") or []
+        self.assertEqual(links, [{"peer": SENDER, "goalId": SENDER + ":g1", "msgId": MID}],
+                         "the link rides links[], never origin — born-from stays truthful")
+        self.assertFalse(jd._attach_courier_link(st, "seg-d1", MID), "idempotent by msgId")
+
+    def test_no_sender_backref_means_no_link(self):
+        st = jd.load_goals(RECIP)
+        self.assertFalse(jd._attach_courier_link(st, "seg-d1", "msg-unknown-9999"))
+        self.assertNotIn("links", dict(jd.load_goals(RECIP)["nodes"][RECIP + ":g5"]))
+
+    def test_propagate_completes_the_sender_from_links(self):
+        st = jd.load_goals(RECIP)
+        jd._attach_courier_link(st, "seg-d1", MID)
+        st = jd.load_goals(RECIP)
+        jd.record_verdict(st, st["nodes"][RECIP + ":g5"], "closer", "done", T + 100, why="shipped")
+        jd.rollup_status(st, True)
+        jd.save_goals(RECIP, st)
+        n = jd.run_propagate(now=T + 200)
+        self.assertGreaterEqual(n, 1)
+        snd = jd.load_goals(SENDER)["nodes"][SENDER + ":g1"]
+        self.assertTrue(snd.get("nodeComplete"), "the handoff checks off from the repaired link")
+
+    def test_courier_scan_carries_the_repair_branch(self):
+        src = open(os.path.join(BIN, "romp-judge")).read()
+        self.assertIn("_attach_courier_link(cstore, seg[\"id\"], pm0[1])", src)
+        self.assertIn('_seg_peer_kind(seg) == "delegate"', src)
+
+
+class DormantHandoffConverts(unittest.TestCase):
+    def setUp(self):
+        _seed_sender()
+        d = jd.STATE / "states"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / (SENDER + ".jsonl")).write_text(json.dumps({"state": "idle", "t": T + 50}) + "\n")
+        km._PREV_ALIVE = None
+        self.nudged = {}
+
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+        for f in (jd.STATE / "states").glob("*"):
+            f.unlink()
+
+    def test_dormant_sender_handoff_blocks_with_the_dead_wait_why(self):
+        km._dead_wait_sweep(set(), self.nudged, T + 900)
+        nd = jd.load_goals(SENDER)["nodes"][SENDER + ":g1"]
+        self.assertTrue(nd.get("blocked"), "an unpropagatable handoff on a dead sender needs the user")
+        self.assertTrue(str(nd.get("blockWhy") or "").startswith(jd.DEAD_WAIT_WHY_PREFIX))
+        self.assertIn("delegation to", nd.get("blockWhy") or "")
+        km._dead_wait_sweep(set(), self.nudged, T + 990)
+        km._PREV_ALIVE = None
+        self.assertEqual(len([k for k in self.nudged if k == SENDER + ":g1"]), 1, "once per node")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A peer-delegate segment the planner placed before the courier saw it never minted a courier goal, so the sender's "delegated to" node waited on a completion event that could never fire (12 live handoffs found in the audit, five ~240h old).

- Courier: placed segments get a link-only repair — `_attach_courier_link` writes a `links[]` entry on the placement's top ancestor via `_handoff_backref`; idempotent by msgId, origin untouched.
- `run_propagate` honors `links[]` alongside `origin`, so the repaired link completes the sender's handoff node.
- Dead-wait sweep converts a dormant sender's incomplete handoff to the procedural block (`_dead_handoff_block`) instead of pausing forever.

Executed coverage in `tests/test_courier_link.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)