### PR TITLE
Awaiting states carry the wait's own start: elapsed time on the box, the pill, and the peer chip

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11642,9 +11642,13 @@ def _session_delegated_why(sid):
 
 def _session_awaiting(sid, path, idle, stamp=False):
     """A session AWAITING dispatched/delegated background work (a WORKING flavor, the user 2026-06-22) →
-    {"kind", "why"}: the one-line 'why' for the ⏳ awaiting badge plus WHAT the wait is on (jd.AWAIT_KINDS,
-    the user 2026-08-15 — kind rides as DATA so surfaces can word it and rules can scope by it; None =
-    kindless, the legacy shape). Falsy (None) when not awaiting, so truthiness callers read unchanged.
+    {"kind", "why", "since"}: the one-line 'why' for the ⏳ awaiting badge plus WHAT the wait is on
+    (jd.AWAIT_KINDS, the user 2026-08-15 — kind rides as DATA so surfaces can word it and rules can scope
+    by it; None = kindless, the legacy shape) plus WHEN the wait began — each source's own event time
+    (a dispatch stamp, an overlay row's t, the judge's awaitingAt), never wall-clock now, so the chips can
+    say how long the wait has held (the user 2026-08-23: a stuck wait was invisible without a duration).
+    `since` is None when the winning source carries no event time — the surfaces then show no duration
+    rather than a guessed one. Falsy (None) when not awaiting, so truthiness callers read unchanged.
     Only when IDLE — an actively producing turn is just 'working'. The EVENT-BASED sources, in order:
       0. the backend snapshot's LIVE subagent count (SubagentStart/Stop) — genuine delegated Claude
          AGENTS in flight, held in memory, independent of any turn.
@@ -11706,7 +11710,8 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # formatted the list itself with %d (latent TypeError since 3325771, masked because a subagent
         # normally runs inside an open turn → idle=False → this branch never ran) — count via len().
         n = len(subs)
-        return {"kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s")}
+        return {"kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s"),
+                "since": min([s.get("since") for s in subs if s.get("since")] or [None])}   # the oldest live agent's start — the wait has held at least this long
     tasks = _bg_live_norm(sid, path)
     if tasks:
         # Sources 0.5/0.75 — only the PENDING tasks (launch not yet placed) count; a placed launch's
@@ -11718,14 +11723,18 @@ def _session_awaiting(sid, path, idle, stamp=False):
             # (or plain shell work) is kind task — the generic word for in-harness background work
             kind = ("agents" if all("agent" in (t.get("type") or "") or t.get("type") == "local_workflow"
                                     for t in pending) else "task")
+            since = min([t.get("t") for t in pending if t.get("t")] or [None])   # the oldest pending dispatch
             if len(pending) == 1:
-                return {"kind": kind, "why": "waiting on a background task%s" % ((": " + d0) if d0 else "")}
-            return {"kind": kind, "why": "waiting on %d background tasks%s"
-                                         % (len(pending), (" — " + d0 + ", …") if d0 else "")}
+                return {"kind": kind, "since": since,
+                        "why": "waiting on a background task%s" % ((": " + d0) if d0 else "")}
+            return {"kind": kind, "since": since,
+                    "why": "waiting on %d background tasks%s"
+                           % (len(pending), (" — " + d0 + ", …") if d0 else "")}
     ov = _states_awaiting_overlay(sid)
     if ov is not None and ov.get("awaiting"):         # a producer wrote a LIVE awaiting:true → trust its why
         ovk = ov.get("kind")
         return {"kind": ovk if ovk in jd.AWAIT_KINDS else None,
+                "since": ov.get("t") or None,          # the overlay row's own stamp — when the hook declared the wait
                 "why": ov.get("why") or "waiting on dispatched work"}
     # An awaiting:false overlay row is NOT a veto — it says only that THIS channel has nothing to add.
     # The SDK Stop hook has written an unconditional false at every turn end since 2026-07-07 while
@@ -11752,13 +11761,13 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # and nobody else's (the user 2026-08-08): the three surfaces answered one question two ways.
         y = _owned_yield_why(sid, path)
         if y:
-            return {"kind": "task", "why": y}          # a live owned dispatch — in-harness work
+            return {"kind": "task", "why": y, "since": None}   # a live owned dispatch — in-harness work (no single event time to show)
         _gid, _at, st_why, st_kind = _session_stamp_full(sid)
         if st_why:
-            return {"kind": st_kind, "why": st_why}    # the judge's own classification rides the stamp
+            return {"kind": st_kind, "why": st_why, "since": _at or None}   # the judge's own classification rides the stamp, with its awaitingAt
         d = _session_delegated_why(sid)
         if d:
-            return {"kind": "peer", "why": d}          # the courier handoff graph is peer by construction
+            return {"kind": "peer", "why": d, "since": None}   # the courier handoff graph is peer by construction
     return None
 
 
@@ -16837,7 +16846,7 @@ def _provisional_card(s, name, color, fsid, live, now, store=None):
             "provisional": True, "judging": not turn_open, "tree": []}
 
 
-def _awaiting_card(s, name, color, fsid, live, now, why, kind=None):
+def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None):
     """A lightweight WORKING-column placeholder for a LIVE, IDLE session AWAITING a dispatched BACKGROUND
     TASK when there is NO open goal to floor to awaiting (the user 2026-07-13). The turn ended and every
     card is done/cleared/placed, so the goal loop has nothing to floor AND _provisional_card bows out (its
@@ -16871,7 +16880,8 @@ def _awaiting_card(s, name, color, fsid, live, now, why, kind=None):
             # awaiting flavor with the live bg-task descriptions → the "Waiting on task" pill (the user
             # 2026-07-13). judging False: this session is idle-awaiting, not analyzing — the pill, not a
             # "Working…"/"Analyzing…" chip, carries the state (feed.ts defers the provisional chip when awaiting).
-            "awaiting": {"why": why, "kind": kind, "tasks": _awaiting_task_descs(fsid, s["path"])},
+            "awaiting": {"why": why, "kind": kind, "since": since,
+                         "tasks": _awaiting_task_descs(fsid, s["path"])},
             "provisional": True, "judging": False, "tree": []}
 
 
@@ -17514,6 +17524,7 @@ def build_feed(now, tmux=None):
         _sess_aw = _session_awaiting(fsid, s["path"], not who_working) if ps else None   # cache-only: fills in after the warm
         sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
         sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
+        sess_awaiting_since = _sess_aw.get("since") if _sess_aw else None   # the wait's own event time (the user 2026-08-23)
         if sess_awaiting_why and not who_working:
             awaiting.append(name)                    # the AWAITING dot list (await-green, the user 2026-07-13) — the
             #                                          same split _session_chip makes; feed/chat dots match the chip
@@ -17593,6 +17604,7 @@ def build_feed(now, tmux=None):
             #    the user questions while its own background timer ran).
             _await_ok = bool(sess_awaiting_why)
             _owned_why = None
+            _owned_since = None
             if col == "blocked":
                 _blk_t = max([nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid)
                               if nodes[x].get("blocked") and not _closure_done(x)] or [0])
@@ -17604,6 +17616,7 @@ def build_feed(now, tmux=None):
                 if _await_ok:
                     _owned_why = "waiting on a background task%s" % (
                         (": " + _own["descs"][0]) if _own["descs"] else "")
+                    _owned_since = _own["since"]           # the dispatch event that proved the yield
             # The JUDGE's durable ⏳ stamp (the closer's awaiting verdict, kernel/judge.py): this goal's
             # latest audited turn ended waiting on async work it set in motion. Store-backed, so it holds
             # across kernel restarts — exactly where the live snapshot signals above go dark and a
@@ -17613,6 +17626,7 @@ def build_feed(now, tmux=None):
                    if col == "working" else None)
             _stamp_why = _sf[1] if _sf else None
             _stamp_kind = _sf[2] if _sf else None
+            _stamp_since = (_sf[0] or None) if _sf else None   # the stamp's awaitingAt — when the judge filed the wait
             # DELEGATION-derived awaiting (the courier's durable handoff graph, not the question-regex):
             # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
             # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
@@ -17621,13 +17635,17 @@ def build_feed(now, tmux=None):
             # surfaces (rail/chat/timeline) read the SAME evidence via _session_delegated_why in
             # _session_awaiting's stamp branch — keep the two in step (the user 2026-08-08).
             _deleg_why = None
+            _deleg_since = None
             if col == "working" and not _stamp_why and not _await_ok \
                     and _all_outstanding_delegated(nodes, nid):
+                _hnodes = [x for x in _subtree(nid)
+                           if isinstance(nodes[x].get("handoff"), dict)
+                           and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
                 _peers = sorted({(_name_of((nodes[x].get("handoff") or {}).get("peer")) or "a peer")
-                                 for x in _subtree(nid)
-                                 if isinstance(nodes[x].get("handoff"), dict)
-                                 and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")})
+                                 for x in _hnodes})
                 _deleg_why = "delegated to %s; waiting on their result" % (", ".join(_peers) or "a peer")
+                # the newest outstanding handoff's mint — the last local act before the wait began
+                _deleg_since = max([nodes[x].get("t") or 0 for x in _hnodes] or [0]) or None
             if nid != api_top and nid != perm_top and col in ("working", "blocked") and (
                     _await_ok or _stamp_why or _deleg_why or (col == "blocked" and _peer_wait)):
                 col = "awaiting"
@@ -17656,12 +17674,14 @@ def build_feed(now, tmux=None):
                           "peerHost": ("" if pname else o.get("peerHost") or ""),
                           "peerSid": psid, "color": _name_color(psid), "live": live}
             await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
-            await_kind = None                        # the winning why's KIND rides beside it, mirroring the
-            if col == "awaiting":                    # or-chain exactly (a kindless winner stays kindless)
-                for _w, _k in ((sess_awaiting_why, sess_awaiting_kind), (_stamp_why, _stamp_kind),
-                               (_deleg_why, "peer"), (_owned_why, "task")):
+            await_kind = None                        # the winning why's KIND and SINCE ride beside it,
+            await_since = None                       # mirroring the or-chain exactly (a kindless winner
+            if col == "awaiting":                    # stays kindless; since = the wait's own event time)
+                for _w, _k, _s in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since),
+                                   (_stamp_why, _stamp_kind, _stamp_since),
+                                   (_deleg_why, "peer", _deleg_since), (_owned_why, "task", _owned_since)):
                     if _w:
-                        await_kind = _k
+                        await_kind, await_since = _k, _s
                         break
             # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
             # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent
@@ -17921,7 +17941,7 @@ def build_feed(now, tmux=None):
                 # work) — the user 2026-06-22. `tasks` = the live bg-task descriptions (the user 2026-07-13):
                 # when present the card wears the compact "Waiting on task" pill (expands to this list, like
                 # Sub-goals) instead of the boxed why; empty for subagent/overlay flavors, which keep the box.
-                "awaiting": ({"why": await_why, "kind": await_kind,
+                "awaiting": ({"why": await_why, "kind": await_kind, "since": await_since,
                               "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
@@ -18028,7 +18048,7 @@ def build_feed(now, tmux=None):
                 # awaiting card so the wait shows in the FEED, not just on the timeline — the hole the user
                 # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
                 asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
-                                           kind=sess_awaiting_kind))
+                                           kind=sess_awaiting_kind, since=sess_awaiting_since))
     if cold_parse:
         _warm_fleet_bg(now)                          # a living session wasn't parsed yet → warm it + re-push (dots/anchors)
     # NO caption stream. The feed's cards are TOP-LEVEL GOALS ONLY (read-side.md: Inbox = goal cards;

--- a/tests/test_awaiting_card.py
+++ b/tests/test_awaiting_card.py
@@ -51,6 +51,14 @@ class AwaitingCard(unittest.TestCase):
         self.assertEqual(c["awaiting"]["tasks"], ["watching CI run"])
         self.assertEqual(c["awaiting"]["why"], "waiting on a background task: watching CI run")
 
+    def test_awaiting_carries_the_waits_own_start_for_the_elapsed_readout(self):
+        # the user 2026-08-23: Working shows how long it has been running, the awaiting states showed
+        # nothing — `since` (the wait's own event time, never wall-clock now) feeds the chips' duration
+        c = km._awaiting_card({"sid": SID, "path": "/tmp/x"}, "docs", COLOR, SID, True, 2000,
+                              "waiting on a background task", kind="task", since=1234)
+        self.assertEqual(c["awaiting"]["since"], 1234)
+        self.assertIsNone(self._card()["awaiting"]["since"])   # absent → None: the UI shows no duration, never a guess
+
     def test_headline_capitalizes_the_why(self):
         self.assertTrue(self._card()["text"].startswith("Waiting on a background task"))
 

--- a/tests/test_awaiting_since.py
+++ b/tests/test_awaiting_since.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""_session_awaiting (bin/romp-kernel) carries `since` — the wait's OWN event time — beside why/kind,
+so every awaiting surface can say how long the wait has held (the user 2026-08-23: Working shows its
+running minutes; the awaiting states showed nothing, so a wait stuck for hours read the same as one
+seconds old). Each source contributes its own event stamp, never wall-clock now: the oldest live
+agent's start, the oldest pending dispatch, the overlay row's t, the judge stamp's awaitingAt. A source
+with no event time sends None and the UI shows no duration. Synthetic inputs only.
+"""
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+import tempfile
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_awaitsince", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class SessionAwaitingSince(unittest.TestCase):
+    """Stub each source _session_awaiting reads, in precedence order, and check its since."""
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_tmux_sessions", "_bg_live_norm", "_bg_pending", "_states_awaiting_overlay",
+                        "_owned_yield_why", "_session_stamp_full", "_session_delegated_why")}
+        # neutral defaults: a live CLI with nothing in flight, every deeper source empty
+        km._tmux_sessions = lambda: {SID: {}}
+        km._bg_live_norm = lambda sid, path: []
+        km._bg_pending = lambda sid, path, tasks: []
+        km._states_awaiting_overlay = lambda sid: None
+        km._owned_yield_why = lambda sid, path: None
+        km._session_stamp_full = lambda sid: (None, 0, None, None)
+        km._session_delegated_why = lambda sid: None
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+
+    def test_live_subagents_use_the_oldest_agents_start(self):
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "a", "since": 500},
+                                                         {"type": "b", "since": 900}]}}
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual(aw["kind"], "agents")
+        self.assertEqual(aw["since"], 500)   # the wait has held at least since the oldest live agent
+
+    def test_pending_bg_tasks_use_the_oldest_dispatch(self):
+        tasks = [{"tid": "1", "desc": "watching CI run", "t": 700, "type": "bash"},
+                 {"tid": "2", "desc": "poll deploy", "t": 300, "type": "bash"}]
+        km._bg_live_norm = lambda sid, path: tasks
+        km._bg_pending = lambda sid, path, ts: ts
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual(aw["since"], 300)
+        self.assertIn("2 background tasks", aw["why"])
+
+    def test_overlay_rides_its_own_rows_stamp(self):
+        km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "waiting on a build",
+                                                   "kind": "job", "t": 4321}
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual(aw["since"], 4321)
+
+    def test_judge_stamp_rides_its_awaitingAt(self):
+        km._session_stamp_full = lambda sid: ("g1", 8765, "waiting on the test suite", "task")
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertEqual(aw["why"], "waiting on the test suite")
+        self.assertEqual(aw["since"], 8765)
+
+    def test_an_event_less_source_sends_none_never_a_guess(self):
+        km._owned_yield_why = lambda sid, path: "waiting on a background task: sweep"
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertIsNone(aw["since"])
+        km._owned_yield_why = lambda sid, path: None
+        km._session_delegated_why = lambda sid: "delegated to web; waiting on their result"
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertIsNone(aw["since"])
+
+    def test_not_awaiting_stays_falsy(self):
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", True))
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", False))   # an open turn is just working
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1443,7 +1443,8 @@ class ViewBuilder(unittest.TestCase):
         self.assertTrue(km._states_awaiting_overlay(SID).get("awaiting"),
                         "awaiting:true with no later work turn stays awaiting")
         self.assertEqual(km._session_awaiting(SID, str(self.tpath), True),
-                         {"kind": None, "why": "Waiting on 2 background jobs it launched."},
+                         {"kind": None, "since": 200,   # the overlay row's own stamp → the chips' elapsed readout (the user 2026-08-23)
+                          "why": "Waiting on 2 background jobs it launched."},
                          "the genuine awaiting badge still shows")
 
     def test_blocked_rolls_up_the_card_tree_so_a_buried_block_is_visible(self):
@@ -1534,21 +1535,22 @@ class ViewBuilder(unittest.TestCase):
             # per agent); the why counts via len() (the pre-fix code %d-formatted the list itself)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             {"kind": "agents", "why": "2 background agents still working"},
+                             {"kind": "agents", "why": "2 background agents still working",
+                              "since": T0},   # the oldest live agent's start → the chips' elapsed readout (the user 2026-08-23)
                              "a live subagent DOES leave an idle session awaiting (a working flavor)")
             # source 0.5: the live bg-task set — one task shows its description verbatim
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             {"kind": "task",
+                             {"kind": "task", "since": T0 + 9,   # the dispatch stamp (the user 2026-08-23)
                               "why": "waiting on a background task: 20-minute timer for campaign-start check"})
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer, dict(timer, desc="power watcher")]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             {"kind": "task",
+                             {"kind": "task", "since": T0 + 9,
                               "why": "waiting on 2 background tasks — 20-minute timer for campaign-start check, …"})
             # subagents outrank bg tasks when both run (they're the bigger dispatch)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}], "bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             {"kind": "agents", "why": "1 background agent still working"})
+                             {"kind": "agents", "why": "1 background agent still working", "since": T0})
         finally:
             km._tmux_sessions = saved
 
@@ -1563,7 +1565,8 @@ class ViewBuilder(unittest.TestCase):
             {"t": T0 + 2, "state": "idle"},
         ]) + "\n")
         self.assertEqual(km._session_awaiting(SID, "/nonexistent", True),
-                         {"kind": None, "why": "3 agents in flight"},
+                         {"kind": None, "why": "3 agents in flight",
+                          "since": T0 + 1},   # the overlay row's own stamp (the user 2026-08-23)
                          "the latest awaiting overlay (interleaved with state records) drives the badge")
         self.assertIsNone(km._session_awaiting(SID, "/nonexistent", False),
                           "a WORKING session is not 'awaiting' (idle=False short-circuits)")

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -72,7 +72,7 @@ class MergeCarriesBgTasks(unittest.TestCase):
             why = km._session_awaiting(SID, "/nonexistent", True)
         finally:
             km._tmux_sessions = saved_sessions
-        self.assertEqual(why, {"kind": "task",
+        self.assertEqual(why, {"kind": "task", "since": 1,   # the dispatch stamp → the chips' elapsed readout (the user 2026-08-23)
                                "why": "waiting on a background task: 20-minute timer for campaign-start check"})
 
 

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -154,7 +154,8 @@ class SessionLevelStamp(unittest.TestCase):
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": "job", "why": "slurm 4821 regenerating the parts"})
+                         {"kind": "job", "why": "slurm 4821 regenerating the parts",
+                          "since": 200})   # the stamp's awaitingAt → the chips' elapsed readout (the user 2026-08-23)
         self.assertEqual(km._session_stamp_full(SID),
                          ("g1", 200, "slurm 4821 regenerating the parts", "job"))
 
@@ -166,7 +167,8 @@ class SessionLevelStamp(unittest.TestCase):
     def test_stamp_true_lifts_a_live_session_whose_live_sources_are_dark(self):
         self._seed(("g1", "the watcher it armed; files the clip when it triggers", 200))
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "the watcher it armed; files the clip when it triggers"})
+                         {"kind": None, "since": 200,
+                          "why": "the watcher it armed; files the clip when it triggers"})
 
     def test_stamp_false_stays_none_so_the_feed_scopes_per_goal(self):
         # the crux: the feed calls stamp=False, so the session-level signal is None for a stamp-only session
@@ -253,7 +255,8 @@ class SessionLevelDelegation(unittest.TestCase):
     def test_a_fully_delegated_session_reads_awaiting_on_the_session_surfaces(self):
         self._seed(self._delegated_store())
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": "peer", "why": "delegated to probe; waiting on their result"})
+                         {"kind": "peer", "why": "delegated to probe; waiting on their result",
+                          "since": None})   # the handoff graph has no single event time here → no duration
 
     def test_stamp_false_stays_none_so_the_feed_keeps_scoping_per_card(self):
         self._seed(self._delegated_store())
@@ -264,7 +267,7 @@ class SessionLevelDelegation(unittest.TestCase):
         nodes["g1"]["awaitingWhy"], nodes["g1"]["awaitingAt"] = "the sweep it launched", 200
         self._seed(nodes)
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "the sweep it launched"})
+                         {"kind": None, "why": "the sweep it launched", "since": 200})
 
     def test_a_pure_delegation_top_stays_dark_matching_its_suppressed_card(self):
         # EVERY leaf a handoff → the feed suppresses the card in every column, so its dot never lights;
@@ -340,7 +343,7 @@ class KindScopedRules(unittest.TestCase):
     def test_a_peer_answer_supersedes_only_peer_waits(self):
         self._seed("job")
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": "job", "why": "the wait"},
+                         {"kind": "job", "why": "the wait", "since": 200},
                          "unrelated mail cannot end a wait on an external job")
         self._seed("peer")
         self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True),
@@ -408,14 +411,15 @@ class OverlayDoesNotVeto(unittest.TestCase):
         self._overlay({"t": 100, "awaiting": False})
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "a dispatched release watch; tags when green"},
+                         {"kind": None, "why": "a dispatched release watch; tags when green",
+                          "since": 200},
                          "the Stop hook's ambient false must not hide the judge's stamp")
 
     def test_a_live_true_row_still_wins_with_its_own_why(self):
         self._overlay({"t": 100, "awaiting": True, "why": "a job the hook reported"})
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "a job the hook reported"},
+                         {"kind": None, "why": "a job the hook reported", "since": 100},
                          "a positive overlay row keeps its channel")
 
     def test_false_row_and_no_stamp_is_plain_none(self):

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -434,7 +434,8 @@ class DurableAwaitingSource(unittest.TestCase):
         finally:
             self._restore(saved)
             os.unlink(path)
-        self.assertEqual(why, {"kind": "task", "why": "waiting on a background task: power watcher"})
+        self.assertEqual(why, {"kind": "task", "why": "waiting on a background task: power watcher",
+                               "since": None})   # the transcript scan carries no dispatch stamp → no duration, never a guess
 
     def test_the_notification_landing_ends_it(self):
         path = _write([_launch(), _notif_str(tid=TUSE)])

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -113,7 +113,8 @@ class OwnedYieldAwaiting(unittest.TestCase):
     def test_the_session_surfaces_light_from_it_when_idle(self):
         self._store()
         self.assertEqual(km._session_awaiting(SID, self.path, True, stamp=True),
-                         {"kind": "task", "why": "waiting on a background task: " + DESC},
+                         {"kind": "task", "why": "waiting on a background task: " + DESC,
+                          "since": None},   # the owned-yield read has no single event time → no duration
                          "the lane/chip say awaiting instead of READY")
 
     def test_the_feed_path_is_unchanged_no_session_wide_floor(self):

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -21,7 +21,7 @@ test("the swirl element is built in the body, right after the distiller line, an
 });
 
 test("the swirl is driven by spinFor's caption — shown when there is one, else hidden", () => {
-  assert.match(FEED, /import \{ spinFor, KIND_WORD \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, KIND_WORD, waitedSuffix \} from "\.\/spin-caption";/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
@@ -35,8 +35,10 @@ test("a bg-task wait wears the compact 'Awaiting task' pill that expands the tas
   assert.match(FEED, /"bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none"/);
   // "Awaiting task", never "Waiting on task": one word per state across every surface — the chat chip
   // and timeline badge already say Awaiting for this exact state (the user 2026-08-13)
-  assert.match(FEED, /taskList\.length === 1 \? "Awaiting " \+ one : "Awaiting " \+ taskList\.length \+ " "/);
+  assert.match(FEED, /taskList\.length === 1 \? "Awaiting " \+ one\s*\n?\s*: "Awaiting " \+ taskList\.length \+ " "/);
   assert.doesNotMatch(FEED, /"Waiting on task"/);
+  // the pill carries the wait's elapsed time, same readout as the awaiting box (the user 2026-08-23)
+  assert.match(FEED, /\+ pillWaited;/);
   assert.match(FEED, /taskBtn\.onclick = pick\("tasks"\);/);
   // expanded rows render in the checklist spot, same view as Sub-goals, the swirl as each row's mark
   assert.match(FEED, /if \(choice === "tasks"\) \{[\s\S]*?el\("div", "fcheck ftask"\)[\s\S]*?ftask-swirl/);

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -432,6 +432,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   padding: 1px 6px; border-radius: 999px; line-height: 1.4;
   color: #4ec9b0; border: 1px solid rgba(78, 201, 176, 0.6); }
 .fask-waiton-cycle { color: #ff6a6a; border-color: rgba(255, 106, 106, 0.7); }
+/* the chip's elapsed readout (" · 42m") — same size as the chip text, dimmed like a sub-line so the
+   peer name stays the loudest word (the user 2026-08-23) */
+.fask-waiton-dur { opacity: 0.6; font-weight: 400; }
 
 /* ---- ask DAG tree (expanded body) — nodes only; click a node for its history ---- */
 /* width:fit-content hugs the widest row so the right-aligned "(Xm ago)" node times sit just past the

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -7,7 +7,7 @@
 // pushes and updated in place — never torn down — so hovering one doesn't flicker
 // when the fleet streams new deliverables in.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
-import { spinFor, KIND_WORD } from "./spin-caption";
+import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
@@ -101,8 +101,8 @@ interface AskItem {
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
-  waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25)
-  awaiting?: { why?: string | null; kind?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why.
+  waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string; since?: number } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25). since = when the unanswered ask was sent → the chip's elapsed readout (the user 2026-08-23)
+  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why. since = the wait's own event time → the box/pill elapsed readout (the user 2026-08-23)
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
   provisional?: boolean;                           // a LIVE-PROMPT placeholder (kernel _provisional_card): the session is working an in-progress turn the planner hasn't classified yet. No goal node (empty tree) — dim, non-interactive, no clear/nudge/modal; replaced by the real card once the planner places the segment.
@@ -1363,8 +1363,12 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   // class in the visible label (tooltips are dead on the touch PWA); kindless keeps the classic "task"
   const kw = KIND_WORD[(it.awaiting && it.awaiting.kind) || ""] || "task";
   const one = kw === "agents" ? "agent" : kw;   // singular form: "Awaiting agent", plural "N agents"
+  // the wait's elapsed time rides the pill exactly as it rides the awaiting box and the working
+  // narration — a stuck wait must be glanceable everywhere the state shows (the user 2026-08-23)
+  const pillWaited = waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000);
   (a._taskLbl as HTMLElement).textContent =
-    taskList.length === 1 ? "Awaiting " + one : "Awaiting " + taskList.length + " " + (one === kw ? kw + "s" : kw);
+    (taskList.length === 1 ? "Awaiting " + one
+                           : "Awaiting " + taskList.length + " " + (one === kw ? kw + "s" : kw)) + pillWaited;
   taskBtn.classList.toggle("on", choice === "tasks");
   taskBtn.setAttribute("aria-pressed", choice === "tasks" ? "true" : "false");
   taskBtn.title = choice === "tasks" ? "hide the tasks" : "show the tasks";
@@ -1625,6 +1629,13 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     const woName = el("span", "fask-waiton-name"); woName.textContent = wo.name;
     if (wo.color && wo.color.bg) woName.style.color = wo.color.bg;   // the peer's own identity colour
     a._waitOn.append(woPre, woName);
+    // elapsed since the unanswered ask went out (kernel _wait_for_graph's since) — the same readout the
+    // working narration and awaiting box wear, so a wait stuck for hours is glanceable (the user 2026-08-23)
+    const woWaited = waitedSuffix(wo.since, Date.now() / 1000);
+    if (woWaited) {
+      const woDur = el("span", "fask-waiton-dur"); woDur.textContent = woWaited;
+      a._waitOn.append(woDur);
+    }
     a._waitOn.title = wo.inCycle
       ? "MUTUAL WAIT — this session and " + wo.name + " are each waiting on the other (a deadlock); auto-nudge surfaces it instead of nudging"
       : wo.kind === "delegate"

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -69,6 +69,27 @@ test("a peer wait (waitingOn chip) and a bg-TASK wait (pill) both defer — no g
   assert.equal(spinFor({ awaiting: { why: "x", tasks: ["t1"] } }, false, false).caption, null);
 });
 
+// --- the wait's elapsed readout (the user 2026-08-23) -----------------------------------------------
+// Working says how long it has been running; the awaiting states said nothing, so a wait stuck for
+// hours read exactly like one seconds old (the local_misc card sat 2¾ hours with no visible age). The
+// kernel now sends the wait's own event time (`since`) and the box appends the same compact duration
+// the working narration wears.
+test("AWAITING shows how long the wait has held when the kernel supplies its start", () => {
+  const s = spinFor({ awaiting: { why: "", since: 1000 } }, false, false, 1000 + 42 * 60);
+  assert.equal(s.caption, "Awaiting agents · 42m");
+  // a verbatim "waiting on …" why carries it too, and past an hour it reads h+m like the narration
+  const l = spinFor({ awaiting: { why: "waiting on 3 subagents", since: 1000 } }, false, false,
+                    1000 + 3 * 3600 + 5 * 60);
+  assert.equal(l.caption, "Waiting on 3 subagents · 3h 5m");
+});
+
+test("no since (an older kernel, an event-less wait) → no duration, never a guess", () => {
+  assert.equal(spinFor({ awaiting: { why: "" } }, false, false, 5000).caption, "Awaiting agents");
+  assert.equal(spinFor({ awaiting: { why: "", since: null } }, false, false, 5000).caption, "Awaiting agents");
+  // and a caller that passed no clock (nowS) also stays bare — a duration needs both ends
+  assert.equal(spinFor({ awaiting: { why: "", since: 1000 } }, false, false).caption, "Awaiting agents");
+});
+
 test("a PROVISIONAL working card tells the truth about its phase", () => {
   assert.equal(spinFor({ provisional: true, column: "working" }, false, false).caption, "Working…",
     "an OPEN turn is just working — the judge has nothing to classify yet");
@@ -142,7 +163,11 @@ test("a settled card displaced to Working loses its line but never its caption",
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("feed.ts routes the card's swirl through spinFor and keeps no inline copy of the ladder", () => {
-  assert.match(FEED, /import \{ spinFor, KIND_WORD \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, KIND_WORD, waitedSuffix \} from "\.\/spin-caption";/);
+  // the elapsed readout reaches the OTHER two awaiting surfaces through the same helper: the
+  // "Awaiting task" pill and the "Awaiting <peer>" chip (the user 2026-08-23)
+  assert.match(FEED, /const pillWaited = waitedSuffix\(it\.awaiting && it\.awaiting\.since, Date\.now\(\) \/ 1000\);/);
+  assert.match(FEED, /const woWaited = waitedSuffix\(wo\.since, Date\.now\(\) \/ 1000\);/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   // the inline ladder is gone — no second, drifting copy of the rule

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -31,7 +31,7 @@
 
 /** The card fields the ladder reads. Structural, so the test can pass plain objects. */
 export interface SpinItem {
-  awaiting?: { why?: string | null; kind?: string | null; tasks?: unknown[] | null } | null;
+  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: unknown[] | null } | null;   // since = the wait's own event time (kernel or-chain / _session_awaiting; the user 2026-08-23)
   waitingOn?: unknown;
   provisional?: boolean;
   column?: string;
@@ -63,10 +63,18 @@ export const KIND_WORD: Record<string, string> = {
 /** dCompleted/dBlocked come from distillInputs(distillState, column) — the GENUINE resolution state, not
  *  the transient column. distillPending is passed in (rather than recomputed) so the two modules keep one
  *  owner for the "is the distiller still working" rule. */
-/** Compact duration for the working narration: minutes under an hour, then h+m. */
-function workingFor(secs: number): string {
+/** Compact duration for the working narration AND the awaiting box: minutes under an hour, then h+m. */
+export function workingFor(secs: number): string {
   const m = Math.max(0, Math.floor(secs / 60));
   return m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+/** " · 42m" for a wait with a known start, "" otherwise — the awaiting counterpart of the working
+ *  narration's duration (the user 2026-08-23: Working says how long it's been running, the awaiting
+ *  states said nothing, so a wait stuck for hours read the same as one seconds old). Kernel-supplied
+ *  event time only — no since, no duration, never a guess. */
+export function waitedSuffix(since: number | null | undefined, nowS: number | undefined): string {
+  return nowS && since && since > 0 ? " · " + workingFor(nowS - since) : "";
 }
 
 
@@ -85,9 +93,12 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // "waiting on" is shown verbatim (capitalized); the kind word is the fallback frame.
     const why = aw.why || "";
     const word = KIND_WORD[aw.kind || ""] || "agents";   // kindless = the box's historic default
+    // how long the wait has held, from the kernel's event time — the same live readout the working
+    // narration wears, so a stuck wait is visible at a glance (the user 2026-08-23)
+    const waited = waitedSuffix(aw.since, nowS);
     return {
-      caption: /^waiting on/i.test(why) ? why.charAt(0).toUpperCase() + why.slice(1)
-                                        : "Awaiting " + word,
+      caption: (/^waiting on/i.test(why) ? why.charAt(0).toUpperCase() + why.slice(1)
+                                         : "Awaiting " + word) + waited,
       tip: why ? why + ". Not on you; paused until the background work lands."
                : "Paused, waiting on background work it dispatched (not on you). Clears when the result lands.",
       awaitingBg: true,


### PR DESCRIPTION
The Working narration shows how long a turn has been running; the awaiting states showed no age at all, so a wait stuck for hours read exactly like one seconds old. Today's audit found cards sitting in Working/Awaiting for 3 to 240 hours with nothing on screen saying so (a reopen-orphaned card, two stale peer stamps, and a batch of never-completing handoffs, the last two being fixed separately on the devbox side).

**Kernel**
- `_session_awaiting` returns gain `since`, the wait's own event time, never wall-clock now: the oldest live agent's start, the oldest pending dispatch, the states overlay row's own stamp, the judge stamp's `awaitingAt`. Event-less sources (owned yield, delegation graph) send `None`.
- `build_feed`'s awaiting or-chain picks the winning why's `since` alongside its kind (live snapshot / judge stamp / delegation graph / owned dispatch) and both awaiting payloads (`awaiting` on goal cards, `_awaiting_card`) carry it. The `waitingOn` payload already carried `since` (the unanswered ask's send time).

**UI**
- `spin-caption.ts`: new shared `waitedSuffix()` appends the same compact duration the working narration wears (`Awaiting agents · 42m`, `3h 5m` past an hour). No `since` (older kernel, event-less wait) → no duration, never a guess.
- `feed.ts`: the "Awaiting task" pill and the "Awaiting \<peer\>" chip ride the same helper; the chip's duration is dimmed (`.fask-waiton-dur`) so the peer name stays the loudest word.

**Tests**
- `spin-caption.test.ts`: duration present / absent-since bare / no-clock bare, plus the wiring pins extended to the pill and chip.
- `tests/test_awaiting_since.py` (new): each `_session_awaiting` source contributes its own event stamp; event-less sources send None; not-awaiting stays falsy.
- Existing awaiting suites extended with the new field (test_kernel, awaiting_stamp, awaiting_merge, bg_tasks, owned_yield, awaiting_card).

Both suites green locally: 5184 pytest + 2204 node tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)