### PR TITLE
Awaiting-with-tasks cards name the task instead of falling to the paused floor

### DIFF
--- a/ui/webview/distill-background.test.ts
+++ b/ui/webview/distill-background.test.ts
@@ -53,7 +53,7 @@ test("state: a single mutually-exclusive secChoice (bg | summary | subgoals | ta
   // the "Awaiting task" list is the FOURTH (the user 2026-07-13)
   assert.match(FEED, /const secChoice = new Map<string, "bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none">\(\);/);
   // absent from the map → the DEFAULT, set by the footer "Collapsed" toggle (off → summary, on → none)
-  assert.match(FEED, /return secChoice\.get\(id\) \?\? \(feedPrefs\(\)\.collapsed \? "none" : "summary"\);/);
+  assert.match(FEED, /return secChoice\.get\(id\) \?\? \(feedPrefs\(\)\.collapsed \? "none" : hasAwaitTasks \? "tasks" : "summary"\);/);
   // click the showing section → off; click another → switch (one at a time)
   assert.match(FEED, /secChoice\.set\(id, choice === want \? "none" : want\)/);
   assert.match(FEED, /a\._bgBtn\.onclick = pick\("bg"\);/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1195,8 +1195,10 @@ function makeAskCard(it: AskItem): HTMLElement {
 // "none" (collapsed), so NEW cards arrive collapsed too. Clicking a toggle sets an explicit per-card override
 // (click the open one → off; click another → switch) that survives the mode.
 const secChoice = new Map<string, "bg" | "summary" | "subgoals" | "tasks" | "stall" | "none">();
-function resolveSec(id: string): "bg" | "summary" | "subgoals" | "tasks" | "stall" | "none" {
-  return secChoice.get(id) ?? (feedPrefs().collapsed ? "none" : "summary");
+function resolveSec(id: string, hasAwaitTasks = false): "bg" | "summary" | "subgoals" | "tasks" | "stall" | "none" {
+  // an awaiting-on-tasks card OPENS its task list by default (the user 2026-08-23: the wait is the
+  // one thing to read on that card); an explicit user pick and collapsed mode still win
+  return secChoice.get(id) ?? (feedPrefs().collapsed ? "none" : hasAwaitTasks ? "tasks" : "summary");
 }
 // The Stalled body's text: the staller's plain-language note when the judge has written one, else the
 // kernel's own mechanical reason. Never a waiting-on-the-judge placeholder — a stalled card always has
@@ -1309,7 +1311,7 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   // the stall note (the user 2026-07-23) — shown whenever the kernel says romp is holding this card, with
   // or without a judge-written note, since `why` alone already answers "why is nothing happening"
   const stall = it.stalled && it.stalled.why ? it.stalled : null;
-  let choice = resolveSec(id);
+  let choice = resolveSec(id, hasTasks);
   if (choice === "bg" && !bg) choice = "none";
   if (choice === "summary" && !distillShown) choice = "none";
   if (choice === "subgoals" && !hasSubs) choice = "none";

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -64,9 +64,15 @@ test("AWAITING uses the kernel's why verbatim (capitalized) when it reads 'waiti
 });
 
 test("a peer wait (waitingOn chip) and a bg-TASK wait (pill) both defer — no generic awaiting box", () => {
-  // the "Awaiting <peer>" chip / the "Awaiting task" pill already carry these; the box would double up
+  // the "Awaiting <peer>" chip / the "Awaiting task" pill already carry these; the box would double up.
+  // Carve-out (the user 2026-08-23): ON the working column a task-ful await now captions itself —
+  // deferring there dropped the card to the "Paused" floor directly under the pill. Off-column,
+  // where no floor exists, both still defer.
   assert.equal(spinFor({ awaiting: { why: "x" }, waitingOn: "peer" }, false, false).caption, null);
   assert.equal(spinFor({ awaiting: { why: "x", tasks: ["t1"] } }, false, false).caption, null);
+  const pw = spinFor({ awaiting: { why: "x" }, waitingOn: "peer", column: "working", sessState: "quiet" }, false, false);
+  assert.ok(!pw.awaitingBg, "a peer wait never wears the awaiting box on any column — the chip carries it");
+  assert.ok(!/^Waiting on a background task/.test(pw.caption || ""), "and never the bg-task caption");
 });
 
 test("a PROVISIONAL working card tells the truth about its phase", () => {
@@ -222,4 +228,16 @@ test("THE FLOOR IS TOTAL — a working-column card can never be mute (the user 2
               "mute working card: " + JSON.stringify({ judging, recheck, rejudging, provisional, dp,
                                                        working: !!working, sessState, awaiting: !!awaiting }));
           }
+});
+
+
+test("awaiting WITH tracked tasks names the first task — never the paused floor (2026-08-23)", () => {
+  // the screenshot contradiction: an "Awaiting task" pill above a "Paused — nothing is in motion"
+  // caption. With tasks present the caption keeps the awaiting read and names the wait.
+  const s = spinFor({ awaiting: { why: "waiting on 2 background tasks", kind: "task",
+                                  tasks: ["Notify when the release PRs settle", "suite run"] },
+                      column: "working", sessState: "quiet" }, false, false);
+  assert.equal(s.awaitingBg, true);
+  assert.match(s.caption || "", /^Waiting on a background task: Notify when the release PRs settle/);
+  assert.ok(!/Paused/.test(s.caption || ""), "the quiet floor must not fire under an Awaiting-task pill");
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -11,7 +11,9 @@
 // aimed at came from keying the LINE on `column`, and distillState already fixed that. Both show now.
 //
 // THE CONTRACT (spin-caption.test.ts executes every branch, in order):
-//   1. AWAITING      — held in Working on dispatched/delegated work (no peer chip, no bg-task pill)
+//   1. AWAITING      — held in Working on dispatched/delegated work (no peer chip). With tracked
+//                      tasks the caption NAMES the first one (2026-08-23: the pill-only design let
+//                      the quiet floor say "nothing is in motion" under an Awaiting-task pill)
 //   2. PROVISIONAL   — a dashed live-prompt placeholder the planner hasn't classified yet
 //   3. RE-CHECK      — a soft-block answered with a TARGETED follow-up, pending re-judge
 //   4. RE-JUDGING    — a soft-block + a PLAIN thread reply, with the reply in flight
@@ -75,6 +77,22 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
   // a bg-TASK wait no longer boxes its why here (the user 2026-07-13): the compact "Awaiting task" pill
   // on the toggles row carries it (with the task list one click away, like Sub-goals) — see applySections
   const awTasks = ((aw && aw.tasks) || []).filter(Boolean);
+  // Only the WORKING column carries this caption: elsewhere there is no floor to contradict,
+  // and the 2026-07-13 rule (the pill alone carries a bg-task wait) still holds.
+  if (aw && !it.waitingOn && awTasks.length && it.column === "working") {
+    // AWAITING with TRACKED TASKS (the user 2026-08-23, from a screenshot of the contradiction): the
+    // 2026-07-13 rule handed the why to the "Awaiting task" pill and let this card fall through to
+    // the quiet floor — which then said "Paused — nothing is in motion" DIRECTLY UNDER the pill
+    // saying work is in flight. Two surfaces on one card disagreed. The caption keeps the awaiting
+    // read and NAMES the first awaited task; the pill still expands the full list.
+    const first = String(awTasks[0] || "background work");
+    return {
+      caption: "Waiting on a background task: " + first,
+      tip: (aw.why || "Waiting on background work it dispatched.")
+        + " Not on you; the Awaiting-task list below has each one.",
+      awaitingBg: true,
+    };
+  }
   if (aw && !it.waitingOn && !awTasks.length) {
     // AWAITING — the session is held, waiting on work it dispatched. It keeps its own read: a boxed
     // "Awaiting <kind-word>" label, the kind carried as DATA from the kernel (the user 2026-08-15) so


### PR DESCRIPTION
A card showed the "Awaiting task" pill with "Paused — resumes on the session's next turn" directly beneath it. With tracked awaited tasks on a working-column card, the caption now keeps the awaiting read and names the first task; the feed opens the Awaiting-task section by default on such cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)