### PR TITLE
UI-only drift converges by rebuilding dist in place, kernel left up

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2159,6 +2159,42 @@ def _main_drift_verdict(origin, checkout, running):
     return ("", "")
 
 
+KERNEL_CODE_PREFIXES = ("kernel/", "bin/", "postal/", "cli/")
+_REBUILT_FOR = [""]   # the checkout sha this RUNNING kernel already converged to by rebuilding dist
+#                       in place (UI-only change) — the drift check treats it as in-sync until a
+#                       kernel-code commit moves the target past it
+
+
+def _kernel_code_changed(a, b):
+    """Does a..b touch code the RUNNING PROCESS executes? UI/dist inputs, tests, docs, plans do not —
+    a build whose kernel code is unchanged converges by REBUILDING dist in place with the kernel left
+    up (the user 2026-08-23: most changes are UI-only, and every restart cuts every in-flight turn).
+    Any error reads as True: when unsure, the restart is the safe converge."""
+    if not a or not b:
+        return True
+    try:
+        r = subprocess.run(["git", "diff", "--name-only", "%s..%s" % (a, b)], cwd=str(ROOT),
+                           capture_output=True, text=True, timeout=20)
+        if r.returncode != 0:
+            return True
+        files = [f for f in r.stdout.splitlines() if f.strip()]
+        return any(f.startswith(KERNEL_CODE_PREFIXES) for f in files)
+    except Exception:
+        return True
+
+
+def _rebuild_dist():
+    """Rebuild the served bundles in place — the UI-only converge. The same esbuild the launcher runs,
+    kernel left up: _dist_ver() stats per page render so the fresh ?v= token flows on the next paint,
+    and the extension's newer-build prompt keys off the dv keepalive. (ok, err_tail)."""
+    try:
+        r = subprocess.run(["node", "esbuild.js"], cwd=str(ROOT / "vscode-extension"),
+                           capture_output=True, text=True, timeout=180)
+        return r.returncode == 0, (r.stderr or r.stdout or "").strip()[-300:]
+    except Exception as e:
+        return False, str(e)
+
+
 def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
@@ -2166,6 +2202,21 @@ def _main_drift_check():
     if _update_mode() == "off":
         return
     kind, target = _main_drift_verdict(_origin_main_sha(), _checkout_sha(), _kernel_sha())
+    if kind == "restart" and target == _REBUILT_FOR[0]:
+        return                                        # already converged in place (UI-only rebuild)
+    if kind == "restart" and not _kernel_code_changed(_kernel_sha(), target):
+        # UI-ONLY drift (the user 2026-08-23): the checkout moved but nothing the running process
+        # executes changed — converge by rebuilding dist in place, in EVERY mode and with no
+        # cool-down (a rebuild cuts no turns, which is the only thing the gates protect). A failed
+        # build falls through to the normal restart path, loudly.
+        ok, err = _rebuild_dist()
+        if ok:
+            _REBUILT_FOR[0] = target
+            _sync_notice("new build served in place (UI-only change; no restart) — reload the "
+                         "dashboard to pick it up")
+            return
+        _sync_notice("UI-only update failed to build in place (%s) — taking the restart path" % err,
+                     ok=False)
     if not kind:
         _MAIN_DRIFT[0] = _MAIN_DRIFT[1] = ""          # in sync: a future drift is new information again
         return
@@ -2217,6 +2268,16 @@ def _run_main_update(kind, immediate=False):
             _sync_notice("main moved at origin, but the pull step failed: %s" % e, ok=False)
             _MAIN_DRIFT[0] = ""
             return
+    if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):
+        # the pull only moved UI/dist inputs — same in-place converge as the restart-kind branch
+        ok, err = _rebuild_dist()
+        if ok:
+            _REBUILT_FOR[0] = _checkout_sha()
+            _sync_notice("new build served in place (UI-only change; no restart) — reload the "
+                         "dashboard to pick it up")
+            return
+        _sync_notice("UI-only update failed to build in place (%s) — taking the restart path" % err,
+                     ok=False)
     try:
         import urllib.request
         req = urllib.request.Request("http://127.0.0.1:%d/restart-all%s"

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -112,3 +112,77 @@ class DriftWiring(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UiOnlyConverge(unittest.TestCase):
+    """A drift whose commits touch nothing the running process executes converges by rebuilding dist
+    in place — kernel left up, zero cut turns (the user 2026-08-23: most changes are UI-only, and
+    every restart cuts every in-flight turn). Kernel-code drift keeps the restart path unchanged."""
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_main_drift_verdict", "_kernel_code_changed", "_rebuild_dist",
+                        "_sync_notice", "_update_mode", "_send_to_app", "_kernel_sha")}
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        km._REBUILT_FOR[0] = ""
+        self.notices, self.banners, self.rebuilds = [], [], []
+        km._sync_notice = lambda msg, ok=True: self.notices.append((msg, ok))
+        km._send_to_app = lambda app, payload: self.banners.append(payload)
+        km._update_mode = lambda: "ask"
+        km._kernel_sha = lambda: "cur-sha"
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        km._REBUILT_FOR[0] = ""
+
+    def test_ui_only_restart_drift_rebuilds_in_place_and_latches(self):
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-ui")
+        km._kernel_code_changed = lambda a, b: False
+        km._rebuild_dist = lambda: (self.rebuilds.append(1), (True, ""))[1]
+        km._main_drift_check()
+        self.assertEqual(len(self.rebuilds), 1)
+        self.assertEqual(km._REBUILT_FOR[0], "tgt-ui", "the converge latches on the target sha")
+        self.assertEqual(self.banners, [], "no restart banner for a rebuild that cuts nothing")
+        self.assertTrue(any("no restart" in m for m, _ in self.notices))
+        km._main_drift_check()   # same target again: already converged, no second build
+        self.assertEqual(len(self.rebuilds), 1)
+
+    def test_a_failed_build_falls_through_to_the_restart_path_loudly(self):
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-ui")
+        km._kernel_code_changed = lambda a, b: False
+        km._rebuild_dist = lambda: (False, "esbuild boom")
+        km._main_drift_check()
+        self.assertEqual(km._REBUILT_FOR[0], "", "a failed build never latches")
+        self.assertTrue(any(not ok and "esbuild boom" in m for m, ok in self.notices))
+        self.assertEqual([b.get("drift") for b in self.banners], ["restart"],
+                         "the normal restart offer still fires")
+
+    def test_kernel_code_drift_keeps_the_restart_path(self):
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-kern")
+        km._kernel_code_changed = lambda a, b: True
+        km._rebuild_dist = lambda: self.fail("a kernel-code drift must never rebuild in place")
+        km._main_drift_check()
+        self.assertEqual([b.get("drift") for b in self.banners], ["restart"])
+
+    def test_the_classifier_reads_the_touched_paths(self):
+        import subprocess as sp
+        from unittest.mock import patch
+
+        class R:
+            def __init__(self, out, rc=0):
+                self.stdout, self.returncode = out, rc
+        with patch.object(km.subprocess, "run", return_value=R("ui/webview/feed.ts\ndocs/a.md\n")):
+            self.assertFalse(km._kernel_code_changed("a1", "b2"), "UI + docs only: rebuild in place")
+        with patch.object(km.subprocess, "run", return_value=R("ui/webview/feed.ts\nkernel/kernel.py\n")):
+            self.assertTrue(km._kernel_code_changed("a1", "b2"))
+        with patch.object(km.subprocess, "run", return_value=R("", rc=128)):
+            self.assertTrue(km._kernel_code_changed("a1", "b2"), "git failure: the restart is the safe converge")
+        self.assertTrue(km._kernel_code_changed("", "b2"), "unknown shas: the restart is the safe converge")
+
+    def test_the_pull_path_carries_the_same_in_place_converge(self):
+        src = inspect.getsource(km._run_main_update)
+        self.assertIn('if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):', src)
+        self.assertIn("_rebuild_dist()", src)
+        self.assertIn("_REBUILT_FOR[0] = _checkout_sha()", src)


### PR DESCRIPTION
A drift whose commits touch nothing the running process executes (no kernel/, bin/, postal/, cli/ paths) now converges by rebuilding the served bundles in place and posting a reload notice — no kernel restart, zero cut turns. Applies to both the restart-kind drift and the pull path after the checkout advances. Failed builds and git uncertainty fall back to the restart path loudly. Latches per target sha so nothing re-builds or re-nags.

Executed coverage in tests/test_main_drift_notice.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)