### PR TITLE
A goal the user's reply reopened gets a judge's next word

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8323,6 +8323,26 @@ def _status_report_candidates(store, turn):
     return out
 
 
+def _reply_reopened_ids(menu):
+    """Menu goals whose diary says the USER'S OWN REPLY reopened them with no ruling since (the user
+    2026-08-23, the reopen-orphan): a blocked/completed card the user answered flips to Working on the
+    optimistic reopen, and if this closer then closes the reply turn without speaking to the goal,
+    nothing else ever will — the unblocker only examines still-blocked nodes, and the reply turn is
+    romp-injected so the nudge walk cannot re-arm off it. The audited card sat in Working 2h45m with
+    zero judge calls, until the user themselves noticed. The deciding event is the user's msg-reopen
+    (their assertion "not finished", often carrying the answer the block asked for); a later done/block
+    row means a judge already spoke and the flag stands down. Undo-restore reopens are not that
+    assertion and never flag."""
+    out = set()
+    for nd in menu:
+        rows = [e for e in (nd.get("log") or []) if e.get("kind") in ("done", "block", "reopen")]
+        k = max((i for i, e in enumerate(rows) if e.get("kind") in ("done", "block")), default=-1)
+        if any(e.get("kind") == "reopen" and e.get("src") == "user" and e.get("msg")
+               and not e.get("undo") for e in rows[k + 1:]):
+            out.add(nd["id"])
+    return out
+
+
 def _menu_history_text(store, seg_by_id, menu, char_cap):
     """Each menu goal's own raw work-so-far (see _goal_work_text), labeled by its menu number, for the
     closer's <goal-history> block. subtree=False here (unlike the planner's single-target case): the
@@ -8469,6 +8489,19 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                          ", ".join("#%d" % i for i in tflagged),
                          "are" if len(tflagged) > 1 else "is",
                          "each" if len(tflagged) > 1 else "it"))
+    ro_ids = _reply_reopened_ids(menu)
+    rflagged = [i for i, nd in enumerate(menu, 1) if nd["id"] in ro_ids]
+    if rflagged:
+        menu_text += ("\n\nGoal%s %s w%s reopened by the user's own reply after an earlier ruling: "
+                      "they are saying it is not finished, and their reply may answer what it was "
+                      "waiting on. Rule %s explicitly from this turn and its goal history — done only "
+                      "where the outcome plainly landed; blocked where the account ends needing the "
+                      "user again; leaving it open is right only if the session is genuinely "
+                      "continuing the work."
+                      % ("s" if len(rflagged) > 1 else "",
+                         ", ".join("#%d" % i for i in rflagged),
+                         "ere" if len(rflagged) > 1 else "as",
+                         "each" if len(rflagged) > 1 else "it"))
     lift_whys = {nd["id"]: why for nd, why in lifted}
     lflagged = [(i, lift_whys[nd["id"]]) for i, nd in enumerate(menu, 1) if nd["id"] in lift_whys]
     for i, _why in lflagged:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6791,6 +6791,14 @@ def _drive(msg, client):
                     _note_user_goal_write(sid)            # …and it shows even mid-judge-pass (_feed_goals)
                     _mark_views_dirty()                   # a reopen pushes the "Followed up" board at once —
                     #                                       the store write is invisible to the fleet sig
+                    # The reply VOIDS a spent nudge episode (the user 2026-08-23, the reopen-orphan):
+                    # a `failed` latch from the pre-block episode assumed a world where the user hadn't
+                    # answered; their reply IS the answer. The reply turn is romp-injected, so it can
+                    # never re-arm the walk — with the latch left standing, the goal fell into the
+                    # already-nudged branch every tick and sat in Working for hours with no nudge, no
+                    # block, nothing to read (the audited case: 2h45m, ended only by the user noticing).
+                    # Same event-voids-episode reasoning as the awaiting lift's call; live records stay.
+                    _drop_auto_nudge_rec(str(iid))
             except Exception:
                 sys.stderr.write("followup reopen: %s\n" % traceback.format_exc())
             _ack_card_move([iid], ok)                     # …and TELL the client, instead of it timing us out

--- a/tests/test_reopen_next_word.py
+++ b/tests/test_reopen_next_word.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""The reopen-orphan guarantee (the user 2026-08-23): a blocked/completed card the user's reply
+reopened must get a judge's next word. Before this, the optimistic reopen cleared `blocked`, the
+closer could close the reply turn without speaking to the goal, the unblocker skipped it (not
+blocked), and the nudge walk could never re-arm (the reply turn is romp-injected) — while a spent
+`failed` ledger latch from the pre-block episode routed the goal into the already-nudged branch
+every tick. The audited card sat in Working 2h45m with zero judge calls until the user noticed by
+eye. Two arms, executed here: the closer flags reply-reopened menu goals for an explicit ruling,
+and the reply gesture retires the goal's SPENT nudge record so the ladder re-arms. SYNTHETIC only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+T = 1_787_500_000
+
+
+def _node(gid, rows):
+    return {"id": gid, "text": "Run the export pipeline", "parentId": None, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": T, "mt": T, "log": rows}
+
+
+def _row(kind, src, t, **kw):
+    return {"ev_t": t, "at": t, "src": src, "kind": kind, **kw}
+
+
+class ReplyReopenedFlag(unittest.TestCase):
+    def test_a_reply_reopened_goal_flags_until_a_judge_speaks(self):
+        gid = SID + ":g1"
+        nd = _node(gid, [_row("block", "closer", T, why="run this copy command"),
+                         _row("reopen", "user", T + 180, msg=True),
+                         _row("reopen", "planner", T + 180)])
+        self.assertEqual(jd._reply_reopened_ids([nd]), {gid})
+
+    def test_a_later_ruling_stands_the_flag_down(self):
+        gid = SID + ":g1"
+        nd = _node(gid, [_row("block", "closer", T),
+                         _row("reopen", "user", T + 180, msg=True),
+                         _row("done", "closer", T + 400, why="delivered")])
+        self.assertEqual(jd._reply_reopened_ids([nd]), set(),
+                         "the judges already spoke on the reopened goal — nothing owed")
+
+    def test_undo_and_moveless_reopens_never_flag(self):
+        g1, g2 = SID + ":g1", SID + ":g2"
+        undo = _node(g1, [_row("clear", "user", T),
+                          _row("reopen", "user", T + 60, msg=True, undo=True)])
+        judge_only = _node(g2, [_row("block", "closer", T),
+                                _row("reopen", "planner", T + 60)])
+        self.assertEqual(jd._reply_reopened_ids([undo, judge_only]), set(),
+                         "an undo restore and a judge's own unseal are not the user's assertion")
+
+    def test_the_closer_menu_carries_the_instruction(self):
+        src = open(os.path.join(BIN, "romp-judge")).read()
+        self.assertIn("_reply_reopened_ids(menu)", src)
+        self.assertIn("reopened by the user's own reply after an earlier ruling", src)
+
+
+class ReplyRetiresSpentLedger(unittest.TestCase):
+    def test_a_failed_latch_drops_and_a_live_record_stays(self):
+        gid = SID + ":g1"
+        km._put_nudged(gid, {"count": 2, "lastTurnId": "turn-old", "failed": True})
+        km._drop_auto_nudge_rec(gid)
+        self.assertNotIn(gid, km._auto_nudge_data().get("nudged", {}),
+                         "the spent episode's latch is void once the user answered")
+        km._put_nudged(gid, {"count": 1, "lastTurnId": "turn-new"})
+        km._drop_auto_nudge_rec(gid)
+        self.assertIn(gid, km._auto_nudge_data().get("nudged", {}),
+                      "a live mid-episode record is the ladder's memory — never dropped")
+
+    def test_the_reply_gesture_wires_the_retirement(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        i = src.find("jd.optimistic_followup(sid, iid")
+        self.assertGreater(i, 0)
+        self.assertIn("_drop_auto_nudge_rec(str(iid))", src[i:i + 2000],
+                      "the reply that reopens the card also retires its spent nudge episode")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the reopen-orphan: a blocked card the user answers flips to Working and could then sit for hours with no judge ruling, no nudge, and no block (closer omission + unblocker's blocked-only scope + romp-injected reply turn never re-arming the nudge + a spent `failed` ledger latch from the pre-block episode).

- The closer menu flags goals reopened by the user's own reply (no ruling since) and instructs an explicit ruling.
- The reply gesture retires the goal's spent nudge ledger record, so the ladder re-arms; live records stay.

Executed coverage in `tests/test_reopen_next_word.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)