### PR TITLE
Cards stop sticking on Distilling: dead stores settle briefs at the writer, and rebases keep distill fields

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2437,6 +2437,26 @@ def _rebase_onto_disk(fsid, store):
         # verdict FLAGS need no such care: rollup_status below re-derives them all from the merged log.
         if int(dnd.get("mt") or 0) > int(mnd.get("mt") or 0):
             mnd["mt"] = int(dnd["mt"])
+        # DISTILL-FAMILY fields are STATE, not log events, so the event fold above never carried them:
+        # a writer holding a pre-distill snapshot across its model call erased the freshly-published
+        # takeaway/brief on save, the card flipped back to "Distilling…", and the distiller re-ran —
+        # oscillating for as long as writers overlapped (the user 2026-08-23, three live cards mid
+        # restart-storm). Each family merges by its own due stamp: the side whose stamp is newer
+        # distilled a newer episode, so its whole family (line + parts + counters) is adopted as a
+        # unit — half-merged families would pair one episode's text with another's stamps. An EQUAL
+        # or older disk stamp keeps ours, which also preserves the deliberate blockSummary re-open
+        # (the ""→None null keeps its old briefedMt on purpose).
+        for _stamp, _fields in (("distilledMt", ("summary", "summaryParts", "background",
+                                                 "summaryAnchor", "distillFails")),
+                                ("briefedMt", ("blockSummary", "briefParts", "briefFails")),
+                                ("stalledMt", ("stallSummary", "stallFails"))):
+            if int(dnd.get(_stamp) or 0) > int(mnd.get(_stamp) or 0):
+                mnd[_stamp] = dnd[_stamp]
+                for _f in _fields:
+                    if dnd.get(_f) is None:
+                        mnd.pop(_f, None)
+                    else:
+                        mnd[_f] = dnd[_f]
     store["nodes"] = m_nodes
     pl = dict(disk.get("placements") or {}); pl.update(store.get("placements") or {})
     for k, v in list(pl.items()):                    # a tombstoned target re-points to its survivor —

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3502,6 +3502,23 @@ def _dead_wait_sweep(alive_ids, nudged, now):
         try:
             store = jd.load_goals(sid)
             nodes = store.get("nodes", {})
+            # BRIEF REPAIR (the user 2026-08-23, cards "stuck on Distilling" in Blocked): procedural
+            # blocks written before the writers settled briefs inline left blockSummary None on stores
+            # no distill pass will ever visit (dead / transcript-less sessions are outside discover's
+            # 48h window) — the card asked for a brief forever. The why IS the brief for a procedural
+            # block; settle it in place. Runs BEFORE the block calls below, which reload and save
+            # their own store copy — a later save of this snapshot would clobber their writes.
+            healed = False
+            for nid, nd in nodes.items():
+                if (nd.get("blocked") and nd.get("blockSummary") is None
+                        and jd.procedural_block_why(nd.get("blockWhy"))):
+                    nd["blockSummary"] = nd.get("blockWhy") or ""
+                    nd["briefParts"] = None
+                    nd["briefedMt"] = jd._distill_due_t(store, nid, True)
+                    healed = True
+            if healed:
+                jd.save_goals(sid, store)
+                _mark_views_dirty()
             kids = {}
             for nid, nd in nodes.items():
                 if nd.get("parentId"):
@@ -3555,6 +3572,10 @@ def _dead_handoff_block(sid, nid, h, nd, nudged, now):
         if jd.record_verdict(store, cur, "nudge", "block", _ev, why=blkwhy):
             cur["mt"] = _ev
             jd.append_block(sid, nid, "nudge", blkwhy, _ev)
+            if cur.get("blockSummary") is None:       # settle the brief at the writer — same as
+                cur["blockSummary"] = blkwhy          # _dead_wait_block: no distill pass may ever
+                cur["briefParts"] = None              # visit this store, and the why is the decision
+                cur["briefedMt"] = jd._distill_due_t(store, nid, True)
             jd.rollup_status(store, False)
             jd.save_goals(sid, store)
             _mark_views_dirty()
@@ -3599,6 +3620,11 @@ def _dead_wait_block(sid, gid, at, why, nudged, now):
             jd.append_block(sid, gid, "nudge", blkwhy, _ev)   # journal before the save it protects (a judge
             #                                           pass holding this store across its model call erases
             #                                           the row on save; replay re-records it)
+            if nd.get("blockSummary") is None:        # settle the brief AT THE WRITER (the user 2026-08-23,
+                nd["blockSummary"] = blkwhy           # "stuck on Distilling"): this store may never see a
+                nd["briefParts"] = None               # distill pass — dead sessions fall out of discover's
+                #                                       48h window — and the procedural why IS the decision
+                nd["briefedMt"] = jd._distill_due_t(store, gid, True)
             jd.rollup_status(store, False)
             jd.save_goals(sid, store)
             _mark_views_dirty()

--- a/tests/test_dead_wait_block.py
+++ b/tests/test_dead_wait_block.py
@@ -156,6 +156,52 @@ class DeadWaitBlock(unittest.TestCase):
         km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)   # …gone this tick: the death event
         self.assertTrue(jd.load_goals(SID)["nodes"][GID].get("blocked"))
 
+    def test_the_block_writer_settles_the_brief_inline(self):
+        # "Stuck on Distilling" (the user 2026-08-23): a dead store falls out of discover's 48h window,
+        # so no distill pass ever writes its brief — the card asked for one forever. The procedural why
+        # IS the decision; the writer settles blockSummary/briefedMt itself.
+        _seed_store()
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = None
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertTrue(nd.get("blocked"))
+        self.assertEqual(nd.get("blockSummary"), nd.get("blockWhy"),
+                         "the brief settles at the writer — never left for a pass that will not come")
+        self.assertIsNotNone(nd.get("briefedMt"))
+
+    def test_the_sweep_heals_a_pre_existing_briefless_procedural_block(self):
+        # Blocks written before the writers settled briefs inline: blocked, procedural why, no brief.
+        _seed_store()
+        st = jd.load_goals(SID)
+        nd = st["nodes"][GID]
+        jd.record_verdict(st, nd, "nudge", "block", STAMP_T + 100,
+                          why=jd.dead_wait_block_why("the full test suite it kicked off"))
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        self.assertIsNone(jd.load_goals(SID)["nodes"][GID].get("blockSummary"))
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = None
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertTrue((nd.get("blockSummary") or "").startswith(jd.DEAD_WAIT_WHY_PREFIX),
+                        "the repair settles the stuck card's brief from its own why")
+
+    def test_a_genuine_block_why_is_never_repaired_over(self):
+        # The repair takes PROCEDURAL whys only: a genuine decision brief stays the briefer's job.
+        _seed_store()
+        st = jd.load_goals(SID)
+        nd = st["nodes"][GID]
+        jd.record_verdict(st, nd, "closer", "block", STAMP_T + 100,
+                          why="pick a database: sqlite or postgres?")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        _write_state("idle", STAMP_T + 50)
+        km._PREV_ALIVE = None
+        km._dead_wait_sweep(set(), self.nudged, STAMP_T + 900)
+        self.assertIsNone(jd.load_goals(SID)["nodes"][GID].get("blockSummary"),
+                          "a substantive ask keeps waiting for the real briefer")
+
     def test_wake_goal_routes_its_dormant_branch_here(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("return _dead_wait_block(sid, gid, at, why, nudged, now)", src)

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -102,6 +102,57 @@ class StoreCas(unittest.TestCase):
         self.assertIn(("planner", "block"), kinds, "the first writer's event survives")
         self.assertIn(("closer", "done"), kinds, "the second writer's event is there too")
 
+    def test_a_stale_pass_no_longer_erases_a_fresh_takeaway(self):
+        # "Stuck on Distilling" (the user 2026-08-23): distill-family fields are STATE, not log rows,
+        # so the event fold never carried them — a pass holding a pre-distill snapshot across its model
+        # call erased the freshly-published summary on save, the card flipped back to "Distilling…",
+        # and the distiller re-ran, oscillating for as long as writers overlapped.
+        self._seed()
+        gid = self._nid(1)
+        a = jd.load_goals(SID)                       # pass A's snapshot (pre-distill)
+        d = jd.load_goals(SID)                       # the distiller
+        d["nodes"][gid]["summary"] = "Shipped the exporter end to end."
+        d["nodes"][gid]["distilledMt"] = T0 + 500
+        d["nodes"][gid]["blockSummary"] = "Decide: keep or drop the legacy path."
+        d["nodes"][gid]["briefedMt"] = T0 + 500
+        jd.save_goals(SID, d)
+        jd.record_verdict(a, a["nodes"][gid], "planner", "unblock", T0 + 600, why="a's own event")
+        jd.save_goals(SID, a)                        # the stale pass publishes; must rebase, not clobber
+        nd = jd.load_goals(SID)["nodes"][gid]
+        self.assertEqual(nd.get("summary"), "Shipped the exporter end to end.",
+                         "the takeaway survives a stale writer's save")
+        self.assertEqual(nd.get("distilledMt"), T0 + 500)
+        self.assertEqual(nd.get("blockSummary"), "Decide: keep or drop the legacy path.")
+
+    def test_the_newer_distill_episode_wins_and_a_deliberate_reopen_is_kept(self):
+        self._seed()
+        gid = self._nid(1)
+        # disk holds an OLD episode; our snapshot re-distilled a NEWER one → ours stands
+        d0 = jd.load_goals(SID)
+        d0["nodes"][gid]["summary"] = "old episode"
+        d0["nodes"][gid]["distilledMt"] = T0 + 100
+        jd.save_goals(SID, d0)
+        mine = jd.load_goals(SID)
+        stale = jd.load_goals(SID)
+        mine["nodes"][gid]["summary"] = "new episode"
+        mine["nodes"][gid]["distilledMt"] = T0 + 200
+        jd.save_goals(SID, stale)                    # move the rev so mine must rebase
+        jd.save_goals(SID, mine)
+        self.assertEqual(jd.load_goals(SID)["nodes"][gid].get("summary"), "new episode")
+        # the blocked path's deliberate ""→None re-open keeps its OLD briefedMt on purpose: an equal
+        # disk stamp must not resurrect the "" it nulled
+        b0 = jd.load_goals(SID)
+        b0["nodes"][gid]["blockSummary"] = ""
+        b0["nodes"][gid]["briefedMt"] = T0 + 300
+        jd.save_goals(SID, b0)
+        reopener = jd.load_goals(SID)
+        mover = jd.load_goals(SID)
+        reopener["nodes"][gid]["blockSummary"] = None
+        jd.save_goals(SID, mover)                    # rev moves; the re-opener must rebase
+        jd.save_goals(SID, reopener)
+        self.assertIsNone(jd.load_goals(SID)["nodes"][gid].get("blockSummary"),
+                          "an equal disk stamp keeps the re-opener's pending state")
+
     def test_a_node_minted_by_the_other_writer_is_adopted(self):
         self._seed()
         a = jd.load_goals(SID)                       # snapshot before the other writer mints


### PR DESCRIPTION
Resolved cards sat on "Distilling…" indefinitely for two reasons:

1. The dead-wait sweep blocks cards on stores the distiller can never visit (dead/transcript-less sessions fall outside discover's 48h window), so their decision brief was never written. The block writers now settle the brief inline — the procedural why is the decision — and the sweep heals pre-existing briefless procedural blocks. Genuine asks are untouched.
2. `save_goals`' rebase folded log events but carried non-log fields from the stale snapshot, so an overlapping pass erased freshly published takeaways/briefs and the card oscillated back to "Distilling…". Distill families now merge by their own due stamps.

Executed coverage in `tests/test_dead_wait_block.py` and `tests/test_judge_store_cas.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)