### PR TITLE
Docs and help say scripted senders should tag their sends

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -658,7 +658,7 @@ EOF
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
-    _romp_cmd "romp send <session> <text>" -            "Hand a session a message (kernel API, either backend)"
+    _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
     _romp_cmd "romp end <session>"         -            "End a session"
     _romp_cmd "romp checkin <host>"        -            "Publish this machine to an attached hub (romp checkout withdraws)"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -33,7 +33,7 @@ These are for scripting and for agents rather than daily use:
 | `romp url` | Print only the tokened dashboard URL, for piping |
 | `romp sessions [--json]` | The fleet with each session's state, identity colours, directory and backend |
 | `romp mail …` | The postal service from the shell (below) |
-| `romp send <session> <text>` | Hand a session a message, on either backend |
+| `romp send <session> [--tag <label>] <text>` | Hand a session a message, on either backend. Anything a script, cron job, or launcher composes SHOULD carry a tag (one word, letters/digits/dashes, up to 24 chars): the chat then renders it as machine-sent under that label instead of as the user's typed words. Raw POST /send callers pass it as the JSON `tag` field (`{name, text, tag}` — a malformed tag fails the whole send, loudly); `--tag` is the CLI's equivalent. Both resolve to the `<!-- romp-tag: <label> -->` marker in the delivered text |
 | `romp interrupt <session>` | Interrupt whatever turn a session is taking |
 | `romp end <session>` | End a session |
 | `romp checkin <host>` / `romp checkout <host>` | Publish this machine to an attached hub, or withdraw it |

--- a/tests/test_courier_link.py
+++ b/tests/test_courier_link.py
@@ -101,14 +101,27 @@ class DormantHandoffConverts(unittest.TestCase):
         d = jd.STATE / "states"
         d.mkdir(parents=True, exist_ok=True)
         (d / (SENDER + ".jsonl")).write_text(json.dumps({"state": "idle", "t": T + 50}) + "\n")
+        # the names-registry launch record: what marks a reg-less sid as one the owner scan can
+        # answer for — without it the corroborator reads the sid as transcript-derived and stands down
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / SENDER).write_text("web\t~/notes-api\t#3355aa\t#ffffff\n")
         km._PREV_ALIVE = None
         self.nudged = {}
+        # hermetic liveness (the corroboration the sweep runs since the deadwait-probe change): the
+        # owner scan answers WITHOUT this synthetic sid, so the death is corroborated — the world
+        # these tests assert. Same fixture as test_dead_wait_block.py; without it the corroborator
+        # returns None (reg-less sid, no owner answer) and the sweep rightly stands down.
+        km._TMUX.available = lambda: True
+        km._TMUX.alive_sids = lambda t=3: set()
 
     def tearDown(self):
+        for nm in ("available", "alive_sids"):
+            km._TMUX.__dict__.pop(nm, None)   # instance attrs shadow the class methods; drop them
         for f in jd.GOALDIR.glob("*"):
             f.unlink()
         for f in (jd.STATE / "states").glob("*"):
             f.unlink()
+        (jd.NAMES / SENDER).unlink(missing_ok=True)
 
     def test_dormant_sender_handoff_blocks_with_the_dead_wait_why(self):
         km._dead_wait_sweep(set(), self.nudged, T + 900)


### PR DESCRIPTION
The tagged-send convention (POST /send `tag` field, `romp send --tag`, the chat's machine-sent identity) existed but was undocumented, so a host-crontab send went out untagged and rendered as the user's typed words. The help line and reference now state the convention and document both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)