### PR TITLE
run_propagate processes every ref inside the loop, and a refless node is a no-op

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10794,17 +10794,17 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                      if isinstance(l, dict) and l.get("peer") and l.get("goalId")]
             for ref in refs:
                 a_sid, a_gid = ref["peer"], ref["goalId"]
-            a_store = load_goals(a_sid)
-            a_node = a_store.get("nodes", {}).get(a_gid)
-            if not a_node or a_node.get("nodeComplete"):
-                continue                                # sender's tracking node gone or already done → idempotent
-            record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now,
-                           why="completed by %s (delegated)" % (name or fsid[:8]))
-            _mark_node_done(a_store, a_gid, "completed by %s (delegated)" % (name or fsid[:8]), now,
-                            src="courier")
-            rollup_status(a_store, False)               # sender just had work close → recompute its columns
-            save_goals(a_sid, a_store)
-            n += 1
+                a_store = load_goals(a_sid)
+                a_node = a_store.get("nodes", {}).get(a_gid)
+                if not a_node or a_node.get("nodeComplete"):
+                    continue                            # sender's tracking node gone or already done → idempotent
+                record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now,
+                               why="completed by %s (delegated)" % (name or fsid[:8]))
+                _mark_node_done(a_store, a_gid, "completed by %s (delegated)" % (name or fsid[:8]), now,
+                                src="courier")
+                rollup_status(a_store, False)           # sender just had work close → recompute its columns
+                save_goals(a_sid, a_store)
+                n += 1
     if verbose:
         sys.stderr.write("romp-judge: propagated %d delegation completions\n" % n)
     return n

--- a/tests/test_courier_link.py
+++ b/tests/test_courier_link.py
@@ -89,6 +89,40 @@ class CourierLinkRepair(unittest.TestCase):
         snd = jd.load_goals(SENDER)["nodes"][SENDER + ":g1"]
         self.assertTrue(snd.get("nodeComplete"), "the handoff checks off from the repaired link")
 
+    def test_a_refless_completed_node_never_kills_the_pass(self):
+        # THE 2026-08-23 REGRESSION: the refs loop's body sat OUTSIDE the loop, so the first completed
+        # node with NO origin/links hit an unbound name and the exception killed run_propagate — and
+        # with it every stage after it in the triage pass (grouper, consolidator, distiller), which is
+        # how "everything stuck on Distilling" happened. A plain completed node must be a no-op.
+        st = jd.load_goals(RECIP)
+        st["nodes"][RECIP + ":g0"] = jd.GuardedNode({
+            "id": RECIP + ":g0", "text": "An ordinary finished goal", "parentId": None,
+            "nodeComplete": True, "blocked": False, "cleared": False, "trail": [],
+            "t": T - 100, "mt": T - 100, "log": []})
+        jd.save_goals(RECIP, st)
+        jd.run_propagate(now=T + 200)   # must not raise, and must not touch the sender
+
+    def test_every_ref_completes_its_own_sender_node(self):
+        # Multi-ref: origin AND a repaired link each complete their sender's tracking node — the
+        # mis-indented loop processed only the LAST ref.
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":g2"] = jd.GuardedNode({
+            "id": SENDER + ":g2", "text": "↪ delegated to api: second thread of the exporter",
+            "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
+            "trail": [], "t": T, "mt": T, "handoff": {"peer": RECIP, "msgId": "msg-bbbb-2222"}, "log": []})
+        jd.save_goals(SENDER, st)
+        st = jd.load_goals(RECIP)
+        nd = st["nodes"][RECIP + ":g5"]
+        nd["origin"] = {"peer": SENDER, "goalId": SENDER + ":g1", "msgId": MID}
+        nd["links"] = [{"peer": SENDER, "goalId": SENDER + ":g2", "msgId": "msg-bbbb-2222"}]
+        jd.record_verdict(st, nd, "closer", "done", T + 100, why="shipped")
+        jd.rollup_status(st, True)
+        jd.save_goals(RECIP, st)
+        jd.run_propagate(now=T + 200)
+        snd = jd.load_goals(SENDER)
+        self.assertTrue(snd["nodes"][SENDER + ":g1"].get("nodeComplete"), "the origin's sender node completes")
+        self.assertTrue(snd["nodes"][SENDER + ":g2"].get("nodeComplete"), "the link's sender node completes too")
+
     def test_courier_scan_carries_the_repair_branch(self):
         src = open(os.path.join(BIN, "romp-judge")).read()
         self.assertIn("_attach_courier_link(cstore, seg[\"id\"], pm0[1])", src)


### PR DESCRIPTION
The courier-link change left the refs loop's body outside the loop: the first completed node with no origin/links raised an unbound name, killing run_propagate and every later triage stage (grouper, consolidator, distiller) — the deepest cause of cards accumulating on "Distilling…" tonight. Multi-ref nodes also only completed their last ref.

Fix: body inside the loop. Regression tests: refless completed node is a no-op (the crash repro), and every ref completes its own sender node.

Found by the restart-hygiene audit's adversarial verify pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)