### PR TITLE
The Stage button rests neutral — accent is a hover cue, not rest chrome

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -221,7 +221,11 @@ test("context stages ALONE, and the chips strip carries the visible Stage button
   assert.match(RENDER, /if \(!typed && !\(composerCitations\.get\(activeId\) \|\| \[\]\)\.some\(\(c\) => c\.quote\)\) return;/,
     "empty box + a quote chip is stageable; empty box + nothing is not");
   assert.match(RENDER, /fireStage = \(\) => stageComposer\(\);/, "the strip's door into the composer closure");
-  assert.match(RENDER, /const st = el\("button", "staged-go composer-stage-btn"\) as HTMLButtonElement;/);
+  assert.match(RENDER, /const st = el\("button", "composer-stage-btn"\) as HTMLButtonElement;/);
+  // neutral at rest (the user 2026-08-23): an accent outline beside the accent-blue chips read as
+  // already-pressed. Rest = the button family's dress; the accent appears only on hover.
+  assert.match(CSS, /\.composer-stage-btn \{ position: absolute; right: 2px; top: 0; background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
+  assert.match(CSS, /\.composer-stage-btn:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/);
   assert.match(RENDER, /st\.title = "hold this context \(and anything typed\) for one combined send later — ⌘⏎ does the same";/);
   assert.match(CSS, /\.composer-stage-btn \{ position: absolute; right: 2px; top: 0;/,
     "pinned to the RIGHT of the blue context chips");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9368,7 +9368,7 @@ function renderComposerChips(id: string | null): void {
   // context is held the strip carries its visible face — right of the blue chips, gone with them.
   // Same action as the shortcut: stage the context (and any typed text) and keep going.
   {
-    const st = el("button", "staged-go composer-stage-btn") as HTMLButtonElement;
+    const st = el("button", "composer-stage-btn") as HTMLButtonElement;
     st.type = "button";
     st.textContent = "Stage";
     st.title = "hold this context (and anything typed) for one combined send later — ⌘⏎ does the same";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -605,12 +605,14 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
 .staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }
-/* the chips strip's Stage button (the user 2026-08-23): the staged strip's own button dress, pinned
-   to the RIGHT of the blue context chips; it exists exactly while context is held (the strip
-   renders it, and the strip hides with the chips) */
-.composer-stage-btn { position: absolute; right: 2px; top: 0; background: none; border: 1px solid var(--accent);
-  color: var(--accent); border-radius: 5px; font-size: 0.78em; padding: 1px 8px; cursor: pointer; }
-.composer-stage-btn:hover { background: var(--accent); color: var(--accent-fg); }
+/* the chips strip's Stage button (the user 2026-08-23), pinned to the RIGHT of the blue context
+   chips; it exists exactly while context is held (the strip renders it, and the strip hides with
+   the chips). NEUTRAL at rest (the under-bubble button family's dress): an accent outline next to
+   the accent-blue chips read as already-pressed — accent is for hover/selected, never rest chrome */
+.composer-stage-btn { position: absolute; right: 2px; top: 0; background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.78em;
+  padding: 1px 8px; cursor: pointer; }
+.composer-stage-btn:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 .staged-chip { display: flex; flex-direction: column; gap: 2px; border: 1px dashed rgba(156, 210, 255, 0.45);
   border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg);
   cursor: pointer; }


### PR DESCRIPTION
## What

The composer's Stage button (right of the blue context chips) no longer wears the accent outline at rest: it rests in the button family's neutral dress (box-border outline, dim text, the 0.06 white ground) and lights accent only on hover. It also carries its own class alone instead of borrowing the staged strip's, so no strip-scoped rule can re-skin it by mount point.

## Why

Accent at rest beside accent-blue chips read as an already-pressed control (the user 2026-08-23). The borrowed dress works inside the staged strip's dim header, where it marks that strip's primary action; next to blue chips it misreads. Accent is for hover/selected states, never rest chrome (CLAUDE.md's accent rule).

## Tests

`composer-citation.test.ts` repins the element's class and the neutral-rest + accent-hover rules. Suites: 2205 JS tests green; the styles-adjacent python files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)