### PR TITLE
An awaiting card says its wait once, and a delegation wait names its peers

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11746,6 +11746,26 @@ def _session_stamped_tops(sid):
     return _session_stamp_read(sid)[1]
 
 
+def _handoff_peer_identities(nodes, hnodes):
+    """The STRUCTURED peer identities behind a delegation wait — [{name, host, sid, color}] sorted by
+    name, or None. Rides the card's awaiting payload beside the prose why (the user 2026-08-23: an
+    awaiting-a-peer card must NAME the peer the way every other surface does — identity colour, quiet
+    host: prefix), so the feed's awaiting box renders it like the ↪ from line. Same resolution as
+    `origin`: live registry name first (a rename reads fresh), the sid stub when this kernel cannot
+    resolve; a ":" in the recorded sid is federation's own host marker, carried as `host` only when
+    the name did NOT resolve locally (a local resolve means a local peer, no prefix)."""
+    seen = {}
+    for x in hnodes:
+        psid = str((nodes.get(x, {}).get("handoff") or {}).get("peer") or "")
+        if not psid or psid in seen:
+            continue
+        pn = _name_of(psid)
+        seen[psid] = {"name": pn or psid.split(":")[-1][:8],
+                      "host": ("" if pn or ":" not in psid else psid.split(":", 1)[0]),
+                      "sid": psid, "color": _name_color(psid)}
+    return sorted(seen.values(), key=lambda d: d["name"]) or None
+
+
 def _session_delegated_why(sid):
     """The session-scoped DELEGATION wait (or None): every open leaf of some inbox-visible top is a
     courier handoff — the only outstanding work lives with peers. The SAME evidence the feed's per-card
@@ -17757,14 +17777,15 @@ def build_feed(now, tmux=None):
             # _session_awaiting's stamp branch — keep the two in step (the user 2026-08-08).
             _deleg_why = None
             _deleg_since = None
+            _deleg_peers = None
             if col == "working" and not _stamp_why and not _await_ok \
                     and _all_outstanding_delegated(nodes, nid):
                 _hnodes = [x for x in _subtree(nid)
                            if isinstance(nodes[x].get("handoff"), dict)
                            and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
-                _peers = sorted({(_name_of((nodes[x].get("handoff") or {}).get("peer")) or "a peer")
-                                 for x in _hnodes})
-                _deleg_why = "delegated to %s; waiting on their result" % (", ".join(_peers) or "a peer")
+                _deleg_peers = _handoff_peer_identities(nodes, _hnodes)
+                _peers = sorted({d["name"] for d in (_deleg_peers or [])} or {"a peer"})
+                _deleg_why = "delegated to %s; waiting on their result" % ", ".join(_peers)
                 # the newest outstanding handoff's mint — the last local act before the wait began
                 _deleg_since = max([nodes[x].get("t") or 0 for x in _hnodes] or [0]) or None
             if nid != api_top and nid != perm_top and col in ("working", "blocked") and (
@@ -17797,12 +17818,14 @@ def build_feed(now, tmux=None):
             await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
             await_kind = None                        # the winning why's KIND and SINCE ride beside it,
             await_since = None                       # mirroring the or-chain exactly (a kindless winner
-            if col == "awaiting":                    # stays kindless; since = the wait's own event time)
-                for _w, _k, _s in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since),
-                                   (_stamp_why, _stamp_kind, _stamp_since),
-                                   (_deleg_why, "peer", _deleg_since), (_owned_why, "task", _owned_since)):
+            await_peers = None                       # stays kindless; since = the wait's own event time).
+            if col == "awaiting":                    # peers = structured identities, delegation arm only
+                for _w, _k, _s, _p in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, None),
+                                       (_stamp_why, _stamp_kind, _stamp_since, None),
+                                       (_deleg_why, "peer", _deleg_since, _deleg_peers),
+                                       (_owned_why, "task", _owned_since, None)):
                     if _w:
-                        await_kind, await_since = _k, _s
+                        await_kind, await_since, await_peers = _k, _s, _p
                         break
             # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
             # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent
@@ -18063,6 +18086,7 @@ def build_feed(now, tmux=None):
                 # when present the card wears the compact "Waiting on task" pill (expands to this list, like
                 # Sub-goals) instead of the boxed why; empty for subagent/overlay flavors, which keep the box.
                 "awaiting": ({"why": await_why, "kind": await_kind, "since": await_since,
+                              "peers": await_peers,   # delegation wait → [{name, host, sid, color}] for the identity-coloured box (the user 2026-08-23)
                               "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -258,6 +258,27 @@ class SessionLevelDelegation(unittest.TestCase):
                          {"kind": "peer", "why": "delegated to probe; waiting on their result",
                           "since": None})   # the handoff graph has no single event time here → no duration
 
+    def test_handoff_peer_identities_carry_name_host_and_colour_for_the_card(self):
+        # the card's awaiting box names the peers the way the origin line does (the user 2026-08-23):
+        # identity colour + quiet host: prefix. The helper resolves the live registry name first; a
+        # sid it cannot resolve keeps federation's recorded host marker and falls to the sid stub.
+        saved = km._name_color
+        km._name_color = lambda s: {"bg": "#abc", "fg": "#000"}
+        try:
+            far = "farhost:88888888-9999-aaaa-bbbb-cccccccccccc"
+            nodes = self._delegated_store()
+            h2 = self._handoff("h2", "g1"); h2["handoff"]["peer"] = far
+            h3 = self._handoff("h3", "g1")                       # duplicate peer → one identity
+            nodes.update({"h2": h2, "h3": h3})
+            got = km._handoff_peer_identities(nodes, ["h1", "h2", "h3"])
+            self.assertEqual(got, [
+                {"name": "88888888", "host": "farhost", "sid": far, "color": {"bg": "#abc", "fg": "#000"}},
+                {"name": "probe", "host": "", "sid": self.PEER, "color": {"bg": "#abc", "fg": "#000"}},
+            ])
+            self.assertIsNone(km._handoff_peer_identities(nodes, []), "no handoffs, no list — never []")
+        finally:
+            km._name_color = saved
+
     def test_stamp_false_stays_none_so_the_feed_keeps_scoping_per_card(self):
         self._seed(self._delegated_store())
         self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=False))

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -134,6 +134,13 @@ function _prefixIdBearing(host: string, o: any, idKey: string): any {
   // and keep peerSid bare — the viewer may be that very host, where the bare uuid opens directly.
   if (out.origin && typeof out.origin === "object" && typeof out.origin.peerSid === "string" && !out.origin.peerHost)
     out.origin = { ...out.origin, peerHost: host, peerSid: prefixId(host, out.origin.peerSid) };
+  // The awaiting box's delegation peers (asks[].awaiting.peers) — same rule as origin: a peer the
+  // card's own kernel resolved (host "") is LOCAL TO THAT KERNEL, so attribute it here and prefix
+  // its sid for routing; an already-hosted peer passes through untouched (the user 2026-08-23).
+  if (out.awaiting && typeof out.awaiting === "object" && Array.isArray(out.awaiting.peers))
+    out.awaiting = { ...out.awaiting, peers: out.awaiting.peers.map((p: Record<string, unknown>) =>
+      p && typeof p === "object" && typeof p.sid === "string" && !p.host
+        ? { ...p, host, sid: prefixId(host, p.sid) } : p) };
   // a timeline lane's fork parent (sessions[].branch.fromId): the view looks it up against PREFIXED
   // lane ids (vidx), so an unprefixed remote parent silently missed and the branch connector never
   // drew for remote lanes (found 2026-08-17 auditing the merge)

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -26,7 +26,7 @@ test("the swirl is driven by spinFor's caption — shown when there is one, else
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
   assert.match(FEED, /a\._awaitSpin\.style\.display = spinCaption \? "" : "none";/);
-  assert.match(FEED, /a\._awaitWhy\.textContent = spinCaption; a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
+  assert.match(FEED, /\} else a\._awaitWhy\.textContent = spinCaption;\n\s*a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });
 
 test("a bg-task wait wears the compact 'Awaiting task' pill that expands the task list (the user 2026-07-13)", () => {
@@ -80,4 +80,21 @@ test("the swirl uses the shared glyph, spins SLOWER (calmer) + reverse like the 
   assert.match(CSS, /animation: fask-swirl-spin 2\.4s linear infinite;/);   // slowed from 1.4s (the user 2026-06-29)
   assert.match(CSS, /@keyframes fask-swirl-spin \{ to \{ transform: rotate\(-360deg\); \} \}/);   // reverse, like rl-spin
   assert.match(CSS, /@media \(prefers-reduced-motion: reduce\) \{ \.fask-awaiting-swirl \{ animation: none; \} \}/);
+});
+
+test("a DELEGATION wait names its peers like the ↪ from line — identity colour, quiet host: prefix (the user 2026-08-23)", () => {
+  // the kernel ships structured identities on the delegation arm (awaiting.peers); the box renders
+  // them with hostPartsNodes + the peer's identity colour instead of a colourless "Awaiting peer"
+  assert.match(FEED, /const awPeers = \(awaitingBg && it\.awaiting && it\.awaiting\.peers\) \|\| \[\];/);
+  assert.match(FEED, /nm\.replaceChildren\(\.\.\.hostPartsNodes\(p\.host, p\.name\)\);/);
+  assert.match(FEED, /if \(p\.color && p\.color\.bg\) nm\.style\.color = p\.color\.bg;/);
+  // the elapsed readout survives the structured path (the pill/box parity rule of 2026-08-23)
+  assert.match(FEED, /a\._awaitWhy\.append\(waitedSuffix\(it\.awaiting && it\.awaiting\.since, Date\.now\(\) \/ 1000\)\);/);
+  // older kernels ship no peers → the ladder's plain caption is the fallback
+  assert.match(FEED, /\} else a\._awaitWhy\.textContent = spinCaption;/);
+  // federation attributes a kernel-local peer to that kernel and prefixes its sid, exactly as it
+  // does for origin.peerSid — a merged card's peer name keeps its host and its click routes home
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  assert.match(FED, /if \(out\.awaiting && typeof out\.awaiting === "object" && Array\.isArray\(out\.awaiting\.peers\)\)/);
+  assert.match(FED, /\? \{ \.\.\.p, host, sid: prefixId\(host, p\.sid\) \} : p\) \};/);
 });

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -102,7 +102,8 @@ interface AskItem {
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string; since?: number } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25). since = when the unanswered ask was sent → the chip's elapsed readout (the user 2026-08-23)
-  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why. since = the wait's own event time → the box/pill elapsed readout (the user 2026-08-23)
+  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: string[] | null;
+               peers?: { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null }[] | null } | null;   // peers: delegation wait → the box names them in identity colour (the user 2026-08-23)   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why. since = the wait's own event time → the box/pill elapsed readout (the user 2026-08-23)
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
   provisional?: boolean;                           // a LIVE-PROMPT placeholder (kernel _provisional_card): the session is working an in-progress turn the planner hasn't classified yet. No goal node (empty tree) — dim, non-interactive, no clear/nudge/modal; replaced by the real card once the planner places the segment.
@@ -1674,7 +1675,25 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // because spin reads as in-flight and nothing is (the user 2026-08-14).
   a._awaitSpin.classList.toggle("await-paused", awaitingBg);
   a._awaitSpin.classList.toggle("await-still", !!spin.still);
-  if (spinCaption) { a._awaitWhy.textContent = spinCaption; a._awaitSpin.title = spinTip || spinCaption; }
+  if (spinCaption) {
+    // a DELEGATION wait names its peers the way the "↪ from" line does (the user 2026-08-23): the
+    // quiet host: prefix + the peer's identity colour, never a colourless "Awaiting peer". The
+    // ladder's caption stays the fallback (older kernel payloads carry no peers).
+    const awPeers = (awaitingBg && it.awaiting && it.awaiting.peers) || [];
+    if (awPeers.length) {
+      a._awaitWhy.replaceChildren();
+      a._awaitWhy.append("Awaiting ");
+      awPeers.forEach((p, i) => {
+        if (i) a._awaitWhy.append(", ");
+        const nm = el("span", "fask-waiton-name");
+        nm.replaceChildren(...hostPartsNodes(p.host, p.name));
+        if (p.color && p.color.bg) nm.style.color = p.color.bg;
+        a._awaitWhy.appendChild(nm);
+      });
+      a._awaitWhy.append(waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000));
+    } else a._awaitWhy.textContent = spinCaption;
+    a._awaitSpin.title = spinTip || spinCaption;
+  }
   // The swirl's "Analyzing…" caption + tooltip REPLACES the separate "↩ re-judging" chip (the user
   // 2026-06-29: don't show both) — drop the chip the recheck branch set above when the swirl is saying it.
   // ("Analyzing…" is the user-facing label for the re-judging spin, the user 2026-07-08.)

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -65,14 +65,11 @@ test("AWAITING uses the kernel's why verbatim (capitalized) when it reads 'waiti
 
 test("a peer wait (waitingOn chip) and a bg-TASK wait (pill) both defer — no generic awaiting box", () => {
   // the "Awaiting <peer>" chip / the "Awaiting task" pill already carry these; the box would double up.
-  // Carve-out (the user 2026-08-23): ON the working column a task-ful await now captions itself —
-  // deferring there dropped the card to the "Paused" floor directly under the pill. Off-column,
-  // where no floor exists, both still defer.
   assert.equal(spinFor({ awaiting: { why: "x" }, waitingOn: "peer" }, false, false).caption, null);
   assert.equal(spinFor({ awaiting: { why: "x", tasks: ["t1"] } }, false, false).caption, null);
   const pw = spinFor({ awaiting: { why: "x" }, waitingOn: "peer", column: "working", sessState: "quiet" }, false, false);
   assert.ok(!pw.awaitingBg, "a peer wait never wears the awaiting box on any column — the chip carries it");
-  assert.ok(!/^Waiting on a background task/.test(pw.caption || ""), "and never the bg-task caption");
+  assert.ok(!/task/.test(pw.caption || ""), "and never a bg-task caption");
 });
 
 // --- the wait's elapsed readout (the user 2026-08-23) -----------------------------------------------
@@ -183,7 +180,7 @@ test("feed.ts routes the card's swirl through spinFor and keeps no inline copy o
   // …and it still drives the same DOM
   assert.match(FEED, /a\._awaitSpin\.style\.display = spinCaption \? "" : "none";/);
   assert.match(FEED, /a\._awaitSpin\.classList\.toggle\("await-paused", awaitingBg\);/);
-  assert.match(FEED, /a\._awaitWhy\.textContent = spinCaption; a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
+  assert.match(FEED, /\} else a\._awaitWhy\.textContent = spinCaption;\n\s*a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });
 
 // --- the working narration (the user 2026-08-13): the previously-mute ordinary working card ---------
@@ -240,7 +237,9 @@ test("THE FLOOR IS TOTAL — a working-column card can never be mute (the user 2
   assert.equal(unk.still, true);
   assert.match(spinFor({ column: "working" }, false, false, 100).caption || "",
                /unknown/, "even a payload with NO floor field reads as unknown, never as silence");
-  // the totality sweep: every combination of the ladder's inputs with column=working → a caption
+  // the totality sweep: every combination of the ladder's inputs with column=working → a caption.
+  // The ONE documented exception is awaiting-with-TASKS (not in this matrix): its pill + open list
+  // carry the card, so the spin line alone goes quiet — the card is never mute (see the test above).
   const bools: (true | undefined)[] = [undefined, true];
   for (const judging of bools) for (const recheck of bools) for (const rejudging of bools)
     for (const provisional of bools) for (const dp of [false, true])
@@ -256,13 +255,21 @@ test("THE FLOOR IS TOTAL — a working-column card can never be mute (the user 2
 });
 
 
-test("awaiting WITH tracked tasks names the first task — never the paused floor (2026-08-23)", () => {
-  // the screenshot contradiction: an "Awaiting task" pill above a "Paused — nothing is in motion"
-  // caption. With tasks present the caption keeps the awaiting read and names the wait.
+test("awaiting WITH tracked tasks says it ONCE — no caption, and never the paused floor (2026-08-23)", () => {
+  // Two screenshots, one day. The first: the pill above a "Paused — nothing is in motion" floor —
+  // fixed by naming the first task in a caption. The second: pill + that caption + the now
+  // open-by-default task list saying one wait three times. The pill and its list ARE the awaiting
+  // read; the ladder stays silent for it, floors included.
   const s = spinFor({ awaiting: { why: "waiting on 2 background tasks", kind: "task",
                                   tasks: ["Notify when the release PRs settle", "suite run"] },
                       column: "working", sessState: "quiet" }, false, false);
-  assert.equal(s.awaitingBg, true);
-  assert.match(s.caption || "", /^Waiting on a background task: Notify when the release PRs settle/);
-  assert.ok(!/Paused/.test(s.caption || ""), "the quiet floor must not fire under an Awaiting-task pill");
+  assert.equal(s.caption, null, "the pill + open task list are the one awaiting read");
+  assert.equal(spinFor({ awaiting: { tasks: ["t"] }, column: "working", sessState: "unknown" },
+                       false, false).caption, null, "the unknown floor stands down under the pill too");
+  // an OPEN turn still narrates: the session working WHILE tasks run is new information
+  const open = spinFor({ awaiting: { tasks: ["t"] }, column: "working", sessState: "open" }, false, false);
+  assert.equal(open.caption, "Working…");
+  // …and so do the richer in-motion stories (a re-judge under an awaiting pill is worth a line)
+  const rj = spinFor({ awaiting: { tasks: ["t"] }, rejudging: true, column: "working" }, false, false);
+  assert.equal(rj.caption, "Analyzing…");
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -12,15 +12,19 @@
 //
 // THE CONTRACT (spin-caption.test.ts executes every branch, in order):
 //   1. AWAITING      — held in Working on dispatched/delegated work (no peer chip). With tracked
-//                      tasks the caption NAMES the first one (2026-08-23: the pill-only design let
-//                      the quiet floor say "nothing is in motion" under an Awaiting-task pill)
+//                      tasks there is NO caption at all (2026-08-23): the "Awaiting task" pill and
+//                      its open-by-default list are the one awaiting read, and the quiet/unknown
+//                      floors stand down under them (branch 8) — a caption here said the same wait
+//                      a third time. A wait on PEERS renders their names in identity colour
+//                      (feed.ts reads awaiting.peers; the caption is the colourless fallback).
 //   2. PROVISIONAL   — a dashed live-prompt placeholder the planner hasn't classified yet
 //   3. RE-CHECK      — a soft-block answered with a TARGETED follow-up, pending re-judge
 //   4. RE-JUDGING    — a soft-block + a PLAIN thread reply, with the reply in flight
 //   5. SETTLE GAP    — the turn finished, the closer's verdict hasn't landed
 //   6. DISTILLING    — a resolved card whose takeaway/brief hasn't been written yet
 //   7. NARRATION     — the ordinary working card with its turn open: live tool count + duration
-//   8. THE FLOOR     — any OTHER working-column card, by sessState: "open" (turn running, narration
+//   8. THE FLOOR     — any OTHER working-column card, by sessState — except quiet/unknown under an
+//                      Awaiting-task pill, which return NO caption (see 1): "open" (turn running, narration
 //                      not reported — an older/disconnected kernel) spins a plain Working…; "quiet"
 //                      (between turns) and "unknown" (no signal at all) render a STILLED glyph + a
 //                      line saying exactly that. Total: a working-column card can never be mute
@@ -85,22 +89,12 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
   // a bg-TASK wait no longer boxes its why here (the user 2026-07-13): the compact "Awaiting task" pill
   // on the toggles row carries it (with the task list one click away, like Sub-goals) — see applySections
   const awTasks = ((aw && aw.tasks) || []).filter(Boolean);
-  // Only the WORKING column carries this caption: elsewhere there is no floor to contradict,
-  // and the 2026-07-13 rule (the pill alone carries a bg-task wait) still holds.
-  if (aw && !it.waitingOn && awTasks.length && it.column === "working") {
-    // AWAITING with TRACKED TASKS (the user 2026-08-23, from a screenshot of the contradiction): the
-    // 2026-07-13 rule handed the why to the "Awaiting task" pill and let this card fall through to
-    // the quiet floor — which then said "Paused — nothing is in motion" DIRECTLY UNDER the pill
-    // saying work is in flight. Two surfaces on one card disagreed. The caption keeps the awaiting
-    // read and NAMES the first awaited task; the pill still expands the full list.
-    const first = String(awTasks[0] || "background work");
-    return {
-      caption: "Waiting on a background task: " + first,
-      tip: (aw.why || "Waiting on background work it dispatched.")
-        + " Not on you; the Awaiting-task list below has each one.",
-      awaitingBg: true,
-    };
-  }
+  // A bg-TASK wait says it ONCE (the user 2026-08-23, second screenshot of the day): the "Awaiting
+  // task" pill + its open-by-default list are the whole read. The first cut of today's fix named the
+  // first task in a caption here — and with the list now open by default, one card said the same
+  // wait three times (pill, caption, list row). No caption, then; the floor guards below keep the
+  // quiet/unknown lines from contradicting the pill instead (that contradiction is what the caption
+  // was for).
   if (aw && !it.waitingOn && !awTasks.length) {
     // AWAITING — the session is held, waiting on work it dispatched. It keeps its own read: a boxed
     // "Awaiting <kind-word>" label, the kind carried as DATA from the kernel (the user 2026-08-15) so
@@ -210,6 +204,11 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // kernel, a cold parse cache), rendered a MUTE card. Every working-column card now says its
     // state; when nothing is in motion the glyph STILLS (`still`) — a spinning swirl on a quiet
     // card would claim work that isn't happening.
+    // …except under an Awaiting-task pill (the user 2026-08-23): the pill + its open list already
+    // say what this card is doing, and the quiet/unknown lines below would either contradict them
+    // ("Paused — nothing is in motion" under in-flight tasks — the morning's screenshot) or repeat
+    // them. An OPEN turn still narrates: the session working WHILE tasks run is new information.
+    if (awTasks.length && it.sessState !== "open") return NONE;
     if (it.sessState === "open") {
       return {
         caption: "Working…",


### PR DESCRIPTION
## What

Two changes to the feed's awaiting cards:

1. **One awaiting read.** The card said one wait three times: the "Awaiting task" pill, a boxed body caption naming the first task, and the (now open-by-default) task list. The caption branch is deleted; the pill + its list are the whole read. The quiet/unknown floors stand down under tracked tasks instead of contradicting the pill ("Paused — nothing is in motion" under in-flight work — the caption existed only to paper over that). An OPEN turn still narrates, and the richer in-motion stories (re-check, re-judging, settle gap, distilling) still fire. The ladder's totality contract records the one documented exemption: the card is never mute — the spin line alone goes quiet.

2. **A delegation wait names its peers.** Instead of a colourless "Awaiting peer", the box renders the peers the way the "↳ from" line does: quiet `host:` prefix, name in the peer's identity colour, elapsed readout intact. A new pure kernel helper (`_handoff_peer_identities`) resolves the identities (live registry name first; sid stub + federation's `:` host marker when unresolvable); they ride `awaiting.peers` only when the delegation arm wins the why or-chain; `federation.ts` attributes kernel-local peers on merge exactly as it does `origin.peerSid`. Older kernels ship no peers and keep the plain caption.

## Tests

- `spin-caption.test.ts` (executed ladder): the one-read rule, both floor stand-downs, open-turn narration and re-judging still firing, and the totality matrix's documented exemption.
- `feed-awaiting-swirl.test.ts`: the peers render (hostPartsNodes + identity colour + elapsed + plain-caption fallback) and the federation merge rule.
- `tests/test_kernel_awaiting_stamp.py`: `_handoff_peer_identities` executed — local resolve, federated stub + host marker, dedupe, None-not-empty.
- Full suites green: 2206 JS tests, 5205 python tests (+281 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)