### PR TITLE
The timeline's view control is a filter with a removable chip

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2313,8 +2313,11 @@ class TimelinePanel {
   // gray = off), its label + state word, and a plain-language line on what it does. Clicking a row
   // toggles that flag with the SAME optimistic + sticky treatment as the old direct icons, and the menu
   // stays open, repainting in place — it's a settings panel, not a command.
-  // ── the corner control panel (the user 2026-08-18): "Show: <view> ▾ · N more" in the bottom-left
-  // corner — the empty strip under the lane gutter, left of the first time label. Progressive
+  // ── the corner control panel (the user 2026-08-18; filter-chip form 2026-08-23): "Filter ▾" in
+  // the bottom-left corner — the empty strip under the lane gutter, left of the first time label.
+  // An active group renders as a REMOVABLE CHIP beside it ("· <name> ✕", the group's colour):
+  // clicking the chip clears the filter back to the default view, no menu trip — the control is
+  // named for what it does now (it FILTERS the lanes; "Show:" read as a passive label). Progressive
   // disclosure: the trigger is the one-line version; the dropdown holds the views and the two
   // timeline display toggles; the dialog holds the per-session checkboxes. All pointerdown-based
   // (the redraw-eats-click rule) and rebuilt per draw like the gear/lock.
@@ -2369,17 +2372,32 @@ class TimelinePanel {
     const v = this._curViews();
     const g = (v.groups || []).find((x) => x.id === v.active);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
+    const active = !!g && v.active && v.active !== 'all';
     // ellipsize so the WHOLE trigger stays inside the gutter — measured on the full string (the
     // 650-weight lane font over-measures the plain spans, which is the safe direction), because a
     // fixed reserve under-counted "· NN more" and let the tail cross into the first time label
-    let name = viewLabel(v);
-    const tail = ' ▾' + (more ? ' · ' + more + ' more' : '');
-    const fits = (n) => this.labelWidth('Show: ' + n + tail) <= this.M.left - PADL - 6;
-    while (name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
+    let name = active ? viewLabel(v) : '';
+    const line = (n) => 'Filter ▾' + (active ? ' · ' + n + ' ✕' : '') + (more ? ' · ' + more + ' more' : '');
+    const fits = (n) => this.labelWidth(line(n)) <= this.M.left - PADL - 6;
+    while (active && name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
     const t = el('text', { x: PADL, y: axisY + 14, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG });
-    const lead = el('tspan', {}); lead.textContent = 'Show: '; t.appendChild(lead);
-    const nm = el('tspan', { fill: (g && g.color) || '#cccccc', 'font-weight': 650 }); nm.textContent = name; t.appendChild(nm);
-    const caret = el('tspan', {}); caret.textContent = ' ▾'; t.appendChild(caret);
+    const lead = el('tspan', {}); lead.textContent = 'Filter ▾'; t.appendChild(lead);
+    if (active) {
+      const sepc = el('tspan', { opacity: 0.7 }); sepc.textContent = ' · '; t.appendChild(sepc);
+      // the active group as a removable filter chip: its own colour, an ✕, ITS OWN pointerdown —
+      // one click back to the default view, no menu trip (the user 2026-08-23)
+      const chip = el('tspan', { fill: g.color || '#cccccc', 'font-weight': 650 });
+      chip.textContent = name + ' ✕';
+      chip.setAttribute('style', 'cursor:pointer;');
+      const tt = el('title', {});
+      tt.textContent = 'showing only ' + (g.name || 'this group') + ' — click to remove the filter (back to the default view)';
+      chip.appendChild(tt);
+      chip.addEventListener('pointerdown', (e) => {
+        e.preventDefault(); e.stopPropagation();
+        const nv = JSON.parse(JSON.stringify(v)); nv.active = 'all'; this._setViews(nv);
+      });
+      t.appendChild(chip);
+    }
     if (more) { const m = el('tspan', { opacity: 0.7 }); m.textContent = ' · ' + more + ' more'; t.appendChild(m); }
     t.setAttribute('style', 'cursor:pointer;user-select:none;');
     t.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(t); });

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -1,4 +1,4 @@
-// The timeline's corner control panel (the user 2026-08-18): "Show: <view> ▾ · N more" in the
+// The timeline's corner control panel (the user 2026-08-18; filter-chip form 2026-08-23): "Filter ▾" in the
 // bottom-left corner — the strip under the lane gutter, left of the time labels. The dropdown picks
 // the active VIEW (the default group / named groups), holds New group… / Edit sessions…, and carries the
 // two timeline display toggles (collapse idle gaps, active only) so they finally work in every host.
@@ -65,9 +65,22 @@ test("the lane gate composes the view filter first, and the all-quiet fallback r
 
 test("the trigger sits in the corner strip and opens on pointerdown, like every timeline control", () => {
   assert.match(SRC, /_drawViewsTrigger\(svg, axisY\);/);
-  assert.match(SRC, /lead\.textContent = 'Show: ';/);
+  // named for what it does (the user 2026-08-23): it FILTERS the lanes — "Show:" read as a passive label
+  assert.match(SRC, /lead\.textContent = 'Filter ▾';/);
   assert.match(SRC, /t\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(t\); \}\);/);
   assert.match(SRC, /' · ' \+ more \+ ' more';/, "a filtered-out live session is always one glance away");
+});
+
+test("an active group is a REMOVABLE CHIP: its own colour, an ✕, one click back to default (the user 2026-08-23)", () => {
+  // the chip's own pointerdown clears the filter without a menu trip; stopPropagation keeps the
+  // text element's menu handler out of it (both are pointerdown — the redraw-eats-click rule)
+  assert.match(SRC, /chip\.textContent = name \+ ' ✕';/);
+  assert.match(SRC, /chip\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\); nv\.active = 'all'; this\._setViews\(nv\);/);
+  // the chip wears the group's identity colour and a hover title saying what the click does
+  assert.match(SRC, /const chip = el\('tspan', \{ fill: g\.color \|\| '#cccccc', 'font-weight': 650 \}\);/);
+  assert.match(SRC, /click to remove the filter \(back to the default view\)/);
+  // no chip on the default view — nothing to remove
+  assert.match(SRC, /const active = !!g && v\.active && v\.active !== 'all';/);
 });
 
 test("the dropdown and dialog wear the shared menu vocabulary and adopt into the menu host", () => {
@@ -116,7 +129,8 @@ test("executed: the dialog's two checkbox mutations, pure", () => {
 });
 
 test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {
-  assert.match(SRC, /const fits = \(n\) => this\.labelWidth\('Show: ' \+ n \+ tail\) <= this\.M\.left - PADL - 6;/);
+  assert.match(SRC, /const line = \(n\) => 'Filter ▾' \+ \(active \? ' · ' \+ n \+ ' ✕' : ''\) \+ \(more \? ' · ' \+ more \+ ' more' : ''\);/);
+  assert.match(SRC, /const fits = \(n\) => this\.labelWidth\(line\(n\)\) <= this\.M\.left - PADL - 6;/);
   assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
   assert.match(SRC, /this\._viewsDialogKey\.doc\.removeEventListener\('keydown', this\._viewsDialogKey\.fn\);/);
 });


### PR DESCRIPTION
## What

The timeline's corner control is renamed "Show: <group> ▾" → "Filter ▾", and an active group now rides beside it as a **removable chip**: "· <name> ✕" in the group's own colour. Clicking the chip clears the filter straight back to the default view — no menu trip — with a hover title saying exactly that. The default view shows no chip (nothing to remove).

## Why

"Show:" named the control for what it displays; what it does is filter the lanes — and removing the filter took opening the dropdown and picking "default" (the user 2026-08-23, who asked for filter chips you can click to remove, and for the control to be renamed to match).

## How

The chip is its own tspan with its own pointerdown (stopPropagation keeps the text element's menu handler out — the redraw-eats-click rule keeps both on pointerdown), rebuilt per draw like the rest of the corner panel. The gutter fit measures the new full line, chip and "· N more" tail included; the "N more" cue is untouched.

## Tests

`ui/timeline-views-panel.test.ts`: the rename, the chip (colour, ✕, one-click clear, stopPropagation, no chip on default), and the new fit measurement. Suite green: 2206 JS tests; full python suite green on the branch (5204 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)