### PR TITLE
manager workflow: group + color one-shot POST routes, CLI verbs, bundled manager skill

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -657,6 +657,8 @@ EOF
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
+    _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
+    _romp_cmd "romp group [<name>] [--add ...]" -       "Session groups: bare lists them; <name> with --add/--remove/--color/--delete merges one"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> <text>" -            "Hand a session a message (kernel API, either backend)"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -860,6 +862,219 @@ if [[ "${1:-}" == "rename" ]]; then
     fi
     _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
     echo "romp rename: refused — $_err" >&2
+    exit 1
+fi
+
+# Recolor a session's identity color (the user 2026-08-23, via the manager/worker session workflow:
+# a manager keeps its worker roster as a session group, all one identity color): the kernel's
+# POST /color, the exact sibling of `romp rename` — a names-registry write, so a dormant session
+# recolors by sid. With no color argument it READS: the session's current bg and fg off
+# GET /sessions, tab-separated, for scripts. A slot digit 1-9 resolves HERE against the
+# STATE/palette-colors mirror the kernel rewrites at boot — the same file the launcher assigns
+# from, so "slot 3" is the same hex at recolor time as at launch time; a missing mirror is a loud
+# error, never a silent fall-back to the hardcoded default set the gear may have switched away
+# from. TRAP: the kernel accepts only swatches of KNOWN palettes (the swatch's palette supplies
+# the fg word), so an arbitrary hex is refused loudly with the pointer to GET /palette — never
+# stored half-styled.
+if [[ "${1:-}" == "color" ]]; then
+    shift
+    _cl_usage="usage: romp color <session> [<#hex|1-9>]"
+    if [[ $# -lt 1 || $# -gt 2 || "$1" == -* || ( $# -eq 2 && -z "$2" ) ]]; then echo "$_cl_usage" >&2; exit 2; fi
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp color: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
+        exit 1
+    fi
+    if [[ $# -eq 1 ]]; then
+        _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions")" \
+            || { echo "romp color: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        _pair="$(printf '%s' "$_resp" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
+for r in rows:
+    if isinstance(r, dict) and (r.get("name") == sys.argv[1] or r.get("id") == sys.argv[1]):
+        print("%s\t%s" % (r.get("bg") or "", r.get("fg") or ""))
+        break
+' "$1")"
+        if [[ -z "$_pair" ]]; then
+            echo "romp color: no session named \"$1\" (see: romp sessions)" >&2
+            exit 1
+        fi
+        printf '%s\n' "$_pair"
+        exit 0
+    fi
+    _cl_bg="$2"
+    if [[ "$_cl_bg" =~ ^[1-9]$ ]]; then
+        _palfile="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/palette-colors"
+        if [[ ! -r "$_palfile" ]]; then
+            echo "romp color: no palette mirror at $_palfile — the kernel writes it at boot (is romp running?)" >&2
+            exit 1
+        fi
+        _cl_slot="$_cl_bg"
+        _cl_bg="$(awk -F'\t' -v n="$_cl_slot" 'NR == n { print $1 }' "$_palfile")"
+        if [[ -z "$_cl_bg" ]]; then
+            echo "romp color: the active palette has no slot $_cl_slot (see $_palfile)" >&2
+            exit 1
+        fi
+    fi
+    _payload="$(python3 -c 'import json,sys; print(json.dumps({"target": sys.argv[1], "bg": sys.argv[2]}))' "$1" "$_cl_bg")"
+    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/color" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp color: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        echo "romp color: \"$1\" is now $_cl_bg"
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp color: refused — $_err" >&2
+    exit 1
+fi
+
+# Session groups from the CLI (the user 2026-08-23, via the manager/worker session workflow: a
+# manager keeps its worker roster as a session group, all one identity color). Bare / --json READS
+# GET /views; bare maps member sids to live names via GET /sessions and prints an unmappable id
+# RAW — a dead member is information, not noise. Everything else is POST /group, the kernel's
+# targeted per-group merge — deliberately NOT the dashboard's setTimelineViews op, which replaces
+# the whole blob and would let a stale read clobber the active view and every group this command
+# never looked at (the kernel's _edit_group comment has the full story). TRAPS: --add/--remove eat
+# every following arg up to the next flag, so flag order carries the grouping; members go up as
+# live names or raw sids (a dead session rides by sid) and the kernel refuses an unknown name
+# loudly rather than minting a member nothing will ever match; "color" and "delete" ride the
+# payload only when given — an absent color means keep, "" would mean clear. A bare NAME with no
+# edit flag READS that one group (exit 1 when absent) — creating on a read-shaped call minted
+# phantom groups from typos.
+if [[ "${1:-}" == "group" ]]; then
+    shift
+    _gr_usage="usage: romp group [--json]
+       romp group <name> [--add <session>...] [--remove <session>...] [--color <#hex>] [--delete]"
+    _gr_name=""; _gr_json=false; _gr_color=""; _gr_cset=0; _gr_del=0
+    _gr_add=(); _gr_remove=(); _gr_mode=""; _gr_add_seen=0; _gr_rm_seen=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json)   _gr_json=true; _gr_mode=""; shift ;;
+            --add)    _gr_add_seen=1; _gr_mode="add"; shift ;;
+            --remove) _gr_rm_seen=1; _gr_mode="remove"; shift ;;
+            --color)  shift
+                      if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_gr_usage" >&2; exit 2; fi
+                      _gr_color="$1"; _gr_cset=1; _gr_mode=""; shift ;;
+            --delete) _gr_del=1; _gr_mode=""; shift ;;
+            -*)       echo "$_gr_usage" >&2; exit 2 ;;
+            *)        case "$_gr_mode" in
+                          add)    _gr_add+=("$1") ;;
+                          remove) _gr_remove+=("$1") ;;
+                          *)      if [[ -n "$_gr_name" ]]; then echo "$_gr_usage" >&2; exit 2; fi
+                                  _gr_name="$1" ;;
+                      esac
+                      shift ;;
+        esac
+    done
+    if $_gr_json && [[ -n "$_gr_name" || $_gr_add_seen -eq 1 || $_gr_rm_seen -eq 1 || $_gr_cset -eq 1 || $_gr_del -eq 1 ]]; then
+        echo "$_gr_usage" >&2; exit 2
+    fi
+    if [[ -z "$_gr_name" && ( $_gr_add_seen -eq 1 || $_gr_rm_seen -eq 1 || $_gr_cset -eq 1 || $_gr_del -eq 1 ) ]]; then
+        echo "$_gr_usage" >&2; exit 2
+    fi
+    if [[ ( $_gr_add_seen -eq 1 && ${#_gr_add[@]} -eq 0 ) || ( $_gr_rm_seen -eq 1 && ${#_gr_remove[@]} -eq 0 ) ]]; then
+        echo "$_gr_usage" >&2; exit 2
+    fi
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp group: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
+        exit 1
+    fi
+    if [[ -z "$_gr_name" ]]; then
+        _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/views")" \
+            || { echo "romp group: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        if $_gr_json; then
+            printf '%s\n' "$_resp"
+            exit 0
+        fi
+        _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
+        python3 -c '
+import json, sys
+v = json.loads(sys.argv[1])
+if not isinstance(v, dict):
+    v = {}
+rows = json.loads(sys.argv[2])
+rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
+names = {r.get("id"): r.get("name") for r in rows if isinstance(r, dict)}
+groups = v.get("groups") or []
+act = v.get("active") or "all"
+act = next((g.get("name") for g in groups if g.get("id") == act), act)
+print("active view: %s" % act)
+for g in groups:
+    m = [names.get(x) or x for x in (g.get("members") or [])]
+    print("%s  %s  %d member%s%s" % (g.get("name"), g.get("color") or "(no color)",
+                                     len(m), "" if len(m) == 1 else "s",
+                                     (": " + ", ".join(m)) if m else ""))
+' "$_resp" "$_rows"
+        exit 0
+    fi
+    if [[ $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 ]]; then
+        # a bare name is a READ of that one group, never a write — POSTing here would CREATE a
+        # missing group, so a typo'd "view" would mint a phantom and burn one of the 32 slots
+        _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/views")" \
+            || { echo "romp group: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
+        if ! python3 -c '
+import json, sys
+v = json.loads(sys.argv[1])
+rows = json.loads(sys.argv[2])
+rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
+names = {r.get("id"): r.get("name") for r in rows if isinstance(r, dict)}
+g = next((g for g in (v.get("groups") or []) if isinstance(v, dict) and g.get("name") == sys.argv[3]), None)
+if g is None:
+    sys.exit(3)
+m = [names.get(x) or x for x in (g.get("members") or [])]
+print("%s  %s  %d member%s%s" % (g.get("name"), g.get("color") or "(no color)",
+                                 len(m), "" if len(m) == 1 else "s",
+                                 (": " + ", ".join(m)) if m else ""))
+' "$_resp" "$_rows" "$_gr_name"; then
+            echo "romp group: no group named \"$_gr_name\" (see: romp group)" >&2
+            exit 1
+        fi
+        exit 0
+    fi
+    _payload="$(python3 -c '
+import json, sys
+n = int(sys.argv[5])
+body = {"name": sys.argv[1], "add": sys.argv[6:6 + n], "remove": sys.argv[6 + n:]}
+if sys.argv[2] == "1":
+    body["color"] = sys.argv[3]
+if sys.argv[4] == "1":
+    body["delete"] = True
+print(json.dumps(body))
+' "$_gr_name" "$_gr_cset" "$_gr_color" "$_gr_del" "${#_gr_add[@]}" \
+        "${_gr_add[@]+"${_gr_add[@]}"}" "${_gr_remove[@]+"${_gr_remove[@]}"}")"
+    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/group" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp group: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
+        python3 -c '
+import json, sys
+resp = json.loads(sys.argv[1])
+rows = json.loads(sys.argv[2])
+rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
+names = {r.get("id"): r.get("name") for r in rows if isinstance(r, dict)}
+if resp.get("deleted"):
+    print("romp group: \"%s\" deleted" % (resp.get("name") or sys.argv[3]))
+else:
+    g = resp.get("group") or {}
+    m = [names.get(x) or x for x in (g.get("members") or [])]
+    nm = g.get("name") or sys.argv[3]
+    if m:
+        print("romp group: \"%s\" now: %s" % (nm, ", ".join(m)))
+    else:
+        print("romp group: \"%s\" is empty" % nm)
+' "$_resp" "$_rows" "$_gr_name"
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp group: refused — $_err" >&2
     exit 1
 fi
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -12,6 +12,9 @@ place by `install.sh`):
 - **`skills/romp-postal/`** — the full postal-service guide, loaded on demand
   (sessions get only a compact pointer at start — see
   `hooks/romp-postal-context.sh`).
+- **`skills/manager/`** — the manager workflow: one session dispatching work to
+  a group of worker sessions (roster = a session group, uniform worker color,
+  dispatch/track/verify/report norms). Loaded on demand.
 
 Skills live in this repo (not `~/.claude/skills/` directly) so a skill and the
 tool it documents change in the same commit; the installer creates the

--- a/claude/skills/manager/SKILL.md
+++ b/claude/skills/manager/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: manager
+description: Run this session as the MANAGER of a group of worker sessions — take incoming work, dispatch it to your workers over the Romp Postal Service, track and verify their results, and report up. Use when this session manages workers (managers are conventionally named <team>_manager) and receives work to distribute, a worker's report or question, or a status ask. Only applies inside a romp session; a plain Claude Code session has no workers and can ignore it.
+---
+
+# Manager (running a worker group)
+
+You manage a team of worker sessions: work arrives with you, workers do it, you dispatch, track, verify, and report. You do not implement — except a trivial read or answer where the round-trip to a worker costs more than doing it. A lead drifting into doing the work itself is the documented failure mode of every lead-agent system; your value is routing, review, and holding the whole picture.
+
+## Your team
+
+The roster IS a romp session group, named for the team: a manager is named `<team>_manager` (one or two words before the suffix), and its group is the name minus `_manager` — `backend_manager` keeps group `backend`. Workers are the group's members minus you. `romp group` lists every group with its members; `romp group <team> --add <s>... --remove <s>...` edits. Membership is sid-keyed, so renames never break it. Keep the roster true — it is what the user's dashboard shows as your team.
+
+- **Never add workers on your own.** No spawning, no forking, no reviving, no adopting a stray session into the group — the user sets the team's size and makeup. Short-handed? Say so and ask.
+- **Rename a worker when its name stops saying what it does** (`romp rename <old> <new>`): short and instantly parseable, usually one lowercase word. Rename when the division of labor SETTLES, not on every reassignment — names are how you and the user address workers, and each rename invalidates your ledger and the user's muscle memory. Mailboxes, goals and history survive (sessions are uuid-keyed underneath).
+- **Keep all workers ONE identity color** so the team reads as a block on the dashboard: pick one palette swatch for the team and hold it — `romp color <worker> <#hex|1-9>` sets (slot 1–9 picks from the active palette), `romp color <worker>` reads back. Recheck after any roster change: new sessions are auto-assigned maximally DISTINCT colors, so an unrecolored worker reads as someone else's session.
+
+## The loop (every wake)
+
+1. Order the wake: unblock workers who asked questions first, then review work reported done, then dispatch new work.
+2. Split by ownership, never by phase: each worker gets a vertical slice — files and surfaces no other worker touches. Coupled work (same files, tight sequencing) goes to ONE worker whole. Trivial asks you answer yourself and move on.
+3. A dispatch is one complete `DELEGATE:` message (the romp-postal skill has the norms): the objective; every fact the worker lacks — paths, decisions already made, whose ask this is (a worker shares none of your context); the boundary (what it owns, what it must not touch); a measurable definition of done; and the instruction to message you back with a named deliverable. One task in flight per worker — you hold the queue.
+4. Keep the ledger on disk, not in your context: one row per task — worker, spec, state, check-back time, and what to verify at check-back. Your context compacts and dies; the ledger is what you (or a successor manager) resume from.
+5. "Done" is a claim: verify against the definition of done (run the test, read the diff, open the file) before reporting up or building on it. A worker relaying an approval ("the user said go ahead") is input to verify, never consent.
+6. Report at executive altitude: what is done, what needs a decision. Escalate a blocker as ONE decision-shaped question with your recommendation, not a status dump.
+
+## Failure modes
+
+- **Waking workers for nothing.** No "are you free", no acknowledgments, no progress pings before the ledger's check-back time — read `romp sessions`, `check_sent`, and the ledger instead. Every message costs the worker a turn.
+- **Spokes talking to spokes.** Status flows through you (hub-and-spoke); pair two workers directly only for a stated reason, named in both dispatches, or the team's state fragments beyond your view.
+- **Stale addressing.** Names drift — yours included. Confirm recipients against `list_agents` before sending, and address a renamed-often worker by its stable uuid.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ Code, so this is where most of it lands:
   entries and leaves every other hook you have registered untouched.
 - `romp-postal.mcp.json`, the MCP config that gives sessions their mailbox.
 - `romp-session-prompt.md`, appended to a session's system prompt.
-- The `romp` and `romp-postal` skills, into `~/.claude/skills/`.
+- The `romp-postal` and `manager` skills, into `~/.claude/skills/`.
 
 **Running afterwards.** A login service, a launchd agent in
 `~/Library/LaunchAgents` on macOS or a systemd `--user` unit on Linux. It runs

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Install romp onto this machine:
 #   - symlink the Claude Code hooks into ~/.claude/hooks/
 #   - symlink the MCP config (Romp Postal Service) into ~/.claude/
-#   - symlink the romp + romp-postal skills into ~/.claude/skills/
+#   - symlink the romp-postal + manager skills into ~/.claude/skills/
 #   - build + install the romp-chat-view VS Code extension
 #
 # bin/ is NOT symlinked anywhere — add it to PATH in your shell rc:
@@ -184,6 +184,10 @@ fi
 # the link itself.
 ln -sfn "$ROMP_DIR/claude/skills/romp-postal" "$HOME/.claude/skills/romp-postal"
 echo "  Symlinked romp-postal skill"
+
+# manager skill — running one session as the dispatcher of a worker group (same -n rationale)
+ln -sfn "$ROMP_DIR/claude/skills/manager" "$HOME/.claude/skills/manager"
+echo "  Symlinked manager skill"
 
 # The Agent SDK venv — the backend plain `romp new` uses. Best-effort: a host missing python >= 3.10
 # or Debian's python3-venv still runs tmux sessions (romp-sdk-setup says exactly what to install).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1523,6 +1523,7 @@ def _ordered_alive(now, tmux):
 # kernel cannot reach this blob) — same accepted gap session-flags has; SDK sids are stable anyway.
 _VIEWS_MAX_GROUPS = 32
 _VIEWS_MAX_NAME = 40
+_views_lock = threading.Lock()   # read-modify-write on the views blob from handler threads (_comments_lock precedent)
 
 
 def _views_path():
@@ -1603,6 +1604,60 @@ def _heal_timeline_views(old_sid, new_sid):
         if old_sid in g["members"]:
             g["members"] = sorted(set(g["members"]) | {new_sid})
     _set_timeline_views(v)
+
+
+def _b36(n):
+    """Date.now().toString(36) — the id mint the timeline corner panel uses for new groups, so a group
+    gets ONE id shape whether it was born in the dashboard or over POST /group."""
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    out, n = "", int(n)
+    while n:
+        n, r = divmod(n, 36)
+        out = digits[r] + out
+    return out or "0"
+
+
+def _edit_group(name, add=(), remove=(), color=None, delete=False):
+    """Targeted edit of ONE named group in the views blob — the merge op behind POST /group. The WS
+    setTimelineViews op replaces the whole blob, which is right for the dashboard (it holds the
+    current one) and wrong for an agent: replaying a stale read would clobber the active view and
+    every group it never looked at. So: read, edit the one group, write back through the
+    normalizer. The group is addressed by NAME (the id is a UI-internal mint); two same-named
+    groups refuse rather than guess. Members are stored ids — the route resolves live names before
+    calling. A missing group is created on any edit, never on delete. Returns
+    (group-or-None, error-or-None); the returned row is the post-normalize one."""
+    # Clamp the name into the STORED basis before the lookup: the normalizer clamps names to
+    # _VIEWS_MAX_NAME on write, so matching on the raw name would miss the stored group and mint an
+    # unaddressable same-named duplicate on every subsequent edit.
+    name = str(name)[:_VIEWS_MAX_NAME]
+    with _views_lock:   # the server is threaded; two unlocked merges would both copy the same pre-state
+        v = json.loads(json.dumps(_timeline_views()))     # deep copy: never mutate the cached blob
+        hits = [g for g in v["groups"] if g["name"] == name]
+        if len(hits) > 1:
+            return None, 'two groups are named "%s" — rename one in the dashboard first' % name
+        if delete:
+            if not hits:
+                return None, 'no group named "%s"' % name
+            v["groups"] = [g for g in v["groups"] if g["id"] != hits[0]["id"]]
+            _set_timeline_views(v)      # an active pointing at it falls back to "all" in the normalizer
+            return None, None
+        if hits:
+            g = hits[0]
+        else:
+            if len(v["groups"]) >= _VIEWS_MAX_GROUPS:     # the normalizer would drop the appended 33rd, SILENTLY
+                return None, "the views blob caps at %d groups" % _VIEWS_MAX_GROUPS
+            n = int(time.time() * 1000)
+            taken = {g2["id"] for g2 in v["groups"]}
+            while "g" + _b36(n) in taken:   # same-ms creates must not share an id — delete filters by id
+                n += 1
+            g = {"id": "g" + _b36(n), "name": name, "color": "", "members": []}
+            v["groups"].append(g)
+        g["members"] = sorted((set(g["members"]) | set(add)) - set(remove))
+        if color is not None:
+            g["color"] = color
+        v = _norm_timeline_views(v)
+        _set_timeline_views(v)
+        return next(g2 for g2 in v["groups"] if g2["id"] == g["id"]), None
 
 
 # ── per-session view flags (the user 2026-06-19) ──────────────────────────────────────────────────
@@ -26196,6 +26251,11 @@ class Handler(BaseHTTPRequestHandler):
                     "colors": pal.colors(_pn), "active": _pn,
                     "palettes": [{"name": k, "label": v["label"], "colors": v["bg"]}
                                  for k, v in pal.PALETTES.items()]}), "application/json", cache="no-cache")
+            if p == "/views":                             # the session-views blob (active view, hidden set,
+                # groups) for scripts/agents: the read half of POST /group. The dashboard reads the same
+                # blob off the tabOrder WS push; this route exists for token-bearing curl consumers
+                # (`romp group` with no args prints it).
+                return self._send(200, json.dumps(_timeline_views()), "application/json", cache="no-cache")
             if p == "/models":                                # the ONE model + effort choice list — chat statusline, timeline lanes, AND judge settings all read it (the user 2026-07-02: no hardcoding in multiple places)
                 # each choice carries its colormap tint (the user 2026-08-17: the new-comment dialog's
                 # selectors wear the same colors the statusline badges do, for ANY pick — the badge
@@ -26754,6 +26814,89 @@ class Handler(BaseHTTPRequestHandler):
                 _mark_views_dirty()
                 return self._send(200, json.dumps({"ok": True, "id": tsid, "name": nm}),
                                   "application/json")
+            if u.path == "/color":
+                # Headless recolor (`romp color`, the user 2026-08-23 via the manager/worker workflow:
+                # a manager keeps its whole worker group one identity color): the setSessionColor WS op
+                # as a one-shot POST, sibling of /rename. Body: {"target": <live name or sid>,
+                # "bg": <swatch hex>}. Only a swatch from a known palette is accepted (its palette
+                # supplies the fg word) — GET /palette lists the choosable ones. A recolor is a
+                # names-registry write, so a dormant session works by sid, same as /rename. Loud errors.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                target = str((b or {}).get("target") or "").strip()
+                bg = str((b or {}).get("bg") or "").strip()
+                if not target or not bg:
+                    return self._send(400, json.dumps({"ok": False, "error": "target and bg required"}),
+                                      "application/json")
+                live = _live_names(_tmux_sessions())
+                tsid = live.get(target) or ""
+                if not tsid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", target):
+                    tsid = target
+                if not tsid:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'no live session named "%s" (a dormant one can be recolored by sid)' % target}),
+                                      "application/json")
+                if not pal.find(bg):
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        '"%s" is not a swatch of any palette — GET /palette lists the choosable ones' % bg}),
+                                      "application/json")
+                if not _set_session_color(tsid, bg):
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        "no names record for that session — is it known to this kernel?"}),
+                                      "application/json")
+                _mark_views_dirty()
+                return self._send(200, json.dumps({"ok": True, "id": tsid, "bg": bg,
+                                                   "fg": pal.fg_for(bg)}), "application/json")
+            if u.path == "/group":
+                # Headless group edit (`romp group`, the user 2026-08-23, same manager/worker workflow:
+                # the worker roster IS a session group, so an agent needs to keep one current). NOT the
+                # WS setTimelineViews op re-exposed — that op replaces the whole views blob; this is a
+                # targeted merge on ONE group (_edit_group has the why). Body: {"name": <group>,
+                # "add": [name-or-sid...], "remove": [...], "color": <swatch, optional>,
+                # "delete": true|false}. Member names resolve against live sessions; sids (dead
+                # sessions) and host-prefixed remote SIDs (host:<sid>) pass through verbatim — the
+                # same opaque-id contract the blob keeps. Unknown names — host:NAME included, since
+                # the blob stores ids and a stored name would be a member nothing ever matches —
+                # refuse loudly.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                name = str((b or {}).get("name") or "").strip()
+                if not name:
+                    return self._send(400, json.dumps({"ok": False, "error": "name required"}),
+                                      "application/json")
+                live = _live_names(_tmux_sessions())
+                ids, unknown = {"add": [], "remove": []}, []
+                for k in ("add", "remove"):
+                    for x in (b.get(k) if isinstance(b.get(k), list) else []):
+                        x = str(x).strip()
+                        if not x:
+                            continue
+                        if x in live:
+                            ids[k].append(live[x])
+                        elif re.fullmatch(r"[0-9a-fA-F-]{32,36}", x) or \
+                                re.fullmatch(r"[^:]+:[0-9a-fA-F-]{32,36}", x):
+                            ids[k].append(x)          # a sid, or a host-prefixed remote SID, verbatim
+                        else:
+                            unknown.append(x)
+                if unknown:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        "no live session named %s (dead ones go by sid, remote ones by host:<sid>)" %
+                        ", ".join('"%s"' % x for x in unknown)}), "application/json")
+                color = b.get("color")
+                g, err = _edit_group(name, add=ids["add"], remove=ids["remove"],
+                                     color=(str(color) if isinstance(color, str) else None),
+                                     delete=bool(b.get("delete")))
+                if err:
+                    return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
+                _mark_views_dirty()
+                if g is None:
+                    return self._send(200, json.dumps({"ok": True, "deleted": True, "name": name}),
+                                      "application/json")
+                return self._send(200, json.dumps({"ok": True, "group": g}), "application/json")
             if u.path == "/working":
                 # Publish/clear a session's working-note in the backend-agnostic store, so the postal bus's
                 # set_working goes through the kernel (no tmux @romp-working) and an SDK session can publish a

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -59,6 +59,8 @@ PY
     # the link.
     [ ! -e "$ROMP_DIR/claude/skills/romp-postal/romp-postal" ]
     [ -L "$HOME/.claude/skills/romp-postal" ]
+    [ ! -e "$ROMP_DIR/claude/skills/manager/manager" ]
+    [ -L "$HOME/.claude/skills/manager" ]
 }
 
 @test "install.sh: upgrading unlinks the retired romp skill, leaving no dangling link" {

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -200,6 +200,86 @@ MOCK
     [[ "$output" == *"kernel isn't running"* ]]
 }
 
+@test "color: POST /color with target and a literal hex; prints the new color" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp color exp-web '#1EA1EB'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'is now #1EA1EB'* ]]
+    grep '/color' "$MOCK_LOG" | grep -q '"target": *"exp-web"'
+    grep '/color' "$MOCK_LOG" | grep -q '"bg": *"#1EA1EB"'
+}
+
+@test "color: a slot digit resolves through the kernel's palette-colors mirror; no mirror is loud" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    # the mirror the kernel writes at boot: bg<TAB>fg per line; slot 3 = line 3's first field
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf '#AA0000\twhite\n#00BB00\tblack\n#0000CC\twhite\n' > "$XDG_STATE_HOME/romp/palette-colors"
+    run run_romp color exp-api 3
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'is now #0000CC'* ]]
+    grep '/color' "$MOCK_LOG" | grep -q '"target": *"exp-api"'
+    grep '/color' "$MOCK_LOG" | grep -q '"bg": *"#0000CC"'
+    # a missing mirror never falls back to a built-in set — the kernel writes it at boot
+    rm "$XDG_STATE_HOME/romp/palette-colors"
+    run run_romp color exp-api 3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"palette mirror"* ]]
+}
+
+@test "group: POST /group carries the name and the whole --add list" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp group workers --add exp-web exp-api --color '#54B204'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'romp group: "workers"'* ]]
+    grep '/group' "$MOCK_LOG" | grep -q '"name": *"workers"'
+    grep '/group' "$MOCK_LOG" | grep -q '"add": *\["exp-web", *"exp-api"\]'
+    grep '/group' "$MOCK_LOG" | grep -q '"color": *"#54B204"'
+}
+
+@test "group: a bare name reads the group — GET /views, never a POST that could create" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp group workers
+    grep -q '/views' "$MOCK_LOG"
+    [ "$(grep -c '/group' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "color/group: usage errors exit 2" {
+    run run_romp color
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp color"* ]]
+    run run_romp color exp-web '#1EA1EB' extra
+    [ "$status" -eq 2 ]
+    run run_romp group workers stray-word
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp group"* ]]
+    run run_romp group --add exp-web
+    [ "$status" -eq 2 ]
+    run run_romp group workers --color
+    [ "$status" -eq 2 ]
+    run run_romp group --json workers
+    [ "$status" -eq 2 ]
+}
+
+@test "color/group: no kernel token is a loud exit 1, and no API call is made" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    run run_romp color exp-web '#1EA1EB'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel isn't running"* ]]
+    run run_romp group workers --add exp-web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel isn't running"* ]]
+    [ "$(grep -Ec '/(color|group)' "$MOCK_LOG")" -eq 0 ]
+}
+
 @test "fork: usage errors exit 2; no kernel token is a loud exit 1" {
     touch "$MOCK_LOG"
     run run_romp fork

--- a/tests/test_color_route.py
+++ b/tests/test_color_route.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""POST /color (the user 2026-08-23, manager/worker workflow): the setSessionColor WS op as a
+one-shot token-gated route, the exact sibling of /rename — a manager keeps its whole worker group
+one identity color without WS surgery. Only a swatch of a known palette is accepted (its own
+palette supplies the fg word), and a recolor is a names-registry write, so a dormant session
+recolors by sid just like /rename renames one. Drives the REAL Handler over HTTP (the
+test_new_route_prefs.py pattern). Synthetic only."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_cr", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "22222222-3333-4444-5555-666666666666"
+
+
+class ColorRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.names = Path(self.tmp) / "names"
+        self.names.mkdir()
+        self._saved = (km.NAMES, km.jd.STATE, km._tmux_sessions, km._live_names,
+                       km._mark_views_dirty)
+        km.NAMES = self.names
+        km.jd.STATE = Path(self.tmp) / "state"
+        km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})   # drop the mtime cache between sandboxes
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": SID}
+        self.dirty = []                                       # the route must poke the views push
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        (km.NAMES, km.jd.STATE, km._tmux_sessions, km._live_names,
+         km._mark_views_dirty) = self._saved
+        km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})
+
+    def _post(self, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/color" % self.port, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_live_name_recolors_the_names_registry(self):
+        (self.names / SID).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        st, r = self._post({"target": "web", "bg": "#54B204"})
+        self.assertEqual(st, 200)
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r.get("id"), SID)
+        self.assertEqual(r.get("bg"), "#54B204")
+        self.assertEqual(r.get("fg"), "black", "the owning palette's fg word rides the ack")
+        parts = (self.names / SID).read_text().rstrip("\n").split("\t")
+        self.assertEqual(parts[0], "web", "name preserved")
+        self.assertEqual(parts[1], "/proj/TESTHOST/app", "cwd preserved")
+        self.assertEqual(parts[2], "#54B204", "new bg written")
+        self.assertEqual(parts[3], "black", "the palette's fg word for green")
+        self.assertTrue(self.dirty, "a successful recolor marks views dirty — the dashboards' repaint signal")
+
+    def test_a_sid_target_recolors_a_dormant_session(self):
+        # SID2 is NOT in _live_names — a recolor is a names-registry write, so dormant works by sid
+        (self.names / SID2).write_text("worker\t/proj/TESTHOST/svc\t#1EA1EB\twhite\n")
+        st, r = self._post({"target": SID2, "bg": "#54B204"})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r.get("id"), SID2)
+        self.assertEqual((self.names / SID2).read_text().rstrip("\n").split("\t"),
+                         ["worker", "/proj/TESTHOST/svc", "#54B204", "black"])
+
+    def test_a_non_swatch_refuses_and_leaves_the_file_alone(self):
+        (self.names / SID).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        st, r = self._post({"target": "web", "bg": "#123456"})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("not a swatch", r.get("error") or "")
+        self.assertEqual((self.names / SID).read_text(),
+                         "web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n",
+                         "a refused recolor writes nothing")
+
+    def test_an_unknown_target_is_loud(self):
+        st, r = self._post({"target": "ghost", "bg": "#54B204"})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("no live session named", r.get("error") or "")
+
+    def test_missing_target_or_bg_is_a_400(self):
+        st, r = self._post({"target": "web"})
+        self.assertEqual(st, 400)
+        st, r = self._post({"bg": "#54B204"})
+        self.assertEqual(st, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_group_route.py
+++ b/tests/test_group_route.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""GET /views + POST /group (the user 2026-08-23, manager/worker workflow): the worker roster IS a
+session group, so an agent reads the views blob over GET /views and keeps ONE group current over
+POST /group. NOT the setTimelineViews WS op re-exposed — that op replaces the whole blob, and an
+agent replaying a stale read would clobber the active view and every group it never looked at;
+/group is a targeted merge on one NAMED group (_edit_group): live names resolve to sids, opaque
+ids (dead sids, host-prefixed remote ids) pass through verbatim, unknown names refuse loudly.
+Drives the REAL Handler over HTTP (the test_new_route_prefs.py pattern). Synthetic only."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_gr", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "22222222-3333-4444-5555-666666666666"
+DEAD = "33333333-4444-5555-6666-777777777777"                        # a sid no live session answers to
+REMOTE = "TESTHOST:11111111-2222-3333-4444-555555555555"             # a host-prefixed remote id
+
+
+class GroupRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+        self._saved = (km._tmux_sessions, km._live_names, km._mark_views_dirty)
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": SID, "api": SID2}
+        self.dirty = []                                       # the routes must poke the views push
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        (km._tmux_sessions, km._live_names, km._mark_views_dirty) = self._saved
+        km.jd.STATE = self._state
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def _post(self, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/group" % self.port, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def _views(self):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/views" % self.port,
+            headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return r.status, json.loads(r.read().decode())
+
+    def test_get_views_serves_the_normalized_default(self):
+        st, v = self._views()
+        self.assertEqual(st, 200)
+        self.assertEqual(v, {"active": "all", "hidden": [], "groups": []})
+
+    def test_create_resolves_a_live_name_and_mints_the_ui_id_shape(self):
+        st, r = self._post({"name": "pool", "add": ["web"]})
+        self.assertEqual(st, 200)
+        self.assertTrue(r.get("ok"), r)
+        g = r.get("group") or {}
+        self.assertRegex(g.get("id") or "", r"^g[0-9a-z]+$",
+                         "the UI's Date.now-base36 mint shape — one id shape either birthplace")
+        self.assertEqual(g.get("name"), "pool")
+        self.assertEqual(g.get("members"), [SID], "the live NAME resolved to its sid")
+        self.assertTrue(self.dirty, "a successful edit marks views dirty — the dashboards' repaint signal")
+
+    def test_sids_and_remote_ids_pass_through_verbatim(self):
+        st, r = self._post({"name": "mixed", "add": [DEAD, REMOTE]})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r["group"]["members"], sorted([DEAD, REMOTE]),
+                         "opaque ids stored as sent — the blob's own contract")
+
+    def test_remove_drops_a_member_even_a_dead_one_by_sid(self):
+        st, r = self._post({"name": "pool", "add": ["web", DEAD]})
+        self.assertEqual(r["group"]["members"], sorted([SID, DEAD]))
+        st, r = self._post({"name": "pool", "remove": [DEAD]})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r["group"]["members"], [SID], "a dead member goes by sid")
+
+    def test_color_is_stored_on_the_group(self):
+        self._post({"name": "pool", "add": ["web"]})
+        st, r = self._post({"name": "pool", "color": "#DD42FF"})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r["group"]["color"], "#DD42FF")
+        self.assertEqual(r["group"]["members"], [SID], "a color edit does not clobber membership")
+
+    def test_delete_removes_the_group_and_the_active_view_falls_back(self):
+        gid = "g1a2b3c"
+        km._set_timeline_views({"active": gid, "hidden": [],
+                                "groups": [{"id": gid, "name": "pool", "color": "",
+                                            "members": [SID]}]})
+        km._flags_cache.clear()
+        st, v = self._views()
+        self.assertEqual(v["active"], gid, "precondition: the group IS the active view")
+        st, r = self._post({"name": "pool", "delete": True})
+        self.assertTrue(r.get("ok"), r)
+        self.assertTrue(r.get("deleted"))
+        st, v = self._views()
+        self.assertEqual(v["groups"], [])
+        self.assertEqual(v["active"], "all", "the normalizer falls the orphaned active back to all")
+
+    def test_an_unknown_add_name_refuses_loudly_and_writes_nothing(self):
+        st, r = self._post({"name": "pool", "add": ["ghost"]})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("no live session named", r.get("error") or "")
+        st, v = self._views()
+        self.assertEqual(v["groups"], [], "a refused edit writes nothing — no member no session matches")
+
+    def test_two_same_named_groups_refuse_any_edit(self):
+        km._set_timeline_views({"active": "all", "hidden": [], "groups": [
+            {"id": "g1", "name": "dup", "color": "", "members": []},
+            {"id": "g2", "name": "dup", "color": "", "members": []}]})
+        km._flags_cache.clear()
+        st, r = self._post({"name": "dup", "add": ["web"]})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("rename one in the dashboard first", r.get("error") or "")
+
+    def test_the_group_cap_refuses_a_33rd_instead_of_silently_dropping_it(self):
+        groups = [{"id": "g%02d" % i, "name": "grp%02d" % i, "color": "", "members": []}
+                  for i in range(32)]
+        km._set_timeline_views({"active": "all", "hidden": [], "groups": groups})
+        km._flags_cache.clear()
+        st, r = self._post({"name": "overflow", "add": []})
+        self.assertFalse(r.get("ok"))
+        self.assertIn("caps at 32", r.get("error") or "",
+                      "the normalizer would drop the appended 33rd SILENTLY — the route must refuse")
+        st, v = self._views()
+        self.assertEqual(len(v["groups"]), 32)
+        self.assertNotIn("overflow", [g["name"] for g in v["groups"]])
+
+    def test_back_to_back_creates_mint_distinct_ids_and_delete_hits_only_its_group(self):
+        st, ra = self._post({"name": "alpha"})
+        st, rb = self._post({"name": "beta"})
+        ida, idb = ra["group"]["id"], rb["group"]["id"]
+        self.assertNotEqual(ida, idb, "same-millisecond creates must not share an id")
+        st, r = self._post({"name": "alpha", "delete": True})
+        self.assertTrue(r.get("ok"), r)
+        st, v = self._views()
+        self.assertEqual([g["id"] for g in v["groups"]], [idb],
+                         "delete filters by id, so a shared id would have taken beta with it")
+
+    def test_a_long_name_is_clamped_at_entry_so_it_stays_addressable(self):
+        long_name = "x" * 44
+        self._post({"name": long_name, "add": ["web"]})
+        st, r = self._post({"name": long_name, "add": ["api"]})
+        self.assertTrue(r.get("ok"), r)
+        st, v = self._views()
+        self.assertEqual(len(v["groups"]), 1,
+                         "the raw name must address the stored (clamped) group — never mint a duplicate")
+        self.assertEqual(v["groups"][0]["name"], "x" * 40)
+        self.assertEqual(v["groups"][0]["members"], sorted([SID, SID2]))
+
+    def test_a_host_prefixed_NAME_refuses_like_any_unknown_name(self):
+        st, r = self._post({"name": "pool", "add": ["TESTHOST:exp-ghost"]})
+        self.assertFalse(r.get("ok"), "host:NAME is not an id — storing it would never match a session")
+        self.assertIn("no live session named", r.get("error") or "")
+
+    def test_missing_name_is_a_400(self):
+        st, r = self._post({"add": ["web"]})
+        self.assertEqual(st, 400)
+
+    def test_an_edit_merges_and_never_clobbers_the_rest_of_the_blob(self):
+        GB = {"id": "gb", "name": "beta", "color": "#DD42FF", "members": ["s2"]}
+        km._set_timeline_views({"active": "gb", "hidden": ["s9"], "groups": [
+            {"id": "ga", "name": "alpha", "color": "", "members": ["s1"]}, GB]})
+        km._flags_cache.clear()
+        st, r = self._post({"name": "alpha", "add": ["api"]})
+        self.assertTrue(r.get("ok"), r)
+        st, v = self._views()
+        self.assertEqual(v["active"], "gb", "the active view survives the merge")
+        self.assertEqual(v["hidden"], ["s9"], "the hidden list survives")
+        self.assertEqual([g for g in v["groups"] if g["id"] == "gb"], [GB],
+                         "the group the edit never looked at is untouched")
+        alpha = next(g for g in v["groups"] if g["id"] == "ga")
+        self.assertEqual(alpha["members"], sorted(["s1", SID2]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One manager session runs a worker roster as a session group: workers all one identity color, renamed as the division of labor settles, dispatched over the postal service. POST /rename (earlier today) covered renames; this PR lands the rest:

- **POST /color** — the setSessionColor WS op as a one-shot POST, sibling of /rename (palette-validated; dormant sessions by sid).
- **GET /views + POST /group** — read the views blob; targeted merge on ONE named group (never the whole-blob replace, so a stale agent read can't clobber the active view or other groups). Name clamped to the stored basis before lookup, RMW under a lock (_comments_lock precedent), collision-proof id mint in the dashboard's id shape, members = live names / sids / host:<sid> (host:NAME refuses loudly).
- **romp color / romp group** — bare forms read (a bare group name views, never creates); slot 1-9 resolves via the palette-colors mirror; token via curl config, never argv.
- **claude/skills/manager** — the bundled manager-session skill (roster = a session group, one worker color, dispatch/track/verify/report doctrine), wired by install.sh beside romp-postal; claude/README + architecture doc updated.

Tests: 19 new route tests driving the real Handler over HTTP (491 pass in the touched suites), bats for both verbs (payload shapes, slot resolution, usage/no-token exits, read-never-posts), install double-run pins the new symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
