### PR TITLE
The filter chip wears the context chip's dress

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2373,35 +2373,58 @@ class TimelinePanel {
     const g = (v.groups || []).find((x) => x.id === v.active);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
     const active = !!g && v.active && v.active !== 'all';
-    // ellipsize so the WHOLE trigger stays inside the gutter — measured on the full string (the
+    const PADH = 7, GAP = 6;   // the chip's horizontal padding; the space between the line's parts
+    // ellipsize so the WHOLE line stays inside the gutter — measured on the full string (the
     // 650-weight lane font over-measures the plain spans, which is the safe direction), because a
-    // fixed reserve under-counted "· NN more" and let the tail cross into the first time label
+    // fixed reserve under-counted "N more" and let the tail cross into the first time label
     let name = active ? viewLabel(v) : '';
-    const line = (n) => 'Filter ▾' + (active ? ' · ' + n + ' ✕' : '') + (more ? ' · ' + more + ' more' : '');
-    const fits = (n) => this.labelWidth(line(n)) <= this.M.left - PADL - 6;
+    const tailStr = more ? more + ' more' : '';
+    const width = (n) => this.labelWidth('Filter ▾')
+      + (active ? GAP + PADH * 2 + this.labelWidth(n + ' ✕') : 0)
+      + (tailStr ? GAP + this.labelWidth(tailStr) : 0);
+    const fits = (n) => width(n) <= this.M.left - PADL - 6;
     while (active && name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
-    const t = el('text', { x: PADL, y: axisY + 14, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG });
-    const lead = el('tspan', {}); lead.textContent = 'Filter ▾'; t.appendChild(lead);
-    if (active) {
-      const sepc = el('tspan', { opacity: 0.7 }); sepc.textContent = ' · '; t.appendChild(sepc);
-      // the active group as a removable filter chip: its own colour, an ✕, ITS OWN pointerdown —
-      // one click back to the default view, no menu trip (the user 2026-08-23)
-      const chip = el('tspan', { fill: g.color || '#cccccc', 'font-weight': 650 });
-      chip.textContent = name + ' ✕';
-      chip.setAttribute('style', 'cursor:pointer;');
-      const tt = el('title', {});
-      tt.textContent = 'showing only ' + (g.name || 'this group') + ' — click to remove the filter (back to the default view)';
-      chip.appendChild(tt);
-      chip.addEventListener('pointerdown', (e) => {
-        e.preventDefault(); e.stopPropagation();
-        const nv = JSON.parse(JSON.stringify(v)); nv.active = 'all'; this._setViews(nv);
-      });
-      t.appendChild(chip);
-    }
-    if (more) { const m = el('tspan', { opacity: 0.7 }); m.textContent = ' · ' + more + ' more'; t.appendChild(m); }
+    const y = axisY + 14;
+    const t = el('text', { x: PADL, y, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG });
+    t.textContent = 'Filter ▾';
     t.setAttribute('style', 'cursor:pointer;user-select:none;');
     t.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(t); });
     svg.appendChild(t);
+    let x = PADL + this.labelWidth('Filter ▾');
+    if (active) {
+      x += GAP;
+      const cw = PADH * 2 + this.labelWidth(name + ' ✕');
+      // the active group as a removable filter chip wearing the composer context chip's dress in
+      // the GROUP's colour (the user 2026-08-23): 18% fill, 1px solid border, pill radius — a
+      // bordered chip reads as removable where bare coloured text read as a label. Its own
+      // pointerdown clears the filter — one click back to the default view, no menu trip.
+      const grp = el('g', {});
+      grp.setAttribute('style', 'cursor:pointer;');
+      const box = el('rect', { x, y: y - 12, width: cw, height: 16, rx: 8,
+        fill: g.color || '#cccccc', 'fill-opacity': 0.18,
+        stroke: g.color || '#cccccc', 'stroke-width': 1 });
+      grp.appendChild(box);
+      const ct = el('text', { x: x + PADH, y, 'font-size': 12, 'font-family': FONT,
+        fill: g.color || '#cccccc', 'font-weight': 650 });
+      ct.textContent = name + ' ✕';
+      ct.setAttribute('style', 'user-select:none;');
+      grp.appendChild(ct);
+      const tt = el('title', {});
+      tt.textContent = 'showing only ' + (g.name || 'this group') + ' — click to remove the filter (back to the default view)';
+      grp.appendChild(tt);
+      grp.addEventListener('pointerdown', (e) => {
+        e.preventDefault(); e.stopPropagation();
+        const nv = JSON.parse(JSON.stringify(v)); nv.active = 'all'; this._setViews(nv);
+      });
+      svg.appendChild(grp);
+      x += cw;
+    }
+    if (more) {
+      const m = el('text', { x: x + GAP, y, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG, opacity: 0.7 });
+      m.textContent = tailStr;   // a filtered-out live session is always one glance away
+      m.setAttribute('style', 'user-select:none;');
+      svg.appendChild(m);
+    }
   }
 
   _closeViewsMenu() { if (this._viewsMenu) { this._viewsMenu.remove(); this._viewsMenu = null; } }

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -66,18 +66,21 @@ test("the lane gate composes the view filter first, and the all-quiet fallback r
 test("the trigger sits in the corner strip and opens on pointerdown, like every timeline control", () => {
   assert.match(SRC, /_drawViewsTrigger\(svg, axisY\);/);
   // named for what it does (the user 2026-08-23): it FILTERS the lanes — "Show:" read as a passive label
-  assert.match(SRC, /lead\.textContent = 'Filter ▾';/);
+  assert.match(SRC, /t\.textContent = 'Filter ▾';/);
   assert.match(SRC, /t\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(t\); \}\);/);
-  assert.match(SRC, /' · ' \+ more \+ ' more';/, "a filtered-out live session is always one glance away");
+  assert.match(SRC, /const tailStr = more \? more \+ ' more' : '';/, "a filtered-out live session is always one glance away");
 });
 
-test("an active group is a REMOVABLE CHIP: its own colour, an ✕, one click back to default (the user 2026-08-23)", () => {
+test("an active group is a REMOVABLE CHIP in the composer chip's dress: border + faded fill in the group's colour (the user 2026-08-23)", () => {
   // the chip's own pointerdown clears the filter without a menu trip; stopPropagation keeps the
   // text element's menu handler out of it (both are pointerdown — the redraw-eats-click rule)
-  assert.match(SRC, /chip\.textContent = name \+ ' ✕';/);
-  assert.match(SRC, /chip\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\); nv\.active = 'all'; this\._setViews\(nv\);/);
-  // the chip wears the group's identity colour and a hover title saying what the click does
-  assert.match(SRC, /const chip = el\('tspan', \{ fill: g\.color \|\| '#cccccc', 'font-weight': 650 \}\);/);
+  assert.match(SRC, /ct\.textContent = name \+ ' ✕';/);
+  assert.match(SRC, /grp\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\); nv\.active = 'all'; this\._setViews\(nv\);/);
+  // the composer context chip's treatment in the GROUP's colour (styles.css .composer-chip: 18%
+  // fill + 1px solid border + pill radius) — a bordered chip reads as removable, loose text didn't
+  assert.match(SRC, /fill: g\.color \|\| '#cccccc', 'fill-opacity': 0\.18,\n\s*stroke: g\.color \|\| '#cccccc', 'stroke-width': 1/);
+  assert.match(SRC, /rx: 8,/);
+  assert.match(SRC, /fill: g\.color \|\| '#cccccc', 'font-weight': 650/);
   assert.match(SRC, /click to remove the filter \(back to the default view\)/);
   // no chip on the default view — nothing to remove
   assert.match(SRC, /const active = !!g && v\.active && v\.active !== 'all';/);
@@ -129,8 +132,9 @@ test("executed: the dialog's two checkbox mutations, pure", () => {
 });
 
 test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {
-  assert.match(SRC, /const line = \(n\) => 'Filter ▾' \+ \(active \? ' · ' \+ n \+ ' ✕' : ''\) \+ \(more \? ' · ' \+ more \+ ' more' : ''\);/);
-  assert.match(SRC, /const fits = \(n\) => this\.labelWidth\(line\(n\)\) <= this\.M\.left - PADL - 6;/);
+  // the fit measures the whole line as LAID OUT: trigger + gap + padded chip + gap + tail
+  assert.match(SRC, /const width = \(n\) => this\.labelWidth\('Filter ▾'\)\n\s*\+ \(active \? GAP \+ PADH \* 2 \+ this\.labelWidth\(n \+ ' ✕'\) : 0\)\n\s*\+ \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
+  assert.match(SRC, /const fits = \(n\) => width\(n\) <= this\.M\.left - PADL - 6;/);
   assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
   assert.match(SRC, /this\._viewsDialogKey\.doc\.removeEventListener\('keydown', this\._viewsDialogKey\.fn\);/);
 });


### PR DESCRIPTION
## What

The timeline's active-group filter chip now renders as a real chip: 18% fill of the group's colour, a 1px solid border in the same colour, pill radius — the composer context chip's exact treatment (`styles.css` `.composer-chip`), in the group's colour instead of the accent. The name + ✕ stay in the group's colour; click still clears straight back to the default view.

## Why

Bare coloured text with an ✕ read as a label, not a removable chip (the user 2026-08-23, who liked the functionality and asked for the context-chip styling: keep the assigned colour, add a border and a faded background).

## How

The trigger's single text element becomes three positioned parts — trigger text ("Filter ▾", opens the menu), a chip group (rect + text + title, carrying the clear-filter pointerdown), and the "N more" tail — each placed off measured widths. The gutter fit measures the line as laid out: trigger + gap + padded chip + gap + tail.

## Tests

`ui/timeline-views-panel.test.ts` repinned: the chip's dress (fill-opacity 0.18, solid stroke, pill radius, coloured 650-weight text), the group-level clear handler, and the new layout-aware fit. Suite green: 2209 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)