### PR TITLE
The automatic-model-change card mints on downgrades only, and drops the word fallback

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9460,10 +9460,11 @@ def mint_fallback_card(sid, from_model, to_model, ev_t=None):
         store["seq"] = n
         gid = "%s:g%d" % (sid, n)
         t = int(ev_t or time.time())
-        why = ("The model was swapped mid-turn without a request: %s fell back to %s. Work continued "
-               "on the fallback; switch back from the statusline if that isn't what you want."
+        why = ("The model changed mid-turn without a request: %s fell back to %s — an API-side "
+               "capacity fallback, not a pick. Work continued on the fallback; switch back from the "
+               "statusline if that isn't what you want."
                % (from_model or "the pinned model", to_model))
-        nd = GuardedNode({"id": gid, "text": "Model fallback: %s → %s" % (from_model or "?", to_model),
+        nd = GuardedNode({"id": gid, "text": "Model changed automatically: %s → %s" % (from_model or "?", to_model),
                           "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
                           "trail": [], "promptUuid": "", "quote": "", "t": t, "mt": t,
                           "why": "kernel-observed API model fallback", "log": []})

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1291,6 +1291,29 @@ class _AskCancelled(Exception):
     pass
 
 
+
+_MODEL_TIERS = ("haiku", "sonnet", "opus", "fable", "mythos")   # rank = index; fable/mythos share the top in
+#                                                                 practice but a swap between them is lateral,
+#                                                                 not a fallback, so distinct ranks are fine
+
+
+def _model_rank(name):
+    """The model FAMILY rank of a model id/display name, or None when no family matches — substring
+    match, so 'claude-sonnet-5', 'Sonnet 5' and 'us.anthropic.claude-sonnet-…' all rank the same."""
+    low = str(name or "").lower()
+    for i, fam in enumerate(_MODEL_TIERS):
+        if fam in low:
+            return i
+    return None
+
+
+def _model_downgrade(frm, to):
+    """True only for a KNOWN down-tier transition — the shape of an API capacity fallback. Unknown
+    names never qualify: a mint on a user's own exotic pick is worse than a missed exotic fallback."""
+    a, b = _model_rank(frm), _model_rank(to)
+    return a is not None and b is not None and b < a
+
+
 class SdkSession:
     """One long-lived SDK client running in its own thread + asyncio loop."""
 
@@ -2196,10 +2219,16 @@ class SdkSession:
             if cleared:
                 self.backend._poke()
             return
-        if self.model and not self._model_pending and not cleared:
-            # A model TRANSITION nobody asked for (no /model pick pending): the API fell back
+        if self.model and not self._model_pending and not cleared \
+                and _model_downgrade(self.model, pm):
+            # A DOWN-TIER transition nobody asked for (no /model pick pending): the API fell back
             # mid-turn. Surface it as a completed card via the kernel-wired hook (the user
-            # 2026-08-23) — never silently (the swap was invisible before this).
+            # 2026-08-23) — never silently (the swap was invisible before this). DOWNGRADES ONLY
+            # (the user 2026-08-23, from a card reading "fallback" on their own upgrade): romp only
+            # sees ITS OWN picks pending — a /model typed inside the CLI, or any user-side switch,
+            # arrives here as an unrequested transition too, and a capacity fallback never moves a
+            # session UP-tier. An up-tier, lateral, or unknown-name change is treated as the user's
+            # doing and just updates the badge, exactly as before the card existed.
             fb = getattr(type(self.backend), "on_model_fallback", None)
             if fb:
                 try:

--- a/tests/test_model_fallback_card.py
+++ b/tests/test_model_fallback_card.py
@@ -33,7 +33,7 @@ class FallbackCard(unittest.TestCase):
         nd = store["nodes"][gid]
         self.assertTrue(nd["nodeComplete"])
         self.assertIn("fell back to claude-sonnet-5", nd["doneWhy"])
-        self.assertIn("Model fallback: claude-fable-5 → claude-sonnet-5", nd["text"])
+        self.assertIn("Model changed automatically: claude-fable-5 → claude-sonnet-5", nd["text"])
         self.assertEqual(store["status"].get(gid), "completed", "pops straight into Completed")
         dones = [e for e in nd["log"] if e.get("kind") == "done"]
         self.assertEqual(len(dones), 1)
@@ -41,11 +41,38 @@ class FallbackCard(unittest.TestCase):
 
     def test_the_backend_transition_gates_are_pinned(self):
         src = open(os.path.join(HERE, "..", "kernel", "sdk_backend.py")).read()
-        self.assertIn("if self.model and not self._model_pending and not cleared:", src,
+        self.assertIn("if self.model and not self._model_pending and not cleared \\", src,
                       "first learns and user-driven picks never mint")
         self.assertIn('on_model_fallback', src)
         ksrc = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("jd.mint_fallback_card(sid, frm, to)", ksrc, "the kernel wires the hook at boot")
+
+
+class DowngradeOnlyGate(unittest.TestCase):
+    """The card mints ONLY on a known down-tier transition (the user 2026-08-23, whose own upgrade
+    to a bigger model wore a "fallback" card): romp only sees its own picks pending, so a /model
+    typed inside the CLI arrives as an unrequested transition too — and a capacity fallback never
+    moves a session up-tier."""
+
+    def test_rank_and_downgrade_shapes(self):
+        # exec just the pure helper block: loading the whole backend pulls the live SDK dependency
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        i = src.index("_MODEL_TIERS")
+        j = src.index("\nclass SdkSession", i)
+        sb = type("NS", (), {})
+        ns = {}
+        exec(src[i:j], ns)
+        sb._model_downgrade = staticmethod(ns["_model_downgrade"])
+        self.assertTrue(sb._model_downgrade("claude-fable-5", "claude-sonnet-5"))
+        self.assertTrue(sb._model_downgrade("Opus 5", "claude-haiku-4-5"))
+        self.assertFalse(sb._model_downgrade("claude-opus-5", "claude-fable-5"), "an upgrade is the user's doing")
+        self.assertFalse(sb._model_downgrade("claude-sonnet-5", "claude-sonnet-4-5"), "lateral within a family: no card")
+        self.assertFalse(sb._model_downgrade("claude-opus-5", "some-experimental-model"), "unknown target: no card")
+        self.assertFalse(sb._model_downgrade("", "claude-haiku-4-5"), "unknown source: no card")
+
+    def test_the_learn_path_wires_the_gate(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        self.assertIn("and _model_downgrade(self.model, pm):", src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A user-picked upgrade inside the CLI wore a "Model fallback" card: romp only sees its own picks pending, so CLI-side switches arrive as unrequested transitions. A capacity fallback never moves a session up-tier, so the mint now requires a known down-tier transition; up-tier/lateral/unknown changes just update the badge. Retitled "Model changed automatically: X → Y" per the user's wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)