### PR TITLE
The sessions & tags dialog becomes a table in romp's conventions; the pane is named Sessions

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23633,7 +23633,7 @@ if(m&&m.romp==='notify'&&m.text)window.__rompNotify(m.kind||'error',m.text,
 var st={};
 function shown(k){return document.body.classList.contains('po-'+k);}
 function liveDown(){for(var k in st){if(st[k]==='down'&&shown(k))return true;}return false;}
-var PN={chat:'Chat',feed:'Feed',timeline:'Timeline',fleet:'Outline'};
+var PN={chat:'Chat',feed:'Feed',timeline:'Sessions',fleet:'Outline'};   // timeline key stays internal; the pane outgrew the name (filter, tags, lane controls — the user 2026-08-24)
 window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='wsState')return;
 var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;
 if(s==='down'&&prev!=='down'&&shown(m.app))
@@ -25808,7 +25808,7 @@ def _landing():
             "<div class=pane-rail>"
             "<div class=rail-scroll>"
             "<div class=rail-btn data-pane=chat>Chat</div>"
-            "<div class=rail-btn data-pane=timeline>Timeline</div>"
+            "<div class=rail-btn data-pane=timeline>Sessions</div>"   # data-pane key stays 'timeline' (internal); the pane outgrew the label (the user 2026-08-24)
             "<div class=rail-btn data-pane=fleet>Outline</div>"   # data-pane key stays 'fleet' (internal); the user-facing label is Outline
             "<div class=rail-btn data-pane=feed>Feed</div>"
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
@@ -25861,7 +25861,7 @@ def _landing():
             "<button data-pane=chat class=on>Chat</button>"
             "<button data-pane=fleet>Outline</button>"   # data-pane key stays 'fleet' (internal), label Outline
             "<button data-pane=feed>Feed</button>"
-            "<button data-pane=timeline>Timeline</button>"
+            "<button data-pane=timeline>Sessions</button>"   # same rename on the phone tabs
             # the rail's ACTIONS, reachable on mobile too (the user 2026-07-11): settings + the network
             # panel + a usage panel showing the desktop tooltip's window bars. data-act (not data-pane) —
             # they fire, they don't switch the shown pane.

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -34,7 +34,9 @@ class PaneRailTest(unittest.TestCase):
         # the by-session view is labelled "Outline" (the user 2026-06-29); the data-pane KEY stays 'fleet' internally
         self.assertIn("<div class=rail-btn data-pane=fleet>Outline</div>", self.html)
         self.assertIn("<div class=rail-btn data-pane=feed>Feed</div>", self.html)
-        self.assertIn("<div class=rail-btn data-pane=timeline>Timeline</div>", self.html)
+        # the LABEL is Sessions (the user 2026-08-24: the pane outgrew "Timeline" — filter, tags, lane
+        # controls); the data-pane key stays 'timeline', the fleet/Outline precedent
+        self.assertIn("<div class=rail-btn data-pane=timeline>Sessions</div>", self.html)
         # Chat before Timeline before Outline(fleet) before Feed in the rail (fixed user-chosen order)
         idxs = [self.html.index("data-pane=" + k) for k in ("chat", "timeline", "fleet", "feed")]
         self.assertEqual(idxs, sorted(idxs), "rail order must be Chat, Timeline, Outline, Feed")

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -1,7 +1,7 @@
 """The Settings gear groups its rows into labelled SUBSECTIONS (the user 2026-06-24), re-cut
 2026-07-12 (the user): the knobs that steer the fleet lead — Sessions (default directory, Auto
 Nudge, backend), the judge model tiers, keyboard shortcuts — the day-to-day view prefs sit in the
-middle (Chat, Timeline), and the cosmetic color pickers + the debug-only judge-visibility toggles
+middle (Chat, Sessions pane), and the cosmetic color pickers + the debug-only judge-visibility toggles
 sink to the bottom, with the version footer last. (The Feed section is gone — its only row, the
 global Colormap, lives under Colors now.)
 """
@@ -25,12 +25,12 @@ class SettingsSectionsTest(unittest.TestCase):
     def test_the_subsection_headers_are_present_in_order(self):
         h = _gear_src()
         self.assertIn("<div class='rs-sec rs-sec-first'>Sessions</div>", h)
-        for sec in ("Judges", "Keyboard shortcuts", "Chat", "Feed", "Timeline", "Colors", "Debug"):
+        for sec in ("Judges", "Keyboard shortcuts", "Chat", "Feed", "Sessions pane", "Colors", "Debug"):
             self.assertIn("<div class=rs-sec>%s</div>" % sec, h)
         # (The 2026-07-12 "Feed dissolved into Colors" rule ended 2026-08-18: the Feed section is back,
         # carrying the collapse-by-default checkbox moved off the feed footer.)
         order = [">Sessions<", ">Judges<", ">Keyboard shortcuts<", ">Chat<",
-                 ">Feed<", ">Timeline<", ">Colors<", ">Debug<", ">romp · version<"]
+                 ">Feed<", ">Sessions pane<", ">Colors<", ">Debug<", ">romp · version<"]
         idx = [h.index(t) for t in order]
         self.assertEqual(idx, sorted(idx), "sections in the 2026-07-12 order, version last")
 
@@ -43,11 +43,11 @@ class SettingsSectionsTest(unittest.TestCase):
         # Judges (top): the four model/effort dropdowns — the SHOW toggles are NOT here anymore
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgemodel") < h.index(">Keyboard shortcuts<"))
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-indexeffort") < h.index(">Keyboard shortcuts<"))
-        # Chat (middle): compact + branch between Chat and Timeline
-        self.assertTrue(h.index(">Chat<") < h.index("id=rs-compact") < h.index(">Timeline<"))
-        self.assertTrue(h.index(">Chat<") < h.index("id=rs-branch") < h.index(">Timeline<"))
-        # Timeline (middle towards the bottom): collapse idle gaps before the Colors header
-        self.assertTrue(h.index(">Timeline<") < h.index("id=rs-collapsegaps") < h.index(">Colors<"))
+        # Chat (middle): compact + branch between Chat and the Sessions-pane section
+        self.assertTrue(h.index(">Chat<") < h.index("id=rs-compact") < h.index(">Sessions pane<"))
+        self.assertTrue(h.index(">Chat<") < h.index("id=rs-branch") < h.index(">Sessions pane<"))
+        # Sessions pane (middle towards the bottom): collapse idle gaps before the Colors header
+        self.assertTrue(h.index(">Sessions pane<") < h.index("id=rs-collapsegaps") < h.index(">Colors<"))
         # Colors (bottom): the global colormap + the session palette between Colors and Debug
         self.assertTrue(h.index(">Colors<") < h.index("id=rs-cmap") < h.index(">Debug<"))
         self.assertTrue(h.index(">Colors<") < h.index("id=rs-pal") < h.index(">Debug<"))

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -47,9 +47,9 @@ function viewVisible(views, id) {
   return t ? (t.members || []).indexOf(id) >= 0 : true;
 }
 function viewLabel(views) {
-  if (!views || !views.active || views.active === 'all') return 'default';
+  if (!views || !views.active || views.active === 'all') return '(untagged)';
   const t = viewTags(views).find((x) => x.id === views.active);
-  return t ? (t.name || 'tag') : 'default';
+  return t ? (t.name || 'tag') : '(untagged)';
 }
 // live sessions the current view is NOT showing — the "N more" cue that keeps a hidden or tagged
 // session exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
@@ -2440,7 +2440,13 @@ class TimelinePanel {
     if (more) {
       const m = el('text', { x: x + GAP, y, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG, opacity: 0.7 });
       m.textContent = tailStr;   // a filtered-out live session is always one glance away
-      m.setAttribute('style', 'user-select:none;');
+      // …and one CLICK away (the user 2026-08-24): the count opens the same views menu, so "what am
+      // I not seeing?" answers itself with the list of tags to switch to
+      m.setAttribute('style', 'user-select:none;cursor:pointer;');
+      const mt = el('title', {}); mt.textContent = 'live sessions outside this view — click to pick a tag view';
+      m.appendChild(mt);
+      m.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(m); });
+      m.addEventListener('click', (e) => e.stopPropagation());
       svg.appendChild(m);
     }
   }
@@ -2485,7 +2491,7 @@ class TimelinePanel {
     };
     const v = this._curViews();
     const pick = (active) => { const nv = JSON.parse(JSON.stringify(v)); nv.active = active; this._setViews(nv); this._closeViewsMenu(); };
-    item('default', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
+    item('(untagged)', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
     for (const tg of viewTags(v))
       item(tg.name, { dot: tg.color || MODEL_FG, current: v.active === tg.id }).addEventListener('click', () => pick(tg.id));
     sep();
@@ -2528,30 +2534,45 @@ class TimelinePanel {
     this._viewsMenu = menu;
   }
 
-  // The sessions & tags dialog (the user 2026-08-23, replacing the one-checkbox-per-session form):
-  // TAG-CENTRIC — one row per session wearing its tag CHIPS (the tag's colour, ✕ leaves it) and a
-  // [+] menu to join existing tags or mint a new one, so multi-tag assignment happens in one visit.
-  // Opened WITH a tag id (New tag…, or Sessions & tags… while a tag view is active) it adds that
-  // tag's identity header — name input, palette swatches, Delete — on top of the same rows. An
-  // eye-off glyph appears only on a HIDDEN session (the manual one-off hide) to un-hide it; hiding
-  // itself stays where it lives (the chat tab's context menu). A centered card over the usual 0.55
-  // dim, adopted into the topmost same-origin document like every timeline overlay.
+  // The sessions & tags dialog (the user 2026-08-23; table form 2026-08-24, designed to the JLD
+  // display rules): a GRID — one row per session, columns [name | tag chips | + | feed | eye] — so
+  // the [+] column's alignment carries the table structure, and every convention matches the rest
+  // of romp (similarity = same meaning): the session NAME wears its identity colour (never a proxy
+  // dot), the "host:" prefix is quiet lowercase italic, a dead session is struck, interactive
+  // elements change on hover, and the whole card speaks the menu chrome. No instruction caption —
+  // the display explains itself. A SEARCH box (name or host) filters the rows, and the two bulk
+  // controls act on the FILTERED set (tag all, feed all), which is how a batch is selected. Opened
+  // WITH a tag id (New tag…) it adds that tag's identity header — name input, palette swatches,
+  // Delete — on top. An eye-off appears only on a HIDDEN session to un-hide it. A centered card
+  // over the usual 0.55 dim, adopted into the topmost same-origin document.
   _openViewsDialog(gid) {
     this._closeViewsDialog();
     const back = document.body.createDiv();
     back.setAttribute('style', 'position:fixed;inset:0;z-index:1002;background:rgba(0,0,0,0.55);'
       + 'display:flex;align-items:center;justify-content:center;');
     const card = back.createDiv();
-    card.setAttribute('style', 'width:min(470px,92vw);max-height:76vh;overflow:auto;padding:10px 12px;' + MENU_STYLE);
+    card.setAttribute('style', 'width:min(560px,94vw);max-height:78vh;overflow:auto;padding:14px 16px;' + MENU_STYLE);
     card.addEventListener('click', (e) => e.stopPropagation());
-    let addMenuFor = null;                       // the session id whose [+] menu is open (survives repaints)
+    let addMenuFor = null;                 // session id with its [+] menu open, or '*' for the bulk one
+    let query = '';                        // the search filter (name or host), survives repaints
+    const hover = (n, on, off) => {        // the one hover helper: interactive chrome changes colour
+      n.addEventListener('mouseenter', () => n.setAttribute('style', n.getAttribute('style') + on));
+      n.addEventListener('mouseleave', () => n.setAttribute('style', String(n.getAttribute('style')).replace(on, off)));
+    };
+    const nameParts = (s) => {             // ["host:" or null, bare name] — the sid's own colon marks federation
+      const i = String(s.id || '').indexOf(':');
+      const pre = i > 0 ? String(s.id).slice(0, i + 1) : null;
+      if (pre && s.name && s.name.startsWith(pre) && s.name.length > pre.length)
+        return [pre.toLowerCase(), s.name.slice(pre.length)];
+      return [null, s.name || String(s.id || '').slice(0, 8)];
+    };
     const build = () => {
       card.textContent = '';
       const v = this._curViews();
       const tg = gid ? viewTags(v).find((x) => x.id === gid) : null;
       if (gid && !tg) { this._closeViewsDialog(); return; }   // the tag was deleted elsewhere
       const head = card.createDiv();
-      head.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 4px;');
+      head.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 8px;');
       if (tg) {
         const nameIn = document.createElement('input');
         nameIn.value = tg.name; nameIn.maxLength = 40;
@@ -2566,6 +2587,7 @@ class TimelinePanel {
         head.appendChild(nameIn);
         const del = head.createSpan({ text: 'Delete' });
         del.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.7;color:#F85B5A;');
+        hover(del, 'opacity:1;', 'opacity:0.7;');
         del.addEventListener('click', () => {
           const nv = JSON.parse(JSON.stringify(this._curViews()));
           nv.tags = viewTags(nv).filter((x) => x.id !== gid); delete nv.groups;
@@ -2578,7 +2600,7 @@ class TimelinePanel {
       }
       if (tg) {
         const sw = card.createDiv();
-        sw.setAttribute('style', 'display:flex;gap:6px;margin:2px 0 6px;flex-wrap:wrap;');
+        sw.setAttribute('style', 'display:flex;gap:6px;margin:2px 0 8px;flex-wrap:wrap;');
         for (const c of (this._palette && this._palette.length ? this._palette : [tg.color || '#1EA1EB'])) {
           const d = sw.createSpan();
           d.setAttribute('style', 'width:16px;height:16px;border-radius:50%;cursor:pointer;background:' + c + ';'
@@ -2590,88 +2612,71 @@ class TimelinePanel {
           });
         }
       }
-      const sub = card.createDiv({ text: 'Tags mark specialized sessions: a tagged session leaves the '
-        + 'default view and shows under its tags. A session can wear several. ✕ takes a tag off; + adds one.' });
-      sub.setAttribute('style', 'opacity:0.6;font-size:0.82em;margin:0 0 6px;');
-      for (const s of (this.data && this.data.sessions) || []) {
-        const row = card.createDiv();
-        row.setAttribute('style', 'display:flex;align-items:center;gap:6px;padding:3px 4px;border-radius:4px;');
-        const dot = row.createSpan();
-        dot.setAttribute('style', 'width:8px;height:8px;border-radius:50%;flex:0 0 auto;background:' + (s.color || MODEL_FG) + ';');
-        const nm = row.createSpan({ text: s.name || s.id.slice(0, 8) });
-        nm.setAttribute('style', 'flex:0 0 auto;max-width:34%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;'
-          + (s.live ? '' : 'opacity:0.55;'));
-        // the session's tags, each a removable chip in the tag's colour (the trigger chip's dress)
-        const chips = row.createSpan();
-        chips.setAttribute('style', 'display:inline-flex;gap:4px;flex-wrap:wrap;min-width:0;align-items:center;');
-        for (const t of viewTags(v)) {
-          if ((t.members || []).indexOf(s.id) < 0) continue;
-          const tc = t.color || '#cccccc';
-          const ch = chips.createSpan();
-          ch.setAttribute('style', 'display:inline-flex;align-items:center;gap:5px;max-width:110px;'
-            + 'padding:2px 7px;border-radius:9px;font-size:0.82em;cursor:pointer;white-space:nowrap;'
-            + 'overflow:hidden;color:' + tc + ';border:1px solid ' + tc + ';');
-          ch.createSpan({ text: t.name });
-          const chx = ch.createSpan({ text: '✕' });
-          chx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
-          ch.setAttribute('title', 'tagged "' + t.name + '" — click to take this tag off');
-          ch.addEventListener('click', () => { this._setViews(viewToggleMember(this._curViews(), t.id, s.id)); build(); });
-        }
-        // [+] joins an existing tag or mints a new one — the mini-menu repaints in place with the row
-        const plus = chips.createSpan({ text: '+' });
-        plus.setAttribute('style', 'display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;'
-          + 'border-radius:50%;border:1px solid rgba(255,255,255,0.25);opacity:0.7;cursor:pointer;font-size:0.85em;');
-        plus.setAttribute('title', 'add a tag');
-        plus.addEventListener('click', () => { addMenuFor = addMenuFor === s.id ? null : s.id; build(); });
-        const st = row.createSpan({ text: s.live ? (s.model || '') : 'gone' });
-        st.setAttribute('style', 'margin-left:auto;flex:0 0 auto;opacity:0.5;font-size:0.82em;');
-        // an eye-off on a HIDDEN session un-hides it; the hide gesture itself lives on the chat tab
-        if ((v.hidden || []).indexOf(s.id) >= 0) {
-          const eye = row.createSpan({ text: '⌀' });
-          eye.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.6;');
-          eye.setAttribute('title', 'hidden from the default view — click to show it again');
-          eye.addEventListener('click', () => { this._setViews(viewToggleHidden(this._curViews(), s.id)); build(); });
-        }
-        // The pool-builder's second switch (the user 2026-08-19, from the manager/worker experiment):
-        // a background worker usually wants BOTH edits — tagged out of the default view AND off the
-        // feed — so the same row carries the lane gear's feed toggle. Reused machinery end to end
-        // (icon, optimistic _pendingFlags, _setSessionFlag); deliberately NOT auto-coupled to
-        // membership: hideFromFeed seals goals and gates the planner, an edit made knowingly.
-        const ft = LANE_TOGGLES.find((t) => t.flag === 'hideFromFeed');
-        if (ft && s.live) {
-          const on = ft.enabled(s);
-          const fic = el('svg', { viewBox: '0 0 17 17', width: 14, height: 14 });
-          fic.setAttribute('style', 'flex:0 0 auto;cursor:pointer;' + (on ? '' : 'opacity:0.55;'));
-          fic.appendChild(ft.icon(!on, 8.5, 8.5, on ? ROMP_BLUE : MODEL_FG));
-          fic.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const next = ft.value(!on);
-            s.hideFromFeed = next;
-            (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).hideFromFeed = next;
-            this._setSessionFlag(s, 'hideFromFeed', next);
-            this._reconcilePendingFlags();
-            build();
-          });
-          const tip = on ? 'its prompts make feed cards — click to mute (a background worker usually wants this off)'
-                         : 'feed-muted: new prompts mint no cards — click to restore';
-          fic.addEventListener('mouseenter', () => { fic.setAttribute('title', tip); });
-          row.appendChild(fic);
-        }
-        row.addEventListener('mouseenter', () => { row.style.background = 'rgba(255,255,255,0.07)'; });
-        row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
-        // the open [+] menu renders under its row: existing tags this session lacks, then New tag…
-        if (addMenuFor === s.id) {
-          const am = card.createDiv();
-          am.setAttribute('style', 'margin:0 0 4px 22px;display:flex;gap:4px;flex-wrap:wrap;align-items:center;');
-          for (const t of viewTags(v)) {
-            if ((t.members || []).indexOf(s.id) >= 0) continue;
-            const opt = am.createSpan({ text: t.name });
+      // search + the bulk controls, one row: the search names the SET, the controls act on it
+      const bar = card.createDiv();
+      bar.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 8px;');
+      const q = document.createElement('input');
+      q.placeholder = 'search name or host…'; q.value = query;
+      q.setAttribute('style', 'flex:1 1 auto;min-width:0;background:#1e1e1e;color:#ccc;'
+        + 'border:1px solid rgba(255,255,255,0.12);border-radius:5px;padding:3px 8px;font:inherit;');
+      q.addEventListener('input', () => { query = q.value; renderRows(); });
+      bar.appendChild(q);
+      const btnStyle = 'flex:0 0 auto;cursor:pointer;padding:2px 8px;border-radius:5px;'
+        + 'border:1px solid rgba(255,255,255,0.25);color:#cccccc;background:transparent;font-size:0.9em;';
+      const tagAll = bar.createSpan({ text: '+ tag all' });
+      tagAll.setAttribute('style', btnStyle);
+      hover(tagAll, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
+      tagAll.setAttribute('title', 'add a tag to every session the search shows');
+      tagAll.addEventListener('click', () => { addMenuFor = addMenuFor === '*' ? null : '*'; renderRows(); });
+      const feedAll = bar.createSpan();
+      feedAll.setAttribute('style', btnStyle);
+      hover(feedAll, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
+      bar.appendChild(feedAll);
+      const gridBox = card.createDiv();
+      const ft = LANE_TOGGLES.find((t) => t.flag === 'hideFromFeed');
+      const renderRows = () => {
+        gridBox.textContent = '';
+        const needle = query.trim().toLowerCase();
+        const rows = ((this.data && this.data.sessions) || []).filter((s) =>
+          !needle || String(s.name || s.id || '').toLowerCase().indexOf(needle) >= 0);
+        // the feed-all control speaks for the FILTERED live set: any card-minting session → mute
+        const liveRows = rows.filter((s) => s.live);
+        const anyOn = !!ft && liveRows.some((s) => ft.enabled(s));
+        feedAll.textContent = anyOn ? 'mute feed for all' : 'restore feed for all';
+        feedAll.setAttribute('title', anyOn
+          ? 'mute feed cards for every live session the search shows'
+          : 'restore feed cards for every live session the search shows');
+        feedAll.onclick = () => {
+          if (!ft) return;
+          const flagVal = ft.value(!anyOn);   // any still minting → mute all; all muted → restore all
+          for (const s of liveRows) {
+            s.hideFromFeed = flagVal;
+            (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).hideFromFeed = flagVal;
+            this._setSessionFlag(s, 'hideFromFeed', flagVal);
+          }
+          this._reconcilePendingFlags();
+          renderRows();
+        };
+        const grid = gridBox.createDiv();
+        grid.setAttribute('style', 'display:grid;grid-template-columns:max-content 1fr max-content max-content max-content;'
+          + 'column-gap:10px;row-gap:3px;align-items:center;');
+        const addMenu = (rowIds) => {   // the [+] menu, per-row or bulk — spans the grid
+          const am = grid.createDiv();
+          am.setAttribute('style', 'grid-column:1 / -1;margin:2px 0 4px 8px;display:flex;gap:5px;flex-wrap:wrap;align-items:center;');
+          const joinable = viewTags(this._curViews()).filter((t) =>
+            rowIds.some((id) => (t.members || []).indexOf(id) < 0));
+          for (const t of joinable) {
             const tc = t.color || '#cccccc';
-            opt.setAttribute('style', 'padding:0 7px;border-radius:9px;font-size:0.82em;cursor:pointer;'
-              + 'color:' + tc + ';border:1px solid ' + tc + ';opacity:0.85;');
+            const opt = am.createSpan({ text: t.name });
+            opt.setAttribute('style', 'padding:1px 8px;border-radius:9px;font-size:0.82em;cursor:pointer;'
+              + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
+            hover(opt, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
             opt.addEventListener('click', () => {
+              const nv = JSON.parse(JSON.stringify(this._curViews()));
+              const t2 = viewTags(nv).find((x) => x.id === t.id); if (!t2) return;
+              t2.members = Array.from(new Set((t2.members || []).concat(rowIds)));
               addMenuFor = null;
-              this._setViews(viewToggleMember(this._curViews(), t.id, s.id)); build();
+              this._setViews(nv); build();
             });
           }
           const ni = document.createElement('input');
@@ -2683,16 +2688,92 @@ class TimelinePanel {
             const nv = JSON.parse(JSON.stringify(this._curViews()));
             const used = new Set(viewTags(nv).map((t) => t.color));
             const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
-            const nt = { id: 'g' + Date.now().toString(36), name: ni.value.trim().slice(0, 40), color,
-                         members: [s.id] };
-            nv.tags = viewTags(nv).concat([nt]); delete nv.groups;
+            nv.tags = viewTags(nv).concat([{ id: 'g' + Date.now().toString(36),
+              name: ni.value.trim().slice(0, 40), color, members: rowIds.slice() }]);
+            delete nv.groups;
             addMenuFor = null;
             this._setViews(nv); build();
           });
           am.appendChild(ni);
           ni.focus();
+        };
+        if (addMenuFor === '*') addMenu(rows.map((s) => s.id));
+        for (const s of rows) {
+          const vv = this._curViews();
+          // NAME — the session's identity colour on the name itself (never a proxy dot), the
+          // "host:" prefix quiet lowercase italic, a dead session struck: every other surface's read
+          const nameCell = grid.createDiv();
+          nameCell.setAttribute('style', 'white-space:nowrap;' + (s.live ? '' : 'opacity:0.55;'));
+          const [hpre, bare] = nameParts(s);
+          if (hpre) {
+            const hp = nameCell.createSpan({ text: hpre });
+            hp.setAttribute('style', 'color:' + MODEL_FG + ';font-style:italic;font-size:0.88em;');
+          }
+          const nm = nameCell.createSpan({ text: bare });
+          nm.setAttribute('style', 'font-weight:650;color:' + (s.color || '#cccccc') + ';'
+            + (s.live ? '' : 'text-decoration:line-through;'));
+          // TAGS — removable chips, outline in the tag's colour, dim separate ✕
+          const chips = grid.createDiv();
+          chips.setAttribute('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;min-width:0;');
+          for (const t of viewTags(vv)) {
+            if ((t.members || []).indexOf(s.id) < 0) continue;
+            const tc = t.color || '#cccccc';
+            const ch = chips.createSpan();
+            ch.setAttribute('style', 'display:inline-flex;align-items:center;gap:5px;'
+              + 'padding:2px 7px;border-radius:9px;font-size:0.82em;cursor:pointer;white-space:nowrap;'
+              + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
+            hover(ch, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
+            ch.createSpan({ text: t.name });
+            const chx = ch.createSpan({ text: '✕' });
+            chx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
+            ch.setAttribute('title', 'tagged "' + t.name + '" — click to take this tag off');
+            ch.addEventListener('click', () => { this._setViews(viewToggleMember(this._curViews(), t.id, s.id)); build(); });
+          }
+          // [+] — one aligned column, so the table reads as a table
+          const plusCell = grid.createDiv();
+          const plus = plusCell.createSpan({ text: '+' });
+          plus.setAttribute('style', 'display:inline-flex;align-items:center;justify-content:center;width:17px;height:17px;'
+            + 'border-radius:50%;border:1px solid rgba(255,255,255,0.25);color:#cccccc;opacity:0.7;cursor:pointer;font-size:0.85em;background:transparent;');
+          hover(plus, 'background:rgba(255,255,255,0.09);opacity:1;', 'background:transparent;opacity:0.7;');
+          plus.setAttribute('title', 'add a tag');
+          plus.addEventListener('click', () => { addMenuFor = addMenuFor === s.id ? null : s.id; renderRows(); });
+          // FEED — the pool-builder switch rides every live row (the user 2026-08-19), aligned
+          const feedCell = grid.createDiv();
+          if (ft && s.live) {
+            const on = ft.enabled(s);
+            const fic = el('svg', { viewBox: '0 0 17 17', width: 14, height: 14 });
+            fic.setAttribute('style', 'cursor:pointer;' + (on ? '' : 'opacity:0.55;'));
+            fic.appendChild(ft.icon(!on, 8.5, 8.5, on ? ROMP_BLUE : MODEL_FG));
+            fic.addEventListener('click', (e) => {
+              e.stopPropagation();
+              const next = ft.value(!on);
+              s.hideFromFeed = next;
+              (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).hideFromFeed = next;
+              this._setSessionFlag(s, 'hideFromFeed', next);
+              this._reconcilePendingFlags();
+              renderRows();
+            });
+            fic.addEventListener('mouseenter', () => { fic.setAttribute('title', on
+              ? 'its prompts make feed cards — click to mute (a background worker usually wants this off)'
+              : 'feed-muted: new prompts mint no cards — click to restore'); fic.style.opacity = '1'; });
+            fic.addEventListener('mouseleave', () => { fic.style.opacity = on ? '' : '0.55'; });
+            feedCell.appendChild(fic);
+          }
+          // EYE — only on a hidden session, to un-hide (hiding lives on the chat tab)
+          const eyeCell = grid.createDiv();
+          if (((vv.hidden || [])).indexOf(s.id) >= 0) {
+            const eye = eyeCell.createSpan({ text: '⌀' });
+            eye.setAttribute('style', 'cursor:pointer;opacity:0.6;');
+            hover(eye, 'opacity:1;', 'opacity:0.6;');
+            eye.setAttribute('title', 'hidden from the (untagged) view — click to show it again');
+            eye.addEventListener('click', () => { this._setViews(viewToggleHidden(this._curViews(), s.id)); build(); });
+          }
+          if (addMenuFor === s.id) addMenu([s.id]);
         }
-      }
+      };
+      renderRows();
+      // a repaint mid-typing keeps the search box live: re-focus with the caret at the end
+      if (query) { q.focus(); try { q.setSelectionRange(q.value.length, q.value.length); } catch (e) {} }
     };
     build();
     const h = this._menuHost({ left: 0, top: 0, bottom: 0, right: 0 });

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -33,7 +33,9 @@ test("executed: the default view shows UNTAGGED minus hidden; a tag view its mem
 });
 
 test("executed: the trigger label and the N-more cue (live sessions outside the view)", () => {
-  assert.equal(viewLabel(null), "default");
+  // the default view is named for what it shows (the user 2026-08-24): "(untagged)", parenthesized
+  // as the built-in it is — "default" said nothing about the rule
+  assert.equal(viewLabel(null), "(untagged)");
   assert.equal(viewLabel(V("g1")), "pool");
   const sessions = [{ id: "s1", live: true }, { id: "s2", live: true }, { id: "s4", live: false }];
   assert.equal(viewMoreCount(V("g1"), sessions), 1, "s1 is live and outside; dead s4 never counts");
@@ -108,29 +110,50 @@ test("the dropdown and dialog wear the shared menu vocabulary and adopt into the
   assert.match(SRC, /const h = this\._menuHost\(anchorEl\.getBoundingClientRect\(\)\);[\s\S]{0,400}this\._viewsMenu = menu;/);
 });
 
-test("the sessions dialog is TAG-CENTRIC: chips per row, a [+] to join or mint, the feed toggle rides along", () => {
-  // the user 2026-08-23: multi-tag assignment in one visit — each row wears its tags as removable
-  // chips (the tag's colour, the trigger chip's dress) and a [+] menu of the tags it lacks + a
-  // new-tag input. The menu items say so: New tag… / Sessions & tags…
-  assert.match(SRC, /item\('New tag…', \{ dim: true \}\)/);
-  assert.match(SRC, /item\('Sessions & tags…', \{ dim: true \}\)/);
+test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2026-08-24, JLD-designed)", () => {
+  // one grid, columns [name | chips | + | feed | eye] — the [+] column's ALIGNMENT carries the
+  // table structure (JLD: sequence in space suggests structure)
+  assert.match(SRC, /grid-template-columns:max-content 1fr max-content max-content max-content;/);
+  // the session NAME wears its identity colour directly (JLD: label directly, never a legend-like
+  // proxy dot), the host: prefix is quiet lowercase italic, a dead session is struck — the same
+  // read as the lanes and the feed. No model column, no instruction caption, no ellipsized names.
+  assert.match(SRC, /font-weight:650;color:' \+ \(s\.color \|\| '#cccccc'\)/);
+  assert.match(SRC, /font-style:italic;font-size:0\.88em;/);
+  assert.match(SRC, /text-decoration:line-through;/);
+  const DLG = SRC.slice(SRC.indexOf('_openViewsDialog'), SRC.indexOf('_openLaneMenu('));
+  assert.doesNotMatch(DLG, /s\.model/, "no model column");
+  assert.doesNotMatch(SRC, /Tags mark specialized sessions/, "the display explains itself");
+  // SEARCH (name or host — one string, the host prefix rides the name) + the bulk controls that
+  // act on the FILTERED set: search is how a batch is selected (the user 2026-08-24)
+  assert.match(SRC, /q\.placeholder = 'search name or host…';/);
+  assert.match(SRC, /const tagAll = bar\.createSpan\(\{ text: '\+ tag all' \}\);/);
+  assert.match(SRC, /anyOn \? 'mute feed for all' : 'restore feed for all'/);
+  assert.match(SRC, /const flagVal = ft\.value\(!anyOn\);/, "any still minting → mute all; all muted → restore");
+  // chips: outline in the tag's colour, dim separate ✕, hover changes colour (menu chrome)
   assert.match(SRC, /ch\.createSpan\(\{ text: t\.name \}\);/);
   assert.match(SRC, /const chx = ch\.createSpan\(\{ text: '✕' \}\);/, "the ✕ is its own dim span — the composer chip's read");
   assert.doesNotMatch(SRC, /background:color-mix/, "no tinted chip grounds anywhere in the dialog");
+  assert.match(SRC, /hover\(ch, 'background:rgba\(255,255,255,0\.09\);', 'background:transparent;'\);/);
   assert.match(SRC, /this\._setViews\(viewToggleMember\(this\._curViews\(\), t\.id, s\.id\)\); build\(\);/,
     "chip click = leave that tag; [+] option = join — both through the one pure mutation");
-  assert.match(SRC, /ni\.placeholder = 'new tag…';/, "minting a tag right from a session row");
-  assert.match(SRC, /nv\.tags = viewTags\(nv\)\.concat\(\[nt\]\); delete nv\.groups;/,
-    "a write normalizes onto the tags key, never re-emitting the legacy one");
+  assert.match(SRC, /ni\.placeholder = 'new tag…';/, "minting a tag right from a row or the bulk bar");
+  assert.match(SRC, /delete nv\.groups;/, "a write normalizes onto the tags key, never re-emitting the legacy one");
   // the eye-off appears ONLY on a hidden session, to un-hide it (hiding lives on the chat tab)
-  assert.match(SRC, /if \(\(v\.hidden \|\| \[\]\)\.indexOf\(s\.id\) >= 0\) \{/);
-  // the feed toggle still rides every live row (the user 2026-08-19 pool-builder rule): a
-  // background worker wants BOTH edits — tagged out of the default view AND off the feed — in one
-  // visit. Reused machinery, never a new one; NOT auto-coupled to membership.
+  assert.match(SRC, /if \(\(\(vv\.hidden \|\| \[\]\)\)\.indexOf\(s\.id\) >= 0\) \{/);
+  // the feed toggle still rides every live row (the user 2026-08-19 pool-builder rule), aligned in
+  // its own column; NOT auto-coupled to membership.
   assert.match(SRC, /const ft = LANE_TOGGLES\.find\(\(t\) => t\.flag === 'hideFromFeed'\);/);
   assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.hideFromFeed = next;/,
     "the same optimistic sticky flags the lane gear uses");
-  assert.match(SRC, /this\._setSessionFlag\(s, 'hideFromFeed', next\);\s*\n\s*this\._reconcilePendingFlags\(\);/);
+  // the menu items say so: New tag… / Sessions & tags… / the (untagged) default
+  assert.match(SRC, /item\('New tag…', \{ dim: true \}\)/);
+  assert.match(SRC, /item\('Sessions & tags…', \{ dim: true \}\)/);
+  assert.match(SRC, /item\('\(untagged\)', \{ current: !v\.active \|\| v\.active === 'all' \}\)/);
+});
+
+test("the N-more count opens the views menu — what am I not seeing answers itself (the user 2026-08-24)", () => {
+  assert.match(SRC, /m\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(m\); \}\);/);
+  assert.match(SRC, /m\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/, "and survives its own opening click");
 });
 
 test("the two display toggles write the host's own romp:settings — reachable in every host now", () => {

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -105,7 +105,7 @@ var GEAR_HTML =
   '<span><b>Collapse cards by default</b>' +
   '<span class=rs-sub>Every card arrives collapsed to its one-line gist; expanding one is a per-card override. Moved here from the feed footer — a set-and-forget default, not a per-glance action.</span>' +
   '</span></label>' +
-  '<div class=rs-sec>Timeline</div>' +
+  '<div class=rs-sec>Sessions pane</div>' +   // the pane's label (renamed from Timeline, the user 2026-08-24); "pane" disambiguates from the session-defaults section above
   '<label class=rs-row><input type=checkbox id=rs-activeonly checked>' +
   '<span><b>Show active sessions only</b>' +
   '<span class=rs-sub>Only draw lanes for sessions with work in the visible time range, so idle sessions do not take up room. They stay in the chat, and a lane reappears the moment you zoom or pan to a stretch where it did something.</span>' +


### PR DESCRIPTION
## The dialog (the user 2026-08-24, designed to the JLD display rules)

- **A real table**: one grid, columns `name | tag chips | + | feed | eye` — every [+] aligns in its own column (alignment carries structure).
- **Romp's own conventions** (similarity = same meaning): the session name wears its identity colour directly — never a proxy dot — full width, no ellipsis; the `host:` prefix is quiet lowercase italic; a dead session is struck. No model column, no instruction caption (remove what can be removed; the display explains itself).
- **Search + bulk**: a search box (name or host) filters the rows; "+ tag all" and "mute/restore feed for all" act on the filtered set — search is how a batch is selected.
- **Menu chrome throughout**: hover colour changes on every interactive element, more edge padding, the shared menu font.

## Around it

- The **"N more"** count in the timeline corner opens the views menu — "what am I not seeing?" answers itself.
- The default view is named **"(untagged)"** — "default" said nothing about the rule.
- The **pane is renamed Sessions** (desktop rail, phone tabs, pane-name dictionary; `data-pane` key stays `timeline`, the fleet/Outline precedent) — it outgrew "Timeline". Its settings section becomes "Sessions pane" (gear already has a session-defaults "Sessions" section). Docs prose describing the timeline visualization keeps the word.

## Tests

`ui/timeline-views-panel.test.ts` repinned to the table (grid columns, direct-colour names, italic host prefix, struck dead rows, search + bulk controls, no-model/no-caption assertions, hover chrome, the N-more click, "(untagged)"). `tests/test_kernel_pane_rail.py` + `test_kernel_settings_sections.py` repinned to the Sessions labels. Suites green: 2211 JS tests, 5323 python tests (+281 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)