### PR TITLE
The feed grows a search box: type-to-filter by session name, host included

### DIFF
--- a/ui/webview/feed-search.test.ts
+++ b/ui/webview/feed-search.test.ts
@@ -1,0 +1,51 @@
+// The feed search filter (the user 2026-08-23): type-to-filter the board by session name, HOST PREFIX
+// INCLUDED — a machine name keeps every session on it, and host:name narrows to one. Pure rule
+// executed here; the feed wiring and the expandable footer control pinned by source.
+import { test } from "node:test";
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { searchMatches, searchSids } from "./feed-search";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("substring match over the full display name, case-insensitive, host prefix included", () => {
+  assert.ok(searchMatches("TESTHOST", "TESTHOST:notes-api"), "a machine name finds its sessions");
+  assert.ok(searchMatches("notes", "TESTHOST:notes-api"));
+  assert.ok(searchMatches("TESTHOST:NOTES", "TESTHOST:notes-api"), "case-insensitive");
+  assert.ok(searchMatches("t:n", "TESTHOST:notes-api"), "plain substring — spans the host separator");
+  assert.ok(!searchMatches("otherbox", "TESTHOST:notes-api"));
+  assert.ok(searchMatches("  api ", "api"), "the query is trimmed");
+});
+
+test("a blank query is the filter OFF, never matched-none", () => {
+  assert.ok(searchMatches("", "anything"));
+  assert.ok(searchMatches("   ", "anything"));
+  assert.ok(searchMatches(null, "anything"));
+  assert.equal(searchSids("", [{ sid: "a", name: "web" }]), null, "null = no filter, distinct from an empty set");
+});
+
+test("searchSids collects the matching sids; a query matching nothing yields an EMPTY set", () => {
+  const metas = [{ sid: "a", name: "TESTHOST:web" }, { sid: "b", name: "otherbox:web" }, { sid: "c", name: "otherbox:api" }];
+  assert.deepEqual([...searchSids("web", metas)!].sort(), ["a", "b"]);
+  assert.deepEqual([...searchSids("otherbox", metas)!].sort(), ["b", "c"]);
+  assert.equal(searchSids("zzz", metas)!.size, 0, "an empty board is the honest answer, not filter-off");
+});
+
+test("the feed composes search WITH the session filter, and cards fall back to their own label", () => {
+  assert.match(FEED, /const sMatch = searchSids\(feedSearchQ, sessionsMeta\);/);
+  assert.match(FEED, /sMatch\.has\(a\.sid\) \|\| searchMatches\(feedSearchQ, \(a as \{ name\?: string \}\)\.name\)/,
+               "a just-died session's cards keep matching by their per-card label");
+});
+
+test("the footer control is ensure-once, expandable, and an active query can never be hidden", () => {
+  assert.match(FEED, /function ensureSearchBox\(\): HTMLElement/);
+  assert.match(FEED, /if \(active\) wrap\.classList\.add\("open"\);/,
+               "a live query forces the input open — the compact state never hides an active filter");
+  assert.match(FEED, /if \(inp\.value\.trim\(\)\) \{ inp\.value = ""; setFeedSearch\(""\); render\(\); \}/,
+               "folding with a live query clears it, never hides it");
+  assert.match(FEED, /sessionStorage\.getItem\("romp:feedSearch"\)/,
+               "same storage lifetime as the session filter: reload-proof, never a fresh window");
+  assert.match(CSS, /#feed-search\.open input \{ width: \d+px/, "the expansion is a real width transition");
+});

--- a/ui/webview/feed-search.ts
+++ b/ui/webview/feed-search.ts
@@ -1,0 +1,23 @@
+// The feed's SEARCH filter (the user 2026-08-23): a footer search box that live-filters the board to
+// sessions whose NAME matches the typed text — host prefix included, so "snape" finds every session on
+// that machine and "snape:api" narrows to one. Compact by default (a "Search" button, the footer's
+// word-button vocabulary), expanding to an inline input on click — progressive disclosure, like every
+// feed surface. Pure matching lives here so node --test executes the rule without a DOM.
+
+/** Case-insensitive SUBSTRING match over the session's full display name (host prefix included).
+ *  An empty/blank query matches everything — the filter off. */
+export function searchMatches(query: string | null | undefined, name: string | null | undefined): boolean {
+  const q = (query || "").trim().toLowerCase();
+  if (!q) return true;
+  return (name || "").toLowerCase().includes(q);
+}
+
+/** The sids whose session name matches — the set the render's `shown` pass filters by. Cards also
+ *  carry their own per-card name; the caller ORs both so a card whose session fell out of the meta
+ *  list (a just-died session's last cards) still matches by its own label. */
+export function searchSids(query: string | null | undefined,
+                           metas: { sid: string; name: string }[]): Set<string> | null {
+  const q = (query || "").trim();
+  if (!q) return null;                               // null = no filter (distinct from "matched none")
+  return new Set(metas.filter((m) => searchMatches(q, m.name)).map((m) => m.sid));
+}

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -38,7 +38,8 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
   assert.ok(FEED.includes("let feedOnlySid: string | null = null;"));
   assert.ok(FEED.includes('sessionStorage.getItem("romp:feedOnly")'),
     "survives this tab's reloads only — a fresh window always starts unfiltered");
-  assert.ok(FEED.includes("const shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;"));
+  assert.ok(FEED.includes("let shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;"));
+  // (`let`, since 2026-08-23: the SEARCH filter composes onto the same render-side view — see feed-search.test.ts)
   assert.ok(FEED.includes("for (const a of shown) {"), "the group-fold loop reads the filtered view");
   assert.ok(FEED.includes("for (const a of shown) { if (grouped.has(a.itemId)) continue;"), "…and the singles loop");
   // a filter aimed at a session the tab strip no longer shows clears itself — the deciding EVENT is

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1370,3 +1370,19 @@ body.filebrowse-open { overflow: hidden; }
   color: var(--accent); border-color: var(--accent); }
 #feed-foot .feed-modetoggle.forced:hover { opacity: 0.75;
   background: rgba(156, 210, 255, 0.12); }   /* keep the pressed wash — never the action hover's promise */
+
+/* The footer SEARCH box (the user 2026-08-23): a "Search" word-button expanding to an inline input
+   that live-filters the board by session name, host prefix included. The input wears the footer's
+   scale and the shared dark-panel vocabulary; expansion is a width transition, so it "grows" out of
+   the button instead of popping. Active (a live query) keeps the button accented like every .on toggle. */
+#feed-search { display: inline-flex; align-items: center; gap: 5px; }
+#feed-search input { width: 0; padding: 0; border: 0; opacity: 0;
+  transition: width 0.15s ease, opacity 0.15s ease;
+  font-size: 10.5px; font-family: inherit; color: var(--fg, #ccc);
+  background: var(--vscode-editorWidget-background, #252526);
+  border-radius: 3px; outline: none; }
+#feed-search.open input { width: 138px; padding: 1px 7px; opacity: 1;
+  border: 1px solid var(--card-border); }
+#feed-search.open input:focus { border-color: var(--accent); }
+#feed-search input::-webkit-search-cancel-button { -webkit-appearance: none; }   /* the button folds/clears; no double affordance */
+@media (prefers-reduced-motion: reduce) { #feed-search input { transition: none; } }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -9,6 +9,7 @@
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
+import { searchMatches, searchSids } from "./feed-search";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
@@ -470,6 +471,15 @@ try { feedOnlySid = sessionStorage.getItem("romp:feedOnly") || null; } catch { /
 function setFeedOnly(sid: string | null): void {
   feedOnlySid = sid;
   try { sid ? sessionStorage.setItem("romp:feedOnly", sid) : sessionStorage.removeItem("romp:feedOnly"); } catch { /* ignore */ }
+}
+// The SEARCH query (the user 2026-08-23): type-to-filter by session name, host prefix included —
+// "snape" keeps every session on that machine. Same storage lifetime as the session filter: survives
+// this tab's reloads, never a fresh window (a filter persisting for days reads as silently lost cards).
+let feedSearchQ = "";
+try { feedSearchQ = sessionStorage.getItem("romp:feedSearch") || ""; } catch { /* storage blocked */ }
+function setFeedSearch(q: string): void {
+  feedSearchQ = q;
+  try { q ? sessionStorage.setItem("romp:feedSearch", q) : sessionStorage.removeItem("romp:feedSearch"); } catch { /* ignore */ }
 }
 
 // OPTIMISTIC colour echo from the chat pane's tab menu (the user 2026-08-08): the chat repaints its
@@ -3290,6 +3300,46 @@ function openSessMenu(btn: HTMLElement): void {
   document.addEventListener("pointerdown", sessMenuAway, true);
   document.addEventListener("keydown", sessMenuKey, true);
 }
+// The SEARCH box (the user 2026-08-23): a footer "Search" word-button that expands to an inline
+// input filtering the board live by session name, host prefix included. Ensure-once like every foot
+// control — render() never rebuilds it, so focus and the caret survive pushes (the click-safety rule).
+// An ACTIVE query keeps the input open and the control accented; Escape (or emptying + blur) folds it
+// back to the button — a compact state can never hide a live filter (progressive disclosure's no-dead-end).
+function ensureSearchBox(): HTMLElement {
+  let wrap = document.getElementById("feed-search") as HTMLElement | null;
+  if (!wrap) {
+    wrap = el("span", "");
+    wrap.id = "feed-search";
+    const btn = el("button", "fdismiss ffollow feed-modetoggle");
+    btn.id = "feed-search-btn";
+    btn.textContent = "Search";
+    btn.title = "filter cards by session name — the host prefix counts, so a machine name finds all its sessions";
+    const inp = document.createElement("input");
+    inp.id = "feed-search-input";
+    inp.type = "search";
+    inp.placeholder = "session or host…";
+    inp.setAttribute("aria-label", "filter cards by session name (host prefix included)");
+    const openBox = () => { wrap!.classList.add("open"); inp.focus(); };
+    const foldBox = () => {                             // folding with a live query CLEARS it — the button
+      if (inp.value.trim()) { inp.value = ""; setFeedSearch(""); render(); }   // never hides an active filter
+      wrap!.classList.remove("open");
+    };
+    btn.onclick = (ev) => { ev.stopPropagation(); wrap!.classList.contains("open") ? foldBox() : openBox(); };
+    inp.oninput = () => { setFeedSearch(inp.value); render(); };   // live: the keyed render reuses every card
+    inp.onkeydown = (ev) => { if (ev.key === "Escape") { ev.stopPropagation(); foldBox(); } };
+    inp.onblur = () => { if (!inp.value.trim()) wrap!.classList.remove("open"); };
+    wrap.appendChild(btn); wrap.appendChild(inp);
+    (document.getElementById("feed-foot") || document.body).appendChild(wrap);
+  }
+  const inp = wrap.querySelector("input") as HTMLInputElement;
+  if (inp && inp.value !== feedSearchQ && document.activeElement !== inp) inp.value = feedSearchQ;
+  const active = !!feedSearchQ.trim();
+  if (active) wrap.classList.add("open");
+  const btn = document.getElementById("feed-search-btn");
+  if (btn) { btn.classList.toggle("on", active); btn.setAttribute("aria-pressed", active ? "true" : "false"); }
+  return wrap;
+}
+
 function ensureSessionFilter(): HTMLElement {
   let b = document.getElementById("feed-sessfilter") as HTMLElement | null;
   if (!b) {
@@ -3670,6 +3720,7 @@ function render() {
   ensureStackToggle().style.display = showCA ? "" : "none";       // force one-column at any width (the user 2026-08-18)
   ensureGroupToggle().style.display = showCA ? "" : "none";       // by-session grouping (the user 2026-07-13)
   ensureSessionFilter().style.display = showCA ? "" : "none";     // one-session filter menu (the user 2026-08-08)
+  ensureSearchBox().style.display = showCA ? "" : "none";          // type-to-filter by name/host (the user 2026-08-23)
   ensureClearAll().style.display = showCA ? "" : "none";
   ensureUndoClear().style.display = canUndoClear ? "" : "none";
   const foot = document.getElementById("feed-foot");
@@ -3699,7 +3750,12 @@ function render() {
   // The footer session filter (the user 2026-08-08): with a session picked, the board draws ONLY its
   // cards. Display-side only — `asks` stays complete, so flipping the filter needs no kernel round-trip
   // and everything else (the modal, optimistic moves, the empty check above) still sees the whole board.
-  const shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;
+  let shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;
+  // The search query composes with the session filter, display-side like it: a card passes when its
+  // session's meta name matches OR its own per-card label does (a just-died session's cards keep
+  // matching by label after the meta list drops it).
+  const sMatch = searchSids(feedSearchQ, sessionsMeta);
+  if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
   // Derive sibling GROUPS at render time, keyed by the shared typed turn (turnId).
   // Only host-flagged asks (groupTitle) participate, and a turn needs ≥2 current
   // members to fold — a lone survivor (siblings cleared) renders as a single card.


### PR DESCRIPTION
A "Search" button in the feed footer expands to an inline input that live-filters the board by session name, host prefix included — a machine name keeps every session on that host. Composes with the session-filter menu; active queries can never be hidden by the compact state; ensure-once so focus survives pushes. Local suites: 5323 py / 2215 ui, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)