### PR TITLE
Timeline postal stubs: hidden-counterpart messages draw a clipped band-edge diagonal

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -15,7 +15,9 @@ const LANE_GAP = 26, BAR_H = 8, CORNER = 6, MSG_DROP = 10, DOT_R = 6, CLEAR = DO
 // Demo/recording VIEW filter (the user 2026-07-14): the dashboard loaded at `#only=<tag>` scopes every
 // pane to sessions whose name starts with <tag>. The timeline reads the SHELL's URL (window.top) so one
 // tag on the dashboard URL filters the lanes here too; a cross-origin top falls back to our own URL.
-// Filtering data.sessions is enough — cross-session flows already skip when a lane is absent (vidx guard).
+// Filtering data.sessions is enough for FULL connectors — those skip when a lane is absent (vidx
+// guard). A message with exactly ONE endpoint on-camera still draws its band-edge stub (the stub
+// pass in draw()), whose tooltip names the off-camera counterpart — mind that when recording.
 function _rompOnlyTag() {
   const read = (loc) => { try { const hay = (loc.hash || "") + " " + (loc.search || ""); const m = hay.match(/only=([^&\s]+)/i); return m ? (decodeURIComponent(m[1]).trim().toLowerCase() || null) : null; } catch (e) { return null; } };
   if (typeof window === "undefined") return null;   // no DOM (a test/headless context) → no filter
@@ -2996,7 +2998,7 @@ class TimelinePanel {
       data.messages.forEach((mm) => {
         const s1 = midStart[mm.toId + '|' + (mm.id || '')], s2 = midStart[mm.toId + '|' + (mm.dmid || '')];
         const st = (s1 != null && s2 != null) ? Math.min(s1, s2) : (s1 != null ? s1 : s2);
-        if (st != null) { mm.exec = st; mm.pending = false; }
+        if (st != null) { mm.exec = st; mm.pending = false; mm.hasExec = true; }   // a join IS exec knowledge — the hidden-counterpart stub color keys on hasExec
       });
     }
     const startAt = (t) => t.pending ? nowS : t.start;
@@ -3670,9 +3672,74 @@ class TimelinePanel {
     const msgUI = {};   // message index → { hl, dot }, shared across the line + dot passes
     const msgHtml = (mm) => () => { const col = colorOf(mm.fromId); return '<div class="r"><span class="chip" style="background:' + col + '"></span><span class="who" style="color:' + col + '">' + esc(mm.from) + '</span><span class="ar">→</span><span class="who" style="color:' + colorOf(mm.toId) + '">' + esc(mm.to) + '</span>' + (mm.pending ? ' <span class="k">pending</span>' : '') + '<span class="t">' + clock(mm.sent) + (mm.pending ? ' → …' : ' → ' + clock(mm.exec)) + '</span></div>' + this.body(esc(mm.summary || mm.text || '')); };
     const msgNav = (mm) => () => { const an = this.nearestTurnAnchor(mm.toId, execAt(mm)); this._select(mm.toId); this.openChat((an && an.tid) || mm.toId, mm.id || (an && (an.uuid || an.replyUuid)), false, false, execAt(mm)); };   // land on the message's OWN postal card BY ID — the chat matches mm.id to the card's data-mid (the user 2026-06-20); nearest-turn uuid / time only as fallback
+    // ── HIDDEN-COUNTERPART STUBS (the user 2026-08-24): a message whose OTHER endpoint has no
+    // visible lane still shows on the lane it does touch — a short diagonal stub through the band
+    // edge, exiting (recipient hidden) or entering (sender hidden), clipped BY ARITHMETIC to the
+    // lane's own band (y stays within laneY(i) ± LANE_GAP/2; this file has no clipPath — keep it
+    // that way), so it visibly leaves for / arrives from somewhere off-view without entering other
+    // lanes' space.
+    // SLOPE: toward where the hidden lane WOULD sit — lanes render in data.sessions order (vis
+    // filters, never reorders), so a counterpart sorted AFTER the shown session would sit below →
+    // the stub points down (+1); sorted before → up (-1). A counterpart absent from data.sessions
+    // entirely (dismissed, #only= filtered, or a foreign session) has no would-be slot: fixed
+    // convention, down (+1, toward the axis), so unknowable counterparts always read one way.
+    // TWO-STATE COLOR, keyed on the exec EVENT, never a timer: mm.pending folds in the kernel's
+    // in-flight staleness window (MSG_INFLIGHT_MAX), so it is NOT the key. Exec knowledge is:
+    // hasExec (the logged exec event — kernel serialization, the federation upgrade, or the
+    // midStart join above) OR exec moved off its sent-time fallback (the kernel serializes
+    // exec = sent until a binder writes a real landing; _bind_message_execs' text-heuristic path
+    // binds exec without ever logging an event, so hasExec alone would miss it — and federation
+    // shifts sent and a fallback exec by the same offset, so the comparison survives rebasing).
+    // No exec known → await-green; exec known → working-yellow — both faded, the awaitingBg
+    // stretch's treatment. This file cannot load ui/webview/styles.css (it also runs inside
+    // Obsidian), so the two tokens are inlined with their names — the MENU_STYLE precedent:
+    const STUB_GREEN = '#54B204';    // --st-awaitbg-bg (await-green)
+    const STUB_YELLOW = '#e0b020';   // --st-working-bg (working-yellow)
+    const STUB_W = 3;                // a hair over MSG_W0 — a ~15px stroke needs the weight to read
+    const STUB_DX = LANE_GAP / 2;    // full-height run → 45° in the lane grid; a nearer landing steepens it
+    const stub = (mm, i, senderVisible) => {
+      const sid = senderVisible ? mm.fromId : mm.toId, hid = senderVisible ? mm.toId : mm.fromId;
+      const ly = laneY(vidx[sid]);
+      const oi = data.sessions.findIndex((s) => s.id === sid), hi = data.sessions.findIndex((s) => s.id === hid);
+      const dir = (hi < 0 || hi > oi) ? 1 : -1;   // toward the hidden lane's would-be slot (see SLOPE above)
+      let x1, y1, x2, y2;
+      if (senderVisible) {
+        // outgoing: anchored at the send, exits through the band edge toward the landing x (the
+        // live edge while pending, via execAt inside landXT) — never past it, never past the window
+        if (!inWin(sendXT(mm))) return;
+        x1 = x(sendXT(mm)); y1 = ly;
+        x2 = Math.max(x1, Math.min(x(Math.min(landXT(mm), t1)), x1 + STUB_DX)); y2 = ly + dir * LANE_GAP / 2;
+      } else {
+        // incoming: the mirror — enters from the band edge, arrives at the landing point
+        if (!inWin(landXT(mm))) return;
+        x2 = x(landXT(mm)); y2 = ly;
+        x1 = Math.min(x2, Math.max(x(Math.max(sendXT(mm), t0)), x2 - STUB_DX)); y1 = ly + dir * LANE_GAP / 2;
+      }
+      const col = (mm.hasExec || mm.exec !== mm.sent) ? STUB_YELLOW : STUB_GREEN;
+      svg.appendChild(el('line', { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W, opacity: 0.45,
+                                   'stroke-linecap': 'round', 'pointer-events': 'none' }));
+      // same affordances as a full connector: own-color highlight overlay + wide transparent hit,
+      // co-lit with the arrival dot (PASS 2 links via msgUI), tooltip + click → where it landed
+      const msgLit = dagOrHoverMsg(mm.id);
+      const hl = el('line', { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W + 3, opacity: msgLit ? 0.95 : 0,
+                              'stroke-linecap': 'round', 'pointer-events': 'none' });
+      svg.appendChild(hl);
+      const u = (msgUI[i] = { hl, dot: null, lit: msgLit });
+      const hit = el('line', { x1, y1, x2, y2, stroke: 'transparent', 'stroke-width': MSG_HIT_W, 'stroke-linecap': 'round' });
+      hit.style.cursor = 'pointer';
+      const mEnter = (e) => { hl.setAttribute('opacity', '0.95'); if (u.dot) u.dot.setAttribute('r', DOT_R + 2); this.showTip(msgHtml(mm)(), e); };
+      hit.__tlHoverIn = mEnter;                    // re-armable after a redraw rebuilds this stub (_rehover)
+      hit.addEventListener('mouseenter', mEnter);
+      hit.addEventListener('mousemove', (e) => this.moveTip(e));
+      hit.addEventListener('mouseleave', () => { hl.setAttribute('opacity', msgLit ? '0.95' : '0'); if (u.dot) u.dot.setAttribute('r', msgLit ? DOT_R + 2 : DOT_R); this.hideTip(); });
+      hit.addEventListener('click', msgNav(mm));
+      u.hit = hit;   // appended in PASS 3 with the connector hits, over the dots
+    };
     // PASS 1: connector line + highlight (drawn first so the dots sit on top).
     data.messages.forEach((mm, i) => {
-      if (vidx[mm.fromId] == null || vidx[mm.toId] == null) return;
+      const sVis = vidx[mm.fromId] != null, rVis = vidx[mm.toId] != null;
+      if (sVis !== rVis) { stub(mm, i, sVis); return; }   // exactly one endpoint visible → a band-edge stub
+      if (!sVis) return;                                  // both endpoints hidden → nothing to draw
       if (landXT(mm) < t0 || sendXT(mm) > t1) return;
       const sLane = vidx[mm.fromId], rLane = vidx[mm.toId];
       const offL = sendXT(mm) < t0;   // sent BEFORE the visible window — only the delivery is in view

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -1,0 +1,265 @@
+// Hidden-counterpart message STUBS (the user 2026-08-24): a postal message whose OTHER endpoint has
+// no visible lane must still show on the lane it touches — a short diagonal stub through the lane's
+// band edge (exiting when the recipient is hidden, entering when the sender is), clipped to the band
+// by arithmetic (no clipPath), sloped toward where the hidden lane would sort, and colored by the
+// exec EVENT: await-green (--st-awaitbg-bg #54B204) until the exec binds, working-yellow
+// (--st-working-bg #e0b020) after — never a timer. Headless draw() over the render test's DOM shim,
+// asserting on the SVG child tree.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+// ---- minimal DOM shim (the timeline-render.test.ts shim: only what the view touches) ----
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) { c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    _listeners: {} as any,
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 1400, height: 420, left: 0, top: 0, right: 1400, bottom: 420 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+g.requestAnimationFrame = () => 0;
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+const SRC = fs.readFileSync(viewPath, "utf8");
+
+const GREEN = "#54B204";    // --st-awaitbg-bg (await-green): exec not yet bound
+const YELLOW = "#e0b020";   // --st-working-bg (working-yellow): exec bound
+const HALF = 13;            // LANE_GAP/2 — the band-edge clip distance AND the 45° stub run
+
+// Four sessions in a FIXED sort order — ada/cee view-hidden, bee/dee visible. The hidden ones
+// bracket bee so both slope directions (toward-above and toward-below) are exercised.
+function synthData(): any {
+  const now = 1_781_000_000;
+  const turn = (id: string, dt0: number, dt1: number) => ({
+    id, promptId: id + "#p", workId: id + "#w",
+    start: now - dt0, end: now - dt1, prompt: "do the thing", src: "typed", mids: [],
+    pending: false, summary: "did the thing", reply: "did it", tid: "fork-" + id, uuid: "u-" + id,
+    workUuid: "w-" + id, replyUuid: "r-" + id,
+  });
+  const sess = (id: string, name: string, color: string) => ({
+    id, name, color, state: "working", live: true, model: "Opus 4.8", effort: "xhigh",
+    context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+  });
+  return {
+    now,
+    sessions: [sess("SA", "ada", "#f7768e"), sess("SB", "bee", "#7aa2f7"), sess("SC", "cee", "#9ece6a"), sess("SD", "dee", "#bb9af7")],
+    turns: { SB: [turn("SB:1:aa", 300, 60)], SD: [turn("SD:1:bb", 250, 40)] },
+    views: { active: "all", hidden: ["SA", "SC"], tags: [] },
+    messages: [], activeChat: null, focus: null, hover: null, usage: null,
+  };
+}
+
+function draw(messages: any[]): any {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const d = synthData();
+  d.messages = messages;
+  panel.update(d);
+  return panel;
+}
+function nodes(panel: any): any[] {
+  const out: any[] = [];
+  (function walk(n: any) { for (const c of n.children || []) { out.push(c); walk(c); } })(panel.svg);
+  return out;
+}
+const stubLines = (panel: any, hex?: string) =>
+  nodes(panel).filter((n) => n.tag === "line" && (hex ? n._attrs.stroke === hex : (n._attrs.stroke === GREEN || n._attrs.stroke === YELLOW)) && n._attrs["stroke-width"] === 3);
+const connPaths = (panel: any, color: string) =>
+  nodes(panel).filter((n) => n.tag === "path" && n._attrs.fill === "none" && n._attrs.stroke === color && (n._attrs.opacity === 0.5 || n._attrs.opacity === 0.4));
+// expected coordinates from the SAME geometry draw() used (compress map included)
+const X = (panel: any) => (t: number) => { const gm = panel._geom; return gm.ml + (gm.compress(t) - gm.cT0) / gm.winSec * gm.plotW; };
+const laneY = (panel: any) => (i: number) => panel._geom.top + i * 26 + 13;
+const near = (a: number, b: number, msg: string) => assert.ok(Math.abs(a - b) < 1e-6, msg + " (got " + a + ", want " + b + ")");
+
+test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped toward the hidden lane, clipped at the band edge, await-green while pending", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m1", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+                        sent: now - 300, exec: now - 300, hasExec: false, pending: true, summary: "on its way" }]);
+  const [s, ...rest] = stubLines(panel);
+  assert.ok(s, "the stub line draws");
+  assert.equal(rest.length, 0, "exactly one stub");
+  assert.equal(s._attrs.stroke, GREEN, "pending (no exec yet) wears await-green");
+  assert.ok(s._attrs.opacity < 1, "faded, the awaitingBg treatment");
+  near(s._attrs.x1, X(panel)(now - 300), "anchored at the send x");
+  near(s._attrs.y1, laneY(panel)(0), "starts on the sender's lane center");
+  near(s._attrs.y2, laneY(panel)(0) + HALF, "clipped AT the band edge — cee sorts after bee, so it exits downward");
+  near(s._attrs.x2, s._attrs.x1 + HALF, "the 45° run toward the live edge, capped");
+  assert.equal(s._attrs.opacity, 0.45, "the awaitingBg fade level exactly — not invisible, not solid");
+  assert.equal(s._attrs["pointer-events"], "none", "the visible mark never eats the hover — the hit target owns it");
+  const hl = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === GREEN && n._attrs["stroke-width"] === 6);
+  assert.ok(hl && hl._attrs.opacity === 0, "the own-color highlight overlay rides the stub, dark until hover/DAG");
+  assert.equal(hl._attrs["pointer-events"], "none", "the highlight overlay is inert too");
+  const hit = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
+  assert.ok(hit, "a wide transparent hit target covers the stub");
+  // spec item 4: the SAME affordances as a full connector — tooltip via showTip/moveTip/hideTip,
+  // the __tlHoverIn re-arm (a kernel-push redraw rebuilds the node; _rehover re-enters through it),
+  // and the connector's click (jump to where the message landed, by the message's own id)
+  assert.equal(typeof hit.__tlHoverIn, "function", "__tlHoverIn re-arm is wired");
+  assert.equal(hit.style.cursor, "pointer", "the hit target reads as clickable");
+  for (const ev of ["mouseenter", "mousemove", "mouseleave", "click"])
+    assert.equal(typeof hit._listeners[ev], "function", ev + " is wired");
+  hit._listeners.mouseenter({ clientX: 200, clientY: 30, currentTarget: hit });
+  assert.equal(hl._attrs.opacity, "0.95", "hover lights the highlight overlay");
+  assert.ok(panel.tip.classList.contains("show"), "hover shows the tooltip (showTip)");
+  hit._listeners.mouseleave({});
+  assert.equal(hl._attrs.opacity, "0", "leave restores the dark overlay");
+  const calls: any[] = [];
+  panel._select = (id: string) => calls.push(["select", id]);
+  panel.openChat = (...a: any[]) => calls.push(["open", ...a]);
+  hit._listeners.click({});
+  assert.deepEqual(calls[0], ["select", "SC"], "click selects the recipient — where the message landed");
+  assert.equal(calls[1] && calls[1][2], "m1", "click deep-links the message's OWN postal card by id");
+  assert.equal(connPaths(panel, "#7aa2f7").length, 0, "no full connector is drawn for a half-hidden message");
+});
+
+test("the stub turns yellow for a heuristic-bound exec too — exec moved off its sent fallback, hasExec never logged", () => {
+  const now = 1_781_000_000;
+  // the kernel's _bind_message_execs text-heuristic path writes exec/pending but no exec event is
+  // ever logged, so the row ships hasExec:false with a REAL landing time — that is exec knowledge
+  const panel = draw([{ id: "m10", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+                        sent: now - 200, exec: now - 50, hasExec: false, pending: false, summary: "heuristic-bound" }]);
+  const [s] = stubLines(panel);
+  assert.ok(s, "the stub draws");
+  assert.equal(s._attrs.stroke, YELLOW, "a bound exec is exec knowledge, with or without the logged event");
+});
+
+test("the midStart join upgrades the stub to yellow — the join IS exec knowledge (hasExec set)", () => {
+  const now = 1_781_000_000;
+  // recipient turn's mids carry the message id and its start EQUALS the sent time, so the ONLY
+  // yellow source is the join setting hasExec — pins the mm.hasExec = true half of this change
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const d = synthData();
+  d.turns.SC = [{ id: "SC:1:cc", promptId: "SC:1:cc#p", workId: "SC:1:cc#w", start: now - 300, end: now - 200,
+                  prompt: "x", src: "typed", mids: ["m11"], pending: false, summary: "s", reply: "r",
+                  tid: "fork-SC", uuid: "u-SC", workUuid: "w-SC", replyUuid: "r-SC" }];
+  d.messages = [{ id: "m11", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+                  sent: now - 300, exec: now - 300, hasExec: false, pending: true, summary: "joined" }];
+  panel.update(d);
+  assert.equal(panel.data.messages[0].hasExec, true, "the join marks the exec as known");
+  const [s] = stubLines(panel);
+  assert.ok(s, "the stub draws");
+  assert.equal(s._attrs.stroke, YELLOW, "joined landing → working-yellow even with exec equal to sent");
+});
+
+test("the stub flips to working-yellow on the exec event — hasExec, never the staleness timer", () => {
+  const now = 1_781_000_000;
+  const landed = draw([{ id: "m2", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+                         sent: now - 300, exec: now - 30, hasExec: true, pending: false, summary: "landed" }]);
+  const [ys] = stubLines(landed);
+  assert.ok(ys, "the arrived stub draws");
+  assert.equal(ys._attrs.stroke, YELLOW, "exec bound → working-yellow");
+  // a STALE in-flight message (kernel: pending aged out by MSG_INFLIGHT_MAX, still no exec) must NOT
+  // flip yellow — the color keys on the exec event, and no exec event ever happened here
+  const stale = draw([{ id: "m3", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+                        sent: now - 400, exec: now - 400, hasExec: false, pending: false, summary: "never seen landing" }]);
+  const [gs] = stubLines(stale);
+  assert.ok(gs, "the stale stub still draws");
+  assert.equal(gs._attrs.stroke, GREEN, "no exec event → still await-green (the timer is not the key)");
+  near(gs._attrs.x2, gs._attrs.x1, "with the landing x AT the send, the stub steepens to vertical — arithmetic clamp, no clipPath");
+  near(gs._attrs.y2, laneY(stale)(0) + HALF, "still exits through the band edge");
+});
+
+test("a hidden-sender message draws the mirror stub: entering from the band edge, arriving at the exec point, dot kept on top", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m4", fromId: "SA", toId: "SB", from: "ada", to: "bee",
+                        sent: now - 400, exec: now - 100, hasExec: true, pending: false, summary: "delivered" }]);
+  const [s] = stubLines(panel);
+  assert.ok(s, "the incoming stub draws");
+  assert.equal(s._attrs.stroke, YELLOW, "already executed → working-yellow");
+  near(s._attrs.x2, X(panel)(now - 100), "arrives at the exec x");
+  near(s._attrs.y2, laneY(panel)(0), "arrives on the recipient's lane center");
+  near(s._attrs.y1, laneY(panel)(0) - HALF, "enters from the TOP band edge — ada sorts before bee");
+  near(s._attrs.x1, s._attrs.x2 - HALF, "the 45° entry run");
+  const kids = panel.svg.children;
+  const dotI = kids.findIndex((n: any) => n.tag === "circle" && Math.abs(n._attrs.cx - X(panel)(now - 100)) < 1e-6);
+  assert.ok(dotI >= 0, "the arrival dot still draws on the recipient lane");
+  const hitI = kids.findIndex((n: any) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
+  assert.ok(hitI > dotI, "the stub's hit target is appended after the dots (PASS 3), so the line wins the hover");
+});
+
+test("a counterpart absent from data.sessions slopes by the fixed convention: down", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m5", fromId: "SB", toId: "SX", from: "bee", to: "gone",
+                        sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "to a cleared session" }]);
+  const [s] = stubLines(panel);
+  assert.ok(s, "the stub draws even with no would-be lane to lean toward");
+  near(s._attrs.y2, s._attrs.y1 + HALF, "fixed convention: down, toward the axis");
+});
+
+test("both endpoints hidden → no stub, no connector", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m6", fromId: "SA", toId: "SC", from: "ada", to: "cee",
+                        sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "between hidden lanes" }]);
+  assert.equal(stubLines(panel).length, 0, "no stub for a fully hidden flow");
+  assert.equal(connPaths(panel, "#f7768e").length, 0, "no connector either");
+  const lx = X(panel)(now - 50);
+  assert.ok(!nodes(panel).some((n) => n.tag === "circle" && Math.abs(n._attrs.cx - lx) < 1e-6),
+    "no arrival dot draws for a fully hidden flow");
+});
+
+test("two visible lanes keep today's full connector — no stub elements", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m7", fromId: "SB", toId: "SD", from: "bee", to: "dee",
+                        sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "visible to visible" }]);
+  assert.equal(connPaths(panel, "#7aa2f7").length, 1, "the full elbow connector draws exactly as before");
+  assert.equal(stubLines(panel).length, 0, "no stub-colored lines anywhere");
+});
+
+test("window clamping is arithmetic: an off-window send or landing draws no stub", () => {
+  const now = 1_781_000_000;
+  const out = draw([{ id: "m8", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+                      sent: now - 500_000, exec: now - 500_000, hasExec: false, pending: true, summary: "sent long ago" }]);
+  assert.equal(stubLines(out).length, 0, "an outgoing stub is anchored at its send — off-window send, nothing to draw");
+  const inc = draw([{ id: "m9", fromId: "SA", toId: "SB", from: "ada", to: "bee",
+                      sent: now - 600_000, exec: now - 500_000, hasExec: true, pending: false, summary: "landed long ago" }]);
+  assert.equal(stubLines(inc).length, 0, "an incoming stub is anchored at its landing — off-window exec, nothing to draw");
+  // …and the mirror of the mirror: routine OLD mail (sent before the window, delivered inside it)
+  // must still stub — the incoming gate reads the landing, never the send
+  const old = draw([{ id: "m12", fromId: "SA", toId: "SB", from: "ada", to: "bee",
+                      sent: now - 500_000, exec: now - 100, hasExec: true, pending: false, summary: "old but delivered here" }]);
+  const [s] = stubLines(old);
+  assert.ok(s, "an off-window send with an in-window landing still draws the incoming stub");
+  near(s._attrs.x2, X(old)(now - 100), "arriving at the exec x");
+  near(s._attrs.y1, laneY(old)(0) - HALF, "entering from the band edge");
+});
+
+// The window clamps only bind within ~13px of a window edge — hard to pin behaviorally — so pin
+// them at the source, the timeline-threadarc.test.ts idiom for exactly this kind of plumbing.
+test("both stub anchors gate on their own endpoint and clamp x to the window by arithmetic (source pins)", () => {
+  assert.match(SRC, /if \(!inWin\(sendXT\(mm\)\)\) return;/);
+  assert.match(SRC, /if \(!inWin\(landXT\(mm\)\)\) return;/);
+  assert.match(SRC, /x2 = Math\.max\(x1, Math\.min\(x\(Math\.min\(landXT\(mm\), t1\)\), x1 \+ STUB_DX\)\)/);
+  assert.match(SRC, /x1 = Math\.min\(x2, Math\.max\(x\(Math\.max\(sendXT\(mm\), t0\)\), x2 - STUB_DX\)\)/);
+  assert.doesNotMatch(SRC, /el\('clipPath'|clip-path/i, "clipped by arithmetic, never a clipPath element");
+});


### PR DESCRIPTION
## What

A postal message used to vanish from the timeline whenever the counterpart session's lane was hidden (view-filtered, dismissed, or absent from the merged board) — the connector pass draws only when both lanes are visible. Now a message with exactly ONE visible endpoint draws a short diagonal stub in that lane:

- **Outgoing** (recipient hidden): starts at the send point on the sender's lane, slopes toward the hidden counterpart, extends forward toward the landing x (the live edge while pending), and is clipped at the lane's band edge — it visibly exits and disappears, never entering other lanes' space.
- **Incoming** (sender hidden): the mirror — enters from the band edge and arrives at the exec point, co-highlighting with the arrival dot that already drew for this case.
- Both hidden → nothing; visible-to-visible connectors untouched (source-pin tests unchanged and green).

**Slope convention:** toward where the hidden lane would sort in `data.sessions` order; a counterpart absent from `data.sessions` entirely (dismissed, `#only=` filtered, or foreign) slopes down by fixed convention. One consequence worth knowing: under the `#only=` demo filter, mail to/from off-camera sessions now shows a stub whose tooltip names the counterpart (previously it drew nothing) — the comment at the filter notes it.

**Two-state color, keyed on the exec event (never a timer):** await-green `#54B204` (`--st-awaitbg-bg`) until the exec is known, working-yellow `#e0b020` (`--st-working-bg`) after. Exec knowledge = `hasExec` (the logged exec event) OR exec moved off its sent-time fallback — the kernel's `_bind_message_execs` text-heuristic path binds an exec without logging an event, so `hasExec` alone would miss it (adversarial-review finding). The view's midStart join now sets `hasExec` too. `mm.pending` is NOT the key: it folds in the `MSG_INFLIGHT_MAX` staleness timer. Hexes are inlined with their token names (the MENU_STYLE precedent — this file also runs inside Obsidian and cannot load styles.css).

**Affordances** match full connectors: visible marks `pointer-events:none`, wide transparent hit path, `__tlHoverIn` re-arm, showTip/moveTip/hideTip, click deep-links the message's own postal card by id. Clipping is arithmetic; no clipPath introduced.

## Tests

`ui/timeline-hidden-stub.test.ts` — headless `draw()` over the render test's DOM shim, asserting on the SVG child tree: outgoing stub geometry + pending green, exec-event yellow flip (including the stale-timer non-flip and the heuristic-bound case), incoming mirror geometry + dot z-order, fixed slope convention, both-hidden nothing, visible-visible unchanged, off-window gating, midStart-join upgrade, hover/click affordance wiring, and window-clamp source pins. Each was mutation-verified: gate flip, clamp drop, color-key regression, join regression, affordance strip, and invisible-stub mutants all fail the suite. Full suite: 2226 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)