### PR TITLE
Session views gain a true All view, and it becomes the default

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -658,7 +658,7 @@ EOF
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
-    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the default view)"
+    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -933,7 +933,7 @@ for r in rows:
 fi
 
 # Session tags from the CLI (the user 2026-08-23; renamed from "group" the same day: a tag marks a
-# SPECIALIZED session, excluded from the default view and shown under its tag — the accurate name.
+# SPECIALIZED session, excluded from the untagged view and shown under its tag — the accurate name.
 # The manager/worker workflow keeps its worker roster as a tag, all one identity color, and an agent
 # can mint/color/fill a tag programmatically, sessions it just spawned included). Bare / --json READS
 # GET /views; bare maps member sids to live names via GET /sessions and prints an unmappable id

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1511,12 +1511,16 @@ def _ordered_alive(now, tmux):
 
 # ── session VIEWS: which sessions the user is looking at (the user 2026-08-18) ────────────────────
 # One blob under STATE (timeline-views.json), shared by every dashboard this kernel serves (browser,
-# VS Code, Obsidian): {"active": "all"|group-id, "hidden": [id...], "groups": [{"id","name","color",
-# "members": [id...]}]}. "all" shows every session EXCEPT the hidden set — hiding makes a BACKGROUND
-# session: out of the timeline lanes and the chat tab strip, still judged, carded and reachable (the
-# feed and the session pickers keep surfacing it, so nothing runs in secret — the 2026-08-11 rule).
-# A named group shows exactly its members; explicit membership beats the hidden set, which is the
-# one clean answer to "does a hidden session show when its group is picked". Persisted by the LOCAL
+# VS Code, Obsidian): {"active": "all"|"untagged"|tag-id, "hidden": [id...], "tags": [{"id","name",
+# "color", "members": [id...]}]}. TWO built-in sentinels, not tags: "all" — the DEFAULT (the user
+# 2026-08-24) — shows every session EXCEPT the hidden set; "untagged" shows the sessions no tag
+# holds, minus hidden. "all" used to MEAN untagged, so reinterpreting the sentinel as truly-all
+# lands every legacy persisted blob on the new All default with no migration step. Hiding stays the
+# deliberate one-off gesture and makes a BACKGROUND session: out of the timeline lanes and the chat
+# tab strip, still judged, carded and reachable (the feed and the session pickers keep surfacing
+# it, so nothing runs in secret — the 2026-08-11 rule).
+# A tag view shows exactly its members; explicit membership beats the hidden set, which is the
+# one clean answer to "does a hidden session show when its tag is picked". Persisted by the LOCAL
 # kernel like colormap/palette (a viewer display pref, deliberately not federated); ids are stored
 # as the viewer sees them (host-prefixed for remote sessions), opaque to this kernel. mtime-cached
 # like _session_flags. Remote-session ids that churn on a REMOTE kernel are not healed here (that
@@ -1533,8 +1537,11 @@ def _views_path():
 def _norm_timeline_views(d):
     """Validate + normalize a views blob from disk or a client: always returns the full shape, drops
     junk quietly, clamps sizes, and falls back active→"all" when the named tag does not exist.
+    "all" and "untagged" are the two built-in sentinels; "untagged" must pass the whitelist below,
+    or a picked untagged view silently reverts on the next read (the client's optimistic hold makes
+    that failure read as flicker three pushes later, not as an error).
     TAGS, not groups (the user 2026-08-23): a tag marks a SPECIALIZED session, excluded from the
-    default view and viewable under its tag — the accurate name for what membership always did.
+    untagged view and viewable under its tag — the accurate name for what membership always did.
     Stored under "tags"; a blob carrying only the legacy "groups" key (a pre-rename file, an
     un-updated Obsidian panel posting the whole blob) reads as tags, so nothing is lost on upgrade."""
     if not isinstance(d, dict):
@@ -1552,7 +1559,7 @@ def _norm_timeline_views(d):
                      "color": str(g.get("color") or "")[:16],
                      "members": sorted(set(members))})
     active = d.get("active") if isinstance(d.get("active"), str) else "all"
-    if active != "all" and not any(t["id"] == active for t in tags):
+    if active not in ("all", "untagged") and not any(t["id"] == active for t in tags):
         active = "all"
     return {"active": active, "hidden": sorted(set(hidden)), "tags": tags}
 
@@ -1581,11 +1588,15 @@ def _set_timeline_views(blob):
 
 def _view_visible(views, sid):
     """The one visibility decision, kernel-authoritative: mirrored by the chat renderer and the
-    timeline for optimistic feedback — tests pin all three against this shape. The DEFAULT view
-    shows UNTAGGED sessions (the user 2026-08-23): tagging a session says "specialized — out of the
-    main view, viewable under its tag", so membership itself excludes; `hidden` stays the manual
-    one-off hide for untagged sessions."""
+    timeline for optimistic feedback — tests pin all three against this shape. ALL — the default
+    (the user 2026-08-24) — shows every session minus the `hidden` set: hiding is a deliberate user
+    gesture, so All respects it (the dialog's eye stays the un-hide affordance). UNTAGGED keeps the
+    old default's meaning (the user 2026-08-23): tagging a session says "specialized — out of the
+    untagged view, viewable under its tag", so membership itself excludes there; `hidden` hides in
+    both sentinel views. A tag view shows exactly its members — membership beats the hidden bit."""
     if views["active"] == "all":
+        return sid not in views["hidden"]
+    if views["active"] == "untagged":
         return sid not in views["hidden"] and not any(sid in t["members"] for t in views["tags"])
     for t in views["tags"]:
         if t["id"] == views["active"]:
@@ -1647,7 +1658,7 @@ def _edit_tag(name, add=(), remove=(), color=None, delete=False):
             if not hits:
                 return None, 'no tag named "%s"' % name
             v["tags"] = [t for t in v["tags"] if t["id"] != hits[0]["id"]]
-            _set_timeline_views(v)      # an active pointing at it falls back to "all" in the normalizer
+            _set_timeline_views(v)      # an active pointing at it falls back to "all" (the All view) in the normalizer
             return None, None
         if hits:
             t = hits[0]
@@ -20542,23 +20553,30 @@ def _reveal_chat_for(client, focus_msg):
     duplicate rather than the only mover."""
     wid = (client or {}).get("wid") or ""
     # The reveal rule (the user 2026-08-18; reshaped 2026-08-19, re-grounded 2026-08-23 on the TAG
-    # model): every gesture that focuses a session's chat — create, open, revive, a deep link, a
-    # feed chip — must land on a visible tab. Focusing SWITCHES the active view to one that shows
-    # the session and never mutates membership: peeking at a tagged worker must not strip its tag.
-    # Preference order: the first tag holding it (a tagged session's home view — the default never
-    # shows it now); else, untagged: unhide if hidden, and land on the default view.
+    # model; ALL default 2026-08-24): every gesture that focuses a session's chat — create, open,
+    # revive, a deep link, a feed chip — must land on a visible tab, with the MINIMAL move. Under
+    # All only the hidden bit can hide a session, so a focus unhides it and STAYS — it never kicks
+    # the user off the all-sessions view. Elsewhere focusing SWITCHES the active view to one that
+    # shows the session and never mutates membership: peeking at a tagged worker must not strip its
+    # tag. Preference order: the first tag holding it (a tagged session's home view); else unhide
+    # if hidden, then switch to All only if the session is STILL invisible (an unhidden tagless
+    # session already shows in the untagged view — no gratuitous view change).
     sid = focus_msg.get("id") if isinstance(focus_msg, dict) else None
     if sid:
         v = _timeline_views()
         if not _view_visible(v, sid):
             v = json.loads(json.dumps(v))
-            holder = next((t["id"] for t in v["tags"] if sid in t["members"]), None)
-            if holder:
-                v["active"] = holder
+            if v["active"] == "all":
+                v["hidden"] = [x for x in v["hidden"] if x != sid]
             else:
-                if sid in v["hidden"]:
-                    v["hidden"] = [x for x in v["hidden"] if x != sid]
-                v["active"] = "all"
+                holder = next((t["id"] for t in v["tags"] if sid in t["members"]), None)
+                if holder:
+                    v["active"] = holder
+                else:
+                    if sid in v["hidden"]:
+                        v["hidden"] = [x for x in v["hidden"] if x != sid]
+                    if not _view_visible(v, sid):
+                        v["active"] = "all"
             _set_timeline_views(v)
             _mark_views_dirty()
     _send_to_view("chat", focus_msg, wid)

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Session views (the user 2026-08-18; TAG model 2026-08-23): one timeline-views.json blob under
 STATE — {"active", "hidden", "tags"} — deciding which sessions show on the timeline lanes AND the
-chat tab strip. A TAG marks a SPECIALIZED session: tagging excludes it from the default view
-("all" = untagged minus the hidden set), and its tag views are where it shows. A tagged or hidden
+chat tab strip. TWO built-in sentinels: "all" — the DEFAULT (2026-08-24) — shows every session
+minus the hidden set; "untagged" keeps the old default's meaning (a TAG marks a SPECIALIZED
+session, excluded from the untagged view and shown under its tag views). "all" used to MEAN
+untagged, so reinterpreting it lands every legacy blob on the new All default. A tagged or hidden
 session is a BACKGROUND session: still judged and carded, surfaced by the feed, the pickers, and
 the "N more" cue. The legacy "groups" key (pre-rename files and un-updated panels) reads as tags.
 Local-kernel persisted (a viewer display pref, not federated). These pin the storage helpers, the
@@ -39,19 +41,30 @@ class TimelineViews(unittest.TestCase):
         self.td.cleanup()
 
     def test_default_shows_everything(self):
+        # fresh blobs open on "all" — and since 2026-08-24 that sentinel means truly-ALL, so a
+        # legacy blob persisted when "all" meant untagged lands on the new default automatically
         v = km._timeline_views()
         self.assertEqual(v, {"active": "all", "hidden": [], "tags": []})
         self.assertTrue(km._view_visible(v, "anything"))
 
-    def test_default_shows_untagged_only_and_a_tag_view_its_members(self):
-        # the TAG rule (the user 2026-08-23): tagging a session says "specialized — out of the main
-        # view, viewable under its tag", so membership itself excludes it from "all"
+    def test_all_shows_every_session_and_untagged_the_tagless_ones(self):
+        # ALL — the default (the user 2026-08-24) — is every session minus the hidden set: hiding is
+        # a deliberate gesture, so All respects it, but a tag no longer excludes a session there
         km._set_timeline_views({"active": "all", "hidden": ["s9"], "tags": [G1]})
         km._flags_cache.clear()
         v = km._timeline_views()
-        self.assertFalse(km._view_visible(v, "s9"), "hidden in the all view")
-        self.assertFalse(km._view_visible(v, "s2"), "TAGGED → out of the default view")
-        self.assertTrue(km._view_visible(v, "s1"), "untagged, not hidden → the default view shows it")
+        self.assertFalse(km._view_visible(v, "s9"), "hidden — All respects the deliberate hide")
+        self.assertTrue(km._view_visible(v, "s2"), "TAGGED → All still shows it")
+        self.assertTrue(km._view_visible(v, "s1"), "untagged → shown")
+        # the untagged view keeps the old default's meaning under its own sentinel (the user
+        # 2026-08-23 TAG rule: tagging says "specialized — out of the main view")
+        km._set_timeline_views({"active": "untagged", "hidden": ["s9"], "tags": [G1]})
+        km._flags_cache.clear()
+        v = km._timeline_views()
+        self.assertEqual(v["active"], "untagged", "the sentinel survives the normalizer round-trip")
+        self.assertFalse(km._view_visible(v, "s9"), "hidden hides in the untagged view too")
+        self.assertFalse(km._view_visible(v, "s2"), "TAGGED → out of the untagged view")
+        self.assertTrue(km._view_visible(v, "s1"), "tagless, not hidden → shown")
         km._set_timeline_views({"active": "g1", "hidden": ["s2"], "tags": [G1]})
         km._flags_cache.clear()
         v = km._timeline_views()
@@ -78,6 +91,9 @@ class TimelineViews(unittest.TestCase):
         self.assertEqual(km._norm_timeline_views({"tags": [{"id": "g", "members": 3}]})["tags"][0]["members"],
                          [], "a wrong-typed members list drops, never raises")
         self.assertEqual(v["active"], "all", "an active tag that does not exist falls back to all")
+        self.assertEqual(km._norm_timeline_views({"active": "untagged"})["active"], "untagged",
+                         "the untagged sentinel passes the whitelist — a rewrite here is SILENT and"
+                         " reads as flicker after the client's optimistic hold expires")
         self.assertEqual(v["hidden"], ["a"], "junk and duplicates dropped")
         self.assertEqual(len(v["tags"]), 1)
         self.assertEqual(len(v["tags"][0]["name"]), km._VIEWS_MAX_NAME)
@@ -132,24 +148,48 @@ class TimelineViews(unittest.TestCase):
         self.assertIn('post({type:"setTimelineViews",views:views});', src)
 
     def test_focus_switches_to_a_view_that_shows_the_session(self):
-        # the reveal rule, TAG model (re-grounded 2026-08-23): focusing switches the active view and
-        # never mutates membership — peeking at a tagged worker must not strip its tag. Order: the
-        # first tag holding it (its home view — the default never shows a tagged session), else,
-        # untagged: unhide if hidden, and land on the default view.
+        # the reveal rule (re-grounded 2026-08-23 on the TAG model; ALL default 2026-08-24): focusing
+        # lands on a visible tab with the MINIMAL move and never mutates membership. Under All only
+        # the hidden bit can hide a session — unhide and STAY, never kick the user off All. Elsewhere:
+        # the first tag holding it, else unhide if hidden and switch only if still invisible.
         G = {"id": "g1", "name": "pool", "members": ["s2"]}
         km._set_timeline_views({"active": "g1", "hidden": [], "tags": [G]})
         km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s9"})
         v = km._timeline_views()
-        self.assertEqual(v["active"], "all", "untagged → land on the default view")
-        km._set_timeline_views({"active": "all", "hidden": [], "tags": [G]})
+        self.assertEqual(v["active"], "all", "tagless session from a tag view → land on All, the default")
+        km._set_timeline_views({"active": "untagged", "hidden": [], "tags": [G]})
         km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
         v = km._timeline_views()
         self.assertEqual(v["active"], "g1", "tagged → its holder tag is its home view")
         self.assertEqual(v["tags"][0]["members"], ["s2"], "membership untouched — the peek never strips a tag")
+        km._set_timeline_views({"active": "all", "hidden": [], "tags": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
+        self.assertEqual(km._timeline_views()["active"], "all", "tagged is VISIBLE under All → no move at all")
         km._set_timeline_views({"active": "all", "hidden": ["sX"], "tags": [G]})
         km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "sX"})
         v = km._timeline_views()
-        self.assertEqual(v["hidden"], [], "hidden and untagged → un-hidden onto the default view")
+        self.assertEqual(v["hidden"], [], "hidden under All → un-hidden")
+        self.assertEqual(v["active"], "all", "…and the focus NEVER kicks the user off All")
+        km._set_timeline_views({"active": "all", "hidden": ["s2"], "tags": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
+        v = km._timeline_views()
+        self.assertEqual(v["hidden"], [], "hidden AND tagged under All → the unhide wins")
+        self.assertEqual(v["active"], "all", "…not a kick to the holder tag")
+        km._set_timeline_views({"active": "untagged", "hidden": ["s9"], "tags": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s9"})
+        v = km._timeline_views()
+        self.assertEqual(v["hidden"], [], "hidden tagless session under untagged → un-hidden")
+        self.assertEqual(v["active"], "untagged", "…already visible here — no gratuitous switch to All")
+        km._set_timeline_views({"active": "g1", "hidden": ["sX"], "tags": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "sX"})
+        v = km._timeline_views()
+        self.assertEqual(v["hidden"], [], "hidden AND tagless from a tag view → BOTH edits: un-hidden…")
+        self.assertEqual(v["active"], "all", "…and still invisible after the unhide, so the view switches to All")
+        km._set_timeline_views({"active": "untagged", "hidden": ["s2"], "tags": [G]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
+        v = km._timeline_views()
+        self.assertEqual(v["active"], "g1", "hidden AND tagged under untagged → the holder tag wins")
+        self.assertEqual(v["hidden"], ["s2"], "…hidden bit untouched — membership beats hidden in a tag view")
         km._set_timeline_views({"active": "g1", "hidden": [], "tags": [G]})
         km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
         self.assertEqual(km._timeline_views()["active"], "g1", "a member's focus changes nothing")

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -27,31 +27,36 @@ function _rompOnlyTag() {
 // <tag> may be a comma-separated LIST (`#only=api,tests,web`) so demo sessions need no shared
 // on-camera prefix (the user 2026-07-16). Mirrors ui/webview/only-filter.ts's matchesOnly.
 // ── session VIEWS (the user 2026-08-18): which sessions the lanes — and the chat tab strip — show.
-// {active:"all"|gid, hidden:[id...], groups:[{id,name,color,members:[id...]}]}, kernel-persisted
-// (timeline-views.json) and echoed on every payload as data.views. The DEFAULT-GROUP model (the user
-// 2026-08-19): every session is in the default group at birth; `hidden` stores the sessions REMOVED
-// from it ("all" minus hidden IS the default group, so the wire shape is unchanged). A session out of
-// the default group is a BACKGROUND session — still judged and carded, surfaced by the feed and the
-// pickers. Named groups are independent member lists (multi-membership by construction: put a manager
-// in the default group AND its workers' group; remove the workers from default and they live only in
-// their group). A named group shows exactly its members — membership beats the hidden bit. The
-// kernel's _view_visible is the decision of record; this is its mirror for the lanes. TAGS
-// (the user 2026-08-23): a tag marks a SPECIALIZED session — tagging excludes it from the default
-// view, and its tag views are where it shows. The kernel emits `tags`; `groups` is honored as the
-// pre-rename key an un-updated kernel still pushes, in ONE place so every rule reads through it.
+// {active:"all"|"untagged"|gid, hidden:[id...], tags:[{id,name,color,members:[id...]}]},
+// kernel-persisted (timeline-views.json) and echoed on every payload as data.views. TWO built-in
+// sentinels, not tags: "all" — the DEFAULT (the user 2026-08-24) — shows every session minus the
+// `hidden` set (hiding is a deliberate gesture, so All respects it); "untagged" keeps the old
+// default's meaning under its own honest name — a TAG marks a SPECIALIZED session (the user
+// 2026-08-23), excluded from the untagged view and shown under its tag views (independent member
+// lists, multi-membership by construction). "all" used to MEAN untagged, so reinterpreting it as
+// truly-all lands every legacy persisted blob on the new All default with no migration. A tag view
+// shows exactly its members — membership beats the hidden bit. A hidden session is a BACKGROUND
+// session — still judged and carded, surfaced by the feed and the pickers. The kernel's
+// _view_visible is the decision of record; this is its mirror for the lanes. The kernel emits
+// `tags`; `groups` is honored as the pre-rename key an un-updated kernel still pushes, in ONE
+// place so every rule reads through it.
 function viewTags(views) { return (views && (views.tags || views.groups)) || []; }
 function viewVisible(views, id) {
   if (!views || !views.active || views.active === 'all') {
-    if (views && Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0) return false;
+    return !(views && Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0);
+  }
+  if (views.active === 'untagged') {
+    if (Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0) return false;
     return !viewTags(views).some((t) => (t.members || []).indexOf(id) >= 0);
   }
   const t = viewTags(views).find((x) => x.id === views.active);
   return t ? (t.members || []).indexOf(id) >= 0 : true;
 }
 function viewLabel(views) {
-  if (!views || !views.active || views.active === 'all') return '(untagged)';
+  if (!views || !views.active || views.active === 'all') return 'All';
+  if (views.active === 'untagged') return '(untagged)';
   const t = viewTags(views).find((x) => x.id === views.active);
-  return t ? (t.name || 'tag') : '(untagged)';
+  return t ? (t.name || 'tag') : 'All';
 }
 // live sessions the current view is NOT showing — the "N more" cue that keeps a hidden or tagged
 // session exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
@@ -2380,7 +2385,10 @@ class TimelinePanel {
     const v = this._curViews();
     const g = viewTags(v).find((x) => x.id === v.active);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
-    const active = !!g && v.active && v.active !== 'all';
+    // any non-All view is a FILTER now, the untagged view included (it excludes tagged sessions),
+    // so the chip shows for untagged and tag views alike; its ✕ resets to All, the unfiltered default
+    const active = !!v.active && v.active !== 'all' && (!!g || v.active === 'untagged');
+    const gcol = (g && g.color) || '#cccccc';
     const PADH = 7, GAP = 6;   // the chip's horizontal padding; the space between the line's parts
     // ellipsize so the WHOLE line stays inside the gutter — measured on the full string (the
     // 650-weight lane font over-measures the plain spans, which is the safe direction), because a
@@ -2416,10 +2424,10 @@ class TimelinePanel {
       grp.setAttribute('style', 'cursor:pointer;');
       const box = el('rect', { x, y: y - 13, width: cw, height: 18, rx: 9,
         fill: 'transparent',
-        stroke: g.color || '#cccccc', 'stroke-width': 1 });
+        stroke: gcol, 'stroke-width': 1 });
       grp.appendChild(box);
       const ct = el('text', { x: x + PADH, y, 'font-size': 12, 'font-family': FONT,
-        fill: g.color || '#cccccc', 'font-weight': 650 });
+        fill: gcol, 'font-weight': 650 });
       ct.textContent = name;
       ct.setAttribute('style', 'user-select:none;');
       grp.appendChild(ct);
@@ -2429,7 +2437,7 @@ class TimelinePanel {
       cx.setAttribute('style', 'user-select:none;');
       grp.appendChild(cx);
       const tt = el('title', {});
-      tt.textContent = 'showing only ' + (g.name || 'this group') + ' — click to remove the filter (back to the default view)';
+      tt.textContent = 'showing only ' + (g ? (g.name || 'this tag') : 'untagged sessions') + ' — click to remove the filter (back to the default view)';
       grp.appendChild(tt);
       grp.addEventListener('pointerdown', (e) => {
         e.preventDefault(); e.stopPropagation();
@@ -2445,7 +2453,7 @@ class TimelinePanel {
       // …and one CLICK away (the user 2026-08-24): the count opens the same views menu, so "what am
       // I not seeing?" answers itself with the list of tags to switch to
       m.setAttribute('style', 'user-select:none;cursor:pointer;');
-      const mt = el('title', {}); mt.textContent = 'live sessions outside this view — click to pick a tag view';
+      const mt = el('title', {}); mt.textContent = 'live sessions outside this view — click to switch views, or un-hide via Sessions & tags…';
       m.appendChild(mt);
       m.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(m); });
       m.addEventListener('click', (e) => e.stopPropagation());
@@ -2493,7 +2501,10 @@ class TimelinePanel {
     };
     const v = this._curViews();
     const pick = (active) => { const nv = JSON.parse(JSON.stringify(v)); nv.active = active; this._setViews(nv); this._closeViewsMenu(); };
-    item('(untagged)', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
+    // All is the default and sits first (the user 2026-08-24); (untagged) — the old default's
+    // meaning under its own sentinel — second; both are built-ins, not rows in the tags dialog
+    item('All', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
+    item('(untagged)', { current: v.active === 'untagged' }).addEventListener('click', () => pick('untagged'));
     for (const tg of viewTags(v))
       item(tg.name, { dot: tg.color || MODEL_FG, current: v.active === tg.id }).addEventListener('click', () => pick(tg.id));
     sep();
@@ -2510,7 +2521,7 @@ class TimelinePanel {
     });
     item('Sessions & tags…', { dim: true }).addEventListener('click', () => {
       this._closeViewsMenu();
-      this._openViewsDialog(v.active !== 'all' ? v.active : null);
+      this._openViewsDialog(v.active !== 'all' && v.active !== 'untagged' ? v.active : null);
     });
     sep();
     // the two timeline display prefs, finally reachable in every host (they lived only in the web
@@ -2767,7 +2778,7 @@ class TimelinePanel {
             const eye = eyeCell.createSpan({ text: '⌀' });
             eye.setAttribute('style', 'cursor:pointer;opacity:0.6;');
             hover(eye, 'opacity:1;', 'opacity:0.6;');
-            eye.setAttribute('title', 'hidden from the (untagged) view — click to show it again');
+            eye.setAttribute('title', 'hidden from the All and (untagged) views — click to show it again');
             eye.addEventListener('click', () => { this._setViews(viewToggleHidden(this._curViews(), s.id)); build(); });
           }
           if (addMenuFor === s.id) addMenu([s.id]);

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -1,6 +1,7 @@
 // The timeline's corner control panel (the user 2026-08-18; filter-chip form + TAG model
 // 2026-08-23): "Filter ▾" in the bottom-left corner — the strip under the lane gutter, left of the
-// time labels. The dropdown picks the active VIEW (default = UNTAGGED sessions / the named tags),
+// time labels. The dropdown picks the active VIEW (All — every session minus hidden, the default
+// since 2026-08-24 — / the (untagged) built-in / the named tags),
 // holds New tag… / Sessions & tags…, and carries the two timeline display toggles (collapse idle
 // gaps, active only) so they finally work in every host. The dialog is TAG-CENTRIC: one row per
 // session wearing its tag chips (✕ leaves a tag; [+] joins or mints one) — a tagged session leaves
@@ -20,26 +21,31 @@ const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2", "s3"] };
 const V = (active: string, hidden: string[] = [], tags: any[] = [G]) => ({ active, hidden, tags });
 
-test("executed: the default view shows UNTAGGED minus hidden; a tag view its members exactly", () => {
+test("executed: All shows every session minus hidden; untagged the tagless; a tag view its members", () => {
   assert.equal(viewVisible(null, "s1"), true, "no blob yet → everything shows");
-  assert.equal(viewVisible(V("all", ["s9"]), "s9"), false, "hidden");
-  assert.equal(viewVisible(V("all"), "s2"), false, "TAGGED → out of the default view (the user 2026-08-23)");
+  assert.equal(viewVisible(V("all", ["s9"]), "s9"), false, "hidden — All respects the deliberate hide");
+  assert.equal(viewVisible(V("all"), "s2"), true, "TAGGED → All still shows it (the user 2026-08-24)");
   assert.equal(viewVisible(V("all"), "s1"), true, "untagged → shown");
+  assert.equal(viewVisible(V("untagged", ["s9"]), "s9"), false, "hidden hides in the untagged view too");
+  assert.equal(viewVisible(V("untagged"), "s2"), false, "TAGGED → out of the untagged view (the user 2026-08-23)");
+  assert.equal(viewVisible(V("untagged"), "s1"), true, "tagless → the untagged view shows it");
   assert.equal(viewVisible(V("g1", ["s2"]), "s2"), true, "a tag view shows its members, hidden or not");
   assert.equal(viewVisible(V("g1"), "s1"), false, "a tag view shows exactly its members");
   assert.equal(viewVisible(V("ghost", [], []), "s1"), true, "an orphaned active falls back open");
-  assert.equal(viewVisible({ active: "all", groups: [G] }, "s2"), false,
+  assert.equal(viewVisible({ active: "untagged", groups: [G] }, "s2"), false,
     "the legacy `groups` key an un-updated kernel pushes reads identically");
 });
 
 test("executed: the trigger label and the N-more cue (live sessions outside the view)", () => {
-  // the default view is named for what it shows (the user 2026-08-24): "(untagged)", parenthesized
-  // as the built-in it is — "default" said nothing about the rule
-  assert.equal(viewLabel(null), "(untagged)");
+  // the views are named for what they show: "All" (every session minus hidden — the default since
+  // 2026-08-24) and "(untagged)", parenthesized as the built-in it is
+  assert.equal(viewLabel(null), "All");
+  assert.equal(viewLabel(V("untagged")), "(untagged)");
   assert.equal(viewLabel(V("g1")), "pool");
   const sessions = [{ id: "s1", live: true }, { id: "s2", live: true }, { id: "s4", live: false }];
   assert.equal(viewMoreCount(V("g1"), sessions), 1, "s1 is live and outside; dead s4 never counts");
-  assert.equal(viewMoreCount(V("all", ["s1"]), sessions), 2, "hidden live s1 AND tagged live s2 count; dead s4 never");
+  assert.equal(viewMoreCount(V("all", ["s1"]), sessions), 1, "hidden live s1 counts under All; tagged s2 shows now");
+  assert.equal(viewMoreCount(V("untagged", ["s1"]), sessions), 2, "hidden s1 AND tagged s2 sit outside untagged");
 });
 
 test("executed: an optimistic edit holds until the kernel echoes it — then yields to authority", () => {
@@ -81,14 +87,14 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
   assert.match(SRC, /grp\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\); nv\.active = 'all'; this\._setViews\(nv\);/);
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
-  assert.match(SRC, /fill: 'transparent',\n\s*stroke: g\.color \|\| '#cccccc', 'stroke-width': 1/);
+  assert.match(SRC, /fill: 'transparent',\n\s*stroke: gcol, 'stroke-width': 1/);
   assert.match(SRC, /y: y - 13, width: cw, height: 18, rx: 9,/, "taller chip");
   assert.match(SRC, /cx\.textContent = '✕';/);
   assert.match(SRC, /fill: MODEL_FG, opacity: 0\.75/);
-  assert.match(SRC, /fill: g\.color \|\| '#cccccc', 'font-weight': 650/);
+  assert.match(SRC, /fill: gcol, 'font-weight': 650/);
   assert.match(SRC, /click to remove the filter \(back to the default view\)/);
-  // no chip on the default view — nothing to remove
-  assert.match(SRC, /const active = !!g && v\.active && v\.active !== 'all';/);
+  // no chip on All — the unfiltered default; the untagged view IS a filter now, so it wears one
+  assert.match(SRC, /const active = !!v\.active && v\.active !== 'all' && \(!!g \|\| v\.active === 'untagged'\);/);
   // …and the bottom strip grew so the taller chip has air
   assert.match(SRC, /bottom: 27 \}/);
 });
@@ -145,10 +151,14 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
   assert.match(SRC, /const ft = LANE_TOGGLES\.find\(\(t\) => t\.flag === 'hideFromFeed'\);/);
   assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.hideFromFeed = next;/,
     "the same optimistic sticky flags the lane gear uses");
-  // the menu items say so: New tag… / Sessions & tags… / the (untagged) default
+  // the menu items say so: All first (the default), (untagged) second, then New tag… / Sessions & tags…
   assert.match(SRC, /item\('New tag…', \{ dim: true \}\)/);
   assert.match(SRC, /item\('Sessions & tags…', \{ dim: true \}\)/);
-  assert.match(SRC, /item\('\(untagged\)', \{ current: !v\.active \|\| v\.active === 'all' \}\)/);
+  assert.match(SRC, /item\('All', \{ current: !v\.active \|\| v\.active === 'all' \}\)/);
+  assert.match(SRC, /item\('\(untagged\)', \{ current: v\.active === 'untagged' \}\)/);
+  assert.match(SRC, /item\('All',[\s\S]{0,300}item\('\(untagged\)',/, "All sits ABOVE (untagged) in the menu");
+  assert.match(SRC, /item\('\(untagged\)',[\s\S]{0,200}for \(const tg of viewTags\(v\)\)/,
+    "…and the tag rows come AFTER both built-ins — the DoD's menu order, pinned end to end");
 });
 
 test("the N-more count opens the views menu — what am I not seeing answers itself (the user 2026-08-24)", () => {

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -1,7 +1,8 @@
-// Session views on the chat side (the user 2026-08-18; TAG model 2026-08-23): the kernel's views
-// blob — echoed on every tabOrder push — gates which sessions get TABS. The default view shows
-// UNTAGGED sessions: a tag marks a specialized session, excluded from the main view and shown
-// under its tag views. A tagged or hidden session is a BACKGROUND session: still running, judged,
+// Session views on the chat side (the user 2026-08-18; TAG model 2026-08-23; ALL default
+// 2026-08-24): the kernel's views blob — echoed on every tabOrder push — gates which sessions get
+// TABS. Two built-in sentinels: "all" — the default — shows every session minus the hidden set;
+// "untagged" keeps the old default's meaning (a tag marks a specialized session, excluded from the
+// untagged view and shown under its tag views). A hidden session is a BACKGROUND session: still running, judged,
 // carded; the + picker lists it under "Hidden — reveal" and the timeline's corner panel counts it,
 // so nothing runs in secret (the 2026-08-11 rule this feature deliberately carves an exception
 // into, keeping its spirit). Executed tests on the pure module + source pins.
@@ -15,16 +16,19 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2"] };
 
-test("executed: the default view shows UNTAGGED minus hidden; a tag view its members exactly", () => {
+test("executed: All shows every session minus hidden; untagged the tagless; a tag view its members", () => {
   assert.equal(viewVisible(null, "s1"), true);
-  assert.equal(viewVisible({ active: "all", hidden: ["s1"] }, "s1"), false);
-  assert.equal(viewVisible({ active: "all", tags: [G] }, "s2"), false, "TAGGED → out of the default view");
-  assert.equal(viewVisible({ active: "all", tags: [G] }, "s1"), true, "untagged → the default view shows it");
+  assert.equal(viewVisible({ active: "all", hidden: ["s1"] }, "s1"), false, "All respects the deliberate hide");
+  assert.equal(viewVisible({ active: "all", tags: [G] }, "s2"), true, "TAGGED → All still shows it (2026-08-24)");
+  assert.equal(viewVisible({ active: "all", tags: [G] }, "s1"), true, "untagged → shown");
+  assert.equal(viewVisible({ active: "untagged", tags: [G] }, "s2"), false, "TAGGED → out of the untagged view");
+  assert.equal(viewVisible({ active: "untagged", tags: [G] }, "s1"), true, "tagless → the untagged view shows it");
+  assert.equal(viewVisible({ active: "untagged", hidden: ["s1"], tags: [G] }, "s1"), false, "hidden hides there too");
   assert.equal(viewVisible({ active: "g1", hidden: ["s2"], tags: [G] }, "s2"), true, "a tag view shows its members, hidden or not");
   assert.equal(viewVisible({ active: "g1", tags: [G] }, "s1"), false);
   assert.equal(viewVisible({ active: "gone", tags: [] }, "s1"), true, "an orphaned active fails open");
   // the pre-rename key an un-updated kernel still pushes reads identically
-  assert.equal(viewVisible({ active: "all", groups: [G] }, "s2"), false, "legacy `groups` key honored");
+  assert.equal(viewVisible({ active: "untagged", groups: [G] }, "s2"), false, "legacy `groups` key honored");
   assert.equal(viewVisible({ active: "g1", groups: [G] }, "s2"), true);
 });
 
@@ -39,17 +43,29 @@ test("executed: hide sets the one-off bit (and leaves the active tag); reveal SW
   assert.deepEqual(g.tags![0].members, ["s3"], "dropped from the ACTIVE tag");
   assert.deepEqual(g.tags![1].members, ["s2"], "other tags keep it — multi-tag membership");
   // reveal never mutates membership (re-grounded 2026-08-23: peeking at a tagged worker must not
-  // strip its tag) — it switches the active view to one that shows the session
+  // strip its tag) — it lands on a visible tab with the MINIMAL move (ALL default 2026-08-24)
   const rev = revealIn({ active: "g1", hidden: [], tags: [G] }, "s1");
-  assert.equal(rev.active, "all", "untagged → land on the default view");
+  assert.equal(rev.active, "all", "tagless session from a tag view → land on All, the default");
   assert.deepEqual(rev.hidden, [], "…and nothing edited");
-  const rev2 = revealIn({ active: "all", hidden: [], tags: [G] }, "s2");
+  const rev2 = revealIn({ active: "untagged", hidden: [], tags: [G] }, "s2");
   assert.equal(rev2.active, "g1", "tagged → its holder tag is its home view");
   assert.deepEqual(rev2.tags![0].members, ["s2"], "membership untouched — the peek never strips a tag");
-  const rev3 = revealIn({ active: "all", hidden: ["sX"], tags: [G] }, "sX");
-  assert.deepEqual(rev3.hidden, [], "hidden and untagged → un-hidden onto the default view (the one edit)");
+  const revAll = revealIn({ active: "all", hidden: [], tags: [G] }, "s2");
+  assert.equal(revAll.active, "all", "tagged is VISIBLE under All → nothing changes at all");
+  const revHid = revealIn({ active: "all", hidden: ["s2"], tags: [G] }, "s2");
+  assert.equal(revHid.active, "all", "hidden under All → unhide and STAY — a focus never kicks off All");
+  assert.deepEqual(revHid.hidden, [], "…even for a tagged session: the unhide wins, not a holder switch");
+  const rev3 = revealIn({ active: "untagged", hidden: ["sX"], tags: [G] }, "sX");
+  assert.equal(rev3.active, "untagged", "unhidden tagless session already shows here — no gratuitous switch");
+  assert.deepEqual(rev3.hidden, [], "hidden and tagless → un-hidden (the one edit)");
   const rev4 = revealIn({ active: "g1", hidden: ["s2"], tags: [G] }, "s2");
   assert.equal(rev4.active, "g1", "already visible in the active tag → nothing changes");
+  const rev5 = revealIn({ active: "g1", hidden: ["sX"], tags: [G] }, "sX");
+  assert.deepEqual(rev5.hidden, [], "hidden AND tagless from a tag view → BOTH edits: un-hidden…");
+  assert.equal(rev5.active, "all", "…and still invisible after the unhide, so the view switches to All");
+  const rev6 = revealIn({ active: "untagged", hidden: ["s2"], tags: [G] }, "s2");
+  assert.equal(rev6.active, "g1", "hidden AND tagged under untagged → the holder tag wins");
+  assert.deepEqual(rev6.hidden, ["s2"], "…hidden bit untouched — membership beats hidden in a tag view");
 });
 
 test("executed: the canonical key ignores list order AND which key the kernel used", () => {

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -1,8 +1,11 @@
-// Session views (the user 2026-08-18; TAG model 2026-08-23): the kernel's timeline-views blob,
-// echoed on every tabOrder push — which sessions the chat TAB STRIP (and the timeline lanes) show.
-// A TAG marks a SPECIALIZED session: tagging it excludes it from the DEFAULT view ("all"), and its
-// tag views are where it shows — so "all" = untagged sessions minus the `hidden` set (the manual
-// one-off hide). A tagged session is a BACKGROUND session: still running, judged and carded; the
+// Session views (the user 2026-08-18; TAG model 2026-08-23; ALL default 2026-08-24): the kernel's
+// timeline-views blob, echoed on every tabOrder push — which sessions the chat TAB STRIP (and the
+// timeline lanes) show. TWO built-in sentinels, not tags: "all" — the DEFAULT — shows every session
+// minus the `hidden` set (the manual one-off hide, deliberate, so All respects it); "untagged"
+// keeps the old default's meaning under its own honest name — a TAG marks a SPECIALIZED session,
+// excluded from the untagged view and shown under its tag views. "all" used to MEAN untagged, so
+// reinterpreting it as truly-all lands every legacy persisted blob on the new All default with no
+// migration. A hidden session is a BACKGROUND session: still running, judged and carded; the
 // feed, the + picker, and the "N more" cue keep surfacing it, so nothing runs in secret — the
 // 2026-08-11 rule. A tag view shows exactly its members. The kernel's _view_visible is the decision
 // of record; this is its client mirror (the timeline carries its own copy — it cannot import TS).
@@ -18,7 +21,10 @@ export function viewTags(views: SessionViews | null | undefined): SessionTag[] {
 
 export function viewVisible(views: SessionViews | null | undefined, id: string): boolean {
   if (!views || !views.active || views.active === "all") {
-    if (views && Array.isArray(views.hidden) && views.hidden.includes(id)) return false;
+    return !(views && Array.isArray(views.hidden) && views.hidden.includes(id));
+  }
+  if (views.active === "untagged") {
+    if (Array.isArray(views.hidden) && views.hidden.includes(id)) return false;
     return !viewTags(views).some((t) => (t.members || []).includes(id));
   }
   const t = viewTags(views).find((x) => x.id === views.active);
@@ -49,16 +55,23 @@ export function hideIn(views: SessionViews | null | undefined, id: string): Sess
   return v;
 }
 
-// the reveal gesture (re-grounded 2026-08-23 on the TAG model): explicitly opening a session
-// SWITCHES the active view to one that shows it and never mutates membership — peeking at a tagged
-// worker must not strip its tag. A tagged session's home is its first holder tag (the default view
-// never shows it now); an untagged one is unhidden if hidden, and lands on the default view.
+// the reveal gesture (re-grounded 2026-08-23 on the TAG model; ALL default 2026-08-24): explicitly
+// opening a session lands on a visible tab with the MINIMAL move and never mutates membership —
+// peeking at a tagged worker must not strip its tag. Under All only the hidden bit can hide a
+// session, so a focus unhides it and STAYS — it never kicks the user off the all-sessions view.
+// Elsewhere: a tagged session's home is its first holder tag; a tagless one is unhidden if hidden,
+// switching to All only if still invisible (an unhidden tagless session already shows in the
+// untagged view — no gratuitous view change).
 export function revealIn(views: SessionViews | null | undefined, id: string): SessionViews {
   const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
   if (viewVisible(v, id)) return v;
+  if (!v.active || v.active === "all") {
+    v.hidden = (v.hidden || []).filter((x) => x !== id);
+    return v;
+  }
   const holder = viewTags(v).find((t) => (t.members || []).includes(id));
   if (holder) { v.active = holder.id; return v; }
   if ((v.hidden || []).includes(id)) v.hidden = (v.hidden || []).filter((x) => x !== id);
-  v.active = "all";
+  if (!viewVisible(v, id)) v.active = "all";
   return v;
 }


### PR DESCRIPTION
The timeline's views menu grows a true **All** view — every session minus the explicit `hidden` set — and it becomes the default, sitting first in the menu above **(untagged)** and the tag rows.

**How:** the sentinel `active:"all"` used to *mean* "untagged minus hidden". It is reinterpreted as truly-all, and the old meaning moves to a new sentinel `"untagged"` (whitelisted in the kernel normalizer, which otherwise rewrites unknown actives to `"all"` silently). Every legacy persisted blob (`active:"all"`) therefore lands on the new All default automatically — the sentinel name is honest again and no migration step exists to forget.

**Behavior:**
- All = every session minus hidden (hiding stays a deliberate gesture; the dialog's eye stays the un-hide affordance). Untagged behaves exactly as the old default.
- The filter chip shows for any non-All view — untagged is a real filter now — and its ✕ resets to All. Tag-delete and chip-clear land on All, the reset target.
- The reveal rule moves minimally: under All a focus only unhides and never kicks the user off the view; elsewhere the holder tag wins, else unhide and switch to All only if the session is still invisible.
- The three visibility deciders (kernel `_view_visible`, timeline `viewVisible`, TS twin) stay in lockstep, so lanes and chat tabs agree.

**Tests:** truth tables for both sentinels in all three homes (`tests/test_timeline_views.py`, `ui/webview/session-views.test.ts`, `ui/timeline-views-panel.test.ts`), the untagged normalizer round-trip, legacy-blob-lands-on-All, the reveal rule's two-edit branch and holder-beats-unhide precedence (mutant-verified gaps), and menu-order pins end to end. Stale user-facing copy (`romp tag` help, the N-more tooltip, the eye tooltip) made truthful. Both suites green locally: `npm test` 2226/2226, `pytest tests/ -q` 5323 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)