### PR TITLE
Timeline: the corner filter line matches the lane labels; message stubs join the sender-color language

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1019,7 +1019,22 @@ class TimelinePanel {
     return [24, 24, 24];
   }
 
-  _font(b) { this._mc.font = (b ? '700 ' + BADGE_FS + 'px ' : '650 12px ') + FONT; }
+  // the family the svg's text ACTUALLY renders in — inherited from the host (VS Code, Obsidian and
+  // the web page each set their own UI font; svg text carries no family of its own). Measuring with
+  // the hardcoded FONT stack drifted from rendered widths wherever the host font differs — the
+  // gutter width and the corner chip's box/ellipsis are sized from these measures. Resolved once
+  // per panel: a host's UI font does not change under a live pane. FONT stays the fallback for a
+  // measure before the wrap is styled (and for bare-node tests, where getComputedStyle is absent).
+  _fontFace() {
+    if (!this._fontFaceCache) {
+      try {
+        this._fontFaceCache = (this.wrap && typeof getComputedStyle === 'function'
+          && getComputedStyle(this.wrap).fontFamily) || FONT;
+      } catch (e) { this._fontFaceCache = FONT; }
+    }
+    return this._fontFaceCache;
+  }
+  _font(b) { this._mc.font = (b ? '700 ' + BADGE_FS + 'px ' : '650 12px ') + this._fontFace(); }
   labelWidth(s) { this._font(false); return this._mc.measureText(s || '').width; }
   badgeWidth(s) { this._font(true); return this._mc.measureText(s || '').width; }
   ctxWidth(s) { this._mc.font = '600 11px ' + FONT; return this._mc.measureText(s || '').width; }
@@ -2402,7 +2417,14 @@ class TimelinePanel {
     const fits = (n) => width(n) <= this.M.left - PADL - 6;
     while (active && name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
     const y = axisY + 14;
-    const t = el('text', { x: PADL, y, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG });
+    // the whole corner line wears the LANE LABELS' typography (the user 2026-08-24, who read the
+    // chip as the wrong font): no explicit family — inherit the host font exactly like the lane
+    // names above, which carry none. The old explicit FONT override rendered the line in the
+    // fallback stack while the lanes wore the host's UI font, so at the same nominal 12px the chip
+    // read visibly bigger. Sizes/weights already match the lanes (12px; chip name at the lane-name
+    // 650), and labelWidth measures in the same inherited family (_fontFace), so the box/ellipsis
+    // math stays in step with what renders.
+    const t = el('text', { x: PADL, y, 'font-size': 12, fill: MODEL_FG });
     t.textContent = 'Filter ▾';
     t.setAttribute('style', 'cursor:pointer;user-select:none;');
     t.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(t); });
@@ -2426,13 +2448,12 @@ class TimelinePanel {
         fill: 'transparent',
         stroke: gcol, 'stroke-width': 1 });
       grp.appendChild(box);
-      const ct = el('text', { x: x + PADH, y, 'font-size': 12, 'font-family': FONT,
-        fill: gcol, 'font-weight': 650 });
+      const ct = el('text', { x: x + PADH, y, 'font-size': 12, fill: gcol, 'font-weight': 650 });
       ct.textContent = name;
       ct.setAttribute('style', 'user-select:none;');
       grp.appendChild(ct);
       const cx = el('text', { x: x + PADH + this.labelWidth(name) + XGAP, y, 'font-size': 11,
-        'font-family': FONT, fill: MODEL_FG, opacity: 0.75 });
+        fill: MODEL_FG, opacity: 0.75 });
       cx.textContent = '✕';
       cx.setAttribute('style', 'user-select:none;');
       grp.appendChild(cx);
@@ -2448,7 +2469,7 @@ class TimelinePanel {
       x += cw;
     }
     if (more) {
-      const m = el('text', { x: x + GAP, y, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG, opacity: 0.7 });
+      const m = el('text', { x: x + GAP, y, 'font-size': 12, fill: MODEL_FG, opacity: 0.7 });
       m.textContent = tailStr;   // a filtered-out live session is always one glance away
       // …and one CLICK away (the user 2026-08-24): the count opens the same views menu, so "what am
       // I not seeing?" answers itself with the list of tags to switch to

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1037,7 +1037,7 @@ class TimelinePanel {
   _font(b) { this._mc.font = (b ? '700 ' + BADGE_FS + 'px ' : '650 12px ') + this._fontFace(); }
   labelWidth(s) { this._font(false); return this._mc.measureText(s || '').width; }
   badgeWidth(s) { this._font(true); return this._mc.measureText(s || '').width; }
-  ctxWidth(s) { this._mc.font = '600 11px ' + FONT; return this._mc.measureText(s || '').width; }
+  ctxWidth(s) { this._mc.font = '600 11px ' + this._fontFace(); return this._mc.measureText(s || '').width; }
 
   // Number.isFinite (not != null): the min/max clamp passes NaN straight through, and a NaN window
   // makes every x() NaN — the whole plot vanishes. Non-finite → the same default as unset.
@@ -1831,7 +1831,7 @@ class TimelinePanel {
     for (const e of ends) {
       svg.appendChild(el('line', { x1: e[0], y1: top, x2: e[0], y2: axisY, stroke: '#ffffff20', 'stroke-width': 1, 'pointer-events': 'none' }));
       const s = clock(e[1]), lx = e[0] + e[3];
-      this._mc.font = '9px ' + FONT;
+      this._mc.font = '9px ' + this._fontFace();
       const w = this._mc.measureText(s).width;
       if (placeLabel && !placeLabel(e[2] === 'end' ? lx - w : lx, e[2] === 'end' ? lx : lx + w)) continue;
       const tx = el('text', { x: lx, y: axisY + 14, 'text-anchor': e[2], fill: 'var(--text-muted)', 'font-size': 9, 'pointer-events': 'none' }); tx.textContent = s; svg.appendChild(tx);
@@ -3160,7 +3160,7 @@ class TimelinePanel {
     for (let tk = Math.ceil(t0 / step) * step; tk <= t1; tk += step) {
       if (inGap(tk)) continue;
       svg.appendChild(el('line', { x1: x(tk), y1: M.top, x2: x(tk), y2: axisY, stroke: '#ffffff10', 'stroke-width': 1 }));
-      this._mc.font = '10px ' + FONT;
+      this._mc.font = '10px ' + this._fontFace();
       const hw = this._mc.measureText(clock(tk)).width / 2;
       if (!placeLabel(x(tk) - hw, x(tk) + hw)) continue;
       const tx = el('text', { x: x(tk), y: axisY + 14, 'text-anchor': 'middle', fill: 'var(--text-muted)', 'font-size': 10 }); tx.textContent = clock(tk); svg.appendChild(tx);

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3715,18 +3715,18 @@ class TimelinePanel {
     // the stub points down (+1); sorted before → up (-1). A counterpart absent from data.sessions
     // entirely (dismissed, #only= filtered, or a foreign session) has no would-be slot: fixed
     // convention, down (+1, toward the axis), so unknowable counterparts always read one way.
-    // TWO-STATE COLOR, keyed on the exec EVENT, never a timer: mm.pending folds in the kernel's
+    // TWO-STATE STROKE, keyed on the exec EVENT, never a timer: mm.pending folds in the kernel's
     // in-flight staleness window (MSG_INFLIGHT_MAX), so it is NOT the key. Exec knowledge is:
     // hasExec (the logged exec event — kernel serialization, the federation upgrade, or the
     // midStart join above) OR exec moved off its sent-time fallback (the kernel serializes
     // exec = sent until a binder writes a real landing; _bind_message_execs' text-heuristic path
     // binds exec without ever logging an event, so hasExec alone would miss it — and federation
     // shifts sent and a fallback exec by the same offset, so the comparison survives rebasing).
-    // No exec known → await-green; exec known → working-yellow — both faded, the awaitingBg
-    // stretch's treatment. This file cannot load ui/webview/styles.css (it also runs inside
-    // Obsidian), so the two tokens are inlined with their names — the MENU_STYLE precedent:
-    const STUB_GREEN = '#54B204';    // --st-awaitbg-bg (await-green)
-    const STUB_YELLOW = '#e0b020';   // --st-working-bg (working-yellow)
+    // Exec known → SOLID, it arrived; none → DASHED, still in flight — the pending-connector
+    // idiom. The stroke COLOR is the sender's identity color, the full connectors' own resolution
+    // (the user 2026-08-24: the old state colors at stub alpha read as mud beside sender-colored
+    // connectors — working-yellow at 0.45 was a muddy orange). The faded 0.45 stays, keeping
+    // stubs subordinate to the work bars.
     const STUB_W = 3;                // a hair over MSG_W0 — a ~15px stroke needs the weight to read
     const STUB_DX = LANE_GAP / 2;    // full-height run → 45° in the lane grid; a nearer landing steepens it
     const stub = (mm, i, senderVisible) => {
@@ -3747,9 +3747,12 @@ class TimelinePanel {
         x2 = x(landXT(mm)); y2 = ly;
         x1 = Math.min(x2, Math.max(x(Math.max(sendXT(mm), t0)), x2 - STUB_DX)); y1 = ly + dir * LANE_GAP / 2;
       }
-      const col = (mm.hasExec || mm.exec !== mm.sent) ? STUB_YELLOW : STUB_GREEN;
-      svg.appendChild(el('line', { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W, opacity: 0.45,
-                                   'stroke-linecap': 'round', 'pointer-events': 'none' }));
+      const col = colorOf(mm.fromId);   // the SENDER's color — the full connectors' own resolution
+      const arrived = mm.hasExec || mm.exec !== mm.sent;
+      const attrs = { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W, opacity: 0.45,
+                      'stroke-linecap': 'round', 'pointer-events': 'none' };
+      if (!arrived) attrs['stroke-dasharray'] = '1 4';   // in flight — the pending-connector dash
+      svg.appendChild(el('line', attrs));
       // same affordances as a full connector: own-color highlight overlay + wide transparent hit,
       // co-lit with the arrival dot (PASS 2 links via msgUI), tooltip + click → where it landed
       const msgLit = dagOrHoverMsg(mm.id);

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -1,9 +1,10 @@
 // Hidden-counterpart message STUBS (the user 2026-08-24): a postal message whose OTHER endpoint has
 // no visible lane must still show on the lane it touches — a short diagonal stub through the lane's
 // band edge (exiting when the recipient is hidden, entering when the sender is), clipped to the band
-// by arithmetic (no clipPath), sloped toward where the hidden lane would sort, and colored by the
-// exec EVENT: await-green (--st-awaitbg-bg #54B204) until the exec binds, working-yellow
-// (--st-working-bg #e0b020) after — never a timer. Headless draw() over the render test's DOM shim,
+// by arithmetic (no clipPath), sloped toward where the hidden lane would sort, in the SENDER's
+// identity color like every full connector (the user 2026-08-24: state colors at stub alpha read as
+// mud), with the arrived/in-flight state on the STROKE STYLE — dashed until the exec binds, solid
+// after, keyed on the exec EVENT, never a timer. Headless draw() over the render test's DOM shim,
 // asserting on the SVG child tree.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -54,8 +55,7 @@ const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"
 const { TimelinePanel } = createRequire(__filename)(viewPath);
 const SRC = fs.readFileSync(viewPath, "utf8");
 
-const GREEN = "#54B204";    // --st-awaitbg-bg (await-green): exec not yet bound
-const YELLOW = "#e0b020";   // --st-working-bg (working-yellow): exec bound
+const ADA = "#f7768e", BEE = "#7aa2f7";   // sender identity colors (synthData below) — a stub wears its SENDER's
 const HALF = 13;            // LANE_GAP/2 — the band-edge clip distance AND the 45° stub run
 
 // Four sessions in a FIXED sort order — ada/cee view-hidden, bee/dee visible. The hidden ones
@@ -94,7 +94,8 @@ function nodes(panel: any): any[] {
   return out;
 }
 const stubLines = (panel: any, hex?: string) =>
-  nodes(panel).filter((n) => n.tag === "line" && (hex ? n._attrs.stroke === hex : (n._attrs.stroke === GREEN || n._attrs.stroke === YELLOW)) && n._attrs["stroke-width"] === 3);
+  nodes(panel).filter((n) => n.tag === "line" && n._attrs["stroke-width"] === 3 && n._attrs.opacity === 0.45
+    && (!hex || n._attrs.stroke === hex));
 const connPaths = (panel: any, color: string) =>
   nodes(panel).filter((n) => n.tag === "path" && n._attrs.fill === "none" && n._attrs.stroke === color && (n._attrs.opacity === 0.5 || n._attrs.opacity === 0.4));
 // expected coordinates from the SAME geometry draw() used (compress map included)
@@ -102,23 +103,25 @@ const X = (panel: any) => (t: number) => { const gm = panel._geom; return gm.ml 
 const laneY = (panel: any) => (i: number) => panel._geom.top + i * 26 + 13;
 const near = (a: number, b: number, msg: string) => assert.ok(Math.abs(a - b) < 1e-6, msg + " (got " + a + ", want " + b + ")");
 
-test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped toward the hidden lane, clipped at the band edge, await-green while pending", () => {
+test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped toward the hidden lane, clipped at the band edge, sender-colored and dashed while pending", () => {
   const now = 1_781_000_000;
   const panel = draw([{ id: "m1", fromId: "SB", toId: "SC", from: "bee", to: "cee",
                         sent: now - 300, exec: now - 300, hasExec: false, pending: true, summary: "on its way" }]);
   const [s, ...rest] = stubLines(panel);
   assert.ok(s, "the stub line draws");
   assert.equal(rest.length, 0, "exactly one stub");
-  assert.equal(s._attrs.stroke, GREEN, "pending (no exec yet) wears await-green");
-  assert.ok(s._attrs.opacity < 1, "faded, the awaitingBg treatment");
+  assert.equal(s._attrs.stroke, BEE, "the stub wears its SENDER's identity color — the connector language");
+  assert.equal(s._attrs["stroke-dasharray"], "1 4", "no exec yet → dashed, the pending-connector idiom");
+  assert.ok(s._attrs.opacity < 1, "faded — subordinate to the work bars");
   near(s._attrs.x1, X(panel)(now - 300), "anchored at the send x");
   near(s._attrs.y1, laneY(panel)(0), "starts on the sender's lane center");
   near(s._attrs.y2, laneY(panel)(0) + HALF, "clipped AT the band edge — cee sorts after bee, so it exits downward");
   near(s._attrs.x2, s._attrs.x1 + HALF, "the 45° run toward the live edge, capped");
-  assert.equal(s._attrs.opacity, 0.45, "the awaitingBg fade level exactly — not invisible, not solid");
+  assert.equal(s._attrs.opacity, 0.45, "the stub fade level exactly — not invisible, not full-strength");
   assert.equal(s._attrs["pointer-events"], "none", "the visible mark never eats the hover — the hit target owns it");
-  const hl = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === GREEN && n._attrs["stroke-width"] === 6);
+  const hl = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === BEE && n._attrs["stroke-width"] === 6);
   assert.ok(hl && hl._attrs.opacity === 0, "the own-color highlight overlay rides the stub, dark until hover/DAG");
+  assert.equal(hl._attrs["stroke-dasharray"], undefined, "the highlight stays solid — the full-connector hl idiom");
   assert.equal(hl._attrs["pointer-events"], "none", "the highlight overlay is inert too");
   const hit = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
   assert.ok(hit, "a wide transparent hit target covers the stub");
@@ -143,7 +146,7 @@ test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped t
   assert.equal(connPaths(panel, "#7aa2f7").length, 0, "no full connector is drawn for a half-hidden message");
 });
 
-test("the stub turns yellow for a heuristic-bound exec too — exec moved off its sent fallback, hasExec never logged", () => {
+test("the stub goes solid for a heuristic-bound exec too — exec moved off its sent fallback, hasExec never logged", () => {
   const now = 1_781_000_000;
   // the kernel's _bind_message_execs text-heuristic path writes exec/pending but no exec event is
   // ever logged, so the row ships hasExec:false with a REAL landing time — that is exec knowledge
@@ -151,13 +154,14 @@ test("the stub turns yellow for a heuristic-bound exec too — exec moved off it
                         sent: now - 200, exec: now - 50, hasExec: false, pending: false, summary: "heuristic-bound" }]);
   const [s] = stubLines(panel);
   assert.ok(s, "the stub draws");
-  assert.equal(s._attrs.stroke, YELLOW, "a bound exec is exec knowledge, with or without the logged event");
+  assert.equal(s._attrs["stroke-dasharray"], undefined, "a bound exec is exec knowledge, with or without the logged event — solid");
+  assert.equal(s._attrs.stroke, BEE, "…still the sender's color: state never recolors a stub");
 });
 
-test("the midStart join upgrades the stub to yellow — the join IS exec knowledge (hasExec set)", () => {
+test("the midStart join upgrades the stub to solid — the join IS exec knowledge (hasExec set)", () => {
   const now = 1_781_000_000;
   // recipient turn's mids carry the message id and its start EQUALS the sent time, so the ONLY
-  // yellow source is the join setting hasExec — pins the mm.hasExec = true half of this change
+  // solid source is the join setting hasExec — pins the mm.hasExec = true half of this change
   const panel: any = new TimelinePanel(makeNode("div"));
   const d = synthData();
   d.turns.SC = [{ id: "SC:1:cc", promptId: "SC:1:cc#p", workId: "SC:1:cc#w", start: now - 300, end: now - 200,
@@ -169,23 +173,24 @@ test("the midStart join upgrades the stub to yellow — the join IS exec knowled
   assert.equal(panel.data.messages[0].hasExec, true, "the join marks the exec as known");
   const [s] = stubLines(panel);
   assert.ok(s, "the stub draws");
-  assert.equal(s._attrs.stroke, YELLOW, "joined landing → working-yellow even with exec equal to sent");
+  assert.equal(s._attrs["stroke-dasharray"], undefined, "joined landing → solid even with exec equal to sent");
 });
 
-test("the stub flips to working-yellow on the exec event — hasExec, never the staleness timer", () => {
+test("the stub flips dashed→solid on the exec event — hasExec, never the staleness timer", () => {
   const now = 1_781_000_000;
   const landed = draw([{ id: "m2", fromId: "SB", toId: "SC", from: "bee", to: "cee",
                          sent: now - 300, exec: now - 30, hasExec: true, pending: false, summary: "landed" }]);
   const [ys] = stubLines(landed);
   assert.ok(ys, "the arrived stub draws");
-  assert.equal(ys._attrs.stroke, YELLOW, "exec bound → working-yellow");
+  assert.equal(ys._attrs["stroke-dasharray"], undefined, "exec bound → solid, it arrived");
   // a STALE in-flight message (kernel: pending aged out by MSG_INFLIGHT_MAX, still no exec) must NOT
-  // flip yellow — the color keys on the exec event, and no exec event ever happened here
+  // go solid — the stroke keys on the exec event, and no exec event ever happened here
   const stale = draw([{ id: "m3", fromId: "SB", toId: "SC", from: "bee", to: "cee",
                         sent: now - 400, exec: now - 400, hasExec: false, pending: false, summary: "never seen landing" }]);
   const [gs] = stubLines(stale);
   assert.ok(gs, "the stale stub still draws");
-  assert.equal(gs._attrs.stroke, GREEN, "no exec event → still await-green (the timer is not the key)");
+  assert.equal(gs._attrs["stroke-dasharray"], "1 4", "no exec event → still dashed (the timer is not the key)");
+  assert.equal(gs._attrs.stroke, BEE, "…and still the sender's color, stale or not");
   near(gs._attrs.x2, gs._attrs.x1, "with the landing x AT the send, the stub steepens to vertical — arithmetic clamp, no clipPath");
   near(gs._attrs.y2, laneY(stale)(0) + HALF, "still exits through the band edge");
 });
@@ -196,7 +201,8 @@ test("a hidden-sender message draws the mirror stub: entering from the band edge
                         sent: now - 400, exec: now - 100, hasExec: true, pending: false, summary: "delivered" }]);
   const [s] = stubLines(panel);
   assert.ok(s, "the incoming stub draws");
-  assert.equal(s._attrs.stroke, YELLOW, "already executed → working-yellow");
+  assert.equal(s._attrs.stroke, ADA, "the HIDDEN sender's color paints the incoming stub — sender, both directions");
+  assert.equal(s._attrs["stroke-dasharray"], undefined, "already executed → solid");
   near(s._attrs.x2, X(panel)(now - 100), "arrives at the exec x");
   near(s._attrs.y2, laneY(panel)(0), "arrives on the recipient's lane center");
   near(s._attrs.y1, laneY(panel)(0) - HALF, "enters from the TOP band edge — ada sorts before bee");
@@ -233,7 +239,7 @@ test("two visible lanes keep today's full connector — no stub elements", () =>
   const panel = draw([{ id: "m7", fromId: "SB", toId: "SD", from: "bee", to: "dee",
                         sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "visible to visible" }]);
   assert.equal(connPaths(panel, "#7aa2f7").length, 1, "the full elbow connector draws exactly as before");
-  assert.equal(stubLines(panel).length, 0, "no stub-colored lines anywhere");
+  assert.equal(stubLines(panel).length, 0, "no stub lines anywhere");
 });
 
 test("window clamping is arithmetic: an off-window send or landing draws no stub", () => {
@@ -262,4 +268,11 @@ test("both stub anchors gate on their own endpoint and clamp x to the window by 
   assert.match(SRC, /x2 = Math\.max\(x1, Math\.min\(x\(Math\.min\(landXT\(mm\), t1\)\), x1 \+ STUB_DX\)\)/);
   assert.match(SRC, /x1 = Math\.min\(x2, Math\.max\(x\(Math\.max\(sendXT\(mm\), t0\)\), x2 - STUB_DX\)\)/);
   assert.doesNotMatch(SRC, /el\('clipPath'|clip-path/i, "clipped by arithmetic, never a clipPath element");
+  // the sender-color + dash retarget (the user 2026-08-24): color from the full connectors' own
+  // lookup, arrived/in-flight on the stroke style, and the old state-color tokens are GONE
+  assert.match(SRC, /const col = colorOf\(mm\.fromId\);\s*\/\/ the SENDER's color/);
+  assert.match(SRC, /const arrived = mm\.hasExec \|\| mm\.exec !== mm\.sent;/);
+  assert.match(SRC, /if \(!arrived\) attrs\['stroke-dasharray'\] = '1 4';/);
+  assert.doesNotMatch(SRC, /STUB_GREEN|STUB_YELLOW/, "the state-color tokens are deleted with their comments"
+    + " (their hexes live on legitimately in the badges/gauges — only the stub tokens die)");
 });

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -99,6 +99,24 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
   assert.match(SRC, /bottom: 27 \}/);
 });
 
+test("the corner line wears the LANE LABELS' typography — inherited family, measured as rendered", () => {
+  // the user 2026-08-24, who read the chip as the wrong font: the corner texts carried an explicit
+  // 'font-family: FONT' while the lane names inherit the host's UI font, so at the same nominal
+  // 12px the chip rendered visibly bigger. The whole corner line now inherits like the lanes do —
+  // no family override anywhere in the trigger drawing…
+  const TRIG = SRC.slice(SRC.indexOf("_drawViewsTrigger(svg, axisY) {"), SRC.indexOf("_closeViewsMenu() {"));
+  assert.doesNotMatch(TRIG, /font-family/, "corner texts inherit the host font exactly like lane labels");
+  // …at the lane-label scale: trigger and N-more at the lane 12px, the chip name at the lane-name 650
+  assert.match(TRIG, /const t = el\('text', \{ x: PADL, y, 'font-size': 12, fill: MODEL_FG \}\);/);
+  assert.match(TRIG, /'font-size': 12, fill: gcol, 'font-weight': 650/);
+  assert.match(SRC, /'font-weight': 650, 'font-size': 12, fill: F\(s\.color\)/, "the lane-name reference the line matches");
+  // …and the width/ellipsis math measures in the SAME family the text renders in: _font resolves
+  // the wrap's computed family (FONT is only the unstyled/bare-node fallback), so box and ellipsis
+  // can never drift from the rendered glyphs
+  assert.match(SRC, /_font\(b\) \{ this\._mc\.font = \(b \? '700 ' \+ BADGE_FS \+ 'px ' : '650 12px '\) \+ this\._fontFace\(\); \}/);
+  assert.match(SRC, /getComputedStyle\(this\.wrap\)\.fontFamily\) \|\| FONT;/);
+});
+
 test("a pointerdown-opened menu survives its OWN opening click (the user 2026-08-24, click-and-hold bug)", () => {
   // the browser fires a click after pointerup; unstopped it bubbles to the document's menu-closer
   // and shuts the menu the instant it opened — only a mid-press redraw (element swapped, no click

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -115,6 +115,11 @@ test("the corner line wears the LANE LABELS' typography — inherited family, me
   // can never drift from the rendered glyphs
   assert.match(SRC, /_font\(b\) \{ this\._mc\.font = \(b \? '700 ' \+ BADGE_FS \+ 'px ' : '650 12px '\) \+ this\._fontFace\(\); \}/);
   assert.match(SRC, /getComputedStyle\(this\.wrap\)\.fontFamily\) \|\| FONT;/);
+  // …and EVERY measure goes through it: the only ctx.font writers left are _font/_fontFace-based
+  // (ctxWidth and the two inline 9px/10px axis measures included), so no measure site can drift
+  const MEASURES = SRC.match(/this\._mc\.font = [^;]+;/g) || [];
+  assert.ok(MEASURES.length >= 4, "the known measure sites are present");
+  for (const m of MEASURES) assert.match(m, /this\._fontFace\(\)/, "a measure bypasses _fontFace: " + m);
 });
 
 test("a pointerdown-opened menu survives its OWN opening click (the user 2026-08-24, click-and-hold bug)", () => {


### PR DESCRIPTION
Two visual-truth fixes on the timeline, both user-reported today.

**Corner filter line typography.** The corner line ("Filter ▾", the view chip, its ✕, the "N more" cue) forced an explicit `font-family` — the hardcoded fallback stack — while the lane-name labels above carry no family attribute and inherit the host's UI font. Same nominal 12px, different face: in any host whose UI font differs from the fallback stack, the chip read visibly bigger, as the wrong font. The corner texts now inherit exactly like the lane labels (sizes and weights already matched: 12px, chip name at the lane-name 650). The measuring helper resolves the family from the wrap's computed style (`_fontFace`, cached; fallback stack only for unstyled/bare-node runs), and a follow-through sweep routes **every** canvas measure (`labelWidth`, `badgeWidth`, `ctxWidth`, the two inline axis measures) through it, with a pin that no `ctx.font` writer can bypass it — so box, ellipsis, gutter, and caret math always measure the family that actually renders.

**Hidden-counterpart stubs.** The band-edge message stubs drop their state colors — working-yellow at the stubs' 0.45 fade read as muddy orange beside the sender-colored full connectors. Every stub, outgoing and incoming, now wears its sender's identity color through the same lookup the full connectors use, at the same subordinate fade. The arrived/in-flight distinction moves from color to stroke style: solid once arrived, dashed while pending (the pending-connector idiom), keeping the exact exec-event keying (`hasExec`, or exec moved off its sent-time fallback — never the staleness timer). The `STUB_GREEN`/`STUB_YELLOW` tokens are deleted.

**Tests:** `ui/timeline-views-panel.test.ts` gains the typography pin (corner texts inherit, lane-label reference, every measure through `_fontFace`); `ui/timeline-hidden-stub.test.ts` retargets color assertions to sender colors and the green→yellow flips to dashed→solid, keeping the event-keyed and mutation-strength pins (stale in-flight stays dashed; heuristic-bound and midStart-joined execs go solid). Suite green locally: 2227/2227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)