### PR TITLE
Stub tooltips name both endpoints from the message row, id as backstop

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3702,7 +3702,11 @@ class TimelinePanel {
     // co-highlights both and shows the tooltip; clicking either jumps to where the message LANDED
     // (the recipient's transcript at exec). No longer separate hover/click targets.
     const msgUI = {};   // message index → { hl, dot }, shared across the line + dot passes
-    const msgHtml = (mm) => () => { const col = colorOf(mm.fromId); return '<div class="r"><span class="chip" style="background:' + col + '"></span><span class="who" style="color:' + col + '">' + esc(mm.from) + '</span><span class="ar">→</span><span class="who" style="color:' + colorOf(mm.toId) + '">' + esc(mm.to) + '</span>' + (mm.pending ? ' <span class="k">pending</span>' : '') + '<span class="t">' + clock(mm.sent) + (mm.pending ? ' → …' : ' → ' + clock(mm.exec)) + '</span></div>' + this.body(esc(mm.summary || mm.text || '')); };
+    // tooltip names resolve from the message ROW (the kernel serializes from/to display names),
+    // never from visible lanes — a stub whose counterpart has no lane still names both ends (the
+    // user 2026-08-24). A nameless row falls back to the raw id: information, not an empty span
+    // (the CLI's unmappable-member precedent).
+    const msgHtml = (mm) => () => { const col = colorOf(mm.fromId); return '<div class="r"><span class="chip" style="background:' + col + '"></span><span class="who" style="color:' + col + '">' + esc(mm.from || mm.fromId) + '</span><span class="ar">→</span><span class="who" style="color:' + colorOf(mm.toId) + '">' + esc(mm.to || mm.toId) + '</span>' + (mm.pending ? ' <span class="k">pending</span>' : '') + '<span class="t">' + clock(mm.sent) + (mm.pending ? ' → …' : ' → ' + clock(mm.exec)) + '</span></div>' + this.body(esc(mm.summary || mm.text || '')); };
     const msgNav = (mm) => () => { const an = this.nearestTurnAnchor(mm.toId, execAt(mm)); this._select(mm.toId); this.openChat((an && an.tid) || mm.toId, mm.id || (an && (an.uuid || an.replyUuid)), false, false, execAt(mm)); };   // land on the message's OWN postal card BY ID — the chat matches mm.id to the card's data-mid (the user 2026-06-20); nearest-turn uuid / time only as fallback
     // ── HIDDEN-COUNTERPART STUBS (the user 2026-08-24): a message whose OTHER endpoint has no
     // visible lane still shows on the lane it does touch — a short diagonal stub through the band

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -135,6 +135,8 @@ test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped t
   hit._listeners.mouseenter({ clientX: 200, clientY: 30, currentTarget: hit });
   assert.equal(hl._attrs.opacity, "0.95", "hover lights the highlight overlay");
   assert.ok(panel.tip.classList.contains("show"), "hover shows the tooltip (showTip)");
+  assert.ok(String(panel.tip.innerHTML).includes(">bee<") && String(panel.tip.innerHTML).includes(">cee<"),
+    "the tooltip names BOTH endpoints — the hidden counterpart resolves from the row, not the lanes");
   hit._listeners.mouseleave({});
   assert.equal(hl._attrs.opacity, "0", "leave restores the dark overlay");
   const calls: any[] = [];
@@ -221,6 +223,23 @@ test("a counterpart absent from data.sessions slopes by the fixed convention: do
   const [s] = stubLines(panel);
   assert.ok(s, "the stub draws even with no would-be lane to lean toward");
   near(s._attrs.y2, s._attrs.y1 + HALF, "fixed convention: down, toward the axis");
+  // the tooltip must name BOTH endpoints even with no counterpart row in data.sessions at all
+  // (the user 2026-08-24): the names come from the message ROW itself, never from visible lanes
+  const hit = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
+  hit._listeners.mouseenter({ clientX: 200, clientY: 30, currentTarget: hit });
+  assert.ok(String(panel.tip.innerHTML).includes(">bee<"), "the visible sender is named");
+  assert.ok(String(panel.tip.innerHTML).includes(">gone<"), "…and the ABSENT counterpart is named, from the row");
+});
+
+test("a nameless row still names both ends — the raw id backstops a missing display name", () => {
+  const now = 1_781_000_000;
+  // a row the kernel could not resolve a display name for (cleared/foreign session) must not
+  // render an empty who-span: the raw id is information, not noise
+  const panel = draw([{ id: "m13", fromId: "SB", toId: "SX", from: "bee", to: "",
+                        sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "to a nameless one" }]);
+  const hit = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
+  hit._listeners.mouseenter({ clientX: 200, clientY: 30, currentTarget: hit });
+  assert.ok(String(panel.tip.innerHTML).includes(">SX<"), "the raw id names the endpoint — never an empty span");
 });
 
 test("both endpoints hidden → no stub, no connector", () => {


### PR DESCRIPTION
Follow-up to the stub sender-color change: the stub tooltip must name **both** endpoints even when the counterpart session isn't drawn on the timeline.

The tooltip already did the right thing structurally — stubs share the full connector's tooltip builder, which resolves names from the message row's own display-name fields (never from visible lanes) — so this lands as regression tests plus one hardening the tests surfaced: a row whose display name the kernel could not resolve (cleared or foreign session) rendered an empty who-span, silently naming only one endpoint. The raw id now backstops a nameless row: information, not an empty span.

**Tests** (`ui/timeline-hidden-stub.test.ts`, suite 2228/2228): the hidden-counterpart tooltip names both ends; a counterpart absent from `data.sessions` entirely is still named from the row; a nameless row falls back to the raw id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)