### PR TITLE
Feed footer: one view menu replaces the three word-buttons; search restyle; Undo

### DIFF
--- a/docs/goal-state.md
+++ b/docs/goal-state.md
@@ -95,7 +95,7 @@ the card's whole subtree (you reply to the card, never to its blocked
 sub-goals) · Continue (a needs-you card's one-click canned reply, 2026-08-08:
 "nothing needed from me, keep going" — the same reply path end to end, so it
 inherits the optimistic reopen and the judges' reassert; never a bare column
-move) · Clear / Undo clear · Resolve · the agent checking off its to-dos ·
+move) · Clear / Undo · Resolve · the agent checking off its to-dos ·
 a peer completing delegated work (courier link-back) · a failed auto-nudge
 (records a block) · the settle moment · the live floors below.
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23595,7 +23595,7 @@ apierror:"a session stopped on an API error (rate limit, spend cap, or prompt to
 sdk:"romp's SDK backend, the machinery that actually runs your sessions, hit an error: a session thread that died, a stream that dropped, a setting the CLI refused. The session usually recovers on its own, and the full traceback is in the kernel log under ~/.local/state/romp",
 sync:"romp moved commits between your machines by itself \u2014 a push to a remote, a pull from one, or an ask that a peer fast-forward itself. Successes are logged as well as failures, so this is the record of what romp did to your machines; the network panel shows a sync while it is still running",
 locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
-cleared:"a /clear in a session dropped still-open cards at the boundary; Undo clear on the feed restores them",
+cleared:"a /clear in a session dropped still-open cards at the boundary; Undo on the feed restores them",
 undelivered:"something you sent never reached a session — the kernel it was addressed to has no session by that id, which on a board showing more than one machine means the pane addressed the wrong one. Nothing was delivered. Your text is kept verbatim in undelivered.jsonl under ~/.local/state/romp"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -97,7 +97,7 @@ test("a /clear boundary that dropped cards logs once, naming them and the way ba
   assert.equal(first.notices.length, 1);
   assert.equal(first.notices[0].kind, "cleared");
   assert.match(first.notices[0].text, /^web — \/clear dropped 2 open cards: ship the notes-api, tune the rate limits/);
-  assert.match(first.notices[0].text, /Undo clear/, "the way back is in the entry itself");
+  assert.match(first.notices[0].text, /Undo on the feed/, "the way back is in the entry itself");
   const again = clearBoundaryNotices(rows, new Set(first.active));
   assert.equal(again.notices.length, 0, "the same boundary never re-logs across pushes/reloads");
 });

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -75,7 +75,7 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
 // episodes log's own settle record). Same episode-identity contract as the badges above: one bell
 // entry per boundary (sid + its t), so a clear that silently dropped cards is always findable in
 // the bell after the fact (the user 2026-07-27). The entry names the dropped cards and the way back
-// (Undo clear restores the batch).
+// (Undo restores the batch).
 export interface ClearNoticeRow { sid: string; name: string; t: number; titles: string[]; ended?: boolean; }   // ended: a session death finalized these cards (2026-08-13), not a /clear
 
 export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
@@ -87,14 +87,14 @@ export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>):
     if (seen.has(sig)) continue;
     const n = r.titles.length;
     // an ENDED row is a session death that finalized open cards (2026-08-13) — same channel as the
-    // /clear drop, its own phrasing: nothing here is restorable by Undo clear, the session is gone
+    // /clear drop, its own phrasing: nothing here is restorable by Undo, the session is gone
     notices.push(r.ended
       ? { kind: "ended", sig, sid: r.sid, itemId: "",
           text: r.name + " ended with " + n + " open card" + (n === 1 ? "" : "s") + ": "
             + cap(r.titles.join(", "), 120) }
       : { kind: "cleared", sig, sid: r.sid, itemId: "",   // no single card — the jump opens the session
           text: r.name + " — /clear dropped " + n + " open card" + (n === 1 ? "" : "s") + ": "
-            + cap(r.titles.join(", "), 120) + " (Undo clear on the feed restores them)" });
+            + cap(r.titles.join(", "), 120) + " (Undo on the feed restores them)" });
   }
   return { notices, active };
 }

--- a/ui/webview/clear-confirm.test.ts
+++ b/ui/webview/clear-confirm.test.ts
@@ -38,7 +38,7 @@ test("the confirm detail: null with nothing open; singular/plural; long lists ca
   assert.match(clearConfirmDetail(["one card"])!, /Its 1 open card gets dropped with it: one card/);
   const two = clearConfirmDetail(["a", "b"])!;
   assert.match(two, /Its 2 open cards get dropped with it: a, b/);
-  assert.match(two, /Undo clear/, "the way back is named in the same breath");
+  assert.match(two, /Undo on the feed/, "the way back is named in the same breath");
   const long = clearConfirmDetail(Array.from({ length: 30 }, (_, i) => "card number " + i))!;
   assert.ok(long.length < 400, "the titles list is capped so the modal stays readable");
   assert.match(long, /…/);

--- a/ui/webview/clear-confirm.ts
+++ b/ui/webview/clear-confirm.ts
@@ -27,7 +27,7 @@ export function clearConfirmDetail(titles: string[]): string | null {
   const n = titles.length;
   return (n === 1 ? "Its 1 open card gets dropped with it: " : "Its " + n + " open cards get dropped with it: ")
     + shown
-    + ". Undo clear on the feed restores the cards, but the agent will no longer remember the work behind them.";
+    + ". Undo on the feed restores the cards, but the agent will no longer remember the work behind them.";
 }
 
 // The END confirm's detail (the user 2026-08-15, who ended a session holding an open task and got no

--- a/ui/webview/feed-card-prefs.test.ts
+++ b/ui/webview/feed-card-prefs.test.ts
@@ -21,7 +21,7 @@ test("feed prefs from romp:settings: newestFirst/collapsed default OFF, grouped 
   assert.doesNotMatch(FEED, /explanations/);   // every trace of the old pref is gone from the feed
 });
 
-test("footer layout: view toggles left, Clear all + Undo clear dock right (the user 2026-07-13)", () => {
+test("footer layout: view controls left, Clear all + Undo dock right (the user 2026-07-13)", () => {
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
   // flex `order` + margin-left:auto so the split holds whatever order the ensure* calls appended in
   assert.match(CSS, /#feed-clearall \{ order: 10; margin-left: auto; \}/);

--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -58,28 +58,25 @@ test("both controls live on the build-once header — click-safe across re-rende
     "wired inside ensureCols' one-time scaffold, never in a render loop");
 });
 
-test("the Stack toggle says so when narrow width already forces stacking (2026-08-19)", () => {
-  // at or under the container query's 540px the layout stacks regardless of the pref, so the
-  // toggle is a no-op there: faded (aria-disabled), click no-ops, tooltip names the way out.
-  // The width constant must match the CSS query — the two stacking owners cannot drift.
+test("the Single-column menu row says so when narrow width already forces stacking (2026-08-19)", () => {
+  // at or under the container query's 540px the layout stacks regardless of the pref, so the row
+  // (the footer Stack button before 2026-08-24) is a no-op there: still ✓-checked — stacking IS
+  // on — but faded (aria-disabled), click no-ops, tooltip names the way out. The width constant
+  // must match the CSS query — the two stacking owners cannot drift.
   assert.match(FEED, /const STACK_FORCED_W = 540;/);
   assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\)/);
-  assert.match(FEED, /b\.classList\.toggle\("forced", forced\);/);
+  assert.match(FEED, /list\.clientWidth <= STACK_FORCED_W/);
   assert.match(FEED, /widen the feed to unstack into three columns/);
-  assert.match(FEED, /if \(b\.classList\.contains\("forced"\)\) return;/,
+  assert.match(FEED, /current: p\.stacked \|\| stackForced, forced: stackForced/,
+    "forced = checked AND inert — the ✓ never strips while stacking is active");
+  assert.match(FEED, /if \(r\.classList\.contains\("forced"\)\) return;/,
     "keyboard activation bypasses pointer-events, so the handler itself no-ops");
-  assert.match(FEED, /new ResizeObserver\(\(\) => refreshStackForced\(b\)\)/,
+  assert.match(FEED, /new ResizeObserver\(\(\) => refreshStackForced\(\)\)/,
     "width changes are the event — never a poll");
-  assert.match(CSS, /#feed-foot \.feed-modetoggle\.forced \{ opacity: 0\.5; cursor: default;\s*\n\s*color: var\(--accent\); border-color: var\(--accent\); \}/,
-    "grayed but still wearing the on-accent — stacking IS active (the user 2026-08-19)");
-  assert.match(CSS, /#feed-foot \.feed-modetoggle\.forced:hover \{ opacity: 0\.75;/, "hover stays responsive");
-  // THE CASCADE, not just the rule (the user's third report, 2026-08-19): `.on { opacity: 1 }` ties
-  // the forced fade's specificity, so the fade only paints if its rule comes LATER in the file. The
-  // first two cuts pinned the rule's existence while `.on` silently won — pin the tiebreak itself.
-  const onAt = CSS.indexOf("#feed-foot .feed-modetoggle.on");
-  const forcedAt = CSS.indexOf("#feed-foot .feed-modetoggle.forced");
-  assert.ok(onAt >= 0 && forcedAt > onAt,
-    "the forced rule must follow the .on rule at equal specificity, or opacity: 1 wins and the fade never shows");
-  assert.doesNotMatch(CSS, /#feed-stacked\.forced/,
-    "no (1,1,0) leftovers — every forced rule must tie the .on rule's specificity");
+  assert.match(FEED, /if \(viewMenuEl\) paintViewMenu\(viewMenuEl\);   \/\/ an open menu repaints on the deciding event/);
+  assert.match(CSS, /\.feed-viewmenu \.ctx-item\.forced \{ opacity: 0\.55; cursor: default; \}/,
+    "faded but never stripped of its checked state (the user 2026-08-19)");
+  assert.match(CSS, /\.feed-viewmenu \.ctx-item\.forced:hover \{ background: transparent; color: inherit; \}/,
+    "an inert row makes no hover promise — .ctx-item:hover recolours as well as washes");
+  assert.doesNotMatch(CSS, /feed-modetoggle\.forced/, "the footer-button forced rules are gone with the button");
 });

--- a/ui/webview/feed-foot.test.ts
+++ b/ui/webview/feed-foot.test.ts
@@ -1,6 +1,7 @@
-// The feed's Clear-all / Undo-clear controls sit in a small bordered sub-pane in the BOTTOM-RIGHT of
-// the feed, not a full-width footer bar, and the button label is two words "Undo clear" (the user
-// 2026-06-16). The chat renderer has no jsdom harness, so — like the ledger tests — pin at the source.
+// The feed's Clear-all / Undo controls sit in a small bordered sub-pane in the BOTTOM-RIGHT of
+// the feed, not a full-width footer bar, and the restore button reads one word "Undo" (the user
+// 2026-08-24, dropping 2026-06-16's "Undo clear" — it sits right beside Clear all, context enough).
+// The chat renderer has no jsdom harness, so — like the ledger tests — pin at the source.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -9,8 +10,9 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("the Undo-clear button label is two words", () => {
-  assert.match(FEED, /b\.textContent = "Undo clear"/);
+test("the restore button label is the one word Undo", () => {
+  assert.match(FEED, /b\.textContent = "Undo";/);
+  assert.doesNotMatch(FEED, /textContent = "Undo clear"/);
   assert.doesNotMatch(FEED, /"UndoClear"/);
 });
 

--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -13,10 +13,12 @@ const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", 
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
 
-test("the footer Group toggle persists `grouped` in romp:settings; grouping is the DEFAULT (the user 2026-07-13)", () => {
-  assert.match(FEED, /grouped: s\.grouped !== false/);   // default ON — the toggle opts OUT
-  assert.match(FEED, /ensureFeedToggle\("feed-grouped", "Group", \(\) => feedPrefs\(\)\.grouped, "grouped",/);
-  assert.match(FEED, /ensureGroupToggle\(\)\.style\.display = showCA \? "" : "none";/);
+test("the view menu's Group-by-session row persists `grouped` in romp:settings; grouping is the DEFAULT (the user 2026-07-13)", () => {
+  assert.match(FEED, /grouped: s\.grouped !== false/);   // default ON — the row opts OUT
+  // the footer "Group" word-button folded into the view menu (the user 2026-08-24) — same pref, same default
+  assert.match(FEED, /set\(2, "Group by session", \{/);
+  assert.match(FEED, /current: p\.grouped,/, "the ✓ reads the same !== false default — a missing key stays checked");
+  assert.match(FEED, /mk\(true, \(\) => setViewPref\("grouped", !feedPrefs\(\)\.grouped\)\)/);
 });
 
 test("session rank = the kernel's session-order list (tab/lane order); unknown sids keep time order after it", () => {

--- a/ui/webview/feed-search.test.ts
+++ b/ui/webview/feed-search.test.ts
@@ -47,5 +47,24 @@ test("the footer control is ensure-once, expandable, and an active query can nev
                "folding with a live query clears it, never hides it");
   assert.match(FEED, /sessionStorage\.getItem\("romp:feedSearch"\)/,
                "same storage lifetime as the session filter: reload-proof, never a fresh window");
-  assert.match(CSS, /#feed-search\.open input \{ width: \d+px/, "the expansion is a real width transition");
+});
+
+test("the expanded bar wears the top search bar's look, footer-scaled, and FLEXES instead of a fixed width", () => {
+  // the user 2026-08-24: the open wrap takes the row's spare space with a floor and a cap — a narrow
+  // pane wraps it onto its own row (the footer wraps) instead of overflowing or squeezing to nothing
+  assert.match(CSS, /#feed-search\.open \{ flex: 1 1 150px; min-width: 110px; max-width: 340px; \}/);
+  assert.match(CSS, /#feed-search input \{ flex: 1 1 auto; min-width: 0;/);
+  assert.doesNotMatch(CSS, /#feed-search\.open input \{ width: \d+px/, "no fixed-width expansion survives");
+  // the top bar's vocabulary, scaled to the footer's 10.5px rhythm — never the outline bar's 12.5px verbatim
+  assert.match(CSS, /#feed-search input \{[^}]*font-size: 10\.5px/);
+  assert.match(CSS, /#feed-search input \{[^}]*background: var\(--vscode-input-background, #3c3c3c\)/);
+  assert.match(CSS, /#feed-search\.open input:focus \{ border-color: var\(--accent\); \}/);
+  // the inner ✕ clear: hidden while empty, clearing REFOCUSES (the top bar's semantics)
+  assert.match(FEED, /clr\.id = "feed-search-clear";/);
+  assert.match(FEED, /inp\.value = ""; setFeedSearch\(""\); inp\.focus\(\); render\(\);/);
+  assert.match(FEED, /clrBtn\.hidden = !inp\.value\.trim\(\);/,
+    "trimmed, like the fold and the filter — a whitespace-only value must not strand a floating ✕");
+  assert.match(CSS, /#feed-search-clear\[hidden\] \{ display: none; \}/);
+  assert.match(CSS, /#feed-search:not\(\.open\) #feed-search-clear \{ display: none; \}/,
+    "the ✕ exists only on an open box — a folded control can never wear a stray ×");
 });

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -47,8 +47,8 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
   assert.ok(FEED.includes("if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);"));
 });
 
-test("the menu sits right of Group, lists sessions in tab order, canonical form, click-safe", () => {
-  assert.match(FEED, /ensureGroupToggle\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionFilter\(\)\.style\.display = showCA \? "" : "none";/);
+test("the menu sits right of the view-menu icon, lists sessions in tab order, canonical form, click-safe", () => {
+  assert.match(FEED, /ensureViewMenuBtn\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionFilter\(\)\.style\.display = showCA \? "" : "none";/);
   // tab order: ranked by the kernel's session-order list — the same rank grouped mode sorts by
   assert.ok(FEED.includes("const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));"));
   // the menu lives on document.body — outside render()'s reconcile, so a push can't rebuild it mid-press

--- a/ui/webview/feed-sort.test.ts
+++ b/ui/webview/feed-sort.test.ts
@@ -1,6 +1,7 @@
 // Feed card sort order: oldest-at-top by DEFAULT (the user 2026-06-27) — the newest work sits at the BOTTOM
-// of each column, and new/moved cards stack onto the bottom. A footer "Newest first" toggle (default OFF,
-// the user 2026-07-07) reverses each column. The old ⛭ "Oldest first" gear checkbox stays gone. Source-pins.
+// of each column, and new/moved cards stack onto the bottom. The view menu's "Sort by most recent ↓/↑" row
+// (the footer "Newest first"/"Modified" button before 2026-08-24, default OFF since the user 2026-07-07)
+// reverses each column. The old ⛭ "Oldest first" gear checkbox stays gone. Source-pins.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -9,14 +10,17 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
 
-test("each column sorts by modified time; the footer 'Modified ↑/↓' control reverses the direction", () => {
+test("each column sorts by modified time; the view menu's 'Sort by most recent ↓/↑' row reverses the direction", () => {
   assert.match(FEED, /const newestFirst = feedPrefs\(\)\.newestFirst;/);
   assert.match(FEED, /buckets\[k\]\.sort\(\(x, y\) => newestFirst \? y\.t - x\.t : x\.t - y\.t\)/);
-  // renamed from the "Newest first" on/off toggle (the user 2026-08-18): the arrow IS the state —
-  // ↓ newest at the top, ↑ oldest at the top — so the button drops the pressed accent
-  assert.match(FEED, /ensureFeedToggle\("feed-newestfirst", "Modified", \(\) => feedPrefs\(\)\.newestFirst, "newestFirst"/);
-  assert.match(FEED, /b\.textContent = "Modified " \+ \(feedPrefs\(\)\.newestFirst \? "\\u2193" : "\\u2191"\);/);
-  assert.match(FEED, /b\.classList\.remove\("on"\);/);
+  // folded into the footer VIEW MENU (the user 2026-08-24), keeping the Modified button's rule (the
+  // user 2026-08-18): the arrow IS the state — ↓ newest at the top, ↑ oldest at the top — a DIRECTION
+  // row, so it is a plain menuitem that never wears the ✓-current mark
+  assert.match(FEED, /"Sort by most recent " \+ \(p\.newestFirst \? "\\u2193" : "\\u2191"\)/);
+  // the click reads the prefs AS OF the click (feedPrefs() inside the handler), never a paint-time capture
+  assert.match(FEED, /mk\(false, \(\) => setViewPref\("newestFirst", !feedPrefs\(\)\.newestFirst\)\)/);
+  assert.match(FEED, /set\(0, "Sort by most recent[\s\S]{0,160}?current: false/,
+    "the direction row never wears the ✓-current mark — both directions are valid sorts");
   assert.doesNotMatch(FEED, /oldestFirst/, "no oldestFirst pref — the natural order is oldest-first");
 });
 

--- a/ui/webview/feed-stack.test.ts
+++ b/ui/webview/feed-stack.test.ts
@@ -18,11 +18,13 @@ test("one stacked block, two triggers: the narrow size query OR the forced style
   assert.equal(count, 1, "still exactly one container query — no duplicated stacked rules");
 });
 
-test("the footer Stack button writes the pref and applies the style var; boot applies a persisted one", () => {
+test("the view menu's Single-column row writes the pref and applies the style var; boot applies a persisted one", () => {
   assert.match(FEED, /stacked: s\.stacked === true/);
-  assert.match(FEED, /ensureFeedToggle\("feed-stacked", "Stack", \(\) => feedPrefs\(\)\.stacked, "stacked"/);
+  // the footer "Stack" word-button folded into the view menu (the user 2026-08-24) — same pref, same var
+  assert.match(FEED, /set\(1, "Single column view", \{/);
+  assert.match(FEED, /mk\(true, \(\) => setViewPref\("stacked", !feedPrefs\(\)\.stacked, applyStacked\)\)/);
   assert.match(FEED, /\.style\.setProperty\("--romp-stack", on \? "on" : "off"\)/);
   assert.match(FEED, /applyStacked\(feedPrefs\(\)\.stacked\);\s*\/\/ boot/);
   assert.match(FEED, /applyStacked\(p\.stacked\);/, "a settings change from any surface re-applies it");
-  assert.match(FEED, /ensureStackToggle\(\)\.style\.display = showCA \? "" : "none";/, "docked in the footer row");
+  assert.match(FEED, /ensureViewMenuBtn\(\)\.style\.display = showCA \? "" : "none";/, "docked in the footer row");
 });

--- a/ui/webview/feed-viewmenu.test.ts
+++ b/ui/webview/feed-viewmenu.test.ts
@@ -1,0 +1,106 @@
+// The footer VIEW MENU (the user 2026-08-24): the three view controls — sort direction, single-column
+// layout, by-session grouping — live behind ONE monochrome icon button, replacing the Modified/Stack/
+// Group word-buttons. The popup wears the repo-wide menu vocabulary (.ctx-menu chrome + the ✓-in-circle
+// current mark); prefs still write the shared romp:settings, so the gear watcher and other panes read
+// the same keys. feed.ts has no jsdom harness → source pins (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("one icon button replaces the three word-buttons; the old footer toggles are gone", () => {
+  assert.match(FEED, /function ensureViewMenuBtn\(\): HTMLElement/);
+  assert.match(FEED, /b\.id = "feed-viewbtn";/);
+  assert.doesNotMatch(FEED, /ensureFeedToggle|makeFeedToggle/, "the word-button helper went with its buttons");
+  assert.doesNotMatch(FEED, /feed-newestfirst|feed-stacked|feed-grouped/, "no old toggle ids survive");
+  // monochrome by construction: THE GLYPH ITSELF strokes currentColor (scoped to the function — an
+  // unscoped match would ride any other svg in the file), so it wears the button's own states
+  // (dim, hover accent) with no colors of its own — and it is NOT a gear (the kernel page's strip
+  // shows its ⛭ right below this footer)
+  const glyph = FEED.slice(FEED.indexOf("function viewMenuGlyph"), FEED.indexOf("function ensureViewMenuBtn"));
+  assert.ok(glyph.includes('stroke="currentColor"'), "the glyph strokes currentColor");
+  assert.ok(!/#[0-9a-fA-F]{3,8}|rgb\(/.test(glyph), "no hardcoded color anywhere in the glyph");
+  assert.ok(!glyph.includes("⛭"), "not a gear");
+  assert.match(FEED, /b\.setAttribute\("aria-haspopup", "menu"\);/);
+});
+
+test("the menu holds exactly the three rows, in order: sort direction, single column, group", () => {
+  const sortAt = FEED.indexOf('set(0, "Sort by most recent');
+  const stackAt = FEED.indexOf('set(1, "Single column view');
+  const groupAt = FEED.indexOf('set(2, "Group by session');
+  assert.ok(sortAt > 0 && stackAt > sortAt && groupAt > stackAt, "three rows, this order");
+  // each ✓ row declares its role; the direction row stays a plain menuitem (feed-sort.test.ts owns that)
+  assert.match(FEED, /r\.setAttribute\("role", check \? "menuitemcheckbox" : "menuitem"\);/);
+  assert.match(FEED, /r\.setAttribute\("aria-checked", opts\.current \? "true" : "false"\);/);
+});
+
+test("rows are real <button>s — the keyboard operability the replaced footer buttons had", () => {
+  // the old Modified/Stack/Group controls were Tab-reachable, Enter/Space-activatable <button>s; div
+  // rows would have made all three controls mouse-only (found in review, 2026-08-24)
+  assert.match(FEED, /const r = el\("button", "ctx-item"\);/);
+  assert.match(FEED, /\(r as HTMLButtonElement\)\.type = "button";/);
+  assert.match(FEED, /\?\.focus\(\);   \/\/ a keyboard open lands on the first row/);
+  assert.match(FEED, /if \(viewMenuEl\?\.contains\(document\.activeElement\)\) document\.getElementById\("feed-viewbtn"\)\?\.focus\(\);/,
+    "closing from inside the menu hands focus back to the button");
+  // buttons need the UA chrome stripped and the menu font re-inherited — a button that doesn't
+  // inherit is exactly how a menu drifts onto the host font (the 2026-08-09 timeline-gear bug)
+  assert.match(CSS, /\.feed-viewmenu \.ctx-item \{ position: relative; padding-right: 30px; display: block; width: 100%;\s*\n\s*text-align: left; background: none; border: 0; font: inherit; color: inherit; \}/);
+  assert.match(CSS, /\.feed-viewmenu \.ctx-item:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/);
+});
+
+test("a live menu syncs IN PLACE — rows are never rebuilt under a pressed pointer", () => {
+  // paintViewMenu runs on an OPEN menu (settings change from another pane, the width crossing 540px);
+  // rebuilding rows there would drop a click landing between mousedown and mouseup (click-safety)
+  const paint = FEED.slice(FEED.indexOf("function paintViewMenu"), FEED.indexOf("function openViewMenu"));
+  assert.ok(paint.includes('const rows = menu.querySelectorAll(".ctx-item");'), "sync finds the existing rows");
+  assert.ok(!paint.includes("replaceChildren") && !paint.includes("appendChild"),
+    "paint never rebuilds — buildViewMenu appends once per open");
+  assert.match(FEED, /act\(\);\s*\n\s*closeViewMenu\(\);/, "handlers attach once in buildViewMenu");
+  assert.match(FEED, /mk\(false, \(\) => setViewPref\("newestFirst", !feedPrefs\(\)\.newestFirst\)\)/,
+    "clicks read the prefs at CLICK time, not a paint-time capture");
+});
+
+test("one menu at a time: the view menu and the session menu close each other on open", () => {
+  // the pointerdown-away closers cover mouse opens; a keyboard Enter fires click with NO pointerdown,
+  // so each opener must close the other explicitly (found in review, 2026-08-24)
+  assert.match(FEED, /function openViewMenu\(btn: HTMLElement\): void \{\s*\n\s*closeSessMenu\(\);/);
+  assert.match(FEED, /function openSessMenu\(btn: HTMLElement\): void \{\s*\n\s*closeViewMenu\(\);/);
+});
+
+test("the popup wears the repo menu vocabulary: .ctx-menu chrome + the ✓-in-circle current mark", () => {
+  assert.match(FEED, /el\("div", "ctx-menu feed-viewmenu"\)/, "the shared chrome, not a bespoke card");
+  // the ✓-in-circle every romp menu uses (styles.css .ctx-sub/.meta-item.current), ported here because
+  // the feed page loads only feed.css — on --check-bg, the panel-wide checkmark disc
+  assert.match(CSS, /\.feed-viewmenu \.ctx-item\.current::after \{\s*\n\s*content: "✓"; position: absolute; right: 8px; top: 50%; transform: translateY\(-50%\);\s*\n\s*background: var\(--check-bg\); color: #fff; border-radius: 50%;\s*\n\s*width: 13px; height: 13px; font-size: 9px; font-weight: 900;/);
+  // THE CASCADE, both ways (the repo's recurring bug class): the icon button's padding must carry two
+  // ids or #feed-foot .fdismiss's (1,1,0) wins; and the row reset ties .ctx-item:hover at (0,2,0), so
+  // the reset must sit EARLIER in the file for the hover wash to win its tie by order.
+  assert.match(CSS, /#feed-foot #feed-viewbtn \{ display: inline-flex; align-items: center; padding: 2px 7px; \}/);
+  assert.doesNotMatch(CSS, /^#feed-viewbtn \{/m, "no (1,0,0) button rule that #feed-foot .fdismiss would beat");
+  const resetAt = CSS.indexOf(".feed-viewmenu .ctx-item {");
+  const hoverAt = CSS.indexOf(".ctx-item:hover {");
+  assert.ok(resetAt >= 0 && hoverAt > resetAt,
+    "the button reset precedes .ctx-item:hover — the hover wash wins the background tie by order");
+});
+
+test("menu mechanics mirror the session menu: on document.body, opens upward, away/Escape close", () => {
+  // on document.body, OUTSIDE render()'s reconcile — a push can never rebuild it mid-press (click-safety)
+  const open = FEED.slice(FEED.indexOf("function openViewMenu"), FEED.indexOf("function viewMenuGlyph"));
+  assert.ok(open.includes("document.body.appendChild(menu);"));
+  assert.ok(open.includes('menu.style.bottom = Math.round(window.innerHeight - r.top + 6) + "px";'), "opens upward from the footer");
+  assert.match(FEED, /function viewMenuAway\(ev: Event\): void/);
+  assert.match(FEED, /function viewMenuKey\(ev: KeyboardEvent\): void \{ if \(ev\.key === "Escape"\) closeViewMenu\(\); \}/);
+  assert.match(FEED, /document\.addEventListener\("pointerdown", viewMenuAway, true\);/);
+});
+
+test("rows write the shared romp:settings and signal the same-doc re-render, like the buttons did", () => {
+  assert.match(FEED, /function setViewPref\(key: string, on: boolean, after\?: \(on: boolean\) => void\): void/);
+  assert.match(FEED, /localStorage\.setItem\("romp:settings", JSON\.stringify\(s\)\);/);
+  assert.match(FEED, /window\.dispatchEvent\(new Event\("romp:settings"\)\);/);
+  // a settings change from ANY surface (the gear, another pane) repaints an open menu — its rows
+  // display those prefs, so a stale menu would lie
+  assert.match(FEED, /if \(viewMenuEl\) paintViewMenu\(viewMenuEl\);   \/\/ an open view menu re-reads the prefs it shows/);
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -826,13 +826,13 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* the expand toggle is a compact square showing "+" (collapsed) / "−" (open) */
 .fdismiss { padding: 2px 10px; }
 /* One accent hover for every action button (the user 2026-07-21): Clear, Move to Working, Follow up,
-   Clear all, UndoClear all share it — no red on any action, only on error/blocked STATUS. */
+   Clear all, Undo all share it — no red on any action, only on error/blocked STATUS. */
 .fdismiss:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }
-/* UndoClear — restorative, so it hovers BLUE like Follow up, not Clear's red. */
+/* Undo — restorative, so it hovers BLUE like Follow up, not Clear's red. */
 /* The feed's DOCKED control bar (the user 2026-06-29): its own dedicated rectangle in normal flow at the
    bottom of the pane, NOT a floating overlay. The body is a column flex, so #feed-list flexes to fill above
-   it and the bar sits below without overlapping a card. Layout (the user 2026-07-13): the VIEW toggles
-   (Newest first · Collapsed · Group) sit left; the ACTIONS (Clear all, then Undo clear) dock right — flex
+   it and the bar sits below without overlapping a card. Layout (the user 2026-07-13): the VIEW controls
+   (the view-menu icon · Session ▴ · Search) sit left; the ACTIONS (Clear all, then Undo) dock right — flex
    `order` + margin-left:auto, so the split holds whatever order the ensure* calls appended the buttons in. */
 #feed-foot { flex: 0 0 auto; z-index: 5;
   display: flex; align-items: center; gap: 8px; padding: 6px 12px;
@@ -843,7 +843,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-undoclear { order: 11; }                     /* restorative — far right */
 #feed-foot .fdismiss { font-size: 10.5px; padding: 1px 9px; opacity: 0.95; }
 
-/* Undo clear, WORKING (the user 2026-07-31): when the cleared batch isn't in this page's cache the
+/* Undo, WORKING (the user 2026-07-31): when the cleared batch isn't in this page's cache the
    restore is a full kernel round-trip and the button read dead for a beat. Accent border + three
    pulsing accent dots say "on it" — WITHOUT disabling: each further click keeps popping older
    batches. Cleared by the next feed payload (feed.ts clearUndoBusy — event-based, timeout backstop). */
@@ -855,8 +855,8 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-undoclear .undo-dots i:nth-child(3) { animation-delay: 0.36s; }
 @keyframes undo-dot { 0%, 100% { opacity: 0.25; } 40% { opacity: 1; } }
 @media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; } }
-/* the "Newest first" / "Collapsed" MODE toggles: pressed (.on) wears the accent language (blue text + border
-   + faint wash), the same selected-state look the card section toggles use (the user 2026-07-07) */
+/* the footer MODE buttons (Session filter, Search): active (.on) wears the accent language (blue text +
+   border + faint wash), the same selected-state look the card section toggles use (the user 2026-07-07) */
 #feed-foot .feed-modetoggle.on { color: var(--accent); border-color: var(--accent);
   background: rgba(156, 210, 255, 0.12); opacity: 1; }
 /* the SESSION FILTER (the user 2026-08-08): the footer button quotes the picked session; its menu
@@ -874,6 +874,34 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   border-radius: 4px; cursor: pointer; font-size: 11.5px; white-space: nowrap; }
 .feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
 .feed-sessmenu .fsm-row.on { background: rgba(156, 210, 255, 0.12); }
+/* the VIEW MENU (the user 2026-08-24): the sort + layout controls live behind one monochrome ordering
+   glyph now (NOT a gear — the strip's ⛭ sits right below this footer on the kernel page). The popup
+   wears the shared .ctx-menu vocabulary (chrome defined with the card menus below); these rules add
+   the ✓-in-circle current mark every romp menu uses (ported from styles.css — the feed page loads
+   only this sheet) and the forced row's inert fade. */
+/* two ids, deliberately: #feed-foot .fdismiss's (1,1,0) padding beats a bare #feed-viewbtn — the
+   repo's recurring cascade trap (the 2026-08-19 forced-fade bug class) */
+#feed-foot #feed-viewbtn { display: inline-flex; align-items: center; padding: 2px 7px; }
+#feed-viewbtn svg { display: block; }
+.feed-viewmenu { min-width: 178px; }
+/* rows are real <button>s (keyboard operability) — strip the UA chrome and re-inherit the menu's
+   font/colour (a button that doesn't inherit is exactly how a menu drifts onto the host font, the
+   2026-08-09 timeline-gear bug). Same (0,2,0) specificity as .ctx-item:hover, which sits LATER in
+   this file — so the hover wash still wins the background tie on hover, by order, deliberately. */
+.feed-viewmenu .ctx-item { position: relative; padding-right: 30px; display: block; width: 100%;
+  text-align: left; background: none; border: 0; font: inherit; color: inherit; }
+.feed-viewmenu .ctx-item:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
+.feed-viewmenu .ctx-item.current::after {
+  content: "✓"; position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  background: var(--check-bg); color: #fff; border-radius: 50%;
+  width: 13px; height: 13px; font-size: 9px; font-weight: 900;
+  display: inline-flex; align-items: center; justify-content: center; line-height: 1;
+}
+/* the Single-column row while the narrow container query FORCES stacking (2026-08-19): stacking IS on,
+   so the row keeps its ✓ — faded and inert, never stripped of its checked state (the user 2026-08-19,
+   who wanted the then-button grayed but still blue). No hover promise on an inert row. */
+.feed-viewmenu .ctx-item.forced { opacity: 0.55; cursor: default; }
+.feed-viewmenu .ctx-item.forced:hover { background: transparent; color: inherit; }   /* .ctx-item:hover also recolours */
 /* downstream sessions an ask is waiting on (drop points) — experiment
    2026-06-10; live working dot + age per session, newest first */
 /* active downstream sessions (the user's handoff spec, 2026-06-10): one line per
@@ -1358,31 +1386,33 @@ body.filebrowse-open { overflow: hidden; }
 .judge-limit-banner .jl-switch:hover { background: #3c3c3c; }
 .judge-limit-banner .jl-switch:disabled { opacity: 0.6; cursor: default; }
 
-/* the Stack toggle while the narrow container query FORCES stacking (2026-08-19): stacking IS on,
-   so the button keeps the pressed accent — grayed by opacity, never stripped of its on-state (the
-   user 2026-08-19, who wanted it grayed but still blue). Hover stays responsive (a gentle brighten,
-   not the action-blue that promises a click); the tooltip names the way out. The selector MUST tie
-   the .on rule's (1,2,0) specificity and sit LATER in this file: the first two cuts keyed the
-   rule on the button id alone at (1,1,0), so `.on { opacity: 1 }` silently won the cascade and the
-   fade never painted while the button was pressed — which forced stacking always implies (the user's
-   third report, 2026-08-19). */
-#feed-foot .feed-modetoggle.forced { opacity: 0.5; cursor: default;
-  color: var(--accent); border-color: var(--accent); }
-#feed-foot .feed-modetoggle.forced:hover { opacity: 0.75;
-  background: rgba(156, 210, 255, 0.12); }   /* keep the pressed wash — never the action hover's promise */
-
-/* The footer SEARCH box (the user 2026-08-23): a "Search" word-button expanding to an inline input
-   that live-filters the board by session name, host prefix included. The input wears the footer's
-   scale and the shared dark-panel vocabulary; expansion is a width transition, so it "grows" out of
-   the button instead of popping. Active (a live query) keeps the button accented like every .on toggle. */
-#feed-search { display: inline-flex; align-items: center; gap: 5px; }
-#feed-search input { width: 0; padding: 0; border: 0; opacity: 0;
-  transition: width 0.15s ease, opacity 0.15s ease;
-  font-size: 10.5px; font-family: inherit; color: var(--fg, #ccc);
-  background: var(--vscode-editorWidget-background, #252526);
-  border-radius: 3px; outline: none; }
-#feed-search.open input { width: 138px; padding: 1px 7px; opacity: 1;
-  border: 1px solid var(--card-border); }
+/* The footer SEARCH box (the user 2026-08-23; restyled 2026-08-24): a "Search" word-button expanding
+   to an inline input that live-filters the board by session name, host prefix included. The expanded
+   bar wears the TOP search bar's look (the outline pane's "Search sessions and tasks…" input: rounded,
+   input-background field, inner ✕ clear) scaled to the footer's 10.5px rhythm — never its 12.5px verbatim —
+   and FLEXES into the row's spare space with a floor instead of a fixed width; a too-narrow row wraps
+   it whole (the footer wraps) rather than overflowing. Expansion animates max-width, so it still
+   "grows" out of the button instead of popping. Active (a live query) keeps the button accented like
+   every .on toggle. */
+#feed-search { display: inline-flex; align-items: center; gap: 5px; position: relative; }
+#feed-search.open { flex: 1 1 150px; min-width: 110px; max-width: 340px; }
+#feed-search input { flex: 1 1 auto; min-width: 0; max-width: 0; padding: 0; border: 0; opacity: 0;
+  transition: max-width 0.15s ease, opacity 0.15s ease;
+  font-size: 10.5px; font-family: inherit; color: var(--vscode-input-foreground, var(--fg, #ccc));
+  background: var(--vscode-input-background, #3c3c3c);
+  border-radius: 6px; outline: none; }
+#feed-search.open input { max-width: 340px; padding: 2px 22px 2px 8px; opacity: 1;
+  border: 1px solid var(--vscode-input-border, var(--card-border)); }
 #feed-search.open input:focus { border-color: var(--accent); }
-#feed-search input::-webkit-search-cancel-button { -webkit-appearance: none; }   /* the button folds/clears; no double affordance */
+#feed-search input::placeholder { color: var(--vscode-descriptionForeground, #9a9a9a); }
+#feed-search input::-webkit-search-cancel-button { -webkit-appearance: none; }   /* we draw our own ✕ */
+/* the inner ✕ (the top bar's clear button, footer-scaled): shown only with text to clear; clearing
+   REFOCUSES the input — the user is mid-search, never fold under them */
+#feed-search-clear { position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
+  display: flex; align-items: center; justify-content: center; width: 15px; height: 15px; padding: 0;
+  border: 0; border-radius: 50%; background: transparent;
+  color: var(--vscode-descriptionForeground, #9a9a9a); font-size: 13px; line-height: 1; cursor: pointer; }
+#feed-search-clear:hover { color: var(--fg); background: rgba(255, 255, 255, 0.10); }
+#feed-search-clear[hidden] { display: none; }
+#feed-search:not(.open) #feed-search-clear { display: none; }   /* the ✕ exists only on an open box — a folded control can never wear a stray × */
 @media (prefers-reduced-motion: reduce) { #feed-search input { transition: none; } }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -165,7 +165,7 @@ const askEls = new Map<string, HTMLElement>();
 // lists them), so a stale push can't resurrect a card mid-dismiss (the user 2026-06-19).
 const pendingCleared = new Set<string>();
 // A LIFO of recently-cleared card batches, holding the AskItem data itself (a single Clear pushes [it]; a
-// Clear-all pushes the whole batch). "Undo clear" pops the latest and re-inserts those cards IMMEDIATELY —
+// Clear-all pushes the whole batch). "Undo" pops the latest and re-inserts those cards IMMEDIATELY —
 // optimistic restore — so the card reappears on click instead of waiting on the kernel round-trip + next feed
 // build. Mirrors the kernel's _undo_clear (restores the most-recent clear batch). (the user 2026-06-27.)
 const clearedStack: AskItem[][] = [];
@@ -1104,7 +1104,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     // synthetic mouseleave runs the exact leave logic (clears the highlight, or restores a pinned card's).
     card.dispatchEvent(new MouseEvent("mouseleave"));
     pendingCleared.add(it.itemId);   // suppress from incoming pushes until the kernel confirms the clear
-    clearedStack.push([it]);         // cache for an instant optimistic Undo clear
+    clearedStack.push([it]);         // cache for an instant optimistic Undo
     card.classList.add("dismissing");
     vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId, sid: it.sid });
     setTimeout(() => { if (askEls.get(it.itemId) === card && card.classList.contains("dismissing")) { card.remove(); askEls.delete(it.itemId); dropDismissed([it.itemId]); } }, 180);
@@ -2115,7 +2115,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     card.dispatchEvent(new MouseEvent("mouseleave"));   // flush the group's stuck hover highlight (see the ask card's clear)
     const cur = (card as any)._g as AskGroup;
     card.classList.add("dismissing");
-    clearedStack.push(cur.members.slice());   // cache the whole batch for an instant optimistic Undo clear
+    clearedStack.push(cur.members.slice());   // cache the whole batch for an instant optimistic Undo
     for (const m of cur.members) { pendingCleared.add(m.itemId); vscodeApi?.postMessage({ type: "askClear", itemId: m.itemId, sid: m.sid }); }   // clear every member
     // only finalize if a render in the 180ms window didn't revive (re-render clears
     // .dismissing) or replace this card — else a stale timeout yanks the wrong one
@@ -3081,14 +3081,15 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   }));
 }
 
-// UndoClear (top right): restore the most recently cleared card — the host pops
+// Undo (top right): restore the most recently cleared card — the host pops
 // the newest cleared.jsonl row. Built fresh wherever the top strip renders: on
 // the legend row when columns exist, and on the empty state too (clearing the
-// LAST card is exactly when undo is wanted).
+// LAST card is exactly when undo is wanted). One word (the user 2026-08-24,
+// dropping "Undo clear"): it sits right beside Clear all — context enough.
 function makeUndoClearBtn(): HTMLElement {
   const b = el("button", "fdismiss ffollow");   // restorative → blue hover (.ffollow), not Clear's red
   b.id = "feed-undoclear";
-  b.textContent = "Undo clear";
+  b.textContent = "Undo";
   b.title = "restore the most recently cleared card";
   b.onclick = (ev) => {
     ev.stopPropagation();
@@ -3144,12 +3145,12 @@ function ensureUndoClear(): HTMLElement {
 }
 
 // Clear all: inbox-zero every open card at once. Destructive, so it hovers RED (.fdismiss); the single
-// UndoClear restores the whole batch (the host clears them as one cleared.jsonl batch).
+// Undo restores the whole batch (the host clears them as one cleared.jsonl batch).
 function makeClearAllBtn(): HTMLElement {
   const b = el("button", "fdismiss");
   b.id = "feed-clearall";
   b.textContent = "Clear all";
-  b.title = "clear every open card (inbox-zero) — UndoClear restores them";
+  b.title = "clear every open card (inbox-zero) — Undo restores them";
   b.onclick = (ev) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "clearAll" }); };
   return b;
 }
@@ -3160,89 +3161,163 @@ function ensureClearAll(): HTMLElement {
   return b;
 }
 
-// A persisted toggle-button helper for the footer (the user 2026-07-07): a small pressed-state button that
-// writes a boolean into the shared romp:settings and re-renders. Used for "Newest first" and "Collapsed".
-// `after` runs BEFORE the re-render (e.g. drop per-card overrides), on the NEW value.
-function makeFeedToggle(id: string, label: string, get: () => boolean, key: string, after?: (on: boolean) => void): HTMLElement {
-  const b = el("button", "fdismiss ffollow feed-modetoggle");   // view action → blue hover; .on = accent (pressed)
-  b.id = id; b.textContent = label;
-  b.onclick = (ev) => {
-    ev.stopPropagation();
-    if (b.classList.contains("forced")) return;   // stacking is automatic at this width — a no-op toggle lies
-    const on = !get();
-    try {
-      const s = JSON.parse(localStorage.getItem("romp:settings") || "{}");
-      s[key] = on;
-      localStorage.setItem("romp:settings", JSON.stringify(s));
-    } catch { /* ignore */ }
-    after?.(on);
-    window.dispatchEvent(new Event("romp:settings"));   // same-doc signal → re-render (order / default section)
-  };
-  return b;
+// The footer VIEW MENU (the user 2026-08-24): the three view controls — sort direction, single-column
+// layout, by-session grouping — live behind ONE monochrome icon button now, a popup wearing the shared
+// .ctx-menu vocabulary, where three word-buttons crowded the footer and the labels can breathe.
+// Prefs still write the shared romp:settings (the ⛭ gear's watcher and other panes read the same keys).
+// The button is ensure-once; the menu lives on document.body outside render()'s reconcile, opening
+// upward like the session menu (click-safety: a push can never rebuild it mid-press).
+function setViewPref(key: string, on: boolean, after?: (on: boolean) => void): void {
+  try {
+    const s = JSON.parse(localStorage.getItem("romp:settings") || "{}");
+    s[key] = on;
+    localStorage.setItem("romp:settings", JSON.stringify(s));
+  } catch { /* ignore */ }
+  after?.(on);   // runs BEFORE the re-render (e.g. apply the stack style var), on the NEW value
+  window.dispatchEvent(new Event("romp:settings"));   // same-doc signal -> re-render (order / layout / grouping)
 }
-function ensureFeedToggle(id: string, label: string, get: () => boolean, key: string, onTitle: string, offTitle: string, after?: (on: boolean) => void): HTMLElement {
-  let b = document.getElementById(id) as HTMLElement | null;
-  if (!b) { b = makeFeedToggle(id, label, get, key, after); (document.getElementById("feed-foot") || document.body).appendChild(b); }
-  const on = get();
-  b.classList.toggle("on", on);
-  b.setAttribute("aria-pressed", on ? "true" : "false");
-  b.title = on ? onTitle : offTitle;
-  return b;
-}
-// "Modified ↑/↓" — the sort control (the user 2026-08-18, renamed from the "Newest first" toggle): cards
-// sort by modified time, the arrow shows the direction, and a click reverses it. Both directions are
-// valid sorts, so the button never wears the pressed accent — the arrow IS the state.
-function ensureNewestFirst(): HTMLElement {
-  const b = ensureFeedToggle("feed-newestfirst", "Modified", () => feedPrefs().newestFirst, "newestFirst",
-    "newest at the top — click for oldest first",
-    "oldest at the top — click for newest first");
-  b.textContent = "Modified " + (feedPrefs().newestFirst ? "\u2193" : "\u2191");
-  b.classList.remove("on");
-  return b;
-}
-// "Stack" — force the one-column layout at ANY width (the user 2026-08-18): the same stacked view the
-// narrow container query produces, as a standing choice. The pref drives a style() container condition
-// on #feed-list (see feed.css), so the CSS stays the single owner of what stacking means; the narrow
-// query still stacks regardless.
+// "Single column view" (the user 2026-08-18, the footer "Stack" button then): force the one-column
+// layout at ANY width — the same stacked view the narrow container query produces, as a standing
+// choice. The pref drives a style() container condition on #feed-list (see feed.css), so the CSS
+// stays the single owner of what stacking means; the narrow query still stacks regardless.
 function applyStacked(on: boolean) {
   document.getElementById("feed-list")?.style.setProperty("--romp-stack", on ? "on" : "off");
 }
 // FORCED stacking (the user 2026-08-19): at or under the container query's own 540px the layout
-// stacks regardless of the pref, so the toggle is a no-op there — unclicking it would change
-// nothing. The button says so instead of lying: faded, unclickable, tooltip naming the way out
-// (more width). Width changes are the event — a ResizeObserver on #feed-list, installed once.
+// stacks regardless of the pref, so the toggle is a no-op there — the menu row says so instead of
+// lying: still ✓-checked (stacking IS on), faded, inert, tooltip naming the way out (more width).
+// Width changes are the event — a ResizeObserver on #feed-list, installed once.
 const STACK_FORCED_W = 540;   // MUST match feed.css's @container (max-width: 540px) stack query
 let stackResizeWatch: ResizeObserver | null = null;
-function refreshStackForced(b: HTMLElement): void {
+let stackForced = false;
+function refreshStackForced(): void {
   const list = document.getElementById("feed-list");
   const forced = !!list && list.clientWidth > 0 && list.clientWidth <= STACK_FORCED_W;
-  b.classList.toggle("forced", forced);
-  b.setAttribute("aria-disabled", forced ? "true" : "false");
-  if (forced) b.title = "stacked automatically at this width — widen the feed to unstack into three columns";
-}
-function ensureStackToggle(): HTMLElement {
-  const b = ensureFeedToggle("feed-stacked", "Stack", () => feedPrefs().stacked, "stacked",
-    "one-column layout at any width — click for side-by-side columns when the feed is wide",
-    "stack the columns into one, whatever the width",
-    (on) => applyStacked(on));
-  refreshStackForced(b);                      // per render: the ensure title above just overwrote ours
-  const list = document.getElementById("feed-list");
-  if (!stackResizeWatch && list && typeof ResizeObserver !== "undefined") {
-    stackResizeWatch = new ResizeObserver(() => refreshStackForced(b));
-    stackResizeWatch.observe(list);
-  }
-  return b;
+  if (forced === stackForced) return;
+  stackForced = forced;
+  if (viewMenuEl) paintViewMenu(viewMenuEl);   // an open menu repaints on the deciding event
 }
 // (The "Collapsed" default-section toggle moved into the settings modal, 2026-08-18 — a set-and-forget
 // preference, not a per-glance view action. The pref and its behavior are unchanged; the gear writes
 // romp:settings.collapsed and the settings watcher below drops the per-card overrides on change.)
 
-// "Group" — organize each column BY SESSION (the user 2026-07-13): kernel tab/lane order, a name+dot header
-// on the backdrop opening each session's run, per-card names dropped (the header carries the identity).
-function ensureGroupToggle(): HTMLElement {
-  return ensureFeedToggle("feed-grouped", "Group", () => feedPrefs().grouped, "grouped",
-    "grouped by session — click for the flat column order",
-    "group each column's cards by session (tab order), a session header between runs");
+let viewMenuEl: HTMLElement | null = null;
+function closeViewMenu(): void {
+  if (viewMenuEl?.contains(document.activeElement)) document.getElementById("feed-viewbtn")?.focus();
+  viewMenuEl?.remove(); viewMenuEl = null;
+  document.removeEventListener("pointerdown", viewMenuAway, true);
+  document.removeEventListener("keydown", viewMenuKey, true);
+}
+function viewMenuAway(ev: Event): void {
+  const t = ev.target as Node;
+  if (viewMenuEl && !viewMenuEl.contains(t) && !(document.getElementById("feed-viewbtn")?.contains(t))) closeViewMenu();
+}
+function viewMenuKey(ev: KeyboardEvent): void { if (ev.key === "Escape") closeViewMenu(); }
+// The rows: "Sort by most recent ↓/↑" keeps the Modified button's rule (the user 2026-08-18) — both
+// directions are valid sorts, so the arrow IS the state and the row never wears the ✓; "Single column
+// view" and "Group by session" are ✓ rows over the same prefs the old Stack/Group buttons wrote
+// ("Group" organizes each column BY SESSION, the user 2026-07-13 — kernel tab/lane order, a name+dot
+// header opening each session's run; grouped still defaults ON via feedPrefs' !== false, so the ✓
+// reads exactly the way the pressed button did). Rows are real <button>s — Tab-reachable and
+// Enter/Space-activatable, the operability the replaced footer buttons had — built ONCE per open and
+// then synced IN PLACE (paintViewMenu below), so a live repaint (a settings change from another pane,
+// the width crossing 540px) never swaps a row out from under a pressed pointer (click-safety), and a
+// click always acts on the prefs AS OF the click, not as of the last paint.
+function buildViewMenu(menu: HTMLElement): void {
+  const mk = (check: boolean, act: () => void): HTMLElement => {
+    const r = el("button", "ctx-item");
+    (r as HTMLButtonElement).type = "button";
+    r.setAttribute("role", check ? "menuitemcheckbox" : "menuitem");
+    r.onclick = (ev) => {
+      ev.stopPropagation();
+      if (r.classList.contains("forced")) return;   // stacking is automatic at this width — a no-op toggle lies
+      act();
+      closeViewMenu();
+    };
+    menu.appendChild(r);
+    return r;
+  };
+  mk(false, () => setViewPref("newestFirst", !feedPrefs().newestFirst));
+  mk(true, () => setViewPref("stacked", !feedPrefs().stacked, applyStacked));
+  mk(true, () => setViewPref("grouped", !feedPrefs().grouped));
+}
+// Sync the three rows to the CURRENT prefs — labels, ✓s, the forced state — without rebuilding them.
+function paintViewMenu(menu: HTMLElement): void {
+  const p = feedPrefs();
+  const rows = menu.querySelectorAll(".ctx-item");
+  if (rows.length !== 3) return;
+  const set = (i: number, label: string, opts: { current: boolean; forced?: boolean; title: string }) => {
+    const r = rows[i] as HTMLElement;
+    r.textContent = label;
+    r.title = opts.title;
+    r.classList.toggle("current", opts.current);
+    r.classList.toggle("forced", !!opts.forced);
+    if (r.getAttribute("role") === "menuitemcheckbox") r.setAttribute("aria-checked", opts.current ? "true" : "false");
+    if (opts.forced) r.setAttribute("aria-disabled", "true"); else r.removeAttribute("aria-disabled");
+  };
+  set(0, "Sort by most recent " + (p.newestFirst ? "\u2193" : "\u2191"), {
+    current: false,   // a DIRECTION row — never the ✓-current mark
+    title: p.newestFirst ? "newest at the top — click for oldest first" : "oldest at the top — click for newest first",
+  });
+  set(1, "Single column view", {
+    current: p.stacked || stackForced, forced: stackForced,
+    title: stackForced ? "stacked automatically at this width — widen the feed to unstack into three columns"
+      : p.stacked ? "one-column layout at any width — click for side-by-side columns when the feed is wide"
+      : "stack the columns into one, whatever the width",
+  });
+  set(2, "Group by session", {
+    current: p.grouped,
+    title: p.grouped ? "grouped by session — click for the flat column order"
+      : "group each column's cards by session (tab order), a session header between runs",
+  });
+}
+function openViewMenu(btn: HTMLElement): void {
+  closeSessMenu();   // one menu at a time: a keyboard open fires no pointerdown, so the away-closers never ran
+  const menu = el("div", "ctx-menu feed-viewmenu");
+  menu.setAttribute("role", "menu");
+  refreshStackForced();   // decide the forced row from the CURRENT width, not the last observed one
+  buildViewMenu(menu);
+  paintViewMenu(menu);
+  document.body.appendChild(menu);
+  // above the footer, left-aligned to the button, clamped into the viewport (the session menu's placement)
+  const r = btn.getBoundingClientRect();
+  menu.style.bottom = Math.round(window.innerHeight - r.top + 6) + "px";
+  menu.style.left = Math.round(Math.max(6, Math.min(r.left, window.innerWidth - menu.offsetWidth - 6))) + "px";
+  viewMenuEl = menu;
+  (menu.querySelector(".ctx-item") as HTMLElement | null)?.focus();   // a keyboard open lands on the first row
+  document.addEventListener("pointerdown", viewMenuAway, true);
+  document.addEventListener("keydown", viewMenuKey, true);
+}
+// The icon: an ordering glyph — three shortening bars + a direction arrow — drawn inline so
+// currentColor keeps it monochrome in every state. NOT a gear: the kernel page's strip shows its
+// ⛭ right below this footer, and two gears would read as the same control (the user 2026-08-24).
+function viewMenuGlyph(): string {
+  return '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.6" stroke-linecap="round" aria-hidden="true">'
+    + '<path d="M2.5 4h8"/><path d="M2.5 8h5.5"/><path d="M2.5 12h3"/>'
+    + '<path d="M12.5 5.5v5.8"/><path d="M10.6 9.6l1.9 2 1.9-2"/></svg>';
+}
+function ensureViewMenuBtn(): HTMLElement {
+  let b = document.getElementById("feed-viewbtn") as HTMLElement | null;
+  if (!b) {
+    b = el("button", "fdismiss ffollow feed-modetoggle");
+    b.id = "feed-viewbtn";
+    b.innerHTML = viewMenuGlyph();
+    b.title = "view options — sort direction, single column, group by session";
+    b.setAttribute("aria-label", "view options");
+    b.setAttribute("aria-haspopup", "menu");
+    b.onclick = (ev) => {   // opening the menu IS the acknowledgement (same as the session filter)
+      ev.stopPropagation();
+      if (viewMenuEl) closeViewMenu(); else openViewMenu(b!);
+    };
+    (document.getElementById("feed-foot") || document.body).appendChild(b);
+  }
+  const list = document.getElementById("feed-list");
+  if (!stackResizeWatch && list && typeof ResizeObserver !== "undefined") {
+    stackResizeWatch = new ResizeObserver(() => refreshStackForced());
+    stackResizeWatch.observe(list);
+  }
+  return b;
 }
 
 // The SESSION FILTER (the user 2026-08-08): a footer menu listing every session the chat tab strip
@@ -3274,6 +3349,7 @@ function sessMenuName(s: { sid: string; name: string; color: { bg: string; fg: s
   return nm;
 }
 function openSessMenu(btn: HTMLElement): void {
+  closeViewMenu();   // one menu at a time: a keyboard open fires no pointerdown, so the away-closers never ran
   const menu = el("div", "feed-sessmenu");
   const row = (on: boolean, pick: string | null, label: HTMLElement, dotName?: string) => {
     const r = el("div", "fsm-row" + (on ? " on" : ""));
@@ -3305,6 +3381,9 @@ function openSessMenu(btn: HTMLElement): void {
 // control — render() never rebuilds it, so focus and the caret survive pushes (the click-safety rule).
 // An ACTIVE query keeps the input open and the control accented; Escape (or emptying + blur) folds it
 // back to the button — a compact state can never hide a live filter (progressive disclosure's no-dead-end).
+// The expanded bar wears the TOP search bar's look scaled to the footer (the user 2026-08-24): rounded
+// input-background field, an inner ✕ that clears and REFOCUSES, flexing into the row's spare space
+// instead of a fixed width (feed.css owns the metrics).
 function ensureSearchBox(): HTMLElement {
   let wrap = document.getElementById("feed-search") as HTMLElement | null;
   if (!wrap) {
@@ -3328,11 +3407,24 @@ function ensureSearchBox(): HTMLElement {
     inp.oninput = () => { setFeedSearch(inp.value); render(); };   // live: the keyed render reuses every card
     inp.onkeydown = (ev) => { if (ev.key === "Escape") { ev.stopPropagation(); foldBox(); } };
     inp.onblur = () => { if (!inp.value.trim()) wrap!.classList.remove("open"); };
-    wrap.appendChild(btn); wrap.appendChild(inp);
+    const clr = el("button", "");
+    clr.id = "feed-search-clear";
+    (clr as HTMLButtonElement).type = "button";
+    clr.setAttribute("aria-label", "Clear search");
+    clr.title = "Clear search";
+    clr.hidden = true;   // shown only with text to clear (the top bar's semantics); render() below syncs it
+    clr.textContent = "\u00d7";
+    clr.onclick = (ev) => {   // clear + REFOCUS — the user is mid-search, never fold under them
+      ev.stopPropagation();
+      inp.value = ""; setFeedSearch(""); inp.focus(); render();
+    };
+    wrap.appendChild(btn); wrap.appendChild(inp); wrap.appendChild(clr);
     (document.getElementById("feed-foot") || document.body).appendChild(wrap);
   }
   const inp = wrap.querySelector("input") as HTMLInputElement;
   if (inp && inp.value !== feedSearchQ && document.activeElement !== inp) inp.value = feedSearchQ;
+  const clrBtn = document.getElementById("feed-search-clear");
+  if (clrBtn && inp) clrBtn.hidden = !inp.value.trim();   // trimmed, like the fold + the filter — whitespace is no query
   const active = !!feedSearchQ.trim();
   if (active) wrap.classList.add("open");
   const btn = document.getElementById("feed-search-btn");
@@ -3714,11 +3806,9 @@ function render() {
   paintJudgeLimit();   // the usage-limit banner above the columns (build-once; hidden when unlatched)
   auditShownColumns(asks); // tripwire: what this render SHOWS is the record a bounce report needs
   const prevScroll = list.scrollTop;
-  // footer pane (below the cards, no overlap): Newest first · Collapsed · Clear all · UndoClear
+  // footer pane (below the cards, no overlap): view menu · Session filter · Search | Clear all · Undo
   const showCA = !!asks.length;
-  ensureNewestFirst().style.display = showCA ? "" : "none";       // Modified ↑/↓ — the sort direction
-  ensureStackToggle().style.display = showCA ? "" : "none";       // force one-column at any width (the user 2026-08-18)
-  ensureGroupToggle().style.display = showCA ? "" : "none";       // by-session grouping (the user 2026-07-13)
+  ensureViewMenuBtn().style.display = showCA ? "" : "none";       // sort + layout menu (the user 2026-08-24)
   ensureSessionFilter().style.display = showCA ? "" : "none";     // one-session filter menu (the user 2026-08-08)
   ensureSearchBox().style.display = showCA ? "" : "none";          // type-to-filter by name/host (the user 2026-08-23)
   ensureClearAll().style.display = showCA ? "" : "none";
@@ -3996,6 +4086,7 @@ function onSettingsChanged(): void {
   const p = feedPrefs();
   if (p.collapsed !== lastCollapsedPref) { lastCollapsedPref = p.collapsed; secChoice.clear(); }
   applyStacked(p.stacked);
+  if (viewMenuEl) paintViewMenu(viewMenuEl);   // an open view menu re-reads the prefs it shows
   render();
 }
 window.addEventListener("storage", (e) => { if (e.key === "romp:settings") onSettingsChanged(); });
@@ -4094,7 +4185,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       ? m.buildIds as Record<string, number> : undefined;
     reconcileFollowMove(incomingAsks, lastPayloadBuildId, perHostBuildIds);
     reconcilePendingDone(incomingAsks);   // retire an optimistic tick once the real tree carries it
-    // An optimistic Undo clear is CONFIRMED once the kernel's payload carries the id again → stop forcing it.
+    // An optimistic Undo is CONFIRMED once the kernel's payload carries the id again → stop forcing it.
     // Until then, keep the cached card in `asks` so the replace above can't drop the just-restored card (flicker).
     if (pendingRestored.size) {
       for (const id of Array.from(pendingRestored.keys())) if (incomingAsks.some((a) => a.itemId === id)) pendingRestored.delete(id);


### PR DESCRIPTION
The feed pane's bottom toolbar collapses its three ordering/layout word-buttons (Modified ↑/↓, Stack, Group) into one monochrome icon button — an ordering glyph, deliberately not a gear, since the kernel page's strip shows its ⛭ right below this footer — opening a popup in the shared .ctx-menu vocabulary:

- **Sort by most recent ↓/↑** — a direction row; the arrow is the state, and it never wears the ✓ (both directions are valid sorts, the Modified button's standing rule).
- **Single column view** — ✓ row over the `stacked` pref; when the narrow container query already forces stacking it shows checked, faded, and inert, with the tooltip naming the way out, and an open menu repaints in place on the deciding resize event.
- **Group by session** — ✓ row over the `grouped` pref, keeping its `!== false` default (a missing key stays checked).

Rows are real buttons (Tab/Enter operability the replaced buttons had; the first row takes focus on a keyboard open), built once per open and synced in place so a live repaint never swaps a row out from under a pressed pointer. The view menu and the session menu close each other on open, since a keyboard open fires no pointerdown for the away-closers.

The footer **Search** still expands in place, but the expanded bar now wears the top outline search bar's look scaled to the footer's 10.5px rhythm — rounded input-background field, focus border in the accent, an inner ✕ that clears and refocuses — and flexes into the row's spare space (floor 110px, cap 340px) instead of the fixed 138px. The ✕ syncs on the trimmed value and is scoped to the open state, so a folded control can never wear a stray ×.

**Undo clear** reads **Undo** everywhere the user sees it: the feed button, the clear-confirm modal detail, the bell entries, the Log page's kind blurb, and the docs. Identifiers (`canUndoClear`, `makeUndoClearBtn`, kernel docstrings) deliberately keep their names.

Tests updated in lockstep (feed-sort, feed-stack, feed-group-mode, feed-col-fold, feed-search, feed-foot, feed-session-filter, feed-card-prefs, clear-confirm, badge-mirror); new `feed-viewmenu.test.ts` pins the row order, the menu skin + ✓-in-circle mark, keyboard operability, the in-place sync, one-menu-at-a-time, both cascade tiebreaks (the two-id button padding rule and the reset-before-hover order), and the prefs write path. 2235 extension tests and 435 kernel tests pass; visuals verified headlessly in Chromium at wide and narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)