### PR TITLE
Chat tabs follow the kernel's recurring push: headless rename/color/tag render live

### DIFF
--- a/tests/test_tab_meta_push.py
+++ b/tests/test_tab_meta_push.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""The chat strip's LIVE carrier for headless edits (the user 2026-08-24): a one-shot POST
+/rename | /color | /tag must render in the chat pane with no reload — and the design says the
+recurring tabOrder push is the carrier (name + identity color per tab, plus the views/tags blob),
+never per-route confirm frames. These tests pin the KERNEL half of that loop end to end: each POST
+lands in its authoritative store, the NEXT push cycle's tabOrder frame carries the fresh value to a
+chat client (assembled per cycle, no caching between), the per-client dedup passes the changed frame
+(and keeps suppressing unchanged ones), and /rename pokes the pusher awake like its siblings already
+do. Drives the REAL Handler over HTTP + the REAL _push (the test_color_route.py pattern).
+Synthetic only: the notes-api demo world (web), TESTHOST paths, placeholder UUIDs."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_tmp", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class TabMetaPush(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.names = Path(self.tmp) / "names"
+        self.names.mkdir()
+        (self.names / SID).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        self._saved = (km.NAMES, km.jd.STATE, km._tmux_sessions, km._live_names,
+                       km._mark_views_dirty, km.Sessions.backend_for,
+                       km._chat_tab_sessions, km._cached_feed)
+        km.NAMES = self.names
+        km.jd.STATE = Path(self.tmp) / "state"
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {self._name(): SID}
+        self.dirty = []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+        names = self.names
+
+        class BE:  # the rename path a dormant/live session takes: the names registry's first field
+            def rename(self, sid, name):
+                rec = (names / sid).read_text().split("\t")
+                rec[0] = name
+                (names / sid).write_text("\t".join(rec))
+                return True
+        km.Sessions.backend_for = staticmethod(lambda sid: BE())
+        # ONE shown session whose row reads the registry live — the same store the real
+        # _chat_tab_sessions labels rows from — so the push assembles from current truth each cycle.
+        km._chat_tab_sessions = lambda now, tmux: [
+            {"sid": SID, "name": self._name(), "path": os.path.join(self.tmp, "none.jsonl"),
+             "anchor": SID}]
+        km._cached_feed = lambda *a, **k: None   # no feed build — this pins the tabOrder frame only
+        self.frames = []
+        self.client = {"app": "chat", "alive": True, "sent": {},
+                       "send": lambda s: self.frames.append(json.loads(s))}
+
+    def tearDown(self):
+        (km.NAMES, km.jd.STATE, km._tmux_sessions, km._live_names,
+         km._mark_views_dirty, km.Sessions.backend_for,
+         km._chat_tab_sessions, km._cached_feed) = self._saved
+        km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})
+
+    def _name(self):
+        return (self.names / SID).read_text().split("\t")[0]
+
+    def _post(self, path, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d%s" % (self.port, path), data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode())
+
+    def _tab_orders(self):
+        return [f for f in self.frames if f.get("type") == "tabOrder"]
+
+    def _cycle(self):
+        km._push([self.client])
+
+    def test_rename_rides_the_next_push_cycle(self):
+        self._cycle()
+        self.assertEqual(self._tab_orders()[-1]["tabs"][0]["name"], "web")
+        r = self._post("/rename", {"target": "web", "name": "api"})
+        self.assertTrue(r.get("ok"), r)
+        self.assertTrue(self.dirty, "a successful rename marks views dirty — the pusher wakes NOW, "
+                                    "not at the backstop (its siblings /color and /tag already do)")
+        n = len(self._tab_orders())
+        self._cycle()
+        tabs = self._tab_orders()[-1]["tabs"]
+        self.assertGreater(len(self._tab_orders()), n, "the changed frame passes the per-client dedup")
+        self.assertEqual(tabs[0]["name"], "api", "the very next cycle's tabOrder carries the new label")
+
+    def test_recolor_rides_the_next_push_cycle(self):
+        self._cycle()
+        self.assertEqual(self._tab_orders()[-1]["tabs"][0]["color"]["bg"], "#1EA1EB")
+        r = self._post("/color", {"target": "web", "bg": "#54B204"})
+        self.assertTrue(r.get("ok"), r)
+        self._cycle()
+        c = self._tab_orders()[-1]["tabs"][0]["color"]
+        self.assertEqual(c["bg"], "#54B204", "the next cycle's tabOrder carries the new identity color")
+        self.assertTrue(c.get("fg"), "the palette's fg word rides with it")
+
+    def test_tag_edit_rides_the_next_push_cycle(self):
+        self._cycle()
+        base = self._tab_orders()[-1]["views"]
+        self.assertFalse(any(t.get("name") == "workers" for t in (base.get("tags") or [])))
+        r = self._post("/tag", {"name": "workers", "add": ["web"]})
+        self.assertTrue(r.get("ok"), r)
+        self._cycle()
+        tags = self._tab_orders()[-1]["views"].get("tags") or []
+        mine = [t for t in tags if t.get("name") == "workers"]
+        self.assertTrue(mine, "the next cycle's tabOrder views blob carries the new tag")
+        self.assertIn(SID, mine[0].get("members") or [], "…with the session filed under it")
+
+    def test_an_unchanged_cycle_is_deduped_but_never_a_changed_one(self):
+        self._cycle()
+        n = len(self._tab_orders())
+        self._cycle()
+        self.assertEqual(len(self._tab_orders()), n,
+                         "no change → the per-client dedup suppresses the re-send")
+        self._post("/rename", {"target": "web", "name": "tests"})
+        self._cycle()
+        self.assertGreater(len(self._tab_orders()), n,
+                           "a name change defeats the dedup — tabs/views must never join "
+                           "_DEDUP_VOLATILE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -14,6 +14,7 @@ import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
 import { SessionViews, viewVisible, viewsKey, hideIn, revealIn } from "./session-views";
+import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { senderKind } from "./sender-identity";
@@ -440,6 +441,9 @@ const closingTabs = new Map<string, number>();
 // the sole evidence a close didn't take is the kernel still listing the tab long after. Past this we say
 // so and let the tab back, rather than hiding a session that's really still open.
 const CLOSE_ACK_MS = 15_000;
+// Optimistic label/color edits awaiting their kernel echo — holds a stale in-flight push from
+// reverting the strip (see tab-meta.ts; the sessionViews pending machinery's reasoning).
+const pendingTabMeta = new Map<string, PendingTabMeta>();
 // The romp identity palette for the tab right-click color picker (the user 2026-06-29). Fetched once from the
 // kernel's /palette so the client holds no color literals; empty until it lands (the menu just omits the row).
 // The palette is SELECTABLE now (the user 2026-07-12): a {type:"palette"} push lands the new set on switch.
@@ -3824,6 +3828,13 @@ function applyTabOrder(o: any, tabs?: any) {
                             color: (t.color && typeof t.color.bg === "string") ? t.color : null });
       }
     }
+    // …and apply the same blob to EXISTING sessions (the user 2026-08-24): the label/color used to
+    // stick until a per-session frame happened to rebuild — which, after a headless POST
+    // /rename | /color, is never for a background tab (the chat build cache's sig watches
+    // transcript+states only, deliberately). The recurring push is the authoritative carrier, so
+    // ANY writer — CLI POST, WS op, another dashboard, a remote kernel — renders here within a
+    // cycle (see tab-meta.ts); the renderTabs() below repaints with it.
+    syncSessionsFromTabMeta(tabs, (id) => sessions.get(id), pendingTabMeta);
   }
   // Adopt the kernel order verbatim, keeping any just-arrived tab the push doesn't carry yet (see tab-order.ts).
   const kernelOrder = Array.isArray(o) ? o.filter((x: any) => typeof x === "string") : [];
@@ -4326,6 +4337,7 @@ function setSessionFlag(id: string, flag: "hideFromFeed" | "postalServiceOff" | 
 // _name_color. The kernel accepts only a real palette value, so a stale id is a harmless no-op there.
 function setSessionColor(id: string, bg: string) {
   const color: Color = { bg, fg: "#ffffff" };
+  notePendingMeta(pendingTabMeta, id, { colorBg: bg });   // a push built before the kernel applied this cannot revert the swatch
   const s = sessions.get(id);
   if (s) s.color = color;
   const meta = tabMeta.get(id);
@@ -9913,6 +9925,10 @@ function upsert(msg: any) {
     notify: ("notify" in msg) ? !!msg.notify : (prev ? prev.notify : undefined),
   };
   sessions.set(msg.id, s);
+  // a session frame can ride the kernel's chat build cache with a stale name/color embedded (its sig
+  // watches transcript+states only) — the freshest tabOrder meta wins over it, pending guard included
+  const tm = tabMeta.get(msg.id);
+  if (tm) applyMetaToSession(s, tm, pendingTabMeta.get(msg.id));
   reconcileRewind(s);       // pending-rewind overlay + the editable-bubble set, from the fresh payload
   reconcileOptimistic(s);   // re-assert (or retire) any in-flight optimistic sends across the rebuild
   // The kernel re-sends the FULL "session" payload on every push. Distinguish an APPEND (more turns
@@ -10462,6 +10478,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null);
   else if (m.type === "tabOrder") { captureViews(m.views || null); applyTabOrder(m.order, m.tabs); }
   else if (m.type === "renamed" && m.id && typeof m.name === "string") {
+    notePendingMeta(pendingTabMeta, m.id, { name: m.name });   // kernel truth — hold it against a push built pre-rename
     const s = sessions.get(m.id);
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }
   }

--- a/ui/webview/tab-meta.test.ts
+++ b/ui/webview/tab-meta.test.ts
@@ -1,0 +1,120 @@
+// Live tab label/color/tag application from the kernel's recurring tabOrder push (the user
+// 2026-08-24): a headless `romp rename` / `romp color` / `romp tag` used to update kernel state —
+// and the timeline — while the CHAT strip held the old label/color until reload, because the pushed
+// per-tab meta was applied only to placeholder tabs, never to existing sessions, and per-session
+// frames ride a build cache whose sig (transcript+states) a rename/recolor never busts. The pure
+// sync lives in tab-meta.ts (executable below); the render.ts wiring is pinned at the source
+// (render.ts has no jsdom harness — the apierror-retry-now.test.ts idiom). Synthetic names only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PENDING_META_MAX_AGE,
+         TabSessionMeta, PendingTabMeta } from "./tab-meta";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const sess = (name: string, bg?: string): TabSessionMeta =>
+  ({ name, color: bg ? { bg, fg: "#ffffff" } : null });
+
+test("a pushed rename and recolor land on the existing session — the strip follows the push, not a reload", () => {
+  const s = sess("web", "#336699");
+  const store = new Map([["S1", s]]);
+  const changed = syncSessionsFromTabMeta(
+    [{ id: "S1", name: "api", color: { bg: "#aa3366", fg: "#ffffff" } }],
+    (id) => store.get(id), new Map());
+  assert.equal(changed, true, "the caller learns it must repaint");
+  assert.equal(s.name, "api", "the pushed rename lands");
+  assert.deepEqual(s.color, { bg: "#aa3366", fg: "#ffffff" }, "the pushed recolor lands");
+});
+
+test("an unchanged push reports no visible change, and junk entries are ignored", () => {
+  const s = sess("web", "#336699");
+  const store = new Map([["S1", s]]);
+  assert.equal(syncSessionsFromTabMeta(
+    [{ id: "S1", name: "web", color: { bg: "#336699", fg: "#ffffff" } },
+     { id: 42 as any, name: "junk" }, null as any, { name: "no-id" }],
+    (id) => store.get(id), new Map()), false);
+  assert.equal(s.name, "web");
+});
+
+test("an empty pushed name or malformed color never wipes what the session has", () => {
+  const s = sess("web", "#336699");
+  assert.equal(applyMetaToSession(s, { name: "", color: { bg: 7 } }), false);
+  assert.equal(s.name, "web");
+  assert.deepEqual(s.color, { bg: "#336699", fg: "#ffffff" });
+});
+
+test("a pending optimistic edit holds a stale in-flight push, and the kernel echo clears it", () => {
+  const s = sess("web", "#336699");
+  const store = new Map([["S1", s]]);
+  const pending = new Map<string, PendingTabMeta>();
+  notePendingMeta(pending, "S1", { colorBg: "#AA3366" });        // the swatch click, case differs on purpose
+  s.color = { bg: "#AA3366", fg: "#ffffff" };                    // …applied optimistically by the caller
+  // a push BUILT BEFORE the kernel processed the recolor still carries the old color → held
+  syncSessionsFromTabMeta([{ id: "S1", name: "web", color: { bg: "#336699", fg: "#ffffff" } }],
+    (id) => store.get(id), pending);
+  assert.equal(s.color!.bg, "#AA3366", "the stale push cannot revert the optimistic swatch");
+  assert.ok(pending.has("S1"), "the expectation stands until echoed");
+  // the echo (case-insensitive on the hex) adopts and clears
+  syncSessionsFromTabMeta([{ id: "S1", name: "web", color: { bg: "#aa3366", fg: "#ffffff" } }],
+    (id) => store.get(id), pending);
+  assert.equal(pending.has("S1"), false, "the echo retires the pending edit");
+});
+
+test("an unechoed pending edit yields to the kernel after " + PENDING_META_MAX_AGE + " pushes — the store of record wins", () => {
+  const s = sess("web");
+  const store = new Map([["S1", s]]);
+  const pending = new Map<string, PendingTabMeta>();
+  notePendingMeta(pending, "S1", { name: "api" });
+  for (let i = 0; i < PENDING_META_MAX_AGE; i++)
+    syncSessionsFromTabMeta([{ id: "S1", name: "tests" }], (id) => store.get(id), pending);
+  assert.equal(pending.has("S1"), false, "the silent-push cap retires it");
+  syncSessionsFromTabMeta([{ id: "S1", name: "tests" }], (id) => store.get(id), pending);
+  assert.equal(s.name, "tests", "after yielding, the kernel's name lands");
+});
+
+test("a pending edit whose tab left the push ages out too", () => {
+  const pending = new Map<string, PendingTabMeta>();
+  notePendingMeta(pending, "S9", { name: "gone" });
+  for (let i = 0; i < PENDING_META_MAX_AGE; i++)
+    syncSessionsFromTabMeta([{ id: "S1", name: "web" }], () => undefined, pending);
+  assert.equal(pending.size, 0);
+});
+
+test("a rename pending guard holds the NAME against a pre-rename push — a pushed recolor still lands (fields are independent)", () => {
+  // the renamed confirm applied "api" optimistically; a push BUILT BEFORE the kernel's rename
+  // still carries "web" — the guard must keep the confirm's label, never flap back
+  const s = sess("api", "#336699");
+  const store = new Map([["S1", s]]);
+  const pending = new Map<string, PendingTabMeta>();
+  notePendingMeta(pending, "S1", { name: "api" });
+  syncSessionsFromTabMeta([{ id: "S1", name: "web", color: { bg: "#aa3366", fg: "#ffffff" } }],
+    (id) => store.get(id), pending);
+  assert.equal(s.name, "api", "the stale pre-rename push cannot revert the confirmed label");
+  assert.equal(s.color!.bg, "#aa3366", "the color field is not hostage to the name's guard");
+});
+
+// ── render.ts wiring (source pins — no jsdom harness for the monolith) ─────────────────────────────
+test("applyTabOrder syncs the pushed meta onto existing sessions inside the tabs branch", () => {
+  assert.match(RENDER, /syncSessionsFromTabMeta\(tabs, \(id\) => sessions\.get\(id\), pendingTabMeta\);/);
+  // inside the Array.isArray(tabs) rebuild — the same frame that refreshes the placeholders
+  const block = (RENDER.match(/if \(Array\.isArray\(tabs\)\) \{[\s\S]*?\n  \}/) || [""])[0];
+  assert.ok(block.includes("syncSessionsFromTabMeta"), "the sync rides the tabMeta rebuild");
+});
+
+test("a session frame cannot roll the strip back: upsert re-applies the freshest pushed meta", () => {
+  assert.match(RENDER, /sessions\.set\(msg\.id, s\);\n[\s\S]{0,400}?const tm = tabMeta\.get\(msg\.id\);\n\s*if \(tm\) applyMetaToSession\(s, tm, pendingTabMeta\.get\(msg\.id\)\);/);
+});
+
+test("both optimistic paths note their expectation: the color swatch and the renamed confirm", () => {
+  assert.match(RENDER, /notePendingMeta\(pendingTabMeta, id, \{ colorBg: bg \}\);/);
+  assert.match(RENDER, /notePendingMeta\(pendingTabMeta, m\.id, \{ name: m\.name \}\);/);
+});
+
+test("the tabOrder frame's views land before the strip repaints — a CLI tag edit re-filters the tabs on the same push", () => {
+  // captureViews (adopt the pushed views/tags blob) must run BEFORE applyTabOrder (whose renderTabs
+  // re-filters via tabInView) in the tabOrder handler — the (c) leg of the live-update fix
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ captureViews\(m\.views \|\| null\); applyTabOrder\(m\.order, m\.tabs\); \}/);
+  assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
+});

--- a/ui/webview/tab-meta.ts
+++ b/ui/webview/tab-meta.ts
@@ -1,0 +1,84 @@
+// Chat tab label + color follow the kernel's recurring tabOrder push (the user 2026-08-24, who ran
+// `romp rename` / `romp color` headless and watched the strip hold the old label until reload): the
+// push's per-tab meta (name + identity color) is rebuilt by the kernel every cycle from the names
+// registry — the AUTHORITATIVE store every writer hits (a WS op, a headless POST /rename | /color, a
+// remote kernel) — while per-session frames can ride the chat build cache with a stale name/color
+// embedded (that cache's sig watches transcript+states only, deliberately). So the strip applies THIS
+// blob to existing sessions on every push, and any writer's change renders within a push cycle, no
+// reload, no per-route confirm frames. Pure and DOM-free, split out of render.ts for tests (the
+// session-views.ts pattern).
+//
+// The pending guard keeps the strip flap-free (the cards-move-on-new-information rule, applied to
+// labels): an OPTIMISTIC local edit (the color-swatch click; the kernel's one-shot renamed confirm)
+// records what it expects here, and a push built BEFORE the kernel applied that edit cannot revert
+// the strip while the expectation stands. Cleared by the echo (the push agreeing), or yielded after
+// three silent pushes — the sessionViews pendingViewsAge machinery's constants and reasoning.
+
+export interface TabColor { bg: string; fg: string }
+export interface TabSessionMeta { name: string; color: TabColor | null }
+export interface PendingTabMeta { name?: string; colorBg?: string; age: number }
+
+export const PENDING_META_MAX_AGE = 3;
+
+/** Record a local optimistic edit so pushes built before it cannot revert the strip. */
+export function notePendingMeta(pending: Map<string, PendingTabMeta>, id: string,
+                                edit: { name?: string; colorBg?: string }): void {
+  const p = pending.get(id) || { age: 0 };
+  if (edit.name !== undefined) p.name = edit.name;
+  if (edit.colorBg !== undefined) p.colorBg = edit.colorBg;
+  p.age = 0;
+  pending.set(id, p);
+}
+
+const validColor = (c: unknown): TabColor | null =>
+  (c && typeof (c as any).bg === "string" && typeof (c as any).fg === "string")
+    ? { bg: (c as any).bg, fg: (c as any).fg } : null;
+
+/** Apply one pushed tab-meta entry to its session — a pending local edit holds its field until the
+ *  push echoes it. Returns true when something visible changed (the caller repaints). */
+export function applyMetaToSession(s: TabSessionMeta, t: { name?: unknown; color?: unknown },
+                                   p?: PendingTabMeta): boolean {
+  let changed = false;
+  const name = typeof t.name === "string" && t.name ? t.name : null;
+  const color = validColor(t.color);
+  if (name !== null && (!p || p.name === undefined || p.name === name) && s.name !== name) {
+    s.name = name; changed = true;
+  }
+  if (color && (!p || p.colorBg === undefined || p.colorBg.toLowerCase() === color.bg.toLowerCase())
+      && (!s.color || s.color.bg !== color.bg || s.color.fg !== color.fg)) {
+    s.color = color; changed = true;
+  }
+  return changed;
+}
+
+/** Sync every pushed tab's meta onto its existing session (placeholder tabs read the blob directly).
+ *  Ages the pending guard: an edit this push echoes clears; an unechoed one yields after
+ *  PENDING_META_MAX_AGE pushes so the kernel's view wins eventually (it is the store of record).
+ *  Returns true when any session visibly changed. */
+export function syncSessionsFromTabMeta(
+  tabs: ReadonlyArray<{ id?: unknown; name?: unknown; color?: unknown }>,
+  get: (id: string) => TabSessionMeta | undefined,
+  pending: Map<string, PendingTabMeta>,
+): boolean {
+  let changed = false;
+  const seen = new Set<string>();
+  for (const t of tabs) {
+    if (!t || typeof t.id !== "string") continue;
+    seen.add(t.id);
+    const p = pending.get(t.id);
+    const s = get(t.id);
+    if (s && applyMetaToSession(s, t, p)) changed = true;
+    if (p) {
+      const c = validColor(t.color);
+      const nameEchoed = p.name === undefined || (typeof t.name === "string" && t.name === p.name);
+      const colorEchoed = p.colorBg === undefined || (!!c && c.bg.toLowerCase() === p.colorBg.toLowerCase());
+      if (nameEchoed && colorEchoed) pending.delete(t.id);
+      else if (++p.age >= PENDING_META_MAX_AGE) pending.delete(t.id);
+    }
+  }
+  // a pending edit for a tab the push no longer carries ages out the same way (closed mid-edit)
+  for (const [id, p] of pending) {
+    if (!seen.has(id) && ++p.age >= PENDING_META_MAX_AGE) pending.delete(id);
+  }
+  return changed;
+}


### PR DESCRIPTION
## What

`romp rename`, `romp color`, and `romp tag <t> --add <s>` (the headless one-shot POST routes) updated kernel state and the timeline, but the **chat tab strip** kept the old label and color — and didn't visibly apply the tag — until reload.

**The real bug was client application, not push emission.** Verified before building: the kernel's recurring `tabOrder` push already rebuilds per-tab `name` + identity `color` from the names registry every cycle and carries the views/tags blob; each POST route marks views dirty so the pusher wakes immediately; `_send_client`'s dedup passes any changed frame. But `render.ts` applied that pushed blob only to **placeholder** tabs — existing sessions kept name/color from per-session frames, whose build-cache sig (transcript+states mtimes, deliberate) a rename/recolor never busts, and a cached frame can even re-serve stale values on reconnect. Kernel untouched.

## Fix (the design-direction way: read the authoritative recurring push)

- New pure module `ui/webview/tab-meta.ts` (the `session-views.ts` split-for-tests pattern): `applyTabOrder` now syncs the pushed per-tab meta onto existing sessions on every frame, and `upsert` re-applies the freshest pushed meta so a cache-stale session frame can't roll the strip back. Any writer — CLI POST, WS op, a second dashboard, a remote kernel — renders within a push cycle.
- **WS-twin behavior identical and flap-free:** the `renamed` confirm and the optimistic color swatch record a pending expectation; a push built before the kernel applied the edit can't revert the strip. Cleared by the kernel's echo, or yielded after three silent pushes (the `sessionViews` pending machinery's constants and reasoning — push-count, not a timer).
- Tags/views already applied live through `captureViews` on the same frame; that path is now pinned by tests (the strip re-filters via `tabInView` on the very push that carries a CLI tag edit).

## Tests

- `ui/webview/tab-meta.test.ts` — executable coverage of the pure module (apply, junk tolerance, pending hold + case-insensitive echo, 3-push yield, field independence) plus source pins on the render.ts wiring (no jsdom harness for the monolith — the house idiom). Mutation-verified: dropping the sync call, the name pending guard, the aging yield, or the upsert re-apply each fails the suite.
- `tests/test_tab_meta_push.py` — real Handler over HTTP + the real `_push` with a captured chat client: each POST lands in its authoritative store and the **next** push cycle's `tabOrder` frame carries it through the per-client dedup; unchanged cycles stay deduped; a changed one never is (pins that `tabs`/`views` must not join `_DEDUP_VOLATILE` — mutation-verified); `/rename` wakes the pusher like `/color` and `/tag` already do.
- Suites: 2237 npm tests green; targeted pytest (this + the three route test files) 42 green.

Synthetic names only (notes-api demo world, TESTHOST, placeholder UUIDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)