### PR TITLE
Ephemeral peek tabs: focusing an out-of-view session opens a temporary tab, not a view edit

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20552,33 +20552,14 @@ def _reveal_chat_for(client, focus_msg):
     revealSelfPane) — which covers every kernel, local included, and makes the shell line a harmless
     duplicate rather than the only mover."""
     wid = (client or {}).get("wid") or ""
-    # The reveal rule (the user 2026-08-18; reshaped 2026-08-19, re-grounded 2026-08-23 on the TAG
-    # model; ALL default 2026-08-24): every gesture that focuses a session's chat — create, open,
-    # revive, a deep link, a feed chip — must land on a visible tab, with the MINIMAL move. Under
-    # All only the hidden bit can hide a session, so a focus unhides it and STAYS — it never kicks
-    # the user off the all-sessions view. Elsewhere focusing SWITCHES the active view to one that
-    # shows the session and never mutates membership: peeking at a tagged worker must not strip its
-    # tag. Preference order: the first tag holding it (a tagged session's home view); else unhide
-    # if hidden, then switch to All only if the session is STILL invisible (an unhidden tagless
-    # session already shows in the untagged view — no gratuitous view change).
-    sid = focus_msg.get("id") if isinstance(focus_msg, dict) else None
-    if sid:
-        v = _timeline_views()
-        if not _view_visible(v, sid):
-            v = json.loads(json.dumps(v))
-            if v["active"] == "all":
-                v["hidden"] = [x for x in v["hidden"] if x != sid]
-            else:
-                holder = next((t["id"] for t in v["tags"] if sid in t["members"]), None)
-                if holder:
-                    v["active"] = holder
-                else:
-                    if sid in v["hidden"]:
-                        v["hidden"] = [x for x in v["hidden"] if x != sid]
-                    if not _view_visible(v, sid):
-                        v["active"] = "all"
-            _set_timeline_views(v)
-            _mark_views_dirty()
+    # A focus is a PEEK, not a view edit (the user 2026-08-24, superseding the 2026-08-18/19/23
+    # reveal rule, which unhid / switched views here): the chat now opens an out-of-view session as
+    # an EPHEMERAL PEEK TAB client-side — real and scrollable, dressed as outside the view, dropped
+    # the moment another tab is activated — so the kernel never rewrites the views blob for a focus
+    # gesture. No unhide, no view switch; timeline-views.json is untouched and nothing here marks
+    # views dirty. The picker's explicit "Hidden — reveal" row keeps the real unhide (a deliberate
+    # choice from the hidden list, via setTimelineViews), and the dead-session confirmRevive path
+    # below this call is unchanged. tests/test_timeline_views.py pins the no-mutation contract.
     _send_to_view("chat", focus_msg, wid)
     _send_to_view("shell", {"type": "reveal", "pane": "chat"}, wid)
 

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -147,49 +147,33 @@ class TimelineViews(unittest.TestCase):
         self.assertIn("window.__rompTimelineSetViews=function(views)", src)
         self.assertIn('post({type:"setTimelineViews",views:views});', src)
 
-    def test_focus_switches_to_a_view_that_shows_the_session(self):
-        # the reveal rule (re-grounded 2026-08-23 on the TAG model; ALL default 2026-08-24): focusing
-        # lands on a visible tab with the MINIMAL move and never mutates membership. Under All only
-        # the hidden bit can hide a session — unhide and STAY, never kick the user off All. Elsewhere:
-        # the first tag holding it, else unhide if hidden and switch only if still invisible.
+    def test_focus_never_mutates_the_views_blob(self):
+        # A focus is a PEEK, not a view edit (the user 2026-08-24, superseding the 2026-08-18/19/23
+        # reveal rule this test used to pin): the chat opens an out-of-view session as an EPHEMERAL
+        # peek tab client-side, so _reveal_chat_for must leave timeline-views.json byte-identical and
+        # never mark views dirty — for EVERY case the old rule used to rewrite (hidden under All,
+        # tagged from untagged, tagless from a tag view, hidden+tagged, unknown sid), and for the
+        # confirmRevive shape too. The focus/shell send pair itself is pinned by
+        # tests/test_kernel_mobile.py::RevealRouting.
         G = {"id": "g1", "name": "pool", "members": ["s2"]}
-        km._set_timeline_views({"active": "g1", "hidden": [], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s9"})
-        v = km._timeline_views()
-        self.assertEqual(v["active"], "all", "tagless session from a tag view → land on All, the default")
-        km._set_timeline_views({"active": "untagged", "hidden": [], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
-        v = km._timeline_views()
-        self.assertEqual(v["active"], "g1", "tagged → its holder tag is its home view")
-        self.assertEqual(v["tags"][0]["members"], ["s2"], "membership untouched — the peek never strips a tag")
-        km._set_timeline_views({"active": "all", "hidden": [], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
-        self.assertEqual(km._timeline_views()["active"], "all", "tagged is VISIBLE under All → no move at all")
-        km._set_timeline_views({"active": "all", "hidden": ["sX"], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "sX"})
-        v = km._timeline_views()
-        self.assertEqual(v["hidden"], [], "hidden under All → un-hidden")
-        self.assertEqual(v["active"], "all", "…and the focus NEVER kicks the user off All")
-        km._set_timeline_views({"active": "all", "hidden": ["s2"], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
-        v = km._timeline_views()
-        self.assertEqual(v["hidden"], [], "hidden AND tagged under All → the unhide wins")
-        self.assertEqual(v["active"], "all", "…not a kick to the holder tag")
-        km._set_timeline_views({"active": "untagged", "hidden": ["s9"], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s9"})
-        v = km._timeline_views()
-        self.assertEqual(v["hidden"], [], "hidden tagless session under untagged → un-hidden")
-        self.assertEqual(v["active"], "untagged", "…already visible here — no gratuitous switch to All")
-        km._set_timeline_views({"active": "g1", "hidden": ["sX"], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "sX"})
-        v = km._timeline_views()
-        self.assertEqual(v["hidden"], [], "hidden AND tagless from a tag view → BOTH edits: un-hidden…")
-        self.assertEqual(v["active"], "all", "…and still invisible after the unhide, so the view switches to All")
-        km._set_timeline_views({"active": "untagged", "hidden": ["s2"], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
-        v = km._timeline_views()
-        self.assertEqual(v["active"], "g1", "hidden AND tagged under untagged → the holder tag wins")
-        self.assertEqual(v["hidden"], ["s2"], "…hidden bit untouched — membership beats hidden in a tag view")
-        km._set_timeline_views({"active": "g1", "hidden": [], "tags": [G]})
-        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
-        self.assertEqual(km._timeline_views()["active"], "g1", "a member's focus changes nothing")
+        dirty = []
+        saved = km._mark_views_dirty
+        km._mark_views_dirty = lambda: dirty.append(1)
+        try:
+            for blob, sid in [
+                ({"active": "g1", "hidden": [], "tags": [G]}, "s9"),      # tagless from a tag view
+                ({"active": "untagged", "hidden": [], "tags": [G]}, "s2"),  # tagged from untagged
+                ({"active": "all", "hidden": ["sX"], "tags": [G]}, "sX"),   # hidden under All
+                ({"active": "all", "hidden": ["s2"], "tags": [G]}, "s2"),   # hidden AND tagged
+                ({"active": "g1", "hidden": ["sX"], "tags": [G]}, "sX"),    # hidden tagless, tag view
+                ({"active": "g1", "hidden": [], "tags": [G]}, "s2"),        # already visible member
+            ]:
+                km._set_timeline_views(blob)
+                before = (jd.STATE / "timeline-views.json").read_bytes()
+                km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": sid})
+                km._reveal_chat_for({"wid": "w1"}, {"type": "confirmRevive", "id": sid, "name": "web"})
+                self.assertEqual((jd.STATE / "timeline-views.json").read_bytes(), before,
+                                 "a focus gesture rewrote the views blob (%s → %s)" % (blob, sid))
+            self.assertEqual(dirty, [], "no gratuitous views-dirty wake for a pure focus")
+        finally:
+            km._mark_views_dirty = saved

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -78,7 +78,10 @@ test("a filtered view re-points the CHAT BODY, not just the tab bar", () => {
   // the re-point covers BOTH filters since session views landed (2026-08-18): a hidden or
   // filtered-out active session must not keep its transcript on screen
   assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next\) setActive\(next\); \}, 0\);/);
+  // the deferred bounce re-validates at FIRE time since the ephemeral peek (2026-08-24): an
+  // activation between schedule and fire (a feed click opening a peek) makes the active tab
+  // visible again — bouncing then would kick the user off the tab they just opened
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/);
 });
 
 test("feed cards filter by the #only tag; clear bookkeeping still uses the FULL payload", () => {

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -1,0 +1,79 @@
+// EPHEMERAL PEEK TABS (the user 2026-08-24, superseding the kernel's reveal-rule view mutation):
+// focusing/clicking a session the current view hides opens it as a TEMPORARY tab — real and
+// scrollable, dressed as outside the view — that auto-closes the moment any other tab is activated.
+// Per-dashboard client state; never persisted, federated, or written to timeline-views.json. The
+// kernel half (a focus never mutates the views blob) is executed in tests/test_timeline_views.py.
+// render.ts has no jsdom harness → source pins (the apierror-retry-now.test.ts idiom); the CSS
+// cascade order is pinned executably below.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("peek OPEN: every activation routes the peek decision — setActive derives peek-vs-normal from the CURRENT views", () => {
+  // the single entry: setActive (tab clicks, the focus handler, jumpSession, cycleTab and
+  // nav-history's apply all land here), before its already-active early-return
+  assert.match(RENDER, /function setActive\(id: string[\s\S]{0,500}?assertPeekFor\(id\);[\s\S]{0,400}?if \(activeId === id && anchor == null && anchorT == null\) return;/);
+  // the derivation: in-view → no peek; out-of-view → THIS session is the peek
+  assert.match(RENDER, /const next = viewVisible\(effViews\(\), id\) \? null : id;\s*\n\s*if \(next !== peekId\) \{ peekId = next; renderTabs\(\); \}/);
+});
+
+test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no explicit close affordance", () => {
+  // an in-view target computes next=null and a different hidden target computes next=id — either
+  // way a click-away replaces/clears the peek in one place; and a dismissed session can't hold it
+  assert.match(RENDER, /if \(peekId === id\) peekId = null;\s*\/\/ its tab is going — the peek goes with it/);
+  // no message-send path touches the peek: sending from a peeked session does NOT pin it (decided
+  // 2026-08-24) — the ONLY writers are assertPeekFor and the dismiss clear above
+  const writers = RENDER.match(/peekId = /g) || [];
+  assert.equal(writers.length, 2, "peekId writers: assertPeekFor and dismissSession — nothing else (send never pins; the typed declaration matches separately)");
+  assert.match(RENDER, /let peekId: string \| null = null;/);
+});
+
+test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands in setActive, re-deriving peek", () => {
+  assert.match(RENDER, /const navHist = new NavHistory\(\{[\s\S]{0,900}?apply: \(spot\) => \{[\s\S]{0,400}?setActive\(spot\.sid\);/);
+  // documented: back/forward re-pops as peek or normal per the views AT NAVIGATION TIME
+  assert.match(RENDER, /Nav history stores only the sid/);
+});
+
+test("the first-tab fallback never fires on an active peek: tabInView counts the peek as visible", () => {
+  assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| viewVisible\(effViews\(\), id\); \}/);
+  // the #only=-era bounce reads visibleIds, which is built from tabInView — an active peek is in it
+  assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
+  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
+  // …and the DEFERRED bounce re-validates at fire time: an activation between schedule and fire
+  // (the feed click that just opened this peek) makes the active tab visible — no bounce then
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/);
+});
+
+test("the focus fast path (already-active live jump) still re-asserts the peek — setActive is skipped there", () => {
+  assert.match(RENDER, /assertPeekFor\(m\.id\);\s*\/\/ an out-of-view focus peeks even on the already-active fast path/);
+  // …and the reveal-pane pin stays first in the branch (tests/test_per_viewer_focus.py's contract)
+  assert.match(RENDER, /else if \(m\.type === "focus"\) \{\n    revealSelfPane\(\);/);
+});
+
+test("the strip dresses the peek: .tab-peek on the tab, ghost treatment in CSS, no status color stolen", () => {
+  assert.match(RENDER, /if \(id === peekId\) tab\.classList\.add\("tab-peek"\);/);
+  assert.match(CSS, /\.tab\.tab-peek \{ outline: [\d.]+px dashed rgba\(255, 255, 255, [\d.]+\); outline-offset: -2px; \}/);
+  assert.match(CSS, /\.tab\.tab-peek \.tab-label \{ font-style: italic; opacity: [\d.]+; \}/);
+  assert.doesNotMatch(CSS.match(/\.tab\.tab-peek[^\n]*/g)!.join("\n"), /--st-|var\(--state\)/,
+    "structure, not status — the peek never wears a status color");
+});
+
+test("CASCADE: the peek outline is declared BEFORE the state outlines, so a real state wins at equal specificity", () => {
+  const peekAt = CSS.indexOf(".tab.tab-peek {");
+  const stateAt = CSS.indexOf(".tab.tab-awaiting, .tab.tab-blocked, .tab.tab-retrying { outline:");
+  assert.ok(peekAt >= 0 && stateAt >= 0, "both rules present");
+  assert.ok(peekAt < stateAt, "peek before states — order IS the tiebreak (competing `outline` at equal specificity)");
+});
+
+test("the peek is a PEEK, not a view edit: the client never posts a views change from focus, and the picker's reveal row keeps the real unhide", () => {
+  // the only setTimelineViews writers are the deliberate gestures (hide menu-item, picker reveal,
+  // timeline dialog) via postViews — the focus handler and setActive never call it
+  const focusBlock = (RENDER.match(/else if \(m\.type === "focus"\) \{[\s\S]*?\n  \}/) || [""])[0];
+  assert.ok(focusBlock.length > 100, "found the focus handler");
+  assert.doesNotMatch(focusBlock, /postViews|setTimelineViews|revealSession/);
+  assert.match(RENDER, /function revealSession\(id: string\) \{ postViews\(revealIn\(effViews\(\), id\)\); \}/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -472,7 +472,22 @@ function postViews(v: SessionViews) {
   if (vscodeApi) vscodeApi.postMessage({ type: "setTimelineViews", views: v });
   renderTabs();
 }
-function tabInView(id: string): boolean { return viewVisible(effViews(), id); }
+// ── EPHEMERAL PEEK TAB (the user 2026-08-24, superseding the kernel's reveal-rule view mutation):
+// activating a session the current view HIDES opens it as a TEMPORARY tab — real and scrollable,
+// dressed .tab-peek ("breaks the view's rules") — and auto-closing: activating any other tab drops
+// it, no explicit close. Per-dashboard client state like the pending-views copy above: never
+// persisted, never federated, never written to timeline-views.json — a click is a peek, not a view
+// edit (the picker's "Hidden — reveal" row keeps the real unhide). Sending a message from a peeked
+// session does NOT pin it: the peek still drops on click-away, and the session stays reachable via
+// the feed and the nav trail. Nav history stores only the sid — back/forward lands in setActive
+// like every activation, which re-derives peek-vs-normal from the CURRENT views (a since-revealed
+// session re-pops as a normal tab, a since-hidden one as a peek).
+let peekId: string | null = null;
+function assertPeekFor(id: string): void {
+  const next = viewVisible(effViews(), id) ? null : id;
+  if (next !== peekId) { peekId = next; renderTabs(); }
+}
+function tabInView(id: string): boolean { return id === peekId || viewVisible(effViews(), id); }
 function visibleOrder(): string[] { return order.filter(tabInView); }
 function revealSession(id: string) { postViews(revealIn(effViews(), id)); }
 
@@ -4122,7 +4137,10 @@ function renderTabs() {
   // setActive is a no-op once activeId is visible, so this settles in one pass.
   if (activeId && ids.includes(activeId) && !visibleIds.includes(activeId) && visibleIds.length) {
     const next = visibleIds[0];
-    setTimeout(() => { if (activeId !== next) setActive(next); }, 0);
+    // re-validate at FIRE time, not schedule time: an activation between the two (a feed click
+    // opening an ephemeral peek, a reveal landing) can have made the active tab visible — bouncing
+    // then would kick the user off the very tab they just opened (the no-flap rule)
+    setTimeout(() => { if (activeId !== next && activeId && !tabInView(activeId)) setActive(next); }, 0);
   }
   for (const id of visibleIds) {
     const s = sessions.get(id);
@@ -4157,6 +4175,7 @@ function renderTabs() {
       tab.style.setProperty("--chip-fg", s.color.fg);
       tab.classList.add("colored");
     }
+    if (id === peekId) tab.classList.add("tab-peek");   // ephemeral peek — ghost/dashed dress (styles.css)
     const st = s.status.state;
     if (st === "working") tab.classList.add("tab-working");
     // "blocked" is an API error. An on-YOU one — "prompt is too long" (compact), a monthly spend cap (raise it,
@@ -9833,6 +9852,10 @@ const navHist = new NavHistory({
 
 function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: string) {
   noteMru(id);
+  // EPHEMERAL PEEK (see peekId): an out-of-view target opens as the peek; activating anything else
+  // drops it. Before the already-active early-return, so a re-focus of a hidden session re-asserts
+  // its peek even when nothing else changes.
+  assertPeekFor(id);
   if (activeId === id && anchor == null && anchorT == null) return; // already active, nothing to do
   navHist.record();   // every real navigation records the spot being LEFT (the user 2026-08-14: Ctrl+M / Ctrl+, walk the trail)
   closeMetaMenu(); // an open model/effort menu targets the tab we're leaving
@@ -10208,6 +10231,7 @@ function closeTabLocally(id: string): void {
 // close) and wrong under federation, where a `closed` ack can predate stale merged frames that still list
 // the id: the moment nothing suppresses it, the strip re-draws the swirl placeholder.
 function dismissSession(id: string): void {
+  if (peekId === id) peekId = null;   // its tab is going — the peek goes with it
   sessions.delete(id);
   liveAsks.delete(id);
   ledgers.delete(id);
@@ -10293,6 +10317,7 @@ window.addEventListener("message", (e: MessageEvent) => {
     closingTabs.delete(m.id);   // an explicit reveal outranks a pending close-suppression: closing a tab and
     //                             reopening it from the picker inside the ack window must show it at once
     if (revivePending && m.id === revivePending) clearReviveLoader();   // the revive landed — the loader's success event
+    assertPeekFor(m.id);   // an out-of-view focus peeks even on the already-active fast path below (setActive is skipped there)
     // `live` (the user 2026-07-08): land on the LIVE TAIL. A blocked card's picker/permission prompt IS the
     // live bottom of the chat, so its feed chip drops the user right on it. Stick the target view to bottom so
     // showActive scrolls there; and cover the ALREADY-ACTIVE case, where setActive early-returns (activeId ===

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -168,6 +168,14 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    outline-offset:-2px insets it where the old shadow sat; Chromium follows the
    border-radius. (For a dash length decoupled from thickness we'd need an SVG
    border — say the word if 2px dashes aren't long enough.) */
+/* EPHEMERAL PEEK TAB (the user 2026-08-24): a session the current view hides, opened temporarily by a
+   focus/click — it breaks the view's rules and dresses accordingly: STRUCTURE, not status, so a neutral
+   ghost (dim short-dash ring + italic faded label), never a status color. Declared BEFORE the state
+   outlines below on purpose: at equal specificity a real state (awaiting/blocked/retrying) must still
+   win the outline — the cascade ORDER is the tiebreak and is pinned in peek-tab.test.ts. The italic
+   label survives a state overlap either way. */
+.tab.tab-peek { outline: 1.5px dashed rgba(255, 255, 255, 0.35); outline-offset: -2px; }
+.tab.tab-peek .tab-label { font-style: italic; opacity: 0.85; }
 .tab.tab-awaiting, .tab.tab-blocked, .tab.tab-retrying { outline: 2px dashed var(--state); outline-offset: -2px; }
 /* WORKING: a small yellow dot left of the name (replaces the old yellow outline). */
 .tab-dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--st-working-bg); }   /* solid — dot oscillation was distracting (the user 2026-06-16) */


### PR DESCRIPTION
## What

Clicking or focusing anything from a session the current view hides (a feed card, a palette jump, a nav-history step) now opens that session as an **ephemeral peek tab** in the chat pane: a real, scrollable tab, visually marked as breaking the view's rules (neutral dashed ghost ring + italic label — structure, not status), that **auto-closes the moment any other tab is activated**. No explicit close. Back/forward re-pops the same peek.

## Why (root cause)

The old reveal rule made the kernel mutate the views blob on every focus gesture (`_reveal_chat_for` unhid the session or switched the active view) while the `{type:"focus"}` raced ahead of the views push — the chat applied it against stale local views and the first-tab fallback bounced to the first visible session. Palette `jumpSession` and nav-history bypassed the kernel reveal entirely, so they never worked on hidden sessions at all.

## How

- **One client-side entry:** the peek decision lives at the activation choke point — `setActive` (which tab clicks, the focus handler, `jumpSession`, keyboard cycling, and nav-history's `apply` all flow through), plus a re-assert on the focus handler's already-active fast path. In view → normal focus; out of view → peek.
- **Nav history stores only the sid:** back/forward lands in `setActive` like every activation and re-derives peek-vs-normal from the views *at navigation time* (a since-revealed session re-pops normal, a since-hidden one re-pops as a peek).
- **Kernel:** `_reveal_chat_for` stops rewriting the views blob for focus gestures — no unhide, no view switch, no dirty mark; the per-viewer focus/shell send pair and the dead-session `confirmRevive` path are unchanged. The picker's explicit "Hidden — reveal" row keeps its real unhide.
- **No bounce, no flap:** `tabInView` counts the active peek as visible, so the first-tab fallback never fires on it — and the fallback's deferred bounce now re-validates at fire time, so an activation between schedule and fire can't be kicked off its just-opened peek.
- Sending a message from a peeked session does **not** pin it (decided 2026-08-24) — the peek still drops on click-away; the session stays reachable via the feed and the nav trail.
- Peek state is per-dashboard client state: never persisted, never federated, never written to `timeline-views.json`.
- **CSS cascade:** the peek outline is declared *before* the state outlines so awaiting/blocked/retrying still win at equal specificity (order pinned by test); the italic label survives a state overlap. No status color stolen, no new font sizes.

## Tests

- `tests/test_timeline_views.py` — the old reveal-rule pin deliberately retargeted to the no-mutation contract: for every case the old rule rewrote (hidden under All, tagged from untagged, tagless from a tag view, hidden+tagged, confirmRevive), `timeline-views.json` stays byte-identical and no views-dirty wake fires. Mutation-verified (re-adding a views write fails it).
- `ui/webview/peek-tab.test.ts` (new) — pins peek open (the single setActive entry + derivation), auto-close (writer census: nothing but the derivation and the dismiss clear ever writes the peek, so sending never pins), nav-history sid-only storage, first-tab-fallback suppression + fire-time revalidation, the focus fast-path re-assert, the `.tab-peek` dress, and the CSS cascade order tiebreak.
- `ui/webview/only-filter.test.ts` — its re-point pin retargeted to the revalidating bounce, with the why.
- Suites: 2256 npm tests green; targeted pytest (`test_timeline_views.py`, `test_per_viewer_focus.py`, `test_kernel_mobile.py`, `test_tag_route.py`) 87 green.

Synthetic names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)