### PR TITLE
Inline figures heal on their own: no preview failure class is a dead end anymore

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -3,7 +3,7 @@
 // follows the block whose prose names it (the user 2026-08-15) — absolute OR relative path; the
 // kernel resolves a relative one against the session's cwd exactly like click-to-open. Per surface:
 // web renders via previewFull (kernel /file bytes → <img> at the user-image scale / a PDF card;
-// kernel-verified paths fail LOUDLY with a retry chip, only unverified ones self-remove); the VS Code
+// kernel-verified paths fail LOUDLY with a retry chip; unverified ones hide but stay healable); the VS Code
 // webview can't reach the kernel origin from an <img>, so images ride the SAME host data-URL flow the
 // user-message pictures use (imgRequest, now carrying the session id) and PDFs keep the click-to-open
 // link. Source pins.
@@ -27,15 +27,18 @@ test("previewFull renders the image itself; a PDF is a click-to-view CARD, never
   assert.doesNotMatch(pf, /createElement\("iframe"\)/, "no auto-loading PDF frame in the chat strip");
   assert.match(pf, /box\.classList\.add\("path-full-pdfcard"\);/);
   assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openLightbox\(path, sid\); \};/);
-  // the HEAD probe (headers only — never a download) still removes a dead UNVERIFIED card; a
-  // kernel-verified card skips it — a transient probe failure must not erase a real file's card
-  assert.match(pf, /if \(!verified\) fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)/);
+  // the HEAD probe (headers only — never a download) HIDES a failed UNVERIFIED card and keeps it
+  // registered for the heal events (2026-08-24 — self-removal erased the spot until a send); a
+  // kernel-verified card skips the probe — the kernel already stat'd the file
+  assert.match(pf, /const probe = \(\) => fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)/);
 });
 
 test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's spot, never silent removal", () => {
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
-  // unverified (old kernel, no pathLinks verdict) keeps self-removal — there the error means "no such file"
-  assert.match(pf, /if \(!verified\) \{ box\.remove\(\); return; \}/);
+  // unverified (a file:// mention, an old kernel's no-pathLinks payload) now rides the SAME retry
+  // machinery hidden instead of self-removing (2026-08-24): one transient failure used to erase the
+  // figure until a send's re-render minted a fresh box — preview-heal.test.ts pins the sentinel
+  assert.match(pf, /if \(!verified\) box\.style\.display = "none";/);
   assert.match(pf, /chip\.className = "path-full-retry";/);
   assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; ackTap\(ev\); build\(true\); \};/,
     "a tap re-arms persistence, acknowledges even mid-attempt, then retries");

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -213,22 +213,28 @@ test("quote chips send a plain message wrapped by quoteReplyBody — never askFo
   assert.match(RENDER, /mark\.textContent = cite\.quote \? "“" : "↩";/);
 });
 
-test("context stages ALONE, and the chips strip carries the visible Stage button", () => {
+test("context stages ALONE, and the chips strip carries the visible Stage button AFTER the chips", () => {
   // the user 2026-08-23: nobody discovers ⌘⏎ on their own. Select a passage → the chip appears with
-  // a Stage button pinned at its right; press it (or ⌘⏎) with an EMPTY box and just the context
-  // stages — repeat, then one typed message flushes the whole run. The button lives in the chips
-  // strip, so it exists exactly while context is held and vanishes with it.
+  // a Stage button; press it (or ⌘⏎) with an EMPTY box and just the context stages — repeat, then
+  // one typed message flushes the whole run. The button lives in the chips strip, so it exists
+  // exactly while context is held and vanishes with it. MOVED 2026-08-24: it now sits immediately
+  // AFTER the context chip(s) it acts on — right-justified it floated detached and its meaning
+  // didn't read — so the DOM appends it after the cites loop and the CSS drops the absolute pin.
   assert.match(RENDER, /if \(!typed && !\(composerCitations\.get\(activeId\) \|\| \[\]\)\.some\(\(c\) => c\.quote\)\) return;/,
     "empty box + a quote chip is stageable; empty box + nothing is not");
   assert.match(RENDER, /fireStage = \(\) => stageComposer\(\);/, "the strip's door into the composer closure");
   assert.match(RENDER, /const st = el\("button", "composer-stage-btn"\) as HTMLButtonElement;/);
+  // DOM order: chips loop first, then the button — adjacency is the point of the move
+  const loop = RENDER.indexOf("cites.forEach((cite, i) => {");
+  const btn = RENDER.indexOf('el("button", "composer-stage-btn")');
+  assert.ok(loop >= 0 && btn > loop, "the Stage button is appended AFTER the context chips");
   // neutral at rest (the user 2026-08-23): an accent outline beside the accent-blue chips read as
   // already-pressed. Rest = the button family's dress; the accent appears only on hover.
-  assert.match(CSS, /\.composer-stage-btn \{ position: absolute; right: 2px; top: 0; background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
+  assert.match(CSS, /\.composer-stage-btn \{ background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
   assert.match(CSS, /\.composer-stage-btn:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/);
+  assert.doesNotMatch(CSS, /\.composer-stage-btn \{ position: absolute/,
+    "no absolute pin — the button flows in the chips column, immediately after what it acts on");
   assert.match(RENDER, /st\.title = "hold this context \(and anything typed\) for one combined send later — ⌘⏎ does the same";/);
-  assert.match(CSS, /\.composer-stage-btn \{ position: absolute; right: 2px; top: 0;/,
-    "pinned to the RIGHT of the blue context chips");
   assert.match(RENDER, /label\.textContent = s\.text \|\| "\(context only — sends with your message\)";/,
     "a context-only staged row says what it is");
 });

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -40,3 +40,22 @@ test("render.ts's message listener heals previews unconditionally at the top, so
   assert.ok(heal >= 0 && firstCase >= 0 && heal < firstCase,
     "the heal must run before the type dispatch — moving it under a type check would silently drop hostUp");
 });
+
+// ── RECONNECT-class heals go further than the per-message retry (the user 2026-08-24) ───────────
+test("hostUp also drains the settled chips and un-parks the path-image chips", () => {
+  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{ refreshSettledPreviews\(\); healPathImgs\(\); \}/,
+    "a tunnel recovery re-attempts spent budgets and imgFailed paths — bounded by the event's rarity");
+});
+
+test("the page's own kernel-socket recovery (romp:wsup) heals everything the same way", () => {
+  // kernel.py's ws.onopen fires romp:wsup on a RECONNECT; nothing in render/preview listened until
+  // now, so a single-kernel dashboard had no reconnect-class heal at all (hostUp is federation-only)
+  assert.match(RENDER, /window\.addEventListener\("romp:wsup", \(\) => \{ retryFailedPreviews\(\); refreshSettledPreviews\(\); healPathImgs\(\); \}\);/);
+});
+
+test("imgFailed is no longer forever: a reconnect gives every parked path ONE fresh host round-trip", () => {
+  assert.match(RENDER, /function healPathImgs\(\): void \{/);
+  assert.match(RENDER, /const failed = Array\.from\(imgFailed\);\s*\n\s*imgFailed\.clear\(\);/);
+  assert.match(RENDER, /if \(!imgRequested\.has\(p\)\) \{/, "in-flight asks still dedup");
+  assert.match(RENDER, /installMdImgHeal\(\);/, "the md-img capture heal is installed once at boot");
+});

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -14,7 +14,7 @@ const PREVIEW = fs.readFileSync(path.join(UI, "preview.ts"), "utf8");
 const CHAT_CSS = fs.readFileSync(path.join(UI, "styles.css"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
 
-test("preview.ts: kind classification, kernel /file URL, and self-removing renders", () => {
+test("preview.ts: kind classification, kernel /file URL, and hide-but-heal unverified renders", () => {
   // the client's renderable-extension list must stay in step with the kernel's _PREVIEW_MIME
   assert.match(PREVIEW, /IMG_EXT = new Set\(\["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"\]\)/);
   assert.match(KERNEL, /_PREVIEW_MIME = dict\(_IMG_MIME, \*\*\{"\.pdf": "application\/pdf"\}\)/,
@@ -27,10 +27,11 @@ test("preview.ts: kind classification, kernel /file URL, and self-removing rende
   assert.match(PREVIEW, /"\/remote\/" \+ encodeURIComponent\(host\) \+ "\/file"/);
   // web dashboard only: the VS Code webview can't reach the kernel origin from an <img>
   assert.match(PREVIEW, /location\.protocol === "http:" \|\| location\.protocol === "https:"/);
-  // an UNVERIFIED render the kernel can't serve REMOVES ITSELF (no dead chips): img onerror, pdf HEAD
-  // probe. Kernel-VERIFIED paths keep a visible retry chip instead — chat-inline-preview.test.ts pins that.
-  assert.match(PREVIEW, /if \(!verified\) \{ box\.remove\(\); return; \}/);
-  assert.match(PREVIEW, /if \(!verified\) fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)\.then\(\(r\) => \{ if \(!r\.ok\) box\.remove\(\); \}\)\.catch\(\(\) => box\.remove\(\)\)/);
+  // an UNVERIFIED render the kernel can't serve HIDES itself but stays HEALABLE (2026-08-24; it
+  // used to remove itself permanently — no dead chips, but also no recovery until a send re-rendered
+  // the turn). Kernel-VERIFIED paths keep the visible retry chip — chat-inline-preview.test.ts.
+  assert.match(PREVIEW, /if \(!verified\) box\.style\.display = "none";/);
+  assert.match(PREVIEW, /box\.style\.display = "none"; failedPreviews\.set\(box, probe\);/);
   assert.match(KERNEL, /if p == "\/file":/, "the preview bytes endpoint exists");
   assert.match(KERNEL, /def do_HEAD\(self\):/, "HEAD probe for chips that can't self-verify like an <img>");
 });
@@ -46,7 +47,7 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   // (the user 2026-07-20: full renders replaced the 2026-07-08 thumbnails in the chat; the user
   // 2026-08-15: figures moved from a tail strip to the mentioning block —
   // chat-inline-preview.test.ts pins the placement shape)
-  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews \} from "\.\/preview";/);
+  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal \} from "\.\/preview";/);
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /previewable\.slice\(0, 4\)/, "capped so a directory listing doesn't wallpaper the chat");

--- a/ui/webview/preview-heal.test.ts
+++ b/ui/webview/preview-heal.test.ts
@@ -36,3 +36,48 @@ test("every tap acknowledges, even mid-attempt when build() no-ops on its fetchi
   assert.equal((PREVIEW.match(/ackTap\(ev\); build\(true\)/g) || []).length, 2,
     "both the retrying note and the settled chip acknowledge");
 });
+
+// ── the three no-retry dead-ends (the user 2026-08-24: figures stayed blank until a new message
+// forced a re-render — the send's registerOptimistic full-window rebuild minted fresh boxes, which
+// is why "sending anything fixes them") ─────────────────────────────────────────────────────────
+
+test("an UNVERIFIED failure never self-removes — it hides, registers, and unhides on a later success", () => {
+  // box.remove() erased the figure's spot permanently: no failedPreviews registration, nothing for
+  // the push-heal to retry. Every file:// mention and every no-pathLinks payload is unverified, so
+  // ONE transient failure in a kernel-restart window meant a blank figure until the next send.
+  assert.doesNotMatch(PREVIEW, /box\.remove\(\)/, "the self-remove is gone from every failure path");
+  // the happy-path onerror and the managed catch both hide instead (same retry machinery as verified)
+  assert.match(PREVIEW, /if \(!verified\) box\.style\.display = "none";\s*\n\s*failAfterBeat\(0\);/);
+  assert.match(PREVIEW, /if \(!verified\) box\.style\.display = "none";\s*\/\/ hidden while failed, healable — never removed\s*\n\s*failAfterBeat\(started\);/);
+  // …and both success paths unhide the healed sentinel in place
+  assert.equal((PREVIEW.match(/box\.style\.display = "";\s+\/\/ a hidden unverified sentinel that healed comes back/g) || []).length, 2,
+    "the resolved-url fast path AND the managed success both unhide");
+  // the PDF card's HEAD probe re-registers itself for the heal on every failure, and unhides on ok
+  assert.match(PREVIEW, /const probe = \(\) => fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)/);
+  assert.match(PREVIEW, /box\.style\.display = "none"; failedPreviews\.set\(box, probe\);/);
+});
+
+test("a settled chip re-registers for RECONNECT-class heals regardless of error text", () => {
+  // the push-heal stays new-evidence-gated (the pin above), but a byte-identical 404 while the file
+  // was still being written — or a constant connection-refused — parked the chip inert forever. The
+  // link coming back (romp:wsup / hostUp) is new information even when the words didn't change; the
+  // budget refills exactly like a send's fresh box (autoRetries = 3, not the push-heal's 1).
+  assert.match(PREVIEW, /settledPreviews\.set\(box, \(\) => \{ chipHealedErr = lastErr; autoRetries = 3; build\(true\); \}\);/);
+  assert.match(PREVIEW, /const settledPreviews = new Map<HTMLElement, \(\) => void>\(\);/);
+  assert.match(PREVIEW, /export function refreshSettledPreviews\(\): void \{/);
+  assert.match(PREVIEW, /settledPreviews\.delete\(box\);\s*\/\/ one attempt per registration; re-registers on error/);
+});
+
+test("markdown-inline <img> failures register through ONE capture-phase listener", () => {
+  // DOMPurify strips inline handlers (correctly) and md() returns a string, so per-site onerror
+  // wiring is impossible — a failed md img sat as a dead element in the cached DOM forever. Error
+  // events don't bubble but DO capture: one document-level listener covers every md img, skips the
+  // preview machinery's own imgs (they run budgets/resume/chips), and rides failedPreviews so every
+  // kernel message re-attempts.
+  assert.match(PREVIEW, /export function installMdImgHeal\(\): void \{/);
+  assert.match(PREVIEW, /document\.addEventListener\("error", \(e\) => \{/);
+  assert.match(PREVIEW, /\}, true\);\s*\n\}/, "capture phase — error events do not bubble");
+  assert.match(PREVIEW, /if \(!src \|\| src\.startsWith\("data:"\)\) return;/, "a broken data: URI has no server to heal");
+  assert.match(PREVIEW, /if \(img\.onerror \|\| img\.closest\("\.path-full"\)\) return;/, "previews own their own retries");
+  assert.match(PREVIEW, /if \(mdImgHealOn\) return;/, "ensure-once");
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -209,7 +209,17 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     // a chip can't self-verify like an <img> — HEAD-probe (headers only, no body — never a download)
     // so a missing PDF never shows a dead card. A kernel-VERIFIED card skips the probe: the kernel
     // said the file exists, and a transient probe failure must not erase the card.
-    if (!verified) fetch(fileUrl(path, sid), { method: "HEAD" }).then((r) => { if (!r.ok) box.remove(); }).catch(() => box.remove());
+    // an UNVERIFIED card's failed probe HIDES the card and keeps it registered for the heal
+    // events — never removed from the DOM: one transient failure (a kernel-restart window, a tunnel blip)
+    // used to erase the figure until a send's re-render minted a fresh box (the user 2026-08-24).
+    // The hidden sentinel keeps the spot healable with zero visual noise when the mention really
+    // is dead; a probe that later succeeds unhides the card in place.
+    if (!verified) {
+      const probe = () => fetch(fileUrl(path, sid), { method: "HEAD" })
+        .then((r) => { if (r.ok) { box.style.display = ""; } else { box.style.display = "none"; failedPreviews.set(box, probe); } })
+        .catch(() => { box.style.display = "none"; failedPreviews.set(box, probe); });
+      probe();
+    }
   } else {
     // `pin` freezes this MESSAGE's embed to its mention-time bytes (kernel _pin_mention): the sid
     // rides too (the pin store lives on the owning kernel; the relay forwards the query untouched),
@@ -298,6 +308,12 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       if (lastErr !== chipHealedErr) {
         failedPreviews.set(box, () => { chipHealedErr = lastErr; autoRetries = 1; build(true); });
       }
+      // …and a RECONNECT-class event (romp:wsup / hostUp) heals a settled chip REGARDLESS of the
+      // error text (the user 2026-08-24): a byte-identical 404 while the file was still being
+      // written — or a constant connection-refused — parked the chip inert forever, though the
+      // link coming back is new information even when the words didn't change. The budget refills
+      // exactly like a send's fresh box; reconnects are rare, so this can't hammer.
+      settledPreviews.set(box, () => { chipHealedErr = lastErr; autoRetries = 3; build(true); });
       if (fails > 1) {
         chip.classList.add("path-retry-flash");
         chip.addEventListener("animationend", () => chip.classList.remove("path-retry-flash"), { once: true });
@@ -371,6 +387,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     const build = (bust: boolean) => {
       const done = resolvedUrls.get(url);
       if (done) {                                    // already fully fetched this page-life → instant
+        box.style.display = "";                      // a hidden unverified sentinel that healed comes back
         box.textContent = "";
         box.appendChild(mkImg(done));
         return;
@@ -379,7 +396,10 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         box.textContent = "";
         const img = mkImg(url);
         img.onerror = () => {
-          if (!verified) { box.remove(); return; }
+          // unverified → the SAME retry machinery as verified, just invisible while failed (see
+          // the probe note above): the box hides instead of wearing the chip, and a later success
+          // unhides it — never self-removed, which erased the spot until a send re-rendered
+          if (!verified) box.style.display = "none";
           failAfterBeat(0);                          // no beat on the first attempt — the cue was already up
         };
         withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (memo on the un-busted url)
@@ -404,13 +424,14 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         rememberResolved(url, objUrl);
         loadedOnce.add(url);                         // re-renders skip the cue — the bytes are in hand
         if (!box.isConnected) return;
+        box.style.display = "";                      // a hidden unverified sentinel that healed comes back
         box.textContent = "";
         box.appendChild(mkImg(objUrl));
       }).catch((e: unknown) => {
         fetching = false;
         lastErr = String((e as Error)?.message || "");
         if (lastErr.startsWith("cut at ")) lastErr = "";   // a mid-stream cut narrates via got/fmtBytes
-        if (!verified) { box.remove(); return; }
+        if (!verified) box.style.display = "none";         // hidden while failed, healable — never removed
         failAfterBeat(started);
       });
     };
@@ -430,4 +451,41 @@ export function retryFailedPreviews(): void {
     failedPreviews.delete(box);                      // one attempt per registration; re-registers on error
     if (box.isConnected) rebuild();                  // a re-rendered turn made a fresh box — let the old go
   }
+}
+
+// Settled chips (auto-retry budget spent) awaiting a RECONNECT-class heal — romp:wsup (this page's
+// kernel socket came back) or hostUp (a federated tunnel recovered). Drained only by these events,
+// never by the per-message heal above, so a dead figure costs one fetch per reconnect, not per push.
+const settledPreviews = new Map<HTMLElement, () => void>();
+export function refreshSettledPreviews(): void {
+  if (!settledPreviews.size) return;
+  for (const [box, rebuild] of Array.from(settledPreviews.entries())) {
+    settledPreviews.delete(box);                     // one attempt per registration; re-registers on error
+    if (box.isConnected) rebuild();
+  }
+}
+
+// Markdown-inline <img> (a figure pasted as markdown in a message body) had NO failure handling at
+// all: DOMPurify strips inline handlers (correctly — untrusted transcript HTML) and nothing
+// re-attached one, so a load that failed once sat as a dead element in the cached DOM until a send
+// re-rendered the turn (the user 2026-08-24). Error events don't bubble but DO capture: one
+// document-level capture listener covers every md() img on the page — no per-render wiring — and
+// registers the element in the same failedPreviews machinery, so every kernel message re-attempts
+// it. Previews' own <img>s are skipped: their machinery (budgets, resume, chips) owns those.
+let mdImgHealOn = false;
+export function installMdImgHeal(): void {
+  if (mdImgHealOn) return;                           // ensure-once (the click-safety installation rule)
+  mdImgHealOn = true;
+  document.addEventListener("error", (e) => {
+    const img = e.target as HTMLImageElement | null;
+    if (!img || img.tagName !== "IMG") return;
+    const src = img.src || "";
+    if (!src || src.startsWith("data:")) return;     // a broken data: URI has no server to heal
+    if (img.onerror || img.closest(".path-full")) return;   // the preview machinery retries its own
+    failedPreviews.set(img, () => {
+      const u = img.src;
+      img.removeAttribute("src");
+      img.src = u;                                   // a fresh attempt; a repeat error re-registers here
+    });
+  }, true);
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -33,7 +33,7 @@ import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional 
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
-import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews } from "./preview";
+import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal } from "./preview";
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView } from "./file-view";
@@ -976,6 +976,30 @@ function onImgData(p: string, url: string | null): void {
     const e = n as HTMLElement; if (e.dataset.imgpath === p) fillPathImg(e, p);
   });
 }
+// RECONNECT-class heal for the path-image chips (the user 2026-08-24): imgFailed was "never retry
+// for the page lifetime", so a figure that failed while the kernel/tunnel was away stayed a dead
+// chip forever. A reconnect un-parks every failed path for ONE fresh host round-trip — the same
+// request flow buildPathImg runs on mint (imgRequested still dedups in-flight asks).
+function healPathImgs(): void {
+  if (!imgFailed.size) return;
+  const failed = Array.from(imgFailed);
+  imgFailed.clear();
+  for (const p of failed) {
+    document.querySelectorAll(".js-pathimg").forEach((n) => {
+      const e = n as HTMLElement;
+      if (e.dataset.imgpath !== p) return;
+      fillPathImg(e, p);                             // back to the pending pulse while the ask is out
+      if (!imgRequested.has(p)) {
+        imgRequested.add(p);
+        if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: activeId });
+      }
+    });
+  }
+}
+// the page shim fires romp:wsup when THIS pane's kernel socket reconnects (kernel.py ws.onopen) —
+// the same kernel-is-back event a hostUp is for a federated tunnel; heal everything on it
+window.addEventListener("romp:wsup", () => { retryFailedPreviews(); refreshSettledPreviews(); healPathImgs(); });
+installMdImgHeal();   // markdown-inline <img> failures register for the per-message heal (capture-phase, once)
 
 // One image of a user turn: the picture (or its hydration chip) plus, when the
 // on-disk path is known, a caption line — the full absolute path (click → open),
@@ -9408,17 +9432,6 @@ function renderComposerChips(id: string | null): void {
   const cites = id ? composerCitations.get(id) : undefined;
   if (!cites || !cites.length) { strip.style.display = "none"; return; }
   strip.style.display = "flex";
-  // The STAGE button (the user 2026-08-23): nobody discovers ⌘⏎ on their own, so whenever quote
-  // context is held the strip carries its visible face — right of the blue chips, gone with them.
-  // Same action as the shortcut: stage the context (and any typed text) and keep going.
-  {
-    const st = el("button", "composer-stage-btn") as HTMLButtonElement;
-    st.type = "button";
-    st.textContent = "Stage";
-    st.title = "hold this context (and anything typed) for one combined send later — ⌘⏎ does the same";
-    st.addEventListener("click", (e) => { e.stopPropagation(); fireStage(); });
-    strip.appendChild(st);
-  }
   // one chip per held context, in the order they were added — the strip stacks them (flex column)
   cites.forEach((cite, i) => {
     const chip = el("div", "composer-chip");
@@ -9435,6 +9448,18 @@ function renderComposerChips(id: string | null): void {
     chip.appendChild(x);
     strip.appendChild(chip);
   });
+  // The STAGE button (the user 2026-08-23; moved 2026-08-24): nobody discovers ⌘⏎ on their own, so
+  // while quote context is held the strip carries its visible face — IMMEDIATELY AFTER the chips it
+  // acts on (right-justified it floated detached, and its meaning didn't read), gone with them.
+  // Same action as the shortcut: stage the context (and any typed text) and keep going.
+  {
+    const st = el("button", "composer-stage-btn") as HTMLButtonElement;
+    st.type = "button";
+    st.textContent = "Stage";
+    st.title = "hold this context (and anything typed) for one combined send later — ⌘⏎ does the same";
+    st.addEventListener("click", (e) => { e.stopPropagation(); fireStage(); });
+    strip.appendChild(st);
+  }
 }
 
 // The attachment strip: one little thumbnail per dropped/pasted/picked file, above the textarea (the
@@ -10293,6 +10318,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   // so relay-failed figures heal the moment the tunnel returns even when no chat traffic flows
   // (idle sessions generated no messages, so figures sat until the user's next send — 2026-08-17)
   retryFailedPreviews();
+  // a RECONNECT-class event goes further: settled chips (budget spent) re-attempt regardless of
+  // their error text, and the path-image chips parked in imgFailed get one fresh host round-trip
+  // (bounded: reconnects are rare events, never a per-push loop)
+  if (m.type === "hostUp") { refreshSettledPreviews(); healPathImgs(); }
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {
     globalRetryPaused = !!m.value;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -555,7 +555,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* ── citation chip strip (the user 2026-07-01) ── a click on a feed card summary / sub-goal seeds a
    dismissible pill here, ABOVE the textarea: "you're following up on THIS". Accent-blue, with an ✕ to
    dismiss (Backspace-at-start dismisses too). Reads as attached context, not typed text. */
-#composer-chips { flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding: 0 0 6px 2px; position: relative; }   /* anchors the Stage button at its top-right */
+#composer-chips { flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding: 0 0 6px 2px; position: relative; }   /* (the Stage button flows in the column now — 2026-08-24) */
 /* attachment thumbnails (the user 2026-08-04): dropped/pasted/picked files sit as little previews above
    the box until send — a row that wraps, unlike the stacked context chips below it */
 #composer-files { flex: 1 1 100%; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 0 0 6px 2px; }
@@ -613,11 +613,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
 .staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }
-/* the chips strip's Stage button (the user 2026-08-23), pinned to the RIGHT of the blue context
-   chips; it exists exactly while context is held (the strip renders it, and the strip hides with
-   the chips). NEUTRAL at rest (the under-bubble button family's dress): an accent outline next to
-   the accent-blue chips read as already-pressed — accent is for hover/selected, never rest chrome */
-.composer-stage-btn { position: absolute; right: 2px; top: 0; background: rgba(255, 255, 255, 0.06);
+/* the chips strip's Stage button (the user 2026-08-23; moved 2026-08-24): it FOLLOWS the blue
+   context chips in the strip's column — immediately after what it acts on, where its meaning reads;
+   right-justified it floated detached. Exists exactly while context is held (the strip renders it,
+   and the strip hides with the chips). NEUTRAL at rest (the under-bubble button family's dress): an
+   accent outline next to the accent-blue chips read as already-pressed — accent is for
+   hover/selected, never rest chrome */
+.composer-stage-btn { background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.78em;
   padding: 1px 8px; cursor: pointer; }
 .composer-stage-btn:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }


### PR DESCRIPTION
## What

Figures in the chat stayed blank until the user sent another message — the send's full-window re-render minted fresh preview boxes with fresh retry budgets, which is the only reason it "fixed" them. Three no-retry dead-ends, all fixed:

1. **Unverified previews self-removed permanently.** Every `file://` mention and any payload without a pathLinks verdict renders unverified, and all three failure paths (img onerror, managed-fetch catch, the PDF HEAD probe) called `box.remove()` with no heal registration — one transient failure in a kernel-restart window erased the figure until a send. Now the box **hides** instead, rides the same `failedPreviews` machinery as verified ones (so every kernel message re-attempts, budget-bounded), and unhides in place when an attempt succeeds. A genuinely dead mention stays invisible — same UX as before, but healable.
2. **Settled chips ignored identical errors.** A spent budget re-registered for the push-heal only when the error text *changed*, so a stable 404 (file still being written) or constant connection-refused parked the chip inert forever. Settled chips now also register for **reconnect-class events** — `romp:wsup` (the page's own kernel socket recovering; previously nothing in render/preview listened to it, so a single-kernel dashboard had no reconnect heal at all) and `hostUp` (federated tunnel recovery) — regardless of error text, budget refilled exactly like a send's fresh box. Bounded by the events' rarity, never per push.
3. **Markdown-inline `<img>` and VS Code path-images never retried.** DOMPurify strips inline handlers (correctly) and `md()` returns a string, so failed md images sat as dead elements in the cached DOM; the `imgFailed` set was never-retry-for-the-page-lifetime. One document-level **capture-phase** error listener (error events don't bubble but do capture) registers failed md imgs into the same heal machinery — skipping the preview machinery's own imgs, which run their budgets/resume/chips — and a reconnect gives every `imgFailed` path one fresh host round-trip.

All heals are event-keyed (kernel messages, `romp:wsup`, `hostUp`) — no timers; the bounded per-mint budgets stay.

## Rider (user ask)

The composer's **Stage** button now sits immediately after the context chips it acts on, instead of floating right-justified and detached: DOM-appended after the chips loop, the absolute pin dropped from its CSS. No other composer changes.

## Tests

- `preview-heal.test.ts`: the self-remove is gone from every failure path; the hidden sentinel and both unhide paths; the settled reconnect registration + `refreshSettledPreviews`; the capture-phase md-img heal with its data-URI / own-machinery guards and ensure-once install.
- `heal-on-hostup.test.ts`: `hostUp` drains settled chips and un-parks path-image chips; the `romp:wsup` listener heals everything the same way; `imgFailed` reconnect round-trip is bounded.
- `composer-citation.test.ts`: Stage button appended after the chips (DOM-order pin), no absolute positioning.
- `chat-inline-preview.test.ts` / `preview-core.test.ts`: pins deliberately retargeted from the retired self-removal contract to the hide-but-heal one.
- Full suite: 2262 npm tests + typecheck green. No kernel changes (the routes/push were verified sound), so no pytest surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)