### PR TITLE
Model-fallback cards: never learn from sidechain turns; existence-keyed mint dedupe

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9452,10 +9452,24 @@ def mint_fallback_card(sid, from_model, to_model, ev_t=None):
     08-19 and revived: "it'd be nice to get a model fallback card pop up and just go to
     completed"). The API swapped the session's model without anyone asking — the card makes the
     swap visible on the board (it pops into Completed; the distiller writes its takeaway like any
-    completed top). Kernel-authored bookkeeping: minted done, never a question."""
+    completed top). Kernel-authored bookkeeping: minted done, never a question. Returns None without
+    minting while an identical uncleared card is on the board (existence-keyed dedupe, 2026-08-24)."""
     try:
         store = load_goals(sid)
         nodes = store.setdefault("nodes", {})
+        text = "Model changed automatically: %s → %s" % (from_model or "?", to_model)
+        # Existence-keyed dedupe (the user 2026-08-24): while an identical UNCLEARED card is already
+        # on the board, another observation of the same swap mints nothing — the board already says
+        # exactly this, and a repeat is the same fact, not new information. Clearing the card
+        # re-arms the mint; the deciding event is the user's own dismissal, never a time window.
+        # Both clear shapes count: the verdict flag (a /clear boundary settle) and the feed's
+        # view-clear, which lives in cleared.jsonl — not on the node (_view_cleared).
+        vc = _view_cleared()
+        for prev in nodes.values():
+            if prev.get("why") == "kernel-observed API model fallback" \
+                    and prev.get("text") == text and not prev.get("cleared") \
+                    and prev.get("id") not in vc:
+                return None
         n = store.get("seq", 0) + 1
         store["seq"] = n
         gid = "%s:g%d" % (sid, n)
@@ -9464,7 +9478,7 @@ def mint_fallback_card(sid, from_model, to_model, ev_t=None):
                "capacity fallback, not a pick. Work continued on the fallback; switch back from the "
                "statusline if that isn't what you want."
                % (from_model or "the pinned model", to_model))
-        nd = GuardedNode({"id": gid, "text": "Model changed automatically: %s → %s" % (from_model or "?", to_model),
+        nd = GuardedNode({"id": gid, "text": text,
                           "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
                           "trail": [], "promptUuid": "", "quote": "", "t": t, "mt": t,
                           "why": "kernel-observed API model fallback", "log": []})

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2453,6 +2453,16 @@ class SdkSession:
             self.retry_count = 0
             self.retry_info = None
             m = getattr(msg, "model", None)
+            # SIDECHAIN turns never teach the session its model (the user 2026-08-24): a Task/Agent
+            # subagent streams its OWN AssistantMessages tagged parent_tool_use_id, routinely on a
+            # LOWER tier than the parent — learning one filed a false "Model changed automatically"
+            # downgrade card (the subagent's model read as a capacity fallback) and wrote the
+            # subagent's model over the registry's liveModel, which the statusline badge reads,
+            # until _do_refresh_context healed it after the turn. The same drop the chat-atom path
+            # applies to sidechain traffic (msg_to_atom) — the parent stream teaches only the
+            # parent's own turns.
+            if getattr(msg, "parent_tool_use_id", None):
+                m = None
             # Only adopt a REAL model id. Injected / synthetic assistant turns carry model="<synthetic>" (and
             # the CLI writes it to the transcript too); pretty_model passes unrecognised ids through verbatim,
             # so an unguarded assign would CORRUPT the model badge to "<synthetic>". A real id always contains

--- a/tests/test_model_fallback_card.py
+++ b/tests/test_model_fallback_card.py
@@ -17,6 +17,8 @@ os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+sb = SourceFileLoader("romp_sdk_backend",
+                      os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"
 
@@ -73,6 +75,151 @@ class DowngradeOnlyGate(unittest.TestCase):
     def test_the_learn_path_wires_the_gate(self):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
         self.assertIn("and _model_downgrade(self.model, pm):", src)
+
+
+class SidechainNeverLearns(unittest.TestCase):
+    """Subagent traffic must never teach the session its model (the user 2026-08-24): a Task/Agent
+    subagent streams its OWN AssistantMessages tagged parent_tool_use_id, routinely on a LOWER tier
+    than the parent, and learning one filed a false "Model changed automatically" downgrade card and
+    wrote the subagent's model over the registry liveModel the statusline badge reads. _on_message
+    takes the SDK message classes as PARAMETERS (the lazy-import seam), so the branch runs
+    hermetically with synthetic classes."""
+
+    class _SM:                       # SystemMessage stand-in — never instantiated here
+        pass
+
+    class _RM:                       # ResultMessage stand-in — never instantiated here
+        pass
+
+    class _AM:                       # AssistantMessage stand-in
+        def __init__(self, model, ptid=None):
+            self.model = model
+            self.parent_tool_use_id = ptid
+            self.error = None
+            self.content = []
+
+    def _session(self):
+        calls = {"fallback": [], "reg": []}
+
+        class Backend:
+            state_dir = None
+
+            def on_model_fallback(sid, frm, to):        # looked up on the CLASS, called unbound —
+                calls["fallback"].append((frm, to))     # exactly how the kernel wires the hook
+
+            def _update_reg(self, sid, **kw):
+                calls["reg"].append(kw)
+
+            def _poke(self):
+                pass
+
+            def _forward(self, sess, msg):              # the unconditional kernel forward at the branch tail
+                pass
+
+            def _log(self, *a, **k):
+                pass
+
+        s = object.__new__(sb.SdkSession)               # just the state the branch touches
+        s.backend = Backend()
+        s.sid = SID
+        s.name = "web"
+        s.model = "Fable 5"
+        s._model_pending = ""
+        s.retrying = False
+        s.retry_count = 0
+        s.retry_info = None
+        return s, calls
+
+    def _msg(self, s, msg):
+        s._on_message(msg, self._AM, self._RM, self._SM)
+
+    def test_a_tagged_downgrade_teaches_and_mints_nothing(self):
+        s, calls = self._session()
+        self._msg(s, self._AM("claude-opus-5", ptid="toolu_01AAAAAAAAAAAAAAAAAAAAAA"))
+        self.assertEqual(calls["fallback"], [], "a subagent's own turns never read as a capacity fallback")
+        self.assertEqual(s.model, "Fable 5", "self.model untouched")
+        self.assertEqual(calls["reg"], [], "registry liveModel untouched")
+
+    def test_a_genuine_main_loop_downgrade_still_mints_exactly_once(self):
+        s, calls = self._session()
+        self._msg(s, self._AM("claude-opus-5"))         # untagged: the main loop itself fell back
+        self.assertEqual(calls["fallback"], [("Fable 5", "Opus 5")])
+        self.assertEqual(s.model, "Opus 5")
+        self.assertEqual(calls["reg"][-1].get("liveModel"), "Opus 5")
+
+    def test_livemodel_stays_main_loop_across_a_subagent_burst(self):
+        s, calls = self._session()
+        for i in range(3):                              # an Explore fan-out: three sidechain turns, lower tier
+            self._msg(s, self._AM("claude-opus-5", ptid="toolu_01BBBBBBBBBBBBBBBBBB%02d" % i))
+        self._msg(s, self._AM("claude-fable-5"))        # the main loop comes back unchanged
+        self.assertEqual(s.model, "Fable 5")
+        self.assertEqual(calls["fallback"], [])
+        self.assertEqual(calls["reg"], [], "an unchanged main-loop model is a no-op write")
+
+    def test_the_sidechain_guard_is_pinned_at_the_source(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        i = src.index("elif isinstance(msg, AssistantMessage):")
+        j = src.index("elif isinstance(msg, ResultMessage):", i)
+        branch = src[i:j]
+        self.assertIn('if getattr(msg, "parent_tool_use_id", None):', branch)
+        self.assertLess(branch.index("parent_tool_use_id"), branch.index("self._learn_model("),
+                        "the sidechain drop gates the learn, mirroring msg_to_atom's drop")
+
+
+class DedupeBackstop(unittest.TestCase):
+    """One open card per identical swap (the user 2026-08-24): mint_fallback_card returns None while
+    an identical UNCLEARED frm→to card sits on the board — existence-keyed, never a time cooldown.
+    Clearing the card (either shape: the feed's view-clear in cleared.jsonl, or a /clear boundary's
+    verdict flag) is the re-arming event.
+
+    OWN sid, deliberately: load_goals replays the per-sid user-override journal on every load, and
+    other test modules journal user gestures against the shared placeholder SID — a journaled resolve
+    for a colliding "<SID>:g1" id replayed onto our store mid-test and folded the cleared card back
+    to done/uncleared, so the dedupe (correctly, per its own rule) blocked the re-arm. A sid nobody
+    else touches keeps these tests about the dedupe, not the journal."""
+
+    DSID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+        for fp in (jd.STATE / "cleared.jsonl", jd._overrides_dir() / (self.DSID + ".jsonl")):
+            try:
+                fp.unlink()
+            except OSError:
+                pass
+
+    def test_an_identical_open_card_blocks_a_second_mint(self):
+        g1 = jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_000)
+        self.assertTrue(g1)
+        self.assertIsNone(jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_060))
+        store = jd.load_goals(self.DSID)
+        same = [nd for nd in store["nodes"].values()
+                if nd.get("text") == "Model changed automatically: Fable 5 → Opus 5"]
+        self.assertEqual(len(same), 1, "however many identical observations, one card")
+
+    def test_a_different_swap_mints_beside_the_open_card(self):
+        self.assertTrue(jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_000))
+        self.assertTrue(jd.mint_fallback_card(self.DSID, "Opus 5", "Sonnet 5", ev_t=1_787_500_001),
+                        "a different frm→to is new information, not a repeat")
+
+    def test_a_feed_view_clear_rearms_the_mint(self):
+        g1 = jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_000)
+        with open(jd.STATE / "cleared.jsonl", "a") as f:      # the feed clear's authoritative record
+            f.write('{"id": "%s"}\n' % g1)
+        g2 = jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_200)
+        self.assertTrue(g2, "the user's cross-off is the re-arming event")
+        self.assertNotEqual(g1, g2)
+
+    def test_a_verdict_clear_rearms_the_mint(self):
+        g1 = jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_000)
+        store = jd.load_goals(self.DSID)
+        self.assertTrue(jd.record_verdict(store, store["nodes"][g1], "romp", "clear",
+                                          1_787_500_100, why="dropped with the cleared conversation"))
+        jd.rollup_status(store, True)
+        jd.save_goals(self.DSID, store)
+        g2 = jd.mint_fallback_card(self.DSID, "Fable 5", "Opus 5", ev_t=1_787_500_200)
+        self.assertTrue(g2, "a boundary-settle clear re-arms too")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The "Model changed automatically: Fable 5 → Opus 5" cards were false alarms minted by subagent traffic, and the statusline's liveModel was polluted the same way.

**Mechanism.** A Task/Agent subagent streams its own AssistantMessages tagged `parent_tool_use_id`, routinely on a lower tier than the parent. The AssistantMessage branch fed those to `_learn_model` with no sidechain filter — unlike the chat-atom path, which has always dropped sidechain traffic — so every subagent launch read as a capacity downgrade: a false card, and the subagent's model written over the registry `liveModel` the statusline badge reads, until the per-turn context refresh silently healed it.

**Fix, all event-based:**
- The AssistantMessage branch drops `parent_tool_use_id`-tagged turns before the learn, mirroring `msg_to_atom`'s sidechain rule. Subagent models now touch neither `self.model` nor `liveModel`. The only other `_learn_model` caller is the SystemMessage init payload — the main loop's own, authoritative, unchanged.
- `mint_fallback_card` gains an existence-keyed dedupe backstop: while an identical uncleared frm→to card sits on the board, a repeat observation mints nothing. Both clear shapes re-arm it — the verdict flag (a /clear boundary settle) and the feed's view-clear, which lives in cleared.jsonl off the node. The user's dismissal is the deciding event, never a time cooldown.

**Tests** (tests/test_model_fallback_card.py previously had no subagent case): hermetic behavioral coverage through the real `_on_message` branch — the SDK message classes are parameters, so synthetic classes drive it. A tagged downgrade teaches and mints nothing; a genuine main-loop downgrade still mints exactly once; liveModel survives a three-launch subagent burst; the dedupe blocks an identical repeat, lets a different swap mint, and re-arms on both clear shapes. The dedupe tests run under their own synthetic sid: the per-sid user-override journal replays onto every `load_goals`, and other test modules' journaled gestures against the shared placeholder sid re-flagged a colliding `g1` mid-test under full-suite ordering.

Full pytest suite green (5331 passed) and the extension suite green as a backstop (source pins read kernel files through bin/romp-kernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)