### PR TITLE
Timeline polish: horizontal stubs, incognito sentinel chip, one dash key

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2403,7 +2403,8 @@ class TimelinePanel {
     // any non-All view is a FILTER now, the untagged view included (it excludes tagged sessions),
     // so the chip shows for untagged and tag views alike; its ✕ resets to All, the unfiltered default
     const active = !!v.active && v.active !== 'all' && (!!g || v.active === 'untagged');
-    const gcol = (g && g.color) || '#cccccc';
+    const gcol = (g && g.color) || MODEL_FG;   // a sentinel view (untagged) wears the corner line's own gray
+    const gdim = g ? 1 : 0.7;                  // …at the N-more's opacity: it reads as a FILTER, not a tag
     const PADH = 7, GAP = 6;   // the chip's horizontal padding; the space between the line's parts
     // ellipsize so the WHOLE line stays inside the gutter — measured on the full string (the
     // 650-weight lane font over-measures the plain spans, which is the safe direction), because a
@@ -2446,9 +2447,9 @@ class TimelinePanel {
       grp.setAttribute('style', 'cursor:pointer;');
       const box = el('rect', { x, y: y - 13, width: cw, height: 18, rx: 9,
         fill: 'transparent',
-        stroke: gcol, 'stroke-width': 1 });
+        stroke: gcol, 'stroke-width': 1, opacity: gdim });
       grp.appendChild(box);
-      const ct = el('text', { x: x + PADH, y, 'font-size': 12, fill: gcol, 'font-weight': 650 });
+      const ct = el('text', { x: x + PADH, y, 'font-size': 12, fill: gcol, 'font-weight': 650, opacity: gdim });
       ct.textContent = name;
       ct.setAttribute('style', 'user-select:none;');
       grp.appendChild(ct);
@@ -3708,17 +3709,16 @@ class TimelinePanel {
     // (the CLI's unmappable-member precedent).
     const msgHtml = (mm) => () => { const col = colorOf(mm.fromId); return '<div class="r"><span class="chip" style="background:' + col + '"></span><span class="who" style="color:' + col + '">' + esc(mm.from || mm.fromId) + '</span><span class="ar">→</span><span class="who" style="color:' + colorOf(mm.toId) + '">' + esc(mm.to || mm.toId) + '</span>' + (mm.pending ? ' <span class="k">pending</span>' : '') + '<span class="t">' + clock(mm.sent) + (mm.pending ? ' → …' : ' → ' + clock(mm.exec)) + '</span></div>' + this.body(esc(mm.summary || mm.text || '')); };
     const msgNav = (mm) => () => { const an = this.nearestTurnAnchor(mm.toId, execAt(mm)); this._select(mm.toId); this.openChat((an && an.tid) || mm.toId, mm.id || (an && (an.uuid || an.replyUuid)), false, false, execAt(mm)); };   // land on the message's OWN postal card BY ID — the chat matches mm.id to the card's data-mid (the user 2026-06-20); nearest-turn uuid / time only as fallback
-    // ── HIDDEN-COUNTERPART STUBS (the user 2026-08-24): a message whose OTHER endpoint has no
-    // visible lane still shows on the lane it does touch — a short diagonal stub through the band
-    // edge, exiting (recipient hidden) or entering (sender hidden), clipped BY ARITHMETIC to the
-    // lane's own band (y stays within laneY(i) ± LANE_GAP/2; this file has no clipPath — keep it
-    // that way), so it visibly leaves for / arrives from somewhere off-view without entering other
-    // lanes' space.
-    // SLOPE: toward where the hidden lane WOULD sit — lanes render in data.sessions order (vis
-    // filters, never reorders), so a counterpart sorted AFTER the shown session would sit below →
-    // the stub points down (+1); sorted before → up (-1). A counterpart absent from data.sessions
-    // entirely (dismissed, #only= filtered, or a foreign session) has no would-be slot: fixed
-    // convention, down (+1, toward the axis), so unknowable counterparts always read one way.
+    // ── HIDDEN-COUNTERPART STUBS (the user 2026-08-24; HORIZONTAL form later the same day — the
+    // angled diagonals fanned out of a busy lane like a starburst and read as noise): a message
+    // whose OTHER endpoint has no visible lane still shows on the lane it does touch, as a short
+    // HORIZONTAL tick on a fixed offset inside the band (clipped BY ARITHMETIC — this file has no
+    // clipPath, keep it that way). The CONVENTION carries the direction, not a slope: an INCOMING
+    // stub rides just ABOVE the lane line and ends at the arrival x, where the dot pass puts the
+    // arrival dot ON the lane — the dot IS the arrival mark; an OUTGOING stub rides just BELOW,
+    // and has NO dot (its recipient's lane is not here to land on — the dot pass never draws for a
+    // hidden recipient by construction). The offset is MSG_DROP, the same track height the full
+    // connectors approach a lane on, so a stub reads as a truncated connector, not a new mark.
     // TWO-STATE STROKE, keyed on the exec EVENT, never a timer: mm.pending folds in the kernel's
     // in-flight staleness window (MSG_INFLIGHT_MAX), so it is NOT the key. Exec knowledge is:
     // hasExec (the logged exec event — kernel serialization, the federation upgrade, or the
@@ -3732,24 +3732,23 @@ class TimelinePanel {
     // connectors — working-yellow at 0.45 was a muddy orange). The faded 0.45 stays, keeping
     // stubs subordinate to the work bars.
     const STUB_W = 3;                // a hair over MSG_W0 — a ~15px stroke needs the weight to read
-    const STUB_DX = LANE_GAP / 2;    // full-height run → 45° in the lane grid; a nearer landing steepens it
+    const STUB_DX = LANE_GAP / 2;    // the tick's max run — short on purpose; the tooltip carries the true span
     const stub = (mm, i, senderVisible) => {
-      const sid = senderVisible ? mm.fromId : mm.toId, hid = senderVisible ? mm.toId : mm.fromId;
+      const sid = senderVisible ? mm.fromId : mm.toId;
       const ly = laneY(vidx[sid]);
-      const oi = data.sessions.findIndex((s) => s.id === sid), hi = data.sessions.findIndex((s) => s.id === hid);
-      const dir = (hi < 0 || hi > oi) ? 1 : -1;   // toward the hidden lane's would-be slot (see SLOPE above)
       let x1, y1, x2, y2;
       if (senderVisible) {
-        // outgoing: anchored at the send, exits through the band edge toward the landing x (the
-        // live edge while pending, via execAt inside landXT) — never past it, never past the window
+        // outgoing: BELOW the lane, anchored at the send, running toward the landing x (the live
+        // edge while pending, via execAt inside landXT) — never past it, never past the window
         if (!inWin(sendXT(mm))) return;
-        x1 = x(sendXT(mm)); y1 = ly;
-        x2 = Math.max(x1, Math.min(x(Math.min(landXT(mm), t1)), x1 + STUB_DX)); y2 = ly + dir * LANE_GAP / 2;
+        x1 = x(sendXT(mm)); y1 = ly + MSG_DROP;
+        x2 = Math.max(x1, Math.min(x(Math.min(landXT(mm), t1)), x1 + STUB_DX)); y2 = y1;
       } else {
-        // incoming: the mirror — enters from the band edge, arrives at the landing point
+        // incoming: ABOVE the lane, the mirror — ending at the landing x, the arrival dot on the
+        // lane just beneath it
         if (!inWin(landXT(mm))) return;
-        x2 = x(landXT(mm)); y2 = ly;
-        x1 = Math.min(x2, Math.max(x(Math.max(sendXT(mm), t0)), x2 - STUB_DX)); y1 = ly + dir * LANE_GAP / 2;
+        x2 = x(landXT(mm)); y2 = ly - MSG_DROP;
+        x1 = Math.min(x2, Math.max(x(Math.max(sendXT(mm), t0)), x2 - STUB_DX)); y1 = y2;
       }
       const col = colorOf(mm.fromId);   // the SENDER's color — the full connectors' own resolution
       const arrived = mm.hasExec || mm.exec !== mm.sent;
@@ -3793,8 +3792,14 @@ class TimelinePanel {
                 : (xc > xs + 0.5) ? [{ x: xs, y: ys }, { x: xc, y: ys }, { x: xc, y: track }, { x: xe, y: track }, { x: xe, y: ye }]
                                   : [{ x: xs, y: ys }, { x: xs, y: track }, { x: xe, y: track }, { x: xe, y: ye }];
       const d = roundedPath(pts, CORNER);
-      const lineAttr = { d, fill: 'none', stroke: col, 'stroke-width': MSG_W0, opacity: mm.pending ? 0.4 : 0.5, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' };
-      if (mm.pending) lineAttr['stroke-dasharray'] = '1 4';
+      // dash + fade key on EXEC KNOWLEDGE — the stubs' exact event key (the user 2026-08-24: the
+      // connector dashed on the kernel's staleness-aged mm.pending, so the same stale message
+      // flipped solid/dashed whenever a lane filter toggled it between connector and stub form;
+      // exact events over time heuristics). mm.pending stays for what it truthfully says: execAt's
+      // live-edge x and the tooltip's "pending → …" wording.
+      const arrived = mm.hasExec || mm.exec !== mm.sent;
+      const lineAttr = { d, fill: 'none', stroke: col, 'stroke-width': MSG_W0, opacity: arrived ? 0.5 : 0.4, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' };
+      if (!arrived) lineAttr['stroke-dasharray'] = '1 4';
       svg.appendChild(el('path', lineAttr));
       // A connector in the focused journey (DAG card hover) or the hovered subtree's delegation messages
       // lights EXACTLY like its native hover: the own-color highlight overlay at full strength — no white

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -1,7 +1,8 @@
-// Hidden-counterpart message STUBS (the user 2026-08-24): a postal message whose OTHER endpoint has
-// no visible lane must still show on the lane it touches — a short diagonal stub through the lane's
-// band edge (exiting when the recipient is hidden, entering when the sender is), clipped to the band
-// by arithmetic (no clipPath), sloped toward where the hidden lane would sort, in the SENDER's
+// Hidden-counterpart message STUBS (the user 2026-08-24; HORIZONTAL form later the same day — the
+// angled diagonals fanned out of a lane like a starburst): a postal message whose OTHER endpoint
+// has no visible lane must still show on the lane it touches — a short HORIZONTAL tick on the
+// connectors' own MSG_DROP track offset, incoming ABOVE the lane (ending at the arrival dot ON the
+// lane), outgoing BELOW it with no dot, clipped by arithmetic (no clipPath), in the SENDER's
 // identity color like every full connector (the user 2026-08-24: state colors at stub alpha read as
 // mud), with the arrived/in-flight state on the STROKE STYLE — dashed until the exec binds, solid
 // after, keyed on the exec EVENT, never a timer. Headless draw() over the render test's DOM shim,
@@ -56,7 +57,8 @@ const { TimelinePanel } = createRequire(__filename)(viewPath);
 const SRC = fs.readFileSync(viewPath, "utf8");
 
 const ADA = "#f7768e", BEE = "#7aa2f7";   // sender identity colors (synthData below) — a stub wears its SENDER's
-const HALF = 13;            // LANE_GAP/2 — the band-edge clip distance AND the 45° stub run
+const HALF = 13;            // LANE_GAP/2 — the tick's max x-run
+const OFF = 10;             // MSG_DROP — the stub's track offset, the connectors' own approach height
 
 // Four sessions in a FIXED sort order — ada/cee view-hidden, bee/dee visible. The hidden ones
 // bracket bee so both slope directions (toward-above and toward-below) are exercised.
@@ -103,7 +105,7 @@ const X = (panel: any) => (t: number) => { const gm = panel._geom; return gm.ml 
 const laneY = (panel: any) => (i: number) => panel._geom.top + i * 26 + 13;
 const near = (a: number, b: number, msg: string) => assert.ok(Math.abs(a - b) < 1e-6, msg + " (got " + a + ", want " + b + ")");
 
-test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped toward the hidden lane, clipped at the band edge, sender-colored and dashed while pending", () => {
+test("a hidden-recipient message draws an outgoing stub: send-anchored, horizontal just BELOW the lane, sender-colored and dashed while pending, no dot", () => {
   const now = 1_781_000_000;
   const panel = draw([{ id: "m1", fromId: "SB", toId: "SC", from: "bee", to: "cee",
                         sent: now - 300, exec: now - 300, hasExec: false, pending: true, summary: "on its way" }]);
@@ -114,9 +116,11 @@ test("a hidden-recipient message draws an outgoing stub: send-anchored, sloped t
   assert.equal(s._attrs["stroke-dasharray"], "1 4", "no exec yet → dashed, the pending-connector idiom");
   assert.ok(s._attrs.opacity < 1, "faded — subordinate to the work bars");
   near(s._attrs.x1, X(panel)(now - 300), "anchored at the send x");
-  near(s._attrs.y1, laneY(panel)(0), "starts on the sender's lane center");
-  near(s._attrs.y2, laneY(panel)(0) + HALF, "clipped AT the band edge — cee sorts after bee, so it exits downward");
-  near(s._attrs.x2, s._attrs.x1 + HALF, "the 45° run toward the live edge, capped");
+  near(s._attrs.y1, laneY(panel)(0) + OFF, "OUTGOING rides just BELOW the lane line — the fixed convention");
+  near(s._attrs.y2, s._attrs.y1, "…and stays horizontal: no angles (the starburst read)");
+  near(s._attrs.x2, s._attrs.x1 + HALF, "the short run toward the live edge, capped");
+  assert.ok(!nodes(panel).some((n) => n.tag === "circle" && Math.abs(n._attrs.cx - s._attrs.x2) < 1e-6),
+    "an outgoing stub has NO dot — the dot is the ARRIVAL mark, and the arrival is off-view");
   assert.equal(s._attrs.opacity, 0.45, "the stub fade level exactly — not invisible, not full-strength");
   assert.equal(s._attrs["pointer-events"], "none", "the visible mark never eats the hover — the hit target owns it");
   const hl = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === BEE && n._attrs["stroke-width"] === 6);
@@ -193,11 +197,11 @@ test("the stub flips dashed→solid on the exec event — hasExec, never the sta
   assert.ok(gs, "the stale stub still draws");
   assert.equal(gs._attrs["stroke-dasharray"], "1 4", "no exec event → still dashed (the timer is not the key)");
   assert.equal(gs._attrs.stroke, BEE, "…and still the sender's color, stale or not");
-  near(gs._attrs.x2, gs._attrs.x1, "with the landing x AT the send, the stub steepens to vertical — arithmetic clamp, no clipPath");
-  near(gs._attrs.y2, laneY(stale)(0) + HALF, "still exits through the band edge");
+  near(gs._attrs.x2, gs._attrs.x1, "with the landing x AT the send, the tick collapses to a point — arithmetic clamp, no clipPath");
+  near(gs._attrs.y2, laneY(stale)(0) + OFF, "still on its outgoing track below the lane");
 });
 
-test("a hidden-sender message draws the mirror stub: entering from the band edge, arriving at the exec point, dot kept on top", () => {
+test("a hidden-sender message draws the mirror stub: horizontal just ABOVE the lane, ending at the arrival dot's x, dot kept on top", () => {
   const now = 1_781_000_000;
   const panel = draw([{ id: "m4", fromId: "SA", toId: "SB", from: "ada", to: "bee",
                         sent: now - 400, exec: now - 100, hasExec: true, pending: false, summary: "delivered" }]);
@@ -205,10 +209,10 @@ test("a hidden-sender message draws the mirror stub: entering from the band edge
   assert.ok(s, "the incoming stub draws");
   assert.equal(s._attrs.stroke, ADA, "the HIDDEN sender's color paints the incoming stub — sender, both directions");
   assert.equal(s._attrs["stroke-dasharray"], undefined, "already executed → solid");
-  near(s._attrs.x2, X(panel)(now - 100), "arrives at the exec x");
-  near(s._attrs.y2, laneY(panel)(0), "arrives on the recipient's lane center");
-  near(s._attrs.y1, laneY(panel)(0) - HALF, "enters from the TOP band edge — ada sorts before bee");
-  near(s._attrs.x1, s._attrs.x2 - HALF, "the 45° entry run");
+  near(s._attrs.x2, X(panel)(now - 100), "ends at the exec x — where the arrival dot sits on the lane");
+  near(s._attrs.y2, laneY(panel)(0) - OFF, "INCOMING rides just ABOVE the lane line — the fixed convention");
+  near(s._attrs.y1, s._attrs.y2, "…and stays horizontal");
+  near(s._attrs.x1, s._attrs.x2 - HALF, "the short entry run");
   const kids = panel.svg.children;
   const dotI = kids.findIndex((n: any) => n.tag === "circle" && Math.abs(n._attrs.cx - X(panel)(now - 100)) < 1e-6);
   assert.ok(dotI >= 0, "the arrival dot still draws on the recipient lane");
@@ -216,13 +220,14 @@ test("a hidden-sender message draws the mirror stub: entering from the band edge
   assert.ok(hitI > dotI, "the stub's hit target is appended after the dots (PASS 3), so the line wins the hover");
 });
 
-test("a counterpart absent from data.sessions slopes by the fixed convention: down", () => {
+test("a counterpart absent from data.sessions rides the same fixed track: outgoing = below", () => {
   const now = 1_781_000_000;
   const panel = draw([{ id: "m5", fromId: "SB", toId: "SX", from: "bee", to: "gone",
                         sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "to a cleared session" }]);
   const [s] = stubLines(panel);
-  assert.ok(s, "the stub draws even with no would-be lane to lean toward");
-  near(s._attrs.y2, s._attrs.y1 + HALF, "fixed convention: down, toward the axis");
+  assert.ok(s, "the stub draws even for a counterpart nowhere in data.sessions");
+  near(s._attrs.y1, laneY(panel)(0) + OFF, "outgoing = below the lane, whoever the counterpart is");
+  near(s._attrs.y2, s._attrs.y1, "horizontal — the direction convention carries the meaning, not a slope");
   // the tooltip must name BOTH endpoints even with no counterpart row in data.sessions at all
   // (the user 2026-08-24): the names come from the message ROW itself, never from visible lanes
   const hit = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
@@ -261,6 +266,26 @@ test("two visible lanes keep today's full connector — no stub elements", () =>
   assert.equal(stubLines(panel).length, 0, "no stub lines anywhere");
 });
 
+test("the full connector's dash keys on exec knowledge — the stubs' event key, never the staleness flag", () => {
+  // the user 2026-08-24: the connector dashed on the kernel's staleness-aged mm.pending, so the
+  // same stale message flipped solid/dashed when a lane filter toggled it between forms
+  const now = 1_781_000_000;
+  const landed = draw([{ id: "m20", fromId: "SB", toId: "SD", from: "bee", to: "dee",
+                         sent: now - 200, exec: now - 50, hasExec: true, pending: false, summary: "landed" }]);
+  const [pl] = connPaths(landed, "#7aa2f7");
+  assert.equal(pl._attrs["stroke-dasharray"], undefined, "exec known -> solid");
+  assert.equal(pl._attrs.opacity, 0.5, "…at the arrived weight");
+  const stale = draw([{ id: "m21", fromId: "SB", toId: "SD", from: "bee", to: "dee",
+                        sent: now - 400, exec: now - 400, hasExec: false, pending: false, summary: "aged out, never seen landing" }]);
+  const [ps] = connPaths(stale, "#7aa2f7");
+  assert.equal(ps._attrs["stroke-dasharray"], "1 4", "no exec knowledge -> dashed, however old (the timer is not the key)");
+  assert.equal(ps._attrs.opacity, 0.4, "…at the in-flight weight");
+  const pending = draw([{ id: "m22", fromId: "SB", toId: "SD", from: "bee", to: "dee",
+                          sent: now - 60, exec: now - 60, hasExec: false, pending: true, summary: "on its way" }]);
+  const [pp] = connPaths(pending, "#7aa2f7");
+  assert.equal(pp._attrs["stroke-dasharray"], "1 4", "a genuinely in-flight message stays dashed — same render as before");
+});
+
 test("window clamping is arithmetic: an off-window send or landing draws no stub", () => {
   const now = 1_781_000_000;
   const out = draw([{ id: "m8", fromId: "SB", toId: "SC", from: "bee", to: "cee",
@@ -276,7 +301,7 @@ test("window clamping is arithmetic: an off-window send or landing draws no stub
   const [s] = stubLines(old);
   assert.ok(s, "an off-window send with an in-window landing still draws the incoming stub");
   near(s._attrs.x2, X(old)(now - 100), "arriving at the exec x");
-  near(s._attrs.y1, laneY(old)(0) - HALF, "entering from the band edge");
+  near(s._attrs.y1, laneY(old)(0) - OFF, "riding its incoming track above the lane");
 });
 
 // The window clamps only bind within ~13px of a window edge — hard to pin behaviorally — so pin

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -87,11 +87,15 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
   assert.match(SRC, /grp\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\); nv\.active = 'all'; this\._setViews\(nv\);/);
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
-  assert.match(SRC, /fill: 'transparent',\n\s*stroke: gcol, 'stroke-width': 1/);
+  assert.match(SRC, /fill: 'transparent',\n\s*stroke: gcol, 'stroke-width': 1, opacity: gdim/);
+  // a SENTINEL view's chip dims to the corner line's own gray at the N-more opacity (the user
+  // 2026-08-24: at #cccccc it read bright as a tag) — real tag chips keep their tag colors, full strength
+  assert.match(SRC, /const gcol = \(g && g\.color\) \|\| MODEL_FG;/);
+  assert.match(SRC, /const gdim = g \? 1 : 0\.7;/);
   assert.match(SRC, /y: y - 13, width: cw, height: 18, rx: 9,/, "taller chip");
   assert.match(SRC, /cx\.textContent = '✕';/);
   assert.match(SRC, /fill: MODEL_FG, opacity: 0\.75/);
-  assert.match(SRC, /fill: gcol, 'font-weight': 650/);
+  assert.match(SRC, /fill: gcol, 'font-weight': 650, opacity: gdim/);
   assert.match(SRC, /click to remove the filter \(back to the default view\)/);
   // no chip on All — the unfiltered default; the untagged view IS a filter now, so it wears one
   assert.match(SRC, /const active = !!v\.active && v\.active !== 'all' && \(!!g \|\| v\.active === 'untagged'\);/);


### PR DESCRIPTION
Three user-reported reads fixed on the timeline's message layer and corner line.

**Stubs go horizontal.** The angled band-edge diagonals fanned out of a busy lane like a starburst and read as noise. The direction convention now carries the meaning instead of a slope: an **incoming** stub rides just above the lane line and ends at the arrival dot on the lane (the dot is the arrival mark); an **outgoing** one rides just below, with no dot. The offset reuses `MSG_DROP` — the full connectors' own approach-track height — so a stub reads as a truncated connector, not a new mark. Everything else from the stub work stays: sender color both directions, dashed while in flight / solid on the exec-knowledge event, sent→exec x-span with arithmetic window clamps, tooltips naming both endpoints.

**The (untagged) filter chip dims.** At the `#cccccc` fallback it rendered bright and read like a tag. A sentinel view's chip now wears the corner line's own gray (`MODEL_FG` at the N-more opacity 0.7), so a built-in filter reads incognito — a filter, not a tag. Real tag chips keep their tag colors at full strength.

**The connector's dash joins the exec-knowledge key.** Full connectors dashed on the kernel's staleness-aged `pending` flag while stubs dash on exec knowledge (`hasExec || exec !== sent`), so the same stale message flipped solid/dashed whenever a lane filter toggled it between connector and stub form. Both now key on the same exact event; `pending` stays for what it truthfully says (the live-edge x and the tooltip's wording). No other dash consumer existed.

**Tests:** `ui/timeline-hidden-stub.test.ts` geometry retargeted to the horizontal convention (above/below tracks, no-dot pin for outgoing, collapse-to-point clamp) plus a new executed connector-dash truth table (landed → solid 0.5; stale-unexecuted → dashed 0.4, the timer is not the key; genuinely pending → dashed as before); `ui/timeline-views-panel.test.ts` pins the sentinel dim treatment. Suite green: 2257/2257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)