### PR TITLE
Comment threads: await-green in-flight, a continuous rail, and the quote as context

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -178,7 +178,7 @@ test("a comments frame refreshes the open popover IN PLACE — composer and care
   assert.match(UI, /function fillCommentMsgs\(list: HTMLElement, th: CommentThread\)/);
 });
 
-test("the ants start on the gesture, and delete is optimistic and cuts the work", () => {
+test("the working state starts on the gesture, and delete is optimistic and cuts the work", () => {
   // create: a synthetic working thread marks the passage before any round-trip; the frame's
   // wholesale list replacement retires it, and a refusal drops it with the warn
   assert.match(UI, /tid: "pending:" \+ create\.uuid, anchorUuid: create\.uuid/);
@@ -368,27 +368,21 @@ test("ticks and message notches share ONE scrollbar frame, so they can never dis
   assert.match(UI, /kids\[i\]\.style\.top = t\.y \+ "px";/);
 });
 
-test("while the thread is WRITING the passage pales and the CRAWL rides the scroll-rail tick", () => {
-  // the user 2026-08-23 (superseding the same-day ants-on-top design): a crawl around the passage
-  // read as distraction, not progress. The passage now holds a PALER solid tint — visibly not the
-  // final color — and the four-strip march lives in miniature on the thread's scroll-rail tick.
+test("while the thread is WRITING the passage holds the await-green tint and NOTHING crawls", () => {
+  // the user 2026-08-24 (superseding 2026-08-23's tick-crawl compromise): the in-flight cue is the
+  // await-green STATE COLOR on the passage itself — its own new-test block below pins the colors;
+  // this one keeps the class wiring and holds the line on motion: no strips, no keyframes, anywhere.
   assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
-  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--cmt-hl\) 16%, transparent\);\s*\n\}/);
   assert.doesNotMatch(CSS, /mark\.cmt-hl\.busy \{[^}]*repeating-linear-gradient/s, "no strips on prose");
-  assert.doesNotMatch(CSS, /@keyframes cmt-ants /, "the passage keyframes are gone with them");
-  // the tick's miniature march: 6px dash cycle, strips oversized by one period (the 2026-08-19
-  // loop-point lesson, scaled down), and the tick class rides threadBusy with the sig tracking it
-  assert.match(CSS, /\.cmt-tick\.busy::after \{[\s\S]*?animation: cmt-tick-ants 1\.8s linear infinite;/);
-  assert.match(CSS, /@keyframes cmt-tick-ants \{\s*\n\s*to \{ background-position: 0 0, -6px 100%, 0 -6px, 100% 0; \}/);
+  assert.doesNotMatch(CSS, /@keyframes cmt-ants /, "the passage keyframes stay gone");
+  assert.doesNotMatch(CSS, /@keyframes cmt-tick-ants/, "…and the tick's miniature march followed them out");
   assert.match(UI, /\+ \(threadBusy\(th\.state\) && th\.status === "open" \? " busy" : ""\);/);
   assert.match(UI, /\+ ":" \+ \(threadBusy\(t\.th\.state\) \? 1 : 0\)\)/, "a state flip re-renders the tick");
-  // the code/math hosts pale the same way — no strips there either
-  assert.match(CSS, /\.md \.katex\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{\s*\n\s*background-color: color-mix\(in srgb, var\(--cmt-hl\) 16%, transparent\);\s*\n\}/);
 });
 
 test("the popover renders the thread with the CHAT's own renderer from the branch point", () => {
   assert.match(UI, /renderingSid = th\.tid;/);
-  assert.match(UI, /list\.appendChild\(renderEvent\(ev, prev, null\)\);/);
+  assert.match(UI, /const node = renderEvent\(ev, prev, null\);\s*\n\s*list\.appendChild\(node\);/);
   assert.match(KERNEL, /def _thread_events\(tsid, cut_uuid, now, tmux\):/);
   assert.match(KERNEL, /evs = evs\[at \+ 1:\]/, "sliced to AFTER the branch point — the head system card never rides");
   // the thread's own live model/effort chips post the chat's own ops, keyed to the thread sid
@@ -406,4 +400,52 @@ test("the tint ladder keeps every state distinct: base < unread < hover", () => 
 test("comment chrome (badge, popover card) stays on the menu vocabulary", () => {
   assert.match(CSS, /\.cmt-pop \{[^}]*#252526[^}]*\}/s);
   assert.match(CSS, /\.cmt-pop \{[^}]*border-radius: 6px/s);
+});
+
+// ── the comment-thread UI pass (the user 2026-08-24, three asks) ─────────────────────────────────
+
+test("an in-flight thread's highlight goes await-green — the color is the signal, nothing crawls", () => {
+  // the green/yellow request was always about comments: mid-reply the passage wears a faded
+  // await-green blend, settling into the EXISTING full yellow when the reply lands. The tick's
+  // marching ants (the "spinning dots") are retired — no motion anywhere in the state.
+  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);\s*\n\}/);
+  // the code/math HOST pairing greens the same way — its element tint must not stay full yellow
+  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\),\s*\n\.md \.katex\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);/);
+  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{ background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, var\(--code-bg\)\); \}/);
+  // the crawl is gone root and branch; the rail tick wears the same state green instead
+  assert.doesNotMatch(CSS, /cmt-tick-ants/);
+  assert.match(CSS, /\.cmt-tick\.busy \{ background: var\(--st-awaitbg-bg\); \}/);
+  // the other highlight states are untouched: base, unread, hover, resolved stay the yellow family
+  assert.match(CSS, /mark\.cmt-hl \{\s*\n\s*background: color-mix\(in srgb, var\(--cmt-hl\) 30%, transparent\);/);
+  assert.match(CSS, /mark\.cmt-hl\.unread \{ background: color-mix\(in srgb, var\(--cmt-hl\) 45%, transparent\); \}/);
+  assert.match(CSS, /mark\.cmt-hl:hover \{ background: color-mix\(in srgb, var\(--cmt-hl\) 58%, transparent\); \}/);
+  assert.match(CSS, /mark\.cmt-hl\.resolved \{ background: rgba\(255, 255, 255, 0\.08\); \}/);
+});
+
+test("the thread's identity rail runs continuous — no holes at the list's flex gaps", () => {
+  // each chat-parity turn's ::before rail segment spans only its own box (top:0..bottom:0), and
+  // .cmt-msgs' 6px flex gap sat UNPAINTED between consecutive turns — visible holes in the line.
+  // Every turn following another turn stretches its segment up across the gap; non-turn items
+  // (pending bubbles, dots, notes) render after the turns, so the + pair never misses.
+  assert.match(CSS, /\.turn::before \{ content: ""; position: absolute; left: 10\.5px; top: 0; bottom: 0; width: 2px;/,
+    "the base segment this fix extends");
+  assert.match(CSS, /\.cmt-msgs \{ max-height: 45vh; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; \}/,
+    "the 6px gap the -6px below must stay paired with");
+  assert.match(CSS, /\.cmt-msgs \.turn \+ \.turn::before \{ top: -6px; \}/);
+});
+
+test("the quoted passage is CONTEXT on the thread's opening message — never an item above the branch divider", () => {
+  // chronology: the branch happened before the quote, so the quote cannot sit above the divider.
+  // It attaches to the opening user message (the chat's citation-as-context idiom), and the
+  // standalone block — minted only while the events hadn't landed — is swept when they arrive,
+  // which used to leave BOTH on screen: quote on top, "branched" marker below it.
+  assert.match(UI, /let quoteHost: HTMLElement \| null = null;\s*\/\/ the thread's OPENING message — the quote's home/);
+  assert.match(UI, /if \(!quoteHost && ev\.kind === "user"\) quoteHost = node;/);
+  assert.match(UI, /const ctx = el\("div", "cmt-quote cmt-quote-ctx"\);/);
+  assert.match(UI, /quoteHost\.insertBefore\(ctx, quoteHost\.firstChild\);/);
+  assert.match(UI, /list\.closest\("\.cmt-pop"\)\?\.querySelector\(":scope > \.cmt-quote"\)\?\.remove\(\);/);
+  // the pre-events standalone block still renders (there is nothing to attach to yet, and no
+  // divider to misorder against) — the create/no-events guard is unchanged
+  assert.match(UI, /if \(create \|\| !\(th!\.events \|\| \[\]\)\.length\) \{/);
+  assert.match(CSS, /\.cmt-quote-ctx \{ margin: 0 0 4px; \}/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6043,13 +6043,29 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     renderingSid = th.tid;
     renderingIntoThread = true;   // same renderer, minus the transcript-coupled hover chrome (see the flag)
     let prev: number | null = null;
+    let quoteHost: HTMLElement | null = null;   // the thread's OPENING message — the quote's home
     for (const ev of evs) {
-      list.appendChild(renderEvent(ev, prev, null));
+      const node = renderEvent(ev, prev, null);
+      list.appendChild(node);
+      if (!quoteHost && ev.kind === "user") quoteHost = node;
       const ep = eventEpoch(ev);
       if (ep != null) prev = ep;
     }
     renderingIntoThread = false;
     renderingSid = saved;
+    // The quoted passage renders as CONTEXT attached to the thread's opening message (the user
+    // 2026-08-24): it used to sit as a standalone block ABOVE the whole list — above the branch
+    // divider too, misreading chronology, since the branch happened before the quote. Same idiom
+    // as the chat's citation-as-context. The standalone block only mints while the events haven't
+    // landed yet (openCommentPop), so it is swept here the moment they have — otherwise the frame's
+    // arrival left BOTH on screen, quote on top, "branched" below it.
+    if (th.exact && quoteHost) {
+      const ctx = el("div", "cmt-quote cmt-quote-ctx");
+      ctx.textContent = th.exact;
+      ctx.title = "the highlighted passage this thread is about";
+      quoteHost.insertBefore(ctx, quoteHost.firstChild);
+      list.closest(".cmt-pop")?.querySelector(":scope > .cmt-quote")?.remove();
+    }
   } else for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
   for (const p of pend) {
     const n = commentMsgEl("you", p.text);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2557,24 +2557,25 @@ mark.cmt-hl.unread.hl-last::after {
 mark.cmt-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
 mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
 /* WRITING (the user 2026-08-17; re-reshaped 2026-08-23 — the marching ants left the PROSE: a crawl
-   around the passage read as distraction, not progress): while the thread is mid-reply the region
-   keeps its solid highlight in a PALER blend — visibly "not the final color yet", settling into the
-   full yellow the moment the reply lands. The crawl itself lives on the scroll-rail tick now (see
-   .cmt-tick.busy), where motion informs without sitting inside the text you're reading. */
+   around the passage read as distraction, not progress; the tick's marching ants followed it out
+   2026-08-24 — the user wanted no crawling cue at all): while the thread is mid-reply the region
+   wears a faded AWAIT-GREEN blend — the awaitbg state color, "a reply is being worked on here" —
+   settling into the full yellow the moment the reply lands. The color IS the in-flight signal now;
+   nothing moves. */
 mark.cmt-hl.busy {
-  background-color: color-mix(in srgb, var(--cmt-hl) 16%, transparent);
+  background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, transparent);
 }
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
 
 }
-/* a code/math HOST whose mark is mid-reply pales the same way — its element tint would otherwise
-   stay full-strength and hide the writing state */
+/* a code/math HOST whose mark is mid-reply greens the same way — its element tint would otherwise
+   stay full-strength yellow and hide the writing state */
 .md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),
 .md .katex.cmt-hl-host:has(mark.cmt-hl.busy) {
-  background-color: color-mix(in srgb, var(--cmt-hl) 16%, transparent);
+  background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, transparent);
 }
-.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: color-mix(in srgb, var(--cmt-hl) 16%, var(--code-bg)); }
+.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host > mark.cmt-hl { background: transparent; }
 .md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }
@@ -2620,6 +2621,15 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 /* chat-parity turns inside the popover (the user 2026-08-17): the chat's own .turn nodes, given a
    little rail room; the popover's card is the backdrop, so no extra chrome */
 .cmt-msgs .turn { max-width: 100%; box-sizing: border-box; }
+/* the identity rail runs CONTINUOUS through the thread (the user 2026-08-24, who saw holes): each
+   turn's ::before segment spans only its own box, and the list's 6px flex gap sat unpainted between
+   them — so every turn AFTER another turn stretches its segment up across the gap. Non-turn items
+   (pending bubbles, dots, notes) come after the turns, so the + combinator never misses a pair;
+   keep the -6px paired with .cmt-msgs' gap above. */
+.cmt-msgs .turn + .turn::before { top: -6px; }
+/* the quoted passage as CONTEXT on the thread's opening message (the user 2026-08-24) — the
+   .cmt-quote dress, sitting inside the turn above its bubble, the chat's citation-as-context shape */
+.cmt-quote-ctx { margin: 0 0 4px; }
 .cmt-msg { padding: 5px 8px; border-radius: 6px; line-height: 1.35; overflow-wrap: anywhere; }
 .cmt-msg.you { background: color-mix(in srgb, var(--accent) 14%, transparent); align-self: flex-end; max-width: 92%; white-space: pre-wrap; }
 .cmt-msg.agent { background: rgba(255, 255, 255, 0.05); align-self: flex-start; max-width: 96%; }
@@ -2722,25 +2732,10 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    faint glow read as a rendering artifact, not as "new here" */
 .cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1;
   box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl) 85%, transparent); }
-/* a WRITING thread's tick carries the crawl (the user 2026-08-23, moving the ants off the prose):
-   the same four-strip march in miniature — 6px dash cycle, strips oversized by one period so the
-   loop point is invisible (the passage ants' 2026-08-19 lesson, scaled down) — around the tick */
-.cmt-tick.busy { overflow: visible; }
-.cmt-tick.busy::after {
-  content: ""; position: absolute; inset: -3px;
-  background-image:
-    repeating-linear-gradient(90deg, var(--cmt-hl) 0 3px, transparent 3px 6px),
-    repeating-linear-gradient(90deg, var(--cmt-hl) 0 3px, transparent 3px 6px),
-    repeating-linear-gradient(0deg,  var(--cmt-hl) 0 3px, transparent 3px 6px),
-    repeating-linear-gradient(0deg,  var(--cmt-hl) 0 3px, transparent 3px 6px);
-  background-size: calc(100% + 6px) 1.5px, calc(100% + 6px) 1.5px, 1.5px calc(100% + 6px), 1.5px calc(100% + 6px);
-  background-position: -6px 0, 0 100%, 0 0, 100% -6px;
-  background-repeat: no-repeat;
-  animation: cmt-tick-ants 1.8s linear infinite;
-}
-@keyframes cmt-tick-ants {
-  to { background-position: 0 0, -6px 100%, 0 -6px, 100% 0; }
-}
+/* a WRITING thread's tick wears the same await-green as the passage (the user 2026-08-24: the
+   marching-ants crawl — the "spinning dots" — is retired; the state COLOR is the in-flight cue,
+   here as everywhere on the rail) */
+.cmt-tick.busy { background: var(--st-awaitbg-bg); }
 
 /* a fully-covered KaTeX block tints at the ELEMENT (cmt-hl-host, same contract as inline code):
    a mark inside it cannot paint the glyph boxes' spacing, which punched gaps through highlighted


### PR DESCRIPTION
## What (three user asks, one pass)

**1. In-flight comments go green; the crawl dies.** While a thread is mid-reply, the passage's highlight wears a faded await-green blend (`--st-awaitbg-bg` at 24%), settling into the existing full yellow the moment the reply lands — the state color is the in-flight signal now. The scroll-rail tick wears the same green, and its marching-ants crawl (the "spinning dots") is retired outright, keyframes and all. The code/math host pairing (`cmt-hl-host:has(.busy)`) greens the same way so an element tint can't hide the state. Base / unread / hover / resolved are untouched. (The popover's in-thread typing dots stay — they mark reply-in-progress at the reply's own location, not on the prose.)

**2. Rail holes — reproduced, then fixed.** Each chat-parity turn's `::before` rail segment spans only its own box (`top:0; bottom:0`), and `.cmt-msgs`' 6px flex gap sat unpainted between consecutive turns — visible holes in the thread's identity line. Every turn following another turn now stretches its segment up across the gap (`.cmt-msgs .turn + .turn::before { top: -6px; }`, deliberately paired with the list's gap). Non-turn items (pending bubbles, dots, notes) render after the turns, so the `+` combinator never misses a pair.

**3. The quote renders as context, not a stacked item.** The quoted passage now attaches to the thread's opening message — the chat's citation-as-context idiom — instead of standing above the whole list, where it sat ABOVE the branch divider and misread chronology (the branch happened before the quote). Root cause of the stacked layout: the standalone block mints while the thread's events haven't landed yet, and the frame's arrival only refilled the list, leaving both on screen. It is now swept the moment events land. Pre-events (create / no thread yet) keeps the standalone block: nothing to attach to, no divider to misorder against.

## Verification

Screenshot-verified headless (playwright driving the built webview bundle with synthetic frames): the busy mark computes to `#54B204` at 0.24 alpha, the tick shows `animation: none`, the popover renders divider-first with `.cmt-quote-ctx` leading the opening turn and no standalone quote, and consecutive turns' rail segments meet flush (`::before` computed `top: -6px`). Harness lived in /tmp; nothing recorded enters the repo.

Tests in `comments.test.ts` updated in lockstep — the 2026-08-23 tick-crawl pins retargeted to the no-motion contract (its `cmt-tick-ants` / pale-yellow assertions now assert absence/green), plus one new test per item. 2265 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)