### PR TITLE
Long to-do lists fold to on-deck + '+N more completed'; the thread typing dots retire

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -239,10 +239,11 @@ test("the /kill route sweeps comment threads like the WS endSession op", () => {
   assert.match(KERNEL, /_comment_kill_all\(sid, be\)\s+# its comment threads must not outlive it \(the WS endSession twin\)/);
 });
 
-test("a thread that couldn't start says so instead of pulsing dots forever", () => {
+test("a thread that couldn't start says so — the error note renders in the thread", () => {
+  // (the pulsing dots this note used to preempt are retired outright — the dots-gone test below)
   assert.match(KERNEL, /be\.launch_error\(tsid\) if hasattr\(be, "launch_error"\) else None/);
   assert.match(UI, /cmt-note cmt-err/);
-  assert.match(UI, /!th\.error && \(threadBusy\(th\.state\) \|\| pend\.length\)/);
+  assert.match(UI, /if \(th\.status === "open" && th\.error\) \{/);
 });
 
 test("Delete is offered on open and resolved threads, never mid-promote", () => {
@@ -448,4 +449,13 @@ test("the quoted passage is CONTEXT on the thread's opening message — never an
   // divider to misorder against) — the create/no-events guard is unchanged
   assert.match(UI, /if \(create \|\| !\(th!\.events \|\| \[\]\)\.length\) \{/);
   assert.match(CSS, /\.cmt-quote-ctx \{ margin: 0 0 4px; \}/);
+});
+
+test("the popover's typing dots are retired — the green highlight is the only in-flight cue", () => {
+  // the user 2026-08-24 (closing the 2026-08-24 green-highlight pass): "rather than the little
+  // spinning dot dot dot thing" — the ellipsis animation goes too. The reply's arrival is announced
+  // by the green→yellow settle; the pending bubble still acknowledges the user's own send.
+  assert.doesNotMatch(UI, /cmt-dots/);
+  assert.doesNotMatch(CSS, /cmt-dots|cmt-dot-pulse/);
+  assert.match(UI, /the pending bubble IS the acknowledgement/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2668,16 +2668,49 @@ function renderTodo(ev: Extract<ChatEvent, { kind: "todo" }>): HTMLElement {
   const done = ev.tasks.filter((t) => t.status === "completed").length;
   const head = el("div", "todo-head"); head.textContent = `To-do · ${done}/${ev.tasks.length}`;
   card.appendChild(head);
-  for (const t of ev.tasks) {
-    const row = el("div", "todo-item todo-" + t.status);
+  const row = (t: (typeof ev.tasks)[number]) => {
+    const r = el("div", "todo-item todo-" + t.status);
     const mark = el("span", "todo-mark");
     mark.textContent = t.status === "completed" ? "✓" : t.status === "in_progress" ? "◐" : "○";
-    row.appendChild(mark);
+    r.appendChild(mark);
     const txt = el("span", "todo-text");
     txt.textContent = t.status === "in_progress" && t.activeForm ? t.activeForm : t.subject;
-    row.appendChild(txt);
-    card.appendChild(row);
-  }
+    r.appendChild(txt);
+    return r;
+  };
+  // PROGRESSIVE DISCLOSURE (the user 2026-08-24): a continuously-dispatched session — a manager
+  // especially — accumulates dozens of finished tasks and the card showed them all. Default = the
+  // ON-DECK work (in_progress + pending); the finished bulk (completed — and cancelled/deleted,
+  // should the store carry them: anything not on deck) folds into one row, "+N more completed",
+  // click to expand and click again to re-fold, nothing lost. The fold sits WHERE the bulk lives
+  // (finished work precedes current work in the list), keyed per session so the state survives the
+  // per-push re-renders (the openFolds idiom); a list with ≤ 2 finished rows stays inline — a fold
+  // hiding two rows costs a click for nothing. The label flip + rows appearing ARE the click's
+  // acknowledgement, immediate and local (no round-trip).
+  const onDeck = ev.tasks.filter((t) => t.status === "in_progress" || t.status === "pending");
+  const finished = ev.tasks.filter((t) => t.status !== "in_progress" && t.status !== "pending");
+  if (finished.length >= 3) {
+    const foldKey = "todo-done:" + (renderingSid || "");
+    const doneBox = el("div", "todo-done");
+    for (const t of finished) doneBox.appendChild(row(t));
+    applyFold(doneBox, "todo-open", foldKey);
+    const tog = el("button", "todo-fold") as HTMLButtonElement;
+    tog.type = "button";
+    const label = () => {
+      const open = doneBox.classList.contains("todo-open");
+      tog.textContent = open ? `hide ${finished.length} completed` : `+ ${finished.length} more completed`;
+      tog.title = open ? "collapse the completed items" : "show the completed items";
+    };
+    label();
+    tog.addEventListener("click", (e) => {
+      e.stopPropagation();
+      rememberFold(doneBox, "todo-open", foldKey);
+      label();
+    });
+    card.appendChild(tog);
+    card.appendChild(doneBox);
+  } else for (const t of finished) card.appendChild(row(t));
+  for (const t of onDeck) card.appendChild(row(t));
   turn.appendChild(card);
   return turn;
 }
@@ -6072,11 +6105,9 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     n.classList.add("pending");
     list.appendChild(n);
   }
-  if (th.status === "open" && !th.error && (threadBusy(th.state) || pend.length)) {
-    const dots = el("div", "cmt-dots");
-    dots.append(el("span"), el("span"), el("span"));
-    list.appendChild(dots);
-  }
+  // (the typing dots that rendered here while the thread was busy are RETIRED — the user 2026-08-24:
+  // the await-green highlight carries the in-flight signal, and the reply's arrival is announced by
+  // the green→yellow settle; the pending bubble still acknowledges the user's own send)
   if (th.status === "open" && threadStuck(th.state)) {
     const note = el("div", "cmt-note");
     note.textContent = "This thread hit a prompt it can't answer from here. Break it out to continue.";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1619,6 +1619,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .todo-card-error .todo-head { color: var(--err); }
 .todo-error-msg { color: var(--err); font-size: 0.86em; line-height: 1.4; }
 .todo-item { display: flex; gap: 8px; align-items: baseline; padding: 1px 0; line-height: 1.45; }
+/* the completed bulk's fold (the user 2026-08-24): a quiet row where the finished items live —
+   on-deck stays visible, the bulk is one click away; the box holds the rows when expanded */
+.todo-fold { display: block; background: none; border: none; color: var(--dim); font: inherit;
+  padding: 1px 0; cursor: pointer; text-align: left; }
+.todo-fold:hover { color: var(--fg); }
+.todo-done { display: none; }
+.todo-done.todo-open { display: block; }
 .todo-mark { flex: 0 0 auto; width: 1.1em; text-align: center; font-weight: 700; }
 .todo-text { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
 .todo-completed .todo-mark {
@@ -2636,14 +2643,6 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-msg.agent > *:first-child { margin-top: 0; }
 .cmt-msg.agent > *:last-child { margin-bottom: 0; }
 .cmt-msg.pending { opacity: 0.55; }
-.cmt-dots { display: flex; gap: 4px; padding: 2px 6px; }
-.cmt-dots span {
-  width: 5px; height: 5px; border-radius: 50%; background: var(--accent);
-  animation: cmt-dot-pulse 1.2s ease-in-out infinite;
-}
-.cmt-dots span:nth-child(2) { animation-delay: 0.2s; }
-.cmt-dots span:nth-child(3) { animation-delay: 0.4s; }
-@keyframes cmt-dot-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
 .cmt-note { font-size: 0.92em; opacity: 0.7; padding: 2px 6px; }
 /* the popover's message row mirrors the CHAT composer (the user 2026-08-17): clip left, ➤ right,
    pill input — the attach/send buttons share the chat's own selectors above, so they stay in sync */

--- a/ui/webview/todo-error.test.ts
+++ b/ui/webview/todo-error.test.ts
@@ -20,8 +20,8 @@ test("renderTodo shows the surfaced error instead of the task list", () => {
   // and it returns early — the normal per-task rendering is skipped when erroring
   const body = RENDER.slice(RENDER.indexOf("function renderTodo"));
   const errIdx = body.indexOf("if (ev.error)");
-  const loopIdx = body.indexOf("for (const t of ev.tasks)");
-  assert.ok(errIdx > -1 && loopIdx > -1 && errIdx < loopIdx, "the error branch precedes (and returns before) the task loop");
+  const rowIdx = body.indexOf("const row = (t:");
+  assert.ok(errIdx > -1 && rowIdx > -1 && errIdx < rowIdx, "the error branch precedes (and returns before) the row machinery");
 });
 
 test("the error card is styled in the error color, not a normal card", () => {

--- a/ui/webview/todo-fold.test.ts
+++ b/ui/webview/todo-fold.test.ts
@@ -1,0 +1,47 @@
+// Long to-do lists auto-collapse (the user 2026-08-24): a continuously-dispatched session (a manager
+// especially) accumulates dozens of finished tasks and the chat's to-do card showed every one. The
+// DEFAULT view is the on-deck work (in_progress + pending); the finished bulk folds into one
+// "+N more completed" row — click to expand, click to re-fold, nothing lost, state keyed so it
+// survives the per-push re-renders. Source pins (render.ts has no jsdom harness — the repo
+// convention); the acceptance case was screenshot-verified headless against a synthetic list of the
+// live report's scale (52 completed + 1 in progress).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const TODO = RENDER.slice(RENDER.indexOf("function renderTodo"), RENDER.indexOf("function renderCompact"));
+
+test("the card partitions on-deck from finished, and on-deck ALWAYS renders", () => {
+  assert.match(TODO, /const onDeck = ev\.tasks\.filter\(\(t\) => t\.status === "in_progress" \|\| t\.status === "pending"\);/);
+  // finished = anything NOT on deck — completed, and cancelled/deleted should the store carry them
+  // (the kernel's _TASK_DONE_STATUSES semantics, client-side)
+  assert.match(TODO, /const finished = ev\.tasks\.filter\(\(t\) => t\.status !== "in_progress" && t\.status !== "pending"\);/);
+  assert.match(TODO, /for \(const t of onDeck\) card\.appendChild\(row\(t\)\);/, "on-deck rows render unconditionally");
+});
+
+test("the finished bulk folds at 3+, and a tiny list stays inline (no click for two rows)", () => {
+  assert.match(TODO, /if \(finished\.length >= 3\) \{/);
+  assert.match(TODO, /\} else for \(const t of finished\) card\.appendChild\(row\(t\)\);/);
+});
+
+test("the fold row reads '+N more completed', flips on click, and the flip acknowledges in place", () => {
+  assert.match(TODO, /tog\.textContent = open \? `hide \$\{finished\.length\} completed` : `\+ \$\{finished\.length\} more completed`;/);
+  assert.match(TODO, /rememberFold\(doneBox, "todo-open", foldKey\);\s*\n\s*label\(\);/,
+    "the toggle records the keyed state and re-labels — the visible flip is the acknowledgement");
+  assert.match(TODO, /tog\.addEventListener\("click", \(e\) => \{/);
+});
+
+test("expand state survives re-renders — the openFolds keyed idiom, keyed per session", () => {
+  assert.match(TODO, /const foldKey = "todo-done:" \+ \(renderingSid \|\| ""\);/);
+  assert.match(TODO, /applyFold\(doneBox, "todo-open", foldKey\);/);
+});
+
+test("the fold's chrome is the card's own dress: hidden box, quiet row, no new font sizes", () => {
+  assert.match(CSS, /\.todo-done \{ display: none; \}/);
+  assert.match(CSS, /\.todo-done\.todo-open \{ display: block; \}/);
+  assert.match(CSS, /\.todo-fold \{ display: block; background: none; border: none; color: var\(--dim\); font: inherit;/,
+    "font: inherit — the standing no-new-font-sizes rule");
+});


### PR DESCRIPTION
## What

**Auto-collapse long to-do lists (user ask).** A continuously-dispatched session — a manager especially — accumulates dozens of finished tasks, and the chat's to-do card rendered every one. The default view is now the **on-deck** work (in_progress + pending); the finished bulk (completed, plus cancelled/deleted should the store carry them — the kernel's `_TASK_DONE_STATUSES` semantics client-side) folds into one quiet row, **"+N more completed"** — click to expand, click to re-fold, nothing lost.

- The fold sits where the bulk lives: finished work precedes current work in list order, so expanding restores natural reading order.
- **Threshold: 3+.** A fold hiding one or two rows costs a click for nothing; tiny lists stay inline.
- Expand state is keyed per session through the existing `openFolds` idiom, so it survives the per-push re-renders; the label flip + rows appearing are the click's immediate, local acknowledgement (no round-trip).
- Data stays the kernel's authoritative task-store event, exactly as the card reads it today. The fail-loudly error branch is untouched.
- No new font sizes (`font: inherit` on the fold row).

**Rider: the popover's typing dots go.** Closing the previous pass's open question the way the user's words point ("rather than the little spinning dot dot dot thing"): the pulsing ellipsis in the comment thread retires. The await-green highlight carries the in-flight signal, the green→yellow settle announces the reply, and the pending bubble still acknowledges the user's own send. CSS keyframes removed with it.

## Verification

Screenshot-verified headless (playwright over the built bundle) against a synthetic list at the live acceptance report's exact scale (52 completed + 1 in progress): collapsed renders one on-deck row + "+ 52 more completed" under the `To-do · 52/53` head; click expands all 53 and flips the label to "hide 52 completed"; the expanded state survives a fresh session-frame re-render; a second click re-folds. Harness in /tmp, synthetic text only, nothing recorded enters the repo.

Tests: new `todo-fold.test.ts` (partition + unconditional on-deck rendering, the 3+ threshold with inline small lists, the wording and in-place acknowledgement, keyed-state survival, fold chrome); `todo-error.test.ts` and `comments.test.ts` pins retargeted in lockstep (the error-branch anchor; the launch-error note pin now asserts the note's own gate; new dots-gone pins). Full suite: 2272 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)