### PR TITLE
Chat text schemes: a contrast lift and Solarized Dark, with the text hierarchy held

### DIFF
--- a/ui/webview/chat-scheme.test.ts
+++ b/ui/webview/chat-scheme.test.ts
@@ -1,0 +1,94 @@
+// Chat TEXT schemes (the user 2026-08-24): raise body-text contrast without collapsing the
+// tool-dimmer-than-prose hierarchy, pickable in the gear, persisted in romp:settings, applied live.
+// The tier audit found the chat's text riding THREE variables — --fg (prose, 78 uses), --dim (tool
+// heads/commands/meta, 127 uses), --code-fg (code) — so a scheme is just a tier set on a body class.
+// settings.ts is executable; the CSS/render/gear wiring is pinned at the source (repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { chatScheme, loadSettings, saveSettings, DEFAULT_SETTINGS } from "./settings";
+
+const UI = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
+
+// minimal localStorage for the executable round-trip
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+};
+
+test("executable: the scheme persists round-trip, unknown/legacy values normalize to default", () => {
+  store.clear();
+  assert.equal(DEFAULT_SETTINGS.chatScheme, "default");
+  assert.equal(loadSettings().chatScheme, "default", "a fresh install is Default — zero visual change");
+  saveSettings({ chatScheme: "solarized-dark" });
+  assert.equal(loadSettings().chatScheme, "solarized-dark", "the pick survives a reload (localStorage)");
+  store.set("romp:settings", JSON.stringify({ chatScheme: "neon-vaporwave" }));
+  assert.equal(loadSettings().chatScheme, "default", "junk in the blob can never wedge the chat unreadable");
+  assert.equal(chatScheme(undefined), "default");
+  assert.equal(chatScheme("high-contrast"), "high-contrast");
+});
+
+const tierBlock = (cls: string) => {
+  const m = CSS.match(new RegExp("body\\." + cls + " \\{([^}]*)\\}", "s"));
+  return m ? m[1] : null;
+};
+const tier = (block: string, name: string) => {
+  const m = block.match(new RegExp("--" + name + ": (#[0-9a-fA-F]{6})"));
+  return m ? m[1] : null;
+};
+const lum = (hex: string) => {
+  const c = [1, 3, 5].map((i) => {
+    const v = parseInt(hex.slice(i, i + 2), 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+};
+
+test("Default IS today's values: the :root tiers are untouched and no scheme-default rule exists", () => {
+  assert.match(CSS, /--fg: var\(--vscode-foreground, #cccccc\);/);
+  assert.match(CSS, /--dim: var\(--vscode-descriptionForeground, #9a9a9a\);/);
+  assert.match(CSS, /--code-fg: #e1c08d;/);
+  assert.doesNotMatch(CSS, /scheme-default/, "default applies NOTHING — absence is the guarantee");
+});
+
+test("every scheme defines ALL three tiers, and the dim tier stays measurably dimmer than prose", () => {
+  for (const cls of ["scheme-high-contrast", "scheme-solarized-dark"]) {
+    const block = tierBlock(cls);
+    assert.ok(block, cls + " block exists");
+    const fg = tier(block!, "fg"), dim = tier(block!, "dim"), code = tier(block!, "code-fg");
+    assert.ok(fg && dim && code, cls + " defines --fg, --dim, --code-fg");
+    assert.ok(lum(dim!) < lum(fg!) * 0.75, cls + ": the hierarchy holds — dim visibly below prose, never collapsed");
+  }
+});
+
+test("high contrast actually raises contrast: prose and dim both sit above the defaults", () => {
+  const block = tierBlock("scheme-high-contrast")!;
+  assert.ok(lum(tier(block, "fg")!) > lum("#cccccc"), "prose brighter than today's default");
+  assert.ok(lum(tier(block, "dim")!) > lum("#9a9a9a"), "the dim tier lifts with it — proportionally, not collapsed");
+});
+
+test("Solarized Light is deliberately absent — an unreadable preset is worse than none", () => {
+  assert.doesNotMatch(CSS, /solarized-light/i);
+  assert.doesNotMatch(GEAR, /solarized-light/i);
+});
+
+test("the scheme applies live as a body class, at startup and on every settings change", () => {
+  assert.match(UI, /function applyChatScheme\(s: RompSettings\): void \{/);
+  assert.match(UI, /classList\.toggle\("scheme-high-contrast", s\.chatScheme === "high-contrast"\);/);
+  assert.match(UI, /classList\.toggle\("scheme-solarized-dark", s\.chatScheme === "solarized-dark"\);/);
+  assert.match(UI, /applyChatScheme\(settings\);   \/\/ the persisted pick applies at startup — it survives reloads/);
+  assert.match(UI, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\);/);
+});
+
+test("the gear carries the picker: three options, filled from the store, saved through the shared blob", () => {
+  assert.match(GEAR, /<select id=rs-chatscheme/);
+  assert.match(GEAR, /<option value=default>Default<\/option><option value=high-contrast>High contrast<\/option><option value=solarized-dark>Solarized Dark<\/option>/);
+  assert.match(GEAR, /if \(cs\) cs\.addEventListener\('change', function \(\) \{ var s = load\(\); s\.chatScheme = cs\.value; save\(s\); \}\);/,
+    "save() dispatches romp:settings + settingsSync — the chat re-applies live, event-based");
+  assert.match(GEAR, /if \(cs\) cs\.value = \(s\.chatScheme === 'high-contrast' \|\| s\.chatScheme === 'solarized-dark'\) \? s\.chatScheme : 'default';/);
+});

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -100,6 +100,12 @@ var GEAR_HTML =
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
   '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
   '</select></span></div>' +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Text scheme</b>" +
+  "<span class=rs-sub>Chat text colors only. High contrast lifts prose and the dimmer tool text together; Solarized Dark wears its text tiers on romp's dark ground. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
+  "<select id=rs-chatscheme style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
+  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
+  '<option value=default>Default</option><option value=high-contrast>High contrast</option><option value=solarized-dark>Solarized Dark</option>' +
+  '</select></span></div>' +
   '<div class=rs-sec>Feed</div>' +
   '<label class=rs-row><input type=checkbox id=rs-feedcollapsed>' +
   '<span><b>Collapse cards by default</b>' +
@@ -169,6 +175,7 @@ function initGear(post) {
     an = document.getElementById('rs-autonudge'), bk = document.getElementById('rs-backend'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
+    cs = document.getElementById('rs-chatscheme'),
     cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
     fc = document.getElementById('rs-feedcollapsed'),
     jm = document.getElementById('rs-judgemodel'),
@@ -197,6 +204,8 @@ function initGear(post) {
   cc.addEventListener('change', function () { var s = load(); s.compact = cc.checked; save(s); });
   if (gb) gb.addEventListener('change', function () { var s = load(); s.showBranch = gb.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
+  // mirrors settings.ts chatScheme (this file can't import the TS module): unknown → default
+  if (cs) cs.addEventListener('change', function () { var s = load(); s.chatScheme = cs.value; save(s); });
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -409,7 +418,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cs) cs.value = (s.chatScheme === 'high-contrast' || s.chatScheme === 'solarized-dark') ? s.chatScheme : 'default'; if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -35,7 +35,7 @@ test("the chat has NO gear of its own — it only consumes the shared setting (g
   assert.doesNotMatch(RENDER, /chat-settings-gear/, "the gear was moved to the timeline");
   // renderTabs rides the change too: the tab strip reads settings (the context gauge toggle,
   // the user 2026-08-08) and rerenderAll only rebuilds the transcript views.
-  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; renderTabs\(\); rerenderAll\(\); \}\)/);
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\)/);
 });
 
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11447,10 +11447,17 @@ function shipFileToHost(f: File, sidAt: string | null = activeId) {
 // ---- settings: the gear + modal live on the TIMELINE now (the user 2026-06-14). The chat just
 // CONSUMES the shared 'romp:settings' (compact mode) — applying a change made there, in a same-origin
 // tab, live via the storage event; and reading it at startup. ----
+// The chat TEXT scheme (the user 2026-08-24) is a body class the tier variables key on
+// (styles.css body.scheme-*) — toggled here so a gear pick recolors live, event-based.
+function applyChatScheme(s: RompSettings): void {
+  document.body.classList.toggle("scheme-high-contrast", s.chatScheme === "high-contrast");
+  document.body.classList.toggle("scheme-solarized-dark", s.chatScheme === "solarized-dark");
+}
 function setupSettings(): void {
+  applyChatScheme(settings);   // the persisted pick applies at startup — it survives reloads
   // renderTabs too: the tab strip reads settings (the context gauge toggle) but rerenderAll only
   // rebuilds the transcript views, so without it a gear change waited for the next kernel push.
-  onExternalSettingsChange((s) => { settings = s; renderTabs(); rerenderAll(); });
+  onExternalSettingsChange((s) => { settings = s; applyChatScheme(s); renderTabs(); rerenderAll(); });
 }
 
 setupComposer();

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -17,6 +17,14 @@ export interface RompSettings {
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
+  chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
+}
+// Solarized LIGHT is deliberately absent (the user allowed skipping it): its text tiers are designed
+// for a paper-light ground and invert into mud on romp's dark canvas — an unreadable preset is worse
+// than none.
+export type ChatScheme = "default" | "high-contrast" | "solarized-dark";
+export function chatScheme(v: unknown): ChatScheme {
+  return v === "high-contrast" || v === "solarized-dark" ? v : "default";
 }
 // When the tab strip's context gauge shows. "over50" is the default (the user 2026-08-08): a gauge
 // on every tab is clutter while nothing is filling up — it should appear only when it has news.
@@ -32,7 +40,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50" };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", chatScheme: "default" };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {
@@ -41,6 +49,7 @@ export function loadSettings(): RompSettings {
     if (raw) {
       const s = { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
       s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
+      s.chatScheme = chatScheme(s.chatScheme);   // unknown/legacy values normalize to "default"
       return s;
     }
   } catch { /* corrupt / unavailable → defaults */ }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -12,6 +12,24 @@
 /* A wide display formula scrolls inside its own box instead of stretching the bubble. */
 .katex-display { overflow-x: auto; overflow-y: hidden; }
 
+/* ── chat TEXT schemes (the user 2026-08-24) ─────────────────────────────────────────────────────
+   The chat's text runs on THREE tiers, all variables: --fg (prose), --dim (tool heads / commands /
+   meta — always dimmer than prose), --code-fg (inline/block code). A scheme is JUST a tier set on a
+   body class, applied live by render.ts from the gear's romp:settings pick. No body class = the
+   Default scheme = the :root values below, byte-identical to before this block existed. Text only:
+   backgrounds, status colors, and the accent are never a scheme's to change. Solarized LIGHT is
+   deliberately absent — its tiers are made for a paper-light ground and invert into mud here. */
+body.scheme-high-contrast {
+  --fg: #e8e8e8;        /* prose lifted from #cccccc… */
+  --dim: #b8b8b8;       /* …and the dim tier lifted with it, still clearly dimmer than prose */
+  --code-fg: #ecd9ae;   /* the warm code tone, brightened in step */
+}
+body.scheme-solarized-dark {
+  --fg: #839496;        /* solarized base0 — the canonical body text */
+  --dim: #586e75;       /* solarized base01 — its secondary/comment tier */
+  --code-fg: #b58900;   /* solarized yellow — an accent it uses for emphasis/code */
+}
+
 :root {
   /* Chat reading-column width. 100% = fill the pane and grow with it (the user 2026-06-15);
      set a px value (e.g. 980px) to re-cap for prose readability. Shared by the transcript,

--- a/ui/webview/tab-ctx-gauge.test.ts
+++ b/ui/webview/tab-ctx-gauge.test.ts
@@ -70,5 +70,5 @@ test("gear → Chat picker (When above 50% / Always / Never), persisted as setti
 });
 
 test("a gear change repaints the tab strip live, not on the next kernel push", () => {
-  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; renderTabs\(\); rerenderAll\(\); \}\)/);
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\)/);
 });


### PR DESCRIPTION
## What

The chat's default body text reads a bit dim (user ask). **Tier audit first:** the chat's text already rides three CSS variables — `--fg` (prose, 78 uses), `--dim` (tool heads/commands/meta, 127 uses), `--code-fg` (code, plus its 2 literal fallback echoes) — and every other `color:` in the sheet is a status, accent, or identity tone, none of them text tiers. Nothing needed collapsing; the tiers were already clean. A **scheme** is therefore just a tier set on a body class:

- **Default** — no class, no override: the `:root` values byte-identical to before, theme-variable fallback chain (`--vscode-foreground` etc.) intact. Zero visual change until the user picks.
- **High contrast** — prose `#cccccc → #e8e8e8`, dim `#9a9a9a → #b8b8b8`, code lifted in step. The tool-dimmer-than-prose hierarchy is preserved and pinned by a computed-luminance test (dim < 75% of prose luminance in every scheme), not by eyeball.
- **Solarized Dark** — base0/base01 text tiers plus solarized yellow for code, on romp's existing dark ground (text only; the canvas stays romp's). **Solarized Light is deliberately absent:** its tiers are designed for a paper-light ground and invert into mud on a dark canvas — an unreadable preset is worse than none, per the delegation's own out.

**Picker:** a select row in the gear settings panel's Chat section (the existing row dress, no new font sizes), persisted in `romp:settings`, applied live as a body class by the chat's settings subscriber — event-based (the gear `save()`'s `romp:settings` dispatch + `settingsSync` fan-out), at startup and on every change, so the pick survives reloads. Scope guard held: chat pane text only; feed/timeline/shell untouched.

## Verification

Headless through the real event path (localStorage write + `romp:settings` dispatch, exactly what the gear's save() emits): Default probes today's values (`--fg #cccccc`, `--dim` = the theme rgba), each scheme flips the body class and tiers live, the pick survives a page reload, and switching back to Default restores the original values exactly. Screenshots eyeballed per scheme; harness in /tmp, nothing enters the repo.

Tests — `chat-scheme.test.ts`: executable settings round-trip + junk-value normalization (a corrupt blob can never wedge the chat unreadable), the untouched-default guarantee (`:root` pins + no `scheme-default` rule exists — absence is the guarantee), all-tiers-defined + luminance-hierarchy invariants per scheme, high-contrast actually-brighter checks, the deliberate Solarized Light absence, live-application and gear wiring pins. `render-settings.test.ts` / `tab-ctx-gauge.test.ts` pins extended in lockstep. Full suite: 2279 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)