### PR TITLE
The spend section owns its age, never speaks for rate limits, and ages visibly on failure

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18753,6 +18753,10 @@ def _usage():
             ss = _spend_series()          # TOTAL, like the windows above: everything here bills the key
             if ss:
                 out["spendSeries"] = ss   # the hover's money-rate graph (the user 2026-08-13)
+            sa = _spend_recorded_at()
+            if sa:
+                out["spendAt"] = sa       # the spend's OWN freshness (the user 2026-08-24: the windows'
+                                          # stale "updated 9h ago" sat over the spend and read as its age)
             return out
         return None
     # LIMIT REACHED (the user 2026-07-01): a window at 100% whose reset is still in the future = the account is
@@ -18787,6 +18791,9 @@ def _usage():
             ss = _spend_series(keyed_only=True)   # the keyed split, like the windows it graphs
             if ss:
                 out["spendSeries"] = ss
+            sa = _spend_recorded_at()
+            if sa:
+                out["spendAt"] = sa               # same own-freshness stamp as the key-only arm
     # (the winSeries per-window utilization series is gone — the user 2026-08-14, who wanted the one
     # fleet $/h graph and nothing per window. usage-history.json keeps recording — sdk_backend
     # _record_usage_history — so a future graph starts with history instead of a blank.)
@@ -18864,6 +18871,18 @@ def _spend_budgets():
                 if isinstance(d.get(k), (int, float)) and d[k] > 0}
     except Exception:
         return {}
+
+
+def _spend_recorded_at():
+    """spend.json's last-record moment (mtime, epoch seconds), or None. The spend display's OWN
+    freshness stamp (the user 2026-08-24): the hover's "updated Xh ago" belongs to the rate-limit
+    WINDOWS (usage.json's t — which nothing writes under key auth, and which sleeps with the user's
+    login machines overnight), yet it sat directly above the spend section and read as the spend's
+    age. The recorder writes per turn RESULT, so the mtime IS the last charge's event time."""
+    try:
+        return int((jd.STATE / "spend.json").stat().st_mtime)
+    except OSError:
+        return None
 
 
 def _spend_windows(keyed_only=False):
@@ -23807,6 +23826,7 @@ var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 
 // hover scaled each window's bar to the largest window, a shape with no meaning, and the budget-fill
 // tracks die with it): the numbers are the information, so the numbers are the rendering.
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
+if(typeof u.spendAt==='number')det._spendAt=u.spendAt;   // the spend's OWN last-record moment
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
 (det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});
 if(u.spendSeries&&u.spendSeries.usd)det._spendSeries=u.spendSeries;}   // $/hour, for the hover graph (the user 2026-08-13)
@@ -24004,6 +24024,10 @@ else{var off=ss.h0-series.h0;   // align on the base hour — hosts' polls may s
 for(var i=0;i<ss.usd.length;i++){var j=i+off;if(j>=0&&j<series.usd.length)series.usd[j]+=ss.usd[i];}}}});
 var ks=SPEND_WINS.map(function(w){return w[0];}).filter(function(k){return sum[k];});
 if(!ks.length)return '';
+// the spend's OWN freshness (the user 2026-08-24, whose windows' "updated 9h 38m ago" sat directly
+// above this section and read as the spend's age): the newest contributing host's last-record
+// moment — the recorder writes per turn result, so this is an event time, not a poll time
+var sAt=0;sets.forEach(function(e){var a=e.det&&e.det._spendAt;if(typeof a==='number'&&a>sAt)sAt=a;});
 var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>API spend'+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
 +ks.map(function(k){var v=sum[k];
 return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
@@ -24023,6 +24047,7 @@ if(series){var st=Math.max(0,series.usd.length-168),wk=series.usd.slice(st),mx=0
 if(mx>0)h+='<div class=ru-tip-row><span class=ru-tip-k>$/h \u00b7 7d</span>'
 +'<span class=ru-tip-v>peak '+fmtUsd(mx)+'/h</span></div>'
 +moneyGraph(wk,'#9cd2ff',series.h0+st);}
+if(sAt)h+='<div class=ru-tip-age>last charge recorded '+fmtAgo(sAt)+'</div>';
 return h+'</div>';}
 function tipHTML(){var sets=LAST||[];if(!sets.length)return '';
 var many=sets.length>1;
@@ -24035,13 +24060,15 @@ var blocks=sets.map(function(e){return setHTML(e,many);}).filter(function(b){ret
 // return on empty blocks left the API cell with an EMPTY hover exactly when spend was all there
 // was to show (the user 2026-08-15).
 var h=blocks.length?(many?('<div class=ru-tip-cols>'+blocks.map(function(b){return '<div class=ru-tip-col>'+b+'</div>';}).join('')+'</div>'):blocks[0]):'';
+// one quiet line saying WHY some machine shows no bars (the acct line's dim dress): under key auth
+// the windows cannot arrive — absence is the designed state, not a stale read (the user 2026-08-15).
+// It sits with the WINDOWS it explains, ABOVE the spend section (the user 2026-08-24: as the tip's
+// last line it hung under the spend, which must never claim anything about rate limits).
+if(h&&sets.some(function(e){return e.det._telemUnavail;}))h+='<div class=ru-tip-acct>rate-limit telemetry unavailable under API-key auth</div>';
 // no footer hint: refresh is AUTOMATIC (the 60s pull below + the timeline's live forward), and a
 // click-me line misread on a hover surface (the user 2026-08-14) — the click stays as a manual
 // kick, it just doesn't advertise. An OPEN tip follows every data landing via renderRows.
 h+=fleetSpendHTML(sets);
-// one quiet line saying WHY there are no bars (the acct line's dim dress): under key auth the
-// windows cannot arrive — absence is the designed state, not a stale read (the user 2026-08-15)
-if(h&&sets.some(function(e){return e.det._telemUnavail;}))h+='<div class=ru-tip-acct>rate-limit telemetry unavailable under API-key auth</div>';
 return h;}
 // The tip anchors ABOVE the rail, centered on the cursor (the user 2026-08-08: it used to pin to the
 // container's RIGHT edge, nowhere near a hover on the left end of a wide multi-account rail).
@@ -24086,7 +24113,10 @@ notices(local);renderRows(rows,SELF);});}
 function pull(ack){if(_ruBusy)return;_ruBusy=true;
 if(ack){el.style.opacity='0.45';tip.style.display='none';}   // instant ack only on a real click
 var done=function(){_ruBusy=false;el.style.opacity='';};
-pullFleet().then(done,done);}
+// a FAILED pull re-renders from the cached rows (the user 2026-08-24, fail loudly): the age lines
+// are computed at render time, so repainting makes "updated/recorded … ago" keep climbing — a dead
+// kernel route shows visibly aging data, never a frozen "3m ago" that quietly lies for hours
+pullFleet().then(done,function(){if(ROWS.length)renderRows(ROWS,SELF);done();});}
 el.addEventListener('click',function(){pull(true);});
 setInterval(function(){pull(false);},60000);     // backup auto-refresh: re-read usage.json every 60s
 pull(false);                                     // fill on load, independent of the timeline-forward path

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -86,6 +86,24 @@ class RailUsage(unittest.TestCase):
         # and drops the old explanatory prose ("...rate-limit window") — no extra stuff
         self.assertNotIn("rate-limit window", self.html, "no explanatory prose, just the bars + %")
 
+    def test_the_spend_section_owns_its_age_and_never_speaks_for_rate_limits(self):
+        # Three pins from one screenshot (the user 2026-08-24, "updated 9h 38m ago" over the spend):
+        # 1. the telemetry-unavailable note sits with the WINDOWS it explains, ABOVE the spend
+        #    section — the spend section never claims anything about rate limits;
+        # 2. the spend section ends with its OWN age line, from the newest contributor's
+        #    last-record moment (event time, not a poll time);
+        # 3. a FAILED fleet pull re-renders from the cached rows, so every age line keeps climbing
+        #    instead of freezing at a quietly lying "3m ago".
+        note = self.html.index("rate-limit telemetry unavailable under API-key auth")
+        self.assertLess(note, self.html.index("h+=fleetSpendHTML(sets);"),
+                        "the note renders BEFORE the spend section, in the windows area")
+        self.assertIn("if(sAt)h+='<div class=ru-tip-age>last charge recorded '+fmtAgo(sAt)+'</div>';", self.html)
+        self.assertIn("if(typeof u.spendAt==='number')det._spendAt=u.spendAt;", self.html)
+        self.assertIn("pullFleet().then(done,function(){if(ROWS.length)renderRows(ROWS,SELF);done();});", self.html)
+        # the kernel side: the payload stamps spend.json's own mtime on both spend-attaching arms
+        ksrc = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertEqual(ksrc.count('out["spendAt"] = sa'), 2, "the key-only arm and the mixed-host arm")
+
     def test_the_tooltip_shows_the_snapshots_age(self):
         # "updated ... ago" (the user 2026-07-02): the bars lagged the CLI's own /usage with no cue the reading
         # was old — usage.json refreshes only when a statusline render or a rate-limit event produces a NEW

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -142,6 +142,42 @@ class ApiKeyHostReportsSpend(unittest.TestCase):
     def test_nothing_recorded_still_answers_none(self):
         self.assertIsNone(km._usage(), "a fresh box with neither login nor spend has nothing to show")
 
+    def test_spend_carries_its_own_freshness_stamp(self):
+        # the user 2026-08-24: the windows' "updated 9h 38m ago" (usage.json's t — which nothing
+        # writes under key auth) sat directly above the spend section and read as the spend's age.
+        # The payload now stamps the spend's OWN last-record moment: spend.json's mtime, an event
+        # time (the recorder writes per turn result), so the hover can say when the last charge
+        # actually landed — and a frozen number visibly ages instead of hiding behind the windows.
+        hour_key = time.strftime("%Y-%m-%dT%H")
+        p = jd.STATE / "spend.json"
+        p.write_text(json.dumps({"hours": {hour_key: {"usd": 1.0, "turns": 1, "tok": 5}},
+                                 "days": {time.strftime("%Y-%m-%d"): {"usd": 1.0, "turns": 1, "tok": 5}}}))
+        os.utime(p, (1000000000, 1000000000))
+        u = km._usage()
+        self.assertEqual(u.get("spendAt"), 1000000000, "the stamp is the record file's own mtime")
+
+    def test_view_and_tag_state_never_filters_the_spend_aggregation(self):
+        # the user 2026-08-24 asked whether hidden/tagged sessions count toward the spend. They MUST:
+        # the series is machine-level API-key billing, recorded per turn result before any view
+        # exists, and read straight from spend.json's buckets. This pins that a views blob hiding
+        # and tagging everything changes NOTHING about the sums — if a view/tag filter ever leaks
+        # into the aggregation, this breaks.
+        hour_key = time.strftime("%Y-%m-%dT%H")
+        (jd.STATE / "spend.json").write_text(json.dumps({
+            "hours": {hour_key: {"usd": 7.5, "turns": 3, "tok": 30}},
+            "days": {time.strftime("%Y-%m-%d"): {"usd": 7.5, "turns": 3, "tok": 30}}}))
+        before = km._usage()
+        (jd.STATE / "timeline-views.json").write_text(json.dumps({
+            "active": "g1", "hidden": ["11111111-2222-3333-4444-555555555555"],
+            "tags": [{"id": "g1", "name": "workers", "color": "#DD42FF",
+                      "members": ["22222222-3333-4444-5555-666666666666"]}]}))
+        km._flags_cache.clear()
+        after = km._usage()
+        self.assertEqual(after["spend"], before["spend"],
+                         "hiding/tagging sessions must never change the billed sums")
+        self.assertEqual(after["spendSeries"], before["spendSeries"],
+                         "…or the $/h series behind the graph")
+
 
 class RemoteUsageStaleness(unittest.TestCase):
     def test_an_answered_empty_payload_clears_instead_of_freezing(self):


### PR DESCRIPTION
## What (three asks from one screenshot, the user 2026-08-24)

1. **Footnote**: "rate-limit telemetry unavailable under API-key auth" now renders with the window columns it explains, **above** the spend section — the spend section never claims anything about rate limits.
2. **Staleness root cause**: a stamp lying by position, not a dead refresher. The "updated 9h 38m ago" was the rate-limit windows' stamp (usage.json's `t` — which nothing writes under key auth, and which sleeps with login machines overnight) sitting directly over the spend section. Spend recording is already event-based (per turn result) and already restart-armed (each new CLI process resets the cumulative-cost watermark — pinned in `test_sdk_backend`). Fixes: the payload stamps the spend's **own** last-record moment (spend.json mtime, an event time) on both spend-carrying arms; the spend section ends with "last charge recorded Xm ago"; a **failed** fleet pull re-renders from cached rows so age lines keep climbing instead of freezing at a quietly lying "3m ago". The residual under-report is structural and now visible instead of silent: a turn killed mid-flight by a kernel restart loses its ResultMessage — the only carrier of cost.
3. **Pin**: hidden/tagged sessions **do** count toward the spend (machine-level billing, recorded before any view exists, read straight from spend.json buckets — no view filtering anywhere in the pipeline). A new test seeds spend, then hides and tags everything, and asserts the sums and $/h series byte-identical.

## Tests

- `tests/test_usage_series.py::ApiKeyHostReportsSpend::test_spend_carries_its_own_freshness_stamp` and `::test_view_and_tag_state_never_filters_the_spend_aggregation`.
- `tests/test_kernel_rail_usage.py::…::test_the_spend_section_owns_its_age_and_never_speaks_for_rate_limits` (note-before-spend ordering, the age line, the failure re-render, both kernel stamp arms).
- Full suites green: 5360 python tests (+281 subtests), 2272 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)