### PR TITLE
The comment mark stays green from send to landed reply — keyed on the exchange, not the CLI boot wobble

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { threadsByAnchor, threadBusy, threadStuck, findExact, findAnchorRange, sliceRanges, prunePending,
+import { threadsByAnchor, threadBusy, threadStuck, threadInFlight, replyOwed, findExact, findAnchorRange, sliceRanges, prunePending,
          type CommentThread } from "./comments";
 
 const th = (over: Partial<CommentThread>): CommentThread => ({
@@ -373,12 +373,12 @@ test("while the thread is WRITING the passage holds the await-green tint and NOT
   // the user 2026-08-24 (superseding 2026-08-23's tick-crawl compromise): the in-flight cue is the
   // await-green STATE COLOR on the passage itself — its own new-test block below pins the colors;
   // this one keeps the class wiring and holds the line on motion: no strips, no keyframes, anywhere.
-  assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
+  assert.match(UI, /m\.classList\.toggle\("busy", commentInFlight\(th\)\);/);
   assert.doesNotMatch(CSS, /mark\.cmt-hl\.busy \{[^}]*repeating-linear-gradient/s, "no strips on prose");
   assert.doesNotMatch(CSS, /@keyframes cmt-ants /, "the passage keyframes stay gone");
   assert.doesNotMatch(CSS, /@keyframes cmt-tick-ants/, "…and the tick's miniature march followed them out");
-  assert.match(UI, /\+ \(threadBusy\(th\.state\) && th\.status === "open" \? " busy" : ""\);/);
-  assert.match(UI, /\+ ":" \+ \(threadBusy\(t\.th\.state\) \? 1 : 0\)\)/, "a state flip re-renders the tick");
+  assert.match(UI, /\+ \(commentInFlight\(th\) \? " busy" : ""\);/);
+  assert.match(UI, /\+ ":" \+ \(commentInFlight\(t\.th\) \? 1 : 0\)\)/, "an in-flight flip re-renders the tick");
 });
 
 test("the popover renders the thread with the CHAT's own renderer from the branch point", () => {
@@ -458,4 +458,27 @@ test("the popover's typing dots are retired — the green highlight is the only 
   assert.doesNotMatch(UI, /cmt-dots/);
   assert.doesNotMatch(CSS, /cmt-dots|cmt-dot-pulse/);
   assert.match(UI, /the pending bubble IS the acknowledgement/);
+});
+
+// ── the in-flight color keys on the EXCHANGE, not the worker session's state (the user 2026-08-24,
+// second report): create → green for a second → YELLOW while the thread CLI booted (its live state
+// read idle) → green once generation started. The exact reported sequence, executed: ─────────────
+test("the mark stays green from send to landed reply, through the CLI-boot state wobble", () => {
+  const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
+  // 1) optimistic create: a synthetic working thread — green
+  assert.ok(threadInFlight(th({ state: "working", msgs: [] })), "optimistic create reads in-flight");
+  // 2) the kernel's frame replaces it mid-boot: state idle/empty, the comment is the newest message —
+  //    the reply is OWED, so STILL green (this is the wobble that flashed yellow)
+  assert.ok(threadInFlight(th({ state: "", msgs: [msg("you")] })), "boot window: owed reply keeps it green");
+  // 3) the reply lands: agent message newest, state settled — yellow
+  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you"), msg("agent")] })), "landed reply settles to yellow");
+  // 4) a follow-up from the user re-arms it
+  assert.ok(threadInFlight(th({ state: "", msgs: [msg("you"), msg("agent"), msg("you")] })), "a follow-up re-owes");
+  // live work still counts even with the agent's message newest (a continuing turn)
+  assert.ok(threadInFlight(th({ state: "working", msgs: [msg("you"), msg("agent")] })));
+  // …but never on a blocked, errored, or closed thread — green must not lie
+  assert.ok(!threadInFlight(th({ state: "permission", msgs: [msg("you")] })), "a stuck reply is NOT on the way");
+  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)), "errored: the note speaks, not the green");
+  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], status: "resolved" })), "resolved threads are done");
+  assert.equal(replyOwed(th({ msgs: [] })), false, "an empty thread owes nothing");
 });

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -44,6 +44,23 @@ export function threadBusy(state: string): boolean {
 
 /** The thread session is stuck on an interactive prompt the popover can't answer — say so, and point
  *  at Break out (a full session can). */
+// A reply is OWED the moment the user's message is the thread's newest with no agent reply landed
+// since (the user 2026-08-24, second report: the mark flashed green on create, dropped to YELLOW
+// while the thread CLI was still booting — its live state read idle, a flapping boot-time proxy —
+// then went green again once generation started). The in-flight color keys on the EXCHANGE's own
+// events: user message in → green until the reply message lands, however the worker session's state
+// wobbles on the way. The find-the-event rule, applied to a color.
+export function replyOwed(th: CommentThread): boolean {
+  const last = th.msgs.length ? th.msgs[th.msgs.length - 1] : null;
+  return !!last && last.who === "you";
+}
+// The ONE in-flight predicate every busy surface reads (the passage mark, the rail tick): live work
+// OR an owed reply, on an open, non-errored thread that isn't blocked on the user — a stuck thread's
+// reply is NOT on the way, and green would lie.
+export function threadInFlight(th: CommentThread): boolean {
+  return th.status === "open" && !th.error && !threadStuck(th.state)
+    && (threadBusy(th.state) || replyOwed(th));
+}
 export function threadStuck(state: string): boolean {
   return state === "permission" || state === "picker";
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -44,7 +44,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
-import { threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { threadInFlight, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -5722,6 +5722,10 @@ function showForkPrompt(sid: string, uuid: string): void {
 // re-render (the transcript rebuilds constantly) reapplies it — the openFolds pattern.
 const commentThreads = new Map<string, CommentThread[]>();          // parent sid → last frame's threads
 const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
+// the one busy answer for the mark + rail tick: the pure predicate, plus this pane's own optimistic
+// sends (a reply just typed, frame echo still in flight) — see comments.ts replyOwed for the why
+const commentInFlight = (th: CommentThread): boolean =>
+  threadInFlight(th) || (th.status === "open" && !!(commentPending.get(th.tid) || []).length);
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
 let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
@@ -5895,7 +5899,7 @@ function updateCommentRail(): void {
   }
   const sig = activeId + "|" + Math.round(r.top) + "," + Math.round(r.right) + "," + Math.round(r.height)
     + "|" + ticks.map((t) => t.th.tid + ":" + t.y + ":" + t.th.status + ":" + (t.th.unread ? 1 : 0)
-                            + ":" + (threadBusy(t.th.state) ? 1 : 0)).join(",");
+                            + ":" + (commentInFlight(t.th) ? 1 : 0)).join(",");
   if (sig === cmtRailSig && rail) return;
   cmtRailSig = sig;
   if (!rail) { rail = el("div", "cmt-rail"); rail.id = "cmt-rail"; document.body.appendChild(rail); }
@@ -5904,7 +5908,7 @@ function updateCommentRail(): void {
   rail.style.height = r.height + "px";
   const cls = (th: CommentThread) => "cmt-tick" + (th.status === "resolved" || th.status === "merged" ? " resolved" : "")
     + (th.unread && th.status === "open" ? " unread" : "")
-    + (threadBusy(th.state) && th.status === "open" ? " busy" : "");   // the crawl rides the tick (2026-08-23)
+    + (commentInFlight(th) ? " busy" : "");   // green while working OR a reply is owed (2026-08-24)
   const kids = Array.from(rail.children) as HTMLElement[];
   if (kids.length === ticks.length && kids.every((k, i) => k.dataset.tid === ticks[i].th.tid)) {
     ticks.forEach((t, i) => { kids[i].style.top = t.y + "px"; kids[i].className = cls(t.th); });
@@ -5990,7 +5994,7 @@ function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
 function styleCommentMark(m: HTMLElement, th: CommentThread): void {
   m.classList.toggle("resolved", th.status === "resolved" || th.status === "merged");
   m.classList.toggle("unread", !!th.unread && th.status === "open");
-  m.classList.toggle("busy", threadBusy(th.state) && th.status === "open");
+  m.classList.toggle("busy", commentInFlight(th));
   m.title = th.status === "promoted" ? "thread, now the session '" + th.promotedName + "'"
     : th.status === "merged" ? "merged thread: its outcome was folded back into the session"
     : th.status === "resolved" ? "resolved thread: click to read or reopen"


### PR DESCRIPTION
## What

The user's live check caught a gap in the await-green pass: creating a comment flashed green (the optimistic working thread), flipped **yellow while the reply was still coming**, then went green again once generation started. The busy color keyed on the thread session's live state (`threadBusy(th.state)`) — a proxy that reads idle through the thread CLI's boot window. The find-the-event rule, applied to a color: the event the proxy was approximating is **a reply is owed** — the user's message is the thread's newest and no agent reply has landed since.

- `comments.ts` exports `replyOwed(th)` (msgs-tail, pure) and `threadInFlight(th)` = open && !error && !stuck && (live work || owed).
- `render.ts` reads one predicate (`commentInFlight` — the pure one plus this pane's optimistic pending sends) at all three busy sites: the passage mark, the rail tick's class, and the tick's re-render signature.
- A stuck thread stays un-green (its reply is NOT on the way — the popover's note speaks); errored/resolved/merged never green.

## Tests

The exact reported sequence is executed in `comments.test.ts` ("the mark stays green from send to landed reply, through the CLI-boot state wobble"): optimistic create → in-flight; the kernel's frame replacing it mid-boot (state empty, comment newest) → still in-flight; reply landed → settled to yellow; a follow-up re-owes; stuck/errored/resolved never green. The three call-site pins retargeted. 2280 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)