### PR TITLE
A view change that excludes the active session converts it into the peek, never a bounce

### DIFF
--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -30,6 +30,22 @@ test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no
   const writers = RENDER.match(/peekId = /g) || [];
   assert.equal(writers.length, 2, "peekId writers: assertPeekFor and dismissSession — nothing else (send never pins; the typed declaration matches separately)");
   assert.match(RENDER, /let peekId: string \| null = null;/);
+  // …and the DERIVATION call sites, each named (the census, extended 2026-08-24 with the two
+  // views-arrival paths): setActive (every activation), the focus fast path (already-active),
+  // captureViews (kernel-pushed views), postViews (local optimistic edit). Nothing else derives.
+  const sites = RENDER.match(/assertPeekFor\(/g) || [];
+  assert.equal(sites.length, 5, "definition + 4 call sites: setActive, focus fast path, captureViews, postViews");
+});
+
+test("a view change that excludes the ACTIVE session converts it into the peek — never a bounce (the user 2026-08-24)", () => {
+  // both views-arrival paths re-derive the active session's peek: the kernel-pushed blob…
+  assert.match(RENDER, /pendingSessionViews = null; pendingViewsAge = 0;\s*\n\s*\}[\s\S]{0,700}?if \(activeId\) assertPeekFor\(activeId\);\s*\n\}/);
+  // …and the local optimistic edit, BEFORE its renderTabs so the repaint sees the fresh peek state
+  assert.match(RENDER, /pendingSessionViews = v; pendingViewsAge = 0;\s*\n\s*if \(activeId\) assertPeekFor\(activeId\);[\s\S]{0,200}?renderTabs\(\);/);
+  // the derivation is symmetric, so a view that now INCLUDES the active peek sheds the dress — the
+  // same next-null branch the auto-close pin above holds; and the fallback's fire-time revalidation
+  // (below) re-checks tabInView, so a converted peek can never be bounced by an in-flight timeout
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/);
 });
 
 test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands in setActive, re-deriving peek", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -466,9 +466,19 @@ function captureViews(v: SessionViews | null) {
   if (pendingSessionViews && ((v && viewsKey(v) === viewsKey(pendingSessionViews)) || ++pendingViewsAge >= 3)) {
     pendingSessionViews = null; pendingViewsAge = 0;
   }
+  // A VIEW CHANGE that excludes the ACTIVE session converts it into the peek instead of bouncing
+  // (the user 2026-08-24: open All, pick a session, re-apply the tag filter — keep reading it in
+  // the ghost dress, and it evaporates on the next tab switch). The same derivation setActive runs
+  // on activation, run here on every views arrival; symmetric, so a view that now INCLUDES the
+  // active peek sheds the dress for free. With the active session counted by tabInView as the peek,
+  // the deferred first-tab bounce never fires (its fire-time revalidation re-checks tabInView).
+  if (activeId) assertPeekFor(activeId);
 }
+// (postViews below runs the same re-derivation for the LOCAL optimistic edit — both views-arrival
+// paths keep the active session's peek state current.)
 function postViews(v: SessionViews) {
   pendingSessionViews = v; pendingViewsAge = 0;
+  if (activeId) assertPeekFor(activeId);   // the optimistic edit re-derives the active session's peek too
   if (vscodeApi) vscodeApi.postMessage({ type: "setTimelineViews", views: v });
   renderTabs();
 }


### PR DESCRIPTION
## What

The user's flow: open All, pick a session, re-apply the tag filter — keep reading it in the ghost dress, and have it evaporate on the next tab switch. Today the first-tab fallback bounced them off the session when the filter applied.

One move, as scoped: the peek derivation ran only on **activation** (setActive + the focus fast path). It now also runs for the **active session on every views arrival** — the kernel-pushed blob (`captureViews`, after the pending-edit aging so it reads the settled `effViews()`) and the local optimistic edit (`postViews`, before its `renderTabs` so the repaint sees the fresh peek state). The derivation is symmetric, so a view that now **includes** the active peek sheds the dress for free. With the active session counted by `tabInView` as the peek, the deferred first-tab bounce never fires — its fire-time revalidation re-checks `tabInView`.

Every existing peek guarantee holds: auto-close on activating another tab, send never pins, nav-history stores only the sid, cascade order untouched, no views-blob writes from any of this.

## Verification

Headless through the exact flow (playwright over the built bundle): S2 active under All → the untagged filter excludes it → **stays selected wearing `.tab-peek`** through a 300ms window covering the deferred bounce → the view re-including it sheds the dress in place → re-excluded, then clicking another tab evaporates it from the strip entirely. (First harness run used a tag under All and correctly produced no peek — under the true-All semantics only `hidden` hides there; the flow's real exclusion is a tag/untagged view, and the fixture was fixed, not the code.)

## Tests

`peek-tab.test.ts`: new "a view change that excludes the ACTIVE session converts it into the peek — never a bounce" (both arrival paths, plus the fire-time revalidation pin); the writer census deliberately extended — still exactly two `peekId` writers (assertPeekFor, dismissSession), now four named derivation call sites (setActive, focus fast path, captureViews, postViews). Existing peek suite green unchanged. Full suite: 2281 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)