### PR TITLE
Hover-freeze: a feed card under the pointer never moves; deferred churn hints +N/-N

### DIFF
--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -1,0 +1,122 @@
+// HOVER-FREEZE (the user 2026-08-24): a feed card under the pointer must never move on screen.
+// While a card is hovered, incoming feed payloads QUEUE (newest wins) instead of rendering; the
+// deferred churn hints as +N/-N beside the column pills and (grouped) the session headers; the
+// hovered card's mouseleave flushes everything at once, window blur is the backstop — no timers.
+// The counting rule EXECUTES here (feed-freeze.ts is pure); the feed wiring is source-pinned
+// (feed.ts has no jsdom harness — the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { freezeDiff } from "./feed-freeze";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+const it = (id: string, col: string, sid = "s1") => ({ id, col, sid });
+
+test("freezeDiff counts arrivals and departures per column and per session", () => {
+  const d = freezeDiff(
+    [it("a", "asks"), it("b", "completed"), it("c", "needsInput", "s2")],
+    [it("a", "asks"), it("d", "completed"), it("e", "completed", "s2")],
+  );
+  assert.deepEqual(d.cols.completed, { add: 2, del: 1 });
+  assert.deepEqual(d.cols.needsInput, { add: 0, del: 1 });
+  assert.equal(d.cols.asks, undefined, "an unmoved card counts nothing");
+  assert.deepEqual(d.sess.s1, { add: 1, del: 1 });
+  assert.deepEqual(d.sess.s2, { add: 1, del: 1 });
+  assert.ok(d.any);
+});
+
+test("a column move is one departure + one arrival — it leaves one header and joins another", () => {
+  const d = freezeDiff([it("a", "asks")], [it("a", "completed")]);
+  assert.deepEqual(d.cols.asks, { add: 0, del: 1 });
+  assert.deepEqual(d.cols.completed, { add: 1, del: 0 });
+  assert.deepEqual(d.sess.s1, { add: 1, del: 1 }, "grouped mode groups per column, so the run moves too");
+});
+
+test("identical views count nothing — in-place content edits are not movement", () => {
+  const d = freezeDiff([it("a", "asks"), it("b", "completed")], [it("a", "asks"), it("b", "completed")]);
+  assert.equal(d.any, false);
+  assert.deepEqual(d.cols, {});
+  assert.deepEqual(d.sess, {});
+});
+
+test("the feed payload path defers while a card is hovered — and ONLY the payload path", () => {
+  // the message handler's feed branch gates on the freeze; the newest payload supersedes by overwrite
+  assert.match(FEED, /if \(freezeKey\) \{ pendingFeedPayload = m; paintFreezeBadges\(\); return; \}\s*\n\s*applyFeedPayload\(m\);/);
+  const queues = FEED.match(/pendingFeedPayload = m;/g) || [];
+  assert.equal(queues.length, 1, "one queue write, in the payload path — local gestures and render() are never gated");
+  assert.doesNotMatch(FEED, /function render\(\) \{\s*\n[^\n]*freezeKey/, "render is not gated — the hovered card's controls stay live");
+  // one body, two callers: live application and the flush
+  assert.match(FEED, /function applyFeedPayload\(m: any\): void \{/);
+  assert.match(FEED, /if \(m\) applyFeedPayload\(m\);/, "flush applies the newest queued payload");
+});
+
+test("flush is event-based: card mouseleave, window blur backstop — no timers anywhere in the freeze", () => {
+  assert.match(FEED, /function freezeLeave\(key: string\): void \{\s*\n\s*if \(freezeKey !== key\) return;\s*\n\s*freezeKey = null;\s*\n\s*flushFreeze\(\);/);
+  assert.match(FEED, /window\.addEventListener\("blur", \(\) => \{ freezeKey = null; flushFreeze\(\); \}\);/);
+  const block = FEED.slice(FEED.indexOf("// ── HOVER-FREEZE"), FEED.indexOf("function applyFeedPayload"));
+  assert.ok(!/setTimeout|setInterval/.test(block), "no timers — mouseleave and blur are the flush events");
+  // the flush is a MICROTASK — same gesture, after its handlers finish (found in review 2026-08-24:
+  // the clear path's synthetic mouseleave used to re-render the board under the rest of its own
+  // click handler, before pendingCleared.add ran). Ordering, not a time window.
+  assert.match(FEED, /queueMicrotask\(\(\) => \{/);
+  assert.match(FEED, /if \(freezeKey\) return; \/\/ re-armed before the tick ended → keep the queue for the next leave/);
+});
+
+test("a local render that detaches or re-keys the hovered element heals the freeze (:hover truth)", () => {
+  // found in review 2026-08-24: a removed element never fires mouseleave — typing in search can
+  // filter the hovered card out, and toggling Group swaps it for a group card in place with no
+  // enter/leave events. The render tail checks live pointer truth per render — event-based.
+  assert.match(FEED, /const hov = document\.querySelector<HTMLElement>\("\.feed-cols \.fitem:hover"\);/);
+  assert.match(FEED, /if \(!hov\) \{ freezeKey = null; flushFreeze\(\); \}/);
+  assert.match(FEED, /else \{ const k = kbHoverId\(hov\); if \(k && k !== freezeKey\) freezeKey = k; \}/,
+    "a re-keyed card under a stationary pointer re-arms to the element actually hovered");
+});
+
+test("the badge hint mirrors the optimistic-restore overlay — a card the flush restores is no departure", () => {
+  // found in review 2026-08-24: the displayed board holds a pendingRestored card the queued payload
+  // lacks; without the mirror the badge promised a -1 that the flush immediately took back
+  const pv = FEED.slice(FEED.indexOf("function payloadView"), FEED.indexOf("function paintFreezeParts"));
+  assert.ok(pv.includes(
+    "for (const it of pendingRestored.values()) if (!present.has(it.itemId) && !inIncoming.has(it.itemId)) out.push(it);"),
+    "exact mirror: an entry the payload itself carries is the flush's to drop, not the hint's to re-add");
+  assert.ok(!pv.includes("pendingRestored.delete"), "read-only — the flush re-runs the real bookkeeping");
+});
+
+test("both card shapes arm the freeze on the same events the hover highlight rides", () => {
+  assert.match(FEED, /freezeEnter\(it\.itemId\);\s*[^\n]*\n\s*if \(it\.provisional\) return;/, "ask cards enter before the provisional bail");
+  assert.match(FEED, /freezeLeave\(it\.itemId\);/, "ask cards flush on leave");
+  assert.match(FEED, /freezeEnter\(fkey\);/, "group cards enter");
+  assert.match(FEED, /freezeLeave\(fkey\);/, "group cards flush on leave");
+  // a card CLEARED under the pointer flushes via its synthetic mouseleave — the existing dispatch
+  // (feed.ts's clear paths) runs the exact leave logic, freezeLeave included
+  assert.match(FEED, /card\.dispatchEvent\(new MouseEvent\("mouseleave"\)\);/);
+});
+
+test("the badge hint counts the USER'S view and never mutates state computing it", () => {
+  // render and the painter share one view filter, so the hint counts exactly what would move
+  assert.match(FEED, /function viewFiltered\(list: AskItem\[\]\): AskItem\[\]/);
+  assert.match(FEED, /let shown = viewFiltered\(asks\);/);
+  assert.match(FEED, /const d = freezeDiff\(toItems\(asks\), toItems\(payloadView\(pendingFeedPayload\)\)\);/);
+  // payloadView reads pendingCleared but must not write it (the flush re-runs the real bookkeeping)
+  const pv = FEED.slice(FEED.indexOf("function payloadView"), FEED.indexOf("function paintFreezeParts"));
+  assert.ok(!pv.includes("pendingCleared.delete") && !pv.includes("pruneViewStateTo"),
+    "the hint path is side-effect free");
+});
+
+test("badges wear the header conventions: accent adds, block-red removes, the count's own scale", () => {
+  assert.match(CSS, /\.freeze-badge \{ font-weight: 600; opacity: 0\.7; margin-left: 6px; white-space: nowrap; \}/);
+  assert.match(CSS, /\.freeze-badge \.fz-add \{ color: var\(--accent\); \}/, "never a re-hardcoded accent hex");
+  assert.match(CSS, /\.freeze-badge \.fz-del \{ color: var\(--err\); \}/, "the board's existing block red");
+  assert.doesNotMatch(CSS, /\.freeze-badge[^}]*font-size/, "no new font sizes — the badge inherits the head's scale");
+  // painted on the build-once column heads and the data-fsid-stamped session headers; cleared when quiet
+  assert.match(FEED, /put\(document\.querySelector\("\.feed-col\.col-" \+ key \+ " \.feed-col-head"\), d\.cols\[key\]\);/);
+  assert.match(FEED, /h\.setAttribute\("data-fsid", e\.sid\);/);
+  assert.match(FEED, /put\(h, groupedNow \? d\.sess\[h\.getAttribute\("data-fsid"\) \|\| ""\] : undefined\);/);
+  assert.match(FEED, /document\.querySelectorAll\("\.freeze-badge"\)\.forEach\(\(n\) => n\.remove\(\)\);/,
+    "nothing pending → every badge comes off");
+  // local renders while frozen re-sync the hints, so a rebuilt board never strands a stale count
+  assert.match(FEED, /paintFreezeBadges\(\);   \/\/ hover-freeze: local renders while frozen re-sync/);
+});

--- a/ui/webview/feed-freeze.ts
+++ b/ui/webview/feed-freeze.ts
@@ -1,0 +1,42 @@
+// HOVER-FREEZE (the user 2026-08-24): while the pointer rests on a card, the board must not move
+// under it — incoming feed payloads queue in feed.ts instead of rendering, and the deferred churn
+// surfaces as a subtle "+N/-N" hint beside the column pills (and the session headers in grouped
+// mode). The pure counting lives here so node --test executes the rule without a DOM: given the
+// DISPLAYED view and the QUEUED payload's would-be view (both already view-filtered by the caller),
+// count per-column and per-session arrivals and departures. A card present in both views in the
+// same column counts nothing — the badge hints at deferred MOVEMENT, not content edits.
+
+export type FreezeItem = { id: string; col: string; sid: string };
+export type FreezeCount = { add: number; del: number };
+export type FreezeCounts = {
+  cols: Record<string, FreezeCount>;
+  sess: Record<string, FreezeCount>;
+  any: boolean;
+};
+
+export function freezeDiff(displayed: FreezeItem[], pending: FreezeItem[]): FreezeCounts {
+  const cols: Record<string, FreezeCount> = {};
+  const sess: Record<string, FreezeCount> = {};
+  const at = (m: Record<string, FreezeCount>, k: string) => (m[k] ??= { add: 0, del: 0 });
+  const dById = new Map(displayed.map((d) => [d.id, d] as const));
+  const pById = new Map(pending.map((p) => [p.id, p] as const));
+  let any = false;
+  for (const p of pending) {
+    const d = dById.get(p.id);
+    if (!d) {
+      at(cols, p.col).add++; at(sess, p.sid).add++; any = true;
+    } else if (d.col !== p.col) {
+      // a column MOVE leaves one header and arrives at another — one del + one add, and the same
+      // for its session (grouped mode groups per column, so the run moves too)
+      at(cols, d.col).del++; at(cols, p.col).add++;
+      at(sess, d.sid).del++; at(sess, p.sid).add++;
+      any = true;
+    }
+  }
+  for (const d of displayed) {
+    if (!pById.has(d.id)) {
+      at(cols, d.col).del++; at(sess, d.sid).del++; any = true;
+    }
+  }
+  return { cols, sess, any };
+}

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -38,7 +38,10 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
   assert.ok(FEED.includes("let feedOnlySid: string | null = null;"));
   assert.ok(FEED.includes('sessionStorage.getItem("romp:feedOnly")'),
     "survives this tab's reloads only — a fresh window always starts unfiltered");
-  assert.ok(FEED.includes("let shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;"));
+  // the filter chain lives in viewFiltered now (hover-freeze 2026-08-24: the deferred-churn badge
+  // painter must count exactly what the user sees, so render and the painter share one view)
+  assert.ok(FEED.includes("let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list;"));
+  assert.ok(FEED.includes("let shown = viewFiltered(asks);"), "render reads the shared view");
   // (`let`, since 2026-08-23: the SEARCH filter composes onto the same render-side view — see feed-search.test.ts)
   assert.ok(FEED.includes("for (const a of shown) {"), "the group-fold loop reads the filtered view");
   assert.ok(FEED.includes("for (const a of shown) { if (grouped.has(a.itemId)) continue;"), "…and the singles loop");

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -122,6 +122,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   color: var(--dim); background: var(--bg);
 }
 .feed-col-count { font-weight: 600; opacity: 0.7; }
+/* HOVER-FREEZE badges (the user 2026-08-24): while the pointer holds a card still, the deferred
+   adds/removes hint beside the column pill and (grouped mode) the session header — +N in the romp
+   accent, -N in the block red (--err, the board's existing red), at the count's own scale and
+   weight (no new font sizes; the badge inherits the head's size like .feed-col-count does).
+   A hint, not a shout: same 0.7 opacity as the counts. */
+.freeze-badge { font-weight: 600; opacity: 0.7; margin-left: 6px; white-space: nowrap; }
+.freeze-badge i { font-style: normal; }
+.freeze-badge .fz-add { color: var(--accent); }
+.freeze-badge .fz-del { color: var(--err); }
 /* margin-top, NOT header padding: the liveness rings are outlines drawn ~2.5px
    OUTSIDE the first card's top edge, and the sticky header paints its padding as
    opaque background over them — only unpainted margin space lets them show */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -10,6 +10,7 @@ import { distillText, distillInputs, applyDistillLine, distillPending, distillSt
 import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
+import { freezeDiff } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
@@ -1124,6 +1125,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // clear if none pinned.
   let hoverTimer: number | undefined;
   card.addEventListener("mouseenter", () => {
+    freezeEnter(it.itemId);                            // hover-freeze: pointer truth, no debounce
     if (it.provisional) return;                        // no timeline path for a placeholder
     hoverTimer = window.setTimeout(() => {
       hoverTimer = undefined;
@@ -1132,6 +1134,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     }, 120);
   });
   card.addEventListener("mouseleave", () => {
+    freezeLeave(it.itemId);                            // hover-freeze: leaving the card flushes queued payloads
     if (hoverTimer) { clearTimeout(hoverTimer); hoverTimer = undefined; }
     if (hoverAskId === it.itemId) {
       hoverAskId = null; applyFocus();
@@ -2125,6 +2128,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
   // (first member). leave → restore the pin (ask OR group) or clear.
   let hoverTimer: number | undefined;
   card.addEventListener("mouseenter", () => {
+    freezeEnter(fkey);                                 // hover-freeze: pointer truth, no debounce
     hoverTimer = window.setTimeout(() => {
       hoverTimer = undefined;
       hoverAskId = fkey; applyFocus();
@@ -2132,6 +2136,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     }, 120);
   });
   card.addEventListener("mouseleave", () => {
+    freezeLeave(fkey);                                 // hover-freeze: leaving the card flushes queued payloads
     if (hoverTimer) { clearTimeout(hoverTimer); hoverTimer = undefined; }
     if (hoverAskId === fkey) {
       hoverAskId = null; applyFocus();
@@ -3041,6 +3046,7 @@ function makeSessHead(): HTMLElement {
   return h;
 }
 function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
+  h.setAttribute("data-fsid", e.sid);   // the hover-freeze badge painter finds headers by sid
   const nm = (h as any)._name as HTMLElement;
   nm.replaceChildren(...hostNameNodes(e.name, e.sid));
   if (e.color) nm.style.color = e.color.bg;
@@ -3799,6 +3805,19 @@ function paintJudgeLimit(): void {
   b.style.display = "";
 }
 
+// The render's display-side view: the footer session filter (the user 2026-08-08 — display-side
+// only, `asks` stays complete so flipping it needs no kernel round-trip) composed with the search
+// query (the user 2026-08-23 — a card passes when its session's meta name matches OR its own
+// per-card label does, so a just-died session's cards keep matching after the meta list drops it).
+// Shared by render() and the hover-freeze badge painter, so the deferred-churn hint counts exactly
+// what the user would see move.
+function viewFiltered(list: AskItem[]): AskItem[] {
+  let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list;
+  const sMatch = searchSids(feedSearchQ, sessionsMeta);
+  if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
+  return shown;
+}
+
 function render() {
   const list = document.getElementById("feed-list")!;
   pruneAgeTip();   // drop the tip only if the render tore its hovered stamp out (see pruneAgeTip)
@@ -3837,15 +3856,9 @@ function render() {
 
   const cols = ensureCols(list);
   const buckets: Record<Column, Entry[]> = { asks: [], needsInput: [], completed: [] };
-  // The footer session filter (the user 2026-08-08): with a session picked, the board draws ONLY its
-  // cards. Display-side only — `asks` stays complete, so flipping the filter needs no kernel round-trip
-  // and everything else (the modal, optimistic moves, the empty check above) still sees the whole board.
-  let shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;
-  // The search query composes with the session filter, display-side like it: a card passes when its
-  // session's meta name matches OR its own per-card label does (a just-died session's cards keep
-  // matching by label after the meta list drops it).
-  const sMatch = searchSids(feedSearchQ, sessionsMeta);
-  if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
+  // The display-side view filters (session filter + search), shared with the hover-freeze badge
+  // painter so the deferred-churn hint counts exactly what the user would see move (viewFiltered).
+  let shown = viewFiltered(asks);
   // Derive sibling GROUPS at render time, keyed by the shared typed turn (turnId).
   // Only host-flagged asks (groupTitle) participate, and a turn needs ≥2 current
   // members to fold — a lone survivor (siblings cleared) renders as a single card.
@@ -3954,6 +3967,18 @@ function render() {
   for (const tid of Array.from(groupEls.keys())) if (!desired.has("g:" + tid) && undismissed(groupEls.get(tid))) { groupEls.get(tid)?.remove(); groupEls.delete(tid); }
 
   list.scrollTop = prevScroll;
+  // Stale-freeze heal (hover-freeze): a LOCAL render can detach or re-key the hovered element with
+  // no mouseleave — a removed element never fires leave events (typing in search filters the card
+  // out; toggling Group swaps the ask card for a group card in place). :hover is live pointer
+  // truth, checked per render (event-based, never a timer): no card under the pointer → the freeze
+  // is stale, clear it and flush the queue; a DIFFERENT card under the pointer (re-keyed in place,
+  // so no enter event ever fired) → re-arm to the element actually being hovered.
+  if (freezeKey) {
+    const hov = document.querySelector<HTMLElement>(".feed-cols .fitem:hover");
+    if (!hov) { freezeKey = null; flushFreeze(); }
+    else { const k = kbHoverId(hov); if (k && k !== freezeKey) freezeKey = k; }
+  }
+  paintFreezeBadges();   // hover-freeze: local renders while frozen re-sync the +N/-N hints (no-op unfrozen)
   // FLIP-across-identity: a card whose KEY is new this render (group→solo, solo→group, umbrella absorb) has no
   // First rect of its own, so the normal FLIP can't slide it. Alias it to its PREDECESSOR's rect — the card
   // key that covered one of its goals LAST render — so it glides in from where that predecessor sat instead of
@@ -4136,6 +4161,163 @@ function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[], sdk: SdkNotice
   try { localStorage.setItem(BADGE_SEEN_KEY, JSON.stringify(Array.from(active))); } catch { /* storage full */ }
 }
 
+// ── HOVER-FREEZE (the user 2026-08-24) ──────────────────────────────────────────────────────────
+// While the pointer rests on a card, the board must not move under it: incoming feed payloads QUEUE
+// (newest wins — intermediate states were never on screen, so nothing owes them an animation)
+// instead of rendering, and the deferred churn shows as a subtle +N/-N beside the column pills and,
+// in grouped mode, the session headers. Only the PAYLOAD path defers: the hovered card's own
+// controls and every local gesture still render live from the displayed model. Flush is event-based
+// (repo rule, no timers): the hovered card's mouseleave applies everything at once — a card CLEARED
+// under the pointer flushes too, via its synthetic mouseleave — and window blur is the backstop.
+let freezeKey: string | null = null;     // the hovered card's focus key, or null — pointer truth, no debounce
+let pendingFeedPayload: any = null;      // newest queued payload; older ones are superseded unseen
+function freezeEnter(key: string): void { freezeKey = key; }
+function freezeLeave(key: string): void {
+  if (freezeKey !== key) return;
+  freezeKey = null;
+  flushFreeze();
+}
+let flushQueued = false;
+function flushFreeze(): void {
+  if (flushQueued) return;
+  flushQueued = true;
+  queueMicrotask(() => {   // after the CURRENT gesture's handlers finish — a synthetic mouseleave
+    flushQueued = false;   // dispatched mid-click (the clear path) must not re-render the board under
+    //                        the rest of its own handler (pendingCleared.add, .dismissing come after
+    //                        the dispatch). Gesture-ordering, not a timer: no time window anywhere.
+    if (freezeKey) return; // re-armed before the tick ended → keep the queue for the next leave
+    const m = pendingFeedPayload;
+    pendingFeedPayload = null;
+    if (m) applyFeedPayload(m);          // render() repaints the badges away (nothing pending)
+  });
+}
+window.addEventListener("blur", () => { freezeKey = null; flushFreeze(); });   // backstop: focus left the pane
+
+// The queued payload's would-be card list — the same pre-filters applyFeedPayload will apply,
+// WITHOUT its bookkeeping side effects (a hint must never mutate pendingCleared or the disclosure
+// state; the flush re-runs the real thing).
+function payloadView(m: any): AskItem[] {
+  const incoming: AskItem[] = Array.isArray(m.asks) ? m.asks : [];
+  const only = onlyTag();
+  const vis = only ? incoming.filter((a) => matchesOnly(a.name, only)) : incoming;
+  let out = pendingCleared.size ? vis.filter((a) => !pendingCleared.has(a.itemId)) : vis;
+  // mirror the optimistic-restore overlay applyFeedPayload keeps (read-only): a restored card the
+  // flush will push right back must not hint as a departure
+  if (pendingRestored.size) {
+    const present = new Set(out.map((a) => a.itemId));
+    const inIncoming = new Set(incoming.map((a) => a.itemId));   // carried by the payload → the flush DROPS
+    out = out.slice();                                            // its overlay entry; it rides (or is filtered
+    //                                                               with) the normal path, so no re-add here
+    for (const it of pendingRestored.values()) if (!present.has(it.itemId) && !inIncoming.has(it.itemId)) out.push(it);
+  }
+  return out;
+}
+// Paint (or clear) the deferred-churn badges: +N accent / -N block-red beside each column pill, and
+// beside each on-board session header in grouped mode. Ensure-once spans on the build-once column
+// heads; session badges ride the reconciled headers (found by the data-fsid stamp) and are re-synced
+// at every render tail, so a local re-render while frozen can never strand a stale count.
+function paintFreezeParts(b: HTMLElement, c: { add: number; del: number }): void {
+  b.replaceChildren();
+  if (c.add) { const i = el("i", "fz-add"); i.textContent = "+" + c.add; b.appendChild(i); }
+  if (c.add && c.del) b.appendChild(document.createTextNode("/"));
+  if (c.del) { const i = el("i", "fz-del"); i.textContent = "-" + c.del; b.appendChild(i); }
+  b.title = "updates waiting while you hover — they apply when the pointer leaves the card";
+}
+function paintFreezeBadges(): void {
+  if (!pendingFeedPayload) {
+    document.querySelectorAll(".freeze-badge").forEach((n) => n.remove());
+    return;
+  }
+  const toItems = (list: AskItem[]) => viewFiltered(list).map((a) => ({ id: a.itemId, col: askColumn(a) as string, sid: a.sid }));
+  const d = freezeDiff(toItems(asks), toItems(payloadView(pendingFeedPayload)));
+  const put = (host: Element | null, c: { add: number; del: number } | undefined) => {
+    if (!host) return;
+    let b = host.querySelector(":scope > .freeze-badge") as HTMLElement | null;
+    if (!c || (!c.add && !c.del)) { b?.remove(); return; }
+    if (!b) { b = el("span", "freeze-badge"); host.appendChild(b); }
+    paintFreezeParts(b, c);
+  };
+  for (const key of ["asks", "needsInput", "completed"]) {
+    put(document.querySelector(".feed-col.col-" + key + " .feed-col-head"), d.cols[key]);
+  }
+  const groupedNow = feedPrefs().grouped;
+  document.querySelectorAll<HTMLElement>(".feed-sess-head").forEach((h) => {
+    put(h, groupedNow ? d.sess[h.getAttribute("data-fsid") || ""] : undefined);
+  });
+}
+
+// The feed payload's full application — model swap, bookkeeping, render. One body, two callers:
+// the message handler applies live when no card is hovered; flushFreeze applies the newest queued
+// payload when the pointer leaves (hover-freeze above).
+function applyFeedPayload(m: any): void {
+  judgeLimit = m.judgeLimit && typeof m.judgeLimit === "object"
+    ? m.judgeLimit as { bucket?: string; resets_at?: number; model?: string } : null;
+  const incomingAsks: AskItem[] = Array.isArray(m.asks) ? m.asks : [];
+  // A clear is CONFIRMED once the kernel's payload no longer lists it → stop suppressing it. Then drop
+  // any still-pending (kernel hasn't caught up) from this payload so a stale push can't resurrect them.
+  for (const id of Array.from(pendingCleared)) if (!incomingAsks.some((a) => a.itemId === id)) pendingCleared.delete(id);
+  // demo/recording view filter (the user 2026-07-14): `#only=<tag>` shows only matching-name cards; the
+  // clear/follow bookkeeping above still runs against the FULL payload, so hidden cards stay consistent.
+  // Self-clean the persisted disclosure state against the AUTHORITATIVE live set (the user 2026-07-24).
+  // incomingAsks, deliberately — not `visible` below: `#only=` hides cards without ending them, and
+  // pruning against the filtered list would throw away the hidden cards' sections. Event-based: a card
+  // leaving the payload (cleared, archived) IS the signal, so nothing ages out on a timer.
+  pruneViewStateTo(new Set(incomingAsks.map((a) => a.itemId)));
+  const only = onlyTag();
+  const visible = only ? incomingAsks.filter((a) => matchesOnly(a.name, only)) : incomingAsks;
+  asks = pendingCleared.size ? visible.filter((a) => !pendingCleared.has(a.itemId)) : visible;
+  // confirm/clear optimistic follow-up moves against the authoritative payload. buildId says WHEN this
+  // payload read the store, which is what makes "the kernel has answered my click" an event and not a
+  // guess (see reconcileFollowMove); a kernel too old to send one reads as 0 and simply never confirms
+  // an acked prediction early, leaving the backstop to retire it.
+  lastFeedEvent = "payload";                         // tripwire: this render's inputs are the fresh payload
+  lastPayloadBuildId = typeof m.buildId === "number" ? m.buildId : 0;
+  // per-host counters when this is a merged multi-kernel payload (mergeHostFeeds.buildIds);
+  // absent on a single-kernel payload, where the top-level buildId is the one counter there is
+  const perHostBuildIds = m.buildIds && typeof m.buildIds === "object" && !Array.isArray(m.buildIds)
+    ? m.buildIds as Record<string, number> : undefined;
+  reconcileFollowMove(incomingAsks, lastPayloadBuildId, perHostBuildIds);
+  reconcilePendingDone(incomingAsks);   // retire an optimistic tick once the real tree carries it
+  // An optimistic Undo is CONFIRMED once the kernel's payload carries the id again → stop forcing it.
+  // Until then, keep the cached card in `asks` so the replace above can't drop the just-restored card (flicker).
+  if (pendingRestored.size) {
+    for (const id of Array.from(pendingRestored.keys())) if (incomingAsks.some((a) => a.itemId === id)) pendingRestored.delete(id);
+    const present = new Set(asks.map((a) => a.itemId));
+    for (const it of pendingRestored.values()) if (!present.has(it.itemId)) asks.push(it);
+  }
+  workingSet = new Set(Array.isArray(m.working) ? m.working : []);
+  if (typeof m.selfHost === "string" && m.selfHost) feedSelfHost = m.selfHost;
+  // Index every session's colour by the name a peer would address it by. Federation merges the hosts'
+  // payloads, so one pass over the merged asks covers the whole fleet; a card whose session has no
+  // cards of its own simply gets no colour, which is honest rather than invented.
+  for (const a of incomingAsks) {
+    if (!a.color || !a.name) continue;
+    sessionColors.set(a.name, a.color.bg);
+    const c = a.sid ? a.sid.indexOf(":") : -1;             // remote sid → also index the bare name under its host
+    if (c > 0 && !a.name.includes(":")) sessionColors.set(a.sid.slice(0, c) + ":" + a.name, a.color.bg);
+  }
+  awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // await-green awaiting dots (the user 2026-07-13)
+  unknownSet = new Set(Array.isArray(m.stateUnknown) ? m.stateUnknown : []);   // listed-but-unreadable → gray ring, never a blank
+  bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
+  if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
+  if (Array.isArray(m.sessions)) {
+    sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");
+    // a filter aimed at a session the tab strip no longer shows is moot — clear it (the deciding
+    // event: the session left the tab list), rather than leaving the board silently pinned to nothing
+    if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);
+  }
+  hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
+  mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : [],
+    Array.isArray(m.sdkNotices) ? m.sdkNotices : [],
+    Array.isArray(m.syncNotices) ? m.syncNotices : []);   // card trouble chips + /clear drops + SDK failures + fleet syncs also log in the shell's bell (chips stay on the cards)
+  if (typeof m.dismissedCount === "number") dismissedCount = m.dismissedCount;
+  clearUndoBusy();   // the push the undo was waiting on has landed (or any fresher one) — cue off
+  if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
+  if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;
+  render();
+}
+
+
 window.addEventListener("message", (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
@@ -4157,71 +4339,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     return;
   }
   if (m.type === "feed") {
-    judgeLimit = m.judgeLimit && typeof m.judgeLimit === "object"
-      ? m.judgeLimit as { bucket?: string; resets_at?: number; model?: string } : null;
-    const incomingAsks: AskItem[] = Array.isArray(m.asks) ? m.asks : [];
-    // A clear is CONFIRMED once the kernel's payload no longer lists it → stop suppressing it. Then drop
-    // any still-pending (kernel hasn't caught up) from this payload so a stale push can't resurrect them.
-    for (const id of Array.from(pendingCleared)) if (!incomingAsks.some((a) => a.itemId === id)) pendingCleared.delete(id);
-    // demo/recording view filter (the user 2026-07-14): `#only=<tag>` shows only matching-name cards; the
-    // clear/follow bookkeeping above still runs against the FULL payload, so hidden cards stay consistent.
-    // Self-clean the persisted disclosure state against the AUTHORITATIVE live set (the user 2026-07-24).
-    // incomingAsks, deliberately — not `visible` below: `#only=` hides cards without ending them, and
-    // pruning against the filtered list would throw away the hidden cards' sections. Event-based: a card
-    // leaving the payload (cleared, archived) IS the signal, so nothing ages out on a timer.
-    pruneViewStateTo(new Set(incomingAsks.map((a) => a.itemId)));
-    const only = onlyTag();
-    const visible = only ? incomingAsks.filter((a) => matchesOnly(a.name, only)) : incomingAsks;
-    asks = pendingCleared.size ? visible.filter((a) => !pendingCleared.has(a.itemId)) : visible;
-    // confirm/clear optimistic follow-up moves against the authoritative payload. buildId says WHEN this
-    // payload read the store, which is what makes "the kernel has answered my click" an event and not a
-    // guess (see reconcileFollowMove); a kernel too old to send one reads as 0 and simply never confirms
-    // an acked prediction early, leaving the backstop to retire it.
-    lastFeedEvent = "payload";                         // tripwire: this render's inputs are the fresh payload
-    lastPayloadBuildId = typeof m.buildId === "number" ? m.buildId : 0;
-    // per-host counters when this is a merged multi-kernel payload (mergeHostFeeds.buildIds);
-    // absent on a single-kernel payload, where the top-level buildId is the one counter there is
-    const perHostBuildIds = m.buildIds && typeof m.buildIds === "object" && !Array.isArray(m.buildIds)
-      ? m.buildIds as Record<string, number> : undefined;
-    reconcileFollowMove(incomingAsks, lastPayloadBuildId, perHostBuildIds);
-    reconcilePendingDone(incomingAsks);   // retire an optimistic tick once the real tree carries it
-    // An optimistic Undo is CONFIRMED once the kernel's payload carries the id again → stop forcing it.
-    // Until then, keep the cached card in `asks` so the replace above can't drop the just-restored card (flicker).
-    if (pendingRestored.size) {
-      for (const id of Array.from(pendingRestored.keys())) if (incomingAsks.some((a) => a.itemId === id)) pendingRestored.delete(id);
-      const present = new Set(asks.map((a) => a.itemId));
-      for (const it of pendingRestored.values()) if (!present.has(it.itemId)) asks.push(it);
-    }
-    workingSet = new Set(Array.isArray(m.working) ? m.working : []);
-    if (typeof m.selfHost === "string" && m.selfHost) feedSelfHost = m.selfHost;
-    // Index every session's colour by the name a peer would address it by. Federation merges the hosts'
-    // payloads, so one pass over the merged asks covers the whole fleet; a card whose session has no
-    // cards of its own simply gets no colour, which is honest rather than invented.
-    for (const a of incomingAsks) {
-      if (!a.color || !a.name) continue;
-      sessionColors.set(a.name, a.color.bg);
-      const c = a.sid ? a.sid.indexOf(":") : -1;             // remote sid → also index the bare name under its host
-      if (c > 0 && !a.name.includes(":")) sessionColors.set(a.sid.slice(0, c) + ":" + a.name, a.color.bg);
-    }
-    awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // await-green awaiting dots (the user 2026-07-13)
-    unknownSet = new Set(Array.isArray(m.stateUnknown) ? m.stateUnknown : []);   // listed-but-unreadable → gray ring, never a blank
-    bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
-    if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
-    if (Array.isArray(m.sessions)) {
-      sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");
-      // a filter aimed at a session the tab strip no longer shows is moot — clear it (the deciding
-      // event: the session left the tab list), rather than leaving the board silently pinned to nothing
-      if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);
-    }
-    hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
-    mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : [],
-      Array.isArray(m.sdkNotices) ? m.sdkNotices : [],
-      Array.isArray(m.syncNotices) ? m.syncNotices : []);   // card trouble chips + /clear drops + SDK failures + fleet syncs also log in the shell's bell (chips stay on the cards)
-    if (typeof m.dismissedCount === "number") dismissedCount = m.dismissedCount;
-    clearUndoBusy();   // the push the undo was waiting on has landed (or any fresher one) — cue off
-    if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
-    if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;
-    render();
+    // HOVER-FREEZE: a hovered card must not move on screen — queue the payload (newest wins) and
+    // hint the deferred churn on the headers instead; mouseleave/blur flush it (see freezeEnter).
+    if (freezeKey) { pendingFeedPayload = m; paintFreezeBadges(); return; }
+    applyFeedPayload(m);
   } else if (m.type === "hoverCards") {
     // rail-dot hover in the CHAT panel → white-outline the card(s) built from
     // that turn, plus the matching ROWS inside an open modal (eid). The host


### PR DESCRIPTION
While the pointer rests on a feed card, incoming feed payloads queue (newest wins — intermediate states were never on screen, so nothing owes them an animation) instead of rendering, so nothing pops in above the hovered card and nothing shoots it away. Only the payload path defers: the hovered card's own controls and every local gesture still render live from the displayed model.

**Flush is event-based, never a timer.** The hovered card's mouseleave applies everything at once (a card cleared under the pointer flushes via its existing synthetic mouseleave); window blur is the backstop. The flush itself is a microtask — same gesture, after its handlers finish — so a synthetic mouseleave dispatched mid-click can never re-render the board under the rest of its own handler. A render-tail heal covers the removal-without-mouseleave paths (:hover is live pointer truth): a hovered card filtered out by typing in search, or re-keyed in place by toggling Group, can't wedge the freeze.

**The deferred churn hints, subtly.** +N in the romp accent / -N in the board's block red beside the column pills and, in grouped mode, the session headers (stamped data-fsid for the painter) — at the count's own scale, no new font sizes. The counting is a pure helper (feed-freeze.ts) over the render's own display-side view (viewFiltered, extracted so render and the painter count exactly what the user sees), and the hint path is side-effect free — it mirrors the optimistic-restore overlay read-only, so a card the flush will push right back never hints as a departure.

**Review provenance.** Three-lens adversarial review + an independent verification pass: three confirmed findings (stuck freeze on local re-key, clear-click flush ordering, phantom counts for optimistic restores) fixed in this commit; the verifier passed all three fixes and its one marginal finding (mirror inexactness for payload-carried restores) is fixed too.

**Tests** (feed-freeze.test.ts): the counting rule executes (adds/removes per column and session, column moves, no-change); pins cover the single queue-write gate, newest-wins, microtask flush + blur backstop with no timers in the freeze block, the :hover heal, both card shapes arming on the highlight's own events, the side-effect-free hint path, and the badge conventions (var(--accent)/var(--err), inherited scale). feed-session-filter.test.ts's pin follows the filter into viewFiltered. Full extension suite green (2273).

Note for the tracked-delegation branch: its `!a.satellite` filter belongs INSIDE viewFiltered when our textual overlap is reconciled, so the churn hints keep counting exactly what the board shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)