### PR TITLE
Tracked delegation: a report-back handoff files as one card under the delegator

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10762,19 +10762,21 @@ def courier_llm(message_text, menu_text, declared=""):
 _postal_from_memo = {"key": None, "map": {}}   # messages.jsonl (mtime,size) -> {mid: (from, from_host)}
 
 
-def _postal_from(mid):
-    """(from_name, from_host) for a delivered postal message id, from the messages log's "sent" row —
-    the AUTHORITATIVE record of who sent it. The sender may be a session of ANOTHER kernel (federated
-    mail), so the local names registry cannot resolve it; the log row carries the name the sender
-    wore and, since 2026-07-26, the origin host the postal bus stamped on cross-host delivery.
-    ("", "") for None/unknown mids. Memoized on the log file's (mtime, size)."""
+def _postal_row(mid):
+    """(from_name, from_host, tracked) for a delivered postal message id, from the messages log's
+    "sent" row — the AUTHORITATIVE record of who sent it and how (the row schema is the postal
+    consumer contract). The sender may be a session of ANOTHER kernel (federated mail), so the local
+    names registry cannot resolve it; the log row carries the name the sender wore, the origin host
+    the bus stamped on cross-host delivery (2026-07-26), and the tracked report-back flag
+    (2026-08-24 — read off the row, never off message prose). ("", "", False) for None/unknown mids.
+    Memoized on the log file's (mtime, size)."""
     if not mid:
-        return ("", "")
+        return ("", "", False)
     try:
         st = os.stat(MESSAGES)
         key = (st.st_mtime, st.st_size)
     except OSError:
-        return ("", "")
+        return ("", "", False)
     if _postal_from_memo["key"] != key:
         mp = {}
         try:
@@ -10784,11 +10786,16 @@ def _postal_from(mid):
                 except Exception:
                     continue
                 if r.get("ev") == "sent" and r.get("id"):
-                    mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "")
+                    mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "", bool(r.get("tracked")))
         except OSError:
-            return ("", "")
+            return ("", "", False)
         _postal_from_memo["key"], _postal_from_memo["map"] = key, mp
-    return _postal_from_memo["map"].get(mid, ("", ""))
+    return _postal_from_memo["map"].get(mid, ("", "", False))
+
+
+def _postal_from(mid):
+    """(from_name, from_host) — the pre-tracked reader, kept for its call sites."""
+    return _postal_row(mid)[:2]
 
 
 def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None):
@@ -10852,11 +10859,13 @@ def _handoff_backref(mid):
     return "", ""
 
 
-def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid):
+def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tracked=False):
     """Mint a precise '↪ delegated to <peer>' TRACKING node in the SENDER's own tree (the user 2026-06-22):
     the exact item B's completion checks off, so a PARTIAL handoff doesn't over-complete the sender's broader
     goal. Filed under the courier's linked goal (parent_id) if any, else top-level. Carries handoff:{peer,
-    msgId} both as the run_propagate target and so the feed can badge it. Idempotent by msgId. Returns its id."""
+    msgId} both as the run_propagate target and so the feed can badge it; a TRACKED report-back delegation
+    (the user 2026-08-24) adds handoff.tracked — this node's card is the pair's PRIMARY, and the recipient's
+    planted goal is marked its satellite. Idempotent by msgId. Returns its id."""
     nodes = store["nodes"]
     for nid, nd in nodes.items():
         h = nd.get("handoff")
@@ -10867,9 +10876,12 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid):
     store["seq"] = store.get("seq", 0) + 1
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
     label = "↪ delegated to %s: %s" % (peer_name or peer_sid[:8], text or "(work)")
+    handoff = {"peer": peer_sid, "msgId": mid}
+    if tracked:
+        handoff["tracked"] = True
     nodes[nid] = GuardedNode({"id": nid, "text": label[:120], "parentId": parent_id,
                   "nodeComplete": False, "blocked": False, "cleared": False,
-                  "trail": [], "t": t, "mt": t, "handoff": {"peer": peer_sid, "msgId": mid}, "log": []})
+                  "trail": [], "t": t, "mt": t, "handoff": handoff, "log": []})
     return nid
 
 
@@ -11059,16 +11071,30 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                 save_goals(fsid, store)
                 continue
             link_id = menu[edit["n"] - 1]["id"] if edit["n"] else None   # sender's related open goal (or None)
+            # TRACKED report-back delegation (the user 2026-08-24): the sender flagged the send, so
+            # the tracking node below is the pair's PRIMARY (the one card, on the sender's own tree,
+            # carrying the recipient's identity) and B's planted goal is marked its SATELLITE
+            # (origin.tracked) for the feed to collapse off the default board — still one click away
+            # via B's own session views; nothing runs in secret. Read off the postal row, the
+            # authoritative record, never off prose. A NON-LOCAL sender never qualifies: the primary
+            # would live on a kernel this courier cannot write, and a satellite without a primary
+            # hides work — the flag degrades to a plain delegate (the wire also drops it at the
+            # relay). A demoted tracked delegate reaches neither line: no primary, no satellite, no
+            # orphan.
+            trk = bool(_postal_row(mid)[2]) and sender in id2name
             # Mint the sender's precise '↪ delegated to <recipient>' tracking node (the user 2026-06-22) and
             # point B's goal at IT — so run_propagate checks off only the handed-off piece, never the sender's
             # broader linked goal. Saved to the sender's tree before planting G on the recipient's.
-            track_id = _plant_handoff_track(sender_store, link_id, edit["text"], fsid, id2name.get(fsid), seg_t, mid)
+            track_id = _plant_handoff_track(sender_store, link_id, edit["text"], fsid, id2name.get(fsid), seg_t, mid,
+                                            tracked=trk)
             rollup_status(sender_store, False)
             save_goals(sender, sender_store)
             # Origin provenance snapshots the sender's NAME (and, for federated mail, HOST) at plant
             # time: a cross-host sender's sid resolves to nothing in this kernel's names registry, and
             # without the snapshot the "from" chip degrades to a bare sid prefix (the user 2026-07-26).
             origin = {"peer": sender, "goalId": track_id, "msgId": mid}
+            if trk:
+                origin["tracked"] = True               # the satellite mark — the feed collapses on it
             frm_name, frm_host = _postal_from(mid)
             pn = id2name.get(sender) or frm_name       # live local name first; else the log's snapshot
             if pn:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10759,7 +10759,7 @@ def courier_llm(message_text, menu_text, declared=""):
     return _judge_run(_triage_model(), COURIER_SYS, user, judge="courier", mark=mk).strip()[:300]
 
 
-_postal_from_memo = {"key": None, "map": {}}   # messages.jsonl (mtime,size) -> {mid: (from, from_host)}
+_postal_from_memo = {"key": None, "map": {}}   # messages.jsonl (mtime,size) -> {mid: (from, from_host, tracked)}
 
 
 def _postal_row(mid):
@@ -10870,6 +10870,9 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
     for nid, nd in nodes.items():
         h = nd.get("handoff")
         if isinstance(h, dict) and h.get("msgId") == mid:
+            if tracked and not h.get("tracked"):
+                h["tracked"] = True                     # a replant that learned the flag (a crash between
+                #                                         the two store saves) upgrades in place; never down
             return nid                                  # already planted for this message → idempotent
     if parent_id is not None and parent_id not in nodes:
         parent_id = None                                # linked goal vanished → file as a top, never orphan

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18404,7 +18404,13 @@ def build_feed(now, tmux=None):
                 "trgb": list(cm.age_rgb(now - disp_t, _colormap())),
                 "turnId": nid, "origin": origin,
                 **({"delegTracked": _tracked_peers} if _tracked_peers else {}),
-                **({"satellite": True} if isinstance(o, dict) and o.get("tracked") else {}),
+                # the satellite hides ONLY while the pair is INTACT and the work runs its normal
+                # course: a needs-you block always surfaces (interrupt only when the human is the
+                # bottleneck), and a primary that closed or cleared un-hides the copy — origin.live
+                # reads the PRIMARY handoff node, so every pair divergence self-heals to a visible
+                # card instead of work running in secret (review 2026-08-24).
+                **({"satellite": True} if isinstance(o, dict) and o.get("tracked")
+                   and origin and origin.get("live") and column != "needs_input" else {}),
                 "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
                 # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
                 # pending. The card STAYS in Working (the settle gate exists precisely so the column never

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18109,6 +18109,18 @@ def build_feed(now, tmux=None):
             if nid != api_top and nid != perm_top and col in ("working", "blocked") and (
                     _await_ok or _stamp_why or _deleg_why or (col == "blocked" and _peer_wait)):
                 col = "awaiting"
+            # TRACKED delegation payloads (the user 2026-08-24): a report-back handoff renders as ONE
+            # card homed under the DELEGATOR. The sender's card is the PRIMARY — delegTracked names
+            # the recipient identities so the feed shows their live status right on it — and the
+            # recipient's planted copy is the SATELLITE (origin.tracked below) the feed collapses
+            # off the default board, still one click away via that session's own views (nothing runs
+            # in secret, 2026-08-11). Both keys ship only when present, so every untracked payload
+            # is byte-identical to before. The pair link stays the courier's msgId graph: clears and
+            # run_propagate cross it unchanged.
+            _tracked_hn = [x for x in _subtree(nid)
+                           if isinstance(nodes[x].get("handoff"), dict) and nodes[x]["handoff"].get("tracked")
+                           and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
+            _tracked_peers = (_handoff_peer_identities(nodes, _tracked_hn) or None) if _tracked_hn else None
             o = nodes[nid].get("origin")             # courier delegation provenance: planted by a peer
             origin = None
             if isinstance(o, dict) and o.get("peer"):
@@ -18391,6 +18403,8 @@ def build_feed(now, tmux=None):
                 "t": disp_t, "live": live,
                 "trgb": list(cm.age_rgb(now - disp_t, _colormap())),
                 "turnId": nid, "origin": origin,
+                **({"delegTracked": _tracked_peers} if _tracked_peers else {}),
+                **({"satellite": True} if isinstance(o, dict) and o.get("tracked") else {}),
                 "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
                 # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
                 # pending. The card STAYS in Working (the settle gate exists precisely so the column never

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1286,7 +1286,10 @@ class Handler(BaseHTTPRequestHandler):
                 # `tracked` deliberately does NOT ride the relay: the primary view lives on the
                 # SENDER's kernel, which the recipient's courier can never reach across hosts — a
                 # satellite with no primary would hide work, so a cross-host tracked send degrades
-                # to a plain delegate (revisit with federation).
+                # to a plain delegate (revisit with federation) — and the NOTE says so: the sender
+                # asked for a report-back and must hear it degraded (fail loudly, 2026-07-03).
+                tnote = (" — report-back tracking does not cross hosts yet; sent as a plain handoff"
+                         if tracked else "")
                 mid = "px-" + _unique()
                 outbox_put(phost, {"mid": mid, "to": hit.get("name") or to, "frm": frm,
                                    "frm_id": frm_id, "body": body, "kind": kind,
@@ -1298,13 +1301,13 @@ class Handler(BaseHTTPRequestHandler):
                                               "body": body, "kind": kind})
                 if PEERS.get(phost, {}).get("up"):
                     return self._send({"ok": True, "id": mid,
-                                       "note": "relaying to '%s' on %s" % (hit.get("name") or to, phost)})
+                                       "note": "relaying to '%s' on %s%s" % (hit.get("name") or to, phost, tnote)})
                 _kernel_post("/redial", {"host": phost})   # parking IS demand: ask the kernel to
                 #                                             re-dial the host's tunnel now instead of
                 #                                             waiting out its backoff (the user 2026-08-16)
                 return self._send({"ok": True, "id": mid, "parked": phost,
-                                   "note": "parked for %s (unreachable) — delivers on reconnect, "
-                                           "or bounces back to you" % phost})
+                                   "note": ("parked for %s (unreachable) — delivers on reconnect, "
+                                            "or bounces back to you" % phost) + tnote})
             a0 = res["agent"]
             mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)
             if not a0.get("remote", False):

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -265,7 +265,7 @@ def _tl_append(fname, obj):
         pass
 
 def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
-            relay_mid="", relay_via=""):
+            relay_mid="", relay_via="", tracked=False):
     # park=True marks a HANDOFF parked for a session that's currently dead. The
     # maildir is keyed by the session UUID (which `romp resume` reuses), so the
     # message simply waits on disk until that session is revived — delivered then,
@@ -318,6 +318,10 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         ev["park"] = True
     if kind:
         ev["kind"] = kind                            # additive (consumer contract above)
+    if tracked:
+        ev["tracked"] = True                         # additive (consumer contract above): report-back
+        #                                              delegation — the row is the flag's ONE record;
+        #                                              no header, no prose (the recipient reads nothing)
     if from_host:
         ev["from_host"] = from_host                  # additive (consumer contract above)
     _tl_append("messages.jsonl", ev)
@@ -424,7 +428,10 @@ def _queue_read_receipt(meta, unread=False, dmid=""):
 #   1. The `<!-- romp-msg-id: <id> -->` HTML-comment marker emitted after each
 #      message body by format_inbox + format_push — <id> joins to messages.jsonl.
 #   2. The messages.jsonl "sent" event schema written by deliver():
-#      {ev:"sent", id, from, from_id, to_id, body, t, park?}  (park is additive).
+#      {ev:"sent", id, from, from_id, to_id, body, t, park?, kind?, from_host?, tracked?}
+#      (park/kind/from_host/tracked are all additive; `tracked` marks a report-back delegation —
+#      kind stays "delegate" — whose sender-side view is primary: the kernel courier reads it off
+#      this row, never off the message prose).
 # The HUMAN-FACING prose (banner text, headers, the "⏸ parked" tag, REPLY_HINT) is
 # NOT a contract — consumers must not parse it, so it stays free to change.
 
@@ -1255,6 +1262,9 @@ class Handler(BaseHTTPRequestHandler):
             kind = str(data.get("kind", "")).strip().lower()
             if kind not in ("delegate", "coordinate", "question"):
                 kind = ""                              # legacy/CLI mail may be undeclared; never invent one
+            tracked = bool(data.get("tracked")) and kind == "delegate"   # report-back delegation
+            #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing
+            #   about the flag ever appears in message prose (the injected-voice rule)
             if _postal_off(frm_id):                # the sender is in isolation → sending is disabled
                 return self._send({"error": "isolation: YOUR OWN mailbox is OFF. This session is in postal "
                                    "isolation (its mailbox icon is toggled off on its timeline lane), so it "
@@ -1273,6 +1283,10 @@ class Handler(BaseHTTPRequestHandler):
                 # (or the next reconnect) carries it, and a definitive refusal bounces back to the
                 # sender.
                 phost, hit = res["host"], res["agent"]
+                # `tracked` deliberately does NOT ride the relay: the primary view lives on the
+                # SENDER's kernel, which the recipient's courier can never reach across hosts — a
+                # satellite with no primary would hide work, so a cross-host tracked send degrades
+                # to a plain delegate (revisit with federation).
                 mid = "px-" + _unique()
                 outbox_put(phost, {"mid": mid, "to": hit.get("name") or to, "frm": frm,
                                    "frm_id": frm_id, "body": body, "kind": kind,
@@ -1292,7 +1306,7 @@ class Handler(BaseHTTPRequestHandler):
                                    "note": "parked for %s (unreachable) — delivers on reconnect, "
                                            "or bounces back to you" % phost})
             a0 = res["agent"]
-            mid = deliver(a0["id"], frm, frm_id, body, kind=kind)
+            mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)
             if not a0.get("remote", False):
                 # All through the kernel (it owns the tmux status bar + the wake), off-thread so send latency
                 # stays low: paint the recipient's "📬 from X" badge; record correspondence (peer chips) + the
@@ -2582,7 +2596,9 @@ MCP_TOOLS = [
                      "properties": {"to": {"type": "string", "description": "recipient romp session name"},
                                     "body": {"type": "string", "description": "message text"},
                                     "kind": {"type": "string", "enum": ["delegate", "coordinate", "question"],
-                                             "description": "what this message does: delegate = the recipient owns the work now; coordinate = aligning or a heads-up, reply optional; question = you need an answer"}},
+                                             "description": "what this message does: delegate = the recipient owns the work now; coordinate = aligning or a heads-up, reply optional; question = you need an answer"},
+                                    "tracked": {"type": "boolean",
+                                                "description": "delegate only: a report-back handoff — the work stays tracked under YOU as the one view, with the recipient's live progress; their copy files as its satellite. Omit for a plain handoff the recipient owns outright."}},
                      "required": ["to", "body", "kind"]}},
     {"name": "check_inbox",
      "description": "Read and clear any messages other romp sessions have sent you. Messages are also delivered automatically at the end of each turn, so you rarely need to call this.",
@@ -2621,9 +2637,12 @@ def _mcp_call(name, args):
             return ("Cannot send: this session's own identity did not resolve (no session id), so "
                     "the mail would arrive anonymously and the recipient could not place or answer "
                     "it. This is a session-identity bug worth surfacing to the user.", True)
+        tracked = bool(args.get("tracked")) and kind == "delegate"
         try:
-            resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid, "body": body,
-                                           "kind": kind})
+            payload = {"to": to, "from": me or "unknown", "from_id": mid, "body": body, "kind": kind}
+            if tracked:
+                payload["tracked"] = True
+            resp = _http("POST", "/send", payload)
             # "Delivered" has to MEAN delivered. A cross-host send is only relaying (or parked for
             # an unreachable host, or held for the human on the far side), and the bus says so in
             # `note` — which this dropped on the floor, so every one of those read as delivered and
@@ -2641,6 +2660,10 @@ def _mcp_call(name, args):
                 return ("Delivered to '%s' as a question — you are now recorded as waiting on their "
                         "reply until they answer. If you don't actually need a reply, recall this "
                         "message and resend it as coordinate." % to, False)
+            if kind == "delegate" and tracked:
+                return ("Delivered to '%s' as a tracked handoff — they do the work, and it stays "
+                        "tracked under you as the one view with their live progress. You are NOT "
+                        "recorded as waiting; their completion checks it off." % to, False)
             if kind == "delegate":
                 return ("Delivered to '%s' as a handoff — they own it now; you are NOT recorded as "
                         "waiting (the user 2026-08-15: ownership transferred is not a dependency). "
@@ -2740,8 +2763,12 @@ def mcp():
 
 def cli_send(argv):
     kind = frm_label = ""
-    while argv and argv[0] in ("--kind", "--from"):
-        if argv[0] == "--kind":
+    tracked = False
+    while argv and argv[0] in ("--kind", "--from", "--tracked"):
+        if argv[0] == "--tracked":
+            tracked = True
+            argv = argv[1:]
+        elif argv[0] == "--kind":
             kind = (argv[1].strip().lower() if len(argv) > 1 else "")
             argv = argv[2:]
             if kind not in ("delegate", "coordinate", "question"):
@@ -2755,8 +2782,10 @@ def cli_send(argv):
             argv = argv[2:]
             if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,31}", frm_label or ""):
                 sys.stderr.write("[romp mail] --from must be one word (letters/digits/dash/underscore, <=32 chars)\n"); return 2
+    if tracked and kind != "delegate":
+        sys.stderr.write("[romp mail] --tracked is for delegations only (add --kind delegate)\n"); return 2
     if len(argv) < 2:
-        sys.stderr.write('usage: romp mail send [--kind delegate|coordinate|question] [--from <label>] <session> <text>\n'); return 2
+        sys.stderr.write('usage: romp mail send [--kind delegate|coordinate|question] [--tracked] [--from <label>] <session> <text>\n'); return 2
     to, body = argv[0], " ".join(argv[1:])
     if not body.strip():
         sys.stderr.write("[romp mail] refusing to send an empty message\n"); return 2
@@ -2775,8 +2804,10 @@ def cli_send(argv):
                          "name.\n")
         return 1
     try:
-        resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid, "body": body,
-                                       "kind": kind})
+        payload = {"to": to, "from": me or "unknown", "from_id": mid, "body": body, "kind": kind}
+        if tracked:
+            payload["tracked"] = True
+        resp = _http("POST", "/send", payload)
     except BusError as e:
         sys.stderr.write("[romp mail] %s\n" % e); return 1
     # Echo what actually happened, not a blanket "delivered": a cross-host send is only RELAYING (or

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""TRACKED delegation (the user 2026-08-24): a report-back variant of delegate mail whose ONE
+primary card lives under the DELEGATOR. The flag rides the postal sent row (wire metadata, never
+message prose); the courier marks the sender's tracking node primary (handoff.tracked) and the
+recipient's planted goal its satellite (origin.tracked); build_feed ships delegTracked identities on
+the primary card and a satellite mark on the recipient's — both keys only when present, so every
+untracked payload stays byte-identical. Untracked mail is today's behavior exactly. A demoted
+tracked delegate plants neither side (no orphan primary); a non-local sender degrades to a plain
+delegate (a satellite without a reachable primary would hide work). run_propagate and the clear's
+msgId link cross the pair unchanged. Synthetic notes-api world only (web/api, placeholder UUIDs,
+TESTHOST)."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_POSTAL_HOST"] = "TESTHOST"
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
+                                    "state": "waiting", "working": ""}]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+ps = SourceFileLoader("romp_postal_tracked", os.path.join(BIN, "romp-postal-service")).load_module()
+jd = SourceFileLoader("romp_judge_tracked", os.path.join(BIN, "romp-judge")).load_module()
+
+RECIP = "11111111-2222-3333-4444-555555555555"   # the worker (web)
+SENDER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # the delegator (api)
+MID = "1781100000.11111_22222.TESTHOST"
+T0 = 1781100000
+DELEGATING = '{"verdict": "delegating", "goal": 0, "text": "ship the exporter"}'
+COORDINATING = '{"verdict": "coordinating", "goal": 0, "text": ""}'
+
+KSRC = open(os.path.join(BIN, "romp-kernel")).read()
+PSRC = open(os.path.join(BIN, "romp-postal-service")).read()
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class PostalTrackedWire(unittest.TestCase):
+    """The flag's one durable record is the sent row — additive, delegate-only, prose-free."""
+
+    def test_deliver_row_carries_tracked(self):
+        ps.deliver("sess-web", "api", "sess-api", "own the exporter work", kind="delegate", tracked=True)
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        row = rows[-1]
+        self.assertIs(row.get("tracked"), True, "the sent row is the flag's authoritative record")
+        self.assertEqual(row.get("kind"), "delegate")
+
+    def test_untracked_row_has_no_key_at_all(self):
+        ps.deliver("sess-web", "api", "sess-api", "plain handoff", kind="delegate")
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        self.assertNotIn("tracked", rows[-1], "absent flag = today's row byte-for-byte")
+
+    def test_no_prose_ever_carries_the_flag(self):
+        # the injected-voice rule: tracked is wire metadata — the recipient's inbox render says
+        # NOTHING about it (no marker, no banner word), and no header is written either
+        msgs = [{"id": MID, "from": "api", "from_id": "sess-api", "body": "own the exporter work",
+                 "kind": "delegate", "date": ""}]
+        txt = ps.format_inbox(msgs, me_id="sess-web")
+        self.assertNotIn("tracked", txt.lower())
+
+    def test_route_gates_the_flag_to_delegates_and_the_relay_drops_it(self):
+        # source pins on the /send route: coordinate/question can never carry it, and the
+        # cross-host relay branch deliberately drops it (a satellite with an unreachable primary
+        # would hide work)
+        self.assertIn('tracked = bool(data.get("tracked")) and kind == "delegate"', PSRC)
+        self.assertIn("`tracked` deliberately does NOT ride the relay", PSRC)
+        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)', PSRC)
+
+    def test_mcp_and_cli_expose_the_flag(self):
+        self.assertIn('"tracked": {"type": "boolean"', PSRC, "the send_message schema offers it")
+        self.assertIn('"--tracked"', PSRC.replace("'--tracked'", '"--tracked"'), "the CLI flag parses")
+        self.assertIn("--tracked is for delegations only", PSRC, "…and refuses non-delegate kinds loudly")
+
+
+class CourierTracked(unittest.TestCase):
+    """The courier marks both sides from the row — or neither, when demoted or non-local."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        proj = td / "projects"
+        names = td / "names"; names.mkdir()
+        self.dirs = {}
+        for sid, nm in ((RECIP, "web"), (SENDER, "api")):
+            cdir = td / ("launch-" + nm); cdir.mkdir()
+            munged = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+            (proj / munged).mkdir(parents=True)
+            self.dirs[sid] = proj / munged
+            (names / sid).write_text("%s\t%s\t#abcdef\n" % (nm, str(cdir)))
+        tl = td / "timeline"; tl.mkdir()
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+                      jd.MESSAGES, jd.ERRORS, jd.courier_llm)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.GOALDIR = td / "goals"
+        jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        jd.MESSAGES = tl / "messages.jsonl"
+        jd.ERRORS = td / "judge-errors.jsonl"
+        jd.courier_llm = lambda *a, **k: self.reply
+        self.reply = DELEGATING
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        jd._postal_from_memo["key"] = None
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+         jd.MESSAGES, jd.ERRORS, jd.courier_llm) = self.saved
+        jd._postal_from_memo["key"] = None
+        self.td.cleanup()
+
+    def _run(self, tracked=True, sender_id=SENDER, both_transcripts=True):
+        row = {"t": T0 - 5, "ev": "sent", "id": MID, "from": "api", "from_id": sender_id,
+               "to_id": RECIP, "body": "own the exporter work", "kind": "delegate"}
+        if tracked:
+            row["tracked"] = True
+        jd.MESSAGES.write_text(json.dumps(row) + "\n")
+        recs = [uline(T0, "own the exporter work\n<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID, "u1"),
+                aline(T0 + 30, "Starting on it.", "a1", "u1")]
+        (self.dirs[RECIP] / (RECIP + ".jsonl")).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        if both_transcripts:
+            # the sender must be a DISCOVERED local session for tracked to qualify
+            (self.dirs[SENDER] / (SENDER + ".jsonl")).write_text(
+                json.dumps(uline(T0 - 60, "kick off the exporter", "s1")) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache["fp"] = None
+        jd._postal_from_memo["key"] = None
+        jd.run_courier(now=T0 + 100)
+        rstore = jd.load_goals(RECIP)
+        sstore = jd.load_goals(sender_id)
+        planted = [nd for nd in rstore["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        handoffs = [nd for nd in sstore["nodes"].values() if isinstance(nd.get("handoff"), dict)]
+        return rstore, planted, handoffs
+
+    def test_tracked_delegate_marks_primary_and_satellite(self):
+        _, planted, handoffs = self._run(tracked=True)
+        self.assertEqual(len(planted), 1)
+        self.assertEqual(len(handoffs), 1)
+        self.assertIs(handoffs[0]["handoff"].get("tracked"), True, "the sender's node is the PRIMARY")
+        self.assertIs(planted[0]["origin"].get("tracked"), True, "the recipient's goal is its SATELLITE")
+        self.assertEqual(planted[0]["origin"]["goalId"], handoffs[0]["id"],
+                         "the pair link is the same msgId graph run_propagate and clears already walk")
+
+    def test_untracked_delegate_is_todays_shape_exactly(self):
+        _, planted, handoffs = self._run(tracked=False)
+        self.assertEqual((len(planted), len(handoffs)), (1, 1))
+        self.assertNotIn("tracked", handoffs[0]["handoff"], "no flag key at all — byte-compatible")
+        self.assertNotIn("tracked", planted[0]["origin"])
+
+    def test_a_demoted_tracked_delegate_leaves_no_orphan_primary(self):
+        # the courier may demote a declared delegate whose body hands nothing over; a tracked one
+        # must then plant NOTHING on either side — a primary with no satellite (or vice versa)
+        # would be a card about work that does not exist
+        self.reply = COORDINATING
+        rstore, planted, handoffs = self._run(tracked=True)
+        self.assertEqual(planted, [], "demoted → no satellite")
+        self.assertEqual(handoffs, [], "…and no primary either: no orphan")
+        seg_id = next(k for k in rstore["placements"] if not k.endswith(("#p", "#d", "#live")))
+        self.assertEqual(rstore["placements"][seg_id], "fyi")
+
+    def test_a_non_local_sender_degrades_to_a_plain_delegate(self):
+        # the primary would live on a kernel this courier cannot write; a satellite without a
+        # primary hides work, so the flag drops and the pair renders exactly like today
+        ghost = "99999999-8888-7777-6666-555555555555"   # no names entry → not in the local fleet
+        _, planted, handoffs = self._run(tracked=True, sender_id=ghost, both_transcripts=False)
+        self.assertEqual(len(planted), 1, "the delegation itself still plants")
+        self.assertNotIn("tracked", planted[0]["origin"], "…but untracked: no satellite mark")
+        for nd in handoffs:
+            self.assertNotIn("tracked", nd.get("handoff") or {})
+
+    def test_propagate_completes_the_primary_across_the_tracked_pair(self):
+        rstore, planted, handoffs = self._run(tracked=True)
+        gid = planted[0]["id"]
+        # done lands the way every real writer lands it: the diary row first (the fold recomputes
+        # the flags from it on every load), then the flag materialization
+        jd.record_verdict(rstore, rstore["nodes"][gid], "closer", "done", T0 + 500, why="shipped the exporter")
+        jd._mark_node_done(rstore, gid, "shipped the exporter", T0 + 500, src="closer")
+        jd.save_goals(RECIP, rstore)
+        jd.run_propagate(now=T0 + 600)
+        sstore = jd.load_goals(SENDER)
+        prim = sstore["nodes"][handoffs[0]["id"]]
+        self.assertTrue(prim.get("nodeComplete"),
+                        "the recipient's completion checks the tracked primary off — same event as ever")
+
+
+class FeedPayloadPins(unittest.TestCase):
+    """build_feed's card shape, pinned at source (the build_feed internals idiom): the primary
+    carries delegTracked identities, the satellite carries its mark, and BOTH ship only when
+    present so untracked payloads (and the goldens over them) stay byte-identical."""
+
+    def test_the_primary_names_its_tracked_recipients(self):
+        self.assertIn('if isinstance(nodes[x].get("handoff"), dict) and nodes[x]["handoff"].get("tracked")', KSRC)
+        self.assertIn('**({"delegTracked": _tracked_peers} if _tracked_peers else {}),', KSRC)
+
+    def test_the_satellite_wears_its_mark_only_when_tracked(self):
+        self.assertIn('**({"satellite": True} if isinstance(o, dict) and o.get("tracked") else {}),', KSRC)
+
+    def test_completed_and_cleared_handoffs_drop_off_the_primary(self):
+        self.assertIn('and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]', KSRC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -186,7 +186,7 @@ class CourierTracked(unittest.TestCase):
     def test_a_non_local_sender_degrades_to_a_plain_delegate(self):
         # the primary would live on a kernel this courier cannot write; a satellite without a
         # primary hides work, so the flag drops and the pair renders exactly like today
-        ghost = "99999999-8888-7777-6666-555555555555"   # no names entry → not in the local fleet
+        ghost = "99999999-8888-7777-6666-555555555555"   # no names entry → not a local session
         _, planted, handoffs = self._run(tracked=True, sender_id=ghost, both_transcripts=False)
         self.assertEqual(len(planted), 1, "the delegation itself still plants")
         self.assertNotIn("tracked", planted[0]["origin"], "…but untracked: no satellite mark")
@@ -217,8 +217,11 @@ class FeedPayloadPins(unittest.TestCase):
         self.assertIn('if isinstance(nodes[x].get("handoff"), dict) and nodes[x]["handoff"].get("tracked")', KSRC)
         self.assertIn('**({"delegTracked": _tracked_peers} if _tracked_peers else {}),', KSRC)
 
-    def test_the_satellite_wears_its_mark_only_when_tracked(self):
-        self.assertIn('**({"satellite": True} if isinstance(o, dict) and o.get("tracked") else {}),', KSRC)
+    def test_the_satellite_hides_only_while_the_pair_is_intact_and_nothing_needs_you(self):
+        # review 2026-08-24: a needs-you block always surfaces, and a closed/cleared primary
+        # un-hides the copy — a pair divergence self-heals to a visible card, never work in secret
+        self.assertIn('**({"satellite": True} if isinstance(o, dict) and o.get("tracked")\n'
+                      '                   and origin and origin.get("live") and column != "needs_input" else {}),', KSRC)
 
     def test_completed_and_cleared_handoffs_drop_off_the_primary(self):
         self.assertIn('and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]', KSRC)

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -39,8 +39,10 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
   assert.ok(FEED.includes('sessionStorage.getItem("romp:feedOnly")'),
     "survives this tab's reloads only — a fresh window always starts unfiltered");
   // the filter chain lives in viewFiltered now (hover-freeze 2026-08-24: the deferred-churn badge
-  // painter must count exactly what the user sees, so render and the painter share one view)
-  assert.ok(FEED.includes("let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list;"));
+  // painter must count exactly what the user sees, so render and the painter share one view) — and
+  // the tracked-delegation satellite exclusion lives INSIDE it for the same reason (2026-08-24):
+  // the unfiltered board hides only satellites; a picked session still renders ALL its cards
+  assert.ok(FEED.includes("let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list.filter((a) => !a.satellite);"));
   assert.ok(FEED.includes("let shown = viewFiltered(asks);"), "render reads the shared view");
   // (`let`, since 2026-08-23: the SEARCH filter composes onto the same render-side view — see feed-search.test.ts)
   assert.ok(FEED.includes("for (const a of shown) {"), "the group-fold loop reads the filtered view");

--- a/ui/webview/feed-tracked.test.ts
+++ b/ui/webview/feed-tracked.test.ts
@@ -18,14 +18,18 @@ test("the default board hides satellites; the session filter is the one-click pa
     "hidden ONLY on the unfiltered board — picking the worker's session still shows its copy");
 });
 
-test("the primary names its recipients with the board's own live dot, on the origin slot", () => {
-  const BLK = SRC.slice(SRC.indexOf("} else if (it.delegTracked"), SRC.indexOf('og.style.display = "none"'));
-  assert.match(BLK, /pre\.textContent = "↪ delegated to ";/, "the mirrored arrow — same vocabulary as ↪ from");
+test("the primary names its recipients with the board's own live dot, STACKING after any ↪ from", () => {
+  const BLK = SRC.slice(SRC.indexOf("if (it.delegTracked && it.delegTracked.length) {"),
+                        SRC.indexOf("a._time.textContent"));
+  // an else-if hid a MIDDLEMAN's tracked handoff behind its own ↪ from badge (review 2026-08-24):
+  // origin and delegTracked are different facts about one card, so they stack on the slot
+  assert.match(BLK, /const hadOrigin = !!\(it\.origin && it\.origin\.peer\);/);
+  assert.match(BLK, /pre\.textContent = \(hadOrigin \? " · " : ""\) \+ "↪ delegated to ";/);
   assert.match(BLK, /peer\.replaceChildren\(\.\.\.hostPartsNodes\(d\.host, d\.name\)\);/,
     "identity rendering matches every other session name (quiet host: prefix included)");
   assert.match(BLK, /setWorkDot\(peer, dotFor\(d\.name\)\);/,
     "the recipient's LIVE state rides the card — the dot language the board already speaks");
-  assert.match(BLK, /openSession", id: it\.delegTracked!\[0\]\.sid/, "click opens the recipient session");
+  assert.match(BLK, /openSession", id: d\.sid/, "each recipient span opens ITS session — ↪ from keeps its own click");
 });
 
 test("both keys are additive on the type — an untracked payload renders exactly as before", () => {

--- a/ui/webview/feed-tracked.test.ts
+++ b/ui/webview/feed-tracked.test.ts
@@ -1,0 +1,34 @@
+// Tracked delegation on the feed (the user 2026-08-24): a report-back handoff reads as ONE card
+// homed under the DELEGATOR. The kernel ships two additive keys — delegTracked (the primary card's
+// recipient identities) and satellite (the recipient-side copy) — and the feed renders them with
+// machinery it already has: the primary names its recipients on the origin slot with the board's
+// own live dot; the satellite drops off the DEFAULT board only, with the session filter as the
+// one-click path back (nothing runs in secret, the 2026-08-11 rule). Source pins, the feed-panel
+// idiom; the kernel-side truth table lives in tests/test_tracked_delegation.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+test("the default board hides satellites; the session filter is the one-click path back", () => {
+  // inside viewFiltered, so the hover-freeze churn badges count exactly what the board shows
+  assert.match(SRC, /list\.filter\(\(a\) => a\.sid === feedOnlySid\) : list\.filter\(\(a\) => !a\.satellite\)/,
+    "hidden ONLY on the unfiltered board — picking the worker's session still shows its copy");
+});
+
+test("the primary names its recipients with the board's own live dot, on the origin slot", () => {
+  const BLK = SRC.slice(SRC.indexOf("} else if (it.delegTracked"), SRC.indexOf('og.style.display = "none"'));
+  assert.match(BLK, /pre\.textContent = "↪ delegated to ";/, "the mirrored arrow — same vocabulary as ↪ from");
+  assert.match(BLK, /peer\.replaceChildren\(\.\.\.hostPartsNodes\(d\.host, d\.name\)\);/,
+    "identity rendering matches every other session name (quiet host: prefix included)");
+  assert.match(BLK, /setWorkDot\(peer, dotFor\(d\.name\)\);/,
+    "the recipient's LIVE state rides the card — the dot language the board already speaks");
+  assert.match(BLK, /openSession", id: it\.delegTracked!\[0\]\.sid/, "click opens the recipient session");
+});
+
+test("both keys are additive on the type — an untracked payload renders exactly as before", () => {
+  assert.match(SRC, /satellite\?: boolean \| null;/);
+  assert.match(SRC, /delegTracked\?: \{ name: string; host\?: string; sid: string; color\?: \{ bg: string; fg: string \} \| null \}\[\] \| null;/);
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -102,7 +102,9 @@ interface AskItem {
   failLog?: { t: number; line: string; model: string; note: string }[] | null;   // the summarizer's failed ATTEMPTS on this card (judge _fail_log): when, which line, which MODEL, the literal error — the chip's hover history + the modal's "What was tried" (the user 2026-08-18, who needed to SEE "tried opus — 529" ×3 to know switching the model would fix it)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
-  origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
+  origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;
+  satellite?: boolean | null;                        // tracked delegation (the user 2026-08-24): this card is the recipient-side copy of a delegator-homed primary — off the default board; the session filter still reaches it (nothing runs in secret)
+  delegTracked?: { name: string; host?: string; sid: string; color?: { bg: string; fg: string } | null }[] | null;  // tracked delegation PRIMARY: the recipient identities whose live status this one card carries  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string; since?: number } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25). since = when the unanswered ask was sent → the chip's elapsed readout (the user 2026-08-23)
   awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: string[] | null;
                peers?: { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null }[] | null } | null;   // peers: delegation wait → the box names them in identity colour (the user 2026-08-23)   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why. since = the wait's own event time → the box/pill elapsed readout (the user 2026-08-23)
@@ -1566,6 +1568,28 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       : "delegated by " + it.origin.peer + " — clearing this card also clears their linked entry")
       + " · click opens the session";
     og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.origin!.peerSid }); };
+  } else if (it.delegTracked && it.delegTracked.length) {
+    // tracked delegation PRIMARY (the user 2026-08-24): the ONE card, homed here under the
+    // delegator — it names the recipient(s) in their identity colors with the board's own live dot
+    // (working/awaiting/idle), so the manager reads the worker's state without leaving this card.
+    // Rides the origin slot with the mirrored arrow: same row, same vocabulary as "↪ from".
+    og.style.display = "";
+    og.replaceChildren();
+    og.style.color = "";
+    const pre = el("span", "fask-origin-pre"); pre.textContent = "↪ delegated to ";
+    og.append(pre);
+    it.delegTracked.forEach((d, i) => {
+      if (i) og.append(", ");
+      const peer = el("span", "fask-origin-peer");
+      peer.replaceChildren(...hostPartsNodes(d.host, d.name));
+      if (d.color && d.color.bg) peer.style.color = d.color.bg;
+      setWorkDot(peer, dotFor(d.name));
+      og.append(peer);
+    });
+    og.classList.remove("fask-origin-absorbed");
+    og.title = "a tracked handoff: the work runs with " + it.delegTracked.map((d) => d.name).join(", ")
+      + " and reports back to this card · click opens the session";
+    og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.delegTracked![0].sid }); };
   } else {
     og.style.display = "none";
   }
@@ -3812,7 +3836,11 @@ function paintJudgeLimit(): void {
 // Shared by render() and the hover-freeze badge painter, so the deferred-churn hint counts exactly
 // what the user would see move.
 function viewFiltered(list: AskItem[]): AskItem[] {
-  let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list;
+  // A tracked delegation's satellite lives under its delegator's PRIMARY card: the default board
+  // hides it, and picking its session in the filter is the one-click path back. INSIDE this helper
+  // on purpose — the hover-freeze churn badges count through it, so they see exactly what the
+  // board shows (a filter outside would paint +N for cards that never appear).
+  let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list.filter((a) => !a.satellite);
   const sMatch = searchSids(feedSearchQ, sessionsMeta);
   if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
   return shown;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1568,15 +1568,25 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       : "delegated by " + it.origin.peer + " — clearing this card also clears their linked entry")
       + " · click opens the session";
     og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.origin!.peerSid }); };
-  } else if (it.delegTracked && it.delegTracked.length) {
-    // tracked delegation PRIMARY (the user 2026-08-24): the ONE card, homed here under the
-    // delegator — it names the recipient(s) in their identity colors with the board's own live dot
-    // (working/awaiting/idle), so the manager reads the worker's state without leaving this card.
-    // Rides the origin slot with the mirrored arrow: same row, same vocabulary as "↪ from".
+  } else {
+    og.style.display = "none";
+  }
+  // tracked delegation PRIMARY (the user 2026-08-24): the ONE card, homed here under the delegator —
+  // it names the recipient(s) in their identity colors with the board's own live dot
+  // (working/awaiting/idle), so the manager reads the worker's state without leaving this card.
+  // STACKS after an ↪ from badge rather than replacing it (review 2026-08-24: an else-if hid a
+  // middleman's own tracked handoff — origin and delegTracked are different facts about one card);
+  // each recipient span carries its own click, so the ↪ from click keeps opening the sender.
+  if (it.delegTracked && it.delegTracked.length) {
+    const hadOrigin = !!(it.origin && it.origin.peer);
     og.style.display = "";
-    og.replaceChildren();
-    og.style.color = "";
-    const pre = el("span", "fask-origin-pre"); pre.textContent = "↪ delegated to ";
+    if (!hadOrigin) {
+      og.replaceChildren(); og.style.color = ""; og.classList.remove("fask-origin-absorbed");
+      og.title = "a tracked handoff: the work runs with " + it.delegTracked.map((d) => d.name).join(", ")
+        + " and reports back to this card";
+      og.onclick = null;
+    }
+    const pre = el("span", "fask-origin-pre"); pre.textContent = (hadOrigin ? " · " : "") + "↪ delegated to ";
     og.append(pre);
     it.delegTracked.forEach((d, i) => {
       if (i) og.append(", ");
@@ -1584,14 +1594,11 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       peer.replaceChildren(...hostPartsNodes(d.host, d.name));
       if (d.color && d.color.bg) peer.style.color = d.color.bg;
       setWorkDot(peer, dotFor(d.name));
+      peer.title = "a tracked handoff: the work runs with " + d.name + " and reports back to this card · click opens the session";
+      peer.style.cursor = "pointer";
+      peer.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: d.sid }); };
       og.append(peer);
     });
-    og.classList.remove("fask-origin-absorbed");
-    og.title = "a tracked handoff: the work runs with " + it.delegTracked.map((d) => d.name).join(", ")
-      + " and reports back to this card · click opens the session";
-    og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.delegTracked![0].sid }); };
-  } else {
-    og.style.display = "none";
   }
   a._time.textContent = relAge(hostNow - it.t);
   // hover the stamp for provenance (the user 2026-07-27): the age marks the NEWEST event (a done card's


### PR DESCRIPTION
A report-back variant of delegate mail (user-greenlit today): `send_message` gains an optional `tracked: true` on `kind=delegate` (CLI: `romp mail send --tracked --kind delegate …`), and the delegated work reads as **one card under the delegator**, carrying the recipient's live status — instead of a card under the worker plus a thin tracking node on the manager.

**Wire** — the flag rides only the `messages.jsonl` sent row (consumer contract extended in place, additive); no header, no message prose, so the recipient's agent sees nothing (injected-voice rule). Delegate-only, gated at the `/send` route. The cross-host relay drops it *loudly*: the relay note tells the sender report-back tracking doesn't cross hosts yet (the primary would live on a kernel the recipient's courier can't write; a satellite without a primary would hide work).

**Courier** — reads the flag off the row (the authoritative record): the sender's tracking node becomes the pair's PRIMARY (`handoff.tracked`), the recipient's planted goal its SATELLITE (`origin.tracked`). A demoted tracked delegate plants neither (no orphan primary); a non-local sender degrades to a plain delegate; an idempotent replant that learned the flag upgrades in place. `run_propagate` and the clear's msgId link cross the pair unchanged.

**Feed** — the primary card names its recipient(s) with identity colors and the board's own live dot, stacking after any existing "↪ from" badge (each recipient span opens its session). The satellite steps off the *default* board only, and only while the pair is intact and nothing needs the user: a needs-you satellite always surfaces, a closed/cleared primary un-hides the copy (self-healing — nothing runs in secret; the session filter remains the one-click path). Untracked payloads ship neither key and are byte-identical — goldens untouched.

**Known merge overlap**: the unmerged hover-freeze branch rewrites the same feed.ts filter line; its owner has the reconciliation note (the satellite filter belongs inside their `viewFiltered`).

**Tests**: `tests/test_tracked_delegation.py` (wire row/route/CLI, courier matrix incl. demote + non-local, propagate across the pair, feed payload pins) and `ui/webview/feed-tracked.test.ts` (stacking render, satellite filter, additive types). Suites green: pytest 5370 passed, npm 2269/2269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)