### PR TITLE
Tags and identity colors federate: home-kernel ownership, a read-only union, --host edits

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -658,7 +658,7 @@ EOF
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
-    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view)"
+    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view); --host <kernel> edits an attached kernel's tag"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -950,8 +950,8 @@ fi
 if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
     shift
     _gr_usage="usage: romp tag [--json]
-       romp tag <name> [--add <session>...] [--remove <session>...] [--color <#hex>] [--delete]"
-    _gr_name=""; _gr_json=false; _gr_color=""; _gr_cset=0; _gr_del=0
+       romp tag <name> [--host <kernel>] [--add <session>...] [--remove <session>...] [--color <#hex>] [--delete]"
+    _gr_name=""; _gr_json=false; _gr_color=""; _gr_cset=0; _gr_del=0; _gr_host=""
     _gr_add=(); _gr_remove=(); _gr_mode=""; _gr_add_seen=0; _gr_rm_seen=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -961,6 +961,9 @@ if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
             --color)  shift
                       if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_gr_usage" >&2; exit 2; fi
                       _gr_color="$1"; _gr_cset=1; _gr_mode=""; shift ;;
+            --host)   shift
+                      if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_gr_usage" >&2; exit 2; fi
+                      _gr_host="$1"; _gr_mode=""; shift ;;
             --delete) _gr_del=1; _gr_mode=""; shift ;;
             -*)       echo "$_gr_usage" >&2; exit 2 ;;
             *)        case "$_gr_mode" in
@@ -977,6 +980,11 @@ if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
     fi
     if [[ -z "$_gr_name" && ( $_gr_add_seen -eq 1 || $_gr_rm_seen -eq 1 || $_gr_cset -eq 1 || $_gr_del -eq 1 ) ]]; then
         echo "$_gr_usage" >&2; exit 2
+    fi
+    if [[ -n "$_gr_host" && $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 ]]; then
+        # v0: --host modifies an EDIT (the target kernel's store, through the tunnel). Reads stay
+        # local — the dashboard's view menu already shows the union.
+        echo "romp tag: --host goes with an edit (--add/--remove/--color/--delete)" >&2; exit 2
     fi
     if [[ ( $_gr_add_seen -eq 1 && ${#_gr_add[@]} -eq 0 ) || ( $_gr_rm_seen -eq 1 && ${#_gr_remove[@]} -eq 0 ) ]]; then
         echo "$_gr_usage" >&2; exit 2
@@ -1003,12 +1011,18 @@ if not isinstance(v, dict):
 rows = json.loads(sys.argv[2])
 rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
 names = {r.get("id"): r.get("name") for r in rows if isinstance(r, dict)}
+def spell(x):
+    # canonical (host, sid) pair from a federated kernel, or the legacy plain string
+    if isinstance(x, dict):
+        h, s = x.get("host") or "", x.get("sid") or ""
+        return (h + ":" + s) if h else s
+    return x
 groups = v.get("tags") or v.get("groups") or []   # older kernel: pre-rename key
 act = v.get("active") or "all"
 act = next((g.get("name") for g in groups if g.get("id") == act), act)
 print("active view: %s" % act)
 for g in groups:
-    m = [names.get(x) or x for x in (g.get("members") or [])]
+    m = [names.get(spell(x)) or spell(x) for x in (g.get("members") or [])]
     print("%s  %s  %d member%s%s" % (g.get("name"), g.get("color") or "(no color)",
                                      len(m), "" if len(m) == 1 else "s",
                                      (": " + ", ".join(m)) if m else ""))
@@ -1027,10 +1041,15 @@ v = json.loads(sys.argv[1])
 rows = json.loads(sys.argv[2])
 rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
 names = {r.get("id"): r.get("name") for r in rows if isinstance(r, dict)}
+def spell(x):
+    if isinstance(x, dict):
+        h, s = x.get("host") or "", x.get("sid") or ""
+        return (h + ":" + s) if h else s
+    return x
 g = next((g for g in (v.get("tags") or v.get("groups") or []) if isinstance(v, dict) and g.get("name") == sys.argv[3]), None)
 if g is None:
     sys.exit(3)
-m = [names.get(x) or x for x in (g.get("members") or [])]
+m = [names.get(spell(x)) or spell(x) for x in (g.get("members") or [])]
 print("%s  %s  %d member%s%s" % (g.get("name"), g.get("color") or "(no color)",
                                  len(m), "" if len(m) == 1 else "s",
                                  (": " + ", ".join(m)) if m else ""))
@@ -1042,14 +1061,16 @@ print("%s  %s  %d member%s%s" % (g.get("name"), g.get("color") or "(no color)",
     fi
     _payload="$(python3 -c '
 import json, sys
-n = int(sys.argv[5])
-body = {"name": sys.argv[1], "add": sys.argv[6:6 + n], "remove": sys.argv[6 + n:]}
+n = int(sys.argv[6])
+body = {"name": sys.argv[1], "add": sys.argv[7:7 + n], "remove": sys.argv[7 + n:]}
 if sys.argv[2] == "1":
     body["color"] = sys.argv[3]
 if sys.argv[4] == "1":
     body["delete"] = True
+if sys.argv[5]:
+    body["host"] = sys.argv[5]
 print(json.dumps(body))
-' "$_gr_name" "$_gr_cset" "$_gr_color" "$_gr_del" "${#_gr_add[@]}" \
+' "$_gr_name" "$_gr_cset" "$_gr_color" "$_gr_del" "$_gr_host" "${#_gr_add[@]}" \
         "${_gr_add[@]+"${_gr_add[@]}"}" "${_gr_remove[@]+"${_gr_remove[@]}"}")"
     _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/tag" \
                   -H 'Content-Type: application/json' -d "$_payload")" \

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1534,6 +1534,28 @@ def _views_path():
     return jd.STATE / "timeline-views.json"
 
 
+def _member_pair(x):
+    """One tag member, canonicalized to the STORED (host, sid) pair (federation v0, the user
+    2026-08-24): host "" = the tag's HOME kernel; any other host is the home kernel's own name for
+    the member session's kernel. The legacy spelling — a plain sid, or the viewer-relative
+    "host:sid" string every client still posts — reads losslessly (sids are uuids, so the first ":"
+    is unambiguous). None = junk, dropped."""
+    if isinstance(x, dict) and isinstance(x.get("sid"), str) and x.get("sid"):
+        return {"host": str(x.get("host") or "")[:64], "sid": str(x["sid"])[:80]}
+    if isinstance(x, str) and x:
+        i = x.find(":")
+        return {"host": x[:i], "sid": x[i + 1:]} if 0 < i < len(x) - 1 else {"host": "", "sid": x}
+    return None
+
+
+def _member_str(m):
+    """A stored (host, sid) pair in the viewer-relative RENDERING spelling this kernel's clients
+    match lane/tab ids against: a home member is the bare sid, a remote one "host:sid" — exactly
+    the strings the store held before pairs. Storage stays canonical; this is display and matching."""
+    h = m.get("host") or ""
+    return (h + ":" + m["sid"]) if h else m["sid"]
+
+
 def _norm_timeline_views(d):
     """Validate + normalize a views blob from disk or a client: always returns the full shape, drops
     junk quietly, clamps sizes, and falls back active→"all" when the named tag does not exist.
@@ -1543,7 +1565,15 @@ def _norm_timeline_views(d):
     TAGS, not groups (the user 2026-08-23): a tag marks a SPECIALIZED session, excluded from the
     untagged view and viewable under its tag — the accurate name for what membership always did.
     Stored under "tags"; a blob carrying only the legacy "groups" key (a pre-rename file, an
-    un-updated Obsidian panel posting the whole blob) reads as tags, so nothing is lost on upgrade."""
+    un-updated Obsidian panel posting the whole blob) reads as tags, so nothing is lost on upgrade.
+    MEMBERS are stored as canonical (host, sid) PAIRS (federation v0, the user 2026-08-24): the
+    viewer-relative string spelling is RENDERING (_views_client), and legacy string members read
+    losslessly via _member_pair — one tag can span linked kernels. An `active` carrying a ":"
+    points at a REMOTE tag ("host:tagid"), which this kernel cannot validate against another's
+    store: it survives normalization and _view_visible falls open to "all"-like behavior when the
+    remote tag is gone. A plain unknown id still falls back — the typo protection stands. The
+    derived `remoteTags` a client may echo back is IGNORED here: it is this kernel's own read of
+    its attached kernels (_views_client), never client state."""
     if not isinstance(d, dict):
         d = {}
     _lst = lambda x: x if isinstance(x, list) else []   # wrong-typed junk (a number, a string) drops, never raises
@@ -1553,13 +1583,15 @@ def _norm_timeline_views(d):
     for g in _lst(raw)[:_VIEWS_MAX_TAGS]:
         if not isinstance(g, dict) or not g.get("id") or not isinstance(g.get("id"), str):
             continue
-        members = [str(x) for x in _lst(g.get("members")) if isinstance(x, str) and x]
+        members = [m for m in (_member_pair(x) for x in _lst(g.get("members"))) if m]
+        dedup = {(m["host"], m["sid"]): m for m in members}
         tags.append({"id": g["id"][:64],
                      "name": str(g.get("name") or "tag")[:_VIEWS_MAX_NAME],
                      "color": str(g.get("color") or "")[:16],
-                     "members": sorted(set(members))})
+                     "members": [dedup[k] for k in sorted(dedup)]})
     active = d.get("active") if isinstance(d.get("active"), str) else "all"
-    if active not in ("all", "untagged") and not any(t["id"] == active for t in tags):
+    if active not in ("all", "untagged") and ":" not in active \
+            and not any(t["id"] == active for t in tags):
         active = "all"
     return {"active": active, "hidden": sorted(set(hidden)), "tags": tags}
 
@@ -1586,9 +1618,59 @@ def _set_timeline_views(blob):
     _atomic_write(_views_path(), json.dumps(_norm_timeline_views(blob), sort_keys=True))
 
 
+def _remote_tag_member_str(owner_host, m):
+    """A remote kernel's stored member pair, respelled for THIS viewer (federation v0): sid-first,
+    because sids are globally unique and host labels are per-kernel names. The owner's home member
+    ("") wears the owner's host here; a session THIS kernel knows locally is the bare sid (the
+    owner tagged one of ours — its label for us is unknowable and unnecessary); anything else keeps
+    the owner's label for it, which joins correctly whenever that kernel is attached here too."""
+    h = m.get("host") or ""
+    sid = m.get("sid") or ""
+    if not h:
+        return owner_host + ":" + sid
+    try:
+        if (jd.STATE / "names" / sid).exists():
+            return sid
+    except OSError:
+        pass
+    return h + ":" + sid
+
+
+def _views_client():
+    """The views blob every client renders and matches against — the RENDERING of the canonical
+    store (federation v0, the user 2026-08-24): local tags with members as viewer-relative strings
+    (the pre-pairs contract, so no client re-learns anything), plus `remoteTags` — each ATTACHED
+    kernel's own tags, read-only, host-stamped, members respelled for this viewer. Per-host maps
+    joined at the viewer, never merged (the federation counter rule); same-name tags on two kernels
+    stay two entries — the host disambiguates, nothing silently merges. Remote reads ride the
+    supervisor's cached /views poll; a kernel that is down simply contributes nothing this push."""
+    v = json.loads(json.dumps(_timeline_views()))
+    for t in v["tags"]:
+        t["members"] = [_member_str(m) for m in t["members"]]
+    remote = []
+    with _remotes_lock:
+        cand = [(r["host"], r.get("views")) for r in _remotes.values()
+                if r.get("status") == "up" and isinstance(r.get("views"), dict)]
+    for host, rv in sorted(cand):
+        for t in (rv.get("tags") or [])[:_VIEWS_MAX_TAGS]:
+            if not isinstance(t, dict) or not t.get("id"):
+                continue
+            members = [m for m in (_member_pair(x) for x in (t.get("members") or [])) if m]
+            remote.append({"id": host + ":" + str(t["id"])[:64], "host": host,
+                           "name": str(t.get("name") or "tag")[:_VIEWS_MAX_NAME],
+                           "color": str(t.get("color") or "")[:16],
+                           "members": [_remote_tag_member_str(host, m) for m in members]})
+    if remote:
+        v["remoteTags"] = remote
+    return v
+
+
 def _view_visible(views, sid):
     """The one visibility decision, kernel-authoritative: mirrored by the chat renderer and the
-    timeline for optimistic feedback — tests pin all three against this shape. ALL — the default
+    timeline for optimistic feedback — tests pin all three against this shape. Operates on the
+    RENDERED blob (_views_client: string members + remoteTags) — the shape every client holds; a
+    remote-tag active ("host:tagid") resolves in remoteTags and falls OPEN when the remote tag is
+    gone (its kernel detached), never trapping the viewer in an empty view. ALL — the default
     (the user 2026-08-24) — shows every session minus the `hidden` set: hiding is a deliberate user
     gesture, so All respects it (the dialog's eye stays the un-hide affordance). UNTAGGED keeps the
     old default's meaning (the user 2026-08-23): tagging a session says "specialized — out of the
@@ -1597,8 +1679,13 @@ def _view_visible(views, sid):
     if views["active"] == "all":
         return sid not in views["hidden"]
     if views["active"] == "untagged":
+        # LOCAL tags only exclude here (federation v0): a remote kernel's tagging of our session
+        # must not flap our untagged view with its poll cadence — remote tags are extra VIEWS
         return sid not in views["hidden"] and not any(sid in t["members"] for t in views["tags"])
     for t in views["tags"]:
+        if t["id"] == views["active"]:
+            return sid in t["members"]
+    for t in views.get("remoteTags") or []:
         if t["id"] == views["active"]:
             return sid in t["members"]
     return True
@@ -1610,7 +1697,9 @@ def _heal_timeline_views(old_sid, new_sid):
     order-slot inheritance that detects the churn. Without this a hidden tmux session would pop back
     visible on every /clear — and worse, a tagged one would silently fall out of its tag."""
     v = _timeline_views()
-    if old_sid not in v["hidden"] and not any(old_sid in t["members"] for t in v["tags"]):
+    def _has(t):
+        return any(m["host"] == "" and m["sid"] == old_sid for m in t["members"])
+    if old_sid not in v["hidden"] and not any(_has(t) for t in v["tags"]):
         return
     v = json.loads(json.dumps(v))                    # deep copy: never mutate the cached blob
     # COPY, never move: stripping the old sid un-hid its DEAD lane, which lingers on the timeline for
@@ -1620,8 +1709,8 @@ def _heal_timeline_views(old_sid, new_sid):
     if old_sid in v["hidden"]:
         v["hidden"] = sorted(set(v["hidden"]) | {new_sid})
     for t in v["tags"]:
-        if old_sid in t["members"]:
-            t["members"] = sorted(set(t["members"]) | {new_sid})
+        if _has(t):
+            t["members"] = t["members"] + [{"host": "", "sid": new_sid}]   # normalizer dedups + re-sorts
     _set_timeline_views(v)
 
 
@@ -1671,12 +1760,19 @@ def _edit_tag(name, add=(), remove=(), color=None, delete=False):
                 n += 1
             t = {"id": "g" + _b36(n), "name": name, "color": "", "members": []}
             v["tags"].append(t)
-        t["members"] = sorted((set(t["members"]) | set(add)) - set(remove))
+        # add/remove arrive as viewer-relative id strings (the route's contract); the store is
+        # canonical pairs — convert on the way in, match removals by pair (federation v0)
+        addp = [m for m in (_member_pair(x) for x in add) if m]
+        remp = {(m["host"], m["sid"]) for m in (_member_pair(x) for x in remove) if m}
+        t["members"] = [m for m in list(t["members"]) + addp
+                        if (m["host"], m["sid"]) not in remp]
         if color is not None:
             t["color"] = color
         v = _norm_timeline_views(v)
         _set_timeline_views(v)
-        return next(t2 for t2 in v["tags"] if t2["id"] == t["id"]), None
+        out = json.loads(json.dumps(next(t2 for t2 in v["tags"] if t2["id"] == t["id"])))
+        out["members"] = [_member_str(m) for m in out["members"]]   # the route's reply speaks strings
+        return out, None
 
 
 # ── per-session view flags (the user 2026-06-19) ──────────────────────────────────────────────────
@@ -9782,6 +9878,7 @@ def _poll_remote_version(r):
 
 
 REMOTE_USAGE_EVERY = 60.0    # a usage window moves over hours; polling it per supervisor pass would be waste
+REMOTE_VIEWS_EVERY = 60.0    # tag edits are human-paced; the view-menu union tolerates a minute of lag
 
 
 def _poll_remote_usage(r):
@@ -9813,6 +9910,33 @@ def _poll_remote_usage(r):
         return u if isinstance(u, dict) and u else {}
     except Exception:
         return r.get("usage")   # keep the last good reading rather than blanking the bars on one blip
+
+
+def _poll_remote_views(r):
+    """GET a remote kernel's /views THROUGH the -L tunnel — the read half of tag federation v0 (the
+    user 2026-08-24): each attached kernel's own tags ride to this viewer read-only, and
+    _views_client joins them per host (never merging — the federation counter rule). Same shape and
+    rate-gate as _poll_remote_usage; on a blip the last good reading stands (a down host simply
+    stops contributing when its status leaves "up"). An older remote without the route answers
+    non-200 → None, and the union just never includes it — nothing breaks across versions."""
+    import urllib.parse
+    now = time.time()
+    if now - float(r.get("_views_at") or 0) < REMOTE_VIEWS_EVERY:
+        return r.get("views")
+    try:
+        c = http.client.HTTPConnection("127.0.0.1", int(r["local_port"]), timeout=5)
+        path = "/views" + (("?token=" + urllib.parse.quote(r["token"])) if r.get("token") else "")
+        c.request("GET", path)
+        resp = c.getresponse()
+        data = resp.read()
+        c.close()
+        if resp.status != 200:
+            return r.get("views")
+        u = json.loads(data.decode("utf-8"))
+        r["_views_at"] = now
+        return u if isinstance(u, dict) else r.get("views")
+    except Exception:
+        return r.get("views")
 
 
 def _fleet_usage():
@@ -10773,6 +10897,7 @@ def _tunnel_supervisor():
                 # …and which Claude account it burns, so the rail can draw a second set of bars when it is
                 # a different one (self-rate-limited to a minute — these windows are hours wide)
                 ruse = _poll_remote_usage(r) if up else None
+                rviews = _poll_remote_views(r) if up else None   # tag federation v0: the read half
                 with _remotes_lock:
                     if r["host"] not in _remotes:
                         continue
@@ -10860,6 +10985,8 @@ def _tunnel_supervisor():
                             r["usage"] = ruse
                         else:
                             r.pop("usage", None)
+                    if rviews is not None:
+                        r["views"] = rviews
                     auto_check = (st == "up")
                     peer_up = (st == "up")
                     peer_port, peer_tok = r.get("bus_port"), r.get("token") or ""
@@ -20342,7 +20469,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     # letting the bar slide through the map's hues as it compresses — mirroring the context battery fill.
     cmap_grad = [list(cm.ramp(v, ctx_stops)) for v in (0.12, 0.34, 0.56, 0.78, 1.0)]
     return {"type": "timeline", "now": now, "sessions": sessions, "turns": turns,
-            "views": _timeline_views(),
+            "views": _views_client(),
             "palette": pal.colors(_palette_name()),   # tag color choices — the same set sessions draw identity colors from
             "messages": messages, "judging": judging,
             "cmapGrad": cmap_grad,
@@ -21902,7 +22029,7 @@ def _push(targets, connect=False, tmux=None):
                 _send_client(c, ("globalRetryPaused",), {"type": "globalRetryPaused", "value": _retry_paused_on(),
                                                          "resumeAt": _retry_resume_at(),   # limit reset epoch → the card counts down to the real retry
                                                          "reason": _retry_pause_reason()})   # "spend" → the card says 'raise your cap', no countdown
-                _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _timeline_views()})
+                _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()})
             active = {c.get("active") for c in chat_clients if c.get("active")}
             # Stable: active tabs first — and TRANSCRIPT-LESS sessions with them. A just-created session
             # has no transcript, so its build is near-free, and its creator is guaranteed to be staring
@@ -22113,7 +22240,7 @@ def _push_session_now(sid):
             return
         ms = None                                    # lazy: the first full send materializes it, the rest reuse
         for c in targets:
-            _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _timeline_views()})
+            _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()})
             ms = _send_chat(c, m, ms, 0, True)       # change_from 0 → always the full-session form
     except Exception:
         sys.stderr.write("push-session-now (%s): %s\n" % (sid, traceback.format_exc()))
@@ -26470,9 +26597,10 @@ class Handler(BaseHTTPRequestHandler):
                     "palettes": [{"name": k, "label": v["label"], "colors": v["bg"]}
                                  for k, v in pal.PALETTES.items()]}), "application/json", cache="no-cache")
             if p == "/views":                             # the session-views blob (active view, hidden set,
-                # tags) for scripts/agents: the read half of POST /tag. The dashboard reads the same
-                # blob off the tabOrder WS push; this route exists for token-bearing curl consumers
-                # (`romp tag` with no args prints it).
+                # tags) for scripts/agents: the read half of POST /tag, AND the remote-poll source of
+                # tag federation v0. CANONICAL shape (member pairs), remoteTags absent on purpose:
+                # a polling kernel re-spells pairs for ITS viewer, and never re-imports another
+                # viewer's join (no transitive unions in v0). `romp tag` maps either spelling.
                 return self._send(200, json.dumps(_timeline_views()), "application/json", cache="no-cache")
             if p == "/models":                                # the ONE model + effort choice list — chat statusline, timeline lanes, AND judge settings all read it (the user 2026-07-02: no hardcoding in multiple places)
                 # each choice carries its colormap tint (the user 2026-08-17: the new-comment dialog's
@@ -27088,6 +27216,30 @@ class Handler(BaseHTTPRequestHandler):
                 if not name:
                     return self._send(400, json.dumps({"ok": False, "error": "name required"}),
                                       "application/json")
+                # --host (tag federation v0, the user 2026-08-24): the edit targets an ATTACHED
+                # kernel's store, through the tunnel it already holds — Model A home-kernel
+                # ownership, no sync engine. The body forwards minus `host`; the TARGET resolves
+                # member names against ITS live sessions (they are its sessions to know). A miss
+                # refuses loudly: an unreachable kernel must never silently no-op an edit.
+                th = str((b or {}).get("host") or "").strip()
+                if th:
+                    with _remotes_lock:
+                        r = next((x for x in _remotes.values() if x.get("host") == th), None)
+                        r_up = bool(r and r.get("status") == "up")
+                    if not r:
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            'no attached kernel named "%s" (see the network panel)' % th}),
+                            "application/json")
+                    if not r_up:
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            '"%s" is attached but not reachable right now' % th}), "application/json")
+                    fwd = {k: v for k, v in b.items() if k != "host"}
+                    ans = _remote_forward(r, "/tag", fwd)
+                    if ans is None:
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            'the edit never landed on "%s" (tunnel hiccup — try again)' % th}),
+                            "application/json")
+                    return self._send(200, json.dumps(ans), "application/json")
                 live = _live_names(_tmux_sessions())
                 ids, unknown = {"add": [], "remove": []}, []
                 for k in ("add", "remove"):
@@ -27541,7 +27693,7 @@ class Handler(BaseHTTPRequestHandler):
                 _o = [s["sid"] for s in _alive]
                 # name+color per tab → the client paints the whole strip as placeholders up front (tabs-first)
                 _tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in _alive]
-                client["send"](json.dumps({"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _timeline_views()}))
+                client["send"](json.dumps({"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _views_client()}))
             except Exception:
                 pass
             # a push tap parked a reveal for this window's chat pane → deliver it now, AFTER the

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -251,6 +251,19 @@ MOCK
     [ "$(grep -c '/tag' "$MOCK_LOG")" -eq 0 ]
 }
 
+@test "tag: --host rides the payload (an edit on an attached kernel's store)" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp tag team --host alpha --add exp-web
+    [ "$status" -eq 0 ]
+    grep '/tag' "$MOCK_LOG" | grep -q '"host": *"alpha"'
+    # …and --host with no edit flag is a usage error: v0 reads stay local (the menu shows the union)
+    run run_romp tag team --host alpha
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--host goes with an edit"* ]]
+}
+
 @test "tag: the pre-rename group verb still works, posting the new /tag route" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_kernel_tabs_first.py
+++ b/tests/test_kernel_tabs_first.py
@@ -25,12 +25,12 @@ class TabsFirst(unittest.TestCase):
         src = inspect.getsource(km._push)
         self.assertIn('tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', src,
                       "the periodic push builds a name+color list per tab")
-        self.assertIn('{"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _timeline_views()}', src,
+        self.assertIn('{"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()}', src,
                       "and ships it as the tabs field alongside the sid order")
 
     def test_connect_ready_handler_also_sends_tabs(self):
         text = open(KPATH).read()
-        self.assertIn('{"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _timeline_views()}', text,
+        self.assertIn('{"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _views_client()}', text,
                       "the WS 'ready' connect push also carries name+color tabs")
         self.assertIn('_tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', text)
 

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -181,7 +181,9 @@ class TagRoute(unittest.TestCase):
         self.assertEqual(len(v["tags"]), 1,
                          "the raw name must address the stored (clamped) tag — never mint a duplicate")
         self.assertEqual(v["tags"][0]["name"], "x" * 40)
-        self.assertEqual(v["tags"][0]["members"], sorted([SID, SID2]))
+        self.assertEqual(v["tags"][0]["members"],
+                         [{"host": "", "sid": s} for s in sorted([SID, SID2])],
+                         "stored members are canonical pairs (federation v0)")
 
     def test_a_host_prefixed_NAME_refuses_like_any_unknown_name(self):
         st, r = self._post({"name": "pool", "add": ["TESTHOST:exp-ghost"]})
@@ -202,10 +204,56 @@ class TagRoute(unittest.TestCase):
         st, v = self._views()
         self.assertEqual(v["active"], "gb", "the active view survives the merge")
         self.assertEqual(v["hidden"], ["s9"], "the hidden list survives")
-        self.assertEqual([g for g in v["tags"] if g["id"] == "gb"], [GB],
-                         "the tag the edit never looked at is untouched")
+        want = dict(GB, members=[{"host": "", "sid": "s2"}])
+        self.assertEqual([g for g in v["tags"] if g["id"] == "gb"], [want],
+                         "the tag the edit never looked at is untouched (stored as pairs)")
         alpha = next(g for g in v["tags"] if g["id"] == "ga")
-        self.assertEqual(alpha["members"], sorted(["s1", SID2]))
+        self.assertEqual(alpha["members"], [{"host": "", "sid": s} for s in sorted(["s1", SID2])])
+
+
+class HostForward(TagRoute):
+    """POST /tag {"host": ...} — tag federation v0's edit path: the edit targets an ATTACHED
+    kernel's store through the tunnel it already holds (Model A home-kernel ownership). The body
+    forwards minus `host`; the TARGET resolves member names against ITS sessions; failures refuse
+    loudly — an unreachable kernel must never silently no-op an edit."""
+
+    def setUp(self):
+        super().setUp()
+        self._remotes_saved = dict(km._remotes)
+        self._fwd_saved = km._remote_forward
+        km._remotes.clear()
+        km._remotes["alpha"] = {"host": "alpha", "status": "up"}
+        km._remotes["down1"] = {"host": "down1", "status": "down"}
+        self.forwarded = []
+        km._remote_forward = lambda r, path, body: (self.forwarded.append((r["host"], path, body))
+                                                    or {"ok": True, "tag": {"name": body.get("name")}})
+
+    def tearDown(self):
+        km._remotes.clear(); km._remotes.update(self._remotes_saved)
+        km._remote_forward = self._fwd_saved
+        super().tearDown()
+
+    def test_host_edit_forwards_to_the_target_kernel_minus_the_host_key(self):
+        st, r = self._post({"name": "team", "host": "alpha", "add": ["web"], "color": "#DD42FF"})
+        self.assertEqual(st, 200)
+        self.assertTrue(r["ok"])
+        self.assertEqual(self.forwarded, [("alpha", "/tag",
+                                           {"name": "team", "add": ["web"], "color": "#DD42FF"})],
+                         "the target resolves names itself — the body forwards verbatim, minus host")
+        self.assertEqual(km._timeline_views()["tags"], [],
+                         "nothing lands on THIS kernel's store — the edit belongs to alpha")
+
+    def test_unknown_and_down_hosts_refuse_loudly(self):
+        st, r = self._post({"name": "team", "host": "ghost", "add": ["web"]})
+        self.assertFalse(r["ok"]); self.assertIn('no attached kernel named "ghost"', r["error"])
+        st, r = self._post({"name": "team", "host": "down1", "add": ["web"]})
+        self.assertFalse(r["ok"]); self.assertIn("not reachable", r["error"])
+        self.assertEqual(self.forwarded, [], "no forward is attempted either way")
+
+    def test_a_dead_forward_surfaces_never_silently_noops(self):
+        km._remote_forward = lambda r, path, body: None
+        st, r = self._post({"name": "team", "host": "alpha", "add": ["web"]})
+        self.assertFalse(r["ok"]); self.assertIn("never landed", r["error"])
 
 
 class GroupAliasSurvives(TagRoute):

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -52,7 +52,7 @@ class TimelineViews(unittest.TestCase):
         # a deliberate gesture, so All respects it, but a tag no longer excludes a session there
         km._set_timeline_views({"active": "all", "hidden": ["s9"], "tags": [G1]})
         km._flags_cache.clear()
-        v = km._timeline_views()
+        v = km._views_client()   # _view_visible reads the RENDERED shape (string members + remoteTags)
         self.assertFalse(km._view_visible(v, "s9"), "hidden — All respects the deliberate hide")
         self.assertTrue(km._view_visible(v, "s2"), "TAGGED → All still shows it")
         self.assertTrue(km._view_visible(v, "s1"), "untagged → shown")
@@ -60,14 +60,14 @@ class TimelineViews(unittest.TestCase):
         # 2026-08-23 TAG rule: tagging says "specialized — out of the main view")
         km._set_timeline_views({"active": "untagged", "hidden": ["s9"], "tags": [G1]})
         km._flags_cache.clear()
-        v = km._timeline_views()
+        v = km._views_client()
         self.assertEqual(v["active"], "untagged", "the sentinel survives the normalizer round-trip")
         self.assertFalse(km._view_visible(v, "s9"), "hidden hides in the untagged view too")
         self.assertFalse(km._view_visible(v, "s2"), "TAGGED → out of the untagged view")
         self.assertTrue(km._view_visible(v, "s1"), "tagless, not hidden → shown")
         km._set_timeline_views({"active": "g1", "hidden": ["s2"], "tags": [G1]})
         km._flags_cache.clear()
-        v = km._timeline_views()
+        v = km._views_client()
         self.assertTrue(km._view_visible(v, "s2"), "a tag view shows exactly its members — hidden or not")
         self.assertFalse(km._view_visible(v, "s1"), "…and nothing else")
 
@@ -75,7 +75,8 @@ class TimelineViews(unittest.TestCase):
         # a pre-rename timeline-views.json (or an un-updated Obsidian panel posting the whole blob)
         # must lose nothing on upgrade; when BOTH keys appear, "tags" is the authoritative one
         v = km._norm_timeline_views({"active": "g1", "hidden": [], "groups": [G1]})
-        self.assertEqual(v["tags"], [G1], "the legacy key migrates in")
+        want = dict(G1, members=[{"host": "", "sid": "s2"}, {"host": "", "sid": "s3"}])
+        self.assertEqual(v["tags"], [want], "the legacy key migrates in — string members become pairs")
         self.assertEqual(v["active"], "g1", "…and its active tag survives the read")
         self.assertNotIn("groups", v, "the normalized shape carries tags only")
         both = km._norm_timeline_views({"tags": [G1], "groups": [{"id": "gX", "name": "stale"}]})
@@ -97,7 +98,7 @@ class TimelineViews(unittest.TestCase):
         self.assertEqual(v["hidden"], ["a"], "junk and duplicates dropped")
         self.assertEqual(len(v["tags"]), 1)
         self.assertEqual(len(v["tags"][0]["name"]), km._VIEWS_MAX_NAME)
-        self.assertEqual(v["tags"][0]["members"], ["m"])
+        self.assertEqual(v["tags"][0]["members"], [{"host": "", "sid": "m"}])
 
     def test_cache_invalidates_on_write(self):
         self.assertEqual(km._timeline_views()["hidden"], [])
@@ -112,7 +113,9 @@ class TimelineViews(unittest.TestCase):
         km._heal_timeline_views("old", "new")
         v = km._timeline_views()
         self.assertEqual(v["hidden"], ["new", "old"], "the fork inherits the hidden bit; the old sid keeps it")
-        self.assertEqual(v["tags"][0]["members"], ["new", "old", "other"], "membership copies the same way")
+        self.assertEqual(v["tags"][0]["members"],
+                         [{"host": "", "sid": x} for x in ("new", "old", "other")],
+                         "membership copies the same way")
         before = json.loads((jd.STATE / "timeline-views.json").read_text())
         km._heal_timeline_views("stranger", "new2")   # untouched sid → no write at all
         self.assertEqual(json.loads((jd.STATE / "timeline-views.json").read_text()), before)
@@ -137,15 +140,90 @@ class TimelineViews(unittest.TestCase):
 
     def test_payloads_echo_the_views_blob(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn('"views": _timeline_views(),', src, "the timeline payload carries it")
+        self.assertIn('"views": _views_client(),', src, "the timeline payload carries the RENDERED shape")
         self.assertIn('"palette": pal.colors(_palette_name()),', src, "and the palette, for tag colors in every host")
-        self.assertIn('"tabs": tab_meta, "views": _timeline_views()', src, "tabOrder pushes carry it")
-        self.assertIn('"tabs": _tabs, "views": _timeline_views()', src, "the connect-time tabOrder carries it")
+        self.assertIn('"tabs": tab_meta, "views": _views_client()', src, "tabOrder pushes carry it")
+        self.assertIn('"tabs": _tabs, "views": _views_client()', src, "the connect-time tabOrder carries it")
 
     def test_web_boot_exposes_the_set_views_hook(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("window.__rompTimelineSetViews=function(views)", src)
         self.assertIn('post({type:"setTimelineViews",views:views});', src)
+
+    # ── tag federation v0 (the user 2026-08-24): canonical pairs, the rendered union, remote views ──
+
+    def test_member_pairs_round_trip_all_three_spellings(self):
+        # strings ("sid", "host:sid") and pair dicts all land as canonical pairs; the rendered
+        # client shape respells them viewer-relative — a lossless round trip either way
+        km._set_timeline_views({"active": "all", "hidden": [], "tags": [
+            {"id": "g1", "name": "mixed", "members": ["s1", "alpha:s2", {"host": "beta", "sid": "s3"}]}]})
+        km._flags_cache.clear()
+        stored = km._timeline_views()["tags"][0]["members"]
+        self.assertEqual(stored, [{"host": "", "sid": "s1"}, {"host": "alpha", "sid": "s2"},
+                                  {"host": "beta", "sid": "s3"}])
+        rendered = km._views_client()["tags"][0]["members"]
+        self.assertEqual(rendered, ["s1", "alpha:s2", "beta:s3"],
+                         "the rendering spelling is exactly the pre-pairs client contract")
+
+    def _attach(self, host, views, status="up"):
+        km._remotes[host] = {"host": host, "status": status, "views": views}
+
+    def test_remote_tags_join_the_client_shape_read_only_and_host_stamped(self):
+        # a tag created on kernel alpha, with a member of its own, one of beta's, and one of OURS —
+        # the sid-first respelling: alpha's home member wears alpha's host here, beta's keeps
+        # alpha's label for beta (it joins whenever beta is attached here too), and OUR session
+        # (known locally by sid — uuids are global) renders bare, so the lane join lands
+        (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "names" / "00000000-aaaa-bbbb-cccc-000000000001").write_text("web\t/tmp\t#123456\twhite\n")
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            self._attach("alpha", {"active": "all", "hidden": [], "tags": [
+                {"id": "g9", "name": "team", "color": "#DD42FF",
+                 "members": [{"host": "", "sid": "rs1"}, {"host": "beta", "sid": "rs2"},
+                             {"host": "snape", "sid": "00000000-aaaa-bbbb-cccc-000000000001"}]}]})
+            v = km._views_client()
+            self.assertEqual(v["remoteTags"], [{
+                "id": "alpha:g9", "host": "alpha", "name": "team", "color": "#DD42FF",
+                "members": ["alpha:rs1", "beta:rs2", "00000000-aaaa-bbbb-cccc-000000000001"]}])
+            # …and picking it filters exactly like a local tag, falling OPEN when the kernel detaches
+            v["active"] = "alpha:g9"
+            self.assertTrue(km._view_visible(v, "alpha:rs1"))
+            self.assertFalse(km._view_visible(v, "somebody-else"))
+            gone = {"active": "alpha:g9", "hidden": [], "tags": []}
+            self.assertTrue(km._view_visible(gone, "somebody-else"),
+                            "a vanished remote tag falls open, never trapping the viewer in an empty view")
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
+    def test_same_name_tags_on_two_kernels_stay_two_entries(self):
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            self._attach("alpha", {"tags": [{"id": "g1", "name": "team", "members": []}]})
+            self._attach("beta", {"tags": [{"id": "g1", "name": "team", "members": []}]})
+            ids = [t["id"] for t in km._views_client()["remoteTags"]]
+            self.assertEqual(ids, ["alpha:g1", "beta:g1"], "host-disambiguated — never a silent merge")
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
+    def test_a_down_kernel_contributes_nothing_and_active_hidden_stay_local(self):
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            self._attach("alpha", {"tags": [{"id": "g1", "name": "team", "members": []}]}, status="down")
+            v = km._views_client()
+            self.assertNotIn("remoteTags", v, "a down kernel's cached tags never join the union")
+            # a remote-tag ACTIVE survives normalization (validated at read time, ":" is the marker);
+            # hidden stays exactly the viewer-local list — neither is federated state
+            n = km._norm_timeline_views({"active": "alpha:g1", "hidden": ["h1"], "tags": []})
+            self.assertEqual(n["active"], "alpha:g1")
+            self.assertEqual(n["hidden"], ["h1"])
+            # a client echoing the derived remoteTags back never persists it
+            n2 = km._norm_timeline_views({"active": "all", "remoteTags": [{"id": "x"}], "tags": []})
+            self.assertNotIn("remoteTags", n2)
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
 
     def test_focus_never_mutates_the_views_blob(self):
         # A focus is a PEEK, not a view edit (the user 2026-08-24, superseding the 2026-08-18/19/23

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -49,14 +49,17 @@ function viewVisible(views, id) {
     if (Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0) return false;
     return !viewTags(views).some((t) => (t.members || []).indexOf(id) >= 0);
   }
-  const t = viewTags(views).find((x) => x.id === views.active);
+  const t = viewTags(views).find((x) => x.id === views.active)
+    || ((views && views.remoteTags) || []).find((x) => x.id === views.active);   // remote tags are views too (federation v0)
   return t ? (t.members || []).indexOf(id) >= 0 : true;
 }
 function viewLabel(views) {
   if (!views || !views.active || views.active === 'all') return 'All';
   if (views.active === 'untagged') return '(untagged)';
   const t = viewTags(views).find((x) => x.id === views.active);
-  return t ? (t.name || 'tag') : 'All';
+  if (t) return t.name || 'tag';
+  const rt = ((views && views.remoteTags) || []).find((x) => x.id === views.active);
+  return rt ? ((rt.host ? rt.host + ':' : '') + (rt.name || 'tag')) : 'All';
 }
 // live sessions the current view is NOT showing — the "N more" cue that keeps a hidden or tagged
 // session exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
@@ -2529,6 +2532,14 @@ class TimelinePanel {
     item('(untagged)', { current: v.active === 'untagged' }).addEventListener('click', () => pick('untagged'));
     for (const tg of viewTags(v))
       item(tg.name, { dot: tg.color || MODEL_FG, current: v.active === tg.id }).addEventListener('click', () => pick(tg.id));
+    // tag federation v0 (the user 2026-08-24): every ATTACHED kernel's tags join the menu, read-only,
+    // wearing the owner's colour and the "host:name" marker (the list_agents idiom) — a same-named
+    // tag on two kernels is two rows, never a silent merge. Picking one filters exactly like a local
+    // tag; editing it goes through its home kernel (romp tag --host <h>), so no edit affordance here.
+    for (const rt of (v.remoteTags || []))
+      item((rt.host ? rt.host + ':' : '') + (rt.name || 'tag'),
+           { dot: rt.color || MODEL_FG, current: v.active === rt.id, dim: true })
+        .addEventListener('click', () => pick(rt.id));
     sep();
     item('New tag…', { dim: true }).addEventListener('click', () => {
       const nv = JSON.parse(JSON.stringify(v));
@@ -2747,9 +2758,24 @@ class TimelinePanel {
           const nm = nameCell.createSpan({ text: bare });
           nm.setAttribute('style', 'font-weight:650;color:' + (s.color || '#cccccc') + ';'
             + (s.live ? '' : 'text-decoration:line-through;'));
-          // TAGS — removable chips, outline in the tag's colour, dim separate ✕
+          // TAGS — removable chips, outline in the tag's colour, dim separate ✕. A REMOTE kernel's
+          // tag holding this session renders too (federation v0) — read-only, host-marked, no ✕:
+          // its home kernel owns it (romp tag --host <h> edits it from here).
           const chips = grid.createDiv();
           chips.setAttribute('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;min-width:0;');
+          for (const rt of (vv.remoteTags || [])) {
+            if ((rt.members || []).indexOf(s.id) < 0) continue;
+            const rc = rt.color || '#cccccc';
+            const rch = chips.createSpan();
+            rch.setAttribute('style', 'display:inline-flex;align-items:center;gap:4px;'
+              + 'padding:2px 7px;border-radius:9px;font-size:0.82em;white-space:nowrap;opacity:0.85;'
+              + 'color:' + rc + ';border:1px dashed ' + rc + ';background:transparent;');
+            const rh = rch.createSpan({ text: (rt.host || '') + ':' });
+            rh.setAttribute('style', 'color:' + MODEL_FG + ';font-style:italic;font-size:0.88em;');
+            rch.createSpan({ text: rt.name || 'tag' });
+            rch.setAttribute('title', 'tagged on ' + (rt.host || 'another kernel')
+              + ' — read-only here; edit with: romp tag --host ' + (rt.host || '<kernel>'));
+          }
           for (const t of viewTags(vv)) {
             if ((t.members || []).indexOf(s.id) < 0) continue;
             const tc = t.color || '#cccccc';
@@ -3038,7 +3064,20 @@ class TimelinePanel {
     // LANE IDENTITY IS THE SID (data.turns + vidx + connectors all key by session.id, since two
     // live sessions can share a name and a rename keeps the id). `name` is display-only.
     const turnsOf = (sid) => data.turns[sid] || [];
-    const colorOf = (sid) => { const s = data.sessions.find((x) => x.id === sid); return s ? s.color : '#888'; };
+    // Owner-authoritative color (the user 2026-08-24, the gray-glyph fix): each session row rides
+    // its OWNER kernel's frame with the owner's color, but a message endpoint can spell the same
+    // session differently — bare on its home kernel's frame, host-prefixed after the merge, or
+    // prefixed with a THIRD kernel's name for it. Sids are uuids (globally unique), so on an exact
+    // miss the join retries by the bare sid tail — the one spelling every variant shares.
+    const colorOf = (sid) => {
+      let s = data.sessions.find((x) => x.id === sid);
+      if (!s && sid) {
+        const i = String(sid).indexOf(':');
+        const bare = i > 0 ? String(sid).slice(i + 1) : String(sid);
+        s = data.sessions.find((x) => x.id === bare || String(x.id).endsWith(':' + bare));
+      }
+      return s ? s.color : '#888';
+    };
 
     // A lane shows when it has activity intersecting THIS window — a turn bar or a message endpoint.
     // Normally a live session ALSO always gets a lane (even idle, so you can see who's running); with

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -188,6 +188,26 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
     "…and the tag rows come AFTER both built-ins — the DoD's menu order, pinned end to end");
 });
 
+test("federation v0: remote tags in the menu + dialog read-only, and the colour join survives every spelling", () => {
+  // executed: the mirror resolves a remote-tag active and labels it host:name (the list_agents idiom)
+  const rt = { active: "TESTHOST-A:g1", tags: [],
+               remoteTags: [{ id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", members: ["m1"] }] };
+  assert.equal(viewVisible(rt, "m1"), true);
+  assert.equal(viewVisible(rt, "m2"), false);
+  assert.equal(viewLabel(rt), "TESTHOST-A:team");
+  assert.equal(viewVisible({ active: "TESTHOST-A:g1", tags: [] }, "m2"), true, "gone → falls open");
+  // the menu unions attached kernels' tags read-only (owner colour, host-marked, pick-only)
+  assert.match(SRC, /for \(const rt of \(v\.remoteTags \|\| \[\]\)\)/);
+  assert.match(SRC, /item\(\(rt\.host \? rt\.host \+ ':' : ''\) \+ \(rt\.name \|\| 'tag'\),/);
+  // the dialog renders a remote kernel's chip read-only: dashed border, host prefix, NO ✕
+  assert.match(SRC, /border:1px dashed ' \+ rc \+ ';/);
+  assert.match(SRC, /read-only here; edit with: romp tag --host/);
+  // the gray-glyph fix (the user 2026-08-24): a message endpoint can spell a session bare,
+  // host-prefixed, or third-kernel-prefixed — on an exact miss the join retries by the bare sid
+  // tail (sids are uuids, globally unique), so the owner's colour always lands
+  assert.match(SRC, /s = data\.sessions\.find\(\(x\) => x\.id === bare \|\| String\(x\.id\)\.endsWith\(':' \+ bare\)\);/);
+});
+
 test("the N-more count opens the views menu — what am I not seeing answers itself (the user 2026-08-24)", () => {
   assert.match(SRC, /m\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(m\); \}\);/);
   assert.match(SRC, /m\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/, "and survives its own opening click");

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -126,3 +126,19 @@ test("hiding the last visible session blanks its transcript and the placeholder 
   assert.match(RENDER, /Every session is hidden from this view\./);
   assert.match(RENDER, /allHiddenBlanked = false;/, "…and the transcript restores when anything is visible again");
 });
+
+test("executed: a REMOTE tag is a view too — resolved, labeled by its host, gone-falls-open (federation v0)", () => {
+  // the kernel joins attached kernels' tags into remoteTags (read-only, id = "host:tagid", members
+  // already respelled viewer-relative); picking one filters exactly like a local tag
+  const rt = { active: "alpha:g9", tags: [], remoteTags: [{ id: "alpha:g9", host: "alpha", members: ["alpha:rs1", "x"] }] };
+  assert.equal(viewVisible(rt, "alpha:rs1"), true);
+  assert.equal(viewVisible(rt, "y"), false);
+  // its kernel detached → the view falls OPEN, never trapping the viewer in an empty view
+  assert.equal(viewVisible({ active: "alpha:g9", tags: [] }, "y"), true);
+  // the echo key EXCLUDES remoteTags: derived kernel state, not an edit — two blobs differing only
+  // there must reconcile the same optimistic edit
+  const a = { active: "all", hidden: [], tags: [] };
+  const b = { active: "all", hidden: [], tags: [], remoteTags: [{ id: "alpha:g9" }] };
+  assert.equal(viewsKey(a), viewsKey(b));
+});
+

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -11,8 +11,14 @@
 // of record; this is its client mirror (the timeline carries its own copy — it cannot import TS).
 // Pure, split out of render.ts for tests (the time-marker.ts pattern). The kernel emits `tags`;
 // `groups` survives in the type as the pre-rename key an un-updated kernel still pushes.
-export interface SessionTag { id: string; name?: string; color?: string; members?: string[] }
-export interface SessionViews { active?: string; hidden?: string[]; tags?: SessionTag[]; groups?: SessionTag[] }
+export interface SessionTag { id: string; name?: string; color?: string; members?: string[]; host?: string }
+export interface SessionViews {
+  active?: string; hidden?: string[]; tags?: SessionTag[]; groups?: SessionTag[];
+  // tag federation v0 (the user 2026-08-24): each ATTACHED kernel's own tags, read-only, joined by
+  // the kernel per host (id = "host:tagid", members already respelled viewer-relative). Derived —
+  // never an edit target, excluded from the echo key, dropped by the kernel if echoed back.
+  remoteTags?: SessionTag[];
+}
 
 // the one place the legacy key is honored, so every rule below reads through it
 export function viewTags(views: SessionViews | null | undefined): SessionTag[] {
@@ -27,7 +33,8 @@ export function viewVisible(views: SessionViews | null | undefined, id: string):
     if (Array.isArray(views.hidden) && views.hidden.includes(id)) return false;
     return !viewTags(views).some((t) => (t.members || []).includes(id));
   }
-  const t = viewTags(views).find((x) => x.id === views.active);
+  const t = viewTags(views).find((x) => x.id === views.active)
+    || (views.remoteTags || []).find((x) => x.id === views.active);   // a remote tag is a view too (federation v0)
   return t ? (t.members || []).includes(id) : true;
 }
 


### PR DESCRIPTION
## What (tag + identity federation v0, the signed-off Model A design)

- **Store**: tag members become canonical `(host, sid)` pairs — host `""` is the tag's home kernel — so one tag spans linked kernels. Every legacy spelling (plain sids; the viewer-relative `host:sid` strings clients still post) reads losslessly, and clients keep the old string contract: the emitted blob is a rendering (`_views_client`), the pairs are storage.
- **Union**: the supervisor polls each attached kernel's `/views` (the usage-poll idiom; per-host maps joined at the viewer, never merged). The client blob gains read-only `remoteTags` — `host:tagid` ids, the owner's name and color, members respelled **sid-first** (a locally-known member renders bare, so lane joins land; a third kernel keeps the owner's label, joining whenever it's attached here too). Same-name tags on two kernels stay two host-marked rows. A remote-tag active survives normalization (`:` is the marker) and falls **open** when its kernel detaches. `GET /views` stays canonical with `remoteTags` absent — no transitive unions in v0.
- **Menu + dialog**: attached kernels' tags join the view menu read-only (owner color, `host:name`, pick-only); the dialog shows remote chips dashed and host-marked, no ✕, tooltip naming the edit path. Active + hidden stay viewer-local, pinned unchanged.
- **The gray-glyph color join**: `colorOf` falls back to the globally-unique bare-sid tail on an exact miss — an endpoint spelled bare, host-prefixed, or third-kernel-prefixed always finds the color riding the owner's payload.
- **Edit path (v0)**: `romp tag <name> --host <kernel> …` forwards through the existing tunnel to the target kernel's store (it resolves member names against its own sessions). Unknown/down/unresponsive hosts refuse loudly; `--host` without an edit flag is a usage error (reads stay local — the menu shows the union).

## Tests

- `tests/test_timeline_views.py`: pair round-trip across all three spellings (lossless both ways), the host-stamped read-only union with sid-first respelling, same-name divergence = two entries, down-kernel contributes nothing, remote-active + hidden stay local, echoed `remoteTags` never persists.
- `tests/test_tag_route.py::HostForward`: the forward lands minus the `host` key and touches nothing local; unknown/down/dead-forward refusals.
- `ui/webview/session-views.test.ts` + `ui/timeline-views-panel.test.ts` (TESTHOST-A/B): executed remote-tag visibility/label/gone-falls-open, echo key excludes `remoteTags`, menu/dialog read-only pins, and the colour-join fallback.
- `tests/romp.bats`: `--host` rides the payload; `--host` without an edit is a usage error.
- Full suites green: 5381 python tests (+281 subtests), 2282 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)