### PR TITLE
Session combobox: the footer's Session picker and Search merge into one control

### DIFF
--- a/ui/webview/feed-search.test.ts
+++ b/ui/webview/feed-search.test.ts
@@ -39,14 +39,27 @@ test("the feed composes search WITH the session filter, and cards fall back to t
                "a just-died session's cards keep matching by their per-card label");
 });
 
-test("the footer control is ensure-once, expandable, and an active query can never be hidden", () => {
-  assert.match(FEED, /function ensureSearchBox\(\): HTMLElement/);
+test("the footer control is ensure-once, expandable, and an active filter can never be hidden", () => {
+  // merged into the session COMBOBOX (the user 2026-08-24): one control, both filters, same rules
+  assert.match(FEED, /function ensureSessionBox\(\): HTMLElement/);
+  assert.match(FEED, /const active = !!feedSearchQ\.trim\(\) \|\| !!feedOnlySid;/,
+               "EITHER live filter counts as active");
   assert.match(FEED, /if \(active\) wrap\.classList\.add\("open"\);/,
-               "a live query forces the input open — the compact state never hides an active filter");
-  assert.match(FEED, /if \(inp\.value\.trim\(\)\) \{ inp\.value = ""; setFeedSearch\(""\); render\(\); \}/,
-               "folding with a live query clears it, never hides it");
+               "an active filter forces the bar open — the compact state never hides a live filter");
+  // folding with anything live CLEARS it (both kinds), never hides it
+  assert.match(FEED, /if \(feedSearchQ\.trim\(\)\) \{ setFeedSearch\(""\); changed = true; \}/);
+  assert.match(FEED, /if \(feedOnlySid\) \{ setFeedOnly\(null\); changed = true; \}/);
   assert.match(FEED, /sessionStorage\.getItem\("romp:feedSearch"\)/,
                "same storage lifetime as the session filter: reload-proof, never a fresh window");
+  // typing narrows the open list AND applies the live board filter in the same keystroke
+  assert.match(FEED, /inp\.oninput = \(\) => \{ setFeedSearch\(inp\.value\); filterSessList\(inp\.value\); render\(\); \};/);
+  // an away-click closes the LIST only — clicking a card must never wipe a live filter; the
+  // clear-on-fold rule belongs to EXPLICIT folds (Escape, the button)
+  assert.match(FEED, /if \(!feedSearchQ\.trim\(\) && !feedOnlySid\) document\.getElementById\("feed-search"\)\?\.classList\.remove\("open"\);/);
+  const away = FEED.slice(FEED.indexOf("function sessListAway"), FEED.indexOf("function sessListKey"));
+  assert.ok(!away.includes("foldSessBox"), "away never routes through the clearing fold");
+  // an idle empty bar folds quietly on blur once the list is gone (the parent search box's rule)
+  assert.match(FEED, /if \(!sessListEl && !inp\.value\.trim\(\) && !feedOnlySid\) wrap!\.classList\.remove\("open"\);/);
 });
 
 test("the expanded bar wears the top search bar's look, footer-scaled, and FLEXES instead of a fixed width", () => {
@@ -61,7 +74,7 @@ test("the expanded bar wears the top search bar's look, footer-scaled, and FLEXE
   assert.match(CSS, /#feed-search\.open input:focus \{ border-color: var\(--accent\); \}/);
   // the inner ✕ clear: hidden while empty, clearing REFOCUSES (the top bar's semantics)
   assert.match(FEED, /clr\.id = "feed-search-clear";/);
-  assert.match(FEED, /inp\.value = ""; setFeedSearch\(""\); inp\.focus\(\); render\(\);/);
+  assert.match(FEED, /inp\.value = ""; setFeedSearch\(""\); filterSessList\(""\); inp\.focus\(\); render\(\);/);
   assert.match(FEED, /clrBtn\.hidden = !inp\.value\.trim\(\);/,
     "trimmed, like the fold and the filter — a whitespace-only value must not strand a floating ✕");
   assert.match(CSS, /#feed-search-clear\[hidden\] \{ display: none; \}/);

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -50,8 +50,13 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
   assert.ok(FEED.includes("if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);"));
 });
 
-test("the menu sits right of the view-menu icon, lists sessions in tab order, canonical form, click-safe", () => {
-  assert.match(FEED, /ensureViewMenuBtn\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionFilter\(\)\.style\.display = showCA \? "" : "none";/);
+test("the combobox sits right of the view-menu icon, lists sessions in tab order, canonical form, click-safe", () => {
+  // one control since 2026-08-24: the session picker and the search box merged into the combobox
+  assert.match(FEED, /ensureViewMenuBtn\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionBox\(\)\.style\.display = showCA \? "" : "none";/);
+  // the list is built ONCE per open; typing only toggles row display — a keystroke can never
+  // rebuild a row out from under a press (click-safety)
+  assert.match(FEED, /r\.style\.display = name === null \|\| searchMatches\(q, name\) \? "" : "none";/);
+  assert.match(FEED, /row\(null, all, null\);/, "the All-sessions way back is never filtered away");
   // tab order: ranked by the kernel's session-order list — the same rank grouped mode sorts by
   assert.ok(FEED.includes("const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));"));
   // the menu lives on document.body — outside render()'s reconcile, so a push can't rebuild it mid-press
@@ -63,15 +68,20 @@ test("menu rows write a session the way the tabs do — coloured bold name + the
   // colour SWATCH read as a status dot — on this board a dot beside a name means working/awaiting)
   assert.ok(FEED.includes("nm.replaceChildren(...hostNameNodes(s.name, s.sid));"), "host prefix folded quiet");
   assert.ok(FEED.includes("if (s.color) nm.style.color = s.color.bg;"), "name IN the identity colour");
-  assert.ok(FEED.includes("for (const s of rows) row(feedOnlySid === s.sid, s.sid, sessMenuName(s), s.name);"));
+  assert.ok(FEED.includes("for (const s of rows) row(s.sid, sessMenuName(s), s.name, s.name);"));
   assert.ok(FEED.includes("if (dotName) setWorkDot(label, dotFor(dotName));"),
     "the SAME working/awaiting dot the tabs and headers wear — never a colour swatch");
   assert.ok(!FEED.includes("sessDot"), "the swatch helper is gone");
   const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
   assert.match(CSS, /\.fsm-name \{ font-weight: 600; \}/, "bold, like the tab titles and session headers");
   assert.ok(!CSS.includes(".fsm-dot"), "no swatch styles either");
-  // with a filter on, the button quotes the picked session verbatim, dot included — a narrowed board
-  // must never look like the whole one
-  assert.ok(FEED.includes('b.replaceChildren(nm, document.createTextNode(" ▴"));'));
+  // with a filter on, the CHIP in the bar quotes the picked session verbatim, dot included — a
+  // narrowed board must never look like the whole one; its ✕ hands the bar back to typing. The ✕
+  // is built ONCE (a per-render rebuild would swap it under a press — click-safety); the NAME
+  // re-quotes per render so colour echoes and the dot stay live.
+  assert.ok(FEED.includes("chip.replaceChildren(nm, x);"));
+  assert.ok(FEED.includes("(chip as any)._nm = nm;"));
+  assert.ok(FEED.includes("nm.replaceChildren(...hostNameNodes(cur.name, cur.sid));"));
   assert.ok(FEED.includes("setWorkDot(nm, dotFor(cur.name));"));
+  assert.ok(FEED.includes('x.setAttribute("aria-label", "show all sessions");'));
 });

--- a/ui/webview/feed-viewmenu.test.ts
+++ b/ui/webview/feed-viewmenu.test.ts
@@ -66,8 +66,8 @@ test("a live menu syncs IN PLACE — rows are never rebuilt under a pressed poin
 test("one menu at a time: the view menu and the session menu close each other on open", () => {
   // the pointerdown-away closers cover mouse opens; a keyboard Enter fires click with NO pointerdown,
   // so each opener must close the other explicitly (found in review, 2026-08-24)
-  assert.match(FEED, /function openViewMenu\(btn: HTMLElement\): void \{\s*\n\s*closeSessMenu\(\);/);
-  assert.match(FEED, /function openSessMenu\(btn: HTMLElement\): void \{\s*\n\s*closeViewMenu\(\);/);
+  assert.match(FEED, /function openViewMenu\(btn: HTMLElement\): void \{\s*\n\s*closeSessList\(\);/);
+  assert.match(FEED, /function openSessList\(\): void \{\s*\n\s*closeViewMenu\(\);/);
 });
 
 test("the popup wears the repo menu vocabulary: .ctx-menu chrome + the ✓-in-circle current mark", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -864,16 +864,16 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-undoclear .undo-dots i:nth-child(3) { animation-delay: 0.36s; }
 @keyframes undo-dot { 0%, 100% { opacity: 0.25; } 40% { opacity: 1; } }
 @media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; } }
-/* the footer MODE buttons (Session filter, Search): active (.on) wears the accent language (blue text +
-   border + faint wash), the same selected-state look the card section toggles use (the user 2026-07-07) */
+/* the footer MODE button (the session combobox's "Sessions ▴"): active (.on) wears the accent language
+   (blue text + border + faint wash), the same selected-state look the card section toggles use (the
+   user 2026-07-07) */
 #feed-foot .feed-modetoggle.on { color: var(--accent); border-color: var(--accent);
   background: rgba(156, 210, 255, 0.12); opacity: 1; }
-/* the SESSION FILTER (the user 2026-08-08): the footer button quotes the picked session; its menu
-   opens UPWARD (position from the button rect, feed.ts), one row per tab-order session written the
-   way the tabs and session headers write it — .fsm-name is BOLD in the session's identity colour
-   (inline, from the payload), host: prefix quiet (.host-prefix, shared), and the shared .fwork-dot
-   status dot in front. Selection is the accent wash, so the identity colours stay untouched. */
-#feed-sessfilter { display: inline-flex; align-items: center; gap: 5px; }
+/* the SESSION list + chip identity treatment (the user 2026-08-08, now the combobox's list): one row
+   per tab-order session written the way the tabs and session headers write it — .fsm-name BOLD in the
+   session's identity colour (inline, from the payload), host: prefix quiet (.host-prefix, shared), the
+   shared .fwork-dot status dot in front. Selection is the accent wash, so identity colours stay
+   untouched. The list opens UPWARD from the bar (position from the wrap rect, feed.ts). */
 .fsm-name { font-weight: 600; }
 .feed-sessmenu { position: fixed; z-index: 60; min-width: 150px; max-height: 60vh; overflow-y: auto;
   padding: 4px; border: 1px solid var(--card-border); border-radius: 6px;
@@ -1424,4 +1424,16 @@ body.filebrowse-open { overflow: hidden; }
 #feed-search-clear:hover { color: var(--fg); background: rgba(255, 255, 255, 0.10); }
 #feed-search-clear[hidden] { display: none; }
 #feed-search:not(.open) #feed-search-clear { display: none; }   /* the ✕ exists only on an open box — a folded control can never wear a stray × */
+/* the combobox CHIP (the user 2026-08-24): a picked session quoted IN the bar — identity-coloured
+   name + working dot + ✕ back to typing. The accent-wash pill the .on state already wears
+   everywhere; the footer's own 10.5px, no new sizes. */
+#feed-sess-chip { display: inline-flex; align-items: center; gap: 5px; padding: 1px 4px 1px 7px;
+  border: 1px solid var(--accent); border-radius: 6px; background: rgba(156, 210, 255, 0.12);
+  font-size: 10.5px; white-space: nowrap; }
+#feed-sess-chip[hidden] { display: none; }
+#feed-search:not(.open) #feed-sess-chip { display: none; }   /* same backstop as the ✕: chips live on an open bar */
+.fsm-chipx { display: inline-flex; align-items: center; justify-content: center; width: 14px; height: 14px;
+  padding: 0; border: 0; border-radius: 50%; background: transparent; color: var(--dim);
+  font-size: 12px; line-height: 1; cursor: pointer; }
+.fsm-chipx:hover { color: var(--fg); background: rgba(255, 255, 255, 0.10); }
 @media (prefers-reduced-motion: reduce) { #feed-search input { transition: none; } }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3278,7 +3278,7 @@ function paintViewMenu(menu: HTMLElement): void {
   });
 }
 function openViewMenu(btn: HTMLElement): void {
-  closeSessMenu();   // one menu at a time: a keyboard open fires no pointerdown, so the away-closers never ran
+  closeSessList();   // one menu at a time: a keyboard open fires no pointerdown, so the away-closers never ran
   const menu = el("div", "ctx-menu feed-viewmenu");
   menu.setAttribute("role", "menu");
   refreshStackForced();   // decide the forced row from the CURRENT width, not the last observed one
@@ -3326,25 +3326,37 @@ function ensureViewMenuBtn(): HTMLElement {
   return b;
 }
 
-// The SESSION FILTER (the user 2026-08-08): a footer menu listing every session the chat tab strip
-// shows, in ITS order, each written the way every other surface writes a session — bold name in its
-// identity colour, "host:" prefix folded quiet, the shared working/awaiting status dot. Picking one
-// shows only that session's cards; "All sessions" (the default — nothing selected) shows everything.
-// The menu opens UPWARD from the footer (that is where the space is) and lives on document.body,
-// outside render()'s reconcile, so a push can never rebuild it mid-press; the button itself is
-// ensure-once like the other footer controls.
-let sessMenuEl: HTMLElement | null = null;
-function closeSessMenu(): void {
-  sessMenuEl?.remove(); sessMenuEl = null;
-  document.removeEventListener("pointerdown", sessMenuAway, true);
-  document.removeEventListener("keydown", sessMenuKey, true);
+// The SESSION COMBOBOX (the user 2026-08-24, merging the 2026-08-08 session picker and the
+// 2026-08-23 search box): ONE footer control owns "which sessions am I looking at". Collapsed, a
+// single "Sessions ▴" word-button. Open, the top-bar-style input with the session list beneath —
+// every row written the way every other surface writes a session (bold name in its identity colour,
+// "host:" prefix folded quiet, the shared working/awaiting dot; the current pick wears the accent
+// wash, exactly today's menu). TYPING narrows the list AND applies the live substring filter
+// (romp:feedSearch — semantics unchanged); PICKING a row applies the exact-session filter
+// (romp:feedOnly — semantics unchanged), rendered as a chip in the bar whose ✕ hands the bar back
+// to typing. The two filters compose downstream exactly as before (viewFiltered). Invariants kept
+// from both parents: an ACTIVE filter of either kind force-opens the bar (a compact state can never
+// hide a live filter); Escape folds, and folding with anything live CLEARS it; the wrap is
+// ensure-once and the list lives on document.body outside render()'s reconcile (click-safety); the
+// list is built ONCE per open and typing only toggles row display, so a keystroke can never rebuild
+// a row out from under a press.
+let sessListEl: HTMLElement | null = null;
+function closeSessList(): void {
+  sessListEl?.remove(); sessListEl = null;
+  document.removeEventListener("pointerdown", sessListAway, true);
+  document.removeEventListener("keydown", sessListKey, true);
 }
-function sessMenuAway(ev: Event): void {
+function sessListAway(ev: Event): void {
   const t = ev.target as Node;
-  if (sessMenuEl && !sessMenuEl.contains(t) && !(document.getElementById("feed-sessfilter")?.contains(t))) closeSessMenu();
+  if (!sessListEl || sessListEl.contains(t) || document.getElementById("feed-search")?.contains(t)) return;
+  closeSessList();
+  // an away-click closes the LIST only — never a filter-clearing fold: clicking a card must not
+  // wipe a live filter (clear-on-fold is for EXPLICIT folds — Escape, the button). With nothing
+  // live the bar collapses quietly; force-open keeps it up otherwise.
+  if (!feedSearchQ.trim() && !feedOnlySid) document.getElementById("feed-search")?.classList.remove("open");
 }
-function sessMenuKey(ev: KeyboardEvent): void { if (ev.key === "Escape") closeSessMenu(); }
-// A session's name in the menu wears EXACTLY the identity treatment every other surface gives it (the
+function sessListKey(ev: KeyboardEvent): void { if (ev.key === "Escape") { closeSessList(); foldSessBox(); } }
+// A session's name in the list wears EXACTLY the identity treatment every other surface gives it (the
 // user 2026-08-08): bold, in the session's own colour, host prefix folded quiet — the way the chat tabs
 // and the grouped session headers write it. Never a colour swatch: a dot beside a name on this board
 // already MEANS working/awaiting (the shared fwork-dot vocabulary), so that status dot rides here too.
@@ -3354,65 +3366,107 @@ function sessMenuName(s: { sid: string; name: string; color: { bg: string; fg: s
   if (s.color) nm.style.color = s.color.bg;
   return nm;
 }
-function openSessMenu(btn: HTMLElement): void {
+// Typing narrows the OPEN list in place: display toggles only, never a rebuild (click-safety). The
+// "All sessions" row always shows — the way back can never be filtered away (no-dead-end).
+function filterSessList(q: string): void {
+  if (!sessListEl) return;
+  sessListEl.querySelectorAll<HTMLElement>(".fsm-row").forEach((r) => {
+    const name = r.getAttribute("data-name");
+    r.style.display = name === null || searchMatches(q, name) ? "" : "none";
+  });
+}
+function repaintSessListCurrent(): void {
+  if (!sessListEl) return;
+  sessListEl.querySelectorAll<HTMLElement>(".fsm-row").forEach((r) => {
+    const on = (r.getAttribute("data-sid") || null) === feedOnlySid;
+    r.classList.toggle("on", on);
+    r.setAttribute("aria-selected", on ? "true" : "false");   // option rows select; checked is the checkbox pattern
+  });
+}
+function openSessList(): void {
   closeViewMenu();   // one menu at a time: a keyboard open fires no pointerdown, so the away-closers never ran
+  const wrap = document.getElementById("feed-search");
+  if (!wrap || sessListEl) return;
   const menu = el("div", "feed-sessmenu");
-  const row = (on: boolean, pick: string | null, label: HTMLElement, dotName?: string) => {
-    const r = el("div", "fsm-row" + (on ? " on" : ""));
+  menu.setAttribute("role", "listbox");
+  const row = (pick: string | null, label: HTMLElement, name: string | null, dotName?: string) => {
+    const r = el("div", "fsm-row");
     r.appendChild(label);
     if (dotName) setWorkDot(label, dotFor(dotName));   // inserts the status dot before the name, in place
-    r.setAttribute("role", "menuitemradio"); r.setAttribute("aria-checked", on ? "true" : "false");
-    r.onclick = (ev) => { ev.stopPropagation(); setFeedOnly(on ? null : pick); closeSessMenu(); render(); };
+    r.setAttribute("role", "option");
+    if (pick !== null) r.setAttribute("data-sid", pick);
+    if (name !== null) r.setAttribute("data-name", name);
+    r.onclick = (ev) => {   // pick = the exact filter, worn as the bar's chip; the list closes, the bar stays
+      ev.stopPropagation();
+      const already = (r.getAttribute("data-sid") || null) === feedOnlySid;
+      setFeedOnly(already ? null : pick);
+      const inp = document.getElementById("feed-search-input") as HTMLInputElement | null;
+      if (inp) { inp.value = ""; inp.focus(); }   // back to typing mode; the chip carries the pick
+      setFeedSearch("");
+      closeSessList();
+      render();
+    };
     menu.appendChild(r);
   };
   const all = el("span", "");
   all.textContent = "All sessions";
-  row(!feedOnlySid, null, all);
+  row(null, all, null);
   // tab order: rank by the kernel's session-order list (the same rank grouped mode sorts by); a sid the
   // list doesn't know keeps its place in the kernel's tab list (stable sort), after the ranked ones
   const rank = new Map(sessionOrder.map((s, i) => [s, i] as const));
   const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));
-  for (const s of rows) row(feedOnlySid === s.sid, s.sid, sessMenuName(s), s.name);
+  for (const s of rows) row(s.sid, sessMenuName(s), s.name, s.name);
   document.body.appendChild(menu);
-  // above the footer, left-aligned to the button, clamped into the viewport
-  const r = btn.getBoundingClientRect();
+  // above the footer, aligned to the BAR and at least its width (combobox convention), clamped in
+  const r = wrap.getBoundingClientRect();
+  menu.style.minWidth = Math.max(150, Math.round(r.width)) + "px";
   menu.style.bottom = Math.round(window.innerHeight - r.top + 6) + "px";
   menu.style.left = Math.round(Math.max(6, Math.min(r.left, window.innerWidth - menu.offsetWidth - 6))) + "px";
-  sessMenuEl = menu;
-  document.addEventListener("pointerdown", sessMenuAway, true);
-  document.addEventListener("keydown", sessMenuKey, true);
+  sessListEl = menu;
+  repaintSessListCurrent();
+  filterSessList(feedSearchQ);
+  document.addEventListener("pointerdown", sessListAway, true);
+  document.addEventListener("keydown", sessListKey, true);
 }
-// The SEARCH box (the user 2026-08-23): a footer "Search" word-button that expands to an inline
-// input filtering the board live by session name, host prefix included. Ensure-once like every foot
-// control — render() never rebuilds it, so focus and the caret survive pushes (the click-safety rule).
-// An ACTIVE query keeps the input open and the control accented; Escape (or emptying + blur) folds it
-// back to the button — a compact state can never hide a live filter (progressive disclosure's no-dead-end).
-// The expanded bar wears the TOP search bar's look scaled to the footer (the user 2026-08-24): rounded
-// input-background field, an inner ✕ that clears and REFOCUSES, flexing into the row's spare space
-// instead of a fixed width (feed.css owns the metrics).
-function ensureSearchBox(): HTMLElement {
+// Folding with anything live CLEARS it — the bar never hides an active filter of either kind.
+function foldSessBox(): void {
+  const wrap = document.getElementById("feed-search");
+  const inp = document.getElementById("feed-search-input") as HTMLInputElement | null;
+  let changed = false;
+  if (inp && inp.value.trim()) { inp.value = ""; changed = true; }
+  if (feedSearchQ.trim()) { setFeedSearch(""); changed = true; }
+  if (feedOnlySid) { setFeedOnly(null); changed = true; }
+  wrap?.classList.remove("open");
+  closeSessList();
+  if (changed) render();
+}
+function ensureSessionBox(): HTMLElement {
   let wrap = document.getElementById("feed-search") as HTMLElement | null;
   if (!wrap) {
     wrap = el("span", "");
     wrap.id = "feed-search";
     const btn = el("button", "fdismiss ffollow feed-modetoggle");
     btn.id = "feed-search-btn";
-    btn.textContent = "Search";
-    btn.title = "filter cards by session name — the host prefix counts, so a machine name finds all its sessions";
+    btn.textContent = "Sessions \u25b4";
+    btn.title = "filter the board by session — type to narrow (host prefix counts), or pick one exactly";
+    btn.setAttribute("aria-haspopup", "listbox");
+    const chip = el("span", "fsm-chip");
+    chip.id = "feed-sess-chip";
+    chip.hidden = true;
     const inp = document.createElement("input");
     inp.id = "feed-search-input";
     inp.type = "search";
     inp.placeholder = "session or host…";
-    inp.setAttribute("aria-label", "filter cards by session name (host prefix included)");
-    const openBox = () => { wrap!.classList.add("open"); inp.focus(); };
-    const foldBox = () => {                             // folding with a live query CLEARS it — the button
-      if (inp.value.trim()) { inp.value = ""; setFeedSearch(""); render(); }   // never hides an active filter
-      wrap!.classList.remove("open");
+    inp.setAttribute("aria-label", "filter cards by session name (host prefix included), or pick a session from the list");
+    const openBox = () => { wrap!.classList.add("open"); openSessList(); inp.focus(); };
+    btn.onclick = (ev) => { ev.stopPropagation(); wrap!.classList.contains("open") ? foldSessBox() : openBox(); };
+    inp.onfocus = () => { if (!sessListEl) openSessList(); };   // focus re-opens the list (a pick closed it)
+    inp.oninput = () => { setFeedSearch(inp.value); filterSessList(inp.value); render(); };   // live: narrows list AND board
+    inp.onkeydown = (ev) => { if (ev.key === "Escape") { ev.stopPropagation(); foldSessBox(); } };
+    inp.onblur = () => {   // an empty bar folds quietly when focus leaves AND the list is gone — a row
+      //                      press keeps the list (blur fires first); the away-closer owns that case
+      if (!sessListEl && !inp.value.trim() && !feedOnlySid) wrap!.classList.remove("open");
     };
-    btn.onclick = (ev) => { ev.stopPropagation(); wrap!.classList.contains("open") ? foldBox() : openBox(); };
-    inp.oninput = () => { setFeedSearch(inp.value); render(); };   // live: the keyed render reuses every card
-    inp.onkeydown = (ev) => { if (ev.key === "Escape") { ev.stopPropagation(); foldBox(); } };
-    inp.onblur = () => { if (!inp.value.trim()) wrap!.classList.remove("open"); };
     const clr = el("button", "");
     clr.id = "feed-search-clear";
     (clr as HTMLButtonElement).type = "button";
@@ -3422,45 +3476,52 @@ function ensureSearchBox(): HTMLElement {
     clr.textContent = "\u00d7";
     clr.onclick = (ev) => {   // clear + REFOCUS — the user is mid-search, never fold under them
       ev.stopPropagation();
-      inp.value = ""; setFeedSearch(""); inp.focus(); render();
+      inp.value = ""; setFeedSearch(""); filterSessList(""); inp.focus(); render();
     };
-    wrap.appendChild(btn); wrap.appendChild(inp); wrap.appendChild(clr);
+    wrap.appendChild(btn); wrap.appendChild(chip); wrap.appendChild(inp); wrap.appendChild(clr);
     (document.getElementById("feed-foot") || document.body).appendChild(wrap);
   }
   const inp = wrap.querySelector("input") as HTMLInputElement;
   if (inp && inp.value !== feedSearchQ && document.activeElement !== inp) inp.value = feedSearchQ;
   const clrBtn = document.getElementById("feed-search-clear");
   if (clrBtn && inp) clrBtn.hidden = !inp.value.trim();   // trimmed, like the fold + the filter — whitespace is no query
-  const active = !!feedSearchQ.trim();
+  // the chip quotes the picked session verbatim, dot included — a narrowed board must never look whole
+  const chip = document.getElementById("feed-sess-chip") as HTMLElement | null;
+  const cur = feedOnlySid ? sessionsMeta.find((s) => s.sid === feedOnlySid) : undefined;
+  if (chip) {
+    chip.hidden = !cur;
+    if (cur) {
+      // the ✕ is built ONCE (a per-render rebuild would swap it under a press — click-safety);
+      // only the NAME re-quotes each render, so colour echoes and the working/awaiting dot stay live
+      let nm = (chip as any)._nm as HTMLElement | undefined;
+      if (!nm) {
+        nm = el("span", "fsm-name");
+        const x = el("button", "fsm-chipx");
+        (x as HTMLButtonElement).type = "button";
+        x.textContent = "\u00d7";
+        x.setAttribute("aria-label", "show all sessions");
+        x.title = "show all sessions — back to typing";
+        x.onclick = (ev) => {
+          ev.stopPropagation();
+          setFeedOnly(null);
+          repaintSessListCurrent();
+          (document.getElementById("feed-search-input") as HTMLInputElement | null)?.focus();
+          render();
+        };
+        chip.replaceChildren(nm, x);
+        (chip as any)._nm = nm;
+      }
+      nm.replaceChildren(...hostNameNodes(cur.name, cur.sid));
+      nm.style.color = cur.color ? cur.color.bg : "";
+      setWorkDot(nm, dotFor(cur.name));
+    }
+  }
+  // an ACTIVE filter of either kind force-opens the bar — never hidden behind the collapsed button
+  const active = !!feedSearchQ.trim() || !!feedOnlySid;
   if (active) wrap.classList.add("open");
   const btn = document.getElementById("feed-search-btn");
   if (btn) { btn.classList.toggle("on", active); btn.setAttribute("aria-pressed", active ? "true" : "false"); }
   return wrap;
-}
-
-function ensureSessionFilter(): HTMLElement {
-  let b = document.getElementById("feed-sessfilter") as HTMLElement | null;
-  if (!b) {
-    b = el("button", "fdismiss ffollow feed-modetoggle");
-    b.id = "feed-sessfilter";
-    b.onclick = (ev) => {   // opening the menu IS the acknowledgement (same as the fold caret)
-      ev.stopPropagation();
-      if (sessMenuEl) closeSessMenu(); else openSessMenu(b!);
-    };
-    (document.getElementById("feed-foot") || document.body).appendChild(b);
-  }
-  const cur = feedOnlySid ? sessionsMeta.find((s) => s.sid === feedOnlySid) : undefined;
-  const on = !!feedOnlySid;
-  b.classList.toggle("on", on);
-  b.setAttribute("aria-pressed", on ? "true" : "false");
-  b.title = cur ? "showing only " + cur.name + " — click to change or show all"
-    : "show a single session's cards (default: all)";
-  if (cur) {
-    const nm = sessMenuName(cur);
-    b.replaceChildren(nm, document.createTextNode(" ▴"));
-    setWorkDot(nm, dotFor(cur.name));   // the button quotes the picked session verbatim, dot included
-  } else b.replaceChildren(document.createTextNode("Session ▴"));
-  return b;
 }
 
 // (The footer "Sub-goals" checkbox was removed 2026-07-08: sub-goals is now a per-card "Sub-goals" button
@@ -3828,8 +3889,7 @@ function render() {
   // footer pane (below the cards, no overlap): view menu · Session filter · Search | Clear all · Undo
   const showCA = !!asks.length;
   ensureViewMenuBtn().style.display = showCA ? "" : "none";       // sort + layout menu (the user 2026-08-24)
-  ensureSessionFilter().style.display = showCA ? "" : "none";     // one-session filter menu (the user 2026-08-08)
-  ensureSearchBox().style.display = showCA ? "" : "none";          // type-to-filter by name/host (the user 2026-08-23)
+  ensureSessionBox().style.display = showCA ? "" : "none";        // session combobox: type-or-pick filter (the user 2026-08-24)
   ensureClearAll().style.display = showCA ? "" : "none";
   ensureUndoClear().style.display = canUndoClear ? "" : "none";
   const foot = document.getElementById("feed-foot");


### PR DESCRIPTION
One footer control now owns "which sessions am I looking at". Collapsed: a single **Sessions ▴** button. Open: the top-bar-style input with the session list beneath — rows in the shared identity treatment (bold coloured name, quiet host prefix, the working/awaiting dot; the current pick wears the accent wash). **Typing** narrows the open list and applies the live substring filter in the same keystroke; **picking a row** applies the exact-session filter, worn as an accent-wash chip in the bar whose ✕ hands the bar back to typing. Storage semantics are unchanged underneath (`romp:feedOnly` exact + `romp:feedSearch` substring, still composing through `viewFiltered`), so the hover-freeze hints and every other reader are untouched.

Invariants kept from both parents: an active filter of either kind force-opens the bar (a compact state never hides a live filter); Escape and the button fold, and an explicit fold with anything live clears it; an away-click closes the **list only** — clicking a card never wipes a live filter — and an idle empty bar folds quietly on blur; the wrap is ensure-once; the list lives on document.body, is built once per open, and typing only toggles row display; the chip's ✕ is built once with only the name re-quoting per render (colour echoes and the dot stay live). The 'All sessions' way back is never filtered away; the view menu and the list close each other on open; `aria-selected` on the `role=option` rows.

**Review provenance:** two-lens adversarial workflow (16 agents), six confirmed findings, all fixed in this commit — away-click filter wipe, chip-✕ rebuilt per render (the click-safety bug class), the stuck-open empty bar, the aria pairing, dead CSS — plus one split finding (stale two-control comments) taken too.

Tests in lockstep: feed-search pins the merged force-open/clear-on-explicit-fold/either-filter-active rules, same-keystroke narrowing, away-never-clears, and the blur fold; feed-session-filter pins the combobox gating, build-once display-toggle filtering, the ensure-once chip, and tab-order rows; feed-viewmenu's one-menu-at-a-time pins follow the rename. 2291 extension tests green; visuals verified headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)