### PR TITLE
Stacked layout: sections stretch — every card spans the container, whatever its text

### DIFF
--- a/ui/webview/feed-foot.test.ts
+++ b/ui/webview/feed-foot.test.ts
@@ -37,7 +37,7 @@ test("when the feed stacks (narrow), the columns read Completed → Blocked → 
   // the side-by-side DOM order stays Working/Blocked/Completed; a container query stacks them and `order`
   // re-sequences ONLY the stacked case: done first (moved up from the middle, superseding the 2026-07-08
   // Blocked-first order), then needs-you, then still-running.
-  assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; \}/);
+  assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; align-items: stretch; \}/);
   assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/);   // the DEFAULT — a
   // dragged section overrides via --stack-order (feed-col-fold.test.ts owns that rule)
   assert.match(CSS, /\.feed-col\.col-needsInput \{ order: var\(--stack-order, 2\); \}/);

--- a/ui/webview/feed-stack.test.ts
+++ b/ui/webview/feed-stack.test.ts
@@ -18,6 +18,19 @@ test("one stacked block, two triggers: the narrow size query OR the forced style
   assert.equal(count, 1, "still exactly one container query — no duplicated stacked rules");
 });
 
+test("stacked sections stretch — every card spans the container, whatever its text (the user 2026-08-24)", () => {
+  // the row layout's `align-items: flex-start` rides in from the base .feed-cols rule; in COLUMN
+  // direction that same declaration content-sizes each section horizontally, so a long Completed
+  // card spanned the pane while short Working cards hugged their titles (the second
+  // width-inconsistency report; verified headless before/after in the shipped Chromium)
+  assert.match(CSS, /\.feed-cols \{ flex-direction: column; align-items: stretch; \}/);
+  // the cascade: the stretch lives INSIDE the stacked query, after the base rule, same specificity —
+  // the base flex-start must still exist for the side-by-side layout's top alignment
+  const baseAt = CSS.indexOf(".feed-cols { display: flex; align-items: flex-start;");
+  const stretchAt = CSS.indexOf(".feed-cols { flex-direction: column; align-items: stretch; }");
+  assert.ok(baseAt >= 0 && stretchAt > baseAt, "override follows the base rule it ties");
+});
+
 test("the view menu's Single-column row writes the pref and applies the style var; boot applies a persisted one", () => {
   assert.match(FEED, /stacked: s\.stacked === true/);
   // the footer "Stack" word-button folded into the view menu (the user 2026-08-24) — same pref, same var

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -160,7 +160,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fcol-fold { display: none; }
 
 @container (max-width: 540px) or style(--romp-stack: on) {
-  .feed-cols { flex-direction: column; }
+  /* stretch, explicitly: the row layout's align-items: flex-start rides in from the base rule, and in
+     COLUMN direction that same declaration content-sizes each section horizontally — a section was
+     only as wide as its widest card's text, so a long Completed card spanned the pane while short
+     Working cards hugged their titles (the user 2026-08-24, second width-inconsistency report). */
+  .feed-cols { flex-direction: column; align-items: stretch; }
   /* Folding exists ONLY here, so the fold BITING lives here too (the user 2026-08-18): this rule used
      to sit outside the query, so a section collapsed while stacked stayed hidden after the feed
      widened to side-by-side — an empty column with no caret to reopen it (the caret is stacked-only).


### PR DESCRIPTION
In single-column view, a long Completed card spanned the pane while short Working cards hugged their titles (the second width-inconsistency report, screenshot-confirmed and reproduced headlessly with a synthetic board).

**Root cause:** the base `.feed-cols` rule's `align-items: flex-start` — correct in the row layout, where it top-aligns the three columns — rides into the stacked container query, where the cross axis is horizontal, so the very same declaration content-sizes each section to its widest card's text.

**Fix:** the stacked block sets `align-items: stretch` explicitly (one declaration); the base rule keeps `flex-start` for the side-by-side layout. Verified headless before/after in the shipped Chromium: before reproduces the report exactly, after stretches every card to the container.

Pins: feed-stack.test.ts asserts the stretch and the cascade order (the override sits inside the query, after the base rule it ties); feed-foot.test.ts's stacked-layout pin follows the rule's new shape. 2297 extension tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)