### PR TITLE
Feed Retry is one unit with its API-error badge, and retires on live recovery

### DIFF
--- a/ui/webview/apierror-refusal.test.ts
+++ b/ui/webview/apierror-refusal.test.ts
@@ -55,7 +55,7 @@ test("the 1s countdown tick RE-ASSERTS the refusal remedy — it must never writ
 
 test("the feed card badges a refusal and HIDES Retry (a useless click there)", () => {
   assert.match(F, /const refusal = !!\(it\.blocked && it\.blocked\.refusal\)/);
-  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none"/);
+  assert.match(F, /a\._apiRetry\.style\.display = \(showApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none"/);
   assert.match(F, /refusal \? "⚠ Safeguards refused"/);
   assert.match(F, /refusal\?: boolean/);
   // the badge tooltip carries the kernel's plain-terms remedy, not the CLI's boilerplate

--- a/ui/webview/apierror-spend-limit.test.ts
+++ b/ui/webview/apierror-spend-limit.test.ts
@@ -39,7 +39,7 @@ test("the globalRetryPaused push reason is threaded into the client", () => {
 
 test("the feed card badges a spend cap and HIDES Retry (a useless click there)", () => {
   assert.match(F, /const spendLimit = !!\(it\.blocked && it\.blocked\.spendLimit\)/);
-  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none"/);
+  assert.match(F, /a\._apiRetry\.style\.display = \(showApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none"/);
   assert.match(F, /spendLimit \? "⚠ Spend limit"/);
   assert.match(F, /spendLimit\?: boolean/);
 });

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-apierror-working.test.ts
+++ b/ui/webview/feed-apierror-working.test.ts
@@ -18,10 +18,35 @@ test("askColumn maps it.column directly — no crafty it.blocked re-route (the u
 
 test("the apiError chip + Retry still show (they key on blocked.state, not the column)", () => {
   assert.match(FEED, /const isApiErr = it\.blocked\?\.state === "apiError";/);
-  assert.match(FEED, /a\._apiBadge\.style\.display = isApiErr \? "" : "none";/);
+  assert.match(FEED, /a\._apiBadge\.style\.display = showApiErr \? "" : "none";/);
   // Retry shows for a transient/on-you-compactable error but is HIDDEN for a spend cap (retrying can't lift a
   // billing limit) — the user 2026-07-14; the spend-cap wiring is pinned in apierror-spend-limit.test.ts,
   // and a safeguards refusal joins the hide (the user 2026-08-15) — pinned in apierror-refusal.test.ts.
-  assert.match(FEED, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none";/);
+  assert.match(FEED, /a\._apiRetry\.style\.display = \(showApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none";/);
 });
 
+
+// ── the Retry cleanup (the user 2026-08-24, screenshot: a recovered session — GREEN awaiting dot —
+// still wearing a lone red Retry with no badge in sight, reading as arbitrary) ───────────────────
+test("Retry renders WITH its explaining badge as one visual unit — never alone on the action row", () => {
+  // badge immediately before its button, as DIRECT row2 children: grouped mode hides idwrap (the
+  // card drops its name there), which is exactly how the screenshot got a lone Retry with no badge —
+  // the badge sat in the hidden wrap while the action-row button stayed visible
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin,/);
+  assert.match(FEED, /actions\.append\(revive, qApprove, qDeny\);/);
+  assert.doesNotMatch(FEED, /actions\.append\(apiRetry/, "no lone Retry detached from its badge");
+  assert.doesNotMatch(FEED, /idwrap\.append\([^)]*apiBadge/, "…and never inside the grouped-mode-hidden idwrap");
+});
+
+test("badge + Retry RETIRE the moment the session recovers — live payload state, not the stored block record", () => {
+  // recovered = working again OR awaiting its dispatched background work — the exact sets the
+  // session dot reads (the screenshot's green dot), refreshed on every push; event-keyed, no timers
+  assert.match(FEED, /const apiRecovered = workingSet\.has\(it\.name\) \|\| awaitingSet\.has\(it\.name\);/);
+  assert.match(FEED, /const showApiErr = isApiErr && !apiRecovered;/);
+  assert.match(FEED, /a\._apiBadge\.style\.display = showApiErr \? "" : "none";/);
+  assert.match(FEED, /a\._apiRetry\.style\.display = \(showApiErr && !spendLimit && !modelLimit && !refusal\) \? "" : "none";/);
+  // the badge-text/onclick block gates on the same live answer, so a stale record wires nothing
+  assert.match(FEED, /if \(showApiErr && it\.blocked\) \{/);
+  // the button's acknowledge-on-click behavior is untouched
+  assert.match(FEED, /a\._apiRetry\.disabled = true; a\._apiRetry\.textContent = "Retrying…";/);
+});

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -16,12 +16,12 @@ test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails t
   // the TIME now trails the title on row1 (both cards); row3 holds the Background/Summary/Sub-goals toggles
   assert.match(FEED, /row1\.append\(title, time\)/, "the time trails the title on row1");
   assert.match(FEED, /row3\.append\(bgBtn, takeBtn, stallBtn, subBtn, taskBtn, actions\)/, "ask card: row3 is Background/Summary/Stalled/Sub-goals/Waiting-on-task (+ rare Retry/Revive)");
-  assert.match(FEED, /actions\.append\(apiRetry, revive,/, "…so the action row is Retry/Revive (+ resume-gate) only (Clear + toggles moved up)");
+  assert.match(FEED, /actions\.append\(revive,/, "…so the action row is Retry/Revive (+ resume-gate) only (Clear + toggles moved up)");
   // the action corner (the user 2026-08-08): Continue+Clear ride the END of row1 in every mode; the
   // name row keeps only identity + chips
   assert.match(FEED, /btns\.append\(cont, clr\);/, "ask card: Continue left of Clear in the action corner");
   assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
@@ -60,7 +60,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -77,7 +77,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);
@@ -89,10 +89,10 @@ test("session-STATE badges (⏸ approval / ⚠ API error) ride the name row; the
   // the bug: ⏸ approval + buttons + Clear in the SAME footer row shoved them off a narrow card.
   // Fix: the state badges move up beside the session name; the action row holds only the buttons.
   // The ⏳ "awaiting" chip was REMOVED (the user 2026-07-04) — the body "Awaiting background agents" box says it.
-  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, jauthBadge, blkBadge\)/,
-    "state badges sit beside the name (no awaiting chip; retrying joined 2026-07-09, judge-auth 2026-08-12)");
+  assert.match(FEED, /idwrap\.append\(retryBadge, jauthBadge, blkBadge\)/,
+    "state badges sit beside the name (retrying joined 2026-07-09, judge-auth 2026-08-12; the API unit moved to row2 direct 2026-08-24 — grouped mode hides idwrap)");
   assert.doesNotMatch(FEED, /waitBadge/, "the redundant awaiting chip element is gone entirely");
-  assert.match(FEED, /actions\.append\(apiRetry, revive,/, "action row = Retry/Revive (+ resume-gate) only (Clear moved to the name row 2026-07-07)");
+  assert.match(FEED, /actions\.append\(revive,/, "action row = Retry/Revive (+ resume-gate) only (Clear moved to the name row 2026-07-07)");
   assert.match(FEED, /a\._blocked = blkBadge;/);
 });
 

--- a/ui/webview/feed-checkstatus.test.ts
+++ b/ui/webview/feed-checkstatus.test.ts
@@ -16,7 +16,7 @@ test("the manual Nudge button is gone (Auto Nudge replaces it)", () => {
   assert.doesNotMatch(FEED, /nudge\.onclick/);
   assert.doesNotMatch(FEED, /a\._nudge[^A-Za-z]/);
   // the action row is buttons only (the state badges moved up to the name row, 2026-06-19); no Nudge now
-  assert.match(FEED, /actions\.append\(apiRetry, revive,/);
+  assert.match(FEED, /actions\.append\(revive,/);
 });
 
 test("the modal footer is age · Follow up · Check status · Continue · Clear", () => {

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-judge-auth.test.ts
+++ b/ui/webview/feed-judge-auth.test.ts
@@ -18,7 +18,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the judge-auth chip is built once, rides the session-state row, and keys on blocked.state", () => {
   assert.match(FEED, /const jauthBadge = el\("span", "fask-jauth"\)/);
-  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, jauthBadge, blkBadge\)/,
+  assert.match(FEED, /idwrap\.append\(retryBadge, jauthBadge, blkBadge\)/,
     "the chip rides the name row with its api-trouble siblings");
   assert.match(FEED, /a\._jauthBadge = jauthBadge;/);
   assert.match(FEED, /const isJudgeAuth = it\.blocked\?\.state === "judgeAuth"/);

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-parked-handoff.test.ts
+++ b/ui/webview/feed-parked-handoff.test.ts
@@ -11,7 +11,7 @@ const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", 
 
 test("a parkedHandoff card gets a Revive button, shown only for that block state", () => {
   assert.match(FEED, /const revive = el\("button", "fdismiss frevive"\)/);
-  assert.match(FEED, /actions\.append\(apiRetry, revive,/);   // resume-gate buttons ride the same row
+  assert.match(FEED, /actions\.append\(revive,/);   // resume-gate buttons ride the same row (Retry moved beside its badge 2026-08-24)
   assert.match(FEED, /const isParked = it\.blocked\?\.state === "parkedHandoff"/);
   assert.match(FEED, /a\._revive\.style\.display = isParked \? "" : "none"/);
 });

--- a/ui/webview/feed-retrying.test.ts
+++ b/ui/webview/feed-retrying.test.ts
@@ -15,7 +15,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the retrying badge is built once and rides the session-state row beside the API-error badge", () => {
   assert.match(FEED, /const retryBadge = el\("span", "fask-retrying"\)/);
-  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, jauthBadge, blkBadge\)/,
+  assert.match(FEED, /idwrap\.append\(retryBadge, jauthBadge, blkBadge\)/,
     "session-STATE badges ride the name row, off the action row");
   assert.match(FEED, /a\._retryBadge = retryBadge;/);
 });

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -972,16 +972,20 @@ function makeAskCard(it: AskItem): HTMLElement {
   // name — they describe the session's live state, and keeping them OFF the action row stops them shoving
   // the buttons past the card's right edge on a narrow card (the user 2026-06-19; mirrors the ↻ Followed-up
   // chip moved up 2026-06-18). idwrap is flex:1 so the name ellipsizes before the badge is ever clipped.
-  idwrap.append(retryBadge, apiBadge, jauthBadge, blkBadge);
+  idwrap.append(retryBadge, jauthBadge, blkBadge);
   // COMPACTNESS (the user 2026-07-07): Clear rides the NAME row (right side, after the chips) and the
   // Background/Summary toggles ride the TIME row — freeing a whole action row. So the action row holds only
   // Retry / Revive (rare states); both rows flex-WRAP so nothing overflows or overlaps on a narrow card.
-  actions.append(apiRetry, revive, qApprove, qDeny);
+  actions.append(revive, qApprove, qDeny);
   // "↪ from <peer>" provenance + the "reopened"/"↻ Followed up" chips ride the name row's right side;
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // (Clear left this row 2026-08-08 — it rides row1's action corner in every mode now, see fask-btns.)
-  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
+  // the API-error badge + Retry ride row2 DIRECTLY, badge immediately before its button — one
+  // visual unit in BOTH modes (the user 2026-08-24, screenshot: grouped mode hides idwrap — the
+  // card drops its name there — which hid the badge while the action-row Retry stayed, a lone red
+  // button with no visible reason). Direct children also count toward row2's grouped-mode liveness.
+  row2.append(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
   // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
   // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
   // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or
@@ -1863,14 +1867,22 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   const spendLimit = !!(it.blocked && it.blocked.spendLimit);
   const modelLimit = !!(it.blocked && it.blocked.modelLimit);
   const refusal = !!(it.blocked && it.blocked.refusal);
-  a._apiBadge.style.display = isApiErr ? "" : "none";
+  // …and the whole unit RETIRES the moment the session recovers (the user 2026-08-24, screenshot: a
+  // GREEN awaiting dot beside a lone red Retry — the control read as arbitrary): visibility keys on
+  // the session's LIVE state from this very payload — a session working again, or awaiting the
+  // background work it dispatched, has resumed, and there is nothing to resume by hand no matter
+  // what the card's stored block record still says. The same sets the session dot reads
+  // (workingSet/awaitingSet), refreshed on every push — event-keyed, never a timer.
+  const apiRecovered = workingSet.has(it.name) || awaitingSet.has(it.name);
+  const showApiErr = isApiErr && !apiRecovered;
+  a._apiBadge.style.display = showApiErr ? "" : "none";
   // Retry pastes "retry" to resume a stalled turn — useless against a monthly spend cap (retrying can't lift a
   // billing limit), so hide it there and let the badge tell you to raise the cap (the user 2026-07-14).
   // A spent MODEL allowance is the same shape: Retry re-fails until you switch model or top up, and the
   // badge says so (the user 2026-08-01). Its window does reset on its own, which the badge title carries.
   // A safeguards REFUSAL is the same shape again (the user 2026-08-15): deterministic on the same input,
   // so Retry re-collects the same refusal — the badge names the real fix (rewrite it or drop the thread).
-  a._apiRetry.style.display = (isApiErr && !spendLimit && !modelLimit && !refusal) ? "" : "none";
+  a._apiRetry.style.display = (showApiErr && !spendLimit && !modelLimit && !refusal) ? "" : "none";
   // "Continue" shows on a LIVE needs-you card with no live ask attached: the gesture claims "you're not
   // waiting on me", which means nothing in Working/Completed, can't answer a real permission prompt or
   // picker (it.blocked — text sent there would just queue behind the ask), and has no one to tell on a
@@ -1882,7 +1894,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   if (contBtn.disabled && !it.followupPending && !it.recheck && !it.rejudging) {
     contBtn.disabled = false; contBtn.textContent = "Continue";
   }
-  if (isApiErr && it.blocked) {
+  if (showApiErr && it.blocked) {
     // on-you errors name themselves: a spend cap (raise it), "prompt too long" (compact), or a spent model
     // allowance (switch model); other API errors are transient and auto-retrying (2026-06-29 / 07-14 / 08-01).
     a._apiBadge.textContent = spendLimit ? "⚠ Spend limit"


### PR DESCRIPTION
## What

A blocked card showed a lone red **Retry** with no visible explanation — beside a green (recovered) session dot (user screenshot). Two rules, both event-keyed:

**1. One visual unit.** The harness reproduced the deeper cause: the API-error badge lived in `idwrap` (the name wrap), which **grouped mode hides wholesale** (the card drops its name there) — so the explaining badge never showed on grouped-mode cards while the button sat on the always-visible action row. The badge + Retry now ride row2 as direct children, badge immediately before its button — visible in both modes, counted toward row2's grouped-mode liveness. The action row holds only Revive/approve/deny.

**2. Live retirement.** Visibility keyed on the card's stored block record, which can outlive recovery. The unit now also keys on the session's **live state from the same payload** — working again, or awaiting its dispatched background work (the screenshot's green dot) — via the exact sets the session dot reads (`workingSet`/`awaitingSet`), refreshed every push. Badge and button retire together; tooltip and acknowledge-on-click untouched.

## Audit (as delegated — report, fix only Retry)

- The grouped-mode `idwrap` hiding equally blanks the **other** state badges — ⚠ retrying-since, judge-auth, and the ⏸ approval chip never show on grouped-mode cards. Worth its own pass; not touched here.
- `Revive` on parkedHandoff is the one other action keyed solely on a stored block record with no live-payload cross-check (the kernel owns that record's lifecycle, so lower risk).
- Everything else reads live per-push state (the retrying chip) or has explicit event-based retirement (recheck/rejudging for ⏸; quarantine handled kernel-side).

## Verification

Headless (playwright over the built feed bundle, synthetic frames): genuinely API-blocked → badge+Retry adjacent as one unit (screenshot eyeballed); recovered-awaiting and recovered-working → both retire. Tests: `feed-apierror-working.test.ts` gains the unit + live-retirement pins; ten sibling source-pin files retargeted in lockstep. Full suite: 2298 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)