### PR TITLE
Remote tags edit transparently: routed to the home kernel, optimistically, loudly

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -658,7 +658,7 @@ EOF
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
-    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view); --host <kernel> edits an attached kernel's tag"
+    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view); --host <kernel> edits an attached kernel's tag; --rename renames"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -950,8 +950,8 @@ fi
 if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
     shift
     _gr_usage="usage: romp tag [--json]
-       romp tag <name> [--host <kernel>] [--add <session>...] [--remove <session>...] [--color <#hex>] [--delete]"
-    _gr_name=""; _gr_json=false; _gr_color=""; _gr_cset=0; _gr_del=0; _gr_host=""
+       romp tag <name> [--host <kernel>] [--add <session>...] [--remove <session>...] [--color <#hex>] [--rename <new>] [--delete]"
+    _gr_name=""; _gr_json=false; _gr_color=""; _gr_cset=0; _gr_del=0; _gr_host=""; _gr_rename=""
     _gr_add=(); _gr_remove=(); _gr_mode=""; _gr_add_seen=0; _gr_rm_seen=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -961,6 +961,9 @@ if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
             --color)  shift
                       if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_gr_usage" >&2; exit 2; fi
                       _gr_color="$1"; _gr_cset=1; _gr_mode=""; shift ;;
+            --rename) shift
+                      if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_gr_usage" >&2; exit 2; fi
+                      _gr_rename="$1"; _gr_mode=""; shift ;;
             --host)   shift
                       if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then echo "$_gr_usage" >&2; exit 2; fi
                       _gr_host="$1"; _gr_mode=""; shift ;;
@@ -978,10 +981,10 @@ if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
     if $_gr_json && [[ -n "$_gr_name" || $_gr_add_seen -eq 1 || $_gr_rm_seen -eq 1 || $_gr_cset -eq 1 || $_gr_del -eq 1 ]]; then
         echo "$_gr_usage" >&2; exit 2
     fi
-    if [[ -z "$_gr_name" && ( $_gr_add_seen -eq 1 || $_gr_rm_seen -eq 1 || $_gr_cset -eq 1 || $_gr_del -eq 1 ) ]]; then
+    if [[ -z "$_gr_name" && ( $_gr_add_seen -eq 1 || $_gr_rm_seen -eq 1 || $_gr_cset -eq 1 || $_gr_del -eq 1 || -n "$_gr_rename" ) ]]; then
         echo "$_gr_usage" >&2; exit 2
     fi
-    if [[ -n "$_gr_host" && $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 ]]; then
+    if [[ -n "$_gr_host" && $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 && -z "$_gr_rename" ]]; then
         # v0: --host modifies an EDIT (the target kernel's store, through the tunnel). Reads stay
         # local — the dashboard's view menu already shows the union.
         echo "romp tag: --host goes with an edit (--add/--remove/--color/--delete)" >&2; exit 2
@@ -1029,7 +1032,7 @@ for g in groups:
 ' "$_resp" "$_rows"
         exit 0
     fi
-    if [[ $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 ]]; then
+    if [[ $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 && -z "$_gr_rename" ]]; then
         # a bare name is a READ of that one group, never a write — POSTing here would CREATE a
         # missing group, so a typo'd "view" would mint a phantom and burn one of the 32 slots
         _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/views")" \
@@ -1061,16 +1064,18 @@ print("%s  %s  %d member%s%s" % (g.get("name"), g.get("color") or "(no color)",
     fi
     _payload="$(python3 -c '
 import json, sys
-n = int(sys.argv[6])
-body = {"name": sys.argv[1], "add": sys.argv[7:7 + n], "remove": sys.argv[7 + n:]}
+n = int(sys.argv[7])
+body = {"name": sys.argv[1], "add": sys.argv[8:8 + n], "remove": sys.argv[8 + n:]}
 if sys.argv[2] == "1":
     body["color"] = sys.argv[3]
 if sys.argv[4] == "1":
     body["delete"] = True
 if sys.argv[5]:
     body["host"] = sys.argv[5]
+if sys.argv[6]:
+    body["rename"] = sys.argv[6]
 print(json.dumps(body))
-' "$_gr_name" "$_gr_cset" "$_gr_color" "$_gr_del" "$_gr_host" "${#_gr_add[@]}" \
+' "$_gr_name" "$_gr_cset" "$_gr_color" "$_gr_del" "$_gr_host" "$_gr_rename" "${#_gr_add[@]}" \
         "${_gr_add[@]+"${_gr_add[@]}"}" "${_gr_remove[@]+"${_gr_remove[@]}"}")"
     _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/tag" \
                   -H 'Content-Type: application/json' -d "$_payload")" \

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1636,6 +1636,34 @@ def _remote_tag_member_str(owner_host, m):
     return h + ":" + sid
 
 
+def _forward_tag_edit(host, body):
+    """Route a tag edit to its HOME kernel through the tunnel this kernel already holds (tag
+    federation: v0 gave `romp tag --host` this arm; v1 routes the dialog/menu edits through it too,
+    so a remote tag just works). Returns (answer, error): answer is the home kernel's own /tag reply
+    passed through verbatim; error is the LOUD refusal when the edit cannot land — an unreachable
+    kernel must never silently no-op an edit (the fail-loudly rule)."""
+    with _remotes_lock:
+        r = next((x for x in _remotes.values() if x.get("host") == host), None)
+        r_up = bool(r and r.get("status") == "up")
+    if not r:
+        return None, 'no attached kernel named "%s" (see the network panel)' % host
+    if not r_up:
+        return None, '"%s" is attached but not reachable right now' % host
+    ans = _remote_forward(r, "/tag", body)
+    if ans is None:
+        return None, 'the edit never landed on "%s" (tunnel hiccup — try again)' % host
+    # a landed edit should ECHO fast: drop the poll gate so the next supervisor pass re-reads the
+    # owner's store, and try an inline refresh now (best-effort — the poll loop is the backstop)
+    r.pop("_views_at", None)
+    try:
+        rv = _poll_remote_views(r)
+        if rv is not None:
+            r["views"] = rv
+    except Exception:
+        pass
+    return ans, None
+
+
 def _views_client():
     """The views blob every client renders and matches against — the RENDERING of the canonical
     store (federation v0, the user 2026-08-24): local tags with members as viewer-relative strings
@@ -1725,7 +1753,7 @@ def _b36(n):
     return out or "0"
 
 
-def _edit_tag(name, add=(), remove=(), color=None, delete=False):
+def _edit_tag(name, add=(), remove=(), color=None, delete=False, rename=None):
     """Targeted edit of ONE named tag in the views blob — the merge op behind POST /tag. The WS
     setTimelineViews op replaces the whole blob, which is right for the dashboard (it holds the
     current one) and wrong for an agent: replaying a stale read would clobber the active view and
@@ -1760,6 +1788,13 @@ def _edit_tag(name, add=(), remove=(), color=None, delete=False):
                 n += 1
             t = {"id": "g" + _b36(n), "name": name, "color": "", "members": []}
             v["tags"].append(t)
+        if rename is not None:
+            rn = str(rename)[:_VIEWS_MAX_NAME].strip()
+            if not rn:
+                return None, "the new name is empty"
+            if any(t2["name"] == rn and t2["id"] != (hits[0]["id"] if hits else None) for t2 in v["tags"]):
+                return None, 'a tag named "%s" already exists' % rn   # names address edits — no twins
+            t["name"] = rn
         # add/remove arrive as viewer-relative id strings (the route's contract); the store is
         # canonical pairs — convert on the way in, match removals by pair (federation v0)
         addp = [m for m in (_member_pair(x) for x in add) if m]
@@ -23503,7 +23538,8 @@ else if(m.type==="hover"&&panel.setHover)panel.setHover(m);
 // chat rail CLICK -> pan + pulse (the user 2026-07-23). Must mirror timeline-boot.ts's dispatchFrame:
 // this inline copy serves the browser, that one the VS Code webview. net-popover-known.test.ts's sibling
 // timeline-boot.test.ts pins the pair.
-else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);});
+else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);
+else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);});
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
 post({type:"deepLink",session:q.get("session"),anchor:q.get("anchor")||undefined,anchorT:Number(q.get("anchorT"))||undefined,anchorKind:q.get("anchorKind")||undefined,compose:q.get("compose")==="1"});
 if(window.parent!==window)window.parent.postMessage({romp:"reveal",pane:"chat"},"*");return;}}catch(e){}window.open(url,"_blank");};
@@ -23512,6 +23548,7 @@ window.__rompTimelineCompact=function(name){post({type:"compact",name:name});};
 window.__rompTimelineSendCommand=function(name,cmd){post({type:"sendCommand",name:name,cmd:cmd});};
 window.__rompTimelineSetFlag=function(id,flag,value){post({type:"setSessionFlag",id:id,flag:flag,value:!!value});};
 window.__rompTimelineSetViews=function(views){post({type:"setTimelineViews",views:views});};
+window.__rompTimelineEditTag=function(edit){post({type:"editTag",edit:edit});};
 window.__rompTimelineDismiss=function(id){post({type:"dismissLane",id:id});};
 window.__rompTimelineHover=function(sid,segIds,t0,t1){post(sid?{type:"timelineHover",sid:sid,segIds:segIds||[],t0:t0,t1:t1}:{type:"timelineHover",off:true});};
 window.__rompConnectTimeline=function(p){panel=p;post({type:"ready"});};})();
@@ -27243,24 +27280,20 @@ class Handler(BaseHTTPRequestHandler):
                 # refuses loudly: an unreachable kernel must never silently no-op an edit.
                 th = str((b or {}).get("host") or "").strip()
                 if th:
-                    with _remotes_lock:
-                        r = next((x for x in _remotes.values() if x.get("host") == th), None)
-                        r_up = bool(r and r.get("status") == "up")
-                    if not r:
-                        return self._send(200, json.dumps({"ok": False, "error":
-                            'no attached kernel named "%s" (see the network panel)' % th}),
-                            "application/json")
-                    if not r_up:
-                        return self._send(200, json.dumps({"ok": False, "error":
-                            '"%s" is attached but not reachable right now' % th}), "application/json")
-                    fwd = {k: v for k, v in b.items() if k != "host"}
-                    ans = _remote_forward(r, "/tag", fwd)
-                    if ans is None:
-                        return self._send(200, json.dumps({"ok": False, "error":
-                            'the edit never landed on "%s" (tunnel hiccup — try again)' % th}),
-                            "application/json")
+                    ans, err = _forward_tag_edit(th, {k: v for k, v in b.items() if k != "host"})
+                    if err:
+                        return self._send(200, json.dumps({"ok": False, "error": err}),
+                                          "application/json")
+                    _mark_views_dirty()
                     return self._send(200, json.dumps(ans), "application/json")
                 live = _live_names(_tmux_sessions())
+                # this kernel's own label for each attached kernel's sids — the HOME-frame
+                # resolution of a bare sid an edit routed here from a third kernel (federation v1:
+                # viewer C adds kernel-B's session to THIS kernel's tag; C cannot know our name for
+                # B, but sids are global — we resolve them into OUR frame ourselves)
+                with _remotes_lock:
+                    rsids = {s: r["host"] for r in _remotes.values()
+                             for s in (r.get("sids") or []) if r.get("host")}
                 ids, unknown = {"add": [], "remove": []}, []
                 for k in ("add", "remove"):
                     for x in (b.get(k) if isinstance(b.get(k), list) else []):
@@ -27269,9 +27302,17 @@ class Handler(BaseHTTPRequestHandler):
                             continue
                         if x in live:
                             ids[k].append(live[x])
-                        elif re.fullmatch(r"[0-9a-fA-F-]{32,36}", x) or \
-                                re.fullmatch(r"[^:]+:[0-9a-fA-F-]{32,36}", x):
-                            ids[k].append(x)          # a sid, or a host-prefixed remote SID, verbatim
+                        elif re.fullmatch(r"[0-9a-fA-F-]{32,36}", x):
+                            local = False
+                            try:
+                                local = (jd.STATE / "names" / x).exists()
+                            except OSError:
+                                pass
+                            # a bare sid we know as a REMOTE's lands in our frame for it; local or
+                            # unknown stays bare (unknown = legacy behavior — inert until known)
+                            ids[k].append(x if (local or x not in rsids) else rsids[x] + ":" + x)
+                        elif re.fullmatch(r"[^:]+:[0-9a-fA-F-]{32,36}", x):
+                            ids[k].append(x)          # a host-prefixed remote SID, verbatim
                         else:
                             unknown.append(x)
                 if unknown:
@@ -27279,9 +27320,11 @@ class Handler(BaseHTTPRequestHandler):
                         "no live session named %s (dead ones go by sid, remote ones by host:<sid>)" %
                         ", ".join('"%s"' % x for x in unknown)}), "application/json")
                 color = b.get("color")
+                rn = b.get("rename")
                 t, err = _edit_tag(name, add=ids["add"], remove=ids["remove"],
                                    color=(str(color) if isinstance(color, str) else None),
-                                   delete=bool(b.get("delete")))
+                                   delete=bool(b.get("delete")),
+                                   rename=(str(rn) if isinstance(rn, str) else None))
                 if err:
                     return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
                 _mark_views_dirty()
@@ -27740,6 +27783,36 @@ class Handler(BaseHTTPRequestHandler):
             # dashboards, like colormap). Validation/normalization happens in the setter.
             _set_timeline_views(msg["views"])
             _mark_views_dirty()
+        elif msg and msg.get("type") == "editTag" and isinstance(msg.get("edit"), dict):
+            # tag federation v1 (the user 2026-08-24): a REMOTE tag edited in the dialog/menu routes
+            # to its HOME kernel through the same channel `romp tag --host` uses — the tag's host
+            # stamp says where. Ids arrive as the viewer's spellings; only the BARE sid tail crosses
+            # (sids are global) and the home kernel resolves each into ITS OWN frame — this kernel's
+            # labels mean nothing there (the federation counter rule). A failure pushes a LOUD
+            # tagEditFailed to the asking dashboard's timeline: a down owner visibly refuses, never
+            # a silent queue. Local tags never come through here — the dialog still posts the whole
+            # blob for them (zero behavior change).
+            e = msg["edit"]
+            host = str(e.get("host") or "").strip()
+            nm = str(e.get("name") or "").strip()
+            if host and nm:
+                tail = lambda x: x.rsplit(":", 1)[-1]
+                body = {"name": nm}
+                for k in ("add", "remove"):
+                    if isinstance(e.get(k), list):
+                        body[k] = [tail(str(x)) for x in e[k] if str(x).strip()]
+                if isinstance(e.get("color"), str):
+                    body["color"] = e["color"]
+                if isinstance(e.get("rename"), str):
+                    body["rename"] = e["rename"]
+                if e.get("delete"):
+                    body["delete"] = True
+                ans, err = _forward_tag_edit(host, body)
+                if err or not (ans or {}).get("ok", False):
+                    _send_to_view("timeline", {"type": "tagEditFailed", "host": host, "name": nm,
+                                               "error": err or (ans or {}).get("error") or "refused"},
+                                  (client or {}).get("wid") or "")
+                _mark_views_dirty()
         elif msg and msg.get("type") == "cardNotify" and msg.get("itemId"):
             # feed card right-click → per-card bell (OS notification when THIS card blocks on you /
             # completes). Persisted to notify-cards.json; build_feed echoes it back as ask.notify.

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -264,6 +264,18 @@ MOCK
     [[ "$output" == *"--host goes with an edit"* ]]
 }
 
+@test "tag: --rename rides the payload and counts as an edit" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp tag team --rename crew
+    [ "$status" -eq 0 ]
+    grep '/tag' "$MOCK_LOG" | grep -q '"rename": *"crew"'
+    run run_romp tag team --host alpha --rename crew
+    [ "$status" -eq 0 ]
+    grep '/tag' "$MOCK_LOG" | grep -q '"host": *"alpha"'
+}
+
 @test "tag: the pre-rename group verb still works, posting the new /tag route" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -256,6 +256,97 @@ class HostForward(TagRoute):
         self.assertFalse(r["ok"]); self.assertIn("never landed", r["error"])
 
 
+class RenameAndHomeFrame(TagRoute):
+    """Federation v1: /tag gains rename (collision-refusing), and a bare sid routed here from a
+    THIRD kernel resolves into THIS kernel's own frame — viewer C adding kernel-B's session to our
+    tag cannot know our name for B, but sids are global, so we look the sid up in our remotes'
+    cached session lists and store the canonical pair ourselves."""
+
+    def test_rename_lands_and_a_collision_refuses(self):
+        self._post({"name": "alpha", "add": []})
+        self._post({"name": "beta", "add": []})
+        st, r = self._post({"name": "alpha", "rename": "gamma"})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["tag"]["name"], "gamma")
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["beta", "gamma"])
+        st, r = self._post({"name": "gamma", "rename": "beta"})
+        self.assertFalse(r["ok"])
+        self.assertIn('a tag named "beta" already exists', r["error"])
+
+    def test_a_third_kernels_bare_sid_lands_in_OUR_frame(self):
+        # TESTHOST-A (this kernel) holds the tag; TESTHOST-B owns the session; viewer TESTHOST-C
+        # routed the edit here with the bare sid tail — we know that sid as TESTHOST-B's
+        bsid = "44444444-5555-6666-7777-888888888888"
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            km._remotes["TESTHOST-B"] = {"host": "TESTHOST-B", "status": "up", "sids": [bsid]}
+            st, r = self._post({"name": "team", "add": [bsid]})
+            self.assertTrue(r["ok"])
+            self.assertEqual(km._timeline_views()["tags"][0]["members"],
+                             [{"host": "TESTHOST-B", "sid": bsid}],
+                             "the canonical pair carries OUR label for B — never the viewer's")
+            # …while a sid nobody knows stays bare (legacy behavior: inert until known)
+            ghost = "99999999-aaaa-bbbb-cccc-dddddddddddd"
+            self._post({"name": "team", "add": [ghost]})
+            self.assertIn({"host": "", "sid": ghost}, km._timeline_views()["tags"][0]["members"])
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
+
+class EditTagOpPins(unittest.TestCase):
+    """The WS op the dialog rides (federation v1) — source pins: only the BARE sid tail crosses
+    kernels (this viewer's host labels mean nothing on the owner), the failure pushes a LOUD
+    tagEditFailed to the asking dashboard, and a landed edit marks views dirty either way."""
+
+    def test_the_op_tails_ids_forwards_and_fails_loudly(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('msg.get("type") == "editTag"', src)
+        self.assertIn('tail = lambda x: x.rsplit(":", 1)[-1]', src)
+        self.assertIn('ans, err = _forward_tag_edit(host, body)', src)
+        self.assertIn('{"type": "tagEditFailed", "host": host, "name": nm,', src)
+        self.assertIn('(client or {}).get("wid") or ""', src, "the refusal goes to the ASKING dashboard")
+
+
+class ForwardHelper(TagRoute):
+    """_forward_tag_edit — the one channel every remote edit rides (romp tag --host, the dialog's
+    editTag op): loud refusals, response passthrough, and the FAST ECHO (a landed edit drops the
+    owner's poll gate and refreshes its cached views inline, so the optimistic copy reconciles
+    within a push, not a poll period)."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved = (dict(km._remotes), km._remote_forward, km._poll_remote_views)
+        km._remotes.clear()
+        km._remotes["alpha"] = {"host": "alpha", "status": "up", "_views_at": 12345.0,
+                                "views": {"tags": []}}
+        self.polled = []
+        km._remote_forward = lambda r, path, body: {"ok": True, "tag": {"name": body.get("name")}}
+        km._poll_remote_views = lambda r: (self.polled.append(r["host"]) or {"tags": [{"id": "g1", "name": "team", "members": []}]})
+
+    def tearDown(self):
+        km._remotes.clear(); km._remotes.update(self._saved[0])
+        km._remote_forward, km._poll_remote_views = self._saved[1], self._saved[2]
+        super().tearDown()
+
+    def test_a_landed_edit_echoes_fast(self):
+        ans, err = km._forward_tag_edit("alpha", {"name": "team", "add": []})
+        self.assertIsNone(err)
+        self.assertTrue(ans["ok"])
+        self.assertEqual(self.polled, ["alpha"], "the owner's views re-poll inline — the fast echo")
+        self.assertNotIn("_views_at", km._remotes["alpha"], "…and the poll gate stays dropped for the loop")
+        self.assertEqual(km._remotes["alpha"]["views"]["tags"][0]["name"], "team")
+
+    def test_refusals_stay_loud(self):
+        self.assertEqual(km._forward_tag_edit("ghost", {"name": "t"})[1],
+                         'no attached kernel named "ghost" (see the network panel)')
+        km._remotes["alpha"]["status"] = "down"
+        self.assertIn("not reachable", km._forward_tag_edit("alpha", {"name": "t"})[1])
+        km._remotes["alpha"]["status"] = "up"
+        km._remote_forward = lambda r, path, body: None
+        self.assertIn("never landed", km._forward_tag_edit("alpha", {"name": "t"})[1])
+
+
 class GroupAliasSurvives(TagRoute):
     """The pre-rename surface (same-day rename, 2026-08-23): an un-updated remote's bin/romp still
     POSTs /group and reads the "group" response key — both stay as quiet aliases of /tag."""

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -617,6 +617,8 @@ class TimelinePanel {
     this._dismissed = new Set(); // sids cleared via the dead-lane Clear pill, held STICKY the same way (see _reconcileDismissed)
     this._views = null;          // the kernel-echoed views blob (data.views); null until the first push
     this._pendingViews = null;   // an optimistic edit held sticky until a push echoes it (see _reconcileViews)
+    this._pendingTagEdits = {};  // remote-tag edits held optimistically until the owner's poll echoes (federation v1): id → {tag: shape|null(=deleted), age}
+    this._tagEditErr = null;     // the LOUD failure of the last remote-tag edit ({host, name, error}), shown in the dialog until dismissed
     this._pendingViewsAge = 0;   // pushes since the edit — the kernel is authoritative, so a stale pending yields
     this._viewsMenu = null;      // the Show-dropdown element, when open
     this._viewsDialog = null;    // the sessions/group dialog backdrop, when open
@@ -1475,6 +1477,7 @@ class TimelinePanel {
     this._reconcilePendingFlags();   // hold an optimistic eye-toggle sticky until THIS push (or a later one) confirms it
     this._reconcileDismissed();      // ...and a Cleared dead lane, so a stale/merged push can't pop it back
     this._reconcileViews();          // ...and an optimistic view edit, until the kernel echoes it
+    this._reconcileTagEdits();       // ...and any remote-tag edits, until the owner's poll echoes them
     this._signalReady();             // first lanes are about to paint → let the shell drop the boot splash
     // Live-edge baseline: the edge free-runs off a FIXED anchor and each poll rebases it MONOTONICALLY
     // (reanchorEdge) — it catches up forward when behind but NEVER moves backward, so bursty/jittery/
@@ -2352,7 +2355,24 @@ class TimelinePanel {
   // disclosure: the trigger is the one-line version; the dropdown holds the views and the two
   // timeline display toggles; the dialog holds the per-session checkboxes. All pointerdown-based
   // (the redraw-eats-click rule) and rebuilt per draw like the gear/lock.
-  _curViews() { return this._pendingViews || this._views || { active: 'all', hidden: [], tags: [] }; }
+  _curViews() {
+    const base = this._pendingViews || this._views || { active: 'all', hidden: [], tags: [] };
+    const ids = Object.keys(this._pendingTagEdits || {});
+    if (!ids.length) return base;
+    // remote-tag edits render optimistically (federation v1): the pending shape overlays the polled
+    // one until the owner's next poll echoes it (or the 3-cycle yield in _reconcileTagEdits)
+    const v = {}; for (const k in base) v[k] = base[k];
+    let rt = (base.remoteTags || []).slice();
+    for (const id of ids) {
+      const pend = this._pendingTagEdits[id];
+      const i = rt.findIndex((t) => t.id === id);
+      if (pend.tag === null) { if (i >= 0) rt.splice(i, 1); }
+      else if (i >= 0) rt[i] = pend.tag;
+      else rt.push(pend.tag);
+    }
+    if (rt.length) v.remoteTags = rt; else delete v.remoteTags;
+    return v;
+  }
 
   // one canonical serialization for echo comparison: the kernel normalizer sorts hidden/members and
   // may clamp names, so compare shapes, not object identity
@@ -2361,6 +2381,58 @@ class TimelinePanel {
       hidden: (v.hidden || []).slice().sort(),
       tags: viewTags(v).map((t) => ({ id: t.id, name: t.name, color: t.color,
                                       members: (t.members || []).slice().sort() })) });
+  }
+
+  _reconcileTagEdits() {
+    // the sessionViews precedent, per REMOTE tag (federation v1): a pending edit clears when the
+    // owner's polled copy matches it (canonical compare — the poll re-sorts members), and yields to
+    // the polled truth after three silent pushes (the owner rejected it, or another dashboard won)
+    const ids = Object.keys(this._pendingTagEdits || {});
+    if (!ids.length) return;
+    const polled = ((this._views && this._views.remoteTags) || []);
+    const canon = (t) => t ? JSON.stringify({ n: t.name, c: t.color, m: (t.members || []).slice().sort() }) : null;
+    for (const id of ids) {
+      const pend = this._pendingTagEdits[id];
+      const seen = polled.find((t) => t.id === id) || null;
+      if (canon(seen) === canon(pend.tag)) { delete this._pendingTagEdits[id]; continue; }
+      if (++pend.age >= 3) delete this._pendingTagEdits[id];
+    }
+  }
+
+  // one remote-tag edit, dispatched to its HOME kernel and rendered optimistically meanwhile.
+  // Ids ride viewer-relative; the kernel sends only the bare sid tails (sids are global) and the
+  // owner resolves them into ITS frame. No hook (the Obsidian panel) → the tag stays read-only
+  // and the refusal is immediate and visible, never a silent drop.
+  _editRemoteTag(rt, edit) {
+    if (typeof window === 'undefined' || typeof window.__rompTimelineEditTag !== 'function') {
+      this._tagEditErr = { host: rt.host, name: rt.name,
+                           error: 'this panel cannot reach ' + (rt.host || 'the owner') + " — edit with: romp tag --host " + (rt.host || '<kernel>') };
+      this.draw();
+      return false;
+    }
+    let next = null;
+    if (!edit.delete) {
+      next = { id: rt.id, host: rt.host, name: edit.rename || rt.name, color: edit.color || rt.color,
+               members: (rt.members || []).slice() };
+      for (const x of (edit.add || [])) if (next.members.indexOf(x) < 0) next.members.push(x);
+      if (edit.remove) next.members = next.members.filter((x) => edit.remove.indexOf(x) < 0);
+    }
+    this._pendingTagEdits[rt.id] = { tag: next, age: 0 };
+    window.__rompTimelineEditTag({ host: rt.host, name: rt.name, rename: edit.rename,
+                                   color: edit.color, add: edit.add, remove: edit.remove,
+                                   delete: !!edit.delete });
+    this.draw();
+    return true;
+  }
+
+  // the kernel's LOUD refusal (a down owner, a name collision there): the optimistic copy reverts
+  // and the reason shows in the dialog (rebuilt in place if open) until dismissed
+  tagEditFailed(m) {
+    for (const id of Object.keys(this._pendingTagEdits || {}))
+      if (id.split(':')[0] === m.host) delete this._pendingTagEdits[id];   // edits are name-addressed per host — revert them all
+    this._tagEditErr = { host: m.host || '', name: m.name || '', error: m.error || 'refused' };
+    if (this._viewsDialog && this._viewsDialogBuild) this._viewsDialogBuild();
+    this.draw();
   }
 
   _reconcileViews() {
@@ -2489,7 +2561,7 @@ class TimelinePanel {
   _closeViewsMenu() { if (this._viewsMenu) { this._viewsMenu.remove(); this._viewsMenu = null; } }
   _closeViewsDialog() {
     if (!this._viewsDialog) return;
-    this._viewsDialog.remove(); this._viewsDialog = null;
+    this._viewsDialog.remove(); this._viewsDialog = null; this._viewsDialogBuild = null;
     if (this._viewsDialogKey) {   // the Escape hook dies with the dialog on EVERY close path, not just Escape
       try { this._viewsDialogKey.doc.removeEventListener('keydown', this._viewsDialogKey.fn); } catch (e) {}
       this._viewsDialogKey = null;
@@ -2616,10 +2688,34 @@ class TimelinePanel {
       card.textContent = '';
       const v = this._curViews();
       const tg = gid ? viewTags(v).find((x) => x.id === gid) : null;
-      if (gid && !tg) { this._closeViewsDialog(); return; }   // the tag was deleted elsewhere
+      // a REMOTE tag opens the same header (federation v1): its edits route to the home kernel
+      const rtg = gid && !tg ? ((v.remoteTags || []).find((x) => x.id === gid) || null) : null;
+      if (gid && !tg && !rtg) { this._closeViewsDialog(); return; }   // the tag was deleted elsewhere
+      const canEdit = typeof window !== 'undefined' && typeof window.__rompTimelineEditTag === 'function';
       const head = card.createDiv();
       head.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 8px;');
-      if (tg) {
+      if (rtg) {
+        const hp = head.createSpan({ text: (rtg.host || '') + ':' });
+        hp.setAttribute('style', 'flex:0 0 auto;color:' + MODEL_FG + ';font-style:italic;font-size:0.88em;');
+        const nameIn = document.createElement('input');
+        nameIn.value = rtg.name || 'tag'; nameIn.maxLength = 40;
+        nameIn.disabled = !canEdit;
+        nameIn.setAttribute('style', 'flex:1 1 auto;min-width:0;background:#1e1e1e;color:#ccc;'
+          + 'border:1px solid rgba(255,255,255,0.12);border-radius:5px;padding:3px 6px;font:inherit;');
+        nameIn.addEventListener('change', () => {
+          const nv = nameIn.value.slice(0, 40).trim();
+          if (nv && nv !== rtg.name) this._editRemoteTag(rtg, { rename: nv });
+          build();
+        });
+        head.appendChild(nameIn);
+        const del = head.createSpan({ text: 'Delete' });
+        del.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.7;color:#F85B5A;' + (canEdit ? '' : 'display:none;'));
+        hover(del, 'opacity:1;', 'opacity:0.7;');
+        del.addEventListener('click', () => {
+          this._editRemoteTag(rtg, { delete: true });
+          this._closeViewsDialog();
+        });
+      } else if (tg) {
         const nameIn = document.createElement('input');
         nameIn.value = tg.name; nameIn.maxLength = 40;
         nameIn.setAttribute('style', 'flex:1 1 auto;min-width:0;background:#1e1e1e;color:#ccc;'
@@ -2643,6 +2739,26 @@ class TimelinePanel {
       } else {
         const ttl = head.createDiv({ text: 'Sessions & tags' });
         ttl.setAttribute('style', 'font-weight:650;');
+      }
+      if (rtg && canEdit) {
+        const sw = card.createDiv();
+        sw.setAttribute('style', 'display:flex;gap:6px;margin:2px 0 8px;flex-wrap:wrap;');
+        for (const c of (this._palette && this._palette.length ? this._palette : [rtg.color || '#1EA1EB'])) {
+          const d = sw.createSpan();
+          d.setAttribute('style', 'width:16px;height:16px;border-radius:50%;cursor:pointer;background:' + c + ';'
+            + (c === rtg.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : 'opacity:0.75;'));
+          d.addEventListener('click', () => { this._editRemoteTag(rtg, { color: c }); build(); });
+        }
+      }
+      // the LOUD failure of the last routed edit (a down owner, a collision there) — dismissible
+      if (this._tagEditErr) {
+        const er = card.createDiv();
+        er.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:0 0 8px;padding:4px 8px;'
+          + 'border:1px solid #F85B5A;border-radius:5px;color:#F85B5A;font-size:0.88em;');
+        er.createSpan({ text: '⚠ ' + (this._tagEditErr.host ? this._tagEditErr.host + ': ' : '') + this._tagEditErr.error });
+        const ex = er.createSpan({ text: '✕' });
+        ex.setAttribute('style', 'margin-left:auto;cursor:pointer;opacity:0.7;');
+        ex.addEventListener('click', () => { this._tagEditErr = null; build(); });
       }
       if (tg) {
         const sw = card.createDiv();
@@ -2709,8 +2825,22 @@ class TimelinePanel {
         const addMenu = (rowIds) => {   // the [+] menu, per-row or bulk — spans the grid
           const am = grid.createDiv();
           am.setAttribute('style', 'grid-column:1 / -1;margin:2px 0 4px 8px;display:flex;gap:5px;flex-wrap:wrap;align-items:center;');
-          const joinable = viewTags(this._curViews()).filter((t) =>
+          const cur = this._curViews();
+          const joinable = viewTags(cur).filter((t) =>
             rowIds.some((id) => (t.members || []).indexOf(id) < 0));
+          if (canEdit)
+            for (const rt of (cur.remoteTags || []).filter((t) => rowIds.some((id) => (t.members || []).indexOf(id) < 0))) {
+              const rc2 = rt.color || '#cccccc';
+              const ropt = am.createSpan({ text: (rt.host || '') + ':' + (rt.name || 'tag') });
+              ropt.setAttribute('style', 'padding:1px 8px;border-radius:9px;font-size:0.82em;cursor:pointer;'
+                + 'color:' + rc2 + ';border:1px dashed ' + rc2 + ';background:transparent;');
+              hover(ropt, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
+              ropt.setAttribute('title', 'joins ' + (rt.host || '?') + "'s tag — the edit routes there");
+              ropt.addEventListener('click', () => {
+                addMenuFor = null;
+                this._editRemoteTag(rt, { add: rowIds.slice() }); build();
+              });
+            }
           for (const t of joinable) {
             const tc = t.color || '#cccccc';
             const opt = am.createSpan({ text: t.name });
@@ -2769,12 +2899,23 @@ class TimelinePanel {
             const rch = chips.createSpan();
             rch.setAttribute('style', 'display:inline-flex;align-items:center;gap:4px;'
               + 'padding:2px 7px;border-radius:9px;font-size:0.82em;white-space:nowrap;opacity:0.85;'
-              + 'color:' + rc + ';border:1px dashed ' + rc + ';background:transparent;');
+              + 'color:' + rc + ';border:1px dashed ' + rc + ';background:transparent;'
+              + (canEdit ? 'cursor:pointer;' : ''));
             const rh = rch.createSpan({ text: (rt.host || '') + ':' });
             rh.setAttribute('style', 'color:' + MODEL_FG + ';font-style:italic;font-size:0.88em;');
             rch.createSpan({ text: rt.name || 'tag' });
-            rch.setAttribute('title', 'tagged on ' + (rt.host || 'another kernel')
-              + ' — read-only here; edit with: romp tag --host ' + (rt.host || '<kernel>'));
+            if (canEdit) {
+              // federation v1: the ✕ routes the removal to the tag's home kernel — same chip
+              // gesture as a local tag, the dashes still saying whose it is
+              const rx = rch.createSpan({ text: '✕' });
+              rx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
+              hover(rch, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
+              rch.setAttribute('title', 'tagged on ' + (rt.host || 'another kernel') + ' — click to take this tag off (routed there)');
+              rch.addEventListener('click', () => { this._editRemoteTag(rt, { remove: [s.id] }); build(); });
+            } else {
+              rch.setAttribute('title', 'tagged on ' + (rt.host || 'another kernel')
+                + ' — read-only here; edit with: romp tag --host ' + (rt.host || '<kernel>'));
+            }
           }
           for (const t of viewTags(vv)) {
             if ((t.members || []).indexOf(s.id) < 0) continue;
@@ -2837,6 +2978,7 @@ class TimelinePanel {
       if (query) { q.focus(); try { q.setSelectionRange(q.value.length, q.value.length); } catch (e) {} }
     };
     build();
+    this._viewsDialogBuild = build;   // tagEditFailed repaints the open dialog with the refusal
     const h = this._menuHost({ left: 0, top: 0, bottom: 0, right: 0 });
     back.addEventListener('pointerdown', (e) => { if (e.target === back) this._closeViewsDialog(); });
     const onKey = (e) => { if (e.key === 'Escape') this._closeViewsDialog(); };

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -252,3 +252,56 @@ test("the views menu closes with its siblings on outside click / Escape / pagehi
   assert.match(SRC, /if \(e\.key === 'Escape'\) \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \}/);
   assert.match(SRC, /this\._closeViewsMenu\(\); this\._closeViewsDialog\(\);/, "pagehide drops both overlays");
 });
+
+test("executed: a remote-tag edit renders optimistically, echoes on the poll, yields after three silences", () => {
+  // the sessionViews reconcile precedent, per remote tag (federation v1)
+  const p: any = Object.create(TimelinePanel.prototype);
+  p._pendingViews = null; p._pendingTagEdits = {}; p._views = { active: "all", hidden: [], tags: [],
+    remoteTags: [{ id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", color: "#DD42FF", members: ["m1"] }] };
+  // the optimistic overlay: a member add renders immediately
+  p._pendingTagEdits["TESTHOST-A:g1"] = { tag: { id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team",
+    color: "#DD42FF", members: ["m1", "m2"] }, age: 0 };
+  assert.deepEqual(p._curViews().remoteTags[0].members, ["m1", "m2"], "pending copy renders");
+  // the owner's poll echoes (order-insensitive) → the pending clears
+  p._views = { active: "all", hidden: [], tags: [], remoteTags: [{ id: "TESTHOST-A:g1", host: "TESTHOST-A",
+    name: "team", color: "#DD42FF", members: ["m2", "m1"] }] };
+  p._reconcileTagEdits();
+  assert.deepEqual(p._pendingTagEdits, {}, "echo match clears the pending edit");
+  // never echoed → three silent pushes yield to the polled truth
+  p._pendingTagEdits["TESTHOST-A:g1"] = { tag: { id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "renamed",
+    color: "#DD42FF", members: [] }, age: 0 };
+  p._reconcileTagEdits(); p._reconcileTagEdits();
+  assert.ok(p._pendingTagEdits["TESTHOST-A:g1"], "two silences → still holding");
+  p._reconcileTagEdits();
+  assert.deepEqual(p._pendingTagEdits, {}, "the third yields — the owner refused or another dashboard won");
+  // a pending DELETE hides the tag meanwhile
+  p._pendingTagEdits["TESTHOST-A:g1"] = { tag: null, age: 0 };
+  assert.equal((p._curViews().remoteTags || []).length, 0, "a pending delete renders as gone");
+});
+
+test("executed: tagEditFailed reverts the optimistic copy and keeps the reason for the dialog", () => {
+  const p: any = Object.create(TimelinePanel.prototype);
+  p._pendingViews = null; p._views = { active: "all", hidden: [], tags: [] };
+  p._pendingTagEdits = { "TESTHOST-A:g1": { tag: null, age: 0 }, "TESTHOST-B:g2": { tag: null, age: 0 } };
+  p._viewsDialog = null; p._viewsDialogBuild = null; p.draw = () => {};
+  p.tagEditFailed({ host: "TESTHOST-A", name: "team", error: "not reachable" });
+  assert.deepEqual(Object.keys(p._pendingTagEdits), ["TESTHOST-B:g2"],
+    "only the failing owner's pendings revert — B's edit is still in flight");
+  assert.equal(p._tagEditErr.error, "not reachable");
+});
+
+test("federation v1 source pins: the dialog edits remote tags in place, routed home, loudly on failure", () => {
+  // the remote header (rename/recolor/delete) and chip ✕ dispatch through ONE method
+  assert.match(SRC, /this\._editRemoteTag\(rtg, \{ rename: nv \}\);/);
+  assert.match(SRC, /this\._editRemoteTag\(rtg, \{ color: c \}\); build\(\);/);
+  assert.match(SRC, /this\._editRemoteTag\(rtg, \{ delete: true \}\);/);
+  assert.match(SRC, /this\._editRemoteTag\(rt, \{ remove: \[s\.id\] \}\); build\(\);/);
+  assert.match(SRC, /this\._editRemoteTag\(rt, \{ add: rowIds\.slice\(\) \}\); build\(\);/);
+  // no hook (the Obsidian panel) → read-only stays, refusal immediate and visible
+  assert.match(SRC, /typeof window\.__rompTimelineEditTag !== 'function'/);
+  // the error line is dismissible and names the owner
+  assert.match(SRC, /er\.createSpan\(\{ text: '⚠ ' \+ \(this\._tagEditErr\.host \? this\._tagEditErr\.host \+ ': ' : ''\) \+ this\._tagEditErr\.error \}\);/);
+  // local tags still post the whole blob — zero behavior change (the editTag op is remote-only)
+  assert.match(SRC, /nv\.tags = viewTags\(nv\)\.concat/);
+});
+

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -188,3 +188,18 @@ test("the view exposes revealEvent, and it never drives the chat", () => {
   assert.match(body, /this\._pulseFocus\(/, "...and pulses the glyph there");
   assert.doesNotMatch(body, /openChat/, "but never calls back into the chat the click came from");
 });
+
+test("dispatchFrame routes tagEditFailed to the panel — the LOUD half of remote-tag edits (federation v1)", () => {
+  const got: any[] = [];
+  const panel = { tagEditFailed: (m: any) => got.push(m) };
+  assert.equal(dispatchFrame(panel, { type: "tagEditFailed", host: "TESTHOST-A", name: "team", error: "not reachable" }), true);
+  assert.equal(got[0].error, "not reachable");
+  assert.equal(dispatchFrame({}, { type: "tagEditFailed" }), false, "an older panel is skipped, never thrown at");
+  // …and the kernel's inline boot + the editTag outbound hook stay mirrored (the pinned pair)
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\}\);/);
+  assert.match(KERNEL, /window\.__rompTimelineEditTag=function\(edit\)\{post\(\{type:"editTag",edit:edit\}\);\};/);
+  const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
+  assert.match(BOOT, /__rompTimelineEditTag: \(edit: unknown\) => post\(\{ type: "editTag", edit \}\),/);
+});
+

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -42,6 +42,7 @@ export function dispatchFrame(panel: any, m: any): boolean {
   // `focus` path: focusEvent also drives openChat, and the click came FROM the chat, so that would be a
   // round trip back into the pane the user is already looking at. revealEvent pans + pulses only.
   if (m.type === "revealEvent" && panel.revealEvent) { panel.revealEvent(m.sid, m.t, m.id); return true; }
+  if (m.type === "tagEditFailed" && panel.tagEditFailed) { panel.tagEditFailed(m); return true; }
   return false;
 }
 
@@ -83,6 +84,7 @@ export function bridgeFunctions(post: Post): Record<string, (...a: any[]) => voi
     __rompTimelineSendCommand: (name: string, cmd: string) => post({ type: "sendCommand", name, cmd }),
     __rompTimelineSetFlag: (id: string, flag: string, value: unknown) => post({ type: "setSessionFlag", id, flag, value: !!value }),
     __rompTimelineSetViews: (views: unknown) => post({ type: "setTimelineViews", views }),
+    __rompTimelineEditTag: (edit: unknown) => post({ type: "editTag", edit }),
     __rompTimelineDismiss: (id: string) => post({ type: "dismissLane", id }),
     __rompTimelineHover: (sid?: string, segIds?: unknown[], t0?: number, t1?: number) =>
       post(sid ? { type: "timelineHover", sid, segIds: segIds || [], t0, t1 } : { type: "timelineHover", off: true }),


### PR DESCRIPTION
## What (tag federation v1 — transparent edit routing)

Remote tags stop being read-only. Rename, recolor, membership (chips/[+]), and delete in the sessions & tags dialog work on a remote tag by routing to its **home kernel** through the same tunnel channel `romp tag --host` uses (the v0 forward arm, factored into `_forward_tag_edit`), addressed by the tag's host stamp.

- **Sid-first crossing** (the federation counter rule): only the bare sid tail leaves the viewer; the owner resolves each sid into *its own* frame — local, or looked up in its remotes' cached session lists and stored as the canonical pair with *its* label. Three-kernel case covered: viewer C adds kernel-B's session to kernel-A's tag → A stores `{host: A's-name-for-B, sid}`.
- **Optimistic echo**: a pending copy of the tag overlays the polled `remoteTags` until the owner's poll echoes it (canonical compare); a landed forward drops the owner's poll gate and refreshes inline so the echo usually beats the next push; three silent pushes yield — the sessionViews reconcile precedent, per tag.
- **Loud refusals**: down/unattached owner, dead tunnel, or a name collision there → `tagEditFailed` pushed to the asking dashboard, the optimistic copy reverts, and the dialog shows a dismissible owner-named error. The Obsidian panel (no kernel bridge) keeps remote tags read-only and says so immediately.
- **Around it**: `_edit_tag`/`POST /tag` gain collision-refusing `rename` (+ `romp tag --rename` for parity); local tags keep posting the whole blob — zero behavior change, pinned. Remote tag creation from the dialog stays out (v2 if wanted; CLI `--host` covers it).

## Tests

- `tests/test_tag_route.py`: `RenameAndHomeFrame` (rename + collision refusal; the three-kernel bare-sid → owner-frame pair, TESTHOST-B; unknown sids stay bare), `ForwardHelper` (fast echo drops the poll gate + inline refresh; loud unknown/down/dead-tunnel refusals), `EditTagOpPins` (bare-tail crossing, refusal to the asking dashboard).
- `ui/timeline-views-panel.test.ts`: executed optimistic overlay / echo-clears / three-silence yield / pending-delete-renders-gone / `tagEditFailed` reverts only the failing owner's pendings; source pins for every dialog affordance and the no-hook read-only degrade.
- `ui/webview/timeline-boot.test.ts`: the `tagEditFailed` dispatch + the mirrored kernel-page bridge and `editTag` outbound hooks.
- `tests/romp.bats`: `--rename` rides the payload, alone and with `--host`.
- Full suites green: 5426 python tests (+281 subtests), 2300 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)