### PR TITLE
Grouped-mode cards carry their state badges: every badge leaves the hidden name wrap

### DIFF
--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-apierror-working.test.ts
+++ b/ui/webview/feed-apierror-working.test.ts
@@ -32,7 +32,7 @@ test("Retry renders WITH its explaining badge as one visual unit — never alone
   // badge immediately before its button, as DIRECT row2 children: grouped mode hides idwrap (the
   // card drops its name there), which is exactly how the screenshot got a lone Retry with no badge —
   // the badge sat in the hidden wrap while the action-row button stayed visible
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin,/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin,/);
   assert.match(FEED, /actions\.append\(revive, qApprove, qDeny\);/);
   assert.doesNotMatch(FEED, /actions\.append\(apiRetry/, "no lone Retry detached from its badge");
   assert.doesNotMatch(FEED, /idwrap\.append\([^)]*apiBadge/, "…and never inside the grouped-mode-hidden idwrap");

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -21,7 +21,7 @@ test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails t
   // name row keeps only identity + chips
   assert.match(FEED, /btns\.append\(cont, clr\);/, "ask card: Continue left of Clear in the action corner");
   assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
@@ -60,7 +60,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -77,7 +77,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);
@@ -89,8 +89,8 @@ test("session-STATE badges (⏸ approval / ⚠ API error) ride the name row; the
   // the bug: ⏸ approval + buttons + Clear in the SAME footer row shoved them off a narrow card.
   // Fix: the state badges move up beside the session name; the action row holds only the buttons.
   // The ⏳ "awaiting" chip was REMOVED (the user 2026-07-04) — the body "Awaiting background agents" box says it.
-  assert.match(FEED, /idwrap\.append\(retryBadge, jauthBadge, blkBadge\)/,
-    "state badges sit beside the name (retrying joined 2026-07-09, judge-auth 2026-08-12; the API unit moved to row2 direct 2026-08-24 — grouped mode hides idwrap)");
+  assert.match(FEED, /idwrap\.append\(name\);/,
+    "idwrap holds ONLY the name now (2026-08-24): grouped mode hides it wholesale, so every state badge moved to row2 direct children where both modes render them");
   assert.doesNotMatch(FEED, /waitBadge/, "the redundant awaiting chip element is gone entirely");
   assert.match(FEED, /actions\.append\(revive,/, "action row = Retry/Revive (+ resume-gate) only (Clear moved to the name row 2026-07-07)");
   assert.match(FEED, /a\._blocked = blkBadge;/);
@@ -129,4 +129,19 @@ test("a long no-space token (file/func/type name) WRAPS instead of overflowing t
   // fit — the title used break-word (kept the longest word as min-width) and the summary had NO wrap at all.
   assert.match(CSS, /\.fcard-title \{[^}]*overflow-wrap: anywhere/);
   // (the .fask-blockwhy/.fask-donewhy auto-line was removed 2026-06-27, so its wrap rule is gone too)
+});
+
+// ── grouped-mode cards carry their state badges (2026-08-24, the Retry-fix audit's finding #1):
+// grouped mode hides idwrap wholesale (the name lives on the session header), which silently
+// blanked every badge inside it — ⚠ retrying-since, judge-auth, and the ⏸ approval chip never
+// showed on grouped-mode cards. Every state badge is a DIRECT row2 child now; placement only.
+test("every session-state badge is a direct row2 child — visible in grouped AND flat mode", () => {
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin,/);
+  assert.match(FEED, /idwrap\.append\(name\);/, "idwrap = the name alone; hiding it hides nothing else");
+  assert.doesNotMatch(FEED, /idwrap\.append\([^)]*(retryBadge|apiBadge|jauthBadge|blkBadge)/,
+    "no state badge ever returns to the grouped-mode-hidden wrap");
+  // the grouped-mode liveness check reads DIRECT children, so a visible badge keeps row2 shown
+  assert.match(FEED, /const r2live = \(Array\.from\(r2\.children\) as HTMLElement\[\]\)\.some\(\(c\) => c\.style\.display !== "none"\);/);
+  // …and only idwrap (the name) is what grouped mode drops
+  assert.match(FEED, /\(\(a\._name as HTMLElement\)\.parentElement as HTMLElement\)\.style\.display = gmode \? "none" : "";/);
 });

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-judge-auth.test.ts
+++ b/ui/webview/feed-judge-auth.test.ts
@@ -18,7 +18,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the judge-auth chip is built once, rides the session-state row, and keys on blocked.state", () => {
   assert.match(FEED, /const jauthBadge = el\("span", "fask-jauth"\)/);
-  assert.match(FEED, /idwrap\.append\(retryBadge, jauthBadge, blkBadge\)/,
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge,/,
     "the chip rides the name row with its api-trouble siblings");
   assert.match(FEED, /a\._jauthBadge = jauthBadge;/);
   assert.match(FEED, /const isJudgeAuth = it\.blocked\?\.state === "judgeAuth"/);

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-retrying.test.ts
+++ b/ui/webview/feed-retrying.test.ts
@@ -15,7 +15,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the retrying badge is built once and rides the session-state row beside the API-error badge", () => {
   assert.match(FEED, /const retryBadge = el\("span", "fask-retrying"\)/);
-  assert.match(FEED, /idwrap\.append\(retryBadge, jauthBadge, blkBadge\)/,
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge,/,
     "session-STATE badges ride the name row, off the action row");
   assert.match(FEED, /a\._retryBadge = retryBadge;/);
 });

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -972,7 +972,6 @@ function makeAskCard(it: AskItem): HTMLElement {
   // name — they describe the session's live state, and keeping them OFF the action row stops them shoving
   // the buttons past the card's right edge on a narrow card (the user 2026-06-19; mirrors the ↻ Followed-up
   // chip moved up 2026-06-18). idwrap is flex:1 so the name ellipsizes before the badge is ever clipped.
-  idwrap.append(retryBadge, jauthBadge, blkBadge);
   // COMPACTNESS (the user 2026-07-07): Clear rides the NAME row (right side, after the chips) and the
   // Background/Summary toggles ride the TIME row — freeing a whole action row. So the action row holds only
   // Retry / Revive (rare states); both rows flex-WRAP so nothing overflows or overlaps on a narrow card.
@@ -981,11 +980,14 @@ function makeAskCard(it: AskItem): HTMLElement {
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // (Clear left this row 2026-08-08 — it rides row1's action corner in every mode now, see fask-btns.)
-  // the API-error badge + Retry ride row2 DIRECTLY, badge immediately before its button — one
-  // visual unit in BOTH modes (the user 2026-08-24, screenshot: grouped mode hides idwrap — the
-  // card drops its name there — which hid the badge while the action-row Retry stayed, a lone red
-  // button with no visible reason). Direct children also count toward row2's grouped-mode liveness.
-  row2.append(idwrap, apiBadge, apiRetry, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
+  // EVERY session-state badge rides row2 DIRECTLY — grouped mode hides idwrap wholesale (the card
+  // drops its name into the session header), which silently blanked whatever lived inside it: first
+  // found as the lone red Retry (the user 2026-08-24, screenshot — its ⚠ badge sat hidden in the
+  // wrap), then the same mechanism for ⚠ retrying-since, judge-auth, and the ⏸ approval chip. As
+  // direct children they render in BOTH modes, count toward row2's grouped-mode liveness, and the
+  // API badge stays immediately before its Retry button — one visual unit. idwrap keeps only the
+  // name. Placement only; every badge's mint/retire semantics are untouched.
+  row2.append(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
   // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
   // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
   // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or


### PR DESCRIPTION
## What

The Retry-fix audit's finding #1 (promoted to its own pass): grouped mode hides `idwrap` wholesale — the card's name lives on the session header there — which silently blanked **every** state badge inside it: ⚠ retrying-since, judge-auth, and the ⏸ approval chip never showed on grouped-mode cards. Same mechanism as the lone-Retry bug, same cure: every session-state badge is now a **direct row2 child**, rendered in both modes and counted toward row2's grouped-mode liveness. `idwrap` keeps only the name, so hiding it hides nothing else; the API badge stays immediately before its Retry button (the one-unit rule holds).

Placement only — every badge's mint/retire semantics untouched. The parked audit finding #2 (revive-on-parkedHandoff keyed on the stored record) is deliberately not touched, per the delegation.

## Verification

Headless per badge in both modes (playwright over the built feed bundle, synthetic frames): retrying / judge-auth / approval / API-error each render exactly once and visibly in flat AND grouped mode — parity, and no double-show of anything `idwrap` still carries. Grouped screenshot eyeballed.

## Tests

`feed-card-layout.test.ts` gains the both-modes placement suite: the full row2 direct-children order, name-only `idwrap`, a guard that no state badge may ever return to the hidden wrap, and pins on the grouped-mode liveness check and the `gmode` hide line. The `row2.append` pins across ten sibling files swept to the new order; the 621 pins stay green. Full suite: 2299 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)