### PR TITLE
Stub spans key on arrival knowledge — aged pending no longer collapses them to points

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5319,6 +5319,22 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(msgs["m2"]["toId"], "foreignsid")
         self.assertEqual(msgs["m2"]["to"], "", "foreign recipient: no local name — the merge fills it")
 
+    def test_postal_exec_joins_regardless_of_recipient_liveness(self):
+        # the 2026-08-24 floating-point report's leg (b), verified CLEAN and pinned: a message
+        # consumed by a session/thread that later DIED keeps its real exec — the join is by id,
+        # never gated on alive_sids, so the view can draw the true sent→exec span for dead-thread
+        # mail instead of an un-arrived point
+        md = jd.STATE / "timeline"; md.mkdir(parents=True, exist_ok=True)
+        a = "aaaa1111"
+        (md / "messages.jsonl").write_text(
+            json.dumps({"ev": "sent", "id": "m9", "from_id": a, "to_id": "dead-thread-sid",
+                        "t": NOW - 300, "from": "alpha", "body": "do the piece"}) + "\n"
+            + json.dumps({"ev": "exec", "id": "m9", "t": NOW - 60}) + "\n")
+        m = km._postal_messages(NOW, {a}, {a: "alpha"})[0]
+        self.assertTrue(m["hasExec"], "the exec joined although the recipient is in no alive set")
+        self.assertEqual(m["exec"], NOW - 60)
+        self.assertFalse(m["pending"])
+
     def test_postal_connector_ships_no_dead_goal_binding(self):
         # toGoal (the courier-planted goal id) shipped on every connector but no view ever rendered it —
         # dropped (2026-07-07 payload audit), along with the hardcoded-False `parked`.

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3917,27 +3917,35 @@ class TimelinePanel {
     const stub = (mm, i, senderVisible) => {
       const sid = senderVisible ? mm.fromId : mm.toId;
       const ly = laneY(vidx[sid]);
+      // the LANDING x keys on arrival knowledge — the dash/fade's own event key — never the
+      // kernel's staleness-aged mm.pending: once the aging window flipped pending off, execAt
+      // collapsed to the exec=sent fallback and an un-arrived stub rendered as a ZERO-LENGTH
+      // floating point at the lane offset (the user 2026-08-24, dead-thread mail). Un-arrived
+      // mail spans sent → the LIVE EDGE, dashed, however old; a thread-anchor override is a real
+      // drawn position and keeps priority.
+      const arrived = mm.hasExec || mm.exec !== mm.sent;
+      const landT = arrived ? landXT(mm) : (mm.toThreadT || nowS);
       let x1, y1, x2, y2;
       if (senderVisible) {
-        // outgoing: BELOW the lane, the FULL flight span — send x to the landing x (the live edge
-        // while pending, via execAt inside landXT), clamped to the window by arithmetic. The old
-        // run cap bounded a 45° diagonal's rise; flattened it shrank every stub to a ~13px nub
-        // (the user 2026-08-24) — the span IS the feature: how long the message was in flight.
+        // outgoing: BELOW the lane, the FULL flight span — send x to the landing x, clamped to the
+        // window by arithmetic. The old run cap bounded a 45° diagonal's rise; flattened it shrank
+        // every stub to a ~13px nub (the user 2026-08-24) — the span IS the feature.
         if (!inWin(sendXT(mm))) return;
         x1 = x(sendXT(mm)); y1 = ly + MSG_DROP;
-        x2 = Math.max(x1, x(Math.min(landXT(mm), t1))); y2 = y1;
+        x2 = Math.max(x1, x(Math.min(landT, t1))); y2 = y1;
       } else {
         // incoming: ABOVE the lane, the mirror — the full span into the landing x, the arrival dot
         // on the lane just beneath it; an off-window send clamps to the window edge
-        if (!inWin(landXT(mm))) return;
-        x2 = x(landXT(mm)); y2 = ly - MSG_DROP;
+        if (!inWin(landT)) return;
+        x2 = x(landT); y2 = ly - MSG_DROP;
         x1 = Math.min(x2, x(Math.max(sendXT(mm), t0))); y1 = y2;
       }
+      if (x2 - x1 < 2) x2 = x1 + 2;   // a same-instant consume is real but must never render as a
+      //                                 floating point — two px keeps the mark a mark
       const col = colorOf(mm.fromId);   // the SENDER's color — the full connectors' own resolution
-      const arrived = mm.hasExec || mm.exec !== mm.sent;
       const attrs = { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W, opacity: 0.45,
                       'stroke-linecap': 'round', 'pointer-events': 'none' };
-      if (!arrived) attrs['stroke-dasharray'] = '1 4';   // in flight — the pending-connector dash
+      if (!arrived) attrs['stroke-dasharray'] = '1 4';   // in flight — the pending-connector dash (same key as the span)
       svg.appendChild(el('line', attrs));
       // same affordances as a full connector: own-color highlight overlay + wide transparent hit,
       // co-lit with the arrival dot (PASS 2 links via msgUI), tooltip + click → where it landed

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -201,8 +201,35 @@ test("the stub flips dashed→solid on the exec event — hasExec, never the sta
   assert.ok(gs, "the stale stub still draws");
   assert.equal(gs._attrs["stroke-dasharray"], "1 4", "no exec event → still dashed (the timer is not the key)");
   assert.equal(gs._attrs.stroke, BEE, "…and still the sender's color, stale or not");
-  near(gs._attrs.x2, gs._attrs.x1, "with the landing x AT the send, the tick collapses to a point — arithmetic clamp, no clipPath");
+  // the SPAN keys on the same arrival knowledge as the dash (the user 2026-08-24, floating-point
+  // regression): aging pending out collapsed execAt to the exec=sent fallback and the stub drew as
+  // a zero-length point — un-arrived mail spans sent → the LIVE EDGE, however old
+  assert.ok(Math.abs(gs._attrs.x2 - X(stale)(now)) < 0.5, "un-arrived → out to the live edge, not a point");
+  assert.ok(gs._attrs.x2 - gs._attrs.x1 > 13.5, "…a real span (got " + (gs._attrs.x2 - gs._attrs.x1) + ")");
   near(gs._attrs.y2, laneY(stale)(0) + OFF, "still on its outgoing track below the lane");
+});
+
+test("a message to a DEAD counterpart with a REAL exec row spans sent to exec — never a point", () => {
+  // leg (b) of the 2026-08-24 floating-point report: the kernel joins exec rows by id with no
+  // liveness gate (pinned kernel-side in test_kernel.py), so the view gets hasExec + a real exec
+  // even when the counterpart session/thread is dead — the span must render exactly like live mail
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m14", fromId: "SB", toId: "SX", from: "bee", to: "gone-thread",
+                        sent: now - 300, exec: now - 60, hasExec: true, pending: false, summary: "consumed, then died" }]);
+  const [s] = stubLines(panel);
+  assert.ok(s, "the stub draws");
+  assert.equal(s._attrs["stroke-dasharray"], undefined, "a real exec → solid");
+  assert.ok(Math.abs((s._attrs.x2 - s._attrs.x1) - (X(panel)(now - 60) - X(panel)(now - 300))) < 0.5,
+    "the true sent→exec span, into the counterpart's own work period");
+});
+
+test("a same-instant consume keeps a visible mark — zero-length is impossible by geometry", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m15", fromId: "SB", toId: "SX", from: "bee", to: "gone",
+                        sent: now - 200, exec: now - 200, hasExec: true, pending: false, summary: "instant" }]);
+  const [s] = stubLines(panel);
+  assert.ok(s, "the stub draws");
+  assert.ok(s._attrs.x2 - s._attrs.x1 >= 2, "the 2px floor: a real instant consume is a mark, not a floating point");
 });
 
 test("a hidden-sender message draws the mirror stub: horizontal just ABOVE the lane, ending at the arrival dot's x, dot kept on top", () => {
@@ -312,8 +339,11 @@ test("window clamping is arithmetic: an off-window send or landing draws no stub
 // them at the source, the timeline-threadarc.test.ts idiom for exactly this kind of plumbing.
 test("both stub anchors gate on their own endpoint and clamp x to the window by arithmetic (source pins)", () => {
   assert.match(SRC, /if \(!inWin\(sendXT\(mm\)\)\) return;/);
-  assert.match(SRC, /if \(!inWin\(landXT\(mm\)\)\) return;/);
-  assert.match(SRC, /x2 = Math\.max\(x1, x\(Math\.min\(landXT\(mm\), t1\)\)\)/);
+  assert.match(SRC, /if \(!inWin\(landT\)\) return;/, "the incoming gate reads the arrival-keyed landing");
+  assert.match(SRC, /const landT = arrived \? landXT\(mm\) : \(mm\.toThreadT \|\| nowS\);/,
+    "the span's landing keys on arrival knowledge, never the staleness-aged pending");
+  assert.match(SRC, /if \(x2 - x1 < 2\) x2 = x1 \+ 2;/, "zero-length is impossible by geometry");
+  assert.match(SRC, /x2 = Math\.max\(x1, x\(Math\.min\(landT, t1\)\)\)/);
   assert.match(SRC, /x1 = Math\.min\(x2, x\(Math\.max\(sendXT\(mm\), t0\)\)\)/);
   assert.doesNotMatch(SRC, /STUB_DX/, "the run cap is GONE — it bounded a diagonal's rise; flattened it made nubs");
   assert.doesNotMatch(SRC, /el\('clipPath'|clip-path/i, "clipped by arithmetic, never a clipPath element");


### PR DESCRIPTION
Residual floating-point stubs after the full-span fix (user report with dead-thread mail): diagnosis confirmed **leg (a)** — once the kernel's staleness window ages `pending` out, `execAt` falls back to `exec = sent`, so an un-arrived stub's span collapsed to zero length and drew as a point at the lane offset. The span (like the dash and fade before it) now keys on the arrival-knowledge event (`hasExec || exec !== sent`): un-arrived mail spans **sent → live edge**, dashed, however old; a thread-anchor override (`toThreadT`) keeps priority; a real same-instant consume keeps a 2px mark — zero-length is impossible by geometry.

**Leg (b)** — the kernel dropping exec joins for dead counterparts — was verified **clean**: `_postal_messages` joins exec rows by id with no liveness gate, so dead-thread mail with a real exec draws its true sent→exec span into the counterpart's work period. Pinned with a new kernel test rather than fixed.

**Tests:** the old stale-case pin (which asserted the collapse-to-a-point as correct) retargeted to the live-edge span; dead-counterpart-with-real-exec span; the 2px floor; the arrival-keyed landing + no-zero-length source pins; kernel-side liveness-blind join pin. Suites green: JS 2306/2306, `tests/test_kernel.py` 436 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)