### PR TITLE
Solarized Dark brightens instead of darkening, and the scheme picker previews every scheme

### DIFF
--- a/ui/webview/chat-scheme.test.ts
+++ b/ui/webview/chat-scheme.test.ts
@@ -85,10 +85,42 @@ test("the scheme applies live as a body class, at startup and on every settings 
   assert.match(UI, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\);/);
 });
 
-test("the gear carries the picker: three options, filled from the store, saved through the shared blob", () => {
-  assert.match(GEAR, /<select id=rs-chatscheme/);
-  assert.match(GEAR, /<option value=default>Default<\/option><option value=high-contrast>High contrast<\/option><option value=solarized-dark>Solarized Dark<\/option>/);
-  assert.match(GEAR, /if \(cs\) cs\.addEventListener\('change', function \(\) \{ var s = load\(\); s\.chatScheme = cs\.value; save\(s\); \}\);/,
+test("the gear picker is PREVIEW CARDS: each row painted with its own tiers, current \u2713-marked, click applies", () => {
+  // the user 2026-08-24, on the live check: "I need to see a preview of the solarized stuff in the
+  // selection" — a native <select> can't paint options, so each scheme is a card sampling its own
+  // prose/tool/code tiers; the current pick wears the menu vocabulary's ✓ (#1EA1EB)
+  assert.match(GEAR, /<div id=rs-chatscheme style='margin-top:5px;display:flex;flex-direction:column;gap:4px'><\/div>/);
+  assert.match(GEAR, /var SCHEMES = \[/);
+  assert.match(GEAR, /row\.addEventListener\('click', function \(\) \{ var s = load\(\); s\.chatScheme = sc\.id; save\(s\); csPaint\(\); \}\);/,
     "save() dispatches romp:settings + settingsSync — the chat re-applies live, event-based");
-  assert.match(GEAR, /if \(cs\) cs\.value = \(s\.chatScheme === 'high-contrast' \|\| s\.chatScheme === 'solarized-dark'\) \? s\.chatScheme : 'default';/);
+  assert.match(GEAR, /#1EA1EB/);
+  assert.match(GEAR, /csPaint\(\);/);
+});
+
+test("the gear's preview hexes mirror styles.css exactly — the cards can never lie about a scheme", () => {
+  const gearRow = (id: string) => {
+    const m = GEAR.match(new RegExp("\\{ id: '" + id + "'[^}]*\\}"));
+    assert.ok(m, id + " row exists in the gear's SCHEMES table");
+    const g = (k: string) => (m![0].match(new RegExp(k + ": '(#[0-9a-fA-F]{6})'")) || [])[1];
+    return { fg: g("fg"), dim: g("dim"), code: g("code") };
+  };
+  for (const [id, cls] of [["high-contrast", "scheme-high-contrast"], ["solarized-dark", "scheme-solarized-dark"]] as const) {
+    const block = tierBlock(cls)!;
+    const want = { fg: tier(block, "fg"), dim: tier(block, "dim"), code: tier(block, "code-fg") };
+    assert.deepEqual(gearRow(id), want, id + ": gear preview === styles.css tiers");
+  }
+  // the Default card previews the stock :root values
+  assert.deepEqual(gearRow("default"), { fg: "#cccccc", dim: "#9a9a9a", code: "#e1c08d" });
+});
+
+test("no scheme's prose ever drops below the default's luminance — a 'scheme' that darkens the chat is a regression", () => {
+  // the user 2026-08-24, live check on the first Solarized Dark cut (base0 prose, ≈0.28 luminance vs
+  // the default's ≈0.60): "it's darkening everything … the exact opposite of what I wanted". A text
+  // scheme on romp's dark ground exists to RAISE readability; base2 is solarized's bright content
+  // tone and the right prose tier here.
+  for (const cls of ["scheme-high-contrast", "scheme-solarized-dark"]) {
+    const block = tierBlock(cls)!;
+    assert.ok(lum(tier(block, "fg")!) >= lum("#cccccc"), cls + ": prose at or above the default");
+    assert.ok(lum(tier(block, "dim")!) >= lum("#9a9a9a") * 0.9, cls + ": the dim tier never sinks below its default either");
+  }
 });

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -101,11 +101,9 @@ var GEAR_HTML =
   '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
   '</select></span></div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Text scheme</b>" +
-  "<span class=rs-sub>Chat text colors only. High contrast lifts prose and the dimmer tool text together; Solarized Dark wears its text tiers on romp's dark ground. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
-  "<select id=rs-chatscheme style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
-  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
-  '<option value=default>Default</option><option value=high-contrast>High contrast</option><option value=solarized-dark>Solarized Dark</option>' +
-  '</select></span></div>' +
+  "<span class=rs-sub>Chat text colors only. Each row previews its own tiers — prose, the dimmer tool text, code. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
+  "<div id=rs-chatscheme style='margin-top:5px;display:flex;flex-direction:column;gap:4px'></div>" +
+  '</span></div>' +
   '<div class=rs-sec>Feed</div>' +
   '<label class=rs-row><input type=checkbox id=rs-feedcollapsed>' +
   '<span><b>Collapse cards by default</b>' +
@@ -204,8 +202,35 @@ function initGear(post) {
   cc.addEventListener('change', function () { var s = load(); s.compact = cc.checked; save(s); });
   if (gb) gb.addEventListener('change', function () { var s = load(); s.showBranch = gb.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
-  // mirrors settings.ts chatScheme (this file can't import the TS module): unknown → default
-  if (cs) cs.addEventListener('change', function () { var s = load(); s.chatScheme = cs.value; save(s); });
+  // The scheme PREVIEW CARDS (the user 2026-08-24, on the live check: "I need to see a preview").
+  // Tier hexes MIRROR styles.css body.scheme-* (this file can't read the sheet across webviews);
+  // chat-scheme.test.ts pins the two byte-equal so they cannot drift. Default previews the stock
+  // tiers. Each card paints ITS OWN tiers on the chat's dark ground; the current pick wears the
+  // menu vocabulary's ✓-in-circle. Clicking applies live (save() dispatches romp:settings).
+  var SCHEMES = [
+    { id: 'default', name: 'Default', fg: '#cccccc', dim: '#9a9a9a', code: '#e1c08d' },
+    { id: 'high-contrast', name: 'High contrast', fg: '#e8e8e8', dim: '#b8b8b8', code: '#ecd9ae' },
+    { id: 'solarized-dark', name: 'Solarized Dark', fg: '#eee8d5', dim: '#93a1a1', code: '#d5b02d' }
+  ];
+  function csPaint() {
+    if (!cs) return;
+    var cur = load().chatScheme; cur = (cur === 'high-contrast' || cur === 'solarized-dark') ? cur : 'default';
+    cs.innerHTML = '';
+    SCHEMES.forEach(function (sc) {
+      var row = document.createElement('button');
+      row.type = 'button'; row.dataset.scheme = sc.id;
+      row.style.cssText = 'display:flex;align-items:center;gap:8px;text-align:left;background:#1e1e1e;' +
+        'border:1px solid ' + (sc.id === cur ? '#1EA1EB' : '#3a3a3a') + ';border-radius:5px;padding:5px 8px;cursor:pointer;font:inherit;color:#ccc';
+      row.innerHTML = '<span style="flex:0 0 auto;width:15px;color:#1EA1EB">' + (sc.id === cur ? '\u2713' : '') + '</span>' +
+        '<span style="flex:0 0 auto;min-width:96px;color:#ccc">' + sc.name + '</span>' +
+        '<span style="flex:1 1 auto;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' +
+        '<span style="color:' + sc.fg + '">Prose text</span> \u00b7 ' +
+        '<span style="color:' + sc.dim + '">tool / meta</span> \u00b7 ' +
+        '<span style="color:' + sc.code + ';font-family:monospace">code()</span></span>';
+      row.addEventListener('click', function () { var s = load(); s.chatScheme = sc.id; save(s); csPaint(); });
+      cs.appendChild(row);
+    });
+  }
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -418,7 +443,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cs) cs.value = (s.chatScheme === 'high-contrast' || s.chatScheme === 'solarized-dark') ? s.chatScheme : 'default'; if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); csPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -25,9 +25,14 @@ body.scheme-high-contrast {
   --code-fg: #ecd9ae;   /* the warm code tone, brightened in step */
 }
 body.scheme-solarized-dark {
-  --fg: #839496;        /* solarized base0 — the canonical body text */
-  --dim: #586e75;       /* solarized base01 — its secondary/comment tier */
-  --code-fg: #b58900;   /* solarized yellow — an accent it uses for emphasis/code */
+  /* REBUILT on the user's live check (2026-08-24): the first cut used base0/base01 — solarized's
+     canonical body tiers on its OWN canvas — which sit far BELOW our default's luminance
+     (#839496 ≈ 0.28 vs #cccccc ≈ 0.60), so picking the scheme DARKENED the chat: the exact opposite
+     of the contrast-raising ask. On romp's dark ground the bright solarized content tones are the
+     text tiers: a scheme here must never drop prose below the default (pinned by luminance test). */
+  --fg: #eee8d5;        /* solarized base2 — its bright content tone; ≈0.81 luminance, above default */
+  --dim: #93a1a1;       /* solarized base1 — clearly dimmer than prose, a shade above default dim */
+  --code-fg: #d5b02d;   /* solarized yellow, lifted for the dark ground (#b58900 reads muddy here) */
 }
 
 :root {


### PR DESCRIPTION
## What

The user's live check caught the first Solarized Dark cut backwards: it used base0/base01 — solarized's canonical body tiers **on its own canvas** — which sit far below our default's luminance (base0 ≈0.28 vs `#cccccc` ≈0.60). Picking the scheme darkened the chat while user bubbles' hardcoded white stayed bright: the exact opposite of the contrast-raising ask.

- **Rebuilt tiers:** prose = base2 (`#eee8d5`, ≈0.81 — above the default), dim = base1 (`#93a1a1`, still clearly below prose), code = solarized yellow lifted for the dark ground (`#b58900` reads muddy there).
- **Direction invariant, pinned:** a new test asserts every scheme's prose sits at or above the default's luminance, and the dim tier never sinks below its default — a "scheme" that darkens the chat is a regression by definition. (The first cut fails this test.)
- **Preview in the picker** (the second ask): the native select can't paint options, so the gear row is now preview cards — one per scheme, each sampling its own prose / tool / code tiers on the chat's dark ground, current pick ✓-marked in the menu vocabulary, click applies live through the same `save()` path. The card hexes mirror styles.css and a test pins the two **byte-equal**, so the preview can never lie.

## Tests

`chat-scheme.test.ts`: gear pins retargeted to the cards ("the gear picker is PREVIEW CARDS…"), plus "no scheme's prose ever drops below the default's luminance" and "the gear's preview hexes mirror styles.css exactly". All existing scheme invariants (all-tiers, hierarchy, untouched default, Solarized Light absence) stay green. Full suite: 2306 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)