### PR TITLE
Column drag in both layouts: one persisted order, two renderings

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -1,8 +1,9 @@
-// Stacked-layout column controls (the user 2026-08-16): a caret LEFT of each category chip folds the
-// whole section to its header, and a hover-revealed grip drags the section to a new slot in the
-// stack. Both live on the build-once headers (click-safe across the feed's constant re-renders),
-// both persist with the view state, and both exist ONLY in the stacked layout — the side-by-side
-// layout hides them and ignores the dragged order entirely. Source pins.
+// Column controls (the user 2026-08-16; drag extended 2026-08-24): a caret folds each category to
+// its header (STACKED-only — side by side always shows every card), and the category CHIP drags the
+// section to a new slot — in BOTH layouts since the user's 2026-08-24 ask reversed the stacked-only
+// exclusion (vertically stacked, horizontally side by side, ONE persisted order feeding both).
+// Both controls live on the build-once headers (click-safe across the feed's constant re-renders)
+// and persist with the view state. Source pins.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -14,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the caret folds a category to its header and persists like every other disclosure", () => {
   assert.match(FEED, /const fold = el\("button", "fcol-fold"\);/);
   assert.match(FEED, /if \(collapsedCols\.has\(key\)\) collapsedCols\.delete\(key\); else collapsedCols\.add\(key\);/);
-  assert.match(FEED, /cols: \[\.\.\.collapsedCols\],\s*\n\s*order: stackOrder\.slice\(\)/, "rides the persisted view state");
+  assert.match(FEED, /cols: \[\.\.\.collapsedCols\],\s*\n\s*order: colOrder\.slice\(\)/, "rides the persisted view state (the key stays `order` across the 2026-08-24 merge)");
   // The fold BITES only in the stacked layout (the user 2026-08-18): collapsed while stacked, then
   // widened to three columns, the section stayed hidden with no caret to reopen it. The rule must
   // live INSIDE the stacked container query — side by side, every card always shows.
@@ -31,25 +32,48 @@ test("the caret folds a category to its header and persists like every other dis
   assert.match(CSS, /\.fcol-fold \{ display: inline-block; flex: none; padding: 0 5px; margin-left: -2px;[^}]*font-size: 1\.389em;/);
 });
 
-test("the chip itself drags — grab cursor as the affordance, live provisional movement, stacked only", () => {
-  // the user 2026-08-16, dropping the earlier grip handle: grabbing the Working/Blocked/Completed
-  // chip moves the section, the grabbed section follows the pointer, and the displaced sections
-  // FLIP-animate into their provisional slots — what you see mid-drag is what you get on drop.
+test("the chip drags in BOTH layouts — grab affordance, live provisional movement, one shared order", () => {
+  // the user 2026-08-16 (chip as the drag surface, dropping the earlier grip handle), extended
+  // 2026-08-24 by the user's own ask — REVERSING the 2026-08-16 stacked-only exclusion: side by
+  // side the chip now reorders the three columns horizontally, just as the sections already drag
+  // stacked, and ONE persisted order feeds both renderings.
   assert.match(CSS, /\.feed-col-head \.fcol-chip \{ cursor: grab; touch-action: none; user-select: none; \}/);
   assert.match(CSS, /\.feed-col\.col-dragging \{ position: relative; z-index: 5;/, "lifted over siblings while following");
-  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/,
-    "the dragged order overrides the stacked default and only there");
+  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--col-order, 1\); \}/,
+    "the stacked default rules consume the SAME var the base layout's rules do");
+  assert.match(CSS, /\.feed-col\.col-asks\s+\{ order: var\(--col-order, 1\); \}/,
+    "…and the base layout keeps its own Working-first fallback");
+  // THE CASCADE (the repo's recurring bug class): same var, same specificity — the stacked rules
+  // must sit LATER than the base fallbacks AND INSIDE the container query (later-but-flattened
+  // would win the cascade in BOTH layouts and impose Completed-first side by side)
+  const baseAt = CSS.indexOf(".feed-col.col-asks       { order: var(--col-order, 1); }");
+  const queryStart = CSS.indexOf("@container (max-width: 540px) or style(--romp-stack: on)");
+  const queryEnd = CSS.indexOf("\n}", queryStart);
+  const queryAt = CSS.indexOf(".feed-col.col-completed  { order: var(--col-order, 1); }");
+  assert.ok(baseAt >= 0 && baseAt < queryStart, "base fallbacks live before (outside) the query");
+  assert.ok(queryAt > queryStart && queryAt < queryEnd, "the stacked overrides live INSIDE the query");
   assert.match(FEED, /wireColDrag\(name, col, key\);/, "no separate handle — the chip is the drag surface");
   assert.doesNotMatch(FEED, /fcol-grip/, "the grip is gone");
-  assert.match(FEED, /if \(!colsEl \|\| getComputedStyle\(colsEl\)\.flexDirection !== "column"\) return;/,
-    "side by side, the chip never captures the pointer");
+  assert.match(FEED, /const vertical = getComputedStyle\(colsEl\)\.flexDirection === "column";/,
+    "the layout picks the drag AXIS now — never a capture refusal (the 2026-08-16 exclusion is reversed)");
+  assert.match(FEED, /const fallback = vertical \? STACK_DEFAULT : ROW_DEFAULT;/,
+    "each layout's own default order seeds the drag until a custom order exists");
+  assert.match(FEED, /const ROW_DEFAULT = \["asks", "needsInput", "completed"\];/);
+  assert.match(FEED, /else col\.style\.removeProperty\("--col-order"\);/,
+    "no custom order → the var comes OFF and each layout keeps its own default");
   assert.match(FEED, /chip\.setPointerCapture\(down\.pointerId\);/, "the drag survives leaving the chip");
-  assert.match(FEED, /col\.style\.transform = "translateY\(" \+ \(ev\.clientY - startY - slotShift\) \+ "px\)";/,
-    "the grabbed section follows the pointer");
-  assert.match(FEED, /e\.animate\(\[\{ transform: "translateY\(" \+ d \+ "px\)" \}, \{ transform: "translateY\(0\)" \}\]/,
-    "displaced sections FLIP into their provisional slots");
+  assert.match(FEED, /col\.style\.transform = translate\(pos\(ev\) - start - slotShift\);/,
+    "the grabbed section follows the pointer along the drag axis");
+  assert.match(FEED, /e\.animate\(\[\{ transform: translate\(d\) \}, \{ transform: translate\(0\) \}\]/,
+    "displaced sections FLIP into their provisional slots, axis-generic");
   assert.match(FEED, /\{ slotShift -= d; continue; \}/, "a re-slot never yanks the section out from under the pointer");
   assert.match(FEED, /chip\.addEventListener\("pointercancel", up\);/, "a cancelled drag still settles + persists");
+  // a no-op drag leaves no trace: ending on the layout's own default with no pre-existing custom
+  // order resets to [] — an explicit order would silently re-arrange the OTHER layout (review 2026-08-24)
+  assert.match(FEED, /if \(!hadCustom && colOrder\.length === 3 && colOrder\.join\(\) === fallback\.join\(\)\) \{/);
+  // the keyboard card cursor walks the VISUAL order — the effective column `order`, var resolved
+  assert.match(FEED, /slot\.set\(e, col \? parseInt\(getComputedStyle\(col\)\.order \|\| "0", 10\) \|\| 0 : 0\);/);
+  assert.match(FEED, /\.sort\(\(a, b\) => a\.s - b\.s \|\| a\.i - b\.i\)/, "column slot first, DOM order within");
 });
 
 test("both controls live on the build-once header — click-safe across re-renders", () => {

--- a/ui/webview/feed-foot.test.ts
+++ b/ui/webview/feed-foot.test.ts
@@ -38,8 +38,8 @@ test("when the feed stacks (narrow), the columns read Completed → Blocked → 
   // re-sequences ONLY the stacked case: done first (moved up from the middle, superseding the 2026-07-08
   // Blocked-first order), then needs-you, then still-running.
   assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; align-items: stretch; \}/);
-  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/);   // the DEFAULT — a
-  // dragged section overrides via --stack-order (feed-col-fold.test.ts owns that rule)
-  assert.match(CSS, /\.feed-col\.col-needsInput \{ order: var\(--stack-order, 2\); \}/);
-  assert.match(CSS, /\.feed-col\.col-asks\s+\{ order: var\(--stack-order, 3\); \}/);
+  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--col-order, 1\); \}/);   // the DEFAULT — a
+  // dragged section overrides via --col-order (feed-col-fold.test.ts owns that rule)
+  assert.match(CSS, /\.feed-col\.col-needsInput \{ order: var\(--col-order, 2\); \}/);
+  assert.match(CSS, /\.feed-col\.col-asks\s+\{ order: var\(--col-order, 3\); \}/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -112,6 +112,18 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    paints behind EVERY column's cards (true back layer, any direction) yet above the feed background. */
 .feed-cols { display: flex; align-items: flex-start; gap: 12px; position: relative; z-index: 0; }
 .feed-col { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; }
+/* ONE dragged order, two renderings (the user 2026-08-24): a custom --col-order (set inline by
+   applyColStack once the user drags, either layout) re-sequences the columns HERE too; without it
+   the build order stands (Working → Blocked → Completed). The stacked container query's own rules
+   below override these fallbacks with its Completed-first default — same var, later in the file. */
+.feed-col.col-asks       { order: var(--col-order, 1); }
+.feed-col.col-needsInput { order: var(--col-order, 2); }
+.feed-col.col-completed  { order: var(--col-order, 3); }
+/* the chip drags in BOTH layouts (the user 2026-08-24, reversing the 2026-08-16 stacked-only
+   exclusion): grab cursor as the affordance, the section lifted over its siblings while it follows. */
+.feed-col-head .fcol-chip { cursor: grab; touch-action: none; user-select: none; }
+.feed-col.col-dragging { position: relative; z-index: 5; opacity: 0.9; }
+.feed-col.col-dragging .fcol-chip { cursor: grabbing; }
 .feed-col-head {
   position: sticky; top: -12px; z-index: 3;
   display: flex; align-items: baseline; gap: 7px;
@@ -174,12 +186,12 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   /* stacked, the columns read TOP-DOWN as Completed → Blocked (needs you) → Working by default (the
      user 2026-07-30, moving Completed up from the middle; supersedes the 2026-07-08 Blocked-first
      order): what finished first, then what needs you, then what's still running. DOM order stays
-     Working/Blocked/Completed (unchanged for the side-by-side layout); `order` only re-sequences the
-     stacked case — and a dragged section (feed.ts applyColStack) overrides via --stack-order, so the
-     user's arrangement wins and survives reloads with the rest of the view state. */
-  .feed-col.col-completed  { order: var(--stack-order, 1); }
-  .feed-col.col-needsInput { order: var(--stack-order, 2); }
-  .feed-col.col-asks       { order: var(--stack-order, 3); }
+     Working/Blocked/Completed; these rules override the base layout's fallbacks for the stacked
+     case — and a dragged order (feed.ts applyColStack, EITHER layout since 2026-08-24) overrides
+     both via --col-order, so the user's arrangement wins everywhere and survives reloads. */
+  .feed-col.col-completed  { order: var(--col-order, 1); }
+  .feed-col.col-needsInput { order: var(--col-order, 2); }
+  .feed-col.col-asks       { order: var(--col-order, 3); }
   /* the SAME caret the session headers wear (.feed-sess-fold): same glyphs, same side (right of
      the label), same rendered size — the header's 0.72em is compensated explicitly so the glyph
      paints at the feed's base size instead of shrinking with the label (the user 2026-08-16) */
@@ -187,9 +199,6 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
     background: transparent; border: 0; font: inherit; font-size: 1.389em; font-weight: 400;
     line-height: 1; cursor: pointer; transition: color 0.12s ease; }
   .fcol-fold:hover, .fcol-fold:focus-visible { color: var(--fg); }
-  .feed-col-head .fcol-chip { cursor: grab; touch-action: none; user-select: none; }
-  .feed-col.col-dragging { position: relative; z-index: 5; opacity: 0.9; }   /* lifted over its siblings while it follows the pointer */
-  .feed-col.col-dragging .fcol-chip { cursor: grabbing; }
 }
 
 /* ---------- ask card (the inbox unit): three rows (the user 2026-06-14) ---------- */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1237,10 +1237,13 @@ const cardTreeExpanded = new Set<string>();
 // above are exactly the state worth carrying: what the USER chose to open. Everything else module-level here
 // is a DOM cache or an in-flight optimistic record, and restoring those would resurrect predictions made
 // against a kernel that no longer exists — see feed-view-state.ts.
-// Stacked-layout column state (the user 2026-08-16): which categories are folded to their header, and
-// the dragged top-down order. Layout state, not card state — prune-exempt, persisted with the rest.
+// Column-layout state (the user 2026-08-16; drag extended to BOTH layouts 2026-08-24): which
+// categories are folded to their header, and the dragged column order — ONE order, two renderings
+// (the user thinks of the two layouts as one arrangement): a drag in either layout re-sequences both. Layout
+// state, not card state — prune-exempt, persisted with the rest (the key stays `order`, so an
+// arrangement dragged before the merge survives it).
 const collapsedCols = new Set<string>();
-let stackOrder: string[] = [];                       // [] = the CSS default (Completed, Blocked, Working)
+let colOrder: string[] = [];                         // [] = each layout's own CSS default
 
 (function hydrateViewState() {
   let st;
@@ -1252,7 +1255,7 @@ let stackOrder: string[] = [];                       // [] = the CSS default (Co
   for (const k of st.asks) expandedAsks.add(k);
   for (const k of st.threads) collapsedThreads.add(k);
   for (const k of st.cols) collapsedCols.add(k);
-  stackOrder = st.order.slice();
+  colOrder = st.order.slice();
 })();
 
 function currentViewState(): FeedViewState {
@@ -1260,7 +1263,7 @@ function currentViewState(): FeedViewState {
   secChoice.forEach((v, k) => { sec[k] = v; });
   return { v: 1, sec, tree: [...cardTreeExpanded], nodes: [...collapsedNodes], logs: [...nodeLogOpen],
            asks: [...expandedAsks], threads: [...collapsedThreads], cols: [...collapsedCols],
-           order: stackOrder.slice() };
+           order: colOrder.slice() };
 }
 
 // Written at the END of every render rather than from each toggle handler: the feed re-renders on every
@@ -3562,19 +3565,23 @@ function ensureSessionBox(): HTMLElement {
 // rebuild if torn down (empty state). "Awaiting" (the user's ruling 2026-06-10):
 // matches the session-chip vocabulary — anything here awaits HIM (a question,
 // an action like reload, an idea), red like the awaiting chip.
-const STACK_DEFAULT = ["completed", "needsInput", "asks"];   // the CSS default top-down stacking
+const STACK_DEFAULT = ["completed", "needsInput", "asks"];   // the stacked CSS default, top-down (2026-07-30)
+const ROW_DEFAULT = ["asks", "needsInput", "completed"];     // the side-by-side CSS default — the build order
 
-// Paint the stacked-column state: each section's fold (list hidden, caret pointed) and its top-down
-// slot (a --stack-order var the container query applies — the side-by-side layout ignores it, so a
-// drag in the narrow view never rearranges the wide one). Idempotent; runs at build and per toggle.
+// Paint the column-order state (ONE order, two renderings — the user 2026-08-24): each column's
+// --col-order var feeds BOTH layouts' `order:` rules; with no custom order the var comes OFF, so
+// each layout keeps its own default (stacked: Completed→Blocked→Working, the user 2026-07-30; side
+// by side: Working→Blocked→Completed, the build order). Also each section's fold (stacked-only CSS).
+// Idempotent; runs at build, per toggle, and per drag re-slot.
 function applyColStack(): void {
-  const order = stackOrder.length === 3 ? stackOrder : STACK_DEFAULT;
+  const custom = colOrder.length === 3 ? colOrder : null;
   for (const key of ["asks", "needsInput", "completed"]) {
     const col = document.querySelector<HTMLElement>(".feed-col.col-" + key);
     if (!col) continue;
     const folded = collapsedCols.has(key);
     col.classList.toggle("col-collapsed", folded);
-    col.style.setProperty("--stack-order", String(order.indexOf(key) + 1));
+    if (custom) col.style.setProperty("--col-order", String(custom.indexOf(key) + 1));
+    else col.style.removeProperty("--col-order");
     const fold = col.querySelector<HTMLElement>(".fcol-fold");
     if (fold) {
       fold.textContent = folded ? "▸" : "▾";
@@ -3583,24 +3590,30 @@ function applyColStack(): void {
   }
 }
 
-// Drag a section header by its grip to re-slot the category in the STACK (pointer events, capture on
-// the grip so the drag survives leaving it). Only the stacked layout listens: in the side-by-side
-// layout the grip is display:none. The order updates live while dragging (flex `order` reflows), and
-// the drop persists it.
-// Drag a section by its CATEGORY CHIP (the user 2026-08-16, dropping the earlier grip handle): the
-// grab cursor on the chip is the affordance. While dragging, the grabbed section FOLLOWS the pointer
-// (a transform, so nothing reflows under the hand) and the displaced sections FLIP-animate into their
-// provisional slots — the arrangement you see mid-drag is the arrangement you get. Only the stacked
-// layout listens: side by side the chip keeps its normal cursor and this returns before capturing.
+// Drag a section by its CATEGORY CHIP — in BOTH layouts now (the user 2026-08-24, reversing the
+// 2026-08-16 stacked-only exclusion with their own ask: the columns should drag around in
+// three-column view just as the sections already do stacked): stacked, the drag re-slots the section vertically;
+// side by side, it reorders the three columns horizontally. ONE persisted order feeds both
+// renderings (colOrder). The grab cursor on the chip is the affordance. While dragging, the grabbed
+// section FOLLOWS the pointer along the drag axis (a transform, so nothing reflows under the hand)
+// and the displaced sections FLIP-animate into their provisional slots — the arrangement you see
+// mid-drag is the arrangement you get on drop.
 function wireColDrag(chip: HTMLElement, col: HTMLElement, key: string): void {
   chip.addEventListener("pointerdown", (down) => {
     const colsEl = document.getElementById("feed-cols");
-    if (!colsEl || getComputedStyle(colsEl).flexDirection !== "column") return;
+    if (!colsEl) return;
+    const vertical = getComputedStyle(colsEl).flexDirection === "column";   // the drag AXIS, per layout
     down.preventDefault();
     down.stopPropagation();
     chip.setPointerCapture(down.pointerId);
     col.classList.add("col-dragging");
-    const startY = down.clientY;
+    const pos = (ev: PointerEvent) => (vertical ? ev.clientY : ev.clientX);
+    const edge = (r: DOMRect) => (vertical ? r.top : r.left);
+    const midOf = (r: DOMRect) => (vertical ? r.top + r.height / 2 : r.left + r.width / 2);
+    const translate = (d: number) => (vertical ? "translateY(" + d + "px)" : "translateX(" + d + "px)");
+    const fallback = vertical ? STACK_DEFAULT : ROW_DEFAULT;
+    const hadCustom = colOrder.length === 3;   // for the no-trace rule in up()
+    const start = pos(down);
     let slotShift = 0;   // the dragged section's own accumulated slot movement — folded into its
     //                      follow-transform so a re-slot never yanks it out from under the pointer
     const applyOrderFlip = (order: string[]) => {
@@ -3609,38 +3622,37 @@ function wireColDrag(chip: HTMLElement, col: HTMLElement, key: string): void {
         const e = document.querySelector<HTMLElement>(".feed-col.col-" + k);
         if (e) els.push([k, e]);
       }
-      const before = new Map(els.map(([k, e]) => [k, e.getBoundingClientRect().top]));
-      stackOrder = order;
+      const before = new Map(els.map(([k, e]) => [k, edge(e.getBoundingClientRect())]));
+      colOrder = order;
       applyColStack();
       for (const [k, e] of els) {
-        const d = (before.get(k) || 0) - e.getBoundingClientRect().top;
+        const d = (before.get(k) || 0) - edge(e.getBoundingClientRect());
         if (!d) continue;
         if (k === key) { slotShift -= d; continue; }   // both rects carry the follow-transform, so d is pure slot delta
-        e.animate([{ transform: "translateY(" + d + "px)" }, { transform: "translateY(0)" }],
+        e.animate([{ transform: translate(d) }, { transform: translate(0) }],
                   { duration: 150, easing: "ease" });
       }
     };
     const move = (ev: PointerEvent) => {
-      const order = (stackOrder.length === 3 ? stackOrder : STACK_DEFAULT).slice();
+      const order = (colOrder.length === 3 ? colOrder : fallback).slice();
       const from = order.indexOf(key);
-      // the slot whose vertical midpoint the pointer is past — walk the OTHER two sections' rects
+      // the slot whose axis midpoint the pointer is past — walk the OTHER two sections' rects
       let to = from;
       for (const other of order) {
         if (other === key) continue;
         const oc = document.querySelector<HTMLElement>(".feed-col.col-" + other);
         if (!oc) continue;
-        const r = oc.getBoundingClientRect();
-        const mid = r.top + r.height / 2;
+        const m = midOf(oc.getBoundingClientRect());
         const oi = order.indexOf(other);
-        if (oi < from && ev.clientY < mid) { to = Math.min(to, oi); }
-        if (oi > from && ev.clientY > mid) { to = Math.max(to, oi); }
+        if (oi < from && pos(ev) < m) { to = Math.min(to, oi); }
+        if (oi > from && pos(ev) > m) { to = Math.max(to, oi); }
       }
       if (to !== from) {
         order.splice(from, 1);
         order.splice(to, 0, key);
         applyOrderFlip(order);
       }
-      col.style.transform = "translateY(" + (ev.clientY - startY - slotShift) + "px)";
+      col.style.transform = translate(pos(ev) - start - slotShift);
     };
     const up = () => {
       chip.removeEventListener("pointermove", move);
@@ -3649,11 +3661,18 @@ function wireColDrag(chip: HTMLElement, col: HTMLElement, key: string): void {
       // settle: animate from wherever the hand left it into its slot, then drop the transform
       const hang = col.style.transform;
       col.style.transform = "";
-      if (hang && hang !== "translateY(0px)") {
-        col.animate([{ transform: hang }, { transform: "translateY(0)" }],
+      if (hang && hang !== translate(0)) {
+        col.animate([{ transform: hang }, { transform: translate(0) }],
                     { duration: 150, easing: "ease" });
       }
       col.classList.remove("col-dragging");
+      // a drag dropped back where it started leaves NO trace (review 2026-08-24): without a
+      // pre-existing custom order, ending on this layout's own default must not mint an EXPLICIT
+      // order — that would silently re-arrange the OTHER layout, which keeps a different default
+      if (!hadCustom && colOrder.length === 3 && colOrder.join() === fallback.join()) {
+        colOrder = [];
+        applyColStack();
+      }
       persistViewState();
     };
     chip.addEventListener("pointermove", move);
@@ -3673,10 +3692,10 @@ function ensureCols(list: HTMLElement) {
     for (const [key, label, chip] of [["asks", "Working", "working"], ["needsInput", "Blocked", "blocked"], ["completed", "Completed", "completed"]] as const) {
       const col = el("div", "feed-col col-" + key);
       const head = el("div", "feed-col-head");
-      // stacked-layout furniture (the user 2026-08-16), both hidden in the side-by-side layout by CSS:
-      // a caret LEFT of the chip folds the whole category to its header, and a grip (hover-revealed on
-      // pointer devices, faintly visible on touch) drags the section to a new spot in the stack. These
-      // live on the build-once header, so they are click-safe across the feed's constant re-renders.
+      // header furniture (the user 2026-08-16): a caret LEFT of the chip folds the whole category to
+      // its header (stacked-only, hidden side by side by CSS), and the CHIP ITSELF drags the section
+      // to a new slot — in BOTH layouts since 2026-08-24 (see wireColDrag). These live on the
+      // build-once header, so they are click-safe across the feed's constant re-renders.
       const fold = el("button", "fcol-fold");
       fold.setAttribute("aria-label", "Collapse " + label);
       fold.addEventListener("click", (ev) => {
@@ -4131,7 +4150,18 @@ window.addEventListener("click", (e) => {
 // hover) and Enter calls the element's own click() — so the keyboard can never drift from the mouse.
 const KB_EL_SEL = ".fcard-title.nav,.fask-distill-link,.fname,.fask-apiRetry,.fask-revive,.fdismiss,.fcheck .lz-nav,.fask-delegation";
 function kbCardEls(): HTMLElement[] {
-  return Array.from(document.querySelectorAll<HTMLElement>(".feed-cols .fitem:not(.dismissing)"));
+  // VISUAL order, not DOM order (review 2026-08-24): the columns re-sequence via --col-order — in
+  // both layouts since the drag extended — so the arrow cursor sorts cards by their column's
+  // effective `order` (getComputedStyle resolves the var), DOM order within a column.
+  const els = Array.from(document.querySelectorAll<HTMLElement>(".feed-cols .fitem:not(.dismissing)"));
+  const slot = new Map<HTMLElement, number>();
+  for (const e of els) {
+    const col = e.closest<HTMLElement>(".feed-col");
+    slot.set(e, col ? parseInt(getComputedStyle(col).order || "0", 10) || 0 : 0);
+  }
+  return els.map((e, i) => ({ e, i, s: slot.get(e) || 0 }))
+    .sort((a, b) => a.s - b.s || a.i - b.i)
+    .map((x) => x.e);
 }
 function kbHoverId(el: HTMLElement): string {
   const key = el.dataset.key || "";


### PR DESCRIPTION
The section-chip drag extends to the side-by-side layout — the user's own ask, deliberately reversing the 2026-08-16 stacked-only exclusion (the retargeted pin and the code comments cite the reversal rather than routing around it).

**Mechanics.** `wireColDrag` is axis-generic: the layout picks the drag axis (vertical stacked, horizontal side by side) with the same FLIP provisional movement, slotShift math, pointer capture, and cancel-settle paths as before. **One persisted order feeds both renderings**: `stackOrder` becomes `colOrder` (the persisted key stays `order`, so pre-existing arrangements survive), `applyColStack` writes a `--col-order` var consumed by both layouts' order rules, and with no custom order the var comes off so each layout keeps its own default (stacked Completed-first per the 2026-07-30 ruling; side by side the Working-first build order). A drag dropped back where it started leaves no trace — it must not mint an explicit order that would silently re-arrange the other layout. The keyboard card cursor now walks the visual order (each column's effective `order`, var resolved) instead of DOM order.

**Verification.** Headless Chromium renders of the contract: row default, row custom, stacked custom (same custom order in both layouts; per-layout defaults where none). 2297 extension tests green.

**Review provenance.** Two-lens adversarial workflow, two skeptics per finding: 6 confirmed findings all fixed in this commit (stale stacked-only comments in the test header and ensureCols, the cascade pin not proving query membership, a stale var name in a comment, the no-op-drag explicit-order leak, the keyboard cursor walking DOM order), 1 refuted as pre-existing and unreachable. The cascade tiebreak is pinned both ways: base fallbacks before and outside the query, stacked overrides inside it.

Closes out the column-layout bundle (the stacked-width fix landed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)