### PR TITLE
A tag is its name everywhere — and the lane gear tags sessions too

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1710,13 +1710,14 @@ def _view_visible(views, sid):
         # LOCAL tags only exclude here (federation v0): a remote kernel's tagging of our session
         # must not flap our untagged view with its poll cadence — remote tags are extra VIEWS
         return sid not in views["hidden"] and not any(sid in t["members"] for t in views["tags"])
-    for t in views["tags"]:
-        if t["id"] == views["active"]:
-            return sid in t["members"]
-    for t in views.get("remoteTags") or []:
-        if t["id"] == views["active"]:
-            return sid in t["members"]
-    return True
+    # a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24: a tag is its NAME; kernels
+    # are plumbing) — whichever store's id is active, membership joins every same-name tag's,
+    # local and remote alike. The stored duplicates stay separate (anti-clobber); this is the read.
+    everything = list(views["tags"]) + list(views.get("remoteTags") or [])
+    act = next((t for t in everything if t["id"] == views["active"]), None)
+    if act is None:
+        return True
+    return any(sid in t["members"] for t in everything if t["name"] == act["name"])
 
 
 def _heal_timeline_views(old_sid, new_sid):

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -196,6 +196,29 @@ class TimelineViews(unittest.TestCase):
         finally:
             km._remotes.clear(); km._remotes.update(saved)
 
+    def test_a_tag_view_is_the_name_keyed_union_across_kernels(self):
+        # user ruling 2026-08-24: a tag IS its name — whichever store's id is active, the view shows
+        # the union of every same-name tag's members, local and remote joined. The stored duplicates
+        # stay separate (anti-clobber); this is the read, and both client mirrors pin it identically.
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            self._attach("TESTHOST-A", {"tags": [{"id": "g1", "name": "team", "color": "#DD42FF",
+                                                  "members": [{"host": "", "sid": "rs1"}]}]})
+            km._set_timeline_views({"active": "all", "hidden": [],
+                                    "tags": [{"id": "gL", "name": "team", "color": "#123456",
+                                              "members": ["local1"]}]})
+            km._flags_cache.clear()
+            v = km._views_client()
+            v["active"] = "gL"                     # the LOCAL id activates the union
+            self.assertTrue(km._view_visible(v, "local1"))
+            self.assertTrue(km._view_visible(v, "TESTHOST-A:rs1"), "the remote store's member joins")
+            self.assertFalse(km._view_visible(v, "other"))
+            v["active"] = "TESTHOST-A:g1"          # …and so does the remote id — same union
+            self.assertTrue(km._view_visible(v, "local1"))
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
     def test_same_name_tags_on_two_kernels_stay_two_entries(self):
         saved = dict(km._remotes)
         try:

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -41,6 +41,33 @@ function _rompOnlyTag() {
 // `tags`; `groups` is honored as the pre-rename key an un-updated kernel still pushes, in ONE
 // place so every rule reads through it.
 function viewTags(views) { return (views && (views.tags || views.groups)) || []; }
+// A tag IS its NAME, everywhere (user ruling 2026-08-24: "if the UX requires understanding that
+// tags exist across different kernels, it is not good"): one name = one identity, membership the
+// UNION across every kernel defining that name, the LOCAL store's color winning the render. The
+// stored duplicates stay separate under the hood (no automatic store merges — the anti-clobber
+// rule); this is PRESENTATION, and the mirrors (session-views.ts, kernel _view_visible) agree.
+function viewTagUnion(views) {
+  const out = [], byName = {};
+  for (const t of viewTags(views)) {
+    const g = byName[t.name] || (byName[t.name] = { name: t.name || 'tag', color: '', members: [],
+                                                    ids: [], localId: null, homes: [], remotes: [] });
+    if (!g.localId) { g.localId = t.id; g.color = t.color || g.color; }
+    g.ids.push(t.id);
+    for (const m of (t.members || [])) if (g.members.indexOf(m) < 0) g.members.push(m);
+    if (out.indexOf(g) < 0) out.push(g);
+  }
+  for (const rt of ((views && views.remoteTags) || [])) {
+    const g = byName[rt.name] || (byName[rt.name] = { name: rt.name || 'tag', color: '', members: [],
+                                                      ids: [], localId: null, homes: [], remotes: [] });
+    if (!g.localId && !g.color) g.color = rt.color || '';
+    g.ids.push(rt.id);
+    g.homes.push(rt.host || '');
+    g.remotes.push(rt);
+    for (const m of (rt.members || [])) if (g.members.indexOf(m) < 0) g.members.push(m);
+    if (out.indexOf(g) < 0) out.push(g);
+  }
+  return out;
+}
 function viewVisible(views, id) {
   if (!views || !views.active || views.active === 'all') {
     return !(views && Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0);
@@ -49,17 +76,16 @@ function viewVisible(views, id) {
     if (Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0) return false;
     return !viewTags(views).some((t) => (t.members || []).indexOf(id) >= 0);
   }
-  const t = viewTags(views).find((x) => x.id === views.active)
-    || ((views && views.remoteTags) || []).find((x) => x.id === views.active);   // remote tags are views too (federation v0)
-  return t ? (t.members || []).indexOf(id) >= 0 : true;
+  // a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24): whichever store's id is
+  // active, the members are every same-name tag's, local and remote joined
+  const g = viewTagUnion(views).find((x) => x.ids.indexOf(views.active) >= 0);
+  return g ? g.members.indexOf(id) >= 0 : true;
 }
 function viewLabel(views) {
   if (!views || !views.active || views.active === 'all') return 'All';
   if (views.active === 'untagged') return '(untagged)';
-  const t = viewTags(views).find((x) => x.id === views.active);
-  if (t) return t.name || 'tag';
-  const rt = ((views && views.remoteTags) || []).find((x) => x.id === views.active);
-  return rt ? ((rt.host ? rt.host + ':' : '') + (rt.name || 'tag')) : 'All';
+  const g = viewTagUnion(views).find((x) => x.ids.indexOf(views.active) >= 0);
+  return g ? g.name : 'All';   // the NAME, never a host prefix — kernels are plumbing
 }
 // live sessions the current view is NOT showing — the "N more" cue that keeps a hidden or tagged
 // session exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
@@ -2435,6 +2461,107 @@ class TimelinePanel {
     this.draw();
   }
 
+  // ── the NAME-KEYED tag editor (user ruling 2026-08-24), shared by the dialog and the lane gear ──
+  // One union group = one tag identity. Edits stay routed under the hood: an ADD lands on the LOCAL
+  // store when the name exists locally, else the tag's single home; a REMOVE removes the
+  // (name, member) pair from EVERY store holding it — a removal never half-works; rename/recolor/
+  // delete fan out to every home the same way. Local writes post the whole blob (unchanged);
+  // remote writes ride _editRemoteTag (optimistic overlay + loud tagEditFailed, federation v1).
+  _editTagUnion(g, edit) {
+    if (edit.add && edit.add.length) {
+      if (g.localId) {
+        const nv = JSON.parse(JSON.stringify(this._curViews()));
+        const t = viewTags(nv).find((x) => x.id === g.localId);
+        if (t) { t.members = Array.from(new Set((t.members || []).concat(edit.add))); this._setViews(nv); }
+      } else if (g.remotes.length) this._editRemoteTag(g.remotes[0], { add: edit.add.slice() });
+    }
+    if (edit.remove && edit.remove.length) {
+      if (g.localId) {
+        const nv = JSON.parse(JSON.stringify(this._curViews()));
+        const t = viewTags(nv).find((x) => x.id === g.localId);
+        if (t && (t.members || []).some((m) => edit.remove.indexOf(m) >= 0)) {
+          t.members = (t.members || []).filter((m) => edit.remove.indexOf(m) < 0);
+          this._setViews(nv);
+        }
+      }
+      for (const rt of g.remotes)
+        if ((rt.members || []).some((m) => edit.remove.indexOf(m) >= 0))
+          this._editRemoteTag(rt, { remove: edit.remove.slice() });
+    }
+    if (edit.rename || edit.color || edit.delete) {
+      if (g.localId) {
+        const nv = JSON.parse(JSON.stringify(this._curViews()));
+        if (edit.delete) {
+          nv.tags = viewTags(nv).filter((x) => x.id !== g.localId); delete nv.groups;
+          if (nv.active === g.localId) nv.active = 'all';
+        } else {
+          const t = viewTags(nv).find((x) => x.id === g.localId);
+          if (t) { if (edit.rename) t.name = edit.rename; if (edit.color) t.color = edit.color; }
+        }
+        this._setViews(nv);
+      }
+      for (const rt of g.remotes)
+        this._editRemoteTag(rt, { rename: edit.rename, color: edit.color, delete: !!edit.delete });
+    }
+  }
+
+  // the chips for ONE session — one solid chip per union tag holding it, ✕ = remove-everywhere.
+  // Home-kernel detail lives in the tooltip at most (kernels are plumbing).
+  _tagChips(box, s, rebuild) {
+    for (const g of viewTagUnion(this._curViews())) {
+      if (g.members.indexOf(s.id) < 0) continue;
+      const tc = g.color || '#cccccc';
+      const ch = box.createSpan();
+      ch.setAttribute('style', 'display:inline-flex;align-items:center;gap:5px;'
+        + 'padding:2px 7px;border-radius:9px;font-size:0.82em;cursor:pointer;white-space:nowrap;'
+        + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
+      ch.addEventListener('mouseenter', () => { ch.style.background = 'rgba(255,255,255,0.09)'; });
+      ch.addEventListener('mouseleave', () => { ch.style.background = 'transparent'; });
+      ch.createSpan({ text: g.name });
+      const chx = ch.createSpan({ text: '✕' });
+      chx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
+      ch.setAttribute('title', 'tagged "' + g.name + '"'
+        + (g.homes.length ? ' (also defined on ' + g.homes.join(', ') + ')' : '')
+        + ' — click to take this tag off everywhere it holds this session');
+      ch.addEventListener('click', () => { this._editTagUnion(g, { remove: [s.id] }); rebuild(); });
+    }
+  }
+
+  // the join menu for one-or-many sessions: one option per union tag some rowId lacks, plus the
+  // new-tag input (a new tag mints LOCALLY, as always)
+  _tagJoinMenu(box, rowIds, rebuild) {
+    for (const g of viewTagUnion(this._curViews())) {
+      if (!rowIds.some((id) => g.members.indexOf(id) < 0)) continue;
+      const tc = g.color || '#cccccc';
+      const opt = box.createSpan({ text: g.name });
+      opt.setAttribute('style', 'padding:1px 8px;border-radius:9px;font-size:0.82em;cursor:pointer;'
+        + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
+      opt.addEventListener('mouseenter', () => { opt.style.background = 'rgba(255,255,255,0.09)'; });
+      opt.addEventListener('mouseleave', () => { opt.style.background = 'transparent'; });
+      opt.addEventListener('click', () => {
+        this._tagAddFor = null;
+        this._editTagUnion(g, { add: rowIds.filter((id) => g.members.indexOf(id) < 0) }); rebuild();
+      });
+    }
+    const ni = document.createElement('input');
+    ni.placeholder = 'new tag…'; ni.maxLength = 40;
+    ni.setAttribute('style', 'width:90px;background:#1e1e1e;color:#ccc;border:1px solid rgba(255,255,255,0.12);'
+      + 'border-radius:9px;padding:1px 7px;font:inherit;font-size:0.82em;');
+    ni.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter' || !ni.value.trim()) return;
+      const nv = JSON.parse(JSON.stringify(this._curViews()));
+      const used = new Set(viewTags(nv).map((t) => t.color));
+      const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
+      nv.tags = viewTags(nv).concat([{ id: 'g' + Date.now().toString(36),
+        name: ni.value.trim().slice(0, 40), color, members: rowIds.slice() }]);
+      delete nv.groups;
+      this._tagAddFor = null;
+      this._setViews(nv); rebuild();
+    });
+    box.appendChild(ni);
+    ni.focus();
+  }
+
   _reconcileViews() {
     if (!this._pendingViews) return;
     if (this._views && this._viewsKey(this._views) === this._viewsKey(this._pendingViews)) {
@@ -2602,16 +2729,13 @@ class TimelinePanel {
     // meaning under its own sentinel — second; both are built-ins, not rows in the tags dialog
     item('All', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
     item('(untagged)', { current: v.active === 'untagged' }).addEventListener('click', () => pick('untagged'));
-    for (const tg of viewTags(v))
-      item(tg.name, { dot: tg.color || MODEL_FG, current: v.active === tg.id }).addEventListener('click', () => pick(tg.id));
-    // tag federation v0 (the user 2026-08-24): every ATTACHED kernel's tags join the menu, read-only,
-    // wearing the owner's colour and the "host:name" marker (the list_agents idiom) — a same-named
-    // tag on two kernels is two rows, never a silent merge. Picking one filters exactly like a local
-    // tag; editing it goes through its home kernel (romp tag --host <h>), so no edit affordance here.
-    for (const rt of (v.remoteTags || []))
-      item((rt.host ? rt.host + ':' : '') + (rt.name || 'tag'),
-           { dot: rt.color || MODEL_FG, current: v.active === rt.id, dim: true })
-        .addEventListener('click', () => pick(rt.id));
+    // NAME-KEYED (user ruling 2026-08-24, superseding the v0 host-marked two-rows render: "if the
+    // UX requires understanding that tags exist across different kernels, it is not good"): one row
+    // per tag NAME, membership the union across every kernel defining it, the local store's colour
+    // winning. Picking one activates the union view via whichever id is handiest (local first).
+    for (const g of viewTagUnion(v))
+      item(g.name, { dot: g.color || MODEL_FG, current: g.ids.indexOf(v.active) >= 0 })
+        .addEventListener('click', () => pick(g.localId || g.ids[0]));
     sep();
     item('New tag…', { dim: true }).addEventListener('click', () => {
       const nv = JSON.parse(JSON.stringify(v));
@@ -2671,7 +2795,9 @@ class TimelinePanel {
     const card = back.createDiv();
     card.setAttribute('style', 'width:min(560px,94vw);max-height:78vh;overflow:auto;padding:14px 16px;' + MENU_STYLE);
     card.addEventListener('click', (e) => e.stopPropagation());
-    let addMenuFor = null;                 // session id with its [+] menu open, or '*' for the bulk one
+    // the open [+] menu's key rides the INSTANCE (this._tagAddFor: sid, or '*' for the bulk bar)
+    // so the shared join builder can close it from either surface — the dialog or the lane gear
+    if (this._tagAddFor === undefined) this._tagAddFor = null;
     let query = '';                        // the search filter (name or host), survives repaints
     const hover = (n, on, off) => {        // the one hover helper: interactive chrome changes colour
       n.addEventListener('mouseenter', () => n.setAttribute('style', n.getAttribute('style') + on));
@@ -2687,68 +2813,37 @@ class TimelinePanel {
     const build = () => {
       card.textContent = '';
       const v = this._curViews();
-      const tg = gid ? viewTags(v).find((x) => x.id === gid) : null;
-      // a REMOTE tag opens the same header (federation v1): its edits route to the home kernel
-      const rtg = gid && !tg ? ((v.remoteTags || []).find((x) => x.id === gid) || null) : null;
-      if (gid && !tg && !rtg) { this._closeViewsDialog(); return; }   // the tag was deleted elsewhere
+      // NAME-KEYED (user ruling 2026-08-24): whichever store's id opened this, the header is the
+      // tag's ONE identity — rename/recolor/delete fan out to every kernel defining the name
+      // (_editTagUnion), and no host prefix appears; kernels are plumbing.
+      const tg = gid ? (viewTagUnion(v).find((x) => x.ids.indexOf(gid) >= 0) || null) : null;
+      if (gid && !tg) { this._closeViewsDialog(); return; }   // the tag was deleted elsewhere
       const canEdit = typeof window !== 'undefined' && typeof window.__rompTimelineEditTag === 'function';
       const head = card.createDiv();
       head.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 8px;');
-      if (rtg) {
-        const hp = head.createSpan({ text: (rtg.host || '') + ':' });
-        hp.setAttribute('style', 'flex:0 0 auto;color:' + MODEL_FG + ';font-style:italic;font-size:0.88em;');
+      if (tg) {
         const nameIn = document.createElement('input');
-        nameIn.value = rtg.name || 'tag'; nameIn.maxLength = 40;
-        nameIn.disabled = !canEdit;
+        nameIn.value = tg.name; nameIn.maxLength = 40;
+        nameIn.disabled = !tg.localId && !canEdit;   // remote-only + no bridge (Obsidian) → read-only
         nameIn.setAttribute('style', 'flex:1 1 auto;min-width:0;background:#1e1e1e;color:#ccc;'
           + 'border:1px solid rgba(255,255,255,0.12);border-radius:5px;padding:3px 6px;font:inherit;');
         nameIn.addEventListener('change', () => {
           const nv = nameIn.value.slice(0, 40).trim();
-          if (nv && nv !== rtg.name) this._editRemoteTag(rtg, { rename: nv });
+          if (nv && nv !== tg.name) this._editTagUnion(tg, { rename: nv });
           build();
         });
         head.appendChild(nameIn);
         const del = head.createSpan({ text: 'Delete' });
-        del.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.7;color:#F85B5A;' + (canEdit ? '' : 'display:none;'));
+        del.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.7;color:#F85B5A;'
+          + (tg.localId || canEdit ? '' : 'display:none;'));
         hover(del, 'opacity:1;', 'opacity:0.7;');
         del.addEventListener('click', () => {
-          this._editRemoteTag(rtg, { delete: true });
+          this._editTagUnion(tg, { delete: true });
           this._closeViewsDialog();
-        });
-      } else if (tg) {
-        const nameIn = document.createElement('input');
-        nameIn.value = tg.name; nameIn.maxLength = 40;
-        nameIn.setAttribute('style', 'flex:1 1 auto;min-width:0;background:#1e1e1e;color:#ccc;'
-          + 'border:1px solid rgba(255,255,255,0.12);border-radius:5px;padding:3px 6px;font:inherit;');
-        nameIn.addEventListener('change', () => {
-          const nv = JSON.parse(JSON.stringify(this._curViews()));
-          const t2 = viewTags(nv).find((x) => x.id === gid); if (!t2) return;
-          t2.name = nameIn.value.slice(0, 40) || t2.name;
-          this._setViews(nv); build();
-        });
-        head.appendChild(nameIn);
-        const del = head.createSpan({ text: 'Delete' });
-        del.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.7;color:#F85B5A;');
-        hover(del, 'opacity:1;', 'opacity:0.7;');
-        del.addEventListener('click', () => {
-          const nv = JSON.parse(JSON.stringify(this._curViews()));
-          nv.tags = viewTags(nv).filter((x) => x.id !== gid); delete nv.groups;
-          if (nv.active === gid) nv.active = 'all';
-          this._setViews(nv); this._closeViewsDialog();
         });
       } else {
         const ttl = head.createDiv({ text: 'Sessions & tags' });
         ttl.setAttribute('style', 'font-weight:650;');
-      }
-      if (rtg && canEdit) {
-        const sw = card.createDiv();
-        sw.setAttribute('style', 'display:flex;gap:6px;margin:2px 0 8px;flex-wrap:wrap;');
-        for (const c of (this._palette && this._palette.length ? this._palette : [rtg.color || '#1EA1EB'])) {
-          const d = sw.createSpan();
-          d.setAttribute('style', 'width:16px;height:16px;border-radius:50%;cursor:pointer;background:' + c + ';'
-            + (c === rtg.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : 'opacity:0.75;'));
-          d.addEventListener('click', () => { this._editRemoteTag(rtg, { color: c }); build(); });
-        }
       }
       // the LOUD failure of the last routed edit (a down owner, a collision there) — dismissible
       if (this._tagEditErr) {
@@ -2760,18 +2855,14 @@ class TimelinePanel {
         ex.setAttribute('style', 'margin-left:auto;cursor:pointer;opacity:0.7;');
         ex.addEventListener('click', () => { this._tagEditErr = null; build(); });
       }
-      if (tg) {
+      if (tg && (tg.localId || canEdit)) {
         const sw = card.createDiv();
         sw.setAttribute('style', 'display:flex;gap:6px;margin:2px 0 8px;flex-wrap:wrap;');
         for (const c of (this._palette && this._palette.length ? this._palette : [tg.color || '#1EA1EB'])) {
           const d = sw.createSpan();
           d.setAttribute('style', 'width:16px;height:16px;border-radius:50%;cursor:pointer;background:' + c + ';'
             + (c === tg.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : 'opacity:0.75;'));
-          d.addEventListener('click', () => {
-            const nv = JSON.parse(JSON.stringify(this._curViews()));
-            const t2 = viewTags(nv).find((x) => x.id === gid); if (!t2) return;
-            t2.color = c; this._setViews(nv); build();
-          });
+          d.addEventListener('click', () => { this._editTagUnion(tg, { color: c }); build(); });
         }
       }
       // search + the bulk controls, one row: the search names the SET, the controls act on it
@@ -2789,7 +2880,7 @@ class TimelinePanel {
       tagAll.setAttribute('style', btnStyle);
       hover(tagAll, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
       tagAll.setAttribute('title', 'add a tag to every session the search shows');
-      tagAll.addEventListener('click', () => { addMenuFor = addMenuFor === '*' ? null : '*'; renderRows(); });
+      tagAll.addEventListener('click', () => { this._tagAddFor = this._tagAddFor === '*' ? null : '*'; renderRows(); });
       const feedAll = bar.createSpan();
       feedAll.setAttribute('style', btnStyle);
       hover(feedAll, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
@@ -2822,58 +2913,12 @@ class TimelinePanel {
         const grid = gridBox.createDiv();
         grid.setAttribute('style', 'display:grid;grid-template-columns:max-content 1fr max-content max-content max-content;'
           + 'column-gap:10px;row-gap:3px;align-items:center;');
-        const addMenu = (rowIds) => {   // the [+] menu, per-row or bulk — spans the grid
+        const addMenu = (rowIds) => {   // the [+] menu, per-row or bulk — the SHARED join builder, grid-spanning
           const am = grid.createDiv();
           am.setAttribute('style', 'grid-column:1 / -1;margin:2px 0 4px 8px;display:flex;gap:5px;flex-wrap:wrap;align-items:center;');
-          const cur = this._curViews();
-          const joinable = viewTags(cur).filter((t) =>
-            rowIds.some((id) => (t.members || []).indexOf(id) < 0));
-          if (canEdit)
-            for (const rt of (cur.remoteTags || []).filter((t) => rowIds.some((id) => (t.members || []).indexOf(id) < 0))) {
-              const rc2 = rt.color || '#cccccc';
-              const ropt = am.createSpan({ text: (rt.host || '') + ':' + (rt.name || 'tag') });
-              ropt.setAttribute('style', 'padding:1px 8px;border-radius:9px;font-size:0.82em;cursor:pointer;'
-                + 'color:' + rc2 + ';border:1px dashed ' + rc2 + ';background:transparent;');
-              hover(ropt, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
-              ropt.setAttribute('title', 'joins ' + (rt.host || '?') + "'s tag — the edit routes there");
-              ropt.addEventListener('click', () => {
-                addMenuFor = null;
-                this._editRemoteTag(rt, { add: rowIds.slice() }); build();
-              });
-            }
-          for (const t of joinable) {
-            const tc = t.color || '#cccccc';
-            const opt = am.createSpan({ text: t.name });
-            opt.setAttribute('style', 'padding:1px 8px;border-radius:9px;font-size:0.82em;cursor:pointer;'
-              + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
-            hover(opt, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
-            opt.addEventListener('click', () => {
-              const nv = JSON.parse(JSON.stringify(this._curViews()));
-              const t2 = viewTags(nv).find((x) => x.id === t.id); if (!t2) return;
-              t2.members = Array.from(new Set((t2.members || []).concat(rowIds)));
-              addMenuFor = null;
-              this._setViews(nv); build();
-            });
-          }
-          const ni = document.createElement('input');
-          ni.placeholder = 'new tag…'; ni.maxLength = 40;
-          ni.setAttribute('style', 'width:90px;background:#1e1e1e;color:#ccc;border:1px solid rgba(255,255,255,0.12);'
-            + 'border-radius:9px;padding:1px 7px;font:inherit;font-size:0.82em;');
-          ni.addEventListener('keydown', (e) => {
-            if (e.key !== 'Enter' || !ni.value.trim()) return;
-            const nv = JSON.parse(JSON.stringify(this._curViews()));
-            const used = new Set(viewTags(nv).map((t) => t.color));
-            const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
-            nv.tags = viewTags(nv).concat([{ id: 'g' + Date.now().toString(36),
-              name: ni.value.trim().slice(0, 40), color, members: rowIds.slice() }]);
-            delete nv.groups;
-            addMenuFor = null;
-            this._setViews(nv); build();
-          });
-          am.appendChild(ni);
-          ni.focus();
+          this._tagJoinMenu(am, rowIds, build);
         };
-        if (addMenuFor === '*') addMenu(rows.map((s) => s.id));
+        if (this._tagAddFor === '*') addMenu(rows.map((s) => s.id));
         for (const s of rows) {
           const vv = this._curViews();
           // NAME — the session's identity colour on the name itself (never a proxy dot), the
@@ -2888,49 +2933,12 @@ class TimelinePanel {
           const nm = nameCell.createSpan({ text: bare });
           nm.setAttribute('style', 'font-weight:650;color:' + (s.color || '#cccccc') + ';'
             + (s.live ? '' : 'text-decoration:line-through;'));
-          // TAGS — removable chips, outline in the tag's colour, dim separate ✕. A REMOTE kernel's
-          // tag holding this session renders too (federation v0) — read-only, host-marked, no ✕:
-          // its home kernel owns it (romp tag --host <h> edits it from here).
+          // TAGS — one solid chip per union tag holding this session (user ruling 2026-08-24:
+          // a tag is its NAME; kernels are plumbing — the twin dashed/solid render is gone), ✕ =
+          // remove-everywhere. The shared builder; the lane gear renders the identical editor.
           const chips = grid.createDiv();
           chips.setAttribute('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;min-width:0;');
-          for (const rt of (vv.remoteTags || [])) {
-            if ((rt.members || []).indexOf(s.id) < 0) continue;
-            const rc = rt.color || '#cccccc';
-            const rch = chips.createSpan();
-            rch.setAttribute('style', 'display:inline-flex;align-items:center;gap:4px;'
-              + 'padding:2px 7px;border-radius:9px;font-size:0.82em;white-space:nowrap;opacity:0.85;'
-              + 'color:' + rc + ';border:1px dashed ' + rc + ';background:transparent;'
-              + (canEdit ? 'cursor:pointer;' : ''));
-            const rh = rch.createSpan({ text: (rt.host || '') + ':' });
-            rh.setAttribute('style', 'color:' + MODEL_FG + ';font-style:italic;font-size:0.88em;');
-            rch.createSpan({ text: rt.name || 'tag' });
-            if (canEdit) {
-              // federation v1: the ✕ routes the removal to the tag's home kernel — same chip
-              // gesture as a local tag, the dashes still saying whose it is
-              const rx = rch.createSpan({ text: '✕' });
-              rx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
-              hover(rch, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
-              rch.setAttribute('title', 'tagged on ' + (rt.host || 'another kernel') + ' — click to take this tag off (routed there)');
-              rch.addEventListener('click', () => { this._editRemoteTag(rt, { remove: [s.id] }); build(); });
-            } else {
-              rch.setAttribute('title', 'tagged on ' + (rt.host || 'another kernel')
-                + ' — read-only here; edit with: romp tag --host ' + (rt.host || '<kernel>'));
-            }
-          }
-          for (const t of viewTags(vv)) {
-            if ((t.members || []).indexOf(s.id) < 0) continue;
-            const tc = t.color || '#cccccc';
-            const ch = chips.createSpan();
-            ch.setAttribute('style', 'display:inline-flex;align-items:center;gap:5px;'
-              + 'padding:2px 7px;border-radius:9px;font-size:0.82em;cursor:pointer;white-space:nowrap;'
-              + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
-            hover(ch, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
-            ch.createSpan({ text: t.name });
-            const chx = ch.createSpan({ text: '✕' });
-            chx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
-            ch.setAttribute('title', 'tagged "' + t.name + '" — click to take this tag off');
-            ch.addEventListener('click', () => { this._setViews(viewToggleMember(this._curViews(), t.id, s.id)); build(); });
-          }
+          this._tagChips(chips, s, build);
           // [+] — one aligned column, so the table reads as a table
           const plusCell = grid.createDiv();
           const plus = plusCell.createSpan({ text: '+' });
@@ -2938,7 +2946,7 @@ class TimelinePanel {
             + 'border-radius:50%;border:1px solid rgba(255,255,255,0.25);color:#cccccc;opacity:0.7;cursor:pointer;font-size:0.85em;background:transparent;');
           hover(plus, 'background:rgba(255,255,255,0.09);opacity:1;', 'background:transparent;opacity:0.7;');
           plus.setAttribute('title', 'add a tag');
-          plus.addEventListener('click', () => { addMenuFor = addMenuFor === s.id ? null : s.id; renderRows(); });
+          plus.addEventListener('click', () => { this._tagAddFor = this._tagAddFor === s.id ? null : s.id; renderRows(); });
           // FEED — the pool-builder switch rides every live row (the user 2026-08-19), aligned
           const feedCell = grid.createDiv();
           if (ft && s.live) {
@@ -2970,7 +2978,7 @@ class TimelinePanel {
             eye.setAttribute('title', 'hidden from the All and (untagged) views — click to show it again');
             eye.addEventListener('click', () => { this._setViews(viewToggleHidden(this._curViews(), s.id)); build(); });
           }
-          if (addMenuFor === s.id) addMenu([s.id]);
+          if (this._tagAddFor === s.id) addMenu([s.id]);
         }
       };
       renderRows();
@@ -3026,6 +3034,32 @@ class TimelinePanel {
           this.draw();
           build();                                   // repaint states in place; the panel stays open
         });
+      }
+      // ── Tags (the user 2026-08-24: taggable from the gear too, not only the filter dialog) ──
+      // The SAME name-keyed editor the dialog rows carry — the shared builders, never a fork:
+      // one solid chip per tag holding this session (✕ = remove-everywhere), [+] to join an
+      // existing tag or mint one. Compact: one section, mechanics inline under it.
+      const div = menu.createDiv();
+      div.setAttribute('style', 'height:1px;margin:4px 6px;background:rgba(255,255,255,0.12);');
+      const trow = menu.createDiv();
+      trow.setAttribute('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;padding:4px 10px;');
+      const tlab = trow.createSpan({ text: 'Tags' });
+      tlab.setAttribute('style', 'opacity:0.6;font-size:0.82em;flex:0 0 auto;margin-right:2px;');
+      this._tagChips(trow, s, build);
+      const plus = trow.createSpan({ text: '+' });
+      plus.setAttribute('style', 'display:inline-flex;align-items:center;justify-content:center;width:17px;height:17px;'
+        + 'border-radius:50%;border:1px solid rgba(255,255,255,0.25);color:#cccccc;opacity:0.7;cursor:pointer;font-size:0.85em;background:transparent;');
+      plus.addEventListener('mouseenter', () => { plus.style.background = 'rgba(255,255,255,0.09)'; plus.style.opacity = '1'; });
+      plus.addEventListener('mouseleave', () => { plus.style.background = 'transparent'; plus.style.opacity = '0.7'; });
+      plus.setAttribute('title', 'add a tag');
+      plus.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._tagAddFor = this._tagAddFor === s.id ? null : s.id; build();
+      });
+      if (this._tagAddFor === s.id) {
+        const am = menu.createDiv();
+        am.setAttribute('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;padding:2px 10px 6px 24px;');
+        this._tagJoinMenu(am, [s.id], build);
       }
     };
     build();
@@ -4304,4 +4338,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember, viewTagUnion };

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -16,7 +16,7 @@ import { createRequire } from "node:module";
 const requireCjs = createRequire(__filename);
 const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
 const SRC = fs.readFileSync(VIEW_PATH, "utf8");
-const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember } = requireCjs(VIEW_PATH);
+const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember, viewTagUnion } = requireCjs(VIEW_PATH);
 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2", "s3"] };
 const V = (active: string, hidden: string[] = [], tags: any[] = [G]) => ({ active, hidden, tags });
@@ -163,12 +163,13 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
   assert.match(SRC, /anyOn \? 'mute feed for all' : 'restore feed for all'/);
   assert.match(SRC, /const flagVal = ft\.value\(!anyOn\);/, "any still minting → mute all; all muted → restore");
   // chips: outline in the tag's colour, dim separate ✕, hover changes colour (menu chrome)
-  assert.match(SRC, /ch\.createSpan\(\{ text: t\.name \}\);/);
+  // the chips live in the SHARED name-keyed builder now (user ruling 2026-08-24): one chip per
+  // tag NAME, ✕ = remove-everywhere via the union dispatcher — the dialog and the gear both call it
+  assert.match(SRC, /ch\.createSpan\(\{ text: g\.name \}\);/);
   assert.match(SRC, /const chx = ch\.createSpan\(\{ text: '✕' \}\);/, "the ✕ is its own dim span — the composer chip's read");
   assert.doesNotMatch(SRC, /background:color-mix/, "no tinted chip grounds anywhere in the dialog");
-  assert.match(SRC, /hover\(ch, 'background:rgba\(255,255,255,0\.09\);', 'background:transparent;'\);/);
-  assert.match(SRC, /this\._setViews\(viewToggleMember\(this\._curViews\(\), t\.id, s\.id\)\); build\(\);/,
-    "chip click = leave that tag; [+] option = join — both through the one pure mutation");
+  assert.match(SRC, /this\._editTagUnion\(g, \{ remove: \[s\.id\] \}\); rebuild\(\);/,
+    "chip ✕ = remove-everywhere, through the one dispatcher");
   assert.match(SRC, /ni\.placeholder = 'new tag…';/, "minting a tag right from a row or the bulk bar");
   assert.match(SRC, /delete nv\.groups;/, "a write normalizes onto the tags key, never re-emitting the legacy one");
   // the eye-off appears ONLY on a hidden session, to un-hide it (hiding lives on the chat tab)
@@ -184,27 +185,30 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
   assert.match(SRC, /item\('All', \{ current: !v\.active \|\| v\.active === 'all' \}\)/);
   assert.match(SRC, /item\('\(untagged\)', \{ current: v\.active === 'untagged' \}\)/);
   assert.match(SRC, /item\('All',[\s\S]{0,300}item\('\(untagged\)',/, "All sits ABOVE (untagged) in the menu");
-  assert.match(SRC, /item\('\(untagged\)',[\s\S]{0,200}for \(const tg of viewTags\(v\)\)/,
-    "…and the tag rows come AFTER both built-ins — the DoD's menu order, pinned end to end");
+  assert.match(SRC, /item\('\(untagged\)',[\s\S]{0,600}for \(const g of viewTagUnion\(v\)\)/,
+    "…and the tag rows come AFTER both built-ins — the DoD's menu order, pinned end to end (the rows are the NAME-KEYED union since the 2026-08-24 ruling)");
 });
 
-test("federation v0: remote tags in the menu + dialog read-only, and the colour join survives every spelling", () => {
-  // executed: the mirror resolves a remote-tag active and labels it host:name (the list_agents idiom)
-  const rt = { active: "TESTHOST-A:g1", tags: [],
-               remoteTags: [{ id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", members: ["m1"] }] };
-  assert.equal(viewVisible(rt, "m1"), true);
-  assert.equal(viewVisible(rt, "m2"), false);
-  assert.equal(viewLabel(rt), "TESTHOST-A:team");
+test("federation, NAME-KEYED (user ruling 2026-08-24): one name = one row/label/union — kernels are plumbing", () => {
+  // the ruling superseded the v0 host-marked two-rows render: "if the UX requires understanding
+  // that tags exist across different kernels, it is not good". Executed on the mirror:
+  const both = { active: "TESTHOST-A:g1",
+                 tags: [{ id: "gL", name: "team", color: "#123456", members: ["local1"] }],
+                 remoteTags: [{ id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", color: "#DD42FF", members: ["m1"] }] };
+  assert.equal(viewLabel(both), "team", "the NAME, never a host prefix");
+  assert.equal(viewVisible(both, "m1"), true, "the union: the remote store's member shows");
+  assert.equal(viewVisible(both, "local1"), true, "…and the local store's, under ONE view");
+  assert.equal(viewVisible(both, "other"), false);
+  const u = viewTagUnion(both);
+  assert.equal(u.length, 1, "one name = one identity — the twin-chip render is gone");
+  assert.equal(u[0].color, "#123456", "the LOCAL store's colour wins the render, deterministically");
+  assert.deepEqual(u[0].members.slice().sort(), ["local1", "m1"]);
   assert.equal(viewVisible({ active: "TESTHOST-A:g1", tags: [] }, "m2"), true, "gone → falls open");
-  // the menu unions attached kernels' tags read-only (owner colour, host-marked, pick-only)
-  assert.match(SRC, /for \(const rt of \(v\.remoteTags \|\| \[\]\)\)/);
-  assert.match(SRC, /item\(\(rt\.host \? rt\.host \+ ':' : ''\) \+ \(rt\.name \|\| 'tag'\),/);
-  // the dialog renders a remote kernel's chip read-only: dashed border, host prefix, NO ✕
-  assert.match(SRC, /border:1px dashed ' \+ rc \+ ';/);
-  assert.match(SRC, /read-only here; edit with: romp tag --host/);
-  // the gray-glyph fix (the user 2026-08-24): a message endpoint can spell a session bare,
-  // host-prefixed, or third-kernel-prefixed — on an exact miss the join retries by the bare sid
-  // tail (sids are uuids, globally unique), so the owner's colour always lands
+  // the menu: one row per union tag, picked via the handiest id (local first)
+  assert.match(SRC, /for \(const g of viewTagUnion\(v\)\)/);
+  assert.match(SRC, /pick\(g\.localId \|\| g\.ids\[0\]\)/);
+  assert.doesNotMatch(SRC, /border:1px dashed/, "no dashed twin chips anywhere — one solid chip per name");
+  // the gray-glyph fix (unchanged): on an exact miss the colour join retries by the bare sid tail
   assert.match(SRC, /s = data\.sessions\.find\(\(x\) => x\.id === bare \|\| String\(x\.id\)\.endsWith\(':' \+ bare\)\);/);
 });
 
@@ -290,18 +294,66 @@ test("executed: tagEditFailed reverts the optimistic copy and keeps the reason f
   assert.equal(p._tagEditErr.error, "not reachable");
 });
 
-test("federation v1 source pins: the dialog edits remote tags in place, routed home, loudly on failure", () => {
-  // the remote header (rename/recolor/delete) and chip ✕ dispatch through ONE method
-  assert.match(SRC, /this\._editRemoteTag\(rtg, \{ rename: nv \}\);/);
-  assert.match(SRC, /this\._editRemoteTag\(rtg, \{ color: c \}\); build\(\);/);
-  assert.match(SRC, /this\._editRemoteTag\(rtg, \{ delete: true \}\);/);
-  assert.match(SRC, /this\._editRemoteTag\(rt, \{ remove: \[s\.id\] \}\); build\(\);/);
-  assert.match(SRC, /this\._editRemoteTag\(rt, \{ add: rowIds\.slice\(\) \}\); build\(\);/);
-  // no hook (the Obsidian panel) → read-only stays, refusal immediate and visible
+test("federation v1+ruling source pins: header/chips route through the UNION dispatcher, loudly on failure", () => {
+  // rename/recolor/delete fan out to EVERY home; chip ✕ removes everywhere; add prefers local
+  assert.match(SRC, /this\._editTagUnion\(tg, \{ rename: nv \}\);/);
+  assert.match(SRC, /this\._editTagUnion\(tg, \{ color: c \}\); build\(\);/);
+  assert.match(SRC, /this\._editTagUnion\(tg, \{ delete: true \}\);/);
+  assert.match(SRC, /this\._editTagUnion\(g, \{ remove: \[s\.id\] \}\); rebuild\(\);/);
+  assert.match(SRC, /this\._editTagUnion\(g, \{ add: rowIds\.filter\(\(id\) => g\.members\.indexOf\(id\) < 0\) \}\); rebuild\(\);/);
+  // the remote transport underneath is unchanged: no hook (the Obsidian panel) → read-only + an
+  // immediate visible refusal; the error line is dismissible and names the owner
   assert.match(SRC, /typeof window\.__rompTimelineEditTag !== 'function'/);
-  // the error line is dismissible and names the owner
   assert.match(SRC, /er\.createSpan\(\{ text: '⚠ ' \+ \(this\._tagEditErr\.host \? this\._tagEditErr\.host \+ ': ' : ''\) \+ this\._tagEditErr\.error \}\);/);
-  // local tags still post the whole blob — zero behavior change (the editTag op is remote-only)
+  // a NEW tag still mints locally, posting the whole blob (zero local-path change)
   assert.match(SRC, /nv\.tags = viewTags\(nv\)\.concat/);
+});
+
+test("executed: the union dispatcher — add prefers local, remove reaches every store, delete fans out", () => {
+  const p: any = Object.create(TimelinePanel.prototype);
+  const setViews: any[] = []; const remote: any[] = [];
+  p._setViews = (v: any) => setViews.push(v);
+  p._editRemoteTag = (rt: any, e: any) => remote.push([rt.id, e]);
+  const rtA = { id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", members: ["m1", "x"] };
+  const rtB = { id: "TESTHOST-B:g7", host: "TESTHOST-B", name: "team", members: ["m1"] };
+  const local = { id: "gL", name: "team", color: "#123456", members: ["m1"] };
+  p._views = { active: "all", hidden: [], tags: [local], remoteTags: [rtA, rtB] };
+  p._pendingViews = null; p._pendingTagEdits = {};
+  const g = { name: "team", color: "#123456", members: ["m1", "x"], ids: ["gL", rtA.id, rtB.id],
+              localId: "gL", homes: ["TESTHOST-A", "TESTHOST-B"], remotes: [rtA, rtB] };
+  // ADD prefers the local store when the name exists locally — no remote call at all
+  p._editTagUnion(g, { add: ["new1"] });
+  assert.equal(setViews.length, 1);
+  assert.deepEqual(setViews[0].tags[0].members.slice().sort(), ["m1", "new1"]);
+  assert.equal(remote.length, 0, "add lands locally, never forks to remotes");
+  // …and on the single home when the name is remote-only
+  const gRemote = { ...g, localId: null, ids: [rtA.id], homes: ["TESTHOST-A"], remotes: [rtA] };
+  p._editTagUnion(gRemote, { add: ["new2"] });
+  assert.deepEqual(remote.pop(), ["TESTHOST-A:g1", { add: ["new2"] }]);
+  // REMOVE removes the (name, member) pair from EVERY store holding it — never half-works
+  setViews.length = 0; remote.length = 0;
+  p._editTagUnion(g, { remove: ["m1"] });
+  assert.equal(setViews.length, 1, "the local store cleans");
+  assert.deepEqual(remote.map((r: any) => r[0]).sort(), ["TESTHOST-A:g1", "TESTHOST-B:g7"],
+    "…and BOTH remote stores holding the pair");
+  // a remote NOT holding the member is left alone
+  setViews.length = 0; remote.length = 0;
+  p._editTagUnion(g, { remove: ["x"] });
+  assert.deepEqual(remote.map((r: any) => r[0]), ["TESTHOST-A:g1"], "only the holder is touched");
+  // DELETE fans out to every home
+  setViews.length = 0; remote.length = 0;
+  p._editTagUnion(g, { delete: true });
+  assert.equal(setViews.length, 1);
+  assert.equal(setViews[0].tags.length, 0, "the local tag goes");
+  assert.deepEqual(remote.map((r: any) => r[1].delete), [true, true], "…and every remote home");
+});
+
+test("the lane gear carries the SAME tag editor — the shared builders, never a fork (the user 2026-08-24)", () => {
+  // both surfaces call the one chip builder and the one join menu
+  assert.ok((SRC.match(/this\._tagChips\(/g) || []).length >= 2, "dialog rows AND the gear");
+  assert.ok((SRC.match(/this\._tagJoinMenu\(/g) || []).length >= 2, "dialog [+] menus AND the gear");
+  // the gear's section: compact label row + [+] behind it, menu vocabulary throughout
+  assert.match(SRC, /const tlab = trow\.createSpan\(\{ text: 'Tags' \}\);/);
+  assert.match(SRC, /this\._tagJoinMenu\(am, \[s\.id\], build\);/);
 });
 

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -142,3 +142,13 @@ test("executed: a REMOTE tag is a view too — resolved, labeled by its host, go
   assert.equal(viewsKey(a), viewsKey(b));
 });
 
+test("executed: a tag view is the NAME-KEYED union (user ruling 2026-08-24) — kernels are plumbing", () => {
+  const both = { active: "gL",
+                 tags: [{ id: "gL", name: "team", members: ["local1"] }],
+                 remoteTags: [{ id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", members: ["m1"] }] };
+  assert.equal(viewVisible(both, "local1"), true);
+  assert.equal(viewVisible(both, "m1"), true, "the remote store's member joins the local id's view");
+  assert.equal(viewVisible(both, "other"), false);
+  assert.equal(viewVisible({ ...both, active: "TESTHOST-A:g1" }, "local1"), true, "either id, same union");
+});
+

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -33,9 +33,13 @@ export function viewVisible(views: SessionViews | null | undefined, id: string):
     if (Array.isArray(views.hidden) && views.hidden.includes(id)) return false;
     return !viewTags(views).some((t) => (t.members || []).includes(id));
   }
-  const t = viewTags(views).find((x) => x.id === views.active)
-    || (views.remoteTags || []).find((x) => x.id === views.active);   // a remote tag is a view too (federation v0)
-  return t ? (t.members || []).includes(id) : true;
+  // a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24: a tag is its NAME; kernels are
+  // plumbing) — whichever store's id is active, membership joins every same-name tag's
+  const act = viewTags(views).find((x) => x.id === views.active)
+    || (views.remoteTags || []).find((x) => x.id === views.active);
+  if (!act) return true;
+  const same = viewTags(views).concat(views.remoteTags || []).filter((x) => x.name === act.name);
+  return same.some((t) => (t.members || []).includes(id));
 }
 
 // one canonical serialization for echo comparison — the kernel normalizer re-sorts lists and may


### PR DESCRIPTION
## The ruling (user, 2026-08-24): kernels are plumbing

The federated tag UX rendered twin near-identical chips per row (dashed `devbox: romp_workers` beside solid `romp_workers`). Now **a tag is its NAME, everywhere**:

- **Name-keyed presentation** (`viewTagUnion`, mirrored in `session-views.ts` and kernel `_view_visible`): one name = one chip / one menu row / one dialog identity — membership the **union** across every kernel defining the name, the **local store's colour** winning deterministically. No host prefixes, no dashed/solid split; home detail lives in the tooltip at most. Whichever store's id is active, the view shows the union — all three deciders agree, pinned in all three homes.
- **Edits route under the hood** through one union dispatcher (`_editTagUnion`; the v1 transport unchanged beneath): **add prefers local** (else the single home); **remove removes the (name, member) pair from every store holding it** — never half-works; rename/recolor/delete fan out to every home. New tags mint locally. Stored duplicates stay separate (anti-clobber) — they just present as one, so the screenshot's twin-chip state renders as one chip per tag per session immediately.
- **Kept**: optimistic overlay per remote home, loud owner-named `tagEditFailed`, viewer-local active/hidden, explicit `romp tag --host`.

## The gear (user, same day)

The lane gear menu gains a compact **Tags** section — the session's chips (✕ = remove-everywhere) plus [+] to join or mint — the **same shared builders** (`_tagChips`/`_tagJoinMenu`) the dialog rows and bulk bar now call. Never a fork; menu vocabulary throughout. (The chat tab context menu deliberately does not gain a Tags row — noted per the dispatch.)

## Tests

- Executed: `viewTagUnion` (one name → one identity, union members, local colour), union visibility via either id (panel + `session-views.test.ts` + `tests/test_timeline_views.py` — all three deciders), the union dispatcher (add-prefers-local, add-to-single-home, remove-everywhere incl. the not-holding store left alone, delete fan-out).
- The old two-rows/host-marked pins retargeted with the ruling cited; shared-builder reuse pinned (both surfaces call both builders); gear section pins; no dashed chips anywhere.
- Full suites green: 5428 python tests (+281 subtests), 2306 JS tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)