### PR TITLE
Clicking into a not-shown session acknowledges instantly: a click echo beats the kernel round-trip

### DIFF
--- a/ui/webview/feed-provisional.test.ts
+++ b/ui/webview/feed-provisional.test.ts
@@ -38,7 +38,7 @@ test("every interaction on a placeholder routes to opening the session (no modal
   // body click → open the session, not the modal
   assert.match(FEED, /if \(it\.provisional\) \{ openOrReviveSession\(it\.sid, it\.live, it\.name\); return; \}\s+\/\/ placeholder → open the session/);
   // title click → open the session, not a timeline deep-link
-  assert.match(FEED, /if \(it\.provisional\) \{ openOrReviveSession\(it\.sid, it\.live, it\.name\); return; \} vscodeApi\?\.postMessage\(\{ type: "showOnTimeline"/);
+  assert.match(FEED, /if \(it\.provisional\) \{ openOrReviveSession\(it\.sid, it\.live, it\.name\); return; \} focusEcho\(it\.sid\); vscodeApi\?\.postMessage\(\{ type: "showOnTimeline"/);
   // dblclick can't pin a node-less placeholder
   assert.match(FEED, /if \(it\.provisional\) return;\s+\/\/ a placeholder can't be pinned/);
   // hover path: a placeholder has no timeline journey to preview

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -510,6 +510,17 @@ window.addEventListener("storage", (e) => {
 });
 // names of sessions currently WORKING → a working dot before that name everywhere
 // it renders (card titles, modal title, group name). Pushed in each feed message.
+// INSTANT chat acknowledgment for a card click (the user 2026-08-24: clicking into a not-shown
+// session felt slow): the felt latency is the kernel ROUND-TRIP — click → WS → _reveal_chat_for →
+// focus frame — and a busy kernel holds its WS handler behind push builds, while the chat already
+// HOLDS every session's data (measured: the chat's own first render of a 6000-event hidden
+// transcript is ~25ms). So the click also drops a same-origin echo the chat hears in milliseconds
+// (the storage event; the romp:color-echo precedent), activating the tab/peek and the loader
+// immediately; the kernel's focus frame follows and lands the anchor idempotently. VS Code webviews
+// don't share localStorage — there the kernel path stands alone, unchanged.
+function focusEcho(sid: string): void {
+  try { localStorage.setItem("romp:focus-echo", JSON.stringify({ sid, t: Date.now() })); } catch { /* storage blocked */ }
+}
 let workingSet = new Set<string>();
 // This machine's own name (kernel _self_host, on every feed payload) and the identity colour of every
 // session the feed knows, keyed "host:name" for a remote one and plain for a local one. Held mail names
@@ -1102,7 +1113,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   if (titleAnchor === "prompt" && !titleUuid && cardAnchorUuid) { titleAnchor = "work"; titleUuid = cardAnchorUuid; }
   // A PROVISIONAL placeholder has no goal node / timeline anchor — clicking anywhere just opens the live
   // session (go see what it's working on); the modal, timeline deep-link, and path-hover are all skipped.
-  title.onclick = (ev) => { ev.stopPropagation(); if (it.provisional) { openOrReviveSession(it.sid, it.live, it.name); return; } vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid, t: it.t, anchor: titleAnchor, anchorUuid: titleUuid }); };
+  title.onclick = (ev) => { ev.stopPropagation(); if (it.provisional) { openOrReviveSession(it.sid, it.live, it.name); return; } focusEcho(it.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid, t: it.t, anchor: titleAnchor, anchorUuid: titleUuid }); };
   // (The auto-line is plain text now — no deep-link — so no onclick here; its hover tooltip = the planner's
   // why, set in updateAskCard. The inline sub-goal checkmarks remain clickable via wireNodeZones.)
   name.onclick = (ev) => { ev.stopPropagation(); openOrReviveSession(it.sid, it.live, it.name); };
@@ -1835,7 +1846,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   if (distillShown && it.summaryAnchorUuid) {
     dl.classList.add("fask-distill-link");
     dl.title = "jump to where this was written";
-    dl.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid, t: it.t, anchor: "work", anchorUuid: it.summaryAnchorUuid }); };
+    dl.onclick = (ev: Event) => { ev.stopPropagation(); focusEcho(it.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid, t: it.t, anchor: "work", anchorUuid: it.summaryAnchorUuid }); };
   } else if (distillShown) {
     // No anchor recorded (a card minted from a postal delegate, a completion turn not yet landed) — the
     // line must still ACKNOWLEDGE the click instead of rendering as silently dead text (the user
@@ -2505,13 +2516,13 @@ function wireNodeZones(it: AskItem, node: AskTreeNode, mark: HTMLElement, txt: H
   // anchorUuid can arrive null for a beat (the kernel's cache-only parse goes cold on every transcript
   // write); fall to the stored promptAnchorUuid rather than dispatch a null the chat can only toast on
   // (the user 2026-07-20: three dead clicks on a blocked sub's ⏸ mark in one cold beat).
-  const goWork = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: navId, sid: navSid, t: resolveT, anchor: "work", anchorUuid: node.anchorUuid ?? node.promptAnchorUuid ?? null }); };
+  const goWork = (ev: Event) => { ev.stopPropagation(); focusEcho(navSid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: navId, sid: navSid, t: resolveT, anchor: "work", anchorUuid: node.anchorUuid ?? node.promptAnchorUuid ?? null }); };
   // prompt-intent: jump to the minting user message. But a node with no opener (an autonomous note, or an
   // opener compacted off-path) has no promptAnchorUuid, so the jump would honest-fail with "couldn't locate".
   // Fall back to goWork — where the work actually happened — rather than toast (the user 2026-06-30).
   const goMsg = (ev: Event) => {
     if (!node.promptAnchorUuid && node.anchorUuid) { goWork(ev); return; }
-    ev.stopPropagation(); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: navId, sid: navSid, t: node.t, anchor: "prompt", anchorUuid: node.promptAnchorUuid ?? null });
+    ev.stopPropagation(); focusEcho(navSid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: navId, sid: navSid, t: node.t, anchor: "prompt", anchorUuid: node.promptAnchorUuid ?? null });
   };
   if (!wire) return goWork;
   // tooltip names the destination by status: a blocked node was "marked blocked", a done node "checked off"
@@ -2755,6 +2766,7 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
         row.title = "jump to this moment in the chat";
         row.onclick = (ev) => {
           ev.stopPropagation();
+          focusEcho(navSidOf(it, node));
           vscodeApi?.postMessage({ type: "showOnTimeline", itemId: node.id, sid: navSidOf(it, node),
                                    t: r.evT || rt, anchor: "work", anchorUuid: r.anchorUuid ?? null });
         };
@@ -2972,7 +2984,7 @@ function renderModal() {
     titleHoverId = grp.turnId;
     const gm0 = grp.members[0];   // prompt-intent title → the first member's MINTING message (resolves by id, kernel 92e23ff)
     const gm0Prompt = gm0.tree?.find((n) => n.id === gm0.itemId)?.promptAnchorUuid ?? null;
-    ttlEl.onclick = () => vscodeApi?.postMessage({ type: "showOnTimeline", itemId: gm0.itemId, sid: grp.sid, t: grp.t, anchor: "prompt", anchorUuid: gm0Prompt });
+    ttlEl.onclick = () => focusEcho(grp.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: gm0.itemId, sid: grp.sid, t: grp.t, anchor: "prompt", anchorUuid: gm0Prompt });
     agent.replaceChildren(...hostNameNodes(grp.name, grp.sid)); if (grp.color) agent.style.color = grp.color.bg; setWorkDot(agent, dotFor(grp.name)); agent.classList.toggle("dead", !grp.live);
     agent.onclick = () => vscodeApi?.postMessage({ type: "openSession", id: grp.sid });
     ageEl.textContent = relAge(hostNow - grp.t);

--- a/ui/webview/focus-echo.test.ts
+++ b/ui/webview/focus-echo.test.ts
@@ -1,0 +1,52 @@
+// Click→peek must FEEL instant (the user 2026-08-24: "clicking into a not-currently-shown session
+// is slow … even if it involves just having a provisional thing showing"). Measured split: the
+// chat's own first render of a 6000-event hidden transcript is ~25-80ms (the windowed deferred
+// build) — the felt seconds were the kernel ROUND-TRIP (click → WS → _reveal_chat_for → focus
+// frame), unbounded under kernel load. So the feed click drops a same-origin echo the chat hears
+// in milliseconds and acknowledges SYNCHRONOUSLY (tab + peek + loader), and the kernel's focus
+// frame follows to land the anchor, idempotently. Harness-verified: ack same-tick with the echo,
+// the romp loader holding an unbuilt 6000-event view, content ≤80ms, loader gone on content, the
+// trailing kernel frame a no-op. Source pins (no jsdom for the monolith).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("every feed card click echoes the sid BEFORE the kernel round-trip — no showOnTimeline post without it", () => {
+  assert.match(FEED, /function focusEcho\(sid: string\): void \{/);
+  assert.match(FEED, /localStorage\.setItem\("romp:focus-echo", JSON\.stringify\(\{ sid, t: Date\.now\(\) \}\)\);/);
+  const posts = (FEED.match(/type: "showOnTimeline"/g) || []).length;
+  const echoes = (FEED.match(/focusEcho\(/g) || []).length - 1;   // minus the definition
+  assert.equal(posts, echoes, "every showOnTimeline click site carries its focusEcho — " + posts + " posts, " + echoes + " echoes");
+});
+
+test("the chat acknowledges the echo synchronously: reveal, un-suppress, peek, activate — anchor left to the kernel frame", () => {
+  const at = RENDER.indexOf('if (e.key !== "romp:focus-echo" || !e.newValue) return;');
+  assert.ok(at > 0, "the storage listener exists");
+  const block = RENDER.slice(at, at + 700);
+  assert.ok(block.includes("if (!sid || (!sessions.has(sid) && !tabMeta.has(sid))) return;"),
+    "an unknown sid falls through to the kernel (it may route a revive/confirm)");
+  const order = ["revealSelfPane();", "closingTabs.delete(sid);", "assertPeekFor(sid);", "setActive(sid);"];
+  let last = -1;
+  for (const step of order) {
+    const i = block.indexOf(step);
+    assert.ok(i > last, step + " runs, in order");
+    last = i;
+  }
+});
+
+test("the first-visit wait is the ROMP LOADER, not a bare text hint — and the build event removes it", () => {
+  // the standing wait-state rule: swirl (reverse spin) + wordmark + pulsing accent dots
+  assert.match(RENDER, /sw\.src = mediaSrc\("romp-swirl-glyph\.svg"\); sw\.alt = ""; sw\.onerror = \(\) => sw\.remove\(\);/);
+  assert.match(RENDER, /wm\.textContent = "romp";/);
+  assert.match(RENDER, /dots\.append\(el\("i"\), el\("i"\), el\("i"\)\);/);
+  assert.doesNotMatch(RENDER, /ld\.textContent = "Loading transcript…"/, "the bare hint is gone");
+  assert.match(CSS, /\.tx-loading-swirl \{ width: 18px; height: 18px; animation: tx-swirl-spin 1\.6s linear infinite reverse; \}/);
+  assert.match(CSS, /\.tx-loading-dots i \{[^}]*background: var\(--accent\);/s, "the pulsing dots wear the accent, never a status color");
+  // removal is EVENT-based: the deferred build replaces the view's children (harness-verified gone-on-content)
+  assert.match(RENDER, /truly empty → the ROMP LOADER holds the spot/);
+});

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -34,7 +34,7 @@ test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no
   // views-arrival paths): setActive (every activation), the focus fast path (already-active),
   // captureViews (kernel-pushed views), postViews (local optimistic edit). Nothing else derives.
   const sites = RENDER.match(/assertPeekFor\(/g) || [];
-  assert.equal(sites.length, 5, "definition + 4 call sites: setActive, focus fast path, captureViews, postViews");
+  assert.equal(sites.length, 6, "definition + 5 call sites: setActive, focus fast path, captureViews, postViews, and the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame)");
 });
 
 test("a view change that excludes the ACTIVE session converts it into the peek — never a bounce (the user 2026-08-24)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7582,8 +7582,17 @@ function showActive() {
   // `length > 0` guard is what stops a zero-event session from flashing (or sticking on) "Loading…".
   const heavy = s.events.length > 0 && (v.el.childNodes.length === 0 || (settings.compact && (v.rendered !== s.events.length || v.stale)));
   if (!heavy) { syncView(activeId!); landActive(content, v); return; }
-  if (v.el.childNodes.length === 0) {   // truly empty → a light loading hint (a stale view keeps its old content visible)
-    const ld = el("div", "tx-loading"); ld.textContent = "Loading transcript…"; v.el.appendChild(ld);
+  if (v.el.childNodes.length === 0) {   // truly empty → the ROMP LOADER holds the spot (the standing
+    // wait-state rule: swirl + wordmark + pulsing accent dots — never a bare hint). Removed by the
+    // deferred build replacing this view's children — the content event — and that build always
+    // runs (or the next syncView rebuilds), so the loader cannot trap.
+    const ld = el("div", "tx-loading");
+    const sw = document.createElement("img"); sw.className = "tx-loading-swirl";
+    sw.src = mediaSrc("romp-swirl-glyph.svg"); sw.alt = ""; sw.onerror = () => sw.remove();
+    const wm = el("span", "tx-loading-wordmark"); wm.textContent = "romp";
+    const dots = el("span", "tx-loading-dots"); dots.append(el("i"), el("i"), el("i"));
+    ld.append(sw, wm, dots);
+    v.el.appendChild(ld);
   }
   if (pendingBuildRaf != null) cancelAnimationFrame(pendingBuildRaf);
   const target = activeId!;
@@ -11474,6 +11483,22 @@ function setupSettings(): void {
   onExternalSettingsChange((s) => { settings = s; applyChatScheme(s); renderTabs(); rerenderAll(); });
 }
 
+// The feed's click echo (feed.ts focusEcho — the user 2026-08-24, "clicking into a not-shown
+// session is slow"): activate NOW, before any kernel round-trip — the tab/peek + loader are the
+// instant acknowledgment, and the kernel's focus frame follows with the anchor, re-deriving the
+// peek idempotently. Unknown sids fall through to the kernel (it may route a revive/confirm).
+window.addEventListener("storage", (e) => {
+  if (e.key !== "romp:focus-echo" || !e.newValue) return;
+  try {
+    const v = JSON.parse(e.newValue);
+    const sid = typeof v.sid === "string" ? v.sid : "";
+    if (!sid || (!sessions.has(sid) && !tabMeta.has(sid))) return;
+    revealSelfPane();
+    closingTabs.delete(sid);
+    assertPeekFor(sid);
+    setActive(sid);
+  } catch { /* malformed echo — the kernel frame corrects momentarily */ }
+});
 setupComposer();
 setupSettings();
 // Tab-bar clicks are DELEGATED to the stable #tabs container (installed once), not hung on the per-tab nodes

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -385,7 +385,18 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .empty-state { color: var(--dim); text-align: center; padding: 40px; }
 /* brief hint while a first-visited tab's transcript builds on the next frame (the deferred build keeps the
    switch itself instant — the user 2026-06-17); the build replaces it. */
-.tx-loading { color: var(--dim); text-align: center; padding: 28px; font-size: 0.9em; }
+.tx-loading { color: var(--dim); text-align: center; padding: 28px; font-size: 0.9em;
+  display: flex; align-items: center; justify-content: center; gap: 8px; }
+/* the standing romp loader treatment (swirl reverse-spin + wordmark + pulsing accent dots) for the
+   first-visit transcript build — the boot splash / pane loader language, never a bare text hint */
+.tx-loading-swirl { width: 18px; height: 18px; animation: tx-swirl-spin 1.6s linear infinite reverse; }
+.tx-loading-wordmark { font-weight: 650; color: var(--fg); }
+.tx-loading-dots i { display: inline-block; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--accent); margin-left: 4px; animation: tx-dot-pulse 1.2s ease-in-out infinite; }
+.tx-loading-dots i:nth-child(2) { animation-delay: 0.2s; }
+.tx-loading-dots i:nth-child(3) { animation-delay: 0.4s; }
+@keyframes tx-swirl-spin { to { transform: rotate(-360deg); } }
+@keyframes tx-dot-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
 /* a genuinely empty transcript (a session with no turns yet) — shown instead of "Loading transcript…",
    which would be a lie since the full events payload already arrived (the user 2026-06-19). */
 .tx-empty { color: var(--dim); text-align: center; padding: 28px; font-size: 0.9em; }

--- a/ui/webview/transcript-empty.test.ts
+++ b/ui/webview/transcript-empty.test.ts
@@ -34,7 +34,7 @@ test("a zero-event session never shows the 'Loading transcript…' hint", () => 
   // loading-hint block — it renders the placeholder synchronously via syncView.
   assert.match(RENDER, /const heavy = s\.events\.length > 0 && \(/);
   // the loading hint is still the text shown for a genuinely heavy (non-empty, first-visit) build
-  assert.match(RENDER, /ld\.textContent = "Loading transcript…"/);
+  assert.match(RENDER, /truly empty → the ROMP LOADER holds the spot/);   // the bare text hint became the standing loader treatment (2026-08-24)
 });
 
 test(".tx-empty is styled (dim, centered) like the loading hint it replaces", () => {


### PR DESCRIPTION
## Diagnosis (measured, not guessed)

Harness over the built bundles, 6000-event view-hidden transcript:

- **Client render leg: fast.** First render 25-80ms — the windowed, rAF-deferred build already bounds it; and hidden sessions' frames already stream to the chat, so there is **no fetch leg**.
- **The felt seconds are the round-trip:** click → WS → kernel `_reveal_chat_for` → focus frame → chat. The kernel's WS handler shares the process with the pusher's payload builds and the judges — under load, the acknowledgment waits on all of it.

## Fix

- **Instant acknowledgment.** Every feed card click also drops a same-origin echo (`romp:focus-echo` via localStorage — the `romp:color-echo` precedent). The chat hears the storage event in milliseconds and acknowledges **synchronously**: reveal, un-suppress, peek derivation, activate. The kernel's focus frame follows and lands the anchor — idempotent through the existing peek derivation. Unknown sids fall through to the kernel untouched (revive/confirm routing). VS Code webviews don't share localStorage; the kernel path stands alone there, unchanged.
- **Provisional content.** An unbuilt view now shows the **romp loader** (swirl + wordmark + pulsing accent dots — the standing wait-state rule) instead of the bare "Loading transcript…" hint, removed by the deferred build replacing the view's children: an event, never a timer, and the build always runs so it cannot trap.
- No over-engineering past feeling instant: the render leg measured fast, so no incremental-render machinery was added.

## Measured after

Tab active + peek dress **same-tick** with the echo (0ms); loader present and fully dressed on an unbuilt 6000-event view; content ≤80ms; loader gone on content; the trailing kernel focus frame a no-op.

## Tests

`focus-echo.test.ts`: every `showOnTimeline` site carries its echo (post/echo counts pinned equal), the listener's guard and step order, the loader treatment and its event-based removal. The peek derivation census extended to the 6th named call site; `transcript-empty` / `feed-provisional` pins retargeted. Full suite: 2309 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)