### PR TITLE
Peer-wait bookkeeping: stamps name their peer; cross-host delegates track and complete

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3823,7 +3823,8 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
             # through machinery that already exists. Lifted by the closer's next audit of the goal.
             t = _target(o)
             k = o.get("kind")
-            if k == "peer" and t and not _open_peer_asks(nodes[t]["id"].rsplit(":", 1)[0]):
+            kp = (_open_ask_peers(nodes[t]["id"].rsplit(":", 1)[0]) if k == "peer" and t else None)
+            if k == "peer" and t and not kp:
                 # the peer-kind write gate (the user 2026-08-24, same rule as apply_close): no open
                 # sent-question, no peer wait. DEMOTED to kindless rather than dropped — this op's
                 # whole job is marking "progressing, nothing owed to the user" so the nudge-failed
@@ -3832,7 +3833,7 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
                 # any-answer supersede and the closer's next lift).
                 k = None
             if t and record_verdict(store, nodes[t], "planner", "awaiting", seg_t, why=o["why"], seg=seg_id,
-                                    await_kind=k):
+                                    await_kind=k, await_peers=(kp if k == "peer" else None)):
                 touched = t                           # mt deliberately NOT bumped: an annotation, not work
         elif do == "extend":
             # A queued-fragment landing (the opener's sibling <note>, the user 2026-07-11): this message
@@ -5975,7 +5976,7 @@ LOG_CAP = 64                             # per-node verdict-log bound (a node ra
 
 
 def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=False, undo=False, lift=False,
-                   await_kind=None):
+                   await_kind=None, await_peers=None):
     """P3.1 DUAL-WRITE (the user 2026-07-06): the gate AND the recorder, fused into the one seam every
     verdict write goes through. Asks may_apply; when allowed, appends the event to the node's
     append-only verdict LOG and returns True — the caller then writes the flags exactly as before
@@ -6004,6 +6005,10 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
                     # what an `awaiting` assert waits ON (AWAIT_KINDS; "kind" is taken by the verdict kind).
                     # Absent = a kindless legacy stamp, which every rule treats exactly as before the enum.
                     **({"awaitKind": await_kind} if await_kind else {}),
+                    # WHICH peer(s) an awaiting-peer assert waits on (2026-08-24): the admit gate's
+                    # open-ask keys, so the supersede can match the awaited pair's answer and stop
+                    # letting unrelated mail from the same log end unrelated waits. Absent = legacy.
+                    **({"awaitPeers": sorted(await_peers)} if await_peers else {}),
                     "at": int(time.time())})
         if len(log) > LOG_CAP:
             del log[:len(log) - LOG_CAP]
@@ -6083,7 +6088,7 @@ def _fold_node(nd):
                    audited turn's own processing, not a fresh event (see the guard in the loop)."""
     state, floor = "open", 0
     cur_settle, prev_settle = None, None
-    awaiting_why = awaiting_at = awaiting_kind = None     # the live ⏳ stamp (see docstring); None = not awaiting
+    awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None     # the live ⏳ stamp (see docstring); None = not awaiting
     done_why = block_why = None           # the landing verdicts' rationale (doneWhy/blockWhy derivation)
     held = pending = False                # held: an unanswered USER reopen pins the node open (no bottom-up
     #                                       re-completion); pending: an unanswered msg-reopen wears the chip.
@@ -6107,7 +6112,7 @@ def _fold_node(nd):
                 # peer's postal reply sat wedged-invisible in Working. Same-trigger symmetry as the
                 # assert's own `t >= floor` equality-lands rule below: within one turn the reopen is the
                 # trigger, the wait is how the turn ENDED.
-                awaiting_why = awaiting_at = awaiting_kind = None
+                awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
             if e.get("undo") and clear_snap is not None:
                 state, cur_settle, prev_settle = clear_snap      # restore what the cross-off displaced
                 clear_snap = None
@@ -6130,13 +6135,13 @@ def _fold_node(nd):
                 state = "done"
                 done_why = e.get("why") or done_why
                 reopen_snap = None
-                awaiting_why = awaiting_at = awaiting_kind = None
+                awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
         elif kind == "block":
             if src in ("user", "agent") or t > floor:
                 state = "blocked"
                 block_why = e.get("why") or block_why
                 reopen_snap = None
-                awaiting_why = awaiting_at = awaiting_kind = None
+                awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
         elif kind == "unblock":
             if state == "blocked":
                 state = "open"
@@ -6144,12 +6149,12 @@ def _fold_node(nd):
             clear_snap = (state, cur_settle, prev_settle)
             state = "cleared"
             reopen_snap = None
-            awaiting_why = awaiting_at = awaiting_kind = None
+            awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
         elif kind == "settle":            # display annotation: WHEN the card entered Completed; never state
             cur_settle = t
         elif kind == "awaiting":          # ⏳ annotation (like settle, never state): the closer audited a
             if e.get("lift"):             # turn on this goal — either the wait is (still) on, or it ended
-                awaiting_why = awaiting_at = awaiting_kind = None
+                awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
             elif src in ("user", "agent") or t >= floor:   # done-style floor: equality LANDS — the turn that
                 new_why = e.get("why") or awaiting_why       # processes the user's reply may itself dispatch
                 #                                              and wait (the reply IS that turn's trigger)
@@ -6158,6 +6163,11 @@ def _fold_node(nd):
                 # a neighbor's label onto it would ship an affirmatively wrong kind (review 2026-08-15)
                 awaiting_kind = (e.get("awaitKind")
                                  or (awaiting_kind if new_why == awaiting_why else None))
+                # the awaited-PEER identity (2026-08-24, pair-aware supersede) rides the same
+                # coalesce: a peers-less re-assert of the SAME why keeps the standing identity, a
+                # different why is a different wait
+                awaiting_peers = (e.get("awaitPeers")
+                                  or (awaiting_peers if new_why == awaiting_why else None))
                 awaiting_why = new_why
                 awaiting_at = t
         elif kind == "dismiss":           # the judge rejected the provisional msg-reopen: restore what the
@@ -6173,6 +6183,7 @@ def _fold_node(nd):
             "awaitingWhy": awaiting_why if state == "open" else None,
             "awaitingAt": awaiting_at if state == "open" else None,
             "awaitingKind": awaiting_kind if state == "open" else None,
+            "awaitingPeers": awaiting_peers if state == "open" else None,
             "doneWhy": done_why, "blockWhy": block_why}
 
 
@@ -6385,10 +6396,15 @@ def _materialize_node(nd):
                 nd["awaitingKind"] = f["awaitingKind"]
             else:
                 nd.pop("awaitingKind", None)           # a kindless stamp carries no kind field at all
+            if f.get("awaitingPeers"):
+                nd["awaitingPeers"] = f["awaitingPeers"]   # WHICH peer(s) the wait is on — the pair-aware
+            else:                                          # supersede's key; absent = legacy, pair-blind
+                nd.pop("awaitingPeers", None)
         else:
             nd.pop("awaitingWhy", None)
             nd.pop("awaitingAt", None)
             nd.pop("awaitingKind", None)
+            nd.pop("awaitingPeers", None)
     return f
 
 
@@ -8100,13 +8116,20 @@ def _postal_ask_maps():
     return last_any, last_ask
 
 
+def _open_ask_peers(sid):
+    """The peer keys `sid` itself sent a kind=question to that no reply of any kind has come back
+    for — the awaiting-peer admit gate's evidence AND the identity the stamp records (2026-08-24):
+    _peer_answered's pair-aware supersede matches these exact keys (sids, or the wait maps' own
+    "peer:<host>:<name>" for an unresolved cross-host recipient — both sides derive them from the
+    same alias re-key, so they can never disagree)."""
+    last_any, last_ask = _postal_ask_maps()
+    return sorted(peer for (f, peer), ts in last_ask.items()
+                  if f == sid and last_any.get((peer, f), 0) < ts)
+
+
 def _open_peer_asks(sid):
     """True iff `sid` itself sent a kind=question no reply of any kind has come back for."""
-    last_any, last_ask = _postal_ask_maps()
-    for (f, peer), ts in last_ask.items():
-        if f == sid and last_any.get((peer, f), 0) < ts:
-            return True
-    return False
+    return bool(_open_ask_peers(sid))
 
 
 def _parse_close(raw, menu_len):
@@ -8497,7 +8520,8 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
         elif i in awaiting:
             aw_why = (awaiting[i] or {}).get("why") or None
             aw_kind = (awaiting[i] or {}).get("kind")
-            if aw_kind == "peer" and not _open_peer_asks(nd["id"].rsplit(":", 1)[0]):
+            aw_peers = (_open_ask_peers(nd["id"].rsplit(":", 1)[0]) if aw_kind == "peer" else None)
+            if aw_kind == "peer" and not aw_peers:
                 # the peer-kind write gate (the user 2026-08-24): awaiting-a-peer requires an
                 # outstanding kind=question this session ITSELF sent. A delegate transferred
                 # ownership (the courier handoff graph carries that visibility, with the peer's
@@ -8509,7 +8533,8 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
                 continue
             if nd.get("awaitingWhy") != aw_why:
                 # a changed why is a real event → new row, new anchor (as ever)
-                record_verdict(store, nd, "closer", "awaiting", t, why=aw_why, await_kind=aw_kind)
+                record_verdict(store, nd, "closer", "awaiting", t, why=aw_why, await_kind=aw_kind,
+                               await_peers=aw_peers)
             elif aw_why and aw_kind and not nd.get("awaitingKind"):
                 # a kind GAIN on the standing why lands AT THE ORIGINAL ANCHOR: the stamp's since-time,
                 # the wake's patience, and the peer-supersede ordering all key on the first assertion —
@@ -8517,7 +8542,7 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
                 # an unchanged why coalesces like any same-why re-assert: an LLM relabel (task↔job) is
                 # not new information, and landing it would re-anchor + chew LOG_CAP every audit.
                 record_verdict(store, nd, "closer", "awaiting", nd.get("awaitingAt"),
-                               why=aw_why, await_kind=aw_kind)
+                               why=aw_why, await_kind=aw_kind, await_peers=aw_peers)
         elif nd.get("awaitingWhy") and (touched is None or i <= touched):
             record_verdict(store, nd, "closer", "awaiting", t, lift=True)
     return newly

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8077,7 +8077,7 @@ AWAIT_KINDS = ("agents", "task", "job", "peer", "timer")
 # edge-drop. Dead peers are NOT excluded: the gate asks "does an open ask exist", and a dead peer's
 # wait is the dead-wait sweep's business, not a reason to refuse the stamp.
 _PEER_ASK_RE = re.compile(r"^\s*(?:QUESTION|ASK|Q)\b", re.I)   # legacy pre-`kind` rows only
-_PEER_ASK_CACHE = [None, ({}, {})]   # (mtime_ns, size) , (last_any, last_ask) — one scan per log change
+_PEER_ASK_CACHE = [None, ({}, {}, {})]   # (mtime_ns, size) , (last_any, last_ask, alias) — one scan per log change
 
 
 def _postal_ask_maps():
@@ -8085,7 +8085,7 @@ def _postal_ask_maps():
         st = MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
     except OSError:
-        return {}, {}
+        return {}, {}, {}
     if _PEER_ASK_CACHE[0] == key:
         return _PEER_ASK_CACHE[1]
     last_any, last_ask, rows, alias = {}, {}, [], {}
@@ -8112,8 +8112,8 @@ def _postal_ask_maps():
                 last_ask[(f, t_)] = ts
     except OSError:
         pass
-    _PEER_ASK_CACHE[:] = [key, (last_any, last_ask)]
-    return last_any, last_ask
+    _PEER_ASK_CACHE[:] = [key, (last_any, last_ask, alias)]
+    return last_any, last_ask, alias
 
 
 def _open_ask_peers(sid):
@@ -8122,7 +8122,7 @@ def _open_ask_peers(sid):
     _peer_answered's pair-aware supersede matches these exact keys (sids, or the wait maps' own
     "peer:<host>:<name>" for an unresolved cross-host recipient — both sides derive them from the
     same alias re-key, so they can never disagree)."""
-    last_any, last_ask = _postal_ask_maps()
+    last_any, last_ask, _alias = _postal_ask_maps()
     return sorted(peer for (f, peer), ts in last_ask.items()
                   if f == sid and last_any.get((peer, f), 0) < ts)
 
@@ -10945,6 +10945,41 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                 rollup_status(a_store, False)           # sender just had work close → recompute its columns
                 save_goals(a_sid, a_store)
                 n += 1
+    # REMOTE recipients (the user 2026-08-24): their goal stores live on another kernel, so the
+    # origin back-link above can never fire for them. The local log still records the exact
+    # report-back event: the recipient's REPLY mail — any kind — at/after the delegate's send, the
+    # same event the stamp machinery has treated as a handoff's ending since the 2026-08-18 audit
+    # ("a delegated peer's reply lifts the awaiting stamp"). `relayed` is deliberately NOT it: that
+    # ack only says the ASK was delivered, and completing on delivery would check off undone work.
+    # Granularity is per-PEER, not per-message — the log carries no reply→delegate join, so one
+    # reply completes every outstanding cross-host handoff to that peer sent at/before it; coarse,
+    # but forward-only and honest, where the alternative was a wait no event could ever end. Keys
+    # re-derive from the stored toName exactly as the wait maps do: the alias when the peer has
+    # spoken (it must have, to reply), else the raw relay key.
+    last_any, _la, alias = _postal_ask_maps()
+    for fsid, path, anchor, name in discover(now)[:sessions_cap]:
+        store = load_goals(fsid)
+        changed = False
+        for nid, nd in list(store.get("nodes", {}).items()):
+            h = nd.get("handoff")
+            if not (isinstance(h, dict) and h.get("peer") and not nd.get("nodeComplete")):
+                continue
+            pk = str(h["peer"])
+            if ":" not in pk:                          # a LOCAL recipient: the origin back-link owns it
+                continue
+            keys = {"peer:" + pk}
+            if alias.get(pk):
+                keys.add(alias[pk])
+            reply = max((last_any.get((k, fsid), 0) for k in keys), default=0)
+            if reply and reply >= (nd.get("t") or 0):
+                why = "reported back by %s (delegated cross-host)" % pk
+                if record_verdict(store, nd, "courier", "done", reply, why=why):
+                    _mark_node_done(store, nid, why, reply, src="courier")
+                    changed = True
+                    n += 1
+        if changed:
+            rollup_status(store, False)
+            save_goals(fsid, store)
     if verbose:
         sys.stderr.write("romp-judge: propagated %d delegation completions\n" % n)
     return n
@@ -11004,8 +11039,47 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                     continue
                 pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
                                 _seg_peer_kind(seg), _seg_anchor(seg), str(path)))
-    pending.sort(key=lambda x: x[0])                  # global cross-session oldest-first
+    # CROSS-HOST delegates plant the SENDER-side tracking node here too (the user 2026-08-24, the
+    # paused-cards investigation): the recipient lives on a remote kernel, so no inbound segment
+    # ever reaches this courier and _plant_handoff_track never ran — the sender's goal waited on a
+    # completion event that could not exist (a live specimen's done-line arrived and was relayed in
+    # 90 seconds; the goal sat paused for hours). The sent row is the authoritative record (to_id
+    # "peer:<host>", toName "<host>:<name>", declared kind): plant from it directly, trusting the
+    # DECLARED kind exactly as the parse give-up path always has — no recipient segment exists to
+    # judge, and the send ack already told the sender "they own it now". Declared-only on purpose:
+    # a kindless legacy row is indistinguishable from a coordinate, and planting from a guess mints
+    # noise. handoff.peer stores toName ("<host>:<name>") — the identity every display resolves
+    # (the quiet host: prefix) and the key run_propagate's remote arm re-derives pair keys from.
+    # `tracked` never rides here: the relay drops the flag by design (a primary/satellite pair
+    # cannot span kernels yet). Horizon-bounded like every courier retry, so old history is never
+    # backfilled; idempotent by msgId, so one plant per message ever.
     placed = 0
+    fleet_ids = {f for f, p, a, nm in fleet}
+    try:
+        xrows = []
+        for line in MESSAGES.read_text(errors="replace").splitlines():
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            if (o.get("ev") == "sent" and o.get("kind") == "delegate" and o.get("id")
+                    and o.get("from_id") in fleet_ids and o.get("toName")
+                    and str(o.get("to_id") or "").startswith("peer:")
+                    and now - (o.get("t") or 0) <= COURIER_RETRY_HORIZON):
+                xrows.append(o)
+    except OSError:
+        xrows = []
+    for o in xrows:
+        sstore = load_goals(o["from_id"])
+        if any(isinstance(nd.get("handoff"), dict) and nd["handoff"].get("msgId") == o["id"]
+               for nd in sstore["nodes"].values()):
+            continue
+        head = " ".join(str(o.get("body") or "").split())[:120]
+        _plant_handoff_track(sstore, None, head, str(o["toName"]), str(o["toName"]), int(o["t"]), o["id"])
+        rollup_status(sstore, False)
+        save_goals(o["from_id"], sstore)
+        placed += 1
+    pending.sort(key=lambda x: x[0])                  # global cross-session oldest-first
     for seg_t, fsid, seg_id, text, mid, sender, declared, anchor_uuid, path in pending:
         store = load_goals(fsid)
         if _placed_key(store["placements"], seg_id):  # drift-safe: never re-plant a t-shifted duplicate

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2889,12 +2889,11 @@ def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
             # A KINDLESS stamp keeps the old behavior: it may well be a peer wait (the enum predates
             # it), and a false lift there is the known, tested legacy trade.
             kind = nd.get("awaitingKind")
-            # keyed on the stamp's WRITE time, not the anchor (2026-08-19 audit): awaitingAt is the
-            # audited turn's TRIGGER, which predates the reply that turn solicited — so a fresh
-            # re-stamp was superseded the instant it was filed, contradicting this machinery's own
-            # "a stamp filed AFTER the reply survives" contract. The write time is the closer's
-            # epistemic moment; a reply older than it was already in the audited world.
-            if not (at and answered_at and _stamp_written_at(nd) < answered_at and kind in (None, "peer")):
+            # the compare lives in _peer_stamp_superseded — pair-aware since 2026-08-24 (a stamp
+            # naming its awaited peers ends only on THAT pair's answer), write-time keyed since the
+            # 2026-08-19 audit. `answered_at` here may be the pair-aware _peer_answered(sid) tuple
+            # or a legacy scalar (tests, older callers) — the predicate normalizes both.
+            if not _peer_stamp_superseded(nd, answered_at):
                 cand = (at, nd["awaitingWhy"], kind or "")   # "" keeps max() comparable
                 best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
@@ -2931,7 +2930,7 @@ def _mark_nudge_failed(gid, ev_t=None, wake=False):
             if _session_awaiting(_sid, _path_of(_sid) or "", True):
                 return None
             if _goal_awaiting_stamp(jd.load_goals(_sid).get("nodes", {}), gid,
-                                    answered_at=_peer_answered_at(_sid)):
+                                    answered_at=_peer_answered(_sid)):
                 return None                            # the judge's durable ⏳ stamp says the goal waits on
                 #                                        async work — same rule as above, restart-proof
         except Exception:
@@ -3616,9 +3615,9 @@ def _lift_spent_awaiting(now, tmux):
             # exactly like the reader (job/agents/task/timer stamps stand through mail); DORMANT sessions
             # never reach here (the sweep's own gate above) — the dead-wait conversion reads the stamp RAW
             # on purpose (2026-08-23) and owns that ending.
-            answered = _peer_answered_at(sid)
-            for nd in (list(stamped) if answered else ()):
-                if nd.get("awaitingKind") not in (None, "peer") or _stamp_written_at(nd) >= answered:
+            answered = _peer_answered(sid)
+            for nd in (list(stamped) if answered[0] else ()):
+                if not _peer_stamp_superseded(nd, answered):
                     continue
                 if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
@@ -4079,7 +4078,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
         # last-moment fresh-store re-read (the judges run concurrently with this tick): the wake's whole
         # justification is "the stamp stands and the goal is open" — re-key on the store as written
         _fresh = jd.load_goals(sid)
-        if (not _goal_awaiting_stamp(_fresh.get("nodes", {}), gid, answered_at=_peer_answered_at(sid))
+        if (not _goal_awaiting_stamp(_fresh.get("nodes", {}), gid, answered_at=_peer_answered(sid))
                 or _fresh.get("status", {}).get(gid, "working") != "working"):
             return False
     except Exception:
@@ -4687,7 +4686,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             continue                                 # all open work handed to peers → nothing for THIS session
         if sid in waitfor and nd.get("t", 0) <= waitfor[sid]["since"]:
             continue                                 # awaiting a live peer's reply to a question this goal predates
-        _stamp = _goal_awaiting_stamp_full(nodes, gid, _kids, answered_at=_peer_answered_at(sid))
+        _stamp = _goal_awaiting_stamp_full(nodes, gid, _kids, answered_at=_peer_answered(sid))
         if _stamp:
             # The judge's durable ⏳ stamp (closer awaiting verdict): the goal's latest audited turn ended
             # waiting on async work it dispatched — not a stall, so the status nudge stays off. Restart-
@@ -4974,9 +4973,7 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
             # reviver at all. Same read as the walk and the wake's own re-check (answered_at,
             # peer/kindless only): symmetric ends, no flap — and the sweep's superseded-peer lift
             # retires the raw fields durably a beat later either way.
-            _ans = _peer_answered_at(f[0].rsplit(":", 1)[0])
-            if not (_ans and nd.get("awaitingKind") in (None, "peer")
-                    and _stamp_written_at(nd) < _ans):
+            if not _peer_stamp_superseded(nd, _peer_answered(f[0].rsplit(":", 1)[0])):
                 continue
         keep.append(f)
     return keep
@@ -12123,12 +12120,12 @@ def _session_stamp_read(sid):
         nodes = store.get("nodes", {})
         status = store.get("status", {}) or {}
         best = None
-        answered = _peer_answered_at(sid)              # a peer's later answer supersedes older PEER waits
+        answered = _peer_answered(sid)                 # a peer's later answer supersedes older PEER waits
         for nid, nd in nodes.items():
             if nd.get("awaitingWhy") and not nd.get("rolledUp"):
                 at = nd.get("awaitingAt") or 0
                 kind = nd.get("awaitingKind")
-                if at and answered and _stamp_written_at(nd) < answered and kind in (None, "peer"):
+                if _peer_stamp_superseded(nd, answered):
                     continue                           # peer-scoped (the user 2026-08-15): a reply can only
                 #                                        end a wait that was ON a peer; kindless keeps the
                 #                                        legacy trade. Keyed on the stamp's WRITE time like
@@ -17739,6 +17736,45 @@ def _peer_answered_at(sid):
     return best
 
 
+def _peer_answered(sid):
+    """(answered_any, {peer_key: reply_t}) — _peer_answered_at with the PAIR kept (2026-08-24): the
+    pair-blind scalar let ANY answered exchange supersede ANY peer stamp, so an unrelated coordinate
+    from the same log hid a real wait (three stuck stamps, one ~14h). Stamps that record WHICH
+    peer(s) they await (awaitingPeers, written by the closer's admit gate) are matched against their
+    own pair's reply; identity-less legacy stamps keep the scalar read. Keys are the wait maps' own
+    (sids, or "peer:<host>:<name>" for an unresolved cross-host recipient) — the same alias re-key
+    the admit gate derives them from, so the two sides can never disagree."""
+    best = _peer_answered_at(sid)        # the scalar rides the existing name — the tests' stub seam
+    last_any, _la = _postal_wait_maps()
+    per = {}
+    for (f, t_), sent in last_any.items():
+        if f != sid:
+            continue
+        r = last_any.get((t_, f), 0)
+        if r >= sent:
+            per[t_] = max(per.get(t_, 0), r)
+    return best, per
+
+
+def _peer_stamp_superseded(nd, answered):
+    """THE pair-aware peer-answer supersede — the ONE predicate every stamp reader (card, chip/lane,
+    walk, wake re-check), the nudge fire-gate, and the sweep's superseded-peer lift share; extend
+    HERE (2026-08-24), never inline a compare. `answered` = _peer_answered(sid), or a bare scalar
+    from a legacy caller (kept pair-blind). Peer-scoped exactly as before: job/agents/task/timer
+    stamps stand through mail; write-time keyed (the 2026-08-19 audit): a stamp filed after the
+    reply survives — the closer's verdict is fresher than the answer it already saw."""
+    if nd.get("awaitingKind") not in (None, "peer"):
+        return False
+    if isinstance(answered, tuple):
+        any_t, per = answered
+    else:
+        any_t, per = (answered or 0), None   # a legacy SCALAR stays pair-blind for every stamp —
+        #                                      it carries no pair map to match an identity against
+    peers = nd.get("awaitingPeers")
+    ans = (max((per.get(pk, 0) for pk in peers), default=0) if (peers and per is not None) else any_t)
+    return bool((nd.get("awaitingAt") or 0) and ans and _stamp_written_at(nd) < ans)
+
+
 # ───────────────────────── view-builder: goals → feed (parity: feed = ADAPT; minimal here) ─────────────────────────
 _jerr_cache = {}   # str(path) -> ((mtime_ns, size), rows)
 
@@ -18282,7 +18318,7 @@ def build_feed(now, tmux=None):
             # across kernel restarts — exactly where the live snapshot signals above go dark and a
             # genuinely-waiting goal used to read as plain working, then "stalled". It floors WORKING
             # only: a real needs-you (block) always outranks the annotation.
-            _sf = (_goal_awaiting_stamp_full(nodes, nid, children, answered_at=_peer_answered_at(fsid))
+            _sf = (_goal_awaiting_stamp_full(nodes, nid, children, answered_at=_peer_answered(fsid))
                    if col == "working" else None)
             _stamp_why = _sf[1] if _sf else None
             _stamp_kind = _sf[2] if _sf else None

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -53,7 +53,7 @@ class _Base(unittest.TestCase):
         self.td.cleanup()
 
     def _reset_caches(self):
-        jd._PEER_ASK_CACHE[:] = [None, ({}, {})]
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
         km._POSTAL_WAIT_CACHE[:] = [None, None]
         km._SESSION_STAMP_CACHE.clear()
 
@@ -121,6 +121,8 @@ class MatrixCloserGate(_Base):
             if admitted:
                 self.assertEqual(k, "peer", "an open sent-question admits the closer's peer stamp")
                 self.assertTrue(why)
+                self.assertEqual(s["nodes"][gid].get("awaitingPeers"), [MGR],
+                                 "…and records WHICH peer it awaits — the pair-aware supersede's key")
             else:
                 self.assertEqual((why, k), (None, None),
                                  "a sent %s never mints awaiting-peer (ownership moved / nothing asked)" % kind)
@@ -253,6 +255,152 @@ class MatrixSupersedeTwins(_Base):
                           "the peer answered after the stamp was written -> superseded (card)")
         self.assertIsNone(km._session_stamp_read(SID)[0][0],
                           "…and on the session surfaces alike — one fact, one answer")
+
+
+class PairAwareSupersede(_Base):
+    """Hole (b), 2026-08-24: an identity-carrying stamp ends only on the AWAITED pair's answer; an
+    unrelated exchange no longer hides a real wait. Legacy identity-less stamps keep the pair-blind
+    read — nothing strands. One predicate for every reader (pinned below)."""
+
+    OTHER = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"    # an unrelated peer on the same log
+
+    def _stamped(self, ev_t=T0 + 100):
+        s, gid = self._store()
+        self._log([_msg(1, SID, MGR, T0 + 10, "question")])
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
+                       "awaiting": {1: {"why": "asked the manager which port", "kind": "peer"}}}, t=ev_t)
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(s))
+        km._SESSION_STAMP_CACHE.clear()
+        return s, gid
+
+    def test_an_unrelated_pair_answer_no_longer_supersedes(self):
+        s, gid = self._stamped()
+        future = int(time.time()) + 10_000
+        # an answered exchange with a DIFFERENT peer, after the stamp's write time
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"),
+                   _msg(2, SID, self.OTHER, T0 + 20, "coordinate"),
+                   _msg(3, self.OTHER, SID, future, "coordinate")])
+        answered = km._peer_answered(SID)
+        self.assertGreater(answered[0], 0, "the pair-blind scalar WOULD have superseded")
+        nodes = s["nodes"]
+        self.assertIsNotNone(km._goal_awaiting_stamp_full(nodes, gid, answered_at=answered),
+                             "the stamp awaits MGR — mail from another peer cannot end it (card)")
+        self.assertEqual(km._session_stamp_read(SID)[0][2], "asked the manager which port",
+                         "…and the session-level twin agrees (chip/lane)")
+
+    def test_the_awaited_pair_answer_still_supersedes_instantly(self):
+        s, gid = self._stamped()
+        future = int(time.time()) + 10_000
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"), _msg(2, MGR, SID, future, "coordinate")])
+        answered = km._peer_answered(SID)
+        nodes = s["nodes"]
+        self.assertIsNone(km._goal_awaiting_stamp_full(nodes, gid, answered_at=answered),
+                          "the awaited peer answered after the write -> superseded (card)")
+        self.assertIsNone(km._session_stamp_read(SID)[0][0], "…both readers, one predicate")
+
+    def test_a_legacy_identity_less_stamp_keeps_the_pair_blind_read(self):
+        s, gid = self._stamped()
+        del s["nodes"][gid]["awaitingPeers"]           # a pre-identity stamp, as stored stores hold
+        future = int(time.time()) + 10_000
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"),
+                   _msg(2, SID, self.OTHER, T0 + 20, "coordinate"),
+                   _msg(3, self.OTHER, SID, future, "coordinate")])
+        self.assertIsNone(km._goal_awaiting_stamp_full(s["nodes"], gid, answered_at=km._peer_answered(SID)),
+                          "no identity on the stamp -> today's behavior exactly (never strand legacy)")
+
+    def test_every_reader_shares_the_one_predicate(self):
+        # the twins rule, extended (the manager's ask): no reader may inline its own compare — the
+        # write-time-vs-answer compare exists ONLY inside _peer_stamp_superseded
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        inline = [l for l in src.splitlines()
+                  if "_stamp_written_at(nd) <" in l or "_stamp_written_at(nd) >=" in l]
+        self.assertEqual(len(inline), 1, "one compare, inside the predicate: %r" % inline)
+        self.assertGreaterEqual(src.count("_peer_stamp_superseded(nd,"), 4,
+                                "card reader, session twin, sweep lift, fire-gate — all through it")
+
+
+class CrossHostDelegation(_Base):
+    """Hole (a), 2026-08-24: a cross-host delegate plants the sender-side tracking node from the
+    sent row (declared kind, horizon-bounded, idempotent), and the recipient's REPLY mail — never
+    the relay ack — completes it."""
+
+    RHOST, RNAME = "TESTHOST-B", "web"
+    RSID = "eeeeeeee-ffff-0000-1111-222222222222"     # the remote recipient's sid, learned on reply
+
+    def _xrow(self, i, ts, kind="delegate", body="own the exporter work"):
+        return json.dumps({"id": "px-%d.mail.TESTHOST-A" % i, "ev": "sent", "from": "api",
+                           "from_id": SID, "to_id": "peer:%s" % self.RHOST,
+                           "toName": "%s:%s" % (self.RHOST, self.RNAME), "t": ts,
+                           "kind": kind, "body": body})
+
+    def _reply(self, i, ts):
+        return json.dumps({"id": "rx-%d.mail.%s" % (i, self.RHOST), "ev": "sent", "from": self.RNAME,
+                           "from_id": self.RSID, "from_host": self.RHOST, "to_id": SID,
+                           "t": ts, "kind": "coordinate", "body": "done: exporter shipped"})
+
+    def _fleet_stub(self):
+        # run_courier/run_propagate discover the fleet from names+transcripts; stub the discovery
+        # to the one local sender (the recipient is REMOTE by construction)
+        self._saved_discover = jd.discover
+        jd.discover = lambda now: [(SID, "/tmp/none.jsonl", None, "api")]
+        self.addCleanup(lambda: setattr(jd, "discover", self._saved_discover))
+
+    def _handoffs(self):
+        st = jd.load_goals(SID)
+        return [nd for nd in st["nodes"].values() if isinstance(nd.get("handoff"), dict)]
+
+    def test_a_cross_host_delegate_plants_the_tracking_node(self):
+        self._fleet_stub()
+        self._log([self._xrow(1, T0 + 10)])
+        jd.run_courier(now=T0 + 100)
+        hs = self._handoffs()
+        self.assertEqual(len(hs), 1, "the sent row is the authoritative record — planted from it")
+        self.assertEqual(hs[0]["handoff"]["peer"], "TESTHOST-B:web",
+                         "the identity is toName — displays resolve it, the remote arm re-keys from it")
+        self.assertIn("↪ delegated to TESTHOST-B:web", hs[0]["text"])
+        self.assertNotIn("tracked", hs[0]["handoff"], "tracked never rides the relay — the boundary")
+        jd.run_courier(now=T0 + 200)
+        self.assertEqual(len(self._handoffs()), 1, "idempotent by msgId — one plant per message ever")
+
+    def test_declared_only_and_horizon_bounded(self):
+        self._fleet_stub()
+        self._log([self._xrow(1, T0 + 10, kind="coordinate"),
+                   self._xrow(2, T0 - jd.COURIER_RETRY_HORIZON - 60)])
+        jd.run_courier(now=T0 + 100)
+        self.assertEqual(self._handoffs(), [], "a non-delegate never plants; ancient rows never backfill")
+
+    def test_the_reply_completes_and_the_relay_ack_does_not(self):
+        self._fleet_stub()
+        self._log([self._xrow(1, T0 + 10)])
+        jd.run_courier(now=T0 + 100)
+        # the far host's delivery ack lands — the ASK arrived; the work is NOT done
+        rows = [self._xrow(1, T0 + 10),
+                json.dumps({"id": "px-1.mail.TESTHOST-A", "ev": "relayed", "t": T0 + 100})]
+        self._log(rows)
+        jd.run_propagate(now=T0 + 200)
+        self.assertFalse(self._handoffs()[0].get("nodeComplete"),
+                         "relayed = delivered, not completed — delivery cannot check work off")
+        # the recipient's reply mail is the report-back event
+        rows.append(self._reply(1, T0 + 300))
+        self._log(rows)
+        jd.run_propagate(now=T0 + 400)
+        nd = self._handoffs()[0]
+        self.assertTrue(nd.get("nodeComplete"), "the reply completes the tracking node")
+        self.assertIn("reported back by TESTHOST-B:web", nd.get("doneWhy") or "")
+
+    def test_an_unrelated_peers_reply_never_completes(self):
+        self._fleet_stub()
+        self._log([self._xrow(1, T0 + 10)])
+        jd.run_courier(now=T0 + 100)
+        other = json.dumps({"id": "rx-9.mail.TESTHOST-C", "ev": "sent", "from": "tests",
+                            "from_id": "dddddddd-0000-1111-2222-333333333333",
+                            "from_host": "TESTHOST-C", "to_id": SID, "t": T0 + 300,
+                            "kind": "coordinate", "body": "unrelated news"})
+        self._log([self._xrow(1, T0 + 10), other])
+        jd.run_propagate(now=T0 + 400)
+        self.assertFalse(self._handoffs()[0].get("nodeComplete"),
+                         "only the delegated peer's own reply is the report-back event")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the two verified holes from the paused-cards investigation, atop the superseded-peer sweep.

**(b) The peer-answer supersede matches the pair.** It was pair-blind: any answered outbound exchange superseded any peer stamp, so an unrelated coordinate from the same peer hid a real wait (what put all three stuck stamps in the dark). The closer's admit gate already knows exactly which open sent-questions it admitted over — the stamp now records them (`awaitPeers` on the diary row, `awaitingPeers` via the fold, same coalesce as the kind), and **one predicate** — `_peer_stamp_superseded`, shared by the card reader, the session-level twin, the nudge walk/wake re-check, the fire-gate veto, and the sweep's lift arm — matches an identity-carrying stamp only against its own pair's answer (`_peer_answered` keeps the per-pair map; the scalar keeps its name, which is also the tests' stub seam). Legacy identity-less stamps and scalar callers keep today's pair-blind read; a source pin asserts no reader can inline its own compare.

**(a) Cross-host delegates plant and complete their tracking node.** A delegate to a remote peer planted nothing sender-side (the courier only sees inbound segments), so the completion linkage never existed — the live specimen's done-line arrived and relayed in 90s while the goal sat paused for hours. The courier now plants from the sent row itself (`to_id "peer:<host>"` + `toName`, the authoritative record), trusting the **declared** kind exactly as the parse give-up path always has (declared-only; kindless legacy rows are indistinguishable from coordinates), horizon-bounded, idempotent by msgId. **Completion event: the recipient's reply mail** — any kind, at/after the delegate's send — the same report-back event the stamp machinery has keyed on since the 08-18 audit; `relayed` is deliberately not it (that ack says the *ask* arrived; completing on delivery would check off undone work). Granularity is per-peer (the log carries no reply→delegate join) — coarse but forward-only, where the alternative was a wait no event could end. `tracked` never rides the relay, unchanged boundary.

**Tests** (`tests/test_awaiting_peer_matrix.py` extensions): the admitted stamp records its peer; unrelated-pair answer no longer supersedes while the awaited pair's still does instantly, on both readers; legacy stamps unchanged; the one-predicate pin (exactly one write-time compare in the file); cross-host plant (declared-only, horizon, idempotent, no tracked), reply-completes vs relay-ack-does-not, unrelated peer never completes. Suites green: pytest 5454 passed, npm 2304/2304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)