### PR TITLE
Top-level handoff cards title the work; the delegation rides a provenance badge

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12211,6 +12211,46 @@ def _handoff_peer_identities(nodes, hnodes):
     return sorted(seen.values(), key=lambda d: d["name"]) or None
 
 
+_HANDOFF_LABEL_RE = re.compile(r"^\s*↪\s*delegated to (.+?): (.*)$", re.S)
+
+
+def _handoff_card_fields(nodes, nid):
+    """(handoffTo badge, card title) for a feed card whose ROOT node is a courier handoff tracking
+    node — (None, the node's text unchanged) for every other card.
+
+    _plant_handoff_track parents its "↪ delegated to <peer>: <work>" tracking node under the sender's
+    related open goal when one exists, else TOP-LEVEL — a designed fallback that showed its seams: a
+    top-level node's text is the card TITLE, so the card read arrow-and-all as its name (the user
+    2026-08-24, screenshot). Presentation only, mint/retire/propagate untouched: the card titles the
+    WORK and wears the delegation as a provenance badge — the exact mirror of the recipient's
+    "↪ from <peer>" (origin): identity color, quiet host: prefix for a recipient this kernel can't
+    resolve, click opens the recipient session. Identity resolves through the chain origin uses —
+    the live registry first (a rename reads fresh, via _handoff_peer_identities, the same resolver
+    the awaiting box trusts), then the courier's plant-time label (the only human name source for a
+    federated recipient), then the sid stub. The title falls back through the node's own why/summary
+    before keeping the de-arrowed label, so a label-only node still reads as work, not provenance.
+    NESTED handoff rows are untouched: they render as identity rows in the delegations section under
+    a real title, where the label never was the problem."""
+    nd = nodes.get(nid) or {}
+    txt = nd.get("text") or ""
+    if not (isinstance(nd.get("handoff"), dict) and nd["handoff"].get("peer")):
+        return None, txt
+    ident = (_handoff_peer_identities(nodes, [nid]) or [{}])[0]
+    badge = {"peer": ident.get("name") or "", "peerHost": ident.get("host") or "",
+             "peerSid": ident.get("sid") or str(nd["handoff"]["peer"]), "color": ident.get("color")}
+    m = _HANDOFF_LABEL_RE.match(txt)
+    if m and not _name_of(badge["peerSid"]):
+        # registry miss → the plant-time label names the recipient better than a sid stub
+        lh, _, ln = m.group(1).strip().rpartition(":")
+        if ln:
+            badge.update({"peer": ln, "peerHost": lh or badge["peerHost"]})
+    work = (m.group(2).strip() if m else "")
+    if not work or work == "(work)":
+        work = ((nd.get("why") or "").strip() or (nd.get("summary") or "").strip()
+                or txt.replace("↪ ", "", 1).strip() or txt)
+    return badge, work
+
+
 def _session_delegated_why(sid):
     """The session-scoped DELEGATION wait (or None): every open leaf of some inbox-visible top is a
     courier handoff — the only outstanding work lives with peers. The SAME evidence the feed's per-card
@@ -18345,6 +18385,11 @@ def build_feed(now, tmux=None):
                 origin = {"peer": pname or o.get("peerName") or psid[:8],
                           "peerHost": ("" if pname else o.get("peerHost") or ""),
                           "peerSid": psid, "color": _name_color(psid), "live": live}
+            # SENDER-SIDE handoff provenance (the user 2026-08-24): a TOP-LEVEL "↪ delegated to
+            # <peer>" tracking node wore its provenance as the card TITLE, arrow and all. The card
+            # now titles the WORK and ships the delegation as the badge mirroring origin above —
+            # see _handoff_card_fields. Every other card keeps its text untouched.
+            handoff_to, card_text = _handoff_card_fields(nodes, nid)
             await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
             await_kind = None                        # the winning why's KIND and SINCE ride beside it,
             await_since = None                       # mirroring the or-chain exactly (a kindless winner
@@ -18599,10 +18644,11 @@ def build_feed(now, tmux=None):
                 # honestly, and the validated tiers take back over on the first warm push.
                 _sa_u = _cited
             asks.append({
-                "itemId": nid, "sid": fsid, "name": name, "color": color, "text": nodes[nid]["text"],
+                "itemId": nid, "sid": fsid, "name": name, "color": color, "text": card_text,
                 "t": disp_t, "live": live,
                 "trgb": list(cm.age_rgb(now - disp_t, _colormap())),
                 "turnId": nid, "origin": origin,
+                **({"handoffTo": handoff_to} if handoff_to else {}),
                 **({"delegTracked": _tracked_peers} if _tracked_peers else {}),
                 # the satellite hides ONLY while the pair is INTACT and the work runs its normal
                 # course: a needs-you block always surfaces (interrupt only when the human is the

--- a/tests/test_handoff_card_title.py
+++ b/tests/test_handoff_card_title.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""A TOP-LEVEL courier handoff tracking node's card titles the WORK and wears the delegation as a
+provenance badge (the user 2026-08-24, screenshot of a manager-board card titled
+"↪ delegated to <peer>: <work>", arrow and all).
+
+_plant_handoff_track parents its tracking node under the sender's related open goal when one exists,
+else top-level — a designed fallback whose seams showed: a top-level node's text IS the card title.
+Presentation only (mint/retire/propagate untouched): build_feed now derives the card's title and a
+handoffTo badge through _handoff_card_fields — the badge mirrors the recipient-side "↪ from <peer>"
+(origin): identity color, quiet host: prefix for a recipient this kernel can't resolve, click opens
+the recipient. Identity resolves registry-first (a rename reads fresh), then the courier's
+plant-time label, then the sid stub; the title falls back through why/summary before keeping the
+de-arrowed label. Nested handoff rows are untouched. SYNTHETIC fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from inspect import getsource
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_hocard", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"    # the delegating session
+PEER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"   # the recipient
+T0 = 1_781_100_000
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved_state, self._saved_names = jd.STATE, km.NAMES
+        jd._rebind_state(td)
+        km.NAMES = td / "names"          # _name_of reads the kernel-module global, not jd.STATE live
+        km.NAMES.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        jd._rebind_state(self._saved_state)
+        km.NAMES = self._saved_names
+        self.td.cleanup()
+
+    def _store_with_track(self, text="Build tracked exporter with delegator-homed card",
+                          peer_name="worker_two", parent=None):
+        """A sender store whose handoff tracking node was minted by the REAL planter, so the label
+        format under test is the one production writes."""
+        store = {"rompUuid": SID, "seq": 0, "placements": {}, "status": {}, "nodes": {}}
+        nid = jd._plant_handoff_track(store, parent, text, PEER, peer_name, T0, "m1")
+        return store, nid
+
+    def _name(self, sid, name):
+        (km.NAMES / sid).write_text(name + "\t/tmp\t#123456\t#ffffff")
+
+
+class HandoffCardFields(_Base):
+    def test_top_level_track_titles_the_work_and_badges_the_peer(self):
+        store, nid = self._store_with_track()
+        badge, title = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual(title, "Build tracked exporter with delegator-homed card",
+                         "the WORK is the title — no arrow, no provenance phrase")
+        self.assertNotIn("↪", title)
+        self.assertEqual(badge["peerSid"], PEER, "click target: the recipient session")
+        self.assertEqual(badge["peer"], "worker_two",
+                         "registry miss → the plant-time label names the recipient")
+        self.assertIn("color", badge, "identity color rides the badge like origin's")
+
+    def test_registry_name_outranks_the_plant_time_label(self):
+        store, nid = self._store_with_track(peer_name="stale_old_name")
+        self._name(PEER, "renamed_worker")
+        badge, _ = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual(badge["peer"], "renamed_worker", "a rename reads fresh, same as origin")
+        self.assertEqual(badge["peerHost"], "", "a local resolve means a local peer — no host prefix")
+
+    def test_federated_label_splits_into_quiet_host_prefix(self):
+        store, nid = self._store_with_track(peer_name="boxa:worker_two")
+        badge, _ = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual((badge["peerHost"], badge["peer"]), ("boxa", "worker_two"),
+                         "host: prefix renders the way remote names do everywhere else")
+
+    def test_label_only_node_falls_back_to_why_then_summary(self):
+        store, nid = self._store_with_track(text="")          # planter writes "(work)"
+        store["nodes"][nid]["why"] = "port the exporter to the new card schema"
+        _, title = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual(title, "port the exporter to the new card schema")
+        store["nodes"][nid]["why"] = None
+        store["nodes"][nid]["summary"] = "the exporter now ships cards"
+        _, title = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual(title, "the exporter now ships cards")
+
+    def test_a_plain_goal_is_untouched(self):
+        nodes = {SID + ":g9": {"id": SID + ":g9", "text": "Ship the exporter", "parentId": None}}
+        badge, title = km._handoff_card_fields(nodes, SID + ":g9")
+        self.assertIsNone(badge, "no handoff → no badge")
+        self.assertEqual(title, "Ship the exporter", "…and the text passes through verbatim")
+
+
+class BuildFeedWiring(_Base):
+    """Source pins: build_feed routes the card's title/badge through the helper, and NESTED handoff
+    rows keep their raw text (they render as identity rows in the delegations section — the label
+    never was the problem there)."""
+
+    def test_the_item_ships_the_derived_title_and_badge(self):
+        src = getsource(km.build_feed)
+        self.assertIn("handoff_to, card_text = _handoff_card_fields(nodes, nid)", src)
+        self.assertIn('"text": card_text', src)
+        self.assertIn('**({"handoffTo": handoff_to} if handoff_to else {})', src)
+
+    def test_nested_tree_rows_keep_their_raw_text(self):
+        src = getsource(km.build_feed)
+        self.assertIn('"kind": "handoff" if _ho_sid else "ask", "text": nd["text"]', src,
+                      "flatten's rows are untouched — nested handoff rows render as before")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-handoff-badge.test.ts
+++ b/ui/webview/feed-handoff-badge.test.ts
@@ -1,0 +1,36 @@
+// Sender-side handoff provenance on the feed (the user 2026-08-24): a TOP-LEVEL "↪ delegated to
+// <peer>" tracking node wore its provenance as the card TITLE, arrow and all. The kernel now titles
+// the card with the WORK and ships the delegation as `handoffTo` — rendered on the origin slot as
+// the exact mirror of the recipient's "↪ from <peer>" badge: identity color, quiet host: prefix for
+// a federated recipient, click opens the recipient session, STACKING after an ↪ from badge (origin
+// and handoffTo are different facts about one card). Source pins, the feed-panel idiom; the
+// kernel-side truth table lives in tests/test_handoff_card_title.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const BLK = SRC.slice(SRC.indexOf("if (it.handoffTo && it.handoffTo.peerSid) {"),
+                      SRC.indexOf("a._time.textContent"));
+
+test("the badge is additive on the type — a payload without it renders exactly as before", () => {
+  assert.match(SRC, /handoffTo\?: \{ peer: string; peerSid: string; peerHost\?: string; color\?: \{ bg: string; fg: string \} \| null \} \| null;/);
+});
+
+test("the title is the kernel-shipped text verbatim — the de-arrowing lives kernel-side", () => {
+  assert.match(SRC, /a\._title\.textContent = it\.text;/,
+    "no client-side munging: one place (kernel _handoff_card_fields) owns the derivation");
+});
+
+test("the badge mirrors ↪ from: identity rendering, recipient click, stacking after origin", () => {
+  assert.ok(BLK.length > 0, "the handoffTo render block exists");
+  // stacks after an ↪ from badge rather than replacing it — same rule the tracked slot pinned
+  assert.match(BLK, /const hadOrigin = !!\(it\.origin && it\.origin\.peer\);/);
+  assert.match(BLK, /pre\.textContent = \(hadOrigin \? " · " : ""\) \+ "↪ delegated to ";/);
+  // identity rendering matches every other session name (quiet host: prefix included)
+  assert.match(BLK, /peer\.replaceChildren\(\.\.\.hostPartsNodes\(it\.handoffTo\.peerHost, it\.handoffTo\.peer\)\);/);
+  assert.match(BLK, /peer\.style\.color = it\.handoffTo\.color\.bg;/);
+  // the click opens the RECIPIENT session — symmetric with the origin badge's click
+  assert.match(BLK, /openSession", id: it\.handoffTo!\.peerSid/);
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -103,6 +103,7 @@ interface AskItem {
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;
+  handoffTo?: { peer: string; peerSid: string; peerHost?: string; color?: { bg: string; fg: string } | null } | null;  // sender-side handoff provenance (the user 2026-08-24): this card IS a top-level "↪ delegated to <peer>" tracking node — the kernel titles it with the WORK and ships the delegation here, the mirror of origin's "↪ from"; click opens the recipient
   satellite?: boolean | null;                        // tracked delegation (the user 2026-08-24): this card is the recipient-side copy of a delegator-homed primary — off the default board; the session filter still reaches it (nothing runs in secret)
   delegTracked?: { name: string; host?: string; sid: string; color?: { bg: string; fg: string } | null }[] | null;  // tracked delegation PRIMARY: the recipient identities whose live status this one card carries  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string; since?: number } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25). since = when the unanswered ask was sent → the chip's elapsed readout (the user 2026-08-23)
@@ -1576,6 +1577,29 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.origin!.peerSid }); };
   } else {
     og.style.display = "none";
+  }
+  // ↪ sender-side handoff provenance (the user 2026-08-24): a TOP-LEVEL "↪ delegated to <peer>"
+  // tracking node wore its provenance as the card TITLE, arrow and all. The kernel now titles the
+  // card with the WORK and ships the delegation here — the mirror of ↪ from above: identity color,
+  // quiet host: prefix for a federated recipient, click opens the recipient session. STACKS after
+  // an ↪ from badge rather than replacing it (origin and this are different facts about one card —
+  // the same rule the 2026-08-24 review pinned on this slot).
+  if (it.handoffTo && it.handoffTo.peerSid) {
+    const hadOrigin = !!(it.origin && it.origin.peer);
+    og.style.display = "";
+    if (!hadOrigin) {
+      og.replaceChildren(); og.style.color = ""; og.classList.remove("fask-origin-absorbed");
+      og.title = "delegated to " + it.handoffTo.peer + "; their result checks this card off · click opens the session";
+      og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.handoffTo!.peerSid }); };
+    }
+    const pre = el("span", "fask-origin-pre"); pre.textContent = (hadOrigin ? " · " : "") + "↪ delegated to ";
+    const peer = el("span", "fask-origin-peer");
+    peer.replaceChildren(...hostPartsNodes(it.handoffTo.peerHost, it.handoffTo.peer));
+    if (it.handoffTo.color) peer.style.color = it.handoffTo.color.bg;
+    peer.title = "delegated to " + it.handoffTo.peer + "; their result checks this card off · click opens the session";
+    peer.style.cursor = "pointer";
+    peer.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.handoffTo!.peerSid }); };
+    og.append(pre, peer);
   }
   // tracked delegation PRIMARY (the user 2026-08-24): the ONE card, homed here under the delegator —
   // it names the recipient(s) in their identity colors with the board's own live dot


### PR DESCRIPTION
A manager-board card read "↪ delegated to <peer>: <work>" as its TITLE, arrow and all (user screenshot, 2026-08-24). Not a state bug — a designed fallback showing its seams: `_plant_handoff_track` parents its tracking node under the sender's related open goal when one exists, else plants it top-level, and a top-level node's text becomes the card title. Nested rows render fine below a real title; top-level ones read wrong.

**Presentation only** (mint/retire/propagate untouched):
- build_feed derives the card's title and a `handoffTo` badge through the new `_handoff_card_fields`: the WORK is the title (label remainder → the node's why → summary → the de-arrowed label), and the delegation ships as the exact mirror of the recipient-side "↪ from <peer>" badge — identity color, quiet `host:` prefix for a recipient this kernel can't resolve, click opens the recipient session, stacking after an ↪ from badge rather than replacing it.
- Identity resolves registry-first (a rename reads fresh, via `_handoff_peer_identities` — the same resolver the awaiting box trusts), then the courier's plant-time label, then the sid stub.
- Nested handoff rows keep their raw text: they render as identity rows in the delegations section, where the label never was the problem.
- No coupling to the tracked-delegation fields (retired before first use; removal queued separately).

**Tests**: `tests/test_handoff_card_title.py` pins the derivation against the real planter's label format (registry-over-label, federated host split, why/summary fallbacks, plain goals untouched) plus the build_feed wiring; `ui/webview/feed-handoff-badge.test.ts` pins the badge render (additive type, verbatim kernel-shipped title, ↪ from mirroring, recipient click, origin stacking). Local: full Python suite 5453 passed; UI 2307 passed; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)