### PR TITLE
Stubs grow their riser: the half-elbow limb that ties the track to the work bar

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3976,27 +3976,61 @@ class TimelinePanel {
       }
       if (x2 - x1 < 2) x2 = x1 + 2;   // a same-instant consume is real but must never render as a
       //                                 floating point — two px keeps the mark a mark
+      // the RISER (the user 2026-08-24, third stub round): the vertical limb tying the track to the
+      // WORK BAR itself — the full connectors' elbow grammar as a half-elbow; without it the
+      // horizontal stubs read as floating lines. OUTGOING: bar → track at the SEND x (the early
+      // return above guarantees the true, unclamped x — the message visibly leaves the work).
+      // INCOMING: track → bar at the ARRIVAL x, meeting the arrival dot — only when the message
+      // actually ARRIVED: an un-arrived stub has no arrival to tie to, and a clamped/live-edge x
+      // would tie it to a false one, so the riser is skipped rather than drawn at a lie.
+      const riser = senderVisible ? { x: x1, yA: ly, yB: y1 }
+                                  : (arrived ? { x: x2, yA: y2, yB: ly } : null);
       const col = colorOf(mm.fromId);   // the SENDER's color — the full connectors' own resolution
       const attrs = { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W, opacity: 0.45,
                       'stroke-linecap': 'round', 'pointer-events': 'none' };
       if (!arrived) attrs['stroke-dasharray'] = '1 4';   // in flight — the pending-connector dash (same key as the span)
       svg.appendChild(el('line', attrs));
+      if (riser) {
+        const rattrs = { x1: riser.x, y1: riser.yA, x2: riser.x, y2: riser.yB, stroke: col,
+                         'stroke-width': STUB_W, opacity: 0.45, 'stroke-linecap': 'round',
+                         'pointer-events': 'none' };   // the stub's own stroke, dash and fade — one mark
+        if (!arrived) rattrs['stroke-dasharray'] = '1 4';
+        svg.appendChild(el('line', rattrs));
+      }
       // same affordances as a full connector: own-color highlight overlay + wide transparent hit,
       // co-lit with the arrival dot (PASS 2 links via msgUI), tooltip + click → where it landed
       const msgLit = dagOrHoverMsg(mm.id);
       const hl = el('line', { x1, y1, x2, y2, stroke: col, 'stroke-width': STUB_W + 3, opacity: msgLit ? 0.95 : 0,
                               'stroke-linecap': 'round', 'pointer-events': 'none' });
       svg.appendChild(hl);
+      const rhl = riser ? el('line', { x1: riser.x, y1: riser.yA, x2: riser.x, y2: riser.yB, stroke: col,
+                                       'stroke-width': STUB_W + 3, opacity: msgLit ? 0.95 : 0,
+                                       'stroke-linecap': 'round', 'pointer-events': 'none' }) : null;
+      if (rhl) svg.appendChild(rhl);
       const u = (msgUI[i] = { hl, dot: null, lit: msgLit });
       const hit = el('line', { x1, y1, x2, y2, stroke: 'transparent', 'stroke-width': MSG_HIT_W, 'stroke-linecap': 'round' });
       hit.style.cursor = 'pointer';
-      const mEnter = (e) => { hl.setAttribute('opacity', '0.95'); if (u.dot) u.dot.setAttribute('r', DOT_R + 2); this.showTip(msgHtml(mm)(), e); };
+      const mEnter = (e) => { hl.setAttribute('opacity', '0.95'); if (rhl) rhl.setAttribute('opacity', '0.95'); if (u.dot) u.dot.setAttribute('r', DOT_R + 2); this.showTip(msgHtml(mm)(), e); };
+      const mLeave = () => { hl.setAttribute('opacity', msgLit ? '0.95' : '0'); if (rhl) rhl.setAttribute('opacity', msgLit ? '0.95' : '0'); if (u.dot) u.dot.setAttribute('r', msgLit ? DOT_R + 2 : DOT_R); this.hideTip(); };
       hit.__tlHoverIn = mEnter;                    // re-armable after a redraw rebuilds this stub (_rehover)
       hit.addEventListener('mouseenter', mEnter);
       hit.addEventListener('mousemove', (e) => this.moveTip(e));
-      hit.addEventListener('mouseleave', () => { hl.setAttribute('opacity', msgLit ? '0.95' : '0'); if (u.dot) u.dot.setAttribute('r', msgLit ? DOT_R + 2 : DOT_R); this.hideTip(); });
+      hit.addEventListener('mouseleave', mLeave);
       hit.addEventListener('click', msgNav(mm));
       u.hit = hit;   // appended in PASS 3 with the connector hits, over the dots
+      if (riser) {
+        // the riser is part of the stub's one interactive unit: its own hit strip shares the
+        // handlers, so hovering the limb lights the whole half-elbow and the same tooltip
+        const rhit = el('line', { x1: riser.x, y1: riser.yA, x2: riser.x, y2: riser.yB,
+                                  stroke: 'transparent', 'stroke-width': MSG_HIT_W, 'stroke-linecap': 'round' });
+        rhit.style.cursor = 'pointer';
+        rhit.__tlHoverIn = mEnter;
+        rhit.addEventListener('mouseenter', mEnter);
+        rhit.addEventListener('mousemove', (e) => this.moveTip(e));
+        rhit.addEventListener('mouseleave', mLeave);
+        rhit.addEventListener('click', msgNav(mm));
+        u.rhit = rhit;                              // appended beside `hit` in PASS 3
+      }
     };
     // PASS 1: connector line + highlight (drawn first so the dots sit on top).
     data.messages.forEach((mm, i) => {
@@ -4082,7 +4116,7 @@ class TimelinePanel {
     // Nothing is lost by sitting over a message dot: the dot's tooltip, growth and click are the same
     // message's, and mEnter grows the linked dot too. Prompt dots are drawn after this pass, so they
     // keep their own hover.
-    Object.keys(msgUI).forEach((k) => { const u = msgUI[k]; if (u && u.hit) svg.appendChild(u.hit); });
+    Object.keys(msgUI).forEach((k) => { const u = msgUI[k]; if (u && u.hit) svg.appendChild(u.hit); if (u && u.rhit) svg.appendChild(u.rhit); });
 
     // turn process-start (prompt) dots — at startAt; CLICKABLE → jump to the prompt that started
     // the period. Skipped where a PROCESSED message dot coincides (the message dot stands in).

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -96,7 +96,10 @@ function nodes(panel: any): any[] {
 }
 const stubLines = (panel: any, hex?: string) =>
   nodes(panel).filter((n) => n.tag === "line" && n._attrs["stroke-width"] === 3 && n._attrs.opacity === 0.45
-    && (!hex || n._attrs.stroke === hex));
+    && n._attrs.y1 === n._attrs.y2 && (!hex || n._attrs.stroke === hex));
+const riserLines = (panel: any) =>
+  nodes(panel).filter((n) => n.tag === "line" && n._attrs["stroke-width"] === 3 && n._attrs.opacity === 0.45
+    && n._attrs.x1 === n._attrs.x2);
 const connPaths = (panel: any, color: string) =>
   nodes(panel).filter((n) => n.tag === "path" && n._attrs.fill === "none" && n._attrs.stroke === color && (n._attrs.opacity === 0.5 || n._attrs.opacity === 0.4));
 // expected coordinates from the SAME geometry draw() used (compress map included)
@@ -125,6 +128,15 @@ test("a hidden-recipient message draws an outgoing stub: send-anchored, horizont
   assert.ok(s._attrs.x2 - s._attrs.x1 > 13.5, "…and it beats the old 13px cap on this fixture");
   assert.ok(!nodes(panel).some((n) => n.tag === "circle" && Math.abs(n._attrs.cx - s._attrs.x2) < 1e-6),
     "an outgoing stub has NO dot — the dot is the ARRIVAL mark, and the arrival is off-view");
+  // the RISER (third stub round): the half-elbow limb tying the track to the work bar at the SEND x
+  const [r, ...rrest] = riserLines(panel);
+  assert.ok(r, "the riser draws");
+  assert.equal(rrest.length, 0, "exactly one riser");
+  near(r._attrs.x1, s._attrs.x1, "…at the send x — the message visibly leaves the work");
+  near(r._attrs.y1, laneY(panel)(0), "…from the bar");
+  near(r._attrs.y2, s._attrs.y1, "…down to the track");
+  assert.equal(r._attrs["stroke-dasharray"], "1 4", "the riser wears the stub's own dash");
+  assert.equal(r._attrs.stroke, BEE, "…and its color");
   assert.equal(s._attrs.opacity, 0.45, "the stub fade level exactly — not invisible, not full-strength");
   assert.equal(s._attrs["pointer-events"], "none", "the visible mark never eats the hover — the hit target owns it");
   const hl = nodes(panel).find((n) => n.tag === "line" && n._attrs.stroke === BEE && n._attrs["stroke-width"] === 6);
@@ -244,11 +256,27 @@ test("a hidden-sender message draws the mirror stub: horizontal just ABOVE the l
   near(s._attrs.y2, laneY(panel)(0) - OFF, "INCOMING rides just ABOVE the lane line — the fixed convention");
   near(s._attrs.y1, s._attrs.y2, "…and stays horizontal");
   near(s._attrs.x1, X(panel)(now - 400), "the FULL span back to the send x — no run cap");
+  const [r] = riserLines(panel);
+  assert.ok(r, "the incoming riser draws — the message visibly enters the work");
+  near(r._attrs.x1, s._attrs.x2, "…at the arrival x");
+  near(r._attrs.y1, s._attrs.y2, "…from the track");
+  near(r._attrs.y2, laneY(panel)(0), "…down to the bar, meeting the arrival dot");
+  assert.equal(r._attrs["stroke-dasharray"], undefined, "solid, like its arrived stub");
   const kids = panel.svg.children;
   const dotI = kids.findIndex((n: any) => n.tag === "circle" && Math.abs(n._attrs.cx - X(panel)(now - 100)) < 1e-6);
   assert.ok(dotI >= 0, "the arrival dot still draws on the recipient lane");
   const hitI = kids.findIndex((n: any) => n.tag === "line" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
   assert.ok(hitI > dotI, "the stub's hit target is appended after the dots (PASS 3), so the line wins the hover");
+});
+
+test("an un-arrived INCOMING stub has no riser — nothing entered the work, and its live-edge x is not a real arrival", () => {
+  const now = 1_781_000_000;
+  const panel = draw([{ id: "m16", fromId: "SA", toId: "SB", from: "ada", to: "bee",
+                        sent: now - 120, exec: now - 120, hasExec: false, pending: true, summary: "still coming" }]);
+  const [s] = stubLines(panel);
+  assert.ok(s, "the un-arrived incoming stub itself draws (dashed, to the live edge)");
+  assert.equal(riserLines(panel).length, 0,
+    "…but no riser: a limb at a clamped/live-edge x would tie the work to a false arrival");
 });
 
 test("a counterpart absent from data.sessions rides the same fixed track: outgoing = below", () => {


### PR DESCRIPTION
Third stub geometry round (user report: the horizontal stubs read as floating lines). Each stub now carries the full connectors' elbow grammar as a **half-elbow**: a short vertical riser spanning exactly the `MSG_DROP` track gap, in the stub's own stroke, color, dash and fade, part of the same interactive unit (its own hit strip shares the hover/highlight/tooltip/click).

- **Outgoing** (below the lane): bar → track at the **send** x — the message visibly leaves the work, runs the track, ends with no dot. The outgoing window-gate already guarantees the send x is true, so the riser always draws.
- **Incoming** (above the lane): track → bar at the **arrival** x, meeting the existing arrival dot — drawn **only when the message actually arrived**: an un-arrived stub has no arrival to tie to, and a clamped/live-edge x would tie the work to a false one, so the riser is skipped rather than drawn at a lie (the same honesty rule as the window clamps).

**Tests:** selectors split track (horizontal) from riser (vertical); pins for the outgoing riser at the send x with dash/color parity, the incoming riser meeting the dot, and the un-arrived-incoming no-riser rule. Suite green: 2316/2316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)