### PR TITLE
The rate-limit-telemetry notice dies entirely

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18962,15 +18962,11 @@ def _usage():
             out = {"apiKey": True, "spend": _spend_windows(),
                    "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
                    "acct": _claude_account()}
-            # Under key auth the windows are STRUCTURALLY absent, not late — both usage.json writers
-            # skip keyed sessions — so the payload says why and the rail hover can say it too (fail
-            # loudly, not silence; the user 2026-08-15). Key auth is the reason when the manager env
-            # carries a key (_auth_key_present) or the box declares ROMP_EXPECTED_AUTH=key (the
-            # apiKeyHelper box, where the key never rides service.env). A no-login, no-key machine
-            # showing legacy spend gets no line: its windows could yet arrive with a login.
-            if (_auth_key_present()
-                    or (os.environ.get("ROMP_EXPECTED_AUTH") or "").strip().lower() == "key"):
-                out["telemetryUnavailable"] = True
+            # (The telemetryUnavailable flag + its "rate-limit telemetry unavailable under API-key
+            # auth" hover line are GONE — the user 2026-08-24: they know which machines are
+            # key-only and want the spend without a notice about rate limits that don't apply.
+            # Absence of windows on a keyed host is the designed state and now simply looks like
+            # what it is: no windows.)
             ss = _spend_series()          # TOTAL, like the windows above: everything here bills the key
             if ss:
                 out["spendSeries"] = ss   # the hover's money-rate graph (the user 2026-08-13)
@@ -24143,7 +24139,6 @@ var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
 shareFreshest(live);
 LAST=live.map(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
-if(r.usage.telemetryUnavailable)det._telemUnavail=true;   // key auth: the windows are structurally absent, and the hover says why
 winDet(r.usage,det);spendDet(r.usage,det);
 return {host:r.host||selfHost||'this machine',det:det};});
 el.innerHTML=aggBarsHTML(LAST)+apiCellHTML(LAST);
@@ -24283,11 +24278,6 @@ var blocks=sets.map(function(e){return setHTML(e,many);}).filter(function(b){ret
 // return on empty blocks left the API cell with an EMPTY hover exactly when spend was all there
 // was to show (the user 2026-08-15).
 var h=blocks.length?(many?('<div class=ru-tip-cols>'+blocks.map(function(b){return '<div class=ru-tip-col>'+b+'</div>';}).join('')+'</div>'):blocks[0]):'';
-// one quiet line saying WHY some machine shows no bars (the acct line's dim dress): under key auth
-// the windows cannot arrive — absence is the designed state, not a stale read (the user 2026-08-15).
-// It sits with the WINDOWS it explains, ABOVE the spend section (the user 2026-08-24: as the tip's
-// last line it hung under the spend, which must never claim anything about rate limits).
-if(h&&sets.some(function(e){return e.det._telemUnavail;}))h+='<div class=ru-tip-acct>rate-limit telemetry unavailable under API-key auth</div>';
 // no footer hint: refresh is AUTOMATIC (the 60s pull below + the timeline's live forward), and a
 // click-me line misread on a hover surface (the user 2026-08-14) — the click stays as a manual
 // kick, it just doesn't advertise. An OPEN tip follows every data landing via renderRows.

--- a/tests/test_expected_auth.py
+++ b/tests/test_expected_auth.py
@@ -14,7 +14,7 @@ the per-init apiKeySource mismatch line was a permanent false alarm. The mechani
     rate-limit events landed in the login's usage.json between a kernel restart and its next init.
   * An all-keyed box fails loudly, not silently: refresh_usage says "no session can poll" once per
     episode (the rail timer calls it every 60s), as a problem only when no declaration explains it;
-    kernel _usage() marks the keyed no-window payload telemetryUnavailable so the hover can say why
+    the keyed no-window payload carries spend and nothing about rate limits (the notice was deleted 2026-08-24)
     the bars are absent.
 
 Synthetic sids/paths only; no real key material or session data.
@@ -383,42 +383,28 @@ class UsageTelemetryUnavailable(unittest.TestCase):
         if self._exp_before is not None:
             os.environ["ROMP_EXPECTED_AUTH"] = self._exp_before
 
-    def test_the_marker_arm_with_a_manager_key_carries_the_flag(self):
+    def test_no_payload_carries_the_retired_telemetry_flag(self):
+        # the flag and its "rate-limit telemetry unavailable under API-key auth" hover line were
+        # DELETED (the user 2026-08-24: they know which machines are key-only and want the spend
+        # without a notice about rate limits that don't apply). A keyed host's payload carries
+        # spend and NOTHING about rate limits; a login host's windows are untouched.
         (Path(self.d) / "usage.json").write_text(json.dumps({"t": 1000, "apiKey": True}))
         km._auth_key_present = lambda: True
         km._claude_account = lambda: ""
         u = km._usage()
         self.assertTrue(u.get("apiKey"))
-        self.assertIs(u.get("telemetryUnavailable"), True)
-
-    def test_the_helper_box_reaches_the_flag_through_the_declaration(self):
-        # no usage.json at all, no manager key — the apiKeyHelper box: the no-login spend arm plus
-        # ROMP_EXPECTED_AUTH=key is what marks the absence as designed
-        (Path(self.d) / "spend.json").write_text(json.dumps({"days": {}, "hours": {}}))
-        km._auth_key_present = lambda: False
-        km._claude_account = lambda: ""
-        os.environ["ROMP_EXPECTED_AUTH"] = "key"
-        u = km._usage()
-        self.assertTrue(u.get("apiKey"))
-        self.assertIs(u.get("telemetryUnavailable"), True)
-
-    def test_no_key_reason_no_flag(self):
-        # the same spend-only arm on a keyless, undeclared machine (a login could yet arrive):
-        # absence stays unexplained rather than blamed on key auth
-        (Path(self.d) / "spend.json").write_text(json.dumps({"days": {}, "hours": {}}))
-        km._auth_key_present = lambda: False
-        km._claude_account = lambda: ""
-        u = km._usage()
-        self.assertTrue(u.get("apiKey"))
         self.assertNotIn("telemetryUnavailable", u)
+        os.environ["ROMP_EXPECTED_AUTH"] = "key"    # the apiKeyHelper declaration marks nothing either
+        (Path(self.d) / "spend.json").write_text(json.dumps({"days": {}, "hours": {}}))
+        self.assertNotIn("telemetryUnavailable", km._usage())
 
-    def test_the_bars_arm_never_carries_it(self):
+    def test_login_windows_stay_untouched_by_the_deletion(self):
         (Path(self.d) / "usage.json").write_text(json.dumps(
             {"t": 1000, "five_hour": {"pct": 40, "resets_at": None}}))   # unstamped legacy keeps bars
         km._auth_key_present = lambda: True
         km._claude_account = lambda: ""
         u = km._usage()
-        self.assertTrue(u.get("fiveHour"), "the windows exist — telemetry IS available")
+        self.assertTrue(u.get("fiveHour"), "rate-limit windows render exactly as before")
         self.assertNotIn("telemetryUnavailable", u)
 
 

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -87,16 +87,16 @@ class RailUsage(unittest.TestCase):
         self.assertNotIn("rate-limit window", self.html, "no explanatory prose, just the bars + %")
 
     def test_the_spend_section_owns_its_age_and_never_speaks_for_rate_limits(self):
-        # Three pins from one screenshot (the user 2026-08-24, "updated 9h 38m ago" over the spend):
-        # 1. the telemetry-unavailable note sits with the WINDOWS it explains, ABOVE the spend
-        #    section — the spend section never claims anything about rate limits;
+        # Pins from the 2026-08-24 spend-staleness screenshot — minus the telemetry note, which the
+        # user later the same day had DELETED entirely (they know which machines are key-only; no
+        # notice about rate limits that don't apply):
+        # 1. the notice is gone from the whole page;
         # 2. the spend section ends with its OWN age line, from the newest contributor's
         #    last-record moment (event time, not a poll time);
         # 3. a FAILED fleet pull re-renders from the cached rows, so every age line keeps climbing
         #    instead of freezing at a quietly lying "3m ago".
-        note = self.html.index("rate-limit telemetry unavailable under API-key auth")
-        self.assertLess(note, self.html.index("h+=fleetSpendHTML(sets);"),
-                        "the note renders BEFORE the spend section, in the windows area")
+        self.assertNotIn("rate-limit telemetry unavailable", self.html)
+        self.assertNotIn("_telemUnavail", self.html)
         self.assertIn("if(sAt)h+='<div class=ru-tip-age>last charge recorded '+fmtAgo(sAt)+'</div>';", self.html)
         self.assertIn("if(typeof u.spendAt==='number')det._spendAt=u.spendAt;", self.html)
         self.assertIn("pullFleet().then(done,function(){if(ROWS.length)renderRows(ROWS,SELF);done();});", self.html)

--- a/ui/webview/expected-auth.test.ts
+++ b/ui/webview/expected-auth.test.ts
@@ -1,10 +1,10 @@
-// TELEMETRY-UNAVAILABLE surfaces on an all-keyed box (the user 2026-08-15): under API-key auth the
-// usage windows are structurally absent — both usage.json writers skip keyed sessions — so the rail
-// must not read as broken. The kernel's keyed no-window payload carries telemetryUnavailable (the
-// manager env holds a key, or the box declares ROMP_EXPECTED_AUTH=key — the apiKeyHelper machine,
-// where no key ever rides service.env); the hover renders the spend it advertises even when no host
-// has window bars, plus ONE quiet line saying why the bars are absent. No jsdom harness → source
-// pins (the repo convention; rail-spend.test.ts is the pattern).
+// The ALL-KEYED box's rail read (the user 2026-08-15; notice deleted 2026-08-24): under API-key
+// auth the usage windows are structurally absent — both usage.json writers skip keyed sessions —
+// and the rail must not read as broken: the hover renders the spend it advertises even when no
+// host has window bars. The old telemetryUnavailable flag + its "rate-limit telemetry unavailable
+// under API-key auth" hover line were DELETED entirely (the user 2026-08-24: they know which
+// machines are key-only and want the spend without a notice about rate limits that don't apply).
+// No jsdom harness → source pins (the repo convention; rail-spend.test.ts is the pattern).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -25,16 +25,10 @@ test("the hover renders the spend section even when NO host has window bars", ()
     "the return-time append (unreachable on empty blocks) is gone with it");
 });
 
-test("the keyed no-window payload says WHY, and the hover carries one quiet line", () => {
-  // the kernel marks the spend-only payload when the reason is key auth — a manager-env key, or
-  // the ROMP_EXPECTED_AUTH=key declaration (the apiKeyHelper box has no key in the manager env)
-  assert.ok(KERNEL.includes('out["telemetryUnavailable"] = True'));
-  assert.match(KERNEL, /if \(_auth_key_present\(\)\s*\n\s*or \(os\.environ\.get\("ROMP_EXPECTED_AUTH"\) or ""\)\.strip\(\)\.lower\(\) == "key"\):/);
-  // the rail captures the flag per host and renders ONE dim line (the acct line's dress — the
-  // hover's existing quiet-note affordance), never a bar-shaped guess
-  assert.ok(usageJS.includes("if(r.usage.telemetryUnavailable)det._telemUnavail=true;"));
-  assert.ok(usageJS.includes(
-    "<div class=ru-tip-acct>rate-limit telemetry unavailable under API-key auth</div>"));
-  assert.ok(usageJS.includes("sets.some(function(e){return e.det._telemUnavail;})"),
-    "any keyed host's payload is enough — the line renders once, not per host");
+test("the telemetry-unavailable notice is GONE end to end (the user 2026-08-24)", () => {
+  // deleted, not relocated: they know which machines are key-only and want the spend without a
+  // notice about rate limits that don't apply. No flag in the payload, no capture, no hover line.
+  assert.ok(!KERNEL.includes('out["telemetryUnavailable"] = True'));
+  assert.ok(!usageJS.includes("_telemUnavail"));
+  assert.ok(!usageJS.includes("rate-limit telemetry unavailable"));
 });


### PR DESCRIPTION
## What

The "rate-limit telemetry unavailable under API-key auth" notice is **deleted, not relocated** (the user's ruling, 2026-08-24: they know which machines are key-only and want the API spend without a notice about rate limits that don't apply). The whole chain goes: the hover line, the per-host `_telemUnavail` capture, and the kernel payload's `telemetryUnavailable` flag — nothing else consumed it. Absence of windows on a keyed host now simply looks like what it is: no windows. Rate-limit **windows on login machines are untouched**, pinned.

## Tests

All three homes retarget to absence with the ruling cited: `tests/test_expected_auth.py` (no flag on any payload arm — manager-env key, `ROMP_EXPECTED_AUTH=key`, or neither; login windows unchanged), `ui/webview/expected-auth.test.ts` (no flag emit, no capture, no hover line), `tests/test_kernel_rail_usage.py` (the notice absent from the whole page; the spend-age and failure-re-render pins keep standing). Suites green: 5446 python tests (+293 subtests), 2315 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)