### PR TITLE
Card keyboard cycling + the paused floor tells the plain truth

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3604,7 +3604,7 @@ def _lift_spent_awaiting(now, tmux):
             # NOTHING, so the stamp sat invisibly forever — the closer was never re-nominated (its
             # filed-since gate needs a diary row newer than closerLookT, and the newest row was the stamp
             # itself), the plain-nudge fire gate read the RAW fields and vetoed every fire, and a LIVE
-            # session's Working card wore the quiet floor ("Paused — resumes on the session's next turn")
+            # session's Working card wore the quiet floor ("Paused — resumes when its wait ends")
             # indefinitely — three live specimens on one board, one ~14h, breaking the recorded 2026-08-22
             # promise that every Working card is nudged/woken until it lands (_dead_wait_block's docstring).
             # File the lift the readers already act on: the reply is the wait's designed exact ending event

--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -44,7 +44,8 @@ test("identical views count nothing — in-place content edits are not movement"
 
 test("the feed payload path defers while a card is hovered — and ONLY the payload path", () => {
   // the message handler's feed branch gates on the freeze; the newest payload supersedes by overwrite
-  assert.match(FEED, /if \(freezeKey\) \{ pendingFeedPayload = m; paintFreezeBadges\(\); return; \}\s*\n\s*applyFeedPayload\(m\);/);
+  assert.match(FEED, /if \(freezeKey \|\| tabScopeKey\) \{ pendingFeedPayload = m; paintFreezeBadges\(\); return; \}\s*\n\s*applyFeedPayload\(m\);/,
+    "the keyboard scope holds the same gate (the user 2026-08-24) — a card being keyed cannot move either");
   const queues = FEED.match(/pendingFeedPayload = m;/g) || [];
   assert.equal(queues.length, 1, "one queue write, in the payload path — local gestures and render() are never gated");
   assert.doesNotMatch(FEED, /function render\(\) \{\s*\n[^\n]*freezeKey/, "render is not gated — the hovered card's controls stay live");
@@ -54,8 +55,9 @@ test("the feed payload path defers while a card is hovered — and ONLY the payl
 });
 
 test("flush is event-based: card mouseleave, window blur backstop — no timers anywhere in the freeze", () => {
-  assert.match(FEED, /function freezeLeave\(key: string\): void \{\s*\n\s*if \(freezeKey !== key\) return;\s*\n\s*freezeKey = null;\s*\n\s*flushFreeze\(\);/);
-  assert.match(FEED, /window\.addEventListener\("blur", \(\) => \{ freezeKey = null; flushFreeze\(\); \}\);/);
+  assert.match(FEED, /function freezeLeave\(key: string\): void \{\s*\n\s*if \(tabScopeKey === key\) releaseTabScope\(\);[^\n]*\n\s*if \(freezeKey !== key\) return;\s*\n\s*freezeKey = null;\s*\n\s*flushFreeze\(\);/);
+  assert.match(FEED, /window\.addEventListener\("blur", \(\) => \{ releaseTabScope\(\); freezeKey = null; flushFreeze\(\); \}\);/,
+    "blur releases BOTH gate holders — the keyboard scope has no pointer to leave with");
   const block = FEED.slice(FEED.indexOf("// ── HOVER-FREEZE"), FEED.indexOf("function applyFeedPayload"));
   assert.ok(!/setTimeout|setInterval/.test(block), "no timers — mouseleave and blur are the flush events");
   // the flush is a MICROTASK — same gesture, after its handlers finish (found in review 2026-08-24:

--- a/ui/webview/feed-kbscope.test.ts
+++ b/ui/webview/feed-kbscope.test.ts
@@ -1,0 +1,73 @@
+// CARD KEYBOARD SCOPE (the user 2026-08-24): Tab, pressed while a card is hovered (a click puts the
+// pointer there too) or held by the keyboard card cursor, cycles ALL that card's visible controls,
+// wrapping; Enter/Space activate; the accent .kbd-focus ring marks the stop; Escape or hover-away
+// releases to normal page order. Focus survives the feed's 0.5s re-renders by LOGICAL control
+// identity, and a focused card holds the hover-freeze payload gate. feed.ts has no jsdom harness →
+// source pins (the repo convention); the gate composition is pinned in feed-freeze.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+test("scope entry: the hovered card (clicks hover too), else the keyboard card cursor", () => {
+  assert.match(FEED, /if \(!card\) card = \(freezeKey \? cardElByKey\(freezeKey\) : null\) \|\| kbCardEl;/,
+    "hover truth (freezeKey rides the card's own mouseenter) first, the kb cursor as the keyboard-only path");
+  assert.match(FEED, /function cardElByKey\(key: string\): HTMLElement \| null/,
+    "keys resolve through the same data-key vocabulary the reconcile writes");
+  // typing in an input OUTSIDE the card keeps its normal Tab
+  assert.match(FEED, /if \(ae && \/\^\(INPUT\|TEXTAREA\|SELECT\)\$\/\.test\(ae\.tagName\) && !card\.contains\(ae\)\) return;/);
+});
+
+test("the cycle covers every visible control in the card's own (visual) order, and WRAPS", () => {
+  assert.match(FEED, /return Array\.from\(card\.querySelectorAll<HTMLElement>\(KB_EL_SEL\)\)\.filter\(\(e\) => e\.offsetParent !== null\);/,
+    "one selector, DOM order — the card's reading order — visible controls only");
+  assert.match(FEED, /i = e\.shiftKey \? \(i <= 0 \? els\.length - 1 : i - 1\) : \(i >= els\.length - 1 \? 0 : i \+ 1\);/,
+    "both directions wrap at the ends");
+  assert.match(FEED, /\.fask-secbtn,\.fask-bellbtn/, "the section pills and the bell are in the set");
+});
+
+test("Enter/Space activate — native controls natively, span controls by an exact synthetic click", () => {
+  assert.match(FEED, /if \(ae\.matches\("button, a, input"\)\) return;   \/\/ native activation already fires the click/);
+  assert.match(FEED, /ae\.click\(\);\s*[^\n]*\/\/ EXACTLY a mouse click on that control/);
+  // non-native controls become focusable without joining the page's own Tab order
+  assert.match(FEED, /if \(el2\.tabIndex < 0 && !el2\.matches\("button, a, input"\)\) el2\.tabIndex = -1;/);
+  // the accent ring rides the shared .kbd-focus class (feed.css owns the style)
+  assert.match(FEED, /el2\.classList\.add\("kbd-focus"\);/);
+});
+
+test("focus survives a re-render by LOGICAL identity — a rebuild must not eat keyboard focus", () => {
+  const tail = FEED.slice(FEED.indexOf("// keyboard-scope focus restore"), FEED.indexOf("function feedWantsKeys"));
+  assert.ok(tail.includes("let i = els.findIndex((e2) => ctrlSig(e2) === tabScopeSig!.sig);"),
+    "identity first: class + label");
+  assert.ok(tail.includes("if (i < 0) i = Math.min(tabScopeSig.idx, els.length - 1);"),
+    "the old slot as the fallback when the control's identity changed");
+  assert.ok(tail.includes("else releaseTabScope();"), "a card gone entirely releases cleanly");
+  // a card detached WITH the ring (filtered out mid-scope) may be reattached by the reconcile later;
+  // with no scope active any in-card ring is stale — the render tail strips it (kbMode owns its own)
+  assert.match(FEED, /if \(!tabScopeKey && !kbMode\) document\.querySelectorAll\("\.fitem \.kbd-focus"\)/);
+  assert.match(FEED, /function ctrlSig\(e: HTMLElement\): string \{\s*\n\s*return e\.className \+ "\|" \+ \(e\.getAttribute\("aria-label"\) \|\| e\.textContent \|\| ""\)\.trim\(\)\.slice\(0, 24\);/);
+});
+
+test("release: Escape anywhere, or the pointer leaving the card — back to normal page order", () => {
+  assert.match(FEED, /if \(e\.key === "Escape" && tabScopeKey\) \{/);
+  assert.match(FEED, /if \(tabScopeKey === key\) releaseTabScope\(\);   \/\/ hover-away releases the keyboard scope too/,
+    "rides the same leave event the freeze uses");
+  const relStart = FEED.indexOf("function releaseTabScope");
+  const rel = FEED.slice(relStart, FEED.indexOf('window.addEventListener("keydown"', relStart));
+  assert.ok(rel.includes('document.querySelectorAll(".kbd-focus").forEach((n) => n.classList.remove("kbd-focus"));'),
+    "the ring comes off");
+  assert.ok(rel.includes("if (!freezeKey) flushFreeze();"),
+    "the scope held the payload gate — releasing applies whatever queued");
+  // window blur is the scope's backstop too — otherwise a blurred pane with an armed scope would
+  // queue payloads forever (the scope has no pointer to leave with)
+  assert.match(FEED, /window\.addEventListener\("blur", \(\) => \{ releaseTabScope\(\); freezeKey = null; flushFreeze\(\); \}\);/);
+});
+
+test("the modal owns keys while open; the scoped handlers stop propagation so nothing double-fires", () => {
+  const kd = FEED.slice(FEED.indexOf("// ── CARD KEYBOARD SCOPE"), FEED.indexOf("// The feed payload's full application"));
+  assert.ok(kd.includes('if (document.getElementById("feed-modal")) return;'));
+  assert.ok((kd.match(/e\.stopPropagation\(\);/g) || []).length >= 2, "Escape and Tab both stop propagation");
+  assert.ok(kd.includes("}, true);"), "capture phase — ahead of the page's own key handling");
+});

--- a/ui/webview/feed-keynav.test.ts
+++ b/ui/webview/feed-keynav.test.ts
@@ -24,7 +24,9 @@ test("the card cursor reuses the mouse-hover highlight path (applyFocus + showAs
 });
 
 test("Enter descends into a card; arrows step its elements; Enter activates via a real click", () => {
-  assert.match(FEED, /const KB_EL_SEL = "\.fcard-title\.nav,\.fask-distill-link,\.fname,\.fask-apiRetry,\.fask-revive,\.fdismiss,\.fcheck \.lz-nav,\.fask-delegation";/);
+  // section pills + the bell joined the set with the Tab scope (the user 2026-08-24) — every
+  // visible control on a card cycles
+  assert.match(FEED, /const KB_EL_SEL = "\.fcard-title\.nav,\.fask-distill-link,\.fname,\.fask-apiRetry,\.fask-revive,\.fdismiss,\.fask-secbtn,\.fask-bellbtn,\.fcheck \.lz-nav,\.fask-delegation";/);
   assert.match(FEED, /function kbEnterCard\(\): void \{/);
   // element highlight dispatches the element's OWN hover event (zone .lz-hl + timeline), not a reimplementation
   assert.match(FEED, /el\.dispatchEvent\(new MouseEvent\("mouseenter"\)\);/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4107,6 +4107,25 @@ function render() {
     else { const k = kbHoverId(hov); if (k && k !== freezeKey) freezeKey = k; }
   }
   paintFreezeBadges();   // hover-freeze: local renders while frozen re-sync the +N/-N hints (no-op unfrozen)
+  // stale-ring heal: releaseTabScope sweeps the DOCUMENT, but a card DETACHED at release (filtered
+  // out by search, say) keeps its ring and the reconcile may reattach that cached element later —
+  // with no scope active, any ring inside a card is stale; strip per render (kbMode owns its own)
+  if (!tabScopeKey && !kbMode) document.querySelectorAll(".fitem .kbd-focus").forEach((n) => n.classList.remove("kbd-focus"));
+  // keyboard-scope focus restore (the user 2026-08-24): a re-render may rebuild the focused
+  // control's element, and a rebuild must not eat keyboard focus (click-safety, applied to the
+  // keyboard). Find the control again by LOGICAL identity — class + label, then the old slot.
+  if (tabScopeKey && tabScopeSig) {
+    const card = cardElByKey(tabScopeKey);
+    const ae = document.activeElement;
+    if (!card) releaseTabScope();
+    else if (!ae || ae === document.body || !card.contains(ae)) {
+      const els = cardControls(card);
+      let i = els.findIndex((e2) => ctrlSig(e2) === tabScopeSig!.sig);
+      if (i < 0) i = Math.min(tabScopeSig.idx, els.length - 1);
+      if (i >= 0) tabScopeFocus(card, els, i);
+      else releaseTabScope();
+    }
+  }
   // FLIP-across-identity: a card whose KEY is new this render (group→solo, solo→group, umbrella absorb) has no
   // First rect of its own, so the normal FLIP can't slide it. Alias it to its PREDECESSOR's rect — the card
   // key that covered one of its goals LAST render — so it glides in from where that predecessor sat instead of
@@ -4162,7 +4181,7 @@ window.addEventListener("click", (e) => {
 // out. Every highlight + action reuses the mouse path — card cursor = the same hoverAskId/applyFocus/showAskPath
 // the hover uses; element cursor dispatches a real mouseenter (so zone highlights + timeline light exactly as on
 // hover) and Enter calls the element's own click() — so the keyboard can never drift from the mouse.
-const KB_EL_SEL = ".fcard-title.nav,.fask-distill-link,.fname,.fask-apiRetry,.fask-revive,.fdismiss,.fcheck .lz-nav,.fask-delegation";
+const KB_EL_SEL = ".fcard-title.nav,.fask-distill-link,.fname,.fask-apiRetry,.fask-revive,.fdismiss,.fask-secbtn,.fask-bellbtn,.fcheck .lz-nav,.fask-delegation";
 function kbCardEls(): HTMLElement[] {
   // VISUAL order, not DOM order (review 2026-08-24): the columns re-sequence via --col-order — in
   // both layouts since the drag extended — so the arrow cursor sorts cards by their column's
@@ -4312,6 +4331,7 @@ let freezeKey: string | null = null;     // the hovered card's focus key, or nul
 let pendingFeedPayload: any = null;      // newest queued payload; older ones are superseded unseen
 function freezeEnter(key: string): void { freezeKey = key; }
 function freezeLeave(key: string): void {
+  if (tabScopeKey === key) releaseTabScope();   // hover-away releases the keyboard scope too
   if (freezeKey !== key) return;
   freezeKey = null;
   flushFreeze();
@@ -4330,7 +4350,8 @@ function flushFreeze(): void {
     if (m) applyFeedPayload(m);          // render() repaints the badges away (nothing pending)
   });
 }
-window.addEventListener("blur", () => { freezeKey = null; flushFreeze(); });   // backstop: focus left the pane
+window.addEventListener("blur", () => { releaseTabScope(); freezeKey = null; flushFreeze(); });   // backstop:
+//   focus left the pane — BOTH gate holders release (the keyboard scope has no pointer to leave with)
 
 // The queued payload's would-be card list — the same pre-filters applyFeedPayload will apply,
 // WITHOUT its bookkeeping side effects (a hint must never mutate pendingCleared or the disclosure
@@ -4384,6 +4405,77 @@ function paintFreezeBadges(): void {
     put(h, groupedNow ? d.sess[h.getAttribute("data-fsid") || ""] : undefined);
   });
 }
+
+// ── CARD KEYBOARD SCOPE (the user 2026-08-24) ──────────────────────────────────────────────────
+// Tab, pressed while a card is hovered (a click puts the pointer there too) or held by the keyboard
+// card cursor, scopes to THAT card: it cycles every visible control on it — section pills, Clear,
+// retries, the bell, follow-up, sub-goal links — wrapping at the ends; Enter/Space activate; the
+// accent .kbd-focus ring marks the stop. Escape or the pointer leaving the card releases back to
+// normal page order. Focus survives the feed's constant re-renders by LOGICAL control identity
+// (class + label, then the old slot) — the click-safety rule applied to keyboard focus. While focus
+// is inside, the card holds the payload gate hover-freeze uses, so the board cannot move the card
+// being keyed (same gate as the pointer).
+let tabScopeKey: string | null = null;
+let tabScopeSig: { sig: string; idx: number } | null = null;
+function cardElByKey(key: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-key="' + (key.startsWith("g:") ? key : "a:" + key) + '"]');
+}
+function cardControls(card: HTMLElement): HTMLElement[] {
+  // the card's own DOM order IS its visual reading order — title row, pills, tail controls
+  return Array.from(card.querySelectorAll<HTMLElement>(KB_EL_SEL)).filter((e) => e.offsetParent !== null);
+}
+function ctrlSig(e: HTMLElement): string {
+  return e.className + "|" + (e.getAttribute("aria-label") || e.textContent || "").trim().slice(0, 24);
+}
+function tabScopeFocus(card: HTMLElement, els: HTMLElement[], i: number): void {
+  document.querySelectorAll(".kbd-focus").forEach((n) => n.classList.remove("kbd-focus"));
+  const el2 = els[i];
+  if (!el2) return;
+  tabScopeKey = kbHoverId(card);
+  tabScopeSig = { sig: ctrlSig(el2), idx: i };
+  if (el2.tabIndex < 0 && !el2.matches("button, a, input")) el2.tabIndex = -1;   // focusable, outside page order
+  el2.classList.add("kbd-focus");
+  el2.focus();
+}
+function releaseTabScope(): void {
+  if (!tabScopeKey) return;
+  tabScopeKey = null;
+  tabScopeSig = null;
+  document.querySelectorAll(".kbd-focus").forEach((n) => n.classList.remove("kbd-focus"));
+  const ae = document.activeElement as HTMLElement | null;
+  if (ae && ae.closest(".fitem")) ae.blur();
+  if (!freezeKey) flushFreeze();   // the scope held the payload gate — releasing applies the queue
+}
+window.addEventListener("keydown", (e) => {
+  if (document.getElementById("feed-modal")) return;   // the modal owns keys while it is open
+  if (e.key === "Escape" && tabScopeKey) {
+    e.preventDefault(); e.stopPropagation();
+    releaseTabScope();
+    return;
+  }
+  if (e.key === "Tab") {
+    let card = tabScopeKey ? cardElByKey(tabScopeKey) : null;
+    if (!card) card = (freezeKey ? cardElByKey(freezeKey) : null) || kbCardEl;   // hover/click, else the kb cursor
+    if (!card || !card.isConnected) return;
+    const ae = document.activeElement as HTMLElement | null;
+    if (ae && /^(INPUT|TEXTAREA|SELECT)$/.test(ae.tagName) && !card.contains(ae)) return;   // typing elsewhere
+    const els = cardControls(card);
+    if (!els.length) return;
+    e.preventDefault(); e.stopPropagation();
+    let i = ae ? els.indexOf(ae) : -1;
+    i = e.shiftKey ? (i <= 0 ? els.length - 1 : i - 1) : (i >= els.length - 1 ? 0 : i + 1);   // WRAP at the ends
+    tabScopeFocus(card, els, i);
+    return;
+  }
+  if ((e.key === "Enter" || e.key === " ") && tabScopeKey) {
+    const ae = document.activeElement as HTMLElement | null;
+    const card = cardElByKey(tabScopeKey);
+    if (!ae || !card || !card.contains(ae)) return;
+    if (ae.matches("button, a, input")) return;   // native activation already fires the click
+    e.preventDefault();
+    ae.click();                                   // EXACTLY a mouse click on that control
+  }
+}, true);
 
 // The feed payload's full application — model swap, bookkeeping, render. One body, two callers:
 // the message handler applies live when no card is hovered; flushFreeze applies the newest queued
@@ -4480,7 +4572,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   if (m.type === "feed") {
     // HOVER-FREEZE: a hovered card must not move on screen — queue the payload (newest wins) and
     // hint the deferred churn on the headers instead; mouseleave/blur flush it (see freezeEnter).
-    if (freezeKey) { pendingFeedPayload = m; paintFreezeBadges(); return; }
+    if (freezeKey || tabScopeKey) { pendingFeedPayload = m; paintFreezeBadges(); return; }
     applyFeedPayload(m);
   } else if (m.type === "hoverCards") {
     // rail-dot hover in the CHAT panel → white-outline the card(s) built from

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -230,7 +230,9 @@ test("THE FLOOR IS TOTAL — a working-column card can never be mute (the user 2
   assert.equal(open.caption, "Working…");
   assert.ok(!open.still, "an open turn spins — it IS in flight");
   const quiet = spinFor({ column: "working", sessState: "quiet" }, false, false, 100);
-  assert.match(quiet.caption || "", /^Paused — resumes/);
+  assert.match(quiet.caption || "", /^Paused — resumes when its wait ends$/);   // plain truth (the user
+  // 2026-08-24): never promise the session's NEXT turn — waits lift on their own ending events, and
+  // the next turn may work another thread entirely
   assert.equal(quiet.still, true, "nothing in motion → the glyph stills (a spin would lie)");
   const unk = spinFor({ column: "working", sessState: "unknown" }, false, false, 100);
   assert.match(unk.caption || "", /unknown — this machine isn't reporting/);

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -219,9 +219,12 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     }
     if (it.sessState === "quiet") {
       return {
-        caption: "Paused — resumes on the session's next turn",
+        // plain truth (the user 2026-08-24): the old line promised the session's NEXT turn, but the
+        // next turn may work another thread entirely — this goal resumes when its own wait ends
+        caption: "Paused — resumes when its wait ends",
         tip: "Nothing is in motion right now: the session is between turns and this goal stays open. "
-           + "It picks back up the next time the session works this thread.",
+           + "It picks back up when the session returns to this thread — not necessarily on its very "
+           + "next turn.",
         awaitingBg: false,
         still: true,
       };


### PR DESCRIPTION
Two riders, one PR.

**Card keyboard cycling** (the user's ask): Tab, pressed while a card is hovered (a click puts the pointer there too) or held by the keyboard card cursor, scopes to that card and cycles **every** visible control on it — section pills, Clear, retries, the bell, follow-up, sub-goal links (the pills and bell join `KB_EL_SEL`) — wrapping at the ends. Enter/Space activate (native controls natively; span controls get an exact synthetic click). The accent `.kbd-focus` ring marks the stop. Escape, the pointer leaving the card, or window blur releases back to normal page order. Focus survives the feed's constant re-renders by **logical control identity** (class + label, then the old slot) — the click-safety rule applied to keyboard focus — and a card being keyed holds the hover-freeze payload gate, so the board cannot move it while it's being keyed; releasing the scope flushes whatever queued. A render-tail heal strips any stale ring a detached-then-reattached card could carry back.

**Paused floor tells the plain truth**: the quiet Working card promised the session's *next turn*, but the next turn may work another thread entirely — waits lift on their own ending events. It now reads "Paused — resumes when its wait ends", tip aligned, kernel comment and pins updated.

**Tests**: new `feed-kbscope.test.ts` covers scope entry (hover/click and the kb cursor), the visible-controls cycle and wrap, activation with the native guard, identity-based focus restore, release on Escape/hover-away/blur, and the capture/stop-propagation discipline; `feed-freeze.test.ts` pins the gate composition; `feed-keynav.test.ts` follows the widened selector; `spin-caption.test.ts` pins the new caption exactly. 2315 extension tests and the kernel-side suites green.

**Review note**: the usual adversarial review workflow was attempted four times and killed each time by kernel restarts before any result could bank; it was replaced by a structured self-audit of the same seeded questions (existing-kb-nav interference, identity-collision restore, gate flush coverage on every release path, cleared/removed-card paths, stale-ring reattachment — the last two produced the blur backstop and render-tail heal included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
