### PR TITLE
Comment highlights: the settle latches past turn boundaries, and math greens with the prose

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { threadsByAnchor, threadBusy, threadStuck, threadInFlight, replyOwed, findExact, findAnchorRange, sliceRanges, prunePending,
+import { threadsByAnchor, threadBusy, threadStuck, threadInFlight, replyOwed, latchBusy, type BusyLatch, SETTLE_CONFIRM_PUSHES, findExact, findAnchorRange, sliceRanges, prunePending,
          type CommentThread } from "./comments";
 
 const th = (over: Partial<CommentThread>): CommentThread => ({
@@ -481,4 +481,36 @@ test("the mark stays green from send to landed reply, through the CLI-boot state
   assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)), "errored: the note speaks, not the green");
   assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], status: "resolved" })), "resolved threads are done");
   assert.equal(replyOwed(th({ msgs: [] })), false, "an empty thread owes nothing");
+});
+
+// ── the SETTLE LATCH (the user 2026-08-24, third report: green → a ~1s YELLOW blip mid-churn →
+// green → correct settle). At a turn boundary inside a continuing thread one push reads
+// quiet-state + agent-tail — frame-locally identical to the true end — so the green now holds until
+// TWO consecutive pushes confirm the settle (pushes are events; the pendingSessionViews idiom).
+// The user's exact sequence, executed: the state changes at most ONCE across it. ────────────────
+test("the mark never blips: the user's churn sequence yields exactly one green→yellow transition", () => {
+  const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
+  const frames = [
+    th({ state: "working", msgs: [msg("you")] }),                    // churn
+    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // the boundary frame that blipped
+    th({ state: "working", msgs: [msg("you"), msg("agent")] }),      // churn resumes
+    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // quiet 1
+    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // quiet 2 → settle
+  ];
+  let l: BusyLatch | undefined;
+  const seen: boolean[] = [];
+  for (const f of frames) { l = latchBusy(l, f); seen.push(l.green); }
+  assert.deepEqual(seen, [true, true, true, true, false], "green held through the boundary, settled on confirmation");
+  assert.equal(seen.filter((s, i) => i && s !== seen[i - 1]).length, 1, "at most one change per deciding event");
+  assert.equal(SETTLE_CONFIRM_PUSHES, 2, "two consecutive confirming pushes decide the settle");
+});
+
+test("status flips decide IMMEDIATELY — resolve/merge/error never wait out the confirmation window", () => {
+  const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
+  let l = latchBusy(undefined, th({ state: "working", msgs: [msg("you")] }));
+  assert.equal(l.green, true);
+  assert.equal(latchBusy(l, th({ state: "working", msgs: [msg("you")], status: "resolved" })).green, false, "resolved drops the green on ITS event");
+  assert.equal(latchBusy(l, th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)).green, false, "an errored thread is never green");
+  // an optimistic pending send (alsoBusy) arms the latch like any busy reading
+  assert.equal(latchBusy(undefined, th({ state: "", msgs: [] }), true).green, true, "a just-typed reply reads busy immediately");
 });

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -61,6 +61,24 @@ export function threadInFlight(th: CommentThread): boolean {
   return th.status === "open" && !th.error && !threadStuck(th.state)
     && (threadBusy(th.state) || replyOwed(th));
 }
+// SETTLE LATCH (the user 2026-08-24, second report: the passage went green, blipped YELLOW for a
+// second mid-churn, then back to green). At a turn boundary inside a continuing thread, one push can
+// read quiet-state + agent-tail — frame-locally indistinguishable from the true end, so no predicate
+// over a single frame can avoid the flap. The repo rule: transient states latch until the deciding
+// event. Here the deciding evidence is CONSECUTIVE confirming pushes (the pendingSessionViews idiom:
+// pushes are events, never timers): the green holds until TWO pushes in a row read settled; any busy
+// or owed reading resets the count; a status flip (resolved/merged/error) decides IMMEDIATELY — those
+// are real events, never held. The state changes at most once per deciding event by construction.
+export type BusyLatch = { green: boolean; quiet: number };
+export const SETTLE_CONFIRM_PUSHES = 2;
+export function latchBusy(prev: BusyLatch | undefined, th: CommentThread, alsoBusy = false): BusyLatch {
+  if (th.status !== "open" || th.error) return { green: false, quiet: 0 };
+  const raw = alsoBusy || (!threadStuck(th.state) && (threadBusy(th.state) || replyOwed(th)));
+  if (raw) return { green: true, quiet: 0 };
+  if (!prev || !prev.green) return { green: false, quiet: 0 };
+  const quiet = prev.quiet + 1;
+  return quiet >= SETTLE_CONFIRM_PUSHES ? { green: false, quiet: 0 } : { green: true, quiet };
+}
 export function threadStuck(state: string): boolean {
   return state === "permission" || state === "picker";
 }

--- a/ui/webview/css-balance.test.ts
+++ b/ui/webview/css-balance.test.ts
@@ -1,0 +1,36 @@
+// CSS brace balance (the user 2026-08-24, screenshot: math never went green while prose did). An
+// UNMATCHED stray `}` — left at styles.css:2612 by an earlier block removal — makes Chromium's error
+// recovery EAT the rule that follows it: the combined code/katex busy rule sat right after one and
+// was dead on arrival, verified by a browser A/B (withStray → the next rule's declaration lost;
+// without → applied). A selector can pass every source pin and still be inert this way, so the guard
+// is structural: every stylesheet parses with balanced braces, no stray closes anywhere.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SHEETS = ["styles.css", "feed.css", "fleet-pane.css"];
+
+function scan(css: string): { finalDepth: number; strayCloseLines: number[] } {
+  let depth = 0, line = 1, i = 0;
+  const stray: number[] = [];
+  while (i < css.length) {
+    if (css.startsWith("/*", i)) { const j = css.indexOf("*/", i) + 2; line += (css.slice(i, j).match(/\n/g) || []).length; i = j; continue; }
+    const c = css[i];
+    if (c === "\n") line++;
+    else if (c === "{") depth++;
+    else if (c === "}") { depth--; if (depth < 0) { stray.push(line); depth = 0; } }
+    i++;
+  }
+  return { finalDepth: depth, strayCloseLines: stray };
+}
+
+for (const f of SHEETS) {
+  test(f + " has balanced braces — a stray } silently kills the rule after it", () => {
+    const p = path.resolve(process.cwd(), "..", "ui", "webview", f);
+    if (!fs.existsSync(p)) return;   // sheet renamed/retired → nothing to scan
+    const r = scan(fs.readFileSync(p, "utf8"));
+    assert.deepEqual(r.strayCloseLines, [], f + ": stray closing braces at lines " + r.strayCloseLines.join(", "));
+    assert.equal(r.finalDepth, 0, f + ": unclosed blocks at EOF");
+  });
+}

--- a/ui/webview/katex-host.test.ts
+++ b/ui/webview/katex-host.test.ts
@@ -1,0 +1,29 @@
+// The comment highlight's KaTeX pairing, pinned against REAL katex output (the user 2026-08-24: the
+// hand-approximated fixture is how the dead selector shipped — the math stayed yellow while prose
+// greened). katex here is the exact package the bundle renders with (math.ts, output:"html").
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import katex from "katex";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("real katex output matches the marking code's structural assumptions", () => {
+  const html = katex.renderToString("\\Sigma_a v = \\lambda \\Sigma_b v", { output: "html", throwOnError: false });
+  assert.match(html, /^<span class="katex">/, "the host root the marker's closest('.katex') finds");
+  assert.ok(/>[^<>]+</.test(html), "glyph text nodes exist inside — sliceRanges can wrap marks there");
+  assert.doesNotMatch(html, /katex-mathml/, "html-only output — no MathML twin for a mark to double-cover");
+});
+
+test("the busy/settled pairing keys on the HOST carrying a busy mark, and the rule is alive (not brace-eaten)", () => {
+  assert.match(RENDER, /const kat = segs\[i\]\.parentElement\?\.closest\("\.katex"\) as HTMLElement \| null;/);
+  assert.match(RENDER, /if \(kat\) kat\.classList\.toggle\("cmt-hl-host", th\.status !== "resolved" && th\.status !== "merged"\);/);
+  assert.match(CSS, /\.md \.katex\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{/);
+  // the rule directly above the combined selector must be a CLOSED comment, never a stray } (the
+  // brace-eater — css-balance.test.ts guards the whole class; this pins the one that shipped)
+  const at = CSS.indexOf(".md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),");
+  const before = CSS.slice(Math.max(0, at - 220), at);
+  assert.doesNotMatch(before, /\}\s*\n\s*\}/, "no doubled close ahead of the combined busy rule");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -44,7 +44,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
-import { threadInFlight, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { threadInFlight, latchBusy, type BusyLatch, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -5732,10 +5732,16 @@ function showForkPrompt(sid: string, uuid: string): void {
 // re-render (the transcript rebuilds constantly) reapplies it — the openFolds pattern.
 const commentThreads = new Map<string, CommentThread[]>();          // parent sid → last frame's threads
 const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
-// the one busy answer for the mark + rail tick: the pure predicate, plus this pane's own optimistic
-// sends (a reply just typed, frame echo still in flight) — see comments.ts replyOwed for the why
-const commentInFlight = (th: CommentThread): boolean =>
-  threadInFlight(th) || (th.status === "open" && !!(commentPending.get(th.tid) || []).length);
+// the one busy answer for the mark + rail tick: the LIVE reading (the pure predicate plus this
+// pane's own optimistic sends) OR the settle latch — a turn boundary inside a continuing thread can
+// read settled for one push, and the green must not blip yellow on it (the user 2026-08-24, second
+// report; comments.ts latchBusy has the rule). The latch advances once per comments FRAME (the
+// event); the live OR keeps optimistic sends instant between frames.
+const commentBusyLatch = new Map<string, BusyLatch>();
+const commentInFlight = (th: CommentThread): boolean => {
+  const raw = threadInFlight(th) || (th.status === "open" && !!(commentPending.get(th.tid) || []).length);
+  return raw || !!commentBusyLatch.get(th.tid)?.green;
+};
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
 let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
@@ -10656,6 +10662,9 @@ window.addEventListener("message", (e: MessageEvent) => {
     const sid = String(m.id);
     const threads = (m.threads || []) as CommentThread[];
     commentThreads.set(sid, threads);
+    // the settle latch steps ONCE per frame — the deciding events are pushes (see comments.ts)
+    for (const t of threads) commentBusyLatch.set(t.tid, latchBusy(commentBusyLatch.get(t.tid), t, !!(commentPending.get(t.tid) || []).length));
+    for (const k of Array.from(commentBusyLatch.keys())) if (!threads.some((t) => t.tid === k)) commentBusyLatch.delete(k);
     const live = new Set(threads.filter((t) => t.status !== "promoted").map((t) => t.tid));
     for (const k of Array.from(commentPending.keys())) if (!live.has(k)) commentPending.delete(k);
     for (const k of Array.from(commentDrafts.keys())) if (!k.startsWith("new:") && !live.has(k)) commentDrafts.delete(k);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2608,8 +2608,10 @@ mark.cmt-hl.busy {
 }
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
-
-}
+/* (an unmatched stray `}` sat here from 7f0c9b8c's block removal, 2026-08-23→24: Chromium's error
+   recovery EATS the rule that follows one, which silently killed the combined code/katex busy rule
+   below — math never greened while prose did (the user 2026-08-24, screenshot). A brace-balance
+   test guards the whole class now.) */
 /* a code/math HOST whose mark is mid-reply greens the same way — its element tint would otherwise
    stay full-strength yellow and hide the writing state */
 .md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),


### PR DESCRIPTION
## Leg A — the transient yellow blip

At a turn boundary inside a continuing thread, one push reads quiet-state + agent-tail — **frame-locally identical to the true end** — so no predicate over a single frame can avoid the flap. The busy green now latches (`comments.ts latchBusy`): it holds until **two consecutive pushes** confirm the settle (pushes are events — the `pendingSessionViews` idiom, never a timer); any busy/owed reading resets the count; status flips (resolved/merged/error) decide immediately on their own events. The latch steps once per comments frame; the live reading still ORs in, so optimistic sends stay instant. The user's exact sequence executes as a test — green through the boundary frame, exactly one green→yellow transition across the churn.

## Leg B — math never went green

The pairing selector was correct, matching, **and dead**: an unmatched stray `}` (left at styles.css:2612 by an earlier block removal, predating the pairing) sat immediately before it, and Chromium's error recovery **eats the rule that follows a stray close** — verified with a browser A/B (withStray → the following rule's declaration lost; without → applied). Code hosts survived via their second standalone rule; the katex host had only the combined rule, so math stayed yellow while prose greened — the screenshot exactly.

- The stray brace is removed; the katex host now computes the identical green/yellow/none as the marks in every state (harness-verified over the built bundle with real rendered math).
- **The whole bug class is guarded:** `css-balance.test.ts` scans every stylesheet for stray closes and unclosed blocks — a selector can pass every source pin and still be inert this way.
- `katex-host.test.ts` pins the marking assumptions against **real katex output** (the exact package the bundle renders with; html-only, no MathML twin), per the delegation's fixture requirement.

## Verification

Headless over the built bundle, real `$\Sigma_a v = \lambda \Sigma_b v$` through the md pipeline: busy → mark and katex host compute the **identical** green blend; landed → identical yellow; resolved → both drop; the churn sequence replays `green, green, green, green, yellow` — one transition. Full suite: 2322 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)