### PR TITLE
The comment popover honors the chat's display settings: same units, live on change

### DIFF
--- a/ui/webview/chat-scheme.test.ts
+++ b/ui/webview/chat-scheme.test.ts
@@ -82,7 +82,7 @@ test("the scheme applies live as a body class, at startup and on every settings 
   assert.match(UI, /classList\.toggle\("scheme-high-contrast", s\.chatScheme === "high-contrast"\);/);
   assert.match(UI, /classList\.toggle\("scheme-solarized-dark", s\.chatScheme === "solarized-dark"\);/);
   assert.match(UI, /applyChatScheme\(settings\);   \/\/ the persisted pick applies at startup — it survives reloads/);
-  assert.match(UI, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\);/);
+  assert.match(UI, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); refillOpenCommentPop\(\); \}\);/);
 });
 
 test("the gear picker is PREVIEW CARDS: each row painted with its own tiers, current \u2713-marked, click applies", () => {

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -7,6 +7,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { threadsByAnchor, threadBusy, threadStuck, threadInFlight, replyOwed, latchBusy, type BusyLatch, SETTLE_CONFIRM_PUSHES, findExact, findAnchorRange, sliceRanges, prunePending,
          type CommentThread } from "./comments";
+import { compactDisplay } from "./compact";
 
 const th = (over: Partial<CommentThread>): CommentThread => ({
   tid: "t1", anchorUuid: "a1", exact: "the passage", status: "open", createdT: 0,
@@ -513,4 +514,38 @@ test("status flips decide IMMEDIATELY — resolve/merge/error never wait out the
   assert.equal(latchBusy(l, th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)).green, false, "an errored thread is never green");
   // an optimistic pending send (alsoBusy) arms the latch like any busy reading
   assert.equal(latchBusy(undefined, th({ state: "", msgs: [] }), true).green, true, "a just-typed reply reads busy immediately");
+});
+
+// ── LEG C (the user 2026-08-24): the popover ignored the chat's display settings — thinking blocks
+// and raw tool runs rendered regardless of the gear's compact option. The popover now renders the
+// chat's OWN display units. Audit (setting → chat honors → popover before/after): compact/hide-
+// thinking ✓chat / showed→hidden; compact/fold-tools ✓chat / raw cards→folded (shared expand keys);
+// chatScheme ✓both already (body-class CSS, popover in scope); colormap/subgoals/collapsed/grouped
+// (feed), judge toggles (timeline), backend/defaultDir (create), showBranch (statusline), tabCtx
+// (tab strip) — not transcript-rendering settings, N/A both before and after. ───────────────────
+test("the popover renders the chat's display units — thinking hidden, tool runs folded, per the gear", () => {
+  const at = UI.indexOf("renderingIntoThread = true;");
+  const block = UI.slice(at, at + 2200);
+  assert.ok(block.includes("? compactDisplay(evs.map((e) => e.kind), evs.map((e) => e.kind === \"tool\" ? e.name : undefined))"),
+    "the SAME unit builder the chat uses, gated on the SAME settings.compact");
+  assert.ok(block.includes("const key = toolGroupKey(tools[0]);"), "the chat's group identity — expands survive refills");
+  assert.ok(block.includes("list.appendChild(renderToolGroup(tools, prev, key, open));"), "the chat's own folded line");
+  assert.ok(block.includes('child.classList.add("tg-child");'), "expanded children wear the chat's classes");
+});
+
+test("executable, real thinking fixture: the unit stream drops thinking and folds the tool run", () => {
+  // the exact shape the popover receives (a thread that thought, ran two tools, then replied)
+  const kinds = ["user", "thinking", "tool", "tool", "assistant"];
+  const units = compactDisplay(kinds, [undefined, undefined, "Read", "Edit", undefined]);
+  assert.deepEqual(units, [
+    { kind: "event", index: 0 },
+    { kind: "toolgroup", indices: [2, 3] },
+    { kind: "event", index: 4 },
+  ], "no unit for the thinking block; the consecutive tools fold to one group");
+});
+
+test("everything that re-renders the chat's units refills the open popover live", () => {
+  assert.match(UI, /function refillOpenCommentPop\(\): void \{/);
+  assert.match(UI, /refillOpenCommentPop\(\);   \/\/ the popover renders the same units — its copy of this run must flip too/);
+  assert.match(UI, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); refillOpenCommentPop\(\); \}\);/);
 });

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -35,7 +35,7 @@ test("the chat has NO gear of its own — it only consumes the shared setting (g
   assert.doesNotMatch(RENDER, /chat-settings-gear/, "the gear was moved to the timeline");
   // renderTabs rides the change too: the tab strip reads settings (the context gauge toggle,
   // the user 2026-08-08) and rerenderAll only rebuilds the transcript views.
-  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\)/);
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); refillOpenCommentPop\(\); \}\)/);
 });
 
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6097,7 +6097,34 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     renderingIntoThread = true;   // same renderer, minus the transcript-coupled hover chrome (see the flag)
     let prev: number | null = null;
     let quoteHost: HTMLElement | null = null;   // the thread's OPENING message — the quote's home
-    for (const ev of evs) {
+    // the SAME display units the chat renders (the user 2026-08-24, leg C: the popover ignored the
+    // compact/hide-thinking setting — thinking blocks and raw tool runs showed regardless of the
+    // gear): thinking dropped, consecutive tools folded to the chat's own renderToolGroup line,
+    // expansion keyed by the SHARED expandedGroups store so a toggle survives refills. The group
+    // toggle and a settings flip both refill the open popover live (toggleToolGroup / setupSettings
+    // → refillOpenCommentPop).
+    const items: DisplayItem[] = settings.compact
+      ? compactDisplay(evs.map((e) => e.kind), evs.map((e) => e.kind === "tool" ? e.name : undefined))
+      : evs.map((_, i) => ({ kind: "event", index: i } as DisplayItem));
+    for (const it of items) {
+      if (it.kind === "toolgroup") {
+        const tools = it.indices.map((ix) => evs[ix]) as Extract<ChatEvent, { kind: "tool" }>[];
+        const key = toolGroupKey(tools[0]);
+        const open = expandedGroups.has(key);
+        list.appendChild(renderToolGroup(tools, prev, key, open));
+        if (open) {
+          it.indices.forEach((ix, j) => {   // the tools only — it.indices already excludes thinking
+            const child = renderEvent(evs[ix], prev, null);
+            child.classList.add("tg-child"); if (j === it.indices.length - 1) child.classList.add("tg-last");
+            list.appendChild(child);
+            const ep = eventEpoch(evs[ix]); if (ep != null) prev = ep;
+          });
+        } else {
+          const ep = eventEpoch(tools[tools.length - 1]); if (ep != null) prev = ep;
+        }
+        continue;
+      }
+      const ev = evs[it.index];
       const node = renderEvent(ev, prev, null);
       list.appendChild(node);
       if (!quoteHost && ev.kind === "user") quoteHost = node;
@@ -6140,6 +6167,17 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     list.appendChild(note);
   }
   list.scrollTop = atTail ? list.scrollHeight : prevScroll;
+}
+
+// Refill the OPEN popover's conversation in place (leg C, the user 2026-08-24): the popover renders
+// the chat's display units, so everything that re-renders the chat's units — a tool-group toggle, a
+// compact/settings flip — must refill the popover too, or it holds the stale shape until the next
+// comments frame.
+function refillOpenCommentPop(): void {
+  if (!openCommentKey) return;
+  const th = (commentThreads.get(openCommentKey.sid) || []).find((t) => t.tid === openCommentKey!.tid);
+  const list = document.querySelector(".cmt-pop .cmt-msgs") as HTMLElement | null;
+  if (th && list) fillCommentMsgs(list, th);
 }
 
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
@@ -7390,6 +7428,7 @@ function toggleToolGroup(key: string): void {
   // the compact rebuild past the cache guard (a plain tab switch leaves stale false → reuses the cache).
   if (activeId) { const v = views.get(activeId); if (v) v.stale = true; syncView(activeId); }
   if (content) content.scrollTop = top;
+  refillOpenCommentPop();   // the popover renders the same units — its copy of this run must flip too
   scheduleRailSticky();
 }
 
@@ -11489,7 +11528,7 @@ function setupSettings(): void {
   applyChatScheme(settings);   // the persisted pick applies at startup — it survives reloads
   // renderTabs too: the tab strip reads settings (the context gauge toggle) but rerenderAll only
   // rebuilds the transcript views, so without it a gear change waited for the next kernel push.
-  onExternalSettingsChange((s) => { settings = s; applyChatScheme(s); renderTabs(); rerenderAll(); });
+  onExternalSettingsChange((s) => { settings = s; applyChatScheme(s); renderTabs(); rerenderAll(); refillOpenCommentPop(); });
 }
 
 // The feed's click echo (feed.ts focusEcho — the user 2026-08-24, "clicking into a not-shown

--- a/ui/webview/tab-ctx-gauge.test.ts
+++ b/ui/webview/tab-ctx-gauge.test.ts
@@ -70,5 +70,5 @@ test("gear → Chat picker (When above 50% / Always / Never), persisted as setti
 });
 
 test("a gear change repaints the tab strip live, not on the next kernel push", () => {
-  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); \}\)/);
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); refillOpenCommentPop\(\); \}\)/);
 });


### PR DESCRIPTION
## What (leg C of the comment-thread pass)

The popover rendered the thread's **raw event stream**, so thinking blocks and unfolded tool runs showed regardless of the gear's compact option. It now renders the chat's **own display units** — the same `compactDisplay` over the same `settings.compact`: thinking dropped, consecutive tools folded to the chat's `renderToolGroup` line, expansion keyed by the shared `expandedGroups` store (a toggle survives refills and matches the chat). Everything that re-renders the chat's units refills the open popover live (`refillOpenCommentPop`, called from the tool-group toggle and the settings subscriber) — event-based, no reload.

## Audit table (setting → chat honors → popover before/after)

| setting | chat | popover before | popover after |
|---|---|---|---|
| compact: hide thinking | ✓ | **showed thinking** | hidden |
| compact: fold tool runs | ✓ | **raw tool cards** | folded, shared expand keys |
| chatScheme (text tiers) | ✓ | ✓ already (body-class CSS scope) | unchanged |
| colormap / subgoals / collapsed / grouped | feed-only | N/A | N/A |
| showIndexJudges / showTriageJudges | timeline band | N/A | N/A |
| backend / defaultDir | create flow | N/A | N/A |
| showBranch | statusline | N/A | N/A |
| tabCtx | tab strip | N/A | N/A |

## Verification

Harness over the built bundle with a **real thinking fixture** (a thread that thought, ran two tools, replied): compact on → zero thinking turns, one folded "1 Read, 1 Edit" line, zero raw tool cards; the gear flipping compact **off** refills the open popover live (thinking appears, tools unfold); expanding the folded run inside the popover shows the two `tg-child` cards with thinking still hidden (the 2026-06-29 rule).

Tests: the unit-machinery pins, an executable real-kind-sequence fixture through `compactDisplay` (thinking dropped, tools folded), and the live-refill wiring pins; the three settings-subscriber pins moved in lockstep. Full suite: 2325 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)