### PR TITLE
Peers reconnect on their own after a kernel restart

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9148,6 +9148,31 @@ def _checkin_payload(r):
             "token": _load_token()}
 
 
+def _handshake_due(r, ssh_pid, now):
+    """Whether the check-in handshake should fire this pass (the user 2026-08-24, auto-reconnect):
+    the old key was the ssh pid alone — "once per tunnel incarnation" — which made a HUB kernel
+    restart invisible: the mobile's ssh survives (sshd holds it), the pid never changes, and the
+    freshly-booted hub, having lost or never restored the peer row, waits forever for a handshake
+    that never comes. Caught live: the reverse forward standing, remotes.json on the hub empty, the
+    panel saying disconnected until a manual re-dial minted a new pid. Due when:
+      - never handshaken this ssh incarnation (the original rule), or
+      - the HUB's kernel incarnation changed (its /version pid, polled every pass — the restart IS
+        the event), or
+      - the last handshake is older than the slow refresh floor (the bounded steady re-announce:
+        idempotent on the hub, and the healer of any row loss no event announces).
+    """
+    hk = r.get("_handshook")
+    if not isinstance(hk, dict) or hk.get("ssh") != ssh_pid:
+        return True
+    hub = r.get("hub_pid")
+    if hub and hk.get("hub") and hk.get("hub") != hub:
+        return True
+    return (now - float(hk.get("at") or 0)) >= CHECKIN_REFRESH_S
+
+
+CHECKIN_REFRESH_S = 300      # the slow steady re-announce floor while checked in (5 min; idempotent)
+
+
 def _checkin_handshake(r):
     """Tell the hub (through our own -L to its kernel) where our reverse forwards landed and hand it
     our token — the PUSH that replaces the hub ever fetching credentials. Authorizes with the HUB's
@@ -11044,6 +11069,8 @@ def _tunnel_supervisor():
                         # _start_remote wrote it (the user 2026-07-11)
                     if sids is not None:
                         r["sids"] = sids
+                    if rver and rver.get("pid"):
+                        r["hub_pid"] = rver["pid"]   # the peer kernel's incarnation — a restart changes it (auto-reconnect 2026-08-24)
                     if rsha is not None:
                         r["kernel_sha"] = rsha
                         r["kernel_ver"] = (rver or {}).get("ver") or ""
@@ -11083,14 +11110,17 @@ def _tunnel_supervisor():
                             if r["host"] in _remotes:
                                 r["_peer_notified"] = want
                 if _postal_peers_on() and r.get("checkin") and peer_up:
-                    # CHECK-IN handshake, once per tunnel incarnation (keyed on the ssh pid): the hub
-                    # learns our reverse-forward ports + token the moment our tunnel answers. A failed
-                    # handshake retries every pass while the tunnel is up — the hub may be restarting.
+                    # CHECK-IN handshake (re-keyed 2026-08-24, auto-reconnect): fires on a new ssh
+                    # incarnation, on a HUB kernel restart (its /version pid, polled every pass —
+                    # the restart is the event), and on the slow refresh floor — so the hub re-learns
+                    # us within a pass of coming back, with zero user action, and any hub-side row
+                    # loss heals within CHECKIN_REFRESH_S. A failed handshake retries every pass
+                    # while the tunnel is up — the hub may be mid-boot.
                     pid = r["proc"].pid if r.get("proc") else 0
-                    if r.get("_handshook") != pid and _checkin_handshake(r):
+                    if _handshake_due(r, pid, now) and _checkin_handshake(r):
                         with _remotes_lock:
                             if r["host"] in _remotes:
-                                r["_handshook"] = pid
+                                r["_handshook"] = {"ssh": pid, "hub": r.get("hub_pid"), "at": now}
             if _postal_peers_on():
                 # Trust-by-origin (the user 2026-07-25): remembered-but-unattached hosts carry a
                 # tier too — their mail arrives relayed through a hub and is judged by true origin.
@@ -24594,7 +24624,7 @@ function fillHosts(){if(!dl)return;var hs=[];
 dl.innerHTML=hs.map(function(h){return '<option value=\"'+h+'\"></option>';}).join('');}
 function loadHosts(){fetch('/ssh-hosts',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
 _cfg=(d&&d.hosts)||[];fillHosts();}).catch(function(){});}
-var LBL={up:'connected',authorizing:'authorizing\\u2026',connecting:'connecting\\u2026',starting:'connecting\\u2026','no-kernel':'kernel not answering',down:'disconnected',error:'error'};
+var LBL={up:'connected',authorizing:'authorizing\\u2026',connecting:'connecting\\u2026',starting:'connecting\\u2026','no-kernel':'kernel not answering',down:'reconnecting\\u2026',error:'error'};
 // Every status explains itself on hover (the user 2026-07-22: learn it from tooltips, not the CLI).
 var TIP={up:'Connected: the ssh tunnel is open and that machine\\u2019s romp kernel is answering through it. Its sessions appear in your tabs and timeline.',
 authorizing:'Opening an ssh connection and reading that machine\\u2019s access token. Needs `ssh <host>` to work without a prompt.',

--- a/tests/test_peer_reconnect.py
+++ b/tests/test_peer_reconnect.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Kernel-to-kernel reconnect is AUTOMATIC after restarts (the user 2026-08-24): attachment is a
+persisted intent — created on attach/check-in, ended only by an explicit detach — and while it
+stands, both sides keep re-dialing with zero user effort.
+
+The live bug this pins against (caught in the act on a deploy-heavy day): the check-in handshake
+was keyed "once per ssh incarnation" alone, so a HUB kernel restart — the mobile's ssh survives,
+sshd holds the reverse forward — left the freshly-booted hub without its peer row and the mobile
+never re-announcing: the reverse listener stood while remotes.json sat empty and the panel said
+disconnected until a manual re-dial minted a new ssh pid. _handshake_due now keys on the hub's
+kernel INCARNATION too (its /version pid, polled every pass — the restart is the event) plus a slow
+idempotent refresh floor that heals any row loss no event announces.
+
+Synthetic only — hermetic temp STATE, placeholder hosts."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_reconnect", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class HandshakeDue(unittest.TestCase):
+    """The pure re-announce rule, executed."""
+
+    def test_fires_on_a_new_ssh_incarnation(self):
+        self.assertTrue(km._handshake_due({}, 111, 1000.0), "never handshaken → due")
+        r = {"_handshook": {"ssh": 111, "hub": 9, "at": 1000.0}}
+        self.assertTrue(km._handshake_due(r, 222, 1001.0), "the tunnel respawned → due")
+
+    def test_fires_when_the_hub_kernel_restarts(self):
+        # the mobile's ssh SURVIVES a hub kernel restart (sshd holds it) — the hub's /version pid is
+        # the restart event this rule keys on, so the hub re-learns us within one pass
+        r = {"_handshook": {"ssh": 111, "hub": 9, "at": 1000.0}, "hub_pid": 10}
+        self.assertTrue(km._handshake_due(r, 111, 1001.0))
+
+    def test_quiet_while_the_same_incarnations_stand(self):
+        r = {"_handshook": {"ssh": 111, "hub": 9, "at": 1000.0}, "hub_pid": 9}
+        self.assertFalse(km._handshake_due(r, 111, 1000.0 + km.CHECKIN_REFRESH_S - 1))
+
+    def test_the_slow_refresh_floor_heals_unannounced_row_loss(self):
+        # a hub that lost the row WITHOUT restarting emits no event this side can see — the bounded
+        # idempotent refresh is the healer (never a hot loop: one handshake per CHECKIN_REFRESH_S)
+        r = {"_handshook": {"ssh": 111, "hub": 9, "at": 1000.0}, "hub_pid": 9}
+        self.assertTrue(km._handshake_due(r, 111, 1000.0 + km.CHECKIN_REFRESH_S))
+
+    def test_a_legacy_pid_keyed_stamp_reads_as_due(self):
+        # pre-2026-08-24 rows carried a bare int — the shape mismatch re-announces once, then re-keys
+        self.assertTrue(km._handshake_due({"_handshook": 111}, 111, 1000.0))
+
+
+class PersistedIntent(unittest.TestCase):
+    """Attach intent survives a kernel restart and ends ONLY on explicit detach."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.REMOTES_FILE, dict(km._remotes))
+        km.REMOTES_FILE = Path(self.td.name) / "remotes.json"
+        km._remotes.clear()
+
+    def tearDown(self):
+        km.REMOTES_FILE = self._saved[0]
+        km._remotes.clear(); km._remotes.update(self._saved[1])
+        self.td.cleanup()
+
+    def test_a_restart_restores_the_row_and_dials_immediately(self):
+        km._remotes["alpha"] = {"host": "alpha", "proc": None, "status": "up", "fails": 7,
+                                "next_try": 99999.0, "token": "tok", "kernel_port": 29855,
+                                "local_port": 50001, "bus_port": 50002, "sids": ["s1"]}
+        km._remotes_save()
+        km._remotes.clear()
+        km._remotes_load()                      # the boot path (the restart event's own re-arm)
+        r = km._remotes["alpha"]
+        self.assertEqual(r["status"], "down")
+        self.assertEqual((r["fails"], r["next_try"]), (0, 0),
+                         "a fresh boot dials immediately rather than resuming a long backoff")
+
+    def test_a_checkin_peer_row_survives_the_hub_restart(self):
+        # the hub side of the same bug: the mobile's row must come back on boot, so the standing
+        # reverse forward reads up within one pass with no handshake needed at all
+        ans, code = km.checkin_apply({"host": "mobile1", "kernelPort": 29855, "busPort": 25302,
+                                      "token": "mtok"})
+        self.assertEqual(code, 200)
+        km._remotes.clear()
+        km._remotes_load()
+        self.assertTrue(km._remotes["mobile1"].get("checkin_peer"),
+                        "the persisted intent includes checked-in peers")
+
+    def test_detach_is_the_one_end_of_intent(self):
+        km._remotes["alpha"] = {"host": "alpha", "proc": None, "status": "up", "token": "tok",
+                                "kernel_port": 29855, "local_port": 50001, "bus_port": 50002,
+                                "sids": [], "trust": "directed"}
+        km._remotes_save()
+        km.detach_remote("alpha")
+        km._remotes.clear()
+        km._remotes_load()
+        self.assertNotIn("alpha", km._remotes, "after detach, no boot ever re-dials it")
+
+    def test_the_backoff_never_answers_stop(self):
+        # the ladder always schedules a next attempt — 15s doubling to the 5-min ceiling, relaxing
+        # to 15 min once the outage is clearly not a blip; there is no give-up state
+        waits = [km._tunnel_backoff(n) for n in range(0, 16)]
+        self.assertEqual(waits[0], km.TUNNEL_BACKOFF_BASE)
+        self.assertTrue(all(w > 0 for w in waits))
+        self.assertEqual(max(waits), km.TUNNEL_BACKOFF_LONG)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -207,7 +207,7 @@ class RemotesPanelRender(unittest.TestCase):
     def test_a_disconnected_row_marks_its_drift_as_remembered_not_live(self):
         out = self._run(tunnels=self._drifted(status="down", stale=True, last_ok=1785272930))
         html = out.get("html", "")
-        self.assertIn("disconnected", html, "the row still reports its live state")
+        self.assertIn("reconnecting", html, "the row still reports its live state — and says romp is on it (the 2026-08-24 auto-reconnect wording: a row's existence IS standing intent)")
         self.assertIn("last known: v0.1.3 abc1234 (behind 2)", html,
                       "a drift count from an unreachable host must read as memory, not as a finding")
         self.assertIn("rnet-stale", html, "and must carry the muted cue that overrides the accent")

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -398,7 +398,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
 
   const LBL: Record<string, string> = {
     up: "connected", authorizing: "authorizing…", connecting: "connecting…", starting: "connecting…",
-    "no-kernel": "kernel not answering", down: "disconnected", error: "error",
+    "no-kernel": "kernel not answering", down: "reconnecting…", error: "error",   // a row exists = intent stands; romp never stops dialing (the user 2026-08-24)
   };
   // Every status explains itself on hover (the user 2026-07-22: learn it from tooltips, not the CLI).
   // Mirrors the web popover's TIP map — the two copies must say the same thing.


### PR DESCRIPTION
## Diagnosis (two lines, verified against live state)

Outbound `-L` attachments already self-heal (boot restores remotes.json and dials immediately; the ladder never stops; a peer-kernel restart reads as refusal-shaped no-kernel polled every pass). The broken direction was **check-in**: the handshake fired once per **ssh pid** — and a hub kernel restart leaves that pid untouched (sshd holds the reverse forward), so a hub that lost its peer row waited forever for a handshake the mobile would never resend; caught live on this devbox (reverse listener standing, remotes.json empty, panel "disconnected" until a manual re-dial minted a new pid).

## Fix (event-grounded)

- `_handshake_due` (pure, executed): fires on a new ssh incarnation, on a **hub kernel restart** (its `/version` pid, polled every pass — the restart is the event), and on an idempotent 5-minute refresh floor — the bounded steady re-announce that heals row loss no event announces. Legacy pid-keyed stamps read as due once, then re-key.
- Hub-side persistence + boot fresh-dial were already right — now **pinned** (check-in rows survive the hub restart; a fresh boot dials immediately rather than resuming a long backoff; detach is the one end of intent, no boot ever re-dials it; the ladder never answers "stop").
- Panel truth: the down label becomes **"reconnecting…"** on both surfaces (a row's existence is standing intent); the manual button stays as the immediate-retry accelerator.

## Tests

`tests/test_peer_reconnect.py` (new): the handshake-due matrix (new ssh / hub restart / quiet-while-standing / refresh floor / legacy stamp), restore-on-boot for both row kinds with immediate re-dial, detach-never-redials, the no-stop ladder. `tests/test_remotes_panel_render.py` label pin updated. Suites green: 5470 python tests (+293 subtests), 2319 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)