### PR TITLE
Flush keep-guard holds for EITHER gate holder, not just the pointer's

### DIFF
--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -64,7 +64,8 @@ test("flush is event-based: card mouseleave, window blur backstop — no timers 
   // the clear path's synthetic mouseleave used to re-render the board under the rest of its own
   // click handler, before pendingCleared.add ran). Ordering, not a time window.
   assert.match(FEED, /queueMicrotask\(\(\) => \{/);
-  assert.match(FEED, /if \(freezeKey\) return; \/\/ re-armed before the tick ended → keep the queue for the next leave/);
+  assert.match(FEED, /if \(freezeKey \|\| tabScopeKey\) return;/,
+    "EITHER holder keeps the queue — a stranger card's mouseleave must not flush under an armed keyboard scope");
 });
 
 test("a local render that detaches or re-keys the hovered element heals the freeze (:hover truth)", () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4380,7 +4380,10 @@ function flushFreeze(): void {
     flushQueued = false;   // dispatched mid-click (the clear path) must not re-render the board under
     //                        the rest of its own handler (pendingCleared.add, .dismissing come after
     //                        the dispatch). Gesture-ordering, not a timer: no time window anywhere.
-    if (freezeKey) return; // re-armed before the tick ended → keep the queue for the next leave
+    // EITHER holder keeps the queue (post-merge audit 2026-08-24): with the keyboard scope on card
+    // A and the pointer merely visiting card B, B's mouseleave queues this flush — running it would
+    // apply the payload and move the card being keyed. The scope's own release paths all flush.
+    if (freezeKey || tabScopeKey) return;
     const m = pendingFeedPayload;
     pendingFeedPayload = null;
     if (m) applyFeedPayload(m);          // render() repaints the badges away (nothing pending)


### PR DESCRIPTION
Post-merge audit of the keyboard-scope seams (the pass the manager requested after the riders PR): with the keyboard scope armed on card A and the pointer merely visiting card B, B's mouseleave queued a flush whose microtask guard checked `freezeKey` only — the payload applied while A's scope still held the gate, moving the card being keyed. The guard now keeps the queue while **either** holder is armed; every scope release path (Escape, hover-away, window blur) already flushes, so nothing leaks. One line + its pin.

The rest of both seams audited clean by direct trace: single-flush idempotence on every release ordering (the microtask dedupe), correct skip-then-flush when the pointer still holds after Escape, badge painting under a scope-only hold, ring-free signature capture ordering, slot-fallback degradation on class churn, and group-card key handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)