### PR TITLE
View pills select on focus; Shift+Tab reverse verified and pinned

### DIFF
--- a/ui/webview/feed-kbscope.test.ts
+++ b/ui/webview/feed-kbscope.test.ts
@@ -23,9 +23,27 @@ test("scope entry: the hovered card (clicks hover too), else the keyboard card c
 test("the cycle covers every visible control in the card's own (visual) order, and WRAPS", () => {
   assert.match(FEED, /return Array\.from\(card\.querySelectorAll<HTMLElement>\(KB_EL_SEL\)\)\.filter\(\(e\) => e\.offsetParent !== null\);/,
     "one selector, DOM order — the card's reading order — visible controls only");
+  // Shift+Tab is the SAME cycle reversed (the user 2026-08-24, verified + pinned): shiftKey picks the
+  // decrement arm, both arms wrap, and the reverse path shares release/flush/restore with forward
   assert.match(FEED, /i = e\.shiftKey \? \(i <= 0 \? els\.length - 1 : i - 1\) : \(i >= els\.length - 1 \? 0 : i \+ 1\);/,
     "both directions wrap at the ends");
   assert.match(FEED, /\.fask-secbtn,\.fask-bellbtn/, "the section pills and the bell are in the set");
+});
+
+test("view pills SELECT on focus; action buttons stay inert until Enter/Space (the user 2026-08-24)", () => {
+  // radio-group semantics for the SELECTORS only — .fask-secbtn switches what the card shows; every
+  // other control is an ACTION (the safe default) and must never fire from mere focus
+  assert.match(FEED, /if \(landed && landed\.matches\("\.fask-secbtn"\) && !landed\.classList\.contains\("on"\)\) landed\.click\(\);/);
+  // exactly ONE application per user gesture: the click lives in the Tab branch, never in
+  // tabScopeFocus — the render-tail restore calls tabScopeFocus, and a click there would re-apply
+  // per re-render (select-on-focus itself triggers a render whose restore re-focuses the pill)
+  const tsf = FEED.slice(FEED.indexOf("function tabScopeFocus"), FEED.indexOf("function releaseTabScope"));
+  assert.ok(!tsf.includes(".click()"), "tabScopeFocus never clicks — the restore path rides it");
+  const restore = FEED.slice(FEED.indexOf("// keyboard-scope focus restore"), FEED.indexOf("function feedWantsKeys"));
+  assert.ok(!restore.includes(".click()"), "the restore path never clicks either");
+  // the already-selected pill is a no-op on focus: pick() toggles a showing section OFF on click,
+  // and cycling through the active pill must not flip the card's view closed
+  assert.match(FEED, /!landed\.classList\.contains\("on"\)/);
 });
 
 test("Enter/Space activate — native controls natively, span controls by an exact synthetic click", () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4500,7 +4500,18 @@ window.addEventListener("keydown", (e) => {
     e.preventDefault(); e.stopPropagation();
     let i = ae ? els.indexOf(ae) : -1;
     i = e.shiftKey ? (i <= 0 ? els.length - 1 : i - 1) : (i >= els.length - 1 ? 0 : i + 1);   // WRAP at the ends
+    //                                                     (Shift+Tab = the same cycle, reversed)
     tabScopeFocus(card, els, i);
+    // SELECT-ON-FOCUS for the view pills (the user 2026-08-24): landing on a SELECTOR applies it at
+    // once, no Enter — radio-group semantics. The split: .fask-secbtn (Background/Summary/Sub-goals,
+    // which switch what the card SHOWS) are selectors; everything else — Clear, retries, the bell,
+    // follow-up, session names, sub-goal links — is an ACTION and must never fire from mere focus
+    // (action is the default for anything ambiguous). The click lives HERE, in the Tab gesture, and
+    // NOT in tabScopeFocus: the render-tail focus restore calls tabScopeFocus too, and a click there
+    // would re-apply per re-render — one application per user gesture. The already-selected pill is
+    // a no-op (focus keeps, nothing toggles), so cycling through it never flips the card's view off.
+    const landed = els[i];
+    if (landed && landed.matches(".fask-secbtn") && !landed.classList.contains("on")) landed.click();
     return;
   }
   if ((e.key === "Enter" || e.key === " ") && tabScopeKey) {


### PR DESCRIPTION
Two refinements to the just-landed card keyboard cycling, from the user's feedback.

**Select-on-focus for the view pills.** Tab landing on a `.fask-secbtn` (Background / Summary / Sub-goals — the selectors that switch what the card shows) applies it immediately, radio-group style, no Enter. Every other control — Clear, retries, the bell, follow-up, session names, sub-goal links — is an **action** and stays inert until Enter/Space (action is the safe default for anything ambiguous; the split is documented at the site). The application lives in the Tab gesture branch, never in `tabScopeFocus`: the render-tail focus restore rides `tabScopeFocus`, and a click there would re-apply on every re-render — so it's exactly one application per user gesture, with the resulting render's restore landing back on the pill without re-triggering. Focusing the already-selected pill is a no-op (`pick()` toggles a showing section off on click, so cycling through the active pill must not flip the card's view closed).

**Shift+Tab reverse** shipped with the original feature (the shared wrap ternary) — now explicitly verified and pinned: shiftKey picks the decrement arm, both arms wrap, and reverse shares the release/flush/restore paths with forward.

Tests: the select-on-focus rule with its one-application-per-gesture guards (no `.click()` in `tabScopeFocus` or the restore path), the inert-actions rule, the already-selected no-op, and the reverse-cycle pins. 2337 extension tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)