### PR TITLE
Overlapping message marks hover as one modal listing them all

### DIFF
--- a/tests/test_timeline_msg_hover.py
+++ b/tests/test_timeline_msg_hover.py
@@ -108,7 +108,13 @@ class TimelineMessageHover(unittest.TestCase):
         end = self.src.index("dot helper: optional onClick")
         pass1 = self.src[start:end]
         self.assertIn("hit.__tlHoverIn = mEnter", pass1, "the hit must stay re-armable after draw() rebuilds it")
-        self.assertRegex(pass1, r"u\.dot\.setAttribute\('r', DOT_R \+ 2\)", "hovering the line grows its arrival dot")
+        # the co-highlight routes through the overlap-hover set since 2026-08-24 (hovering lists
+        # every message under the point): the grow lives in msgSetLight's one formula, which the
+        # connector's mEnter reaches for its whole hovered set — the invariant (hovering the line
+        # grows its arrival dot) holds through it
+        self.assertRegex(pass1, r"msgSetLight\(u\.hoverSet, true\)", "hovering lights the hovered set")
+        self.assertRegex(self.src, r"u\.dot\.setAttribute\('r', \(on \|\| u\.lit\) \? DOT_R \+ 2 : DOT_R\)",
+                         "…whose one formula grows the arrival dot")
 
 
 if __name__ == "__main__":

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3924,6 +3924,36 @@ class TimelinePanel {
     // (the CLI's unmappable-member precedent).
     const msgHtml = (mm) => () => { const col = colorOf(mm.fromId); return '<div class="r"><span class="chip" style="background:' + col + '"></span><span class="who" style="color:' + col + '">' + esc(mm.from || mm.fromId) + '</span><span class="ar">→</span><span class="who" style="color:' + colorOf(mm.toId) + '">' + esc(mm.to || mm.toId) + '</span>' + (mm.pending ? ' <span class="k">pending</span>' : '') + '<span class="t">' + clock(mm.sent) + (mm.pending ? ' → …' : ' → ' + clock(mm.exec)) + '</span></div>' + this.body(esc(mm.summary || mm.text || '')); };
     const msgNav = (mm) => () => { const an = this.nearestTurnAnchor(mm.toId, execAt(mm)); this._select(mm.toId); this.openChat((an && an.tid) || mm.toId, mm.id || (an && (an.uuid || an.replyUuid)), false, false, execAt(mm)); };   // land on the message's OWN postal card BY ID — the chat matches mm.id to the card's data-mid (the user 2026-06-20); nearest-turn uuid / time only as fallback
+    // OVERLAP HOVER (the user 2026-08-24): message marks stack — several exchanges on one pair, a
+    // stub riding another's track — and the topmost hit swallowed the hover, so the modal named ONE
+    // message where the cursor covered several. Resolve every message element under the point
+    // (elementsFromPoint walks the whole paint stack; every message hit and arrival dot carries its
+    // message index) and show them ALL: one modal, each message its own block, every unit lit
+    // together, oldest first. Capped so a pile-up stays a modal, not a wall. Environments without
+    // elementsFromPoint (bare-node tests, odd hosts) fall back to the hovered message alone —
+    // exactly the old behavior.
+    const MSG_TIP_CAP = 8;
+    const msgHoverSet = (e, selfI) => {
+      const found = new Set([selfI]);
+      try {
+        const doc = (this.svg && this.svg.ownerDocument) || document;
+        if (e && e.clientX != null && doc.elementsFromPoint)
+          for (const n of doc.elementsFromPoint(e.clientX, e.clientY))
+            if (n && n.__tlMsgI != null && data.messages[n.__tlMsgI]) found.add(n.__tlMsgI);
+      } catch (err) { /* fall back to the hovered message alone */ }
+      return Array.from(found).sort((a, b) => (data.messages[a].sent || 0) - (data.messages[b].sent || 0));
+    };
+    const msgSetHtml = (set) => set.slice(0, MSG_TIP_CAP).map((ix, k) =>
+      (k ? '<div style="margin-top:6px;border-top:1px solid #ffffff1f;padding-top:6px">' : '<div>')
+      + msgHtml(data.messages[ix])() + '</div>').join('')
+      + (set.length > MSG_TIP_CAP
+         ? '<div class="k" style="margin-top:4px">+' + (set.length - MSG_TIP_CAP) + ' more messages here</div>' : '');
+    const msgSetLight = (set, on) => set.forEach((ix) => {
+      const u = msgUI[ix];
+      if (!u) return;
+      if (u.hl) u.hl.setAttribute('opacity', (on || u.lit) ? '0.95' : '0');
+      if (u.dot) u.dot.setAttribute('r', (on || u.lit) ? DOT_R + 2 : DOT_R);
+    });
     // ── HIDDEN-COUNTERPART STUBS (the user 2026-08-24; HORIZONTAL form later the same day — the
     // angled diagonals fanned out of a busy lane like a starburst and read as noise): a message
     // whose OTHER endpoint has no visible lane still shows on the lane it does touch, as a
@@ -4008,8 +4038,9 @@ class TimelinePanel {
       const hit = el('path', { d, fill: 'none', stroke: 'transparent', 'stroke-width': MSG_HIT_W,
                                'stroke-linecap': 'round', 'stroke-linejoin': 'round' });
       hit.style.cursor = 'pointer';
-      const mEnter = (e) => { hl.setAttribute('opacity', '0.95'); if (u.dot) u.dot.setAttribute('r', DOT_R + 2); this.showTip(msgHtml(mm)(), e); };
-      const mLeave = () => { hl.setAttribute('opacity', msgLit ? '0.95' : '0'); if (u.dot) u.dot.setAttribute('r', msgLit ? DOT_R + 2 : DOT_R); this.hideTip(); };
+      const mEnter = (e) => { u.hoverSet = msgHoverSet(e, i); msgSetLight(u.hoverSet, true); this.showTip(msgSetHtml(u.hoverSet), e); };
+      const mLeave = () => { msgSetLight(u.hoverSet || [i], false); u.hoverSet = null; this.hideTip(); };
+      hit.__tlMsgI = i;                            // the overlap resolver's key (msgHoverSet)
       hit.__tlHoverIn = mEnter;                    // re-armable after a redraw rebuilds this stub (_rehover)
       hit.addEventListener('mouseenter', mEnter);
       hit.addEventListener('mousemove', (e) => this.moveTip(e));
@@ -4061,11 +4092,12 @@ class TimelinePanel {
       // and a wider stroke so a short vertical (an immediately-delivered message is almost ALL vertical)
       // is still an easy target.
       const hit = el('path', { d, fill: 'none', stroke: 'transparent', 'stroke-width': MSG_HIT_W, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }); hit.style.cursor = 'pointer';
-      const mEnter = (e) => { hl.setAttribute('opacity', '0.95'); if (u.dot) u.dot.setAttribute('r', DOT_R + 2); this.showTip(msgHtml(mm)(), e); };
+      const mEnter = (e) => { u.hoverSet = msgHoverSet(e, i); msgSetLight(u.hoverSet, true); this.showTip(msgSetHtml(u.hoverSet), e); };
+      hit.__tlMsgI = i;                            // the overlap resolver's key (msgHoverSet)
       hit.__tlHoverIn = mEnter;                    // re-armable after a redraw rebuilds this path (_rehover)
       hit.addEventListener('mouseenter', mEnter);
       hit.addEventListener('mousemove', (e) => this.moveTip(e));
-      hit.addEventListener('mouseleave', () => { hl.setAttribute('opacity', msgLit ? '0.95' : '0'); if (u.dot) u.dot.setAttribute('r', msgLit ? DOT_R + 2 : DOT_R); this.hideTip(); });
+      hit.addEventListener('mouseleave', () => { msgSetLight(u.hoverSet || [i], false); u.hoverSet = null; this.hideTip(); });
       hit.addEventListener('click', msgNav(mm));
       u.hit = hit;
     });
@@ -4073,13 +4105,20 @@ class TimelinePanel {
     // dot helper: optional onClick (deep-link) + optional linkedHl (co-light a connector on hover).
     // lit = cross-hover focus (feed-card hover / DAG journey): drawn GROWN in its own color — the same
     // growth the native hover applies, no white ring (the user 2026-07-17) — and mouseleave restores it.
-    const dot = (cx, cy, color, html, onClick, linkedHl, lit) => {
+    const dot = (cx, cy, color, html, onClick, linkedHl, lit, msgI) => {
       const c = el('circle', { cx, cy, r: lit ? DOT_R + 2 : DOT_R, fill: color, stroke: '#e8eef5', 'stroke-width': 0.75 }); c.style.cursor = onClick ? 'pointer' : 'default';   // thinner white border on EVERY dot — romp + user (the user 2026-06-23)
-      const dEnter = (e) => { c.setAttribute('r', DOT_R + 2); if (linkedHl) linkedHl.setAttribute('opacity', '0.95'); this.showTip(html(), e); };
+      // a MESSAGE dot (msgI) hovers as its whole overlap set — stacked arrivals on one lane x are
+      // the commonest pile-up of all; a non-message dot keeps the plain single tooltip
+      const dEnter = (msgI != null)
+        ? (e) => { const u0 = msgUI[msgI] || (msgUI[msgI] = { hl: linkedHl, dot: c, lit }); u0.hoverSet = msgHoverSet(e, msgI); msgSetLight(u0.hoverSet, true); c.setAttribute('r', DOT_R + 2); this.showTip(msgSetHtml(u0.hoverSet), e); }
+        : (e) => { c.setAttribute('r', DOT_R + 2); if (linkedHl) linkedHl.setAttribute('opacity', '0.95'); this.showTip(html(), e); };
       c.__tlHoverIn = dEnter;                      // re-armable after a redraw rebuilds this dot (_rehover)
+      if (msgI != null) c.__tlMsgI = msgI;         // the overlap resolver's key (msgHoverSet)
       c.addEventListener('mouseenter', dEnter);
       c.addEventListener('mousemove', (e) => this.moveTip(e));
-      c.addEventListener('mouseleave', () => { c.setAttribute('r', lit ? DOT_R + 2 : DOT_R); if (linkedHl) linkedHl.setAttribute('opacity', lit ? '0.95' : '0'); this.hideTip(); });
+      c.addEventListener('mouseleave', (msgI != null)
+        ? () => { const u0 = msgUI[msgI]; msgSetLight((u0 && u0.hoverSet) || [msgI], false); if (u0) u0.hoverSet = null; c.setAttribute('r', lit ? DOT_R + 2 : DOT_R); this.hideTip(); }
+        : () => { c.setAttribute('r', lit ? DOT_R + 2 : DOT_R); if (linkedHl) linkedHl.setAttribute('opacity', lit ? '0.95' : '0'); this.hideTip(); });
       if (onClick) c.addEventListener('click', onClick);
       svg.appendChild(c);
       return c;
@@ -4092,7 +4131,7 @@ class TimelinePanel {
       if (vidx[mm.toId] == null || !inWin(landXT(mm))) return;
       const col = colorOf(mm.fromId), cy = laneY(vidx[mm.toId]);
       const u = msgUI[i];
-      const c = dot(x(landXT(mm)), cy, col, msgHtml(mm), msgNav(mm), u && u.hl, dagOrHoverMsg(mm.id));
+      const c = dot(x(landXT(mm)), cy, col, msgHtml(mm), msgNav(mm), u && u.hl, dagOrHoverMsg(mm.id), i);
       if (u) u.dot = c;
     });
 

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -284,6 +284,38 @@ test("a hidden-sender message draws the mirror stub: horizontal just ABOVE the l
   assert.ok(hitI > dotI, "the stub's hit target is appended after the dots (PASS 3), so the line wins the hover");
 });
 
+test("overlapping message marks hover as ONE modal listing them all, every unit lit together", () => {
+  // the user 2026-08-24: stacked marks (several exchanges on one pair, a stub riding another's
+  // track) let the topmost hit swallow the hover — the modal named one message where the cursor
+  // covered several. elementsFromPoint resolves the whole paint stack; hosts without it (this
+  // shim's default) keep the old single-message read, which the earlier tooltip tests still pin.
+  const now = 1_781_000_000;
+  const panel = draw([
+    { id: "m18", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+      sent: now - 300, exec: now - 240, hasExec: true, pending: false, summary: "first of the pile" },
+    { id: "m19", fromId: "SB", toId: "SC", from: "bee", to: "cee",
+      sent: now - 200, exec: now - 140, hasExec: true, pending: false, summary: "second of the pile" },
+  ]);
+  const hits = nodes(panel).filter((n) => n.tag === "path" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);
+  const hls = nodes(panel).filter((n) => n.tag === "path" && n._attrs["stroke-width"] === 6);
+  assert.equal(hits.length, 2); assert.equal(hls.length, 2);
+  (globalThis as any).document.elementsFromPoint = () => hits;   // both marks under the cursor
+  try {
+    hits[0]._listeners.mouseenter({ clientX: 200, clientY: 30, currentTarget: hits[0] });
+    const tip = String(panel.tip.innerHTML);
+    assert.ok(tip.includes("first of the pile") && tip.includes("second of the pile"),
+      "the modal lists ALL messages under the point, oldest first");
+    assert.ok(tip.indexOf("first of the pile") < tip.indexOf("second of the pile"), "…oldest first");
+    assert.equal(hls[0]._attrs.opacity, "0.95", "every covered unit lights");
+    assert.equal(hls[1]._attrs.opacity, "0.95");
+    hits[0]._listeners.mouseleave({});
+    assert.equal(hls[0]._attrs.opacity, "0", "…and every one restores on leave");
+    assert.equal(hls[1]._attrs.opacity, "0");
+  } finally {
+    delete (globalThis as any).document.elementsFromPoint;
+  }
+});
+
 test("a stub is ONE path — riser and track share a single stroke, so the corner never double-paints", () => {
   // round 4 (the user 2026-08-24): two <line>s overlapped at the elbow and the 0.45 alpha stacked
   // to a darker joint; the connectors' own elbow-path idiom draws it contiguous

--- a/ui/webview/timeline-hover-consistent.test.ts
+++ b/ui/webview/timeline-hover-consistent.test.ts
@@ -25,13 +25,18 @@ test("a cross-lit bar is drawn GROWN + opaque in its own color, and a local hove
 test("a cross-lit connector lights via its native own-color highlight overlay, not a white casing", () => {
   assert.match(SRC, /const msgLit = dagOrHoverMsg\(mm\.id\);/);
   assert.match(SRC, /opacity: msgLit \? 0\.95 : 0/, "the hl overlay starts lit");
-  assert.match(SRC, /hl\.setAttribute\('opacity', msgLit \? '0\.95' : '0'\)/, "mouseleave restores the lit overlay");
+  // overlap-hover (2026-08-24): enters/leaves route through the shared set machinery; the lit
+  // restore lives in msgSetLight's one formula, which every covered unit passes through
+  assert.match(SRC, /msgSetLight\(u\.hoverSet \|\| \[i\], false\)/, "mouseleave restores the whole hovered set");
+  assert.match(SRC, /u\.hl\.setAttribute\('opacity', \(on \|\| u\.lit\) \? '0\.95' : '0'\)/,
+    "…and the restore formula keeps a cross-lit overlay lit");
 });
 
 test("cross-lit dots are drawn grown via dot()'s lit param — arrival and prompt dots both", () => {
-  assert.match(SRC, /const dot = \(cx, cy, color, html, onClick, linkedHl, lit\) =>/);
+  assert.match(SRC, /const dot = \(cx, cy, color, html, onClick, linkedHl, lit, msgI\) =>/);
   assert.match(SRC, /r: lit \? DOT_R \+ 2 : DOT_R/, "lit → the same +2 growth the native hover applies");
   assert.match(SRC, /c\.setAttribute\('r', lit \? DOT_R \+ 2 : DOT_R\)/, "mouseleave restores the lit radius");
-  assert.match(SRC, /dot\(x\(landXT\(mm\)\), cy, col, msgHtml\(mm\), msgNav\(mm\), u && u\.hl, dagOrHoverMsg\(mm\.id\)\)/);
+  assert.match(SRC, /dot\(x\(landXT\(mm\)\), cy, col, msgHtml\(mm\), msgNav\(mm\), u && u\.hl, dagOrHoverMsg\(mm\.id\), i\)/,
+    "the arrival dot carries its message index — it hovers as its whole overlap set");
   assert.match(SRC, /, null, dotLit\(t, dagOrHover\)\);/, "the prompt dot passes its lit state through");
 });


### PR DESCRIPTION
User ask: when several message marks overlap under the cursor, the hover modal should show all of them, not just the topmost.

Every message hit path and arrival dot now carries its message index; on hover, `elementsFromPoint` resolves the whole paint stack under the cursor and the tooltip lists **every** message found — oldest first, each as its own block with a thin separator, capped at eight with a "+N more messages here" tail. All covered units light together (highlight overlays + dots) and restore together, with cross-lit (DAG/feed-hover) state preserved through the one restore formula. Hosts without `elementsFromPoint` (bare-node tests, unusual embedders) keep the previous single-message behavior — the existing tooltip tests pin that fallback unchanged.

**Tests:** an executed case drives two stacked marks through a stubbed `elementsFromPoint` (both listed oldest-first, both lit, both restored on leave); the hover-consistency pins retargeted to the shared set machinery (the lit-restore formula, the dot's message-index parameter). Suite green: 2337/2337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)