### PR TITLE
The tab menu restructures around Browse files: pane-local over the chat, a way back, always-wrapped text

### DIFF
--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -181,24 +181,26 @@ test("the hljs token palette lives in feed.css too, identical to the chat's", ()
 // call, 2026-08-09) and any malformed stored value reads as the defaults — a corrupt entry may cost the
 // preference, never the viewer (feed-view-state's parseViewState contract).
 test("format prefs: rendered is the markdown default, and a corrupt entry reads as the defaults", () => {
-  type Fmt = { md: "rendered" | "raw"; wrap: boolean };
+  // wrap is GONE from the format state (the user 2026-08-24) — a stored wrap key from the toggle
+  // era parses away silently
+  type Fmt = { md: "rendered" | "raw" };
   const parseFmt = (raw: string | null): Fmt => {
-    const def: Fmt = { md: "rendered", wrap: false };
+    const def: Fmt = { md: "rendered" };
     if (!raw) return def;
     try {
-      const o = JSON.parse(raw) as { md?: unknown; wrap?: unknown };
+      const o = JSON.parse(raw) as { md?: unknown };
       if (!o || typeof o !== "object") return def;
-      return { md: o.md === "raw" ? "raw" : "rendered", wrap: o.wrap === true };
+      return { md: o.md === "raw" ? "raw" : "rendered" };
     } catch { return def; }
   };
-  assert.deepEqual(parseFmt(null), { md: "rendered", wrap: false }, "first open: rendered, unwrapped");
-  assert.deepEqual(parseFmt('{"md":"raw","wrap":true}'), { md: "raw", wrap: true }, "the round-trip");
-  assert.deepEqual(parseFmt("not json"), { md: "rendered", wrap: false });
-  assert.deepEqual(parseFmt('{"md":"purple","wrap":"yes"}'), { md: "rendered", wrap: false },
+  assert.deepEqual(parseFmt(null), { md: "rendered" }, "first open: rendered");
+  assert.deepEqual(parseFmt('{"md":"raw","wrap":true}'), { md: "raw" }, "the toggle-era wrap key parses away");
+  assert.deepEqual(parseFmt("not json"), { md: "rendered" });
+  assert.deepEqual(parseFmt('{"md":"purple","wrap":"yes"}'), { md: "rendered" },
                    "foreign values fall to the defaults field by field");
   // replica ↔ source
-  assert.match(VIEW, /const def: FileViewFmt = \{ md: "rendered", wrap: false \};/);
-  assert.match(VIEW, /return \{ md: o\.md === "raw" \? "raw" : "rendered", wrap: o\.wrap === true \};/);
+  assert.match(VIEW, /const def: FileViewFmt = \{ md: "rendered" \};/);
+  assert.match(VIEW, /return \{ md: o\.md === "raw" \? "raw" : "rendered" \};/);
   // …and the prefs persist in localStorage, the feed-view-state call: per-BROWSER view state that must
   // survive a kernel restart without a round-trip to the thing that just restarted
   assert.match(VIEW, /const FMT_KEY = "romp:fileviewFmt";/);
@@ -271,8 +273,9 @@ test("wrap mode: per-line rows, spans rebalanced across newlines, no phantom tra
 });
 
 // C: the toggle and the CSS that carries the honest gutter answer
-test("the Wrap toggle persists, hides with rendered prose, and its numbers still never copy", () => {
-  assert.match(VIEW, /wrapBtn\.addEventListener\("click", \(\) => \{ fmt\.wrap = !fmt\.wrap; saveFmt\(fmt\); renderBody\(\); \}\);/);
+test("long lines ALWAYS soft-wrap — the dedicated toggle button is gone (the user 2026-08-24)", () => {
+  assert.doesNotMatch(VIEW, /wrapBtn/, "no wrap chrome anywhere in the modal");
+  assert.match(VIEW, /codeBlock\(text, path, true\)/, "the pre view is born wrapped");
   // wrap mode returns BEFORE the sibling gutter is built — a misaligned column cannot exist
   assert.match(VIEW, /if \(wrapLines\) \{[\s\S]*?return wrap;\s*\}\s*const gutter = el\("div", "fileview-gutter"\);/);
   // plain files wrap too: no grammar → the text is HTML-escaped before the line walk
@@ -282,10 +285,14 @@ test("the Wrap toggle persists, hides with rendered prose, and its numbers still
     assert.match(SHEET, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?counter-increment: fvln/);
     assert.match(SHEET, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?user-select: none/);
   }
-  // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
-  // (and with edit mode, whose textarea has no wrap toggle to govern — the raw-mode slice)
-  assert.match(VIEW, /wrapBtn\.hidden = rendered \|\| editing;/);
-  assert.match(VIEW, /wrapBtn\.classList\.toggle\("on", fmt\.wrap\);/, "pressed state flips synchronously");
+});
+
+test("a file opened FROM the listing offers the way back — close only the viewer, listing intact beneath", () => {
+  // the one-directional stack: the browser sits beneath, so closing just the viewer IS the back;
+  // presence-gated on the browser's DOM id (import-free), absent for path-link opens
+  assert.match(VIEW, /if \(document\.getElementById\("romp-filebrowse"\)\) \{/);
+  assert.match(VIEW, /back\.textContent = "‹ Files"; back\.title = "Back to the file listing";/);
+  assert.match(VIEW, /back\.addEventListener\("click", \(\) => closeFileView\(\)\);/);
 });
 
 // ── download (the user 2026-08-09): any linked file can be SAVED, including everything the pane cannot

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -81,17 +81,19 @@ marked.use({
 // must survive a kernel restart without a round-trip to the thing that just restarted). RENDERED is the
 // default for markdown (the user 2026-08-09); Raw stays one click away.
 const FMT_KEY = "romp:fileviewFmt";
-type FileViewFmt = { md: "rendered" | "raw"; wrap: boolean };
+// wrap is GONE from the format state (the user 2026-08-24: "there doesn't need to be a button for
+// that") — long lines always soft-wrap; a stored wrap key from the toggle era is simply ignored.
+type FileViewFmt = { md: "rendered" | "raw" };
 
 // Any malformed/foreign value reads as the defaults rather than throwing — a corrupt entry may cost the
 // stored preference, never the viewer (feed-view-state's parseViewState contract).
 function parseFmt(raw: string | null | undefined): FileViewFmt {
-  const def: FileViewFmt = { md: "rendered", wrap: false };
+  const def: FileViewFmt = { md: "rendered" };
   if (!raw) return def;
   try {
-    const o = JSON.parse(raw) as { md?: unknown; wrap?: unknown };
+    const o = JSON.parse(raw) as { md?: unknown };
     if (!o || typeof o !== "object") return def;
-    return { md: o.md === "raw" ? "raw" : "rendered", wrap: o.wrap === true };
+    return { md: o.md === "raw" ? "raw" : "rendered" };
   } catch { return def; }
 }
 
@@ -204,6 +206,17 @@ export function openFileView(path: string, sid?: string | null): void {
   document.body.classList.add("fileview-open");
 
   const bar = el("div", "fileview-bar");
+  // BACK to the listing (the user 2026-08-24): a file opened FROM the browser overlays it with the
+  // listing intact beneath (the one-directional stack above) — closing just the viewer IS the back.
+  // The button renders only when a listing is actually underneath; a viewer opened from a path link
+  // has nowhere to go back to and shows none. Import-free by design: presence is the DOM id (the
+  // browser may not even be loaded in this document).
+  if (document.getElementById("romp-filebrowse")) {
+    const back = el("button", "fileview-btn fileview-back") as HTMLButtonElement;
+    back.type = "button"; back.textContent = "‹ Files"; back.title = "Back to the file listing";
+    back.addEventListener("click", () => closeFileView());
+    bar.appendChild(back);
+  }
   // Directory then basename as TWO elements, because only the directory may be truncated: the filename
   // is what identifies the file, so it never shrinks however deep the path is. (A single text node with
   // the rtl-ellipsis trick would truncate the right end — exactly the wrong half.)
@@ -259,10 +272,6 @@ export function openFileView(path: string, sid?: string | null): void {
       acts.appendChild(b);
     }
   }
-  const wrapBtn = el("button", "fileview-btn") as HTMLButtonElement;
-  wrapBtn.type = "button"; wrapBtn.textContent = "Wrap"; wrapBtn.title = "Soft-wrap long lines";
-  wrapBtn.addEventListener("click", () => { fmt.wrap = !fmt.wrap; saveFmt(fmt); renderBody(); });
-  acts.appendChild(wrapBtn);
 
   // ── edit (the raw-mode slice) ── exactly what raw mode can show is what Edit can touch: the
   // button arms only when the kernel served text/plain WITH a Last-Modified to anchor the save's
@@ -360,15 +369,11 @@ export function openFileView(path: string, sid?: string | null): void {
       b.setAttribute("aria-pressed", String(on));
       b.hidden = editing;                       // format choices leave with edit mode; Save/Cancel own the bar
     }
-    // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
-    wrapBtn.hidden = rendered || editing;
-    wrapBtn.classList.toggle("on", fmt.wrap);
-    wrapBtn.setAttribute("aria-pressed", String(fmt.wrap));
     editBtn.hidden = editing || text === null || !isText || !mtimeNs;
     saveBtn.hidden = !editing;
     cancelBtn.hidden = !editing;
     if (text === null || editing) return;   // loading, or the textarea owns the body right now
-    body.replaceChildren(rendered ? mdBlock(text) : codeBlock(text, path, fmt.wrap));
+    body.replaceChildren(rendered ? mdBlock(text) : codeBlock(text, path, true));   // long lines always soft-wrap (the user 2026-08-24)
   };
 
   // Selection → labeled quote chip (the user 2026-08-23): mouseup is the gesture's settle point.

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -89,10 +89,13 @@ test("Escape closes the TOPMOST surface only, and Backspace walks up", () => {
 });
 
 test("every entry point is gated to where the click can land, and posts the one shell message", () => {
-  // chat: openBrowse posts {romp:'browseFiles'} to the shell, web-only
-  assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "browseFiles", path: path \|\| "\.", sid: sid \|\| activeId \|\| null \}, "\*"\);/);
-  // tab right-click menu row, web-only
-  assert.match(RENDER, /browse\.textContent = "Browse files";/);
+  // chat: openBrowse is PANE-LOCAL (2026-08-24 — it used to relay to the shell and open over the
+  // FEED, the wrong pane): the browser opens over the chat that launched it, web-only, framed or not
+  assert.match(RENDER, /openFileBrowse\(path \|\| "\.", sid \|\| activeId \|\| null\);/);
+  assert.match(RENDER, /initFileBrowse\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/, "the chat hosts its own browser instance");
+  assert.doesNotMatch(RENDER, /window\.parent\.postMessage\(\{ romp: "browseFiles"/, "no shell relay from the chat anymore");
+  // tab right-click menu row: bottom of the menu, behind a divider, icon + sub-description
+  assert.match(RENDER, /l\.textContent = "Browse files"; bodyEl\.appendChild\(l\);/);
   // feed card menu row rides canPreview (web only — the VS Code webview can't reach the kernel
   // origin), and sends only the sid — the kernel resolves "." against the session's cwd authoritatively
   assert.match(FEED, /openFileBrowse\("\.", it\.sid\);/);
@@ -100,7 +103,7 @@ test("every entry point is gated to where the click can land, and posts the one 
 });
 
 test("the statusline folder link BROWSES on the web; OS-open lives on its right-click (the user 2026-08-14)", () => {
-  assert.match(RENDER, /elem\.dataset\.act = web && window\.parent !== window \? "browseFiles" : "openFolder";/);
+  assert.match(RENDER, /elem\.dataset\.act = web \? "browseFiles" : "openFolder";/);   // pane-local browse needs no shell (2026-08-24)
   assert.match(RENDER, /click to browse this folder/);
   // the demoted OS-open: one document-level contextmenu on folder links, posting the old openFolder
   assert.match(RENDER, /item\.textContent = "Open folder window";/);
@@ -180,4 +183,22 @@ test("the row menu carries the plan's full vocabulary: Copy path / Download / Op
   assert.match(BROWSE, /add\("Copy path", \(\) => \{ navigator\.clipboard\?\.writeText\(path\); \}\);/);
   assert.match(BROWSE, /if \(!isDir\) add\("Download", \(\) => startDownload\(path\)\);/);
   assert.match(BROWSE, /add\("Open folder window", \(\) => \{/);
+});
+
+// ── the tab-menu restructure (the user 2026-08-24) ───────────────────────────────────────────────
+test("Browse files sits at the BOTTOM of the tab menu, behind a divider, wearing icon + sub-description", () => {
+  const at = RENDER.indexOf("function showTabMenu");
+  const menuBody = RENDER.slice(at, RENDER.indexOf("document.body.appendChild(menu);", at));
+  const browseAt = menuBody.indexOf('l.textContent = "Browse files"');
+  assert.ok(browseAt > 0, "the item exists");
+  // nothing else is appended to the menu after the Browse block — it is the last thing before mount
+  assert.equal(menuBody.indexOf("menu.appendChild(", browseAt + 200) > 0 ? menuBody.slice(browseAt).match(/menu\.appendChild\(browse\);/) !== null : true, true);
+  assert.ok(menuBody.lastIndexOf('menu.appendChild(el("div", "ctx-sep"));') < browseAt
+            && menuBody.slice(0, browseAt).trimEnd().includes('menu.appendChild(el("div", "ctx-sep"));'),
+    "a divider immediately precedes it — a different kind of thing");
+  assert.match(menuBody.slice(browseAt - 400, browseAt), /ctxIcon\("folder", false\)/, "the folder icon");
+  assert.match(menuBody, /sb\.textContent = "the session's working tree, in a viewer over this chat";/,
+    "the standard sub-description line");
+  // …and the Billing submenu (the previous last item) now sits ABOVE it
+  assert.ok(menuBody.indexOf('l.textContent = "Billing"') < browseAt, "Browse is last");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -37,6 +37,7 @@ import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, ref
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView } from "./file-view";
+import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { hostNameNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
@@ -786,25 +787,18 @@ function openPath(path: string, sid?: string | null): void {
 // gated off at their call sites (the editor has its own explorer, and the webview can't reach the
 // kernel origin anyway).
 function openBrowse(path: string, sid?: string | null): void {
+  // PANE-LOCAL since 2026-08-24 (the user: it opened over the FEED cards — the wrong pane): the
+  // browser is a modal over the chat that launched it, the same document the viewer already uses —
+  // no shell lift, no pane juggling (the shell's browseClosed restore is a no-op here: it only
+  // fires when the shell itself lifted the feed). Web-only stands — the VS Code webview cannot
+  // reach the kernel origin, and the editor has its own explorer.
   const web = location.protocol === "http:" || location.protocol === "https:";
-  if (!web || window.parent === window) return;
-  try {
-    window.parent.postMessage({ romp: "browseFiles", path: path || ".", sid: sid || activeId || null }, "*");
-  } catch { /* no shell — nothing to surface into */ }
+  if (!web) return;
+  openFileBrowse(path || ".", sid || activeId || null);
 }
-
-// The viewer's directory half asks for the BROWSER by posting {romp:'browseFiles'} to its OWN window
-// (file-view.ts): in the feed document initFileBrowse answers it, but the chat hosts no browser, so
-// this forwarder hands the ask to the shell — openBrowse's exact relay — which brings the feed pane
-// forward and delivers it there. Without it that click is a silent no-op in a chat-opened viewer.
-// openBrowse's own gates apply (web-only, framed-only: standalone /chat has no feed to surface, and
-// a repost to window.parent === window would only echo back here). Own-window messages only — the
-// pane shim redispatches kernel frames through this channel too, and no OTHER window sends this ask.
-window.addEventListener("message", (e: MessageEvent) => {
-  const m = e.data as { romp?: unknown; path?: unknown; sid?: unknown } | null;
-  if (!m || m.romp !== "browseFiles" || e.source !== window) return;
-  openBrowse(typeof m.path === "string" ? m.path : ".", typeof m.sid === "string" ? m.sid : null);
-});
+// (The old forwarder that relayed the viewer's directory-half {romp:'browseFiles'} ask to the shell
+// is gone with the move: initFileBrowse's own listener answers it in THIS document now.)
+initFileBrowse((m) => vscodeApi?.postMessage(m));
 
 // A clickable file name that opens the real file — in the editor (VS Code) or the in-pane viewer
 // modal (web). Shared open/navigate surface; see extension.ts's openFile handler and file-view.ts.
@@ -2474,7 +2468,7 @@ function asFolderLink(elem: HTMLElement, cwd: string, sid?: string): void {
   // the row's right-click menu for the genuinely-local case (the contextmenu delegate below). In
   // VS Code the browser overlay doesn't exist, so the click keeps opening the folder host-side.
   const web = location.protocol === "http:" || location.protocol === "https:";
-  elem.dataset.act = web && window.parent !== window ? "browseFiles" : "openFolder";
+  elem.dataset.act = web ? "browseFiles" : "openFolder";   // pane-local browse needs no shell (2026-08-24)
   elem.dataset.cwd = cwd;
   if (sid) elem.dataset.id = sid;
   elem.classList.add("folder-link");
@@ -4442,7 +4436,7 @@ function setSessionColor(id: string, bg: string) {
 
 // Small inline-SVG icon for the tab menu's toggle items (trusted constant markup; `off` slashes + dims it,
 // matching the timeline lane toggles). 16-unit viewBox; currentColor so .ctx-icon/.off set the tint.
-function ctxIcon(kind: "feed" | "mail" | "bell" | "bill", off: boolean): HTMLElement {
+function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder", off: boolean): HTMLElement {
   const span = el("span", "ctx-icon" + (off ? " off" : ""));
   const slash = off ? '<line x1="1.6" y1="14.4" x2="14.4" y2="1.6"/>' : "";
   const body = kind === "feed"
@@ -4451,7 +4445,9 @@ function ctxIcon(kind: "feed" | "mail" | "bell" | "bill", off: boolean): HTMLEle
       ? '<rect x="2" y="4" width="12" height="8" rx="1.5"/><path d="M2.5 5 L8 9 L13.5 5"/>'  // envelope (on the postal service)
       : kind === "bill"
         ? '<rect x="2" y="4" width="12" height="8" rx="1.5"/><line x1="2" y1="6.8" x2="14" y2="6.8"/><line x1="4.2" y1="9.6" x2="7.4" y2="9.6"/>'  // payment card (billing)
-        : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
+        : kind === "folder"
+          ? '<path d="M2 4.5 A1.2 1.2 0 0 1 3.2 3.3 L6.2 3.3 L7.6 4.9 L12.8 4.9 A1.2 1.2 0 0 1 14 6.1 L14 11.5 A1.2 1.2 0 0 1 12.8 12.7 L3.2 12.7 A1.2 1.2 0 0 1 2 11.5 Z"/>'  // folder (browse files)
+          : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
   span.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
     + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + body + slash + "</svg>";
   return span;
@@ -4492,37 +4488,16 @@ function showTabMenu(e: MouseEvent, id: string) {
     offMail ? "Rejoin mail" : "Mute mail",
     offMail ? "reconnect it to the postal service" : "hide from peers — no messages in or out",
     () => setSessionFlag(id, "postalServiceOff", !offMail));
-  // Browse the session's working tree in the feed pane. Web-only: openBrowse no-ops outside the
-  // shell, and VS Code's editor has its own explorer, so the row only renders where the click can
-  // land.
-  if ((location.protocol === "http:" || location.protocol === "https:") && window.parent !== window) {
-    const browse = el("div", "ctx-item");
-    browse.textContent = "Browse files";
-    browse.addEventListener("click", (ev) => {
-      ev.stopPropagation(); dismissTabMenu();
-      openBrowse(s?.cwd || ".", id);
-    });
-    menu.appendChild(browse);
-  }
   // system-notification bell (the user 2026-07-28) — same flag the timeline lane bell toggles. NOTE the
   // inverted polarity vs the two above: `notify` true is the ENABLED state, so the icon slashes on !onBell.
   toggle("bell", !onBell,
     onBell ? "Stop notifying" : "Notify me",
     onBell ? "no more system notifications for this session" : "system notification when its work blocks on you or completes",
     () => setSessionFlag(id, "notify", !onBell));
-  // Background the session (the user 2026-08-18): out of the tab strip AND the timeline lanes — it
-  // keeps running, judged and carded; the + picker lists it under "Hidden — reveal" and the
-  // timeline's corner panel counts it. Same views blob the timeline dialog edits. A plain item, not
-  // a toggle: its undo lives where the hidden session lives (the picker, the timeline panel).
-  {
-    const hide = el("div", "ctx-item ctx-item-toggle");
-    const bodyEl = el("span", "ctx-item-body");
-    const l = el("span", "ctx-item-label"); l.textContent = "Hide from chat & timeline"; bodyEl.appendChild(l);
-    const sb = el("span", "ctx-item-sub"); sb.textContent = "background it — the + picker and the feed still surface it"; bodyEl.appendChild(sb);
-    hide.appendChild(bodyEl);
-    hide.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); postViews(hideIn(effViews(), id)); });
-    menu.appendChild(hide);
-  }
+  // (The hide-session item left this menu 2026-08-24 — the user: the tag/view system
+  // covers backgrounding a session. The MECHANISM stands untouched underneath: hideIn/revealIn, the
+  // views blob's hidden set, the timeline dialog's eye, and the + picker's "Hidden — reveal" section
+  // all remain; whether to retire the machinery outright is the user's separate call.)
   // Billing submenu (the user 2026-08-09, who wants the login/API-key switch here rather than as a
   // statusline badge). Only when the machine offers BOTH choices (st.authBoth) — a one-auth machine
   // keeps the fact on the tab hover, never a dead selector — and the key stays labelled plainly
@@ -4583,6 +4558,24 @@ function showTabMenu(e: MouseEvent, id: string) {
       row.appendChild(sw);
     }
     menu.appendChild(row);
+  }
+  // BROWSE FILES — at the BOTTOM behind its own divider (the user 2026-08-24: it is a different
+  // kind of thing from the toggles above), wearing the standard icon + sub-description dress, and
+  // opening PANE-LOCAL over this chat (openBrowse). Web-only: the VS Code webview cannot reach the
+  // kernel origin, and the editor has its own explorer.
+  if (location.protocol === "http:" || location.protocol === "https:") {
+    menu.appendChild(el("div", "ctx-sep"));
+    const browse = el("div", "ctx-item ctx-item-toggle");
+    browse.appendChild(ctxIcon("folder", false));
+    const bodyEl = el("span", "ctx-item-body");
+    const l = el("span", "ctx-item-label"); l.textContent = "Browse files"; bodyEl.appendChild(l);
+    const sb = el("span", "ctx-item-sub"); sb.textContent = "the session's working tree, in a viewer over this chat"; bodyEl.appendChild(sb);
+    browse.appendChild(bodyEl);
+    browse.addEventListener("click", (ev) => {
+      ev.stopPropagation(); dismissTabMenu();
+      openBrowse(s?.cwd || ".", id);
+    });
+    menu.appendChild(browse);
   }
   document.body.appendChild(menu);
   ctxMenuEl = menu;

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -104,9 +104,14 @@ test("a hidden session keeps one visible home: the picker's Hidden section, and 
   assert.match(RENDER, /revealSession\(it\.id\);\s*\/\/ its tab already exists[\s\S]{0,80}setActive\(it\.id\);/);
 });
 
-test("the tab menu's hide gesture posts the same blob the timeline dialog edits", () => {
-  assert.match(RENDER, /l\.textContent = "Hide from chat & timeline";/);
-  assert.match(RENDER, /postViews\(hideIn\(effViews\(\), id\)\);/);
+test("the hide MENU ITEM is gone; the mechanism underneath is intact (the user 2026-08-24)", () => {
+  // the tag/view system covers backgrounding a session, so the tab menu's "Hide from chat &
+  // timeline" affordance retired — but ONLY the affordance: whether to retire the machinery
+  // outright is the user's separate call, so hideIn/revealIn, the picker's reveal, and the views
+  // blob's hidden set all still stand (the executed tests above pin their behavior).
+  assert.doesNotMatch(RENDER, /Hide from chat & timeline/);
+  assert.match(RENDER, /revealSession\(it\.id\);/, "the picker's Hidden — reveal arm still works");
+  assert.match(RENDER, /function revealSession\(id: string\) \{ postViews\(revealIn\(effViews\(\), id\)\); \}/);
 });
 
 test("federation carries the LOCAL kernel's views blob through merged tabOrder re-emits", () => {

--- a/vscode-extension/src/statusline-terminal-link.test.ts
+++ b/vscode-extension/src/statusline-terminal-link.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("asFolderLink routes by host: BROWSE on the web, folder-open in VS Code (the user 2026-08-14)", () => {
   assert.match(SRC, /function asFolderLink\(elem: HTMLElement, cwd: string, sid\?: string\): void/);
   // web dashboard → the file browser (works from every device); VS Code keeps the host-side open
-  assert.match(SRC, /elem\.dataset\.act = web && window\.parent !== window \? "browseFiles" : "openFolder";/);
+  assert.match(SRC, /elem\.dataset\.act = web \? "browseFiles" : "openFolder";/);   // pane-local browse needs no shell frame (2026-08-24)
   assert.match(SRC, /elem\.dataset\.cwd = cwd;/);
   assert.match(SRC, /elem\.classList\.add\("folder-link"\)/);
   assert.match(SRC, /click to browse this folder/);

--- a/vscode-extension/src/tab-menu-flags.test.ts
+++ b/vscode-extension/src/tab-menu-flags.test.ts
@@ -28,7 +28,7 @@ test("the tab menu adds Feed + Mail toggle items with state-dependent labels", (
 });
 
 test("each toggle item carries an icon (slashed when off) and a sub-description", () => {
-  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill", off: boolean\)/);   // "bill" joined for the Billing submenu (2026-08-09)
+  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill" \| "folder", off: boolean\)/);   // "bill" joined 2026-08-09; "folder" for the Browse row 2026-08-24
   assert.match(SRC, /off \? '<line /);   // slash when the flag is off
   assert.match(SRC, /ctx-item-sub/);
   assert.match(CSS, /\.ctx-item-toggle \{ display: flex;/);


### PR DESCRIPTION
## What (five user asks, one package)

1. **Browse files → bottom of the tab menu**, behind its own divider (a different kind of thing from the toggles), wearing the standard menu vocabulary: a folder icon (`ctxIcon` gains the kind) and the sub-description line the other items wear.
2. **It opens over the CHAT it was launched from** — pane-local, per the panels rule — not over the feed. The chat hosts its own browser instance (`initFileBrowse` in render.ts; `openBrowse` calls `openFileBrowse` directly); the shell relay + feed-pane lift leave the chat's path, and the old forwarder that bounced the viewer's directory-half ask to the shell is gone (the browser's own listener answers it in this document). The shell's `browseClosed` restore is naturally a no-op here — it only fires when the shell itself lifted the feed. The statusline folder link and the menu row drop their framed-only gates (standalone /chat browses too); web-only stands.
3. **Back navigation:** a file opened from the listing shows a "‹ Files" button — the one-directional stack already keeps the listing intact beneath the viewer, so closing just the viewer IS the back. Presence-gated on the browser's DOM id; a path-link open (no listing beneath) shows none.
4. **Always-wrap:** the Wrap toggle dies; the `wrap` field leaves the persisted format state (a stored toggle-era key parses away); the pre view is born wrapped. No gear toggle either, per the user's words.
5. **The hide-session item leaves the menu** — the tag/view system covers backgrounding. Only the affordance: `hideIn`/`revealIn`, the views blob's `hidden` set, the timeline dialog's eye, and the picker's "Hidden — reveal" all stand untouched; full mechanism retirement is mapped in the delegation report for the user's separate call.

## Verification

Headless over the built bundle (HTTP-served so the web-only gates arm; kernel `listDir` answered synthetically): the menu renders toggles → divider → Browse (icon + sub, last) with no hide item; clicking Browse mounts `#romp-filebrowse` **in the chat document** with **zero** shell posts and a real listing; opening `notes.md` from it overlays the viewer with the back button and the listing intact beneath; back returns to the listing; no Wrap button anywhere in the chrome. Screenshots eyeballed.

## Tests

Menu order/divider/icon/sub pins (`filebrowse.test.ts`); pane-local open + no-shell-relay + own-instance pins; back-button pins and wrap-always pins (`file-view.test.ts`, format state without `wrap`, born-wrapped pre, no chrome button); hide-item-absent + mechanism-intact pins (`session-views.test.ts`); the statusline/`asFolderLink` and `ctxIcon`-kind pins moved in lockstep. Full suite: 2340 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)