### PR TITLE
The chat tab menu gains a Tags section: the dialog's union semantics, one flyout away

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13,7 +13,7 @@ import diff from "highlight.js/lib/languages/diff";
 import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
-import { SessionViews, viewVisible, viewsKey, hideIn, revealIn } from "./session-views";
+import { SessionViews, viewVisible, viewsKey, hideIn, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
@@ -4436,7 +4436,7 @@ function setSessionColor(id: string, bg: string) {
 
 // Small inline-SVG icon for the tab menu's toggle items (trusted constant markup; `off` slashes + dims it,
 // matching the timeline lane toggles). 16-unit viewBox; currentColor so .ctx-icon/.off set the tint.
-function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder", off: boolean): HTMLElement {
+function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag", off: boolean): HTMLElement {
   const span = el("span", "ctx-icon" + (off ? " off" : ""));
   const slash = off ? '<line x1="1.6" y1="14.4" x2="14.4" y2="1.6"/>' : "";
   const body = kind === "feed"
@@ -4447,6 +4447,8 @@ function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder", off: boolea
         ? '<rect x="2" y="4" width="12" height="8" rx="1.5"/><line x1="2" y1="6.8" x2="14" y2="6.8"/><line x1="4.2" y1="9.6" x2="7.4" y2="9.6"/>'  // payment card (billing)
         : kind === "folder"
           ? '<path d="M2 4.5 A1.2 1.2 0 0 1 3.2 3.3 L6.2 3.3 L7.6 4.9 L12.8 4.9 A1.2 1.2 0 0 1 14 6.1 L14 11.5 A1.2 1.2 0 0 1 12.8 12.7 L3.2 12.7 A1.2 1.2 0 0 1 2 11.5 Z"/>'  // folder (browse files)
+        : kind === "tag"
+          ? '<path d="M2 3.4 A1.4 1.4 0 0 1 3.4 2 L7.6 2 A1.4 1.4 0 0 1 8.6 2.4 L13.6 7.4 A1.4 1.4 0 0 1 13.6 9.4 L9.4 13.6 A1.4 1.4 0 0 1 7.4 13.6 L2.4 8.6 A1.4 1.4 0 0 1 2 7.6 Z"/><circle cx="5.4" cy="5.4" r="1.1"/>'  // luggage tag (session tags)
           : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
   span.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
     + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + body + slash + "</svg>";
@@ -4558,6 +4560,130 @@ function showTabMenu(e: MouseEvent, id: string) {
       row.appendChild(sw);
     }
     menu.appendChild(row);
+  }
+  // TAGS (the user 2026-08-24, overruling the earlier skip: tag editing belongs everywhere a
+  // session is in front of you — you might not have the timeline open and still want to organize
+  // or dispatch). A compact one-line row — the current tag names as the sub-line — with the
+  // mechanics one click away in a flyout (progressive disclosure; the Billing submenu's chrome).
+  // SAME semantics as the timeline dialog, name-keyed union rules throughout (kernels are plumbing,
+  // no host prefixes): an ADD lands on the local store when the name exists locally, else the
+  // tag's single home over the editTag wire; a REMOVE removes the (name, member) pair from EVERY
+  // store holding it; New tag… creates locally with the next unused palette colour. Local writes
+  // post the whole blob (postViews — pendingSessionViews echoes instantly); remote writes ride the
+  // editTag op and settle on the next push (a refused edit re-appears — the kernel's loud
+  // tagEditFailed lands on the timeline dialog, 628's surface).
+  {
+    menu.appendChild(el("div", "ctx-sep"));
+    const unionFor = () => viewTagUnion(effViews());
+    const holding = () => unionFor().filter((g) => g.members.includes(id));
+    const tagsItem = el("div", "ctx-item ctx-item-toggle ctx-item-tags");
+    tagsItem.appendChild(ctxIcon("tag", false));
+    const bodyEl = el("span", "ctx-item-body");
+    const l = el("span", "ctx-item-label"); l.textContent = "Tags"; bodyEl.appendChild(l);
+    const sb = el("span", "ctx-item-sub");
+    const subText = () => { const names = holding().map((g) => g.name); return names.length ? names.join(" · ") : "none yet — tag it to organize and dispatch"; };
+    sb.textContent = subText();
+    bodyEl.appendChild(sb);
+    tagsItem.appendChild(bodyEl);
+    const caret = el("span", "ctx-caret"); caret.textContent = "▸"; tagsItem.appendChild(caret);
+    const editUnion = (g: TagUnion, edit: { add?: string[]; remove?: string[] }) => {
+      // ONE optimistic blob per gesture: the local store's edit AND the remote entries' mirror both
+      // land in pendingSessionViews so the flyout reads true instantly. Echoed remoteTags are
+      // DERIVED — the kernel drops them from the echo — so mutating the copy is presentation-only;
+      // the remote's own next push is the durable truth (a refused edit re-appears there).
+      const nv = JSON.parse(JSON.stringify(effViews() || {})) as SessionViews;
+      let dirty = false;
+      const nvRemote = (rt: SessionTag) => (nv.remoteTags || []).find((x) => x.id === rt.id);
+      if (edit.add?.length) {
+        if (g.localId) {
+          const t = viewTags(nv).find((x) => x.id === g.localId);
+          if (t) { t.members = Array.from(new Set((t.members || []).concat(edit.add))); dirty = true; }
+        } else if (g.remotes.length) {
+          vscodeApi?.postMessage({ type: "editTag", edit: { host: g.remotes[0].host || "", name: g.name, add: edit.add.slice() } });
+          const mine = nvRemote(g.remotes[0]);
+          if (mine) { mine.members = Array.from(new Set((mine.members || []).concat(edit.add))); dirty = true; }
+        }
+      }
+      if (edit.remove?.length) {
+        if (g.localId) {
+          const t = viewTags(nv).find((x) => x.id === g.localId);
+          if (t && (t.members || []).some((m) => edit.remove!.includes(m))) {
+            t.members = (t.members || []).filter((m) => !edit.remove!.includes(m));
+            dirty = true;
+          }
+        }
+        for (const rt of g.remotes) {
+          if (!(rt.members || []).some((m) => edit.remove!.includes(m))) continue;
+          vscodeApi?.postMessage({ type: "editTag", edit: { host: rt.host || "", name: g.name, remove: edit.remove!.slice() } });
+          const mine = nvRemote(rt);
+          if (mine) { mine.members = (mine.members || []).filter((m) => !edit.remove!.includes(m)); dirty = true; }
+        }
+      }
+      if (dirty) postViews(nv);
+    };
+    tagsItem.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      const openFly = menu.querySelector(".ctx-sub-tags");
+      if (openFly) { openFly.remove(); return; }                 // second click folds the flyout
+      menu.querySelector(".ctx-sub")?.remove();                  // one flyout at a time (Billing's rule)
+      const sub = el("div", "ctx-menu ctx-sub ctx-sub-tags");
+      const build = () => {
+        sub.replaceChildren();
+        for (const g of holding()) {                             // one chip per NAME — never a host prefix
+          const row = el("div", "ctx-item ctx-item-toggle");
+          const chip = el("span", "ctx-tag-dot"); chip.style.background = g.color || "var(--dim)"; row.appendChild(chip);
+          const bodyE = el("span", "ctx-item-body");
+          const lb = el("span", "ctx-item-label"); lb.textContent = g.name; bodyE.appendChild(lb);
+          row.appendChild(bodyE);
+          const x = el("button", "ctx-tag-x") as HTMLButtonElement;
+          x.type = "button"; x.textContent = "✕"; x.title = "remove this tag from the session — everywhere it holds it";
+          x.addEventListener("click", (e2) => { e2.stopPropagation(); editUnion(g, { remove: [id] }); build(); sb.textContent = subText(); });
+          row.appendChild(x);
+          sub.appendChild(row);
+        }
+        const others = unionFor().filter((g) => !g.members.includes(id));
+        if (holding().length && others.length) sub.appendChild(el("div", "ctx-sep"));
+        for (const g of others) {
+          const row = el("div", "ctx-item ctx-item-toggle");
+          const chip = el("span", "ctx-tag-dot"); chip.style.background = g.color || "var(--dim)"; row.appendChild(chip);
+          const bodyE = el("span", "ctx-item-body");
+          const lb = el("span", "ctx-item-label"); lb.textContent = "+ " + g.name; bodyE.appendChild(lb);
+          row.appendChild(bodyE);
+          row.addEventListener("click", (e2) => { e2.stopPropagation(); editUnion(g, { add: [id] }); build(); sb.textContent = subText(); });
+          sub.appendChild(row);
+        }
+        if (holding().length || others.length) sub.appendChild(el("div", "ctx-sep"));
+        // New tag… — an inline input, never a native prompt (the menus vocabulary)
+        const nrow = el("div", "ctx-item ctx-item-newtag");
+        const inp = el("input", "ctx-tag-input") as HTMLInputElement;
+        inp.placeholder = "New tag…"; inp.maxLength = 40;
+        inp.addEventListener("click", (e2) => e2.stopPropagation());
+        inp.addEventListener("keydown", (e2) => {
+          if (e2.key !== "Enter") return;
+          const name = inp.value.trim();
+          if (!name) return;
+          const existing = unionFor().find((g) => g.name === name);
+          if (existing) { editUnion(existing, { add: [id] }); build(); sb.textContent = subText(); return; }
+          const nv = JSON.parse(JSON.stringify(effViews() || {})) as SessionViews;
+          const used = new Set(viewTags(nv).map((t) => t.color));
+          const color = paletteColors.find((c) => !used.has(c)) || paletteColors[0] || "#1EA1EB";
+          nv.tags = viewTags(nv).concat([{ id: "g" + Date.now().toString(36), name, color, members: [id] }]);
+          delete nv.groups;
+          postViews(nv);
+          build(); sb.textContent = subText();
+        });
+        nrow.appendChild(inp);
+        sub.appendChild(nrow);
+      };
+      build();
+      menu.appendChild(sub);
+      const ir = tagsItem.getBoundingClientRect();
+      const sr = sub.getBoundingClientRect();
+      sub.style.left = Math.max(0, Math.min(ir.right + 2, window.innerWidth - sr.width - 4)) + "px";
+      sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
+      (sub.querySelector(".ctx-tag-input") as HTMLInputElement | null)?.focus();
+    });
+    menu.appendChild(tagsItem);
   }
   // BROWSE FILES — at the BOTTOM behind its own divider (the user 2026-08-24: it is a different
   // kind of thing from the toggles above), wearing the standard icon + sub-description dress, and

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -19,6 +19,32 @@ export interface SessionViews {
   // never an edit target, excluded from the echo key, dropped by the kernel if echoed back.
   remoteTags?: SessionTag[];
 }
+// One union group = one tag NAME across every kernel defining it (user ruling 2026-08-24: kernels
+// are plumbing — no host prefixes in any tag presentation). The typed mirror of the timeline's
+// viewTagUnion over the same client blob (local tags + remoteTags); the local store's colour wins.
+// The chat's tab-menu Tags section reads and edits through this exact shape.
+export interface TagUnion { name: string; color: string; members: string[]; ids: string[]; localId: string | null; remotes: SessionTag[] }
+export function viewTagUnion(views: SessionViews | null | undefined): TagUnion[] {
+  const out: TagUnion[] = [], byName: Record<string, TagUnion> = {};
+  for (const t of viewTags(views)) {
+    const key = t.name || "tag";
+    const g = byName[key] || (byName[key] = { name: key, color: "", members: [], ids: [], localId: null, remotes: [] });
+    if (!g.localId) { g.localId = t.id; g.color = t.color || g.color; }
+    g.ids.push(t.id);
+    for (const m of (t.members || [])) if (!g.members.includes(m)) g.members.push(m);
+    if (!out.includes(g)) out.push(g);
+  }
+  for (const rt of (views?.remoteTags || [])) {
+    const key = rt.name || "tag";
+    const g = byName[key] || (byName[key] = { name: key, color: "", members: [], ids: [], localId: null, remotes: [] });
+    if (!g.localId && !g.color) g.color = rt.color || "";
+    g.ids.push(rt.id);
+    g.remotes.push(rt);
+    for (const m of (rt.members || [])) if (!g.members.includes(m)) g.members.push(m);
+    if (!out.includes(g)) out.push(g);
+  }
+  return out;
+}
 
 // the one place the legacy key is honored, so every rule below reads through it
 export function viewTags(views: SessionViews | null | undefined): SessionTag[] {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -300,6 +300,14 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    gray + slashed. So the same blue marks "enabled" in both the menu and the timeline. */
 .ctx-item-toggle .ctx-icon { flex: 0 0 auto; margin-top: 1px; color: var(--accent); display: flex; }
 .ctx-item-toggle .ctx-icon.off { color: var(--dim); }
+/* the tab menu's Tags flyout (the user 2026-08-24): identity dot per union tag, ✕ = remove-
+   everywhere, an inline New tag… input — all in the menu vocabulary, no new font sizes */
+.ctx-tag-dot { flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; }
+.ctx-tag-x { flex: 0 0 auto; background: none; border: none; color: var(--dim); cursor: pointer; font: inherit; padding: 0 2px; }
+.ctx-tag-x:hover { color: var(--fg); }
+.ctx-item-newtag { cursor: default; }
+.ctx-tag-input { width: 100%; background: #1e1e1e; color: #ccc; border: 1px solid #3a3a3a; border-radius: 5px; padding: 3px 6px; font: inherit; }
+.ctx-tag-input:focus { outline: none; border-color: var(--accent); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
 /* identity-color swatches (the user 2026-06-29): the romp palette as circles, the current one ringed. A grid

--- a/ui/webview/tab-tags.test.ts
+++ b/ui/webview/tab-tags.test.ts
@@ -1,0 +1,76 @@
+// The chat tab menu's TAGS section (the user 2026-08-24, overruling the earlier skip: tag editing
+// belongs everywhere a session is in front of you). Same semantics as the timeline dialog — the
+// name-keyed union rules bind (kernels are plumbing, never a host prefix in presentation), edits
+// reuse the wire (local = the whole blob via postViews; remote-homed = the editTag op family) —
+// never a forked implementation. Executable union coverage + source pins (no jsdom for render.ts).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { viewTagUnion } from "./session-views";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("executable: the union joins local and remote tags BY NAME — one group, local id/colour winning", () => {
+  const u = viewTagUnion({
+    active: "all", hidden: [],
+    tags: [{ id: "g1", name: "pool", color: "#1EA1EB", members: ["S1"] }],
+    remoteTags: [
+      { id: "TESTHOST:g9", name: "pool", color: "#999999", members: ["TESTHOST:S7"], host: "TESTHOST" },
+      { id: "TESTHOST:g8", name: "ops", color: "#54B204", members: ["TESTHOST:S7"], host: "TESTHOST" },
+    ],
+  });
+  assert.equal(u.length, 2, "pool unions across kernels; ops stands alone");
+  const pool = u.find((g) => g.name === "pool")!;
+  assert.equal(pool.localId, "g1", "the local store is the union's write-home for adds");
+  assert.equal(pool.color, "#1EA1EB", "the local colour wins");
+  assert.deepEqual(pool.members.sort(), ["S1", "TESTHOST:S7"], "membership is the union");
+  assert.equal(pool.remotes.length, 1);
+  const ops = u.find((g) => g.name === "ops")!;
+  assert.equal(ops.localId, null, "a remote-only tag has no local write-home");
+  assert.equal(ops.remotes[0].host, "TESTHOST");
+});
+
+test("the Tags row sits with the session controls ABOVE the divider; Browse stays last", () => {
+  const at = RENDER.indexOf("function showTabMenu");
+  const body = RENDER.slice(at, RENDER.indexOf("document.body.appendChild(menu);", at));
+  const tagsAt = body.indexOf('l.textContent = "Tags"');
+  const browseAt = body.indexOf('l.textContent = "Browse files"');
+  assert.ok(tagsAt > 0 && browseAt > 0 && tagsAt < browseAt, "Tags above, Browse last");
+  assert.match(body.slice(tagsAt - 500, tagsAt), /ctxIcon\("tag", false\)/, "the tag icon");
+  assert.match(body, /return names\.length \? names\.join\(" · "\) : "none yet — tag it to organize and dispatch";/,
+    "the compact one-line row: current names, or the honest empty state");
+});
+
+test("edits reuse the wire — never a fork: local adds post the whole blob, remote edits ride editTag", () => {
+  const at = RENDER.indexOf("const editUnion = (g: TagUnion");
+  const body = RENDER.slice(at, at + 2400);
+  assert.ok(body.includes("t.members = Array.from(new Set((t.members || []).concat(edit.add))); dirty = true;"),
+    "local add edits the whole blob (posted once below — pendingSessionViews echoes instantly)");
+  assert.ok(body.includes('vscodeApi?.postMessage({ type: "editTag", edit: { host: g.remotes[0].host || "", name: g.name, add: edit.add.slice() } });'),
+    "an add with no local home routes to the tag's single home over the editTag wire");
+  assert.ok(body.includes("for (const rt of g.remotes) {"),
+    "a REMOVE walks every remote store holding the pair — remove-everywhere, never half");
+  assert.ok(body.includes("if (dirty) postViews(nv);"), "ONE optimistic blob per gesture — the flyout reads true instantly");
+  assert.ok(body.includes("const nvRemote = (rt: SessionTag)"),
+    "the remote entries mirror optimistically too — echoed remoteTags are derived, kernel-dropped, presentation-only");
+  assert.match(RENDER, /x\.title = "remove this tag from the session — everywhere it holds it";/);
+});
+
+test("New tag… is an inline input (menu vocabulary, no native prompt) that creates locally with a palette colour", () => {
+  assert.match(RENDER, /inp\.placeholder = "New tag…"; inp\.maxLength = 40;/);
+  assert.doesNotMatch(RENDER.slice(RENDER.indexOf("const editUnion")), /window\.prompt/);
+  assert.match(RENDER, /const color = paletteColors\.find\(\(c\) => !used\.has\(c\)\) \|\| paletteColors\[0\] \|\| "#1EA1EB";/);
+  assert.match(RENDER, /nv\.tags = viewTags\(nv\)\.concat\(\[\{ id: "g" \+ Date\.now\(\)\.toString\(36\), name, color, members: \[id\] \}\]\);/);
+  // an existing name typed into the box ADDS to that union instead of minting a duplicate tag
+  assert.match(RENDER, /const existing = unionFor\(\)\.find\(\(g\) => g\.name === name\);/);
+});
+
+test("presentation: one chip per NAME, identity dot, ✕ — and never a host prefix in the flyout", () => {
+  assert.match(RENDER, /lb\.textContent = g\.name; bodyE\.appendChild\(lb\);/);
+  assert.match(RENDER, /lb\.textContent = "\+ " \+ g\.name; bodyE\.appendChild\(lb\);/);
+  assert.match(CSS, /\.ctx-tag-dot \{ flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; \}/);
+  const fly = RENDER.slice(RENDER.indexOf("const sub = el(\"div\", \"ctx-menu ctx-sub ctx-sub-tags\");"));
+  assert.doesNotMatch(fly.slice(0, 2500), /host-prefix|hostNameNodes/, "kernels are plumbing — no host chrome in the flyout");
+});

--- a/vscode-extension/src/tab-menu-flags.test.ts
+++ b/vscode-extension/src/tab-menu-flags.test.ts
@@ -28,7 +28,7 @@ test("the tab menu adds Feed + Mail toggle items with state-dependent labels", (
 });
 
 test("each toggle item carries an icon (slashed when off) and a sub-description", () => {
-  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill" \| "folder", off: boolean\)/);   // "bill" joined 2026-08-09; "folder" for the Browse row 2026-08-24
+  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill" \| "folder" \| "tag", off: boolean\)/);   // bill 2026-08-09; folder + tag 2026-08-24
   assert.match(SRC, /off \? '<line /);   // slash when the flag is off
   assert.match(SRC, /ctx-item-sub/);
   assert.match(CSS, /\.ctx-item-toggle \{ display: flex;/);


### PR DESCRIPTION
## What

Tag editing belongs everywhere a session is in front of you (the user's ruling, overruling the earlier skip). The tab context menu gains a compact **Tags** row — current tag names as its sub-line, an honest "none yet" otherwise — with the mechanics one click away in a flyout (progressive disclosure, the Billing submenu's chrome). It sits with the session controls above the divider; Browse files stays last (the 642 order holds, pinned).

**Same semantics as the dialog, the same wire, never a fork:**

- `viewTagUnion` gains a **typed mirror in session-views.ts** over the same client blob (local tags + the kernel-joined `remoteTags`) — one union group per tag NAME, the local store's colour winning, no host prefix anywhere in presentation.
- An **add** lands on the local store when the name exists locally (whole blob via `postViews`, echoing instantly through `pendingSessionViews`), else routes to the tag's single home over the **editTag op**.
- A **remove** removes the (name, member) pair from **every** store holding it — the local one and each remote home — per the union rules from the dialog work.
- **One optimistic blob per gesture:** the remote entries mirror in the posted copy too (echoed `remoteTags` are derived and kernel-dropped — presentation-only), so the flyout reads true the instant of the click; the remote's own next push is the durable truth, and a refused edit re-appears there (the kernel's loud tagEditFailed remains the dialog's surface).
- **New tag…** is an inline input in the menu vocabulary (no native prompt), creating locally with the next unused palette colour; typing an existing name adds to that union instead of minting a duplicate.

## Verification

Harness over the built bundle, TESTHOST union fixture (local `pool` + same-name remote + remote-only `ops`): the row shows the names; the flyout renders one chip per NAME with the local colour winning and no host chrome; ✕ fires **both** the local blob post and the remote `editTag` remove and flips to "+ pool" instantly; "+ infra" and a created `web-squad` land live with the row's sub-line following. Screenshot eyeballed.

## Tests

`tab-tags.test.ts`: executable union coverage (name-keyed join, local id/colour winning, remote-only groups), menu-order pins (Tags above the divider, Browse last), wire-reuse pins (whole-blob local path, editTag remote routing, remove-everywhere walk, the one-optimistic-blob rule), inline-input + one-chip-per-name presentation pins. The `ctxIcon`-kind pin extended in lockstep. Full suite: 2345 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)