### PR TITLE
Leapfrogged rows wear a quiet parked cue; a delegation's completion never closes its neighbors

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3961,6 +3961,21 @@ def rollup_status(store, session_closed, now=None):
     nodes = store["nodes"]
     folds = _materialize_from_log(nodes)               # P3.3: history → flags; the log is the authority
     #                                                    (migration is a BOOT sweep now — migrate_all_stores)
+    # DONE-BY-ASSOCIATION GUARD (the user 2026-08-24): before the roll-down loops can fold them, the
+    # OPEN children of every COMPLETED handoff tracking node move up beside it (_lift_handoff_children)
+    # — a delegation's completion is evidence about the delegation, never about the un-ruled asks filed
+    # under it by topical placement (the audited case: the completing report explicitly DECLINED a
+    # child's ask, and the fold sealed it done anyway). Living HERE, in every writer's rollup, the
+    # guard covers every completer alike — the courier link-back, a closer done on the tracking node,
+    # a planner op — and SELF-HEALS the save-rebase race: a concurrent pass that republishes a stale
+    # parentId puts the child back under the completed node, and the very next rollup lifts it again
+    # (the rebase folds diary rows, not parents). rolledUp tracking nodes are skipped on purpose:
+    # their completion rolled down from an ANCESTOR the judges actually ruled — that absorb is the
+    # designed umbrella ending, not an association.
+    for _hid in list(nodes):
+        _hn = nodes[_hid]
+        if isinstance(_hn.get("handoff"), dict) and _hn.get("nodeComplete") and not _hn.get("rolledUp"):
+            _lift_handoff_children(store, _hid)
     children = {}
     for nid, nd in nodes.items():
         children.setdefault(nd.get("parentId"), []).append(nid)
@@ -6224,8 +6239,19 @@ def migrate_store(store):
 def _migrate_node(nd):
     changed = nd.pop("logBorn", None) is not None
     changed = nd.pop("everDone", None) is not None or changed   # retired 2026-07-08: once-done now lives in
-    if not nd.get("log") and (nd.get("nodeComplete") or nd.get("blocked") or nd.get("cleared")
-                              or nd.get("followupAt")):         #   the diary (done events), nowhere reads the flag
+    # KEY-PRESENCE, not truthiness (the user 2026-08-24): the diary KEY is the era marker — every
+    # diary-era mint writes "log": [] at birth, and the two sibling guards encoding the same concept
+    # (record_verdict's frozen check, _materialize_node's fail-loud) both test absence. Testing
+    # `not nd.get("log")` also matched a DIARY-ERA node whose flags were set eventlessly — a rollup
+    # roll-down child, whose flags are "tree-derived display cache", never verdicts — and manufactured
+    # a witnessed-looking src=judge done row from that cache. The live case: a delegation completed
+    # while the completing report explicitly DECLINED a child's ask; the roll-down folded the child,
+    # the next boot synthesized its "done", and the reopen un-resolve then re-completed it forever
+    # (the synth fold outranks the popped flags — done by association, unrecoverable). Genuinely
+    # legacy nodes (no log key at all) keep the synth, rolledUp included: pre-diary flags are the
+    # only history they have, so archives render unchanged.
+    if "log" not in nd and (nd.get("nodeComplete") or nd.get("blocked") or nd.get("cleared")
+                            or nd.get("followupAt")):           #   the diary (done events), nowhere reads the flag
         _synth_log(nd)
         changed = True
     if "log" not in nd:
@@ -8013,7 +8039,10 @@ CLOSER_SYS = (
     "No-work-filed rule: a note may instead flag goals that have had no work filed since they were "
     "created while other pieces of the same effort settled. Judge each from goal history and the other "
     "goals' state: done if its outcome was in fact delivered under another goal, or the approach it "
-    "names was replaced by one that shipped — say which in the why; blocked if it genuinely awaits the "
+    "names was replaced by one that shipped — say which in the why, and only where that covering work "
+    "answers this goal's own ask affirmatively (a report that explicitly declines or defers the ask is "
+    "evidence AGAINST closing: leave it open — or blocked, if the decline hands the user a decision — "
+    "and say in the why that the report declined it); blocked if it genuinely awaits the "
     "user; omit it (leave it open) if its work is simply still pending. Never close a flagged goal just "
     "because it is old or quiet: the ruling needs the covering work, named.\n"
     "- awaiting: the turn **ends** with the goal waiting on something the assistant itself set running "
@@ -8613,8 +8642,10 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                       "elsewhere on the same board: judge %s ONLY from what the reply explicitly says "
                       "about it — done only where the reply plainly reports that goal's outcome "
                       "delivered or nothing left to do on it; block where the reply's account of it "
-                      "ends by asking the user for a decision or go-ahead. A goal the reply does not "
-                      "clearly cover is a considered omission, not a completion."
+                      "ends by asking the user for a decision or go-ahead. A reply that declines or "
+                      "defers a goal's ask is not a completion either: leave that goal open (or block "
+                      "it, if the decline itself asks the user), and say the reply declined it. A goal "
+                      "the reply does not clearly cover is a considered omission, not a completion."
                       % ("s" if len(tflagged) > 1 else "",
                          ", ".join("#%d" % i for i in tflagged),
                          "are" if len(tflagged) > 1 else "is",
@@ -10911,6 +10942,35 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
                   "nodeComplete": False, "blocked": False, "cleared": False,
                   "trail": [], "t": t, "mt": t, "handoff": handoff, "log": []})
     return nid
+
+
+def _lift_handoff_children(store, hid):
+    """Move a COMPLETED handoff tracking node's OPEN direct children (their subtrees ride along) up
+    beside it — to its own parent, top-level when it is a top — before the roll-down can fold them.
+    Called from rollup_status's pre-pass, i.e. after every writer, for every completer alike.
+
+    The courier's link-back evidence — the recipient finished the DELEGATED work — supports completing
+    the tracking node and nothing else. But completion triggers rollup's roll-down, which folds every
+    open descendant into an eventless done-display cache, seals it out of every judge menu, and renders
+    it a full ✓: done by tree position, never by a ruling (the user 2026-08-24: a delegation's
+    completing report explicitly DECLINED a child's ask, and the child read done anyway). An ask filed
+    under a delegation sits there by topical placement; the delegation shipping WITHOUT it is the exact
+    event proving it is its own outstanding work. Moved up, it stays open, visible, and judgeable — the
+    closer's channels rule it done with the covering work named, or leave it open/blocked per the
+    decline rule (CLOSER_SYS) — while the completed delegation keeps the children that earned their own
+    verdicts. A moved child that is itself a handoff node keeps its own link-back alive: folding it
+    used to mark a live sub-delegation satisfied by association. Idempotent (after the move the node
+    has no open children), and the rollup pre-pass re-runs it on every write, so a stale concurrent
+    republish of the old parent is healed a pass later instead of sealing the child forever.
+    Returns the number moved."""
+    nodes = store.get("nodes", {})
+    dest = (nodes.get(hid) or {}).get("parentId")
+    moved = 0
+    for nd in list(nodes.values()):
+        if nd.get("parentId") == hid and not nd.get("nodeComplete") and not nd.get("cleared"):
+            nd["parentId"] = dest
+            moved += 1
+    return moved
 
 
 def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12242,6 +12242,69 @@ def _handoff_peer_identities(nodes, hnodes):
 _HANDOFF_LABEL_RE = re.compile(r"^\s*↪\s*delegated to (.+?): (.*)$", re.S)
 
 
+def _parked_rows(nodes, children):
+    """{nid: N} for every OPEN row that newer sibling work has LEAPFROGGED: nothing has happened in
+    nid's own subtree — no delegation edge, no witnessed verdict row — while N (>= 1) YOUNGER siblings
+    under the same parent gained "↪ delegated to" handoff edges in theirs.
+
+    The audit case (the user 2026-08-24): a queued ask sat 40+ minutes with zero rows while the same
+    umbrella's younger items were dispatched one after another. To the judges that sibling traffic
+    reads as an active card, so no nudge horizon applies — and nothing on the surface said "this one
+    was passed over". The sibling's handoff edge is the exact event: the operator DECIDING to spend
+    attention past this node. The threshold is 1 and the signal is handoff-only, both measured (a
+    replay over every live store): the true positives accumulate exactly one leapfrogging sibling
+    before retiring, so any higher K trades recall for nothing, and sibling VERDICT activity is
+    strictly noisier — judges batch-file over a whole store on their own cadence, which is not new
+    information about this node (the cards-move rule). Derived per build from monotone event inputs —
+    a courier-planted handoff node, a diary row — and retired by exactly the deciding events: nid's
+    own subtree gaining a delegation edge, or ANY witnessed verdict row landing under it. Synth rows
+    don't count as history: a migration reconstruction is not a ruling (judge _synth_log). Row chrome
+    only — the cue must never touch the card's column."""
+    hmemo, rmemo = {}, {}
+
+    def _sub_has(x, memo, hit):
+        # any(hit) over x's subtree — ITERATIVE with a seen-set (review 2026-08-24): the recursive
+        # form crashed on a parentId cycle, and a corrupted store (two rebased reparent writers can
+        # compose a cycle neither wrote) must degrade to a wrong-but-terminating answer, never a
+        # RecursionError killing the whole feed build.
+        if x in memo:
+            return memo[x]
+        seen, stack, found = set(), [x], False
+        while stack:
+            y = stack.pop()
+            if y in seen:
+                continue
+            seen.add(y)
+            if hit(nodes.get(y) or {}):
+                found = True
+                break
+            stack.extend(children.get(y, []))
+        memo[x] = found
+        return found
+
+    def _sub_handoff(x):
+        return _sub_has(x, hmemo, lambda nd: isinstance(nd.get("handoff"), dict))
+
+    def _sub_row(x):
+        return _sub_has(x, rmemo, lambda nd: any(not r.get("synth") for r in (nd.get("log") or [])))
+
+    out = {}
+    for kids in children.values():
+        if len(kids) < 2:
+            continue
+        for nid in kids:
+            nd = nodes.get(nid) or {}
+            if nd.get("nodeComplete") or nd.get("blocked") or nd.get("cleared") \
+                    or _sub_handoff(nid) or _sub_row(nid):
+                continue
+            t0 = nd.get("t") or 0
+            n = sum(1 for sib in kids
+                    if sib != nid and ((nodes.get(sib) or {}).get("t") or 0) > t0 and _sub_handoff(sib))
+            if n:
+                out[nid] = n
+    return out
+
+
 def _handoff_card_fields(nodes, nid):
     """(handoffTo badge, card title) for a feed card whose ROOT node is a courier handoff tracking
     node — (None, the node's text unchanged) for every other card.
@@ -18107,6 +18170,7 @@ def build_feed(now, tmux=None):
         for nid, nd in nodes.items():
             children.setdefault(nd.get("parentId"), []).append(nid)
         agent_open = _agent_open_set(nodes, children)   # authoritative-open subtree → never rendered 'done' (see helper)
+        parked_rows = _parked_rows(nodes, children)     # leapfrogged open rows → the quiet "parked" row cue (see helper)
 
         def _subtree(root):                          # all node ids at/under root (pre-order)
             stack, acc = [root], []
@@ -18236,6 +18300,11 @@ def build_feed(now, tmux=None):
                         # a rolled-UP question (the block lives in a descendant, not here) — the client's
                         # mark tooltip says "blocked inside", and the actual ask keeps its own ⏸ below
                         "qderived": st == "question" and not nd.get("blocked"),
+                        # LEAPFROGGED row (the user 2026-08-24): open, nothing filed under it, while N
+                        # younger siblings were dispatched past it — the quiet "parked" tag + the card's
+                        # dim sub-goals suffix. Gated on the OPEN render state so a rolled-down or
+                        # closed row can never wear it; mint/retire events live in _parked_rows.
+                        "parked": ({"n": parked_rows[nid]} if (st == "open" and nid in parked_rows) else None),
                         # AUTHORITATIVE tier: this node mirrors an item on the agent's OWN to-do list, so its
                         # open/done is agent-asserted (solidity = authority in the disc render). None = a plain
                         # judge-inferred node. (the user 2026-07-01)

--- a/tests/test_decline_never_closes.py
+++ b/tests/test_decline_never_closes.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""A goal is never DONE BY ASSOCIATION (the user 2026-08-24 audit): a delegation's completion may not
+close an adjacent ask the completing report never affirmed — and explicitly declining the ask is
+evidence AGAINST closing.
+
+The audited shape: an ask filed under a "↪ delegated to <peer>" tracking node; the peer's completing
+report explicitly declined it; the courier link-back completed the tracking node, rollup's roll-down
+folded the open child into an eventless done-display cache (sealed out of every judge menu), and the
+next kernel boot's migrate sweep — whose era check was truthiness, not the diary KEY — synthesized a
+witnessed-looking src=judge done row from that cache, making the fold irreversible even by reopen.
+Three guards under test:
+  * _lift_handoff_children: a completing handoff node's OPEN children move up beside it BEFORE the
+    fold — they stay open, visible, judgeable; done children stay under the delegation;
+  * the migrate gate keys on diary-KEY ABSENCE ("log" not in nd): a diary-era node whose flags were
+    set eventlessly (roll-down cache) never gains manufactured history; genuinely legacy nodes (no
+    key) keep the synth so archives render unchanged;
+  * the closer's evidence rules name the decline: covering work closes a goal only when it answers
+    that goal's own ask affirmatively; a decline/defer leaves it open (or blocks) and says so.
+All fixtures SYNTHETIC: placeholder UUIDs, invented text."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from inspect import getsource
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge_dnc", os.path.join(BIN, "romp-judge")).load_module()
+
+SENDER = "11111111-2222-3333-4444-555555555555"
+RECIP = "66666666-7777-8888-9999-000000000000"
+MID = "msg-aaaa-1111"
+T = 1_787_500_000
+U, H, X, Y = (SENDER + ":g1", SENDER + ":g2", SENDER + ":g3", SENDER + ":g4")
+
+
+def _node(nid, text, parent, t=T, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return jd.GuardedNode(base)
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self._saved_discover = jd.discover
+        jd.discover = lambda now, window=None, forks=True: [
+            (SENDER, "/dev/null", None, "web"), (RECIP, "/dev/null", None, "api")]
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {})]
+
+    def tearDown(self):
+        jd.discover = self._saved_discover
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {})]
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+        if jd.MESSAGES.exists():
+            jd.MESSAGES.unlink()
+
+    def _seed_sender(self, peer=RECIP):
+        st = jd.load_goals(SENDER)
+        st["nodes"][U] = _node(U, "Improve the notes app across surfaces", None)
+        st["nodes"][H] = _node(H, "↪ delegated to api: rework the gear menu", U,
+                               handoff={"peer": peer, "msgId": MID})
+        # the adjacent ask the report will DECLINE — open, nothing ever filed under it
+        st["nodes"][X] = _node(X, "Add tag editing to the tab dropdown", H, t=T + 10)
+        # a step that earned its own verdict — it belongs to the delegation's history and stays
+        st["nodes"][Y] = _node(Y, "Send the design spec over", H, t=T + 5)
+        jd.record_verdict(st, st["nodes"][Y], "closer", "done", T + 6)
+        jd.save_goals(SENDER, st)
+
+    def _seed_recipient_done(self):
+        st = jd.load_goals(RECIP)
+        st["nodes"][RECIP + ":g5"] = _node(RECIP + ":g5", "Rework the gear menu", None,
+                                           origin={"peer": SENDER, "goalId": H, "msgId": MID})
+        jd.record_verdict(st, st["nodes"][RECIP + ":g5"], "closer", "done", T + 50)
+        jd.save_goals(RECIP, st)
+
+
+class LinkBackLift(_Base):
+    """The specimen shape, synthetically: delegation ships -> the open adjacent ask STAYS OPEN."""
+
+    def test_open_child_moves_up_and_stays_open(self):
+        self._seed_sender()
+        self._seed_recipient_done()
+        self.assertEqual(jd.run_propagate(now=T + 200), 1, "the link-back fired")
+        st = jd.load_goals(SENDER)
+        self.assertTrue(st["nodes"][H].get("nodeComplete"), "the delegation itself completed")
+        x = st["nodes"][X]
+        self.assertEqual(x.get("parentId"), U, "the un-ruled ask moved up beside the delegation")
+        self.assertFalse(x.get("nodeComplete"), "…and STAYS OPEN — done-by-association never lands")
+        self.assertFalse(x.get("rolledUp"), "the roll-down never saw it")
+        self.assertFalse(any(e.get("kind") == "done" for e in x.get("log") or []),
+                         "no manufactured history either")
+
+    def test_a_child_with_its_own_verdict_stays_under_the_delegation(self):
+        self._seed_sender()
+        self._seed_recipient_done()
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        self.assertEqual(st["nodes"][Y].get("parentId"), H,
+                         "a step the judges ruled belongs to the delegation's history")
+
+    def test_a_closer_completion_of_the_tracking_node_lifts_too(self):
+        # the guard lives in rollup_status's pre-pass, so it covers EVERY completer — not only the
+        # courier link-back (review 2026-08-24: a status-report reply can legitimately let the closer
+        # rule the tracking node done before the courier's pass reaches it)
+        self._seed_sender()
+        st = jd.load_goals(SENDER)
+        jd.record_verdict(st, st["nodes"][H], "closer", "done", T + 100, why="the peer reported it shipped")
+        jd.rollup_status(st, False)
+        self.assertEqual(st["nodes"][X].get("parentId"), U)
+        self.assertFalse(st["nodes"][X].get("nodeComplete"))
+
+    def test_a_stale_republish_heals_on_the_next_rollup(self):
+        # the save-rebase race (review 2026-08-24): a concurrent pass republishes the child's OLD
+        # parentId back under the already-completed tracking node — the rebase folds diary rows, not
+        # parents. The guard re-runs in every writer's rollup, so the very next pass lifts it again
+        # instead of the roll-down sealing it forever.
+        self._seed_sender()
+        st = jd.load_goals(SENDER)
+        jd.record_verdict(st, st["nodes"][H], "courier", "done", T + 100)   # H complete...
+        self.assertEqual(st["nodes"][X].get("parentId"), H, "...and X (stale) still under it")
+        jd.rollup_status(st, False)                                         # any writer's rollup
+        self.assertEqual(st["nodes"][X].get("parentId"), U, "the pre-pass lifted it")
+        self.assertFalse(st["nodes"][X].get("nodeComplete"), "no fold, no done-by-association")
+        self.assertFalse(st["nodes"][X].get("rolledUp"))
+
+    def test_an_umbrella_ruling_still_absorbs_the_whole_subtree(self):
+        # the guard is scoped to the HANDOFF node's own completion: when the judges rule the umbrella
+        # TOP done, the designed roll-down absorb applies to everything under it, handoff children
+        # included — that completion DID consider the tree (goal history rides the closer menu)
+        self._seed_sender()
+        st = jd.load_goals(SENDER)
+        jd.record_verdict(st, st["nodes"][U], "closer", "done", T + 100, why="the whole effort shipped")
+        jd.rollup_status(st, True)
+        self.assertEqual(st["nodes"][X].get("parentId"), H, "no lift — the ancestor's ruling absorbs")
+        self.assertTrue(st["nodes"][X].get("rolledUp"), "the designed umbrella ending, unchanged")
+
+    def test_cross_host_reply_lifts_the_same_way(self):
+        self._seed_sender(peer="boxa:worker_two")
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        jd.MESSAGES.write_text(json.dumps({"id": "m1", "ev": "sent", "from": "worker_two",
+                                           "from_id": "peer:boxa:worker_two", "to_id": SENDER,
+                                           "t": T + 60, "kind": "coordinate", "body": "x"}) + "\n")
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {})]
+        self.assertEqual(jd.run_propagate(now=T + 200), 1)
+        st = jd.load_goals(SENDER)
+        self.assertTrue(st["nodes"][H].get("nodeComplete"))
+        self.assertEqual(st["nodes"][X].get("parentId"), U)
+        self.assertFalse(st["nodes"][X].get("nodeComplete"))
+
+
+class MigrateGateKeyPresence(_Base):
+    """The era marker is the diary KEY: eventless flags on a diary-era node never become history."""
+
+    def test_rolldown_cache_is_never_synthesized(self):
+        nd = _node(X, "an ask the roll-down folded", H, nodeComplete=True, rolledUp=True)
+        self.assertEqual(nd["log"], [], "precondition: diary-era node (empty diary at birth)")
+        jd._migrate_node(nd)
+        self.assertEqual(nd["log"], [],
+                         "flags without rows on a diary-era node are display cache, not verdicts — "
+                         "no src=judge done row is manufactured")
+
+    def test_genuinely_legacy_node_still_synthesizes(self):
+        nd = dict(_node(Y, "a pre-diary done item", None, nodeComplete=True))
+        del nd["log"]                                  # NO key: the true legacy shape
+        jd._migrate_node(nd)
+        rows = [e for e in nd["log"] if e.get("kind") == "done"]
+        self.assertEqual(len(rows), 1, "archives keep rendering: legacy flags are their only history")
+        self.assertTrue(rows[0].get("synth"), "…and the reconstruction is marked as such")
+
+    def test_legacy_rolledup_node_keeps_the_synth_too(self):
+        nd = dict(_node(X, "a pre-diary rolled item", H, nodeComplete=True, rolledUp=True))
+        del nd["log"]
+        jd._migrate_node(nd)
+        self.assertTrue(any(e.get("kind") == "done" for e in nd["log"]),
+                        "pre-diary rolledUp flags are the only record there is — unchanged behavior")
+
+
+class CloserDeclineRules(_Base):
+    """The evidence rules SAY the decline never closes — pinned where the closer reads them."""
+
+    def test_no_work_filed_rule_requires_affirmative_coverage(self):
+        i = jd.CLOSER_SYS.index("No-work-filed rule:")
+        j = jd.CLOSER_SYS.index("- awaiting:")
+        blk = jd.CLOSER_SYS[i:j]
+        self.assertIn("answers this goal's own ask affirmatively", blk)
+        self.assertIn("declines or defers the ask is", blk)
+        self.assertIn("evidence AGAINST closing", blk)
+        self.assertIn("say in the why that the report declined it", blk)
+
+    def test_status_report_note_names_the_decline_case(self):
+        src = getsource(jd._close_turn)
+        self.assertIn("declines or ", src)
+        self.assertIn("defers a goal's ask is not a completion", src)
+        self.assertIn("say the reply declined it", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parked_cue.py
+++ b/tests/test_parked_cue.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""The PARKED cue (the user 2026-08-24 audit): an open row nothing has happened under — no
+delegation edge, no witnessed verdict row — while YOUNGER siblings gained "↪ delegated to" handoff
+edges, wears a quiet {n} marker; it retires the instant the row's own subtree gains a delegation
+edge or ANY witnessed verdict row (the deciding events; synth reconstructions are not rulings).
+Threshold 1, handoff-only — both measured over every live store's replay: true positives accumulate
+exactly one leapfrogging sibling before retiring, and sibling VERDICT activity flaps with judge
+batch cadence, which is not new information about this row. Mint x retire, pinned synthetically."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from inspect import getsource
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_parked", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+def _world(nodes_spec):
+    """nodes: {short_id: (parent_short, t, extras)} -> (nodes, children) in store shape."""
+    nodes = {}
+    for sid_, (parent, t, extras) in nodes_spec.items():
+        nid = SID + ":" + sid_
+        nd = {"id": nid, "text": "item " + sid_, "parentId": (SID + ":" + parent) if parent else None,
+              "nodeComplete": False, "blocked": False, "cleared": False, "t": t, "log": []}
+        nd.update(extras or {})
+        nodes[nid] = nd
+    children = {}
+    for nid, nd in nodes.items():
+        children.setdefault(nd.get("parentId"), []).append(nid)
+    return nodes, children
+
+
+def _parked(nodes_spec):
+    nodes, children = _world(nodes_spec)
+    return {k.split(":")[1]: v for k, v in km._parked_rows(nodes, children).items()}
+
+
+HO = {"handoff": {"peer": "66666666-7777-8888-9999-000000000000", "msgId": "m1"}}
+
+
+class MintGrid(unittest.TestCase):
+    def test_the_audit_shape_one_younger_dispatch_mints_the_cue(self):
+        # the specimen: an older open ask under an umbrella; a younger sibling's subtree gains a
+        # handoff edge -> the older one was passed over, n=1
+        got = _parked({"u": (None, 50, {}),
+                       "a": ("u", 100, {}),
+                       "b": ("u", 200, {}),
+                       "b1": ("b", 210, HO)})
+        self.assertEqual(got, {"a": 1})
+
+    def test_each_further_dispatch_raises_the_count(self):
+        got = _parked({"u": (None, 50, {}),
+                       "a": ("u", 100, {}),
+                       "b": ("u", 200, HO),
+                       "c": ("u", 300, HO)})
+        self.assertEqual(got.get("a"), 2, "two younger siblings dispatched past it")
+
+    def test_an_older_siblings_dispatch_does_not_count(self):
+        got = _parked({"u": (None, 50, {}),
+                       "old": ("u", 40, HO),
+                       "a": ("u", 100, {})})
+        self.assertNotIn("a", got, "only YOUNGER siblings leapfrog — older traffic predates the ask")
+
+    def test_top_level_siblings_count_too(self):
+        got = _parked({"a": (None, 100, {}),
+                       "b": (None, 200, {}),
+                       "b1": ("b", 210, HO)})
+        self.assertEqual(got, {"a": 1}, "tops are siblings under the None parent")
+
+    def test_sibling_verdict_activity_alone_never_mints(self):
+        # measured strictly noisier (judge batch cadence): a younger sibling with rulings but no
+        # handoff edge is not a leapfrog
+        got = _parked({"u": (None, 50, {}),
+                       "a": ("u", 100, {}),
+                       "b": ("u", 200, {"log": [{"ev_t": 250, "src": "closer", "kind": "done",
+                                                 "at": 250}]})})
+        self.assertEqual(got, {})
+
+
+class RetireGrid(unittest.TestCase):
+    def test_own_delegation_edge_retires_it(self):
+        got = _parked({"u": (None, 50, {}),
+                       "a": ("u", 100, {}),
+                       "a1": ("a", 400, HO),
+                       "b": ("u", 200, HO)})
+        self.assertNotIn("a", got, "its own dispatch is the deciding event — the wait is over")
+
+    def test_any_witnessed_verdict_row_retires_it(self):
+        for kind in ("done", "block", "awaiting", "unblock"):
+            got = _parked({"u": (None, 50, {}),
+                           "a": ("u", 100, {"log": [{"ev_t": 300, "src": "closer", "kind": kind,
+                                                     "at": 300}]}),
+                           "b": ("u", 200, HO)})
+            self.assertNotIn("a", got, "a %s row is a ruling — the judges have seen it" % kind)
+
+    def test_a_synth_row_is_not_history(self):
+        # a migration reconstruction is not a ruling (judge _synth_log) — the cue stands
+        got = _parked({"u": (None, 50, {}),
+                       "a": ("u", 100, {"log": [{"ev_t": 100, "src": "judge", "kind": "done",
+                                                 "at": 900, "synth": True}]}),
+                       "b": ("u", 200, HO)})
+        self.assertEqual(got.get("a"), 1)
+
+    def test_a_row_deeper_in_the_subtree_also_retires(self):
+        got = _parked({"u": (None, 50, {}),
+                       "a": ("u", 100, {}),
+                       "a1": ("a", 150, {"log": [{"ev_t": 300, "src": "planner", "kind": "done",
+                                                  "at": 300}]}),
+                       "b": ("u", 200, HO)})
+        self.assertNotIn("a", got, "activity anywhere under it means it was not passed over")
+
+    def test_resolved_rows_never_wear_it(self):
+        for extras in ({"nodeComplete": True}, {"blocked": True}, {"cleared": True}):
+            got = _parked({"u": (None, 50, {}),
+                           "a": ("u", 100, dict(extras)),
+                           "b": ("u", 200, HO)})
+            self.assertNotIn("a", got)
+
+    def test_an_only_child_never_wears_it(self):
+        got = _parked({"u": (None, 50, {}), "a": ("u", 100, {})})
+        self.assertEqual(got, {})
+
+    def test_a_parent_cycle_degrades_instead_of_crashing(self):
+        # a corrupted store (two rebased reparent writers can compose a cycle neither wrote) must
+        # never kill the feed build — the walk terminates (review 2026-08-24, verified crash)
+        nodes, children = _world({"x": ("y", 100, {}), "y": ("x", 200, {}),
+                                  "z": ("y", 300, HO), "w": ("y", 50, {})})
+        km._parked_rows(nodes, children)   # must return, whatever it answers for the cycle members
+
+
+class BuildFeedWiring(unittest.TestCase):
+    def test_the_row_field_ships_gated_on_the_open_render_state(self):
+        src = getsource(km.build_feed)
+        self.assertIn("parked_rows = _parked_rows(nodes, children)", src)
+        self.assertIn('"parked": ({"n": parked_rows[nid]} if (st == "open" and nid in parked_rows)'
+                      " else None)", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-parked-cue.test.ts
+++ b/ui/webview/feed-parked-cue.test.ts
@@ -1,0 +1,50 @@
+// The PARKED row cue on the feed (the user 2026-08-24 audit): a queued ask silently sat 40 minutes
+// while the same card's younger items were dispatched past it, and nothing on the surface said so.
+// The kernel ships a per-row `parked: {n}` (kernel _parked_rows: leapfrogged by n younger siblings'
+// handoff edges, retiring on the row's own delegation edge or any witnessed verdict); the feed wears
+// it as a quiet one-word tag on the checklist row and the modal row — the cleared tag's exact idiom,
+// dim by design, never the trouble-chip family — plus a dim " · N parked" suffix on the sub-goals
+// button as the card-level gist (progressive disclosure: the button that shows the rows IS the
+// click). Source pins, the feed-panel idiom; the kernel truth table lives in tests/test_parked_cue.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const FEED = W("feed.ts");
+const FEEDCSS = W("feed.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+
+test("kernel: the row field is additive and gated on the OPEN render state", () => {
+  assert.match(KERNEL, /"parked": \(\{"n": parked_rows\[nid\]\} if \(st == "open" and nid in parked_rows\) else None\)/);
+  assert.match(KERNEL, /parked_rows = _parked_rows\(nodes, children\)/);
+  assert.match(FEED, /parked\?: \{ n: number \} \| null;/, "additive on the type — old payloads render as before");
+});
+
+test("the tag is the cleared tag's quiet idiom, on both the checklist row and the modal row", () => {
+  assert.match(FEED, /function parkedTag\(n: number\): HTMLElement \{/);
+  assert.match(FEED, /tag\.textContent = "parked";/);
+  assert.match(FEED, /if \(s\.parked && s\.parked\.n && !s\.cleared\) row\.appendChild\(parkedTag\(s\.parked\.n\)\);/,
+    "card checklist row");
+  assert.match(FEED, /if \(node\.parked && node\.parked\.n && !node\.cleared\) line\.appendChild\(parkedTag\(node\.parked\.n\)\);/,
+    "modal tree row");
+  assert.match(FEEDCSS, /\.fparked-tag \{ flex: 0 0 auto; font-size: 0\.92em; color: var\(--dim\);/,
+    "same metrics as .fcleared-tag — no new font size");
+});
+
+test("the card-level gist is a dim suffix on the sub-goals button, not a trouble chip", () => {
+  // the count mirrors the checklist walk the button toggles — stops at handoff nodes and the root —
+  // so the suffix never advertises rows no expansion of the checklist reveals (review 2026-08-24)
+  assert.match(FEED, /if \(!n \|\| n\.kind === "handoff" \|\| pseen\.has\(n\.id\)\) return;/);
+  assert.match(FEED, /if \(n\.parked && n\.parked\.n\) parkedCount\+\+;/);
+  assert.match(FEED, /pk\.textContent = " · " \+ parkedCount \+ " parked";/);
+  assert.match(FEEDCSS, /\.fask-subparked \{ opacity: 0\.6; font-weight: 400; \}/,
+    "the waiting-chip's sub-line treatment — the sub-goal count stays the loudest word");
+});
+
+test("a parked mint/retire re-renders an open modal — the tag rides treeSig", () => {
+  // tops are siblings, so ANOTHER top's dispatch can mint/retire a root's tag with nothing else in
+  // this tree changing; without the sig component an open group modal kept the stale tag
+  assert.match(FEED, /\+ \(n\.parked && n\.parked\.n \? "p" \+ n\.parked\.n : ""\)/);
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -457,6 +457,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* the chip's elapsed readout (" · 42m") — same size as the chip text, dimmed like a sub-line so the
    peer name stays the loudest word (the user 2026-08-23) */
 .fask-waiton-dur { opacity: 0.6; font-weight: 400; }
+/* the sub-goals button's dim " · N parked" suffix (the user 2026-08-24) — same quiet sub-line
+   treatment as the waiting-chip's elapsed readout; the loud word stays the sub-goal count */
+.fask-subparked { opacity: 0.6; font-weight: 400; }
 
 /* ---- ask DAG tree (expanded body) — nodes only; click a node for its history ---- */
 /* width:fit-content hugs the widest row so the right-aligned "(Xm ago)" node times sit just past the
@@ -568,6 +571,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* the one-word "cleared" chip on a cleared row (the user 2026-07-25: the strike alone read as
    unexplained machinery) — dim, outside the strikethrough, same small-tag size as .ftree-who */
 .fcleared-tag { flex: 0 0 auto; font-size: 0.92em; color: var(--dim);
+  border: 1px solid rgba(255, 255, 255, 0.18); border-radius: 4px; padding: 0 5px; line-height: 1.5; }
+/* the one-word "parked" hint on a leapfrogged open row (the user 2026-08-24: a queued ask sat
+   silently while newer siblings were dispatched past it) — the cleared tag's exact metrics, dim by
+   design: a hint to glance at, never the trouble-chip family's yellow/red */
+.fparked-tag { flex: 0 0 auto; font-size: 0.92em; color: var(--dim);
   border: 1px solid rgba(255, 255, 255, 0.18); border-radius: 4px; padding: 0 5px; line-height: 1.5; }
 .ftree-node.st-cleared .ftree-text { text-decoration: line-through; text-decoration-color: var(--dim); }
 .ftree-node.st-cleared .ftree-mark { color: var(--dim); }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -53,6 +53,7 @@ interface AskTreeNode {
   trgb?: [number, number, number];                               // last-activity recency tint (timestamp)
   cleared?: boolean;                                             // user-cleared sub (nodeOverride op:clear) → struck-through faded row + "cleared" chip; the mark stays tied to status (box = done, the user 2026-07-26)
   reviewedEarlier?: boolean;                                     // this done sub predates the top's review boundary (kernel flatten ↔ jd.review_boundary, the distiller's own scoping) → collapsed behind one "N reviewed earlier" row (the user 2026-08-19)
+  parked?: { n: number } | null;                                 // LEAPFROGGED open row (kernel _parked_rows, the user 2026-08-24): nothing filed under it while n younger siblings were dispatched past it → quiet "parked" tag + the card's dim sub-goals suffix; retires on its own delegation edge or any verdict
   log?: NodeLogRow[] | null;                                     // the node's newest verdict rows (kernel _node_log_rows, non-done only) → the modal's per-item story (the user 2026-07-20)
   children: string[];
 }
@@ -1388,6 +1389,28 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   const subBtn = a._subBtn as HTMLElement;
   subBtn.style.display = hasSubs ? "" : "none";
   subBtn.textContent = subCount === 1 ? "1 sub-goal" : subCount + " sub-goals";
+  // dim " · N parked" suffix (the user 2026-08-24): the card-level gist of the row tags. Counts ONLY
+  // rows the checklist this button toggles can actually reach — the same walk, stopping at handoff
+  // nodes (delegations render in their own section) and at the root (the card head, not a row) — so
+  // the suffix never advertises rows no expansion reveals (review 2026-08-24; a parked ask under a
+  // LIVE delegation is the modal tree's to show).
+  let parkedCount = 0;
+  if (root) {
+    const pseen = new Set<string>([root.id]);
+    const pwalk = (nid: string) => {
+      const n = byId.get(nid);
+      if (!n || n.kind === "handoff" || pseen.has(n.id)) return;
+      pseen.add(n.id);
+      if (n.parked && n.parked.n) parkedCount++;
+      for (const c of n.children || []) pwalk(c);
+    };
+    for (const c of (root.children || [])) pwalk(c);
+  }
+  if (hasSubs && parkedCount) {
+    const pk = el("span", "fask-subparked");
+    pk.textContent = " · " + parkedCount + " parked";
+    subBtn.appendChild(pk);
+  }
   subBtn.classList.toggle("on", choice === "subgoals");
   subBtn.setAttribute("aria-pressed", choice === "subgoals" ? "true" : "false");
   subBtn.title = choice === "subgoals" ? "hide the sub-goals" : "show the sub-goals";
@@ -1491,6 +1514,7 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
       const txt = el("span", "fcheck-text"); txt.textContent = s.text;
       row.append(tri, mark, txt);
       if (s.cleared) row.appendChild(clearedTag());   // the strike alone doesn't say WHY — see CLEARED_TIP
+      if (s.parked && s.parked.n && !s.cleared) row.appendChild(parkedTag(s.parked.n));   // leapfrogged — see parkedTag
       // clicks match the modal tree node exactly (text → the message, checkbox → where it resolved) via the
       // SAME wireNodeZones; a dim repeat is display-only (wire=false).
       wireNodeZones(it, s, mark, txt, null, !repeat);
@@ -2326,6 +2350,18 @@ function clearedTag(): HTMLElement {
   return tag;
 }
 
+// The parked row's plain-language story (the user 2026-08-24: a queued ask silently sat 40 minutes
+// while the same card's younger items were dispatched one after another, and nothing said so). One
+// quiet word on the row, the explanation on hover — a hint, never a needs-you alarm; the kernel
+// retires it the instant the row gets its own delegation or any verdict (_parked_rows).
+function parkedTag(n: number): HTMLElement {
+  const tag = el("span", "fparked-tag");
+  tag.textContent = "parked";
+  tag.title = "nothing has happened here yet — " + n + " newer ask" + (n === 1 ? " was" : "s were")
+    + " dispatched past this one; this tag clears on its own dispatch or any ruling";
+  return tag;
+}
+
 function nodeStatusClass(n: AskTreeNode): string {
   if (n.cleared) return "cleared";
   if (n.status === "done") return "done";
@@ -2437,6 +2473,9 @@ function hasQuestionDescendant(node: AskTreeNode, byId: Map<string, AskTreeNode>
 function treeSig(it: AskItem): string {
   return it.tree.map((n) =>
     n.id + n.status + (n.cleared ? "x" : "") + (n.whoWorking ? "W" : "")
+    // parked can mint/retire off a DIFFERENT top's dispatch (tops are siblings), which changes
+    // nothing else in THIS tree — without it in the sig an open group modal kept a stale tag
+    + (n.parked && n.parked.n ? "p" + n.parked.n : "")
     + (collapsedNodes.has(it.itemId + ":" + n.id) ? "c" : "")
     + (nodeLogOpen.has(it.itemId + ":" + n.id) ? "L" : "") + ((n.log || []).length || "")).join("|");
 }
@@ -2613,6 +2652,7 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
   if (node.status === "question") mark.title = node.qderived ? "a sub-goal inside is blocked — the ⏸ below is the ask" : "blocked — needs you";
   const txt = el("span", "ftree-text"); txt.textContent = node.text || "(node)"; line.appendChild(txt);
   if (node.cleared) line.appendChild(clearedTag());   // same one-word story as the card checklist
+  if (node.parked && node.parked.n && !node.cleared) line.appendChild(parkedTag(node.parked.n));   // and the parked hint
   // (The node's why/blocked/done rationale hover tooltip was removed 2026-06-27 — just the goal text now.)
   if (node.who && node.who !== parentWho) {
     const who = el("a", "ftree-who"); who.title = node.whoWorking ? "open this session (working now)" : "open this session";


### PR DESCRIPTION
Two gaps from the user's 2026-08-24 audit of a silently dropped ask (one queued item sat 40 minutes; a declined ask read done), both fixed at their actual mechanisms — with the threshold and the failure modes measured, not guessed.

## Gap A — the parked cue

A queued ask sat 40+ minutes with zero verdict rows while the same umbrella's younger items were dispatched one after another; to the judges that sibling traffic reads as an active card, so no nudge horizon applies, and nothing on the surface said "this one was passed over."

New per-row derivation `_parked_rows`: an open row whose own subtree has no delegation edge and no witnessed verdict row, leapfrogged by N younger siblings that gained "↪ delegated to" handoff edges, ships `parked:{n}` on its tree row. **The sibling's handoff edge is the exact event** — the operator deciding to spend attention past this node. Threshold 1 and handoff-only, both measured by replaying every live store's history: true positives accumulate exactly one leapfrogging sibling before retiring (the audit specimen never reached two), higher K keeps only batch-mint noise, and sibling *verdict* activity flaps with judge batch cadence — not new information about this row. Retires on exactly the deciding events: the row's own delegation edge, or any witnessed verdict row (synth reconstructions are not rulings). The walks are iterative with a seen-set so a corrupted store (parentId cycle) degrades instead of killing the feed build.

Render: the cleared tag's quiet idiom on checklist and modal rows, plus a dim " · N parked" suffix on the sub-goals button counting only rows that checklist can actually reach; the tag rides `treeSig` so an open modal re-renders on a sibling-top mint/retire. Row chrome only — the column never moves on it.

## Gap B — decline never closes

An ask filed under a completing delegation was ruled done although the completing report **explicitly declined it** — by tree position, never by a judge: the courier link-back completed the tracking node, rollup's roll-down folded the open child into an eventless done-display cache (sealed out of every judge menu), and the boot migrate sweep — whose era check was truthiness, not the diary KEY — synthesized a witnessed-looking `src=judge` done row from that cache, making the fold irreversible even by user reopen.

Three guards:
- **rollup_status pre-pass**: open children of every completed, non-rolledUp handoff tracking node move up beside it (`_lift_handoff_children`) before the roll-down can fold them — they stay open, visible, and judgeable. Living in every writer's rollup, the guard covers every completer alike (courier link-back, closer done, planner op) and self-heals the save-rebase race that republishes a stale parent. An umbrella ancestor's own ruling still absorbs its whole subtree — that completion did consider the tree.
- **The migrate gate keys on diary-KEY absence** (`"log" not in nd`), matching its own introducing commit's invariant and its two sibling guards: eventless flags on a diary-era node never become manufactured history; genuinely legacy nodes keep the synth, archives unchanged. This also restores the reopen un-resolve for rolled-down children.
- **The closer's evidence rules name the decline**: covering work closes a goal only when it answers that goal's own ask affirmatively; an explicit decline/defer is evidence against closing — leave it open (or blocked if the decline hands the user a decision) and say so in the why. Stated in `CLOSER_SYS`'s no-work-filed rule and the status-report menu note.

## Tests

`tests/test_parked_cue.py` (mint×retire grid, cycle degradation, wiring), `tests/test_decline_never_closes.py` (the audit shape synthetically: delegation ships + report declines adjacent ask → the ask stays open beside the delegation; closer-completion, stale-republish self-heal, cross-host, and umbrella-absorb-unchanged variants; migrate-gate key-presence; closer-rule pins), `ui/webview/feed-parked-cue.test.ts` (render idiom pins). Local: 5494 py passed, 2342 UI passed, tsc clean. An adversarial review pass drove the rollup pre-pass placement, the cycle-safe walks, the reachable-count suffix, and the treeSig component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)