### PR TITLE
The untagged view excludes by the union — a remote-homed tag counts everywhere

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1677,8 +1677,13 @@ def _views_client():
         t["members"] = [_member_str(m) for m in t["members"]]
     remote = []
     with _remotes_lock:
+        # every attached host with a CACHED read contributes — down included (the user 2026-08-24):
+        # visibility must not flap with a peer's restart, so the last-known tags keep excluding
+        # from the untagged view and keep their tag views pickable while the link reconnects
+        # (bounded staleness: the auto-reconnect heals within a pass; detach pops the row and its
+        # cache with it — intent-consistent).
         cand = [(r["host"], r.get("views")) for r in _remotes.values()
-                if r.get("status") == "up" and isinstance(r.get("views"), dict)]
+                if isinstance(r.get("views"), dict)]
     for host, rv in sorted(cand):
         for t in (rv.get("tags") or [])[:_VIEWS_MAX_TAGS]:
             if not isinstance(t, dict) or not t.get("id"):
@@ -1707,9 +1712,14 @@ def _view_visible(views, sid):
     if views["active"] == "all":
         return sid not in views["hidden"]
     if views["active"] == "untagged":
-        # LOCAL tags only exclude here (federation v0): a remote kernel's tagging of our session
-        # must not flap our untagged view with its poll cadence — remote tags are extra VIEWS
-        return sid not in views["hidden"] and not any(sid in t["members"] for t in views["tags"])
+        # the union excludes here too (the user 2026-08-24, who tagged a session from the chat and
+        # watched it stay in the untagged view): a tag is its NAME wherever it homes — a session
+        # held by ANY kernel's tag is tagged, period. The v0 flap worry (a remote's poll cadence
+        # toggling untagged membership) is answered by _views_client keeping a down host's CACHED
+        # tags contributing: stability beats freshness for visibility, and the auto-reconnect work
+        # makes the staleness window a pass, not an afternoon.
+        return sid not in views["hidden"] and not any(
+            sid in t["members"] for t in list(views["tags"]) + list(views.get("remoteTags") or []))
     # a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24: a tag is its NAME; kernels
     # are plumbing) — whichever store's id is active, membership joins every same-name tag's,
     # local and remote alike. The stored duplicates stay separate (anti-clobber); this is the read.

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -230,13 +230,18 @@ class TimelineViews(unittest.TestCase):
         finally:
             km._remotes.clear(); km._remotes.update(saved)
 
-    def test_a_down_kernel_contributes_nothing_and_active_hidden_stay_local(self):
+    def test_a_down_kernels_CACHE_keeps_contributing_and_active_hidden_stay_local(self):
+        # REVERSED from v0 (the user 2026-08-24, the untagged-view bug): visibility must not flap
+        # with a peer's restart, so the last-known tags keep excluding from untagged and keep their
+        # views pickable while the link reconnects. Bounded staleness — the auto-reconnect heals
+        # within a pass, and detach pops the row and its cache with it.
         saved = dict(km._remotes)
         try:
             km._remotes.clear()
             self._attach("alpha", {"tags": [{"id": "g1", "name": "team", "members": []}]}, status="down")
             v = km._views_client()
-            self.assertNotIn("remoteTags", v, "a down kernel's cached tags never join the union")
+            self.assertEqual([t["id"] for t in v.get("remoteTags") or []], ["alpha:g1"],
+                             "the cached read stands while the kernel reconnects")
             # a remote-tag ACTIVE survives normalization (validated at read time, ":" is the marker);
             # hidden stays exactly the viewer-local list — neither is federated state
             n = km._norm_timeline_views({"active": "alpha:g1", "hidden": ["h1"], "tags": []})
@@ -245,6 +250,37 @@ class TimelineViews(unittest.TestCase):
             # a client echoing the derived remoteTags back never persists it
             n2 = km._norm_timeline_views({"active": "all", "remoteTags": [{"id": "x"}], "tags": []})
             self.assertNotIn("remoteTags", n2)
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
+    def test_untagged_excludes_by_the_UNION_both_tag_homes(self):
+        # the user's repro (2026-08-24): they tagged a session from the chat while showing only
+        # untagged, and it STAYED — the untagged branch counted local tags only, so a REMOTE-homed
+        # tag never excluded. A tag is its NAME wherever it homes: held by any kernel's tag = tagged.
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            # remote-homed: the viewer's kernel holds no tag at all; alpha's tag holds two sessions —
+            # one of alpha's own, and one of OURS (the local sid, known here)
+            (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
+            (jd.STATE / "names" / "00000000-aaaa-bbbb-cccc-000000000002").write_text("cards\t/tmp\t#123456\twhite\n")
+            self._attach("alpha", {"tags": [{"id": "g1", "name": "workers", "color": "#DD42FF",
+                                             "members": [{"host": "", "sid": "rsid1"},
+                                                         {"host": "viewer", "sid": "00000000-aaaa-bbbb-cccc-000000000002"}]}]})
+            km._set_timeline_views({"active": "untagged", "hidden": [], "tags": []})
+            km._flags_cache.clear()
+            v = km._views_client()
+            self.assertFalse(km._view_visible(v, "alpha:rsid1"),
+                             "a remote-homed tag excludes its member from untagged")
+            self.assertFalse(km._view_visible(v, "00000000-aaaa-bbbb-cccc-000000000002"),
+                             "…including OUR OWN session it holds — the exact reported case")
+            self.assertTrue(km._view_visible(v, "someone-else"))
+            # local-homed: unchanged behavior, pinned beside it
+            km._set_timeline_views({"active": "untagged", "hidden": [],
+                                    "tags": [{"id": "gL", "name": "local", "members": ["locsid"]}]})
+            km._flags_cache.clear()
+            v = km._views_client()
+            self.assertFalse(km._view_visible(v, "locsid"))
         finally:
             km._remotes.clear(); km._remotes.update(saved)
 

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -74,7 +74,9 @@ function viewVisible(views, id) {
   }
   if (views.active === 'untagged') {
     if (Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0) return false;
-    return !viewTags(views).some((t) => (t.members || []).indexOf(id) >= 0);
+    // the UNION excludes (the user 2026-08-24): a session held by ANY kernel's tag is tagged —
+    // a remote-homed tag pulls it out of untagged exactly like a local one
+    return !viewTags(views).concat((views && views.remoteTags) || []).some((t) => (t.members || []).indexOf(id) >= 0);
   }
   // a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24): whichever store's id is
   // active, the members are every same-name tag's, local and remote joined

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -157,3 +157,12 @@ test("executed: a tag view is the NAME-KEYED union (user ruling 2026-08-24) — 
   assert.equal(viewVisible({ ...both, active: "TESTHOST-A:g1" }, "local1"), true, "either id, same union");
 });
 
+test("executed: untagged excludes by the UNION — a remote-homed tag counts (the user 2026-08-24)", () => {
+  // the reported bug: tagging from the chat left the session in the untagged view, because only
+  // LOCAL tags excluded there. Held by any kernel's tag = tagged, on every surface.
+  const v = { active: "untagged", hidden: [], tags: [],
+              remoteTags: [{ id: "alpha:g1", host: "alpha", name: "workers", members: ["cards1"] }] };
+  assert.equal(viewVisible(v, "cards1"), false, "remote-homed tag → out of untagged");
+  assert.equal(viewVisible(v, "other"), true);
+});
+

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -57,7 +57,9 @@ export function viewVisible(views: SessionViews | null | undefined, id: string):
   }
   if (views.active === "untagged") {
     if (Array.isArray(views.hidden) && views.hidden.includes(id)) return false;
-    return !viewTags(views).some((t) => (t.members || []).includes(id));
+    // the UNION excludes (the user 2026-08-24): a session held by ANY kernel's tag is tagged —
+    // a remote-homed tag pulls it out of untagged exactly like a local one
+    return !viewTags(views).concat(views.remoteTags || []).some((t) => (t.members || []).includes(id));
   }
   // a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24: a tag is its NAME; kernels are
   // plumbing) — whichever store's id is active, membership joins every same-name tag's


### PR DESCRIPTION
## The bug (user repro 2026-08-24)

Tagging a session from the chat left it in the untagged view. **Seam 1 was real in all three visibility deciders**: the untagged branch counted local tags only — a deliberate v0 scoping the name-keyed ruling never re-grounded — so a session held only by a **remote-homed** tag (the exact reported shape) stayed "untagged" on the tab strip, the lanes, and the kernel's decision of record.

## The fix

Held by **any** kernel's tag = tagged: the untagged branch reads local tags + `remoteTags` in the kernel, `session-views.ts`, and the timeline mirror. The v0 flap worry gets a better answer than scoping: `_views_client` now keeps a **down** host's cached tags contributing (a deliberate reversal of the v0 down-kernel rule) — visibility stays stable across a peer's restart, with bounded staleness (auto-reconnect heals within a pass; detach pops the row and its cache).

## Also from the diagnosis

- **Seam 2 (feed cards)**: the feed never view-filters cards at all — cards staying is not this bug and not a shipped behavior (a separate feature ask if wanted).
- **Seam 3 (active-tab peek)**: present and working as designed (`.tab-peek` ghost, auto-closing).

## Tests

`tests/test_timeline_views.py`: the repro in both tag-home cases — including *our own session held by a remote's tag* — plus the retargeted down-cache rule (cited reversal); `session-views.test.ts`: the mirror's union case. Suites green: 5471 python tests (+293 subtests), 2346 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)