### PR TITLE
A connector is pending on its own events, at any age: MSG_INFLIGHT_MAX retired

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19004,7 +19004,11 @@ def build_feed(now, tmux=None):
 TL_HORIZON = 48 * 3600                        # how far back stripes/connectors are read (slider max)
 WIN_5H   = 5 * 3600                            # token-usage windows: the two Claude meters — 5h "session" + 7d "week".
 WIN_WEEK = 7 * 86400                           # The footer shows tokens per window so the count lines up with the /usage %.
-MSG_INFLIGHT_MAX = 1800                        # a message older than this isn't "in flight" (30 min)
+# (MSG_INFLIGHT_MAX retired 2026-08-24: "in flight" was a 30-minute age window approximating four
+# distinct OBSERVABLE endings — read (exec row), recalled (recall row), refused/destroyed (bounced
+# row, which the orphan sweep now also writes when it destroys a dead recipient's unread mail), and
+# the recipient dying (the live set). _postal_messages keys pending on those events; an unread
+# message to a live recipient is honestly pending at any age the draw horizon shows.)
 
 
 def _state_intervals(sid, want, now):
@@ -19425,19 +19429,20 @@ def _msg_summaries():
     return _msg_sum_cache["map"]
 
 
-def _postal_messages(now, alive_sids, id2name):
+def _postal_messages(now, alive_sids, id2name, live_sids=None):
     """Inter-session connectors for the timeline, from the postal log (timeline/messages.jsonl): each
     'sent' row joined to its 'exec' by id → a [sent,exec] arrow between two lanes. File-based (the old
     romp-timeline-data.readMessages, trimmed): recent only, no self-messages, and AT LEAST ONE end a
     local lane. A CROSS-MACHINE message has its other end on a federated peer this kernel has never
     heard of — emit it anyway (one-sided): the browser's merge stitches the foreign endpoint onto that
     host's lane by bare sid, and a connector whose far end matches nothing is dropped by the view's
-    lane lookup, exactly like before."""
+    lane lookup, exactly like before. `live_sids` = the TRUE live set for the pending flag's
+    recipient-liveness leg (alive_sids is the broader LANE set); None skips that leg."""
     try:
         lines = (jd.STATE / "timeline" / "messages.jsonl").read_text(errors="replace").splitlines()
     except OSError:
         return []
-    sent, execd = {}, {}
+    sent, execd, ended = {}, {}, set()
     for ln in lines:
         try:
             o = json.loads(ln)
@@ -19449,6 +19454,9 @@ def _postal_messages(now, alive_sids, id2name):
             execd[o["id"]] = (o.get("t"), o.get("dmid"))   # dmid: the recipient-side delivery mid (relayed mail)
         elif o.get("ev") == "unexec" and o.get("id"):    # a drain that CLAIMED the mail then rolled back
             execd.pop(o["id"], None)                     # (postal restore) — it never reached the recipient
+        elif o.get("ev") in ("recall", "bounced") and o.get("id"):
+            ended.add(o["id"])                           # terminally ended: recalled by the sender, or the
+            #                                              bus refused/destroyed it — it can never land now
     cutoff, out = now - TL_HORIZON, []
     msgsum = _msg_summaries()                           # {id: Haiku caption} → the timeline shows it over the raw body
     tanchors = _thread_anchors(alive_sids)              # {tid: (parent sid, anchorT, name)} — thread mail's home
@@ -19467,7 +19475,17 @@ def _postal_messages(now, alive_sids, id2name):
                "from": id2name.get(f, e.get("from", "")), "to": id2name.get(t, ""),
                "fromOrig": e.get("from", id2name.get(f, f)),
                "sent": st, "exec": ex_t if ex_t else st, "hasExec": ex_t is not None,
-               "pending": ex_t is None and (now - st) < MSG_INFLIGHT_MAX,
+               # pending = the deciding events say it can still land: never read (no exec), never
+               # recalled/bounced, and the recipient can still read it — alive (live_sids, the TRUE
+               # live set, not the lane set), a thread whose parent lane is alive, or a cross-host
+               # relay whose far end this kernel cannot see (honesty over a guess: it stays pending
+               # until the far host's exec/bounce receipt lands). Replaced the 30-min age window
+               # (retired MSG_INFLIGHT_MAX): an unread message to a live recipient is pending at ANY
+               # age — the age said nothing the events don't.
+               "pending": (ex_t is None and mid not in ended
+                           and (live_sids is None or t in live_sids
+                                or (t in tanchors and tanchors[t][0] in live_sids)
+                                or (isinstance(t, str) and t.startswith("peer:")))),
                "text": (e.get("body", "") or "").strip()[:240], "summary": msgsum.get(mid)}
         if ex_dmid:
             row["dmid"] = ex_dmid   # lets the MERGED view join a relayed connector to the remote turn's mids
@@ -20724,7 +20742,11 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         # shipped, so every live lane painted bar-less with only a "push build:" stderr line as
         # evidence. A band that fails now costs THAT band, loudly, never the frame.
         try:
-            messages = _postal_messages(now, set(id2name), id2name)
+            # alive_sids here is the LANE set (live + dead-within-12h) — right for "draws at all",
+            # wrong for the pending flag's liveness leg, which needs the TRUE live set (a dead
+            # recipient can never read its mail; a dead-lane sender still draws its old arrows)
+            messages = _postal_messages(now, set(id2name), id2name,
+                                        {s for s in id2name if tmux.get(s) is not None})
             _bind_message_execs(messages, turns)         # connector exec → the recipient's process-start (real transit)
             # mids STAY on the wire (2026-08-17): the merged-view dmid join (romp-timeline-view.js) re-binds
             # a relayed connector's exec to the recipient turn by bar mids — the 2026-07-07 payload-audit pop

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -970,6 +970,14 @@ def _sweep_orphans():
                     _log("bounce to %s failed: %s" % (s["name"], e))
             try:
                 f.unlink()
+                # the destroy is the message's TERMINAL EVENT — record it on the original mid, the
+                # way _bounce_apply records a peer's refusal (the user 2026-08-24): without this row
+                # the ledger's last word stayed "sent", and the timeline's pending flag had to lean
+                # on an age window / recipient liveness — which a same-sid REVIVAL then flips back
+                # to pending for mail that no longer exists. The ledger is now terminal-complete.
+                _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": f.name,
+                                              "to": recip or "?",
+                                              "why": "recipient exited; unread mail destroyed by the orphan sweep"})
             except Exception:
                 pass
         _mark_pending(box.name)                         # bounced orphans may have emptied new/

--- a/tests/test_timeline_pending.py
+++ b/tests/test_timeline_pending.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""A postal connector's PENDING flag keys on the message's own deciding events, never its age (the
+user 2026-08-24, the time-windows ruling): pending = never read (no surviving exec row), never
+recalled, never bounced, and the recipient can still read it (the TRUE live set — a dead recipient
+can never read its mail; a cross-host relay's far end is not locally knowable, so it stays honestly
+pending until the far receipt lands). MSG_INFLIGHT_MAX — the 30-minute age window that approximated
+all four endings — is retired; an unread message to a live recipient is pending at any age the draw
+horizon shows. The one ledger hole is closed at the writer: the orphan sweep now records its destroy
+as a terminal bounced row on the original mid, so a same-sid revival can never flip destroyed mail
+back to pending. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_tlpend", os.path.join(BIN, "romp-kernel")).load_module()
+pm = SourceFileLoader("romp_postal_tlpend", os.path.join(BIN, "romp-postal-service")).load_module()
+
+SENDER = "11111111-1111-1111-1111-111111111111"
+RECIP = "22222222-2222-2222-2222-222222222222"
+NOW = 1_787_700_000
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved_state = km.jd.STATE
+        km.jd.STATE = td
+        (td / "timeline").mkdir(parents=True)
+
+    def tearDown(self):
+        km.jd.STATE = self._saved_state
+        self.td.cleanup()
+
+    def _log(self, rows):
+        (km.jd.STATE / "timeline" / "messages.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n")
+
+    def _row(self, live=(RECIP,), to=RECIP):
+        out = km._postal_messages(NOW, {SENDER, RECIP}, {SENDER: "web", RECIP: "api"},
+                                  live_sids=set(live))
+        rows = [r for r in out if r["toId"] == to or r["fromId"] == SENDER]
+        return rows[0] if rows else None
+
+    def _sent(self, t=NOW - 47 * 3600, to=RECIP):
+        return {"t": t, "ev": "sent", "id": "m1", "from": "web", "from_id": SENDER,
+                "to_id": to, "body": "please review the exporter"}
+
+
+class PendingEvents(_Base):
+    def test_unread_to_a_live_recipient_is_pending_at_any_age(self):
+        # 47h old — the retired 30-minute window would have aged this out; age says nothing
+        self._log([self._sent()])
+        r = self._row()
+        self.assertTrue(r["pending"], "no event ended it → it can still land, whatever its age")
+        self.assertFalse(r["hasExec"])
+
+    def test_exec_ends_it_and_unexec_revives_it(self):
+        self._log([self._sent(), {"t": NOW - 100, "ev": "exec", "id": "m1"}])
+        self.assertFalse(self._row()["pending"], "read is the designed ending event")
+        self._log([self._sent(), {"t": NOW - 100, "ev": "exec", "id": "m1"},
+                   {"t": NOW - 50, "ev": "unexec", "id": "m1"}])
+        self.assertTrue(self._row()["pending"], "a rolled-back claim never reached the recipient")
+
+    def test_recall_ends_it(self):
+        self._log([self._sent(), {"t": NOW - 100, "ev": "recall", "id": "m1"}])
+        self.assertFalse(self._row()["pending"], "the sender unsent it — it can never land")
+
+    def test_bounce_ends_it(self):
+        self._log([self._sent(), {"t": NOW - 100, "ev": "bounced", "id": "m1",
+                                  "why": "recipient exited"}])
+        self.assertFalse(self._row()["pending"], "the bus refused/destroyed it — terminal")
+
+    def test_a_dead_recipient_cannot_read_it(self):
+        self._log([self._sent()])
+        r = self._row(live=(SENDER,))                  # recipient absent from the TRUE live set
+        self.assertFalse(r["pending"], "nothing can read a dead session's mail")
+
+    def test_a_cross_host_relay_stays_pending_until_the_far_receipt(self):
+        self._log([self._sent(to="peer:boxa")])
+        r = self._row(live=(SENDER,), to="peer:boxa")
+        self.assertTrue(r["pending"], "the far end's liveness is not locally knowable — stay honest")
+
+    def test_the_age_window_is_gone(self):
+        import inspect
+        src = inspect.getsource(km._postal_messages)
+        self.assertNotIn("(now - st) <", src, "no clock resurrection")
+        self.assertFalse(hasattr(km, "MSG_INFLIGHT_MAX"), "the constant itself is retired")
+
+
+class OrphanSweepTerminalRow(_Base):
+    def test_the_sweep_records_its_destroy_on_the_original_mid(self):
+        # a dead recipient's unread mail, past the grace: the sweep destroys it — the destroy is the
+        # message's terminal event and must land on the LEDGER, or a same-sid revival flips the
+        # (destroyed) message back to pending forever
+        self._saved_pm = (pm.STATE, pm.MAILROOT, pm.TLDIR, pm.local_agents)
+        pm.STATE = km.jd.STATE
+        pm.MAILROOT = km.jd.STATE / "mail"
+        pm.TLDIR = km.jd.STATE / "timeline"
+        pm.local_agents = lambda threads=False: [{"id": SENDER, "name": "web"}]
+        try:
+            box = pm.MAILROOT / RECIP / "new"
+            box.mkdir(parents=True)
+            mid = "1787700000.123_1.TESTHOST"
+            f = box / mid
+            f.write_text("From: web\n\nplease review the exporter")
+            old = time.time() - pm.ORPHAN_GRACE - 60
+            os.utime(f, (old, old))
+            pm._sweep_orphans()
+            rows = [json.loads(l) for l in
+                    (km.jd.STATE / "timeline" / "messages.jsonl").read_text().splitlines()]
+            term = [r for r in rows if r.get("ev") == "bounced" and r.get("id") == mid]
+            self.assertEqual(len(term), 1, "the destroy landed as a terminal bounced row")
+            self.assertFalse(f.exists(), "…and the mail is gone")
+        finally:
+            pm.STATE, pm.MAILROOT, pm.TLDIR, pm.local_agents = self._saved_pm
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**W3 of the time-windows package** (design ruling: a wall-clock window survives only as a named dead-man's backstop for an ending event that genuinely cannot be observed).

The timeline's "in flight" flag was a 30-minute age window approximating four observable endings, all already on or beside the same ledger row: **read** (exec, unexec-retractable), **recalled** (recall row), **refused** (bounced row), and **the recipient dying** (the live set). `_postal_messages` now folds recall/bounced and keys pending on exactly those events plus recipient liveness — the TRUE live set passed alongside the broader lane set (dead-within-12h lanes rightly still draw; a dead recipient can never read). Thread endpoints count through their parent's lane; a cross-host relay's far end is not locally knowable, so it stays honestly pending until the far receipt lands. An unread message to a live recipient is pending at any age the draw horizon shows.

**The one ledger hole closes at the writer**: the orphan sweep destroyed a dead recipient's unread mail with no terminal row, so the ledger's last word stayed "sent" — and with liveness in the predicate, a same-sid revival would flip destroyed mail back to pending forever. The sweep now records its destroy as a bounced row on the original mid (the `_bounce_apply` idiom); the ledger is terminal-complete.

**Deploy impact: zero** — the live ledger has no un-exec'd rows inside the draw horizon (measured before shipping); today's board renders identically.

**Tests** (`tests/test_timeline_pending.py` — the window's first coverage): pending at 47h unread; ended by exec / revived by unexec / recall / bounce / recipient death; cross-host honesty; the constant gone (no clock resurrection); the sweep's terminal row. Local: 5503 passed, 34 skipped.

Window fates so far: W3 **died** (this PR). Remaining per the package: W1a/W1b/W2c/W2d (next PRs), W5/W6 stand, W7 reclassified, W8 documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)