### PR TITLE
The feed follows the active session view; needs-you cards break through

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18980,6 +18980,10 @@ def build_feed(now, tmux=None):
             # the shared session order (session-order.json — the tab/lane order): grouped mode sorts each
             # column's session runs by it (the user 2026-07-13); federation prefixes + concatenates per host
             "order": _session_order(),
+            # the ACTIVE session view gates the board CLIENT-side (the user 2026-08-24): the same
+            # views blob every tabOrder push carries — feed.ts filters through its client mirror
+            # (session-views.ts viewVisible via feed-view.ts), needs-you cards breaking through
+            "views": _views_client(),
             # the chat tab strip's sessions, name+color resolved exactly as tab_meta resolves them: the
             # feed footer's session-filter menu lists precisely the tabs (the user 2026-08-08) — including
             # a session with no cards on the board, which filters to an empty board rather than being

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -580,6 +580,14 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(me["name"], "testsess")
         self.assertEqual(me["color"], km._name_color(SID), "the tab_meta colour resolution, verbatim")
 
+    def test_feed_payload_carries_the_views_blob_the_tabs_read(self):
+        """The board follows the ACTIVE session view (the user 2026-08-24): the feed payload carries
+        the SAME views blob every tabOrder push does, so feed.ts can gate cards through the client
+        mirror of _view_visible (session-views.ts) — one decider, however many surfaces."""
+        feed = km.build_feed(NOW)
+        self.assertIn("views", feed)
+        self.assertEqual(feed["views"], km._views_client())
+
     def test_judge_awaiting_stamp_suppresses_the_stalled_chip(self):
         """The false-'stalled' chain, reproduced end to end: a failed-nudge record exists, the live
         awaiting sources are dark, but the goal store carries the judge's stamp — the card must wear

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -21,10 +21,10 @@ test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails t
   // name row keeps only identity + chips
   assert.match(FEED, /btns\.append\(cont, clr\);/, "ask card: Continue left of Clear in the action corner");
   assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
-  assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
+  assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap, gviewbreak\);/, "group card: Clear in row1's action corner, name row is the name only");
   // the group card has no row3 anymore (its only content, the time, moved to row1)
   assert.match(FEED, /main\.append\(row1, row2, memberList\)/, "group card: no row3 (time moved to row1)");
   assert.doesNotMatch(FEED, /const row3 = el\("div", "fask-row3"\); row3\.append\(time\)/, "the group card's time-only row3 is gone");
@@ -60,7 +60,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -77,7 +77,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -42,7 +42,10 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
   // painter must count exactly what the user sees, so render and the painter share one view) — and
   // the tracked-delegation satellite exclusion lives INSIDE it for the same reason (2026-08-24):
   // the unfiltered board hides only satellites; a picked session still renders ALL its cards
-  assert.ok(FEED.includes("let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list.filter((a) => !a.satellite);"));
+  // the view gate (2026-08-24) runs FIRST; the session filter / satellite split is the second stage
+  assert.ok(FEED.includes("shown = feedOnlySid ? shown.filter((a) => a.sid === feedOnlySid) : shown.filter((a) => !a.satellite);"));
+  assert.ok(FEED.includes("let shown = feedViews ? list.filter((a) => cardInView(feedViews, a.sid, askColumn(a) === \"needsInput\")) : list;"),
+    "the active view gates the board through the shared decider, breakthroughs held");
   assert.ok(FEED.includes("let shown = viewFiltered(asks);"), "render reads the shared view");
   // (`let`, since 2026-08-23: the SEARCH filter composes onto the same render-side view — see feed-search.test.ts)
   assert.ok(FEED.includes("for (const a of shown) {"), "the group-fold loop reads the filtered view");

--- a/ui/webview/feed-tracked.test.ts
+++ b/ui/webview/feed-tracked.test.ts
@@ -14,7 +14,8 @@ const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("the default board hides satellites; the session filter is the one-click path back", () => {
   // inside viewFiltered, so the hover-freeze churn badges count exactly what the board shows
-  assert.match(SRC, /list\.filter\(\(a\) => a\.sid === feedOnlySid\) : list\.filter\(\(a\) => !a\.satellite\)/,
+  // the view gate (2026-08-24) runs first, so the satellite split reads the staged `shown`
+  assert.match(SRC, /shown\.filter\(\(a\) => a\.sid === feedOnlySid\) : shown\.filter\(\(a\) => !a\.satellite\)/,
     "hidden ONLY on the unfiltered board — picking the worker's session still shows its copy");
 });
 

--- a/ui/webview/feed-view.test.ts
+++ b/ui/webview/feed-view.test.ts
@@ -1,0 +1,113 @@
+// The FEED follows the active session view (the user 2026-08-24): the board gates on the SAME
+// union-aware decider the tabs/lanes read (session-views.ts viewVisible through feed-view.ts —
+// never a fourth fork), a needs-you card ALWAYS breaks through wearing its cue, and what's filtered
+// stays one glance away ("N cards outside this view", the 2026-08-11 rule). The deciders EXECUTE
+// here with the tag-home fixtures the untagged-union fix established; the feed/kernel wiring is
+// source-pinned (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { cardInView, outsideView, outsideViewCount } from "./feed-view";
+import type { SessionViews } from "./session-views";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const FED = fs.readFileSync(path.join(ROOT, "ui", "webview", "federation.ts"), "utf8");
+
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+
+test("no views blob (an older kernel) → today's behavior, byte-identical: nothing filters", () => {
+  assert.equal(cardInView(null, U, false), true);
+  assert.equal(outsideView(undefined, U), false);
+  assert.equal(outsideViewCount(null, [{ sid: U, needsYou: false }]), 0);
+});
+
+test("the All view shows everything except the manual hidden set — and hidden still breaks through", () => {
+  const views: SessionViews = { active: "all", hidden: [V] };
+  assert.equal(cardInView(views, U, false), true);
+  assert.equal(cardInView(views, V, false), false, "manually hidden — off the board");
+  assert.equal(cardInView(views, V, true), true, "…until it needs the human (the interrupt rule)");
+  assert.equal(outsideView(views, V), true, "and then it wears the outside-view cue");
+});
+
+test("untagged view: BOTH tag homes exclude — a local tag and a remote-homed tag alike (the union fix)", () => {
+  const local: SessionViews = { active: "untagged", tags: [{ id: "t1", name: "infra", members: [U] }] };
+  assert.equal(cardInView(local, U, false), false, "locally tagged → out of untagged");
+  const remote: SessionViews = { active: "untagged", tags: [],
+    remoteTags: [{ id: "TESTHOST:t9", name: "infra", members: [U] }] };
+  assert.equal(cardInView(remote, U, false), false, "a remote-homed tag counts everywhere");
+  assert.equal(cardInView(remote, U, true), true, "the breakthrough guard outranks both homes");
+  assert.equal(cardInView(remote, V, false), true, "the genuinely untagged session stays");
+});
+
+test("a tag view shows the NAME-KEYED union's members; outsiders only break through", () => {
+  const views: SessionViews = { active: "t1",
+    tags: [{ id: "t1", name: "infra", members: [U] }],
+    remoteTags: [{ id: "TESTHOST:t9", name: "infra", members: [V] }] };
+  assert.equal(cardInView(views, U, false), true, "the active tag's own member");
+  assert.equal(cardInView(views, V, false), true, "the same-NAME remote tag's member joins the union");
+  const w = "77777777-6666-5555-4444-333333333333";
+  assert.equal(cardInView(views, w, false), false, "a session in neither home is outside");
+  assert.equal(cardInView(views, w, true), true, "…unless it needs you");
+});
+
+test("the outside count is exactly what the board is NOT showing — breakthroughs excluded", () => {
+  const views: SessionViews = { active: "untagged", tags: [{ id: "t1", name: "infra", members: [U, V] }] };
+  const n = outsideViewCount(views, [
+    { sid: U, needsYou: false },   // hidden, counted
+    { sid: U, needsYou: false },   // hidden, counted (per card, not per session)
+    { sid: V, needsYou: true },    // breaks through — already visible, NOT counted
+  ]);
+  assert.equal(n, 2);
+});
+
+test("the feed gates through the shared decider and adopts the payload's views blob", () => {
+  assert.match(FEED, /import \{ cardInView, outsideView, outsideViewCount \} from "\.\/feed-view";/);
+  assert.match(FEED, /let shown = feedViews \? list\.filter\(\(a\) => cardInView\(feedViews, a\.sid, askColumn\(a\) === "needsInput"\)\) : list;/,
+    "the view layer runs FIRST in viewFiltered — the freeze badges and the render share it");
+  // adoption rides every payload; the optimistic pending copy follows the tab strip's own
+  // convention (render.ts pendingSessionViews): shape-matched echo or three pushes — never a timer
+  assert.match(FEED, /if \(m\.views && typeof m\.views === "object"\) \{/);
+  assert.match(FEED, /viewsKey\(incoming\) === viewsKey\(feedViewsPending\) \|\| \+\+feedViewsPendingAge >= 3/);
+  // the kernel attaches the SAME blob every tabOrder push carries
+  assert.ok(KERNEL.includes('"views": _views_client(),'), "build_feed carries the views blob");
+  // federation: mergeHostFeeds spreads the LOCAL payload first and never reassigns views — the
+  // viewer's blob passes through untouched (remote kernels' actives are their dashboards' business)
+  const mf = FED.slice(FED.indexOf("export function mergeHostFeeds"), FED.indexOf("return merged;"));
+  assert.ok(mf.includes("const merged: any = { ...local,"), "local spread first");
+  assert.ok(!mf.includes("merged.views"), "and no later reassignment clobbers it");
+});
+
+test("the breakthrough cue rides BOTH card shapes as a row2-visible mark, the ↪ family", () => {
+  assert.match(FEED, /viewbreak\.textContent = "\\u21aa outside this view";/);
+  assert.match(FEED, /\(a\._viewbreak as HTMLElement\)\.style\.display = outsideView\(feedViews, it\.sid\) \? "" : "none";/,
+    "ask cards toggle it by the session's view state");
+  assert.match(FEED, /const gbroke = outsideView\(feedViews, g\.sid\);/,
+    "group cards too — a group is one session's turn");
+  assert.match(FEED, /if \(gvb\) gvb\.style\.display = gbroke \? "" : "none";/);
+  // grouped mode hides the group's row2 (name-only) — EXCEPT when the breakthrough cue is live
+  assert.match(FEED, /\(a\._row2 as HTMLElement\)\.style\.display = gmode && !gbroke \? "none" : "";/);
+  assert.match(FEED, /row2\.append\(idwrap, gviewbreak\);/, "the cue is a row2 SIBLING — idwrap hides wholesale grouped");
+  // a DIRECT row2 child on the ask card: grouped mode hides idwrap wholesale, and a breakthrough
+  // under a session header still needs its why
+  assert.match(FEED, /origin, viewbreak, fupBadge/);
+  assert.match(CSS, /\.fask-viewbreak \{ color: var\(--dim\); font-size: 0\.82em; font-style: italic;/,
+    "dim, sub-line scale, never a status colour");
+});
+
+test("what's filtered stays one glance away: the N-outside line, click-switches to All", () => {
+  assert.match(FEED, /const outN = feedViews \? outsideViewCount\(feedViews,/);
+  assert.match(FEED, /vmore\.id = "feed-viewmore";/);
+  assert.match(FEED, /vmore\.style\.display = outN \? "" : "none";/, "zero outside → no line, not a zero");
+  assert.match(FEED, /outN \+ \(outN === 1 \? " card" : " cards"\) \+ " outside this view — show all";/);
+  // the click switches the ACTIVE view to All — optimistically (the board reflows now, the
+  // click-safety acknowledgement), through the same whole-blob op the dashboard uses
+  assert.match(FEED, /feedViewsPending = \{ \.\.\.feedViews, active: "all" \};/);
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setTimelineViews", views: feedViewsPending \}\);/);
+  assert.match(CSS, /#feed-viewmore \{ padding: 4px 14px 10px; color: var\(--dim\); font-size: 0\.82em; cursor: pointer; \}/);
+  assert.match(CSS, /#feed-viewmore:hover \{ color: var\(--accent\); text-decoration: underline; \}/);
+});

--- a/ui/webview/feed-view.ts
+++ b/ui/webview/feed-view.ts
@@ -1,0 +1,29 @@
+// The FEED follows the active session view (the user 2026-08-24, the expectation surfaced when a
+// just-tagged session's cards stayed on an "untagged"-filtered board): the board's cards gate on
+// the SAME union-aware decider the tabs and timeline lanes read — session-views.ts's viewVisible,
+// the kernel _view_visible's client mirror — never a fourth fork of the rule; the mirrors are
+// pinned against each other for exactly this reason. THE BREAKTHROUGH GUARD (the interrupt rule):
+// a needs-you card always shows regardless of view — a view-hidden session that needs the human is
+// this board's whole job — and wears the outside-the-view cue so the exception explains itself.
+// Pure, split out for node --test (the feed-search.ts pattern): the tag-home fixtures the untagged
+// union fix established compose straight onto these.
+import { SessionViews, viewVisible } from "./session-views";
+
+/** Is this card's session outside the active view? (The cue's question — a breakthrough card is
+ *  shown AND outside.) No blob (an older kernel) → nothing is outside. */
+export function outsideView(views: SessionViews | null | undefined, sid: string): boolean {
+  return !!views && !viewVisible(views, sid);
+}
+
+/** Does this card show on the board? The view's visibility rule, with the breakthrough guard. */
+export function cardInView(views: SessionViews | null | undefined, sid: string, needsYou: boolean): boolean {
+  return !outsideView(views, sid) || needsYou;
+}
+
+/** The dim "N cards outside this view" count: view-hidden and NOT broken through — exactly what
+ *  the board is not showing (a breakthrough already shows; counting it would double-speak). */
+export function outsideViewCount(views: SessionViews | null | undefined,
+                                 cards: { sid: string; needsYou: boolean }[]): number {
+  if (!views) return 0;
+  return cards.filter((c) => outsideView(views, c.sid) && !c.needsYou).length;
+}

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -319,6 +319,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 
 /* drop-point lines on an asks-column card: where the work is currently parked */
 
+/* ↪ BREAKTHROUGH cue (the user 2026-08-24): a needs-you card from a session the active view HIDES
+   still shows (the interrupt rule) — the cue says why it's here. The ↪ provenance family: dim,
+   quiet, the sub-line scale, never a status colour. */
+.fask-viewbreak { color: var(--dim); font-size: 0.82em; font-style: italic; white-space: nowrap; align-self: center; }
+/* "N cards outside this view" (the N-more idiom; the 2026-08-11 rule: filtered is never silent):
+   one dim line after the columns, click switches the view to All. */
+#feed-viewmore { padding: 4px 14px 10px; color: var(--dim); font-size: 0.82em; cursor: pointer; }
+#feed-viewmore:hover { color: var(--accent); text-decoration: underline; }
 /* "↪ from <sender>" — courier handoff provenance beside the owning session: the "↪ from" reads as dim
    gray chrome, the peer name as a bold, identity-coloured session link (the user 2026-06-16). */
 /* a direct child of the WRAPPING name row, kept on one line — .fask-id's flex-grow pushes it to the

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -10,6 +10,8 @@ import { distillText, distillInputs, applyDistillLine, distillPending, distillSt
 import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
+import { cardInView, outsideView, outsideViewCount } from "./feed-view";
+import { SessionViews, viewsKey } from "./session-views";
 import { freezeDiff } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
@@ -468,6 +470,14 @@ let sessionOrder: string[] = [];
 // menu lists exactly the tabs (the user 2026-08-08) — a session with no cards still appears, and
 // filtering to it shows an empty board. Federation prefixes sid+name per host and concatenates.
 let sessionsMeta: { sid: string; name: string; color: { bg: string; fg: string } | null }[] = [];
+// The ACTIVE session view (the user 2026-08-24): the same views blob every tabOrder push carries,
+// riding the feed payload — the board's cards gate on it (feed-view.ts / viewFiltered). The pending
+// copy is the tab strip's own optimistic convention (render.ts pendingSessionViews): a view switch
+// from THIS page applies at once and holds until the kernel's echo matches by shape (viewsKey) or
+// three pushes pass — a push count, never a timer.
+let feedViews: SessionViews | null = null;
+let feedViewsPending: SessionViews | null = null;
+let feedViewsPendingAge = 0;
 // The one session the board is filtered to, or null — the DEFAULT, nothing selected, everything shows.
 // sessionStorage, deliberately: it survives this tab's reloads (webviews reload on updates) but a fresh
 // window always starts unfiltered — a filter that persisted for days would read as silently lost cards.
@@ -876,7 +886,14 @@ function makeAskCard(it: AskItem): HTMLElement {
   // against the chips whenever it does fit on the one line.
   const origin = el("a", "fask-origin"); origin.style.display = "none";
   origin.title = "this work was delegated from another session — click to open it";
-  idwrap.append(name);
+  // ↪ BREAKTHROUGH cue (the user 2026-08-24): this card's session is OUTSIDE the active view — it
+  // shows anyway because it needs you (the interrupt rule); the cue says why it's here. Quiet, the
+  // ↪ provenance family, never a status colour.
+  const viewbreak = el("span", "fask-viewbreak"); viewbreak.style.display = "none";
+  viewbreak.textContent = "\u21aa outside this view";
+  viewbreak.title = "the active view hides this session — this card shows because it needs you";
+  idwrap.append(name);   // the cue is a DIRECT row2 child below: grouped mode hides idwrap wholesale,
+  //                        and a breakthrough under a session header still needs its why
   const actions = el("div", "fask-actions");
   // (the "reopened" chip was DELETED 2026-07-07: dead since cleared-is-sealed-forever made a follow-up
   // to a cleared card a FRESH goal (2026-06-22) — the kernel never produced the flag again.)
@@ -1000,7 +1017,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // direct children they render in BOTH modes, count toward row2's grouped-mode liveness, and the
   // API badge stays immediately before its Retry button — one visual unit. idwrap keeps only the
   // name. Placement only; every badge's mint/retire semantics are untouched.
-  row2.append(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
+  row2.append(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, viewbreak, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
   // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
   // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
   // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or
@@ -1220,6 +1237,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   a._taskBtn = taskBtn; a._taskLbl = taskLbl;
   a._awaitSpin = awaitSpin; a._awaitWhy = awaitWhy;
   a._origin = origin;
+  a._viewbreak = viewbreak;
   return card;
 }
 
@@ -1588,6 +1606,8 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   a._name.replaceChildren(...hostNameNodes(it.name, it.sid));   // remote "host:" prefix = quiet metadata
   if (it.color) a._name.style.color = it.color.bg;
   setWorkDot(a._name, dotFor(it.name));   // working/awaiting dot before the session name
+  // a card on the board whose session the active view HIDES is a breakthrough — say why it's here
+  (a._viewbreak as HTMLElement).style.display = outsideView(feedViews, it.sid) ? "" : "none";
   // ↪ courier handoff: planted by a peer's message → "↪ from <sender>", click opens the sender
   const og = a._origin as HTMLElement;
   if (it.origin && it.origin.peer) {
@@ -2204,6 +2224,9 @@ function makeGroupCard(g: AskGroup): HTMLElement {
   const row2 = el("div", "fask-row2");
   const idwrap = el("div", "fask-id");
   const name = el("a", "fname"); name.title = "open this session";
+  const gviewbreak = el("span", "fask-viewbreak"); gviewbreak.style.display = "none";
+  gviewbreak.textContent = "\u21aa outside this view";   // breakthrough cue — same dress as the ask card's
+  gviewbreak.title = "the active view hides this session — this card shows because it needs you";
   idwrap.append(name);   // no "· N parts" label — the member checklist below already shows the count
   const clr = el("button", "fdismiss"); clr.textContent = "Clear"; clr.title = "clear ALL sub-asks of this request (inbox-zero)";
   // Clear rides row1's action corner in every mode (the user 2026-08-08) — matches the ask card. Same
@@ -2212,7 +2235,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
   const btns = el("span", "fask-btns");
   btns.append(clr);
   row1.append(btns);
-  row2.append(idwrap);
+  row2.append(idwrap, gviewbreak);   // the cue is a row2 SIBLING: grouped mode hides idwrap wholesale
   const memberList = el("div", "fgroup-members");   // no row3: the group card has no time-row content left
   main.append(row1, row2, memberList);
   card.append(main);
@@ -2294,6 +2317,9 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
   a._name.replaceChildren(...hostNameNodes(g.name, g.sid));
   if (g.color) a._name.style.color = g.color.bg;
   setWorkDot(a._name, dotFor(g.name));   // working/awaiting dot before the session name
+  const gbroke = outsideView(feedViews, g.sid);   // shown AND view-hidden = a breakthrough
+  const gvb = card.querySelector(".fask-viewbreak") as HTMLElement | null;
+  if (gvb) gvb.style.display = gbroke ? "" : "none";   // breakthrough cue
   a._time.textContent = relAge(hostNow - g.t);
   wireAgeTip(a._time, () => provenanceGroupRows(g.members.map(rootStart), g.t, hostNow, PROV_FMT));
   // member lines — rebuilt only when the member set or any member's status changes
@@ -2313,7 +2339,8 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
   // user 2026-08-08 — no re-home between renders.)
   const gmode = feedPrefs().grouped;
   ((a._name as HTMLElement).parentElement as HTMLElement).style.display = gmode ? "none" : "";
-  (a._row2 as HTMLElement).style.display = gmode ? "none" : "";   // the group's row2 is only the name now
+  (a._row2 as HTMLElement).style.display = gmode && !gbroke ? "none" : "";   // the group's row2 is only the
+  //   name now — except a BREAKTHROUGH's cue (grouped hides the name via idwrap; the cue stays)
 }
 
 // Transient hover-highlight signal: hovering a modal line emits its event id(s);
@@ -4013,11 +4040,16 @@ function paintJudgeLimit(): void {
 // Shared by render() and the hover-freeze badge painter, so the deferred-churn hint counts exactly
 // what the user would see move.
 function viewFiltered(list: AskItem[]): AskItem[] {
+  // the ACTIVE session view gates the board FIRST (the user 2026-08-24): the same union-aware
+  // decider the tabs read (feed-view.ts cardInView -> session-views.ts viewVisible — never a fourth
+  // fork), with the BREAKTHROUGH GUARD: a needs-you card always shows, wearing the outside-view cue.
+  // Inside this helper like every display filter — the hover-freeze churn badges count through it.
+  let shown = feedViews ? list.filter((a) => cardInView(feedViews, a.sid, askColumn(a) === "needsInput")) : list;
   // A tracked delegation's satellite lives under its delegator's PRIMARY card: the default board
   // hides it, and picking its session in the filter is the one-click path back. INSIDE this helper
   // on purpose — the hover-freeze churn badges count through it, so they see exactly what the
   // board shows (a filter outside would paint +N for cards that never appear).
-  let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list.filter((a) => !a.satellite);
+  shown = feedOnlySid ? shown.filter((a) => a.sid === feedOnlySid) : shown.filter((a) => !a.satellite);
   const sMatch = searchSids(feedSearchQ, sessionsMeta);
   if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
   return shown;
@@ -4170,6 +4202,29 @@ function render() {
   }
   for (const tid of Array.from(groupEls.keys())) if (!desired.has("g:" + tid) && undismissed(groupEls.get(tid))) { groupEls.get(tid)?.remove(); groupEls.delete(tid); }
 
+  // "N cards outside this view" (the user 2026-08-24; the 2026-08-11 rule: what a view filters
+  // away stays one glance from reach, never silently omitted). Dim, one line, after the columns;
+  // the click switches the active view to All — optimistically (the board reflows NOW, the
+  // click-safety acknowledgement), the kernel echo reconciling through the pending-copy above.
+  const outN = feedViews ? outsideViewCount(feedViews,
+    asks.map((a) => ({ sid: a.sid, needsYou: askColumn(a) === "needsInput" }))) : 0;
+  let vmore = document.getElementById("feed-viewmore");
+  if (!vmore) {
+    vmore = el("div", "");
+    vmore.id = "feed-viewmore";
+    vmore.title = "cards from sessions the active view hides — click to switch the view to All";
+    vmore.onclick = () => {
+      if (!feedViews) return;
+      feedViewsPending = { ...feedViews, active: "all" };
+      feedViewsPendingAge = 0;
+      feedViews = feedViewsPending;
+      vscodeApi?.postMessage({ type: "setTimelineViews", views: feedViewsPending });
+      render();
+    };
+    list.appendChild(vmore);
+  }
+  vmore.style.display = outN ? "" : "none";
+  if (outN) vmore.textContent = outN + (outN === 1 ? " card" : " cards") + " outside this view — show all";
   list.scrollTop = prevScroll;
   // Stale-freeze heal (hover-freeze): a LOCAL render can detach or re-key the hovered element with
   // no mouseleave — a removed element never fires leave events (typing in search filters the card
@@ -4621,6 +4676,13 @@ function applyFeedPayload(m: any): void {
   unknownSet = new Set(Array.isArray(m.stateUnknown) ? m.stateUnknown : []);   // listed-but-unreadable → gray ring, never a blank
   bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
   if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
+  if (m.views && typeof m.views === "object") {
+    const incoming = m.views as SessionViews;
+    if (feedViewsPending && (viewsKey(incoming) === viewsKey(feedViewsPending) || ++feedViewsPendingAge >= 3)) {
+      feedViewsPending = null; feedViewsPendingAge = 0;   // the echo landed (or three pushes said it never will)
+    }
+    feedViews = feedViewsPending || incoming;
+  }
   if (Array.isArray(m.sessions)) {
     sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");
     // a filter aimed at a session the tab strip no longer shows is moot — clear it (the deciding


### PR DESCRIPTION
The board never view-filtered its cards: tagging a session while the untagged view was active left its cards on the board. Now **the feed follows the active session view**, gating cards through the SAME union-aware decider the tabs and timeline lanes read — `session-views.ts`'s `viewVisible` via the new pure `feed-view.ts` — never a fourth fork of the rule (the mirrors stay pinned against each other).

**The breakthrough guard (the interrupt rule).** A needs-you card always shows regardless of view — a view-hidden session that needs the human is this board's whole job. The card wears a quiet "↪ outside this view" cue (the ↪ provenance family: dim, sub-line scale, never a status colour) on **both** card shapes, as a row2 direct child — grouped mode hides the name cluster wholesale, and a breakthrough under a session header still needs its why (the group card's row2 stays up exactly when the cue is live).

**What's filtered stays one glance away (the 2026-08-11 rule).** A dim "N cards outside this view — show all" line after the columns counts exactly what the board is not showing (breakthroughs excluded — they already show). Its click switches the active view to All through the same whole-blob op the dashboard uses, optimistically — the board reflows at once, the kernel echo reconciling through a pending copy that follows the tab strip's own convention (shape-matched echo or three pushes; a push count, never a timer).

**Composition.** The view layer runs first inside `viewFiltered`, so the session filter, the search, the satellite split, and the hover-freeze churn badges all count exactly what the board shows; `#only=` is untouched. The kernel's feed payload carries the same views blob every tabOrder push does (views changes already mark the feed dirty, so a view switch pushes fresh); federation passes the viewer's blob through untouched. A payload with no blob (an older kernel) renders byte-identical to today.

**Tests.** `feed-view.test.ts` executes the deciders with the tag-home fixtures (local and remote tag homes, the union rules, breakthrough precedence, the outside count) and pins the wiring end to end; `test_kernel.py` pins the payload blob; the row2 member-list pins across nine test files follow the new cue slot. 2359 extension tests and 437 kernel tests green; the cue and the N-outside line verified headlessly in Chromium.

**Review note:** kernel restarts are still killing multi-minute review agents before results bank, so this shipped on the structured self-audit pattern the manager accepted earlier today — the audit caught and fixed two real issues pre-push (the feed build cache's views-dirty keying was verified, and the group card's cue was invisible in grouped mode until the row2-stays-up rule was added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
