### PR TITLE
The wake's clock is a dead-man's switch for unobservable waits; observable kinds take events

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -325,7 +325,12 @@ permission/API-error floors: one interrupt at a time, the present event first.
   durable awaiting verdict (the goal store's ⏳ stamp) carrying a KIND naming
   what the wait is on: agents, task, job (an external computation), peer, timer.
   The kind scopes the rules: a peer's answer supersedes only peer waits, and a
-  job stamp survives its watcher dying (the wake is its backstop).
+  job stamp survives its watcher dying. The wake's clock is a DEAD-MAN'S SWITCH
+  for waits whose ending romp cannot observe — kind=job (external compute),
+  cross-host peers, legacy kindless stamps, hung-forever agents/tasks, and
+  prose-declared timer check-backs; every observable ending (a notification
+  pairing, the restart epoch, a tool's declared deadline, a peer's answer or
+  death) retires its wait as an event, with no clock at all.
 
 ## Where responsibilities overlap
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9668,6 +9668,18 @@ def dead_wait_block_why(why):
             "card drops the wait." % (DEAD_WAIT_WHY_PREFIX, tail or "background work"))
 
 
+def dead_peer_block_why(peer_name, why):
+    """The block why for a kind=peer wait whose AWAITED PEER died with the ask unanswered (the user
+    2026-08-24, W1a): the asked session can never answer now — its death, observed at the leave
+    transition, is the wait's own ending event, so the card converts to the user's call instead of
+    idling toward a wake on a clock. Same exact-shape rationale as dead_wait_block_why above; the
+    shared prefix keeps it procedural for every reader."""
+    tail = (why or "").strip().rstrip(".")
+    return ("%sthe session it was waiting on ('%s') has exited with the ask unanswered — %s. "
+            "Reviving that session (or re-asking another) picks it back up; replying here or "
+            "clearing the card drops the wait." % (DEAD_WAIT_WHY_PREFIX, peer_name, tail or "a peer reply"))
+
+
 def procedural_block_why(why):
     """True if `why` is romp's own procedural block bookkeeping rather than a decision the user was asked
     for. EXACT match on the kernel-authored constants — plus the TWO prefix-recognized shapes above (their

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1193,7 +1193,7 @@ def _debt_backstop_tick(now):
     """The reminder-outcome sweep for debtors the per-session walk can't reach — dead sessions, or one
     idling forever on its reminder: past the same backstop the awaiting/deferral machinery uses, an
     unanswered reminder escalates (or, if answered meanwhile, retires) regardless. Mirrors
-    AWAITING_BACKSTOP_SECS' rationale: a missing event, surfaced rather than waited on forever."""
+    AWAITING_DEADMAN_SECS' rationale: a missing event, surfaced rather than waited on forever."""
     d = _auto_nudge_data()
     dn = dict(d.get("debtNudged") or {})
     if not dn:
@@ -3487,7 +3487,16 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
 # the stamp also stood down the whole nudge ladder (the ui session, 2026-08-11). Episodes re-arm on the
 # ANSWER (a judged response), not the anchor, so a genuinely long wait is re-checked every window and a
 # dead one surfaces after exactly one unanswered wake.
-AWAITING_BACKSTOP_SECS = 6 * 3600
+# W1a (the user 2026-08-24): the flat 6h "patience" decomposed per stamp KIND. Every kind whose
+# ending event romp can observe never reaches this clock — the lift sweep retires agents/task waits
+# on notification pairing, the restart epoch, and the tool's own declared deadline; peer waits end
+# on the pair-aware answer supersede (+ its durable lift) or the awaited peer's DEATH transition
+# (the conversion arm in _dead_wait_sweep). What remains is a DEAD-MAN'S SWITCH for waits whose
+# ending genuinely cannot be observed, with exactly these residents: kind=job (external compute —
+# romp sees only the carrier, never the job), cross-host peer waits (no local death owner), legacy
+# kindless stamps (zero live at the rename; archives only), hung-forever agents/tasks under a live
+# registry, and prose-declared timer check-backs (a Monitor-backed timer lifts at its own deadline).
+AWAITING_DEADMAN_SECS = 6 * 3600
 # The TEXT reads as the person checking in (the user 2026-08-11): the first version said "goal" twice and
 # announced itself "(Automated re-check…)" — romp vocabulary plus an automated-origin disclosure, both
 # banned by the injected-voice rule — and sat outside tests/test_injected_voice.py's index, which is how it
@@ -3948,6 +3957,39 @@ def _dead_wait_sweep(alive_ids, nudged, now):
                 stamp = _goal_awaiting_stamp_full(nodes, gid, kids)
                 if stamp:
                     _dead_wait_block(sid, gid, stamp[0], stamp[1], nudged, now)
+            # PEER-DEATH CONVERSION (the user 2026-08-24, W1a): this corroborated death is ALSO the
+            # ending event for every LIVE session's kind=peer wait ON this sid — the asked session
+            # can never answer now. Convert each to a procedural block naming the death (liftable by
+            # a revival's reply like any block), the same once-per-episode ledger discipline as the
+            # dormant-owner arm above. A holder mid-turn stands down inside _dead_wait_block
+            # (progressing-state gate); its residue keeps the wake's dead-man — the awake path
+            # requires awaited peers ALIVE to stand down, so a missed conversion still surfaces.
+            _dead_name = _name_of(sid) or sid[:8]
+            for _lsid in alive_ids:
+                try:
+                    _ls = jd.load_goals(_lsid)
+                    _ln = _ls.get("nodes", {})
+                    if not any(sid in (nd.get("awaitingPeers") or ()) for nd in _ln.values()):
+                        continue
+                    _lk = {}
+                    for _nid, _nd in _ln.items():
+                        if _nd.get("parentId"):
+                            _lk.setdefault(_nd["parentId"], []).append(_nid)
+                    for _gid, _st in (_ls.get("status") or {}).items():
+                        if _st != "working":
+                            continue
+                        _sf = _goal_awaiting_stamp_full(_ln, _gid, _lk)
+                        if not _sf or _sf[2] != "peer":
+                            continue
+                        _sn = next((n for n in _ln.values()
+                                    if n.get("awaitingWhy") and n.get("awaitingAt") == _sf[0]), None)
+                        if not _sn or sid not in (_sn.get("awaitingPeers") or ()):
+                            continue
+                        _dead_wait_block(_lsid, _gid, _sf[0], _sf[1], nudged, now,
+                                         blk_why=jd.dead_peer_block_why(_dead_name, _sf[1]))
+                except Exception:
+                    sys.stderr.write("peer-death conversion (%s->%s): %s\n"
+                                     % (sid[:8], _lsid[:8], traceback.format_exc()))
             # …and incomplete DELEGATION handoffs (the user 2026-08-23: a dead sender's "↪ delegated
             # to X" item waits on run_propagate, and if the courier link never landed — or the peer
             # folded the work without one — nothing can ever check it off; five were 240h old). The
@@ -4009,7 +4051,7 @@ def _dead_handoff_block(sid, nid, h, nd, nudged, now):
     return False
 
 
-def _dead_wait_block(sid, gid, at, why, nudged, now):
+def _dead_wait_block(sid, gid, at, why, nudged, now, blk_why=None):
     """Convert a DORMANT session's stamped-awaiting Working card to a procedural block, once per stamp
     episode (the user 2026-08-22, who expected every Working card nudged until it lands in Completed or
     Blocked). Once-only rides the shared nudge ledger ({deadWait, anchor}; a genuinely NEW stamp episode
@@ -4035,7 +4077,7 @@ def _dead_wait_block(sid, gid, at, why, nudged, now):
         if (not nd or store.get("status", {}).get(gid, "working") != "working"
                 or not _goal_awaiting_stamp(store.get("nodes", {}), gid)):   # raw: see the sweep's note
             return False                              # lifted or resolved since the walk read its snapshot
-        blkwhy = jd.dead_wait_block_why(nd.get("awaitingWhy") or why or "")
+        blkwhy = blk_why or jd.dead_wait_block_why(nd.get("awaitingWhy") or why or "")
         _ev = int(max(at or 0, last_t or 0) or now)
         if jd.record_verdict(store, nd, "nudge", "block", _ev, why=blkwhy):
             nd["mt"] = _ev                            # the event materialized blocked + blockWhy
@@ -4064,7 +4106,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
     (the user 2026-08-11): fire the check-in past the backstop, track its outcome through the same record
     + response gates as a nudge, and escalate a wake nobody answered. Returns True when something fired or
     a failure stamped (the tick pushes once at the end). Episodes:
-      due       now - max(anchor, last ANSWERED wake) >= AWAITING_BACKSTOP_SECS → send AWAITING_BACKSTOP_TEXT,
+      due       now - max(anchor, last ANSWERED wake) >= AWAITING_DEADMAN_SECS → send AWAITING_BACKSTOP_TEXT,
                 record {wake, anchor, count, lastTurnId, armAtoms, at} in the shared `nudged` ledger.
                 lastTurnId is the NEWEST turn (romp-injected or not) — the wake isn't arm-keyed like a
                 nudge; the record only needs the growth yardstick _nudge_response_ready reads.
@@ -4077,6 +4119,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
                 the block rides the normal ladder to Needs-you. A failed/moot record re-arms only on a
                 genuinely NEW stamp episode (anchor newer than the one that failed)."""
     at, why = stamp[0], stamp[1]
+    kind = stamp[2] if len(stamp) > 2 else None
     if tmux.get(sid) is None:
         # DORMANT owner (the user 2026-08-22): the CLI died while this judged wait still stood — and a
         # stamped Working card on a dead session was exempt from the WHOLE ladder (this wake, the plain
@@ -4124,9 +4167,22 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
             return False                             # this episode already escalated / was superseded —
             #                                          the anti-loop rule; a user reply unblocks as usual
         rec = {}                                     # a genuinely NEW wait (fresh anchor) re-arms the wake
+    if kind == "peer":
+        # A LOCAL peer wait's endings are all EVENTS now (W1a): the pair-aware answer supersede and
+        # its durable lift, the awaited peer's death conversion (_dead_wait_sweep's arm), and the
+        # debtor-side debt ladder — so it takes NO wake at all while every awaited peer is local and
+        # ALIVE. The dead-man below survives for exactly the unobservable residue: a cross-host peer
+        # (no local death owner), a legacy stamp with no recorded identity, or a dead local peer
+        # whose conversion the sweep missed (its holder was mid-turn when the transition fired).
+        _pn = next((n for n in store.get("nodes", {}).values()
+                    if n.get("awaitingWhy") and n.get("awaitingAt") == at), None)
+        _peers = (_pn or {}).get("awaitingPeers") or ()
+        if _peers and all(":" not in str(p) for p in _peers) \
+                and all(tmux.get(str(p)) is not None for p in _peers):
+            return False                             # every ending is an observable event — no clock
     since = max(at, rec.get("answeredAt") or 0, rec.get("at") or 0)
-    if now - since < AWAITING_BACKSTOP_SECS:
-        return False                                 # still patient
+    if now - since < AWAITING_DEADMAN_SECS:
+        return False                                 # still patient (the dead-man for unobservable waits)
     _defer = _revivers_pending(sid, store, turns, gid)
     if _defer and not _nudge_deferred_ok(gid, _defer, now, sid):
         return False
@@ -4262,7 +4318,7 @@ def _backend_rewind_pending(sid):
 # suppression here is temporary by construction — the nudge is deferred, never lost. The one time
 # threshold is the backstop below, and only for the reason the awaiting backstop already admits: a
 # WEDGED reviver is a MISSING event, and no event announces it.
-NUDGE_DEFER_BACKSTOP_SECS = 6 * 3600     # mirrors AWAITING_BACKSTOP_SECS, and for the same reason
+NUDGE_DEFER_BACKSTOP_SECS = 6 * 3600     # mirrors AWAITING_DEADMAN_SECS, and for the same reason
 _task_plan_cache = {}                    # fsid -> ((mtime, count), plan | None)
 
 

--- a/tests/test_wake_deadman_kinds.py
+++ b/tests/test_wake_deadman_kinds.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""The wake's clock is a DEAD-MAN'S SWITCH for unobservable waits only (the user 2026-08-24, W1a of
+the time-windows package): a LOCAL, ALIVE peer wait takes NO wake at all — its endings are all
+events (the pair-aware answer supersede + its durable lift, the awaited peer's death conversion,
+the debtor-side debt ladder) — while the named residents keep the clock: kind=job (external
+compute), cross-host peers (no local death owner), legacy peer stamps with no recorded identity,
+and a dead local peer whose conversion the sweep missed. The peer-death conversion arm itself:
+a corroborated death converts every LIVE holder's peer wait ON the dead sid to a procedural block
+naming the death (the dead-wait precedent). SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wdk", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-888888888888"    # the wait's holder
+PEER = "99999999-aaaa-bbbb-cccc-dddddddddddd"   # the awaited local peer
+NOW = 1_787_900_000
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, sid, body):
+        self.sent.append((sid, body))
+
+
+def _stamped(gid, kind=None, peers=None, at=NOW - 20 * 3600):
+    nd = {"id": gid, "text": "a goal", "parentId": None, "nodeComplete": False,
+          "blocked": False, "cleared": False, "trail": [], "t": 100, "mt": 100,
+          "awaitingWhy": "asked the worker which port; holding for the answer", "awaitingAt": at,
+          "log": [{"ev_t": at, "src": "closer", "kind": "awaiting",
+                   "why": "asked the worker which port; holding for the answer", "at": 1,
+                   **({"awaitKind": kind} if kind else {}),
+                   **({"awaitPeers": peers} if peers else {})}]}
+    if kind:
+        nd["awaitingKind"] = kind
+    if peers:
+        nd["awaitingPeers"] = list(peers)
+    return nd
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = {k: getattr(km, k) for k in
+                      ("_session_working", "_log_nudge_event", "_push_all", "_revivers_pending",
+                       "_path_of", "_session_awaiting", "_mark_views_dirty")}
+        self.saved_jd = (km.jd.STATE, km.jd.GOALDIR, km.jd.parsed_session)
+        self.saved_backend = km.Sessions.backend_for
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"; km.jd.GOALDIR.mkdir(parents=True)
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        (td / "auto-nudge.json").write_text(json.dumps({"enabled": True, "nudged": {}}))
+        self.fb = _FakeBackend()
+        km.Sessions.backend_for = lambda sid: self.fb
+        km._session_working = lambda turns: False
+        km._log_nudge_event = lambda *a, **k: None
+        km._push_all = lambda *a, **k: None
+        km._mark_views_dirty = lambda *a, **k: None
+        km._revivers_pending = lambda *a, **k: ""
+        km._path_of = lambda sid, now=None: "/p"
+        km._session_awaiting = lambda sid, path, idle, stamp=False: None
+        self.gid = SID + ":g1"
+        self.turns = [{"id": "t1", "ended": True, "end": 100, "t": 90, "atoms": []}]
+        km.jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        km.jd.STATE, km.jd.GOALDIR, km.jd.parsed_session = self.saved_jd
+        km.Sessions.backend_for = self.saved_backend
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _seed(self, **kw):
+        nd = _stamped(self.gid, **kw)
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {},
+            "status": {self.gid: "working"}, "nodes": {self.gid: nd}}))
+
+    def _wake(self, tmux):
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        store = km.jd.load_goals(SID)
+        stamp = km._goal_awaiting_stamp_full(store.get("nodes", {}), self.gid)
+        self.assertIsNotNone(stamp)
+        return km._wake_goal(SID, self.gid, stamp, dict(km._auto_nudge_data().get("nudged", {})),
+                             self.turns, store, NOW, self.turns[-1], tmux)
+
+
+class DeadmanKinds(_Base):
+    def test_a_local_alive_peer_wait_takes_no_wake(self):
+        self._seed(kind="peer", peers=[PEER])
+        fired = self._wake({SID: {"state": ""}, PEER: {"state": ""}})
+        self.assertFalse(fired)
+        self.assertEqual(self.fb.sent, [], "every ending is an observable event — no clock at all")
+
+    def test_a_dead_local_peer_falls_to_the_deadman(self):
+        self._seed(kind="peer", peers=[PEER])
+        self._wake({SID: {"state": ""}})             # the peer is gone from the live map
+        self.assertEqual(len(self.fb.sent), 1,
+                         "the missed-conversion residue keeps the named dead-man")
+
+    def test_a_cross_host_peer_keeps_the_deadman(self):
+        self._seed(kind="peer", peers=["peer:boxa:worker_two"])
+        self._wake({SID: {"state": ""}})
+        self.assertEqual(len(self.fb.sent), 1, "no local death owner exists cross-host")
+
+    def test_a_legacy_peer_stamp_with_no_identity_keeps_the_deadman(self):
+        self._seed(kind="peer")
+        self._wake({SID: {"state": ""}})
+        self.assertEqual(len(self.fb.sent), 1, "no recorded identity → no event to route; clock stays")
+
+    def test_a_job_wait_keeps_the_deadman(self):
+        self._seed(kind="job")
+        self._wake({SID: {"state": ""}})
+        self.assertEqual(len(self.fb.sent), 1, "external compute: romp sees only the carrier")
+
+
+class PeerDeathConversion(_Base):
+    def test_a_corroborated_death_converts_the_live_holders_wait(self):
+        self._seed(kind="peer", peers=[PEER])
+        (km.jd.GOALDIR / (PEER + ".json")).write_text(json.dumps(
+            {"rompUuid": PEER, "seq": 0, "placements": {}, "status": {}, "nodes": {}}))
+        saved = (km._dead_wait_corroborated, km._name_of, getattr(km, "_PREV_ALIVE"))
+        km._dead_wait_corroborated = lambda sid, scan=None, stats=None: True
+        km._name_of = lambda sid: "worker_two"
+        km._PREV_ALIVE = {SID, PEER}
+        try:
+            km._dead_wait_sweep({SID}, dict(km._auto_nudge_data().get("nudged", {})), NOW)
+        finally:
+            km._dead_wait_corroborated, km._name_of, km._PREV_ALIVE = saved
+        nd = km.jd.load_goals(SID)["nodes"][self.gid]
+        self.assertTrue(nd.get("blocked"), "the awaited peer's death is the wait's own ending event")
+        self.assertIn("worker_two", nd.get("blockWhy") or "", "…and the block names the dead peer")
+        self.assertIn("exited with the ask unanswered", nd.get("blockWhy") or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**W1a of the time-windows package.** The awaiting wake's flat 6h "patience" decomposed per stamp kind — every kind whose ending romp can observe takes the event; the clock survives **renamed** (`AWAITING_DEADMAN_SECS`) as a dead-man's switch for exactly the waits whose ending cannot be observed, its residents documented at the constant.

- **kind=peer**: a local, alive peer wait now takes **no wake at all** — its endings are the pair-aware answer supersede (+ durable lift), the debtor-side debt ladder, and (new in this PR) the awaited peer's **death conversion**: the leave transition `_dead_wait_sweep` already observes, corroborated by the same tri-state owner, converts every live holder's wait on the dead sid to a procedural block naming the death (`dead_peer_block_why`, the dead-wait precedent — liftable by a revival's reply like any block). The wake stands down only when every awaited peer is local **and alive**, so a conversion the sweep missed (holder mid-turn at the transition) still surfaces via the dead-man rather than sleeping.
- **Residents that keep the clock**, named and documented: kind=job (external compute — romp sees only the carrier, never the job), cross-host peers (no local death owner), legacy peer stamps with no recorded identity, legacy kindless stamps (zero live at the rename; archives only), hung-forever agents/tasks under a live registry, prose-declared timer check-backs (Monitor-backed timers already lift at their own declared deadline — they never reach this clock).
- `docs/judges.md`'s job-backstop line updated in lockstep.

**Deploy impact per the package guardrails**: the inert past-6h stamps stay inert (working-top walk gates untouched; nothing scans stamps directly); no new state-blind sweep. The one behavior change is stand-down — local alive peer waits stop receiving 6h wakes.

**Tests**: `tests/test_wake_deadman_kinds.py` pins the kind grid (local+alive peer = no wake; dead local peer / cross-host / identity-less legacy / job = dead-man) and the conversion arm. Local: 5518 passed, 34 skipped.

Window fates: W3 died (#647), W1b died (#649), **W1a decomposed** (this PR — the clock survives only as the named dead-man). Next: W2c+W2d. Deferred with a note: the timer `until` schema extension (declared prose check-back times) — Monitor-backed timers are already fully evented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)