### PR TITLE
The tab menu groups by kind: aesthetics, behavior, then Browse alone

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4477,6 +4477,25 @@ function showTabMenu(e: MouseEvent, id: string) {
     rename.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); startTabRename(id); });
     menu.appendChild(rename);
   }
+  // Colors join Rename in the AESTHETIC section (the user 2026-08-24, the final by-kind grouping:
+  // [Rename + colors] / [feed, mail, bell, billing, Tags] / [Browse]). The swatch row itself is
+  // unchanged (the user 2026-06-29): the identity palette as circles, the current one ringed,
+  // omitted until /palette has loaded.
+  if (paletteColors.length) {
+    const sNow = sessions.get(id);
+    const cur = (sNow && sNow.color ? sNow.color.bg : "").toLowerCase();
+    const row = el("div", "ctx-colors");
+    for (const bg of paletteColors) {
+      const sw = el("button", "ctx-swatch" + (bg.toLowerCase() === cur ? " sel" : ""));
+      sw.style.background = bg;
+      sw.title = bg;
+      sw.setAttribute("aria-label", "Set color " + bg);
+      sw.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); setSessionColor(id, bg); });
+      row.appendChild(sw);
+    }
+    menu.appendChild(row);
+  }
+  menu.appendChild(el("div", "ctx-sep"));
   // Feed + Mail per-session toggles (the user 2026-06-26) — the same controls as the timeline lane's feed
   // checkbox + postal mailbox, here as icon + label + a faint "what it does" sub-line. State from the session.
   const s = sessions.get(id);
@@ -4519,7 +4538,7 @@ function showTabMenu(e: MouseEvent, id: string) {
   // reconnects to apply, so the sub-line says "applying…" while st.authPending rides the status).
   const st = s ? s.status : null;
   if (st && st.auth && st.authBoth) {
-    menu.appendChild(el("div", "ctx-sep"));
+    // (no divider: billing sits in the behavior section with the toggles — the by-kind grouping)
     const item = el("div", "ctx-item ctx-item-toggle ctx-item-billing");
     item.appendChild(ctxIcon("bill", false));
     const bodyEl = el("span", "ctx-item-body");
@@ -4556,22 +4575,6 @@ function showTabMenu(e: MouseEvent, id: string) {
     });
     menu.appendChild(item);
   }
-  // Color swatches (the user 2026-06-29): the romp identity palette as circles, the session's current one
-  // ringed. Click one to recolor the session. Omitted until /palette has loaded (paletteColors empty).
-  if (paletteColors.length) {
-    menu.appendChild(el("div", "ctx-sep"));
-    const cur = (s && s.color ? s.color.bg : "").toLowerCase();
-    const row = el("div", "ctx-colors");
-    for (const bg of paletteColors) {
-      const sw = el("button", "ctx-swatch" + (bg.toLowerCase() === cur ? " sel" : ""));
-      sw.style.background = bg;
-      sw.title = bg;
-      sw.setAttribute("aria-label", "Set color " + bg);
-      sw.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); setSessionColor(id, bg); });
-      row.appendChild(sw);
-    }
-    menu.appendChild(row);
-  }
   // TAGS (the user 2026-08-24, overruling the earlier skip: tag editing belongs everywhere a
   // session is in front of you — you might not have the timeline open and still want to organize
   // or dispatch). A compact one-line row — the current tag names as the sub-line — with the
@@ -4584,7 +4587,6 @@ function showTabMenu(e: MouseEvent, id: string) {
   // editTag op and settle on the next push (a refused edit re-appears — the kernel's loud
   // tagEditFailed lands on the timeline dialog, 628's surface).
   {
-    menu.appendChild(el("div", "ctx-sep"));
     const unionFor = () => viewTagUnion(effViews());
     const holding = () => unionFor().filter((g) => g.members.includes(id));
     const tagsItem = el("div", "ctx-item ctx-item-toggle ctx-item-tags");

--- a/ui/webview/tab-tags.test.ts
+++ b/ui/webview/tab-tags.test.ts
@@ -75,7 +75,9 @@ test("presentation: one chip per NAME, identity dot, ✕ — and never a host pr
   assert.doesNotMatch(fly.slice(0, 2500), /host-prefix|hostNameNodes/, "kernels are plumbing — no host chrome in the flyout");
 });
 
-test("Rename leads ONE top section in the standard dress — no divider before the toggles (the user 2026-08-24)", () => {
+test("the menu groups BY KIND: [Rename+colors] / [toggles+billing+Tags] / [Browse] (the user 2026-08-24, final ruling)", () => {
+  // supersedes 644's single top section: aesthetic controls together at the top, the
+  // behavior/membership controls as the middle section, Browse alone at the bottom
   const at = RENDER.indexOf("function showTabMenu");
   const body = RENDER.slice(at, RENDER.indexOf("document.body.appendChild(menu);", at));
   const renameAt = body.indexOf('l.textContent = "Rename"');
@@ -83,12 +85,16 @@ test("Rename leads ONE top section in the standard dress — no divider before t
   assert.match(body.slice(renameAt - 400, renameAt), /ctxIcon\("pencil", false\)/, "…and the pencil icon");
   assert.match(body, /sb\.textContent = "the name is a label — mail, goals and history follow the session";/,
     "…and a sub-line saying what a rename preserves (uuid-keyed truth)");
-  // no divider between Rename and the first toggle: the section is ONE
+  const colorsAt = body.indexOf('el("div", "ctx-colors")');
   const firstToggleAt = body.indexOf('toggle("feed"');
-  const between = body.slice(renameAt, firstToggleAt);
-  assert.ok(!between.includes('el("div", "ctx-sep")'), "one section — the old divider is gone");
-  // and the 642/643 order below stands: colors, Tags, divider, Browse last
   const tagsAt = body.indexOf('l.textContent = "Tags"');
   const browseAt = body.indexOf('l.textContent = "Browse files"');
-  assert.ok(renameAt < firstToggleAt && firstToggleAt < tagsAt && tagsAt < browseAt);
+  assert.ok(renameAt < colorsAt && colorsAt < firstToggleAt && firstToggleAt < tagsAt && tagsAt < browseAt,
+    "order: Rename, colors, toggles, Tags, Browse");
+  // one divider between colors and the toggles; NONE inside section 1 or section 2
+  assert.ok(!body.slice(renameAt, colorsAt).includes('el("div", "ctx-sep")'), "Rename+colors are one section");
+  assert.ok(body.slice(colorsAt, firstToggleAt).includes('menu.appendChild(el("div", "ctx-sep"));'), "a divider splits sections 1/2");
+  assert.ok(!body.slice(firstToggleAt, tagsAt).includes('el("div", "ctx-sep")'),
+    "toggles, billing and Tags are ONE behavior section — no inner dividers");
+  assert.ok(body.slice(tagsAt, browseAt).includes('menu.appendChild(el("div", "ctx-sep"));'), "a divider splits sections 2/3 — Browse alone at the bottom");
 });


### PR DESCRIPTION
## What

The user's final grouping, by kind of thing (superseding the earlier single top section):

- **Section 1 — aesthetics:** Rename + the color swatches, together at the top.
- **Section 2 — behavior/membership:** Hide from feed, Mute mail, Notify me, the Billing selector (when the machine offers both auths — kept in this section by kind, its own divider dropped), and Tags.
- **Section 3:** Browse files alone at the bottom (folder icon + sub-line as shipped in 642).

One divider between each section, none within. The swatch row is unchanged, just hoisted beside Rename (it reads the session at render time). 644's section pin retargets to this ruling, cited in the test.

## Verification

Harness over the built bundle with a served palette: `[Rename, swatches ×3] ─ [Hide from feed, Mute mail, Notify me, Tags] ─ [Browse files]`. Screenshot eyeballed.

## Tests

The retargeted by-kind section pin asserts the full order chain and the exactly-two dividers (none inside sections 1 or 2). Full suite: 2359 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)