### PR TITLE
Testing gains the private-sid fixture rule; the headless UI harness checks in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,19 @@ Every bug fix or feature change must land with a test that covers it (user rule,
 surfaces. Reproduce the bug in a failing test first when practical; fixtures
 live in `tests/fixtures/`.
 
+### Goal-store fixtures use a PRIVATE synthetic sid (2026-08-24)
+An instance of the standing synthetic-fixtures rule with a mechanism behind it:
+any Python test that MINTS GOALS under the shared `11111111-2222-…` placeholder
+sid can be silently re-flagged by OTHER test modules' journaled user overrides —
+`load_goals` replays the per-sid override journal (`STATE/overrides/<sid>.jsonl`)
+on every load, and node ids collide across tests (every fresh store mints `g1`),
+so a resolve another module journaled against the shared sid lands on YOUR node
+mid-test. The failure is ordering-dependent: green alone, red only under the full
+suite. Tests that mint goals therefore use a private synthetic sid of their own
+(any invented uuid; still synthetic, never real) and clean their sid's journal in
+tearDown. Precedent + worked diagnosis: the model-fallback dedupe tests' class
+docstring (`tests/test_model_fallback_card.py`, DedupeBackstop).
+
 ## Authoritative sources — fail loudly, don't degrade silently (user rule, 2026-07-03)
 Read state from its AUTHORITATIVE source — a designed API, or the live store that
 owns the data — never a lossy reconstruction (scraping a transcript, a heuristic

--- a/tools/ui-verify/README.md
+++ b/tools/ui-verify/README.md
@@ -1,0 +1,55 @@
+# ui-verify — headless screenshot checks for the webview surfaces
+
+Verification tooling only: nothing here ships to a production surface. This is the
+checked-in form of the `/tmp` harness the feed-footer, hover-freeze, and
+column-layout work each rebuilt from scratch (2026-08-24) — assemble a page from a
+real stylesheet plus a hand-written body fixture, screenshot it in headless
+Chromium, and eyeball (or pixel-diff) the result before publishing a UI change.
+
+## Run
+
+```sh
+tools/ui-verify/shot.sh \
+  --css ui/webview/feed.css \
+  --body tools/ui-verify/fixtures/feed-footer.html \
+  --out /tmp/feed-footer.png \
+  --size 760x420 \
+  --extra-css '#feed-list { min-height: 260px; }'
+```
+
+Render the same fixture at two widths (or with a state class flipped) to prove a
+before/after; the column-width fix shipped on exactly that evidence.
+
+- `--body` is an HTML fragment inserted into a minimal skeleton, so a fixture
+  mirrors what the TS builders emit — class for class. Copy the example fixture
+  next to your change and edit it; the check is only as good as that mirroring.
+- Fixtures are SYNTHETIC by the repo's privacy rules: the notes-api demo domain
+  (`web`/`api`/`tests` sessions), invented titles, placeholder UUIDs. Never paste
+  a real board's content. Outputs go to `/tmp` and are never committed.
+- This exercises the CSS + a static DOM, not the bundle's runtime. For behavior,
+  the source-pin tests are the harness; this catches what pins can't — cascade
+  outcomes, layout, the actual pixels.
+
+## Where Chromium comes from
+
+`shot.sh` resolves, in order: `$UI_VERIFY_CHROME` (explicit override), the
+playwright browser cache (`$PLAYWRIGHT_BROWSERS_PATH`, default
+`~/.cache/ms-playwright` — newest `chromium-*` wins), then a system
+`chromium`/`google-chrome`. Historically the cache was populated only as a side
+effect of some other project having run playwright — the browser was there by
+luck. `playwright` is now a devDependency of `vscode-extension/`, so the pinned
+CLI is always at hand; on a machine without the cache, populate it once:
+
+```sh
+cd vscode-extension && npx playwright install chromium
+```
+
+## Pointing it at a BUILT bundle
+
+The static-fixture path above needs no build. To check a page whose look depends
+on runtime-computed styles, build first (`cd vscode-extension && npm run build`),
+serve or open the real page (the kernel's own `/feed`, `/fleet` pages, or a file
+URL at `vscode-extension/dist/`), and screenshot that URL with the same Chromium
+flags `shot.sh` uses (`--headless=new --screenshot=... --window-size=...`).
+Screenshots of a LIVE board show real session data — keep them in `/tmp`, never
+in the repo (CLAUDE.md privacy rules).

--- a/tools/ui-verify/fixtures/feed-footer.html
+++ b/tools/ui-verify/fixtures/feed-footer.html
@@ -1,0 +1,30 @@
+<!-- SYNTHETIC example fixture (the notes-api demo domain: web/api/tests — never real session data).
+     The feed footer + a card, the shape most layout checks want: run
+       tools/ui-verify/shot.sh --css ui/webview/feed.css --body tools/ui-verify/fixtures/feed-footer.html \
+           --out /tmp/feed-footer.png --extra-css '#feed-list { min-height: 260px; }'
+     Copy this file next to your change and edit the markup to mirror what your TS emits — the value
+     of the check is that the fixture's DOM matches the builder's output, class for class. -->
+<div id="feed-head"></div>
+<div id="feed-list">
+  <div class="feed-cols">
+    <div class="feed-col col-asks">
+      <div class="feed-col-head"><span class="feed-col-name fcol-chip fcol-chip-working">Working</span><span class="feed-col-count">1</span></div>
+      <div class="feed-col-list">
+        <div class="fitem ask" style="background:#26262e;border-color:rgba(224,176,32,.5)"><div class="fitem-main">
+          <div class="fask-row1"><div class="fcard-title nav">ship the notes-api exporter</div><span class="ftime">2m ago</span></div>
+          <div class="fask-row2"><div class="fask-id"><a class="fname" style="color:#E0A030">api</a></div></div>
+        </div></div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="feed-foot">
+  <button id="feed-viewbtn" class="fdismiss ffollow feed-modetoggle"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M2.5 4h8"/><path d="M2.5 8h5.5"/><path d="M2.5 12h3"/><path d="M12.5 5.5v5.8"/><path d="M10.6 9.6l1.9 2 1.9-2"/></svg></button>
+  <span id="feed-search" class="open">
+    <button id="feed-search-btn" class="fdismiss ffollow feed-modetoggle on">Sessions ▴</button>
+    <input id="feed-search-input" type="search" placeholder="session or host…" value="">
+    <button id="feed-search-clear" type="button" hidden>×</button>
+  </span>
+  <button id="feed-clearall" class="fdismiss">Clear all</button>
+  <button id="feed-undoclear" class="fdismiss ffollow">Undo</button>
+</div>

--- a/tools/ui-verify/shot.sh
+++ b/tools/ui-verify/shot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Headless UI verification: assemble a page from a stylesheet + a body fixture, screenshot it in the
+# playwright-cached Chromium. VERIFICATION TOOLING ONLY — nothing here ships to a production surface.
+# Grown from the harness pattern the feed-footer / hover-freeze / column-layout work rebuilt per task
+# under /tmp (2026-08-24); checked in so the next task starts from here instead of from scratch.
+#
+# Usage:
+#   tools/ui-verify/shot.sh --css ui/webview/feed.css --body tools/ui-verify/fixtures/feed-footer.html \
+#       --out /tmp/shot.png [--size 760x420] [--extra-css '#feed-list { min-height: 300px; }']
+#
+# The output lands OUTSIDE the repo by convention (/tmp): screenshots of real boards are never
+# committed (CLAUDE.md privacy), and fixture screenshots don't need to be either — render, look, delete.
+set -euo pipefail
+
+CSS="" BODY="" OUT="" SIZE="760x420" EXTRA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --css)   CSS="$2"; shift 2 ;;
+    --body)  BODY="$2"; shift 2 ;;
+    --out)   OUT="$2"; shift 2 ;;
+    --size)  SIZE="$2"; shift 2 ;;
+    --extra-css) EXTRA="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$CSS" ] && [ -n "$BODY" ] && [ -n "$OUT" ] || { echo "need --css, --body, --out" >&2; exit 2; }
+[ -f "$CSS" ] || { echo "no such stylesheet: $CSS" >&2; exit 2; }
+[ -f "$BODY" ] || { echo "no such body fixture: $BODY" >&2; exit 2; }
+
+# Chromium resolution, most-deliberate first: an explicit env override, then the playwright browser
+# cache (PLAYWRIGHT_BROWSERS_PATH or the default ~/.cache/ms-playwright — present on any machine that
+# ever ran `npx playwright install chromium`; the devDependency in vscode-extension pins the CLI so
+# the browser stops being cached by luck), then a system chrome.
+find_chrome() {
+  if [ -n "${UI_VERIFY_CHROME:-}" ] && [ -x "$UI_VERIFY_CHROME" ]; then echo "$UI_VERIFY_CHROME"; return; fi
+  local cache="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+  local hit
+  hit=$(ls -d "$cache"/chromium-*/chrome-linux*/chrome 2>/dev/null | sort -V | tail -1 || true)
+  if [ -n "$hit" ] && [ -x "$hit" ]; then echo "$hit"; return; fi
+  for c in chromium chromium-browser google-chrome; do
+    if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return; fi
+  done
+  echo ""
+}
+CHROME=$(find_chrome)
+[ -n "$CHROME" ] || { echo "no Chromium found — run: (cd vscode-extension && npx playwright install chromium)" >&2; exit 3; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+cp "$CSS" "$TMP/page.css"
+{
+  printf '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">\n'
+  printf '<link href="page.css" rel="stylesheet">\n'
+  printf '<style>body { margin: 0; } %s</style></head><body>\n' "$EXTRA"
+  cat "$BODY"
+  printf '\n</body></html>\n'
+} > "$TMP/page.html"
+
+"$CHROME" --headless=new --no-sandbox --disable-gpu --hide-scrollbars \
+  --window-size="${SIZE/x/,}" --screenshot="$OUT" "file://$TMP/page.html" 2>/dev/null
+[ -s "$OUT" ] || { echo "screenshot did not render" >&2; exit 4; }
+echo "wrote $OUT (${SIZE})"

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -32,6 +32,7 @@
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",
         "esbuild": "^0.21.5",
+        "playwright": "^1.62.1",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -792,6 +793,21 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -827,6 +843,38 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/style-mod": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -173,6 +173,7 @@
     "@types/node": "^20.11.0",
     "@types/vscode": "^1.85.0",
     "esbuild": "^0.21.5",
+    "playwright": "^1.62.1",
     "typescript": "^5.4.5"
   },
   "dependencies": {


### PR DESCRIPTION
Two survey-outcome items, verification infrastructure only — no production surface touched.

**CLAUDE.md: the private-synthetic-sid fixture rule** (Testing section). Written as an instance of the standing synthetic-fixtures rule, with the mechanism: any Python test minting goals under the shared `1111…` placeholder sid can be silently re-flagged by other modules' journaled user overrides — `load_goals` replays the per-sid override journal on every load, and node ids collide across tests (every fresh store mints `g1`) — an ordering-dependent failure that is green alone and red only under the full suite. Tests that mint goals use a private synthetic sid and clean their journal in tearDown; the model-fallback dedupe tests' class docstring is the cited precedent and worked diagnosis.

**tools/ui-verify: the headless screenshot harness, checked in.** The `/tmp` harness the feed-footer, hover-freeze, and column-layout work each rebuilt per task: `shot.sh` assembles a page from a real stylesheet + a body fixture and screenshots it in the playwright-cached Chromium (resolution order: explicit env override → the playwright cache, newest chromium → a system chrome; the install one-liner is in the error when none exists). One synthetic example fixture (the notes-api demo domain) shows the DOM-mirroring convention; the README covers pointing it at a built bundle and the privacy rule that outputs stay in `/tmp`. `playwright` joins `vscode-extension`'s devDependencies so the pinned CLI is always at hand and the browser cache stops being populated by luck — the npm dep downloads no browsers; machines populate the cache once with `npx playwright install chromium`.

Self-tested: the example fixture renders the footer and a card correctly from the checked-in paths (verified visually before this PR). Extension suite green on the pushed head (2359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
