### PR TITLE
A lost nudge surfaces on the target's own next turn end, not at hour six

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -186,7 +186,16 @@ def _distill_effort():
     if v == "triage":
         return _triage_effort()
     return "" if v == "none" else v
-WINDOW      = 48 * 3600                  # only caption transcripts touched in the last N hours (matches the parse horizon)
+WINDOW      = 48 * 3600                  # discover()'s default reach — a COST horizon, not semantics: it bounds
+#                                          how much history each pass re-walks, never eligibility or correctness
+#                                          (read-side.md: a time window is allowed only as a perf bound on how far
+#                                          back to parse). Liveness owns visibility (kernel _alive_sessions' wide
+#                                          walk), death owns finalization (run_close's DEATH_BACKFILL_WINDOW drain),
+#                                          the picker reaches 30 days; an untouched store is simply not rescanned and
+#                                          re-enters the fleet the moment its transcript is touched again. ONE
+#                                          consumer aliases this value as POLICY: COURIER_RETRY_HORIZON's give-up
+#                                          deadline below — deliberate, and the reason this number is not free to
+#                                          shrink as a pure perf knob.
 COURIER_RETRY_HORIZON = WINDOW           # a usage-limited courier call comes back empty and retries every pass, but a
 #                                          peer message still unsummarized past this many seconds (matches discover()'s
 #                                          48h WINDOW) is abandoned — marked 'fyi' — so a long limit window can't

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4319,6 +4319,12 @@ def _backend_rewind_pending(sid):
 # threshold is the backstop below, and only for the reason the awaiting backstop already admits: a
 # WEDGED reviver is a MISSING event, and no event announces it.
 NUDGE_DEFER_BACKSTOP_SECS = 6 * 3600     # mirrors AWAITING_DEADMAN_SECS, and for the same reason
+# W2d (the user 2026-08-24): the nudge-silence clock is retired for the LOST-SEND EVENT — a turn of
+# the target that ENDS after the fire carrying no goal-id marker, with the backend queue no longer
+# holding the message, proves the send never reached the transcript (the _debt_reminder_outcomes
+# precedent). This dead-man survives for the one silence with no event at all: a session that never
+# ends another turn after the fire.
+LOST_SEND_DEADMAN_SECS = 6 * 3600
 _task_plan_cache = {}                    # fsid -> ((mtime, count), plan | None)
 
 
@@ -4629,6 +4635,17 @@ def _last_assistant_text(path, cap=4000):
         return ""
 
 
+def _nudge_send_queued(sid, gid):
+    """True while a nudge's own injected message still sits in the backend queue (an SDK send parked
+    behind a running turn): in flight, not lost — the lost-send event must not fire on it. Guarded:
+    a backend hiccup reads as 'not queued' so the dead-man (not a crash) owns the ambiguity."""
+    try:
+        be = Sessions.backend_for(str(sid))
+        return bool(be) and any("romp-goal-id: " + str(gid) in str(t) for t in be.pending_queued(str(sid)))
+    except Exception:
+        return False
+
+
 def _nudge_response_ready(turns, store, rec, gid, now):
     """The nudge-failed stamp's structural gates, as one testable decision: (ready, resp_seg).
     ready False → skip this tick; ready True → every gate passed and the stamp may proceed
@@ -4660,9 +4677,10 @@ def _nudge_response_ready(turns, store, rec, gid, now):
     with the goal-id marker by construction, so its response segment WILL become visible — a
     missing segment means the parse hasn't caught up (2026-07-23: the stamp ran while a second
     nudge turn was still landing, saw no segment for its goal, and blocked it via the old
-    stamp-now fallback). Not ready until the segment shows, bounded by the 6h deferral backstop
-    from the fire time (rec["at"]) so a genuinely lost send still surfaces as needs-you instead
-    of hiding forever. Legacy records (no armAtoms / no at) keep the stamp-now behavior."""
+    stamp-now fallback). Not ready until the segment shows — or until the LOST-SEND EVENT (W2d):
+    a target turn ending after the fire with no marker and nothing queued proves the send never
+    landed, surfacing it as needs-you NOW; only a session that never turns again keeps a clock
+    (LOST_SEND_DEADMAN_SECS). Legacy records (no armAtoms / no at) keep the stamp-now behavior."""
     _arm_atoms = rec.get("armAtoms")
     _ai = next((i for i in range(len(turns) - 1, -1, -1)
                 if turns[i].get("id") == rec.get("lastTurnId")), None)
@@ -4675,9 +4693,23 @@ def _nudge_response_ready(turns, store, rec, gid, now):
                      if jd._seg_nudge(s2) and gid in jd._seg_followup_all(s2)), None)
     except Exception:
         resp = None                                    # minimal/legacy turn shapes → stamp-now, as before
-    if resp is None and isinstance(_arm_atoms, int) \
-            and (now - (rec.get("at") or 0)) <= NUDGE_DEFER_BACKSTOP_SECS:
-        return False, None                             # modern fire, segment not visible yet → parse lag
+    if resp is None and isinstance(_arm_atoms, int):
+        # LOST-SEND EVENT (W2d, the user 2026-08-24, replacing the 6h silence clock): a modern fire
+        # wrote the goal-id marker by construction, so once ANY turn of the target ENDS after the
+        # fire with no marker segment visible — and the backend queue no longer holds the message
+        # (an SDK send parked behind a running turn is in flight, not lost) — the send never reached
+        # the transcript. That turn's end is the exact moment "the parse hasn't caught up" stops
+        # being a possible story (_debt_reminder_outcomes' shape): ready NOW, and the caller stamps
+        # the failure. A restart that dropped an in-memory pending send surfaces within minutes (the
+        # post-boot resume notice opens and ends a turn); before, it hid until hour six. A session
+        # that never ends a turn after the fire emits no event at all — the one residue that keeps
+        # a clock, the named dead-man.
+        _fire_t = rec.get("at") or 0
+        if any((tn.get("end") or 0) > _fire_t for tn in turns) \
+                and not _nudge_send_queued(gid.rsplit(":", 1)[0], gid):
+            return True, None                          # the lost-send event: stamp on real information
+        if (now - _fire_t) <= LOST_SEND_DEADMAN_SECS:
+            return False, None                         # no event yet (parse lag / queued / no turn) → wait
     if resp is not None and not jd._placed_key(store["placements"], resp["id"]):
         return False, resp                             # the planner hasn't ruled on the response yet
     return True, resp

--- a/tests/test_lost_send_event.py
+++ b/tests/test_lost_send_event.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""A nudge's silence surfaces on the LOST-SEND EVENT, not a clock (the user 2026-08-24, W2d of the
+time-windows package): a modern fire writes the goal-id marker by construction, so a turn of the
+TARGET that ends after the fire carrying no marker segment — with the backend queue no longer
+holding the message — proves the send never reached the transcript, and the failure stamps NOW on
+that turn's own end (the _debt_reminder_outcomes precedent). While the message sits in the backend
+queue it is in flight, not lost; a session that never ends a turn after the fire emits no event at
+all — the one silence that keeps a named dead-man (LOST_SEND_DEADMAN_SECS). SYNTHETIC fixtures."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_lse", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-999999999999"
+GID = SID + ":g1"
+NOW = 1_788_000_000
+FIRE = NOW - 3600                                    # ONE hour ago — the retired clock would still wait
+
+
+class LostSendEvent(unittest.TestCase):
+    def setUp(self):
+        self.saved = km.Sessions.backend_for
+        self.queued = []
+        outer = self
+
+        class _BE:
+            def pending_queued(self, sid):
+                return outer.queued
+
+        km.Sessions.backend_for = lambda sid: _BE()
+        self.store = {"placements": {}, "nodes": {}}
+        self.rec = {"wake": True, "anchor": FIRE - 3600, "count": 1,
+                    "lastTurnId": "t1", "armAtoms": 2, "at": FIRE}
+
+    def tearDown(self):
+        km.Sessions.backend_for = self.saved
+
+    def _turns(self, end):
+        # the arm turn, unchanged since the fire (2 atoms), plus a LATER ended turn with no marker
+        return [{"id": "t1", "ended": True, "end": FIRE - 100, "t": FIRE - 200,
+                 "atoms": [{"a": 1}, {"a": 2}]},
+                {"id": "t2", "ended": True, "end": end, "t": end - 50, "atoms": [{"a": 3}]}]
+
+    def test_a_markerless_turn_end_after_the_fire_is_the_event(self):
+        ready, resp = km._nudge_response_ready(self._turns(end=FIRE + 300), self.store,
+                                               self.rec, GID, NOW)
+        self.assertEqual((ready, resp), (True, None),
+                         "the send never landed — surface it NOW, not at hour six")
+
+    def test_a_queued_send_is_in_flight_not_lost(self):
+        self.queued = ["...<!-- romp-goal-id: %s -->..." % GID]
+        ready, resp = km._nudge_response_ready(self._turns(end=FIRE + 300), self.store,
+                                               self.rec, GID, NOW)
+        self.assertEqual((ready, resp), (False, None),
+                         "parked behind a running turn — the event has not happened")
+
+    def test_no_ended_turn_after_the_fire_keeps_the_deadman(self):
+        # the parse moved (a newer turn opened) but nothing has ENDED since the fire: an open turn
+        # may still fold the send, so the event hasn't happened — the dead-man owns this residue
+        turns = [{"id": "t1", "ended": True, "end": FIRE - 100, "t": FIRE - 200,
+                  "atoms": [{"a": 1}, {"a": 2}]},
+                 {"id": "t2", "ended": False, "end": 0, "t": FIRE + 100, "atoms": [{"a": 3}]}]
+        ready, _ = km._nudge_response_ready(turns, self.store, self.rec, GID, NOW)
+        self.assertFalse(ready, "no event yet — an open turn may still fold the send")
+        ready, resp = km._nudge_response_ready(turns, self.store, self.rec, GID,
+                                               FIRE + km.LOST_SEND_DEADMAN_SECS + 60)
+        self.assertEqual((ready, resp), (True, None), "…and past the dead-man, it still surfaces")
+
+    def test_a_landed_marker_keeps_the_judge_gates(self):
+        # the send REACHED the transcript: the event never fires; placement gates rule as before
+        seg = {"id": "s9"}
+        saved = (km.jd._segs, km.jd._seg_nudge, km.jd._seg_followup_all)
+        km.jd._segs = lambda tn, store: ([seg] if tn.get("id") == "t2" else [])
+        km.jd._seg_nudge = lambda s2: True
+        km.jd._seg_followup_all = lambda s2: {GID}
+        try:
+            ready, resp = km._nudge_response_ready(self._turns(end=FIRE + 300), self.store,
+                                                   self.rec, GID, NOW)
+        finally:
+            km.jd._segs, km.jd._seg_nudge, km.jd._seg_followup_all = saved
+        self.assertEqual((ready, resp), (False, seg),
+                         "visible but unplaced → the planner's queue, no clock involved")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**W2d of the time-windows package, plus the W7 comment reclassification.**

The nudge-silence rule was one 6h clock: a fire whose response segment never became visible surfaced as needs-you only when the window ran out. But the fire writes the goal-id marker by construction, so the silence has an exact deciding event (`_debt_reminder_outcomes`' shape): **a turn of the target that ends after the fire carrying no marker segment** — with the backend queue no longer holding the message (an SDK send parked behind a running turn is in flight, not lost) — proves the send never reached the transcript. `_nudge_response_ready` returns ready on that event, stamping the failure on real information; a restart that dropped an in-memory pending send now surfaces within minutes (the post-boot resume notice opens and ends a turn) instead of hiding until hour six. The one silence with no event at all — a session that never ends another turn after the fire — keeps a named dead-man (`LOST_SEND_DEADMAN_SECS`), scoped and documented as exactly that.

**W7**: `discover()`'s 48h `WINDOW` comment reclassified as a **cost horizon** — it bounds how much history each pass re-walks, never eligibility or correctness (liveness owns visibility, death owns finalization, the picker reaches 30 days) — with its one policy consumer named at the constant: `COURIER_RETRY_HORIZON` aliases it as a deliberate give-up deadline, the reason the number is not free to shrink as a perf knob.

**Tests**: `tests/test_lost_send_event.py` — markerless ended turn surfaces at one hour (the retired clock would still wait); a queued send is in flight; open-turn-only movement holds until it ends or the dead-man runs out; a landed marker keeps the judge gates with no clock. Local: 5522 passed, 34 skipped.

Window fates: W3 died (#647), W1b died (#649), W1a decomposed (#650), **W2d died** (this PR), **W7 reclassified** (this PR). Remaining: W2c (per-fsid pass journal), the package's final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)