### PR TITLE
Two read-only observability GETs: the feed's exact payload, and a session's live classification

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27021,6 +27021,54 @@ class Handler(BaseHTTPRequestHandler):
                     "colors": pal.colors(_pn), "active": _pn,
                     "palettes": [{"name": k, "label": v["label"], "colors": v["bg"]}
                                  for k, v in pal.PALETTES.items()]}), "application/json", cache="no-cache")
+            if p == "/feed.json":
+                # The feed's card payload as JSON, for scripts/agents diagnosing card state (both
+                # teams' surveys, 2026-08-24): EXACTLY what build_feed ships to the board — served
+                # from the pusher's warmed build (the connect semantics: never triggers a rebuild;
+                # a cold kernel builds once, a read like any client connect). Token-gated like its
+                # stateful siblings; read-only, no side effects.
+                return self._send(200, json.dumps(_cached_feed(time.time(), _tmux_sessions(), None,
+                                                               connect=True)),
+                                  "application/json", cache="no-cache")
+            if p == "/classify":
+                # One session's LIVE classification as the kernel derives it right now (both teams'
+                # surveys, 2026-08-24 — diagnosing this meant hand-replicating kernel predicates): a
+                # read-only JOIN over reads that already exist — _last_state, _session_awaiting with
+                # the durable-stamp arm on, the wait-for edge, the reply-expecting asks this session
+                # OWES, and the nudge ledger (walkGates journal + deadWait flags ride the records).
+                # Never a second predicate implementation (the mirrors-drift lesson); the one input
+                # this route must CHOOSE is `idle`, and it borrows the nudge gate's own rule (state
+                # not in _PROGRESSING_STATES) — the chat chip's event-model open_now needs a full
+                # transcript parse this debug route deliberately avoids, a noted input divergence,
+                # not a rival derivation.
+                sid = (q.get("id") or [""])[0].strip()
+                if not sid:
+                    return self._send(400, json.dumps({"ok": False, "error": "id required"}),
+                                      "application/json")
+                now = time.time()
+                tm = _tmux_sessions()
+                alive = set(tm)
+                snap = tm.get(sid)
+                st, st_t = _last_state(sid)
+                idle = st not in _PROGRESSING_STATES
+                nd = _auto_nudge_data()
+                mine = lambda k: k == sid or k.startswith(sid + ":")
+                return self._send(200, json.dumps({
+                    "id": sid, "t": now, "live": sid in tm,
+                    "snapshot": ({"state": snap.get("state"), "since": snap.get("since")}
+                                 if isinstance(snap, dict) else None),
+                    "state": {"value": st, "t": st_t},
+                    "idle": idle,
+                    "idleRule": "state not in _PROGRESSING_STATES (the nudge gate's read)",
+                    "awaiting": _session_awaiting(sid, (snap or {}).get("path") or _path_of(sid) or "",
+                                                  idle, stamp=True),
+                    "waitingOn": _wait_for_graph(now, alive).get(sid),
+                    "owesAsks": [{"from": f, "name": n, "t": ts, "kind": k, "head": h}
+                                 for f, n, ts, k, h in _debt_asks(sid, alive)],
+                    "nudge": {"enabled": bool(nd.get("enabled", True)),
+                              "records": {k: v for k, v in (nd.get("nudged") or {}).items() if mine(k)},
+                              "walkGates": {k: v for k, v in (nd.get("walkGates") or {}).items() if mine(k)}},
+                }), "application/json", cache="no-cache")
             if p == "/views":                             # the session-views blob (active view, hidden set,
                 # tags) for scripts/agents: the read half of POST /tag, AND the remote-poll source of
                 # tag federation v0. CANONICAL shape (member pairs), remoteTags absent on purpose:

--- a/tests/test_observability_routes.py
+++ b/tests/test_observability_routes.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""The read-only observability GETs (both teams' surveys, 2026-08-24): GET /feed.json — exactly what
+build_feed ships to the board — and GET /classify?id=<sid> — one session's live classification as
+the kernel derives it, a JOIN over reads that already exist (never a second predicate
+implementation). Both serve-token-gated, read-only, no side effects. Drives the REAL Handler over
+HTTP (the test_tag_route idiom). Synthetic only."""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+import urllib.error
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_obs", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+def _state_snapshot(root):
+    """Every file under STATE with its (mtime_ns, size) — the read-only-ness witness."""
+    out = {}
+    for p in sorted(Path(root).rglob("*")):
+        if p.is_file():
+            st = p.stat()
+            out[str(p)] = (st.st_mtime_ns, st.st_size)
+    return out
+
+
+class ObservabilityRoutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+        self._saved = km._tmux_sessions
+        km._tmux_sessions = lambda: {}
+        km._built_feed[:] = [None, None, 0, 0]     # a cold cache: /feed.json builds once, like a connect
+
+    def tearDown(self):
+        km._tmux_sessions = self._saved
+        jd.STATE = self._state
+        km._flags_cache.clear()
+        km._built_feed[:] = [None, None, 0, 0]
+        self.td.cleanup()
+
+    def _get(self, path, token=True):
+        url = "http://127.0.0.1:%d%s" % (self.port, path)
+        req = urllib.request.Request(url, headers=(
+            {"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]} if token else {}))
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode() or "null")
+        except urllib.error.HTTPError as e:
+            return e.code, (e.read() or b"").decode()
+
+    def test_both_routes_are_token_gated(self):
+        self.assertEqual(self._get("/feed.json", token=False)[0], 403)
+        self.assertEqual(self._get("/classify?id=" + SID, token=False)[0], 403)
+
+    def test_feed_json_is_exactly_the_boards_payload_and_read_only(self):
+        (jd.STATE / "goals").mkdir(parents=True, exist_ok=True)
+        before = _state_snapshot(self.td.name)
+        st, d = self._get("/feed.json")
+        self.assertEqual(st, 200)
+        self.assertEqual(d.get("type"), "feed", "the exact build_feed shape, not a re-derivation")
+        self.assertIn("asks", d)
+        self.assertIn("now", d)
+        self.assertEqual(_state_snapshot(self.td.name), before, "a GET writes nothing")
+
+    def test_classify_requires_an_id(self):
+        st, _ = self._get("/classify")
+        self.assertEqual(st, 400)
+
+    def test_classify_joins_the_existing_reads_and_is_read_only(self):
+        # seed the stores the joined reads consume: a progressing state transition, and a nudge
+        # ledger holding this session's goal record (deadWait flag) + a walk-gate journal entry
+        (jd.STATE / "states").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "states" / (SID + ".jsonl")).write_text(
+            json.dumps({"state": "working", "t": 1000}) + "\n")
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps({
+            "enabled": True,
+            "nudged": {SID + ":g1": {"deadWait": True, "anchor": 5, "at": 6},
+                       "someone-else:g9": {"at": 7}},
+            "walkGates": {SID: {"gate": "compacting", "at": 8},
+                          "someone-else": {"gate": "open-turn", "at": 9}}}))
+        km._autonudge_cache.clear()
+        before = _state_snapshot(self.td.name)
+        st, d = self._get("/classify?id=" + SID)
+        self.assertEqual(st, 200)
+        self.assertEqual(d["id"], SID)
+        self.assertFalse(d["live"], "no live snapshot in this world")
+        self.assertEqual(d["state"], {"value": "working", "t": 1000}, "_last_state verbatim")
+        self.assertFalse(d["idle"], "the nudge gate's own idle rule: working is progressing")
+        self.assertIn("_PROGRESSING_STATES", d["idleRule"], "the input's provenance rides the payload")
+        self.assertIsNone(d["awaiting"])
+        self.assertIsNone(d["waitingOn"])
+        self.assertEqual(d["owesAsks"], [])
+        self.assertEqual(d["nudge"]["records"], {SID + ":g1": {"deadWait": True, "anchor": 5, "at": 6}},
+                         "only THIS session's ledger rows — deadWait flags ride verbatim")
+        self.assertEqual(d["nudge"]["walkGates"], {SID: {"gate": "compacting", "at": 8}},
+                         "…and its walk-gate journal entries")
+        self.assertTrue(d["nudge"]["enabled"])
+        self.assertEqual(_state_snapshot(self.td.name), before, "a GET writes nothing")
+
+    def test_classify_idle_when_the_state_says_stopped(self):
+        (jd.STATE / "states").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "states" / (SID + ".jsonl")).write_text(
+            json.dumps({"state": "waiting", "t": 2000}) + "\n")
+        st, d = self._get("/classify?id=" + SID)
+        self.assertTrue(d["idle"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (both teams' surveys, 2026-08-24 — tooling backlog item 5)

- **`GET /feed.json`** — exactly what `build_feed` ships to the board, served from the pusher's warmed build (connect semantics: never triggers a rebuild; a cold kernel builds once, a read like any client connect).
- **`GET /classify?id=<sid>`** — one session's live classification as the kernel derives it right now: `_last_state`, the durable-stamp `_session_awaiting` (kind + why + since), the wait-for edge (`waitingOn`), the reply-expecting asks the session **owes**, and the nudge ledger with the `walkGates` journal and `deadWait` flags riding verbatim. A read-only **join over reads that already exist** — never a second predicate implementation (the mirrors-drift lesson). The one input the route must choose, `idle`, borrows the nudge gate's own rule (`state not in _PROGRESSING_STATES`) and names its provenance in the payload.

Both are serve-token-gated like their stateful siblings; documented where the siblings are (the inline route comments — no external route list exists).

## Tests

`tests/test_observability_routes.py` (real-Handler idiom): 403 without the token on both; 400 without `id`; the exact `build_feed` shape; the session-scoped ledger filtering (records + walkGates); the idle rule both ways; and **read-only-ness witnessed** — every file under STATE snapshotted before/after each GET and asserted byte-identical. Suites green: 5523 python tests (+293 subtests), 2359 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)