### PR TITLE
A wedged reviver is proven by the owning tier's own pass, not presumed at hour six

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -698,6 +698,25 @@ _judge_ctx = threading.local()                       # per-thread: the fsid bein
 # (SourceFileLoader), so it reads `active_runs()` directly — no file, no cross-process race. Self-cleaning:
 # every call deregisters in a `finally`, so a timeout/parse-fail/exception can't leak a forever-growing bar.
 _active = {}                                          # run_id -> {"judge", "fsid", "sent"}
+_PASS_DONE = {}                                       # (tier, fsid) -> wall clock of that tier's last COMPLETED
+#                                                       per-session pass THIS BOOT. In-memory on purpose (W2c,
+#                                                       the user 2026-08-24): a restart resets it, so "the first
+#                                                       completed post-boot pass over this fsid" is the re-arm
+#                                                       event — a pre-boot deferral can never fire off a stale
+#                                                       stamp. Usage rows can't serve here: they record CALLS,
+#                                                       and a tier with no new work makes zero calls, so keying
+#                                                       the wedged-reviver bound on usage would defer forever in
+#                                                       exactly the wedged cases it exists to catch.
+
+
+def pass_done(tier, fsid):
+    """Stamp: `tier` finished its per-session pass over fsid (work done OR declined-as-no-work)."""
+    _PASS_DONE[(str(tier), str(fsid))] = time.time()
+
+
+def pass_watermark(tier, fsid):
+    """When `tier` last completed a per-session pass over fsid this boot, or None."""
+    return _PASS_DONE.get((str(tier), str(fsid)))
 _active_lock = threading.Lock()
 _active_seq = [0]
 
@@ -7159,6 +7178,7 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verb
         for fut in as_completed(futs):
             try:
                 placed += fut.result()
+                pass_done("plan", futs[fut])          # the pass over THIS fsid completed (W2c's event)
             except Exception:
                 pass
     if verbose:
@@ -9011,6 +9031,7 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ver
         for fut in as_completed(futs):
             try:
                 n += len(fut.result())
+                pass_done("close", futs[fut])         # the pass over THIS fsid completed (W2c's event)
             except Exception:
                 pass
     if verbose:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4494,7 +4494,22 @@ def _nudge_deferred_ok(gid, reason, now, sid=None, ev_t=None):
                    **({"evT": int(ev_t)} if ev_t else {})}
         d["deferred"] = dd
         _write_auto_nudge(d)
-    return (now - first) > NUDGE_DEFER_BACKSTOP_SECS
+    # WEDGED-REVIVER BOUND ON THE PASS EVENT, not a clock (W2c, the user 2026-08-24): the named
+    # reviver is wedged exactly when its OWNING TIER has completed a per-session pass over this fsid
+    # SINCE the deferral was minted and the reason still stands — the pass ran and did not retire it.
+    # jd.pass_watermark is this boot's per-(tier, fsid) completion stamp; a pre-restart deferral
+    # re-arms on the FIRST post-boot pass (the registry resets, never a stale stamp). While the judge
+    # tiers are PAUSED there is NO owner and the deferral holds indefinitely — the pause is the user's
+    # own gesture, and a nudge computed from unjudged state is what it exists to prevent; the UNPAUSE
+    # transition is the deciding event (the producer's next pass stamps the watermark, and this gate
+    # re-evaluates immediately). WHY_JUDGING keeps its own event (the call's finally-deregister, swept
+    # by _deferral_sweep_tick); the pass bound is belt-and-braces behind it.
+    if reason.startswith("the judge tiers are paused"):
+        return False                                 # user's own hold: no owner, no clock — the unpause re-arms
+    _sid = sid or (rec or {}).get("sid") if isinstance(rec, dict) else sid
+    _wm = max(filter(None, (jd.pass_watermark("plan", _sid), jd.pass_watermark("close", _sid))),
+              default=None) if _sid else None
+    return bool(_wm and _wm > first)
 
 
 def _stalled_goals():

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -242,21 +242,40 @@ class DeferBackstop(Base):
                          "the first deferral is stamped with its reason and session — no counter "
                          "(2026-08-13: the sweep owns retirement; existence IS the standing hold)")
 
-    def test_a_legacy_bare_int_deferral_still_backstops(self):
+    def test_a_legacy_bare_int_deferral_still_fires_on_the_pass(self):
         # A live state file written before the record grew a reason still holds bare epoch ints; reading one
         # must keep working (and never crash the tick), it just has no why to tell the card about.
+        km.jd._PASS_DONE.clear()                      # module state: a prior cell's stamp must not leak
         self._d["deferred"] = {GID: NOW}
-        self.assertFalse(km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 5),
+        self.assertFalse(km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 5, sid=SID),
                          "an int record is read as a deferral that started at that time")
-        self.assertTrue(km._nudge_deferred_ok(GID, "the agent's to-do sync is due",
-                                              NOW + km.NUDGE_DEFER_BACKSTOP_SECS + 1),
-                        "…and its backstop still fires")
+        km.jd.pass_done("plan", SID)
+        self.assertTrue(km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 10, sid=SID),
+                        "…and the owning tier's completed pass still fires it")
 
-    def test_a_deferral_past_the_backstop_fires_anyway(self):
-        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW)
-        self.assertTrue(km._nudge_deferred_ok(GID, "the agent's to-do sync is due",
-                                              NOW + km.NUDGE_DEFER_BACKSTOP_SECS + 1),
-                        "a wedged reviver defers the nudge but can never LOSE it")
+    def test_a_deferral_fires_when_the_owning_pass_ran_and_the_reason_stands(self):
+        # W2c (the user 2026-08-24): the wedge event is the owning tier COMPLETING a pass over this
+        # fsid after the mint with the reason still standing — the pass ran and did not retire it.
+        # No clock: without a pass the deferral holds at any age (a PAUSED fleet has no owner, and
+        # the unpause's first pass is the deciding event, re-evaluated immediately).
+        km.jd._PASS_DONE.clear()
+        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW, sid=SID)
+        self.assertFalse(km._nudge_deferred_ok(GID, "the agent's to-do sync is due",
+                                               NOW + 300 * 3600, sid=SID),
+                         "no pass yet → the hold stands, whatever the age")
+        km.jd.pass_done("close", SID)
+        self.assertTrue(km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 300 * 3600 + 5,
+                                              sid=SID),
+                        "the pass ran, the reason stands → wedged, fire — a reviver can defer a "
+                        "nudge but can never LOSE it")
+
+    def test_a_paused_fleet_defers_indefinitely(self):
+        km.jd._PASS_DONE.clear()
+        why = "the judge tiers are paused (nothing could revive it)"
+        km._nudge_deferred_ok(GID, why, NOW, sid=SID)
+        km.jd.pass_done("close", SID)                 # even a (stray) stamp cannot override the pause
+        self.assertFalse(km._nudge_deferred_ok(GID, why, NOW + 300 * 3600, sid=SID),
+                         "the pause is the user's own hold — no owner, no clock; the unpause re-arms")
 
     def test_the_reviver_clearing_forgets_the_deferral(self):
         km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW)

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -217,12 +217,14 @@ class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
                          "the hold is RECORDED — the silent drop is what made the deadlock unreadable")
         self.assertEqual(rec["sid"], SID)
 
-    def test_a_wedged_hold_still_fires_on_the_backstop(self):
+    def test_a_wedged_hold_still_fires_on_the_owning_pass(self):
         self.turns[-1]["ended"] = False
         self._tick()
         self.assertEqual(self.sent, [])
-        later = NOW + km.NUDGE_DEFER_BACKSTOP_SECS + 60
-        self.assertTrue(self._tick(now=later), "a hold that never clears is a missing event, not a veto")
+        # W2c: the wedge event is the owning tier completing a pass over this fsid with the hold
+        # still standing — never a clock (the retired 6h bound)
+        km.jd.pass_done("close", SID)
+        self.assertTrue(self._tick(now=NOW + 120), "a hold the pass did not retire is wedged, not a veto")
         self.assertEqual(len(self.sent), 1)
 
     def test_a_resolved_card_is_never_nudged_either_way(self):


### PR DESCRIPTION
**W2c — the time-windows package's final piece.**

The nudge-deferral bound fired "anyway" after 6h on the theory that a reviver which never clears is a missing event. The event was observable all along, just never journaled: **the owning judge tier completing a per-session pass over this fsid with the deferral's reason still standing** — the pass ran and did not retire it, so the reviver is wedged in fact, not by presumption.

- judge.py gains the per-(tier, fsid) **pass journal** (`pass_done`/`pass_watermark`), stamped where `run_plan`'s and `run_close`'s per-session futures complete. Usage rows could not serve here — they record calls, and a tier with no new work makes zero calls, so keying the bound on usage would defer forever in exactly the wedged cases. The journal is in-memory on purpose: a restart resets it, so a pre-boot deferral re-arms on the first completed post-boot pass, never a stale stamp.
- **Pause semantics, chosen with the user**: while the judge tiers are paused there is no owner and the deferral holds indefinitely — the pause is the user's own gesture, and a nudge computed from unjudged state is what it exists to prevent; the **unpause transition is the deciding event** (the producer's next pass stamps the watermark; the gate re-evaluates immediately). `WHY_JUDGING` keeps its own event (the call's finally-deregister, swept by the deferral sweep). The debt reminder's never-turns-again twin keeps its named dead-man.
- **Deploy impact**: the 4 live deferral records are minutes old with healthy tiers — each retires on its reason's own event or fires on the next completed pass, as the old clock would have resolved them within the hour.

**Tests** moved to the pass contract: no pass → the hold stands at any age (no clock resurrection); pass ran + reason stands → fire; paused → indefinite hold even over a stray stamp; legacy bare-int records fire on the pass like any other. Local: 5523 passed, 34 skipped.

## The package's closing fates table

| Window | Fate |
|---|---|
| W3 `MSG_INFLIGHT_MAX` | **died** (#647) — pending keys on exec/recall/bounce/liveness events |
| W1b walk→sweep 6h handoff | **died** (#649) — journaled gate classes own the handoff |
| W1a wake 6h patience | **decomposed** (#650) — local+alive peer waits take no wake; clock renamed `AWAITING_DEADMAN_SECS`, residents documented |
| W2d nudge-silence 6h | **died** (#653) — the lost-send event (target's next markerless turn end); `LOST_SEND_DEADMAN_SECS` only for never-turns-again |
| W2c wedged-reviver 6h | **replaced** (this PR) — the owning tier's pass journal |
| W5 tool-deadline grace | **stands** — a named dead-man on a declared deadline (death-mid-watch is unobservable) |
| W6 `_WAKE_DRIVE_FLOOR_S` | **stands** — the measured, documented exception (the CLI never records deciding not to deliver) |
| W7 48h discover | **reclassified** (#653) — a cost horizon, with `COURIER_RETRY_HORIZON` named as its one policy alias |
| W8/W2e live-peer residues | **verified event-keyed** — the waitfor edge is the unanswered-question event; the debt backstop is the genuine never-turns dead-man |

Deferred with a note: the timer `until` schema extension (prose-declared check-backs; Monitor-backed timers already lift at their own declared deadline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)