### PR TITLE
A grouped session header leaves as one motion with its run's last card

### DIFF
--- a/ui/webview/feed-clear-hover.test.ts
+++ b/ui/webview/feed-clear-hover.test.ts
@@ -10,8 +10,9 @@ import * as path from "node:path";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
-test("the ask card's Clear flushes the hover highlight, right before pendingCleared", () => {
-  assert.match(FEED, /card\.dispatchEvent\(new MouseEvent\("mouseleave"\)\);\s*\n\s*pendingCleared\.add\(it\.itemId\);/);
+test("the ask card's Clear flushes the hover highlight, right before the header conjunction + pendingCleared", () => {
+  // the one-motion header exit (2026-08-24) rides between the flush and the suppression — same click
+  assert.match(FEED, /card\.dispatchEvent\(new MouseEvent\("mouseleave"\)\);\s*\n\s*dressHeaderIfLast\(card, it\.sid\);[^\n]*\n\s*pendingCleared\.add\(it\.itemId\);/);
 });
 
 test("the group card's Clear flushes the hover highlight too", () => {

--- a/ui/webview/feed-sess-exit.test.ts
+++ b/ui/webview/feed-sess-exit.test.ts
@@ -1,0 +1,56 @@
+// The grouped session header leaves as ONE MOTION with its run's last card (the user 2026-08-24,
+// whose recording showed the header popping out a frame after the card finished fading): the exit
+// wears the card-dismiss family, DOM removal keys on animationend with a can't-trap backstop, a run
+// that still has cards keeps its header rock-steady, and reduced motion removes at once. Source
+// pins (feed.ts has no jsdom harness — the repo convention); the motion itself verified headlessly
+// with tools/ui-verify (steady / mid-exit / end frames).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("a header being removed exits ANIMATED; anything else still removes cold", () => {
+  const sweep = FEED.slice(FEED.indexOf("for (const [k, c] of existing) {"), FEED.indexOf("let cur: ChildNode | null"));
+  assert.ok(sweep.includes('if (c.classList.contains("sess-exit")) continue;'),
+    "a ghost mid-exit is left to its own end event — never re-removed");
+  assert.ok(sweep.includes('if (k.startsWith("s:")) startSessHeadExit(k, c);'),
+    "headers take the animated exit");
+  assert.ok(sweep.includes("else c.remove();"), "cards and groups keep their existing removal paths");
+});
+
+test("the exit un-keys FIRST, removes on the END EVENT, backstops, and honors reduced motion", () => {
+  const ex = FEED.slice(FEED.indexOf("function startSessHeadExit"), FEED.indexOf("function dressHeaderIfLast"));
+  assert.ok(ex.includes("if (sessHeadEls.get(key) === head) sessHeadEls.delete(key);"),
+    "a reappearing run mints a FRESH header while the ghost finishes");
+  assert.ok(ex.includes('head.dataset.key = "x:" + (++sessGhostSeq);'),
+    "tombstone-keyed: survives the reconcile's unkeyed-child sweep, never desired again");
+  assert.ok(ex.includes('head.addEventListener("animationend", done, { once: true });'),
+    "removal keys on the event, not a timer");
+  assert.ok(ex.includes("window.setTimeout(done, 600);"), "…with the standard can't-trap backstop");
+  assert.ok(ex.includes('window.matchMedia("(prefers-reduced-motion: reduce)").matches'),
+    "reduced motion removes at once — no animation ever plays, so no event to wait on");
+});
+
+test("the CONJUNCTION: the run's last card takes its header with it, at the same click", () => {
+  assert.match(FEED, /dressHeaderIfLast\(card, it\.sid\);/, "ask-card clears join the motion");
+  assert.match(FEED, /dressHeaderIfLast\(card, cur\.sid\);/, "group-card clears too — a group is one session's turn");
+  const dh = FEED.slice(FEED.indexOf("function dressHeaderIfLast"), FEED.indexOf("function reconcileCol"));
+  assert.ok(dh.includes("if (!feedPrefs().grouped) return;"), "grouped mode only — flat mode has no headers");
+  assert.ok(dh.includes('if (!head || head.getAttribute("data-fsid") !== sid || head.classList.contains("sess-exit")) return;'),
+    "the walk stops at the run's OWN header, once");
+  // rock-steady: any other live member of the run vetoes the dress — a middle card leaving
+  // never touches the header
+  assert.ok(dh.includes('if (n !== card && n.classList.contains("fitem") && !n.classList.contains("dismissing")) return;'),
+    "a run that lives on keeps its header untouched");
+});
+
+test("the dress is the card-dismiss family: fade + shrink + height collapse, fill held, reduced-motion block", () => {
+  assert.match(CSS, /\.feed-sess-head\.sess-exit \{ animation: sess-exit 0\.18s ease forwards; overflow: hidden; pointer-events: none; \}/,
+    "same 0.18s ease the card exit wears (fask-dismiss)");
+  assert.match(CSS, /@keyframes sess-exit \{\s*\n\s*from \{ opacity: 1; transform: scale\(1\); max-height: 60px; \}\s*\n\s*to\s+\{ opacity: 0; transform: scale\(0\.9\); max-height: 0; margin: 0; padding: 0; \}/);
+  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.feed-sess-head\.sess-exit \{ animation: none; opacity: 0; \} \}/,
+    "the loading-cues convention: no motion, the end state stated");
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -706,6 +706,16 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 }
 /* hover lightens via an inset overlay + lifts — never touches the inline tint */
 .fitem:hover { box-shadow: inset 0 0 0 999px rgba(255, 255, 255, 0.07), 0 2px 7px rgba(0, 0, 0, 0.30); }
+/* the grouped session header leaves as ONE MOTION with its run's last card (the user 2026-08-24,
+   whose recording showed the header popping out a frame after the card): the card-dismiss family —
+   fade + slight shrink + height collapse so the reflow glides. fill-mode holds the end state until
+   the animationend removal lands (feed.ts startSessHeadExit — event-keyed, backstopped). */
+.feed-sess-head.sess-exit { animation: sess-exit 0.18s ease forwards; overflow: hidden; pointer-events: none; }
+@keyframes sess-exit {
+  from { opacity: 1; transform: scale(1); max-height: 60px; }
+  to   { opacity: 0; transform: scale(0.9); max-height: 0; margin: 0; padding: 0; }
+}
+@media (prefers-reduced-motion: reduce) { .feed-sess-head.sess-exit { animation: none; opacity: 0; } }
 /* a cleared/dismissed card CONTRACTS in on itself — scales down + fades while its height collapses so the
    neighbours slide up to close the gap — instead of sliding off to one side (the user 2026-06-18). */
 .fitem.dismissing { animation: fask-dismiss 0.18s ease forwards; overflow: hidden; pointer-events: none; transform-origin: center; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1142,6 +1142,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     // never fires and the timeline/chat highlight stuck until you moved the mouse (the user 2026-07-03). The
     // synthetic mouseleave runs the exact leave logic (clears the highlight, or restores a pinned card's).
     card.dispatchEvent(new MouseEvent("mouseleave"));
+    dressHeaderIfLast(card, it.sid);   // the run's last card takes its header with it — one motion (2026-08-24)
     pendingCleared.add(it.itemId);   // suppress from incoming pushes until the kernel confirms the clear
     clearedStack.push([it]);         // cache for an instant optimistic Undo
     card.classList.add("dismissing");
@@ -2247,6 +2248,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     ev.stopPropagation();
     card.dispatchEvent(new MouseEvent("mouseleave"));   // flush the group's stuck hover highlight (see the ask card's clear)
     const cur = (card as any)._g as AskGroup;
+    dressHeaderIfLast(card, cur.sid);   // a group is one session's turn — same one-motion rule (2026-08-24)
     card.classList.add("dismissing");
     clearedStack.push(cur.members.slice());   // cache the whole batch for an instant optimistic Undo
     for (const m of cur.members) { pendingCleared.add(m.itemId); vscodeApi?.postMessage({ type: "askClear", itemId: m.itemId, sid: m.sid }); }   // clear every member
@@ -3848,6 +3850,44 @@ function ensureCols(list: HTMLElement) {
 // Keyed in-place reconcile of ONE column (mixes ask + standalone cards; a card
 // whose column changed is MOVED, not rebuilt — no hover flicker). Records each key
 // in `globalDesired` for the cross-column cache cleanup the caller runs after.
+// A grouped session header leaves as ONE MOTION with its run's last card (the user 2026-08-24,
+// whose recording showed the header popping out a frame after the card finished fading): the exit
+// wears the card-dismiss family (fade + slight shrink + height collapse) instead of vanishing at
+// the next render. The element is UN-KEYED first — dropped from sessHeadEls and re-keyed to a
+// tombstone — so a reappearing run mints a FRESH header while the ghost finishes; DOM removal keys
+// on animationend (the event), with a backstop timeout so a lost event can never trap the ghost,
+// and reduced motion removes at once (no animation ever plays there).
+let sessGhostSeq = 0;
+function startSessHeadExit(key: string, head: HTMLElement): void {
+  if (sessHeadEls.get(key) === head) sessHeadEls.delete(key);
+  if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    head.remove();
+    return;
+  }
+  head.dataset.key = "x:" + (++sessGhostSeq);   // keyed-but-never-desired: survives the unkeyed-child sweep
+  head.classList.add("sess-exit");
+  const done = () => head.remove();
+  head.addEventListener("animationend", done, { once: true });
+  window.setTimeout(done, 600);                 // backstop — a lost event can never trap the ghost
+}
+// The CONJUNCTION half: when a dismissing card is its run's LAST, the header starts its exit at the
+// same moment (the same click), not at the post-dismiss render. Grouped mode only; a run with other
+// live cards keeps its header rock-steady. The walk reads the CURRENT DOM: back to the run's own
+// header, then across the run for any member that is neither the leaving card nor already dismissing.
+function dressHeaderIfLast(card: HTMLElement, sid: string): void {
+  if (!feedPrefs().grouped) return;
+  let head: HTMLElement | null = null;
+  for (let p = card.previousElementSibling as HTMLElement | null; p; p = p.previousElementSibling as HTMLElement | null) {
+    if (p.classList.contains("feed-sess-head")) { head = p; break; }
+  }
+  if (!head || head.getAttribute("data-fsid") !== sid || head.classList.contains("sess-exit")) return;
+  for (let n = head.nextElementSibling as HTMLElement | null; n && !n.classList.contains("feed-sess-head"); n = n.nextElementSibling as HTMLElement | null) {
+    if (n !== card && n.classList.contains("fitem") && !n.classList.contains("dismissing")) return;   // the run lives on
+  }
+  const key = head.dataset.key || "";
+  startSessHeadExit(key, head);
+}
+
 function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<string>) {
   const existing = new Map<string, HTMLElement>();
   for (const c of Array.from(listEl.children) as HTMLElement[]) {
@@ -3879,7 +3919,12 @@ function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<
     globalDesired.add(key); colDesired.add(key);
     ordered.push(card);
   }
-  for (const [k, c] of existing) if (!colDesired.has(k)) c.remove();
+  for (const [k, c] of existing) {
+    if (colDesired.has(k)) continue;
+    if (c.classList.contains("sess-exit")) continue;             // a ghost mid-exit — its end event removes it
+    if (k.startsWith("s:")) startSessHeadExit(k, c);             // headers leave as one motion (2026-08-24)
+    else c.remove();
+  }
   let cur: ChildNode | null = listEl.firstChild;
   for (const node of ordered) {
     if (cur === node) { cur = cur.nextSibling; continue; }


### PR DESCRIPTION
In grouped mode, the session-name header popped out abruptly a frame after its run's last card finished fading — the card contracts smoothly, then the header vanishes cold and the board jumps (user report with recording). The exit is **one motion** now.

**The reconcile's removal sweep** gives a departing header the card-dismiss family (fade + slight shrink + height collapse, the same 0.18s ease) instead of a cold remove. The element is un-keyed first — dropped from `sessHeadEls` and re-keyed to a tombstone so it survives the unkeyed-child sweep and a reappearing run mints a fresh header while the ghost finishes. DOM removal keys on `animationend` with a 600ms can't-trap backstop; reduced motion removes at once (no animation ever plays there, so no event to wait on).

**The conjunction:** a Clear on the run's last card dresses the header at the same click (`dressHeaderIfLast`, ask and group cards both), so header and card fade together rather than in sequence. Any other live member of the run vetoes the dress — a middle card leaving keeps the header rock-steady (pinned). The column pill's count just changes value in the recording — no motion of its own to join — so it is deliberately untouched.

**Evidence:** verified headlessly with `tools/ui-verify` (dogfooding its first task since landing): a steady frame and a frozen mid-exit frame (negative animation-delay, paused) showing header + card half-faded **together** with the next run gliding up. `feed-sess-exit.test.ts` pins the sweep branches, the un-key/tombstone/event/backstop lifecycle, the conjunction walk with its rock-steady veto, and the CSS family + reduced-motion block. 2360 extension tests green on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
