### PR TITLE
The hide-from-chat mechanism retires: All means literally everything; hidden entries become the archived tag

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1511,7 +1511,7 @@ def _ordered_alive(now, tmux):
 
 # ── session VIEWS: which sessions the user is looking at (the user 2026-08-18) ────────────────────
 # One blob under STATE (timeline-views.json), shared by every dashboard this kernel serves (browser,
-# VS Code, Obsidian): {"active": "all"|"untagged"|tag-id, "hidden": [id...], "tags": [{"id","name",
+# VS Code, Obsidian): {"active": "all"|"untagged"|tag-id, "tags": [{"id","name",   (hidden retired 2026-08-24)
 # "color", "members": [id...]}]}. TWO built-in sentinels, not tags: "all" — the DEFAULT (the user
 # 2026-08-24) — shows every session EXCEPT the hidden set; "untagged" shows the sessions no tag
 # holds, minus hidden. "all" used to MEAN untagged, so reinterpreting the sentinel as truly-all
@@ -1577,7 +1577,9 @@ def _norm_timeline_views(d):
     if not isinstance(d, dict):
         d = {}
     _lst = lambda x: x if isinstance(x, list) else []   # wrong-typed junk (a number, a string) drops, never raises
-    hidden = [str(x) for x in _lst(d.get("hidden")) if isinstance(x, str) and x]
+    # (`hidden` RETIRED, the user 2026-08-24: the tag system covers backgrounding — a stored or
+    # echoed hidden array is tolerated and dropped; _timeline_views migrated existing entries into
+    # the "archived" tag once. Nothing hides from All anymore: that is All's meaning now.)
     tags = []
     raw = d.get("tags") if isinstance(d.get("tags"), list) else d.get("groups")
     for g in _lst(raw)[:_VIEWS_MAX_TAGS]:
@@ -1593,7 +1595,7 @@ def _norm_timeline_views(d):
     if active not in ("all", "untagged") and ":" not in active \
             and not any(t["id"] == active for t in tags):
         active = "all"
-    return {"active": active, "hidden": sorted(set(hidden)), "tags": tags}
+    return {"active": active, "tags": tags}
 
 
 def _timeline_views():
@@ -1609,6 +1611,24 @@ def _timeline_views():
         d = json.loads(p.read_text())
     except Exception:
         d = {}
+    # ONE-TIME MIGRATION (the user 2026-08-24, retiring hide-from-chat outright: "we want to get
+    # rid of that hide from chat thing"): a stored blob still carrying hidden entries maps them
+    # into an "archived" TAG on THIS kernel — preserving the user's intent record and keeping them
+    # out of the untagged view. They WILL show under All: nothing can hide from All
+    # post-retirement — that is All's meaning now, and the feed's needs-you machinery carries
+    # anything that matters. Minted only when hidden entries exist; idempotent (the write drops the
+    # hidden key, so the next read has nothing to migrate).
+    hid = [str(x) for x in (d.get("hidden") or []) if isinstance(x, str) and x] if isinstance(d, dict) else []
+    if hid:
+        raw = d.get("tags") if isinstance(d.get("tags"), list) else (d.get("groups") if isinstance(d.get("groups"), list) else [])
+        tags = [t for t in raw if isinstance(t, dict)]
+        arch = next((t for t in tags if t.get("name") == "archived"), None)
+        if arch is None:
+            arch = {"id": "archived", "name": "archived", "color": "#6b7280", "members": []}   # muted slate — never a status color
+            tags = tags + [arch]
+        arch["members"] = [m for m in (arch.get("members") or []) if m] + hid
+        d = dict(d); d["tags"] = tags; d.pop("groups", None); d.pop("hidden", None)
+        _set_timeline_views(d)                       # persist the mapping; the fresh mtime re-keys the cache
     d = _norm_timeline_views(d)
     _flags_cache[str(p)] = (key, d)
     return d
@@ -1703,14 +1723,14 @@ def _view_visible(views, sid):
     timeline for optimistic feedback — tests pin all three against this shape. Operates on the
     RENDERED blob (_views_client: string members + remoteTags) — the shape every client holds; a
     remote-tag active ("host:tagid") resolves in remoteTags and falls OPEN when the remote tag is
-    gone (its kernel detached), never trapping the viewer in an empty view. ALL — the default
-    (the user 2026-08-24) — shows every session minus the `hidden` set: hiding is a deliberate user
-    gesture, so All respects it (the dialog's eye stays the un-hide affordance). UNTAGGED keeps the
-    old default's meaning (the user 2026-08-23): tagging a session says "specialized — out of the
-    untagged view, viewable under its tag", so membership itself excludes there; `hidden` hides in
-    both sentinel views. A tag view shows exactly its members — membership beats the hidden bit."""
+    gone (its kernel detached), never trapping the viewer in an empty view. ALL — the default —
+    shows LITERALLY EVERYTHING (the user 2026-08-24, retiring the hidden set outright: the tag
+    system covers backgrounding, and existing hidden entries migrated into the "archived" tag).
+    UNTAGGED keeps its meaning (the user 2026-08-23): tagging a session says "specialized — out of
+    the untagged view, viewable under its tag", so membership itself excludes there. A tag view
+    shows exactly its members."""
     if views["active"] == "all":
-        return sid not in views["hidden"]
+        return True                                  # All = literally everything (hidden retired 2026-08-24)
     if views["active"] == "untagged":
         # the union excludes here too (the user 2026-08-24, who tagged a session from the chat and
         # watched it stay in the untagged view): a tag is its NAME wherever it homes — a session
@@ -1718,7 +1738,7 @@ def _view_visible(views, sid):
         # toggling untagged membership) is answered by _views_client keeping a down host's CACHED
         # tags contributing: stability beats freshness for visibility, and the auto-reconnect work
         # makes the staleness window a pass, not an afternoon.
-        return sid not in views["hidden"] and not any(
+        return not any(
             sid in t["members"] for t in list(views["tags"]) + list(views.get("remoteTags") or []))
     # a tag view shows the NAME-KEYED UNION (user ruling 2026-08-24: a tag is its NAME; kernels
     # are plumbing) — whichever store's id is active, membership joins every same-name tag's,
@@ -1732,21 +1752,19 @@ def _view_visible(views, sid):
 
 def _heal_timeline_views(old_sid, new_sid):
     """fsid churn (a /clear, relaunch or revive mints a new transcript fsid for the same logical
-    session): carry the old sid's hidden bit and tag memberships to the new one, exactly like the
-    order-slot inheritance that detects the churn. Without this a hidden tmux session would pop back
-    visible on every /clear — and worse, a tagged one would silently fall out of its tag."""
+    session): carry the old sid's tag memberships to the new one, exactly like the order-slot
+    inheritance that detects the churn. Without this a tagged session would silently fall out of
+    its tag on every /clear. (The hidden half retired with the set, 2026-08-24.)"""
     v = _timeline_views()
     def _has(t):
         return any(m["host"] == "" and m["sid"] == old_sid for m in t["members"])
-    if old_sid not in v["hidden"] and not any(_has(t) for t in v["tags"]):
+    if not any(_has(t) for t in v["tags"]):
         return
     v = json.loads(json.dumps(v))                    # deep copy: never mutate the cached blob
     # COPY, never move: stripping the old sid un-hid its DEAD lane, which lingers on the timeline for
     # hours — and when the old sid is still alive (a fork beside a living parent, or an unrelated new
     # session reusing a name), moving would steal the living session's state. A dead sid left in the
     # lists is inert; the normalizer keeps them bounded.
-    if old_sid in v["hidden"]:
-        v["hidden"] = sorted(set(v["hidden"]) | {new_sid})
     for t in v["tags"]:
         if _has(t):
             t["members"] = t["members"] + [{"host": "", "sid": new_sid}]   # normalizer dedups + re-sorts

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -84,7 +84,7 @@ class TagRoute(unittest.TestCase):
     def test_get_views_serves_the_normalized_default(self):
         st, v = self._views()
         self.assertEqual(st, 200)
-        self.assertEqual(v, {"active": "all", "hidden": [], "tags": []})
+        self.assertEqual(v, {"active": "all", "tags": []})
 
     def test_create_resolves_a_live_name_and_mints_the_ui_id_shape(self):
         st, r = self._post({"name": "pool", "add": ["web"]})
@@ -196,14 +196,14 @@ class TagRoute(unittest.TestCase):
 
     def test_an_edit_merges_and_never_clobbers_the_rest_of_the_blob(self):
         GB = {"id": "gb", "name": "beta", "color": "#DD42FF", "members": ["s2"]}
-        km._set_timeline_views({"active": "gb", "hidden": ["s9"], "tags": [
+        km._set_timeline_views({"active": "gb", "tags": [
             {"id": "ga", "name": "alpha", "color": "", "members": ["s1"]}, GB]})
         km._flags_cache.clear()
         st, r = self._post({"name": "alpha", "add": ["api"]})
         self.assertTrue(r.get("ok"), r)
         st, v = self._views()
         self.assertEqual(v["active"], "gb", "the active view survives the merge")
-        self.assertEqual(v["hidden"], ["s9"], "the hidden list survives")
+        self.assertNotIn("hidden", v, "the hidden key is retired (2026-08-24) — never re-minted by an edit")
         want = dict(GB, members=[{"host": "", "sid": "s2"}])
         self.assertEqual([g for g in v["tags"] if g["id"] == "gb"], [want],
                          "the tag the edit never looked at is untouched (stored as pairs)")

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Session views (the user 2026-08-18; TAG model 2026-08-23): one timeline-views.json blob under
-STATE — {"active", "hidden", "tags"} — deciding which sessions show on the timeline lanes AND the
+STATE — {"active", "tags"} (the hidden set retired 2026-08-24, migrated into an "archived" tag) — deciding which sessions show on the timeline lanes AND the
 chat tab strip. TWO built-in sentinels: "all" — the DEFAULT (2026-08-24) — shows every session
-minus the hidden set; "untagged" keeps the old default's meaning (a TAG marks a SPECIALIZED
+(literally everything since 2026-08-24); "untagged" keeps the old default's meaning (a TAG marks a SPECIALIZED
 session, excluded from the untagged view and shown under its tag views). "all" used to MEAN
-untagged, so reinterpreting it lands every legacy blob on the new All default. A tagged or hidden
+untagged, so reinterpreting it lands every legacy blob on the new All default. A tagged
 session is a BACKGROUND session: still judged and carded, surfaced by the feed, the pickers, and
 the "N more" cue. The legacy "groups" key (pre-rename files and un-updated panels) reads as tags.
 Local-kernel persisted (a viewer display pref, not federated). These pin the storage helpers, the
@@ -44,16 +44,16 @@ class TimelineViews(unittest.TestCase):
         # fresh blobs open on "all" — and since 2026-08-24 that sentinel means truly-ALL, so a
         # legacy blob persisted when "all" meant untagged lands on the new default automatically
         v = km._timeline_views()
-        self.assertEqual(v, {"active": "all", "hidden": [], "tags": []})
+        self.assertEqual(v, {"active": "all", "tags": []})
         self.assertTrue(km._view_visible(v, "anything"))
 
     def test_all_shows_every_session_and_untagged_the_tagless_ones(self):
-        # ALL — the default (the user 2026-08-24) — is every session minus the hidden set: hiding is
-        # a deliberate gesture, so All respects it, but a tag no longer excludes a session there
+        # ALL — the default — shows LITERALLY EVERYTHING (the user 2026-08-24, retiring the hidden
+        # set outright: the tag system covers backgrounding); a legacy hidden key is ignored
         km._set_timeline_views({"active": "all", "hidden": ["s9"], "tags": [G1]})
         km._flags_cache.clear()
         v = km._views_client()   # _view_visible reads the RENDERED shape (string members + remoteTags)
-        self.assertFalse(km._view_visible(v, "s9"), "hidden — All respects the deliberate hide")
+        self.assertTrue(km._view_visible(v, "s9"), "a legacy hidden entry is IGNORED — nothing hides from All")
         self.assertTrue(km._view_visible(v, "s2"), "TAGGED → All still shows it")
         self.assertTrue(km._view_visible(v, "s1"), "untagged → shown")
         # the untagged view keeps the old default's meaning under its own sentinel (the user
@@ -62,13 +62,13 @@ class TimelineViews(unittest.TestCase):
         km._flags_cache.clear()
         v = km._views_client()
         self.assertEqual(v["active"], "untagged", "the sentinel survives the normalizer round-trip")
-        self.assertFalse(km._view_visible(v, "s9"), "hidden hides in the untagged view too")
+        self.assertTrue(km._view_visible(v, "s9"), "…and legacy hidden does not hide in untagged either")
         self.assertFalse(km._view_visible(v, "s2"), "TAGGED → out of the untagged view")
-        self.assertTrue(km._view_visible(v, "s1"), "tagless, not hidden → shown")
+        self.assertTrue(km._view_visible(v, "s1"), "tagless → shown")
         km._set_timeline_views({"active": "g1", "hidden": ["s2"], "tags": [G1]})
         km._flags_cache.clear()
         v = km._views_client()
-        self.assertTrue(km._view_visible(v, "s2"), "a tag view shows exactly its members — hidden or not")
+        self.assertTrue(km._view_visible(v, "s2"), "a tag view shows exactly its members")
         self.assertFalse(km._view_visible(v, "s1"), "…and nothing else")
 
     def test_legacy_groups_key_reads_as_tags(self):
@@ -87,7 +87,7 @@ class TimelineViews(unittest.TestCase):
                                      "tags": [{"id": "g1", "name": "x" * 99, "members": ["m", 3]},
                                               {"noid": True}, "junk"]})
         self.assertEqual(km._norm_timeline_views({"hidden": 7, "tags": "nope"}),
-                         {"active": "all", "hidden": [], "tags": []},
+                         {"active": "all", "tags": []},
                          "wrong-TYPED fields drop instead of raising")
         self.assertEqual(km._norm_timeline_views({"tags": [{"id": "g", "members": 3}]})["tags"][0]["members"],
                          [], "a wrong-typed members list drops, never raises")
@@ -95,27 +95,26 @@ class TimelineViews(unittest.TestCase):
         self.assertEqual(km._norm_timeline_views({"active": "untagged"})["active"], "untagged",
                          "the untagged sentinel passes the whitelist — a rewrite here is SILENT and"
                          " reads as flicker after the client's optimistic hold expires")
-        self.assertEqual(v["hidden"], ["a"], "junk and duplicates dropped")
+        self.assertNotIn("hidden", v, "a legacy hidden key is dropped outright (retired 2026-08-24)")
         self.assertEqual(len(v["tags"]), 1)
         self.assertEqual(len(v["tags"][0]["name"]), km._VIEWS_MAX_NAME)
         self.assertEqual(v["tags"][0]["members"], [{"host": "", "sid": "m"}])
 
     def test_cache_invalidates_on_write(self):
-        self.assertEqual(km._timeline_views()["hidden"], [])
-        km._set_timeline_views({"hidden": ["s9"]})
-        self.assertEqual(km._timeline_views()["hidden"], ["s9"], "mtime+size key sees the write")
+        self.assertEqual(km._timeline_views()["tags"], [])
+        km._set_timeline_views({"tags": [{"id": "g9", "name": "pool", "members": ["s9"]}]})
+        self.assertEqual([t["id"] for t in km._timeline_views()["tags"]], ["g9"], "mtime+size key sees the write")
 
-    def test_churn_heal_copies_hidden_and_membership(self):
-        # COPY, never move: stripping the old sid un-hid its dead lane (it lingers on the timeline for
-        # hours), and a still-alive same-name session would have its state stolen
-        km._set_timeline_views({"active": "all", "hidden": ["old"], "tags": [
+    def test_churn_heal_copies_membership(self):
+        # COPY, never move (the hidden half retired with the set, 2026-08-24): a still-alive
+        # same-name session would have its state stolen by a move
+        km._set_timeline_views({"active": "all", "tags": [
             {"id": "g1", "name": "pool", "members": ["old", "other"]}]})
         km._heal_timeline_views("old", "new")
         v = km._timeline_views()
-        self.assertEqual(v["hidden"], ["new", "old"], "the fork inherits the hidden bit; the old sid keeps it")
         self.assertEqual(v["tags"][0]["members"],
                          [{"host": "", "sid": x} for x in ("new", "old", "other")],
-                         "membership copies the same way")
+                         "the fork inherits membership; the old sid keeps it")
         before = json.loads((jd.STATE / "timeline-views.json").read_text())
         km._heal_timeline_views("stranger", "new2")   # untouched sid → no write at all
         self.assertEqual(json.loads((jd.STATE / "timeline-views.json").read_text()), before)
@@ -125,9 +124,39 @@ class TimelineViews(unittest.TestCase):
         km._write_session_order(["old"])
         (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
         (jd.STATE / "names" / "old").write_text("web\t/tmp\t#123456\twhite\n")
-        km._set_timeline_views({"active": "all", "hidden": ["old"], "tags": []})
+        km._set_timeline_views({"active": "all", "tags": [{"id": "g1", "name": "pool", "members": ["old"]}]})
         km._ordered([{"sid": "old", "name": "web"}, {"sid": "new", "name": "web"}])
-        self.assertEqual(km._timeline_views()["hidden"], ["new", "old"], "copied, so the dead lane stays hidden too")
+        self.assertEqual(km._timeline_views()["tags"][0]["members"],
+                         [{"host": "", "sid": "new"}, {"host": "", "sid": "old"}],
+                         "membership copied, so the fork keeps its tag")
+
+    def test_stored_hidden_entries_migrate_into_the_archived_tag_once(self):
+        # the ONE-TIME MIGRATION (the user 2026-08-24, retiring hide-from-chat outright): a blob
+        # persisted by the pre-retirement normalizer still carries hidden entries — the first read
+        # maps them into an "archived" tag (muted color), drops the key, and persists; they show
+        # under All (nothing hides from All now) and stay out of the untagged view.
+        raw = {"active": "all", "hidden": ["s7", "s8"], "tags": [{"id": "g1", "name": "pool", "members": ["s2"]}]}
+        (jd.STATE / "timeline-views.json").write_text(json.dumps(raw))
+        km._flags_cache.clear()
+        v = km._timeline_views()
+        self.assertNotIn("hidden", v)
+        arch = next(t for t in v["tags"] if t["name"] == "archived")
+        self.assertEqual(arch["members"], [{"host": "", "sid": "s7"}, {"host": "", "sid": "s8"}])
+        self.assertEqual(arch["color"], "#6b7280", "a muted slate — never a status color")
+        on_disk = json.loads((jd.STATE / "timeline-views.json").read_text())
+        self.assertNotIn("hidden", on_disk, "the mapping persisted — the next read has nothing to migrate")
+        rendered = km._views_client()   # _view_visible reads the RENDERED shape (string members)
+        self.assertTrue(km._view_visible(rendered, "s7"), "archived sessions SHOW under All")
+        self.assertFalse(km._view_visible(dict(rendered, active="untagged"), "s7"), "…and stay out of untagged (tagged now)")
+        # idempotent: a second read (fresh cache) neither duplicates members nor re-mints the tag
+        km._flags_cache.clear()
+        v2 = km._timeline_views()
+        self.assertEqual([t["name"] for t in v2["tags"]].count("archived"), 1)
+        self.assertEqual(next(t for t in v2["tags"] if t["name"] == "archived")["members"], arch["members"])
+        # an install with NO hidden entries never mints the tag
+        (jd.STATE / "timeline-views.json").write_text(json.dumps({"active": "all", "tags": []}))
+        km._flags_cache.clear()
+        self.assertEqual(km._timeline_views()["tags"], [], "minted only when hidden entries exist")
 
     def test_ws_op_persists_via_normalizer(self):
         # the handler body is _set_timeline_views + _mark_views_dirty; pin the setter's normalization
@@ -244,9 +273,9 @@ class TimelineViews(unittest.TestCase):
                              "the cached read stands while the kernel reconnects")
             # a remote-tag ACTIVE survives normalization (validated at read time, ":" is the marker);
             # hidden stays exactly the viewer-local list — neither is federated state
-            n = km._norm_timeline_views({"active": "alpha:g1", "hidden": ["h1"], "tags": []})
+            n = km._norm_timeline_views({"active": "alpha:g1", "hidden": ["h1"], "tags": []})   # legacy hidden: dropped below
             self.assertEqual(n["active"], "alpha:g1")
-            self.assertEqual(n["hidden"], ["h1"])
+            self.assertNotIn("hidden", n, "legacy hidden dropped (retired 2026-08-24); active stays local")
             # a client echoing the derived remoteTags back never persists it
             n2 = km._norm_timeline_views({"active": "all", "remoteTags": [{"id": "x"}], "tags": []})
             self.assertNotIn("remoteTags", n2)

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -26,20 +26,18 @@ function _rompOnlyTag() {
 }
 // <tag> may be a comma-separated LIST (`#only=api,tests,web`) so demo sessions need no shared
 // on-camera prefix (the user 2026-07-16). Mirrors ui/webview/only-filter.ts's matchesOnly.
-// ── session VIEWS (the user 2026-08-18): which sessions the lanes — and the chat tab strip — show.
-// {active:"all"|"untagged"|gid, hidden:[id...], tags:[{id,name,color,members:[id...]}]},
+// ── session VIEWS (the user 2026-08-18; the hidden set RETIRED outright 2026-08-24 — the tag
+// system covers backgrounding, and the kernel migrated existing hidden entries into an "archived"
+// tag once): {active:"all"|"untagged"|gid, tags:[{id,name,color,members:[id...]}]},
 // kernel-persisted (timeline-views.json) and echoed on every payload as data.views. TWO built-in
-// sentinels, not tags: "all" — the DEFAULT (the user 2026-08-24) — shows every session minus the
-// `hidden` set (hiding is a deliberate gesture, so All respects it); "untagged" keeps the old
-// default's meaning under its own honest name — a TAG marks a SPECIALIZED session (the user
-// 2026-08-23), excluded from the untagged view and shown under its tag views (independent member
-// lists, multi-membership by construction). "all" used to MEAN untagged, so reinterpreting it as
-// truly-all lands every legacy persisted blob on the new All default with no migration. A tag view
-// shows exactly its members — membership beats the hidden bit. A hidden session is a BACKGROUND
-// session — still judged and carded, surfaced by the feed and the pickers. The kernel's
-// _view_visible is the decision of record; this is its mirror for the lanes. The kernel emits
-// `tags`; `groups` is honored as the pre-rename key an un-updated kernel still pushes, in ONE
-// place so every rule reads through it.
+// sentinels, not tags: "all" — the DEFAULT — shows LITERALLY EVERYTHING (that is All's meaning
+// now; nothing can hide from it); "untagged" keeps the old default's meaning under its own honest
+// name — a TAG marks a SPECIALIZED session (the user 2026-08-23), excluded from the untagged view
+// and shown under its tag views (independent member lists, multi-membership by construction). A
+// tag view shows exactly its members. A tagged session is a BACKGROUND session — still judged and
+// carded, surfaced by the feed and the pickers. The kernel's _view_visible is the decision of
+// record; this is its mirror for the lanes. The kernel emits `tags`; `groups` is honored as the
+// pre-rename key an un-updated kernel still pushes, in ONE place so every rule reads through it.
 function viewTags(views) { return (views && (views.tags || views.groups)) || []; }
 // A tag IS its NAME, everywhere (user ruling 2026-08-24: "if the UX requires understanding that
 // tags exist across different kernels, it is not good"): one name = one identity, membership the
@@ -70,10 +68,9 @@ function viewTagUnion(views) {
 }
 function viewVisible(views, id) {
   if (!views || !views.active || views.active === 'all') {
-    return !(views && Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0);
+    return true;                                   // All = literally everything (hidden retired 2026-08-24)
   }
   if (views.active === 'untagged') {
-    if (Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0) return false;
     // the UNION excludes (the user 2026-08-24): a session held by ANY kernel's tag is tagged —
     // a remote-homed tag pulls it out of untagged exactly like a local one
     return !viewTags(views).concat((views && views.remoteTags) || []).some((t) => (t.members || []).indexOf(id) >= 0);
@@ -89,19 +86,13 @@ function viewLabel(views) {
   const g = viewTagUnion(views).find((x) => x.ids.indexOf(views.active) >= 0);
   return g ? g.name : 'All';   // the NAME, never a host prefix — kernels are plumbing
 }
-// live sessions the current view is NOT showing — the "N more" cue that keeps a hidden or tagged
-// session exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
+// live sessions the current view is NOT showing (tag-filtered) — the "N more" cue that keeps a
+// backgrounded session exactly one glance away (nothing may run in secret: the 2026-08-11 rule)
 function viewMoreCount(views, sessions) {
   return (sessions || []).filter((s) => s.live && !viewVisible(views, s.id)).length;
 }
-// the dialog's two pure mutations (executed by tests; the dialog itself only wires DOM):
-// the hidden bit (the manual one-off hide), and membership in one tag alone
-function viewToggleHidden(views, id) {
-  const v = JSON.parse(JSON.stringify(views || {}));
-  const i = (v.hidden || []).indexOf(id);
-  if (i >= 0) v.hidden.splice(i, 1); else (v.hidden = v.hidden || []).push(id);
-  return v;
-}
+// the dialog's pure mutation (executed by tests; the dialog itself only wires DOM): membership in
+// one tag alone. (the hide toggle retired with the hidden set, the user 2026-08-24.)
 function viewToggleMember(views, gid, id) {
   const v = JSON.parse(JSON.stringify(views || {}));
   const g = viewTags(v).find((x) => x.id === gid);
@@ -2971,15 +2962,9 @@ class TimelinePanel {
             fic.addEventListener('mouseleave', () => { fic.style.opacity = on ? '' : '0.55'; });
             feedCell.appendChild(fic);
           }
-          // EYE — only on a hidden session, to un-hide (hiding lives on the chat tab)
-          const eyeCell = grid.createDiv();
-          if (((vv.hidden || [])).indexOf(s.id) >= 0) {
-            const eye = eyeCell.createSpan({ text: '⌀' });
-            eye.setAttribute('style', 'cursor:pointer;opacity:0.6;');
-            hover(eye, 'opacity:1;', 'opacity:0.6;');
-            eye.setAttribute('title', 'hidden from the All and (untagged) views — click to show it again');
-            eye.addEventListener('click', () => { this._setViews(viewToggleHidden(this._curViews(), s.id)); build(); });
-          }
+          // (the un-hide EYE retired with the hidden set, the user 2026-08-24 — tags cover
+          // backgrounding, and the kernel migrated existing hidden entries into "archived")
+          grid.createDiv();
           if (this._tagAddFor === s.id) addMenu([s.id]);
         }
       };
@@ -4406,4 +4391,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember, viewTagUnion };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion };

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -77,7 +77,7 @@ function synthData(): any {
     now,
     sessions: [sess("SA", "ada", "#f7768e"), sess("SB", "bee", "#7aa2f7"), sess("SC", "cee", "#9ece6a"), sess("SD", "dee", "#bb9af7")],
     turns: { SB: [turn("SB:1:aa", 300, 60)], SD: [turn("SD:1:bb", 250, 40)] },
-    views: { active: "all", hidden: ["SA", "SC"], tags: [] },
+    views: { active: "untagged", hidden: [], tags: [{ id: "gx", name: "pool", color: "", members: ["SA", "SC"] }] },   // tag-hidden (the hidden set retired 2026-08-24)
     messages: [], activeChat: null, focus: null, hover: null, usage: null,
   };
 }

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -1,6 +1,6 @@
 // The timeline's corner control panel (the user 2026-08-18; filter-chip form + TAG model
 // 2026-08-23): "Filter ▾" in the bottom-left corner — the strip under the lane gutter, left of the
-// time labels. The dropdown picks the active VIEW (All — every session minus hidden, the default
+// time labels. The dropdown picks the active VIEW (All — literally everything, the default
 // since 2026-08-24 — / the (untagged) built-in / the named tags),
 // holds New tag… / Sessions & tags…, and carries the two timeline display toggles (collapse idle
 // gaps, active only) so they finally work in every host. The dialog is TAG-CENTRIC: one row per
@@ -16,20 +16,20 @@ import { createRequire } from "node:module";
 const requireCjs = createRequire(__filename);
 const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
 const SRC = fs.readFileSync(VIEW_PATH, "utf8");
-const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember, viewTagUnion } = requireCjs(VIEW_PATH);
+const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion } = requireCjs(VIEW_PATH);
 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2", "s3"] };
 const V = (active: string, hidden: string[] = [], tags: any[] = [G]) => ({ active, hidden, tags });
 
-test("executed: All shows every session minus hidden; untagged the tagless; a tag view its members", () => {
+test("executed: All shows literally everything (hidden retired 2026-08-24); untagged the tagless; a tag view its members", () => {
   assert.equal(viewVisible(null, "s1"), true, "no blob yet → everything shows");
-  assert.equal(viewVisible(V("all", ["s9"]), "s9"), false, "hidden — All respects the deliberate hide");
+  assert.equal(viewVisible(V("all", ["s9"]), "s9"), true, "a legacy hidden entry is IGNORED — nothing hides from All (the user 2026-08-24)");
   assert.equal(viewVisible(V("all"), "s2"), true, "TAGGED → All still shows it (the user 2026-08-24)");
   assert.equal(viewVisible(V("all"), "s1"), true, "untagged → shown");
-  assert.equal(viewVisible(V("untagged", ["s9"]), "s9"), false, "hidden hides in the untagged view too");
+  assert.equal(viewVisible(V("untagged", ["s9"]), "s9"), true, "…and legacy hidden does not hide in untagged either");
   assert.equal(viewVisible(V("untagged"), "s2"), false, "TAGGED → out of the untagged view (the user 2026-08-23)");
   assert.equal(viewVisible(V("untagged"), "s1"), true, "tagless → the untagged view shows it");
-  assert.equal(viewVisible(V("g1", ["s2"]), "s2"), true, "a tag view shows its members, hidden or not");
+  assert.equal(viewVisible(V("g1", ["s2"]), "s2"), true, "a tag view shows its members");
   assert.equal(viewVisible(V("g1"), "s1"), false, "a tag view shows exactly its members");
   assert.equal(viewVisible(V("ghost", [], []), "s1"), true, "an orphaned active falls back open");
   assert.equal(viewVisible({ active: "untagged", groups: [G] }, "s2"), false,
@@ -37,15 +37,15 @@ test("executed: All shows every session minus hidden; untagged the tagless; a ta
 });
 
 test("executed: the trigger label and the N-more cue (live sessions outside the view)", () => {
-  // the views are named for what they show: "All" (every session minus hidden — the default since
+  // the views are named for what they show: "All" (literally everything — the hidden set retired
   // 2026-08-24) and "(untagged)", parenthesized as the built-in it is
   assert.equal(viewLabel(null), "All");
   assert.equal(viewLabel(V("untagged")), "(untagged)");
   assert.equal(viewLabel(V("g1")), "pool");
   const sessions = [{ id: "s1", live: true }, { id: "s2", live: true }, { id: "s4", live: false }];
   assert.equal(viewMoreCount(V("g1"), sessions), 1, "s1 is live and outside; dead s4 never counts");
-  assert.equal(viewMoreCount(V("all", ["s1"]), sessions), 1, "hidden live s1 counts under All; tagged s2 shows now");
-  assert.equal(viewMoreCount(V("untagged", ["s1"]), sessions), 2, "hidden s1 AND tagged s2 sit outside untagged");
+  assert.equal(viewMoreCount(V("all", ["s1"]), sessions), 0, "NOTHING sits outside All — legacy hidden ignored");
+  assert.equal(viewMoreCount(V("untagged", ["s1"]), sessions), 1, "tagged s2 sits outside untagged; legacy-hidden s1 shows");
 });
 
 test("executed: an optimistic edit holds until the kernel echoes it — then yields to authority", () => {
@@ -144,7 +144,7 @@ test("the dropdown and dialog wear the shared menu vocabulary and adopt into the
 });
 
 test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2026-08-24, JLD-designed)", () => {
-  // one grid, columns [name | chips | + | feed | eye] — the [+] column's ALIGNMENT carries the
+  // one grid, columns [name | chips | + | feed | (spare)] — the un-hide eye retired 2026-08-24; the [+] column's ALIGNMENT carries the
   // table structure (JLD: sequence in space suggests structure)
   assert.match(SRC, /grid-template-columns:max-content 1fr max-content max-content max-content;/);
   // the session NAME wears its identity colour directly (JLD: label directly, never a legend-like
@@ -172,8 +172,8 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
     "chip ✕ = remove-everywhere, through the one dispatcher");
   assert.match(SRC, /ni\.placeholder = 'new tag…';/, "minting a tag right from a row or the bulk bar");
   assert.match(SRC, /delete nv\.groups;/, "a write normalizes onto the tags key, never re-emitting the legacy one");
-  // the eye-off appears ONLY on a hidden session, to un-hide it (hiding lives on the chat tab)
-  assert.match(SRC, /if \(\(\(vv\.hidden \|\| \[\]\)\)\.indexOf\(s\.id\) >= 0\) \{/);
+  // (the un-hide eye retired with the hidden set, the user 2026-08-24 — tags cover backgrounding)
+  assert.doesNotMatch(SRC, /viewToggleHidden/);
   // the feed toggle still rides every live row (the user 2026-08-19 pool-builder rule), aligned in
   // its own column; NOT auto-coupled to membership.
   assert.match(SRC, /const ft = LANE_TOGGLES\.find\(\(t\) => t\.flag === 'hideFromFeed'\);/);
@@ -234,13 +234,12 @@ test("_setViews posts through the host hook with a GUARDED, atomic Obsidian fall
   assert.match(SRC, /this\._reconcileViews\(\);\s*\/\/ \.\.\.and an optimistic view edit/);
 });
 
-test("executed: the dialog's two checkbox mutations, pure", () => {
-  const v = { active: "all", hidden: ["a"], tags: [{ id: "g1", members: ["m"] }] };
-  assert.deepEqual(viewToggleHidden(v, "a").hidden, [], "unhide");
-  assert.deepEqual(viewToggleHidden(v, "b").hidden, ["a", "b"], "hide");
+test("executed: the dialog's membership mutation, pure (viewToggleHidden retired 2026-08-24 with the hidden set)", () => {
+  const v = { active: "all", tags: [{ id: "g1", members: ["m"] }] };
   assert.deepEqual(viewToggleMember(v, "g1", "m").tags[0].members, [], "leave");
   assert.deepEqual(viewToggleMember(v, "g1", "n").tags[0].members, ["m", "n"], "join");
   assert.deepEqual(viewToggleMember(v, "ghost", "n"), v, "an unknown tag mutates nothing");
+  assert.ok(!("viewToggleHidden" in requireCjs(VIEW_PATH)), "the hide mutation is gone from the exports");
 });
 
 test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {

--- a/ui/webview/feed-view.test.ts
+++ b/ui/webview/feed-view.test.ts
@@ -26,12 +26,14 @@ test("no views blob (an older kernel) → today's behavior, byte-identical: noth
   assert.equal(outsideViewCount(null, [{ sid: U, needsYou: false }]), 0);
 });
 
-test("the All view shows everything except the manual hidden set — and hidden still breaks through", () => {
-  const views: SessionViews = { active: "all", hidden: [V] };
-  assert.equal(cardInView(views, U, false), true);
-  assert.equal(cardInView(views, V, false), false, "manually hidden — off the board");
-  assert.equal(cardInView(views, V, true), true, "…until it needs the human (the interrupt rule)");
-  assert.equal(outsideView(views, V), true, "and then it wears the outside-view cue");
+test("All shows literally everything (hidden retired 2026-08-24); a tag-filtered card still breaks through", () => {
+  // a legacy hidden entry no longer hides anywhere — the tag system covers backgrounding
+  assert.equal(cardInView({ active: "all", hidden: [V] }, V, false), true, "legacy hidden ignored under All");
+  const tagged: SessionViews = { active: "untagged", tags: [{ id: "t9", name: "pool", members: [V] }] };
+  assert.equal(cardInView(tagged, U, false), true);
+  assert.equal(cardInView(tagged, V, false), false, "tagged — out of the untagged board");
+  assert.equal(cardInView(tagged, V, true), true, "…until it needs the human (the interrupt rule)");
+  assert.equal(outsideView(tagged, V), true, "and then it wears the outside-view cue");
 });
 
 test("untagged view: BOTH tag homes exclude — a local tag and a remote-homed tag alike (the union fix)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13,7 +13,7 @@ import diff from "highlight.js/lib/languages/diff";
 import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
-import { SessionViews, viewVisible, viewsKey, hideIn, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
+import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
@@ -488,7 +488,7 @@ function postViews(v: SessionViews) {
 // dressed .tab-peek ("breaks the view's rules") — and auto-closing: activating any other tab drops
 // it, no explicit close. Per-dashboard client state like the pending-views copy above: never
 // persisted, never federated, never written to timeline-views.json — a click is a peek, not a view
-// edit (the picker's "Hidden — reveal" row keeps the real unhide). Sending a message from a peeked
+// edit (the picker's other-view row jumps views instead — the hidden set retired 2026-08-24). Sending a message from a peeked
 // session does NOT pin it: the peek still drops on click-away, and the session stays reachable via
 // the feed and the nav trail. Nav history stores only the sid — back/forward lands in setActive
 // like every activation, which re-derives peek-vs-normal from the CURRENT views (a since-revealed
@@ -4526,10 +4526,9 @@ function showTabMenu(e: MouseEvent, id: string) {
     onBell ? "Stop notifying" : "Notify me",
     onBell ? "no more system notifications for this session" : "system notification when its work blocks on you or completes",
     () => setSessionFlag(id, "notify", !onBell));
-  // (The hide-session item left this menu 2026-08-24 — the user: the tag/view system
-  // covers backgrounding a session. The MECHANISM stands untouched underneath: hideIn/revealIn, the
-  // views blob's hidden set, the timeline dialog's eye, and the + picker's "Hidden — reveal" section
-  // all remain; whether to retire the machinery outright is the user's separate call.)
+  // (The hide-session mechanism is fully RETIRED, the user 2026-08-24 — the tag system covers
+  // backgrounding; the kernel migrated existing hidden entries into the "archived" tag. revealIn
+  // survives for the picker's tagged-session jump.)
   // Billing submenu (the user 2026-08-09, who wants the login/API-key switch here rather than as a
   // statusline badge). Only when the machine offers BOTH choices (st.authBoth) — a one-auth machine
   // keeps the fact on the tab hover, never a dead selector — and the key stays labelled plainly
@@ -6940,8 +6939,8 @@ function renderPicker(items: any[]) {
     name.replaceChildren(...hostNameNodes(it.name, it.id));
     if (it.color && it.color.bg) name.style.color = it.color.bg;
     const time = el("span", "picker-time");
-    if (it.hiddenTab) {   // open as a tab but view-hidden (a background session) → picking reveals it
-      time.textContent = "hidden";
+    if (it.hiddenTab) {   // open as a tab but filtered out of the CURRENT view (tagged) → picking jumps to its view
+      time.textContent = "other view";
       time.style.opacity = "0.7";
     } else if (it.running) {   // a live session (SDK/tmux backend) whose tab is closed → a green "running" badge
       time.classList.add("picker-running-badge");
@@ -6962,7 +6961,7 @@ function renderPicker(items: any[]) {
         if (vscodeApi) vscodeApi.postMessage({ type: "pickResult", id: it.id, name: it.name });
         pickMode = false; // so closePicker doesn't also post a cancel
       } else if (it.hiddenTab) {
-        revealSession(it.id);   // its tab already exists — un-hide it and switch to it
+        revealSession(it.id);   // its tab already exists — switch to a view that shows it (revealIn, post-retirement)
         setActive(it.id);
       } else if (vscodeApi) {
         vscodeApi.postMessage({ type: "openSession", id: it.id });
@@ -6980,15 +6979,16 @@ function renderPicker(items: any[]) {
     for (const it of items) list.appendChild(mkRow(it));
   } else {
     const avail = items.filter((it) => !isOpenTab(it.id));
-    // open-as-tab but view-HIDDEN sessions still list (the user 2026-08-18): a background session's
-    // one visible home on the chat side — omitting them here plus hiding the tab would recreate the
-    // secret-running-session state abolished 2026-08-11
+    // open-as-tab but filtered out of the CURRENT view (tagged; the hidden set retired 2026-08-24)
+    // still list (the user 2026-08-18): a background session's one visible home on the chat side —
+    // omitting them here plus the tab being out of view would recreate the secret-running-session
+    // state abolished 2026-08-11
     const hidden = items.filter((it) => isOpenTab(it.id) && !tabInView(it.id))
                         .map((it) => Object.assign({}, it, { hiddenTab: true }));
     const running = avail.filter((it) => it.running);
     const rest = avail.filter((it) => !it.running);
     if (running.length) { list.appendChild(label("Running — reopen")); for (const it of running) list.appendChild(mkRow(it)); }
-    if (hidden.length) { list.appendChild(label("Hidden — reveal")); for (const it of hidden) list.appendChild(mkRow(it)); }
+    if (hidden.length) { list.appendChild(label("In another view — open")); for (const it of hidden) list.appendChild(mkRow(it)); }
     if (rest.length) { if (running.length || hidden.length) list.appendChild(label("Recent")); for (const it of rest) list.appendChild(mkRow(it)); }
   }
   if (!list.children.length && pickerListHost) {

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -1,8 +1,8 @@
 // Session views on the chat side (the user 2026-08-18; TAG model 2026-08-23; ALL default
 // 2026-08-24): the kernel's views blob — echoed on every tabOrder push — gates which sessions get
-// TABS. Two built-in sentinels: "all" — the default — shows every session minus the hidden set;
+// TABS. Two built-in sentinels: "all" — the default — shows LITERALLY EVERYTHING (the hidden set retired 2026-08-24);
 // "untagged" keeps the old default's meaning (a tag marks a specialized session, excluded from the
-// untagged view and shown under its tag views). A hidden session is a BACKGROUND session: still running, judged,
+// untagged view and shown under its tag views). A tagged session is a BACKGROUND session: still running, judged,
 // carded; the + picker lists it under "Hidden — reveal" and the timeline's corner panel counts it,
 // so nothing runs in secret (the 2026-08-11 rule this feature deliberately carves an exception
 // into, keeping its spirit). Executed tests on the pure module + source pins.
@@ -10,21 +10,21 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { viewVisible, viewsKey, hideIn, revealIn } from "../../ui/webview/session-views";
+import { viewVisible, viewsKey, revealIn } from "../../ui/webview/session-views";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2"] };
 
-test("executed: All shows every session minus hidden; untagged the tagless; a tag view its members", () => {
+test("executed: All shows literally everything (hidden retired 2026-08-24); untagged the tagless; a tag view its members", () => {
   assert.equal(viewVisible(null, "s1"), true);
-  assert.equal(viewVisible({ active: "all", hidden: ["s1"] }, "s1"), false, "All respects the deliberate hide");
+  assert.equal(viewVisible({ active: "all", hidden: ["s1"] }, "s1"), true, "a legacy hidden entry is IGNORED — nothing hides from All (the user 2026-08-24)");
   assert.equal(viewVisible({ active: "all", tags: [G] }, "s2"), true, "TAGGED → All still shows it (2026-08-24)");
   assert.equal(viewVisible({ active: "all", tags: [G] }, "s1"), true, "untagged → shown");
   assert.equal(viewVisible({ active: "untagged", tags: [G] }, "s2"), false, "TAGGED → out of the untagged view");
   assert.equal(viewVisible({ active: "untagged", tags: [G] }, "s1"), true, "tagless → the untagged view shows it");
-  assert.equal(viewVisible({ active: "untagged", hidden: ["s1"], tags: [G] }, "s1"), false, "hidden hides there too");
-  assert.equal(viewVisible({ active: "g1", hidden: ["s2"], tags: [G] }, "s2"), true, "a tag view shows its members, hidden or not");
+  assert.equal(viewVisible({ active: "untagged", hidden: ["s1"], tags: [G] }, "s1"), true, "…and a legacy hidden entry does not hide in untagged either — only membership excludes");
+  assert.equal(viewVisible({ active: "g1", hidden: ["s2"], tags: [G] }, "s2"), true, "a tag view shows its members");
   assert.equal(viewVisible({ active: "g1", tags: [G] }, "s1"), false);
   assert.equal(viewVisible({ active: "gone", tags: [] }, "s1"), true, "an orphaned active fails open");
   // the pre-rename key an un-updated kernel still pushes reads identically
@@ -32,40 +32,19 @@ test("executed: All shows every session minus hidden; untagged the tagless; a ta
   assert.equal(viewVisible({ active: "g1", groups: [G] }, "s2"), true);
 });
 
-test("executed: hide sets the one-off bit (and leaves the active tag); reveal SWITCHES views", () => {
-  const hid = hideIn({ active: "all", hidden: [] }, "s1");
-  assert.deepEqual(hid.hidden, ["s1"], "hiding = the manual one-off hide");
-  assert.deepEqual(hideIn(hid, "s1").hidden, ["s1"], "idempotent");
-  // hiding while a tag that CONTAINS the session is active must also leave that tag — the tag view
-  // shows its members however hidden they are, so without this the gesture is a silent no-op
-  const g = hideIn({ active: "g1", hidden: [], tags: [{ id: "g1", members: ["s2", "s3"] }, { id: "g2", members: ["s2"] }] }, "s2");
-  assert.deepEqual(g.hidden, ["s2"]);
-  assert.deepEqual(g.tags![0].members, ["s3"], "dropped from the ACTIVE tag");
-  assert.deepEqual(g.tags![1].members, ["s2"], "other tags keep it — multi-tag membership");
-  // reveal never mutates membership (re-grounded 2026-08-23: peeking at a tagged worker must not
-  // strip its tag) — it lands on a visible tab with the MINIMAL move (ALL default 2026-08-24)
-  const rev = revealIn({ active: "g1", hidden: [], tags: [G] }, "s1");
+test("executed: reveal SWITCHES views, never mutates membership (hideIn retired 2026-08-24)", () => {
+  // the hide gesture is GONE with the hidden set (the user 2026-08-24: the tag system covers
+  // backgrounding; the kernel migrated existing entries into "archived"). revealIn survives for the
+  // picker's jump: minimal move, membership untouched (2026-08-23 — a peek never strips a tag).
+  const rev = revealIn({ active: "g1", tags: [G] }, "s1");
   assert.equal(rev.active, "all", "tagless session from a tag view → land on All, the default");
-  assert.deepEqual(rev.hidden, [], "…and nothing edited");
-  const rev2 = revealIn({ active: "untagged", hidden: [], tags: [G] }, "s2");
+  const rev2 = revealIn({ active: "untagged", tags: [G] }, "s2");
   assert.equal(rev2.active, "g1", "tagged → its holder tag is its home view");
-  assert.deepEqual(rev2.tags![0].members, ["s2"], "membership untouched — the peek never strips a tag");
-  const revAll = revealIn({ active: "all", hidden: [], tags: [G] }, "s2");
-  assert.equal(revAll.active, "all", "tagged is VISIBLE under All → nothing changes at all");
-  const revHid = revealIn({ active: "all", hidden: ["s2"], tags: [G] }, "s2");
-  assert.equal(revHid.active, "all", "hidden under All → unhide and STAY — a focus never kicks off All");
-  assert.deepEqual(revHid.hidden, [], "…even for a tagged session: the unhide wins, not a holder switch");
-  const rev3 = revealIn({ active: "untagged", hidden: ["sX"], tags: [G] }, "sX");
-  assert.equal(rev3.active, "untagged", "unhidden tagless session already shows here — no gratuitous switch");
-  assert.deepEqual(rev3.hidden, [], "hidden and tagless → un-hidden (the one edit)");
-  const rev4 = revealIn({ active: "g1", hidden: ["s2"], tags: [G] }, "s2");
+  assert.deepEqual(rev2.tags![0].members, ["s2"], "membership untouched — the jump never strips a tag");
+  const revAll = revealIn({ active: "all", tags: [G] }, "s2");
+  assert.equal(revAll.active, "all", "everything is visible under All → nothing changes at all");
+  const rev4 = revealIn({ active: "g1", tags: [G] }, "s2");
   assert.equal(rev4.active, "g1", "already visible in the active tag → nothing changes");
-  const rev5 = revealIn({ active: "g1", hidden: ["sX"], tags: [G] }, "sX");
-  assert.deepEqual(rev5.hidden, [], "hidden AND tagless from a tag view → BOTH edits: un-hidden…");
-  assert.equal(rev5.active, "all", "…and still invisible after the unhide, so the view switches to All");
-  const rev6 = revealIn({ active: "untagged", hidden: ["s2"], tags: [G] }, "s2");
-  assert.equal(rev6.active, "g1", "hidden AND tagged under untagged → the holder tag wins");
-  assert.deepEqual(rev6.hidden, ["s2"], "…hidden bit untouched — membership beats hidden in a tag view");
 });
 
 test("executed: the canonical key ignores list order AND which key the kernel used", () => {
@@ -97,20 +76,18 @@ test("optimistic edits hold sticky and yield to the kernel after three silent pu
   assert.match(RENDER, /function postViews\(v: SessionViews\) \{[\s\S]{0,300}setTimelineViews/);
 });
 
-test("a hidden session keeps one visible home: the picker's Hidden section, and picking reveals", () => {
+test("a view-filtered session keeps one visible home: the picker's other-view section, and picking jumps views", () => {
+  // (the label was "Hidden — reveal" until the hidden set retired, the user 2026-08-24 — the
+  // section now serves tag-filtered sessions, same no-secret rule from 2026-08-11)
   assert.match(RENDER, /isOpenTab\(it\.id\) && !tabInView\(it\.id\)/);
-  assert.match(RENDER, /label\("Hidden — reveal"\)/);
-  assert.match(RENDER, /time\.textContent = "hidden";/);
-  assert.match(RENDER, /revealSession\(it\.id\);\s*\/\/ its tab already exists[\s\S]{0,80}setActive\(it\.id\);/);
+  assert.match(RENDER, /label\("In another view — open"\)/);
+  assert.match(RENDER, /time\.textContent = "other view";/);
+  assert.match(RENDER, /revealSession\(it\.id\);\s*\/\/ its tab already exists[\s\S]{0,120}setActive\(it\.id\);/);
 });
 
-test("the hide MENU ITEM is gone; the mechanism underneath is intact (the user 2026-08-24)", () => {
-  // the tag/view system covers backgrounding a session, so the tab menu's "Hide from chat &
-  // timeline" affordance retired — but ONLY the affordance: whether to retire the machinery
-  // outright is the user's separate call, so hideIn/revealIn, the picker's reveal, and the views
-  // blob's hidden set all still stand (the executed tests above pin their behavior).
+test("the hide MECHANISM is fully retired (the user 2026-08-24) — reveal survives as the view jump", () => {
   assert.doesNotMatch(RENDER, /Hide from chat & timeline/);
-  assert.match(RENDER, /revealSession\(it\.id\);/, "the picker's Hidden — reveal arm still works");
+  assert.doesNotMatch(RENDER, /hideIn\(/, "no hide gesture anywhere");
   assert.match(RENDER, /function revealSession\(id: string\) \{ postViews\(revealIn\(effViews\(\), id\)\); \}/);
 });
 

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -1,19 +1,19 @@
-// Session views (the user 2026-08-18; TAG model 2026-08-23; ALL default 2026-08-24): the kernel's
-// timeline-views blob, echoed on every tabOrder push — which sessions the chat TAB STRIP (and the
-// timeline lanes) show. TWO built-in sentinels, not tags: "all" — the DEFAULT — shows every session
-// minus the `hidden` set (the manual one-off hide, deliberate, so All respects it); "untagged"
-// keeps the old default's meaning under its own honest name — a TAG marks a SPECIALIZED session,
-// excluded from the untagged view and shown under its tag views. "all" used to MEAN untagged, so
-// reinterpreting it as truly-all lands every legacy persisted blob on the new All default with no
-// migration. A hidden session is a BACKGROUND session: still running, judged and carded; the
-// feed, the + picker, and the "N more" cue keep surfacing it, so nothing runs in secret — the
-// 2026-08-11 rule. A tag view shows exactly its members. The kernel's _view_visible is the decision
-// of record; this is its client mirror (the timeline carries its own copy — it cannot import TS).
+// Session views (the user 2026-08-18; TAG model 2026-08-23; ALL default 2026-08-24; the hidden set
+// RETIRED outright 2026-08-24 — the user: the tag system covers backgrounding, and the kernel
+// migrated existing hidden entries into an "archived" tag once): the kernel's timeline-views blob,
+// echoed on every tabOrder push — which sessions the chat TAB STRIP (and the timeline lanes) show.
+// TWO built-in sentinels, not tags: "all" — the DEFAULT — shows LITERALLY EVERYTHING (that is
+// All's meaning now; nothing can hide from it); "untagged" keeps the old default's meaning under
+// its own honest name — a TAG marks a SPECIALIZED session, excluded from the untagged view and
+// shown under its tag views. A tag view shows exactly its members. The kernel's _view_visible is
+// the decision of record; this is its client mirror (the timeline carries its own copy — it cannot
+// import TS).
 // Pure, split out of render.ts for tests (the time-marker.ts pattern). The kernel emits `tags`;
 // `groups` survives in the type as the pre-rename key an un-updated kernel still pushes.
 export interface SessionTag { id: string; name?: string; color?: string; members?: string[]; host?: string }
 export interface SessionViews {
-  active?: string; hidden?: string[]; tags?: SessionTag[]; groups?: SessionTag[];
+  active?: string; tags?: SessionTag[]; groups?: SessionTag[];
+  hidden?: string[];   // RETIRED 2026-08-24 — read-tolerated on old blobs, ignored everywhere, kernel-dropped
   // tag federation v0 (the user 2026-08-24): each ATTACHED kernel's own tags, read-only, joined by
   // the kernel per host (id = "host:tagid", members already respelled viewer-relative). Derived —
   // never an edit target, excluded from the echo key, dropped by the kernel if echoed back.
@@ -53,10 +53,9 @@ export function viewTags(views: SessionViews | null | undefined): SessionTag[] {
 
 export function viewVisible(views: SessionViews | null | undefined, id: string): boolean {
   if (!views || !views.active || views.active === "all") {
-    return !(views && Array.isArray(views.hidden) && views.hidden.includes(id));
+    return true;                                     // All = literally everything (hidden retired 2026-08-24)
   }
   if (views.active === "untagged") {
-    if (Array.isArray(views.hidden) && views.hidden.includes(id)) return false;
     // the UNION excludes (the user 2026-08-24): a session held by ANY kernel's tag is tagged —
     // a remote-homed tag pulls it out of untagged exactly like a local one
     return !viewTags(views).concat(views.remoteTags || []).some((t) => (t.members || []).includes(id));
@@ -75,42 +74,19 @@ export function viewVisible(views: SessionViews | null | undefined, id: string):
 export function viewsKey(v: SessionViews | null | undefined): string {
   if (!v) return "";
   return JSON.stringify({ active: v.active || "all",
-    hidden: (v.hidden || []).slice().sort(),
     tags: viewTags(v).map((t) => ({ id: t.id, name: t.name, color: t.color,
                                     members: (t.members || []).slice().sort() })) });
 }
 
-// hide: add the session to the hidden set — and when the ACTIVE view is a tag that contains it,
-// drop it from that tag too, or the gesture is a silent no-op (membership shows it there however
-// hidden it is). Other tags keep it: hiding from what you are looking at must not quietly rewrite
-// views you are not.
-export function hideIn(views: SessionViews | null | undefined, id: string): SessionViews {
-  const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
-  if (!(v.hidden || []).includes(id)) v.hidden = (v.hidden || []).concat([id]);
-  if (v.active && v.active !== "all") {
-    const t = viewTags(v).find((x) => x.id === v.active);
-    if (t && (t.members || []).includes(id)) t.members = (t.members || []).filter((x) => x !== id);
-  }
-  return v;
-}
-
-// the reveal gesture (re-grounded 2026-08-23 on the TAG model; ALL default 2026-08-24): explicitly
-// opening a session lands on a visible tab with the MINIMAL move and never mutates membership —
-// peeking at a tagged worker must not strip its tag. Under All only the hidden bit can hide a
-// session, so a focus unhides it and STAYS — it never kicks the user off the all-sessions view.
-// Elsewhere: a tagged session's home is its first holder tag; a tagless one is unhidden if hidden,
-// switching to All only if still invisible (an unhidden tagless session already shows in the
-// untagged view — no gratuitous view change).
+// (hideIn RETIRED with the hidden set, the user 2026-08-24 — the tag system covers backgrounding.)
+// the reveal gesture, post-retirement: explicitly opening a session lands on a visible view with
+// the MINIMAL move and never mutates membership — a tagged session's home is its first holder tag;
+// anything else is already visible under All, so switch there only when actually invisible.
 export function revealIn(views: SessionViews | null | undefined, id: string): SessionViews {
   const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
   if (viewVisible(v, id)) return v;
-  if (!v.active || v.active === "all") {
-    v.hidden = (v.hidden || []).filter((x) => x !== id);
-    return v;
-  }
   const holder = viewTags(v).find((t) => (t.members || []).includes(id));
   if (holder) { v.active = holder.id; return v; }
-  if ((v.hidden || []).includes(id)) v.hidden = (v.hidden || []).filter((x) => x !== id);
-  if (!viewVisible(v, id)) v.active = "all";
+  v.active = "all";
   return v;
 }


### PR DESCRIPTION
## What (the user's confirmed retirement, per the 642 cost map)

**Kernel — views functions only** (disjoint from the judge/nudge regions): `_norm_timeline_views` drops the `hidden` array — read-tolerated on old blobs and client echoes, never re-emitted. `_view_visible`'s All branch collapses to `True` — **nothing hides from All; that is All's meaning now** — and untagged loses its hidden check (membership alone excludes). `_heal_timeline_views` keeps only the membership copy.

**One-time migration** (`_timeline_views`, the decided shape): a stored blob still carrying hidden entries maps them into an **"archived" tag** — muted slate `#6b7280`, minted only when entries exist, idempotent (the persisted write drops the key, so the next read has nothing to migrate). Archived sessions show under All (inherent) and stay out of the untagged view; the feed's needs-you machinery carries anything that matters.

**Client mirrors:** `session-views.ts` `viewVisible`/`viewsKey` drop hidden; `hideIn` deleted; `revealIn` collapses to the pure view jump (holder tag, else All — membership never mutated). The timeline mirror matches; `viewToggleHidden` and the Sessions dialog's un-hide eye are gone; `feed-view.ts` needed nothing (it reads the shared mirror — no fourth fork existed). The picker's section survives with updated meaning — **"In another view — open"** for tag-filtered sessions (the 2026-08-11 no-secret rule), jumping views via `revealIn`.

## Tests (deliberate retargets across every pinned home, each citing the ruling)

The stub-suite fixtures hide via tags now; the executed visibility tests assert legacy hidden entries are **ignored** everywhere (All, untagged, the N-more cue); the churn-heal and fork-splice tests carry membership only; the tag-route merge test pins that edits never re-mint the key; the dialog-mutation test pins the toggle's absence from the exports. New: the **migration test** — mapping, persistence, idempotence (no duplicate tag or members on re-read), mint-only-when-needed, and All/untagged visibility through the rendered client shape.

Suites: 116 targeted kernel tests + 2359 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)