### PR TITLE
PR-landing watches are kernel-owned: register once, get one mail, survive every restart

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -659,6 +659,7 @@ EOF
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
     _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view); --host <kernel> edits an attached kernel's tag; --rename renames"
+    _romp_cmd "romp watch-pr <n> [--repo o/r]" -        "One mail here when the PR lands or fails — the kernel owns the watch, so it survives restarts (replaces the mortal shell loop)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -947,6 +948,64 @@ fi
 # payload only when given — an absent color means keep, "" would mean clear. A bare NAME with no
 # edit flag READS that one tag (exit 1 when absent) — creating on a read-shaped call minted
 # phantoms from typos. "group" is the pre-rename alias, accepted quietly.
+# PR-landing watch (the user 2026-08-24, both teams' surveys): register kernel-owned interest in a
+# PR and get ONE [romp] mail when it reaches a terminal state (merged, closed, or a failed check) —
+# replacing the mortal `while :; gh pr view; sleep 30` loop that died with every kernel restart.
+# The SESSION defaults to the caller (ROMP_SID, spawn-frozen in SDK sessions; --session overrides);
+# the REPO defaults to the caller's checkout (gh resolves it from cwd; --repo overrides). Both
+# resolve CLIENT-side so the kernel route stays explicit.
+if [[ "${1:-}" == "watch-pr" ]]; then
+    shift
+    _wp_usage="usage: romp watch-pr <number> [--repo <owner/name>] [--session <name>]"
+    _wp_pr=""; _wp_repo=""; _wp_sess=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --repo)    shift; [[ $# -eq 0 || -z "$1" || "$1" == -* ]] && { echo "$_wp_usage" >&2; exit 2; }
+                       _wp_repo="$1"; shift ;;
+            --session) shift; [[ $# -eq 0 || -z "$1" || "$1" == -* ]] && { echo "$_wp_usage" >&2; exit 2; }
+                       _wp_sess="$1"; shift ;;
+            -*)        echo "$_wp_usage" >&2; exit 2 ;;
+            *)         [[ -n "$_wp_pr" ]] && { echo "$_wp_usage" >&2; exit 2; }
+                       _wp_pr="$1"; shift ;;
+        esac
+    done
+    if [[ -z "$_wp_pr" || ! "$_wp_pr" =~ ^[0-9]+$ ]]; then echo "$_wp_usage" >&2; exit 2; fi
+    if [[ -z "$_wp_repo" ]]; then
+        _wp_repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+        if [[ -z "$_wp_repo" ]]; then
+            echo "romp watch-pr: no --repo given and the current directory has no gh-resolvable repo" >&2
+            exit 1
+        fi
+    fi
+    _wp_who="$_wp_sess"
+    if [[ -z "$_wp_who" ]]; then
+        if [[ -z "${ROMP_SID:-}" ]]; then
+            echo "romp watch-pr: --session <name> required outside a romp SDK session (ROMP_SID is not set)" >&2
+            exit 2
+        fi
+        _wp_who="$ROMP_SID"
+    fi
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp watch-pr: the kernel isn't running (no serve token). Start romp first." >&2
+        exit 1
+    fi
+    _wp_key="id"; [[ -n "$_wp_sess" ]] && _wp_key="name"
+    _payload="$(python3 -c 'import json,sys; print(json.dumps({"pr": int(sys.argv[1]), "repo": sys.argv[2], sys.argv[3]: sys.argv[4]}))' \
+        "$_wp_pr" "$_wp_repo" "$_wp_key" "$_wp_who")"
+    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/watch-pr" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp watch-pr: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        echo "romp watch-pr: watching $_wp_repo#$_wp_pr — one mail here when it lands or fails"
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp watch-pr: refused — $_err" >&2
+    exit 1
+fi
+
 if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
     shift
     _gr_usage="usage: romp tag [--json]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10199,6 +10199,162 @@ def _poll_remote_views(r):
         return r.get("views")
 
 
+# ── first-class PR-landing watches (the user 2026-08-24, both teams' surveys: every landing watch
+# was a mortal shell loop that died with kernel restarts) ─────────────────────────────────────────
+# A session registers interest in a PR; the KERNEL polls gh for the terminal state and delivers the
+# outcome as one [romp] notice to the registering session. Registrations persist (pr-watches.json)
+# and re-arm on boot exactly like the reconnect intent — a kernel restart moves the watch, never
+# kills it. Polling an external system is the legitimate acquisition of an unobservable event (the
+# USAGE_POLL precedent): modest cadence, a touch slower while checks visibly run. Terminal means
+# MERGED, CLOSED, or a FAILED check — both ends of the standing watcher rule — and a gh failure is
+# LOUD: three consecutive errors deliver a failure notice and retire the watch, never a silent dead
+# loop the worker discovers hours later.
+
+PR_WATCH_FILE = jd.STATE / "pr-watches.json"
+PR_WATCH_EVERY = 60          # the base poll cadence (seconds)
+PR_WATCH_BUSY_EVERY = 90     # …relaxed while checks are visibly still running
+PR_WATCH_MAX_FAILS = 3       # consecutive gh failures before the loud retire
+_pr_watches = []             # [{pr, repo, sid, at} + runtime {_next, _fails, _busy}]
+_pr_watch_lock = threading.Lock()
+
+
+def _pr_watches_load():
+    try:
+        rows = json.loads(PR_WATCH_FILE.read_text())
+    except Exception:
+        return
+    if not isinstance(rows, list):
+        return
+    with _pr_watch_lock:
+        _pr_watches[:] = [dict(r) for r in rows
+                          if isinstance(r, dict) and r.get("pr") and r.get("repo") and r.get("sid")]
+        # boot re-arm (the reconnect-intent precedent): fresh counters, poll immediately
+        for r in _pr_watches:
+            r["_next"], r["_fails"], r["_busy"] = 0, 0, False
+
+
+def _pr_watches_save():
+    with _pr_watch_lock:
+        rows = [{k: r[k] for k in ("pr", "repo", "sid", "at")} for r in _pr_watches]
+    try:
+        _atomic_write(PR_WATCH_FILE, json.dumps(rows))
+    except Exception:
+        sys.stderr.write("pr-watches save: %s\n" % traceback.format_exc())
+
+
+def add_pr_watch(pr, repo, sid, now=None):
+    """Register (idempotently) a landing watch: one mail to `sid` when repo#pr reaches a terminal
+    state. Returns the row."""
+    pr, repo, sid = int(pr), str(repo).strip(), str(sid).strip()
+    with _pr_watch_lock:
+        for r in _pr_watches:
+            if r["pr"] == pr and r["repo"] == repo and r["sid"] == sid:
+                return {k: r[k] for k in ("pr", "repo", "sid", "at")}
+        row = {"pr": pr, "repo": repo, "sid": sid, "at": int(now if now is not None else time.time()),
+               "_next": 0, "_fails": 0, "_busy": False}
+        _pr_watches.append(row)
+    _pr_watches_save()
+    return {k: row[k] for k in ("pr", "repo", "sid", "at")}
+
+
+def _pr_watch_verdict(d):
+    """(verdict, detail) from a `gh pr view --json state,statusCheckRollup` payload, PURE for tests:
+    ("merged"|"closed"|"failed"|None, detail). A FAILURE/TIMED_OUT check conclusion is terminal —
+    in this repo every check is required, so a red check means the auto-merge will never fire (the
+    approximation is named here: gh's rollup does not mark required-ness). None = still in flight;
+    detail then says whether checks are visibly running (the cadence hint)."""
+    state = str((d or {}).get("state") or "").upper()
+    if state == "MERGED":
+        return "merged", ""
+    if state == "CLOSED":
+        return "closed", ""
+    busy = False
+    for c in (d or {}).get("statusCheckRollup") or []:
+        if not isinstance(c, dict):
+            continue
+        con = str(c.get("conclusion") or "").upper()
+        if con in ("FAILURE", "TIMED_OUT"):
+            return "failed", str(c.get("name") or c.get("context") or "a check")
+        if str(c.get("status") or "").upper() in ("IN_PROGRESS", "QUEUED", "PENDING") or con == "":
+            busy = True
+    return None, ("busy" if busy else "")
+
+
+def _pr_watch_notice(verdict, repo, pr, detail=""):
+    """The one mail a landing watch sends — the [romp] mechanics-notice family (it is ABOUT romp's
+    own watch service, like the restart notice): plain, practical, no reply expected. PURE for the
+    voice test."""
+    ref = "%s#%s" % (repo, pr)
+    if verdict == "merged":
+        body = "[romp] The pull request you asked romp to watch has MERGED: %s. This watch is done." % ref
+    elif verdict == "closed":
+        body = ("[romp] The pull request you asked romp to watch was CLOSED without merging: %s. "
+                "This watch is done." % ref)
+    elif verdict == "failed":
+        body = ("[romp] The pull request you asked romp to watch has a FAILED check (%s): %s. "
+                "It will not land on its own — it needs your attention. This watch is done."
+                % (detail or "a check", ref))
+    else:   # the loud gh-failure retire
+        body = ("[romp] romp could not read %s (gh said: %s) after several tries, so this watch was "
+                "dropped — check `gh auth status` on this machine and re-register with `romp watch-pr` "
+                "if you still need it." % (ref, detail or "an unknown error"))
+    return body + "\n\n<!-- romp-tag: pr-watch -->"
+
+
+def _pr_watch_read(pr, repo):
+    """One gh read → (verdict, detail) or ("error", why). Subprocess, bounded."""
+    try:
+        r = subprocess.run(["gh", "pr", "view", str(pr), "--repo", repo,
+                            "--json", "state,statusCheckRollup"],
+                           capture_output=True, text=True, timeout=25)
+        if r.returncode != 0:
+            return "error", (r.stderr or r.stdout or "gh failed").strip()[:200]
+        return _pr_watch_verdict(json.loads(r.stdout or "{}"))
+    except Exception as e:
+        return "error", str(e)[:200]
+
+
+def _pr_watch_deliver(sid, text):
+    """The landing mail, through the same park-aware injection /send uses (a rate-limited or
+    compacting session gets it when it can take it). Best-effort by design: a dead session's mail
+    has no recipient, and the watch is already done."""
+    try:
+        _send_or_park(Sessions.backend_for(sid), sid, text)
+        return True
+    except Exception:
+        return False
+
+
+def _pr_watch_tick(now):
+    """One supervisor-pass sweep over the registered watches (rate-gated per row)."""
+    with _pr_watch_lock:
+        rows = list(_pr_watches)
+    done = []
+    for r in rows:
+        if now < r.get("_next", 0):
+            continue
+        verdict, detail = _pr_watch_read(r["pr"], r["repo"])
+        if verdict == "error":
+            r["_fails"] = int(r.get("_fails") or 0) + 1
+            r["_next"] = now + PR_WATCH_EVERY
+            if r["_fails"] >= PR_WATCH_MAX_FAILS:
+                _pr_watch_deliver(r["sid"], _pr_watch_notice("error", r["repo"], r["pr"], detail))
+                done.append(r)
+            continue
+        r["_fails"] = 0
+        if verdict is None:
+            r["_next"] = now + (PR_WATCH_BUSY_EVERY if detail == "busy" else PR_WATCH_EVERY)
+            continue
+        _pr_watch_deliver(r["sid"], _pr_watch_notice(verdict, r["repo"], r["pr"], detail))
+        done.append(r)
+    if done:
+        with _pr_watch_lock:
+            for r in done:
+                if r in _pr_watches:
+                    _pr_watches.remove(r)
+        _pr_watches_save()
+
+
 def _fleet_usage():
     """One row per HOST whose usage is known — local always first (the notices read off it), each row
     {host, acct, usage}.
@@ -11290,6 +11446,7 @@ def _tunnel_supervisor():
                 # tier too — their mail arrives relayed through a hub and is judged by true origin.
                 # Once per (host, level); a failed push retries next pass.
                 _push_origin_trust_rows()
+            _pr_watch_tick(now)          # PR-landing watches (rate-gated per row; loud on gh failure)
             # Everything above is the supervisor's own state (status, fails, next_try, kernel_sha, detail).
             # None of it used to reach disk — only the act routes saved — so the file could sit frozen on a
             # failure long after the row recovered. Signature-gated: a steady fleet writes nothing.
@@ -27700,6 +27857,33 @@ class Handler(BaseHTTPRequestHandler):
                 _mark_views_dirty()
                 return self._send(200, json.dumps({"ok": True, "id": tsid, "bg": bg,
                                                    "fg": pal.fg_for(bg)}), "application/json")
+            if u.path == "/watch-pr":
+                # Register a PR-landing watch (the user 2026-08-24, both teams' surveys): one [romp]
+                # mail to the registering session when the PR reaches a terminal state — MERGED,
+                # CLOSED, or a failed check — with the watch owned by the KERNEL, so it survives the
+                # restarts that killed every shell loop it replaces. Body: {"pr": <n>,
+                # "repo": "owner/name", "id"|"name": <session>}. Repo is explicit here (the CLI
+                # infers it from the caller's checkout); the session resolves like /send's.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                try:
+                    prn = int(b.get("pr"))
+                except Exception:
+                    prn = 0
+                repo = str(b.get("repo") or "").strip()
+                who = str(b.get("id") or b.get("name") or "").strip()
+                if prn <= 0 or not re.fullmatch(r"[\w.-]+/[\w.-]+", repo) or not who:
+                    return self._send(400, json.dumps({"ok": False, "error":
+                        "pr (number), repo (owner/name) and id|name (the session to mail) required"}),
+                        "application/json")
+                tsid = _sid_of(who)
+                if not tsid:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'no session answers to "%s"' % who}), "application/json")
+                row = add_pr_watch(prn, repo, tsid)
+                return self._send(200, json.dumps({"ok": True, "watch": row}), "application/json")
             if u.path in ("/tag", "/group"):
                 # Headless tag edit (`romp tag`, the user 2026-08-23, the manager/worker workflow:
                 # the worker roster IS a session tag, so an agent needs to keep one current — and can
@@ -29206,6 +29390,7 @@ def main():
     threading.Thread(target=_parent_watch, daemon=True).start()
     _known_load()                                              # remembered past hosts (popover's re-attach rows)
     _remotes_load()                                            # re-attach remote kernels from a prior run
+    _pr_watches_load()                                         # re-arm PR-landing watches (same intent rule)
     _consume_update_report()                                   # last self-update's outcome → the Log, once
     threading.Thread(target=_update_check_loop, daemon=True).start()   # newer release? boot + every 6h (mode-gated inside)
     threading.Thread(target=_ensure_postal_bus, daemon=True).start()   # a sessionless machine still needs its bus

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -264,6 +264,28 @@ MOCK
     [[ "$output" == *"--host goes with an edit"* ]]
 }
 
+@test "watch-pr: posts pr+repo+session; self needs ROMP_SID; usage errors exit 2" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run env ROMP_SID=11111111-2222-3333-4444-555555555555 "$ROMP_SCRIPT" watch-pr 7 --repo TESTORG/testrepo
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"watching TESTORG/testrepo#7"* ]]
+    grep '/watch-pr' "$MOCK_LOG" | grep -q '"pr": *7'
+    grep '/watch-pr' "$MOCK_LOG" | grep -q '"repo": *"TESTORG/testrepo"'
+    grep '/watch-pr' "$MOCK_LOG" | grep -q '"id": *"11111111-2222-3333-4444-555555555555"'
+    # --session overrides self and rides as a NAME
+    run env ROMP_SID= "$ROMP_SCRIPT" watch-pr 8 --repo TESTORG/testrepo --session web
+    [ "$status" -eq 0 ]
+    grep '/watch-pr' "$MOCK_LOG" | grep -q '"name": *"web"'
+    # outside a session with no --session: a loud usage refusal, never a silent guess
+    run env ROMP_SID= "$ROMP_SCRIPT" watch-pr 9 --repo TESTORG/testrepo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--session <name> required"* ]]
+    run run_romp watch-pr
+    [ "$status" -eq 2 ]
+}
+
 @test "tag: --rename rides the payload and counts as an edit" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""First-class PR-landing watches (the user 2026-08-24, both teams' surveys): a session registers
+interest in a PR, the KERNEL polls gh for the terminal state — MERGED, CLOSED, or a FAILED check,
+both ends of the standing watcher rule — and delivers ONE [romp] mail, surviving the kernel
+restarts that killed every shell loop this replaces. Registrations persist and re-arm on boot (the
+reconnect-intent idiom); a gh failure retires the watch LOUDLY after three consecutive errors.
+Synthetic only — gh fully stubbed."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+import urllib.error
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_prw", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class Verdict(unittest.TestCase):
+    """The pure gh-payload reading, executed."""
+
+    def test_merged_and_closed_are_terminal(self):
+        self.assertEqual(km._pr_watch_verdict({"state": "MERGED"}), ("merged", ""))
+        self.assertEqual(km._pr_watch_verdict({"state": "CLOSED"}), ("closed", ""))
+
+    def test_a_failed_check_is_terminal_with_its_name(self):
+        d = {"state": "OPEN", "statusCheckRollup": [
+            {"name": "Python 3.12", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "Shell (bats)", "status": "COMPLETED", "conclusion": "FAILURE"}]}
+        self.assertEqual(km._pr_watch_verdict(d), ("failed", "Shell (bats)"))
+
+    def test_in_flight_says_busy_for_the_cadence_hint(self):
+        d = {"state": "OPEN", "statusCheckRollup": [
+            {"name": "x", "status": "IN_PROGRESS", "conclusion": ""}]}
+        self.assertEqual(km._pr_watch_verdict(d), (None, "busy"))
+        self.assertEqual(km._pr_watch_verdict({"state": "OPEN", "statusCheckRollup": []}), (None, ""))
+
+
+class Notice(unittest.TestCase):
+    """The [romp] mechanics-notice voice, executed (the injected-voice rule: the notice is ABOUT
+    romp — like the restart notice it names romp — and carries none of the board vocabulary)."""
+
+    def test_each_terminal_reads_plainly_and_wears_the_machine_tag(self):
+        for verdict, must in (("merged", "has MERGED"), ("closed", "CLOSED without merging"),
+                              ("failed", "FAILED check"), ("error", "could not read")):
+            n = km._pr_watch_notice(verdict, "TESTORG/testrepo", 7, "Shell (bats)")
+            self.assertTrue(n.startswith("[romp] "), verdict)
+            self.assertIn("TESTORG/testrepo#7", n)
+            self.assertIn(must, n)
+            self.assertIn("<!-- romp-tag: pr-watch -->", n, "machine-sent dress, never the user's words")
+            for word in ("card", "board", "goal", "column", "nudge"):
+                self.assertNotIn(word, n.lower(), "no board vocabulary in an injected body")
+
+
+class Persistence(unittest.TestCase):
+    """Registration is intent: survives a restart, re-arms fresh (the reconnect-intent idiom)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches))
+        km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
+        km._pr_watches[:] = []
+
+    def tearDown(self):
+        km.PR_WATCH_FILE = self._saved[0]
+        km._pr_watches[:] = self._saved[1]
+        self.td.cleanup()
+
+    def test_a_watch_survives_the_restart_and_rearms_fresh(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=1000)
+        km._pr_watches[0]["_fails"] = 2                      # runtime state must NOT persist
+        km._pr_watches[0]["_next"] = 99999
+        km._pr_watches[:] = []
+        km._pr_watches_load()                                # the boot path
+        self.assertEqual(len(km._pr_watches), 1)
+        r = km._pr_watches[0]
+        self.assertEqual((r["pr"], r["repo"], r["sid"], r["at"]), (7, "TESTORG/testrepo", SID, 1000))
+        self.assertEqual((r["_next"], r["_fails"]), (0, 0), "re-armed fresh: polls immediately")
+
+    def test_registration_is_idempotent(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID)
+        km.add_pr_watch(7, "TESTORG/testrepo", SID)
+        self.assertEqual(len(km._pr_watches), 1)
+
+
+class Tick(unittest.TestCase):
+    """The sweep: terminal delivers + retires; gh failure retires LOUDLY after three; in-flight
+    backs off while checks run."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches), km._pr_watch_read, km._pr_watch_deliver)
+        km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
+        km._pr_watches[:] = []
+        self.mail = []
+        km._pr_watch_deliver = lambda sid, text: self.mail.append((sid, text)) or True
+
+    def tearDown(self):
+        km.PR_WATCH_FILE, km._pr_watches[:], km._pr_watch_read, km._pr_watch_deliver = \
+            self._saved[0], self._saved[1], self._saved[2], self._saved[3]
+        self.td.cleanup()
+
+    def test_merged_delivers_once_and_retires(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        km._pr_watch_read = lambda pr, repo: ("merged", "")
+        km._pr_watch_tick(100.0)
+        self.assertEqual(len(self.mail), 1)
+        self.assertIn("has MERGED", self.mail[0][1])
+        self.assertEqual(self.mail[0][0], SID)
+        self.assertEqual(km._pr_watches, [], "terminal → the watch retires")
+        km._pr_watch_tick(200.0)
+        self.assertEqual(len(self.mail), 1, "…and never mails twice")
+
+    def test_a_failed_check_is_just_as_terminal(self):
+        km.add_pr_watch(8, "TESTORG/testrepo", SID, now=0)
+        km._pr_watch_read = lambda pr, repo: ("failed", "Shell (bats)")
+        km._pr_watch_tick(100.0)
+        self.assertEqual(len(self.mail), 1)
+        self.assertIn("FAILED check (Shell (bats))", self.mail[0][1])
+        self.assertEqual(km._pr_watches, [])
+
+    def test_gh_failure_retires_loudly_after_three_never_silently(self):
+        km.add_pr_watch(9, "TESTORG/testrepo", SID, now=0)
+        km._pr_watch_read = lambda pr, repo: ("error", "auth required")
+        km._pr_watch_tick(100.0)
+        km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+        self.assertEqual(self.mail, [], "two failures → still trying, still quiet")
+        km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+        self.assertEqual(len(self.mail), 1, "the third delivers the loud retire")
+        self.assertIn("could not read", self.mail[0][1])
+        self.assertIn("auth required", self.mail[0][1])
+        self.assertEqual(km._pr_watches, [])
+
+    def test_in_flight_backs_off_while_checks_run(self):
+        km.add_pr_watch(10, "TESTORG/testrepo", SID, now=0)
+        km._pr_watch_read = lambda pr, repo: (None, "busy")
+        km._pr_watch_tick(100.0)
+        self.assertEqual(km._pr_watches[0]["_next"], 100.0 + km.PR_WATCH_BUSY_EVERY)
+        km._pr_watch_read = lambda pr, repo: (None, "")
+        km._pr_watch_tick(100.0 + km.PR_WATCH_BUSY_EVERY)
+        self.assertEqual(km._pr_watches[0]["_next"],
+                         100.0 + km.PR_WATCH_BUSY_EVERY + km.PR_WATCH_EVERY)
+        self.assertEqual(self.mail, [])
+
+
+class Route(unittest.TestCase):
+    """POST /watch-pr over the real Handler: registration + refusals; token-gated."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches), km._sid_of)
+        km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
+        km._pr_watches[:] = []
+        km._sid_of = lambda who: SID if who in (SID, "web") else ""
+
+    def tearDown(self):
+        km.PR_WATCH_FILE, km._pr_watches[:], km._sid_of = self._saved
+        self.td.cleanup()
+
+    def _post(self, body, token=True):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/watch-pr" % self.port, data=json.dumps(body).encode(),
+            headers=dict({"Content-Type": "application/json"},
+                         **({"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]} if token else {})))
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, (e.read() or b"").decode()
+
+    def test_registers_by_name_and_persists(self):
+        st, r = self._post({"pr": 7, "repo": "TESTORG/testrepo", "name": "web"})
+        self.assertEqual(st, 200)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["watch"]["sid"], SID)
+        self.assertEqual(json.loads(km.PR_WATCH_FILE.read_text())[0]["pr"], 7)
+
+    def test_refusals_are_loud_and_shaped(self):
+        self.assertEqual(self._post({"repo": "TESTORG/testrepo", "name": "web"})[0], 400)
+        self.assertEqual(self._post({"pr": 7, "repo": "not-a-repo", "name": "web"})[0], 400)
+        st, r = self._post({"pr": 7, "repo": "TESTORG/testrepo", "name": "ghost"})
+        self.assertFalse(r["ok"]); self.assertIn('no session answers to "ghost"', r["error"])
+        self.assertEqual(self._post({"pr": 7, "repo": "TESTORG/testrepo", "name": "web"},
+                                    token=False)[0], 403)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What (both teams' surveys; tooling backlog item 3)

Every landing watch was a mortal `gh pr view` + `sleep` loop that died with kernel restarts. Now:

- **`romp watch-pr <n>`** — repo inferred from the caller's checkout via gh (`--repo` overrides); the session defaults to the caller via `ROMP_SID` (`--session` overrides) → **`POST /watch-pr`** (explicit repo; session resolved like `/send`'s).
- **Registrations persist** (`pr-watches.json`) and **re-arm fresh on boot** — the reconnect-intent idiom: a restart moves the watch, never kills it.
- The **supervisor polls gh** at a modest cadence (60s, relaxing to 90s while checks visibly run — the usage-poll precedent for acquiring an unobservable external event) for **both terminal states** of the standing watcher rule: MERGED/CLOSED, or a **failed check** (named in the mail; every check in this repo is required — the approximation is documented where made).
- The outcome is **one `[romp]` mechanics-notice** (it's about romp's own watch service, like the restart notice), delivered through the same park-aware injection `/send` uses, wearing the machine-sent `romp-tag` dress; the watch retires with the delivery.
- **gh failure is loud**: three consecutive errors deliver a notice carrying gh's own words and retire the watch — never a silent dead loop.

## Tests

`tests/test_pr_watch.py` (12): the pure verdict reading (merged / closed / failed-with-name / busy), the notice voice (plain, `[romp]`-family, machine-tagged, no board vocabulary), restart persistence with fresh re-arm, idempotent registration, deliver-once-and-retire for both terminals, the three-strikes loud retire, the busy backoff, and the route's registration + shaped refusals + token gate. `tests/romp.bats`: the verb's payload + the no-`ROMP_SID` refusal. Suites green: 5539 python tests (+293 subtests), 2359 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)