### PR TITLE
The chat's file browser fills the pane again: its overlay dress mirrors into the chat's sheet

### DIFF
--- a/ui/webview/filebrowse-chat-overlay.test.ts
+++ b/ui/webview/filebrowse-chat-overlay.test.ts
@@ -1,0 +1,41 @@
+// The browser's overlay dress in the CHAT document (the user 2026-08-24, near-verbatim: "the browse
+// file system thing now is totally messed up — showing at the bottom, below the message box. It's
+// supposed to be a giant thing that goes on top of the entire chat area"). The 642 move made the
+// browser pane-local in the chat, but its CSS lived only in feed.css — the chat page loads
+// styles.css alone, so the browser mounted as UNSTYLED block flow at the document bottom. The
+// overlay family now mirrors in styles.css (the .romp-acted two-sheets precedent) and this test
+// pins the two byte-equal so they cannot drift.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const CHAT = read("styles.css");
+const FEED = read("feed.css");
+
+const RULES = [
+  ".filebrowse {", "body.filebrowse-open {", ".fb-bar {", ".fb-crumbs {", ".fb-crumb {",
+  ".fb-list {", ".fb-row {", ".fb-name {", ".fb-size {", ".fb-more {", "#fb-ctx {", ".fb-crumb-up {",
+];
+
+function ruleOf(css: string, head: string): string {
+  const at = css.indexOf(head);
+  assert.ok(at >= 0, head + " present");
+  return css.slice(at, css.indexOf("}", at) + 1);
+}
+
+test("every browser overlay rule exists in BOTH sheets, byte-equal — the chat page loads styles.css alone", () => {
+  for (const head of RULES) {
+    assert.equal(ruleOf(CHAT, head), ruleOf(FEED, head), head + " mirrors exactly");
+  }
+});
+
+test("the overlay geometry: pane-filling, viewer stays one layer above, scroll locked while open", () => {
+  assert.match(CHAT, /\.filebrowse \{ position: fixed; inset: 0; z-index: 890;/,
+    "GIANT — fixed inset-0 fills the pane, thread AND composer beneath");
+  assert.match(CHAT, /body\.filebrowse-open \{ overflow: hidden; \}/, "the thread cannot scroll behind it");
+  // the viewer overlays the listing (the one-directional stack): 1200 > 890
+  const vz = Number((CHAT.match(/#romp-fileview \{[^}]*z-index: (\d+)/s) || [])[1]);
+  assert.ok(vz > 890, "the viewer's backdrop sits above the browser (got " + vz + ")");
+});

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2837,6 +2837,40 @@ a.fileview-btn[hidden] { display: none; }
    feed.css so the viewer behaves identically wherever it mounts */
 .fileview-dir-link { cursor: pointer; }
 .fileview-dir-link:hover { color: var(--accent); text-decoration: underline; }
+
+/* ── the file BROWSER (file-browse.ts) in the CHAT document ── the 642 move made the browser
+   pane-local here, but its overlay dress lived only in feed.css, so it mounted as unstyled block
+   flow at the document bottom, below the composer (the user 2026-08-24, near-verbatim: "totally
+   messed up — showing at the bottom"). This block MIRRORS feed.css's (the .romp-acted precedent:
+   the two pages load different sheets, so shared overlays are declared in both — a test pins the
+   pair equal). The browser fills the pane (fixed inset-0), sits one z layer BENEATH the viewer
+   (890 < 1200) so a file opened from a listing overlays it, and body.filebrowse-open locks the
+   thread's scroll while open. */
+.filebrowse { position: fixed; inset: 0; z-index: 890; display: flex; flex-direction: column;
+  background: var(--bg, #1e1e1e); }
+body.filebrowse-open { overflow: hidden; }
+.fb-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
+  padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
+.fb-crumbs { flex: 1 1 auto; min-width: 0; font-size: 0.86em; color: var(--dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; direction: rtl; text-align: left; }
+.fb-crumbs > * { direction: ltr; unicode-bidi: isolate; }
+.fb-crumb { cursor: pointer; }
+.fb-crumb:hover { color: var(--accent); text-decoration: underline; }
+.fb-crumb:last-child { color: var(--fg); }
+.fb-crumb-sep { margin: 0 3px; opacity: 0.6; }
+.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
+.fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;
+  font-size: 0.86em; }
+.fb-row:hover, .fb-row.active { background: rgba(255, 255, 255, 0.07); }
+.fb-row.active { outline: 1px solid rgba(156, 210, 255, 0.35); outline-offset: -1px; }
+.fb-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; font-family: var(--mono, ui-monospace, monospace); }
+.fb-dir .fb-name { color: var(--accent); }
+.fb-size { flex: 0 0 auto; margin-left: auto; color: var(--dim); font-size: 0.92em; }
+.fb-dlonly .fb-name { color: var(--dim); }
+.fb-more { padding: 6px 14px; color: var(--dim); font-size: 0.82em; }
+#fb-ctx { z-index: 950; }
+.fb-crumb-up { opacity: 0.65; }
 /* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
    and because they are a sibling element a selection of the code copies without dragging them along */
 .fileview-code { display: flex; align-items: flex-start; min-height: 100%; }


### PR DESCRIPTION
## What

The 642 pane-local move was right but half-dressed: the browser's overlay CSS — `.filebrowse`'s fixed inset-0 takeover, the `fb-*` rows/crumbs, `body.filebrowse-open`'s scroll lock — lived only in **feed.css**, and the chat page loads **styles.css alone**. So in the chat the browser mounted as unstyled block flow at the document bottom, below the composer (the user's report, near-verbatim: "totally messed up — showing at the bottom").

The overlay family now mirrors in styles.css (the `.romp-acted` two-sheets precedent), **byte-equal and pinned** so the pair cannot drift:

- The browser fills the pane — fixed inset-0, thread and composer both beneath ("a giant thing that goes on top of the entire chat area").
- It keeps its place one z layer beneath the viewer (890 < 1200), preserving the one-directional stack (file over listing, back returns).
- `body.filebrowse-open` locks the underlying thread's scroll while open; Escape/✕ restore.

## Verification (the machine-checkable proxy)

Headless over the built bundle: with the browser open, its bounding box covers the pane viewport; `document.elementFromPoint` at the composer resolves to the overlay (the composer is not hittable); the scroll lock holds; Escape removes the overlay, unlocks scroll, and the composer is hittable again. Screenshot eyeballed — the listing owns the whole pane.

## Tests

`filebrowse-chat-overlay.test.ts`: every mirrored rule pinned byte-equal across the two sheets (the drift guard), plus the geometry pins — pane-filling inset-0 at z-890, the viewer above it, the scroll lock. Full suite: 2361 npm tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)