### PR TITLE
The view menu's trigger is the word it means: 'View ▴' replaces the glyph

### DIFF
--- a/tools/ui-verify/fixtures/feed-footer.html
+++ b/tools/ui-verify/fixtures/feed-footer.html
@@ -19,7 +19,7 @@
   </div>
 </div>
 <div id="feed-foot">
-  <button id="feed-viewbtn" class="fdismiss ffollow feed-modetoggle"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M2.5 4h8"/><path d="M2.5 8h5.5"/><path d="M2.5 12h3"/><path d="M12.5 5.5v5.8"/><path d="M10.6 9.6l1.9 2 1.9-2"/></svg></button>
+  <button id="feed-viewbtn" class="fdismiss ffollow feed-modetoggle">View ▴</button>
   <span id="feed-search" class="open">
     <button id="feed-search-btn" class="fdismiss ffollow feed-modetoggle on">Sessions ▴</button>
     <input id="feed-search-input" type="search" placeholder="session or host…" value="">

--- a/ui/webview/feed-viewmenu.test.ts
+++ b/ui/webview/feed-viewmenu.test.ts
@@ -11,19 +11,15 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("one icon button replaces the three word-buttons; the old footer toggles are gone", () => {
+test("one 'View ▴' word-button replaces the three toggles; the old footer toggles stay gone", () => {
   assert.match(FEED, /function ensureViewMenuBtn\(\): HTMLElement/);
   assert.match(FEED, /b\.id = "feed-viewbtn";/);
+  // a WORD, not an icon (the user 2026-08-24, round two: the ordering glyph read as "not what I
+  // would expect for what to show") — the footer's word-button vocabulary, the Sessions caret
+  assert.match(FEED, /b\.textContent = "View \\u25b4";/);
+  assert.doesNotMatch(FEED, /viewMenuGlyph/, "the guessable glyph is gone outright");
   assert.doesNotMatch(FEED, /ensureFeedToggle|makeFeedToggle/, "the word-button helper went with its buttons");
   assert.doesNotMatch(FEED, /feed-newestfirst|feed-stacked|feed-grouped/, "no old toggle ids survive");
-  // monochrome by construction: THE GLYPH ITSELF strokes currentColor (scoped to the function — an
-  // unscoped match would ride any other svg in the file), so it wears the button's own states
-  // (dim, hover accent) with no colors of its own — and it is NOT a gear (the kernel page's strip
-  // shows its ⛭ right below this footer)
-  const glyph = FEED.slice(FEED.indexOf("function viewMenuGlyph"), FEED.indexOf("function ensureViewMenuBtn"));
-  assert.ok(glyph.includes('stroke="currentColor"'), "the glyph strokes currentColor");
-  assert.ok(!/#[0-9a-fA-F]{3,8}|rgb\(/.test(glyph), "no hardcoded color anywhere in the glyph");
-  assert.ok(!glyph.includes("⛭"), "not a gear");
   assert.match(FEED, /b\.setAttribute\("aria-haspopup", "menu"\);/);
 });
 
@@ -75,11 +71,11 @@ test("the popup wears the repo menu vocabulary: .ctx-menu chrome + the ✓-in-ci
   // the ✓-in-circle every romp menu uses (styles.css .ctx-sub/.meta-item.current), ported here because
   // the feed page loads only feed.css — on --check-bg, the panel-wide checkmark disc
   assert.match(CSS, /\.feed-viewmenu \.ctx-item\.current::after \{\s*\n\s*content: "✓"; position: absolute; right: 8px; top: 50%; transform: translateY\(-50%\);\s*\n\s*background: var\(--check-bg\); color: #fff; border-radius: 50%;\s*\n\s*width: 13px; height: 13px; font-size: 9px; font-weight: 900;/);
-  // THE CASCADE, both ways (the repo's recurring bug class): the icon button's padding must carry two
-  // ids or #feed-foot .fdismiss's (1,1,0) wins; and the row reset ties .ctx-item:hover at (0,2,0), so
-  // the reset must sit EARLIER in the file for the hover wash to win its tie by order.
-  assert.match(CSS, /#feed-foot #feed-viewbtn \{ display: inline-flex; align-items: center; padding: 2px 7px; \}/);
-  assert.doesNotMatch(CSS, /^#feed-viewbtn \{/m, "no (1,0,0) button rule that #feed-foot .fdismiss would beat");
+  // THE CASCADE (the repo's recurring bug class): the word-button rides the shared #feed-foot
+  // .fdismiss metrics — NO bespoke #feed-viewbtn rule survives to lose (or half-win) a specificity
+  // tie; and the row reset ties .ctx-item:hover at (0,2,0), so the reset must sit EARLIER in the
+  // file for the hover wash to win its tie by order.
+  assert.doesNotMatch(CSS, /#feed-viewbtn/, "no bespoke button rule at all — shared metrics only");
   const resetAt = CSS.indexOf(".feed-viewmenu .ctx-item {");
   const hoverAt = CSS.indexOf(".ctx-item:hover {");
   assert.ok(resetAt >= 0 && hoverAt > resetAt,
@@ -88,7 +84,7 @@ test("the popup wears the repo menu vocabulary: .ctx-menu chrome + the ✓-in-ci
 
 test("menu mechanics mirror the session menu: on document.body, opens upward, away/Escape close", () => {
   // on document.body, OUTSIDE render()'s reconcile — a push can never rebuild it mid-press (click-safety)
-  const open = FEED.slice(FEED.indexOf("function openViewMenu"), FEED.indexOf("function viewMenuGlyph"));
+  const open = FEED.slice(FEED.indexOf("function openViewMenu"), FEED.indexOf("function ensureViewMenuBtn"));
   assert.ok(open.includes("document.body.appendChild(menu);"));
   assert.ok(open.includes('menu.style.bottom = Math.round(window.innerHeight - r.top + 6) + "px";'), "opens upward from the footer");
   assert.match(FEED, /function viewMenuAway\(ev: Event\): void/);

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -927,10 +927,8 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    wears the shared .ctx-menu vocabulary (chrome defined with the card menus below); these rules add
    the ✓-in-circle current mark every romp menu uses (ported from styles.css — the feed page loads
    only this sheet) and the forced row's inert fade. */
-/* two ids, deliberately: #feed-foot .fdismiss's (1,1,0) padding beats a bare #feed-viewbtn — the
-   repo's recurring cascade trap (the 2026-08-19 forced-fade bug class) */
-#feed-foot #feed-viewbtn { display: inline-flex; align-items: center; padding: 2px 7px; }
-#feed-viewbtn svg { display: block; }
+/* ("View ▴" is a word-button since 2026-08-24 round two — the shared #feed-foot .fdismiss metrics
+   cover it, so the old icon-button's bespoke two-id padding rule went with the icon.) */
 .feed-viewmenu { min-width: 178px; }
 /* rows are real <button>s (keyboard operability) — strip the UA chrome and re-inherit the menu's
    font/colour (a button that doesn't inherit is exactly how a menu drifts onto the host font, the

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3447,23 +3447,17 @@ function openViewMenu(btn: HTMLElement): void {
   document.addEventListener("pointerdown", viewMenuAway, true);
   document.addEventListener("keydown", viewMenuKey, true);
 }
-// The icon: an ordering glyph — three shortening bars + a direction arrow — drawn inline so
-// currentColor keeps it monochrome in every state. NOT a gear: the kernel page's strip shows its
-// ⛭ right below this footer, and two gears would read as the same control (the user 2026-08-24).
-function viewMenuGlyph(): string {
-  return '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" '
-    + 'stroke-width="1.6" stroke-linecap="round" aria-hidden="true">'
-    + '<path d="M2.5 4h8"/><path d="M2.5 8h5.5"/><path d="M2.5 12h3"/>'
-    + '<path d="M12.5 5.5v5.8"/><path d="M10.6 9.6l1.9 2 1.9-2"/></svg>';
-}
+// A WORD, not an icon (the user 2026-08-24, round two: the ordering glyph beside "Sessions ▴" read
+// as "not what I would expect for what to show"): "View ▴" says exactly what clicking does — the
+// footer's own word-button vocabulary, the same upward caret its Sessions neighbour wears. The
+// original glyph existed to be compact; one short word costs a few px and buys first-look legibility.
 function ensureViewMenuBtn(): HTMLElement {
   let b = document.getElementById("feed-viewbtn") as HTMLElement | null;
   if (!b) {
     b = el("button", "fdismiss ffollow feed-modetoggle");
     b.id = "feed-viewbtn";
-    b.innerHTML = viewMenuGlyph();
+    b.textContent = "View \u25b4";
     b.title = "view options — sort direction, single column, group by session";
-    b.setAttribute("aria-label", "view options");
     b.setAttribute("aria-haspopup", "menu");
     b.onclick = (ev) => {   // opening the menu IS the acknowledgement (same as the session filter)
       ev.stopPropagation();


### PR DESCRIPTION
User feedback on the shipped combobox: the little button beside the Sessions caret was "not what I would expect for an icon of what to show." That button is the view menu's trigger — a monochrome ordering glyph (three shortening bars + an arrow). The read is fair: the glyph speaks "sort," and the menu it opens controls the whole view (sort direction, single column, grouping).

**Reasoning.** The glyph existed to be compact (it replaced three word-buttons), but a guessable icon is the wrong trade against one short word. Of the candidate redesigns — folding the function into the Sessions trigger (conflates two different menus), a better icon (an eye reads "visibility," sliders read "settings" — still guesses), or a word — the word wins the dispatch's bar outright: a first-time look at **"View ▴"** correctly predicts a menu of view options. It is the footer's own word-button vocabulary, wearing the same upward caret its Sessions neighbour does — two parallel triggers, each predicting a menu.

**Shape.** The icon and its `viewMenuGlyph` helper are deleted outright; the icon-only bespoke two-id padding rule goes with it (the shared `#feed-foot .fdismiss` metrics cover a word-button — and the pins now assert NO bespoke `#feed-viewbtn` rule survives to lose a specificity tie); the redundant aria-label goes too (the text is the label). The `tools/ui-verify` example fixture follows the new anatomy.

**Evidence.** Headless before/after frames via `tools/ui-verify` over the same synthetic footer (outputs in /tmp per its README): before — a boxed glyph beside "Sessions ▴"; after — `View ▴  Sessions ▴`. `feed-viewmenu.test.ts` pins the word, the glyph's absence, and the no-bespoke-rule cascade guarantee; 2363 extension tests green on the pushed head. Whether the new trigger reads instantly is the user's to confirm on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
