### PR TITLE
Postal ergonomics: agents rows disambiguate and address; a renamed session hears its new name

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -860,6 +860,13 @@ BOOT_RESUME_CONCURRENCY = max(1, int(os.environ.get("ROMP_BOOT_RESUME_CONCURRENC
 # forever and trap the whole sweep — after this long the sweep proceeds anyway, loudly.
 BOOT_RESUME_SLOT_S = float(os.environ.get("ROMP_BOOT_RESUME_SLOT_S", "180"))
 
+# The rename ping (the user 2026-08-24): a renamed session hears its OWN new name — one line ahead
+# of whatever next enters it (send() below), never a wake of its own. Same [romp] mechanics-notice
+# family as the restart notices above (the housekeeping note in the session prompt gives the prefix
+# meaning), but MARKER-FREE: this line joins an EXISTING message, and the romp-injected marker
+# would re-author the host message's echo and transcript atom.
+RENAME_NUDGE = "[romp] This session was renamed: it is now '%s'. A note for your own records — carry on."
+
 # Same recovery, different death: the session's OWN claude process died mid-turn (killed or crashed)
 # while the kernel stayed up, so the kernel itself resumes it (_heal_cut_session) instead of waiting
 # for the next boot's reconcile.
@@ -4220,6 +4227,19 @@ class SdkBackend:
         s = self._ensure(sid)
         if not s:
             return False
+        # RENAME PING (the user 2026-08-24): one line ahead of the next thing that enters the
+        # session, so it hears its own new name instead of inferring it. A slash-command send
+        # passes untouched (the CLI must see the bare command) and the note holds for the next
+        # real prompt. MARKER-FREE on purpose, unlike the standalone restart notices: this line
+        # joins an EXISTING message, and the romp-injected marker would re-author the host
+        # message's echo and transcript atom (a typed follow-up would render as a gray romp
+        # bubble). The [romp] prefix is the sanctioned family for mechanics notices — the session
+        # prompt's housekeeping note already tells every session what it means.
+        if not text.lstrip().startswith("/"):
+            _reg = read_reg(self.state_dir, sid) or {}
+            if _reg.get("renameNote"):
+                text = "%s\n\n%s" % (RENAME_NUDGE % _reg["renameNote"], text)
+                self._update_reg(sid, renameNote=None)
         if _is_compact_cmd(text):
             # Delivering /compact: mark the session compacting NOW (authoritative), covering the gap between
             # this send and the CLI actually starting the turn — so a drive op the producer tick checks in
@@ -4647,7 +4667,11 @@ class SdkBackend:
         reg = read_reg(self.state_dir, sid)
         if not reg:
             return False
-        self._update_reg(sid, name=new_name)   # locked RMW — see set_effort's race note
+        # renameNote: the one-line "you were renamed" ping, delivered by send() ahead of whatever
+        # NEXT enters the session (the user 2026-08-24: a renamed worker learned its own new name
+        # only by inference from a peer's prose). Reg-persisted so it survives restarts; never a
+        # wake of its own — the queue wakes sessions, this rides a send that already happens.
+        self._update_reg(sid, name=new_name, renameNote=new_name)   # locked RMW — see set_effort's race note
         # keep the shared names/ identity file in sync (preserve colours)
         try:
             parts = (Path(self.state_dir) / "names" / sid).read_text().rstrip("\n").split("\t")

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -477,6 +477,16 @@ def format_agents(agents, me, me_id=""):
             # say whose it is so nobody mistakes it for a full peer (the user 2026-08-22)
             pn = next((x.get("name") for x in agents if x.get("id") == a.get("parent")), "")
             tag = " (thread of %s)" % (pn or "a session here")
+        # host prefix + short stable id (the user 2026-08-24): a duplicate-name refusal lists its
+        # candidates as host:name, and the uuid is the rename-proof address — without either on the
+        # row, the reader matched an error message by guesswork. Short form: enough to disambiguate
+        # AND to paste as a recipient (resolve_recipient matches an unambiguous id prefix of 8+
+        # chars) — progressive disclosure, not a wall of hex.
+        rid = str(a.get("id") or "")
+        host = rid.split(":", 1)[0] if (a.get("remote") and ":" in rid) else ""
+        disp = ("%s:%s" % (host, a["name"])) if (host and not str(a["name"]).startswith(host + ":")) else a["name"]
+        short = (rid.rsplit(":", 1)[-1] if ":" in rid else rid)[:8]
+        sid_tag = (" · %s" % short) if short else ""
         br = ("  [%s]" % a["branch"]) if a.get("branch") else ""
         wk = ""
         if a.get("working"):
@@ -488,7 +498,7 @@ def format_agents(agents, me, me_id=""):
             st = a.get("state", "")
             stale = "  (idle now — claim may be stale)" if st and st != "working" else ""
             wk = "  — %s%s" % (a["working"], stale)
-        lines.append("  %s%s%s%s" % (a["name"], tag, br, wk))
+        lines.append("  %s%s%s%s%s" % (disp, tag, sid_tag, br, wk))
     return "\n".join(lines)
 
 def _hhmm_epoch(t):
@@ -730,6 +740,15 @@ def resolve_recipient(to, frm_id=""):
     direct_all = ([] if (want_host and want_host != here)
                   else [a for a in all_agents(threads=True)
                         if (a.get("id") == bare if by_id else a["name"] == bare)])   # threads addressable for replies
+    if not direct_all and not by_id and not want_host             and re.fullmatch(r"[0-9a-fA-F][0-9a-fA-F-]{7,35}", bare):
+        # a SHORT id — the ` · <8-char>` form every list_agents row now carries (the user
+        # 2026-08-24) — addresses by unambiguous id PREFIX, so the row is enough to act on. An
+        # exact NAME match always wins first (a name may be hex-shaped); at least 8 characters so
+        # a stray word can never catch a session by luck; a remote row's id ("host:uuid") matches
+        # on its uuid part, the part the row shows. TWO prefix hits fall through to the standing
+        # ambiguity refusal below, exactly like a duplicated name.
+        direct_all = [a for a in all_agents(threads=True)
+                      if str(a.get("id") or "").rsplit(":", 1)[-1].startswith(bare)]
 
     if frm_id and any(a["id"] == frm_id for a in direct_all):
         return {"kind": "error", "status": 409,

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -82,6 +82,10 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     [ "$status" -eq 0 ]
     [[ "$output" == *"alpha (you)"* ]]
     [[ "$output" == *"beta"* ]]
+    # every row carries its short stable id (2026-08-24): the rename-proof address, and what a
+    # duplicate-name refusal's candidates can be matched against
+    [[ "$output" == *"alpha (you) · uuid-a"* ]]
+    [[ "$output" == *"beta · uuid-b"* ]]
 }
 
 # ── comment threads (the user 2026-08-22): a thread is a real forked session hidden until promotion;

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -22,7 +22,9 @@ Scope note — what is deliberately NOT checked:
   session manager's bookkeeping to ignore (the user 2026-07-25). Pinned by test_session_prompt.py.
 - sdk_backend's "[romp] The kernel restarted…" notices, which are genuinely ABOUT romp: they tell a
   session why its turn was cut, so naming it is the point (and the housekeeping note gives the
-  name meaning).
+  name meaning). The rename ping (RENAME_NUDGE, 2026-08-24) is the same family — it tells a session
+  its own new name — and is pinned below to stay one marker-free line with no romp nouns beyond
+  the sanctioned prefix.
 
 SYNTHETIC fixtures only (placeholder ids, invented goal text).
 """
@@ -159,6 +161,23 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
                                      "%r speaks romp at the session (%r: %s). Write it as the person "
                                      "it works for asking — see CLAUDE.md, 'Messages we inject into a "
                                      "session'." % (name, word, why))
+
+    def test_the_rename_ping_stays_one_clean_mechanics_line(self):
+        # the [romp] prefix is the sanctioned mechanics family (the restart notices' shape); past
+        # it, the line must speak plainly — no markers (it joins an EXISTING message and would
+        # re-author it), no romp nouns, one line
+        import os as _os
+        from importlib.machinery import SourceFileLoader as _L
+        sb = _L("romp_sdk_backend_voice", _os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        line = sb.RENAME_NUDGE % "tests"
+        self.assertTrue(line.startswith("[romp] "), "the sanctioned mechanics prefix")
+        self.assertNotIn("\n", line, "one line")
+        self.assertNotIn("<!--", line, "marker-free — it rides inside an existing message")
+        body = line.split("]", 1)[1].lower()
+        for word, why in ROMP_WORDS:
+            self.assertNotIn(word, body, "the ping speaks plainly past its prefix (%r: %s)" % (word, why))
+        self.assertIn("renamed", body)
+        self.assertIn("'tests'", body, "…and it names the new name itself")
 
     def test_the_untitled_fallback_names_no_romp_object(self):
         # a node with no text still renders SOMETHING; that placeholder must not smuggle in "goal"

--- a/tests/test_kernel_effort_reconnect.py
+++ b/tests/test_kernel_effort_reconnect.py
@@ -77,7 +77,7 @@ class EffortReconnect(unittest.TestCase):
                     'self._update_reg(sid, auth=value, authPending=True, apiKeyAuth=None)',
                     'self._update_reg(sid, mode=mode)',
                     'self._update_reg(sid, fast=(value == "on"), liveFast=value)',
-                    'self._update_reg(sid, name=new_name)',
+                    'self._update_reg(sid, name=new_name, renameNote=new_name)',   # + the rename ping (2026-08-24)
                     'self._update_reg(sid, model=value, modelPending=bool(s._model_pending))',
                     'self._update_reg(sid, model=value, liveModel=_alias_label(value), modelPending=False)'):
             self.assertIn(pin, BACKEND_SRC)

--- a/tests/test_postal_agents_render.py
+++ b/tests/test_postal_agents_render.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""list_agents disambiguation (the user 2026-08-24): every row carries its short stable id, and a
+remote row its host prefix — so a duplicate-name refusal ("candidates listed as host:name") can be
+matched against the list instead of guessed at, and the id on the row is enough to ADDRESS by:
+resolve_recipient matches an unambiguous id prefix of 8+ hex-ish chars (an exact NAME always wins
+first; two prefix hits refuse like any duplicated name; your own id still self-refuses). Synthetic
+notes-api world only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_POSTAL_HOST"] = "TESTHOST"
+WEB = "aaaaaaaa-1111-2222-3333-444444444444"
+API = "abcdefab-5555-6666-7777-888888888888"
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([
+    {"id": WEB, "name": "web", "dir": "/tmp/notes-api", "state": "working", "working": ""},
+    {"id": API, "name": "api", "dir": "/tmp/notes-api", "state": "waiting", "working": ""},
+]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+ps = SourceFileLoader("romp_postal_agents_render", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class AgentsRowsDisambiguate(unittest.TestCase):
+    def test_every_row_carries_its_short_stable_id(self):
+        out = ps.format_agents([{"id": WEB, "name": "web", "state": "working"}], "web", WEB)
+        self.assertIn("web (you) · aaaaaaaa", out, "the (you) row keeps its mark and gains the id")
+        out = ps.format_agents([{"id": API, "name": "api", "state": "waiting"}], "web", WEB)
+        self.assertIn("api · abcdefab", out)
+
+    def test_a_remote_row_wears_its_host_prefix_and_its_own_uuid_part(self):
+        row = {"id": "TESTHOST-B:%s" % API, "name": "api", "remote": True}
+        out = ps.format_agents([row], "web", WEB)
+        self.assertIn("TESTHOST-B:api [remote] · abcdefab", out,
+                      "host:name matches the duplicate-name refusal's candidate form; the id is the "
+                      "uuid part, the piece that addresses")
+
+    def test_a_thread_row_keeps_its_minor_player_tag(self):
+        rows = [{"id": WEB, "name": "web", "state": "working"},
+                {"id": "bbbbbbbb-9999-0000-1111-222222222222", "name": "web-comment-1",
+                 "thread": True, "parent": WEB}]
+        out = ps.format_agents(rows, "api", API)
+        self.assertIn("web-comment-1 (thread of web) · bbbbbbbb", out)
+
+
+class ShortIdAddresses(unittest.TestCase):
+    def setUp(self):
+        # the sessions-file seam is read PER CALL, so a batch run's last-imported module owns the
+        # env — bind OUR file for the duration of each test (the seam's own hermetic idiom)
+        self._saved = os.environ.get("ROMP_SESSIONS_FILE")
+        os.environ["ROMP_SESSIONS_FILE"] = _SESS
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("ROMP_SESSIONS_FILE", None)
+        else:
+            os.environ["ROMP_SESSIONS_FILE"] = self._saved
+
+    def test_a_unique_id_prefix_resolves_direct(self):
+        res = ps.resolve_recipient("abcdefab", "some-other-sender")
+        self.assertEqual(res["kind"], "direct")
+        self.assertEqual(res["agent"]["id"], API, "the row's 8-char form is enough to address")
+
+    def test_an_exact_name_always_beats_a_hex_shaped_prefix(self):
+        # a session NAMED like a hex prefix must stay addressable by that name
+        sess = json.loads(Path(_SESS).read_text())
+        sess.append({"id": "cccccccc-1234-5678-9abc-def012345678", "name": "abcdefab",
+                     "dir": "", "state": "waiting", "working": ""})
+        Path(_SESS).write_text(json.dumps(sess))
+        try:
+            res = ps.resolve_recipient("abcdefab", "some-other-sender")
+            self.assertEqual(res["kind"], "direct")
+            self.assertEqual(res["agent"]["name"], "abcdefab", "name-exact wins before any id math")
+        finally:
+            Path(_SESS).write_text(json.dumps(sess[:-1]))
+
+    def test_an_ambiguous_prefix_refuses_like_a_duplicated_name(self):
+        sess = json.loads(Path(_SESS).read_text())
+        sess.append({"id": "abcdefab-0000-1111-2222-333333333333", "name": "tests",
+                     "dir": "", "state": "waiting", "working": ""})
+        Path(_SESS).write_text(json.dumps(sess))
+        try:
+            res = ps.resolve_recipient("abcdefab", "some-other-sender")
+            self.assertEqual(res["kind"], "error", "two prefix hits are an ambiguity, never a pick")
+        finally:
+            Path(_SESS).write_text(json.dumps(sess[:-1]))
+
+    def test_too_short_a_prefix_never_id_matches(self):
+        res = ps.resolve_recipient("abcdef", "some-other-sender")
+        self.assertEqual(res["kind"], "error", "under 8 chars stays a name miss — luck can't address")
+
+    def test_your_own_id_prefix_still_self_refuses(self):
+        res = ps.resolve_recipient("abcdefab", API)
+        self.assertEqual(res["kind"], "error")
+        self.assertEqual(res["status"], 409, "the self-send loopback guard keys on identity, not spelling")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_rename_ping.py
+++ b/tests/test_sdk_rename_ping.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""The rename ping (the user 2026-08-24): a renamed session hears its OWN new name on its next
+wake — rename() stamps the reg (renameNote, restart-proof), and send() delivers RENAME_NUDGE one
+line ahead of whatever next enters the session, never a wake of its own. Voice pinned in
+test_injected_voice.py. Deterministic: reg-level + source pins, no real claude processes."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_renameping", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
+
+
+def _backend(d):
+    return sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+
+
+class RenamePing(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.be = _backend(self.td.name)
+        (Path(self.td.name) / "names").mkdir(parents=True, exist_ok=True)
+        sb.write_reg(Path(self.td.name), SID, {"sid": SID, "name": "web", "cwd": "/tmp"})
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_rename_stamps_the_pending_note_beside_the_name(self):
+        self.assertTrue(self.be.rename(SID, "tests"))
+        reg = sb.read_reg(Path(self.td.name), SID)
+        self.assertEqual(reg.get("name"), "tests")
+        self.assertEqual(reg.get("renameNote"), "tests",
+                         "reg-persisted, so the ping survives a kernel restart unspoken")
+
+    def test_rename_of_an_unknown_sid_stamps_nothing(self):
+        self.assertFalse(self.be.rename("99999999-0000-1111-2222-333333333333", "tests"))
+
+    def test_send_delivers_the_ping_once_and_skips_slash_commands(self):
+        # send()'s consume, pinned at source (driving a real send spawns a CLI): the ping rides
+        # ahead of the next NON-command text, clears after one delivery, and never re-authors the
+        # host message (marker-free — see RENAME_NUDGE's own comment and the voice test)
+        self.assertIn('if not text.lstrip().startswith("/"):', SRC, "a bare /compact must reach the CLI bare")
+        self.assertIn('if _reg.get("renameNote"):', SRC)
+        self.assertIn('text = "%s\\n\\n%s" % (RENAME_NUDGE % _reg["renameNote"], text)', SRC)
+        self.assertIn('self._update_reg(sid, renameNote=None)', SRC, "one delivery, then the note is spent")
+        self.assertNotIn("romp-injected", sb.RENAME_NUDGE, "marker-free: it joins an EXISTING message")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two worker-survey fixes on the postal surface.

**list_agents disambiguation.** Every row now carries its short stable id (` · <8 chars>`), and a remote row its `host:` prefix — a duplicate-name refusal lists its candidates as `host:name`, and without either on the row the reader matched an error message by guesswork (the live handoff case from the survey). The short form also **addresses**: `resolve_recipient` matches an unambiguous id prefix of 8+ hex-ish chars — an exact name always wins first (a name may be hex-shaped), two prefix hits refuse exactly like a duplicated name, a host-qualified reference skips the arm, and your own id still self-refuses. Progressive disclosure: enough to disambiguate and act on, not a wall of hex. Existing bats pins survive as substrings; new pins cover the id, the host form, and the full resolution grid.

**Rename ping.** A renamed session now hears its *own* new name: `rename()` stamps the reg (`renameNote`, restart-proof, both the WS op and `/rename` land here) and `send()` delivers `RENAME_NUDGE` one line ahead of whatever next enters the session — never a wake of its own (the queue wakes sessions; this rides a send that already happens), never a marker (the line joins an *existing* message, and the injected marker would re-author its echo and transcript atom), a slash-command send passes bare with the note holding. Same `[romp]` mechanics family as the restart notices; the injected-voice test pins it as one clean line with no romp nouns past the sanctioned prefix.

**Honest caveats:** tmux-backend sessions don't get the ping (the mechanism rides the SDK reg + send seam, the precedent's home; a tmux rename is interactive); a rename to the same name pings once, harmlessly; the ping piggybacks only non-command sends, so a session whose next input is `/compact` hears it on the send after.

**Tests:** `tests/test_postal_agents_render.py` (row forms incl. remote/thread; the full prefix-resolution grid), `tests/test_sdk_rename_ping.py` (reg stamp, unknown-sid no-op, send-consume source pins), the injected-voice pin, the retargeted setter-family pin, and the extended bats agents test. Suites green on this head: pytest 5539 passed, npm 2359/2359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)