### PR TITLE
Inline previews ask the OWNING session's host: the recurring cross-host 404 loop dies

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28827,8 +28827,10 @@ class Handler(BaseHTTPRequestHandler):
             # resolve ~ AND a relative path against the session's cwd (msg.id), exactly like click-to-open
             # and /file — so an assistant-mentioned "plots/out.png" renders in the VS Code webview too,
             # not just absolute user-attachment paths (the user 2026-07-20). The reply keys on the RAW
-            # requested path: that's what the client's element cache is waiting on.
-            _reply(client, {"type": "imgData", "path": p,
+            # requested path AND echoes the asking session: the same relative path names a different
+            # file per session cwd, so a path-only reply filled every session's chips with the first
+            # asker's answer (2026-08-24) — the client keys its cache on (sid, path).
+            _reply(client, {"type": "imgData", "path": p, "sid": str(msg.get("id") or ""),
                             "url": _img_data_url(_resolve_open_path(p, msg.get("id")))})
         elif msg and msg.get("type") == "redial" and msg.get("host"):
             # the composer just refused a send to a downed host — user demand, dial it now (2026-08-16)

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -93,7 +93,7 @@ test("a failed preview heals on the next kernel push — the kernel-is-back even
 });
 
 test("the chat uses the FULL render on web, and the host data-URL flow for images in VS Code", () => {
-  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p\) : null;/);
+  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p, renderingOwnerSid \?\? activeId\) : null;/);
   assert.doesNotMatch(RENDER, /previewThumb/, "the chat no longer renders mention thumbnails — full renders now");
 });
 
@@ -114,8 +114,10 @@ test("VS Code's pending image chip pulses while the host round-trip is in flight
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.user-img-path\.img-pending::after \{ animation: none;/);
 });
 
-test("imgRequest carries the session id so RELATIVE mentioned paths resolve against the session cwd", () => {
-  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "imgRequest", path: p, id: activeId \}\);/);
+test("imgRequest carries the OWNING session id so relative paths resolve against that session's cwd", () => {
+  // the caller-passed sid, never activeId: a background prebuild renders hidden tabs while another
+  // session is active, and baking activeId asked the wrong session (often the wrong HOST) for the bytes
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "imgRequest", path: p, id: sid \}\);/);
   assert.match(KERNEL, /_img_data_url\(_resolve_open_path\(p, msg\.get\("id"\)\)\)/);
 });
 

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -109,7 +109,7 @@ test("figures render AT their mention: after the block naming them; same-block f
 });
 
 test("VS Code's pending image chip pulses while the host round-trip is in flight; a failed one doesn't", () => {
-  assert.match(RENDER, /"user-img-path" \+ \(imgFailed\.has\(p\) \? "" : " img-pending"\)/);
+  assert.match(RENDER, /"user-img-path" \+ \(imgFailed\.has\(imgKey\(sid, p\)\) \? "" : " img-pending"\)/);
   assert.match(CSS, /\.user-img-path\.img-pending::after \{ content: " ···";/);
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.user-img-path\.img-pending::after \{ animation: none;/);
 });

--- a/ui/webview/chat-pin-history.test.ts
+++ b/ui/webview/chat-pin-history.test.ts
@@ -23,7 +23,7 @@ test("pathPins ride the chat events as a sibling map and thread into every linki
 });
 
 test("the embed and its lightbox request the pinned bytes; unpinned surfaces stay live", () => {
-  assert.match(RENDER, /previewFull\(p, activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/);
+  assert.match(RENDER, /previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/);
   assert.match(PREVIEW, /previewFull\(path: string, sid\?: string \| null, verified = false, pin\?: string\)/);
   assert.match(PREVIEW, /const url = fileUrl\(path, sid\) \+ \(pin \? "&pin=" \+ encodeURIComponent\(pin\) : ""\);/);
   assert.match(PREVIEW, /openLightbox\(path, sid, pin\); \};/, "the big view shows the same pixels the embed did");

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -176,7 +176,7 @@ test("highlights re-apply after every render path", () => {
 
 test("a comments frame refreshes the open popover IN PLACE — composer and caret survive", () => {
   assert.match(UI, /prev\.dataset\.mode === mode && prev\.dataset\.tid === \(th \? th\.tid : create!\.uuid\)\s*\n\s*&& prev\.dataset\.status === status/);
-  assert.match(UI, /function fillCommentMsgs\(list: HTMLElement, th: CommentThread\)/);
+  assert.match(UI, /function fillCommentMsgs\(list: HTMLElement, th: CommentThread, sid: string\)/);
 });
 
 test("the working state starts on the gesture, and delete is optimistic and cuts the work", () => {

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -52,7 +52,7 @@ test("an image thumbnail renders per surface; other files wear an ext + name chi
   // reach the kernel origin, the same split every chat image rides
   assert.match(fn, /if \(canPreview\(\)\) \{/);
   assert.match(fn, /img\.src = fileUrl\(p, id\);/);
-  assert.match(fn, /const w = buildPathImg\(p\);/);
+  assert.match(fn, /const w = buildPathImg\(p, id\);/);   // the composer's own session, in scope — never the render-owner global
   // name first, pixels when ready (the user 2026-08-04): the ext + name chip renders immediately and
   // the image swaps in on its own load event — a slow fetch never shows a blank box, a 404 keeps the chip
   assert.match(fn, /const doc = composerFileDoc\(p\);\s*\n\s*box\.appendChild\(doc\);/);

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -55,7 +55,7 @@ test("the page's own kernel-socket recovery (romp:wsup) heals everything the sam
 
 test("imgFailed is no longer forever: a reconnect gives every parked path ONE fresh host round-trip", () => {
   assert.match(RENDER, /function healPathImgs\(\): void \{/);
-  assert.match(RENDER, /const failed = Array\.from\(imgFailed\);\s*\n\s*imgFailed\.clear\(\);/);
-  assert.match(RENDER, /if \(!imgRequested\.has\(p\)\) \{/, "in-flight asks still dedup");
+  assert.match(RENDER, /const failed = new Set\(imgFailed\);\s*\n\s*imgFailed\.clear\(\);/);
+  assert.match(RENDER, /if \(!imgRequested\.has\(k\)\) \{/, "in-flight asks still dedup — per (sid, path) key");
   assert.match(RENDER, /installMdImgHeal\(\);/, "the md-img capture heal is installed once at boot");
 });

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -51,7 +51,7 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /previewable\.slice\(0, 4\)/, "capped so a directory listing doesn't wallpaper the chat");
-  assert.match(RENDER, /previewFull\(p, activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/, "relative paths resolve against the ACTIVE session's cwd, as openPathLink; verified paths fail loudly");
+  assert.match(RENDER, /previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/, "URLs bake the OWNING session's id — a background build must never capture activeId; verified paths fail loudly");
 });
 
 test("the chat sheet carries the lightbox + preview styles (the feed no longer previews)", () => {

--- a/ui/webview/preview-owner-sid.test.ts
+++ b/ui/webview/preview-owner-sid.test.ts
@@ -1,0 +1,47 @@
+// The owning-session id behind every baked file/preview URL (the user 2026-08-24, the recurring
+// inline-preview failure): transcript DOM is built for BACKGROUND sessions too — update() marks a
+// hidden view stale and the idle prebuild renders it — and previewFull/buildPathImg used to bake
+// the global activeId into their URLs and retry closures at that moment. For a federated session
+// built while a local one was active, every figure then asked the WRONG host's kernel, whose
+// truthful "not found" looped forever (retries and heals re-fetch the closure's captured URL);
+// only the next send's tail re-render, which runs with activeId now correct, ever fixed it. The
+// mechanism: renderingOwnerSid — the SESSION whose DOM is being built, host prefix included —
+// distinct from renderingSid, the fold KEY the comment popover retargets to its thread id.
+import { test } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("renderingOwnerSid exists, documented as the session whose DOM is being built", () => {
+  assert.match(RENDER, /let renderingOwnerSid: string \| null = null;/);
+  // the two-variable split is deliberate: the fold key can be a thread id, the owner never is
+  assert.match(RENDER, /Distinct from renderingSid, which is a fold KEY/);
+});
+
+test("every render entry point sets the owner (and the out-of-sync ones restore it)", () => {
+  // syncView: the per-tab build — prebuild included, since prebuild calls syncView per planned tab
+  assert.match(RENDER, /renderingSid = id; {10}\/\/ so renderSystem can key[\s\S]{0,200}renderingOwnerSid = id;/);
+  // prebuild restores both after its loop, so nothing later keys off the last pre-built tab
+  assert.match(RENDER, /const savedRenderingSid = renderingSid;[\s\S]{0,120}const savedOwnerSid = renderingOwnerSid;/);
+  assert.match(RENDER, /renderingSid = savedRenderingSid;\s*\n\s*renderingOwnerSid = savedOwnerSid;/);
+  // the comment popover renders a thread: fold keys per-thread, URLs per the thread's SESSION
+  assert.match(RENDER, /function fillCommentMsgs\(list: HTMLElement, th: CommentThread, sid: string\)/);
+  assert.match(RENDER, /renderingSid = th\.tid;\s*\n\s*renderingOwnerSid = sid;/);
+  assert.match(RENDER, /renderingSid = saved;\s*\n\s*renderingOwnerSid = savedOwner;/);
+  // chatEpisode fills in the MESSAGE handler, outside any sync — it pins both to the episode's session
+  assert.match(RENDER, /renderingSid = sid;\s*\n\s*renderingOwnerSid = sid;\s*\n\s*try \{[\s\S]{0,220}fillClearBody/);
+});
+
+test("the baked URLs and host image asks carry the owner, never the active tab", () => {
+  // the inline figure family: previewFull (web <img>/PDF card, retry closures) + buildPathImg (VS Code)
+  assert.match(RENDER, /previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\)/);
+  assert.match(RENDER, /buildPathImg\(p, renderingOwnerSid \?\? activeId\)/);
+  // user-turn path images ride the same owner
+  assert.match(RENDER, /buildPathImg\(im\.src\.slice\(5\), renderingOwnerSid \?\? activeId\)/);
+  // buildPathImg itself sends the sid it was handed
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "imgRequest", path: p, id: sid \}\);/);
+  // …and the reconnect heal re-asks for the OWNING view's session, read off the thread root
+  assert.match(RENDER, /closest\("\[data-session\]"\) as HTMLElement \| null\)\?\.dataset\.session \|\| activeId;/);
+});

--- a/ui/webview/preview-owner-sid.test.ts
+++ b/ui/webview/preview-owner-sid.test.ts
@@ -42,6 +42,20 @@ test("the baked URLs and host image asks carry the owner, never the active tab",
   assert.match(RENDER, /buildPathImg\(im\.src\.slice\(5\), renderingOwnerSid \?\? activeId\)/);
   // buildPathImg itself sends the sid it was handed
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "imgRequest", path: p, id: sid \}\);/);
-  // …and the reconnect heal re-asks for the OWNING view's session, read off the thread root
-  assert.match(RENDER, /closest\("\[data-session\]"\) as HTMLElement \| null\)\?\.dataset\.session \|\| activeId;/);
+  // …and the reconnect heal re-asks for the OWNING session, read off the chip's own minted sid
+  assert.match(RENDER, /const own = e\.dataset\.imgsid \|\| activeId;/);
+});
+
+test("the whole imgRequest ride is keyed by (session, path), never the bare path", () => {
+  // the same relative path string in two sessions names two different files (each cwd its own): a
+  // bare-path cache let the FIRST asker's answer fill every session's chips, and a first-ask failure
+  // parked them all (the adversarial review of this fix, 2026-08-24)
+  assert.match(RENDER, /const imgKey = \(sid: string \| null, p: string\): string => \(sid \|\| ""\) \+ "\\u0000" \+ p;/);
+  assert.match(RENDER, /const imgUrlCache = new Map<string, string>\(\); {3}\/\/ \(sid,path\) → dataURL/);
+  assert.match(RENDER, /wrap\.dataset\.imgsid = sid \|\| "";/);
+  // …and the kernel echoes the asking session on the reply, so answers land only on their session's chips
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /\{"type": "imgData", "path": p, "sid": str\(msg\.get\("id"\) or ""\),/);
+  // an older kernel's sid-less reply still fills by path alone — sharing at worst, never a dead chip
+  assert.match(RENDER, /const bySid = typeof sid === "string";/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -954,28 +954,36 @@ function renderAgentNotif(a: AgentNotif, outputs?: TaskOutputs, key?: string): H
 // path; until/unless it returns a dataURL we show a "🖼 filename" chip, then swap in
 // the real thumbnail when the host answers. Re-renders rebuild the element from these
 // caches, so a thumbnail already fetched stays a thumbnail.
-const imgUrlCache = new Map<string, string>();   // path → dataURL (loaded)
-const imgFailed = new Set<string>();             // path → keep the chip, never retry
-const imgRequested = new Set<string>();          // path → request in flight
-function fillPathImg(wrap: HTMLElement, p: string): void {
+// EVERYTHING on this ride is keyed by (session, path), never the bare path: the same RELATIVE path
+// string in two sessions names two different files (each cwd its own), and a bare-path cache let the
+// FIRST asker's answer fill every session's chips — wrong pixels shown silently, and a first-ask
+// failure parked every session's chip (found adversarially reviewing the owner-sid fix, 2026-08-24).
+// The chip carries its sid in data-imgsid so refills and heals match on both halves.
+const imgKey = (sid: string | null, p: string): string => (sid || "") + "\u0000" + p;
+const imgUrlCache = new Map<string, string>();   // (sid,path) → dataURL (loaded)
+const imgFailed = new Set<string>();             // (sid,path) → keep the chip until a reconnect heal
+const imgRequested = new Set<string>();          // (sid,path) → request in flight
+function fillPathImg(wrap: HTMLElement, p: string, sid: string | null): void {
   wrap.textContent = "";
-  const url = imgUrlCache.get(p);
+  const url = imgUrlCache.get(imgKey(sid, p));
   if (url) {
     const img = document.createElement("img"); img.className = "user-img"; img.src = url; img.loading = "lazy"; img.title = p;
     wrap.appendChild(img);
   } else {
     // still waiting on the host round-trip → pulsing-dots loading cue (pure CSS — the sandbox can't
     // fetch the swirl asset); a FAILED path drops the pulse and reads as the plain chip it is
-    const chip = el("div", "user-img-path" + (imgFailed.has(p) ? "" : " img-pending"));
+    const chip = el("div", "user-img-path" + (imgFailed.has(imgKey(sid, p)) ? "" : " img-pending"));
     chip.textContent = "🖼 " + (p.split("/").pop() || p); chip.title = p;
     wrap.appendChild(chip);
   }
 }
 function buildPathImg(p: string, sid: string | null): HTMLElement {
   const wrap = el("span", "js-pathimg"); wrap.dataset.imgpath = p;
-  fillPathImg(wrap, p);
-  if (!imgUrlCache.has(p) && !imgFailed.has(p) && !imgRequested.has(p)) {
-    imgRequested.add(p);
+  wrap.dataset.imgsid = sid || "";
+  fillPathImg(wrap, p, sid);
+  const k = imgKey(sid, p);
+  if (!imgUrlCache.has(k) && !imgFailed.has(k) && !imgRequested.has(k)) {
+    imgRequested.add(k);
     // id → the kernel resolves a RELATIVE path against this session's cwd (assistant-mentioned
     // "plots/out.png" renders too, not just absolute user-attachment paths — the user 2026-07-20).
     // The OWNING session's id, passed by the caller: a background build must never send activeId here.
@@ -983,11 +991,23 @@ function buildPathImg(p: string, sid: string | null): HTMLElement {
   }
   return wrap;
 }
-function onImgData(p: string, url: string | null): void {
-  imgRequested.delete(p);
-  if (url) imgUrlCache.set(p, url); else imgFailed.add(p);
+function onImgData(p: string, url: string | null, sid: string | null): void {
+  // A kernel that echoes the sid answers exactly the chips that asked; an OLDER kernel's reply
+  // (no sid echo) falls back to path-only matching — at worst the old sharing, never a dead chip.
+  const bySid = typeof sid === "string";
+  const keys = bySid ? [imgKey(sid, p)]
+    : Array.from(document.querySelectorAll(".js-pathimg"))
+        .filter((n) => (n as HTMLElement).dataset.imgpath === p)
+        .map((n) => imgKey((n as HTMLElement).dataset.imgsid || null, p));
+  for (const k of keys) {
+    imgRequested.delete(k);
+    if (url) imgUrlCache.set(k, url); else imgFailed.add(k);
+  }
   document.querySelectorAll(".js-pathimg").forEach((n) => {
-    const e = n as HTMLElement; if (e.dataset.imgpath === p) fillPathImg(e, p);
+    const e = n as HTMLElement;
+    if (e.dataset.imgpath !== p) return;
+    if (bySid && (e.dataset.imgsid || "") !== (sid || "")) return;
+    fillPathImg(e, p, e.dataset.imgsid || null);
   });
 }
 // RECONNECT-class heal for the path-image chips (the user 2026-08-24): imgFailed was "never retry
@@ -996,22 +1016,22 @@ function onImgData(p: string, url: string | null): void {
 // request flow buildPathImg runs on mint (imgRequested still dedups in-flight asks).
 function healPathImgs(): void {
   if (!imgFailed.size) return;
-  const failed = Array.from(imgFailed);
+  const failed = new Set(imgFailed);
   imgFailed.clear();
-  for (const p of failed) {
-    document.querySelectorAll(".js-pathimg").forEach((n) => {
-      const e = n as HTMLElement;
-      if (e.dataset.imgpath !== p) return;
-      fillPathImg(e, p);                             // back to the pending pulse while the ask is out
-      if (!imgRequested.has(p)) {
-        imgRequested.add(p);
-        // the OWNING view's session, read off the thread root the chip lives in — a heal fired while
-        // another tab is active must re-ask for the right session, not the one being looked at
-        const own = (e.closest("[data-session]") as HTMLElement | null)?.dataset.session || activeId;
-        if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: own });
-      }
-    });
-  }
+  document.querySelectorAll(".js-pathimg").forEach((n) => {
+    const e = n as HTMLElement;
+    const p = e.dataset.imgpath;
+    // the chip's own minted sid — a heal fired while another tab is active must re-ask for the
+    // OWNING session, not the one being looked at (and the popover's chips carry theirs too)
+    const own = e.dataset.imgsid || activeId;
+    const k = p ? imgKey(own, p) : "";
+    if (!p || !failed.has(k)) return;
+    fillPathImg(e, p, own);                          // back to the pending pulse while the ask is out
+    if (!imgRequested.has(k)) {
+      imgRequested.add(k);
+      if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: own });
+    }
+  });
 }
 // the page shim fires romp:wsup when THIS pane's kernel socket reconnects (kernel.py ws.onopen) —
 // the same kernel-is-back event a hostUp is for a federated tunnel; heal everything on it
@@ -10807,7 +10827,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "clipboardText") insertClipboardText(String(m.text ?? ""));
   else if (m.type === "ledger") setLedger(m.id, m.ledger ?? null);
   else if (m.type === "working") { workingSet = new Set(Array.isArray(m.names) ? m.names : []); refreshPostalDots(); }
-  else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null);
+  else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null, typeof m.sid === "string" ? m.sid : null);
   else if (m.type === "tabOrder") { captureViews(m.views || null); applyTabOrder(m.order, m.tabs); }
   else if (m.type === "renamed" && m.id && typeof m.name === "string") {
     notePendingMeta(pendingTabMeta, m.id, { name: m.name });   // kernel truth — hold it against a push built pre-rename

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -508,6 +508,15 @@ fetch(kernelUrl("/palette"), { cache: "no-store" }).then((r) => r.json())
 const mru: string[] = [];             // recency stack, front = most-recently-active (close → return to previous)
 let activeId: string | null = null;
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
+// The SESSION whose transcript DOM is being built — the id preview/image URLs must bake in, host prefix
+// included. Distinct from renderingSid, which is a fold KEY the comment popover retargets to its thread id.
+// Baking activeId instead routed a background build's file fetches at whatever session the user was READING:
+// the idle prebuild renders hidden tabs' new turns, so a federated session's figures asked the WRONG host's
+// kernel, whose truthful 404 looped "fetching → not found" on files that exist — and every retry/heal
+// re-fetches the closure's captured URL, so only the next send's tail re-render ever fixed it (the user
+// 2026-08-24, the recurring inline-preview failure). Same class for relative paths across LOCAL sessions:
+// they resolved against the active session's cwd, not the owning session's.
+let renderingOwnerSid: string | null = null;
 // TRUE while fillCommentMsgs renders into the comment popover (the user 2026-08-23): the thread uses
 // the chat's own renderer deliberately — but the transcript-COUPLED hover machinery must stay out.
 // wireTurnHover's glow band appends to turn.parentElement (the .cmt-msgs list, positioned nowhere the
@@ -962,14 +971,15 @@ function fillPathImg(wrap: HTMLElement, p: string): void {
     wrap.appendChild(chip);
   }
 }
-function buildPathImg(p: string): HTMLElement {
+function buildPathImg(p: string, sid: string | null): HTMLElement {
   const wrap = el("span", "js-pathimg"); wrap.dataset.imgpath = p;
   fillPathImg(wrap, p);
   if (!imgUrlCache.has(p) && !imgFailed.has(p) && !imgRequested.has(p)) {
     imgRequested.add(p);
     // id → the kernel resolves a RELATIVE path against this session's cwd (assistant-mentioned
-    // "plots/out.png" renders too, not just absolute user-attachment paths — the user 2026-07-20)
-    if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: activeId });
+    // "plots/out.png" renders too, not just absolute user-attachment paths — the user 2026-07-20).
+    // The OWNING session's id, passed by the caller: a background build must never send activeId here.
+    if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: sid });
   }
   return wrap;
 }
@@ -995,7 +1005,10 @@ function healPathImgs(): void {
       fillPathImg(e, p);                             // back to the pending pulse while the ask is out
       if (!imgRequested.has(p)) {
         imgRequested.add(p);
-        if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: activeId });
+        // the OWNING view's session, read off the thread root the chip lives in — a heal fired while
+        // another tab is active must re-ask for the right session, not the one being looked at
+        const own = (e.closest("[data-session]") as HTMLElement | null)?.dataset.session || activeId;
+        if (vscodeApi) vscodeApi.postMessage({ type: "imgRequest", path: p, id: own });
       }
     });
   }
@@ -1015,7 +1028,7 @@ installMdImgHeal();   // markdown-inline <img> failures register for the per-mes
 function userImage(im: { src: string; path?: string }, pathInText = false): HTMLElement {
   const fig = el("span", "user-img-wrap");
   if (im.src.startsWith("path:")) {
-    fig.appendChild(buildPathImg(im.src.slice(5)));   // host reads it → real thumbnail; chip until then / on failure
+    fig.appendChild(buildPathImg(im.src.slice(5), renderingOwnerSid ?? activeId));   // host reads it → real thumbnail; chip until then / on failure
   } else {
     const img = document.createElement("img"); img.className = "user-img"; img.src = im.src; img.loading = "lazy";
     fig.appendChild(img);
@@ -1243,8 +1256,8 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
     const BLOCK_SEL = "p, li, h1, h2, h3, h4, h5, h6, blockquote, td, th";
     const strips = new Map<HTMLElement, HTMLElement>();   // figure anchor → its strip (same block shares one)
     for (const p of previewable.slice(0, 4)) {
-      const full = canPreview() ? previewFull(p, activeId, kernelVerified.has(p), (pathPins || {})[p])
-        : previewKind(p) === "img" ? buildPathImg(p) : null;
+      const full = canPreview() ? previewFull(p, renderingOwnerSid ?? activeId, kernelVerified.has(p), (pathPins || {})[p])
+        : previewKind(p) === "img" ? buildPathImg(p, renderingOwnerSid ?? activeId) : null;
       if (!full) continue;
       const block = mentionAt.get(p)?.closest(BLOCK_SEL) as HTMLElement | null;
       const anchor = block && root.contains(block) && block !== root ? block : root;
@@ -2833,9 +2846,21 @@ function chatEpisode(m: any): void {
   const got = { events: (m.events || []) as ChatEvent[], truncated: m.truncated || 0,
                 error: m.error ? String(m.error) : undefined };
   episodeCache.set(key, got);
-  document.querySelectorAll<HTMLElement>(".clear-body").forEach((b) => {
-    if (b.dataset.clearKey === key) fillClearBody(b, got);
-  });
+  // This fill runs in the MESSAGE handler, outside any syncView — renderingSid/renderingOwnerSid still
+  // hold whatever was built last. Pin both to the episode's own session so fold keys and file/preview
+  // URLs belong to it, then restore.
+  const savedKey = renderingSid;
+  const savedOwner = renderingOwnerSid;
+  renderingSid = sid;
+  renderingOwnerSid = sid;
+  try {
+    document.querySelectorAll<HTMLElement>(".clear-body").forEach((b) => {
+      if (b.dataset.clearKey === key) fillClearBody(b, got);
+    });
+  } finally {
+    renderingSid = savedKey;
+    renderingOwnerSid = savedOwner;
+  }
 }
 
 // LIVE /clear in progress (the user 2026-07-27): an animated inline element between the /clear delivery
@@ -6212,7 +6237,7 @@ function openCommentThread(): { sid: string; th: CommentThread } | null {
 
 /** The popover's conversation area, (re)filled in place — shared by the full build and the
  *  frame-driven refresh so an update never rebuilds the composer under the user's caret. */
-function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
+function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): void {
   const prevScroll = list.scrollTop;
   const atTail = list.scrollTop >= list.scrollHeight - list.clientHeight - 8;
   list.replaceChildren();
@@ -6224,7 +6249,9 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     // rail dots, markdown, tool folds, notice cards — never a simplified twin). renderingSid keys
     // the folds per thread, exactly as a chat tab would.
     const saved = renderingSid;
+    const savedOwner = renderingOwnerSid;
     renderingSid = th.tid;
+    renderingOwnerSid = sid;   // fold keys are per-thread; file/preview URLs belong to the thread's SESSION
     renderingIntoThread = true;   // same renderer, minus the transcript-coupled hover chrome (see the flag)
     let prev: number | null = null;
     let quoteHost: HTMLElement | null = null;   // the thread's OPENING message — the quote's home
@@ -6264,6 +6291,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     }
     renderingIntoThread = false;
     renderingSid = saved;
+    renderingOwnerSid = savedOwner;
     // The quoted passage renders as CONTEXT attached to the thread's opening message (the user
     // 2026-08-24): it used to sit as a standalone block ABOVE the whole list — above the branch
     // divider too, misreading chronology, since the branch happened before the quote. Same idiom
@@ -6308,7 +6336,7 @@ function refillOpenCommentPop(): void {
   if (!openCommentKey) return;
   const th = (commentThreads.get(openCommentKey.sid) || []).find((t) => t.tid === openCommentKey!.tid);
   const list = document.querySelector(".cmt-pop .cmt-msgs") as HTMLElement | null;
-  if (th && list) fillCommentMsgs(list, th);
+  if (th && list) fillCommentMsgs(list, th, openCommentKey.sid);
 }
 
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
@@ -6360,7 +6388,7 @@ function commentSendFromPop(pop: HTMLElement): void {
   commentDrafts.delete(cur.th.tid);
   box.value = "";
   const list = pop.querySelector(".cmt-msgs") as HTMLElement | null;
-  if (list) fillCommentMsgs(list, cur.th);      // the pending bubble IS the acknowledgement
+  if (list) fillCommentMsgs(list, cur.th, cur.sid);      // the pending bubble IS the acknowledgement
 }
 
 /** A live thread's model/effort chip label: the frame's value, tinted from the shared /models
@@ -6394,7 +6422,7 @@ function renderCommentPopover(): void {
     const t = prev.querySelector(".cmt-title") as HTMLElement | null;
     if (t) t.textContent = commentPopTitle(!!create, th);
     const list = prev.querySelector(".cmt-msgs") as HTMLElement | null;
-    if (th && list) fillCommentMsgs(list, th);
+    if (th && list) fillCommentMsgs(list, th, sid);
     if (th) for (const b of Array.from(prev.querySelectorAll(".meta-btn[data-kind]")) as HTMLElement[]) {
       const lbl = b.querySelector(".meta-label") as HTMLElement | null;
       if (lbl) liveMetaLabel(lbl, b.dataset.kind === "model" ? "model" : "effort", th);
@@ -6483,7 +6511,7 @@ function renderCommentPopover(): void {
   }
   if (th) {
     const list = el("div", "cmt-msgs");
-    fillCommentMsgs(list, th);
+    fillCommentMsgs(list, th, sid);
     pop.appendChild(list);
   }
   let metaRowPending: HTMLElement | null = null;   // appended under the composer row — the statusline position
@@ -7277,6 +7305,7 @@ function syncViewInner(id: string, atBottom?: boolean): View {
   // content above is unchanged. true/undefined ⇒ free to evict the top (we're at the bottom, or it's a
   // non-append sync).
   renderingSid = id;          // so renderSystem can key the pinned card's persisted open-state by session
+  renderingOwnerSid = id;     // preview/image URLs bake THIS session's id (host prefix included), never activeId's
   const v = ensureView(id);
   const s = sessions.get(id);
   if (!s) return v;
@@ -7684,6 +7713,7 @@ function runPrebuild(deadline: IdleDeadline): void {
     };
   };
   const savedRenderingSid = renderingSid; // syncView sets this; restore it so nothing keys off a pre-built tab
+  const savedOwnerSid = renderingOwnerSid;
   for (const id of prebuildPlan(activeId, mru, order, viewState)) {
     if (!sessions.has(id)) continue;
     try {
@@ -7693,6 +7723,7 @@ function runPrebuild(deadline: IdleDeadline): void {
     if (deadline.timeRemaining() < 3) { schedulePrebuild(); break; } // out of idle budget → resume next idle
   }
   renderingSid = savedRenderingSid;
+  renderingOwnerSid = savedOwnerSid;
 }
 
 function showActive() {
@@ -9766,7 +9797,7 @@ function renderComposerFiles(id: string | null): void {
         img.addEventListener("load", () => doc.replaceWith(img));
         img.src = fileUrl(p, id);
       } else {
-        const w = buildPathImg(p);                 // VS Code: host-read data URL fills in; chip until then
+        const w = buildPathImg(p, id);             // VS Code: host-read data URL fills in; chip until then
         w.classList.add("composer-file-hostimg");
         box.appendChild(w);
       }


### PR DESCRIPTION
## The bug (recurring; survived several earlier fixes)

A federated session's mentioned figures loop **"fetching → not found"** on files that verifiably exist on the owning host, and heal only when the user's next message lands — and it only happens to turns that arrived **while the user was reading another session**.

## Root cause

Client-side, in the chat webview. Transcript DOM is built for **background** sessions too: `update()` marks a hidden view stale and the idle prebuild renders it. At that moment `previewFull`/`buildPathImg` baked the global `activeId` — the session being **read** — into the preview URL and its retry closures. A remote session's figure built while a local tab was active got a bare sid, so `fileUrl` skipped the `/remote/<host>/file` relay and asked the **viewer machine's kernel**, whose 404 was truthful for *its* disk. Every retry, tap, and heal re-fetches the closure's captured URL, so nothing recovered; the next send's tail re-render ran with `activeId` now correct — exactly the reported "renders when my next message lands."

The report's other two hypotheses are ruled out by the routes themselves: `/file` is a stateless stat (no per-session registration to lapse — `_resolve_open_path` passes absolute paths through untouched), and preview URLs carry only `path + sid (+ pin)` — no epoch to invalidate.

## The fix

`renderingOwnerSid` — the session whose DOM is being built, host prefix included, distinct from `renderingSid` (a fold *key* the comment popover retargets to its thread id). Set by `syncView`, saved/restored by the prebuild, pinned by the comment popover and by `chatEpisode`'s out-of-sync fill; consumed by `previewFull`, `buildPathImg`, and the user-turn images. The reconnect heal re-asks with the chip's own sid. With the owner baked, a genuine miss is the owning kernel's truthful named failure ("not found: `<path>`") — the wrong-host loop is structurally impossible.

**Second commit** (found by adversarial review of the first): the VS Code `imgRequest` ride's caches were keyed by bare path, so two sessions whose cwds each hold a different `plots/out.png` shared the first asker's pixels. The whole ride now keys by **(sid, path)**; the kernel echoes the asking session on the `imgData` reply; an older kernel's sid-less reply degrades to the old path-only matching, never a dead chip.

## Evidence (hermetic, synthetic — TESTHOST idiom)

One server plays both machines: local `/file` 404s ("not found: …"), `/remote/TESTHOST/file` serves the PNG. Playwright drives the exact repro shape: session A (local) active, session B (`TESTHOST:…`) gets its assistant turn in the background, idle prebuild renders it, user switches back.

- **old head**: the hidden build asked local `/file` (relay never touched), and after the switch the figure sat on the retry chip — the reported loop.
- **this branch**: zero local asks, one relay ask, `src=/remote/TESTHOST/file?path=…&sid=<bare>`, image rendered (`naturalWidth > 0`), no chip.

## Tests

`preview-owner-sid.test.ts` pins the mechanism end to end (the global, every set/restore point, the baked consumers, the heal's sid, the (sid,path) keying, the kernel's sid echo). Five neighbor pins that anchored the old `activeId` forms retargeted in the same commits. npm suite + typecheck green; full Python suite green (5557 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)