### PR TITLE
The bottom-left view label reads "(no tags)"

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -658,7 +658,7 @@ EOF
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
-    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the untagged view); --host <kernel> edits an attached kernel's tag; --rename renames"
+    _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the no-tags view); --host <kernel> edits an attached kernel's tag; --rename renames"
     _romp_cmd "romp watch-pr <n> [--repo o/r]" -        "One mail here when the PR lands or fails — the kernel owns the watch, so it survives restarts (replaces the mortal shell loop)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
@@ -1081,7 +1081,8 @@ def spell(x):
     return x
 groups = v.get("tags") or v.get("groups") or []   # older kernel: pre-rename key
 act = v.get("active") or "all"
-act = next((g.get("name") for g in groups if g.get("id") == act), act)
+act = {"all": "All", "untagged": "no tags"}.get(act) \
+    or next((g.get("name") for g in groups if g.get("id") == act), act)
 print("active view: %s" % act)
 for g in groups:
     m = [names.get(spell(x)) or spell(x) for x in (g.get("members") or [])]

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -82,7 +82,7 @@ function viewVisible(views, id) {
 }
 function viewLabel(views) {
   if (!views || !views.active || views.active === 'all') return 'All';
-  if (views.active === 'untagged') return '(untagged)';
+  if (views.active === 'untagged') return '(no tags)';   // the user-chosen words (2026-08-24); parens stay, marking the built-in apart from tag names
   const g = viewTagUnion(views).find((x) => x.ids.indexOf(views.active) >= 0);
   return g ? g.name : 'All';   // the NAME, never a host prefix — kernels are plumbing
 }
@@ -2721,7 +2721,7 @@ class TimelinePanel {
     // All is the default and sits first (the user 2026-08-24); (untagged) — the old default's
     // meaning under its own sentinel — second; both are built-ins, not rows in the tags dialog
     item('All', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
-    item('(untagged)', { current: v.active === 'untagged' }).addEventListener('click', () => pick('untagged'));
+    item('(no tags)', { current: v.active === 'untagged' }).addEventListener('click', () => pick('untagged'));
     // NAME-KEYED (user ruling 2026-08-24, superseding the v0 host-marked two-rows render: "if the
     // UX requires understanding that tags exist across different kernels, it is not good"): one row
     // per tag NAME, membership the union across every kernel defining it, the local store's colour

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -1,7 +1,7 @@
 // The timeline's corner control panel (the user 2026-08-18; filter-chip form + TAG model
 // 2026-08-23): "Filter ▾" in the bottom-left corner — the strip under the lane gutter, left of the
 // time labels. The dropdown picks the active VIEW (All — literally everything, the default
-// since 2026-08-24 — / the (untagged) built-in / the named tags),
+// since 2026-08-24 — / the (no tags) built-in / the named tags),
 // holds New tag… / Sessions & tags…, and carries the two timeline display toggles (collapse idle
 // gaps, active only) so they finally work in every host. The dialog is TAG-CENTRIC: one row per
 // session wearing its tag chips (✕ leaves a tag; [+] joins or mints one) — a tagged session leaves
@@ -38,9 +38,9 @@ test("executed: All shows literally everything (hidden retired 2026-08-24); unta
 
 test("executed: the trigger label and the N-more cue (live sessions outside the view)", () => {
   // the views are named for what they show: "All" (literally everything — the hidden set retired
-  // 2026-08-24) and "(untagged)", parenthesized as the built-in it is
+  // 2026-08-24) and "(no tags)" — the user-chosen words (2026-08-24), parens kept as the built-in marker
   assert.equal(viewLabel(null), "All");
-  assert.equal(viewLabel(V("untagged")), "(untagged)");
+  assert.equal(viewLabel(V("untagged")), "(no tags)");
   assert.equal(viewLabel(V("g1")), "pool");
   const sessions = [{ id: "s1", live: true }, { id: "s2", live: true }, { id: "s4", live: false }];
   assert.equal(viewMoreCount(V("g1"), sessions), 1, "s1 is live and outside; dead s4 never counts");
@@ -179,13 +179,13 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
   assert.match(SRC, /const ft = LANE_TOGGLES\.find\(\(t\) => t\.flag === 'hideFromFeed'\);/);
   assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.hideFromFeed = next;/,
     "the same optimistic sticky flags the lane gear uses");
-  // the menu items say so: All first (the default), (untagged) second, then New tag… / Sessions & tags…
+  // the menu items say so: All first (the default), (no tags) second, then New tag… / Sessions & tags…
   assert.match(SRC, /item\('New tag…', \{ dim: true \}\)/);
   assert.match(SRC, /item\('Sessions & tags…', \{ dim: true \}\)/);
   assert.match(SRC, /item\('All', \{ current: !v\.active \|\| v\.active === 'all' \}\)/);
-  assert.match(SRC, /item\('\(untagged\)', \{ current: v\.active === 'untagged' \}\)/);
-  assert.match(SRC, /item\('All',[\s\S]{0,300}item\('\(untagged\)',/, "All sits ABOVE (untagged) in the menu");
-  assert.match(SRC, /item\('\(untagged\)',[\s\S]{0,600}for \(const g of viewTagUnion\(v\)\)/,
+  assert.match(SRC, /item\('\(no tags\)', \{ current: v\.active === 'untagged' \}\)/);
+  assert.match(SRC, /item\('All',[\s\S]{0,300}item\('\(no tags\)',/, "All sits ABOVE (no tags) in the menu");
+  assert.match(SRC, /item\('\(no tags\)',[\s\S]{0,600}for \(const g of viewTagUnion\(v\)\)/,
     "…and the tag rows come AFTER both built-ins — the DoD's menu order, pinned end to end (the rows are the NAME-KEYED union since the 2026-08-24 ruling)");
 });
 


### PR DESCRIPTION
## What

The user's verbatim ask (2026-08-24): "Change untagged on the bottom left to no tags. Two words." The label changes everywhere it renders — `viewLabel`, the view menu row, and the CLI's active-view print (which now maps all three: All / no tags / the tag's name, instead of leaking the raw sentinel) plus the `romp tag` help wording. The parens stay as the built-in marker (the words were specified; the chrome is the standing treatment). The stored sentinel keeps its internal name — a label change, not a migration.

## Tests

All seven pins swept in the same commit (`ui/timeline-views-panel.test.ts`: the executed label, the menu row, the All-above order, the union-rows-after order). bats grepped for the old wording — the only "untagged" there is about git tags. Suites green: 5557 python tests (+293 subtests), 2369 JS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)