### PR TITLE
A view-narrowed board says which view it shows — the whisper promotes

### DIFF
--- a/ui/webview/feed-view.test.ts
+++ b/ui/webview/feed-view.test.ts
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cardInView, outsideView, outsideViewCount } from "./feed-view";
+import { cardInView, outsideView, outsideViewCount, viewLabel } from "./feed-view";
 import type { SessionViews } from "./session-views";
 
 const ROOT = path.resolve(process.cwd(), "..");
@@ -68,7 +68,7 @@ test("the outside count is exactly what the board is NOT showing — breakthroug
 });
 
 test("the feed gates through the shared decider and adopts the payload's views blob", () => {
-  assert.match(FEED, /import \{ cardInView, outsideView, outsideViewCount \} from "\.\/feed-view";/);
+  assert.match(FEED, /import \{ cardInView, outsideView, outsideViewCount, viewLabel \} from "\.\/feed-view";/);
   assert.match(FEED, /let shown = feedViews \? list\.filter\(\(a\) => cardInView\(feedViews, a\.sid, askColumn\(a\) === "needsInput"\)\) : list;/,
     "the view layer runs FIRST in viewFiltered — the freeze badges and the render share it");
   // adoption rides every payload; the optimistic pending copy follows the tab strip's own
@@ -101,11 +101,29 @@ test("the breakthrough cue rides BOTH card shapes as a row2-visible mark, the �
     "dim, sub-line scale, never a status colour");
 });
 
+test("the near-empty board says WHICH view it shows — the whisper promotes to card chrome", () => {
+  // the user 2026-08-25 read a view-narrowed board as "the feed is broken": one card showed, twenty
+  // hid, the dim line went unseen. Exact promotion rule: the view hides more than the board shows.
+  assert.match(FEED, /const shownN = viewFiltered\(asks\)\.length;/);
+  assert.match(FEED, /vmore\.classList\.toggle\("prominent", outN > shownN\);/);
+  assert.match(FEED, /"Showing the \\u201c" \+ viewLabel\(feedViews\) \+ "\\u201d view — " \+ outN/,
+    "the promoted line NAMES the active view");
+  assert.match(CSS, /#feed-viewmore\.prominent \{ margin: 6px 8px 2px; padding: 10px 14px; background: #252526;/,
+    "the judge-limit banner's own card chrome — neutral, never a status colour");
+  // label truth: a tag view is its name; untagged says plain words; All only excludes the hidden set
+  assert.equal(viewLabel({ active: "untagged" }), "no tags");
+  assert.equal(viewLabel({ active: "t1", tags: [{ id: "t1", name: "infra" }] }), "infra");
+  assert.equal(viewLabel({ active: "TESTHOST:t9", tags: [], remoteTags: [{ id: "TESTHOST:t9", name: "infra" }] }), "infra");
+  assert.equal(viewLabel({ active: "all" }), "All");
+  assert.equal(viewLabel(null), "All");
+});
+
 test("what's filtered stays one glance away: the N-outside line, click-switches to All", () => {
   assert.match(FEED, /const outN = feedViews \? outsideViewCount\(feedViews,/);
   assert.match(FEED, /vmore\.id = "feed-viewmore";/);
   assert.match(FEED, /vmore\.style\.display = outN \? "" : "none";/, "zero outside → no line, not a zero");
-  assert.match(FEED, /outN \+ \(outN === 1 \? " card" : " cards"\) \+ " outside this view — show all";/);
+  assert.match(FEED, /outN \+ \(outN === 1 \? " card" : " cards"\) \+ " outside this view — show all";/,
+    "the whisper stays for a lightly narrowed board (outN <= shown)");
   // the click switches the ACTIVE view to All — optimistically (the board reflows now, the
   // click-safety acknowledgement), through the same whole-blob op the dashboard uses
   assert.match(FEED, /feedViewsPending = \{ \.\.\.feedViews, active: "all" \};/);

--- a/ui/webview/feed-view.ts
+++ b/ui/webview/feed-view.ts
@@ -20,6 +20,17 @@ export function cardInView(views: SessionViews | null | undefined, sid: string, 
   return !outsideView(views, sid) || needsYou;
 }
 
+/** The active view's display label for the outside-view line: a tag view is its NAME (the union is
+ *  name-keyed), untagged is its plain-words self, All is All (only the manual hidden set excludes). */
+export function viewLabel(views: SessionViews | null | undefined): string {
+  const act = views && views.active;
+  if (!act || act === "all") return "All";
+  if (act === "untagged") return "no tags";
+  const tags = (views!.tags || views!.groups || []).concat(views!.remoteTags || []);
+  const t = tags.find((x) => x.id === act);
+  return (t && t.name) || "this";
+}
+
 /** The dim "N cards outside this view" count: view-hidden and NOT broken through — exactly what
  *  the board is not showing (a breakthrough already shows; counting it would double-speak). */
 export function outsideViewCount(views: SessionViews | null | undefined,

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -327,6 +327,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    one dim line after the columns, click switches the view to All. */
 #feed-viewmore { padding: 4px 14px 10px; color: var(--dim); font-size: 0.82em; cursor: pointer; }
 #feed-viewmore:hover { color: var(--accent); text-decoration: underline; }
+/* PROMOTED (the user 2026-08-25, who read a view-narrowed board as broken): when the view hides
+   MORE than the board shows, the whisper trades up to the judge-limit banner's card chrome — same
+   #252526 card, hairline, 6px radius, 0.9em — and names the view. Neutral chrome, never a status
+   colour: a narrowed board is a choice, not an error. */
+#feed-viewmore.prominent { margin: 6px 8px 2px; padding: 10px 14px; background: #252526;
+  border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 6px;
+  color: var(--fg); font-size: 0.9em; }
+#feed-viewmore.prominent:hover { color: var(--fg); text-decoration: none;
+  border-color: var(--accent); }
 /* "↪ from <sender>" — courier handoff provenance beside the owning session: the "↪ from" reads as dim
    gray chrome, the peer name as a bold, identity-coloured session link (the user 2026-06-16). */
 /* a direct child of the WRAPPING name row, kept on one line — .fask-id's flex-grow pushes it to the

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -10,7 +10,7 @@ import { distillText, distillInputs, applyDistillLine, distillPending, distillSt
 import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
-import { cardInView, outsideView, outsideViewCount } from "./feed-view";
+import { cardInView, outsideView, outsideViewCount, viewLabel } from "./feed-view";
 import { SessionViews, viewsKey } from "./session-views";
 import { freezeDiff } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
@@ -4262,8 +4262,20 @@ function render() {
     };
     list.appendChild(vmore);
   }
+  // PROMOTION (the user 2026-08-25, who read a view-narrowed board as "the feed is broken": one card
+  // showed, twenty hid, and the dim line went unseen): when the view hides MORE than the board shows,
+  // the line trades the whisper for the judge-limit banner's card chrome and NAMES the view — the
+  // near-empty board must state plainly which view it is showing and how to widen. Exact rule, no
+  // heuristics: outN > (cards on the board).
+  const shownN = viewFiltered(asks).length;
+  vmore.classList.toggle("prominent", outN > shownN);
   vmore.style.display = outN ? "" : "none";
-  if (outN) vmore.textContent = outN + (outN === 1 ? " card" : " cards") + " outside this view — show all";
+  if (outN) {
+    vmore.textContent = outN > shownN
+      ? "Showing the \u201c" + viewLabel(feedViews) + "\u201d view — " + outN
+        + (outN === 1 ? " card is" : " cards are") + " in other views · show all"
+      : outN + (outN === 1 ? " card" : " cards") + " outside this view — show all";
+  }
   list.scrollTop = prevScroll;
   // Stale-freeze heal (hover-freeze): a LOCAL render can detach or re-key the hovered element with
   // no mouseleave — a removed element never fires leave events (typing in search filters the card


### PR DESCRIPTION
**The incident.** With most sessions tagged today and the untagged view active (chosen before the feed followed views), the board correctly narrowed to one card — and read as broken. The safeguard line rendered but whispered: 0.82em, dim, at the bottom of a near-empty dark board, beside a card whose 10-hour-old recency tint reads near-black.

**The fix.** The outside-view line **promotes** whenever the view hides more cards than the board shows (exact rule, `outN > cards-on-board` — no thresholds): it trades the whisper for the judge-limit banner's card chrome and **names the view** — `Showing the "no tags" view — 20 cards are in other views · show all`. Neutral chrome, never a status colour: a narrowed board is a choice, not an error. A lightly narrowed board keeps the whisper; the click still switches to All optimistically. `viewLabel` (pure, in feed-view.ts) resolves the active view's name across both tag homes.

**Verified.** Headless frame of the regression's exact shape (one synthetic card + the promoted banner) via tools/ui-verify; `viewLabel` executed for all view shapes; the promotion rule, named-view copy, and chrome pinned; the standing guards this incident exercised (needs-you breakthrough, hover-flush backstops) already pinned in their own suites. 2370 extension tests green on the pushed head.

**Also diagnosed, no code needed:** the breakthrough guard was unexercised at report time (the only tagged-session block verdict landed minutes after the report — live-store evidence); the "black card" is the age-darkened recency tint at ~10h over the black page doing its designed fade, made stark by being alone (a laptop-side identity-border check is noted in the report for the user to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
