### PR TITLE
The awaiting audit's surviving classes: kind-laundering gated, stale re-asserts yield, the watch tick runs

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3854,7 +3854,8 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
             # through machinery that already exists. Lifted by the closer's next audit of the goal.
             t = _target(o)
             k = o.get("kind")
-            kp = (_open_ask_peers(nodes[t]["id"].rsplit(":", 1)[0]) if k == "peer" and t else None)
+            kp = (_open_ask_peers(nodes[t]["id"].rsplit(":", 1)[0], since=nodes[t].get("t") or 0)
+                  if k == "peer" and t else None)
             if k == "peer" and t and not kp:
                 # the peer-kind write gate (the user 2026-08-24, same rule as apply_close): no open
                 # sent-question, no peer wait. DEMOTED to kindless rather than dropped — this op's
@@ -8081,7 +8082,13 @@ CLOSER_SYS = (
     "asynchronously and plans to act on when it completes: a background task or agent it launched, a "
     "long job or CI run it kicked off, a check-back it scheduled, a question it sent a peer session "
     "and still needs answered. Work handed OFF to a peer is the peer's own — ownership transferred, "
-    "not a wait; omit it. "
+    "not a wait; omit it. The kind boundaries are strict: job means an external computation the "
+    "session ITSELF launched (a cluster job, CI, a build) — another SESSION's work is never a job, "
+    "however long it runs; agents means background agents this session dispatched and still out; "
+    "timer means a scheduled check-back that actually EXISTS at turn end — never one the turn "
+    "canceled. Waiting for INBOUND mail (the manager's next dispatch, a peer's next message) is not "
+    "a wait at all: an idle recipient reads idle — omit it. Never relabel a wait to a different "
+    "kind to get it filed: work with a peer is kind peer, or no stamp. "
     "The turn must show **both** halves: the async work in flight (dispatched this turn, or re-checked "
     "and found still running) and the stated or clear intent to take action again when its result "
     "arrives. Waiting on the user is blocked, never awaiting. Async work whose result already came "
@@ -8177,20 +8184,24 @@ def _postal_ask_maps():
     return last_any, last_ask, alias
 
 
-def _open_ask_peers(sid):
+def _open_ask_peers(sid, since=0):
     """The peer keys `sid` itself sent a kind=question to that no reply of any kind has come back
     for — the awaiting-peer admit gate's evidence AND the identity the stamp records (2026-08-24):
     _peer_answered's pair-aware supersede matches these exact keys (sids, or the wait maps' own
     "peer:<host>:<name>" for an unresolved cross-host recipient — both sides derive them from the
-    same alias re-key, so they can never disagree)."""
+    same alias re-key, so they can never disagree). `since` (2026-08-25 audit) scopes the evidence
+    in TIME: an ask sent before the GOAL even existed cannot be what its wait is on — the waitfor
+    gate's own evidence-order rule, applied at the write gate. Unscoped, three week-old open
+    questions to another host admitted a peer stamp for a no-reply delegate, and the stamp's
+    awaitPeers named the wrong peers, so the pair-scoped supersede missed the reply that came."""
     last_any, last_ask, _alias = _postal_ask_maps()
     return sorted(peer for (f, peer), ts in last_ask.items()
-                  if f == sid and last_any.get((peer, f), 0) < ts)
+                  if f == sid and ts >= (since or 0) and last_any.get((peer, f), 0) < ts)
 
 
-def _open_peer_asks(sid):
-    """True iff `sid` itself sent a kind=question no reply of any kind has come back for."""
-    return bool(_open_ask_peers(sid))
+def _open_peer_asks(sid, since=0):
+    """True iff `sid` itself sent a kind=question (at/after `since`) no reply has come back for."""
+    return bool(_open_ask_peers(sid, since))
 
 
 def _parse_close(raw, menu_len):
@@ -8581,7 +8592,8 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
         elif i in awaiting:
             aw_why = (awaiting[i] or {}).get("why") or None
             aw_kind = (awaiting[i] or {}).get("kind")
-            aw_peers = (_open_ask_peers(nd["id"].rsplit(":", 1)[0]) if aw_kind == "peer" else None)
+            aw_peers = (_open_ask_peers(nd["id"].rsplit(":", 1)[0], since=nd.get("t") or 0)
+                        if aw_kind == "peer" else None)
             if aw_kind == "peer" and not aw_peers:
                 # the peer-kind write gate (the user 2026-08-24): awaiting-a-peer requires an
                 # outstanding kind=question this session ITSELF sent. A delegate transferred
@@ -8591,6 +8603,14 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
                 # this wait — the design rule's own tell that it is the wrong trigger — so the
                 # closer's claim stands down at the write moment: nothing is filed, no lift either
                 # (a stand-down is not new information in either direction).
+                continue
+            if any(e.get("kind") in ("awaiting", "done") and (e.get("lift") or e.get("kind") == "done")
+                   and (e.get("at") or e.get("ev_t") or 0) > (ev or 0) for e in nd.get("log") or []):
+                # the wait this assert describes already ENDED in the diary AFTER this turn's evidence
+                # (2026-08-25 audit: a closer auditing the pre-merge segment re-asserted a watch whose
+                # lift AND whose goal's done were both already filed — the stamp then stood for hours
+                # with the job kind exempt from every mail retire). The writer's world is older than
+                # the diary: stand down; a REAL new wait re-asserts from the next pass's fresh evidence.
                 continue
             if nd.get("awaitingWhy") != aw_why:
                 # a changed why is a real event → new row, new anchor (as ever)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3774,7 +3774,12 @@ def _lift_spent_awaiting(now, tmux):
                     # every lift: the (re)spawn must be newer than the stamp's anchor.
                     if (nd.get("awaitingKind") == "agents" and reg_ids is not None and not reg_ids
                             and not snap.get("subagents") and not running
-                            and sp > (nd.get("awaitingAt") or 0)):
+                            and (sp > (nd.get("awaitingAt") or 0)
+                                 # …or the transcript itself shows NOTHING running at all (2026-08-25
+                                 # audit): the closer stamped agents over a world with zero live
+                                 # dispatches — the misread-peer-as-agents shape needs no respawn to
+                                 # prove the notification can never arrive; the pairing already did
+                                 or not any(t.get("status") == "running" for t in every))):
                         if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                             changed = True
                             _drop_auto_nudge_rec(top)
@@ -3817,8 +3822,15 @@ def _lift_spent_awaiting(now, tmux):
                 _evidence = max((max(t.get("endT") or 0, t.get("t") or 0, t.get("deadline") or 0,
                                      sp if t.get("id") in dead else 0)
                                  for t in own), default=0)
-                if _last_lift and _last_assert > _last_lift and _stamp_written_at(nd) > _evidence:
-                    continue
+                if _last_lift and _last_assert > _last_lift and _evidence <= _last_lift:
+                    continue                          # every citable return was already ruled on by that
+                    #                                   lift — re-lifting off it is the flap. A return
+                    #                                   NEWER than the last lift is new information even
+                    #                                   when the re-assert's WRITE postdates it by seconds:
+                    #                                   the closer's audit segment ended before the return
+                    #                                   landed (2026-08-25 audit — a watcher's stamp written
+                    #                                   17s after its merge notification stood 9.5h because
+                    #                                   write-time was read as the epistemic boundary)
                 if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
                     # The lift is NEW INFORMATION for the escalation ladder: the wait this goal's last
@@ -11268,6 +11280,12 @@ def _tunnel_supervisor():
                             except Exception:
                                 pass
             last_addr[0] = addr
+            now = time.time()               # bound per PASS, not per remote row: the pass tail below
+            #                                 (_pr_watch_tick) reads it, and on a box with NO remotes the
+            #                                 loop body never ran — every pass died on UnboundLocalError
+            #                                 inside the catch-all, so PR-landing watches never fired and
+            #                                 a merged PR's stamp sat stale for hours (2026-08-25 audit,
+            #                                 the #664 specimen: merged 50s after the stamp, mail never sent)
             for r in rows:
                 now = time.time()
                 skip = False

--- a/tests/test_awaiting_audit_classes.py
+++ b/tests/test_awaiting_audit_classes.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""The 2026-08-25 awaiting audit's surviving classes, pinned (10 stamps live: 3 real, 4 stale, 3
+misfiled — every stale/misfiled one traced to a writer whose evidence the world had outrun):
+
+- KIND-LAUNDERING (C4): the peer write gate narrowed kind=peer, and the closer began filing the
+  same peer/idle waits as job/timer/agents — the kinds exempt from every mail-driven retire. The
+  prompt now draws hard kind boundaries; the agents kind gains the mechanical complement (a stamp
+  over a world with nothing running anywhere lifts — pinned in test_kernel_awaiting_lift).
+- ASK-RECENCY (C6): _open_ask_peers admitted a peer stamp off week-old open questions to another
+  host — asks that predate the GOAL cannot be what its wait is on (the waitfor gate's own
+  evidence-order rule, now applied at the write gate), and the stamp's awaitPeers then named the
+  wrong peers, so the pair-scoped supersede missed the reply that came.
+- DIARY STAND-DOWN (C3): the closer, auditing a pre-ending segment, re-asserted a wait whose lift
+  AND whose goal's done were already in the diary — the re-assert now stands down when the diary
+  ended the wait after the audited evidence (the standing writer-yields rule, applied to awaiting
+  asserts).
+All fixtures SYNTHETIC."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_audit", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+PEER = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+OLDPEER = "99999999-8888-7777-6666-bbbbbbbbbbbb"
+T0 = 1_781_100_000
+
+
+def _msg(i, f, t_, ts, kind):
+    return json.dumps({"id": "m%d" % i, "ev": "sent", "from": "web", "from_id": f,
+                       "to_id": t_, "t": ts, "kind": kind, "body": "x"})
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+
+    def tearDown(self):
+        jd._rebind_state(self._saved)
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+        self.td.cleanup()
+
+    def _log(self, rows):
+        jd.MESSAGES.write_text("\n".join(rows) + ("\n" if rows else ""))
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+
+    def _store(self, mint=T0):
+        s = {"rompUuid": SID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+             "placements": {}, "status": {}}
+        jd.apply_plan(s, "s1", mint, [{"do": "mint", "why": "x", "text": "Ship the exporter"}], [])
+        return s, SID + ":g1"
+
+    def _close_peer(self, s, why="asked the worker to verify; holding for the answer"):
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
+                                            "awaiting": {1: {"why": why, "kind": "peer"}}}, t=T0 + 500)
+
+
+class AskRecency(_Base):
+    """C6: an open ask that PREDATES the goal cannot admit its peer stamp."""
+
+    def test_a_pre_goal_ask_does_not_admit(self):
+        # the specimen: week-old open questions to another host, a fresh goal, a no-reply delegate —
+        # the stamp was admitted off asks that could not possibly be what this wait is on
+        self._log([_msg(1, SID, OLDPEER, T0 - 7 * 86400, "question"),
+                   _msg(2, SID, PEER, T0 + 10, "delegate")])
+        s, gid = self._store(mint=T0)
+        self._close_peer(s)
+        self.assertIsNone(s["nodes"][gid].get("awaitingWhy"),
+                          "no ask at/after the goal's mint → the gate stands down")
+
+    def test_an_ask_after_the_goal_admits_and_names_only_itself(self):
+        self._log([_msg(1, SID, OLDPEER, T0 - 7 * 86400, "question"),
+                   _msg(2, SID, PEER, T0 + 10, "question")])
+        s, gid = self._store(mint=T0)
+        self._close_peer(s)
+        nd = s["nodes"][gid]
+        self.assertEqual(nd.get("awaitingKind"), "peer")
+        self.assertEqual(nd.get("awaitingPeers"), [PEER],
+                         "awaitPeers carries ONLY the qualifying ask's peer — the pair supersede "
+                         "then watches the right pair, not a week-old stranger")
+
+    def test_the_gate_helper_scopes_by_since(self):
+        self._log([_msg(1, SID, OLDPEER, T0 - 100, "question"),
+                   _msg(2, SID, PEER, T0 + 100, "question")])
+        self.assertEqual(jd._open_ask_peers(SID), sorted([OLDPEER, PEER]), "unscoped: both")
+        self.assertEqual(jd._open_ask_peers(SID, since=T0), [PEER], "scoped: only at/after")
+
+
+class DiaryStandDown(_Base):
+    """C3: a re-assert whose audited evidence predates the diary's own ending yields."""
+
+    def _stamped(self):
+        self._log([_msg(1, SID, PEER, T0 + 10, "question")])
+        s, gid = self._store()
+        self._close_peer(s)
+        self.assertEqual(s["nodes"][gid].get("awaitingKind"), "peer", "fixture: stamped")
+        return s, gid
+
+    def test_a_reassert_after_the_diarys_lift_stands_down(self):
+        s, gid = self._stamped()
+        nd = s["nodes"][gid]
+        self.assertTrue(jd.record_verdict(s, nd, "romp", "awaiting", T0 + 600, lift=True),
+                        "fixture: the wait ENDED in the diary (a lift row lands)")
+        # the closer now audits an OLDER segment (ev t=T0+500 < the lift's arrival) and re-asserts
+        # with a CHANGED why — pre-fix this filed a fresh stamp over the ended wait
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
+                                            "awaiting": {1: {"why": "still holding for the verify",
+                                                             "kind": "peer"}}}, t=T0 + 500)
+        self.assertIsNone(s["nodes"][gid].get("awaitingWhy"),
+                          "the diary ended this wait after the audited evidence — the writer yields")
+
+    def test_a_reassert_from_fresh_evidence_still_files(self):
+        s, gid = self._stamped()
+        nd = s["nodes"][gid]
+        jd.record_verdict(s, nd, "romp", "awaiting", T0 + 600, lift=True)
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+        # a NEWER audited turn (evidence past the lift's arrival) re-asserts: a genuinely new wait
+        row_at = max((e.get("at") or 0) for e in nd["log"])
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
+                                            "awaiting": {1: {"why": "asked again after the fix",
+                                                             "kind": "peer"}}}, t=row_at + 60)
+        self.assertEqual(s["nodes"][gid].get("awaitingWhy"), "asked again after the fix",
+                         "fresh evidence out-orders the ending — the new wait files as ever")
+
+
+class KindBoundaries(_Base):
+    """C4a: the prompt's hard kind boundaries (the laundering shapes, named)."""
+
+    def test_the_kind_boundaries_are_stated(self):
+        for phrase in ("another SESSION's work is never a job",
+                       "never one the turn "
+                       "canceled",
+                       "an idle recipient reads idle",
+                       "Never relabel a wait to a different "
+                       "kind to get it filed"):
+            self.assertIn(phrase, jd.CLOSER_SYS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -160,6 +160,30 @@ class AwaitingLift(unittest.TestCase):
         self.assertIsNone(self._stamp(), "a real terminal record ends the wait for every kind")
 
     # ---- self-scoping: the other awaiting flavors are untouched ----
+    def test_a_return_newer_than_the_last_lift_lifts_despite_a_late_reassert(self):
+        # the 2026-08-25 audit's watcher shape: assert → lift → the watch re-armed and RETURNED →
+        # the closer, auditing a segment cut BEFORE that return, re-asserted seconds after it. The
+        # old stand-down read the WRITE time as the epistemic boundary and blocked the lift forever;
+        # the discriminator is the EVIDENCE against the last lift — a return newer than the last
+        # lift was never ruled on, whatever the re-assert's arrival says.
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        why = "the re-armed watcher; reports when it lands"
+        nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
+              "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
+              "awaitingWhy": why, "awaitingAt": STAMP, "log": [
+                  {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "at": STAMP + 10},
+                  {"ev_t": STAMP, "src": "romp", "kind": "awaiting", "lift": True, "at": STAMP + 20},
+                  {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why,
+                   "at": BACK + 10}]}                 # the live shape: a SAME-ANCHOR re-assert (two closer
+        #                                               rows on one ev_t), written AFTER the 400 return
+        #                                               its audit segment never saw
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+        self._tick()
+        self.assertIsNone(self._stamp(),
+                          "the return (endT %d) postdates the last lift (%d) — new information lifts"
+                          % (BACK, STAMP + 20))
+
     def test_a_wait_with_no_dispatches_of_its_own_is_untouched(self):
         # a CI run / scheduled check-back / peer handoff: nothing was dispatched, so nothing can be paired
         self._transcript([])
@@ -494,11 +518,20 @@ class RestartReconcile(unittest.TestCase):
         self.assertIsNone(self._stamp(), "no dispatch anywhere + empty authoritative set -> orphan, lifted")
 
     def test_the_dispatchless_lift_respects_the_anchor_and_the_kind(self):
-        self._transcript([])
+        # (2026-08-25 audit) the respawn is ONE sufficient evidence, not the only one: an agents
+        # stamp over a world with NOTHING running anywhere — registry authoritatively empty, no
+        # subagents, no raw-running task in the pairing — lifts regardless of the spawn epoch (the
+        # misread-peer-as-agents shape: the notification it claims to await can never arrive). A
+        # world with a dispatch still RUNNING keeps every stamp, exactly as before.
+        self._transcript([_monitor("t1", LAUNCH, timeout_ms=30_000_000)])   # one genuinely-running task
         self._seed("agents")
         self.spawn = STAMP - 50                       # the stamp POSTDATES the last restart
+        self._tick({"state": "", "bgTasks": [{"toolUseId": "t1"}]})   # …and the registry agrees it lives
+        self.assertIsNotNone(self._stamp(), "something IS running — no lift without its return")
+        self._transcript([])
+        self._seed("agents")
         self._tick({"state": "", "bgTasks": []})
-        self.assertIsNotNone(self._stamp(), "evidence must postdate the anchor — the wake stays the backstop")
+        self.assertIsNone(self._stamp(), "nothing running anywhere → the wait can never end; lifted")
         self.spawn = BACK
         self._seed(None)                              # a kindless stamp never matches the agents-orphan rule
         self._tick({"state": "", "bgTasks": []})

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -97,6 +97,23 @@ class Persistence(unittest.TestCase):
         self.assertEqual(len(km._pr_watches), 1)
 
 
+class SupervisorReachesTheTick(unittest.TestCase):
+    """The sweep must run on a box with NO remotes (the 2026-08-25 audit's #664 specimen): `now` was
+    bound only inside the supervisor's per-remote loop, so with remotes.json = [] every pass died on
+    UnboundLocalError inside the catch-all before reaching _pr_watch_tick — the landing mail never
+    sent, and a merged PR's awaiting stamp sat stale for hours with no retire path short of the
+    dead-man. The binding is per-pass now; this pins the ORDER (bound before the loop)."""
+
+    def test_now_is_bound_per_pass_before_the_tick(self):
+        import inspect
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn("now = time.time()               # bound per PASS", src,
+                      "the unconditional per-pass binding exists (loop-local bindings do not count)")
+        self.assertLess(src.index("now = time.time()               # bound per PASS"),
+                        src.index("_pr_watch_tick(now)"),
+                        "…and it precedes the tick, so zero remotes can never unbind it")
+
+
 class Tick(unittest.TestCase):
     """The sweep: terminal delivers + retires; gh failure retires LOUDLY after three; in-flight
     backs off while checks run."""


### PR DESCRIPTION
**The 2026-08-25 awaiting audit** (user ask: too much awaiting — investigate, quantify, fix). The numbers: 21 live sessions, 10 awaiting stamps, **zero wait-for edges, zero owed asks** — reply detection is clean; every false "awaiting" was a durable stamp. Verdicts: **3 real, 4 stale, 3 misfiled**. Five mechanisms, each fixed at its writer or its retire, none by hand:

- **C0** — the pr-watch sweep **crashed on every supervisor pass** on a box with no remotes (`now` bound only inside the per-remote loop; empty `remotes.json` → UnboundLocalError inside the catch-all before `_pr_watch_tick`): landing mail never sent, a merged PR's stamp stale for hours. Bound per pass.
- **C4** — **kind-laundering**: the peer write gate narrowed `kind=peer`, and the closer began filing the same peer/idle waits as job/timer/agents — the kinds exempt from every mail-driven retire (a manager's wait on a worker filed as *job*; an idle worker's mail wait filed as *timer* claiming a wakeup its own turn had canceled; a peer handoff filed as *agents* over a provably-empty registry). The prompt draws hard boundaries (another session's work is never a job; a timer must exist at turn end; waiting for inbound mail is no stamp at all; never relabel to get a wait filed), and the agents kind gains the mechanical complement: a stamp over a world with **nothing running anywhere** lifts regardless of respawn epoch.
- **C6** — `_open_ask_peers` was session-global: week-old open questions to another host admitted a peer stamp for a no-reply delegate, and `awaitPeers` named the wrong peers so the pair supersede missed the reply. The gate scopes by **ask recency** (an ask that predates the goal cannot be what its wait is on — the waitfor gate's own evidence-order rule) and records only the qualifying peers.
- **C3** — the closer, auditing a pre-ending segment, re-asserted a wait whose lift **and** whose goal's done were already in the diary; the re-assert now **stands down when the diary ended the wait after the audited evidence**. Fresh-evidence re-asserts file as ever.
- **C1** — the anti-flap stand-down read the re-assert's write time as the epistemic boundary, so a watcher's stamp written 17s after its merge notification could never lift (9.5h live). The discriminator is now the **evidence against the last lift**: a return newer than the last lift was never ruled on; the original flap stays blocked.

The remaining stamps are the designed residents (real cluster jobs; a dead detached capture the 6h dead-man owns). Specimens lift with their classes on the standing sweeps; no live store touched.

**Tests**: `tests/test_awaiting_audit_classes.py` (ask recency + awaitPeers identity, diary stand-down both ways, kind-boundary prompt pins); the lift suite gains the nothing-running agents cell and the same-anchor late-re-assert cell; the pr-watch suite pins the per-pass binding order. Local: 5565 passed, 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)