### PR TITLE
An answered wake files its outcome; the re-affirm-forever loop is impossible

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4130,6 +4130,49 @@ def _dead_wait_block(sid, gid, at, why, nudged, now, blk_why=None):
     return False
 
 
+def _file_wake_answer(store, sid, gid, now):
+    """The answered wake's outcome becomes a FILED event (the user 2026-08-25, closing the awaiting
+    audit's last live mechanism): the answer IS new information, and new information that files no
+    diary row is invisible to every reader that matters — the response segment was often placed
+    under NO goal, so the closer's filed-since re-nomination never fired and an answered wake
+    re-affirmed a dead wait forever (two live specimens, 12-13h). File a same-why re-assert on the
+    stamped node AT ITS OWN ANCHOR (the coalesce convention: the anchor freezes, so wake episodes
+    and patience never churn) — the row's arrival moves _newest_filed past closerLookT, so the
+    closer re-audits WITH the answer in view and rules it — done, lift, block, or keep — from real
+    evidence. Runs once per answer by construction (the answered leg itself runs once per record).
+    Returns True when the row landed."""
+    try:
+        nodes = store.get("nodes", {})
+        kids = {}
+        for x, n in nodes.items():
+            kids.setdefault(n.get("parentId"), []).append(x)
+        best, stack, seen = None, [gid], set()
+        while stack:
+            x = stack.pop()
+            if x in seen:
+                continue
+            seen.add(x)
+            n = nodes.get(x)
+            if not n:
+                continue
+            if n.get("awaitingWhy") and not n.get("rolledUp")                     and (best is None or (n.get("awaitingAt") or 0) > (best.get("awaitingAt") or 0)):
+                best = n
+            stack.extend(kids.get(x, []))
+        if best is None:
+            return False
+        if jd.record_verdict(store, best, "nudge", "awaiting",
+                             best.get("awaitingAt") or int(now),
+                             why=best.get("awaitingWhy"), await_kind=best.get("awaitingKind"),
+                             await_peers=best.get("awaitingPeers")):
+            jd.rollup_status(store, False)
+            jd.save_goals(sid, store)
+            _mark_views_dirty()
+            return True
+    except Exception:
+        sys.stderr.write("wake-answer filing (%s): %s\n" % (gid, traceback.format_exc()))
+    return False
+
+
 def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
     """The AWAITING branch of _auto_nudge_session's goal walk — one stamped top goal. The stamp is a
     judged wait, so the plain status nudge stays off; but a wait is not an exemption from the ladder
@@ -4178,7 +4221,8 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
             # the judges ruled on the answer and the stamp still stands → the wait was re-affirmed
             nudged[gid] = dict(rec, answeredAt=(resp.get("t") or int(now)))
             _put_nudged(gid, nudged[gid])
-            return False
+            _file_wake_answer(store, sid, gid, now)   # the answer becomes a FILED event → the closer
+            return False                              #   re-audits with it in view (see the helper)
         _sdefer = _revivers_pending(sid, store, turns, gid)
         if _sdefer and not _nudge_deferred_ok(gid, _sdefer, now, sid):
             return False                             # something else can still move it (judge pass, retry
@@ -4285,6 +4329,7 @@ def _awaiting_wake_outcomes(now, walked=None):
                 # answered and ruled — re-arm from the answer, exactly as the walk's eval would have (the
                 # walk never got to: its session gates held, e.g. an api-error AFTER the judged response)
                 _put_nudged(gid, dict(rec, answeredAt=(resp.get("t") or int(now))))
+                _file_wake_answer(store, sid, gid, now)   # …and the answer files, same as the walk's leg
                 continue
             if resp is not None:
                 continue                             # visible but not ruled yet — the judges own it

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -595,6 +595,23 @@ class AwaitingWake(unittest.TestCase):
                          "the episode re-arms from the ANSWER — the anchor may never move (coalesced "
                          "re-asserts keep the original stamp), so it cannot be the episode key")
         self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+        # THE ANSWER IS A FILED EVENT (the user 2026-08-25, C2 — closing the awaiting audit's last
+        # live mechanism): the response segment was often placed under NO goal, so an answered wake
+        # re-affirmed a dead wait forever with nothing ever re-nominating the closer. The answered
+        # leg now files a same-why re-assert AT THE ORIGINAL ANCHOR — the anchor never moves, but
+        # the row's ARRIVAL opens the closer's filed-since gate, so it re-audits with the answer in
+        # view; the re-affirm-forever shape is impossible by construction.
+        nd = km.jd.load_goals(SID)["nodes"][self.gid]
+        filed = [e for e in nd["log"] if e.get("src") == "nudge" and e.get("kind") == "awaiting"
+                 and not e.get("lift")]
+        self.assertEqual(len(filed), 1, "the answered wake filed its outcome into the diary")
+        self.assertEqual(filed[0].get("ev_t"), now - 20 * 3600, "…at the frozen anchor (no churn)")
+        self.assertEqual(nd.get("awaitingAt"), now - 20 * 3600, "the stamp's anchor never moved")
+        look = {"closerLookT": nd["log"][0]["at"]}    # the closer last looked when the stamp filed
+        kids = {None: [self.gid]}
+        self.assertTrue(km.jd._filed_since({self.gid: dict(nd, **look)}, kids, self.gid,
+                                           km.jd._look_stamp(dict(nd, **look))),
+                        "…and the filing re-nominates: the closer's gate opens on the answer")
         # ...and the next wake fires once the ANSWER goes stale, same stamp anchor throughout
         self.assertFalse(self._wake(now - 6 * 3600 + 60, rec=rec2), "still patient after the answer")
         self.assertTrue(self._wake(now + 3600, rec=rec2), "re-armed: 6h past the answer it asks again")


### PR DESCRIPTION
**C2 — the awaiting audit's last live mechanism** (two specimens measured at 12–13h). The wake's answered leg recorded `answeredAt` and filed **nothing**: the response segment was often placed under no goal, so the closer's filed-since re-nomination never triggered — an answered wake re-affirmed a dead wait forever, with the next wake six hours out and the same answer waiting for it.

The answer **is** new information, and new information that files no diary row is invisible to every reader that matters — the disease the whole audit treated, at its last address. Both answered legs (the walk's and the outcome sweep's) now file the re-affirm as a same-why re-assert on the stamped node **at its own anchor**: the coalesce convention holds (the anchor freezes — wake episodes and patience never churn), while the row's arrival opens the closer's filed-since gate, so the closer re-audits with the answer in view and rules it — done, lift, block, or keep — from real evidence. Runs once per answer by construction.

The two live specimens get their exit on the next wake-answer cycle instead of waiting on their idle sessions' next genuine turns.

**Tests**: the answered-wake matrix cell pins the filing (one `src=nudge` awaiting row at the frozen anchor, the stamp's anchor unmoved, `jd._filed_since` opening past the stamp-time `closerLookT`); the unanswered and re-arm cells unchanged. Local: full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)