### PR TITLE
The nudge holds its fire when the world outran its evidence, and every verdict is a countable row

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3235,14 +3235,20 @@ def _interrupt_block_tick(now, tmux):
         _push_all()
 
 
-def _log_nudge_event(sid, gid, t, count):
-    """Append one auto-nudge fire to STATE/nudge-events.jsonl — {sid, gid, t, count} — for the timeline's
-    DEBUG judging band to render a per-nudge ⚡ marker and escalate at high counts (the view is business's)."""
+def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None):
+    """Append one auto-nudge event to STATE/nudge-events.jsonl — {sid, gid, t, count, verdict, evT} —
+    for the timeline's DEBUG judging band (per-nudge ⚡ marker) AND the redundancy accounting (the
+    user 2026-08-25): every decision the gate takes is a row — fired / skipped-redundant /
+    held-fresh-re-judged / force-fired-at-cap — carrying the evidence snapshot's timestamp, so
+    redundant fires are countable from the log alone (this decides later whether the freshness
+    guard must extend to the cap path). Additive fields; older readers key on sid/gid/t/count."""
     try:
         p = jd.STATE / "nudge-events.jsonl"
         p.parent.mkdir(parents=True, exist_ok=True)
         with p.open("a") as f:
-            f.write(json.dumps({"sid": sid, "gid": gid, "t": int(t), "count": count}) + "\n")
+            f.write(json.dumps({"sid": sid, "gid": gid, "t": int(t), "count": count,
+                                "verdict": verdict,
+                                **({"evT": int(ev_t)} if ev_t else {})}) + "\n")
     except Exception:
         pass
 
@@ -4698,9 +4704,18 @@ def _deferral_sweep_tick(now):
 
 
 def _last_assistant_text(path, cap=4000):
-    """The newest assistant message's text from the transcript TAIL — what the redundancy gate shows
-    the judge as "the session's most recent report". Tail-read only (the newest turn is always
-    recent); '' on any trouble, which fires the nudge as before."""
+    """The newest assistant message's text from the transcript TAIL — '' on any trouble."""
+    return _last_assistant_report(path, cap)[0]
+
+
+def _last_assistant_report(path, cap=4000):
+    """(text, epoch) of the newest assistant message from the transcript TAIL — what the redundancy
+    gate shows the judge as "the session's most recent report", WITH the record's own timestamp so
+    the fire-time freshness guard can tell whether the world moved while the judge deliberated
+    (the user 2026-08-25, the completion-vs-nudge collision: a due nudge and a completion report
+    meet at the end of every long autonomous run — the report landed 19s before a fire whose
+    redundancy check had read the PRE-report tail). Tail-read only; ('', 0) on any trouble, which
+    fires the nudge as before."""
     try:
         size = os.path.getsize(path)
         with open(path, "rb") as f:
@@ -4719,10 +4734,16 @@ def _last_assistant_text(path, cap=4000):
             if isinstance(c, list):
                 txt = " ".join(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text")
                 if txt.strip():
-                    return txt[-cap:]
-        return ""
+                    ts = 0
+                    try:
+                        ts = int(datetime.fromisoformat(
+                            (rec.get("timestamp") or "").replace("Z", "+00:00")).timestamp())
+                    except Exception:
+                        pass
+                    return txt[-cap:], ts
+        return "", 0
     except Exception:
-        return ""
+        return "", 0
 
 
 def _nudge_send_queued(sid, gid):
@@ -5027,6 +5048,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                         if _nudge_deferred_ok(f[0], _why, now, sid, ev_t=_ev or None)]
         except Exception:
             pass
+    _verdicts, recent_ts = {}, None                  # per-goal fire verdicts + the evidence snapshot's
+    #                                                  timestamp — both ride every nudge-events row so
+    #                                                  redundant fires are countable from the log alone
     if to_fire:
         # REDUNDANCY GATE (the user 2026-08-23, approved via the optimizer's audit): the session's
         # own LAST message may already report exactly the status this nudge would ask for — 2 of 3
@@ -5035,34 +5059,58 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         # report as the ANSWER (answeredAt: the ladder measures its next patience window from it,
         # exactly as it would from a real reply) and skips the fire. Any failure fires as before —
         # the gate is an optimization, the ladder is the job.
-        recent = _last_assistant_text(s["path"])
+        recent, recent_ts = _last_assistant_report(s["path"])
         if recent:
             try:
                 _nodes = jd.load_goals(sid).get("nodes", {})
             except Exception:
                 _nodes = {}
-            still = []
-            for f in to_fire:
-                gtxt = (_nodes.get(f[0]) or {}).get("text") or ""
-                rec0 = nudged.get(f[0]) or {}
-                skips = rec0.get("redundantSkips") or 0
-                try:
-                    # CAPPED at two consecutive skips (the user 2026-08-23, the same day the gate
-                    # shipped: on a status-heavy session every due nudge can read as redundant, and
-                    # each skip restarting the patience window is a forever-pause with no reviver —
-                    # the exact suppressed-without-reviver class the ladder exists to prevent). Past
-                    # the cap the nudge fires regardless; any real fire or answer resets the count.
-                    if skips < 2 and gtxt and jd.nudge_redundant(gtxt, recent):
-                        nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1)
+
+            def _judge_batch(cands, report, report_ts, held_pass):
+                keep = []
+                for f in cands:
+                    if held_pass and _verdicts.get(f[0], ("",))[0] == "force-fired-at-cap":
+                        keep.append(f)               # the cap path is UNCHANGED: it fires regardless,
+                        continue                     #   and never re-judges — only its log row says so
+                    gtxt = (_nodes.get(f[0]) or {}).get("text") or ""
+                    rec0 = nudged.get(f[0]) or {}
+                    skips = rec0.get("redundantSkips") or 0
+                    try:
+                        # CAPPED at two consecutive skips (the user 2026-08-23, the same day the gate
+                        # shipped: on a status-heavy session every due nudge can read as redundant, and
+                        # each skip restarting the patience window is a forever-pause with no reviver —
+                        # the exact suppressed-without-reviver class the ladder exists to prevent). Past
+                        # the cap the nudge fires regardless; any real fire or answer resets the count.
+                        if skips < 2 and gtxt and jd.nudge_redundant(gtxt, report):
+                            nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1)
+                            _put_nudged(f[0], nudged[f[0]])
+                            _v = "held-fresh-re-judged" if held_pass else "skipped-redundant"
+                            _log_nudge_event(sid, f[0], now, f[1], verdict=_v, ev_t=report_ts)
+                            continue
+                    except Exception:
+                        pass
+                    if skips >= 2:
+                        _verdicts[f[0]] = ("force-fired-at-cap", report_ts)
+                    if skips:
+                        nudged[f[0]] = dict(rec0, redundantSkips=0)   # firing (or an unjudgeable check) resets
                         _put_nudged(f[0], nudged[f[0]])
-                        continue
-                except Exception:
-                    pass
-                if skips:
-                    nudged[f[0]] = dict(rec0, redundantSkips=0)   # firing (or an unjudgeable check) resets
-                    _put_nudged(f[0], nudged[f[0]])
-                still.append(f)
-            to_fire = still
+                    keep.append(f)
+                return keep
+
+            to_fire = _judge_batch(to_fire, recent, recent_ts, held_pass=False)
+            # FIRE-TIME FRESHNESS GUARD (the user 2026-08-25, the completion-vs-nudge collision): a
+            # due nudge and a completion report meet at the end of every long autonomous run — the
+            # judge deliberated over a snapshot, and a report landing DURING that deliberation was
+            # invisible (the verified specimen: report 11:18:14, stop 11:18:32, fire 11:18:33). The
+            # writer-yields family, at the fire moment: the transcript's newest assistant timestamp
+            # having moved past the snapshot's IS the world outrunning the evidence — HOLD and
+            # re-judge ONCE against the fresh report (once by construction: one guarded re-read per
+            # tick, never a loop). A survivor fires; a fresh redundancy skips as held-fresh-re-judged.
+            if to_fire and recent_ts:
+                _fresh, _fresh_ts = _last_assistant_report(s["path"])
+                if _fresh and _fresh_ts and _fresh_ts > recent_ts:
+                    to_fire = _judge_batch(to_fire, _fresh, _fresh_ts, held_pass=True)
+                    recent_ts = _fresh_ts             # the fired rows carry the evidence they survived
     if len(to_fire) == 1:
         gid, count, stalled = to_fire[0]
         text = _nudge_text(count, stalled)             # variant by escalation count — a repeat re-asks in fresh words
@@ -5076,7 +5124,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         _nudge_deferred_ok(gid, "", now, sid)        # the hold is over — drop any deferral record so a stale
         #                                              why can never outlive the wait it described
         _mark_auto_nudged(gid, arm_id, count, len(arm.get("atoms") or []), at=now)   # {count, lastTurnId, armAtoms, at} → re-arm only on the next GENUINE ended-working turn; a fresh record resets `failed`
-        _log_nudge_event(sid, gid, now, count)       # timeline romp-logo dot + escalation count
+        _log_nudge_event(sid, gid, now, count,       # timeline romp-logo dot + escalation count; the row
+                         verdict=_verdicts.get(gid, ("fired",))[0],   # says HOW it fired and what evidence
+                         ev_t=recent_ts)             # it survived (the 2026-08-25 instrumentation)
         nudged[gid] = {"count": count, "lastTurnId": arm_id}   # mirror in-memory for the rest of this tick
         fired = True
     if not fired:

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""The nudge's FIRE-TIME FRESHNESS GUARD + verdict instrumentation (the user 2026-08-25, the
+completion-vs-nudge collision): a due nudge and a completion report meet at the end of every long
+autonomous run — the redundancy judge deliberates over a snapshot of the transcript tail, and a
+report landing DURING that deliberation was invisible (the verified specimen: report 11:18:14, the
+session stopped its own loop 11:18:32, the nudge fired 11:18:33 asking where the work stood). The
+guard is the writer-yields family at the fire moment: the transcript's newest assistant timestamp
+moving past the snapshot's IS the world outrunning the evidence — hold, re-judge ONCE against the
+fresh report (never a loop), fire only what survives. Every gate decision is now a nudge-events row
+(fired / skipped-redundant / held-fresh-re-judged / force-fired-at-cap, each carrying the evidence
+timestamp), so redundant fires are countable from the log alone. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_freshg", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd                                        # the kernel's OWN judge instance — patches must land
+#                                                   where the walk reads them (a same-named reload would
+#                                                   be a different module object)
+
+SID = "11111111-2222-3333-4444-cccccccccccc"
+G1 = SID + ":g1"
+ARM_T, NOW = 1_787_000_000, 1_787_000_600
+
+
+def _store():
+    return {"rompUuid": SID, "seq": 1, "placements": {}, "status": {},
+            "nodes": {G1: {"id": G1, "text": "Ship the exporter", "parentId": None,
+                           "nodeComplete": False, "blocked": False, "cleared": False,
+                           "trail": [], "t": ARM_T - 100, "mt": ARM_T - 100, "log": []}},
+            "confirming": []}
+
+
+class FreshGuard(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._autonudge_cache.clear()
+        self._orig_km = {n: getattr(km, n) for n in (
+            "_session_flag", "_compacting_now", "_api_error", "_session_working",
+            "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
+            "_last_state", "_session_awaiting", "_closer_settled", "_revivers_pending",
+            "_pending_ops", "_last_assistant_report", "_all_outstanding_delegated")}
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs",
+                                                     "plan_units", "nudge_redundant")}
+        self._orig_backend = km.Sessions.backend_for
+        km._session_flag = lambda sid, flag: False
+        km._compacting_now = lambda sid: False
+        km._api_error = lambda path: None
+        km._session_working = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._backend_queued = lambda sid: False
+        km._backend_rewind_pending = lambda sid: False
+        km._last_state = lambda sid: ("", 0)
+        km._session_awaiting = lambda *a, **k: False
+        km._closer_settled = lambda *a: True
+        km._revivers_pending = lambda *a: ""
+        km._all_outstanding_delegated = lambda nodes, gid: False
+        km._pending_ops = {}
+        jd._segs = lambda tn, store: []
+        jd.plan_units = lambda session, store: []
+        uid = "u-t1"
+        self.turns = [{"id": "t1", "t": ARM_T, "end": ARM_T + 60, "ended": True,
+                       "trigger": {"uuid": uid},
+                       "atoms": [{"uuid": uid, "type": "user", "author": "human", "t": ARM_T}]}]
+        jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+        self.store = _store()
+        jd.load_goals = lambda sid: self.store
+        self.sent = []
+        # the tail reads the gate makes, in order: [snapshot, fire-time freshness re-read]
+        self.reports = [("working through the queue", ARM_T + 50),
+                        ("working through the queue", ARM_T + 50)]
+        self.report_reads = []
+        self.judge_calls = []
+        self.judge_replies = []
+        test = self
+        km._last_assistant_report = lambda path, cap=4000: (
+            test.report_reads.append(1) or test.reports[min(len(test.report_reads) - 1,
+                                                            len(test.reports) - 1)])
+        jd.nudge_redundant = lambda gtxt, recent: (
+            test.judge_calls.append(recent) or
+            test.judge_replies[min(len(test.judge_calls) - 1, len(test.judge_replies) - 1)])
+
+        class FakeBackend:
+            def send(self, sid, body):
+                test.sent.append(body)
+        km.Sessions.backend_for = staticmethod(lambda sid: FakeBackend())
+
+    def tearDown(self):
+        for n, v in self._orig_km.items():
+            setattr(km, n, v)
+        for n, v in self._orig_jd.items():
+            setattr(jd, n, v)
+        km.Sessions.backend_for = self._orig_backend
+        jd.STATE = self.saved_state
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _tick(self):
+        nudged = dict(km._auto_nudge_data().get("nudged", {}))
+        return km._auto_nudge_session({"sid": SID, "path": "/nonexistent.jsonl"}, NOW, {}, nudged, {})
+
+    def _rows(self):
+        p = jd.STATE / "nudge-events.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+    def _seed_rec(self, rec):
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps({"enabled": True, "nudged": {G1: rec}}))
+        km._autonudge_cache.clear()
+
+    def test_a_completion_landing_mid_deliberation_holds_and_rejudges_once(self):
+        # the specimen: the snapshot predates the report; the judge says not-redundant against the
+        # STALE text; the fire-time re-read sees a newer timestamp; the ONE re-judge against the
+        # fresh report says redundant → no fire, and the row says exactly what happened
+        self.reports = [("working through the queue", ARM_T + 50),
+                        ("all done — merged and reported", ARM_T + 590)]
+        self.judge_replies = [False, True]
+        self._tick()
+        self.assertEqual(self.sent, [], "the redundant fire never went out")
+        self.assertEqual(len(self.judge_calls), 2, "held and re-judged exactly ONCE — never a loop")
+        self.assertIn("all done", self.judge_calls[1], "…and the re-judge saw the FRESH report")
+        rows = self._rows()
+        self.assertEqual([r["verdict"] for r in rows], ["held-fresh-re-judged"])
+        self.assertEqual(rows[0]["evT"], ARM_T + 590, "the row carries the evidence it skipped on")
+        rec = km._auto_nudge_data()["nudged"][G1]
+        self.assertEqual(rec.get("answeredAt"), NOW, "the report counts as the answer, as ever")
+
+    def test_a_genuinely_stalled_goal_fires_exactly_as_today(self):
+        self.judge_replies = [False]
+        self.assertTrue(self._tick())
+        self.assertEqual(len(self.sent), 1, "stalled → the fire goes out")
+        self.assertEqual(len(self.judge_calls), 1, "the timestamp never moved — no second judge")
+        rows = self._rows()
+        self.assertEqual([r["verdict"] for r in rows], ["fired"])
+        self.assertEqual(rows[0]["evT"], ARM_T + 50)
+
+    def test_redundant_on_the_first_look_skips_with_its_row(self):
+        self.judge_replies = [True]
+        self._tick()
+        self.assertEqual(self.sent, [])
+        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant"])
+
+    def test_the_cap_path_is_unchanged_and_now_distinguishable(self):
+        # two consecutive skips already recorded → the fire goes out with NO judging at all —
+        # even when the world moved mid-tick, the held pass never re-judges a cap-fire
+        self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
+                        "redundantSkips": 2})
+        self.reports = [("working through the queue", ARM_T + 50),
+                        ("all done — merged and reported", ARM_T + 590)]
+        self.judge_replies = [False]                 # would be consulted only by a bug
+        self.assertTrue(self._tick())
+        self.assertEqual(len(self.sent), 1, "past the cap the nudge fires regardless")
+        self.assertEqual(self.judge_calls, [], "…without asking the judge")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["force-fired-at-cap"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nudge_redundancy.py
+++ b/tests/test_nudge_redundancy.py
@@ -71,8 +71,11 @@ class NudgeRedundancy(unittest.TestCase):
 
     def test_the_fire_path_carries_the_gate_with_the_skip_cap(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("jd.nudge_redundant(gtxt, recent)", src)
-        self.assertIn('recent = _last_assistant_text(s["path"])', src)
+        # the gate judges through _judge_batch since the fire-time freshness guard (2026-08-25):
+        # the snapshot read carries its timestamp so a report landing mid-deliberation holds the
+        # fire and re-judges once — the anchors below moved with it
+        self.assertIn("jd.nudge_redundant(gtxt, report)", src)
+        self.assertIn('recent, recent_ts = _last_assistant_report(s["path"])', src)
         self.assertIn("redundantSkips=skips + 1", src)
         self.assertIn("if skips < 2 and gtxt", src,
                       "two consecutive skips max — past that the nudge fires regardless, so the "


### PR DESCRIPTION
**The completion-vs-nudge collision** (the optimizer's verified specimen): a session posted its completion report at 11:18:14 and stopped its own wakeup loop at 11:18:32 — the auto-nudge fired at 11:18:33 anyway. The redundancy gate HAD run: it judged against a snapshot of the transcript tail read before the LLM deliberated, and the report landing during that deliberation was invisible. The collision is structural — a due nudge and a completion report meet at the end of every long autonomous run.

**The guard** (the writer-yields family, at the fire moment): the tail reader now returns the newest assistant message's own timestamp beside its text (`_last_assistant_report`); after the redundancy verdicts and before the send, the gate re-reads the tail — the timestamp having moved past the snapshot's IS the world outrunning the evidence — and re-judges the survivors **once** against the fresh report (one guarded re-read per tick, never a loop). A survivor fires; a fresh redundancy skips. **The cap path is unchanged**: past two consecutive skips the nudge fires without judging, and the held pass never re-judges a cap fire — only its log row now says so.

**The instrumentation**: every gate decision is a `nudge-events.jsonl` row — `fired` / `skipped-redundant` / `held-fresh-re-judged` / `force-fired-at-cap` — carrying the evidence snapshot's timestamp (`evT`), so redundant fires are countable from the log alone; that count decides later whether the guard must extend to the cap. Additive fields; older readers key on sid/gid/t/count.

**Tests** (`tests/test_nudge_fresh_guard.py`, end to end through `_auto_nudge_session`): the specimen shape (held + re-judged once against the fresh report → no fire, the row naming both), the genuinely-stalled fire (one judge call; no second consulted when the timestamp never moved), the first-look redundancy skip, and the cap fire (zero judge calls even with the world moving mid-tick). Local: full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)