### PR TITLE
The Stage button rides the same row as the context chip, to its right

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -139,8 +139,13 @@ test("⌘-selecting another piece of text ADDS a context below the held ones (th
   assert.match(seeder, /else \{ list\.length = 0; idx = 0; \}/);
   // flavors never mix: any quote seed drops a goal chip (the send routes goal XOR quotes)
   assert.match(seeder, /\.filter\(\(c\) => !c\.itemId\)/);
-  // the second chip sits BELOW the first: the strip stacks (flex column), one chip per row
-  assert.match(CSS, /#composer-chips \{ flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start/);
+  // chips wrap in rows and the Stage button rides the end of the LAST row — never alone on its own
+  // line (the user 2026-08-25, screenshot: the old column layout wrapped Stage beneath a wide chip)
+  assert.match(CSS, /#composer-chips \{ flex: 1 1 100%; display: flex; flex-flow: row wrap; align-items: center/);
+  // the room beside the last chip is GUARANTEED: every chip cedes the Stage button's footprint,
+  // ellipsizing sooner rather than pushing Stage to wrap; the edit pill (no Stage) keeps the full row
+  assert.match(CSS, /max-width: calc\(100% - 64px\);/);
+  assert.match(CSS, /\.composer-chip-edit \{ max-width: 100%; \}/);
   // Backspace-at-start eats the NEWEST chip first, one per press
   assert.match(RENDER, /list\.splice\(idx == null \? list\.length - 1 : idx, 1\);/);
   // the persisted state restores a LIST, and still accepts the pre-stack single-object form
@@ -233,7 +238,7 @@ test("context stages ALONE, and the chips strip carries the visible Stage button
   assert.match(CSS, /\.composer-stage-btn \{ background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
   assert.match(CSS, /\.composer-stage-btn:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/);
   assert.doesNotMatch(CSS, /\.composer-stage-btn \{ position: absolute/,
-    "no absolute pin — the button flows in the chips column, immediately after what it acts on");
+    "no absolute pin — the button flows in the strip, immediately after what it acts on");
   assert.match(RENDER, /st\.title = "hold this context \(and anything typed\) for one combined send later — ⌘⏎ does the same";/);
   assert.match(RENDER, /label\.textContent = s\.text \|\| "\(context only — sends with your message\)";/,
     "a context-only staged row says what it is");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9730,7 +9730,8 @@ function renderComposerChips(id: string | null): void {
   const cites = id ? composerCitations.get(id) : undefined;
   if (!cites || !cites.length) { strip.style.display = "none"; return; }
   strip.style.display = "flex";
-  // one chip per held context, in the order they were added — the strip stacks them (flex column)
+  // one chip per held context, in the order they were added — the strip wraps them in rows, and the
+  // Stage button appended after the loop rides the end of the LAST row (the chip's max-width cedes it room)
   cites.forEach((cite, i) => {
     const chip = el("div", "composer-chip");
     chip.title = cite.quote

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -597,7 +597,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* ── citation chip strip (the user 2026-07-01) ── a click on a feed card summary / sub-goal seeds a
    dismissible pill here, ABOVE the textarea: "you're following up on THIS". Accent-blue, with an ✕ to
    dismiss (Backspace-at-start dismisses too). Reads as attached context, not typed text. */
-#composer-chips { flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding: 0 0 6px 2px; position: relative; }   /* (the Stage button flows in the column now — 2026-08-24) */
+#composer-chips { flex: 1 1 100%; display: flex; flex-flow: row wrap; align-items: center; gap: 6px; padding: 0 0 6px 2px; position: relative; }   /* chips wrap in rows and the Stage button rides the END of the last row (the user 2026-08-25, screenshot: the column layout wrapped Stage to its own line under a wide chip) — .composer-chip's max-width bound below guarantees the room beside the last chip */
 /* attachment thumbnails (the user 2026-08-04): dropped/pasted/picked files sit as little previews above
    the box until send — a row that wraps, unlike the stacked context chips below it */
 #composer-files { flex: 1 1 100%; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 0 0 6px 2px; }
@@ -631,12 +631,17 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .composer-ship-dots i:nth-child(3) { animation-delay: 0.32s; }
 @keyframes ship-bnc { 0%, 75%, 100% { opacity: 0.25; } 38% { opacity: 1; } }
 .composer-chip {
-  display: inline-flex; align-items: center; gap: 5px; max-width: 100%;
+  /* bounded BELOW the strip width: every row keeps the Stage button's footprint (~52px + gap) free,
+     so Stage always fits to the RIGHT of the last chip instead of wrapping alone beneath it (the
+     user 2026-08-25). Long quotes still shorten label-first: the 42ch cap + ellipsis rules there. */
+  display: inline-flex; align-items: center; gap: 5px; max-width: calc(100% - 64px);
   background: color-mix(in srgb, var(--accent) 18%, transparent);
   border: 1px solid var(--accent); color: var(--fg);
   border-radius: 12px; padding: 2px 4px 2px 8px; font-size: 12px; line-height: 1.4;
 }
 .composer-chip-mark { color: var(--accent); font-weight: 600; }
+/* the EDIT pill has no Stage beside it — it may use the full row before ellipsizing */
+.composer-chip-edit { max-width: 100%; }
 .composer-chip-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 42ch; }
 /* STAGED messages (the user 2026-08-15): held in the composer until the next send — deliberately NOT
    the queued idiom (queued = sent, awaiting injection; these are unsent by choice). Same chip anatomy


### PR DESCRIPTION
## What

The user's screenshot (2026-08-25): a wide citation chip took the strip's full width and the **Stage** button wrapped to a second line beneath it. The chips strip was a flex **column**, so Stage — appended after the chips — could only ever get its own row.

- `#composer-chips` becomes a wrapping **row** (`flex-flow: row wrap; align-items: center`).
- Every `.composer-chip` cedes the Stage button's footprint (`max-width: calc(100% - 64px)`), so a wide chip **ellipsizes sooner** rather than pushing Stage to wrap — Stage always fits to the right of the last chip. Long quotes still shorten label-first (the 42ch label cap).
- Multi-chip: chips flow across rows and Stage rides the end of the **last** row, never alone on its own line.
- The edit pill has no Stage beside it and keeps the full row.

## Verification

Headless geometry check with the real sheet, both shapes: a single over-wide chip (the screenshot's case) and wide+short chips. Both report Stage same-row with the last chip, to its right, never on a chip-less row; screenshot eyeballed.

## Tests

`composer-citation.test.ts`: the column-layout pin retargets to the row-wrap form, plus new pins on the chip's width bound and the edit-pill exemption. The Stage-after-chips DOM-order pin stands unchanged. npm suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)