### PR TITLE
Card titles are titles: every fallback leg shapes to one clamped sentence

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12709,6 +12709,24 @@ def _handoff_peer_identities(nodes, hnodes):
 _HANDOFF_LABEL_RE = re.compile(r"^\s*↪\s*delegated to (.+?): (.*)$", re.S)
 
 
+def _title_shaped(text, cap=120):
+    """One TITLE-SHAPED line from arbitrary prose (the user 2026-08-25, the whole-summary-as-title
+    card): every leg of a card-title fallback chain must produce a TITLE — the first sentence of the
+    source, one line, clamped at the card-title length convention (the planter's own 120) with an
+    honest ellipsis — never a paragraph the body then repeats. Already-title-shaped strings pass
+    through BYTE-IDENTICAL (one line, one sentence, inside the cap → untouched), so shaping is a
+    no-op everywhere titles were already titles."""
+    t = text or ""
+    if "\n" in t:
+        t = " ".join(t.split())
+    m = re.search(r"[.!?](?=\s)", t[12:])            # a terminator with more prose after it ends the
+    if m:                                            #   title at sentence one (offset 12: a leading
+        t = t[:12 + m.start() + 1]                   #   "e.g." or an initial never ends a real title)
+    if len(t) > cap:
+        t = t[:cap - 1].rstrip() + "…"
+    return t
+
+
 def _parked_rows(nodes, children):
     """{nid: N} for every OPEN row that newer sibling work has LEAPFROGGED: nothing has happened in
     nid's own subtree — no delegation edge, no witnessed verdict row — while N (>= 1) YOUNGER siblings
@@ -12806,7 +12824,10 @@ def _handoff_card_fields(nodes, nid):
     if not work or work == "(work)":
         work = ((nd.get("why") or "").strip() or (nd.get("summary") or "").strip()
                 or txt.replace("↪ ", "", 1).strip() or txt)
-    return badge, work
+    # EVERY leg title-shapes (the user 2026-08-25): the why and summary legs are unbounded prose —
+    # the specimen card's bold title was the entire stitched three-paragraph summary, repeated
+    # properly in the Summary section below it. One shared shaper, no per-leg clamps.
+    return badge, _title_shaped(work)
 
 
 def _session_delegated_why(sid):

--- a/tests/test_handoff_card_title.py
+++ b/tests/test_handoff_card_title.py
@@ -95,6 +95,37 @@ class HandoffCardFields(_Base):
         _, title = km._handoff_card_fields(store["nodes"], nid)
         self.assertEqual(title, "the exporter now ships cards")
 
+    def test_every_fallback_leg_is_title_shaped(self):
+        # the 2026-08-25 specimen: the summary leg took the WHOLE stitched multi-paragraph summary
+        # as the bold title, which the Summary section below then repeated. Every leg produces a
+        # TITLE now — first sentence, one line, clamped with an honest ellipsis — via ONE shared
+        # shaper; the summary itself stays in the body untouched.
+        summary = ("The tracked change is verified and armed to land. Your board shows one card "
+                   "under the delegator wearing the recipient identity.\n\nSeparately, routing of "
+                   "remote edits was handed off and finished, so changes land where the note lives.")
+        store, nid = self._store_with_track(text="")   # planter writes "(work)" → falls through
+        store["nodes"][nid]["summary"] = summary
+        badge, title = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual(title, "The tracked change is verified and armed to land.",
+                         "first sentence only — a title, not a paragraph")
+        self.assertEqual(store["nodes"][nid]["summary"], summary, "the body keeps the full summary")
+        # the why leg shapes the same way
+        store["nodes"][nid]["why"] = ("Port the exporter to the new schema. Then wire the tests "
+                                      "and clean the old paths out.")
+        store["nodes"][nid]["summary"] = None
+        _, title = km._handoff_card_fields(store["nodes"], nid)
+        self.assertEqual(title, "Port the exporter to the new schema.")
+
+    def test_title_shaping_is_a_no_op_on_titles_and_clamps_the_endless(self):
+        for already in ("Ship the exporter", "Rework Browse files: modal, menu bottom, icon",
+                        "Fix the y-axis labels?"):
+            self.assertEqual(km._title_shaped(already), already,
+                             "an already-title-shaped string passes through byte-identical")
+        long = "word " * 60
+        shaped = km._title_shaped(long)
+        self.assertLessEqual(len(shaped), 120)
+        self.assertTrue(shaped.endswith("…"), "the clamp is an honest ellipsis, never a silent cut")
+
     def test_a_plain_goal_is_untouched(self):
         nodes = {SID + ":g9": {"id": SID + ":g9", "text": "Ship the exporter", "parentId": None}}
         badge, title = km._handoff_card_fields(nodes, SID + ":g9")


### PR DESCRIPTION
**The specimen** (user screenshot, 2026-08-25): a delegation card whose bold title block was the entire stitched three-paragraph summary — the same text then repeating, properly, in the Summary section below. The title-derivation chain (label remainder → node why → summary → de-arrowed label) fell through to the summary leg and used it **unbounded**.

**One shared shaper**, `_title_shaped`, applied to the chain's result — never per-leg clamps: the first sentence of the source, one line, clamped at the card-title length convention (the planter's own 120) with an honest ellipsis. **Already-title-shaped strings pass through byte-identical** (one line, one sentence, inside the cap), so shaping is a no-op everywhere titles were already titles.

**The swept surface**: the handoff chain is the one card-title path sourcing why/summary prose — the legs that needed shaping were the **why** and **summary** legs (unbounded prose); the label legs were already planter-clamped single lines, and the other why/summary reads across the kernel feed bodies, quotes, and task descriptions, not titles.

**Tests**: the specimen synthetically (multi-paragraph summary → one-sentence title, the body keeping the full summary), the why leg shaped identically, byte-identity on already-title-shaped strings, the honest-ellipsis clamp on endless prose. Local: 5570 passed, 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)