### PR TITLE
A card anchored at a machine-cut settle atom lands on the seam that replaced it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16522,6 +16522,15 @@ def _stamp_interrupt_causes(events):
                     # keeps it, where it IS feedback that the interrupt landed and the turn closed clean.
                     # Dropped SERVER-side: rendering it hidden would leave a zero-height turn whose rail
                     # time-marker restampMarkers still measures (at y=0), throwing off the spacing pass.
+                    # The dropped settle's uuid still ANSWERS on the seam (the user 2026-08-25): a cut
+                    # turn's settle atom is its last assistant atom, so verdicts/cards get anchored at
+                    # exactly this uuid — and with the event gone the click honest-failed "couldn't
+                    # locate" though the seam it closed is right there. The marker carries the alias;
+                    # the client lands data-uuids~= on it (event-based; the parent seam, never a
+                    # nearest-time guess).
+                    su = [x.get("uuid") for x in settles if x.get("uuid")]
+                    if su:
+                        ev["settleUuids"] = sorted(set(ev.get("settleUuids") or []) | set(su))
                     for s in settles:
                         s["_dropSettle"] = True
                 break                                     # romp's own notice decides, matched or not

--- a/tests/test_interrupt_settle_machine_cut.py
+++ b/tests/test_interrupt_settle_machine_cut.py
@@ -78,6 +78,23 @@ class InterruptSettleOnMachineCut(unittest.TestCase):
         self.assertTrue(any(e.get("md") == "draft the migration plan" for e in evs), "real turns survive")
         self.assertFalse(any("_dropSettle" in e for e in evs), "the scratch flag never reaches the client")
 
+    def test_a_machine_cut_aliases_the_dropped_settle_uuid_onto_the_marker(self):
+        # The dropped settle atom is the cut turn's LAST assistant atom — exactly where verdicts and
+        # cards get anchored — so its uuid must still land somewhere real: the marker carries it
+        # (settleUuids) and the chat's seam answers to it (the user 2026-08-25, a card click that
+        # honest-failed "couldn't locate" on a dozens-of-restarts session).
+        evs = seam("[romp] The romp kernel " + km.INTR_RESTART_SIG + " this session's in-flight turn.")
+        km._stamp_interrupt_causes(evs)
+        marker = next(e for e in evs if e.get("interruptMarker"))
+        self.assertEqual(marker.get("settleUuids"), [U3], "the seam answers to the dropped settle's uuid")
+
+    def test_a_user_stop_keeps_the_settle_and_mints_no_alias(self):
+        evs = seam(None)
+        km._stamp_interrupt_causes(evs)
+        self.assertEqual(len(self._settles(evs)), 1, "a genuine user stop keeps its settle line")
+        marker = next(e for e in evs if e.get("interruptMarker"))
+        self.assertNotIn("settleUuids", marker, "no alias when nothing was dropped")
+
     def test_the_client_still_renders_the_line_for_user_stops(self):
         # the renderer keeps its seam branch — this change is server-side only
         r = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "render.ts")).read()

--- a/ui/webview/anchor-toolgroup-expand.test.ts
+++ b/ui/webview/anchor-toolgroup-expand.test.ts
@@ -17,8 +17,8 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 
 test("scrollToAnchor's recovery lookup matches resultUuid (the answered-ask anchor) too", () => {
   assert.match(RENDER,
-    /findIndex\(\(e\) => e\.uuid === uuid \|\| \(e as \{ mid\?: string \}\)\.mid === uuid\s*\|\| \(e as \{ resultUuid\?: string \}\)\.resultUuid === uuid\)/,
-    "the events lookup must resolve every uuid renderEvent can stamp as data-uuid");
+    /findIndex\(\(e\) => e\.uuid === uuid \|\| \(e as \{ mid\?: string \}\)\.mid === uuid\s*\|\| \(e as \{ resultUuid\?: string \}\)\.resultUuid === uuid\s*\|\| \(\(\(e as \{ settleUuids\?: string\[\] \}\)\.settleUuids \|\| \[\]\)\.includes\(uuid\)\)\)/,
+    "the events lookup must resolve every uuid renderEvent can stamp as data-uuid or data-uuids");
 });
 
 test("an anchor inside a collapsed tool run expands the run before the window re-render", () => {

--- a/ui/webview/interrupt-seam.test.ts
+++ b/ui/webview/interrupt-seam.test.ts
@@ -31,3 +31,19 @@ test("the interrupt marker names the cause when the kernel stamped one", () => {
   // the unlabeled seam keeps the user-stop reading
   assert.match(R, /you stopped this turn here \(the stop button \/ Ctrl\+C\)/);
 });
+
+test("a card anchored at a DROPPED settle's uuid lands on the seam that replaced it", () => {
+  // A machine-cut turn's settle event is dropped server-side (tests/test_interrupt_settle_machine_cut.py),
+  // but that settle atom is the cut turn's LAST assistant atom — exactly where verdicts/cards get
+  // anchored — so the click honest-failed "couldn't locate" though the seam it closed was right there
+  // (the user 2026-08-25, a card on a dozens-of-restarts session). The kernel aliases the dropped
+  // uuids onto the marker (settleUuids) and the seam answers to them, event-based — never nearest-time.
+  assert.match(R, /const su = \(ev as any\)\.settleUuids as string\[\] \| undefined;/);
+  assert.match(R, /if \(su && su\.length\) turn\.dataset\.uuids = su\.join\(" "\);/);
+  // BOTH anchor lookups honor the alias — the initial query and the post-re-render re-query (the
+  // data-mids precedent: one selector short and the recovery still honest-fails pointer-not-rendered)
+  const both = R.split('data-uuids~=').length - 1;
+  assert.ok(both >= 2, "data-uuids must be in BOTH the initial query and the re-query");
+  // …and the events search finds the alias too, so the window re-renders around the seam
+  assert.match(R, /\(\(\(e as \{ settleUuids\?: string\[\] \}\)\.settleUuids \|\| \[\]\)\.includes\(uuid\)\)/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1305,6 +1305,11 @@ function renderEvent(ev: ChatEvent, prevEpoch?: number | null, worked?: number |
   // anchors on its own uuid.
   const anchorUuid = (ev.kind === "tool" && ev.name === "AskUserQuestion" && ev.resultUuid) ? ev.resultUuid : ev.uuid;
   if (anchorUuid) turn.dataset.uuid = anchorUuid; // deep-link anchor (shared with vs_chat)
+  // A machine-cut turn's settle record is dropped server-side, but anchors minted AT that settle's
+  // uuid (a verdict filed on the cut turn) must still land — the seam that replaced it answers to
+  // them (kernel settleUuids → data-uuids, a token list like the postal data-mids).
+  const su = (ev as any).settleUuids as string[] | undefined;
+  if (su && su.length) turn.dataset.uuids = su.join(" ");
   // epoch-seconds stamp → time-based anchor fallback (when a uuid anchor is
   // stale/orphaned, the deep link can still land on the nearest moment)
   const epoch = eventEpoch(ev);
@@ -7119,7 +7124,8 @@ function scrollToAnchor(uuid: string): boolean {
   // never contains whitespace.
   let target = (v?.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`)
                 || v?.el.querySelector(`.turn[data-mid="${cssEscape(uuid)}"]`)
-                || v?.el.querySelector(`.turn[data-mids~="${cssEscape(uuid)}"]`)) as HTMLElement | null;
+                || v?.el.querySelector(`.turn[data-mids~="${cssEscape(uuid)}"]`)
+                || v?.el.querySelector(`.turn[data-uuids~="${cssEscape(uuid)}"]`)) as HTMLElement | null;
   // Deep-link into history the window doesn't currently cover (the head/tail folded into a spacer): find the
   // event, render a fresh window AROUND its unit, then re-query — the "load it when you jump there" behaviour.
   // (No match anywhere → genuinely off the active path; stash for the next render pass.)
@@ -7129,7 +7135,8 @@ function scrollToAnchor(uuid: string): boolean {
     // (renderEvent's data-uuid — the uuid the timeline emits for the decision), which no event
     // carries as its OWN uuid, so a uuid/mid-only lookup missed it and this recovery never ran.
     const idx = s ? s.events.findIndex((e) => e.uuid === uuid || (e as { mid?: string }).mid === uuid
-                                       || (e as { resultUuid?: string }).resultUuid === uuid) : -1;
+                                       || (e as { resultUuid?: string }).resultUuid === uuid
+                                       || (((e as { settleUuids?: string[] }).settleUuids || []).includes(uuid))) : -1;
     if (s && idx >= 0) {
       const items = displayItems(s);
       let u = items.findIndex((it) => it.kind === "toolgroup" ? it.indices.includes(idx) : it.index === idx);
@@ -7149,7 +7156,8 @@ function scrollToAnchor(uuid: string): boolean {
       // have its window rendered — and then still honest-fail "pointer-not-rendered" on the re-query.
       target = (v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`)
                 || v.el.querySelector(`.turn[data-mid="${cssEscape(uuid)}"]`)
-                || v.el.querySelector(`.turn[data-mids~="${cssEscape(uuid)}"]`)) as HTMLElement | null;
+                || v.el.querySelector(`.turn[data-mids~="${cssEscape(uuid)}"]`)
+                || v.el.querySelector(`.turn[data-uuids~="${cssEscape(uuid)}"]`)) as HTMLElement | null;
     } else if (s && (s.headFrom ?? 0) > 0) {
       // The anchor is OLDER than the resident tail — the chat ships only WIRE_TAIL events and streams older
       // history in on demand, so a deep-link to a message past the tail had nothing to match and honest-failed


### PR DESCRIPTION
## The bug

On a session that has been kernel-restart-cut many times, clicking a card toasted **"couldn't locate this in the transcript"** (locate-audit trail: `pointer-fetch-older` → `pointer-not-rendered` — the fetch-until-resident loop ran and still never found the uuid).

## Root cause (diagnosed on the reported specimen, read-only)

The anchor uuid exists in the live transcript, on the active path. But it names the **null settle-reply of a machine-cut turn** ("No response requested."), and those settle events are deliberately dropped server-side (the 2026-07-22 rule — the line narrates romp's own plumbing, and the marker above already says "interrupted — kernel restart"). A cut turn's settle is its **last assistant atom** — exactly where verdicts/cards get anchored — so the click asked for a uuid the served view could never answer. Not a fork-stitching gap, not a window/fetch gap: the fetch path worked correctly against a view that genuinely lacked the event.

## The fix

The dropped settle's uuid **answers on the seam that replaced it**:

- Kernel: `_stamp_interrupt_causes` aliases dropped settles' uuids onto the surviving interrupt marker (`settleUuids`) — minted only when a machine cut drops settles; a genuine user stop keeps its settle line and mints no alias.
- Client: the marker's turn carries `data-uuids` (token list, the postal `data-mids` idiom); both anchor lookups (initial query + post-re-render re-query) and the events search match it.

Event-based: the click lands on the **parent seam of the very turn the verdict judged** — never a nearest-time guess (that tier stays removed by design).

Verified against the reported session's live transcript in a sandboxed read-only build: the served marker (cause "restart") aliases the exact clicked uuid; the settle stays dropped; suites green (npm 2365, typecheck, Python 5570).

## Tests

- `tests/test_interrupt_settle_machine_cut.py`: the marker carries the dropped settle's uuid on machine cuts; user stops mint no alias (synthetic fixtures, placeholder uuids).
- `ui/webview/interrupt-seam.test.ts`: the render stamps `data-uuids`; the alias is honored in **both** lookups (the data-mids one-selector-short precedent) and the events search.
- `anchor-toolgroup-expand.test.ts`'s findIndex census retargeted to include the new clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)