### PR TITLE
Anchors land where a click can follow: substantive replies, enclosing user messages

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -5268,18 +5268,39 @@ def _session_settled(fsid, path, session, store):
     return _session_closed(session) and not _awaiting_bg_hold(fsid, path, session, store)
 
 
-def _seg_anchor(seg):
-    """The segment's landable anchor uuid: its trigger when the event model recognized one, else the
-    first non-idle atom's uuid. A peer/system segment has no recognized trigger, and every node minted
-    from it stored promptUuid None — an unlinkable card summary that silently dead-ended on the feed
-    (the user 2026-07-20, the g200 federation card). Every landed uuid is landable (scrollToAnchor
-    expands the run holding it), so the segment head is its honest anchor. None only for a segment
-    with no landed uuids at all."""
+def _prompt_anchor_uuid(seg):
+    """The PROMPT anchor for a segment: its trigger uuid — unless that atom is an ATTACHMENT record
+    (2026-08-25, the settle-alias diagnosis): attachments never become chat events, so a title click
+    (prompt intent) on a card whose promptUuid names one can never land by id. Then the ENCLOSING
+    user MESSAGE owns the anchor — the segment's first user-typed, non-attachment atom. None only
+    when the segment has no trigger (callers keep their own fallbacks); the raw trigger survives as
+    the last resort when no user atom exists either (the chat's settle/alias belt covers residue)."""
     t = seg.get("trigger")
+    if not t:
+        return None
+    atoms = seg.get("atoms") or []
+    ta = next((a for a in atoms if a.get("uuid") == t), None)
+    if ta is None or ta.get("type") != "attachment":
+        return t
+    for a in atoms:
+        if a.get("type") == "user" and a.get("uuid"):
+            return a["uuid"]
+    return t
+
+
+def _seg_anchor(seg):
+    """The segment's landable anchor uuid: its trigger when the event model recognized one (routed
+    through the attachment-safe prompt rule above), else the first non-idle, non-attachment atom's
+    uuid. A peer/system segment has no recognized trigger, and every node minted from it stored
+    promptUuid None — an unlinkable card summary that silently dead-ended on the feed (the user
+    2026-07-20, the g200 federation card). Every landed uuid is landable (scrollToAnchor expands the
+    run holding it), so the segment head is its honest anchor. None only for a segment with no
+    landed uuids at all."""
+    t = _prompt_anchor_uuid(seg)
     if t:
         return t
     for a in seg.get("atoms") or []:
-        if a.get("type") != "idle" and a.get("uuid"):
+        if a.get("type") not in ("idle", "attachment") and a.get("uuid"):
             return a["uuid"]
     return None
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18651,7 +18651,9 @@ def build_feed(now, tmux=None):
                     w, r = _seg_anchors(seg["atoms"])
                     seg_uuid[_seg_key(seg["id"])] = r or _seg_jump(seg["atoms"])   # timestamp-invariant key; landable
                     #                                  anchors only — never a thinking-only uuid (SDK echo/real drift)
-                    seg_trig[_seg_key(seg["id"])] = seg.get("trigger")
+                    seg_trig[_seg_key(seg["id"])] = jd._prompt_anchor_uuid(seg)   # attachment-safe: a
+                    #                                  title click must land on the USER message, never an
+                    #                                  attachment record no chat event carries (2026-08-25)
                     _lu, _lsub = _seg_last_text(seg["atoms"])
                     seg_best[_seg_key(seg["id"])] = (_lu, _lsub, seg.get("t", 0))   # latest prose → summary deep-link fallback
                     for _a in seg["atoms"]:              # citable-uuid set: gates the distiller's CITED anchor.
@@ -20107,7 +20109,7 @@ def _seg_anchors(atoms):
     (isApiErrorMessage, tagged isApiError by em), so it carries text and would otherwise WIN the
     reply anchor — deep-linking a done/blocked goal to an 'API Error: …' line instead of its real
     reply. An error is a failure, not a reply, and is never a jump target (the user 2026-06-18)."""
-    work = reply = None
+    work = reply = settle = None
     for a in atoms:
         if a.get("type") != "assistant" or a.get("isApiError"):
             continue
@@ -20117,8 +20119,18 @@ def _seg_anchors(atoms):
         if isinstance(blocks, list) and any(
                 isinstance(b, dict) and b.get("type") == "text" and b.get("text", "").strip()
                 for b in blocks):
-            reply = a.get("uuid")
-    return work, reply
+            # the machine-cut NULL SETTLE ("No response requested." / model "<synthetic>") is an
+            # anchor of last resort, never the reply while a substantive atom exists (2026-08-25):
+            # verdicts anchored at a cut turn's settle deep-linked to a filler the chat renders as
+            # a seam marker — the alias belt covers residue, but the mint prefers the real reply
+            _txt = " ".join(b.get("text", "") for b in blocks
+                            if isinstance(b, dict) and b.get("type") == "text").strip()
+            if _txt == "No response requested." \
+                    or (a.get("message") or {}).get("model") == "<synthetic>":
+                settle = a.get("uuid")
+            else:
+                reply = a.get("uuid")
+    return work, (reply or settle)
 
 
 def _segs_seam(turn, store):

--- a/tests/test_anchor_mints.py
+++ b/tests/test_anchor_mints.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Anchor mints prefer atoms a click can actually land on (the user 2026-08-25, routed from the
+settle-alias diagnosis): (1) the reply anchor skips a machine-cut turn's null settle-reply ("No
+response requested." / model "<synthetic>") whenever a substantive assistant atom exists in the
+same segment — the settle survives as the anchor of last resort on settle-only turns (the chat's
+alias belt covers that residue); (2) the PROMPT anchor resolves to the enclosing user MESSAGE's
+uuid, never a type:"attachment" record — attachments never become chat events, so a title click on
+a card whose promptUuid names one could never land by id. Unaffected anchors are byte-identical.
+SYNTHETIC fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_anch", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+
+def _asst(uuid, text, model="claude-x"):
+    return {"type": "assistant", "uuid": uuid,
+            "message": {"model": model, "content": [{"type": "text", "text": text}]}}
+
+
+class ReplyAnchorSkipsTheSettle(unittest.TestCase):
+    def test_cut_turn_anchors_at_the_substantive_atom(self):
+        atoms = [{"type": "user", "uuid": "u1"},
+                 _asst("a1", "the exporter is wired; tests pass"),
+                 _asst("a2", "No response requested.", model="<synthetic>")]
+        work, reply = km._seg_anchors(atoms)
+        self.assertEqual(reply, "a1", "the last REAL reply wins — the settle is a seam, not a reply")
+        self.assertEqual(work, "a1", "the work anchor is untouched (first assistant atom)")
+
+    def test_settle_only_turn_keeps_the_settle(self):
+        atoms = [{"type": "user", "uuid": "u1"},
+                 _asst("a2", "No response requested.", model="<synthetic>")]
+        _, reply = km._seg_anchors(atoms)
+        self.assertEqual(reply, "a2", "nothing else exists — the alias belt covers this residue")
+
+    def test_the_synthetic_model_marks_the_settle_even_with_other_text(self):
+        atoms = [_asst("a1", "done and verified"),
+                 _asst("a2", "anything the CLI stamped synthetic", model="<synthetic>")]
+        _, reply = km._seg_anchors(atoms)
+        self.assertEqual(reply, "a1")
+
+    def test_ordinary_turns_are_byte_identical(self):
+        atoms = [{"type": "user", "uuid": "u1"},
+                 _asst("a1", "thinking through it"),
+                 _asst("a2", "here is the answer")]
+        self.assertEqual(km._seg_anchors(atoms), ("a1", "a2"), "unaffected anchors never move")
+
+
+class PromptAnchorSkipsAttachments(unittest.TestCase):
+    def test_attachment_trigger_resolves_to_the_user_message(self):
+        seg = {"trigger": "att1",
+               "atoms": [{"type": "attachment", "uuid": "att1"},
+                         {"type": "user", "uuid": "u1"},
+                         _asst("a1", "on it")]}
+        self.assertEqual(jd._prompt_anchor_uuid(seg), "u1",
+                         "a title click lands on the USER message — attachments are not chat events")
+        self.assertEqual(jd._seg_anchor(seg), "u1", "…and every prompt mint flows through the rule")
+
+    def test_a_user_trigger_is_byte_identical(self):
+        seg = {"trigger": "u1", "atoms": [{"type": "user", "uuid": "u1"}, _asst("a1", "ok")]}
+        self.assertEqual(jd._prompt_anchor_uuid(seg), "u1")
+        self.assertEqual(jd._seg_anchor(seg), "u1")
+
+    def test_no_trigger_keeps_the_none_and_the_head_fallback(self):
+        seg = {"trigger": None,
+               "atoms": [{"type": "attachment", "uuid": "att1"}, {"type": "user", "uuid": "u1"}]}
+        self.assertIsNone(jd._prompt_anchor_uuid(seg), "no trigger → callers keep their own fallbacks")
+        self.assertEqual(jd._seg_anchor(seg), "u1",
+                         "the minted-node fallback skips the attachment for the segment's real head")
+
+    def test_attachment_only_segment_keeps_the_raw_trigger(self):
+        seg = {"trigger": "att1", "atoms": [{"type": "attachment", "uuid": "att1"}]}
+        self.assertEqual(jd._prompt_anchor_uuid(seg), "att1",
+                         "nothing better exists — the chat's alias/time fallback owns the residue")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two mint-side fragilities from the settle-alias diagnosis (#672), hardened **at the mint** — the chat's alias stays as the belt for legacy residue; this reduces its use, never removes it:

- **The reply anchor skips the machine-cut null settle** ("No response requested." / model `<synthetic>`) whenever a substantive assistant atom exists in the segment — a verdict anchored at a cut turn's settle deep-linked to a filler the chat renders as a seam marker, not a bubble. A settle-only turn keeps the settle (nothing better exists; the alias covers it). Ordinary turns' anchors are byte-identical.
- **The prompt anchor resolves through the new `_prompt_anchor_uuid` rule**: the trigger uuid — unless that atom is a `type:"attachment"` record, which never becomes a chat event, so a title click on a card whose promptUuid names one could never land by id. Then the **enclosing user message's** uuid owns the anchor. Every prompt mint flows through it (`_seg_anchor` → the planner's and courier's promptUuid; the feed's `seg_trig`); the no-trigger and attachment-only residues keep their existing fallbacks.

**Tests** (`tests/test_anchor_mints.py`): the cut-turn verdict anchoring at the substantive atom; the settle-only turn keeping its settle; the synthetic-model marker; byte-identity on ordinary turns; the attachment trigger resolving to the user message through both entry points; user triggers byte-identical; no-trigger None preserved; the attachment-only segment keeping the raw trigger for the alias belt. Local: 5578 passed, 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)