### PR TITLE
The floating warn notice gains a visible way out: an ✕ and Escape

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7258,19 +7258,39 @@ function landToast(msg: string) {
 // Right-side warning toast: kernel `warn` messages and federation delivery failures
 // land here, so a failed action never dies silently (the user 2026-07-10: creating a
 // session on an unreachable remote host gave no feedback at all — the kernel's warn
-// had no handler and the dropped route had no witness). Click to dismiss; fades on
-// its own otherwise. Toasts stack in #warn-toasts so bursts stay readable.
+// had no handler and the dropped route had no witness). Toasts stack in #warn-toasts
+// so bursts stay readable, and fade on their own.
+// DISMISSAL is the family treatment (the user 2026-08-25: the notice is useful but it
+// floats over the tab strip with no visible way out — "it gets in the way of stuff"):
+// a visible ✕ (the chip-✕ dress: dim, separate, hover-brightens), the whole toast still
+// click-dismisses, and Escape clears the stack. One DELEGATED handler on the stable
+// #warn-toasts container (created once, toasts appended into it — click-safe across
+// re-renders by construction, per the standing button rules; removal IS the immediate
+// acknowledgement). The Escape listener never stops propagation: clearing a toast is
+// additive noise-removal, not a key the rest of the UI loses — and overlay consumers
+// that capture Escape (the lightbox, the viewer) still peel first by construction.
 function warnToast(msg: string) {
   let box = document.getElementById("warn-toasts");
   if (!box) {
     box = el("div", "");
     box.id = "warn-toasts";
     document.body.appendChild(box);
+    box.addEventListener("click", (e) => {
+      (e.target as HTMLElement | null)?.closest(".warn-toast")?.remove();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") for (const w of Array.from(box!.children)) w.remove();
+    });
   }
   const t = el("div", "warn-toast");
-  t.textContent = msg;
+  const txt = el("span", "warn-toast-msg");
+  txt.textContent = msg;
+  const x = el("button", "warn-toast-x");
+  x.setAttribute("aria-label", "Dismiss");
+  x.title = "dismiss (Esc)";
+  x.textContent = "✕";
+  t.append(txt, x);
   t.title = "click to dismiss";
-  t.addEventListener("click", () => t.remove());
   box.appendChild(t);
   setTimeout(() => t.classList.add("fade"), 11000);
   setTimeout(() => t.remove(), 12000);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2310,12 +2310,21 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   display: flex; flex-direction: column; gap: 8px; max-width: 340px;
 }
 .warn-toast {
+  display: flex; align-items: flex-start; gap: 8px;
   padding: 8px 12px; border-radius: 8px; cursor: pointer;
   background: rgba(28, 28, 28, 0.96);
   border: 1px solid var(--vscode-errorForeground, #f48771);
   color: var(--fg); font-size: 0.85em;
   transition: opacity 0.7s ease;
 }
+.warn-toast-msg { min-width: 0; }
+/* the dismiss ✕ — the chip-✕ dress (dim, separate, hover-brightens); the whole toast still
+   click-dismisses, this makes the way out VISIBLE (the user 2026-08-25) */
+.warn-toast-x {
+  flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var(--dim);
+  font-size: 11px; line-height: 1.4; padding: 2px 4px; border-radius: 8px;
+}
+.warn-toast-x:hover { color: var(--fg); background: rgba(255, 255, 255, 0.08); }
 .warn-toast.fade { opacity: 0; }
 
 /* INTERRUPTING… chip (the user 2026-07-02): the stop is in flight — busy-yellow like working (it still

--- a/ui/webview/warn-toast.test.ts
+++ b/ui/webview/warn-toast.test.ts
@@ -23,9 +23,33 @@ test("render handles kernel warn messages with a toast", () => {
 
 test("warn toasts stack on the right and dismiss on click", () => {
   assert.match(RENDER, /getElementById\("warn-toasts"\)/);
-  assert.match(RENDER, /addEventListener\("click", \(\) => t\.remove\(\)\)/);
   assert.match(STYLES, /#warn-toasts \{\s*\n\s*position: fixed; top: 44px; right: 14px;/);
   assert.match(STYLES, /\.warn-toast \{/);
+});
+
+test("the family dismissal: a visible ✕, Escape clears the stack, click-safe by construction", () => {
+  // the user 2026-08-25: the notice floats over the tab strip and "gets in the way" — useful copy,
+  // no visible way out. ONE shared treatment on the family renderer, not per-mint-site ✕s.
+  assert.match(RENDER, /const x = el\("button", "warn-toast-x"\);/);
+  assert.match(RENDER, /x\.setAttribute\("aria-label", "Dismiss"\);/);
+  // dismissal rides ONE delegated handler on the stable container (created once, toasts appended —
+  // the standing click-safety rule), so the ✕ AND the toast body both dismiss, and removal is the
+  // immediate acknowledgement
+  assert.match(RENDER, /box\.addEventListener\("click", \(e\) => \{\s*\n\s*\(e\.target as HTMLElement \| null\)\?\.closest\("\.warn-toast"\)\?\.remove\(\);/);
+  // Escape clears the stack, additively — it never stops propagation, so no other surface loses the key
+  assert.match(RENDER, /if \(e\.key === "Escape"\) for \(const w of Array\.from\(box!\.children\)\) w\.remove\(\);/);
+  assert.doesNotMatch(RENDER.split('if (e.key === "Escape") for (const w of')[1].slice(0, 120), /stopPropagation/);
+  // the ✕ wears the chip-✕ dress: dim at rest, separate, hover-brightens
+  assert.match(STYLES, /\.warn-toast-x \{\s*\n\s*flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var\(--dim\);/);
+  assert.match(STYLES, /\.warn-toast-x:hover \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.08\); \}/);
+  // the auto-fade stays — dismissal is ADDITIVE to the timeout, a user gesture always beats the event
+  assert.match(RENDER, /setTimeout\(\(\) => t\.classList\.add\("fade"\), 11000\);/);
+});
+
+test("the specimen's copy is untouched — only the trap was the bug", () => {
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.ok(KERNEL.includes("that message predates the last context compaction; only newer passages can open a thread"),
+    "the comment-thread refusal keeps its exact wording — the user likes the information");
 });
 
 test("federation surfaces a dropped route instead of vanishing it", () => {


### PR DESCRIPTION
## What

The red-bordered floating notice (kernel `warn`s and federation delivery failures — the comment-thread refusal in the user's screenshot) hovers over the tab strip with **no visible dismissal**. Click-anywhere-to-dismiss existed but was invisible (a title tooltip its only witness), so it read as a trap: "useful, but it gets in the way of stuff."

One shared treatment on the family renderer (`warnToast` — all ten-plus mint sites inherit it):

- A visible **✕** in the corner, wearing the chip-✕ dress (dim, separate, hover-brightens).
- The whole toast still click-dismisses; **Escape** clears the stack.
- Click-safe per the standing button rules: one **delegated** handler on the stable `#warn-toasts` container (created once; toasts are appended, never rebuilt), and removal is the immediate acknowledgement.
- The Escape listener never stops propagation — clearing noise must not steal the key — and overlay consumers that capture Escape (lightbox, viewer) still peel first by construction.
- The 11s auto-fade stays: the user gesture is additive to the event. Copy and delivery untouched.

## The sweep

The chat pane's red floating family is this one renderer (`warn-toast`), so the treatment lands once and covers every mint site. The amber `locate-toast` is deliberately not in the family: it is `pointer-events: none` (clicks pass through — it can never trap interaction) and self-retires in 6 seconds.

## Tests

`warn-toast.test.ts`: the ✕ + its dress, Escape-clears-the-stack with no propagation theft, the delegated container handler (click-safety), the surviving auto-fade, and the specimen's kernel copy pinned verbatim-untouched. npm suite (2367) + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)