### PR TITLE
Revive mints the tab at once and loads pane-local — the window is never blocked

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5775,25 +5775,60 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   requestSessionList("");   // the Host row resets to local on open, so the list starts local too
 }
 
-// ---- revive loader (the user 2026-07-05) ----
+// ---- revive loader (the user 2026-07-05; PANE-LOCAL 2026-08-25) ----
 // Reviving a dead session takes seconds (relaunch + resume), and the Revive click used to give ZERO
 // feedback. Per the repo's loading rule the FIRST thing up is the romp loader — spinning swirl +
 // wordmark + three pulsing dots, the same .rl-* treatment as the boot/pane loaders (their styles are
-// already on this page) — over the chat, with a "reviving <name>…" caption. EVENT-cleared: the
-// kernel's focus for that sid (revive succeeded) or reviveFailed (the loader morphs into the error
-// notice — fail loudly, never silently back to nothing). A 60s backstop can never trap the user.
+// already on this page) — with a "reviving <name>…" caption. EVENT-cleared: the kernel's focus for
+// that sid (revive succeeded) or reviveFailed. A 60s backstop can never trap the user.
+// PANE-LOCAL (the user 2026-08-25): the old overlay covered the WHOLE window and blocked everything
+// while the revive ran. Now the revive gesture mints/foregrounds the session's TAB immediately and
+// the loader covers only THAT session's thread area (#content's box, measured — the tab strip and
+// composer stay live), shown only while the reviving session is the active one: switch away and every
+// other tab is fully interactive, switch back and the loader (or the revived thread) is there.
+// placeReviveLoader() re-runs from showActive (every switch/push) + a ResizeObserver on #content.
 let revivePending: string | null = null;
 let reviveBackstop: number | undefined;
+let reviveRo: ResizeObserver | null = null;
+// sid → the kernel's named revive failure: shown INSIDE that session's pane (the empty-transcript
+// placeholder), plus the dismissible warn-toast family — never a window-blocking overlay.
+const failedRevives = new Map<string, string>();
 
 function clearReviveLoader() {
   revivePending = null;
   if (reviveBackstop !== undefined) { clearTimeout(reviveBackstop); reviveBackstop = undefined; }
+  reviveRo?.disconnect(); reviveRo = null;
   document.getElementById("revive-loader")?.remove();
+}
+
+// Session-local visibility + geometry: the loader shows only while the reviving session is ACTIVE,
+// pinned over the thread area's current box. Runs on every showActive (tab switches, push re-renders)
+// and on #content resizes, so the tab bar wrapping or the ledger appearing never leaves it adrift.
+function placeReviveLoader() {
+  const o = document.getElementById("revive-loader");
+  if (!o) return;
+  const c = document.getElementById("content");
+  if (!c || activeId !== revivePending) { o.style.display = "none"; return; }
+  const r = c.getBoundingClientRect();
+  o.style.display = "flex";
+  o.style.top = r.top + "px"; o.style.left = r.left + "px";
+  o.style.width = r.width + "px"; o.style.height = r.height + "px";
 }
 
 function showReviveLoader(id: string, name: string) {
   clearReviveLoader();
+  failedRevives.delete(id);
   revivePending = id;
+  // The TAB mints immediately (the openProvisional idiom): the session usually already has its closed
+  // tab; a revive reaching a session the chat doesn't hold gets a stub — "opening" is the designed
+  // vocabulary for a tab whose real payload is on its way, and the kernel's first payload for the
+  // revived session continues it seamlessly.
+  if (!sessions.has(id)) {
+    sessions.set(id, { id, name, color: null, events: [], status: { state: "opening", sinceEpoch: Date.now() } });
+    order.push(id);
+  }
+  renderTabs();
+  setActive(id);
   const o = el("div", ""); o.id = "revive-loader";
   const inner = el("div", "rl-in");
   const word = el("div", "rl-word");
@@ -5810,25 +5845,27 @@ function showReviveLoader(id: string, name: string) {
   inner.append(word, dots, cap);
   o.appendChild(inner);
   document.body.appendChild(o);
+  placeReviveLoader();
+  const c = document.getElementById("content");
+  if (c && typeof ResizeObserver === "function") {
+    reviveRo = new ResizeObserver(placeReviveLoader);
+    reviveRo.observe(c);
+  }
   reviveBackstop = window.setTimeout(
-    () => showReviveError(name, "still waiting — the resume may be stuck; check the kernel log"), 60000);
+    () => reviveFailedLocal(id, name, "still waiting — the resume may be stuck; check the kernel log"), 60000);
 }
 
-function showReviveError(name: string, text: string) {
-  // Morph the loader into the failure notice (fail loudly); build the overlay if it's already gone.
-  revivePending = null;
-  if (reviveBackstop !== undefined) { clearTimeout(reviveBackstop); reviveBackstop = undefined; }
-  let o = document.getElementById("revive-loader");
-  if (!o) { o = el("div", ""); o.id = "revive-loader"; document.body.appendChild(o); }
-  o.replaceChildren();
-  const box = el("div", "revive-err");
-  const msg = el("div", "revive-err-text");
-  msg.textContent = `Couldn’t revive “${name}”: ${text}`;
-  const btn = el("button", "revive-err-dismiss");
-  btn.textContent = "Dismiss";
-  btn.addEventListener("click", () => clearReviveLoader());
-  box.append(msg, btn);
-  o.appendChild(box);
+// Failure lands in the SESSION'S OWN PANE (fail loudly, never a window-blocking overlay): the named
+// error fills that session's empty-transcript placeholder, and the dismissible warn-toast carries it
+// to a user who already switched away. A user gesture (tab ✕, another revive) always beats it.
+function reviveFailedLocal(id: string, name: string, text: string) {
+  clearReviveLoader();
+  const msg = `Couldn’t revive “${name}”: ${text}`;
+  failedRevives.set(id, msg);
+  const v = views.get(id);
+  if (v) { v.rendered = 0; v.stale = true; }   // the placeholder re-renders with the failure text
+  if (activeId === id) { syncView(id); showActive(); }
+  warnToast(msg);
 }
 
 // ---- in-webview confirm dialog (replaces the host's native modals) ----
@@ -7373,7 +7410,10 @@ function syncViewInner(id: string, atBottom?: boolean): View {
       // any wait), not the placeholder that tells you to send something. The composer below it is live
       // either way: anything typed here is held and flushed when the session lands. A FAILED create's
       // tab says what happened instead (the user 2026-08-08) — the loader would be a lie.
-      if (isProvisionalId(id) && failedProvisionals.has(id)) {
+      if (failedRevives.has(id)) {
+        ph.textContent = failedRevives.get(id) || "";
+        ph.classList.add("tx-revive-failed");
+      } else if (isProvisionalId(id) && failedProvisionals.has(id)) {
         ph.textContent = "This session couldn't start. What you typed is kept in the box below; "
           + "✕ on the tab discards both.";
       } else if (isProvisionalId(id)) {
@@ -7777,6 +7817,7 @@ function runPrebuild(deadline: IdleDeadline): void {
 function showActive() {
   const content = document.getElementById("content");
   if (!content) return;
+  placeReviveLoader();   // session-local: shows over THIS pane only while the reviving tab is active
   notifyActive();
   renderLedger();  // swap in the active session's digest box (or hide if none)
   renderLiveAsk(); // swap in the active session's pending picker (or hide if none)
@@ -10846,8 +10887,8 @@ window.addEventListener("message", (e: MessageEvent) => {
       });
   }
   else if (m.type === "reviveFailed" && m.id) {
-    // the kernel's loud revive failure → the loader morphs into the reason (never a silent no-op)
-    showReviveError(String(m.name || m.id), String(m.text || "unknown error"));
+    // the kernel's loud revive failure → named, in that session's own pane + the dismissible toast
+    reviveFailedLocal(String(m.id), String(m.name || m.id), String(m.text || "unknown error"));
   }
   else if (m.type === "focusComposer") { const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null; ta?.focus(); }
   else if (m.type === "glowTurns") applyGlow(Array.isArray(m.groups) ? m.groups : [], Array.isArray(m.mids) ? m.mids : []);

--- a/ui/webview/revive-loader.test.ts
+++ b/ui/webview/revive-loader.test.ts
@@ -1,10 +1,11 @@
-// The revive loader (the user 2026-07-05): reviving a dead session from the + picker takes seconds and
-// used to give ZERO feedback after the confirm — and, separately, the revive itself had been silently
-// broken since 2b5e181 (kernel-side; tests/test_kernel_revive.py). Per the repo's loading rule the
-// Revive click puts up the romp loader — swirl + wordmark + pulsing dots, the SAME .rl-* treatment the
-// boot/pane loaders use — with a "reviving <name>…" caption, cleared EVENT-based: the kernel's focus for
-// that sid (success) or reviveFailed (the loader morphs into the failure reason — loud, dismissable).
-// A 60s backstop can never trap the user. Source pin.
+// The revive loader (the user 2026-07-05; PANE-LOCAL 2026-08-25): reviving a dead session takes
+// seconds and the Revive click must acknowledge at once — but the loader used to cover the WHOLE
+// window and block everything (the user: it should revive the tab immediately and show the loading
+// thing on that session only, so you can switch to something else while it loads). Now the gesture
+// mints/foregrounds the TAB immediately, the romp loader (.rl-* treatment) covers only that session's
+// thread area while it is the active tab, and every other tab stays fully interactive. Cleared
+// EVENT-based (the kernel's focus / reviveFailed), 60s backstop. Failure lands pane-local: the named
+// error in the session's own placeholder + the dismissible warn-toast family. Source pin.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -29,10 +30,36 @@ test("event-based clear: the kernel's focus for the reviving sid retires the loa
   assert.match(RENDER, /if \(revivePending && m\.id === revivePending\) clearReviveLoader\(\);/);
 });
 
-test("failure is loud: reviveFailed morphs the loader into the reason, with Dismiss", () => {
+test("the tab mints immediately: stub session + order + setActive, before any waiting", () => {
+  // the openProvisional idiom — "opening" is the designed vocabulary for a tab whose payload is coming
+  assert.match(RENDER, /if \(!sessions\.has\(id\)\) \{\s*\n\s*sessions\.set\(id, \{ id, name, color: null, events: \[\], status: \{ state: "opening", sinceEpoch: Date\.now\(\) \} \}\);\s*\n\s*order\.push\(id\);/);
+  const fn = RENDER.split("function showReviveLoader(")[1].split("\nfunction ")[0];
+  assert.ok(fn.includes("renderTabs();"), "the tab is on the strip at once");
+  assert.ok(fn.includes("setActive(id);"), "and foregrounded");
+});
+
+test("the loader is SESSION-LOCAL: over the thread area only, shown only while that tab is active", () => {
+  // geometry: #content's measured box, never the window — the tab strip and composer stay live
+  assert.match(RENDER, /if \(!c \|\| activeId !== revivePending\) \{ o\.style\.display = "none"; return; \}/);
+  assert.match(RENDER, /const r = c\.getBoundingClientRect\(\);/);
+  // switch-away-and-back mid-revive: showActive re-places on every tab switch and push re-render
+  assert.match(RENDER, /placeReviveLoader\(\);   \/\/ session-local: shows over THIS pane only while the reviving tab is active/);
+  // …and #content resizes (tab bar wrapping, ledger appearing) re-place it too
+  assert.match(RENDER, /reviveRo = new ResizeObserver\(placeReviveLoader\);/);
+  // the absence pin: no window-level blocker — the overlay never spans the window again
+  assert.doesNotMatch(CSS, /#revive-loader \{ position: fixed; inset: 0;/);
+});
+
+test("failure is loud AND pane-local: named error in the session's placeholder + the dismissible toast", () => {
   assert.match(RENDER, /m\.type === "reviveFailed" && m\.id/);
-  assert.match(RENDER, /showReviveError\(String\(m\.name \|\| m\.id\), String\(m\.text \|\| "unknown error"\)\)/);
-  assert.match(RENDER, /btn\.textContent = "Dismiss"/);
+  assert.match(RENDER, /reviveFailedLocal\(String\(m\.id\), String\(m\.name \|\| m\.id\), String\(m\.text \|\| "unknown error"\)\)/);
+  assert.match(RENDER, /failedRevives\.set\(id, msg\);/);
+  assert.match(RENDER, /warnToast\(msg\);/, "the warn-toast family — dismissible (✕ / Esc), never window-blocking");
+  // the session's own pane says it: the empty-transcript placeholder wears the named failure
+  assert.match(RENDER, /if \(failedRevives\.has\(id\)\) \{\s*\n\s*ph\.textContent = failedRevives\.get\(id\) \|\| "";\s*\n\s*ph\.classList\.add\("tx-revive-failed"\);/);
+  assert.match(CSS, /\.tx-empty\.tx-revive-failed \{ color: var\(--vscode-errorForeground, #f48771\); \}/);
+  // a fresh revive attempt clears the parked failure — the gesture beats the stale verdict
+  assert.match(RENDER, /failedRevives\.delete\(id\);/);
 });
 
 test("a 60s backstop keeps the loader from trapping the user", () => {
@@ -40,8 +67,8 @@ test("a 60s backstop keeps the loader from trapping the user", () => {
   assert.match(RENDER, /, 60000\)/);
 });
 
-test("the overlay has styles: dimming backdrop, caption, and error box", () => {
-  assert.match(CSS, /#revive-loader \{ position: fixed; inset: 0;/);
+test("the loader has styles: dimming backdrop + caption; the error-box family is gone", () => {
+  assert.match(CSS, /#revive-loader \{ position: fixed; z-index: 65; display: flex;/);
   assert.match(CSS, /#revive-loader \.revive-cap \{/);
-  assert.match(CSS, /#revive-loader \.revive-err-text \{[^}]*errorForeground/);
+  assert.doesNotMatch(CSS, /revive-err/);
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2418,22 +2418,17 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 @keyframes fl-prov-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .fl-prov-swirl { animation: none; } }
 
-/* ── revive loader (the user 2026-07-05): the romp loader (swirl + wordmark + dots, .rl-* styles from
-   the page's boot-splash block) over the chat while a dead session revives — the Revive click used to
-   give no feedback at all. Backdrop dims the chat; cleared event-based (focus / reviveFailed), 60s
-   backstop. The error morph keeps the same overlay so failure is loud, with a Dismiss escape hatch. */
-#revive-loader { position: fixed; inset: 0; z-index: 65; display: flex; align-items: center;
+/* ── revive loader (the user 2026-07-05; PANE-LOCAL 2026-08-25): the romp loader (swirl + wordmark +
+   dots, .rl-* styles from the page's boot-splash block) while a dead session revives. It covers ONLY
+   the reviving session's thread area — geometry set inline by placeReviveLoader over #content's box,
+   shown only while that session is the active tab — so the tab strip and composer stay live and every
+   other tab is fully interactive (the old inset-0 overlay blocked the whole window). Cleared
+   event-based (focus / reviveFailed), 60s backstop. Failure is pane-local: the named error fills the
+   session's own placeholder (.tx-revive-failed) plus the dismissible warn-toast — no error overlay. */
+#revive-loader { position: fixed; z-index: 65; display: flex; align-items: center;
   justify-content: center; background: rgba(20, 20, 20, 0.82); }
 #revive-loader .revive-cap { font-size: 0.86em; color: var(--vscode-descriptionForeground, #999); }
-#revive-loader .revive-err { display: flex; flex-direction: column; align-items: center; gap: 12px;
-  max-width: 420px; padding: 18px 22px; border-radius: 10px;
-  background: var(--vscode-editorWidget-background, #252526);
-  border: 1px solid var(--vscode-editorHoverWidget-border, #454545); }
-#revive-loader .revive-err-text { font-size: 0.86em; color: var(--vscode-errorForeground, #f48771);
-  text-align: center; line-height: 1.5; overflow-wrap: anywhere; }
-#revive-loader .revive-err-dismiss { font: inherit; font-size: 0.86em; cursor: pointer;
-  padding: 4px 14px; border-radius: 6px; background: var(--vscode-input-background, #3c3c3c);
-  color: var(--vscode-foreground, #ccc); border: 1px solid var(--vscode-widget-border, #303031); }
+.tx-empty.tx-revive-failed { color: var(--vscode-errorForeground, #f48771); }
 
 /* ── path previews in the chat (the user 2026-07-08): a mentioned image/PDF renders under the message
    (render.ts linkifyFileUris → preview.ts previewFull). Chat-only since the feed's artifact strips


### PR DESCRIPTION
## What

Reviving a session put up a window-covering progress overlay that blocked the whole chat — the user asked for the tab to revive immediately with the loading treatment on that session only, so everything else stays usable.

- **The tab mints immediately** on the revive gesture (the `openProvisional` idiom — a stub in the `"opening"` vocabulary when the chat doesn't already hold the closed tab), foregrounded via the normal `setActive` path.
- **The loader is session-local**: the standard romp loader (swirl + wordmark + pulsing dots, unchanged anatomy) covers only that session's thread area — geometry measured off `#content`'s box, re-placed on every `showActive` (tab switches, push re-renders) and on `#content` resizes — and shows only while the reviving session is the **active** tab. The tab strip and composer stay live; switch away and every other tab is fully interactive; switch back and the loader (or the revived thread) is there.
- **Clearing stays event-based**: the kernel's `focus` for the sid, with the 60s can't-trap backstop.
- **Failure is pane-local and loud**: the named error fills the session's own empty-transcript placeholder (`.tx-revive-failed`, the `failedProvisionals` idiom) and rides the warn-toast family — freshly dismissible (✕/Escape, previous PR) — for a user who already switched away. The old window-covering error box is gone with the overlay; a fresh revive attempt clears a parked failure.

## Tests

`revive-loader.test.ts` rewritten to the new contract: immediate tab mint (stub + order + setActive), session-local geometry + active-tab gating, the switch-away-and-back re-place hooks (showActive + ResizeObserver), the **absence pin** on any window-level `inset: 0` blocker, event-based clear + backstop unchanged, and the pane-local failure (placeholder text + dismissible toast + gesture-clears-failure). npm suite (2369) + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)