### PR TITLE
The comment popover reads as the chat it is: pulse, statusline, one boot, live settle

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6400,6 +6400,24 @@ def _comments_frame(sid, tmux=None):
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
         reg = _thread_reg(tsid)
+        # the settle count (see _comment_settle_step): raw_busy mirrors the client's threadInFlight
+        # (comments.ts) exactly — live work or an owed reply, on an open unstuck thread
+        tid = str(th.get("tid") or "")
+        raw_busy = (status == "open" and not err and state not in ("permission", "picker")
+                    and (state in ("working", "retrying", "compacting")
+                         or bool(msgs and msgs[-1]["who"] == "you")))
+        quiet = _comment_settle_step(_comment_settle.get(tid), raw_busy, status != "open" or bool(err))
+        _comment_settle[tid] = quiet
+        if len(_comment_settle) > 512:
+            _comment_settle.clear()
+        # sinceEpoch (MILLISECONDS, the client convention): when the thread's current state began —
+        # the popover's working chip counts from it, exactly as the chat's statusline does
+        since_ms = 0
+        if be and status == "open" and hasattr(be, "session_since"):
+            try:
+                since_ms = int(be.session_since(tsid)) * 1000
+            except Exception:
+                since_ms = 0
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
                         "name": th.get("name") or "", "color": th.get("color") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
@@ -6407,8 +6425,29 @@ def _comments_frame(sid, tmux=None):
                         "unread": unread, "promotedName": th.get("promotedName") or "",
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
+                        "settledPushes": quiet, "sinceEpoch": since_ms,
                         "msgs": msgs, "events": events})
     return {"type": "comments", "id": sid, "threads": threads}
+
+
+# The client's green→yellow settle needs TWO CONFIRMING PUSHES (comments.ts latchBusy), but
+# _send_client's dedup withholds unchanged frames — so after a reply landed, the second confirming
+# frame never arrived and the passage stayed green until some unrelated change minted one (the user
+# 2026-08-25: it didn't flip until clicking back into the main chat). The frame now carries the
+# count ITSELF: pushes since the thread last read busy, clamped at 2 — each step is a real pusher
+# cycle (an event, never a timer), the frame changes at most twice after settling, and then the
+# dedup resumes. tid → count; pure step logic split out for the test.
+_comment_settle = {}
+
+
+def _comment_settle_step(prev, raw_busy, decided):
+    """One pusher cycle's step of the settle count: busy → 0; a decided status (closed/errored)
+    settles immediately; otherwise count up, clamped at 2 (the client's SETTLE_CONFIRM_PUSHES)."""
+    if decided:
+        return 2
+    if raw_busy:
+        return 0
+    return min(2, (2 if prev is None else prev) + 1)
 
 
 def _comment_markers(sid):

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4663,6 +4663,18 @@ class SdkBackend:
                 return ""
         return ""
 
+    def session_since(self, sid: str) -> int:
+        """Epoch seconds the sid's current state began (0 unknown) — session_state's twin, read by
+        the comments frame so the popover's working chip can carry the chat's counting timer."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        if s and s.thread.is_alive():
+            try:
+                return int(float(s.snapshot().get("since") or 0))
+            except Exception:
+                return 0
+        return 0
+
     def rename(self, sid: str, new_name: str) -> bool:
         reg = read_reg(self.state_dir, sid)
         if not reg:

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -686,5 +686,32 @@ class CommentOps(CommentBase):
             self.assertIn('"%s"' % op, src)
 
 
+class SettleStepCarriesTheConfirm(unittest.TestCase):
+    """The client's green→yellow settle needs two confirming pushes, but the wire dedup withholds
+    unchanged frames — so the kernel counts pushes-since-busy ON the frame (_comment_settle_step),
+    clamped so the frame changes at most twice after settling and the dedup resumes (the user
+    2026-08-25: the passage stayed green until clicking back into the main chat)."""
+
+    def test_busy_pins_zero_and_settle_counts_up_clamped(self):
+        q = km._comment_settle_step(None, True, False)
+        self.assertEqual(q, 0, "busy → 0")
+        q = km._comment_settle_step(q, False, False)
+        self.assertEqual(q, 1, "first quiet push confirms once")
+        q = km._comment_settle_step(q, False, False)
+        self.assertEqual(q, 2, "second quiet push settles")
+        self.assertEqual(km._comment_settle_step(q, False, False), 2, "clamped — the frame stops changing")
+
+    def test_a_fresh_quiet_thread_is_settled_and_a_decided_status_settles_immediately(self):
+        self.assertEqual(km._comment_settle_step(None, False, False), 2, "never-busy starts settled")
+        self.assertEqual(km._comment_settle_step(0, False, True), 2, "resolved/errored decides at once")
+
+    def test_the_frame_carries_count_and_epoch(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('"settledPushes": quiet, "sinceEpoch": since_ms,', src)
+        # raw_busy mirrors the client threadInFlight exactly: open + unstuck + (live work or owed reply)
+        self.assertIn('state in ("working", "retrying", "compacting")', src)
+        self.assertIn('bool(msgs and msgs[-1]["who"] == "you")', src)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -1,0 +1,76 @@
+// The comment popover's chat-parity pass (the user 2026-08-25, four asks in one): the thread's
+// statusline carries the chat's own working chip WITH the counting timer; the action buttons wear
+// the chat's under-bubble button family; a fresh thread boots on the standard romp loader and then
+// renders in its final (chat-parity) format ONCE — no intermediate msgs-projection flash; and the
+// green→yellow settle repaints LIVE on the push event, no refocus needed (the kernel carries the
+// settle count on the frame, since the wire dedup withholds the unchanged frames the client latch
+// used to wait for). Source pins — the chat renderer has no jsdom harness (repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const COMMENTS = ui("webview", "comments.ts");
+const CSS = ui("webview", "styles.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the popover's bottom row IS a statusline: the chat's chip anatomy + counting timer", () => {
+  // one vocabulary by construction: the row wears .statusline, the chip wears chip-working +
+  // chip-pulse, the timer wears .status-timer — the chat's own classes, not restyled copies
+  assert.match(RENDER, /const mrow = el\("div", "statusline cmt-meta-row"\);/);
+  assert.match(RENDER, /mrow\.appendChild\(cmtStateChip\(th\)\);/);
+  const chip = RENDER.split("function cmtStateChip(")[1].split("\nfunction ")[0];
+  assert.ok(chip.includes('el("span", "chip chip-working")'), "the chat's working chip");
+  assert.ok(chip.includes('el("span", "chip-pulse")'), "with its pulse label");
+  assert.ok(chip.includes('timer.id = "cmt-work-timer"'), "and the counting timer");
+  assert.ok(chip.includes("elapsedMs(th.sinceEpoch || null)"), "counting from the kernel's state-start epoch");
+  // the 1s tick drives it exactly like the chat's #work-timer
+  assert.match(RENDER, /const ct = document\.getElementById\("cmt-work-timer"\);/);
+  assert.match(RENDER, /if \(cur && threadBusy\(cur\.th\.state\)\) ct\.textContent = elapsedMs\(cur\.th\.sinceEpoch \|\| null\);/);
+  // the model/effort badges cluster right in .sl-right, the statusline's own placement idiom
+  assert.match(RENDER, /right\.append\(mkLive\("model"\), mkLive\("effort"\)\);/);
+  // …and the comments frame carries the epoch (milliseconds, the client convention)
+  assert.match(KERNEL, /"settledPushes": quiet, "sinceEpoch": since_ms,/);
+  // the in-place refresh keeps chip + timer live per frame (chips carry no listeners — click-safe)
+  assert.match(RENDER, /if \(th && cs\) cs\.replaceWith\(cmtStateChip\(th\)\);/);
+});
+
+test("the action buttons wear the chat's under-bubble family; Fork stays out by the user's call", () => {
+  assert.match(CSS, /\.cmt-act \{\s*\n\s*background: rgba\(255, 255, 255, 0\.06\);\s*\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\); border-radius: 5px; font-size: 0\.78em;\s*\n\s*padding: 1px 8px; cursor: pointer;\s*\n\}/);
+  assert.match(CSS, /\.cmt-act:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/);
+  // the popover's verbs stay Break out / Merge / Delete — the chat's Fork button is deliberately absent
+  const pop = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
+  assert.ok(!/data-act="fork"|showForkPrompt/.test(pop), "no fork button in the popover");
+});
+
+test("a fresh thread boots on the romp loader, then renders its final format ONCE", () => {
+  // the loader holds the list until the thread's REAL render (its events) is ready — the plain
+  // msgs projection no longer flashes as an intermediate format
+  assert.match(RENDER, /if \(!evs\.length && th\.status === "open" && !th\.error && cmtBootHolds\(th\.tid\)\) \{/);
+  assert.match(RENDER, /boot\.appendChild\(rompLoaderInner\("opening the thread…"\)\);/);
+  // event-based fade: the frame that carries events refills the list and retires the hold
+  assert.match(RENDER, /if \(evs\.length\) cmtBootSince\.delete\(th\.tid\);/);
+  // …with the can't-trap backstop: past it, the hold releases and the projection paints after all
+  assert.match(RENDER, /const CMT_BOOT_BACKSTOP_MS = 8000;/);
+  assert.match(RENDER, /window\.setTimeout\(\(\) => \{ if \(openCommentKey\?\.tid === tid\) refillOpenCommentPop\(\); \}, CMT_BOOT_BACKSTOP_MS \+ 50\);/);
+  // the user's own pending sends still acknowledge under the loader
+  const gate = RENDER.split("cmtBootHolds(th.tid)) {")[1].split("return;")[0];
+  assert.ok(gate.includes('commentMsgEl("you", pb.text)'), "pending bubbles ride the boot view");
+});
+
+test("green→yellow settles LIVE: the kernel carries the confirm the dedup used to withhold", () => {
+  // the client latch needed two confirming FRAMES; unchanged frames never arrive (wire dedup), so
+  // the flip waited for an unrelated change (the user: it didn't flip until clicking back). The
+  // kernel counts pushes-since-busy on the frame, clamped so dedup resumes once decided.
+  assert.match(KERNEL, /def _comment_settle_step\(prev, raw_busy, decided\):/);
+  assert.match(COMMENTS, /export function settleConfirmed\(th: CommentThread\): boolean \| null \{/);
+  assert.match(COMMENTS, /return typeof sp === "number" \? sp >= SETTLE_CONFIRM_PUSHES : null;/);
+  // commentInFlight prefers the kernel's confirm; the client latch stays as the old-kernel fallback
+  assert.match(RENDER, /const confirmed = settleConfirmed\(th\);/);
+  assert.match(RENDER, /if \(confirmed !== null\) return raw \|\| \(th\.status === "open" && !th\.error && !confirmed\);/);
+  assert.match(RENDER, /return raw \|\| !!commentBusyLatch\.get\(th\.tid\)\?\.green;/);
+  // the frame handler already repaints marks AND the open popover per frame — the live wire
+  assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) \{/);
+});

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -325,7 +325,7 @@ test("the create dialog names the thread right there: prefilled <session>-commen
   assert.match(UI, /send\.setAttribute\("aria-label", create \? "Comment" : "Send"\);/);   // the ➤ carries the word
   assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| "",\s*\n\s*color: create\.color \|\| ""/);
   // the comment's own model/effort selectors reuse the statusline's /models-fed choices + menu skin
-  assert.match(UI, /const metaRow = el\("div", "cmt-meta-row"\);/);
+  assert.match(UI, /const metaRow = el\("div", "statusline cmt-meta-row"\);/);   // the chat statusline dress (2026-08-25 parity)
   assert.match(UI, /META_CHOICES\[kind\]/);
   assert.match(KERNEL, /model=str\(msg\.get\("model"\) or ""\), effort=str\(msg\.get\("effort"\) or ""\)/);
   assert.match(KERNEL, /"%s-comment-%d" % \(sess\["name"\], len\(data\.get\("threads"\) or \[\]\) \+ 1\)/);
@@ -406,14 +406,16 @@ test("comment chrome (badge, popover card) stays on the menu vocabulary", () => 
 
 // ── the comment-thread UI pass (the user 2026-08-24, three asks) ─────────────────────────────────
 
-test("an in-flight thread's highlight goes await-green — the color is the signal, nothing crawls", () => {
-  // the green/yellow request was always about comments: mid-reply the passage wears a faded
-  // await-green blend, settling into the EXISTING full yellow when the reply lands. The tick's
-  // marching ants (the "spinning dots") are retired — no motion anywhere in the state.
-  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);\s*\n\}/);
-  // the code/math HOST pairing greens the same way — its element tint must not stay full yellow
-  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\),\s*\n\.md \.katex\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);/);
-  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{ background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, var\(--code-bg\)\); \}/);
+test("an in-flight thread's highlight PULSES await-green — text and hosts in lockstep", () => {
+  // mid-reply the passage wears the await-green blend, and it PULSES while generating (the user
+  // 2026-08-25, asking for exactly this — superseding the earlier no-motion ruling for THIS state
+  // only; the marching ants stay dead below). Settles into the existing full yellow on landing.
+  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);\s*\n\s*animation: cmt-busy-pulse 2\.2s ease-in-out infinite;\s*\n\}/);
+  // the code/math HOST pairing greens AND pulses the same way, the SAME clock — lockstep by keyframe
+  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\),\s*\n\.md \.katex\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);\s*\n\s*animation: cmt-busy-pulse 2\.2s ease-in-out infinite;/);
+  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\) \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, var\(--code-bg\)\);\s*\n\s*animation: cmt-busy-pulse-code 2\.2s ease-in-out infinite;/);
+  // reduced motion keeps the static green — the pulse joins the loading-cues idiom family
+  assert.match(CSS, /@media \(prefers-reduced-motion: reduce\) \{\s*\n\s*mark\.cmt-hl\.busy,[\s\S]{0,160}animation: none; \}\s*\n\}/);
   // the crawl is gone root and branch; the rail tick wears the same state green instead
   assert.doesNotMatch(CSS, /cmt-tick-ants/);
   assert.match(CSS, /\.cmt-tick\.busy \{ background: var\(--st-awaitbg-bg\); \}/);

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -18,6 +18,8 @@ export type CommentThread = {
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
   error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // an agent reply newer than the read watermark
+  settledPushes?: number;     // kernel pushes since the thread last read busy, clamped at 2 (settleConfirmed)
+  sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   promotedName: string;       // the board session it became, when status === "promoted"
   model?: string;             // the thread's live/chosen model (the popover's switchable chip)
   effort?: string;            // the thread's effort level (ditto)
@@ -81,6 +83,16 @@ export function latchBusy(prev: BusyLatch | undefined, th: CommentThread, alsoBu
 }
 export function threadStuck(state: string): boolean {
   return state === "permission" || state === "picker";
+}
+// The kernel-carried settle confirmation (2026-08-25): the latch above needs two confirming PUSHES,
+// but the wire dedup withholds unchanged frames — the second confirm never arrived, and the green
+// held until an unrelated change minted a frame (the user: it didn't flip until clicking back into
+// the main chat). The kernel now counts pushes-since-busy on the frame itself (settledPushes,
+// clamped at SETTLE_CONFIRM_PUSHES so dedup resumes once decided). null = an older kernel without
+// the field — callers fall back to the client latch.
+export function settleConfirmed(th: CommentThread): boolean | null {
+  const sp = (th as { settledPushes?: number }).settledPushes;
+  return typeof sp === "number" ? sp >= SETTLE_CONFIRM_PUSHES : null;
 }
 
 // ── exact-text re-anchoring ────────────────────────────────────────────────────────────────────

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -45,7 +45,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
-import { threadInFlight, latchBusy, type BusyLatch, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { threadInFlight, latchBusy, settleConfirmed, type BusyLatch, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -5775,6 +5775,26 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   requestSessionList("");   // the Host row resets to local on open, so the list starts local too
 }
 
+// The standard romp loader's inner anatomy — wordmark + spinning swirl + pulsing dots + caption
+// (the boot/pane .rl-* styles already on this page) — shared by every in-page wait that wears it
+// (the revive loader, the comment popover's boot), per the loading-states rule: one treatment.
+function rompLoaderInner(caption: string): HTMLElement {
+  const inner = el("div", "rl-in");
+  const word = el("div", "rl-word");
+  const r = el("span", ""); (r as HTMLElement).style.color = "#1EA1EB"; r.textContent = "R";
+  const swirl = el("img", "rl-o") as HTMLImageElement;
+  swirl.src = mediaSrc("romp-swirl-o.svg"); swirl.alt = "o"; swirl.onerror = () => swirl.remove();
+  const mm = el("span", ""); (mm as HTMLElement).style.color = "#54B204"; mm.textContent = "m";
+  const p = el("span", ""); (p as HTMLElement).style.color = "#4EA8A9"; p.textContent = "p";
+  word.append(r, swirl, mm, p);
+  const dots = el("div", "rl-dots");
+  dots.append(el("i", ""), el("i", ""), el("i", ""));
+  const cap = el("div", "revive-cap");
+  cap.textContent = caption;
+  inner.append(word, dots, cap);
+  return inner;
+}
+
 // ---- revive loader (the user 2026-07-05; PANE-LOCAL 2026-08-25) ----
 // Reviving a dead session takes seconds (relaunch + resume), and the Revive click used to give ZERO
 // feedback. Per the repo's loading rule the FIRST thing up is the romp loader — spinning swirl +
@@ -5830,20 +5850,7 @@ function showReviveLoader(id: string, name: string) {
   renderTabs();
   setActive(id);
   const o = el("div", ""); o.id = "revive-loader";
-  const inner = el("div", "rl-in");
-  const word = el("div", "rl-word");
-  const r = el("span", ""); (r as HTMLElement).style.color = "#1EA1EB"; r.textContent = "R";
-  const swirl = el("img", "rl-o") as HTMLImageElement;
-  swirl.src = mediaSrc("romp-swirl-o.svg"); swirl.alt = "o"; swirl.onerror = () => swirl.remove();
-  const mm = el("span", ""); (mm as HTMLElement).style.color = "#54B204"; mm.textContent = "m";
-  const p = el("span", ""); (p as HTMLElement).style.color = "#4EA8A9"; p.textContent = "p";
-  word.append(r, swirl, mm, p);
-  const dots = el("div", "rl-dots");
-  dots.append(el("i", ""), el("i", ""), el("i", ""));
-  const cap = el("div", "revive-cap");
-  cap.textContent = `reviving “${name}”…`;
-  inner.append(word, dots, cap);
-  o.appendChild(inner);
+  o.appendChild(rompLoaderInner(`reviving “${name}”…`));
   document.body.appendChild(o);
   placeReviveLoader();
   const c = document.getElementById("content");
@@ -5958,9 +5965,26 @@ const commentPending = new Map<string, { text: string; t: number }[]>(); // tid 
 const commentBusyLatch = new Map<string, BusyLatch>();
 const commentInFlight = (th: CommentThread): boolean => {
   const raw = threadInFlight(th) || (th.status === "open" && !!(commentPending.get(th.tid) || []).length);
+  // the kernel-carried confirm makes the settle LIVE (the user 2026-08-25: green→yellow waited for a
+  // click): green holds until the frame says two pushes read settled; older kernels → the client latch
+  const confirmed = settleConfirmed(th);
+  if (confirmed !== null) return raw || (th.status === "open" && !th.error && !confirmed);
   return raw || !!commentBusyLatch.get(th.tid)?.green;
 };
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
+// The popover-boot hold (fillCommentMsgs): tid → when the loader first held the list. Held until the
+// thread's events land (event-based) or the backstop expires (never trap); a backstop timer refills
+// the open popover so the fall-through actually paints.
+const cmtBootSince = new Map<string, number>();
+const CMT_BOOT_BACKSTOP_MS = 8000;
+function cmtBootHolds(tid: string): boolean {
+  const t0 = cmtBootSince.get(tid) ?? Date.now();
+  if (!cmtBootSince.has(tid)) {
+    cmtBootSince.set(tid, t0);
+    window.setTimeout(() => { if (openCommentKey?.tid === tid) refillOpenCommentPop(); }, CMT_BOOT_BACKSTOP_MS + 50);
+  }
+  return Date.now() - t0 < CMT_BOOT_BACKSTOP_MS;
+}
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
 let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
   model?: string; effort?: string; color?: string } | null = null; // create mode (+ the thread's own picks)
@@ -6306,6 +6330,25 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
   const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
   commentPending.set(th.tid, pend);
   const evs = (th.events || []) as ChatEvent[];
+  // ONE final format (the user 2026-08-25: a fresh thread flashed the plain msgs projection for a
+  // couple of seconds before jumping into the chat rendering): until the thread's REAL render — its
+  // events — is ready, the conversation area holds the standard romp loader, and the chat-parity
+  // render appears once. Event-based fade (the comments frame carrying events refills this list);
+  // the backstop falls through to the msgs projection so a thread whose events never come (an old
+  // kernel) can't trap the loader.
+  if (!evs.length && th.status === "open" && !th.error && cmtBootHolds(th.tid)) {
+    const boot = el("div", "cmt-boot");
+    boot.appendChild(rompLoaderInner("opening the thread…"));
+    list.appendChild(boot);
+    for (const pb of pend) {
+      const n = commentMsgEl("you", pb.text);
+      n.classList.add("pending");
+      list.appendChild(n);
+    }
+    list.scrollTop = list.scrollHeight;
+    return;
+  }
+  if (evs.length) cmtBootSince.delete(th.tid);
   if (evs.length) {
     // the CHAT's own renderer, from the branch point on (the user 2026-08-17: the same component —
     // rail dots, markdown, tool folds, notice cards — never a simplified twin). renderingSid keys
@@ -6401,6 +6444,45 @@ function refillOpenCommentPop(): void {
   if (th && list) fillCommentMsgs(list, th, openCommentKey.sid);
 }
 
+/** The popover statusline's LEFT half — the thread's state chip, wearing exactly the chat's chip
+ *  anatomy (chip-working + pulse + counting timer, retrying, compacting-line, Blocked, Ready), so
+ *  the popover says it's working the way the main chat does (the user 2026-08-25: no indication it
+ *  was working, no counting timer). Rebuilt in place per comments frame — chips carry no listeners,
+ *  so the swap is click-safe. */
+function cmtStateChip(th: CommentThread): HTMLElement {
+  const wrap = el("span", "cmt-state");
+  wrap.id = "cmt-state";
+  if (th.status !== "open") return wrap;                    // closed threads carry their status in the title
+  const st = th.state || "";
+  if (st === "working") {
+    const chip = el("span", "chip chip-working");
+    const label = el("span", "chip-pulse");
+    label.textContent = CHIP_LABEL.working;
+    chip.appendChild(label);
+    const timer = el("span", "status-timer");
+    timer.id = "cmt-work-timer";
+    timer.textContent = elapsedMs(th.sinceEpoch || null);
+    wrap.append(chip, timer);
+  } else if (st === "retrying") {
+    const chip = el("span", "chip chip-retrying");
+    chip.textContent = CHIP_LABEL.retrying;
+    wrap.appendChild(chip);
+  } else if (st === "compacting") {
+    const c = el("span", "compacting-line");
+    c.textContent = "⟳ Compacting context…";
+    wrap.appendChild(c);
+  } else if (threadStuck(st)) {
+    const chip = el("span", "chip chip-needsInput");
+    chip.textContent = CHIP_LABEL.needsInput;
+    wrap.appendChild(chip);
+  } else {
+    const chip = el("span", "chip chip-ready");
+    chip.textContent = CHIP_LABEL.ready;
+    wrap.appendChild(chip);
+  }
+  return wrap;
+}
+
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
   const nm = th?.name || "Thread";
   return create ? "New comment:"
@@ -6485,6 +6567,8 @@ function renderCommentPopover(): void {
     if (t) t.textContent = commentPopTitle(!!create, th);
     const list = prev.querySelector(".cmt-msgs") as HTMLElement | null;
     if (th && list) fillCommentMsgs(list, th, sid);
+    const cs = prev.querySelector("#cmt-state");
+    if (th && cs) cs.replaceWith(cmtStateChip(th));   // state chip + timer track every frame, in place
     if (th) for (const b of Array.from(prev.querySelectorAll(".meta-btn[data-kind]")) as HTMLElement[]) {
       const lbl = b.querySelector(".meta-label") as HTMLElement | null;
       if (lbl) liveMetaLabel(lbl, b.dataset.kind === "model" ? "model" : "effort", th);
@@ -6582,7 +6666,7 @@ function renderCommentPopover(): void {
     // chat's statusline selectors use, defaulting to what this session runs now — picking one
     // affects only the thread; the conversation it branches from is never touched
     const st = sessions.get(sid)?.status;
-    const metaRow = el("div", "cmt-meta-row");
+    const metaRow = el("div", "statusline cmt-meta-row");
     const mkSel = (kind: "model" | "effort") => {
       // the statusline's own badge chrome (.meta-btn/.meta-label/.meta-caret) so the two stay in
       // sync by construction (the user 2026-08-17), tinted from the /models list's shared colors
@@ -6623,7 +6707,9 @@ function renderCommentPopover(): void {
       });
       return btn;
     };
-    metaRow.append(mkSel("model"), mkSel("effort"));
+    const metaRight = el("span", "sl-right");
+    metaRight.append(mkSel("model"), mkSel("effort"));
+    metaRow.appendChild(metaRight);
     metaRowPending = metaRow;
   }
   if (create || th!.status !== "promoted") {
@@ -6660,8 +6746,11 @@ function renderCommentPopover(): void {
     if (metaRowPending) pop.appendChild(metaRowPending);   // model/effort under the box, like the chat
     if (th && th.status === "open") {
       // the thread is a real session under the hood — its model/effort switch LIVE through the
-      // chat's own ops (setModel/setEffort route by sid; be.owns makes the thread reachable)
-      const mrow = el("div", "cmt-meta-row");
+      // chat's own ops (setModel/setEffort route by sid; be.owns makes the thread reachable).
+      // The row IS a statusline (the user 2026-08-25): the chat's own .statusline dress — state
+      // chip with the counting timer on the left, the meta badges clustered right in .sl-right —
+      // so the popover and the chat stay one vocabulary by construction.
+      const mrow = el("div", "statusline cmt-meta-row");
       const mkLive = (kind: "model" | "effort") => {
         const btn = el("span", "meta-btn cmt-meta") as HTMLElement;
         btn.dataset.kind = kind;
@@ -6695,7 +6784,10 @@ function renderCommentPopover(): void {
         });
         return btn;
       };
-      mrow.append(mkLive("model"), mkLive("effort"));
+      mrow.appendChild(cmtStateChip(th));
+      const right = el("span", "sl-right");
+      right.append(mkLive("model"), mkLive("effort"));
+      mrow.appendChild(right);
       pop.appendChild(mrow);
     }
     const row = el("div", "cmt-actions");
@@ -11025,6 +11117,11 @@ setInterval(() => {
     const timer = document.getElementById("work-timer");
     if (timer) timer.textContent = elapsedMs(s.status.sinceEpoch);
     else updateStatusline();
+  }
+  const ct = document.getElementById("cmt-work-timer");
+  if (ct) {
+    const cur = openCommentThread();
+    if (cur && threadBusy(cur.th.state)) ct.textContent = elapsedMs(cur.th.sinceEpoch || null);
   }
   const meta = document.getElementById("spinner-meta");
   if (meta) syncMetaControls(meta, s.status);

--- a/ui/webview/revive-loader.test.ts
+++ b/ui/webview/revive-loader.test.ts
@@ -20,10 +20,13 @@ test("the Revive click acknowledges at once: post reviveSession AND show the loa
 });
 
 test("the loader is the romp treatment: wordmark + swirl + pulsing dots + caption", () => {
+  // ONE shared builder (rompLoaderInner) carries the anatomy — the revive loader and the comment
+  // popover's boot both wear it, per the loading-states rule
+  assert.match(RENDER, /function rompLoaderInner\(caption: string\): HTMLElement/);
   assert.match(RENDER, /const word = el\("div", "rl-word"\)/, "reuses the boot-splash .rl-* styles already on the page");
   assert.match(RENDER, /swirl\.src = mediaSrc\("romp-swirl-o\.svg"\)/);
   assert.match(RENDER, /const dots = el\("div", "rl-dots"\)/);
-  assert.match(RENDER, /cap\.textContent = `reviving “\$\{name\}”…`/);
+  assert.match(RENDER, /o\.appendChild\(rompLoaderInner\(`reviving “\$\{name\}”…`\)\);/);
 });
 
 test("event-based clear: the kernel's focus for the reviving sid retires the loader", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2622,6 +2622,7 @@ mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
    nothing moves. */
 mark.cmt-hl.busy {
   background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, transparent);
+  animation: cmt-busy-pulse 2.2s ease-in-out infinite;
 }
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
@@ -2634,8 +2635,29 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),
 .md .katex.cmt-hl-host:has(mark.cmt-hl.busy) {
   background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, transparent);
+  animation: cmt-busy-pulse 2.2s ease-in-out infinite;
 }
-.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) { background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, var(--code-bg)); }
+.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) {
+  background-color: color-mix(in srgb, var(--st-awaitbg-bg) 24%, var(--code-bg));
+  animation: cmt-busy-pulse-code 2.2s ease-in-out infinite;
+}
+/* THE PULSE (the user 2026-08-25, asking for exactly this: the green should pulse on and off while
+   the highlight is generating — superseding the earlier no-motion ruling for THIS state only; the
+   marching ants stay dead). Text and the code/math hosts pulse in LOCKSTEP: same keyframe clock,
+   classes landed by the same applyCommentMarks pass. Static green under prefers-reduced-motion. */
+@keyframes cmt-busy-pulse {
+  0%, 100% { background-color: color-mix(in srgb, var(--st-awaitbg-bg) 12%, transparent); }
+  50% { background-color: color-mix(in srgb, var(--st-awaitbg-bg) 36%, transparent); }
+}
+@keyframes cmt-busy-pulse-code {
+  0%, 100% { background-color: color-mix(in srgb, var(--st-awaitbg-bg) 12%, var(--code-bg)); }
+  50% { background-color: color-mix(in srgb, var(--st-awaitbg-bg) 36%, var(--code-bg)); }
+}
+@media (prefers-reduced-motion: reduce) {
+  mark.cmt-hl.busy,
+  .md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy),
+  .md .katex.cmt-hl-host:has(mark.cmt-hl.busy) { animation: none; }
+}
 .md :not(pre) > code.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host > mark.cmt-hl { background: transparent; }
 .md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }
@@ -2656,6 +2678,11 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   font-size: 12px;
 }
 .cmt-head { display: flex; align-items: center; user-select: none; }
+/* the popover's boot loader (the user 2026-08-25: a fresh thread flashed the plain msgs projection
+   before jumping into the chat rendering) — the standard romp loader holds the conversation area
+   from open until the thread's REAL render (its events) is ready; a backstop falls back so it can
+   never trap. Reuses the page's .rl-* pieces, centered in the list. */
+.cmt-boot { display: flex; align-items: center; justify-content: center; min-height: 90px; }
 .cmt-head .cmt-x { cursor: pointer; }
 .cmt-title { font-weight: 600; }
 .cmt-x {
@@ -2672,6 +2699,11 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-pop.dragging { cursor: grabbing; }
 .cmt-pop .cmt-quote, .cmt-pop .cmt-msgs, .cmt-pop .cmt-input, .cmt-pop .cmt-name { cursor: auto; }
 .cmt-pop button, .cmt-pop .meta-btn { cursor: pointer; }
+/* the thread's own statusline (the user 2026-08-25: the popover should carry the chat's components —
+   the working chip WITH its counting timer, and the model/effort badges in the statusline's own
+   anatomy). Same classes as the chat's row so fonts and chrome stay one vocabulary; only the chat
+   column geometry is neutralized for the card. */
+.cmt-pop .statusline { max-width: none; margin: 0; padding: 2px 0 0; }
 /* user-resized (.sized): the quoted context takes the extra room — its clamp unlocks and it flexes */
 .cmt-pop.sized .cmt-quote {
   display: block; -webkit-line-clamp: unset; flex: 1 1 auto; min-height: 3em; overflow-y: auto;
@@ -2710,11 +2742,15 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-input:focus { outline: none; border-color: var(--accent); }
 .cmt-actions { display: flex; gap: 6px; align-items: center; }
 .cmt-actions:empty { display: none; }
+/* the chat's under-bubble button family, exactly (the composer-stage-btn dress — the user
+   2026-08-25: the popover's buttons should be the chat's, one vocabulary): neutral at rest,
+   accent on hover, the 0.78em label tier */
 .cmt-act {
-  padding: 3px 8px; border: 1px solid var(--box-border); border-radius: 4px; cursor: pointer;
-  background: none; color: inherit; font: inherit; opacity: 0.85;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.78em;
+  padding: 1px 8px; cursor: pointer;
 }
-.cmt-act:hover { opacity: 1; background: rgba(255, 255, 255, 0.06); }
+.cmt-act:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 .cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
 .cmt-note.cmt-err { color: var(--st-blocked-bg, #c94f4f); opacity: 0.9; }
 


### PR DESCRIPTION
## Four user asks (2026-08-25), one chat-parity pass

**1. Pulsing green while generating.** The in-flight await-green mark — text and the code/math hosts in lockstep (same keyframe clock; classes land in one `applyCommentMarks` pass) — gently pulses while the thread works, settling solid then flipping yellow on landing. The user asked for exactly this, superseding the earlier no-motion ruling for this one state (the marching ants stay dead); `prefers-reduced-motion` keeps the static green.

**2. Composer parity.** The popover's bottom row **is** a statusline: the chat's `.statusline` dress, state chip on the left (`chip-working` + pulse + the **counting timer**, fed by the frame's new `sinceEpoch` and ticked by the chat's own 1s loop), model/effort meta badges clustered right in `.sl-right`. The action buttons wear the chat's under-bubble button family (the Stage button's dress). Fork stays out by the user's call. Shared classes, not restyled copies.

**3. One format from boot.** A fresh thread used to flash the plain msgs projection before jumping into the chat-parity render. The standard romp loader (`rompLoaderInner` — extracted, now shared with the revive loader) holds the conversation area until the thread's events are ready; the final format then renders **once**. Event-based fade, 8s can't-trap backstop, pending sends still acknowledged beneath it.

**4. Green→yellow settles live.** The client's settle latch needs two confirming pushes, but the wire dedup withholds unchanged frames — the second confirm never arrived, so the flip waited for an unrelated change (the report: only after clicking back into the main chat). The kernel now counts pushes-since-busy **on the frame** (`settledPushes`, clamped at 2 so dedup resumes once decided; `_comment_settle_step` is the pure, unit-tested logic), and `commentInFlight` prefers that confirm — older kernels fall back to the client latch. The frame handler already repaints marks and the open popover per frame, so the flip lands on the push event itself, no refocus.

## Verification

Headless over the built bundle: the busy mark animates (`cmt-busy-pulse`); opening a fresh thread shows the loader with the working chip + counting timer and **never** the projection frame; the events frame swaps in the chat-parity render once, loader gone; `settledPushes` 1→2 flips green→yellow with no clicks anywhere. Screenshot eyeballed.

## Tests

`comment-popover-parity.test.ts` (statusline anatomy + tick, button family + fork absence, boot lifecycle + backstop, the kernel-carried confirm end to end), the pulse + reduced-motion pins retargeted in `comments.test.ts`, the shared-loader pins in `revive-loader.test.ts`, and `_comment_settle_step` unit tests in `tests/test_comment_threads.py`. npm 2373 + typecheck + Python 5583 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)