### PR TITLE
The freeze badges say what they mean; the frozen card's own update gets its line

### DIFF
--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -109,6 +109,27 @@ test("the badge hint counts the USER'S view and never mutates state computing it
     "the hint path is side-effect free");
 });
 
+test("the badges say what they mean; the frozen card's own update gets its own line (2026-08-25)", () => {
+  // the explicit reading joins the +N/−N (the user liked the numbers, wanted the meaning): one
+  // phrasing everywhere a badge renders, well under their verbosity ceiling, in the accent dress
+  assert.match(FEED, /note\.textContent = " \(" \+ \(c\.add \+ c\.del\) \+ " changed — mouse away to apply\)";/);
+  assert.match(CSS, /\.freeze-badge \.fz-note \{ color: var\(--accent\); font-weight: 400; \}/,
+    "accent var, never re-hardcoded; the badge's own scale");
+  // the hovered card's OWN pending update is a different fact — its own line, INDEPENDENT of the
+  // churn badges (both render when both are true: the self block sits outside the per-header loop)
+  assert.match(FEED, /function pendingSelfChanged\(key: string\): boolean/);
+  assert.match(FEED, /const selfKey = freezeKey \|\| tabScopeKey;/, "the pointer's card or the keyboard-scoped one");
+  assert.match(FEED, /selfNote\.textContent = "\(this card updated — mouse away to refresh\)";/);
+  assert.match(FEED, /if \(!selfKey \|\| !selfCard \|\| !pendingSelfChanged\(selfKey\)\) \{\s*\n\s*selfNote\?\.remove\(\);/,
+    "churn-only: no self line; self-only: badges empty but the line shows; both: both");
+  // group keys compare the turn's member set itemId-sorted — payload order can never fake a change
+  assert.match(FEED, /asks\.filter\(\(a\) => a\.turnId === tid\)\.slice\(\)\.sort\(byId\)/);
+  assert.match(CSS, /#freeze-selfnote \{ position: fixed; z-index: 6; pointer-events: none; color: var\(--accent\);/,
+    "pointer-inert — the note must never affect the hover it describes");
+  assert.match(FEED, /document\.getElementById\("freeze-selfnote"\)\?\.remove\(\);/,
+    "nothing pending → the line comes off with the badges");
+});
+
 test("badges wear the header conventions: accent adds, block-red removes, the count's own scale", () => {
   assert.match(CSS, /\.freeze-badge \{ font-weight: 600; opacity: 0\.7; margin-left: 6px; white-space: nowrap; \}/);
   assert.match(CSS, /\.freeze-badge \.fz-add \{ color: var\(--accent\); \}/, "never a re-hardcoded accent hex");

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -143,6 +143,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .freeze-badge i { font-style: normal; }
 .freeze-badge .fz-add { color: var(--accent); }
 .freeze-badge .fz-del { color: var(--err); }
+/* the explicit reading (the user 2026-08-25): the parenthetical wears the accent — the blue they
+   asked for — at the badge's own scale and normal weight so the +N/−N stays the loudest part */
+.freeze-badge .fz-note { color: var(--accent); font-weight: 400; }
+/* the hovered card's OWN pending update: a floating pointer-inert accent line pinned inside the
+   frozen card's lower edge (the rect is stable — that is the freeze's contract). Page-bg pill so
+   it reads over card content; 10.5px is the footer's existing scale, no new sizes. */
+#freeze-selfnote { position: fixed; z-index: 6; pointer-events: none; color: var(--accent);
+  font-size: 10.5px; font-weight: 600; background: rgba(30, 30, 30, 0.85);
+  border-radius: 4px; padding: 1px 6px; }
 /* margin-top, NOT header padding: the liveness rings are outlines drawn ~2.5px
    OUTSIDE the first card's top edge, and the sticky header paints its padding as
    opaque background over them — only unpainted margin space lets them show */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4503,11 +4503,35 @@ function paintFreezeParts(b: HTMLElement, c: { add: number; del: number }): void
   if (c.add) { const i = el("i", "fz-add"); i.textContent = "+" + c.add; b.appendChild(i); }
   if (c.add && c.del) b.appendChild(document.createTextNode("/"));
   if (c.del) { const i = el("i", "fz-del"); i.textContent = "-" + c.del; b.appendChild(i); }
+  // the explicit reading (the user 2026-08-25, liking the +N/−N but wanting it to say what it
+  // means): a parenthetical in the accent dress, well under their verbosity ceiling
+  const note = el("i", "fz-note");
+  note.textContent = " (" + (c.add + c.del) + " changed — mouse away to apply)";
+  b.appendChild(note);
   b.title = "updates waiting while you hover — they apply when the pointer leaves the card";
+}
+// Has the FROZEN card's own content changed in the withheld payload? Churn elsewhere and a stale
+// card under the pointer are different facts (the user 2026-08-25) — this one gets its own line,
+// shown WITH the churn badges when both are true. Group keys compare the turn's member set
+// (itemId-sorted, so payload order can never fake a change); ask keys compare the one item.
+function pendingSelfChanged(key: string): boolean {
+  if (!pendingFeedPayload) return false;
+  const pend = payloadView(pendingFeedPayload);
+  const byId = (a: AskItem, b2: AskItem) => (a.itemId < b2.itemId ? -1 : 1);
+  if (key.startsWith("g:")) {
+    const tid = key.slice(2);
+    const cur = JSON.stringify(asks.filter((a) => a.turnId === tid).slice().sort(byId));
+    const nxt = JSON.stringify(pend.filter((a) => a.turnId === tid).slice().sort(byId));
+    return cur !== nxt;
+  }
+  const cur = asks.find((a) => a.itemId === key);
+  const nxt = pend.find((a) => a.itemId === key);
+  return JSON.stringify(cur) !== JSON.stringify(nxt);
 }
 function paintFreezeBadges(): void {
   if (!pendingFeedPayload) {
     document.querySelectorAll(".freeze-badge").forEach((n) => n.remove());
+    document.getElementById("freeze-selfnote")?.remove();
     return;
   }
   const toItems = (list: AskItem[]) => viewFiltered(list).map((a) => ({ id: a.itemId, col: askColumn(a) as string, sid: a.sid }));
@@ -4526,6 +4550,25 @@ function paintFreezeBadges(): void {
   document.querySelectorAll<HTMLElement>(".feed-sess-head").forEach((h) => {
     put(h, groupedNow ? d.sess[h.getAttribute("data-fsid") || ""] : undefined);
   });
+  // the hovered/keyed card's OWN pending update — its own line, independent of the churn badges
+  // (both show when both are true). Body-mounted and pointer-inert: it must never affect hover,
+  // and the frozen card's rect is stable by construction (that is the freeze's whole contract).
+  const selfKey = freezeKey || tabScopeKey;
+  const selfCard = selfKey ? cardElByKey(selfKey) : null;
+  let selfNote = document.getElementById("freeze-selfnote");
+  if (!selfKey || !selfCard || !pendingSelfChanged(selfKey)) {
+    selfNote?.remove();
+  } else {
+    if (!selfNote) {
+      selfNote = el("div", "");
+      selfNote.id = "freeze-selfnote";
+      selfNote.textContent = "(this card updated — mouse away to refresh)";
+      document.body.appendChild(selfNote);
+    }
+    const r = selfCard.getBoundingClientRect();
+    selfNote.style.left = Math.round(r.left + 12) + "px";
+    selfNote.style.top = Math.round(r.bottom - 24) + "px";
+  }
 }
 
 // ── CARD KEYBOARD SCOPE (the user 2026-08-24) ──────────────────────────────────────────────────


### PR DESCRIPTION
User feedback on the hover-freeze badges: they like the +N/−N — make it explicit, with their draft as the verbosity ceiling, plus a distinct message when the hovered card itself was modified; both may show at once.

**The churn badges say what they mean.** Each badge gains a parenthetical in the accent dress — `+2/−1 (3 changed — mouse away to apply)` — one phrasing everywhere a badge renders (column pills and grouped session headers), under the ceiling, with the numbers still the loudest part (the note is normal weight at the badge's own scale; accent via `var(--accent)`, never re-hardcoded; no new font sizes).

**The frozen card's own update gets its own line.** When the withheld payload changed the hovered (or keyboard-scoped) card itself, `(this card updated — mouse away to refresh)` floats pointer-inert at the card's lower edge — body-mounted so it never touches the card's DOM or the hover it describes, positioned off the rect the freeze itself holds stable. Independent of the churn badges: churn-only shows badges, self-only shows the line, both show both. Group keys compare the turn's member set itemId-sorted, so payload ordering can never fake a self-change.

**Tests** pin both copies exactly, the accent dress, the three presence conditions, the sorted group compare, the pointer-inert placement, and teardown. 2374 extension tests green on the pushed head; both messages verified headlessly via tools/ui-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
