### PR TITLE
The popover statusline IS the chat's: one builder, sid-scoped

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6418,6 +6418,14 @@ def _comments_frame(sid, tmux=None):
                 since_ms = int(be.session_since(tsid)) * 1000
             except Exception:
                 since_ms = 0
+        # mode + fast ride too (the user 2026-08-25): the popover's statusline shows the chat's FULL
+        # element set — Auto/mode and the fast badge included, fork the one documented exemption
+        meta = {}
+        if be and status == "open" and hasattr(be, "session_meta"):
+            try:
+                meta = be.session_meta(tsid) or {}
+            except Exception:
+                meta = {}
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
                         "name": th.get("name") or "", "color": th.get("color") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
@@ -6426,6 +6434,7 @@ def _comments_frame(sid, tmux=None):
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
                         "settledPushes": quiet, "sinceEpoch": since_ms,
+                        "mode": str(meta.get("mode") or ""), "fast": str(meta.get("fast") or ""),
                         "msgs": msgs, "events": events})
     return {"type": "comments", "id": sid, "threads": threads}
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4675,6 +4675,19 @@ class SdkBackend:
                 return 0
         return 0
 
+    def session_meta(self, sid: str) -> dict:
+        """{'mode','fast'} from the live snapshot ({} unknown) — the comments frame's statusline
+        parity: the popover shows the chat statusline's FULL element set (the user 2026-08-25)."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        if s and s.thread.is_alive():
+            try:
+                snap = s.snapshot()
+                return {"mode": str(snap.get("mode") or ""), "fast": str(snap.get("fast") or "")}
+            except Exception:
+                return {}
+        return {}
+
     def rename(self, sid: str, new_name: str) -> bool:
         reg = read_reg(self.state_dir, sid)
         if not reg:

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -29,8 +29,21 @@ test("the popover's bottom row IS a statusline: the chat's chip anatomy + counti
   // the 1s tick drives it exactly like the chat's #work-timer
   assert.match(RENDER, /const ct = document\.getElementById\("cmt-work-timer"\);/);
   assert.match(RENDER, /if \(cur && threadBusy\(cur\.th\.state\)\) ct\.textContent = elapsedMs\(cur\.th\.sinceEpoch \|\| null\);/);
-  // the model/effort badges cluster right in .sl-right, the statusline's own placement idiom
-  assert.match(RENDER, /right\.append\(mkLive\("model"\), mkLive\("effort"\)\);/);
+  // the meta badges are the CHAT'S OWN controls (the user 2026-08-25 follow-up: sharing classes
+  // wasn't enough — the popover copy drifted in dress, font, and element set): syncMetaControls
+  // builds the FULL set (mode · model · effort · fast) into .sl-right, sid-scoped at the thread
+  assert.match(RENDER, /const metaBox = el\("span", "spinner-meta"\);/);
+  assert.match(RENDER, /syncMetaControls\(metaBox, threadMetaStatus\(th\), th\.tid\);/);
+  const tms = RENDER.split("function threadMetaStatus(")[1].split("\nfunction ")[0];
+  assert.ok(tms.includes("mode: th.mode ||"), "the mode badge's source rides the frame");
+  assert.ok(tms.includes("fast: th.fast ||"), "the fast badge's source rides the frame");
+  // …and the kernel sends both (the element-set gap: Auto and Fast were missing entirely)
+  assert.match(KERNEL, /"mode": str\(meta\.get\("mode"\) or ""\), "fast": str\(meta\.get\("fast"\) or ""\),/);
+  // the popover-local dress is GONE — no .cmt-meta chip skin to drift again; and the row restates
+  // the page's base font inside the popover's 12px context (the adopted-context trap)
+  const CSSs = CSS;
+  assert.ok(!/\.cmt-meta \{/.test(CSSs), "no popover-local meta dress");
+  assert.match(CSSs, /\.cmt-pop \.statusline \{[^}]*font-family: var\(--vscode-font-family\); font-size: var\(--vscode-font-size, 13px\); \}/);
   // …and the comments frame carries the epoch (milliseconds, the client convention)
   assert.match(KERNEL, /"settledPushes": quiet, "sinceEpoch": since_ms,/);
   // the in-place refresh keeps chip + timer live per frame (chips carry no listeners — click-safe)

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -292,10 +292,11 @@ test("picking a model/effort never reads as an outside press — the box stays p
   // on mousedown and null pendingCommentAnchor before the item's click could land the pick, and a
   // click on the break-out dialog's Cancel stranded the user the same way (the user 2026-08-18)
   assert.match(UI, /if \(!pop \|\| pop\.contains\(ev\.target as Node\)\) return;\s*\n\s*if \(\(ev\.target as HTMLElement\)\.closest\?\.\("\.meta-menu, #fork-prompt"\)\) return;\s*\n\s*closeCommentPop\(\);/);
-  // and the surviving popover shows the pick: the click acks the label, the frame keeps it honest
-  assert.match(UI, /function liveMetaLabel\(label: HTMLElement, kind: "model" \| "effort", th: CommentThread\)/);
-  assert.match(UI, /\.meta-btn\[data-kind\]/, "the in-place refresh reaches the live chips");
-  assert.match(UI, /label\.textContent = c\.label;\s+\/\/ acknowledge the pick now/);
+  // and the surviving popover shows the pick THROUGH the chat's own builder (2026-08-25 parity):
+  // the shared menu's click arms the sid-scoped pending dots, and the frame-driven refresh re-runs
+  // syncMetaControls on the popover's row exactly as the chat's tick does
+  assert.match(UI, /metaPending\.set\(`\$\{opSid\}:\$\{kind\}`, \{ was, until: Date\.now\(\) \+ 20_000 \}\);/);
+  assert.match(UI, /if \(th && cm\) syncMetaControls\(cm, threadMetaStatus\(th\), th\.tid\);/);
 });
 
 test("marks use the prefix-tolerant anchor matcher", () => {
@@ -387,8 +388,9 @@ test("the popover renders the thread with the CHAT's own renderer from the branc
   assert.match(UI, /const node = renderEvent\(ev, prev, null\);\s*\n\s*list\.appendChild\(node\);/);
   assert.match(KERNEL, /def _thread_events\(tsid, cut_uuid, now, tmux\):/);
   assert.match(KERNEL, /evs = evs\[at \+ 1:\]/, "sliced to AFTER the branch point — the head system card never rides");
-  // the thread's own live model/effort chips post the chat's own ops, keyed to the thread sid
-  assert.match(UI, /type: kind === "model" \? "setModel" : "setEffort", id: th\.tid, value: c\.value/);
+  // the thread's own statusline posts the chat's own ops through the SHARED menu, keyed to the
+  // thread sid (toggleMetaMenu's opSid — 2026-08-25 parity: one builder, sid-scoped)
+  assert.match(UI, /type: kind === "model" \? "setModel" : kind === "effort" \? "setEffort" : kind === "fast" \? "setFast" : "setMode", id: opSid, value: c\.value/);
 });
 
 test("the tint ladder keeps every state distinct: base < unread < hover", () => {

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -20,6 +20,8 @@ export type CommentThread = {
   unread: boolean;            // an agent reply newer than the read watermark
   settledPushes?: number;     // kernel pushes since the thread last read busy, clamped at 2 (settleConfirmed)
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
+  mode?: string;              // the thread's permission mode — the popover statusline's Auto badge
+  fast?: string;              // fast-mode state ("on"/"off"/"cooldown"; "" = unknown → no badge)
   promotedName: string;       // the board session it became, when status === "promoted"
   model?: string;             // the thread's live/chosen model (the popover's switchable chip)
   effort?: string;            // the thread's effort level (ditto)

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -23,7 +23,7 @@ test("the fast badge appears only when the session reports a state AND the model
   assert.match(RENDER, /fast\?: string;/);                                   // status carries it
   assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast";/);   // billing moved to the tab menu (2026-08-09)
   assert.match(RENDER, /st\.fast && fastAvailable\(st\) \? st\.fast : ""/);  // no state / unsupported model → no badge
-  assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(fast\)\)\)/);
+  assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(fast\), forSid\)\)/);   // sid-scoped: the popover statusline shares this builder (2026-08-25)
   // the availability gate: opus-family (or unknown/default — the account default may be Opus)
   const gate = RENDER.match(/function fastAvailable\(st: Status\): boolean \{[\s\S]*?\n\}/)?.[0] || "";
   assert.match(gate, /!m \|\| m === "default" \|\| m\.includes\("opus"\)/);

--- a/ui/webview/mode-selector.test.ts
+++ b/ui/webview/mode-selector.test.ts
@@ -15,7 +15,7 @@ test("MetaKind includes mode; the status carries it; there's a MODE_CHOICES menu
 });
 
 test("the mode button renders FIRST (left of model) and the picker posts setMode", () => {
-  assert.match(RENDER, /if \(st\.mode\) meta\.appendChild\(metaButton\("mode", prettyMode\(st\.mode\)\)\);\s*\n\s*if \(st\.model\)/);
+  assert.match(RENDER, /if \(st\.mode\) meta\.appendChild\(metaButton\("mode", prettyMode\(st\.mode\), forSid\)\);\s*\n\s*if \(st\.model\)/);   // sid-scoped for the popover statusline (2026-08-25)
   assert.match(RENDER, /"setMode"/);
   assert.match(RENDER, /const META_CHOICES: Record<MetaKind/);   // model/effort + mode share the menu path
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6444,6 +6444,17 @@ function refillOpenCommentPop(): void {
   if (th && list) fillCommentMsgs(list, th, openCommentKey.sid);
 }
 
+/** The open thread's status, in the chat's own Status shape — what the SHARED statusline builders
+ *  (syncMetaControls / toggleMetaMenu) consume, so the popover renders the chat statusline's full
+ *  element set (mode · model · effort · fast; the user 2026-08-25) through the one code path.
+ *  metaPending's switching-dots ride the same keys, sid-scoped. */
+function threadMetaStatus(th: CommentThread): Status {
+  const stuck = threadStuck(th.state);
+  return { state: stuck ? "needsInput" : (threadBusy(th.state) ? "working" : "ready"),
+           sinceEpoch: th.sinceEpoch || null, mode: th.mode || "", model: th.model || "",
+           effort: th.effort || "default", fast: th.fast || "", backend: "sdk" } as Status;
+}
+
 /** The popover statusline's LEFT half — the thread's state chip, wearing exactly the chat's chip
  *  anatomy (chip-working + pulse + counting timer, retrying, compacting-line, Blocked, Ready), so
  *  the popover says it's working the way the main chat does (the user 2026-08-25: no indication it
@@ -6535,16 +6546,6 @@ function commentSendFromPop(pop: HTMLElement): void {
   if (list) fillCommentMsgs(list, cur.th, cur.sid);      // the pending bubble IS the acknowledgement
 }
 
-/** A live thread's model/effort chip label: the frame's value, tinted from the shared /models
- *  colors. Shared by the chip's build and the in-place refresh — the popover survives the pick
- *  now, so the frame's fresh value must reach the label it left behind. */
-function liveMetaLabel(label: HTMLElement, kind: "model" | "effort", th: CommentThread): void {
-  label.textContent = kind === "model" ? (th.model || "Default") : (th.effort || "default");
-  const choice = META_CHOICES[kind].find((c) => (label.textContent || "").toLowerCase().startsWith(c.value));
-  label.style.color = choice?.color && choice.color.length === 3
-    ? `rgb(${choice.color[0]},${choice.color[1]},${choice.color[2]})` : "";
-}
-
 /** The popover — ONE pane-local card (no backdrop: the conversation stays readable beside it).
  *  Same thread still open → the conversation refreshes IN PLACE: the composer, its caret and the
  *  action row survive every comments frame (a full rebuild per push ate mid-press clicks and
@@ -6569,10 +6570,8 @@ function renderCommentPopover(): void {
     if (th && list) fillCommentMsgs(list, th, sid);
     const cs = prev.querySelector("#cmt-state");
     if (th && cs) cs.replaceWith(cmtStateChip(th));   // state chip + timer track every frame, in place
-    if (th) for (const b of Array.from(prev.querySelectorAll(".meta-btn[data-kind]")) as HTMLElement[]) {
-      const lbl = b.querySelector(".meta-label") as HTMLElement | null;
-      if (lbl) liveMetaLabel(lbl, b.dataset.kind === "model" ? "model" : "effort", th);
-    }
+    const cm = prev.querySelector("#cmt-meta") as HTMLElement | null;
+    if (th && cm) syncMetaControls(cm, threadMetaStatus(th), th.tid);   // same in-place refresh as the chat's tick
     return;
   }
   const hadFocus = !!prev?.querySelector(".cmt-input:focus-within, .cmt-input:focus");
@@ -6670,7 +6669,7 @@ function renderCommentPopover(): void {
     const mkSel = (kind: "model" | "effort") => {
       // the statusline's own badge chrome (.meta-btn/.meta-label/.meta-caret) so the two stay in
       // sync by construction (the user 2026-08-17), tinted from the /models list's shared colors
-      const btn = el("span", "meta-btn cmt-meta") as HTMLElement;
+      const btn = el("span", "meta-btn") as HTMLElement;
       const chosen = kind === "model" ? create.model : create.effort;
       const choice = chosen ? META_CHOICES[kind].find((c) => c.value === chosen) : null;
       const label = el("span", "meta-label");
@@ -6751,42 +6750,16 @@ function renderCommentPopover(): void {
       // chip with the counting timer on the left, the meta badges clustered right in .sl-right —
       // so the popover and the chat stay one vocabulary by construction.
       const mrow = el("div", "statusline cmt-meta-row");
-      const mkLive = (kind: "model" | "effort") => {
-        const btn = el("span", "meta-btn cmt-meta") as HTMLElement;
-        btn.dataset.kind = kind;
-        const label = el("span", "meta-label");
-        liveMetaLabel(label, kind, th);
-        const caret = el("span", "meta-caret");
-        caret.textContent = "▾";
-        btn.append(label, caret);
-        btn.title = "the thread's own " + kind + " — switching it never touches the session it branched from";
-        btn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          closeMetaMenu();
-          const menu = el("div", "meta-menu");
-          for (const c of META_CHOICES[kind]) {
-            const item = el("div", "meta-item");
-            item.textContent = c.label;
-            item.addEventListener("click", (ev) => {
-              ev.stopPropagation();
-              vscodeApi?.postMessage({ type: kind === "model" ? "setModel" : "setEffort", id: th.tid, value: c.value });
-              label.textContent = c.label;   // acknowledge the pick now; the next comments frame is authoritative
-              if (c.color && c.color.length === 3) label.style.color = `rgb(${c.color[0]},${c.color[1]},${c.color[2]})`;
-              closeMetaMenu();
-            });
-            menu.appendChild(item);
-          }
-          document.body.appendChild(menu);
-          const r2 = btn.getBoundingClientRect();
-          menu.style.left = r2.left + "px";
-          menu.style.top = (r2.bottom + 4) + "px";
-          metaMenuEl = menu;
-        });
-        return btn;
-      };
       mrow.appendChild(cmtStateChip(th));
+      // the chat's OWN meta controls — mode · model · effort · fast, the full statusline element
+      // set (the user 2026-08-25: fast and the mode badge were missing; a popover-local copy had
+      // drifted in dress too). syncMetaControls builds/refreshes them; forSid routes the ops and
+      // the pending keys at the THREAD, so a pick touches only it.
       const right = el("span", "sl-right");
-      right.append(mkLive("model"), mkLive("effort"));
+      const metaBox = el("span", "spinner-meta");   // the SAME wrapper the chat's badges wear — its
+      metaBox.id = "cmt-meta";                      // mono/0.92em/dim dress is where the font lives
+      syncMetaControls(metaBox, threadMetaStatus(th), th.tid);
+      right.appendChild(metaBox);
       mrow.appendChild(right);
       pop.appendChild(mrow);
     }
@@ -9243,7 +9216,7 @@ function metaDots(): HTMLElement {
   return d;
 }
 
-function metaButton(kind: MetaKind, text: string): HTMLElement {
+function metaButton(kind: MetaKind, text: string, forSid?: string | null): HTMLElement {
   const btn = el("span", "meta-btn");
   btn.dataset.kind = kind;
   const label = el("span", "meta-label");
@@ -9256,7 +9229,7 @@ function metaButton(kind: MetaKind, text: string): HTMLElement {
     : kind === "effort" ? "change thinking effort (sends /effort)"
     : kind === "fast" ? "toggle fast mode (sends /fast)"
     : "change permission mode (shift+tab cycle)";
-  btn.addEventListener("click", (e) => { e.stopPropagation(); toggleMetaMenu(kind, btn); });
+  btn.addEventListener("click", (e) => { e.stopPropagation(); toggleMetaMenu(kind, btn, forSid ?? null); });
   return btn;
 }
 
@@ -9272,7 +9245,7 @@ function metaColor(kind: MetaKind, st: Status): string {
 
 // Build or refresh the model/effort buttons inside #spinner-meta. Called from
 // updateStatusline (fresh container) and the 1s ticker (label refresh in place).
-function syncMetaControls(meta: HTMLElement, st: Status) {
+function syncMetaControls(meta: HTMLElement, st: Status, forSid?: string | null) {
   // order left→right: mode · model · effort · fast — the mode selector sits LEFT of the model name
   // (the user 2026-06-16); fast exists only when the session reports it (SDK init) AND the model can
   // run it (fastAvailable). Billing moved to the tab's right-click menu (the user 2026-08-09) — no
@@ -9282,10 +9255,10 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
   const btns = Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[];
   if (btns.map((b) => b.dataset.kind).join() !== want) {
     meta.replaceChildren();
-    if (st.mode) meta.appendChild(metaButton("mode", prettyMode(st.mode)));
-    if (st.model) meta.appendChild(metaButton("model", st.model));
-    if (st.effort) meta.appendChild(metaButton("effort", st.effort));
-    if (fast) meta.appendChild(metaButton("fast", prettyFast(fast)));
+    if (st.mode) meta.appendChild(metaButton("mode", prettyMode(st.mode), forSid));
+    if (st.model) meta.appendChild(metaButton("model", st.model, forSid));
+    if (st.effort) meta.appendChild(metaButton("effort", st.effort, forSid));
+    if (fast) meta.appendChild(metaButton("fast", prettyFast(fast), forSid));
   }
   for (const b of Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[]) {
     const kind = b.dataset.kind as MetaKind;
@@ -9318,15 +9291,24 @@ function closeMetaMenu() {
   metaMenuEl?.remove();
   metaMenuEl = null;
 }
-function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
+function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null) {
   const wasOpen = metaMenuEl?.dataset.kind === kind;
   closeMetaMenu();
   if (wasOpen) return;
-  const s = activeId ? sessions.get(activeId) : null;
-  if (!s) return;
+  // forSid ≠ the active session: a COMMENT THREAD's own statusline (the user 2026-08-25 — one
+  // builder for both surfaces, so the popover can never drift off the chat's anatomy again). The
+  // thread's status-shape comes from the open popover's frame fields; the ops route by its sid.
+  const forThread = !!forSid && forSid !== activeId;
+  const th0 = forThread ? openCommentThread()?.th : null;
+  if (forThread && !th0) return;
+  const status: Status | null = forThread ? threadMetaStatus(th0!)
+    : (activeId ? sessions.get(activeId)?.status ?? null : null);
+  const opSid = forThread ? forSid! : activeId;
+  if (!status || !opSid) return;
   // a pending permission/picker prompt owns the pane's keyboard — injecting a
   // slash command there would answer the prompt instead (host guards this too)
-  if (s.status.state === "needsInput" || s.status.state === "awaiting") return;
+  if (status.state === "needsInput" || status.state === "awaiting") return;
+  const s = { status };
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
   // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it, and
@@ -9345,10 +9327,10 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
     }
     item.addEventListener("click", (e) => {
       e.stopPropagation();
-      if (activeId && vscodeApi) {
-        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: activeId, value: c.value });
+      if (vscodeApi) {
+        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: opSid, value: c.value });
         const was = metaCurrent(kind, s.status);
-        metaPending.set(`${activeId}:${kind}`, { was, until: Date.now() + 20_000 });
+        metaPending.set(`${opSid}:${kind}`, { was, until: Date.now() + 20_000 });
         btn.classList.add("meta-pending");
       }
       closeMetaMenu();

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2703,7 +2703,12 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    the working chip WITH its counting timer, and the model/effort badges in the statusline's own
    anatomy). Same classes as the chat's row so fonts and chrome stay one vocabulary; only the chat
    column geometry is neutralized for the card. */
-.cmt-pop .statusline { max-width: none; margin: 0; padding: 2px 0 0; }
+.cmt-state { display: inline-flex; align-items: center; gap: 10px; }   /* chip · timer — the statusline's own column gap */
+.cmt-pop .statusline { max-width: none; margin: 0; padding: 2px 0 0;
+  /* the popover card is a 12px context (.cmt-pop) — restate the PAGE's base so every statusline
+     element computes the same font as the chat's row (the user 2026-08-25: "the font is different";
+     the timeline gear menu hit the same adopted-context trap) */
+  font-family: var(--vscode-font-family); font-size: var(--vscode-font-size, 13px); }
 /* user-resized (.sized): the quoted context takes the extra room — its clamp unlocks and it flexes */
 .cmt-pop.sized .cmt-quote {
   display: block; -webkit-line-clamp: unset; flex: 1 1 auto; min-height: 3em; overflow-y: auto;
@@ -2797,14 +2802,11 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-name:focus { outline: none; border-bottom-color: var(--accent); }
 .cmt-name.bad { border-bottom: 1px solid var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
 
-/* the comment's own model/effort selectors (the user 2026-08-17) — chip-shaped buttons opening the
-   same .meta-menu the statusline uses; the picks ride the create call and touch only the thread */
+/* the comment's own statusline row (the user 2026-08-17; full parity 2026-08-25): the CHAT'S meta
+   buttons verbatim — the old .cmt-meta chip dress (border, radius, opacity) made the same classes
+   render as rounded buttons in a different font, exactly the drift the shared classes were meant
+   to prevent. No local dress: .meta-btn/.meta-label/.meta-caret rule here as they do in the chat. */
 .cmt-meta-row { display: flex; gap: 6px; }
-.cmt-meta {
-  padding: 2px 8px; border: 1px solid var(--box-border); border-radius: 4px; cursor: pointer;
-  background: none; color: inherit; font: inherit; opacity: 0.85;
-}
-.cmt-meta:hover { opacity: 1; border-color: var(--accent); }
 
 /* comment ticks on the chat's scroll rail (the user 2026-08-15): where the comments are, at the
    anchor's proportional position in the whole conversation; click = jump + open the thread */


### PR DESCRIPTION
## The two gaps (user follow-up on the parity pass)

**Font.** The chat's badges sit inside `.spinner-meta`, whose dress (`--mono`, `0.92em`, dim) is where their font actually comes from — the popover's copy sat in a bare `.sl-right` and computed the system font, and a leftover `.cmt-meta` skin dressed the same classes as rounded buttons. The popover's badges now sit in their own `.spinner-meta` wrapper, the `.cmt-meta` skin is deleted, and the row restates the page's base font inside the card's 12px context (the adopted-context trap the timeline gear menu documented).

**Element set.** The popover minted only model/effort through a local copy of the menu code. The copy is deleted: `metaButton`/`toggleMetaMenu`/`syncMetaControls` now take an owner sid, and the popover calls the **same** `syncMetaControls` with the thread's Status shape — mode · model · effort · fast, the chat's full set (fork remains the one documented exemption, and it was never a statusline element). Ops (`setMode`/`setModel`/`setEffort`/`setFast`) and the pending-dots keys route at the thread's sid. The comments frame now carries `mode` and `fast` (`session_meta` on the SDK backend, from the live snapshot).

## The bar, machine-checked over the built bundle

Computed `font-family|size|weight` equal chat↔popover for the chip, the timer, and every badge (`mode/model/effort/fast` all `equal: true`), and the element sets are equal (`["mode","model","effort","fast"]` both sides). The check earned its keep: the first font fix alone (base-font restatement) left the badges system-vs-mono — the computed-style diff pointed straight at `.spinner-meta`. Screenshot eyeballed: the popover row reads identically to the chat's statusline below it, orange Fast tint included.

## Tests

`comment-popover-parity.test.ts` retargeted to the shared-builder shape (spinner-meta wrapper, `threadMetaStatus` sourcing mode/fast, kernel frame fields, no `.cmt-meta` dress, the base-font restatement); the shared-builder sid-threading pinned in `fast-toggle.test.ts` / `mode-selector.test.ts` / `comments.test.ts` (each updated where they anchored the old forms). npm 2373 + typecheck + Python 5583 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)