### PR TITLE
Model pickers expose versions: family click = remembered default, hover reveals the rest

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -735,6 +735,54 @@ def _write_palette_mirror():
 # model literals. The judge accepts only a value from here (setJudgeModel/setIndexModel validate against it).
 MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label": "Opus"},
                  {"value": "sonnet", "label": "Sonnet"}, {"value": "haiku", "label": "Haiku"}]
+# Every version a family can pin (the user 2026-08-25: shorthand aliases resolve to the NEWEST —
+# opus became Opus 5 — silently losing the legacy versions that remain live on the API). Newest
+# first; values are the API's DATELESS aliases, verified against the claude-api reference
+# 2026-08-25 (deprecated 4.1/4.0-era models excluded on purpose — they are retiring). Clicking a
+# family in a picker sends that family's DEFAULT: the most recent version the user picked for it
+# (model-picks.json below), else the newest. Full ids ride every set path verbatim already — the
+# alias table stops at the family names, so a version pick needs no new transport.
+MODEL_VERSIONS = {
+    "fable":  [{"value": "claude-fable-5", "label": "Fable 5"}],
+    "opus":   [{"value": "claude-opus-5", "label": "Opus 5"},
+               {"value": "claude-opus-4-8", "label": "Opus 4.8"},
+               {"value": "claude-opus-4-7", "label": "Opus 4.7"},
+               {"value": "claude-opus-4-6", "label": "Opus 4.6"},
+               {"value": "claude-opus-4-5", "label": "Opus 4.5"}],
+    "sonnet": [{"value": "claude-sonnet-5", "label": "Sonnet 5"},
+               {"value": "claude-sonnet-4-6", "label": "Sonnet 4.6"},
+               {"value": "claude-sonnet-4-5", "label": "Sonnet 4.5"}],
+    "haiku":  [{"value": "claude-haiku-4-5", "label": "Haiku 4.5"}],
+}
+_VERSION_FAMILY = {v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v in vs}
+MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pref all surfaces read, like colormap
+
+
+def _model_picks():
+    """The per-family last-picked map. Only known version ids survive the read (a stale or hand-edited
+    entry falls back to the family's newest rather than poisoning the default)."""
+    try:
+        d = json.loads((jd.STATE / MODEL_PICKS_FILE_NAME).read_text())
+        return {f: v for f, v in d.items() if isinstance(v, str) and _VERSION_FAMILY.get(v) == f} \
+            if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+def _note_model_pick(value):
+    """Record a version pick as its family's new default (write-on-change). Family shorthands and
+    unknown strings record nothing — they are not version picks."""
+    fam = _VERSION_FAMILY.get(str(value or ""))
+    if not fam:
+        return
+    picks = _model_picks()
+    if picks.get(fam) == value:
+        return
+    picks[fam] = value
+    try:
+        _atomic_write(jd.STATE / MODEL_PICKS_FILE_NAME, json.dumps(picks))
+    except Exception:
+        sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
 # "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
 # standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
 # SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
@@ -15820,6 +15868,7 @@ def _set_model_or_park(be, sid, value):
     way, the pick is ACCEPTED now: stamp the shared pending signal (_mark_model_pending) so chat + timeline
     both show switching-dots immediately, from whichever surface the click came from (the user 2026-07-03)."""
     _mark_model_pending(sid, value)
+    _note_model_pick(value)          # a version pick becomes its family's remembered default (2026-08-25)
     if _ops_gate(sid):
         _park_op(sid, ("model", value))
     else:
@@ -27492,8 +27541,17 @@ class Handler(BaseHTTPRequestHandler):
                 # selectors wear the same colors the statusline badges do, for ANY pick — the badge
                 # colors only cover the current value, so the list is where the shared tint belongs)
                 _stops = cm.stops_for(_colormap())
+                # each family also carries its VERSIONS (newest first, the family's tint) and its
+                # DEFAULT — the last version the user picked for that family, else the newest (the
+                # user 2026-08-25: family click = remembered pick; the submenu holds the rest).
+                _picks = _model_picks()
                 return self._send(200, json.dumps(
-                    {"models": [dict(c, color=_model_color(c["value"], _stops)) for c in MODEL_CHOICES],
+                    {"models": [dict(c, color=_model_color(c["value"], _stops),
+                                     versions=[dict(v) for v in MODEL_VERSIONS.get(c["value"]) or []],
+                                     default=_picks.get(c["value"])
+                                         or ((MODEL_VERSIONS.get(c["value"]) or [{}])[0].get("value")
+                                             or c["value"]))
+                                for c in MODEL_CHOICES],
                      "efforts": [dict(c, color=_effort_color(c["value"], _stops)) for c in EFFORT_CHOICES]}),
                     "application/json", cache="no-cache")
             if p == "/usage":                                 # the /usage rate-limit bars, re-read on demand: the rail's

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -64,8 +64,10 @@ class JudgeSettings(unittest.TestCase):
     def test_models_endpoint_serves_the_shared_lists(self):
         ksrc = inspect.getsource(km)
         self.assertIn('if p == "/models":', ksrc)
-        # the shared lists, each choice carrying its colormap tint (the user 2026-08-17)
-        self.assertIn('{"models": [dict(c, color=_model_color(c["value"], _stops)) for c in MODEL_CHOICES]', ksrc)
+        # the shared lists, each choice carrying its colormap tint (the user 2026-08-17) — and,
+        # since the version submenus (the user 2026-08-25), each family's versions + default too
+        self.assertIn('{"models": [dict(c, color=_model_color(c["value"], _stops),', ksrc)
+        self.assertIn('versions=[dict(v) for v in MODEL_VERSIONS.get(c["value"]) or []]', ksrc)
 
     # ---- per-tier overrides honored + validated ----
     def test_overrides_are_honored(self):

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Model selectors expose VERSIONS (the user 2026-08-25): shorthand aliases resolve to the newest —
+opus became Opus 5 — silently losing legacy versions that remain live on the API. The kernel's
+/models now carries each family's versions (dateless alias ids, verified against the claude-api
+reference) plus a DEFAULT: the most recent version the user picked for that family (model-picks.json,
+a viewer pref like colormap), else the newest. The pick memory hooks the ONE choke point every set
+path flows through (_set_model_or_park). Synthetic only — hermetic temp STATE."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_mv", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+
+class Catalog(unittest.TestCase):
+    """The version catalog's own invariants."""
+
+    def test_every_family_in_the_picker_has_a_version_list(self):
+        for c in km.MODEL_CHOICES:
+            self.assertIn(c["value"], km.MODEL_VERSIONS, c["value"])
+            self.assertTrue(km.MODEL_VERSIONS[c["value"]], c["value"])
+
+    def test_versions_are_dateless_aliases_newest_first(self):
+        # ids verified against the claude-api reference (2026-08-25) — dateless aliases only,
+        # and the head of each list is the family's newest (what the bare shorthand resolves to)
+        for fam, vs in km.MODEL_VERSIONS.items():
+            for v in vs:
+                self.assertNotRegex(v["value"], r"-20\d{6}$", "dated snapshot id leaked in")
+        self.assertEqual(km.MODEL_VERSIONS["opus"][0]["value"], "claude-opus-5")
+        self.assertEqual(km.MODEL_VERSIONS["sonnet"][0]["value"], "claude-sonnet-5")
+        self.assertIn("claude-opus-4-8", [v["value"] for v in km.MODEL_VERSIONS["opus"]],
+                      "legacy versions live on the API stay pickable")
+
+    def test_reverse_map_covers_every_version(self):
+        for fam, vs in km.MODEL_VERSIONS.items():
+            for v in vs:
+                self.assertEqual(km._VERSION_FAMILY[v["value"]], fam)
+
+
+class PickMemory(unittest.TestCase):
+    """Per-family last-picked defaults: written at the choke point, read into /models."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+
+    def tearDown(self):
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def test_a_version_pick_becomes_the_family_default_and_persists(self):
+        self.assertEqual(km._model_picks(), {})
+        km._note_model_pick("claude-opus-4-8")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8"})
+        # the store is the file (a restart re-reads it) — pin the on-disk shape
+        self.assertEqual(json.loads((jd.STATE / km.MODEL_PICKS_FILE_NAME).read_text()),
+                         {"opus": "claude-opus-4-8"})
+
+    def test_a_family_shorthand_never_downgrades_an_explicit_legacy_pick(self):
+        # THE ALIAS RULE (the user's design): clicking a family sends the REMEMBERED version, and a
+        # bare shorthand reaching the setter records nothing — so an explicit Opus 4.8 pick is never
+        # silently replaced by "opus" resolving to the newest.
+        km._note_model_pick("claude-opus-4-8")
+        km._note_model_pick("opus")
+        km._note_model_pick("default")
+        km._note_model_pick("total-nonsense")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8"})
+
+    def test_the_choke_point_records_picks_from_every_surface(self):
+        # _set_model_or_park is what the WS setModel op, the chat /model command, and POST /new's
+        # prefs all call — one hook covers every surface.
+        class _BE:
+            def set_model(self, sid, value):
+                return True
+        km._set_model_or_park(_BE(), "11111111-2222-3333-4444-555555555555", "claude-sonnet-4-6")
+        self.assertEqual(km._model_picks().get("sonnet"), "claude-sonnet-4-6")
+
+    def test_a_stale_or_foreign_entry_falls_back_on_read(self):
+        (jd.STATE / km.MODEL_PICKS_FILE_NAME).write_text(json.dumps(
+            {"opus": "claude-opus-9-9", "sonnet": "claude-opus-4-8", "haiku": "claude-haiku-4-5"}))
+        self.assertEqual(km._model_picks(), {"haiku": "claude-haiku-4-5"},
+                         "unknown ids and cross-family entries never poison the default")
+
+
+class ModelsRoute(unittest.TestCase):
+    """GET /models carries versions + default per family."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+
+    def tearDown(self):
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def _models(self):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/models" % self.port,
+            headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode())
+
+    def test_each_family_carries_versions_and_a_default(self):
+        d = self._models()
+        rows = {m["value"]: m for m in d["models"]}
+        self.assertEqual([v["value"] for v in rows["opus"]["versions"]],
+                         [v["value"] for v in km.MODEL_VERSIONS["opus"]])
+        self.assertEqual(rows["opus"]["default"], "claude-opus-5",
+                         "no pick yet → the family's newest")
+        self.assertIn("color", rows["opus"], "the colormap tint still rides every family row")
+
+    def test_the_default_follows_the_users_last_pick(self):
+        km._note_model_pick("claude-opus-4-8")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["default"], "claude-opus-4-8")
+        self.assertEqual(rows["sonnet"]["default"], "claude-sonnet-5", "other families unaffected")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2298,7 +2298,7 @@ class TimelinePanel {
     } catch (e) { /* no host hook + no Node → can't send */ }
   }
 
-  _closeMetaMenu() { if (this._metaMenu) { this._metaMenu.remove(); this._metaMenu = null; } }
+  _closeMetaMenu() { if (this._metaMenu) { if (this._metaMenu._sub) this._metaMenu._sub.remove(); this._metaMenu.remove(); this._metaMenu = null; } }
 
   // Where a drop-down should live and be measured: the tip's host document (the topmost same-origin
   // window — in the web shell that's the whole page, so a menu taller than the timeline band gets the
@@ -2333,23 +2333,77 @@ class TimelinePanel {
     const menu = document.body.createDiv();
     menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:96px;' + MENU_STYLE);
     menu._kind = kind; menu._sid = s.id;
+    const h = this._menuHost(anchorEl.getBoundingClientRect());
+    const pick = (value) => {
+      this._sendCommand(s.name, '/' + kind + ' ' + value, kind === 'model');
+      const now = (typeof Date !== 'undefined' && Date.now) ? Date.now() : 0;
+      this._metaPending[s.id + ':' + kind] = { was: (kind === 'model' ? s.model : s.effort) || '', until: now + 20000 };
+      this._closeMetaMenu();
+      this.draw();
+    };
+    const closeSub = () => { if (menu._sub) { menu._sub.remove(); menu._sub = null; } };
     for (const c of (kind === 'model' ? MODEL_CHOICES : EFFORT_CHOICES)) {
       const cur = isCurrentMeta(kind, s, c.value);
+      const versions = kind === 'model' ? (c.versions || []) : [];
       const item = menu.createDiv({ text: c.label });
-      item.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;');
+      item.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;display:flex;align-items:center;');
+      item.setAttribute('tabindex', '0');
       if (cur) { const ck = item.createSpan({ text: '✓' }); ck.setAttribute('style', MENU_CHECK_STYLE); }
-      item.addEventListener('mouseenter', () => { item.style.background = 'rgba(255,255,255,0.09)'; });
+      // A family with more than one live version wears the side-submenu affordance (the user
+      // 2026-08-25): hovering (or right-arrow) reveals every version, each directly pickable with
+      // the ✓ on the lane's current one; clicking the family itself picks its DEFAULT — the version
+      // the user last chose for that family, else the newest (the kernel's /models `default`).
+      // .ctx-caret/.ctx-sub vocabulary inlined — this pane may live in a foreign document (Obsidian).
+      const openSub = versions.length > 1 ? () => {
+        closeSub();
+        const sub = document.body.createDiv();
+        sub.setAttribute('style', 'position:fixed;z-index:1002;min-width:96px;' + MENU_STYLE);
+        for (const v of versions) {
+          const cv = ((s.model || '').toLowerCase() === v.label.toLowerCase());
+          const row = sub.createDiv({ text: v.label });
+          row.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;');
+          row.setAttribute('tabindex', '0');
+          if (cv) { const ck = row.createSpan({ text: '✓' }); ck.setAttribute('style', MENU_CHECK_STYLE); }
+          row.addEventListener('mouseenter', () => { row.style.background = 'rgba(255,255,255,0.09)'; });
+          row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+          row.addEventListener('click', (e) => { e.stopPropagation(); pick(v.value); });
+          row.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); pick(v.value); }
+            else if (e.key === 'ArrowLeft') { e.preventDefault(); closeSub(); item.focus(); }
+          });
+        }
+        const hr = item.getBoundingClientRect();
+        h.doc.body.appendChild(sub);
+        const iw = (h.win.innerWidth || 9999);
+        let sl = Math.round(hr.right + 2);
+        if (sl + (sub.offsetWidth || 120) > iw - 6) sl = Math.max(6, Math.round(hr.left) - (sub.offsetWidth || 120) - 2);
+        sub.style.left = sl + 'px';
+        sub.style.top = Math.round(menuTop(hr, sub.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
+        menu._sub = sub;
+        return sub;
+      } : null;
+      if (openSub) {
+        const caret = item.createSpan({ text: '\u25B8' });
+        caret.setAttribute('style', 'margin-left:auto;padding-left:10px;opacity:0.55;');
+        item.addEventListener('mouseenter', () => { item.style.background = 'rgba(255,255,255,0.09)'; openSub(); });
+      } else {
+        item.addEventListener('mouseenter', () => { item.style.background = 'rgba(255,255,255,0.09)'; closeSub(); });
+      }
       item.addEventListener('mouseleave', () => { item.style.background = 'transparent'; });
       item.addEventListener('click', (e) => {
         e.stopPropagation();
-        this._sendCommand(s.name, '/' + kind + ' ' + c.value, kind === 'model');
-        const now = (typeof Date !== 'undefined' && Date.now) ? Date.now() : 0;
-        this._metaPending[s.id + ':' + kind] = { was: (kind === 'model' ? s.model : s.effort) || '', until: now + 20000 };
-        this._closeMetaMenu();
-        this.draw();
+        pick(kind === 'model' ? (c.default || c.value) : c.value);
+      });
+      item.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); pick(kind === 'model' ? (c.default || c.value) : c.value); }
+        else if (e.key === 'ArrowRight' && openSub) {
+          e.preventDefault();
+          const sub = openSub();
+          const first = sub && sub.querySelector('[tabindex]');
+          if (first) first.focus();
+        }
       });
     }
-    const h = this._menuHost(anchorEl.getBoundingClientRect());
     h.doc.body.appendChild(menu);   // a cross-document append ADOPTS the node; its listeners are kept
     // clamp to the host viewport so a right-edge lane's menu stays on-screen
     const left = Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 140);

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -356,3 +356,22 @@ test("the lane gear carries the SAME tag editor — the shared builders, never a
   assert.match(SRC, /this\._tagJoinMenu\(am, \[s\.id\], build\);/);
 });
 
+test("the lane model menu exposes VERSIONS: submenu affordance, remembered default, keyboard (the user 2026-08-25)", () => {
+  // families with >1 live version wear a side submenu — hover or ArrowRight reveals it, every
+  // version directly pickable with the current-✓; clicking the family picks its remembered DEFAULT
+  // (the kernel /models `default` field), never a bare shorthand that silently resolves to newest
+  assert.match(SRC, /const versions = kind === 'model' \? \(c\.versions \|\| \[\]\) : \[\]/);
+  assert.match(SRC, /pick\(kind === 'model' \? \(c\.default \|\| c\.value\) : c\.value\)/,
+    "family click sends the remembered default");
+  assert.match(SRC, /versions\.length > 1 \?/, "single-version families stay flat");
+  assert.match(SRC, /text: '\\u25B8'/, "the caret affordance marks expandable families");
+  assert.match(SRC, /e\.key === 'ArrowRight' && openSub/, "right-arrow expands (keyboard operable)");
+  assert.match(SRC, /e\.key === 'ArrowLeft'[\s\S]{0,80}closeSub\(\); item\.focus\(\)/,
+    "left-arrow collapses back to the family row");
+  assert.match(SRC, /pick\(v\.value\)/, "version rows pick their own full id");
+  assert.match(SRC, /\(s\.model \|\| ''\)\.toLowerCase\(\) === v\.label\.toLowerCase\(\)/,
+    "the ✓ marks the lane's current version");
+  assert.match(SRC, /if \(this\._metaMenu\._sub\) this\._metaMenu\._sub\.remove\(\)/,
+    "closing the menu drops an open submenu too");
+});
+


### PR DESCRIPTION
## What (user ask 2026-08-25, design preserved exactly — phase 1 of 2)

Shorthand aliases resolve to the newest (opus → Opus 5), silently losing legacy versions still live on the API. Now:

- **`/models` grows per-family `versions`** — dateless alias IDs, newest first, **verified against the claude-api reference** (Fable 5; Opus 5/4.8/4.7/4.6/4.5; Sonnet 5/4.6/4.5; Haiku 4.5; deprecated 4.1/4.0-era excluded) — **and `default`**: the most recent version the user picked for that family, else the newest.
- **Per-family pick memory** (`model-picks.json`, a viewer pref like colormap) hooks `_set_model_or_park` — the one choke point the WS op, the chat `/model` command, and `POST /new` prefs all flow through. A bare family shorthand records nothing, so **a family click never silently downgrades an explicit legacy pick**.
- **Timeline lane gear**: families with >1 live version wear the ▸ caret; hover or **ArrowRight** opens the side submenu (**ArrowLeft** collapses), ✓ marks the lane's current version, each version directly pickable; clicking the family sends its remembered default full ID. MENU_STYLE-inlined (Obsidian host).

**Phase 2 (own PR, deliberately not here):** the chat statusline meta-menu — a peer is mid-queue in render.ts; that surface follows once their PRs land (the popover statusline shares the chat statusline post-676 and should come free).

## Tests

`tests/test_model_versions.py` (9): catalog invariants (dateless, newest-first, reverse-map), pick round-trip + on-disk shape, shorthand-never-downgrades, the choke-point hook, stale-entry fallback, both `/models` arms. Menu source pins (submenu, caret, keyboard both directions, current-✓, teardown) in `ui/timeline-views-panel.test.ts`; the old emission pin in `test_kernel_judge_model.py` retargeted in the same push. Suites green: 5610 python (after the pin fix), 2374 JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)