### PR TITLE
The statusline model menu exposes versions — chat and popover together, one builder

### DIFF
--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -87,3 +87,25 @@ test("green→yellow settles LIVE: the kernel carries the confirm the dedup used
   // the frame handler already repaints marks AND the open popover per frame — the live wire
   assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) \{/);
 });
+
+test("the model meta-menu exposes VERSIONS: submenu, remembered default, keyboard (the user 2026-08-25)", () => {
+  // families with >1 live version wear a side submenu (leftward — the menu anchors bottom-right):
+  // hover or an arrow key reveals every version, each pickable with the current-✓; clicking the
+  // family sends its remembered DEFAULT (the kernel /models `default`), never a bare shorthand.
+  // Rides the ONE builder, so the chat statusline and the popover statusline both grow it.
+  assert.match(RENDER, /const versions = kind === "model" \? \(c\.versions \|\| \[\]\) : \[\]/);
+  assert.match(RENDER, /pickValue\(kind === "model" \? \(c\.default \|\| c\.value\) : c\.value\)/,
+    "family click sends the remembered default");
+  assert.match(RENDER, /versions\.length > 1 \?/, "single-version families stay flat");
+  assert.match(RENDER, /el\("span", "meta-caret"\)/, "the caret affordance marks expandable families");
+  assert.match(RENDER, /\(e\.key === "ArrowRight" \|\| e\.key === "ArrowLeft"\) && openSub/,
+    "arrow keys expand (the submenu opens leftward, so both arrows work)");
+  assert.match(RENDER, /e\.key === "ArrowLeft"[\s\S]{0,90}closeSub\(\); item\.focus\(\)/,
+    "ArrowLeft inside the submenu collapses back to the family row");
+  assert.match(RENDER, /pickValue\(v\.value\)/, "version rows pick their own full id");
+  assert.match(RENDER, /\(s\.status\.model \|\| ""\)\.toLowerCase\(\) === v\.label\.toLowerCase\(\)/,
+    "the ✓ marks the session's current version");
+  assert.match(RENDER, /querySelectorAll\("\.meta-sub"\)\.forEach/, "closing the menu drops an open submenu");
+  assert.match(CSS, /\.meta-caret \{ position: absolute; right: 22px/, "caret sits left of the ✓ slot");
+});
+

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -390,7 +390,7 @@ test("the popover renders the thread with the CHAT's own renderer from the branc
   assert.match(KERNEL, /evs = evs\[at \+ 1:\]/, "sliced to AFTER the branch point — the head system card never rides");
   // the thread's own statusline posts the chat's own ops through the SHARED menu, keyed to the
   // thread sid (toggleMetaMenu's opSid — 2026-08-25 parity: one builder, sid-scoped)
-  assert.match(UI, /type: kind === "model" \? "setModel" : kind === "effort" \? "setEffort" : kind === "fast" \? "setFast" : "setMode", id: opSid, value: c\.value/);
+  assert.match(UI, /type: kind === "model" \? "setModel" : kind === "effort" \? "setEffort" : kind === "fast" \? "setFast" : "setMode", id: opSid, value/);
 });
 
 test("the tint ladder keeps every state distinct: base < unread < hover", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9095,7 +9095,8 @@ function elapsedMs(sinceMs: number | null): string {
 type MetaKind = "mode" | "model" | "effort" | "fast";
 // One dropdown entry. `sub` is the second line for a choice whose consequence is not obvious from its
 // label; `sdkOnly` drops the entry on a tmux session, whose backend cannot apply it.
-interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean; color?: number[] | null }
+interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean; color?: number[] | null;
+  versions?: { label: string; value: string }[]; default?: string }   // model families only (the user 2026-08-25)
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
@@ -9288,6 +9289,7 @@ function syncMetaControls(meta: HTMLElement, st: Status, forSid?: string | null)
 
 let metaMenuEl: HTMLElement | null = null;
 function closeMetaMenu() {
+  document.querySelectorAll(".meta-sub").forEach((n) => n.remove());   // an open version submenu goes with its menu
   metaMenuEl?.remove();
   metaMenuEl = null;
 }
@@ -9311,10 +9313,22 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
   const s = { status };
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
+  const pickValue = (value: string) => {
+    if (vscodeApi) {
+      vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: opSid, value });
+      const was = metaCurrent(kind, s.status);
+      metaPending.set(`${opSid}:${kind}`, { was, until: Date.now() + 20_000 });
+      btn.classList.add("meta-pending");
+    }
+    closeMetaMenu();
+  };
+  let subEl: HTMLElement | null = null;
+  const closeSub = () => { subEl?.remove(); subEl = null; };
   // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it, and
   // a menu that lists a mode you can't have is worse than one that doesn't.
   for (const c of META_CHOICES[kind].filter((c) => !c.sdkOnly || s.status.backend === "sdk")) {
     const item = el("div", "meta-item" + (isCurrentMeta(kind, s.status, c.value) ? " current" : ""));
+    item.tabIndex = 0;
     if (c.sub) {
       const head = el("div");
       head.textContent = c.label;
@@ -9325,15 +9339,54 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
     } else {
       item.textContent = c.label;
     }
+    // A model family with more than one live version wears the side-submenu affordance (the user
+    // 2026-08-25): hover or an arrow key reveals every version, each directly pickable with the ✓
+    // on the session's current one; clicking the family picks its DEFAULT — the version the user
+    // last chose for it, else the newest (the kernel /models `default` field). The submenu opens
+    // LEFTWARD: this menu is anchored at the panel's bottom-right, so left is where the room is.
+    // One builder serves the chat statusline AND the comment-popover statusline (post-676), so
+    // both surfaces grow the affordance together.
+    const versions = kind === "model" ? (c.versions || []) : [];
+    const openSub = versions.length > 1 ? () => {
+      closeSub();
+      const sub = el("div", "meta-menu meta-sub");
+      for (const v of versions) {
+        const cur = (s.status.model || "").toLowerCase() === v.label.toLowerCase();
+        const row = el("div", "meta-item" + (cur ? " current" : ""));
+        row.tabIndex = 0;
+        row.textContent = v.label;
+        row.addEventListener("click", (e) => { e.stopPropagation(); pickValue(v.value); });
+        row.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); pickValue(v.value); }
+          else if (e.key === "ArrowLeft") { e.preventDefault(); closeSub(); item.focus(); }
+        });
+        sub.appendChild(row);
+      }
+      document.body.appendChild(sub);
+      const rr = item.getBoundingClientRect();
+      sub.style.right = Math.max(8, window.innerWidth - rr.left + 4) + "px";
+      sub.style.bottom = Math.max(8, window.innerHeight - rr.bottom) + "px";
+      subEl = sub;
+      return sub;
+    } : null;
+    if (openSub) {
+      item.appendChild(el("span", "meta-caret")).textContent = "\u25C2";
+      item.addEventListener("mouseenter", () => openSub());
+    } else {
+      item.addEventListener("mouseenter", () => closeSub());
+    }
     item.addEventListener("click", (e) => {
       e.stopPropagation();
-      if (vscodeApi) {
-        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: opSid, value: c.value });
-        const was = metaCurrent(kind, s.status);
-        metaPending.set(`${opSid}:${kind}`, { was, until: Date.now() + 20_000 });
-        btn.classList.add("meta-pending");
+      pickValue(kind === "model" ? (c.default || c.value) : c.value);
+    });
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); pickValue(kind === "model" ? (c.default || c.value) : c.value); }
+      else if ((e.key === "ArrowRight" || e.key === "ArrowLeft") && openSub) {
+        // the submenu opens leftward, so both arrows expand — ArrowLeft inside it collapses
+        e.preventDefault();
+        const sub = openSub();
+        (sub.querySelector("[tabindex]") as HTMLElement | null)?.focus();
       }
-      closeMetaMenu();
     });
     menu.appendChild(item);
   }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -965,6 +965,10 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* second line for a choice whose consequence its label doesn't carry (Bypass permissions). Same
    0.82em / 0.6 opacity as .ctx-item-sub — one sub-line size across every romp menu. */
 .meta-item-sub { font-size: 0.82em; opacity: 0.6; }
+/* the version-submenu affordance on model families (the user 2026-08-25): a dim caret at the row's
+   right, sitting left of the current-check slot; the submenu itself is a second .meta-menu beside it */
+.meta-caret { position: absolute; right: 22px; top: 50%; transform: translateY(-50%); opacity: 0.55; }
+.meta-sub { z-index: 61; }
 .meta-item.current::after {
   content: "✓"; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
   background: var(--check-bg); color: #fff; border-radius: 50%;


### PR DESCRIPTION
## What (phase 2 of the model-version submenus; phase 1 = the kernel catalog + timeline lane gear, merged)

The chat statusline's model meta-menu grows the version submenu: families with >1 live version wear a dim ◂ caret; **hover or an arrow key** reveals every version (the submenu opens **leftward** — the menu anchors bottom-right), each directly pickable with the **✓ on the session's current version**; **clicking the family sends its remembered default** (the kernel `/models` `default` field) — never a bare shorthand that silently resolves to newest. ArrowLeft inside the submenu collapses back; closing the menu sweeps the submenu.

Because the comment-popover statusline shares the chat's builder (post-676), **the popover grows the affordance in the same hunk** — no second implementation, as predicted in the dispatch.

Timed around the peer working in render.ts: branched after their statusline-parity PR landed; their in-flight pieces (composer thumbnails, seek indicator) are disjoint regions.

## Tests

Pins in `comment-popover-parity.test.ts` (submenu gating, remembered default, keyboard both directions, current-✓, teardown, caret CSS); the one sibling anchor on the old postMessage literal retargeted in the same commit. Suites green: 5583 python, 2375 JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)