### PR TITLE
The optimistic echo shows the dragged picture, and the landing swap paints on time

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -57,9 +57,9 @@ test("sending with a GOAL citation routes as an askFollowUp (reopen) and consume
   // the three routing branches live in routeUserMessage since the staged flush (2026-08-15) — ONE
   // owner for the live send and the staged release; deliver feeds it activeId as the sid
   assert.match(RENDER, /const cites = composerCitations\.get\(activeId\);/);
-  assert.match(RENDER, /routeUserMessage\(activeId, text, cites\);/);
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text\); \}/);
-  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text\); \}/);
+  assert.match(RENDER, /routeUserMessage\(activeId, text, cites, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/);   // + the echo's thumbnail paths (2026-08-25)
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
+  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
   assert.match(RENDER, /if \(cites\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
 });
 
@@ -71,8 +71,8 @@ test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches 
   // sid from the itemId, owns no such session, and hands it to tmux by uuid — dropped in silence. The card
   // still flashed to Working (the kernel's cardPredict fires before any of that) and snapped back on the
   // ok:false ack, so the only visible trace was a bounce.
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text\); \}/);
-  assert.match(RENDER, /routeUserMessage\(activeId, text, cites\);/);   // deliver's sid IS the active session
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
+  assert.match(RENDER, /routeUserMessage\(activeId, text, cites, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/);   // deliver's sid IS the active session
   // every OTHER card-addressed op already routes this way — the citation follow-up was the lone omission
   assert.match(FEED, /type: "askClear", itemId: it\.itemId, sid: it\.sid/);
   assert.match(FEED, /type: "askFollowUp", itemId: tgt \? tgt\.itemId : fbId, title: tgt \? tgt\.title : fbTitle, text: txt, sid: fbSid/);
@@ -202,11 +202,11 @@ test("closing a session clears its composer reply context — chip, draft, and e
 });
 
 test("quote chips send a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text\); \}/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
   // the quote branch echoes the COMPOSED body — byte-identical to what lands, so the reconcile's
   // includes() match is exact (the user 2026-08-23, whose quoted sends painted nothing until the
   // kernel round-tripped while plain sends painted instantly)
-  assert.match(RENDER, /else if \(quoteCites\.length\) \{ const body = quoteReplyBody\(quoteCites, text\); vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text: body \}\); registerOptimistic\(sid, body\); \}/);
+  assert.match(RENDER, /else if \(quoteCites\.length\) \{ const body = quoteReplyBody\(quoteCites, text\); vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text: body \}\); registerOptimistic\(sid, body, imgPaths\); \}/);
   // the wrap: one section per stacked chip (lead-in + the highlighted text as a markdown quote block), in
   // strip order, then the typed message — a single chip composes byte-identically to the pre-stack form
   // a context-only body (staged with an empty box) carries no dangling blank tail

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -25,9 +25,9 @@ const RENDER = fs.readFileSync(
 test("the plain send registers an optimistic bubble; follow-up/quote sends keep their own kernel echo", () => {
   // only the PLAIN sendMessage branch registers — a citation follow-up/quote has its own kernel-side
   // echo (the branch lives in routeUserMessage since the staged flush, 2026-08-15)
-  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text\); \}/);
+  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
   // registerOptimistic shows it NOW (before any push) via reconcile + appendActive
-  assert.match(RENDER, /function registerOptimistic\(id: string, text: string\): void/);
+  assert.match(RENDER, /function registerOptimistic\(id: string, text: string, imgPaths\?: string\[\]\): void/);   // + the dragged-image paths → echo thumbnails (2026-08-25)
   assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) \{\s*\n\s*appendActive\(\);/);
 });
 
@@ -65,7 +65,7 @@ test("every push entry point re-asserts (or retires) the optimistic tail", () =>
 
 test("retire needs a NEW landed atom (base count); kernel provisionals only suppress", () => {
   // base is stamped on the first reconcile after the send: pre-existing matches are background
-  assert.match(RENDER, /arr\.push\(\{ text, ts: Date\.now\(\), base: -1 \}\);/);
+  assert.match(RENDER, /arr\.push\(\{ text, ts: Date\.now\(\), base: -1, imgPaths \}\);/);
   assert.match(RENDER, /for \(const p of list\) if \(p\.base < 0\) p\.base = landedCount\(p\.text\);/);
   // a landed atom is a user event WITHOUT the backend's "echo:" uuid prefix
   assert.match(RENDER, /&& !String\(\(e as any\)\.uuid \|\| ""\)\.startsWith\("echo:"\)\)\.length;/);
@@ -81,7 +81,7 @@ test("retire needs a NEW landed atom (base count); kernel provisionals only supp
 test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — never a solid user bubble", () => {
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   assert.match(RENDER, /const OPT_PREFIX = "optimistic:";/);
-  assert.match(RENDER, /const mk = \(p: \{ text: string \}\) => \(\{ md: p\.text, optimistic: true, cancelable: false \}\);/);
+  assert.match(RENDER, /const mk = \(p: \{ text: string; imgPaths\?: string\[\] \}\) => \(\{ md: p\.text, optimistic: true, cancelable: false, imgPaths: p\.imgPaths \}\);/);   // the echo carries its dragged-image paths (2026-08-25)
   // stale ones pop cheaply off the end (always tail-appended)
   assert.match(RENDER, /while \(s\.events\.length && isOptimistic\(s\.events\[s\.events\.length - 1\]\)\) s\.events\.pop\(\);/);
   // the abandoned dim/pending idiom is FULLY gone: render, guard fields, and stylesheet — the last
@@ -174,4 +174,31 @@ test("reconcile: inject on nothing, suppress on kernel provisionals, retire only
   // TTL backstop: nothing ever surfaced, but past the window we stop asserting a possibly-dropped send
   r = reconcile([{ kind: "assistant", md: "…" }], fresh(), T0 + OPT_TTL_MS + 1);
   assert.equal(r.keep.length, 0);
+});
+
+test("the echo renders dragged-image THUMBNAILS — composer → provisional → landed, one continuum", () => {
+  // the user 2026-08-25: the composer showed the thumbnail, the provisional dropped to path-only
+  // text, the landing brought the thumbnail back — a flash in the middle. The echo now carries the
+  // send's image paths and renders them through the LANDED form's own component (userImage with the
+  // exact "path:" shape), so buildPathImg's (sid,path)-keyed cache serves the landed bubble the same
+  // bytes and the reconcile swap never re-fetches or flickers.
+  assert.match(RENDER, /if \(t\.imgPaths && t\.imgPaths\.length\) \{\s*\n\s*for \(const ip of t\.imgPaths\) bubble\.appendChild\(userImage\(\{ src: "path:" \+ ip, path: ip \}, true\)\);/);
+  // the paths ride the send at every register site (deliver, staged flush, the provisional hold)
+  assert.match(RENDER, /routeUserMessage\(activeId, text, cites, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/);
+  // …and ONLY image-kind attachments mint thumbs — a dropped .csv stays the path text it always was
+  assert.doesNotMatch(RENDER, /registerOptimistic\(sid, text, attached\)/);
+});
+
+test("the landing SWAP repaints even when it replaces the echo 1:1 — no lingering dashed bubble", () => {
+  // upsert hands reconcileOptimistic a FRESH events array, and a landing frame that nets zero count
+  // change (its user atom in, our bubble out) left syncView's rendered===len fast path skipping the
+  // swap — the dashed echo lingered past its own landing until some later push (the 2026-08-25
+  // continuity harness caught it). The per-sid signature survives the frame and marks the view stale
+  // exactly when the visible echo set changes; the pop-and-reinject-same pass stays a no-op.
+  assert.match(RENDER, /const echoShownSig = new Map<string, string>\(\);/);
+  assert.match(RENDER, /if \(\(echoShownSig\.get\(s\.id\) \|\| ""\) !== sig\) \{/);
+  assert.match(RENDER, /if \(sig\) echoShownSig\.set\(s\.id, sig\); else echoShownSig\.delete\(s\.id\);/);
+  const fn = RENDER.split("function reconcileOptimistic(")[1].split("\nfunction ")[0];
+  const settles = (fn.match(/settle\(/g) || []).length;
+  assert.ok(settles >= 3, "every exit settles the signature (early returns included), got " + settles);
 });

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -70,8 +70,8 @@ test("creating a session opens the provisional tab instead of a modal", () => {
 });
 
 test("a send on a provisional tab is HELD, not posted to a session that doesn't exist", () => {
-  assert.match(RENDER, /provisionalQueue\.push\(text\);\s*\n\s*registerOptimistic\(sid, text\);/,
-    "the dashed bubble goes up now — romp has it, it is not delivered");
+  assert.match(RENDER, /provisionalQueue\.push\(text\);\s*\n\s*registerOptimistic\(sid, text, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/,
+    "the dashed bubble goes up now — with its dragged-image thumbnails — romp has it, it is not delivered");
   // a FAILED tab has no pending spawn to queue onto: refuse loudly, the box keeps the only copy
   assert.match(RENDER, /if \(sid !== provisionalId\) \{\s*\n\s*warnToast\("“" \+ \(sessions\.get\(sid\)\?\.name \|\| "this session"\)/);
 });

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -13,7 +13,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a queued ChatEvent carries the pending messages (backend-agnostic, per-message md)", () => {
   // idx = backend-queue position (SDK); park = _pending_ops position (compaction/model parking, any backend)
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean \}\[\]/);
+  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; imgPaths\?: string\[\] \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25)
 });
 
 test("renderQueued draws a wireframe-hourglass header (singular/plural) + one markdown bubble per queued message", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -147,7 +147,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; imgPaths?: string[] }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25)
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -282,7 +282,7 @@ const OPT_TAIL_SCAN = 30;     // the kernel's version (user atom / queued bubble
 // carried the text, so a resend — or any short message that substrings an older bubble ("continue",
 // "test") — retired its own entry in the very call that created it, and the send showed nothing at
 // all (the user 2026-08-09, who watched sends vanish for a beat before appearing).
-const pendingSent = new Map<string, { text: string; ts: number; base: number }[]>();
+const pendingSent = new Map<string, { text: string; ts: number; base: number; imgPaths?: string[] }[]>();
 const isOptimistic = (e: ChatEvent): boolean => !!e.uuid && e.uuid.startsWith(OPT_PREFIX);
 
 // The kernel's own queued group, if one is at the tail. Ours merges INTO it when present: the session is
@@ -296,7 +296,24 @@ function tailQueuedIdx(evs: ChatEvent[]): number {
 // Rebuild a session's optimistic tail: strip what we injected last push (kernel events are authoritative),
 // then re-add one per still-in-flight send — dropping those the kernel has now surfaced (a landed user atom
 // or a queued bubble carrying our text) or that have aged past the TTL backstop.
+// What each session's tail last SHOWED optimistically (texts, joined) — reconcileOptimistic compares
+// against it so the view repaints exactly when the visible echo set CHANGES, even though the event
+// COUNT may not: a landing frame that replaces the echo 1:1 (its user atom in, our bubble out) left
+// syncView's rendered===len fast path skipping the swap, so the dashed bubble lingered past its own
+// landing until some later push (found by the 2026-08-25 continuity harness). A map, not in-array
+// bookkeeping: upsert hands this function a FRESH events array, so the previous pass's injections
+// are only knowable from state that survives the frame.
+const echoShownSig = new Map<string, string>();
+
 function reconcileOptimistic(s: Session): void {
+  const settle = (after: string[]) => {
+    const sig = after.join("\u0000");
+    if ((echoShownSig.get(s.id) || "") !== sig) {
+      if (sig) echoShownSig.set(s.id, sig); else echoShownSig.delete(s.id);
+      const v = views.get(s.id);
+      if (v) v.stale = true;
+    }
+  };
   // undo our own injections. A standalone bare group is tail-appended (pop it); a kernel group we EXTENDED is
   // restored by dropping the optimistic texts off our clone — so `landed` below only ever sees kernel truth.
   while (s.events.length && isOptimistic(s.events[s.events.length - 1])) s.events.pop();
@@ -306,7 +323,7 @@ function reconcileOptimistic(s: Session): void {
     if (q.texts.some((t) => t.optimistic)) s.events[qi] = { ...q, texts: q.texts.filter((t) => !t.optimistic) };
   }
   const list = pendingSent.get(s.id);
-  if (!list || !list.length) return;
+  if (!list || !list.length) { settle([]); return; }
   const now = Date.now();
   const tail = s.events.slice(-OPT_TAIL_SCAN);
   // A LANDED copy of the text is a real user atom — never the kernel's own provisional echo, whose
@@ -330,8 +347,8 @@ function reconcileOptimistic(s: Session): void {
   const keep = list.filter((p) => now - p.ts < OPT_TTL_MS && landedCount(p.text) <= p.base);
   if (keep.length) pendingSent.set(s.id, keep); else pendingSent.delete(s.id);
   const inject = keep.filter((p) => !shownProvisional(p.text));
-  if (!inject.length) return;
-  const mk = (p: { text: string }) => ({ md: p.text, optimistic: true, cancelable: false });
+  if (!inject.length) { settle([]); return; }
+  const mk = (p: { text: string; imgPaths?: string[] }) => ({ md: p.text, optimistic: true, cancelable: false, imgPaths: p.imgPaths });
   const qj = tailQueuedIdx(s.events);
   if (qj >= 0) {
     // something IS queued here → ours queues behind it: show it in that group, under its header, counted
@@ -341,12 +358,13 @@ function reconcileOptimistic(s: Session): void {
     // nothing known-queued → a BARE dashed bubble: no "N queued messages" header to claim what we can't back
     s.events.push({ kind: "queued", bare: true, texts: inject.map(mk), uuid: OPT_PREFIX + inject[0].ts });
   }
+  settle(inject.map((p) => p.text));
 }
 
 // Record a composer send as in-flight and show its optimistic bubble NOW (before any kernel push).
-function registerOptimistic(id: string, text: string): void {
+function registerOptimistic(id: string, text: string, imgPaths?: string[]): void {
   const arr = pendingSent.get(id) || [];
-  arr.push({ text, ts: Date.now(), base: -1 });   // base is stamped by the reconcile just below
+  arr.push({ text, ts: Date.now(), base: -1, imgPaths });   // base is stamped by the reconcile just below
   pendingSent.set(id, arr);
   const s = sessions.get(id);
   if (!s) return;
@@ -3290,6 +3308,14 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       bubble.title = "queued in the session — it can't be recalled, and joins the conversation at the session's next step";
     const isCmd = renderSlashCmd(bubble, t.md);
     if (!isCmd) bubble.innerHTML = md(t.md);
+    // An optimistic echo's dragged images render as THUMBNAILS, not just their trailing paths (the
+    // user 2026-08-25: composer preview → path-only provisional → thumbnail landing flashed). Same
+    // machinery end to end: userImage with the landed form's exact "path:" shape — buildPathImg's
+    // (sid,path)-keyed cache then serves the LANDED bubble the same bytes, so the reconcile swap
+    // never re-fetches or flickers. pathInText: the send appends the paths to the text above.
+    if (t.imgPaths && t.imgPaths.length) {
+      for (const ip of t.imgPaths) bubble.appendChild(userImage({ src: "path:" + ip, path: ip }, true));
+    }
     // CANCELABLE — an explicit ✕ on the bubble (the user 2026-07-08; the old whole-bubble click was
     // undiscoverable AND hung on a node every push rebuilds, so mid-press rebuilds silently ate the
     // click). The ✕ carries data-act="qx" → the ONE document.body delegate (click-safe per CLAUDE.md);
@@ -9716,7 +9742,7 @@ try { stagedMsgs.restore(((vscodeApi?.getState?.() || {}) as any).staged); } cat
 // One routing owner for a user message (the deliver path and the staged flush both speak it): a goal
 // chip rides askFollowUp, quote chips wrap client-side, a bare message is a plain send with the
 // optimistic bubble (chip sends have their own kernel-side echo).
-function routeUserMessage(sid: string, text: string, cites: Citation[] | undefined): void {
+function routeUserMessage(sid: string, text: string, cites: Citation[] | undefined, imgPaths?: string[]): void {
   if (!vscodeApi) return;
   const goalCite = cites?.find((c) => c.itemId);
   const quoteCites = cites ? cites.filter((c) => c.quote) : [];
@@ -9725,9 +9751,9 @@ function routeUserMessage(sid: string, text: string, cites: Citation[] | undefin
   // inconsistency reported). The quote branch echoes the COMPOSED body, which is byte-identical to
   // what lands (quoteReplyBody IS the send path), so the reconcile's includes() match is exact; the
   // follow-up echoes the typed words, a substring of the goal-wrapped landing.
-  if (goalCite?.itemId) { vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid }); registerOptimistic(sid, text); }
-  else if (quoteCites.length) { const body = quoteReplyBody(quoteCites, text); vscodeApi.postMessage({ type: "sendMessage", id: sid, text: body }); registerOptimistic(sid, body); }
-  else { vscodeApi.postMessage({ type: "sendMessage", id: sid, text }); registerOptimistic(sid, text); }
+  if (goalCite?.itemId) { vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid }); registerOptimistic(sid, text, imgPaths); }
+  else if (quoteCites.length) { const body = quoteReplyBody(quoteCites, text); vscodeApi.postMessage({ type: "sendMessage", id: sid, text: body }); registerOptimistic(sid, body, imgPaths); }
+  else { vscodeApi.postMessage({ type: "sendMessage", id: sid, text }); registerOptimistic(sid, text, imgPaths); }
 }
 
 /** Release the tab's staged stack (deliver's guards — host down, provisional — run before this in the
@@ -11261,7 +11287,7 @@ function setupComposer() {
           return;
         }
         provisionalQueue.push(text);
-        registerOptimistic(sid, text);
+        registerOptimistic(sid, text, attached.filter((p) => previewKind(p) === "img"));
         sendOnShip.delete(sid);                       // a send happened — any held one is superseded
         histWalk.delete(sid);                         // …and the history walk starts fresh
         if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }
@@ -11288,7 +11314,7 @@ function setupComposer() {
       // uuid — nothing sent, no error, the card flashing to Working and back. The kernel keeps deriving
       // its sid from itemId, so this is inert locally; every other card op carries the sid the same way.
       const cites = composerCitations.get(activeId);
-      routeUserMessage(activeId, text, cites);
+      routeUserMessage(activeId, text, cites, attached.filter((p) => previewKind(p) === "img"));
       // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
       if (cites) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
       sendOnShip.delete(sid);                       // a send happened — any held one is superseded

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("queued payload is per-message {md, followUp?, goal?, fuCtx?}, not raw strings", () => {
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean \}\[\]/);
+  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; imgPaths\?: string\[\] \}\[\]/);
 });
 
 test("renderQueued renders markdown (not raw text) + the follow-up header", () => {


### PR DESCRIPTION
## What

Dragging a picture under the chat box shows a thumbnail; pressing Enter dropped the provisional message to **path-only text**; the landing brought the thumbnail back — a flash in the middle of composer → provisional → landed.

- The optimistic echo now carries its send's **image paths** (`registerOptimistic` → `pendingSent` → the queued-idiom bubble's texts) and renders each through the **landed form's own component** — `userImage` with the exact `"path:"` shape — so `buildPathImg`'s (sid,path)-keyed cache serves the landed bubble the same bytes. One thumbnail across all three stages, no parallel renderer, no re-fetch, no flash.
- Only image-kind attachments mint thumbs; the trailing path text stays exactly as the landed form shows it. All three register sites thread the paths (deliver, the staged flush via `routeUserMessage`, the provisional hold).

## Fixed underneath (found by the continuity harness)

A landing frame that replaces the echo 1:1 — its user atom in, our bubble out — nets **zero event-count change**, and `syncView`'s `rendered===len` fast path skipped the repaint: the dashed echo lingered past its own landing until some later push. `reconcileOptimistic` now keeps a per-sid signature of what the tail last showed optimistically (a map, because `upsert` hands it a fresh events array) and marks the view stale exactly when the visible echo set changes. The common pop-and-reinject-same pass stays a no-op, so ordinary pushes don't re-render for nothing.

## Verification (headless, built bundle)

Drop-ack → type → Enter: the echo bubble shows text + path + **thumbnail node** (one `imgRequest`; pixels swap in on the `imgData` reply — the (sid,path) ride end to end). The landing frame retires the echo **immediately**, the landed turn's thumbnail renders **instantly from the cache** (`data:` src), and **zero** additional `imgRequest`s fire across the swap.

## Tests

`optimistic-send.test.ts`: the echo-thumbnail rendering through `userImage` + the image-kind filter at every register site (path-only provisional pinned absent by construction), and the landing-swap repaint (signature map + every-exit settle). Type/behavior pins retargeted where they anchored the old signatures (`composer-citation`, `provisional`, `queued-indicator`, `followup-render`). npm 2375 + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)