### PR TITLE
The board says whose cards are still coming: per-host loading hints

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -372,6 +372,13 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   if (syncs.length) merged.syncNotices = syncs;
   else delete merged.syncNotices;
   merged.buildIds = buildIds;
+  // Hosts ATTACHED but yet to contribute a feed payload (the user 2026-08-25: after attaching, the
+  // sessions land via the faster tabOrder/timeline channels while the cards trail with no cue) —
+  // the sessions-shown/cards-pending window, named per host so the board can say cards are coming.
+  // Presence in perHost is the event: an EMPTY contribution is a valid arrival (the host had nothing
+  // to send) and retires the hint; a detach deletes the entry (dropHost), so a reattach re-pends and
+  // the hint re-arms identically — no timers anywhere in this signal. The local kernel never pends.
+  merged.pendingHosts = hostSeq.filter((h) => h !== LOCAL && !(h in perHost));
   return merged;
 }
 

--- a/ui/webview/feed-hostload.test.ts
+++ b/ui/webview/feed-hostload.test.ts
@@ -1,0 +1,62 @@
+// The per-host card-loading hint (the user 2026-08-25): after attaching a remote host, its sessions
+// land via the faster channels while its cards trail with no cue — the board now says cards are on
+// the way, one quiet loader line per pending host, retiring on the exact event of that host's first
+// merged contribution. The SIGNAL executes here (mergeHostFeeds is pure); the feed wiring is
+// source-pinned (the repo convention). Synthetic hosts only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { mergeHostFeeds } from "./federation";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+const local = { type: "feed", asks: [], sessions: [], order: [] };
+
+test("an attached host with no contribution yet is PENDING; its first payload retires it", () => {
+  const before = mergeHostFeeds({ "": local }, ["", "TESTHOST"]);
+  assert.deepEqual(before.pendingHosts, ["TESTHOST"], "sessions shown, cards pending — the hint window");
+  const after = mergeHostFeeds({ "": local, TESTHOST: { type: "feed", asks: [{ itemId: "TESTHOST:x", sid: "TESTHOST:a" }] } },
+    ["", "TESTHOST"]);
+  assert.deepEqual(after.pendingHosts, [], "the first contribution is the retire event");
+});
+
+test("an EMPTY contribution is a valid arrival — retire, never wait forever", () => {
+  const m = mergeHostFeeds({ "": local, TESTHOST: { type: "feed", asks: [] } }, ["", "TESTHOST"]);
+  assert.deepEqual(m.pendingHosts, [], "a host with nothing to send has still answered");
+});
+
+test("the local kernel never pends; two remotes pend independently", () => {
+  assert.deepEqual(mergeHostFeeds({ "": local }, [""]).pendingHosts, []);
+  const m = mergeHostFeeds({ "": local, HOSTA: { type: "feed", asks: [] } }, ["", "HOSTA", "HOSTB"]);
+  assert.deepEqual(m.pendingHosts, ["HOSTB"], "each host retires on ITS OWN payload");
+});
+
+test("reconnect re-arms by construction: detach deletes the contribution, reattach re-pends", () => {
+  // dropHost deletes perHostFeed[host] and re-emits; the next merge recomputes pendingHosts from
+  // presence alone — no timers anywhere in the signal (pinned at the source)
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  assert.match(FED, /delete this\.perHostFeed\[host\];/);
+  assert.match(FED, /merged\.pendingHosts = hostSeq\.filter\(\(h\) => h !== LOCAL && !\(h in perHost\)\);/);
+  const gone = mergeHostFeeds({ "": local }, ["", "TESTHOST"]);
+  assert.deepEqual(gone.pendingHosts, ["TESTHOST"], "post-detach reattach looks exactly like first attach");
+});
+
+test("the feed adopts the signal and hints in BOTH board states, loader family, backstopped", () => {
+  assert.match(FEED, /pendingHosts = Array\.isArray\(m\.pendingHosts\) \? m\.pendingHosts\.filter\(\(h: any\) => typeof h === "string"\) : \[\];/);
+  assert.match(FEED, /syncHostloadBackstops\(\);/);
+  assert.match(FEED, /txt\.textContent = "loading cards from " \+ h \+ "\\u2026";/);
+  // both board states: the strip rides under the cards AND under the empty wordmark
+  assert.match(FEED, /ensureHostLoad\(list\);   \/\/ an attached host's cards may be the ONLY thing coming — say so here too/);
+  assert.match(FEED, /ensureHostLoad\(list\);\s*\n\s*list\.scrollTop = prevScroll;/);
+  // the standing can't-trap backstop: a stale tunnels row must never pin a loader forever; the
+  // RETIRE path is the payload event (pendingHosts recomputed per merge), never this timer
+  assert.match(FEED, /window\.setTimeout\(\(\) => \{ hostloadGaveUp\.add\(h\); render\(\); \}, 45000\)/);
+  assert.match(FEED, /if \(!pendingHosts\.includes\(h\)\) \{   \/\/ the payload landed \(or the host detached\) — the retire EVENT/);
+  // the loader family: the shared pulsing accent dots, reduced motion honored
+  assert.match(CSS, /\.hostload-dots i \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);\s*\n\s*animation: undo-dot 1s ease-in-out infinite; \}/);
+  assert.match(CSS, /\.hostload-dots i \{ animation: none; opacity: 0\.8; \} \}/);
+  assert.match(CSS, /\.hostload-line \{ display: flex; align-items: center; gap: 7px; color: var\(--dim\); font-size: 0\.82em; \}/,
+    "quiet, dim, existing scale — a hint, never a takeover");
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -903,7 +903,18 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-undoclear .undo-dots i:nth-child(2) { animation-delay: 0.18s; }
 #feed-undoclear .undo-dots i:nth-child(3) { animation-delay: 0.36s; }
 @keyframes undo-dot { 0%, 100% { opacity: 0.25; } 40% { opacity: 1; } }
-@media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; } }
+@media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; }
+  .hostload-dots i { animation: none; opacity: 0.8; } }
+/* The per-host loading strip (the user 2026-08-25): an attached host's sessions are on the tabs but
+   its cards haven't merged yet — one quiet line per pending host, the loader family's pulsing accent
+   dots (the undo-dot keyframes, shared), dim text at the footer's own scale. Never a takeover. */
+#feed-hostload { display: flex; flex-direction: column; gap: 4px; padding: 8px 14px; }
+.hostload-line { display: flex; align-items: center; gap: 7px; color: var(--dim); font-size: 0.82em; }
+.hostload-dots { display: inline-flex; gap: 3px; }
+.hostload-dots i { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  animation: undo-dot 1s ease-in-out infinite; }
+.hostload-dots i:nth-child(2) { animation-delay: 0.18s; }
+.hostload-dots i:nth-child(3) { animation-delay: 0.36s; }
 /* the footer MODE button (the session combobox's "Sessions ▴"): active (.on) wears the accent language
    (blue text + border + faint wash), the same selected-state look the card section toggles use (the
    user 2026-07-07) */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -468,6 +468,28 @@ let sessionOrder: string[] = [];
 // menu lists exactly the tabs (the user 2026-08-08) — a session with no cards still appears, and
 // filtering to it shows an empty board. Federation prefixes sid+name per host and concatenates.
 let sessionsMeta: { sid: string; name: string; color: { bg: string; fg: string } | null }[] = [];
+// Attached hosts whose CARD payload hasn't merged yet (the user 2026-08-25: sessions land via the
+// faster channels, cards trail with no cue) — the federation merge names them (pendingHosts), the
+// board hints per host, and the hint retires on the exact event of that host's first contribution
+// (an empty one included). The backstop set holds hosts whose hint gave up after the standing
+// can't-trap window — a stale tunnels row must never pin a loader forever.
+let pendingHosts: string[] = [];
+const hostloadBackstops = new Map<string, number>();
+const hostloadGaveUp = new Set<string>();
+function syncHostloadBackstops(): void {
+  for (const h of pendingHosts) {
+    if (!hostloadBackstops.has(h)) {
+      hostloadBackstops.set(h, window.setTimeout(() => { hostloadGaveUp.add(h); render(); }, 45000));
+    }
+  }
+  for (const [h, t] of Array.from(hostloadBackstops)) {
+    if (!pendingHosts.includes(h)) {   // the payload landed (or the host detached) — the retire EVENT
+      window.clearTimeout(t);
+      hostloadBackstops.delete(h);
+      hostloadGaveUp.delete(h);
+    }
+  }
+}
 // The one session the board is filtered to, or null — the DEFAULT, nothing selected, everything shows.
 // sessionStorage, deliberately: it survives this tab's reloads (webviews reload on updates) but a fresh
 // window always starts unfiltered — a filter that persisted for days would read as silently lost cards.
@@ -4066,6 +4088,31 @@ function viewFiltered(list: AskItem[]): AskItem[] {
   return shown;
 }
 
+// The per-host loading strip (the user 2026-08-25): while an attached host's cards are pending,
+// one quiet line per host — the romp loader family scoped to a strip, never a board takeover; the
+// cards already present stay fully live. Retires per host on the exact event of its first merged
+// contribution (pendingHosts, federation.ts) or on the standing can't-trap backstop; the lines are
+// non-interactive, so a per-render rebuild is click-safe by construction.
+function ensureHostLoad(list: HTMLElement): void {
+  let strip = document.getElementById("feed-hostload");
+  const show = pendingHosts.filter((h) => !hostloadGaveUp.has(h));
+  if (!show.length) { strip?.remove(); return; }
+  if (!strip) {
+    strip = el("div", "");
+    strip.id = "feed-hostload";
+  }
+  list.appendChild(strip);   // last child in either board state (cards or the empty wordmark)
+  strip.replaceChildren(...show.map((h) => {
+    const line = el("div", "hostload-line");
+    const txt = el("span", "");
+    txt.textContent = "loading cards from " + h + "\u2026";
+    const dots = el("span", "hostload-dots");
+    dots.append(el("i", ""), el("i", ""), el("i", ""));
+    line.append(txt, dots);
+    return line;
+  }));
+}
+
 function render() {
   const list = document.getElementById("feed-list")!;
   pruneAgeTip();   // drop the tip only if the render tore its hovered stamp out (see pruneAgeTip)
@@ -4098,6 +4145,7 @@ function render() {
       e.setAttribute("role", "img"); e.setAttribute("aria-label", "All tasks complete");
       list.appendChild(e);
     }
+    ensureHostLoad(list);   // an attached host's cards may be the ONLY thing coming — say so here too
     return;
   }
 
@@ -4213,6 +4261,7 @@ function render() {
   }
   for (const tid of Array.from(groupEls.keys())) if (!desired.has("g:" + tid) && undismissed(groupEls.get(tid))) { groupEls.get(tid)?.remove(); groupEls.delete(tid); }
 
+  ensureHostLoad(list);
   list.scrollTop = prevScroll;
   // Stale-freeze heal (hover-freeze): a LOCAL render can detach or re-key the hovered element with
   // no mouseleave — a removed element never fires leave events (typing in search filters the card
@@ -4707,6 +4756,8 @@ function applyFeedPayload(m: any): void {
   unknownSet = new Set(Array.isArray(m.stateUnknown) ? m.stateUnknown : []);   // listed-but-unreadable → gray ring, never a blank
   bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
   if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
+  pendingHosts = Array.isArray(m.pendingHosts) ? m.pendingHosts.filter((h: any) => typeof h === "string") : [];
+  syncHostloadBackstops();
   if (Array.isArray(m.sessions)) {
     sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");
     // a filter aimed at a session the tab strip no longer shows is moot — clear it (the deciding

--- a/ui/webview/loading-cues.test.ts
+++ b/ui/webview/loading-cues.test.ts
@@ -52,5 +52,6 @@ test("undo clear: accent dots + accent border, reduced-motion safe (feed.css —
   assert.match(FEED_CSS, /#feed-undoclear\.undo-busy \{ border-color: var\(--accent\); \}/);
   assert.match(FEED_CSS, /#feed-undoclear \.undo-dots i \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);/);
   assert.match(FEED_CSS, /@keyframes undo-dot \{ 0%, 100% \{ opacity: 0\.25; \} 40% \{ opacity: 1; \} \}/);
-  assert.match(FEED_CSS, /prefers-reduced-motion: reduce\) \{ #feed-undoclear \.undo-dots i \{ animation: none; opacity: 0\.8; \} \}/);
+  assert.match(FEED_CSS, /prefers-reduced-motion: reduce\) \{ #feed-undoclear \.undo-dots i \{ animation: none; opacity: 0\.8; \}\s*\n\s*\.hostload-dots i \{ animation: none; opacity: 0\.8; \} \}/,
+    "one media block covers both dot surfaces (the host-load strip joined 2026-08-25)");
 });


### PR DESCRIPTION
Attaching a remote host lands its **sessions** at once (the faster tabOrder/timeline channels) while its **cards** trail with no cue until they pop in. The board now says they're coming.

**The signal** rides the federation merge: `pendingHosts` = attached hosts (hostSeq) with no feed contribution yet (perHost). Presence is the event — an **empty contribution is a valid arrival** that retires the hint; a detach deletes the entry so a reattach re-pends and the hint re-arms identically by construction; the local kernel never pends. No timers anywhere in the signal.

**The hint**: one quiet line per pending host — `loading cards from <host>…` with the loader family's pulsing accent dots (the undo-dot keyframes, shared; reduced motion honored in the same media block) — rendered under the cards or under the empty wordmark alike. Never a takeover: cards already present stay fully live. The standing can't-trap backstop retires a hint whose host never answers (a stale tunnels row must never pin a loader forever); the retire path proper is the payload event.

**Tests**: the signal executes on two-host synthetics (pending window, first-payload retire, empty-arrival retire, local never pends, hosts retire independently, detach/reattach re-arm); pins cover the adoption, both board states, the copy, the dots family + reduced motion, and the backstop. 2383 extension tests green on the pushed head; the strip verified headlessly via tools/ui-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
