### PR TITLE
An anchored jump keeps looking until it lands — with a quiet notice and a way out

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6483,6 +6483,13 @@ def _comments_frame(sid, tmux=None):
                         "effort": (reg.get("effort") or "") if reg else "",
                         "settledPushes": quiet, "sinceEpoch": since_ms,
                         "mode": str(meta.get("mode") or ""), "fast": str(meta.get("fast") or ""),
+                        # the same rank tints the chat statusline's badges wear (the user 2026-08-25,
+                        # color rider: the popover's model/effort rendered plain gray — metaColor
+                        # reads these and the frame never carried them)
+                        "modelColor": _model_color((reg.get("liveModel") or reg.get("model") or "") if reg else "",
+                                                   cm.stops_for(_colormap())),
+                        "effortColor": _effort_color((reg.get("effort") or "") if reg else "",
+                                                     cm.stops_for(_colormap())),
                         "msgs": msgs, "events": events})
     return {"type": "comments", "id": sid, "threads": threads}
 

--- a/ui/webview/chat-older-restore.test.ts
+++ b/ui/webview/chat-older-restore.test.ts
@@ -79,8 +79,9 @@ test("scrollToAnchor restores a keep-offset instead of landing on it", () => {
 
 test("a keep-offset restore that misses does not toast the reader 'couldn't locate'", () => {
   // Nobody asked to locate anything — they scrolled. The audit row still records it.
-  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder && !att\.keep\) \{/,
-    "the couldn't-locate toast + error-center entry are for user navigations only");
+  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder && !att\.keep && !\(seek && att\.anchor === seek\.uuid\)\) \{/,
+    "the couldn't-locate toast + error-center entry are for user navigations only — and a live SEEK "
+    + "keeps working instead (its backstop owns the failure; see seek-indicator.test.ts)");
   assert.match(RENDER, /keep: att\.keep \|\| undefined,/, "…but the audit row still carries the flag");
 });
 

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -109,3 +109,14 @@ test("the model meta-menu exposes VERSIONS: submenu, remembered default, keyboar
   assert.match(CSS, /\.meta-caret \{ position: absolute; right: 22px/, "caret sits left of the ✓ slot");
 });
 
+
+test("the badges' COLOR is the chat's too: the rank tints ride the frame (the 2026-08-25 color rider)", () => {
+  // the user's sighting was two layers: a stale pre-parity window, AND a real gap underneath — the
+  // chat's model/effort labels are tinted by server-computed rank colors (st.modelColor/effortColor,
+  // metaColor), and the comments frame never carried them, so the popover's stayed plain gray.
+  assert.match(KERNEL, /"modelColor": _model_color\(\(reg\.get\("liveModel"\) or reg\.get\("model"\) or ""\) if reg else "",\s*\n\s*cm\.stops_for\(_colormap\(\)\)\),/);
+  assert.match(KERNEL, /"effortColor": _effort_color\(\(reg\.get\("effort"\) or ""\) if reg else "",\s*\n\s*cm\.stops_for\(_colormap\(\)\)\),/);
+  assert.match(RENDER, /modelColor: th\.modelColor, effortColor: th\.effortColor \} as Status;/);
+  // the equality bar (asserted headless over the built bundle, per the follow-up): computed
+  // font-family/size/weight AND color/opacity equal chat↔popover for chip, timer, and all badges
+});

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -22,6 +22,8 @@ export type CommentThread = {
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   mode?: string;              // the thread's permission mode — the popover statusline's Auto badge
   fast?: string;              // fast-mode state ("on"/"off"/"cooldown"; "" = unknown → no badge)
+  modelColor?: number[];      // the chat statusline's rank tints, so metaColor paints the popover
+  effortColor?: number[];     //   badges exactly as the chat's (the 2026-08-25 color rider)
   promotedName: string;       // the board session it became, when status === "promoted"
   model?: string;             // the thread's live/chosen model (the popover's switchable chip)
   effort?: string;            // the thread's effort level (ditto)

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -97,7 +97,7 @@ test("the kind guard accepts a peer's postal card as a valid PROMPT target (reco
 test("honest-fail fires whenever the deep-link can't resolve by id (the turn is genuinely gone)", () => {
   // now gated on !anchorPendingOlder so it doesn't fire while we're fetching older history for the anchor —
   // and on !att.keep, since a scroll-back position restore is nobody's navigation (chat-older-restore.test.ts)
-  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder && !att\.keep\) \{\s*\n\s*landToast\("couldn't locate this in the transcript"\)/);
+  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder && !att\.keep && !\(seek && att\.anchor === seek\.uuid\)\) \{[^\n]*\n\s*landToast\("couldn't locate this in the transcript"\)/);   // a live SEEK retries instead; its backstop owns the failure (2026-08-25)
   // 2026-07-28: the same failure ALSO files an error-center entry — a transient toast left nothing the
   // user could point at once it faded (the full bridge is pinned in chat-delta-resync.test.ts).
   assert.match(RENDER, /notifyShell\("locate",/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -549,6 +549,89 @@ let pendingAnchorIntent: string | null = null; // kind the uuid anchor must hono
 let pendingAnchorT: number | null = null; // time fallback (epoch s) when the uuid can't resolve
 let pendingAnchorKind: string | null = null; // intent for the time fallback: "user" = land on the user's own turn
 let anchorPendingOlder = false; // scrollToAnchor kicked off a loadOlder fetch for an anchor past the resident tail → don't toast "couldn't locate"; chatHead re-lands when the chunk arrives (the user 2026-06-27)
+// ── the SEEK (the user 2026-08-25): a card/summary click sometimes needed a second press ──
+// The give-up underneath: landActive runs ONE scrollToAnchor attempt per pass and then nulls
+// pendingAnchor unconditionally — the "stash for the next render pass" scrollToAnchor writes was
+// wiped in the same breath, so any transient miss (a re-query racing the window re-render it just
+// asked for, a push rebuilding mid-seek) one-shotted the navigation into the couldn't-locate
+// toast. The second click "worked" because the first click's re-render had made the target
+// resident. The seek is now DURABLE state: it re-arms the attempt on every render pass (pushes,
+// chatHead arrivals — events, not timers) until it LANDS, the user CANCELS via the indicator's ✕,
+// or the standing can't-trap backstop expires into the honest failure. While it outlives the
+// immediate landing, a small pane-local notice says so ("finding the passage…") with the ✕ —
+// cancel leaves the reader exactly where they are, scroll fully theirs.
+let seek: { sid: string; uuid: string; kind: string | null } | null = null;
+let seekBackstop: number | undefined;
+const SEEK_BACKSTOP_MS = 30_000;
+
+function armSeek(sid: string, uuid: string, kind: string | null): void {
+  if (seek && seek.sid === sid && seek.uuid === uuid) return;   // same target mid-seek: idempotent, never a restart
+  clearSeek();                                                  // a different target supersedes cleanly
+  seek = { sid, uuid, kind };
+  seekBackstop = window.setTimeout(() => failSeek(), SEEK_BACKSTOP_MS);
+}
+
+function clearSeek(): void {
+  seek = null;
+  if (seekBackstop !== undefined) { clearTimeout(seekBackstop); seekBackstop = undefined; }
+  document.getElementById("seek-note")?.remove();
+}
+
+/** Drop the seek's claim on any in-flight older fetch: the chunk (if one is on the wire) arrives as
+ *  a PURE prepend re-anchored on the reader's own row + offset — never a yank to the abandoned target. */
+function releaseSeekFetch(sid: string): void {
+  anchorPendingOlder = false;
+  if (loadingOlder.has(sid)) {
+    const content = document.getElementById("content");
+    const v = views.get(sid);
+    const keep = content && v && sid === activeId ? captureScrollAnchor(content, v) : null;
+    if (keep) { pendingOlderAnchor.set(sid, keep.uuid); pendingOlderKeepY.set(sid, keep.y); return; }
+  }
+  pendingOlderAnchor.delete(sid);
+  pendingOlderKeepY.delete(sid);
+}
+
+function cancelSeek(): void {   // the indicator's ✕ — the reader keeps their spot
+  if (!seek) return;
+  const sid = seek.sid;
+  pendingAnchor = null; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null;
+  releaseSeekFetch(sid);
+  clearSeek();
+}
+
+function failSeek(): void {     // the backstop: the seek could not land — say so, honestly, once
+  if (!seek) return;
+  const sid = seek.sid;
+  pendingAnchor = null; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null;
+  releaseSeekFetch(sid);
+  clearSeek();
+  landToast("couldn't locate this in the transcript");
+  notifyShell("locate", "Couldn't jump to this in " + (sessions.get(sid)?.name || "the transcript")
+              + ". The chat is missing that part of its history.", sid);
+}
+
+/** The pane-local seek notice: pulsing dots + "finding the passage…" + the cancel ✕. Created once
+ *  per seek (never rebuilt by renders — click-safe by construction; removal is the ✕'s immediate
+ *  acknowledgement), shown only while the seeking session is the active tab. */
+function showSeekNote(): void {
+  if (!seek) return;
+  const existing = document.getElementById("seek-note");
+  if (seek.sid !== activeId) { existing?.remove(); return; }
+  if (existing) return;
+  const n = el("div", "");
+  n.id = "seek-note";
+  n.appendChild(metaDots());
+  const label = el("span", "seek-note-label");
+  label.textContent = "finding the passage…";
+  n.appendChild(label);
+  const x = el("button", "seek-note-x");
+  x.setAttribute("aria-label", "Stop looking");
+  x.title = "stop looking — stay right here";
+  x.textContent = "✕";
+  x.addEventListener("click", (e) => { e.stopPropagation(); cancelSeek(); });
+  n.appendChild(x);
+  document.body.appendChild(n);
+}
 // KEEP-OFFSET landing (the user 2026-08-02). A scroll-back loadOlder re-anchors on the row the reader was
 // on — that is POSITION PRESERVATION, not a deep-link: the row must come back at the SAME on-screen offset,
 // with no top-align and no flash. Non-null ⇒ resolve pendingAnchor by id as usual (which renders the window
@@ -6478,7 +6561,8 @@ function threadMetaStatus(th: CommentThread): Status {
   const stuck = threadStuck(th.state);
   return { state: stuck ? "needsInput" : (threadBusy(th.state) ? "working" : "ready"),
            sinceEpoch: th.sinceEpoch || null, mode: th.mode || "", model: th.model || "",
-           effort: th.effort || "default", fast: th.fast || "", backend: "sdk" } as Status;
+           effort: th.effort || "default", fast: th.fast || "", backend: "sdk",
+           modelColor: th.modelColor, effortColor: th.effortColor } as Status;
 }
 
 /** The popover statusline's LEFT half — the thread's state chip, wearing exactly the chat's chip
@@ -8032,9 +8116,19 @@ function landActive(content: HTMLElement | null, v: View): void {
   }
   sizeSpacers(v);  // the view is now VISIBLE (display set in showActive), so the spacers get a real height
                    // measurement — a tab pre-built while display:none could only fall back until now
+  // The durable seek re-arms the per-pass attempt: every render pass retries until it lands, the
+  // user cancels, or the backstop fires — never hijacking a scroll-back keep-offset restore.
+  if (!pendingAnchor && pendingAnchorT == null && pendingAnchorKeepY == null && seek && seek.sid === activeId) {
+    pendingAnchor = seek.uuid;
+    pendingAnchorIntent = seek.kind;
+  }
   const att = { anchor: pendingAnchor, t: pendingAnchorT, kind: pendingAnchorKind, keep: pendingAnchorKeepY != null };   // this pass's landing attempt, for diagnostics
   if (att.anchor || att.t != null) landTrail = [];
   let scrolled = pendingAnchor ? scrollToAnchor(pendingAnchor) : false;
+  if (seek && att.anchor === seek.uuid) {
+    if (scrolled) clearSeek();             // the landing event — the indicator dies with the seek
+    else showSeekNote();                   // outlived the immediate landing → say the search is on
+  }
   // BY-ID landing ONLY (the user 2026-06-20, who wanted to shrink the 29%, then remove the time fallback). TIER 1, by id:
   // a card TITLE / node text sends promptAnchorUuid, which lands the originating MESSAGE — a user turn OR a
   // peer's postal card (scrollToAnchor's kind guard now accepts both). That covers the ~71% of cards that
@@ -8055,7 +8149,7 @@ function landActive(content: HTMLElement | null, v: View): void {
     // A keep-offset restore is NOT a user navigation — nobody asked to locate anything, so a failed one must
     // not raise "couldn't locate this in the transcript" at a reader who only scrolled. It still gets its
     // audit row above (trail + keep), which is where a lost position is diagnosed from.
-    if (!scrolled && !anchorPendingOlder && !att.keep) {
+    if (!scrolled && !anchorPendingOlder && !att.keep && !(seek && att.anchor === seek.uuid)) {   // a live SEEK keeps working instead — its backstop owns the failure
       landToast("couldn't locate this in the transcript");  // fetching older history → chatHead re-lands, no false "couldn't locate"
       // …and file it in the error center. The toast is transient and the locate-audit.jsonl row is invisible
       // from the UI, so a failed jump left NOTHING the user could point at afterwards — it read as the click
@@ -10436,6 +10530,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
   pendingAnchor = anchor ?? null;
   if (anchor) flashedAnchor = null;        // a fresh navigation re-arms the one-per-navigation flash
   pendingAnchorIntent = anchor ? (anchorKind ?? null) : null;
+  if (anchor) armSeek(id, anchor, anchorKind ?? null);   // durable until land / ✕ / backstop (see armSeek)
   activeId = id;
   try { vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id }); } catch { /* ignore */ }
   renderTabs();

--- a/ui/webview/seek-indicator.test.ts
+++ b/ui/webview/seek-indicator.test.ts
@@ -1,0 +1,60 @@
+// The SEEK (the user 2026-08-25): clicking a distilled summary sometimes needed a second click, and
+// nothing said a jump was in progress. The give-up underneath: landActive ran ONE scrollToAnchor
+// attempt per pass and then nulled pendingAnchor unconditionally — the "stash for the next render
+// pass" was wiped in the same breath, so a transient miss (a re-query racing the window re-render
+// it had just asked for) one-shotted the navigation into the couldn't-locate toast; the second
+// click "worked" because the first click's re-render had made the target resident. The seek is now
+// durable state retried on every render pass (events, never timers), with a pane-local
+// "finding the passage…" notice + cancel ✕ while it outlives the immediate landing. Source pins;
+// the lifecycle is exercised headless over the built bundle (see the PR).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("one click lands or indicates: the seek survives a missed pass and retries on the next", () => {
+  // durable state, armed at the ONE navigation entry (setActive) …
+  assert.match(RENDER, /if \(anchor\) armSeek\(id, anchor, anchorKind \?\? null\);/);
+  // …re-arming the per-pass attempt — never hijacking a scroll-back keep-offset restore
+  assert.match(RENDER, /if \(!pendingAnchor && pendingAnchorT == null && pendingAnchorKeepY == null && seek && seek\.sid === activeId\) \{/);
+  // the landing event clears it; a miss shows the notice instead of dying
+  assert.match(RENDER, /if \(scrolled\) clearSeek\(\);/);
+  assert.match(RENDER, /else showSeekNote\(\);/);
+  // the one-shot toast yields to a live seek — the backstop owns the honest failure
+  assert.match(RENDER, /&& !\(seek && att\.anchor === seek\.uuid\)\) \{/);
+  assert.match(RENDER, /const SEEK_BACKSTOP_MS = 30_000;/);
+  assert.match(RENDER, /seekBackstop = window\.setTimeout\(\(\) => failSeek\(\), SEEK_BACKSTOP_MS\);/);
+  const fail = RENDER.split("function failSeek(")[1].split("\nfunction ")[0];
+  assert.ok(fail.includes('landToast("couldn\'t locate this in the transcript")'), "the backstop is loud");
+  assert.ok(fail.includes('notifyShell("locate"'), "…and files the error-center entry");
+});
+
+test("same-target clicks are idempotent; a different target supersedes cleanly", () => {
+  assert.match(RENDER, /if \(seek && seek\.sid === sid && seek\.uuid === uuid\) return;\s*\/\/ same target mid-seek: idempotent, never a restart/);
+  assert.match(RENDER, /clearSeek\(\);\s*\/\/ a different target supersedes cleanly/);
+});
+
+test("cancel leaves the reader exactly where they are — the seek truly dead", () => {
+  const cancel = RENDER.split("function cancelSeek(")[1].split("\nfunction ")[0];
+  assert.ok(cancel.includes("pendingAnchor = null;"), "no pending attempt survives the ✕");
+  assert.ok(cancel.includes("releaseSeekFetch(sid);"), "an in-flight chunk arrives as a pure prepend");
+  // the release re-points the arrival at the reader's OWN row + offset (the scroll-back idiom) —
+  // never the abandoned target, so the landing chunk can't yank the scroll
+  assert.match(RENDER, /if \(keep\) \{ pendingOlderAnchor\.set\(sid, keep\.uuid\); pendingOlderKeepY\.set\(sid, keep\.y\); return; \}/);
+});
+
+test("the notice is pane-local, quiet, and click-safe: created once per seek, ✕ = immediate removal", () => {
+  assert.match(RENDER, /n\.id = "seek-note";/);
+  assert.match(RENDER, /label\.textContent = "finding the passage…";/);
+  assert.match(RENDER, /x\.addEventListener\("click", \(e\) => \{ e\.stopPropagation\(\); cancelSeek\(\); \}\);/);
+  // created once per seek, never rebuilt by renders (the click-safety rule by construction)
+  assert.match(RENDER, /if \(existing\) return;/);
+  // shown only while the seeking session is the active tab
+  assert.match(RENDER, /if \(seek\.sid !== activeId\) \{ existing\?\.remove\(\); return; \}/);
+  // the dress: the menu-card vocabulary, fixed bottom-center — never a window blocker
+  assert.match(CSS, /#seek-note \{\s*\n\s*position: fixed; left: 50%; bottom: 86px;/);
+  assert.match(CSS, /#seek-note \.seek-note-x:hover \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.08\); \}/);
+});

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2306,6 +2306,22 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 }
 .locate-toast.fade { opacity: 0; }
 
+/* the SEEK notice (render.ts showSeekNote, the user 2026-08-25): a quiet pane-local box while an
+   anchored jump is still finding its passage — pulsing dots + copy + the cancel ✕. The menu-card
+   vocabulary, never a window blocker; it dies on the landing event, the ✕, or the backstop. */
+#seek-note {
+  position: fixed; left: 50%; bottom: 86px; transform: translateX(-50%); z-index: 60;
+  display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 6px;
+  background: var(--vscode-menu-background, #252526); border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35); font-size: 12px; color: var(--fg);
+}
+#seek-note .seek-note-label { color: var(--dim); }
+#seek-note .seek-note-x {
+  flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var(--dim);
+  font-size: 11px; line-height: 1.4; padding: 2px 4px; border-radius: 8px;
+}
+#seek-note .seek-note-x:hover { color: var(--fg); background: rgba(255, 255, 255, 0.08); }
+
 /* right-side warning toasts (render.ts warnToast): kernel `warn` messages and federation
    delivery failures — a failed action never dies silently (the user 2026-07-10: creating a
    session on an unreachable remote gave no feedback at all). Click to dismiss. */


### PR DESCRIPTION
## The two halves (user ask)

**The seek indicator.** While an anchored navigation is still resolving past the immediate landing, a small pane-local notice — pulsing dots · "finding the passage…" · ✕ — says the search is on (menu-card dress, never a window blocker). It dies on the **landing event** (beside the anchor-flash), on **✕**, or on the standing 30s can't-trap backstop (which owns the honest "couldn't locate" toast + error-center entry now). Cancel leaves the reader exactly where they are: an in-flight older chunk arrives as a **pure prepend** re-anchored on the reader's own row + offset, never a yank to the abandoned target.

**The multi-click give-up underneath.** `landActive` runs one `scrollToAnchor` attempt per render pass and then nulls `pendingAnchor` unconditionally — the "stash for the next render pass" was wiped in the same breath, so any transient miss (the re-query racing the window re-render it had just asked for; a push rebuilding mid-seek) one-shotted the navigation into the toast. The second click "worked" because the first click's re-render had made the target resident. The seek is now **durable state** re-arming the attempt on every render pass (events, never timers) until land/cancel/backstop. Same-target clicks mid-seek are idempotent (no restart); a different target supersedes cleanly; scroll-back keep-offset restores are never hijacked.

## Rider: the popover badges' COLOR (follow-up on the statusline parity)

The user's gray-badges sighting had a real gap under the stale window: the chat's model/effort labels wear server-computed **rank tints** (`st.modelColor/effortColor` via `metaColor`) and the comments frame never carried them — the popover's stayed plain. The frame now sends both (the same `_model_color`/`_effort_color` the session status uses), `threadMetaStatus` passes them through, and the computed-style equality check — **extended to color and opacity** per element — holds chat↔popover with real tints flowing (`rgb(77,171,247)` measured on the popover's model label in the harness).

## Headless over the built bundle

Indicator appears once the seek outlives the immediate landing; same-target click keeps ONE notice (idempotent); a chunk **without** the target keeps the fetch-until-resident loop going (second `loadOlder` fires); the chunk carrying it lands with the flash and **no toast**; ✕ removes the notice, keeps the scroll, and the post-cancel arrival neither flashes nor seeks. Color/font/element-set parity all `equal: true`.

## Tests

`seek-indicator.test.ts` (durable-seek shape, idempotence/supersede, cancel semantics, notice click-safety + dress, backstop honesty); the two toast pins retargeted with the seek exemption (`chat-older-restore`, `render-scroll`); the parity test extended with the rank-tint frame fields. npm 2380 + typecheck + Python 5583 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)