### PR TITLE
Per-surface tag lenses: the shared multi-select model, and the timeline mounts it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24444,7 +24444,8 @@ else if(m.type==="hover"&&panel.setHover)panel.setHover(m);
 // this inline copy serves the browser, that one the VS Code webview. net-popover-known.test.ts's sibling
 // timeline-boot.test.ts pins the pair.
 else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);
-else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);});
+else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);
+else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);});
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
 post({type:"deepLink",session:q.get("session"),anchor:q.get("anchor")||undefined,anchorT:Number(q.get("anchorT"))||undefined,anchorKind:q.get("anchorKind")||undefined,compose:q.get("compose")==="1"});
 if(window.parent!==window)window.parent.postMessage({romp:"reveal",pane:"chat"},"*");return;}}catch(e){}window.open(url,"_blank");};

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1604,6 +1604,40 @@ def _member_str(m):
     return (h + ":" + m["sid"]) if h else m["sid"]
 
 
+_LENS_SURFACES = ("chat", "timeline")   # per-surface selections (the user 2026-08-25); the feed's is client-local
+
+
+def _norm_lens(x, tags):
+    """One surface's selection in the shared TagLens shape ({all} | {none?, tags?:[names]} — the
+    feed-authored model, manager-sanctioned as the shared shape 2026-08-25). Tag entries are NAMES
+    (name-keyed union; kernels are plumbing), and an unknown name is KEPT — it may exist only on a
+    linked kernel and match remoteTags at read time. An empty selection normalizes to All (the lens
+    never strands an empty selection)."""
+    if not isinstance(x, dict) or x.get("all"):
+        return {"all": True}
+    names = []
+    for n in (x.get("tags") if isinstance(x.get("tags"), list) else []):
+        if isinstance(n, str) and n[:_VIEWS_MAX_NAME] not in names:
+            names.append(n[:_VIEWS_MAX_NAME])
+    lens = {}
+    if x.get("none"):
+        lens["none"] = True
+    if names:
+        lens["tags"] = names[:_VIEWS_MAX_TAGS]
+    return lens or {"all": True}
+
+
+def _lens_seed(active, tags):
+    """A legacy scalar active as a lens — the migration seed for every surface's initial selection
+    (the user 2026-08-25: the current shared view becomes each surface's starting point). A tag id
+    seeds its NAME; an unresolvable id (a remote tag whose kernel is away) seeds All rather than a
+    view this kernel cannot name."""
+    if active == "untagged":
+        return {"none": True}
+    t = next((t for t in tags if t["id"] == active), None)
+    return {"tags": [t["name"]]} if t else {"all": True}
+
+
 def _norm_timeline_views(d):
     """Validate + normalize a views blob from disk or a client: always returns the full shape, drops
     junk quietly, clamps sizes, and falls back active→"all" when the named tag does not exist.
@@ -1643,7 +1677,16 @@ def _norm_timeline_views(d):
     if active not in ("all", "untagged") and ":" not in active \
             and not any(t["id"] == active for t in tags):
         active = "all"
-    return {"active": active, "tags": tags}
+    # PER-SURFACE SELECTIONS (the user 2026-08-25): each surface owns a multi-select lens under
+    # `actives`; the legacy scalar `active` STAYS — written, validated, echoed — so old clients and
+    # the federation poll keep working, and it SEEDS every surface's initial selection the first
+    # time a blob without `actives` is read (lossless migration, no store rewrite).
+    posted = d.get("actives") if isinstance(d.get("actives"), dict) else None
+    actives = {}
+    for sf in _LENS_SURFACES:
+        actives[sf] = _norm_lens(posted.get(sf), tags) if posted and isinstance(posted.get(sf), dict) \
+            else (_lens_seed(active, tags) if posted is None else {"all": True})
+    return {"active": active, "actives": actives, "tags": tags}
 
 
 def _timeline_views():
@@ -1766,7 +1809,21 @@ def _views_client():
     return v
 
 
-def _view_visible(views, sid):
+def _lens_visible(views, lens, sid):
+    """The multi-select decision (the user 2026-08-25), kernel-authoritative and mirrored by
+    tag-lens.ts: All admits everything; `none` admits a session in NO tag home (the name-keyed
+    union — local and remote alike, my untagged rule); a selected tag NAME admits its union's
+    members; visibility is the UNION over the selected buckets."""
+    if not isinstance(lens, dict) or lens.get("all"):
+        return True
+    everything = list(views["tags"]) + list(views.get("remoteTags") or [])
+    if lens.get("none") and not any(sid in t["members"] for t in everything):
+        return True
+    picked = set(lens.get("tags") or [])
+    return any(t["name"] in picked and sid in t["members"] for t in everything)
+
+
+def _view_visible(views, sid, surface=None):
     """The one visibility decision, kernel-authoritative: mirrored by the chat renderer and the
     timeline for optimistic feedback — tests pin all three against this shape. Operates on the
     RENDERED blob (_views_client: string members + remoteTags) — the shape every client holds; a
@@ -1776,7 +1833,11 @@ def _view_visible(views, sid):
     system covers backgrounding, and existing hidden entries migrated into the "archived" tag).
     UNTAGGED keeps its meaning (the user 2026-08-23): tagging a session says "specialized — out of
     the untagged view, viewable under its tag", so membership itself excludes there. A tag view
-    shows exactly its members."""
+    shows exactly its members. With a SURFACE named (per-surface selections, the user 2026-08-25),
+    the decision is that surface's lens instead — the scalar path below stays for legacy callers
+    and the tests that pin it."""
+    if surface is not None:
+        return _lens_visible(views, (views.get("actives") or {}).get(surface), sid)
     if views["active"] == "all":
         return True                                  # All = literally everything (hidden retired 2026-08-24)
     if views["active"] == "untagged":

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -84,7 +84,8 @@ class TagRoute(unittest.TestCase):
     def test_get_views_serves_the_normalized_default(self):
         st, v = self._views()
         self.assertEqual(st, 200)
-        self.assertEqual(v, {"active": "all", "tags": []})
+        self.assertEqual(v, {"active": "all", "tags": [],
+                             "actives": {"chat": {"all": True}, "timeline": {"all": True}}})   # per-surface lenses (2026-08-25)
 
     def test_create_resolves_a_live_name_and_mints_the_ui_id_shape(self):
         st, r = self._post({"name": "pool", "add": ["web"]})

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -44,7 +44,8 @@ class TimelineViews(unittest.TestCase):
         # fresh blobs open on "all" — and since 2026-08-24 that sentinel means truly-ALL, so a
         # legacy blob persisted when "all" meant untagged lands on the new default automatically
         v = km._timeline_views()
-        self.assertEqual(v, {"active": "all", "tags": []})
+        self.assertEqual(v, {"active": "all", "tags": [],
+                         "actives": {"chat": {"all": True}, "timeline": {"all": True}}})   # per-surface lenses seed from the scalar (2026-08-25)
         self.assertTrue(km._view_visible(v, "anything"))
 
     def test_all_shows_every_session_and_untagged_the_tagless_ones(self):
@@ -87,7 +88,8 @@ class TimelineViews(unittest.TestCase):
                                      "tags": [{"id": "g1", "name": "x" * 99, "members": ["m", 3]},
                                               {"noid": True}, "junk"]})
         self.assertEqual(km._norm_timeline_views({"hidden": 7, "tags": "nope"}),
-                         {"active": "all", "tags": []},
+                         {"active": "all", "tags": [],
+                          "actives": {"chat": {"all": True}, "timeline": {"all": True}}},
                          "wrong-TYPED fields drop instead of raising")
         self.assertEqual(km._norm_timeline_views({"tags": [{"id": "g", "members": 3}]})["tags"][0]["members"],
                          [], "a wrong-typed members list drops, never raises")
@@ -312,6 +314,54 @@ class TimelineViews(unittest.TestCase):
             self.assertFalse(km._view_visible(v, "locsid"))
         finally:
             km._remotes.clear(); km._remotes.update(saved)
+
+    def test_per_surface_lenses_the_truth_table(self):
+        # the multi-select decision (the user 2026-08-25): union over selected buckets, none = in
+        # no tag home (name-keyed, remote included), All admits everything, surfaces independent
+        views = {"active": "all",
+                 "actives": {"chat": {"tags": ["workers"]},
+                             "timeline": {"none": True, "tags": ["infra"]}},
+                 "tags": [{"id": "g1", "name": "workers", "members": ["s1"]},
+                          {"id": "g2", "name": "infra", "members": ["s2"]}],
+                 "remoteTags": [{"id": "alpha:g9", "host": "alpha", "name": "workers",
+                                 "members": ["alpha:r1"]}]}
+        # chat: workers only — name-keyed union pulls the remote member in too
+        self.assertTrue(km._view_visible(views, "s1", surface="chat"))
+        self.assertTrue(km._view_visible(views, "alpha:r1", surface="chat"))
+        self.assertFalse(km._view_visible(views, "s2", surface="chat"))
+        self.assertFalse(km._view_visible(views, "loose", surface="chat"))
+        # timeline: infra ∪ no-tags — arbitrary combinations, independent of chat's pick
+        self.assertTrue(km._view_visible(views, "s2", surface="timeline"))
+        self.assertTrue(km._view_visible(views, "loose", surface="timeline"))
+        self.assertFalse(km._view_visible(views, "s1", surface="timeline"), "tagged, not selected")
+        # a missing lens falls open (a surface never named yet)
+        self.assertTrue(km._view_visible(views, "anything", surface="feed"))
+        # the scalar path is untouched — legacy callers and their pins keep working
+        self.assertTrue(km._view_visible(views, "anything"))
+
+    def test_migration_seeds_every_surface_from_the_scalar_active(self):
+        # lossless legacy (the user 2026-08-25): a blob without `actives` reads as if each surface
+        # had selected the old shared view — untagged seeds the none bucket, a tag id its NAME
+        v = km._norm_timeline_views({"active": "untagged"})
+        self.assertEqual(v["actives"], {"chat": {"none": True}, "timeline": {"none": True}})
+        v = km._norm_timeline_views({"active": "g1",
+                                     "tags": [{"id": "g1", "name": "workers", "members": []}]})
+        self.assertEqual(v["actives"], {"chat": {"tags": ["workers"]},
+                                        "timeline": {"tags": ["workers"]}})
+        # once a blob CARRIES actives, they win — and a surface absent from it reads All, never
+        # a re-seed (the scalar may lag the lenses; seeding again would resurrect a stale pick)
+        v = km._norm_timeline_views({"active": "untagged",
+                                     "actives": {"chat": {"tags": ["workers"]}}})
+        self.assertEqual(v["actives"]["chat"], {"tags": ["workers"]})
+        self.assertEqual(v["actives"]["timeline"], {"all": True})
+
+    def test_lens_normalization_never_strands_an_empty_selection(self):
+        v = km._norm_timeline_views({"actives": {"chat": {"tags": []}, "timeline": {"none": False}}})
+        self.assertEqual(v["actives"]["chat"], {"all": True})
+        self.assertEqual(v["actives"]["timeline"], {"all": True})
+        # unknown names are KEPT — they may live on a linked kernel (name-keyed federation)
+        v = km._norm_timeline_views({"actives": {"chat": {"tags": ["only-on-alpha"]}}})
+        self.assertEqual(v["actives"]["chat"], {"tags": ["only-on-alpha"]})
 
     def test_focus_never_mutates_the_views_blob(self):
         # A focus is a PEEK, not a view edit (the user 2026-08-24, superseding the 2026-08-18/19/23

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -89,8 +89,55 @@ function viewLabel(views) {
 // live sessions the current view is NOT showing (tag-filtered) — the "N more" cue that keeps a
 // backgrounded session exactly one glance away (nothing may run in secret: the 2026-08-11 rule)
 function viewMoreCount(views, sessions) {
-  return (sessions || []).filter((s) => s.live && !viewVisible(views, s.id)).length;
+  const unions = viewTagUnion(views);
+  return (sessions || []).filter((s) => s.live && !lensVisible(timelineLens(views), unions, s.id)).length;
 }
+// ── the shared TagLens, inlined (mirrors ui/webview/tag-lens.ts: this pane loads no modules —
+// Obsidian host). Multi-select per surface (the user 2026-08-25): All exclusive, last-off returns
+// to All, visibility = the UNION over selected buckets, tags addressed by NAME. ──
+function lensAll(l) { if (!l || l.all) return true; return !l.none && !(l.tags && l.tags.length); }
+function lensToggle(l, pick) {
+  if (pick === 'all') return { all: true };
+  const cur = lensAll(l) ? {} : { none: l.none, tags: (l.tags || []).slice() };
+  if (pick === 'none') cur.none = !cur.none;
+  else {
+    const t = cur.tags || (cur.tags = []);
+    const i = t.indexOf(pick.tag);
+    if (i >= 0) t.splice(i, 1); else t.push(pick.tag);
+  }
+  if (!cur.none && !(cur.tags && cur.tags.length)) return { all: true };
+  const out = {};
+  if (cur.none) out.none = true;
+  if (cur.tags && cur.tags.length) out.tags = cur.tags;
+  return out;
+}
+function lensVisible(l, unions, id) {
+  if (lensAll(l)) return true;
+  const inAnyHome = unions.some((u) => u.members.indexOf(id) >= 0);
+  if (l.none && !inAnyHome) return true;
+  const picked = l.tags || [];
+  return unions.some((u) => picked.indexOf(u.name) >= 0 && u.members.indexOf(id) >= 0);
+}
+function lensLabel(l) {
+  if (lensAll(l)) return 'All';
+  const parts = (l.tags || []).slice();
+  if (l.none) parts.push('no tags');
+  return parts.join(' + ') || 'All';
+}
+// THIS surface's lens: the timeline keys on actives.timeline (per-surface selections, the user
+// 2026-08-25). A pre-lens blob (an older kernel, a client-held legacy shape) derives its lens from
+// the legacy scalar EXACTLY as the kernel normalizer seeds it — behavior migrates, not just shape:
+// an untagged view keeps excluding tagged sessions rather than falling open.
+function timelineLens(views) {
+  const l = ((views && views.actives) || {}).timeline;
+  if (l) return l;
+  const a = views && views.active;
+  if (!a || a === 'all') return { all: true };
+  if (a === 'untagged') return { none: true };
+  const g = viewTagUnion(views).find((x) => x.ids.indexOf(a) >= 0);
+  return g ? { tags: [g.name] } : { all: true };
+}
+
 // the dialog's pure mutation (executed by tests; the dialog itself only wires DOM): membership in
 // one tag alone. (the hide toggle retired with the hidden set, the user 2026-08-24.)
 function viewToggleMember(views, gid, id) {
@@ -896,6 +943,15 @@ class TimelinePanel {
     this._onDocKey = (e) => { if (e.key === 'Escape') { this._closeMetaMenu(); this._closeLaneMenu(); this._closeViewsMenu(); } };
     document.addEventListener('click', this._onDocClick);
     document.addEventListener('keydown', this._onDocKey);
+    // CROSS-PANE dismissal (the user 2026-08-25, who clicked another pane and the menu stayed):
+    // sibling panes' pointer events never reach this document, so every pane WRITES a pointerdown
+    // echo (the romp:color-echo idiom) and every open menu LISTENS — the storage event fires only
+    // in the OTHER same-origin panes, exactly the gap the local closers can't cover.
+    this._onMenuEcho = (e) => { if (e.key === 'romp:menu-echo' && e.newValue) this._onDocClick(); };
+    try { window.addEventListener('storage', this._onMenuEcho); } catch (e) { /* storage blocked */ }
+    document.addEventListener('pointerdown', () => {
+      try { localStorage.setItem('romp:menu-echo', JSON.stringify({ t: Date.now() })); } catch (e) { /* storage blocked */ }
+    }, true);
     // The menus render in the tip's host document (see _menuHost), so a click or Escape landing on the
     // HOST page — which now shows the menu — must close them too. Same teardown discipline as the tip:
     // pagehide unhooks the host listeners and drops any open menu, so an iframe reload can't orphan either.
@@ -2647,43 +2703,61 @@ class TimelinePanel {
 
   _drawViewsTrigger(svg, axisY) {
     const v = this._curViews();
-    const g = viewTags(v).find((x) => x.id === v.active);
+    const lens = timelineLens(v);
+    const unions = viewTagUnion(v);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
-    // any non-All view is a FILTER now, the untagged view included (it excludes tagged sessions),
-    // so the chip shows for untagged and tag views alike; its ✕ resets to All, the unfiltered default
-    const active = !!v.active && v.active !== 'all' && (!!g || v.active === 'untagged');
-    const gcol = (g && g.color) || MODEL_FG;   // a sentinel view (untagged) wears the corner line's own gray
-    const gdim = g ? 1 : 0.7;                  // …at the N-more's opacity: it reads as a FILTER, not a tag
+    // any non-All selection is a FILTER; the chip names the whole selection ("infra + no tags" —
+    // ONE combined chip, the honest one-line read inside the gutter's space; per-tag chips would
+    // ellipsize each other out at two picks). Its ✕ resets to All.
+    const active = !lensAll(lens);
+    const firstTag = active ? unions.find((u) => (lens.tags || []).indexOf(u.name) >= 0) : null;
+    const gcol = (firstTag && firstTag.color) || MODEL_FG;   // a pure no-tags pick wears the line's own gray
+    const gdim = firstTag ? 1 : 0.7;
     const PADH = 7, GAP = 6;   // the chip's horizontal padding; the space between the line's parts
-    // ellipsize so the WHOLE line stays inside the gutter — measured on the full string (the
-    // 650-weight lane font over-measures the plain spans, which is the safe direction), because a
-    // fixed reserve under-counted "N more" and let the tail cross into the first time label
-    let name = active ? viewLabel(v) : '';
+    // TWO monochrome icon buttons (the user 2026-08-25): display options (sliders) LEFT of the tag
+    // filter (tag icon) — the display toggles left the tags menu for their own button. Icon-only,
+    // MODEL_FG, 14px, drawn inline (no icon font in the Obsidian host); tooltips carry the words.
+    const ICONW = 18;
+    let name = active ? lensLabel(lens) : '';
     const tailStr = more ? more + ' more' : '';
     const XGAP = 6;                                  // between the name and its dim ✕ (the composer chip's read)
-    const width = (n) => this.labelWidth('Filter ▾')
+    const width = (n) => ICONW * 2
       + (active ? GAP + PADH * 2 + this.labelWidth(n) + XGAP + this.labelWidth('✕') : 0)
       + (tailStr ? GAP + this.labelWidth(tailStr) : 0);
     const fits = (n) => width(n) <= this.M.left - PADL - 6;
     while (active && name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
     const y = axisY + 14;
-    // the whole corner line wears the LANE LABELS' typography (the user 2026-08-24, who read the
-    // chip as the wrong font): no explicit family — inherit the host font exactly like the lane
-    // names above, which carry none. The old explicit FONT override rendered the line in the
-    // fallback stack while the lanes wore the host's UI font, so at the same nominal 12px the chip
-    // read visibly bigger. Sizes/weights already match the lanes (12px; chip name at the lane-name
-    // 650), and labelWidth measures in the same inherited family (_fontFace), so the box/ellipsis
-    // math stays in step with what renders.
-    const t = el('text', { x: PADL, y, 'font-size': 12, fill: MODEL_FG });
-    t.textContent = 'Filter ▾';
-    t.setAttribute('style', 'cursor:pointer;user-select:none;');
-    t.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(t); });
-    // the follow-up click would bubble to the document's menu-closer and shut the menu the same
-    // instant it opened (the user 2026-08-24, who had to click-and-hold: only a mid-press redraw —
-    // swapping the element so no click fires — let the menu survive). Swallow it here.
-    t.addEventListener('click', (e) => e.stopPropagation());
-    svg.appendChild(t);
-    let x = PADL + this.labelWidth('Filter ▾');
+    const iconBtn = (dx, title, draw, open) => {
+      const btn = el('g', {});
+      btn.setAttribute('style', 'cursor:pointer;');
+      const hit = el('rect', { x: PADL + dx, y: y - 12, width: 16, height: 16, fill: 'transparent' });
+      btn.appendChild(hit);
+      draw(btn, PADL + dx, y);
+      const tt = el('title', {}); tt.textContent = title; btn.appendChild(tt);
+      btn.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); open(btn); });
+      // the follow-up click would bubble to the document's menu-closer and shut the menu the same
+      // instant it opened (the click-and-hold bug, 2026-08-24). Swallow it here.
+      btn.addEventListener('click', (e) => e.stopPropagation());
+      svg.appendChild(btn);
+    };
+    // sliders: two horizontal rails with offset knobs — the display-options read
+    iconBtn(0, 'timeline display options', (btn, bx, by) => {
+      for (const [ry, kx] of [[-8, 9], [-3, 4]]) {
+        btn.appendChild(el('line', { x1: bx + 1, y1: by + ry, x2: bx + 13, y2: by + ry,
+          stroke: MODEL_FG, 'stroke-width': 1.4, 'stroke-linecap': 'round' }));
+        btn.appendChild(el('circle', { cx: bx + kx, cy: by + ry, r: 2.4, fill: '#1e1e1e',
+          stroke: MODEL_FG, 'stroke-width': 1.4 }));
+      }
+    }, (btn) => this._openDisplayMenu(btn));
+    // tag: the classic label outline with its hole — the filter-by-tag read (the user chose a tag icon)
+    iconBtn(ICONW, 'filter these lanes by tag', (btn, bx, by) => {
+      const ox = bx + 1, oy = by - 11;
+      btn.appendChild(el('path', {
+        d: 'M ' + ox + ' ' + (oy + 5.5) + ' l 5.5 -4.5 h 6.5 v 6.5 l -5.5 4.5 z',
+        fill: 'transparent', stroke: MODEL_FG, 'stroke-width': 1.4, 'stroke-linejoin': 'round' }));
+      btn.appendChild(el('circle', { cx: ox + 9.5, cy: oy + 3.5, r: 1.3, fill: MODEL_FG }));
+    }, (btn) => this._openViewsMenu(btn));
+    let x = PADL + ICONW * 2;
     if (active) {
       x += GAP;
       const cw = PADH * 2 + this.labelWidth(name) + XGAP + this.labelWidth('✕');
@@ -2708,11 +2782,13 @@ class TimelinePanel {
       cx.setAttribute('style', 'user-select:none;');
       grp.appendChild(cx);
       const tt = el('title', {});
-      tt.textContent = 'showing only ' + (g ? (g.name || 'this tag') : 'untagged sessions') + ' — click to remove the filter (back to the default view)';
+      tt.textContent = 'this timeline shows only: ' + lensLabel(lens) + ' — click to remove the filter (back to All)';
       grp.appendChild(tt);
       grp.addEventListener('pointerdown', (e) => {
         e.preventDefault(); e.stopPropagation();
-        const nv = JSON.parse(JSON.stringify(v)); nv.active = 'all'; this._setViews(nv);
+        const nv = JSON.parse(JSON.stringify(v));
+        nv.actives = Object.assign({}, nv.actives, { timeline: { all: true } });
+        this._setViews(nv);
       });
       grp.addEventListener('click', (e) => e.stopPropagation());
       svg.appendChild(grp);
@@ -2770,39 +2846,81 @@ class TimelinePanel {
       const s = menu.createDiv();
       s.setAttribute('style', 'height:1px;margin:4px 6px;background:rgba(255,255,255,0.12);');
     };
-    const v = this._curViews();
-    const pick = (active) => { const nv = JSON.parse(JSON.stringify(v)); nv.active = active; this._setViews(nv); this._closeViewsMenu(); };
-    // All is the default and sits first (the user 2026-08-24); (untagged) — the old default's
-    // meaning under its own sentinel — second; both are built-ins, not rows in the tags dialog
-    item('All', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
-    item('(no tags)', { current: v.active === 'untagged' }).addEventListener('click', () => pick('untagged'));
-    // NAME-KEYED (user ruling 2026-08-24, superseding the v0 host-marked two-rows render: "if the
-    // UX requires understanding that tags exist across different kernels, it is not good"): one row
-    // per tag NAME, membership the union across every kernel defining it, the local store's colour
-    // winning. Picking one activates the union view via whichever id is handiest (local first).
-    for (const g of viewTagUnion(v))
-      item(g.name, { dot: g.color || MODEL_FG, current: g.ids.indexOf(v.active) >= 0 })
-        .addEventListener('click', () => pick(g.localId || g.ids[0]));
-    sep();
-    item('New tag…', { dim: true }).addEventListener('click', () => {
-      const nv = JSON.parse(JSON.stringify(v));
-      const used = new Set(viewTags(nv).map((t) => t.color));
-      const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
-      const tg = { id: 'g' + Date.now().toString(36), name: 'tag ' + (viewTags(nv).length + 1), color, members: [] };
-      nv.tags = viewTags(nv).concat([tg]); delete nv.groups;
-      nv.active = tg.id;                     // a new tag opens ACTIVE so its edits take effect live
-      this._setViews(nv);
-      this._closeViewsMenu();
-      this._openViewsDialog(tg.id);
-    });
-    item('Sessions & tags…', { dim: true }).addEventListener('click', () => {
-      this._closeViewsMenu();
-      this._openViewsDialog(v.active !== 'all' && v.active !== 'untagged' ? v.active : null);
-    });
-    sep();
-    // the two timeline display prefs, finally reachable in every host (they lived only in the web
-    // gear, whose settingsSync never reached the VS Code timeline and which Obsidian has no way to
-    // open) — written to the host app's own romp:settings, the store the view already re-reads
+    // a CAPTIONED divider (the user 2026-08-25): the hairline carries a tiny italic dim label —
+    // the menu says which surface its selection governs. The sub-line scale (0.82em/0.6), never a
+    // new size; one shared idiom other menus adopt.
+    const capSep = (label) => {
+      const s = menu.createDiv();
+      s.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 6px;');
+      const l1 = s.createDiv(); l1.setAttribute('style', 'height:1px;flex:0 0 8px;background:rgba(255,255,255,0.12);');
+      const t = s.createSpan({ text: label });
+      t.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
+      const l2 = s.createDiv(); l2.setAttribute('style', 'height:1px;flex:1;background:rgba(255,255,255,0.12);');
+    };
+    // MULTI-SELECT (the user 2026-08-25): rows are TOGGLES on this surface's lens — All exclusive
+    // and a plain pick; (no tags) and every tag combine arbitrarily; the ✓ marks each selected row
+    // and the menu STAYS OPEN across toggles (a settings panel, not a command — the gear's rule),
+    // repainting in place. Tag rows stay NAME-KEYED (kernels are plumbing).
+    const build = () => {
+      menu.empty();
+      const v = this._curViews();
+      const lens = timelineLens(v);
+      const apply = (nl, close) => {
+        const nv = JSON.parse(JSON.stringify(v));
+        nv.actives = Object.assign({}, nv.actives, { timeline: nl });
+        this._setViews(nv);
+        if (close) this._closeViewsMenu(); else build();
+      };
+      capSep('filters this timeline');
+      item('All', { current: lensAll(lens) }).addEventListener('click', () => apply({ all: true }, true));
+      item('(no tags)', { current: !lensAll(lens) && !!lens.none })
+        .addEventListener('click', () => apply(lensToggle(lens, 'none'), false));
+      for (const g of viewTagUnion(v))
+        item(g.name, { dot: g.color || MODEL_FG, current: !lensAll(lens) && (lens.tags || []).indexOf(g.name) >= 0 })
+          .addEventListener('click', () => apply(lensToggle(lens, { tag: g.name }), false));
+      sep();
+      item('Configure tags…', { dim: true }).addEventListener('click', () => {
+        this._closeViewsMenu();
+        this._openViewsDialog(null);
+      });
+    };
+    build();
+    const h = this._menuHost(anchorEl.getBoundingClientRect());
+    h.doc.body.appendChild(menu);
+    menu.style.left = Math.max(6, Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 220)) + 'px';
+    menu.style.top = Math.round(menuTop(h.rect, menu.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
+    this._viewsMenu = menu;
+  }
+
+  _openDisplayMenu(anchorEl) {
+    // the two timeline display prefs under their OWN button (the user 2026-08-25: they left the
+    // tags menu — filtering and display are different questions). Reachable in every host; written
+    // to the host app's own romp:settings, the store the view already re-reads.
+    const reopen = !!this._viewsMenu;
+    this._closeViewsMenu(); this._closeLaneMenu(); this._closeMetaMenu();
+    if (reopen) return;
+    const menu = document.body.createDiv();
+    menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:180px;' + MENU_STYLE);
+    menu.addEventListener('click', (e) => e.stopPropagation());
+    const item = (label, opts) => {
+      const row = menu.createDiv();
+      row.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;'
+        + (opts && opts.dim ? 'opacity:0.85;' : ''));
+      row.appendChild(document.createTextNode(label));
+      if (opts && opts.current) {
+        const c = row.createSpan({ text: '✓' });
+        c.setAttribute('style', MENU_CHECK_STYLE);
+      }
+      row.addEventListener('mouseenter', () => { row.style.background = 'rgba(255,255,255,0.09)'; });
+      row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+      return row;
+    };
+    const cap = menu.createDiv();
+    cap.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 6px;');
+    cap.createDiv().setAttribute('style', 'height:1px;flex:0 0 8px;background:rgba(255,255,255,0.12);');
+    const capT = cap.createSpan({ text: 'how this timeline draws' });
+    capT.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
+    cap.createDiv().setAttribute('style', 'height:1px;flex:1;background:rgba(255,255,255,0.12);');
     const flip = (key, cur) => {
       let s = {}; try { s = JSON.parse(localStorage.getItem('romp:settings') || '{}') || {}; } catch (e) {}
       s[key] = !cur;
@@ -2818,9 +2936,9 @@ class TimelinePanel {
       .addEventListener('click', () => flip('activeOnly', this._activeOnly));
     const h = this._menuHost(anchorEl.getBoundingClientRect());
     h.doc.body.appendChild(menu);
-    menu.style.left = Math.max(6, Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 220)) + 'px';
+    menu.style.left = Math.max(6, Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 200)) + 'px';
     menu.style.top = Math.round(menuTop(h.rect, menu.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
-    this._viewsMenu = menu;
+    this._viewsMenu = menu;   // shares the views-menu slot: one corner menu open at a time
   }
 
   // The sessions & tags dialog (the user 2026-08-23; table form 2026-08-24, designed to the JLD
@@ -2923,6 +3041,21 @@ class TimelinePanel {
       bar.appendChild(q);
       const btnStyle = 'flex:0 0 auto;cursor:pointer;padding:2px 8px;border-radius:5px;'
         + 'border:1px solid rgba(255,255,255,0.25);color:#cccccc;background:transparent;font-size:0.9em;';
+      // tag CREATION lives here now (the user 2026-08-25: the corner menu carries only
+      // "Configure tags…" — management, minting included, belongs to this dialog)
+      const newTag = bar.createSpan({ text: 'New tag…' });
+      newTag.setAttribute('style', btnStyle);
+      hover(newTag, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
+      newTag.setAttribute('title', 'create a tag — add sessions to it with the [+] column');
+      newTag.addEventListener('click', () => {
+        const nv = JSON.parse(JSON.stringify(this._curViews()));
+        const used = new Set(viewTags(nv).map((t) => t.color));
+        const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
+        const tg = { id: 'g' + Date.now().toString(36), name: 'tag ' + (viewTags(nv).length + 1), color, members: [] };
+        nv.tags = viewTags(nv).concat([tg]); delete nv.groups;
+        this._setViews(nv);
+        if (this._viewsDialogBuild) this._viewsDialogBuild();
+      });
       const tagAll = bar.createSpan({ text: '+ tag all' });
       tagAll.setAttribute('style', btnStyle);
       hover(tagAll, 'background:rgba(255,255,255,0.09);', 'background:transparent;');
@@ -3319,7 +3452,7 @@ class TimelinePanel {
     const active = (s) => (s.live && !this._activeOnly) || hasWork(s) || (s.live && !barsKnown(s));
     // the VIEW filter first (the user 2026-08-18): the active view decides who is even a candidate;
     // activeOnly then thins candidates. data.sessions stays complete for the sessions dialog.
-    const inView = (s) => viewVisible(this._curViews(), s.id);
+    const inView = (s) => { const v = this._curViews(); return lensVisible(timelineLens(v), viewTagUnion(v), s.id); };
     let vis = data.sessions.filter(inView).filter(active);
     // …but never hide EVERYONE: with every lane idle in this window the filter would blank the whole
     // band — which reads as broken (the loading rule), and leaves no row space to grab-drag back out
@@ -4445,4 +4578,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion, lensAll, lensToggle, lensVisible, lensLabel, timelineLens };

--- a/ui/timeline-menu-place.test.ts
+++ b/ui/timeline-menu-place.test.ts
@@ -34,7 +34,7 @@ test("a band shorter than the menu clamps the top on-screen instead of vanishing
 test("both the lane gear menu and the model/effort menu place through menuTop", () => {
   // the fix must cover BOTH fixed-position drop-downs; a bare `r.bottom + 4` is the bug's signature
   const opens = SRC.match(/menu\.style\.top = Math\.round\(menuTop\(h\.rect, menu\.offsetHeight \|\| 0, h\.win\.innerHeight \|\| 9999\)\)/g) || [];
-  assert.equal(opens.length, 3, "expected _openMetaMenu, _openLaneMenu and _openViewsMenu to all use menuTop");
+  assert.equal(opens.length, 4, "expected _openMetaMenu, _openLaneMenu, _openViewsMenu and _openDisplayMenu to all use menuTop");
   assert.doesNotMatch(SRC, /menu\.style\.top = Math\.round\(r\.bottom \+ 4\)/);
 });
 
@@ -58,7 +58,7 @@ test("offsetRect translates a pane-local anchor by each intervening frame's offs
 
 test("both menus append into the host document and read the host viewport", () => {
   const appends = SRC.match(/h\.doc\.body\.appendChild\(menu\)/g) || [];
-  assert.equal(appends.length, 3, "expected _openMetaMenu, _openLaneMenu and _openViewsMenu to adopt into the host doc");
+  assert.equal(appends.length, 4, "expected _openMetaMenu, _openLaneMenu, _openViewsMenu and _openDisplayMenu to adopt into the host doc");
   assert.match(SRC, /_menuHost\(anchorRect\)[\s\S]*?offsetRect\(anchorRect, frames\)/);
   // the host page shows the menu now, so its clicks/Escape must close it (with pagehide cleanup)
   assert.match(SRC, /tipDoc\.addEventListener\('click', this\._onDocClick\)/);

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -16,7 +16,7 @@ import { createRequire } from "node:module";
 const requireCjs = createRequire(__filename);
 const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
 const SRC = fs.readFileSync(VIEW_PATH, "utf8");
-const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion } = requireCjs(VIEW_PATH);
+const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion, lensAll, lensToggle, lensVisible, lensLabel, timelineLens } = requireCjs(VIEW_PATH);
 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2", "s3"] };
 const V = (active: string, hidden: string[] = [], tags: any[] = [G]) => ({ active, hidden, tags });
@@ -67,7 +67,8 @@ test("executed: an optimistic edit holds until the kernel echoes it — then yie
 });
 
 test("the lane gate composes the view filter first, and the all-quiet fallback respects it", () => {
-  assert.match(SRC, /const inView = \(s\) => viewVisible\(this\._curViews\(\), s\.id\);/);
+  assert.match(SRC, /const inView = \(s\) => \{ const v = this\._curViews\(\); return lensVisible\(timelineLens\(v\), viewTagUnion\(v\), s\.id\); \};/,
+    "lanes key on THIS surface's lens (per-surface selections, 2026-08-25)");
   assert.match(SRC, /let vis = data\.sessions\.filter\(inView\)\.filter\(active\);/);
   assert.match(SRC, /if \(this\._activeOnly && !vis\.length\) vis = data\.sessions\.filter\(inView\)\.filter\(\(s\) => s\.live \|\| hasWork\(s\)\);/,
     "the fallback can never resurrect a view-hidden lane");
@@ -75,30 +76,32 @@ test("the lane gate composes the view filter first, and the all-quiet fallback r
 
 test("the trigger sits in the corner strip and opens on pointerdown, like every timeline control", () => {
   assert.match(SRC, /_drawViewsTrigger\(svg, axisY\);/);
-  // named for what it does (the user 2026-08-23): it FILTERS the lanes — "Show:" read as a passive label
-  assert.match(SRC, /t\.textContent = 'Filter ▾';/);
-  assert.match(SRC, /t\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(t\); \}\);/);
+  // two monochrome icon buttons since 2026-08-25 (display options + the tag filter), both
+  // pointerdown-opened with tooltips carrying the words
+  assert.match(SRC, /btn\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); open\(btn\); \}\);/);
+  assert.match(SRC, /iconBtn\(ICONW, 'filter these lanes by tag'/);
   assert.match(SRC, /const tailStr = more \? more \+ ' more' : '';/, "a filtered-out live session is always one glance away");
 });
 
 test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separate ✕, air below (the user 2026-08-24)", () => {
   // the chip's own pointerdown clears the filter without a menu trip; stopPropagation keeps the
   // text element's menu handler out of it (both are pointerdown — the redraw-eats-click rule)
-  assert.match(SRC, /grp\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\); nv\.active = 'all'; this\._setViews\(nv\);/);
+  assert.match(SRC, /grp\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\);\n\s*nv\.actives = Object\.assign\(\{\}, nv\.actives, \{ timeline: \{ all: true \} \}\);/,
+    "the ✕ clears THIS surface's lens back to All");
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
   assert.match(SRC, /fill: 'transparent',\n\s*stroke: gcol, 'stroke-width': 1, opacity: gdim/);
   // a SENTINEL view's chip dims to the corner line's own gray at the N-more opacity (the user
   // 2026-08-24: at #cccccc it read bright as a tag) — real tag chips keep their tag colors, full strength
-  assert.match(SRC, /const gcol = \(g && g\.color\) \|\| MODEL_FG;/);
-  assert.match(SRC, /const gdim = g \? 1 : 0\.7;/);
+  assert.match(SRC, /const gcol = \(firstTag && firstTag\.color\) \|\| MODEL_FG;/);
+  assert.match(SRC, /const gdim = firstTag \? 1 : 0\.7;/);
   assert.match(SRC, /y: y - 13, width: cw, height: 18, rx: 9,/, "taller chip");
   assert.match(SRC, /cx\.textContent = '✕';/);
   assert.match(SRC, /fill: MODEL_FG, opacity: 0\.75/);
   assert.match(SRC, /fill: gcol, 'font-weight': 650, opacity: gdim/);
-  assert.match(SRC, /click to remove the filter \(back to the default view\)/);
+  assert.match(SRC, /click to remove the filter \(back to All\)/);
   // no chip on All — the unfiltered default; the untagged view IS a filter now, so it wears one
-  assert.match(SRC, /const active = !!v\.active && v\.active !== 'all' && \(!!g \|\| v\.active === 'untagged'\);/);
+  assert.match(SRC, /const active = !lensAll\(lens\);/, "any non-All lens selection shows the chip (2026-08-25)");
   // …and the bottom strip grew so the taller chip has air
   assert.match(SRC, /bottom: 27 \}/);
 });
@@ -110,8 +113,8 @@ test("the corner line wears the LANE LABELS' typography — inherited family, me
   // no family override anywhere in the trigger drawing…
   const TRIG = SRC.slice(SRC.indexOf("_drawViewsTrigger(svg, axisY) {"), SRC.indexOf("_closeViewsMenu() {"));
   assert.doesNotMatch(TRIG, /font-family/, "corner texts inherit the host font exactly like lane labels");
-  // …at the lane-label scale: trigger and N-more at the lane 12px, the chip name at the lane-name 650
-  assert.match(TRIG, /const t = el\('text', \{ x: PADL, y, 'font-size': 12, fill: MODEL_FG \}\);/);
+  // …at the lane-label scale: the N-more at the lane 12px, the chip name at the lane-name 650
+  // (the "Filter ▾" trigger TEXT retired 2026-08-25 — the corner is two icon buttons now)
   assert.match(TRIG, /'font-size': 12, fill: gcol, 'font-weight': 650/);
   assert.match(SRC, /'font-weight': 650, 'font-size': 12, fill: F\(s\.color\)/, "the lane-name reference the line matches");
   // …and the width/ellipsis math measures in the SAME family the text renders in: _font resolves
@@ -130,7 +133,7 @@ test("a pointerdown-opened menu survives its OWN opening click (the user 2026-08
   // the browser fires a click after pointerup; unstopped it bubbles to the document's menu-closer
   // and shuts the menu the instant it opened — only a mid-press redraw (element swapped, no click
   // at all) let it survive, which read as "hold to open". Every pointerdown anchor swallows it.
-  assert.match(SRC, /this\._openViewsMenu\(t\); \}\);[\s\S]{0,400}t\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
+  assert.match(SRC, /open\(btn\); \}\);[\s\S]{0,400}btn\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
   assert.match(SRC, /this\._openLaneMenu\(s, ghit\);\n\s*\}\);[\s\S]{0,300}ghit\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
   assert.match(SRC, /grp\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
 });
@@ -179,11 +182,12 @@ test("the sessions dialog is a TABLE speaking romp's own conventions (the user 2
   assert.match(SRC, /const ft = LANE_TOGGLES\.find\(\(t\) => t\.flag === 'hideFromFeed'\);/);
   assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.hideFromFeed = next;/,
     "the same optimistic sticky flags the lane gear uses");
-  // the menu items say so: All first (the default), (no tags) second, then New tag… / Sessions & tags…
-  assert.match(SRC, /item\('New tag…', \{ dim: true \}\)/);
-  assert.match(SRC, /item\('Sessions & tags…', \{ dim: true \}\)/);
-  assert.match(SRC, /item\('All', \{ current: !v\.active \|\| v\.active === 'all' \}\)/);
-  assert.match(SRC, /item\('\(no tags\)', \{ current: v\.active === 'untagged' \}\)/);
+  // the menu is multi-select toggles since 2026-08-25: All first (a plain pick), (no tags) a
+  // toggle second, tag toggles after; the one management entry is Configure tags… — creation
+  // moved into the dialog's bulk bar
+  assert.match(SRC, /item\('Configure tags…', \{ dim: true \}\)/);
+  assert.match(SRC, /item\('All', \{ current: lensAll\(lens\) \}\)/);
+  assert.match(SRC, /item\('\(no tags\)', \{ current: !lensAll\(lens\) && !!lens\.none \}\)/);
   assert.match(SRC, /item\('All',[\s\S]{0,300}item\('\(no tags\)',/, "All sits ABOVE (no tags) in the menu");
   assert.match(SRC, /item\('\(no tags\)',[\s\S]{0,600}for \(const g of viewTagUnion\(v\)\)/,
     "…and the tag rows come AFTER both built-ins — the DoD's menu order, pinned end to end (the rows are the NAME-KEYED union since the 2026-08-24 ruling)");
@@ -206,7 +210,7 @@ test("federation, NAME-KEYED (user ruling 2026-08-24): one name = one row/label/
   assert.equal(viewVisible({ active: "TESTHOST-A:g1", tags: [] }, "m2"), true, "gone → falls open");
   // the menu: one row per union tag, picked via the handiest id (local first)
   assert.match(SRC, /for \(const g of viewTagUnion\(v\)\)/);
-  assert.match(SRC, /pick\(g\.localId \|\| g\.ids\[0\]\)/);
+  assert.match(SRC, /apply\(lensToggle\(lens, \{ tag: g\.name \}\), false\)/);
   assert.doesNotMatch(SRC, /border:1px dashed/, "no dashed twin chips anywhere — one solid chip per name");
   // the gray-glyph fix (unchanged): on an exact miss the colour join retries by the bare sid tail
   assert.match(SRC, /s = data\.sessions\.find\(\(x\) => x\.id === bare \|\| String\(x\.id\)\.endsWith\(':' \+ bare\)\);/);
@@ -244,7 +248,7 @@ test("executed: the dialog's membership mutation, pure (viewToggleHidden retired
 
 test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {
   // the fit measures the whole line as LAID OUT: trigger + gap + padded chip + gap + tail
-  assert.match(SRC, /const width = \(n\) => this\.labelWidth\('Filter ▾'\)\n\s*\+ \(active \? GAP \+ PADH \* 2 \+ this\.labelWidth\(n\) \+ XGAP \+ this\.labelWidth\('✕'\) : 0\)\n\s*\+ \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
+  assert.match(SRC, /const width = \(n\) => ICONW \* 2\n\s*\+ \(active \? GAP \+ PADH \* 2 \+ this\.labelWidth\(n\) \+ XGAP \+ this\.labelWidth\('✕'\) : 0\)\n\s*\+ \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
   assert.match(SRC, /const fits = \(n\) => width\(n\) <= this\.M\.left - PADL - 6;/);
   assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
   assert.match(SRC, /this\._viewsDialogKey\.doc\.removeEventListener\('keydown', this\._viewsDialogKey\.fn\);/);
@@ -373,5 +377,63 @@ test("the lane model menu exposes VERSIONS: submenu affordance, remembered defau
     "the ✓ marks the lane's current version");
   assert.match(SRC, /if \(this\._metaMenu\._sub\) this\._metaMenu\._sub\.remove\(\)/,
     "closing the menu drops an open submenu too");
+});
+
+test("executed: the timeline lens — toggles, All exclusivity, last-off→All, union visibility (the user 2026-08-25)", () => {
+  // parity with ui/webview/tag-lens.ts (the shared model, promoted from the feed's branch)
+  let l = { all: true };
+  l = lensToggle(l, { tag: "infra" });
+  assert.deepEqual(l, { tags: ["infra"] }, "picking a tag leaves All");
+  l = lensToggle(l, "none");
+  assert.deepEqual(l, { none: true, tags: ["infra"] }, "arbitrary combinations");
+  l = lensToggle(l, { tag: "infra" });
+  l = lensToggle(l, "none");
+  assert.deepEqual(l, { all: true }, "toggling the last selection off returns to All");
+  assert.deepEqual(lensToggle({ none: true, tags: ["a", "b"] }, "all"), { all: true }, "All is exclusive");
+  const unions = [
+    { name: "infra", members: ["s1", "alpha:r1"] },
+    { name: "workers", members: ["s2"] },
+  ];
+  assert.ok(lensVisible({ all: true }, unions, "anything"));
+  assert.ok(lensVisible({ tags: ["infra"] }, unions, "alpha:r1"), "union members incl. remote");
+  assert.ok(!lensVisible({ tags: ["infra"] }, unions, "s2"));
+  assert.ok(lensVisible({ none: true }, unions, "loose"), "none = in no tag home");
+  assert.ok(!lensVisible({ none: true }, unions, "s1"));
+  assert.ok(lensVisible({ none: true, tags: ["workers"] }, unions, "s2"), "union over buckets");
+  assert.equal(lensLabel({ none: true, tags: ["infra"] }), "infra + no tags");
+  assert.deepEqual(timelineLens({ actives: { timeline: { tags: ["x"] } } }), { tags: ["x"] });
+  assert.deepEqual(timelineLens({}), { all: true }, "a pre-lens blob with no view reads All");
+  // a legacy scalar SEEDS the lens client-side too — the kernel's migration rule, mirrored, so an
+  // un-upgraded blob keeps its exact old behavior instead of falling open
+  assert.deepEqual(timelineLens({ active: "untagged" }), { none: true });
+  assert.deepEqual(
+    timelineLens({ active: "g1", tags: [{ id: "g1", name: "pool", members: [] }] }),
+    { tags: ["pool"] });
+});
+
+test("the corner grew two icon buttons and the menus split (the user 2026-08-25)", () => {
+  // display options (sliders) LEFT of the tag filter (tag icon); both monochrome, tooltip-worded
+  assert.match(SRC, /iconBtn\(0, 'timeline display options'/, "sliders sit left");
+  assert.match(SRC, /iconBtn\(ICONW, 'filter these lanes by tag'/, "the tag button beside it");
+  assert.match(SRC, /_openDisplayMenu\(btn\)/);
+  assert.match(SRC, /capSep\('filters this timeline'\)/,
+    "the captioned divider says which surface the selection governs");
+  assert.match(SRC, /font-size:0\.82em;opacity:0\.6;font-style:italic/,
+    "caption at the sub-line scale — no new font sizes");
+  assert.match(SRC, /item\('Configure tags…', \{ dim: true \}\)/, "one management entry");
+  assert.ok(!/item\('New tag…', \{ dim: true \}\)/.test(SRC), "New tag left the menu…");
+  assert.match(SRC, /const newTag = bar\.createSpan\(\{ text: 'New tag…' \}\)/,
+    "…and lives in the dialog's bulk bar");
+  assert.match(SRC, /apply\(lensToggle\(lens, \{ tag: g\.name \}\), false\)/,
+    "tag rows TOGGLE and the menu stays open (repaint in place)");
+  assert.match(SRC, /apply\(\{ all: true \}, true\)/, "All is a plain pick and closes");
+  assert.match(SRC, /nv\.actives = Object\.assign\(\{\}, nv\.actives, \{ timeline: nl \}\)/,
+    "writes land on THIS surface's lens only");
+});
+
+test("cross-pane dismissal rides the storage echo (the user 2026-08-25)", () => {
+  assert.match(SRC, /e\.key === 'romp:menu-echo' && e\.newValue/, "every open menu listens");
+  assert.match(SRC, /localStorage\.setItem\('romp:menu-echo'/, "every pane writes the pointerdown echo");
+  assert.match(SRC, /addEventListener\('storage', this\._onMenuEcho\)/);
 });
 

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -18,6 +18,9 @@ export interface SessionViews {
   // the kernel per host (id = "host:tagid", members already respelled viewer-relative). Derived —
   // never an edit target, excluded from the echo key, dropped by the kernel if echoed back.
   remoteTags?: SessionTag[];
+  /** per-surface multi-select lenses (the user 2026-08-25) — the shared TagLens shape; the legacy
+   *  scalar `active` stays for old clients and seeds these on migration (kernel-normalized) */
+  actives?: { [surface: string]: { all?: boolean; none?: boolean; tags?: string[] } };
 }
 // One union group = one tag NAME across every kernel defining it (user ruling 2026-08-24: kernels
 // are plumbing — no host prefixes in any tag presentation). The typed mirror of the timeline's
@@ -74,6 +77,7 @@ export function viewVisible(views: SessionViews | null | undefined, id: string):
 export function viewsKey(v: SessionViews | null | undefined): string {
   if (!v) return "";
   return JSON.stringify({ active: v.active || "all",
+    actives: v.actives || {},   // per-surface lenses are client-posted state — the echo compares them (2026-08-25)
     tags: viewTags(v).map((t) => ({ id: t.id, name: t.name, color: t.color,
                                     members: (t.members || []).slice().sort() })) });
 }

--- a/ui/webview/tag-lens.ts
+++ b/ui/webview/tag-lens.ts
@@ -1,0 +1,64 @@
+// The SHARED tag lens (the user 2026-08-25): one multi-select model for every surface's view
+// selection — chat tabs, timeline lanes, the outline pane, and the feed's local filter all mount
+// this. All is exclusive; otherwise arbitrary combinations of no-tags + tags toggle, and
+// visibility is the UNION over the selected buckets. Tags are addressed by NAME (the union is
+// name-keyed — kernels are plumbing, the user's 2026-08-24 ruling). Pure on purpose: surfaces
+// mount it, the kernel mirrors it. Model authored on the feed's branch (its feed-tags module,
+// manager-sanctioned as the shared shape 2026-08-25) and promoted here verbatim.
+import { SessionViews, TagUnion, viewTagUnion } from "./session-views";
+
+export interface TagLens {
+  all?: boolean;      // the exclusive default: every session's cards
+  none?: boolean;     // the no-tags bucket (sessions in no tag home)
+  tags?: string[];    // selected tag NAMES (union-keyed)
+}
+
+/** Nothing picked = All: the empty selection never means "matched none" (the search-filter rule). */
+export function lensAll(l: TagLens | null | undefined): boolean {
+  if (!l || l.all) return true;
+  return !l.none && !(l.tags && l.tags.length);
+}
+
+/** Toggle one pick. All is EXCLUSIVE: picking it clears the rest; picking anything else leaves All.
+ *  Toggling the last selection off returns to All — the lens never strands an empty selection. */
+export function toggleLens(l: TagLens | null | undefined, pick: "all" | "none" | { tag: string }): TagLens {
+  if (pick === "all") return { all: true };
+  const cur: TagLens = lensAll(l) ? {} : { none: l!.none, tags: (l!.tags || []).slice() };
+  if (pick === "none") cur.none = !cur.none;
+  else {
+    const t = cur.tags || (cur.tags = []);
+    const i = t.indexOf(pick.tag);
+    if (i >= 0) t.splice(i, 1); else t.push(pick.tag);
+  }
+  if (!cur.none && !(cur.tags && cur.tags.length)) return { all: true };
+  return { none: cur.none || undefined, tags: cur.tags && cur.tags.length ? cur.tags : undefined };
+}
+
+/** Union visibility over the selected buckets: "none" admits a session in NO tag home; a selected
+ *  tag admits its name-keyed union's members. All admits everything. */
+export function lensVisible(l: TagLens | null | undefined, unions: TagUnion[], sid: string): boolean {
+  if (lensAll(l)) return true;
+  const inAnyHome = unions.some((u) => u.members.includes(sid));
+  if (l!.none && !inAnyHome) return true;
+  const picked = l!.tags || [];
+  return unions.some((u) => picked.includes(u.name) && u.members.includes(sid));
+}
+
+/** The lens described in words, for the disclosure line: "no tags", "infra", "infra + no tags". */
+export function lensLabel(l: TagLens | null | undefined): string {
+  if (lensAll(l)) return "All";
+  const parts = (l!.tags || []).slice();
+  if (l!.none) parts.push("no tags");
+  return parts.join(" + ") || "All";
+}
+
+/** Canonical serialization for persistence and change compares. */
+export function lensKey(l: TagLens | null | undefined): string {
+  if (lensAll(l)) return "all";
+  return JSON.stringify({ none: !!l!.none, tags: (l!.tags || []).slice().sort() });
+}
+
+/** The tag rows the menu offers: the name-keyed unions of the payload's views blob. */
+export function lensUnions(views: SessionViews | null | undefined): TagUnion[] {
+  return viewTagUnion(views);
+}

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -197,7 +197,7 @@ test("dispatchFrame routes tagEditFailed to the panel — the LOUD half of remot
   assert.equal(dispatchFrame({}, { type: "tagEditFailed" }), false, "an older panel is skipped, never thrown at");
   // …and the kernel's inline boot + the editTag outbound hook stay mirrored (the pinned pair)
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\}\);/);
+  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\nelse if\(m\.type==="openViewsDialog"&&panel\._openViewsDialog\)panel\._openViewsDialog\(null\);\}\);/);
   assert.match(KERNEL, /window\.__rompTimelineEditTag=function\(edit\)\{post\(\{type:"editTag",edit:edit\}\);\};/);
   const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
   assert.match(BOOT, /__rompTimelineEditTag: \(edit: unknown\) => post\(\{ type: "editTag", edit \}\),/);


### PR DESCRIPTION
## What (T69 PR-A — the reshaped views/tags package, per the architecture note)

**The shared model** (`ui/webview/tag-lens.ts`): TagLens — All exclusive, last-off returns to All, visibility = the union over selected buckets, tags addressed by NAME (kernels are plumbing). Authored on the feed's branch as its feed-tags module, manager-sanctioned as the shared shape, promoted verbatim; the feed's follow-up imports this home.

**Storage**: the views blob grows `actives` ({chat, timeline} lenses). The legacy scalar `active` stays written/validated/echoed — old clients and the federation poll unchanged — and **seeds every surface's initial selection** on first read of a pre-lens blob (lossless, no store rewrite; once actives exist they win). `_lens_visible` is the decision of record; `_view_visible(views, sid, surface=…)` routes to it, the scalar path intact for its pins.

**The timeline mounts it**: two monochrome icon buttons in the corner (display options ▸ sliders LEFT of the tag filter ▸ tag glyph — the user's icon choice); the tags menu is multi-select toggles (✓ per selected row, stays open across toggles) under a **captioned divider** ("*filters this timeline*" — the new shared idiom, sub-line scale); "Configure tags…" is the one management entry (creation moved to the dialog's bulk bar); lanes/N-more/chip key on `actives.timeline`; the chip names the whole selection ("infra + no tags", one combined chip — per-tag chips would ellipsize each other out; ✕ → All). A pre-lens blob derives its lens from the scalar client-side exactly as the kernel seeds it — **behavior migrates, not just shape**.

**Cross-pane dismissal** (user bug): every pane writes a pointerdown echo (`romp:menu-echo`, the color-echo idiom); every open menu listens via the storage event — which fires only in *other* same-origin panes, exactly the gap local closers can't cover.

**The feed's launch route**: the pump handles `openViewsDialog` (agreed shape; their PR lands first, an unhandled broadcast is inert).

**Follow-ups (own PRs)**: PR-B = chat tabs + outline mounts + the dialog's scope section with set-for-all; PR-C = dialog polish + tag delete/recolor. The feed's mount pairs on their branch once this lands.

## Tests

Kernel: per-surface truth tables (union, none-bucket, remote members, surface independence), migration seeding (untagged→none, tag-id→NAME, actives-win-once-present), never-strand-empty, updated shape pins (3 files). JS: executed lens parity (toggles, exclusivity, last-off→All, union visibility, seed-from-scalar), button/divider/stays-open/echo/pump pins; ~14 sibling anchors on old corner/menu literals retargeted in-commit. Suites green: 5595 python, 2378 JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)