### PR TITLE
A loading remote tab is clickable, and fork sits beside the seconds it followed

### DIFF
--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -25,6 +25,18 @@ test("the fork affordance rides BELOW each response run — delegated, with the 
   assert.match(RENDER, /\.turn-assistant\[data-uuid="\$\{cssEscape\(anchor\)\}"\]/);
   // …applied on the marks' hooks, like the branch chips (the transcript DOM rebuilds constantly)
   assert.match(RENDER, /applyForkSpots\(sid, v\);/);
+});
+
+test("the fork button sits INLINE, right of the worked-seconds label — never its own row below it", () => {
+  // the user 2026-08-25: the elapsed footer is the flex host; a turn with no footer (the live tip)
+  // keeps the button on its own row exactly as before. The remover walks closest(.turn-assistant)
+  // because the spot may nest inside the elapsed row.
+  assert.match(RENDER, /const elapsed = turn\.querySelector\(":scope > \.turn-elapsed"\) as HTMLElement \| null;/);
+  assert.match(RENDER, /if \(elapsed\) elapsed\.appendChild\(row\);\s*\n\s*else turn\.appendChild\(row\);/);
+  assert.match(RENDER, /const anchor = \(old\.closest\("\.turn-assistant"\) as HTMLElement \| null\)\?\.dataset\.uuid \|\| "";/);
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.turn-elapsed \{[^}]*display: flex; align-items: center; gap: 8px; min-width: 0;/s);
+  assert.match(CSS, /\.turn-elapsed \.fork-spot \{ margin-top: 0; \}/);
   // the OLD home is gone: the prompt's msg-acts row no longer carries a fork (the user 2026-08-19)
   assert.doesNotMatch(RENDER, /acts\.appendChild\(fk\);/);
   // click-safe: the button is DELEGATED (data-act), landing in the shared modal with the spot's own cut

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4245,14 +4245,20 @@ let tabPointerHeld = false;
 let renderPendingWhilePressed = false;
 // A loading PLACEHOLDER tab (the user 2026-06-26): name + identity color from the kernel's tabOrder push,
 // shown while the session's build_session is still in flight so the strip's full width is reserved up front
-// (no one-by-one pop-in). Non-interactive — no select/close/drag — until the real session arrives and
-// renderTabs swaps in the full tab. It wears the MINI romp swirl (spinning glyph) as its "generating" cue
-// (the user 2026-07-03) instead of a whole-tab opacity pulse — the same romp-loader motif as the panes, so a
-// tab still building reads as "romp is working on this," consistent everywhere.
+// (no one-by-one pop-in). CLICKABLE (the user 2026-08-25: "I'd like to click it so when the session
+// opens I'm already there") — it joins the tab set fully (select via the same #tabs delegate, keyboard,
+// activation → MRU + peek derivation), the thread area holding the pane-local romp loader until the
+// first session frame lands in place (showActive's loading branch). Still no close/drag: there is no
+// session to end yet, and the order is the kernel's until the payload arrives. It wears the MINI romp
+// swirl (spinning glyph) as its "generating" cue (the user 2026-07-03) — the same romp-loader motif as
+// the panes, so a tab still building reads as "romp is working on this," consistent everywhere.
 function makePlaceholderTab(id: string): HTMLElement {
   const meta = tabMeta.get(id);
-  const tab = el("div", "tab tab-placeholder");
+  const tab = el("div", "tab tab-placeholder" + (id === activeId ? " active" : ""));
   tab.dataset.id = id;
+  tab.dataset.act = "select";   // the SAME stable #tabs delegate every real tab rides (click-safe)
+  tab.tabIndex = 0;
+  tab.addEventListener("keydown", onTabKey);
   if (meta?.color) {
     tab.style.setProperty("--chip-bg", meta.color.bg);
     tab.style.setProperty("--chip-fg", meta.color.fg);
@@ -6213,12 +6219,13 @@ function applyForkSpots(sid: string, v: View): void {
   }
   if (run && !spots.has(run)) spots.set(run, "");   // the tip run: nothing follows -> whole conversation
   for (const old of Array.from(v.el.querySelectorAll(".fork-spot")) as HTMLElement[]) {
-    const anchor = (old.parentElement as HTMLElement | null)?.dataset.uuid || "";
+    // closest, not parentElement: the spot may nest inside the turn's elapsed row (below)
+    const anchor = (old.closest(".turn-assistant") as HTMLElement | null)?.dataset.uuid || "";
     if (spots.get(anchor) !== old.dataset.cut) old.remove();   // gone, or its cut moved
   }
   for (const [anchor, cut] of spots) {
     const turn = v.el.querySelector(`.turn-assistant[data-uuid="${cssEscape(anchor)}"]`) as HTMLElement | null;
-    if (!turn || turn.querySelector(":scope > .fork-spot")) continue;
+    if (!turn || turn.querySelector(".fork-spot")) continue;
     const row = el("div", "fork-spot");
     row.dataset.cut = cut;
     const fk = el("button", "msg-fork") as HTMLButtonElement;
@@ -6229,7 +6236,12 @@ function applyForkSpots(sid: string, v: View): void {
       ? "Fork the session from just below this response — a new parallel session carries the conversation to here; this one is untouched"
       : "Fork the session — a new parallel session continues this whole conversation; this one is untouched";
     row.appendChild(fk);
-    turn.appendChild(row);
+    // INLINE with the "worked …" seconds label when the turn has one (the user 2026-08-25: not on a
+    // new row — just to the right of it). The elapsed row is the flex host; a turn with no footer
+    // (the live tip) keeps the button on its own row exactly as before.
+    const elapsed = turn.querySelector(":scope > .turn-elapsed") as HTMLElement | null;
+    if (elapsed) elapsed.appendChild(row);
+    else turn.appendChild(row);
   }
 }
 
@@ -8001,7 +8013,17 @@ function showActive() {
   const s = activeId ? sessions.get(activeId) : null;
   if (!s) {
     for (const v of views.values()) v.el.style.display = "none";
-    if (!empty) {
+    // A KNOWN-LOADING tab (its meta arrived, its payload hasn't — the clicked placeholder): the
+    // thread area holds the pane-local romp loader, and the first session frame renders in place —
+    // you're already there (the user 2026-08-25). Everything else keeps the no-sessions copy.
+    document.getElementById("tab-loading")?.remove();
+    if (activeId && tabMeta.has(activeId)) {
+      const wait = el("div", "tab-loading-wait");
+      wait.id = "tab-loading";
+      wait.appendChild(rompLoaderInner("opening “" + (tabMeta.get(activeId)?.name || "session") + "”…"));
+      content.appendChild(wait);
+      if (empty) empty.style.display = "none";
+    } else if (!empty) {
       empty = el("div", "empty-state"); empty.id = "empty-state";
       empty.textContent = "No session open — click + to add one.";
       content.appendChild(empty);
@@ -8010,6 +8032,7 @@ function showActive() {
     updateStatusline();
     return;
   }
+  document.getElementById("tab-loading")?.remove();   // the payload landed — the real view takes over in place
   if (empty) empty.style.display = "none";
   restoreActiveDraftOnce();   // after a reload, drop the active tab's persisted draft back into the box (once)
   // A closed (dead) session is READ-ONLY: disable the composer so a message can't be black-holed into

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -252,10 +252,11 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    don't pop in one-by-one, and a still-building tab reads as "romp is generating this" (the user 2026-07-03),
    the same loader motif as the panes, instead of a whole-tab opacity pulse. Non-interactive (no select/
    close/drag); cursor stays default, hover doesn't highlight, and the label sits dimmed beside the swirl. */
-.tab.tab-placeholder { cursor: default; }
+.tab.tab-placeholder { cursor: pointer; }   /* clickable while loading (the user 2026-08-25): activate now, be there when it opens */
 .tab.tab-placeholder .tab-label { color: var(--dim); }
 .tab.tab-placeholder.colored .tab-label { opacity: 0.75; }   /* keep the identity color but a touch muted while loading */
-.tab.tab-placeholder:hover { color: var(--dim); background: none; }
+/* the pane-local wait while a clicked loading tab's payload is still on its way (showActive) */
+.tab-loading-wait { display: flex; align-items: center; justify-content: center; min-height: 60vh; }
 .tab-ph-swirl { width: 12px; height: 12px; border-radius: 2px; flex: none;
   animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with its own gap, so no margin needed */
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
@@ -1231,7 +1232,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   margin: 6px 0 2px;
   font-size: 0.72em; font-variant-numeric: tabular-nums; letter-spacing: 0.02em;
   color: var(--dim); opacity: 0.7;
+  /* a flex row so the fork button sits INLINE, just right of the seconds (the user 2026-08-25) —
+     same row-sharing discipline as the Stage fix: the short label never pushes the button to wrap */
+  display: flex; align-items: center; gap: 8px; min-width: 0;
 }
+.turn-elapsed .fork-spot { margin-top: 0; }   /* inline: the row's own alignment rules, no extra drop */
+/* the button must not inherit the footer's 0.7 opacity ceiling — hover reveal still governs via .msg-fork */
+.turn-elapsed .msg-fork { font-size: 11px; }
 /* tool success = a BLUE disc with a white ✓ — the romp "check" blue used everywhere else (the feed,
    ledger, …) so it stays consistent (the user 2026-06-15). Disc colors are decoupled from the session. */
 .dot.green { background: var(--check-bg); display: flex; align-items: center; justify-content: center; }

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -25,20 +25,29 @@ test("renderTabs renders the union of arrived sessions and tabMeta, placeholders
   assert.match(RENDER, /if \(!s\) \{ bar\.appendChild\(makePlaceholderTab\(id\)\); continue; \}/);
 });
 
-test("makePlaceholderTab draws name + identity color, non-interactive (no data-act)", () => {
+test("makePlaceholderTab draws name + identity color, and is CLICKABLE while loading", () => {
   assert.match(RENDER, /function makePlaceholderTab\(id: string\): HTMLElement/);
   assert.match(RENDER, /tab\.classList\.add\("colored"\)/);
-  // a placeholder must NOT declare a select/close action — it's inert until the session lands
+  // the user 2026-08-25: click a loading tab to be there when it opens — it rides the SAME stable
+  // #tabs select delegate as a real tab (activation → MRU + peek), keyboard included; still no
+  // close/drag (no session to end yet)
   const fn = RENDER.slice(RENDER.indexOf("function makePlaceholderTab"), RENDER.indexOf("function renderTabs"));
-  assert.doesNotMatch(fn, /dataset\.act/);
+  assert.match(fn, /tab\.dataset\.act = "select";/);
+  assert.match(fn, /tab\.tabIndex = 0;/);
+  assert.match(fn, /tab\.addEventListener\("keydown", onTabKey\);/);
+  assert.ok(!/close|draggable/.test(fn), "no close ✕, no drag — the only new power is selection");
+  // …and the ACTIVE loading tab's thread area holds the pane-local romp loader until frames land in place
+  assert.match(RENDER, /if \(activeId && tabMeta\.has\(activeId\)\) \{/);
+  assert.match(RENDER, /wait\.appendChild\(rompLoaderInner\("opening “" \+ \(tabMeta\.get\(activeId\)\?\.name \|\| "session"\) \+ "”…"\)\);/);
+  assert.match(RENDER, /document\.getElementById\("tab-loading"\)\?\.remove\(\);   \/\/ the payload landed — the real view takes over in place/);
 });
 
-test("the placeholder shows the mini romp swirl loader (not a whole-tab opacity pulse) and is non-interactive", () => {
+test("the placeholder shows the mini romp swirl loader (not a whole-tab opacity pulse)", () => {
   // the user 2026-07-03: a still-building tab shows the spinning romp swirl glyph — the loader motif — rather
   // than the old .tab-ph-pulse opacity breathing on the whole tab.
   assert.match(RENDER, /swirl\.src = mediaSrc\("romp-swirl-glyph\.svg"\)/);
   assert.match(RENDER, /tab\.appendChild\(swirl\);/);
-  assert.match(CSS, /\.tab\.tab-placeholder \{ cursor: default; \}/);
+  assert.match(CSS, /\.tab\.tab-placeholder \{ cursor: pointer; \}/);   // clickable while loading (2026-08-25)
   assert.match(CSS, /\.tab-ph-swirl \{[\s\S]*?animation: tab-ph-swirl-spin/);
   assert.match(CSS, /@keyframes tab-ph-swirl-spin \{ to \{ transform: rotate\(-360deg\); \} \}/);
   assert.doesNotMatch(CSS, /tab-ph-pulse/, "the whole-tab opacity pulse is gone");


### PR DESCRIPTION
## Clickable loading tabs

After attaching a remote kernel, a session's placeholder tab (spinning swirl, payload in flight) refused clicks — the user wanted to click it and *already be there* when it opens. The placeholder now rides the **same** stable `#tabs` select delegate as a real tab (activation → MRU + peek derivation, keyboard nav included; still no close/drag — there is no session to end yet). The active loading tab's thread area holds the pane-local romp loader ("opening ‹name›…") until the first session frame renders **in place**. The no-sessions empty-state copy is untouched for genuinely session-less panes, and non-loading tab behavior is byte-identical.

## Fork beside the seconds

The per-message fork affordance rendered on its own row under the "worked …" label. It now sits **inline, just right of it**: the elapsed footer is a flex row hosting the spot (the Stage fix's row-sharing discipline), a turn with no footer keeps the button on its own row exactly as before, and the spot-remover walks `closest(.turn-assistant)` since the spot can nest inside the footer.

## Verification (headless, built bundle)

Placeholder click → active class + pane-local loader with the session's name (empty-state absent); the landing frame → content in place, loader gone, tab real and active. Fork → measures same-row and right of the label; zero own-row stray spots.

## Tests

`tabs-first.test.ts` retargeted: the placeholder's select/keyboard wiring pinned present, close/drag pinned absent, the loading-branch loader + in-place takeover pinned; `fork-session.test.ts` grows the inline-placement pins (flex host, fallback row, closest-based removal). npm 2383 + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)