### PR TITLE
The self-note flags content changes only — the aging tint can never cry update

### DIFF
--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { freezeDiff } from "./feed-freeze";
+import { freezeDiff, contentSig } from "./feed-freeze";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
@@ -76,6 +76,33 @@ test("a local render that detaches or re-keys the hovered element heals the free
   assert.match(FEED, /if \(!hov\) \{ freezeKey = null; flushFreeze\(\); \}/);
   assert.match(FEED, /else \{ const k = kbHoverId\(hov\); if \(k && k !== freezeKey\) freezeKey = k; \}/,
     "a re-keyed card under a stationary pointer re-arms to the element actually hovered");
+});
+
+test("the self-note flags CONTENT changes only — the aging tint can never cry update (2026-08-25)", () => {
+  // the live specimen: a Completed card with its brief ready differed between builds ONLY in trgb
+  // (top level + inside every tree node) — the recency ramp aging, not content — yet the whole-item
+  // compare flagged it. The projection is an explicit list; volatile fields cannot silently rejoin.
+  const done = { itemId: "TESTSID:g1", text: "confirm changes under version control", column: "completed",
+    summary: "the brief", blockSummary: null, blocked: false, warns: null,
+    t: 100, mt: 200, last: 200, trgb: [19, 166, 216],
+    tree: [{ id: "TESTSID:g2", text: "step", status: "done", cleared: false, t: 100, mt: 150, trgb: [32, 175, 153] }] };
+  const aged = { ...done, trgb: [19, 166, 215], mt: 260, last: 260,
+    tree: [{ ...done.tree[0], trgb: [32, 175, 152], mt: 260 }] };
+  assert.equal(contentSig(done), contentSig(aged), "the user's exact shape: Completed + brief ready, tint aged → NO flag");
+  assert.notEqual(contentSig(done), contentSig({ ...done, summary: "a NEW brief" }), "real content still flags");
+  assert.notEqual(contentSig(done), contentSig({ ...done, column: "needs_input" }), "a column move flags");
+  assert.notEqual(contentSig(done),
+    contentSig({ ...done, tree: [{ ...done.tree[0], status: "open" }] }), "a sub-goal status change flags");
+  // identity stays strict: the compare joins by itemId (ask) / turnId member-set (group) — a
+  // SIBLING's change never flags the hovered card (each side signs only its own found item)
+  assert.match(FEED, /return contentSig\(asks\.find\(\(a\) => a\.itemId === key\) as any\) !== contentSig\(pend\.find\(\(a\) => a\.itemId === key\) as any\);/);
+  assert.match(FEED, /\.sort\(byId\)\.map\(\(a\) => contentSig\(a as any\)\)\.join\("\|"\)/,
+    "group compare: member-set content signatures, itemId-sorted");
+  const FRZ = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed-freeze.ts"), "utf8");
+  assert.match(FRZ, /const SELF_CONTENT = \["text", "column", "summary", "blockSummary", "blocked", "warns", "retrying", "nudgeFailed"\] as const;/,
+    "the explicit content list — new volatile fields cannot silently rejoin");
+  assert.match(FRZ, /o\.tree = tree\.map\(\(n\) => \[n\.id, n\.text, n\.status, n\.cleared\]\);/,
+    "sub-goals contribute identity/text/status only — never their own aging channels");
 });
 
 test("the badge hint mirrors the optimistic-restore overlay — a card the flush restores is no departure", () => {

--- a/ui/webview/feed-freeze.ts
+++ b/ui/webview/feed-freeze.ts
@@ -14,6 +14,21 @@ export type FreezeCounts = {
   any: boolean;
 };
 
+// The hovered card's "did IT change?" compare projects CONTENT-BEARING fields only (the user
+// 2026-08-25: the whole-item compare flagged the recency tint — trgb recomputes every build as
+// cards age, at the top level AND inside every sub-goal node — as "this card updated" on nearly
+// every card). An EXPLICIT list, so a new volatile field can never silently rejoin the diff; the
+// sub-goal tree contributes its nodes' identity/text/status only, never their own aging channels.
+const SELF_CONTENT = ["text", "column", "summary", "blockSummary", "blocked", "warns", "retrying", "nudgeFailed"] as const;
+export function contentSig(a: Record<string, unknown> | undefined | null): string {
+  if (!a) return "";
+  const o: Record<string, unknown> = {};
+  for (const k of SELF_CONTENT) o[k] = a[k];
+  const tree = Array.isArray(a.tree) ? (a.tree as Record<string, unknown>[]) : [];
+  o.tree = tree.map((n) => [n.id, n.text, n.status, n.cleared]);
+  return JSON.stringify(o);
+}
+
 export function freezeDiff(displayed: FreezeItem[], pending: FreezeItem[]): FreezeCounts {
   const cols: Record<string, FreezeCount> = {};
   const sess: Record<string, FreezeCount> = {};

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -10,7 +10,7 @@ import { distillText, distillInputs, applyDistillLine, distillPending, distillSt
 import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
-import { freezeDiff } from "./feed-freeze";
+import { freezeDiff, contentSig } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
@@ -4567,15 +4567,15 @@ function pendingSelfChanged(key: string): boolean {
   if (!pendingFeedPayload) return false;
   const pend = payloadView(pendingFeedPayload);
   const byId = (a: AskItem, b2: AskItem) => (a.itemId < b2.itemId ? -1 : 1);
+  // CONTENT-projected compares only (contentSig — the user 2026-08-25): the whole-item compare
+  // flagged the per-build recency-tint recompute as "this card updated" on nearly every card
   if (key.startsWith("g:")) {
     const tid = key.slice(2);
-    const cur = JSON.stringify(asks.filter((a) => a.turnId === tid).slice().sort(byId));
-    const nxt = JSON.stringify(pend.filter((a) => a.turnId === tid).slice().sort(byId));
+    const cur = asks.filter((a) => a.turnId === tid).slice().sort(byId).map((a) => contentSig(a as any)).join("|");
+    const nxt = pend.filter((a) => a.turnId === tid).slice().sort(byId).map((a) => contentSig(a as any)).join("|");
     return cur !== nxt;
   }
-  const cur = asks.find((a) => a.itemId === key);
-  const nxt = pend.find((a) => a.itemId === key);
-  return JSON.stringify(cur) !== JSON.stringify(nxt);
+  return contentSig(asks.find((a) => a.itemId === key) as any) !== contentSig(pend.find((a) => a.itemId === key) as any);
 }
 function paintFreezeBadges(): void {
   if (!pendingFeedPayload) {


### PR DESCRIPTION
The "this card updated — mouse away to refresh" line fired near-constantly — the user was hovering a Completed card whose brief had long been ready, and the note kept claiming updates that "mean another card / aren't worth noticing."

**Diagnosis, on the live feed** (two builds compared): the identity join was sound — the compare was reading the right card. The bug was the whole-item stringify: `trgb`, the recency tint's RGB, recomputes every build as cards age — at the top level **and inside every sub-goal node** — so nearly every card differs by a tint tick between any two builds, and the note read the aging as an update. The kernel rewrites no completed-card content: the specimen's text, summary, and tree were byte-identical between builds; only the tint channels moved (216 → 215).

**The fix**: the compare projects content-bearing fields only (`contentSig` in feed-freeze.ts, pure and executed) — text, column, summary, blockSummary, blocked, warns, retrying, nudgeFailed — an **explicit list**, so a new volatile field can never silently rejoin the diff. Sub-goals contribute identity/text/status/cleared only, never their own aging channels. Group compares sign the itemId-sorted member set; a sibling's change never flags the hovered card.

**Tests** execute the user's exact shape (Completed + brief ready, tint aged across builds → no flag) and the real-change flags (summary text, column move, sub-goal status change), plus identity-strictness and the explicit-list pins. 2392 extension tests green on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
