### PR TITLE
Bookkeeping is never an ask: mint floors for romp-rooted tops and files-nothing anchors

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -124,7 +124,15 @@ and tagged follow-ups (file under the cited goal unless the reply starts a
 different thread — and even then the new goal groups with the cited card
 under one umbrella: the follow-up tie). A segment opened by an
 untargeted kernel notice (restart or resume) carries a housekeeping note:
-pure verification sweeps file nothing.
+pure verification sweeps file nothing. Since 2026-08-25 that is also a
+mechanical floor, not just a request: a work-run whose segment was opened by
+romp's own bookkeeping — a kernel notice, or the CLI's `[Request
+interrupted…]` stop artifact — never mints a fresh top-level goal (its
+menu-targeted ops still apply, so the work keeps advancing existing cards),
+and no mint anywhere roots its promptUuid at a record that files nothing (a
+coordinate/question mail, a bookkeeping record): the anchor substitutes the
+segment's first assistant atom. The clear wrap-up is exempt — its one
+blocked card is the designed needs-you escape.
 
 **placer.** The second, scoped call, only when the chosen card already has
 open sub-goals: it sees just that card's subtree and picks the spot, biased

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3614,6 +3614,44 @@ def _restrict_retitle(ops, allowed):
     return [o for o in ops if o["do"] != "retitle" or o.get("goal") == allowed]
 
 
+def _strip_top_mints(ops):
+    """Drop every top-level `mint` op — and every op chained onto a dropped node — remapping the
+    surviving same-reply refs. The deterministic half of the bookkeeping-root gate (the user
+    2026-08-25, the provenance audit): a work-run whose segment was opened by romp's OWN line — a
+    restart/resume/tasks-died notice, or the CLI's '[Request interrupted…]' stop artifact — may
+    still file work under EXISTING goals (sub/done/block on menu targets pass through untouched),
+    but it never opens a fresh top-level card: our own bookkeeping is never an ask. The advisory
+    housekeeping note (plan_units, 2026-07-08) asked the model for this; the audit found a third
+    of one team's board rooted in exactly these records, so the floor is now mechanical.
+    Ref remapping matters: `ref` indexes the reply's CREATED nodes (mints and subs, in order), so
+    removing a mint shifts every later position — an unmapped ref would silently retarget a
+    neighbouring node, and a sub whose ref died would fall back to a TOP mint in apply_plan
+    (the exact hole this closes)."""
+    out, newpos, alive = [], [], 0        # newpos[i]: created-node i's new 1-based position (None = dropped)
+    for o in ops:
+        do, r = o.get("do"), o.get("ref")
+        dead_ref = bool(r) and (r > len(newpos) or newpos[r - 1] is None)
+        if do == "mint":
+            newpos.append(None)
+            continue
+        if do == "sub":
+            if dead_ref:                  # chained onto a dropped mint → drops with it
+                newpos.append(None)
+                continue
+            if r:
+                o = dict(o, ref=newpos[r - 1])
+            alive += 1
+            newpos.append(alive)
+            out.append(o)
+            continue
+        if dead_ref:                      # a verdict aimed at a dropped node evaporates with it
+            continue
+        if r:
+            o = dict(o, ref=newpos[r - 1])
+        out.append(o)
+    return out
+
+
 def _seg_spliced(seg):
     """True when this segment's TRIGGER is an ABSORBED atom — a prompt the CLI spliced into a
     RUNNING turn (a queued_command attachment; em._absorbed_atom marks the synthesized atom
@@ -5301,6 +5339,35 @@ def _seg_anchor(seg):
         return t
     for a in seg.get("atoms") or []:
         if a.get("type") not in ("idle", "attachment") and a.get("uuid"):
+            return a["uuid"]
+    return None
+
+
+def _mint_anchor_uuid(seg):
+    """The anchor a MINT may claim as its ROOT (promptUuid) — the attachment-safe prompt anchor,
+    unless that record is one that must FILE NOTHING on the board (the user 2026-08-25, the
+    provenance audit): a coordinate/question peer mail (binding, no courier call — the audited
+    specimen was a to-do mirror top whose promptUuid named a kind=coordinate mail, so the chain
+    walk read peer chatter as the card's root), or romp's own bookkeeping (a romp-authored notice,
+    the CLI's interrupt artifact — _seg_bookkeeping's classes). Those records stay in the TRAIL as
+    ordinary history; only the ROOT claim is refused. Substitute: the segment's first assistant
+    atom — where the agent actually declared or did the work, still a landable deep-link — else
+    None (an anchorless mint beats a false confession; the chat's alias belt covers residue).
+    A DELEGATE mail keeps the anchor: the courier plants from that same record by design."""
+    t = _prompt_anchor_uuid(seg)
+    if not t:
+        return None
+    atoms = (seg or {}).get("atoms") or []
+    ta = next((a for a in atoms if a.get("uuid") == t), None)
+    if ta is None:
+        return t
+    author = ta.get("author")
+    files_nothing = (isinstance(author, dict)
+                     and (author.get("kind") or "") in ("coordinate", "question"))
+    if not files_nothing and not (author == "romp" or em.is_interrupt_record(ta)):
+        return t
+    for a in atoms:
+        if a.get("type") == "assistant" and a.get("uuid"):
             return a["uuid"]
     return None
 
@@ -7144,6 +7211,19 @@ def _plan_session(fsid, path, now):
                 save_goals(fsid, store)
                 continue
             ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)
+        if _seg_bookkeeping(seg_by_id.get(seg_id) or {}):
+            # DETERMINISTIC top-mint floor (the user 2026-08-25, the provenance audit): this stretch
+            # was opened by romp's own bookkeeping — a restart/resume/tasks-died notice or the CLI's
+            # interrupt artifact — so its work may advance EXISTING goals but never opens a fresh top
+            # card. The housekeeping note above asks the model for this; the floor makes it mechanical
+            # (the note sanctioned "a genuinely new thread", and a third of one team's audited board
+            # was rooted in exactly these records). Bookkeeping roots are never human (_seg_human
+            # excludes them), so an emptied reply retires like any other non-human no-op.
+            ops = _strip_top_mints(ops)
+            if not ops:
+                store["placements"][seg_id] = None
+                save_goals(fsid, store)
+                continue
         ops = _restrict_retitle(ops, pgi)              # only the segment's own prompt-run node is retitle-eligible
         ops = _card_route_subs(store, ops, menu)       # card-first: route subs to the card, then the placer
         if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu, prompt_uuid=trig, quote=vq,
@@ -7169,7 +7249,13 @@ def _plan_session(fsid, path, now):
         _log_judge_error("planner", fsid, "rewind-stand-down",
                          note="plan-sync skipped this pass: the latest segment was rewound away mid-pass")
     elif _sync_declared_plan(store, session, (latest_seg or {}).get("id"), (latest_seg or {}).get("t") or now,
-                             prompt_uuid=_ls_trig):
+                             prompt_uuid=_mint_anchor_uuid(latest_seg) if latest_seg else None):
+        # ^ the VETTED anchor, not the raw trigger (the user 2026-08-25, the audited g-specimen): the
+        #   mirror stamps its promptUuid off whatever segment happens to be syncing, and when that
+        #   segment was opened by a coordinate/question mail or a romp notice, the raw trigger made
+        #   the mail/notice the CARD'S ROOT — a record that must file nothing confessing to an ask
+        #   it never made. The rewind check above stays on the RAW trigger: it asks about the
+        #   segment's chain liveness, not about anchor suitability.
         _group_store(store, fsid, now)
         save_goals(fsid, store)
     rollup_status(store, _session_settled(fsid, path, session, store))
@@ -10863,6 +10949,24 @@ def _seg_clearwrap(seg):
     atoms = seg.get("atoms") or []
     trig = next((a for a in atoms if a.get("uuid") == seg.get("trigger")), None) or (atoms[0] if atoms else None)
     return bool(trig and ROMP_CLEARWRAP_RE.search(_atom_text(trig)))
+
+
+def _seg_bookkeeping(seg):
+    """True if this segment was opened by romp's OWN BOOKKEEPING, never an ask (the user 2026-08-25,
+    the provenance audit): a romp-authored line (the romp-injected marker — restart/resume/tasks-died
+    notices, plus a nudge whose goal marker no longer resolves and so falls to the generic work-run),
+    or the CLI's '[Request interrupted by user…]' stop artifact (written for BOTH a user Esc and a
+    machine cut — either way it is the stop EVENT, not a request). The generic work-run strips top
+    mints from such a segment (_strip_top_mints): its work may advance existing goals, but a fresh
+    top card rooted here claims romp's own turn was an ask — the audit found restart-notice- and
+    interrupt-rooted tops a full third of one team's board. The clear wrap-up is EXEMPT by design:
+    its one blocked card is the needs-you escape the wrap-up exists for (the user 2026-07-29), and
+    its own prompt bounds it. Mirrors _seg_human's trigger lookup."""
+    if _seg_clearwrap(seg):
+        return False
+    atoms = seg.get("atoms") or []
+    trig = next((a for a in atoms if a.get("uuid") == seg.get("trigger")), None) or (atoms[0] if atoms else None)
+    return bool(trig and (trig.get("author") == "romp" or em.is_interrupt_record(trig)))
 
 
 def _parse_courier(raw, menu_len):

--- a/tests/test_mint_hygiene.py
+++ b/tests/test_mint_hygiene.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Mint hygiene (the user 2026-08-25, from the dashboard provenance audit): romp's own bookkeeping is
+never an ask, and mail that files nothing never becomes a card's root.
+
+Two deterministic floors:
+(1) A work-run whose segment was opened by romp's OWN line — a restart/resume/tasks-died notice
+    (romp-authored) or the CLI's '[Request interrupted…]' stop artifact — never opens a fresh
+    TOP-level card (_seg_bookkeeping + _strip_top_mints). Its work may still advance EXISTING goals:
+    menu-targeted sub/done/block ops pass through, with same-reply refs remapped. The advisory
+    housekeeping note asked the model for this; the audit found a third of one team's board rooted
+    in exactly these records, so the floor is now mechanical. The clear wrap-up stays exempt: its
+    one blocked card is the designed needs-you escape.
+(2) A MINT's promptUuid never names a record that must file nothing (_mint_anchor_uuid): a
+    coordinate/question peer mail (binding, no courier call — the audited specimen was a to-do
+    mirror top rooted at a kind=coordinate mail) or a bookkeeping record. The substitute anchor is
+    the segment's first assistant atom (still a landable deep-link); a delegate mail keeps its
+    anchor (the courier plants from that record by design). The to-do mirror keeps MINTING either
+    way — the agent's declared work stays one glance away — only the false root claim is refused.
+
+SYNTHETIC fixtures only; private synthetic sid (goal-store fixture rule, 2026-08-24)."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_mint_hyg", os.path.join(BIN, "romp-judge")).load_module()
+em = jd.em
+
+NOW = 1_787_000_000
+T0 = NOW - 3600
+SID = "d15c4a11-7e00-4b22-9c33-000000000015"   # private synthetic sid — never the shared placeholder
+
+NOTICE = ("<!-- romp-injected --><!-- romp-system -->[romp] The kernel restarted and cut this "
+          "session's in-flight turn; pick the work back up where it stopped.")
+CLEARWRAP = ("<!-- romp-injected --><!-- romp-clear-wrap -->I'm dropping the items above — stop, "
+             "park anything unfinished, and raise at most one thing that genuinely needs me.")
+INTERRUPT = "[Request interrupted by user]"
+MAIL_BODY = "Heads-up: the notes-api demo world regenerated; nothing needed from you."
+MID = "1787000000.000000_1.TESTHOST"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def mail(t, uuid, parent, kind, body=MAIL_BODY):
+    text = "%s\n<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: %s -->" % (body, MID, kind)
+    return uline(t, text, uuid, parent, ps="sdk")
+
+
+def _atom(uuid, typ, text, author=None):
+    a = {"type": typ, "uuid": uuid,
+         "message": {"role": typ, "content": [{"type": "text", "text": text}]}}
+    if author is not None:
+        a["author"] = author
+    return a
+
+
+class StripTopMints(unittest.TestCase):
+    """The op transform: mints drop, chained ops drop with them, surviving refs remap."""
+
+    def test_lone_mint_drops(self):
+        self.assertEqual(jd._strip_top_mints([{"do": "mint", "why": "w", "text": "junk"}]), [])
+
+    def test_sub_chained_onto_a_mint_drops_with_it(self):
+        ops = [{"do": "mint", "why": "w", "text": "junk"},
+               {"do": "sub", "why": "w", "ref": 1, "text": "step"}]
+        self.assertEqual(jd._strip_top_mints(ops), [])
+
+    def test_menu_ops_pass_and_refs_remap(self):
+        ops = [{"do": "mint", "why": "w", "text": "junk"},
+               {"do": "sub", "why": "w", "under": 2, "text": "step"},
+               {"do": "done", "why": "w", "ref": 2}]
+        out = jd._strip_top_mints(ops)
+        self.assertEqual([o["do"] for o in out], ["sub", "done"])
+        self.assertEqual(out[0]["under"], 2, "menu-targeted subs are untouched")
+        self.assertEqual(out[1]["ref"], 1, "the ref follows its node to the new created position")
+
+    def test_verdict_on_a_dropped_mint_evaporates_and_menu_verdicts_stand(self):
+        ops = [{"do": "mint", "why": "w", "text": "junk"},
+               {"do": "done", "why": "w", "ref": 1},
+               {"do": "block", "why": "w", "goal": 3}]
+        self.assertEqual(jd._strip_top_mints(ops), [{"do": "block", "why": "w", "goal": 3}])
+
+    def test_a_chain_of_mints_drops_whole(self):
+        ops = [{"do": "mint", "why": "w", "text": "junk"},
+               {"do": "mint", "why": "w", "text": "junk2"},
+               {"do": "sub", "why": "w", "ref": 2, "text": "step"},
+               {"do": "done", "why": "w", "ref": 3}]
+        self.assertEqual(jd._strip_top_mints(ops), [])
+
+    def test_mintless_replies_are_byte_identical(self):
+        ops = [{"do": "sub", "why": "w", "under": 1, "text": "step"},
+               {"do": "done", "why": "w", "goal": 2}]
+        self.assertEqual(jd._strip_top_mints(ops), ops)
+
+
+class BookkeepingRoots(unittest.TestCase):
+    """_seg_bookkeeping: romp-authored triggers and interrupt artifacts, clear wrap-up exempt."""
+
+    def _seg(self, trig_atom, extra=None):
+        atoms = [trig_atom] + (extra or [_atom("a1", "assistant", "resumed and verified")])
+        return {"trigger": trig_atom["uuid"], "atoms": atoms}
+
+    def test_romp_notice_is_bookkeeping(self):
+        self.assertTrue(jd._seg_bookkeeping(self._seg(_atom("u1", "user", NOTICE, author="romp"))))
+
+    def test_interrupt_artifact_is_bookkeeping(self):
+        self.assertTrue(jd._seg_bookkeeping(self._seg(_atom("u1", "user", INTERRUPT, author="human"))))
+
+    def test_a_human_prompt_is_not(self):
+        self.assertFalse(jd._seg_bookkeeping(self._seg(_atom("u1", "user", "fix the exporter", author="human"))))
+
+    def test_peer_mail_is_not(self):
+        trig = _atom("u1", "user", MAIL_BODY)
+        trig["author"] = {"peer": None, "mid": MID, "kind": "coordinate"}
+        self.assertFalse(jd._seg_bookkeeping(self._seg(trig)),
+                         "mail is the courier's jurisdiction, not the bookkeeping gate's")
+
+    def test_clear_wrap_is_exempt(self):
+        self.assertFalse(jd._seg_bookkeeping(self._seg(_atom("u1", "user", CLEARWRAP, author="romp"))),
+                         "the wrap-up's one blocked card is the designed needs-you escape")
+
+
+class MintAnchorVets(unittest.TestCase):
+    """_mint_anchor_uuid: files-nothing records never become a mint's root."""
+
+    def _seg(self, trig_atom, atoms=None):
+        return {"trigger": trig_atom["uuid"], "atoms": [trig_atom] + (atoms or [])}
+
+    def test_human_trigger_keeps_its_anchor(self):
+        seg = self._seg(_atom("u1", "user", "fix the exporter", author="human"),
+                        [_atom("a1", "assistant", "on it")])
+        self.assertEqual(jd._mint_anchor_uuid(seg), "u1")
+
+    def test_coordinate_mail_substitutes_the_assistant_atom(self):
+        trig = _atom("u1", "user", MAIL_BODY)
+        trig["author"] = {"peer": None, "mid": MID, "kind": "coordinate"}
+        seg = self._seg(trig, [_atom("a1", "assistant", "noted; tracking the verification")])
+        self.assertEqual(jd._mint_anchor_uuid(seg), "a1",
+                         "a coordinate mail files nothing — it never becomes a card's root")
+
+    def test_question_mail_substitutes_too(self):
+        trig = _atom("u1", "user", MAIL_BODY)
+        trig["author"] = {"peer": None, "mid": MID, "kind": "question"}
+        seg = self._seg(trig, [_atom("a1", "assistant", "answering")])
+        self.assertEqual(jd._mint_anchor_uuid(seg), "a1")
+
+    def test_delegate_mail_keeps_its_anchor(self):
+        trig = _atom("u1", "user", MAIL_BODY)
+        trig["author"] = {"peer": None, "mid": MID, "kind": "delegate"}
+        seg = self._seg(trig, [_atom("a1", "assistant", "taking it")])
+        self.assertEqual(jd._mint_anchor_uuid(seg), "u1",
+                         "the courier plants from a delegate's record by design")
+
+    def test_romp_notice_substitutes(self):
+        seg = self._seg(_atom("u1", "user", NOTICE, author="romp"),
+                        [_atom("a1", "assistant", "picked the work back up")])
+        self.assertEqual(jd._mint_anchor_uuid(seg), "a1")
+
+    def test_interrupt_artifact_substitutes(self):
+        seg = self._seg(_atom("u1", "user", INTERRUPT, author="human"),
+                        [_atom("a1", "assistant", "parked the run")])
+        self.assertEqual(jd._mint_anchor_uuid(seg), "a1")
+
+    def test_no_assistant_atom_means_no_anchor_over_a_false_one(self):
+        seg = self._seg(_atom("u1", "user", INTERRUPT, author="human"))
+        self.assertIsNone(jd._mint_anchor_uuid(seg),
+                          "an anchorless mint beats a false confession")
+
+
+class _PlanWorld(unittest.TestCase):
+    """E2E harness (the test_judge_apierror pattern): a synthetic transcript on disk, planner
+    LLMs faked per prompt text, one real _plan_session pass."""
+
+    def _run(self, records, reply_for, task_plan=None):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store,
+                     em.task_store_plan)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+
+            def fake(text, *a, **k):
+                return reply_for(text)
+            jd.plan_llm = jd.opener_llm = fake
+            jd._group_store = lambda *a, **k: None
+            if task_plan is not None:
+                em.task_store_plan = lambda fsid: task_plan
+            try:
+                jd._PARSE_CACHE.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store,
+                 em.task_store_plan) = saved
+            return store
+
+
+MINT_JUNK = ('{"ops":[{"why":"post-restart sweep","do":"mint",'
+             '"text":"Post-restart verification sweep"}]}')
+MINT_REAL = '{"ops":[{"why":"asked to fix it","do":"mint","text":"Fix the exporter test"}]}'
+SKIP = '{"ops":[{"why":"nothing to file","do":"skip"}]}'
+
+
+class WorkRunBookkeepingGate(_PlanWorld):
+    def test_a_restart_notice_never_mints_a_top(self):
+        records = [
+            uline(T0, NOTICE, "u1", ps="sdk"),
+            aline(T0 + 10, "Resumed; re-verified the tree; all clean.", "a1", "u1"),
+            uline(T0 + 100, "fix the exporter test", "u2", "a1"),
+            aline(T0 + 110, "Fixed and green.", "a2", "u2"),
+        ]
+
+        def reply_for(text):
+            return MINT_JUNK if "restarted" in text else MINT_REAL
+        store = self._run(records, reply_for)
+        texts = [nd.get("text") or "" for nd in store["nodes"].values()]
+        self.assertTrue(any("exporter" in t for t in texts),
+                        "the control: the same pass still mints from the human ask")
+        self.assertFalse(any("Post-restart" in t for t in texts),
+                         "romp's own notice is never an ask — the mint is refused mechanically")
+
+    def test_notice_work_still_advances_existing_goals(self):
+        records = [
+            uline(T0, "fix the exporter test", "u1"),
+            aline(T0 + 10, "Working on it.", "a1", "u1"),
+            uline(T0 + 100, NOTICE, "u2", "a1", ps="sdk"),
+            aline(T0 + 110, "Resumed; the fix landed and the suite is green.", "a2", "u2"),
+        ]
+
+        def reply_for(text):
+            if "restarted" in text:
+                return ('{"ops":[{"why":"sweep","do":"mint","text":"Post-restart verification sweep"},'
+                        '{"why":"the fix landed and the suite is green","do":"done","goal":1}]}')
+            return MINT_REAL
+        store = self._run(records, reply_for)
+        goal = next((nd for nd in store["nodes"].values() if "exporter" in (nd.get("text") or "")), None)
+        self.assertIsNotNone(goal, "the human ask minted its goal")
+        self.assertTrue(goal.get("nodeComplete"),
+                        "the notice stretch's done op on a MENU goal survives the mint strip")
+        self.assertFalse(any("Post-restart" in (nd.get("text") or "") for nd in store["nodes"].values()))
+
+
+class MirrorAnchor(_PlanWorld):
+    TODO = [{"key": "7", "text": "verify cross-run references", "status": "in_progress",
+             "activeForm": "verifying"}]
+
+    def _mirror_node(self, store):
+        return next((nd for nd in store["nodes"].values()
+                     if (nd.get("agentTask") or {}).get("key") == "7"), None)
+
+    def test_mirror_never_roots_at_a_coordinate_mail(self):
+        records = [
+            uline(T0, "set up the demo world", "u1"),
+            aline(T0 + 10, "Done.", "a1", "u1"),
+            mail(T0 + 100, "u2", "a1", "coordinate"),
+            aline(T0 + 110, "Noted — I'll verify the references as part of my open work.", "a2", "u2"),
+        ]
+        store = self._run(records, lambda text: SKIP, task_plan=self.TODO)
+        nd = self._mirror_node(store)
+        self.assertIsNotNone(nd, "the agent's declared to-do still mints — visibility holds")
+        self.assertEqual(nd.get("promptUuid"), "a2",
+                         "the anchor is the agent's own work, never the coordinate mail record")
+
+    def test_mirror_keeps_a_delegate_mail_anchor(self):
+        records = [
+            uline(T0, "set up the demo world", "u1"),
+            aline(T0 + 10, "Done.", "a1", "u1"),
+            mail(T0 + 100, "u2", "a1", "delegate"),
+            aline(T0 + 110, "Taking it.", "a2", "u2"),
+        ]
+        store = self._run(records, lambda text: SKIP, task_plan=self.TODO)
+        nd = self._mirror_node(store)
+        self.assertIsNotNone(nd)
+        self.assertEqual(nd.get("promptUuid"), "u2",
+                         "a delegate's record is a legitimate root — the courier plants from it too")
+
+    def test_mirror_never_roots_at_a_romp_notice(self):
+        records = [
+            uline(T0, "set up the demo world", "u1"),
+            aline(T0 + 10, "Done.", "a1", "u1"),
+            uline(T0 + 100, NOTICE, "u2", "a1", ps="sdk"),
+            aline(T0 + 110, "Resumed where it stopped.", "a2", "u2"),
+        ]
+        store = self._run(records, lambda text: SKIP, task_plan=self.TODO)
+        nd = self._mirror_node(store)
+        self.assertIsNotNone(nd)
+        self.assertEqual(nd.get("promptUuid"), "a2",
+                         "a restart notice never becomes the mirror card's root")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Two deterministic mint-hygiene floors in the judge, from the 2026-08-25 provenance audit of one team's board (a `notes-api` world with `web`/`api`/`tests` sessions, in the synthetic examples below):

**1. No top-level mints from bookkeeping-rooted segments.** A work-run whose segment was opened by romp's own line — a restart/resume/tasks-died notice (`<!-- romp-system -->`), or the CLI's `[Request interrupted…]` stop artifact — never opens a fresh top-level card. The housekeeping note (2026-07-08) asked the model for this but stayed advisory (and sanctioned "a genuinely new thread"); about a third of the audited board's top cards were rooted in exactly these records. New `_seg_bookkeeping` classifies the root (clear wrap-up exempt: its one blocked card is the designed needs-you escape); new `_strip_top_mints` drops mint ops and everything chained onto them, remapping surviving same-reply refs — an unmapped ref would silently retarget a neighbouring node, and a sub whose ref died would fall back to a TOP mint in `apply_plan`. Menu-targeted `sub`/`done`/`block` ops pass through, so the stretch still advances existing goals (nothing-runs-in-secret holds).

**2. No mint roots at records that file nothing.** The to-do mirror stamped its `promptUuid` off whatever segment happened to be syncing, so a `kind=coordinate` mail (binding: files nothing, no courier call) became a top card's ROOT and the provenance chain read peer chatter as an ask. The mirror keeps minting — the agent's declared work stays one glance away — but the root claim is vetted (`_mint_anchor_uuid`): coordinate/question mail and bookkeeping records never anchor a mint; the segment's first assistant atom substitutes (still a landable deep-link), else None. Delegate mail keeps its anchor: the courier plants from that same record by design.

## Audit honesty

- The **courier held everywhere**: no coordinate/question mail was ever planted by it. The violation specimens were this pair — one to-do-mirror top rooted at a coordinate mail, and work-run mints on interrupt-artifact-rooted segments (the two "survey-answer" cards). Same class, same fix: both land in floor 1/2 above; no coordinate-specific mint path exists.
- **Existing cards of this class**: no retroactive sweep (no hand-edits of live stores, per the standing rule). They follow the normal lifecycle — closer completion, user clears, consolidation archive. At audit time all but three open tops across the audited team's six sessions were already resolved or archived, so the class drains on its own once the mint stops.

## Tests

`tests/test_mint_hygiene.py` (synthetic worlds, private synthetic sid): the op-strip matrix (drop, chain-drop, ref remap, byte-identical mintless replies), the segment classifier (notice / interrupt artifact / human / peer mail / clear-wrap exemption), the anchor vets (human, coordinate, question, delegate, notice, interrupt, no-assistant-fallback), and end-to-end planner passes — a restart notice cannot mint a top but its `done` on a menu goal still applies; the mirror never roots at a coordinate mail or a notice, keeps a delegate anchor, and still mints. All fail against the previous behavior (verified by running them on the unmodified tree).

Suites: Python 5615 passed / 34 skipped; UI 2378/2378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)