### PR TITLE
The comment popover settles down: logo-only boot, a fixed big box, calm streams, one hover family

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4043,6 +4043,11 @@ class SdkBackend:
             reg["threadOf"] = thread_of
         if parent.get("model") and parent["model"] != "default":
             reg["model"] = parent["model"]
+        if parent.get("fast"):
+            # fast rides the fork like model/effort do (the user 2026-08-25: a comment made from an
+            # Opus-high-FAST session came up slow) — the reg's `fast` is the persisted ask fast_opt
+            # reads at connect, so the thread's first frame already reports it
+            reg["fast"] = True
         # Per-fork model/effort OVERRIDES (the user 2026-08-17: a comment thread on a different model
         # or effort, without touching the parent). Applied HERE, in the reg the first connect reads —
         # never via set_model, whose write_sdk_default side effect would make a thread's pick the seed

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -203,6 +203,23 @@ class ThreadForkInvisibility(unittest.TestCase):
         self.assertEqual(reg.get("forkOf"), PARENT)
         self.assertEqual(reg.get("forkAt"), "a1")
 
+    def test_fast_mode_rides_the_fork_like_model_and_effort(self):
+        # the user 2026-08-25: a comment made from an Opus-high-FAST session came up slow — the fork
+        # reg seeded mode/effort/model from the parent but never fast; fast_opt reads reg["fast"] at
+        # connect, so inheriting it here makes the thread fast from its first frame
+        preg_path = Path(self.td) / "sdk" / (PARENT + ".json")
+        preg = json.loads(preg_path.read_text())
+        preg["fast"] = True
+        preg_path.write_text(json.dumps(preg))
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertTrue(reg.get("fast"), "a fast parent's new thread is fast")
+
+    def test_a_slow_parent_stays_slow(self):
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertNotIn("fast", reg, "no inherited fast key when the parent never asked for it")
+
     def test_a_plain_fork_still_writes_its_names_entry(self):
         self.be.fork("fork-x", PARENT, "a1", sid=THREAD)
         self.assertTrue((Path(self.td) / "names" / THREAD).exists())

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -52,7 +52,7 @@ test("the popover's bottom row IS a statusline: the chat's chip anatomy + counti
 
 test("the action buttons wear the chat's under-bubble family; Fork stays out by the user's call", () => {
   assert.match(CSS, /\.cmt-act \{\s*\n\s*background: rgba\(255, 255, 255, 0\.06\);\s*\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\); border-radius: 5px; font-size: 0\.78em;\s*\n\s*padding: 1px 8px; cursor: pointer;\s*\n\}/);
-  assert.match(CSS, /\.cmt-act:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/);
+  assert.match(CSS, /\.cmt-act:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: rgba\(156, 210, 255, 0\.12\); \}/);   // the feed word-button hover (2026-08-25): text+outline accent, never a fill
   // the popover's verbs stay Break out / Merge / Delete — the chat's Fork button is deliberately absent
   const pop = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
   assert.ok(!/data-act="fork"|showForkPrompt/.test(pop), "no fork button in the popover");
@@ -62,7 +62,12 @@ test("a fresh thread boots on the romp loader, then renders its final format ONC
   // the loader holds the list until the thread's REAL render (its events) is ready — the plain
   // msgs projection no longer flashes as an intermediate format
   assert.match(RENDER, /if \(!evs\.length && th\.status === "open" && !th\.error && cmtBootHolds\(th\.tid\)\) \{/);
-  assert.match(RENDER, /boot\.appendChild\(rompLoaderInner\("opening the thread…"\)\);/);
+  assert.match(RENDER, /boot\.appendChild\(rompLoaderInner\("opening the thread…", \{ wordmark: false \}\)\);/);
+  // logo-only in the POPOVER (the user 2026-08-25): the spinning swirl + dots stay, the R-o-m-p
+  // letters drop — parameterized on the ONE shared builder, so the boot splash and the pane/revive
+  // loaders keep the full treatment (their call sites pass no opts)
+  assert.match(RENDER, /if \(opts\?\.wordmark === false\) \{\s*\n\s*word\.appendChild\(swirl\);/);
+  assert.match(RENDER, /o\.appendChild\(rompLoaderInner\(`reviving “\$\{name\}”…`\)\);/, "the revive loader keeps the wordmark");
   // event-based fade: the frame that carries events refills the list and retires the hold
   assert.match(RENDER, /if \(evs\.length\) cmtBootSince\.delete\(th\.tid\);/);
   // …with the can't-trap backstop: past it, the hold releases and the projection paints after all
@@ -130,3 +135,18 @@ test("the caret faces RIGHT and the submenu side is measured, right-preferred (t
     "left is the measured fallback, not the default");
 });
 
+
+test("the thread popover opens 70% wide right-aligned, 60% tall — and NEVER grows on content", () => {
+  // the user 2026-08-25: "start out pretty big and fill in" — the size is fixed at open, streaming
+  // fills within (.cmt-msgs flexes + scrolls; comments.test.ts pins that rule), the box never
+  // reflows on a content event. Verified headless: 840×480 at 1200×800, right gap 8, zero rect
+  // change across three streaming appends. The CREATE composer keeps its selection-point gesture.
+  assert.match(RENDER, /if \(th && !pop\.style\.width\) \{ pop\.style\.width = Math\.round\(window\.innerWidth \* 0\.7\) \+ "px"; \}/);
+  assert.match(RENDER, /if \(th && !pop\.style\.height\) \{ pop\.style\.height = Math\.round\(window\.innerHeight \* 0\.6\) \+ "px"; \}/);
+  assert.match(RENDER, /const defaultX = th \? \(window\.innerWidth - r\.width - 8\) : \(window\.innerWidth - r\.width\) \/ 2;/);
+  // a thread open ignores click coords — only a real drag parks the box elsewhere
+  const opener = RENDER.split("function openCommentPopover(")[1].split("\nfunction ")[0];
+  assert.ok(!opener.includes("commentPopPos = { x, y }"), "no click-coord seeding on thread open");
+  // …and the CSS no longer hard-sizes the box (the inline open geometry owns it)
+  assert.doesNotMatch(CSS, /\.cmt-pop \{[^}]*width: 440px/s);
+});

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -150,3 +150,27 @@ test("the thread popover opens 70% wide right-aligned, 60% tall — and NEVER gr
   // …and the CSS no longer hard-sizes the box (the inline open geometry owns it)
   assert.doesNotMatch(CSS, /\.cmt-pop \{[^}]*width: 440px/s);
 });
+
+test("the popover resizes from ANY edge or corner, macOS-style; the old grip keeps working", () => {
+  // the user 2026-08-25: an 8px band per side is a live handle with the platform cursor, each pull
+  // moving its own edge with the opposite one anchored, clamped to the CSS mins; the native
+  // bottom-right grip's corner is deliberately deferred to (it keeps working exactly as before)
+  const fn = RENDER.split("function wireEdgeResize(")[1].split("\nfunction ")[0];
+  assert.ok(fn.includes('if (ev.clientX > r.right - 18 && ev.clientY > r.bottom - 18) return "";'), "the native grip corner defers");
+  assert.ok(fn.includes('ne: "nesw-resize", sw: "nesw-resize", nw: "nwse-resize", se: "nwse-resize"'), "corner cursors");
+  assert.ok(fn.includes('n: "ns-resize", s: "ns-resize", e: "ew-resize", w: "ew-resize"'), "edge cursors");
+  assert.ok(fn.includes('if (zone.includes("w")) { wpx = r0.width - dx; left = r0.left + dx; }'), "west pulls west, east anchored");
+  assert.ok(fn.includes('if (zone.includes("n")) { hpx = r0.height - dy; top = r0.top + dy; }'), "north pulls north, south anchored");
+  assert.ok(fn.includes("const MIN_W = 300, MIN_H = 120;"), "min bounds match the CSS");
+  assert.ok(fn.includes("pop.setPointerCapture(ev.pointerId);"), "capture keeps fast pulls on the edge");
+  assert.ok(fn.includes("commentPopPos = { x: left, y: top };"), "a north/west pull persists position like the drag");
+  assert.match(RENDER, /wireEdgeResize\(pop\);/);
+  const CSSs = CSS;
+  assert.match(CSSs, /resize: both/, "the native grip stays");
+});
+
+test("the create name input wears no underline at rest (the user 2026-08-25)", () => {
+  assert.match(CSS, /\.cmt-name \{[^}]*border-bottom: 1px solid transparent;/s);
+  assert.doesNotMatch(CSS, /\.cmt-name \{[^}]*dashed/s);
+  assert.match(CSS, /\.cmt-name:focus \{ outline: none; border-bottom-color: var\(--accent\); \}/, "focus still shows the editing affordance");
+});

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -435,7 +435,7 @@ test("the thread's identity rail runs continuous — no holes at the list's flex
   // (pending bubbles, dots, notes) render after the turns, so the + pair never misses.
   assert.match(CSS, /\.turn::before \{ content: ""; position: absolute; left: 10\.5px; top: 0; bottom: 0; width: 2px;/,
     "the base segment this fix extends");
-  assert.match(CSS, /\.cmt-msgs \{ max-height: 45vh; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; \}/,
+  assert.match(CSS, /\.cmt-msgs \{ flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; \}/,
     "the 6px gap the -6px below must stay paired with");
   assert.match(CSS, /\.cmt-msgs \.turn \+ \.turn::before \{ top: -6px; \}/);
 });

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -236,7 +236,7 @@ test("context stages ALONE, and the chips strip carries the visible Stage button
   // neutral at rest (the user 2026-08-23): an accent outline beside the accent-blue chips read as
   // already-pressed. Rest = the button family's dress; the accent appears only on hover.
   assert.match(CSS, /\.composer-stage-btn \{ background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
-  assert.match(CSS, /\.composer-stage-btn:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/);
+  assert.match(CSS, /\.composer-stage-btn:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: rgba\(156, 210, 255, 0\.12\); \}/);   // the feed word-button hover (2026-08-25)
   assert.doesNotMatch(CSS, /\.composer-stage-btn \{ position: absolute/,
     "no absolute pin — the button flows in the strip, immediately after what it acts on");
   assert.match(RENDER, /st\.title = "hold this context \(and anything typed\) for one combined send later — ⌘⏎ does the same";/);

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -50,9 +50,15 @@ test("sharesAnyUuid: a continuation shares a uuid, a wholesale fork shares none"
   assert.equal(sharesAnyUuid([{}, {}], before), false, "no uuids to match (live tail-only) → treated as a fork-ish rebuild");
 });
 
-test("appendActive snaps only when the user is already near the bottom", () => {
-  assert.match(RENDER, /const stick = nearBottom\(content\);[\s\S]*?if \(stick\) content\.scrollTop = content\.scrollHeight/,
-    "tail-append follows the live edge only if the reader was already at the bottom");
+test("appendActive snaps only when the user is already near the bottom of OVERFLOWING content", () => {
+  // the slack rule (the user 2026-08-25): while nothing overflows, nearBottom is trivially true —
+  // ungated, the very append crossing the overflow boundary yanked the view; now streaming into
+  // slack writes in place and grows the scrollbar, and the stick engages only once overflowing
+  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);[\s\S]*?if \(stick\) content\.scrollTop = content\.scrollHeight/,
+    "tail-append follows the live edge only if content overflows AND the reader was at the bottom");
+  // the popover's thread list speaks the same rule
+  assert.match(RENDER, /const overflowed = list\.scrollHeight > list\.clientHeight \+ 2;/);
+  assert.match(RENDER, /const atTail = overflowed && list\.scrollTop >= list\.scrollHeight - list\.clientHeight - 8;/);
 });
 
 // Scrolled-up re-renders anchor on a TURN, not a pixel offset (the user 2026-07-05): chatTail deep-fills

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5917,16 +5917,24 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
 
 // The standard romp loader's inner anatomy — wordmark + spinning swirl + pulsing dots + caption
 // (the boot/pane .rl-* styles already on this page) — shared by every in-page wait that wears it
-// (the revive loader, the comment popover's boot), per the loading-states rule: one treatment.
-function rompLoaderInner(caption: string): HTMLElement {
+// (the revive loader, the loading-tab wait, the comment popover's boot), per the loading-states
+// rule: one treatment, parameterized rather than forked. wordmark:false (the user 2026-08-25,
+// POPOVER-ONLY: "don't write the whole text of romp — just the spinning logo") keeps the spinning
+// swirl + dots + caption and drops the R-o-m-p letters; everywhere else keeps the full treatment.
+function rompLoaderInner(caption: string, opts?: { wordmark?: boolean }): HTMLElement {
   const inner = el("div", "rl-in");
   const word = el("div", "rl-word");
-  const r = el("span", ""); (r as HTMLElement).style.color = "#1EA1EB"; r.textContent = "R";
   const swirl = el("img", "rl-o") as HTMLImageElement;
-  swirl.src = mediaSrc("romp-swirl-o.svg"); swirl.alt = "o"; swirl.onerror = () => swirl.remove();
-  const mm = el("span", ""); (mm as HTMLElement).style.color = "#54B204"; mm.textContent = "m";
-  const p = el("span", ""); (p as HTMLElement).style.color = "#4EA8A9"; p.textContent = "p";
-  word.append(r, swirl, mm, p);
+  swirl.src = mediaSrc("romp-swirl-o.svg"); swirl.alt = ""; swirl.onerror = () => swirl.remove();
+  if (opts?.wordmark === false) {
+    word.appendChild(swirl);
+  } else {
+    const r = el("span", ""); (r as HTMLElement).style.color = "#1EA1EB"; r.textContent = "R";
+    swirl.alt = "o";
+    const mm = el("span", ""); (mm as HTMLElement).style.color = "#54B204"; mm.textContent = "m";
+    const p = el("span", ""); (p as HTMLElement).style.color = "#4EA8A9"; p.textContent = "p";
+    word.append(r, swirl, mm, p);
+  }
   const dots = el("div", "rl-dots");
   dots.append(el("i", ""), el("i", ""), el("i", ""));
   const cap = el("div", "revive-cap");
@@ -6425,10 +6433,12 @@ function openCommentComposer(sid: string, uuid: string, exact: string, x: number
   renderCommentPopover();
 }
 
-function openCommentPopover(sid: string, tid: string, x?: number, y?: number): void {
+function openCommentPopover(sid: string, tid: string, _x?: number, _y?: number): void {
   openCommentKey = { sid, tid };
   pendingCommentAnchor = null;
-  if (x != null && y != null) commentPopPos = { x, y };
+  // click coords no longer seed the position (the user 2026-08-25): a THREAD popover opens at the
+  // fixed right-aligned geometry below; only a real drag (commentPopPos) parks it elsewhere. The
+  // CREATE composer (openCommentComposer) still opens at the selection point — a different gesture.
   vscodeApi?.postMessage({ type: "commentSeen", id: sid, tid });
   const th = (commentThreads.get(sid) || []).find((t) => t.tid === tid);
   if (th) th.unread = false;                    // optimistic; the kernel's watermark reconciles
@@ -6471,7 +6481,11 @@ function openCommentThread(): { sid: string; th: CommentThread } | null {
  *  frame-driven refresh so an update never rebuilds the composer under the user's caret. */
 function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): void {
   const prevScroll = list.scrollTop;
-  const atTail = list.scrollTop >= list.scrollHeight - list.clientHeight - 8;
+  // the slack rule (the user 2026-08-25, same word as the chat's appendActive): while the thread's
+  // content hasn't overflowed the fixed box, streaming writes in place — no follow, no jump; once
+  // overflowing, the at-tail stick behaves as before
+  const overflowed = list.scrollHeight > list.clientHeight + 2;
+  const atTail = overflowed && list.scrollTop >= list.scrollHeight - list.clientHeight - 8;
   list.replaceChildren();
   const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
   commentPending.set(th.tid, pend);
@@ -6484,7 +6498,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
   // kernel) can't trap the loader.
   if (!evs.length && th.status === "open" && !th.error && cmtBootHolds(th.tid)) {
     const boot = el("div", "cmt-boot");
-    boot.appendChild(rompLoaderInner("opening the thread…"));
+    boot.appendChild(rompLoaderInner("opening the thread…", { wordmark: false }));
     list.appendChild(boot);
     for (const pb of pend) {
       const n = commentMsgEl("you", pb.text);
@@ -6965,8 +6979,17 @@ function renderCommentPopover(): void {
     });
     ro.observe(pop);
   }
+  // OPEN GEOMETRY (the user 2026-08-25), THREAD mode: 70% of the chat pane's width with the RIGHT
+  // edge on the chat's right edge, 60% of the pane's height — and the size is FIXED from open:
+  // streaming text fills within (.cmt-msgs flexes and scrolls; the box never reflows on content
+  // events — the auto-expand was the jarring part). Manual resize (resize: both) still hands the
+  // user control, and a dragged position (commentPopPos) still wins over the default placement.
+  // The CREATE composer keeps its natural size at the selection point — a different gesture.
+  if (th && !pop.style.width) { pop.style.width = Math.round(window.innerWidth * 0.7) + "px"; }
+  if (th && !pop.style.height) { pop.style.height = Math.round(window.innerHeight * 0.6) + "px"; }
   const r = pop.getBoundingClientRect();
-  const px = Math.max(8, Math.min(commentPopPos?.x ?? (window.innerWidth - r.width) / 2, window.innerWidth - r.width - 8));
+  const defaultX = th ? (window.innerWidth - r.width - 8) : (window.innerWidth - r.width) / 2;
+  const px = Math.max(8, Math.min(commentPopPos?.x ?? defaultX, window.innerWidth - r.width - 8));
   const py = Math.max(8, Math.min(commentPopPos?.y ?? 120, window.innerHeight - r.height - 8));
   pop.style.left = px + "px";
   pop.style.top = py + "px";
@@ -8278,7 +8301,12 @@ function appendActive() {
   const content = document.getElementById("content");
   if (!content || !activeId) { showActive(); return; }
   const v = views.get(activeId);
-  const stick = nearBottom(content);
+  // Follow-the-tail engages ONLY once content actually overflows (the user 2026-08-25: with slack
+  // below, a streaming reply should write IN PLACE and grow a scrollbar, not jump the view to the
+  // bottom). nearBottom is trivially true while nothing overflows, so without this gate the very
+  // append that crosses the overflow boundary yanked the view. Overflowing + genuinely at the
+  // bottom keeps the existing stick; scrolled-up keeps its never-yank rule.
+  const stick = content.scrollHeight > content.clientHeight + 2 && nearBottom(content);
   const before = content.scrollTop;
   const anchor = !stick && v ? captureScrollAnchor(content, v) : null;
   syncView(activeId, stick);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6655,6 +6655,66 @@ function cmtStateChip(th: CommentThread): HTMLElement {
   return wrap;
 }
 
+/** Resize from ANY edge or corner, macOS-style (the user 2026-08-25: "only from the little thing
+ *  at the bottom right — I should be able to grab any edge and pull"). An 8px band on each side is
+ *  a live handle with the platform cursor (ew/ns/nwse/nesw); each pull moves its own edge with the
+ *  opposite edge anchored, clamped to the CSS min-size. The bottom-right corner is deliberately
+ *  left to the native resize grip (it keeps working exactly as before). Pointer capture keeps fast
+ *  pulls on the edge; a north/west pull writes the new position through to commentPopPos, the same
+ *  persistence the drag has. Installed once per popover element (the element survives in-place
+ *  refreshes — the click-safety discipline). */
+function wireEdgeResize(pop: HTMLElement): void {
+  const EDGE = 8;
+  const MIN_W = 300, MIN_H = 120;   // the .cmt-pop CSS mins, restated for the math
+  const zoneAt = (ev: PointerEvent): string => {
+    const r = pop.getBoundingClientRect();
+    if (ev.clientX > r.right - 18 && ev.clientY > r.bottom - 18) return "";   // the native grip's corner
+    const n = ev.clientY - r.top < EDGE, so = r.bottom - ev.clientY < EDGE;
+    const w = ev.clientX - r.left < EDGE, e = r.right - ev.clientX < EDGE;
+    return (n ? "n" : so ? "s" : "") + (w ? "w" : e ? "e" : "");
+  };
+  const CUR: Record<string, string> = { n: "ns-resize", s: "ns-resize", e: "ew-resize", w: "ew-resize",
+                                        ne: "nesw-resize", sw: "nesw-resize", nw: "nwse-resize", se: "nwse-resize" };
+  pop.addEventListener("pointermove", (ev: PointerEvent) => {
+    if (ev.buttons) return;                          // mid-press: the active gesture owns the cursor
+    pop.style.cursor = CUR[zoneAt(ev)] || "";
+  });
+  pop.addEventListener("pointerdown", (ev: PointerEvent) => {
+    const zone = zoneAt(ev);
+    if (!zone) return;
+    ev.preventDefault();
+    ev.stopPropagation();                            // the whole-box drag must not also engage
+    const r0 = pop.getBoundingClientRect();
+    const x0 = ev.clientX, y0 = ev.clientY;
+    pop.setPointerCapture(ev.pointerId);
+    const move = (mv: PointerEvent) => {
+      const dx = mv.clientX - x0, dy = mv.clientY - y0;
+      let left = r0.left, top = r0.top, wpx = r0.width, hpx = r0.height;
+      if (zone.includes("e")) wpx = r0.width + dx;
+      if (zone.includes("s")) hpx = r0.height + dy;
+      if (zone.includes("w")) { wpx = r0.width - dx; left = r0.left + dx; }
+      if (zone.includes("n")) { hpx = r0.height - dy; top = r0.top + dy; }
+      if (wpx < MIN_W) { if (zone.includes("w")) left -= MIN_W - wpx; wpx = MIN_W; }
+      if (hpx < MIN_H) { if (zone.includes("n")) top -= MIN_H - hpx; hpx = MIN_H; }
+      left = Math.max(4, left); top = Math.max(4, top);
+      pop.style.width = wpx + "px";
+      pop.style.height = hpx + "px";
+      pop.style.left = left + "px";
+      pop.style.top = top + "px";
+      commentPopPos = { x: left, y: top };           // the drag's own persistence, kept in step
+    };
+    const up = () => {
+      pop.removeEventListener("pointermove", move);
+      pop.removeEventListener("pointerup", up);
+      pop.removeEventListener("pointercancel", up);
+      pop.classList.add("sized");                    // a real user resize unlocks the quote clamp, like the grip
+    };
+    pop.addEventListener("pointermove", move);
+    pop.addEventListener("pointerup", up);
+    pop.addEventListener("pointercancel", up);
+  });
+}
+
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
   const nm = th?.name || "Thread";
   return create ? "New comment:"
@@ -6808,6 +6868,7 @@ function renderCommentPopover(): void {
     pop.addEventListener("pointercancel", up);
   });
   pop.appendChild(head);
+  wireEdgeResize(pop);
   if (create || !(th!.events || []).length) {
     // the chat-parity view opens ON the quoting message, so a second quote block would say it twice
     const quote = el("div", "cmt-quote");

--- a/ui/webview/revive-loader.test.ts
+++ b/ui/webview/revive-loader.test.ts
@@ -22,7 +22,7 @@ test("the Revive click acknowledges at once: post reviveSession AND show the loa
 test("the loader is the romp treatment: wordmark + swirl + pulsing dots + caption", () => {
   // ONE shared builder (rompLoaderInner) carries the anatomy — the revive loader and the comment
   // popover's boot both wear it, per the loading-states rule
-  assert.match(RENDER, /function rompLoaderInner\(caption: string\): HTMLElement/);
+  assert.match(RENDER, /function rompLoaderInner\(caption: string, opts\?: \{ wordmark\?: boolean \}\): HTMLElement/);   // parameterized, never forked (the popover drops the wordmark; everything else keeps it)
   assert.match(RENDER, /const word = el\("div", "rl-word"\)/, "reuses the boot-splash .rl-* styles already on the page");
   assert.match(RENDER, /swirl\.src = mediaSrc\("romp-swirl-o\.svg"\)/);
   assert.match(RENDER, /const dots = el\("div", "rl-dots"\)/);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2829,7 +2829,9 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    failed the session-name charset, matching the fork modal. */
 .cmt-name {
   flex: 1; min-width: 60px; margin: 0 6px; padding: 0 2px;
-  border: 0; border-bottom: 1px dashed color-mix(in srgb, var(--accent) 45%, transparent);
+  /* no underline at rest (the user 2026-08-25: drop the dotted line under the name; everything else
+     stays) — the transparent bottom border keeps the box's height so focus doesn't shift layout */
+  border: 0; border-bottom: 1px solid transparent;
   border-radius: 0; background: transparent;
   color: var(--accent); font: inherit; font-weight: 600;
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -660,7 +660,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .held-head { flex: 1 1 100%; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
-.staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }
+.staged-head .staged-go:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }   /* the feed word-button hover (2026-08-25) */
 /* the chips strip's Stage button (the user 2026-08-23; moved 2026-08-24): it FOLLOWS the blue
    context chips in the strip's column — immediately after what it acts on, where its meaning reads;
    right-justified it floated detached. Exists exactly while context is held (the strip renders it,
@@ -670,7 +670,10 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .composer-stage-btn { background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.78em;
   padding: 1px 8px; cursor: pointer; }
-.composer-stage-btn:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+/* hover = the FEED's word-button treatment exactly (the user 2026-08-25: text + outline light up
+   blue, like Clear/Undo — never a background fill; the wash values are the feed's .ftree-act-btn
+   family, referenced not re-derived) */
+.composer-stage-btn:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }
 .staged-chip { display: flex; flex-direction: column; gap: 2px; border: 1px dashed rgba(156, 210, 255, 0.45);
   border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg);
   cursor: pointer; }
@@ -2694,7 +2697,11 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    below and the scroll-rail tick carry the states it used to) */
 
 .cmt-pop {
-  position: fixed; z-index: 120; width: 440px; max-width: 94vw;
+  position: fixed; z-index: 120; max-width: 94vw;
+  /* SIZE IS FIXED FROM OPEN (the user 2026-08-25: auto-expanding height on new text was jarring —
+     "start out pretty big and fill in"): renderCommentPopover sets width (70% of the pane,
+     right-aligned) and height (60%) inline at open; .cmt-msgs flexes + scrolls inside, so content
+     events never reflow the box. Manual resize (resize: both) stays. */
   resize: both; overflow: auto; min-width: 300px; min-height: 120px; max-height: 90vh;
   cursor: grab;                       /* the whole box drags (interactive children override below) */
   display: flex; flex-direction: column; gap: 6px; padding: 8px;
@@ -2741,7 +2748,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   display: block; -webkit-line-clamp: unset; flex: 1 1 auto; min-height: 3em; overflow-y: auto;
 }
 .cmt-pop.sized .cmt-msgs { flex: 2 1 auto; max-height: none; }
-.cmt-msgs { max-height: 45vh; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+.cmt-msgs { flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }   /* fills the FIXED box; scroll absorbs streams (2026-08-25) */
 /* chat-parity turns inside the popover (the user 2026-08-17): the chat's own .turn nodes, given a
    little rail room; the popover's card is the backdrop, so no extra chrome */
 .cmt-msgs .turn { max-width: 100%; box-sizing: border-box; }
@@ -2782,7 +2789,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.78em;
   padding: 1px 8px; cursor: pointer;
 }
-.cmt-act:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+.cmt-act:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }   /* the feed word-button hover (2026-08-25): Break out / Merge / Delete light up like Clear/Undo */
 .cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
 .cmt-note.cmt-err { color: var(--st-blocked-bg, #c94f4f); opacity: 0.9; }
 
@@ -2981,7 +2988,7 @@ body.filebrowse-open { overflow: hidden; }
    reverse-highlight hover so a selected toggle never reads as dead. */
 .fileview-btn.on { color: var(--accent); border-color: var(--accent);
   background: rgba(156, 210, 255, 0.10); font-weight: 600; }
-.fileview-btn.on:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+.fileview-btn.on:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }   /* the feed word-button hover (2026-08-25) */
 
 /* Wrap mode (the Wrap toggle, persisted per browser): long lines soft-wrap instead of scrolling
    sideways. The flat sibling gutter cannot survive that — one logical line becomes several visual lines


### PR DESCRIPTION
## Five user asks, one pass

**Logo-only boot (popover only).** The popover's boot loader drops the R-o-m-p wordmark; the spinning swirl + pulsing dots + caption stay. One `wordmark` parameter on the shared `rompLoaderInner` — never a fork; the boot splash, pane, loading-tab, and revive loaders keep the full treatment (pinned).

**Open geometry, fixed from open.** A THREAD popover opens at **70% of the pane's width, right edge on the chat's right edge, 60% height** — and the size is fixed: `.cmt-msgs` flexes and scrolls inside, so streaming content never reflows the box. Click coordinates no longer seed the position (only a real drag parks it); the CREATE composer keeps its selection-point gesture and natural size. Manual resize stays.

**No-scroll-while-slack (popover and chat).** Follow-the-tail engages only once content actually overflows: `nearBottom`/`atTail` are trivially true while slack remains, so the very append that crossed the overflow boundary used to yank the view. Streaming into slack now writes in place and grows the scrollbar; overflowing + at-bottom keeps the existing stick; scrolled-up keeps its never-yank rule.

**One hover family.** Break out / Merge / Delete — plus the chat-side sweep: the Stage button, the staged strip's Send now, the file viewer's mode toggle — adopt the feed word-button hover verbatim (`border-color`/`color` to the accent with the faint wash, never a background fill), matching Clear/Undo on the feed.

**Fast inherits into threads (kernel).** The thread fork seeded mode/effort/model from the parent but never `fast` — a comment made from an Opus-high-FAST session came up slow. The fork reg now carries the parent's fast ask; the thread runs fast from its first frame, and the popover statusline's Fast badge reflects it.

## Headless over the built bundle

Boot: dots + caption, zero wordmark letters. Geometry: 840×480 at 1200×800, right gap 8px. Streams: three appends, rect moved **zero** pixels; the slack list never scrolled; overflow only ever adds the scrollbar.

## Tests

`comment-popover-parity.test.ts` (loader variant + full-treatment survivors, thread-scoped geometry, no click seeding, hover reference); `render-scroll.test.ts` (the slack-gated stick on both surfaces); `comments.test.ts` (the flexing scroll pane); `tests/test_comment_threads.py` (fast parent → fast thread; slow parent stays slow). Sweep inventory in the task report. npm 2390 + typecheck + Python 5594 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)