### PR TITLE
The host-loading hint covers the whole wait: swirl, escalate at 45s, never hide

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -315,7 +315,7 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
  *  (local first); keep the scalar chrome fields (now, dismissedCount, flags) from the LOCAL host, since the
  *  dashboard's own controls are local-authoritative. Ids are already prefixed by prefixInbound. */
 export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly string[],
-                               view: readonly string[] = []): any {
+                               view: readonly string[] = [], deadHosts: readonly string[] = []): any {
   const local = perHost[LOCAL] || {};
   const merged: any = { ...local, type: "feed", items: [], asks: [], working: [], awaiting: [], stateUnknown: [], order: [], sessions: [] };
   // `ledgers` drives the FLEET pane (it rides the same feed message). Only include it once at least one host
@@ -379,6 +379,10 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   // to send) and retires the hint; a detach deletes the entry (dropHost), so a reattach re-pends and
   // the hint re-arms identically — no timers anywhere in this signal. The local kernel never pends.
   merged.pendingHosts = hostSeq.filter((h) => h !== LOCAL && !(h in perHost));
+  // …and which of those waits are on a DEAD link (the caller knows its sockets): the board says
+  // THAT instead of an open-ended wait — the fail-loudly rule; still retired only by the real
+  // events (a payload arriving, or the detach dropping the host from hostSeq).
+  merged.pendingDead = merged.pendingHosts.filter((h: string) => deadHosts.includes(h));
   return merged;
 }
 
@@ -669,7 +673,12 @@ export class FederationManager {
       this.lastFeedCounts = sig;
       this.diag("feedmerge", { counts });
     }
-    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view()) }));
+    const dead = this.hostSeq.filter((h) => {
+      if (h === LOCAL) return false;
+      const c = this.conns.get(h);
+      return !c || !c.ws || c.ws.readyState === 3;   // no socket / closed = a dead link right now
+    });
+    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead) }));
   }
 
   private emitMergedTimeline(bars: boolean): void {

--- a/ui/webview/feed-hostload.test.ts
+++ b/ui/webview/feed-hostload.test.ts
@@ -43,20 +43,38 @@ test("reconnect re-arms by construction: detach deletes the contribution, reatta
   assert.deepEqual(gone.pendingHosts, ["TESTHOST"], "post-detach reattach looks exactly like first attach");
 });
 
-test("the feed adopts the signal and hints in BOTH board states, loader family, backstopped", () => {
+test("the hint covers the WHOLE pending window: escalate at 45s, remove only on the real events", () => {
   assert.match(FEED, /pendingHosts = Array\.isArray\(m\.pendingHosts\) \? m\.pendingHosts\.filter\(\(h: any\) => typeof h === "string"\) : \[\];/);
+  assert.match(FEED, /pendingDead = Array\.isArray\(m\.pendingDead\) \? m\.pendingDead\.filter\(\(h: any\) => typeof h === "string"\) : \[\];/);
   assert.match(FEED, /syncHostloadBackstops\(\);/);
-  assert.match(FEED, /txt\.textContent = "loading cards from " \+ h \+ "\\u2026";/);
   // both board states: the strip rides under the cards AND under the empty wordmark
   assert.match(FEED, /ensureHostLoad\(list\);   \/\/ an attached host's cards may be the ONLY thing coming — say so here too/);
   assert.match(FEED, /ensureHostLoad\(list\);\s*\n\s*list\.scrollTop = prevScroll;/);
-  // the standing can't-trap backstop: a stale tunnels row must never pin a loader forever; the
-  // RETIRE path is the payload event (pendingHosts recomputed per merge), never this timer
-  assert.match(FEED, /window\.setTimeout\(\(\) => \{ hostloadGaveUp\.add\(h\); render\(\); \}, 45000\)/);
-  assert.match(FEED, /if \(!pendingHosts\.includes\(h\)\) \{   \/\/ the payload landed \(or the host detached\) — the retire EVENT/);
-  // the loader family: the shared pulsing accent dots, reduced motion honored
-  assert.match(CSS, /\.hostload-dots i \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);\s*\n\s*animation: undo-dot 1s ease-in-out infinite; \}/);
-  assert.match(CSS, /\.hostload-dots i \{ animation: none; opacity: 0\.8; \} \}/);
+  // round two (the user 2026-08-25): the first cut's 45s backstop RETIRED the hint while the host
+  // genuinely still pended — the signal knew, the backstop overrode it. Now 45s = COPY ESCALATION,
+  // never removal; the pending list itself (payload/detach recompute) is the only way off the board.
+  assert.match(FEED, /window\.setTimeout\(\(\) => \{ hostloadLong\.add\(h\); render\(\); \}, 45000\)/);
+  assert.match(FEED, /if \(!pendingHosts\.length\) \{ strip\?\.remove\(\); return; \}   \/\/ the real events emptied the list — the only way off/);
+  assert.match(FEED, /if \(!pendingHosts\.includes\(h\)\) \{   \/\/ the payload landed \(or the host detached\) — the ONLY removals/);
+  assert.doesNotMatch(FEED, /hostloadGaveUp/, "no hide-set survives — nothing ever hides a true wait");
+  // the three honest copies: loading → still waiting (45s) → a dead link names itself (fail-loudly)
+  assert.match(FEED, /"loading cards from " \+ h \+ "\\u2026"/);
+  assert.match(FEED, /"still waiting on " \+ h \+ "\\u2026"/);
+  assert.match(FEED, /"can\\u2019t reach " \+ h \+ " \\u2014 its cards return when it reconnects"/);
+  // the swirl (the user's pick over the dots): the SHARED reverse-spin glyph, LEFT of the text
+  assert.match(FEED, /const swirl = el\("span", "fask-awaiting-swirl"\);/);
+  assert.match(FEED, /line\.append\(swirl, txt\);/);
   assert.match(CSS, /\.hostload-line \{ display: flex; align-items: center; gap: 7px; color: var\(--dim\); font-size: 0\.82em; \}/,
     "quiet, dim, existing scale — a hint, never a takeover");
+  assert.doesNotMatch(CSS, /hostload-dots/, "the dots retired with the swirl swap");
+});
+
+test("the merge names DEAD pending links from socket truth; the feed says that instead of waiting", () => {
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  assert.match(FED, /merged\.pendingDead = merged\.pendingHosts\.filter\(\(h: string\) => deadHosts\.includes\(h\)\);/);
+  assert.match(FED, /return !c \|\| !c\.ws \|\| c\.ws\.readyState === 3;   \/\/ no socket \/ closed = a dead link right now/);
+  const m = mergeHostFeeds({ "": local }, ["", "TESTHOST"], [], ["TESTHOST"]);
+  assert.deepEqual(m.pendingDead, ["TESTHOST"], "pending + dead socket = named");
+  const alive = mergeHostFeeds({ "": local }, ["", "TESTHOST"], [], []);
+  assert.deepEqual(alive.pendingDead, [], "pending on a live socket stays a plain wait");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -903,18 +903,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-undoclear .undo-dots i:nth-child(2) { animation-delay: 0.18s; }
 #feed-undoclear .undo-dots i:nth-child(3) { animation-delay: 0.36s; }
 @keyframes undo-dot { 0%, 100% { opacity: 0.25; } 40% { opacity: 1; } }
-@media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; }
-  .hostload-dots i { animation: none; opacity: 0.8; } }
-/* The per-host loading strip (the user 2026-08-25): an attached host's sessions are on the tabs but
-   its cards haven't merged yet — one quiet line per pending host, the loader family's pulsing accent
-   dots (the undo-dot keyframes, shared), dim text at the footer's own scale. Never a takeover. */
+@media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; } }
+/* The per-host loading strip (the user 2026-08-25; round two same day): an attached host's sessions
+   are on the tabs but its cards haven't merged yet — one quiet line per pending host, the SHARED
+   reverse-spin swirl glyph (.fask-awaiting-swirl, the user's pick over the dots) LEFT of the text,
+   dim at the footer's own scale. Never a takeover, and never hidden while the wait is real: the 45s
+   mark escalates the copy, a dead link names itself, and only the payload/detach events remove. */
 #feed-hostload { display: flex; flex-direction: column; gap: 4px; padding: 8px 14px; }
 .hostload-line { display: flex; align-items: center; gap: 7px; color: var(--dim); font-size: 0.82em; }
-.hostload-dots { display: inline-flex; gap: 3px; }
-.hostload-dots i { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
-  animation: undo-dot 1s ease-in-out infinite; }
-.hostload-dots i:nth-child(2) { animation-delay: 0.18s; }
-.hostload-dots i:nth-child(3) { animation-delay: 0.36s; }
 /* the footer MODE button (the session combobox's "Sessions ▴"): active (.on) wears the accent language
    (blue text + border + faint wash), the same selected-state look the card section toggles use (the
    user 2026-07-07) */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -470,23 +470,27 @@ let sessionOrder: string[] = [];
 let sessionsMeta: { sid: string; name: string; color: { bg: string; fg: string } | null }[] = [];
 // Attached hosts whose CARD payload hasn't merged yet (the user 2026-08-25: sessions land via the
 // faster channels, cards trail with no cue) — the federation merge names them (pendingHosts), the
-// board hints per host, and the hint retires on the exact event of that host's first contribution
-// (an empty one included). The backstop set holds hosts whose hint gave up after the standing
-// can't-trap window — a stale tunnels row must never pin a loader forever.
+// board hints per host, and the hint retires ONLY on the real events: that host's first contribution
+// (an empty one included) or its detach. The 45s mark ESCALATES the copy ("still waiting…"), never
+// hides — the first cut's backstop RETIRED the hint while the host genuinely still pended (the user
+// 2026-08-25, round two: the dots vanished, the cards still hadn't come; the signal knew, the
+// backstop overrode it — a backstop must never make the board lie about a true wait). A DEAD link
+// (pendingDead, from the merge's socket truth) names itself instead of waiting open-endedly.
 let pendingHosts: string[] = [];
-const hostloadBackstops = new Map<string, number>();
-const hostloadGaveUp = new Set<string>();
+let pendingDead: string[] = [];
+const hostloadTimers = new Map<string, number>();
+const hostloadLong = new Set<string>();
 function syncHostloadBackstops(): void {
   for (const h of pendingHosts) {
-    if (!hostloadBackstops.has(h)) {
-      hostloadBackstops.set(h, window.setTimeout(() => { hostloadGaveUp.add(h); render(); }, 45000));
+    if (!hostloadTimers.has(h)) {
+      hostloadTimers.set(h, window.setTimeout(() => { hostloadLong.add(h); render(); }, 45000));
     }
   }
-  for (const [h, t] of Array.from(hostloadBackstops)) {
-    if (!pendingHosts.includes(h)) {   // the payload landed (or the host detached) — the retire EVENT
+  for (const [h, t] of Array.from(hostloadTimers)) {
+    if (!pendingHosts.includes(h)) {   // the payload landed (or the host detached) — the ONLY removals
       window.clearTimeout(t);
-      hostloadBackstops.delete(h);
-      hostloadGaveUp.delete(h);
+      hostloadTimers.delete(h);
+      hostloadLong.delete(h);
     }
   }
 }
@@ -4095,20 +4099,22 @@ function viewFiltered(list: AskItem[]): AskItem[] {
 // non-interactive, so a per-render rebuild is click-safe by construction.
 function ensureHostLoad(list: HTMLElement): void {
   let strip = document.getElementById("feed-hostload");
-  const show = pendingHosts.filter((h) => !hostloadGaveUp.has(h));
-  if (!show.length) { strip?.remove(); return; }
+  if (!pendingHosts.length) { strip?.remove(); return; }   // the real events emptied the list — the only way off
   if (!strip) {
     strip = el("div", "");
     strip.id = "feed-hostload";
   }
   list.appendChild(strip);   // last child in either board state (cards or the empty wordmark)
-  strip.replaceChildren(...show.map((h) => {
+  strip.replaceChildren(...pendingHosts.map((h) => {
     const line = el("div", "hostload-line");
+    const swirl = el("span", "fask-awaiting-swirl");   // the shared reverse-spin glyph, LEFT of the text
     const txt = el("span", "");
-    txt.textContent = "loading cards from " + h + "\u2026";
-    const dots = el("span", "hostload-dots");
-    dots.append(el("i", ""), el("i", ""), el("i", ""));
-    line.append(txt, dots);
+    txt.textContent = pendingDead.includes(h)
+      ? "can\u2019t reach " + h + " \u2014 its cards return when it reconnects"
+      : hostloadLong.has(h)
+        ? "still waiting on " + h + "\u2026"
+        : "loading cards from " + h + "\u2026";
+    line.append(swirl, txt);
     return line;
   }));
 }
@@ -4757,6 +4763,7 @@ function applyFeedPayload(m: any): void {
   bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
   if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
   pendingHosts = Array.isArray(m.pendingHosts) ? m.pendingHosts.filter((h: any) => typeof h === "string") : [];
+  pendingDead = Array.isArray(m.pendingDead) ? m.pendingDead.filter((h: any) => typeof h === "string") : [];
   syncHostloadBackstops();
   if (Array.isArray(m.sessions)) {
     sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");

--- a/ui/webview/loading-cues.test.ts
+++ b/ui/webview/loading-cues.test.ts
@@ -52,6 +52,6 @@ test("undo clear: accent dots + accent border, reduced-motion safe (feed.css —
   assert.match(FEED_CSS, /#feed-undoclear\.undo-busy \{ border-color: var\(--accent\); \}/);
   assert.match(FEED_CSS, /#feed-undoclear \.undo-dots i \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);/);
   assert.match(FEED_CSS, /@keyframes undo-dot \{ 0%, 100% \{ opacity: 0\.25; \} 40% \{ opacity: 1; \} \}/);
-  assert.match(FEED_CSS, /prefers-reduced-motion: reduce\) \{ #feed-undoclear \.undo-dots i \{ animation: none; opacity: 0\.8; \}\s*\n\s*\.hostload-dots i \{ animation: none; opacity: 0\.8; \} \}/,
-    "one media block covers both dot surfaces (the host-load strip joined 2026-08-25)");
+  assert.match(FEED_CSS, /prefers-reduced-motion: reduce\) \{ #feed-undoclear \.undo-dots i \{ animation: none; opacity: 0\.8; \} \}/,
+    "the host-load strip wears the shared swirl now (its own reduced-motion rule) — the undo dots stand alone again");
 });

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -23,7 +23,7 @@ test("the arrangement is re-read per emit, never cached", () => {
   // surfaces arranged one way and this one's another until a reload
   assert.match(FED, /private view\(\): string\[\] \{\s*\n\s*return readViewOrder\(\);\s*\n\s*\}/);
   assert.match(FED, /mergeHostOrder\(this\.perHostOrder, this\.hostSeq, this\.view\(\)\)/);
-  assert.match(FED, /mergeHostFeeds\(this\.perHostFeed, this\.hostSeq, this\.view\(\)\)/);
+  assert.match(FED, /mergeHostFeeds\(this\.perHostFeed, this\.hostSeq, this\.view\(\), dead\)/);
   assert.match(FED, /mergeHostTimelines\(this\.perHostTl, this\.hostSeq, this\.view\(\)\)/);
 });
 


### PR DESCRIPTION
Round two on the per-host loading hint: the user watched the dots run a while, vanish, and the cards still hadn't loaded. The first cut's 45s backstop was **retiring the hint while the host genuinely still pended** — the `pendingHosts` signal knew, the backstop overrode it. A backstop must never make the board lie about a true wait.

**The honest lifecycle:** the hint is removed only by the real events — the host's payload arriving, or its detach (the `pendingHosts` recompute). The 45s mark now **escalates the copy** instead: `still waiting on <host>…`. And a genuinely dead link **names itself**: the merge carries `pendingDead` from socket truth (no socket, or readyState closed), so the line reads `can't reach <host> — its cards return when it reconnects` rather than waiting open-endedly (fail-loudly). No hide-set survives in the code — pinned.

**The visual pick:** the pulsing dots give way to the shared reverse-spin swirl glyph (`.fask-awaiting-swirl`, the awaiting cue's production-shipping class — one loader treatment), sitting **left** of the text.

**Tests:** the escalate-never-hide lifecycle (45s = copy shift; the list recompute is the only removal; `hostloadGaveUp` gone), the three honest copies, the dead-link signal executed on synthetics (pending + dead socket = named; pending on a live socket stays a plain wait), the swirl slot, and the retired dots. 2394 extension tests green on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
