### PR TITLE
T69 PR-B: the chat strip and outline mount the shared tag lens; scope legibility

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1604,7 +1604,7 @@ def _member_str(m):
     return (h + ":" + m["sid"]) if h else m["sid"]
 
 
-_LENS_SURFACES = ("chat", "timeline")   # per-surface selections (the user 2026-08-25); the feed's is client-local
+_LENS_SURFACES = ("chat", "timeline", "outline")   # per-surface selections (the user 2026-08-25); the feed's is client-local
 
 
 def _norm_lens(x, tags):
@@ -19619,6 +19619,7 @@ def build_feed(now, tmux=None):
     for _a in asks:
         _a["notify"] = True if _notify_card_effective(_ncards, _a["itemId"], str(_a.get("sid") or "")) else None
     return {"type": "feed", "asks": asks, "now": now,
+            "views": _views_client(),   # the rendered views blob — the outline + feed tag mounts read it (2026-08-25)
             # usage-limit-down latch (judge-limit.json): analysis is paused because the account
             # cannot bill judge calls — the dashboard must SAY so, never fail quietly into retries
             # (the user 2026-08-18); self-expires at the window reset, cleared by the next success
@@ -28774,6 +28775,11 @@ class Handler(BaseHTTPRequestHandler):
             # dashboards, like colormap). Validation/normalization happens in the setter.
             _set_timeline_views(msg["views"])
             _mark_views_dirty()
+        elif msg and msg.get("type") == "openTagsDialog":
+            # any pane's "Configure tags…" opens THE tags dialog — which lives on the timeline pane
+            # (one dialog, one implementation; the user 2026-08-25). Routed to the SAME dashboard's
+            # timeline like tagEditFailed; an empty wid falls back to the broadcast.
+            _send_to_view("timeline", {"type": "openViewsDialog"}, (client or {}).get("wid") or "")
         elif msg and msg.get("type") == "editTag" and isinstance(msg.get("edit"), dict):
             # tag federation v1 (the user 2026-08-24): a REMOTE tag edited in the dialog/menu routes
             # to its HOME kernel through the same channel `romp tag --host` uses — the tag's host

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -85,7 +85,7 @@ class TagRoute(unittest.TestCase):
         st, v = self._views()
         self.assertEqual(st, 200)
         self.assertEqual(v, {"active": "all", "tags": [],
-                             "actives": {"chat": {"all": True}, "timeline": {"all": True}}})   # per-surface lenses (2026-08-25)
+                             "actives": {"chat": {"all": True}, "timeline": {"all": True}, "outline": {"all": True}}})   # per-surface lenses (2026-08-25)
 
     def test_create_resolves_a_live_name_and_mints_the_ui_id_shape(self):
         st, r = self._post({"name": "pool", "add": ["web"]})

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -45,7 +45,7 @@ class TimelineViews(unittest.TestCase):
         # legacy blob persisted when "all" meant untagged lands on the new default automatically
         v = km._timeline_views()
         self.assertEqual(v, {"active": "all", "tags": [],
-                         "actives": {"chat": {"all": True}, "timeline": {"all": True}}})   # per-surface lenses seed from the scalar (2026-08-25)
+                         "actives": {"chat": {"all": True}, "timeline": {"all": True}, "outline": {"all": True}}})   # per-surface lenses seed from the scalar (2026-08-25)
         self.assertTrue(km._view_visible(v, "anything"))
 
     def test_all_shows_every_session_and_untagged_the_tagless_ones(self):
@@ -89,7 +89,7 @@ class TimelineViews(unittest.TestCase):
                                               {"noid": True}, "junk"]})
         self.assertEqual(km._norm_timeline_views({"hidden": 7, "tags": "nope"}),
                          {"active": "all", "tags": [],
-                          "actives": {"chat": {"all": True}, "timeline": {"all": True}}},
+                          "actives": {"chat": {"all": True}, "timeline": {"all": True}, "outline": {"all": True}}},
                          "wrong-TYPED fields drop instead of raising")
         self.assertEqual(km._norm_timeline_views({"tags": [{"id": "g", "members": 3}]})["tags"][0]["members"],
                          [], "a wrong-typed members list drops, never raises")
@@ -343,11 +343,13 @@ class TimelineViews(unittest.TestCase):
         # lossless legacy (the user 2026-08-25): a blob without `actives` reads as if each surface
         # had selected the old shared view — untagged seeds the none bucket, a tag id its NAME
         v = km._norm_timeline_views({"active": "untagged"})
-        self.assertEqual(v["actives"], {"chat": {"none": True}, "timeline": {"none": True}})
+        self.assertEqual(v["actives"], {"chat": {"none": True}, "timeline": {"none": True},
+                                        "outline": {"none": True}})
         v = km._norm_timeline_views({"active": "g1",
                                      "tags": [{"id": "g1", "name": "workers", "members": []}]})
         self.assertEqual(v["actives"], {"chat": {"tags": ["workers"]},
-                                        "timeline": {"tags": ["workers"]}})
+                                        "timeline": {"tags": ["workers"]},
+                                        "outline": {"tags": ["workers"]}})
         # once a blob CARRIES actives, they win — and a surface absent from it reads All, never
         # a re-seed (the scalar may lag the lenses; seeding again would resurrect a stale pick)
         v = km._norm_timeline_views({"active": "untagged",

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3030,6 +3030,46 @@ class TimelinePanel {
           d.addEventListener('click', () => { this._editTagUnion(tg, { color: c }); build(); });
         }
       }
+      // SCOPE SECTION (the user 2026-08-25): which selection each surface holds, side by side,
+      // with a set-for-all — one gesture applies one surface's selection to every surface. The
+      // feed's selection is pane-local (its own sessionStorage): the dialog can't read it, so its
+      // column says so honestly, and set-for-all reaches it through a localStorage echo the feed
+      // pane adopts (romp:feedTags-set — the menu-echo idiom; noted in the feed pairing).
+      {
+        const scope = card.createDiv();
+        scope.setAttribute('style', 'display:flex;align-items:center;gap:14px;margin:0 0 8px;flex-wrap:wrap;');
+        const vNow = this._curViews();
+        const cell = (label, lens, applyAll) => {
+          const c = scope.createDiv();
+          c.setAttribute('style', 'display:flex;align-items:center;gap:6px;');
+          const l = c.createSpan({ text: label });
+          l.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;');
+          const val = c.createSpan({ text: lens === null ? 'set on the feed' : lensLabel(lens) });
+          val.setAttribute('style', lens === null ? 'font-size:0.82em;opacity:0.5;' : '');
+          if (applyAll) {
+            const btn = c.createSpan({ text: '→ all' });
+            btn.setAttribute('style', 'cursor:pointer;padding:1px 6px;border-radius:5px;'
+              + 'border:1px solid rgba(255,255,255,0.25);font-size:0.82em;opacity:0.85;');
+            btn.setAttribute('title', 'apply this selection to every surface (tabs, timeline, outline, feed)');
+            btn.addEventListener('mouseenter', () => { btn.style.background = 'rgba(255,255,255,0.09)'; });
+            btn.addEventListener('mouseleave', () => { btn.style.background = 'transparent'; });
+            btn.addEventListener('click', () => applyAll());
+          }
+          return c;
+        };
+        const setAll = (lens) => {
+          const nv = JSON.parse(JSON.stringify(this._curViews()));
+          nv.actives = Object.assign({}, nv.actives, { chat: lens, timeline: lens, outline: lens });
+          this._setViews(nv);
+          try { localStorage.setItem('romp:feedTags-set', JSON.stringify({ lens, t: Date.now() })); } catch (e) {}
+          if (this._viewsDialogBuild) this._viewsDialogBuild();
+        };
+        const acts = vNow.actives || {};
+        cell('tabs:', acts.chat || { all: true }, () => setAll(acts.chat || { all: true }));
+        cell('timeline:', acts.timeline || { all: true }, () => setAll(acts.timeline || { all: true }));
+        cell('outline:', acts.outline || { all: true }, () => setAll(acts.outline || { all: true }));
+        cell('feed:', null, null);
+      }
       // search + the bulk controls, one row: the search names the SET, the controls act on it
       const bar = card.createDiv();
       bar.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 8px;');

--- a/ui/webview/feed-unscoped.test.ts
+++ b/ui/webview/feed-unscoped.test.ts
@@ -33,8 +33,10 @@ test("the coupling's artifacts are fully retired: cue, N-outside line, promoted 
   assert.doesNotMatch(CSS, /fask-viewbreak|feed-viewmore/);
 });
 
-test("the kernel's views blob still serves the tabs/timeline; the feed payload no longer carries a copy", () => {
+test("the kernel's views blob serves the tabs/timeline; the feed payload carries it again for the tag mounts", () => {
   assert.ok(KERNEL.includes('"views": _views_client()}'), "tabOrder pushes keep the blob (tabs + timeline consume it)");
   const fp = KERNEL.slice(KERNEL.indexOf('return {"type": "feed", "asks": asks'), KERNEL.indexOf('"clearNotices"'));
-  assert.ok(!fp.includes('"views"'), "the feed payload's copy retired with the gating that read it");
+  // retired 2026-08-25 morning as unread; REVIVED the same day for the per-surface tag lenses —
+  // the outline pane and the feed's own tag filter read the rendered blob off this payload
+  assert.ok(fp.includes('"views": _views_client()'), "the tag mounts' read");
 });

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -5,6 +5,9 @@
 // bottom "Show completed" checkbox (default off). The recency colour helpers are copied verbatim from render.ts
 // so the colours are IDENTICAL to the ledger box.
 import { delegate } from "./actions";
+import { SessionViews, viewTagUnion } from "./session-views";
+import { lensVisible, surfaceLens } from "./tag-lens";
+import { openTagMenu, tagMenuButton } from "./tag-menu";
 import { fleetVisibleRoots } from "./fleet-roots";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostPrefix } from "./host-prefix";
@@ -34,6 +37,7 @@ let sessions: FleetSession[] = [];
 let loaded = false;
 let emptyShown = false;   // the romp wordmark is currently showing → don't replay its fade-in every push
 let searchQuery = "";     // #fleet-search filter (the user 2026-06-29): show only sessions whose NAME matches
+let fleetViews: SessionViews | null = null;   // the rendered views blob off the feed payload — the outline lens reads it (2026-08-25)
 // Provisional cards (the user 2026-06-29): a session working a brand-new prompt the planner hasn't classified
 // into a goal yet has NO ledger node, so it's invisible in the fleet — exactly the "things about to appear" the
 // user wants to track. They ride the SAME feed payload (feed.asks, provisional:true), so surface a dotted
@@ -411,8 +415,11 @@ function render() {
   const sq = searchQuery.trim().toLowerCase();           // search (the user 2026-06-29): session NAME or goal CONTENT
   curSearch = sq;                                        // snapshot for renderFleetNode (highlight + force-expand)
   const only = onlyTag();                                // demo/recording view filter (`#only=<tag>`, the user 2026-07-14)
+  const outlineLens = surfaceLens(fleetViews, "outline");
+  const outlineUnions = viewTagUnion(fleetViews);
   for (const s of sessions) {
     if (only && !matchesOnly(s.name, only)) continue;    // hidden from this view; the real session keeps running
+    if (!lensVisible(outlineLens, outlineUnions, s.sid)) continue;   // the OUTLINE's own lens (per-surface selections, 2026-08-25)
     const tree = s.ledger?.tree || [];
     // "Show completed" surfaces the FULLY-COMPLETED tops the compaction sweep archived out of the live tree
     // (the user 2026-06-27) — otherwise a finished+archived session has an empty live tree and vanishes, and
@@ -628,6 +635,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   // that some feed message arrived. A feed push can reach us before the (cold) ledger build finishes; treating
   // that as loaded would drop the loader onto an empty pane (the user 2026-06-29). Until ledgers land, keep the
   // loader up (render() bails, leaving the list empty so _pane_spin holds).
+  if (m.views && typeof m.views === "object") fleetViews = m.views as SessionViews;   // rides the feed payload (2026-08-25)
   if (!Array.isArray(m.ledgers)) return;
   loaded = true;
   sessions = m.ledgers as FleetSession[];
@@ -818,6 +826,26 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
   const search = document.getElementById("fleet-search") as HTMLInputElement | null;
   const clear = document.getElementById("fleet-search-clear") as HTMLButtonElement | null;
   if (!search) return;
+  // the shared TAG-ICON filter, right of the search box (the user 2026-08-25) — governs the OUTLINE
+  const barEl = document.getElementById("fleet-search-bar");
+  if (barEl) {
+    const tagBtn = tagMenuButton("filter this outline by tag", (btn) => {
+      openTagMenu(btn, {
+        lens: () => surfaceLens(fleetViews, "outline"),
+        unions: () => viewTagUnion(fleetViews),
+        onApply: (l) => {
+          const v = JSON.parse(JSON.stringify(fleetViews || { active: "all", tags: [] }));
+          v.actives = Object.assign({}, v.actives, { outline: l });
+          fleetViews = v;                                        // optimistic: the next feed push echoes it
+          vscodeApi?.postMessage({ type: "setTimelineViews", views: v });
+          render();
+        },
+        scopeCaption: "filters this outline",
+        onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
+      });
+    });
+    barEl.appendChild(tagBtn);
+  }
   const syncClear = () => { if (clear) clear.hidden = search.value === ""; };
   search.addEventListener("input", () => { searchQuery = search.value; syncClear(); render(); });
   clear?.addEventListener("click", () => { search.value = ""; searchQuery = ""; syncClear(); search.focus(); render(); });

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -18,7 +18,7 @@ test("peek OPEN: every activation routes the peek decision — setActive derives
   // nav-history's apply all land here), before its already-active early-return
   assert.match(RENDER, /function setActive\(id: string[\s\S]{0,500}?assertPeekFor\(id\);[\s\S]{0,400}?if \(activeId === id && anchor == null && anchorT == null\) return;/);
   // the derivation: in-view → no peek; out-of-view → THIS session is the peek
-  assert.match(RENDER, /const next = viewVisible\(effViews\(\), id\) \? null : id;\s*\n\s*if \(next !== peekId\) \{ peekId = next; renderTabs\(\); \}/);
+  assert.match(RENDER, /const next = chatVisible\(id\) \? null : id;\s*\n\s*if \(next !== peekId\) \{ peekId = next; renderTabs\(\); \}/);
 });
 
 test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no explicit close affordance", () => {
@@ -55,7 +55,7 @@ test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands
 });
 
 test("the first-tab fallback never fires on an active peek: tabInView counts the peek as visible", () => {
-  assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| viewVisible\(effViews\(\), id\); \}/);
+  assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| chatVisible\(id\); \}/);
   // the #only=-era bounce reads visibleIds, which is built from tabInView — an active peek is in it
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -14,6 +14,8 @@ import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
+import { lensVisible, surfaceLens } from "./tag-lens";
+import { openTagMenu, tagMenuButton } from "./tag-menu";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
@@ -512,11 +514,17 @@ function postViews(v: SessionViews) {
 // like every activation, which re-derives peek-vs-normal from the CURRENT views (a since-revealed
 // session re-pops as a normal tab, a since-hidden one as a peek).
 let peekId: string | null = null;
+// the CHAT surface keys on its own lens (per-surface selections, the user 2026-08-25) — the scalar
+// viewVisible stays for legacy callers; tabs and peeks decide through actives.chat
+function chatVisible(id: string): boolean {
+  const v = effViews();
+  return lensVisible(surfaceLens(v, "chat"), viewTagUnion(v), id);
+}
 function assertPeekFor(id: string): void {
-  const next = viewVisible(effViews(), id) ? null : id;
+  const next = chatVisible(id) ? null : id;
   if (next !== peekId) { peekId = next; renderTabs(); }
 }
-function tabInView(id: string): boolean { return id === peekId || viewVisible(effViews(), id); }
+function tabInView(id: string): boolean { return id === peekId || chatVisible(id); }
 function visibleOrder(): string[] { return order.filter(tabInView); }
 function revealSession(id: string) { postViews(revealIn(effViews(), id)); }
 
@@ -4500,6 +4508,23 @@ function renderTabs() {
   add.title = titleWithKey("Open a session", "session.new");
   add.addEventListener("click", () => openPicker());
   bar.appendChild(add);
+  // the shared TAG-ICON filter (the user 2026-08-25): identical across surfaces, opening the one
+  // multi-select lens menu — this instance governs the TAB STRIP (actives.chat)
+  const tagBtn = tagMenuButton("filter these tabs by tag", (btn) => {
+    openTagMenu(btn, {
+      lens: () => surfaceLens(effViews(), "chat"),
+      unions: () => viewTagUnion(effViews()),
+      onApply: (l) => {
+        const v = JSON.parse(JSON.stringify(effViews() || { active: "all", tags: [] }));
+        v.actives = Object.assign({}, v.actives, { chat: l });
+        postViews(v);
+      },
+      scopeCaption: "filters these tabs",
+      onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
+    });
+  });
+  tagBtn.classList.add("tab-tagfilter");
+  bar.appendChild(tagBtn);
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
   if (refocusTab) focusActiveTab();
   syncNoSessionsPlaceholder(visibleIds.length, ids.length);

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -32,19 +32,23 @@ test("executed: All shows literally everything (hidden retired 2026-08-24); unta
   assert.equal(viewVisible({ active: "g1", groups: [G] }, "s2"), true);
 });
 
-test("executed: reveal SWITCHES views, never mutates membership (hideIn retired 2026-08-24)", () => {
-  // the hide gesture is GONE with the hidden set (the user 2026-08-24: the tag system covers
-  // backgrounding; the kernel migrated existing entries into "archived"). revealIn survives for the
-  // picker's jump: minimal move, membership untouched (2026-08-23 — a peek never strips a tag).
+test("executed: reveal ADDS to the chat lens, never mutates membership (per-surface, 2026-08-25)", () => {
+  // the reveal keys on the CHAT surface's lens now: the minimal move is ADDITIVE — the holder tag
+  // (or the none bucket) JOINS the selection, and what the user was looking at stays visible.
+  // Membership is still never touched (2026-08-23 — a peek never strips a tag), and the legacy
+  // scalar `active` is left alone entirely (old clients own it).
   const rev = revealIn({ active: "g1", tags: [G] }, "s1");
-  assert.equal(rev.active, "all", "tagless session from a tag view → land on All, the default");
+  assert.deepEqual(rev.actives!.chat, { none: true, tags: ["pool"] },
+    "tagless from a tag view: the none bucket JOINS — the pool selection stays visible");
+  assert.equal(rev.active, "g1", "the legacy scalar is never rewritten");
   const rev2 = revealIn({ active: "untagged", tags: [G] }, "s2");
-  assert.equal(rev2.active, "g1", "tagged → its holder tag is its home view");
+  assert.deepEqual(rev2.actives!.chat, { none: true, tags: ["pool"] },
+    "tagged: its holder tag joins the selection; the untagged pick stays");
   assert.deepEqual(rev2.tags![0].members, ["s2"], "membership untouched — the jump never strips a tag");
   const revAll = revealIn({ active: "all", tags: [G] }, "s2");
-  assert.equal(revAll.active, "all", "everything is visible under All → nothing changes at all");
+  assert.equal(revAll.actives?.chat, undefined, "everything visible under All: nothing changes at all");
   const rev4 = revealIn({ active: "g1", tags: [G] }, "s2");
-  assert.equal(rev4.active, "g1", "already visible in the active tag → nothing changes");
+  assert.equal(rev4.actives?.chat, undefined, "already visible in the active tag: nothing changes");
 });
 
 test("executed: the canonical key ignores list order AND which key the kernel used", () => {

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -88,9 +88,26 @@ export function viewsKey(v: SessionViews | null | undefined): string {
 // anything else is already visible under All, so switch there only when actually invisible.
 export function revealIn(views: SessionViews | null | undefined, id: string): SessionViews {
   const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
-  if (viewVisible(v, id)) return v;
-  const holder = viewTags(v).find((t) => (t.members || []).includes(id));
-  if (holder) { v.active = holder.id; return v; }
-  v.active = "all";
+  // the reveal keys on the CHAT surface's lens (per-surface selections, the user 2026-08-25): the
+  // MINIMAL move is ADDING the session's first holder tag to the selection — additive, never a
+  // switch that hides what the user was looking at; a session in no tag home adds the none bucket.
+  const unions = viewTagUnion(v);
+  const lens = (v.actives || {})["chat"] || (v.active === "untagged" ? { none: true }
+    : v.active && v.active !== "all" ? (() => { const g = unions.find((x) => x.ids.includes(v.active!)); return g ? { tags: [g.name] } : { all: true }; })()
+    : { all: true });
+  const visible = !lens || lens.all ? true
+    : (lens.none && !unions.some((u) => u.members.includes(id)))
+      || unions.some((u) => (lens.tags || []).includes(u.name) && u.members.includes(id));
+  if (visible) return v;
+  const holder = unions.find((u) => u.members.includes(id));
+  const next: { none?: boolean; tags?: string[] } = {};
+  if (holder) {
+    if (lens.none) next.none = true;
+    next.tags = [...(lens.tags || []), holder.name];
+  } else {
+    next.none = true;
+    if (lens.tags && lens.tags.length) next.tags = lens.tags;
+  }
+  v.actives = Object.assign({}, v.actives, { chat: next });
   return v;
 }

--- a/ui/webview/tag-lens.ts
+++ b/ui/webview/tag-lens.ts
@@ -62,3 +62,17 @@ export function lensKey(l: TagLens | null | undefined): string {
 export function lensUnions(views: SessionViews | null | undefined): TagUnion[] {
   return viewTagUnion(views);
 }
+
+/** One surface's lens off the views blob. A pre-lens blob (an older kernel, a client-held legacy
+ *  shape) derives its lens from the legacy scalar EXACTLY as the kernel normalizer seeds it —
+ *  behavior migrates, not just shape (an untagged view keeps excluding rather than falling open). */
+export function surfaceLens(views: SessionViews | null | undefined, surface: string): TagLens {
+  const l = views?.actives?.[surface];
+  if (l) return l;
+  const a = views?.active;
+  if (!a || a === "all") return { all: true };
+  if (a === "untagged") return { none: true };
+  const g = viewTagUnion(views).find((x) => x.ids.includes(a));
+  return g ? { tags: [g.name] } : { all: true };
+}
+

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -1,0 +1,139 @@
+// The SHARED tag-lens menu (the user 2026-08-25): one component every webview surface mounts —
+// the outline pane, the chat tab strip, the feed's local filter. (The timeline inlines the same
+// behavior in MENU_STYLE: it may live in Obsidian's document and loads no modules.) The menu is
+// multi-select toggles on ONE surface's lens: All a plain exclusive pick, (no tags) and every
+// name-keyed union tag toggling with the ✓ per selected row, the menu staying open across toggles
+// (a settings panel, not a command). A CAPTIONED DIVIDER says which surface the selection governs
+// ("filters these tabs") — the shared idiom, sub-line scale. One management entry, "Configure
+// tags…", when the surface offers a route to the dialog.
+//
+// CROSS-PANE DISMISSAL is built in (the user's bug): sibling panes' pointer events never reach
+// this document, so every pane WRITES a pointerdown echo (romp:menu-echo — the color-echo idiom)
+// and every open menu LISTENS via the storage event, which fires only in OTHER same-origin panes:
+// exactly the gap the local document closers can't cover. Mounting surfaces inherit the fix free.
+//
+// SUBMENU-LESS by design today; the caret/side rule for menus that DO expand lives with the
+// model-version submenus: carets always face right (▸), expansion prefers the right side and
+// falls left only when the right edge would clip (measured, never assumed).
+import { TagUnion } from "./session-views";
+import { TagLens, lensAll, toggleLens } from "./tag-lens";
+
+export interface TagMenuOpts {
+  lens: () => TagLens;                       // the surface's current selection (re-read per repaint)
+  unions: () => TagUnion[];                  // the name-keyed union rows (re-read per repaint)
+  onApply: (l: TagLens, done: boolean) => void;  // done=true → the pick closes the menu (All)
+  scopeCaption: string;                      // "filters these tabs" — which surface this governs
+  onConfigure?: () => void;                  // the one management entry, when the surface has a route
+}
+
+let echoInstalled = false;
+/** Every pane writes the pointerdown echo ONCE per document — sibling panes' open menus close on it. */
+export function installMenuEcho(): void {
+  if (echoInstalled) return;
+  echoInstalled = true;
+  document.addEventListener("pointerdown", () => {
+    try { localStorage.setItem("romp:menu-echo", JSON.stringify({ t: Date.now() })); } catch { /* storage blocked */ }
+  }, true);
+}
+
+let openMenu: HTMLElement | null = null;
+export function closeTagMenu(): void {
+  openMenu?.remove();
+  openMenu = null;
+}
+document.addEventListener("click", () => closeTagMenu());
+document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeTagMenu(); });
+try {
+  window.addEventListener("storage", (e) => { if (e.key === "romp:menu-echo" && e.newValue) closeTagMenu(); });
+} catch { /* no storage events (foreign host) — local closers still apply */ }
+
+/** Open (or toggle shut) the lens menu anchored under `anchor`. The ctx-family skin — the chat
+ *  pane's .ctx-menu is the reference spec (CLAUDE.md menu vocabulary). */
+export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
+  installMenuEcho();
+  const reopen = !!openMenu && openMenu.dataset.tagMenu === "1";
+  closeTagMenu();
+  if (reopen) return;
+  const menu = document.createElement("div");
+  menu.dataset.tagMenu = "1";
+  menu.setAttribute("style",
+    "position:fixed;z-index:1001;min-width:180px;padding:4px;background:#252526;" +
+    "border:1px solid rgba(255,255,255,0.12);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.35);" +
+    "font-size:12px;line-height:1.4;color:#cccccc;user-select:none;");
+  menu.addEventListener("click", (e) => e.stopPropagation());
+  const build = () => {
+    menu.textContent = "";
+    const lens = opts.lens();
+    const cap = document.createElement("div");
+    cap.setAttribute("style", "display:flex;align-items:center;gap:6px;margin:4px 6px;");
+    const capMk = (grow: boolean) => {
+      const d = document.createElement("div");
+      d.setAttribute("style", "height:1px;" + (grow ? "flex:1;" : "flex:0 0 8px;") + "background:rgba(255,255,255,0.12);");
+      return d;
+    };
+    cap.appendChild(capMk(false));
+    const capT = document.createElement("span");
+    capT.textContent = opts.scopeCaption;
+    capT.setAttribute("style", "font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;");
+    cap.appendChild(capT);
+    cap.appendChild(capMk(true));
+    menu.appendChild(cap);
+    const row = (label: string, current: boolean, dot?: string | null, dim?: boolean) => {
+      const r = document.createElement("div");
+      r.setAttribute("style", "padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;"
+        + (dim ? "opacity:0.85;" : ""));
+      if (dot) {
+        const d = document.createElement("span");
+        d.setAttribute("style", "display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:" + dot + ";");
+        r.appendChild(d);
+      }
+      r.appendChild(document.createTextNode(label));
+      if (current) {
+        const c = document.createElement("span");
+        c.textContent = "✓";
+        c.setAttribute("style", "position:absolute;right:6px;top:50%;transform:translateY(-50%);"
+          + "background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;"
+          + "font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;");
+      r.appendChild(c);
+      }
+      r.addEventListener("mouseenter", () => { r.style.background = "rgba(255,255,255,0.09)"; });
+      r.addEventListener("mouseleave", () => { r.style.background = "transparent"; });
+      menu.appendChild(r);
+      return r;
+    };
+    row("All", lensAll(lens)).addEventListener("click", () => opts.onApply({ all: true }, true));
+    row("(no tags)", !lensAll(lens) && !!lens.none)
+      .addEventListener("click", () => { opts.onApply(toggleLens(lens, "none"), false); build(); });
+    for (const u of opts.unions())
+      row(u.name, !lensAll(lens) && (lens.tags || []).includes(u.name), u.color || "#9aa0a6")
+        .addEventListener("click", () => { opts.onApply(toggleLens(lens, { tag: u.name }), false); build(); });
+    if (opts.onConfigure) {
+      const s = document.createElement("div");
+      s.setAttribute("style", "height:1px;margin:4px 6px;background:rgba(255,255,255,0.12);");
+      menu.appendChild(s);
+      row("Configure tags…", false, null, true).addEventListener("click", () => { closeTagMenu(); opts.onConfigure!(); });
+    }
+  };
+  build();
+  document.body.appendChild(menu);
+  const r = anchor.getBoundingClientRect();
+  const mw = menu.offsetWidth || 200;
+  menu.style.left = Math.max(6, Math.min(Math.round(r.left), window.innerWidth - mw - 8)) + "px";
+  const mh = menu.offsetHeight || 0;
+  menu.style.top = (r.bottom + 4 + mh > window.innerHeight - 8 ? Math.max(8, Math.round(r.top) - mh - 4) : Math.round(r.bottom + 4)) + "px";
+  openMenu = menu;
+}
+
+/** The shared monochrome tag-icon button (the user chose a tag glyph): identical across surfaces. */
+export function tagMenuButton(title: string, open: (btn: HTMLElement) => void): HTMLElement {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.title = title;
+  btn.setAttribute("style", "background:transparent;border:0;padding:2px 4px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;");
+  btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none">'
+    + '<path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>'
+    + '<circle cx="11" cy="5.5" r="1.2" fill="currentColor"/></svg>';
+  btn.addEventListener("pointerdown", (e) => { e.preventDefault(); e.stopPropagation(); open(btn); });
+  btn.addEventListener("click", (e) => e.stopPropagation());   // the click-and-hold rule: swallow the opener's own click
+  return btn;
+}

--- a/ui/webview/tag-mounts.test.ts
+++ b/ui/webview/tag-mounts.test.ts
@@ -1,0 +1,78 @@
+// Per-surface tag lenses, PR-B (the user 2026-08-25): the chat tab strip and the outline pane
+// mount the shared component; the reveal gesture keys on the chat lens additively; every pane's
+// "Configure tags…" routes to THE dialog on the timeline pane. Executed model tests + source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { surfaceLens } from "./tag-lens";
+import { revealIn } from "./session-views";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const FLEET = ui("webview", "fleet.ts");
+const MENU = ui("webview", "tag-menu.ts");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("executed: surfaceLens reads the surface's lens, seeding from the legacy scalar", () => {
+  assert.deepEqual(surfaceLens({ active: "all", tags: [] }, "chat"), { all: true });
+  assert.deepEqual(surfaceLens({ active: "untagged", tags: [] }, "chat"), { none: true });
+  assert.deepEqual(
+    surfaceLens({ active: "g1", tags: [{ id: "g1", name: "pool", members: [] }] } as any, "chat"),
+    { tags: ["pool"] });
+  assert.deepEqual(
+    surfaceLens({ active: "all", actives: { chat: { tags: ["x"] } }, tags: [] } as any, "chat"),
+    { tags: ["x"] }, "an explicit lens wins over the scalar");
+  assert.deepEqual(
+    surfaceLens({ active: "all", actives: { chat: { tags: ["x"] } }, tags: [] } as any, "outline"),
+    { all: true }, "surfaces are independent");
+});
+
+test("executed: revealIn is ADDITIVE on the chat lens — never a switch that hides the rest", () => {
+  const views: any = { active: "all",
+    actives: { chat: { tags: ["infra"] } },
+    tags: [{ id: "g1", name: "infra", members: ["s1"] },
+           { id: "g2", name: "workers", members: ["s2"] }] };
+  const out = revealIn(views, "s2");
+  assert.deepEqual(out.actives!.chat, { tags: ["infra", "workers"] },
+    "the holder tag JOINS the selection — infra stays visible");
+  const out2 = revealIn(views, "loose");
+  assert.deepEqual(out2.actives!.chat, { none: true, tags: ["infra"] },
+    "a session in no tag home adds the none bucket");
+  assert.deepEqual(revealIn(views, "s1").actives!.chat, { tags: ["infra"] },
+    "already visible → no move at all");
+});
+
+test("the chat strip and the outline both mount the shared component (source pins)", () => {
+  assert.match(RENDER, /function chatVisible\(id: string\): boolean/);
+  assert.match(RENDER, /lensVisible\(surfaceLens\(v, "chat"\), viewTagUnion\(v\), id\)/,
+    "tabs + peeks decide through actives.chat");
+  assert.match(RENDER, /tagMenuButton\("filter these tabs by tag"/);
+  assert.match(RENDER, /scopeCaption: "filters these tabs"/);
+  assert.match(RENDER, /Object\.assign\(\{\}, v\.actives, \{ chat: l \}\)/, "writes land on chat's lens only");
+  assert.match(FLEET, /tagMenuButton\("filter this outline by tag"/);
+  assert.match(FLEET, /scopeCaption: "filters this outline"/);
+  assert.match(FLEET, /Object\.assign\(\{\}, v\.actives, \{ outline: l \}\)/);
+  assert.match(FLEET, /if \(!lensVisible\(outlineLens, outlineUnions, s\.sid\)\) continue;/);
+  assert.match(FLEET, /fleetViews = m\.views as SessionViews/, "the outline reads views off the feed payload");
+  assert.match(KERNEL, /"views": _views_client\(\),   # the rendered views blob — the outline \+ feed tag mounts read it/);
+});
+
+test("every pane's Configure tags… routes to THE dialog on the timeline (source pins)", () => {
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "openTagsDialog" \}\)/);
+  assert.match(FLEET, /vscodeApi\?\.postMessage\(\{ type: "openTagsDialog" \}\)/);
+  assert.match(KERNEL, /msg\.get\("type"\) == "openTagsDialog"/);
+  assert.match(KERNEL, /_send_to_view\("timeline", \{"type": "openViewsDialog"\}, \(client or \{\}\)\.get\("wid"\) or ""\)/,
+    "routed to the SAME dashboard's timeline, like tagEditFailed");
+});
+
+test("the shared component: toggles stay open, scope caption, echo dismissal (source pins)", () => {
+  assert.match(MENU, /opts\.onApply\(toggleLens\(lens, \{ tag: u\.name \}\), false\); build\(\);/,
+    "tag rows toggle and repaint in place");
+  assert.match(MENU, /opts\.onApply\(\{ all: true \}, true\)/, "All is a plain pick");
+  assert.match(MENU, /font-size:0\.82em;opacity:0\.6;font-style:italic/, "the captioned divider, sub-line scale");
+  assert.match(MENU, /localStorage\.setItem\("romp:menu-echo"/, "every pane writes the pointerdown echo");
+  assert.match(MENU, /e\.key === "romp:menu-echo" && e\.newValue/, "every open menu listens");
+  assert.match(MENU, /btn\.addEventListener\("click", \(e\) => e\.stopPropagation\(\)\)/,
+    "the opener swallows its own click (the click-and-hold rule)");
+});


### PR DESCRIPTION
## What (T69 PR-B — per the architecture note; PR-A merged)

- **`tag-menu.ts`**: the shared lens menu for webview panes (ctx-family skin) — multi-select toggles that stay open, the captioned divider naming the governed surface, one "Configure tags…" entry, the **cross-pane dismissal echo built in** (mounting surfaces inherit the fix), and the shared monochrome tag-icon button.
- **Chat tab strip** mounts it (`actives.chat`): tabs + peeks decide through the chat lens; the button rides the strip after [+]. Timed with the peer's tab work: branched after their PR 685 merged.
- **Outline** mounts it (`actives.outline`): button right of the search box; rows filter through the outline lens read off the feed payload — **which carries the rendered views blob again** (retired this morning as unread, revived for the tag mounts; the absence-pin retargeted with the history).
- **`surfaceLens`**: per-surface reader with the kernel's exact scalar-seed rule — pre-lens blobs keep their old behavior on every client.
- **`revealIn` is additive on the chat lens**: the holder tag (or none bucket) *joins* the selection — a reveal never hides what the user was looking at, never rewrites the legacy scalar, never touches membership.
- **One dialog**: every pane's "Configure tags…" posts `openTagsDialog`; the kernel routes to the same dashboard's timeline pane (the tagEditFailed wid idiom).
- **Scope section** in the dialog: tabs/timeline/outline selections side by side, each with "→ all" (set-for-all); the feed's column honestly says "set on the feed" (its lens is pane-local sessionStorage), and set-for-all reaches it via a `romp:feedTags-set` localStorage echo **for the feed mount to adopt — flagged to the feed pairing**.
- Kernel `_LENS_SURFACES` grows `outline`.

## Tests

Executed: `surfaceLens` seeding + surface independence; `revealIn`'s additive truth table. Pins: both mounts, the routes, component behavior, the feed-payload revival. Sibling anchors (peek derivation ×2, old reveal semantics, the feed-payload absence pin) retargeted in-commit. Suites green: 5595 python, 2398 JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)