### PR TITLE
Judge pickers gain version submenus; carets face right, sides are measured

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22055,8 +22055,11 @@ def _set_judge_state(fname, value, allowed, allow_empty=False):
             pass
 
 
-def _set_judge_model(v):  _set_judge_state("judge-model", v, _MODEL_VALUES)
-def _set_index_model(v):  _set_judge_state("index-model", v, _MODEL_VALUES)
+# judge tiers accept VERSION ids too (the user 2026-08-25: the settings pickers mirror the
+# family+version submenus) — a version rides the SDK model param verbatim, like session picks
+_JUDGE_MODEL_VALUES = _MODEL_VALUES | set(_VERSION_FAMILY)
+def _set_judge_model(v):  _set_judge_state("judge-model", v, _JUDGE_MODEL_VALUES)
+def _set_index_model(v):  _set_judge_state("index-model", v, _JUDGE_MODEL_VALUES)
 def _set_judge_effort(v): _set_judge_state("judge-effort", v, _EFFORT_VALUES, allow_empty=True)
 def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True)
 # The distilling pair accepts extra sentinels (resolved by jd._distill_model/_distill_effort at call
@@ -22064,7 +22067,7 @@ def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, al
 # staller did before the split (the user 2026-08-14) — and effort's "none" pins no-flag. "none" exists
 # because "" cannot: _state_str folds an empty file into the default, so an allow_empty pin here would
 # read back as "follow" (caught by test_distill_tier before it shipped).
-def _set_distill_model(v):  _set_judge_state("distill-model", v, _MODEL_VALUES | {"triage"})
+def _set_distill_model(v):  _set_judge_state("distill-model", v, _JUDGE_MODEL_VALUES | {"triage"})
 def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES | {"triage", "none"})
 
 

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -70,6 +70,21 @@ class JudgeSettings(unittest.TestCase):
         self.assertIn('versions=[dict(v) for v in MODEL_VERSIONS.get(c["value"]) or []]', ksrc)
 
     # ---- per-tier overrides honored + validated ----
+    def test_judge_tiers_accept_version_ids(self):
+        # the settings pickers mirror the family+version submenus (the user 2026-08-25): a version
+        # id is a valid judge model — it rides the SDK model param verbatim, like session picks.
+        # The setter is effect-only (writes the state file or silently refuses) — assert the file.
+        km._set_judge_model("claude-opus-4-8")
+        jd._state_cache.clear()
+        self.assertEqual(jd._triage_model(), "claude-opus-4-8")
+        km._set_distill_model("claude-sonnet-4-6")
+        self.assertEqual((jd.STATE / "distill-model").read_text(), "claude-sonnet-4-6")
+        km._set_judge_model("claude-nonsense-9")
+        jd._state_cache.clear()
+        self.assertEqual(jd._triage_model(), "claude-opus-4-8", "unknown ids refused — the pick stands")
+        km._set_judge_model("opus")   # restore a family value for the suites that follow
+        jd._state_cache.clear()
+
     def test_overrides_are_honored(self):
         (jd.STATE / "judge-model").write_text("opus")
         (jd.STATE / "index-model").write_text("sonnet")

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -120,3 +120,13 @@ test("the badges' COLOR is the chat's too: the rank tints ride the frame (the 20
   // the equality bar (asserted headless over the built bundle, per the follow-up): computed
   // font-family/size/weight AND color/opacity equal chat↔popover for chip, timer, and all badges
 });
+
+test("the caret faces RIGHT and the submenu side is measured, right-preferred (the user 2026-08-25)", () => {
+  assert.match(RENDER, /textContent = "\\u25B8"/, "the caret marks expandable, never the side");
+  assert.ok(!RENDER.includes("\\u25C2"), "no left-facing caret anywhere");
+  assert.match(RENDER, /if \(rr\.right \+ 4 \+ sw <= window\.innerWidth - 8\) sub\.style\.left = Math\.round\(rr\.right \+ 4\) \+ "px";/,
+    "right side taken whenever it fits");
+  assert.match(RENDER, /else sub\.style\.right = Math\.max\(8, window\.innerWidth - rr\.left \+ 4\) \+ "px";/,
+    "left is the measured fallback, not the default");
+});
+

--- a/ui/webview/gear-judge-versions.test.ts
+++ b/ui/webview/gear-judge-versions.test.ts
@@ -1,0 +1,36 @@
+// The gear's judge MODEL pickers mirror the session pickers (the user 2026-08-25): families
+// top-level, family click = the /models remembered default, a right-facing-caret side submenu of
+// versions, right-preferred side (measured). The native select stays hidden as the value holder so
+// fill()/mixed marks keep working, and version ids ride as options so any stored pick displays.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the three judge model selects grow the version menu; the select stays the value holder", () => {
+  assert.match(GEAR, /function versionMenu\(sel, extraFirst\)/);
+  assert.match(GEAR, /versionMenu\(jm\);\s*\n\s*versionMenu\(im\);\s*\n\s*versionMenu\(dm, \[\{ value: 'triage', label: 'Follow triage', versions: \[\] \}\]\);/,
+    "judge, index, and distill (with its Follow-triage sentinel first)");
+  assert.match(GEAR, /sel\.style\.display = 'none';/, "the native select hides — still the value holder");
+  assert.match(GEAR, /sel\.dispatchEvent\(new Event\('change'\)\)/, "picks flow through the existing change→post wiring");
+  assert.match(GEAR, /versions ride as options too/, "a stored version id still displays and mixed-marks");
+  assert.match(GEAR, /pick\(fam\.default \|\| fam\.value\)/, "family click sends the remembered default");
+});
+
+test("caret faces RIGHT everywhere; the submenu side is measured with the right preference", () => {
+  assert.match(GEAR, /caret\.textContent = '\\u25B8'/);
+  assert.ok(!GEAR.includes("\\u25C2"), "no left-facing caret");
+  assert.match(GEAR, /if \(rr\.right \+ 4 \+ sw <= window\.innerWidth - 8\) sub\.style\.left = Math\.round\(rr\.right \+ 4\) \+ 'px';/,
+    "right side whenever it fits");
+  assert.match(GEAR, /else sub\.style\.left = Math\.max\(8, Math\.round\(rr\.left\) - sw - 4\) \+ 'px';/,
+    "left only as the measured fallback");
+  assert.match(GEAR, /e\.key === 'romp:menu-echo' && e\.newValue/, "cross-pane dismissal adopted");
+});
+
+test("the kernel accepts version ids on every judge tier", () => {
+  assert.match(KERNEL, /_JUDGE_MODEL_VALUES = _MODEL_VALUES \| set\(_VERSION_FAMILY\)/);
+  assert.match(KERNEL, /_set_judge_state\("distill-model", v, _JUDGE_MODEL_VALUES \| \{"triage"\}\)/);
+});

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -247,6 +247,125 @@ function initGear(post) {
   });
   if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked }); });
   if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
+  // The judge MODEL pickers mirror the session pickers (the user 2026-08-25): families top-level,
+  // clicking a family sends its /models `default` (the user's remembered version), hover or
+  // ArrowRight reveals a side submenu of versions. The native select stays (hidden) as the VALUE
+  // holder — fill()/mixed marks keep working — and the button+menu is the visible control. The
+  // caret ALWAYS faces right (▸); the submenu PREFERS the right side, falling left only when the
+  // right edge would clip (measured, never assumed).
+  function versionMenu(sel, extraFirst) {
+    if (!sel) return;
+    sel.style.display = 'none';
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'rs-vermenu-btn';
+    btn.setAttribute('style', 'background:#1e1e1e;color:#ccc;border:1px solid rgba(255,255,255,0.25);'
+      + 'border-radius:5px;padding:2px 8px;cursor:pointer;font:inherit;');
+    sel.parentNode.insertBefore(btn, sel.nextSibling);
+    var labelOf = function (val) {
+      var o = sel.querySelector('option[value="' + val + '"]');
+      return o ? o.textContent : val;
+    };
+    var syncBtn = function () { btn.textContent = labelOf(sel.value) + ' \u25BE'; };
+    var mo = new MutationObserver(syncBtn);
+    mo.observe(sel, { childList: true });
+    sel.addEventListener('change', syncBtn);
+    setTimeout(syncBtn, 0);
+    var menu = null, sub = null;
+    var closeAll = function () { if (sub) { sub.remove(); sub = null; } if (menu) { menu.remove(); menu = null; } };
+    document.addEventListener('click', closeAll);
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') closeAll(); });
+    try { window.addEventListener('storage', function (e) { if (e.key === 'romp:menu-echo' && e.newValue) closeAll(); }); } catch (e) {}
+    var pick = function (val) { sel.value = val; sel.dispatchEvent(new Event('change')); syncBtn(); closeAll(); };
+    var MSTYLE = 'position:fixed;z-index:1001;min-width:130px;padding:4px;background:#252526;'
+      + 'border:1px solid rgba(255,255,255,0.12);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.35);'
+      + 'font-size:12px;line-height:1.4;color:#cccccc;user-select:none;';
+    var rowStyle = 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;display:flex;align-items:center;';
+    btn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (menu) { closeAll(); return; }
+      menu = document.createElement('div');
+      menu.setAttribute('style', MSTYLE);
+      menu.addEventListener('click', function (e2) { e2.stopPropagation(); });
+      (extraFirst || []).concat(choices && choices.models || []).forEach(function (fam) {
+        var row = document.createElement('div');
+        row.setAttribute('style', rowStyle);
+        row.tabIndex = 0;
+        row.appendChild(document.createTextNode(fam.label));
+        var versions = fam.versions || [];
+        var famCur = sel.value === fam.value || versions.some(function (v) { return v.value === sel.value; });
+        if (famCur) {
+          var ck = document.createElement('span'); ck.textContent = '\u2713';
+          ck.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
+          row.appendChild(ck);
+        }
+        var openSub = versions.length > 1 ? function () {
+          if (sub) { sub.remove(); sub = null; }
+          sub = document.createElement('div');
+          sub.setAttribute('style', MSTYLE + 'z-index:1002;');
+          versions.forEach(function (v) {
+            var r2 = document.createElement('div');
+            r2.setAttribute('style', rowStyle);
+            r2.tabIndex = 0;
+            r2.appendChild(document.createTextNode(v.label));
+            if (sel.value === v.value) {
+              var c2 = document.createElement('span'); c2.textContent = '\u2713';
+              c2.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
+              r2.appendChild(c2);
+            }
+            r2.addEventListener('mouseenter', function () { r2.style.background = 'rgba(255,255,255,0.09)'; });
+            r2.addEventListener('mouseleave', function () { r2.style.background = 'transparent'; });
+            r2.addEventListener('click', function (e2) { e2.stopPropagation(); pick(v.value); });
+            r2.addEventListener('keydown', function (e2) {
+              if (e2.key === 'Enter' || e2.key === ' ') { e2.preventDefault(); e2.stopPropagation(); pick(v.value); }
+              else if (e2.key === 'ArrowLeft') { e2.preventDefault(); sub.remove(); sub = null; row.focus(); }
+            });
+            sub.appendChild(r2);
+          });
+          document.body.appendChild(sub);
+          var rr = row.getBoundingClientRect();
+          // the side rule: PREFER right; fall left only when the right edge would clip (measured)
+          var sw = sub.offsetWidth || 130;
+          if (rr.right + 4 + sw <= window.innerWidth - 8) sub.style.left = Math.round(rr.right + 4) + 'px';
+          else sub.style.left = Math.max(8, Math.round(rr.left) - sw - 4) + 'px';
+          var sh = sub.offsetHeight || 0;
+          sub.style.top = Math.min(Math.round(rr.top), Math.max(8, window.innerHeight - sh - 8)) + 'px';
+          return sub;
+        } : null;
+        if (openSub) {
+          var caret = document.createElement('span');
+          caret.textContent = '\u25B8';   // ALWAYS right-facing — it marks "expandable", not the side
+          caret.setAttribute('style', 'margin-left:auto;padding-left:10px;opacity:0.55;');
+          row.appendChild(caret);
+          row.addEventListener('mouseenter', function () { row.style.background = 'rgba(255,255,255,0.09)'; openSub(); });
+        } else {
+          row.addEventListener('mouseenter', function () { row.style.background = 'rgba(255,255,255,0.09)'; if (sub) { sub.remove(); sub = null; } });
+        }
+        row.addEventListener('mouseleave', function () { row.style.background = 'transparent'; });
+        row.addEventListener('click', function (e2) { e2.stopPropagation(); pick(fam.default || fam.value); });
+        row.addEventListener('keydown', function (e2) {
+          if (e2.key === 'Enter' || e2.key === ' ') { e2.preventDefault(); e2.stopPropagation(); pick(fam.default || fam.value); }
+          else if ((e2.key === 'ArrowRight' || e2.key === 'ArrowLeft') && openSub) {
+            e2.preventDefault();
+            var s = openSub();
+            var first = s && s.querySelector('[tabindex]');
+            if (first) first.focus();
+          }
+        });
+        menu.appendChild(row);
+      });
+      document.body.appendChild(menu);
+      var br = btn.getBoundingClientRect();
+      menu.style.left = Math.max(8, Math.min(Math.round(br.left), window.innerWidth - (menu.offsetWidth || 140) - 8)) + 'px';
+      var mh = menu.offsetHeight || 0;
+      menu.style.top = (br.bottom + 4 + mh > window.innerHeight - 8 ? Math.max(8, Math.round(br.top) - mh - 4) : Math.round(br.bottom + 4)) + 'px';
+    });
+  }
+  fillChoices().then(function () {
+    versionMenu(jm);
+    versionMenu(im);
+    versionMenu(dm, [{ value: 'triage', label: 'Follow triage', versions: [] }]);
+  });
   if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value }); });
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
   if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value }); });
@@ -310,7 +429,10 @@ function initGear(post) {
     if (choices) return Promise.resolve(choices);
     return fetch(ku('/models'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
       choices = d || { models: [], efforts: [] };
-      var mo = (choices.models || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
+      var mo = (choices.models || []).map(function (m) {
+        var vs = (m.versions || []).map(function (v) { return '<option value="' + v.value + '">' + v.label + '</option>'; }).join('');
+        return '<option value="' + m.value + '">' + m.label + '</option>' + vs;   // versions ride as options too — the hidden select stays the value holder for any pick
+      }).join('');
       var eff = (choices.efforts || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
       var eo = '<option value="">Default</option>' + eff;
       if (jm) jm.innerHTML = mo; if (im) im.innerHTML = mo;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9532,13 +9532,19 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
       }
       document.body.appendChild(sub);
       const rr = item.getBoundingClientRect();
-      sub.style.right = Math.max(8, window.innerWidth - rr.left + 4) + "px";
+      // side rule (the user 2026-08-25): PREFER opening RIGHT; fall left only when the right edge
+      // would clip — measured, never assumed (this menu anchors bottom-right, so left often wins,
+      // but a narrow window or a wide panel can leave right-room; the measurement decides)
+      const sw = sub.offsetWidth || 140;
+      if (rr.right + 4 + sw <= window.innerWidth - 8) sub.style.left = Math.round(rr.right + 4) + "px";
+      else sub.style.right = Math.max(8, window.innerWidth - rr.left + 4) + "px";
       sub.style.bottom = Math.max(8, window.innerHeight - rr.bottom) + "px";
       subEl = sub;
       return sub;
     } : null;
     if (openSub) {
-      item.appendChild(el("span", "meta-caret")).textContent = "\u25C2";
+      // the caret ALWAYS faces right (the user 2026-08-25) — it marks "expandable", not the side
+      item.appendChild(el("span", "meta-caret")).textContent = "\u25B8";
       item.addEventListener("mouseenter", () => openSub());
     } else {
       item.addEventListener("mouseenter", () => closeSub());
@@ -9550,7 +9556,8 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
     item.addEventListener("keydown", (e) => {
       if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); pickValue(kind === "model" ? (c.default || c.value) : c.value); }
       else if ((e.key === "ArrowRight" || e.key === "ArrowLeft") && openSub) {
-        // the submenu opens leftward, so both arrows expand — ArrowLeft inside it collapses
+        // both arrows expand (the side is measured, so either may be where it opens) —
+        // ArrowLeft inside the submenu collapses back
         e.preventDefault();
         const sub = openSub();
         (sub.querySelector("[tabindex]") as HTMLElement | null)?.focus();


### PR DESCRIPTION
## What (two user asks on the model-version submenus, 2026-08-25)

**Judge model pickers** (gear: triage / index / distill) mirror the session pickers: families top-level, family click = the `/models` remembered default (same pick memory — a judge pick is a config write through the existing `setJudgeModel` wiring), hover/ArrowRight opens the version submenu, ✓ on current. The native selects stay hidden as **value holders** — `fill()` and the cross-machine mixed marks work unchanged, version ids ride as options so stored picks display. Kernel judge tiers accept version ids (they ride the SDK model param verbatim); distill keeps Follow-triage first. Cross-pane dismissal adopted.

**The caret/side rule**: the expand caret **always faces right (▸)** — it marks "expandable", never the side — and the submenu **prefers opening right**, falling left only when the right edge would clip (**measured, not assumed**). The statusline's always-left-with-◂ was the named offender, now fixed; the timeline already complied and is pinned.

## Tests

Right-facing constant + no ◂ anywhere; the measured side rule asserted both ways in render.ts and gear.js; gear wiring pins (hidden value holder, change-event flow, version options, Follow-triage first); kernel whitelist pin + executed judge-tier version acceptance (effect-first — the setter returns nothing). Suites green: 5619 python, 2398 JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)