### PR TITLE
The team-internals lens: the default board shows user-rooted cards

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18708,6 +18708,166 @@ def _state_unknown_names(alive, tmux, working, awaiting):
     return out
 
 
+# ───────────────────────── provenance split (the user 2026-08-25) ─────────────────────────
+# Option (iii) of the dashboard provenance audit, the user's pick: the DEFAULT board shows cards
+# whose evidence chain roots in a USER prompt; team-internal cards (peer-chatter roots, romp's own
+# bookkeeping, machine-injected kickoffs) live one click away behind the feed footer's
+# "team internals" lens. Mint machinery untouched — this classifies at BUILD time and stamps a
+# display field; needs-you always breaks through (feed-side, the same rule the satellite wears).
+
+_prov_auth_cache = {}   # sid -> ((mtime, size), {uuid: klass}) — parse-identity keyed, like _parse_cached
+_prov_store_cache = {}  # sid -> (stat keys, merged nodes) — build_feed runs every push (0.5–3s), and
+#                         re-parsing every session's goals-archive JSON that often is real money; the
+#                         walk reads only immutable-ish chain fields (parentId/promptUuid/origin), so a
+#                         raw stat-keyed read is exact and skips _feed_goals' snapshot/GuardedNode work
+
+
+def _prov_atom_text(a):
+    m = a.get("message")
+    if isinstance(m, dict):
+        c = m.get("content")
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            return " ".join(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text")
+    return a.get("text") or ""
+
+
+def _prov_atom_klass(a):
+    """One record's provenance class: 'user' (a human prompt), 'internal' (romp bookkeeping,
+    machine-injected input, or files-nothing peer mail), 'delegate' (a delegate mail record —
+    the chain continues through the courier's origin link, not this record), or None (no
+    confident read → the card SHOWS; false-quiet is the failure option (iii) was chosen to
+    avoid). Attachment records (old cards minted before the attachment-free anchor rule) are
+    read by their markers: postal kind, romp-injected, else the queued human dictation they
+    wrap."""
+    au = a.get("author")
+    if isinstance(au, dict):
+        k = au.get("kind") or ""
+        if k == "delegate":
+            return "delegate"
+        return "internal" if k in ("coordinate", "question") else None
+    if au == "human":
+        return "internal" if em.is_interrupt_record(a) else "user"
+    if au in ("romp", "sdk"):
+        return "internal"
+    if a.get("type") == "attachment":
+        txt = _prov_atom_text(a)
+        pairs = em.postal_pairs(txt)
+        if pairs:
+            k = pairs[-1][1]
+            return "delegate" if k == "delegate" else ("internal" if k in ("coordinate", "question") else None)
+        if em.ROMP_INJECT_RE.search(txt):
+            return "internal"
+        return "user" if txt.strip() else None
+    return None
+
+
+class _ProvenanceWalk:
+    """Build-time provenance classifier: walks a top card's evidence chain — self-then-ancestors
+    within its store, hopping stores through courier origin links (origin.goalId is the sender's
+    tracking node, parented under the sender's linked ask) — to the nearest record that reads
+    confidently 'user' or 'internal'. Deterministic and cache-only: records come from
+    _parse_cached (never a cold parse — a cold classification is None → SHOWN, and self-heals on
+    the next push once _warm_fleet_bg fills the cache, the working-dot idiom). Cross-host origins
+    are unclassifiable by design (their stores live on another kernel; the row arrives already
+    classified there and the field rides the merge). Cycle-safe, hop-capped."""
+    MAX_HOPS = 12
+
+    def __init__(self, alive):
+        self._paths = {s["sid"]: s["path"] for s in alive}
+        self._stores = {}    # sid -> {nid: node} (live + archive merged; archive never shadows live)
+        self._memo = {}      # (sid, nid) -> "user" | "internal" | None
+
+    def _nodes(self, sid):
+        n = self._stores.get(sid)
+        if n is not None:
+            return n
+        files = [jd.GOALARCHDIR / (sid + ".json"), jd.GOALDIR / (sid + ".json")]   # archive first; live shadows
+        key = []
+        for p in files:
+            try:
+                st = p.stat()
+                key.append((st.st_mtime_ns, st.st_size))
+            except OSError:
+                key.append(None)
+        hit = _prov_store_cache.get(sid)
+        if hit is not None and hit[0] == key:
+            n = hit[1]
+        else:
+            n = {}
+            for p in files:
+                try:
+                    n.update(json.loads(p.read_text()).get("nodes") or {})
+                except Exception:
+                    pass                               # unreadable store → its chains stay unclassifiable (shown)
+            _prov_store_cache[sid] = (key, n)
+        self._stores[sid] = n
+        return n
+
+    def _authors(self, sid):
+        path = self._paths.get(sid)
+        if not path:
+            return None
+        try:
+            st = os.stat(path)
+            key = (st.st_mtime, st.st_size)
+        except OSError:
+            return None
+        hit = _prov_auth_cache.get(sid)
+        if hit is not None and hit[0] == key:
+            return hit[1]
+        ps = _parse_cached(path)
+        if ps is None:
+            return None                                # cold cache → unclassifiable, never a cold parse
+        idx = {}
+        for turn in ps.get("turns") or []:
+            for a in turn.get("atoms") or []:
+                u = a.get("uuid")
+                if u:
+                    idx[u] = _prov_atom_klass(a)
+        _prov_auth_cache[sid] = (key, idx)
+        return idx
+
+    def klass(self, sid, nid, _seen=None, _hops=0):
+        """'user' | 'internal' | None (unclassifiable → shown)."""
+        if _hops >= self.MAX_HOPS:
+            return None
+        key = (sid, nid)
+        if key in self._memo:
+            return self._memo[key]
+        seen = _seen if _seen is not None else set()
+        out = None
+        nodes = self._nodes(sid)
+        x = nid
+        while x is not None and (sid, x) not in seen:
+            seen.add((sid, x))
+            nd = nodes.get(x)
+            if not isinstance(nd, dict):
+                break
+            o = nd.get("origin")
+            if isinstance(o, dict) and o.get("peer") and o.get("goalId") and not o.get("peerHost"):
+                r = self.klass(o["peer"], o["goalId"], seen, _hops + 1)
+                if r is not None:
+                    out = r
+                    break
+            pu = nd.get("promptUuid")
+            if pu:
+                auth = self._authors(sid)
+                k = auth.get(pu) if auth else None
+                if k in ("user", "internal"):
+                    out = k
+                    break
+                # 'delegate' with no usable origin, or a record outside the cached window →
+                # keep climbing; a higher ancestor may still resolve
+            x = nd.get("parentId")
+        self._memo[key] = out
+        return out
+
+    def internal(self, sid, nid):
+        return self.klass(sid, nid) == "internal"
+
+
 def build_feed(now, tmux=None):
     """The {type:"feed"} message the tuned feed.js bundle consumes (ui-parity.md: feed = ADAPT).
     Goals map onto the AskItem/AskTreeNode shape the render already speaks: the goal tree IS the
@@ -18724,6 +18884,7 @@ def build_feed(now, tmux=None):
     asks, working, awaiting = [], [], []
     bg_services = {}          # session name -> live SERVICE descs (judge-classified, _bg_split) → the neutral chip
     alive = _alive_sessions(now, tmux)               # hard filter: living sessions only
+    _prov = _ProvenanceWalk(alive)                   # build-time provenance classes (the user 2026-08-25)
     wmap = _wait_for_graph(now, {s["sid"] for s in alive})   # per-session 'waiting on a live peer' (the user 2026-06-22)
     _stalls = _stalled_goals()                       # goals romp's nudge gate is holding → the card's Stalled section
     _jauth_map = jd._auth_down_map()                 # judge-auth-down latch → the per-session card floor below
@@ -19457,6 +19618,12 @@ def build_feed(now, tmux=None):
                 # card instead of work running in secret (review 2026-08-24).
                 **({"satellite": True} if isinstance(o, dict) and o.get("tracked")
                    and origin and origin.get("live") and column != "needs_input" else {}),
+                # team-internal (the user 2026-08-25, option (iii)): the card's evidence chain roots
+                # in peer chatter / romp bookkeeping / machine-injected input, never a user prompt.
+                # A display CLASS, not a hide: the feed's footer lens decides visibility (its
+                # needs-you breakthrough included) — kernel-side the fact is stamped unconditionally
+                # so counts stay honest and the toggle needs no kernel round-trip.
+                **({"internal": True} if _prov.internal(fsid, nid) else {}),
                 "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
                 # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
                 # pending. The card STAYS in Working (the settle gate exists precisely so the column never

--- a/tests/test_feed_provenance_split.py
+++ b/tests/test_feed_provenance_split.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""The view-side provenance split's classifier (the user 2026-08-25, option (iii) of the audit
+memo): build_feed stamps `internal` on a top card whose evidence chain roots in team-internal
+records — peer chatter (coordinate/question mail), romp's own bookkeeping (notices, interrupt
+artifacts), machine-injected input — and stamps NOTHING when the walk can't classify confidently
+(false-quiet is the failure this option was chosen to avoid: an unclassifiable card SHOWS). The
+walk is deterministic and cache-only: records come from the parse cache (a cold cache is
+unclassifiable, self-healing on the next warm push), stores are live+archive merged, cross-store
+hops follow courier origin links, cross-host origins are unclassifiable by design (their kernel
+classifies them; the field rides the merge). SYNTHETIC fixtures only; private synthetic sids."""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_provsplit", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+WORKER = "aa15c4a1-0016-4b22-9c33-000000000001"   # private synthetic sids — never the shared placeholder
+MGR = "aa15c4a1-0016-4b22-9c33-000000000002"
+MID = "1787000000.000000_1.TESTHOST"
+
+
+def _atom(uuid, typ="user", author=None, text=""):
+    a = {"type": typ, "uuid": uuid,
+         "message": {"role": typ, "content": [{"type": "text", "text": text}]}}
+    if author is not None:
+        a["author"] = author
+    return a
+
+
+class AtomKlass(unittest.TestCase):
+    """_prov_atom_klass: one record's confident class, or None."""
+
+    def test_human_is_user(self):
+        self.assertEqual(km._prov_atom_klass(_atom("u1", author="human", text="fix the exporter")), "user")
+
+    def test_interrupt_artifact_is_internal(self):
+        self.assertEqual(km._prov_atom_klass(_atom("u1", author="human",
+                                                   text="[Request interrupted by user]")), "internal")
+
+    def test_romp_and_sdk_are_internal(self):
+        self.assertEqual(km._prov_atom_klass(_atom("u1", author="romp")), "internal")
+        self.assertEqual(km._prov_atom_klass(_atom("u1", author="sdk")), "internal")
+
+    def test_mail_kinds(self):
+        for kind, want in (("delegate", "delegate"), ("coordinate", "internal"),
+                           ("question", "internal"), ("", None)):
+            a = _atom("u1")
+            a["author"] = {"peer": None, "mid": MID, "kind": kind}
+            self.assertEqual(km._prov_atom_klass(a), want, "kind=%r" % kind)
+
+    def test_attachment_reads_its_markers(self):
+        mk = "<!-- romp-msg-id: %s -->" % MID
+        att = _atom("q1", typ="attachment", text="body\n" + mk + "\n<!-- romp-msg-kind: coordinate -->")
+        self.assertEqual(km._prov_atom_klass(att), "internal")
+        att = _atom("q2", typ="attachment", text="body\n" + mk + "\n<!-- romp-msg-kind: delegate -->")
+        self.assertEqual(km._prov_atom_klass(att), "delegate")
+        att = _atom("q3", typ="attachment", text="<!-- romp-injected -->[romp] restarted")
+        self.assertEqual(km._prov_atom_klass(att), "internal")
+        att = _atom("q4", typ="attachment", text="queued human dictation, no markers")
+        self.assertEqual(km._prov_atom_klass(att), "user")
+        att = _atom("q5", typ="attachment", text="   ")
+        self.assertIsNone(km._prov_atom_klass(att))
+
+    def test_no_signal_is_none(self):
+        self.assertIsNone(km._prov_atom_klass({"type": "user", "uuid": "u1"}))
+
+
+class WalkWorld(unittest.TestCase):
+    """The chain walk over synthetic two-session worlds (worker origin -> manager chain)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.paths = {}
+        for sid in (WORKER, MGR):
+            p = Path(self.td.name) / (sid + ".jsonl")
+            p.write_text("{}\n")
+            self.paths[sid] = str(p)
+        km._prov_auth_cache.clear()
+        km._prov_store_cache.clear()
+
+    def tearDown(self):
+        for sid in (WORKER, MGR):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+        self.td.cleanup()
+
+    def _seed_parse(self, sid, atoms):
+        path = self.paths[sid]
+        st = os.stat(path)
+        km._parse_cache[path] = ((st.st_mtime, st.st_size), {"turns": [{"atoms": atoms}]})
+
+    def _walk(self):
+        return km._ProvenanceWalk([{"sid": s, "path": self.paths[s]} for s in (WORKER, MGR)])
+
+    def _store(self, sid, nodes, archive=False):
+        st = {"rompUuid": sid, "nodes": nodes, "placements": {}, "status": {}}
+        (jd.save_goal_archive if archive else jd.save_goals)(sid, st)
+
+    def test_direct_user_root(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None, "promptUuid": "u1"}})
+        self._seed_parse(WORKER, [_atom("u1", author="human", text="fix the exporter")])
+        self.assertEqual(self._walk().klass(WORKER, "g1"), "user")
+
+    def test_direct_internal_root(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None, "promptUuid": "n1"}})
+        self._seed_parse(WORKER, [_atom("n1", author="romp", text="[romp] restarted")])
+        w = self._walk()
+        self.assertEqual(w.klass(WORKER, "g1"), "internal")
+        self.assertTrue(w.internal(WORKER, "g1"))
+
+    def test_origin_chain_to_a_user_root(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None,
+                                    "origin": {"peer": MGR, "goalId": "t1", "msgId": MID}}})
+        self._store(MGR, {"g9": {"id": "g9", "parentId": None, "promptUuid": "hu"},
+                          "t1": {"id": "t1", "parentId": "g9"}})
+        self._seed_parse(MGR, [_atom("hu", author="human", text="ship the demo")])
+        self.assertEqual(self._walk().klass(WORKER, "g1"), "user")
+
+    def test_origin_chain_to_an_internal_root(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None,
+                                    "origin": {"peer": MGR, "goalId": "t1", "msgId": MID}}})
+        self._store(MGR, {"g9": {"id": "g9", "parentId": None, "promptUuid": "n1"},
+                          "t1": {"id": "t1", "parentId": "g9"}})
+        self._seed_parse(MGR, [_atom("n1", author="romp", text="[romp] tasks died")])
+        self.assertTrue(self._walk().internal(WORKER, "g1"))
+
+    def test_delegate_anchor_defers_to_the_origin_chain(self):
+        # a courier-planted card carries BOTH the delegate mail promptUuid and the origin link:
+        # the mail record itself is neither user nor internal — the chain continues through origin
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None, "promptUuid": "m1",
+                                    "origin": {"peer": MGR, "goalId": "t1", "msgId": MID}}})
+        a = _atom("m1")
+        a["author"] = {"peer": MGR, "mid": MID, "kind": "delegate"}
+        self._seed_parse(WORKER, [a])
+        self._store(MGR, {"g9": {"id": "g9", "parentId": None, "promptUuid": "hu"},
+                          "t1": {"id": "t1", "parentId": "g9"}})
+        self._seed_parse(MGR, [_atom("hu", author="human", text="ship the demo")])
+        self.assertEqual(self._walk().klass(WORKER, "g1"), "user")
+
+    def test_archived_sender_nodes_still_resolve(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None,
+                                    "origin": {"peer": MGR, "goalId": "t1", "msgId": MID}}})
+        self._store(MGR, {"g9": {"id": "g9", "parentId": None, "promptUuid": "hu"},
+                          "t1": {"id": "t1", "parentId": "g9"}}, archive=True)
+        self._seed_parse(MGR, [_atom("hu", author="human", text="ship the demo")])
+        self.assertEqual(self._walk().klass(WORKER, "g1"), "user")
+
+    def test_unclassifiable_defaults_shown(self):
+        # (a) origin to a store with no such node; (b) promptUuid outside the cached window;
+        # (c) a COLD parse cache — all → None, and internal() is False (the card shows)
+        self._store(WORKER, {
+            "g1": {"id": "g1", "parentId": None, "origin": {"peer": MGR, "goalId": "gone", "msgId": MID}},
+            "g2": {"id": "g2", "parentId": None, "promptUuid": "missing"},
+            "g3": {"id": "g3", "parentId": None, "promptUuid": "u1"}})
+        self._store(MGR, {})
+        self._seed_parse(WORKER, [_atom("u1", author="human", text="hello")])
+        w = self._walk()
+        self.assertIsNone(w.klass(WORKER, "g1"))
+        self.assertIsNone(w.klass(WORKER, "g2"))
+        self.assertFalse(w.internal(WORKER, "g1"))
+        self.assertFalse(w.internal(WORKER, "g2"))
+        km._prov_auth_cache.clear()
+        km._parse_cache.pop(self.paths[WORKER], None)   # cold cache → never a cold parse
+        w2 = self._walk()
+        self.assertIsNone(w2.klass(WORKER, "g3"))
+
+    def test_cross_host_origin_is_unclassifiable_by_design(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None,
+                                    "origin": {"peer": MGR, "goalId": "t1", "msgId": MID,
+                                               "peerHost": "TESTHOST"}}})
+        self._store(MGR, {"g9": {"id": "g9", "parentId": None, "promptUuid": "n1"},
+                          "t1": {"id": "t1", "parentId": "g9"}})
+        self._seed_parse(MGR, [_atom("n1", author="romp")])
+        self.assertIsNone(self._walk().klass(WORKER, "g1"),
+                          "another kernel's stores are not ours to read — its row arrives classified")
+
+    def test_ancestor_climb_finds_the_nearest_evidence(self):
+        # the leaf has no evidence; its parent's promptUuid resolves
+        self._store(WORKER, {"top": {"id": "top", "parentId": None, "promptUuid": "u1"},
+                             "kid": {"id": "kid", "parentId": "top"}})
+        self._seed_parse(WORKER, [_atom("u1", author="human", text="hello")])
+        self.assertEqual(self._walk().klass(WORKER, "kid"), "user")
+
+    def test_parent_cycles_terminate_unclassified(self):
+        self._store(WORKER, {"a": {"id": "a", "parentId": "b"},
+                             "b": {"id": "b", "parentId": "a"}})
+        self.assertIsNone(self._walk().klass(WORKER, "a"))
+
+    def test_origin_cycles_terminate(self):
+        self._store(WORKER, {"g1": {"id": "g1", "parentId": None,
+                                    "origin": {"peer": MGR, "goalId": "t1", "msgId": MID}}})
+        self._store(MGR, {"t1": {"id": "t1", "parentId": None,
+                                 "origin": {"peer": WORKER, "goalId": "g1", "msgId": MID}}})
+        self.assertIsNone(self._walk().klass(WORKER, "g1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-internal-lens.test.ts
+++ b/ui/webview/feed-internal-lens.test.ts
@@ -1,0 +1,59 @@
+// The team-internals LENS (the user 2026-08-25, option (iii) of the provenance audit): the DEFAULT
+// board shows cards whose evidence chain roots in the user's own asks; kernel-stamped `internal`
+// cards fold behind a footer "N team-internal" word-button. Needs-you ALWAYS breaks through (the
+// satellite's rule), an unclassifiable card is never stamped (false-quiet is the chosen-against
+// failure), and the lens layers INSIDE viewFiltered's slot family so the session filter, search,
+// the hover-freeze churn badges, and the incoming tag lens all compose structurally. Source pins,
+// the feed-panel idiom; the kernel walk's truth table lives in tests/test_feed_provenance_split.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const FEED = W("feed.ts");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+
+test("kernel: the stamp is additive, class-only, and only on a CONFIDENT internal verdict", () => {
+  assert.match(KERNEL, /\*\*\(\{"internal": True\} if _prov\.internal\(fsid, nid\) else \{\}\)/,
+    "stamped unconditionally of column — the view owns visibility, counts stay honest");
+  assert.match(KERNEL, /return self\.klass\(sid, nid\) == "internal"/,
+    "None (unclassifiable) is never stamped — the card shows");
+  assert.match(FEED, /internal\?: boolean \| null;/, "additive on the type — old payloads render as before");
+});
+
+test("kernel: the walk is cache-only and refuses cross-host hops", () => {
+  assert.match(KERNEL, /ps = _parse_cached\(path\)\n\s+if ps is None:\n\s+return None/,
+    "a cold cache is unclassifiable — never a cold parse on the push path");
+  assert.match(KERNEL, /and not o\.get\("peerHost"\)/,
+    "another kernel's stores are not ours to read; its rows arrive classified and ride the merge");
+});
+
+test("the lens layers inside viewFiltered — breakthrough included — so every counter sees it", () => {
+  assert.match(FEED, /const base = viewBase\(list\);\n\s+if \(internalLensOn\(\)\) return base;\n\s+return base\.filter\(\(a\) => !a\.internal \|\| a\.column === "needs_input"\);/,
+    "needs-you cards show regardless of class — interrupt only when the human is the bottleneck");
+  assert.match(FEED, /function internalLensCount\(list: AskItem\[\]\): number \{\n\s+return viewBase\(list\)\.filter\(\(a\) => a\.internal && a\.column !== "needs_input"\)\.length;/,
+    "the count is what the lens GOVERNS under the current session/search scoping");
+});
+
+test("the footer button wears the mode-toggle vocabulary and persists via romp:settings", () => {
+  assert.match(FEED, /b = el\("button", "fdismiss ffollow feed-modetoggle"\);\n\s+b\.id = "feed-internal-lens";/,
+    "the session combobox's exact button vocabulary — no new footer species");
+  assert.match(FEED, /setViewPref\("teamInternals", !internalLensOn\(\)\)/,
+    "the shared settings write + romp:settings re-render event, like every footer view pref");
+  assert.match(FEED, /\.teamInternals === true;/, "default OFF: the split is the new default board");
+});
+
+test("render wires the honest count, the accent .on state, and hides a zero-card control", () => {
+  assert.match(FEED, /lensBtn\.textContent = lensN \+ " team-internal";/);
+  assert.match(FEED, /lensBtn\.classList\.toggle\("on", lensOn\);/,
+    ".feed-modetoggle.on — the accent language selected footer toggles already wear");
+  assert.match(FEED, /lensBtn\.setAttribute\("aria-pressed", lensOn \? "true" : "false"\);/);
+  assert.match(FEED, /lensBtn\.style\.display = \(showCA && \(lensN > 0 \|\| lensOn\)\) \? "" : "none";/,
+    "a control that governs zero cards is noise — but an ON lens stays reachable to turn off");
+});
+
+test("the button is ensure-once (click-safe across re-renders)", () => {
+  assert.match(FEED, /let b = document\.getElementById\("feed-internal-lens"\);\n\s+if \(!b\) \{/,
+    "the node persists; render() only rewrites its label — a push can never destroy it mid-press");
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -106,6 +106,7 @@ interface AskItem {
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;
   handoffTo?: { peer: string; peerSid: string; peerHost?: string; color?: { bg: string; fg: string } | null } | null;  // sender-side handoff provenance (the user 2026-08-24): this card IS a top-level "↪ delegated to <peer>" tracking node — the kernel titles it with the WORK and ships the delegation here, the mirror of origin's "↪ from"; click opens the recipient
   satellite?: boolean | null;                        // tracked delegation (the user 2026-08-24): this card is the recipient-side copy of a delegator-homed primary — off the default board; the session filter still reaches it (nothing runs in secret)
+  internal?: boolean | null;                         // team-internal provenance (the user 2026-08-25, option (iii)): the card's evidence chain roots in peer chatter / romp bookkeeping / machine-injected input, never a user prompt (kernel _ProvenanceWalk). The footer "team internals" lens folds these off the DEFAULT board; needs-you always breaks through, and an unclassifiable card is never stamped (false-quiet is the failure this option was chosen against)
   delegTracked?: { name: string; host?: string; sid: string; color?: { bg: string; fg: string } | null }[] | null;  // tracked delegation PRIMARY: the recipient identities whose live status this one card carries  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string; since?: number } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25). since = when the unanswered ask was sent → the chip's elapsed readout (the user 2026-08-23)
   awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: string[] | null;
@@ -3315,6 +3316,24 @@ function ensureClearAll(): HTMLElement {
   return b;
 }
 
+// The "team internals" LENS button (the user 2026-08-25, option (iii)): a footer word-button wearing
+// the session combobox's mode-toggle vocabulary — "N team-internal", accent .on while the lens is
+// showing them. Ensure-once (click-safe across re-renders: the node persists, render() only rewrites
+// its label); the pref rides the shared romp:settings via setViewPref, whose romp:settings event
+// re-renders every same-doc listener. Hidden entirely when nothing is folded and the lens is off —
+// a control that governs zero cards is noise.
+function ensureInternalLens(): HTMLElement {
+  let b = document.getElementById("feed-internal-lens");
+  if (!b) {
+    b = el("button", "fdismiss ffollow feed-modetoggle");
+    b.id = "feed-internal-lens";
+    b.setAttribute("aria-pressed", "false");
+    b.onclick = (ev) => { ev.stopPropagation(); setViewPref("teamInternals", !internalLensOn()); };
+    (document.getElementById("feed-foot") || document.body).appendChild(b);
+  }
+  return b;
+}
+
 // The footer VIEW MENU (the user 2026-08-24): the three view controls — sort direction, single-column
 // layout, by-session grouping — live behind ONE monochrome icon button now, a popup wearing the shared
 // .ctx-menu vocabulary, where three word-buttons crowded the footer and the labels can breathe.
@@ -4073,19 +4092,42 @@ function paintJudgeLimit(): void {
 // per-card label does, so a just-died session's cards keep matching after the meta list drops it).
 // Shared by render() and the hover-freeze badge painter, so the deferred-churn hint counts exactly
 // what the user would see move.
-function viewFiltered(list: AskItem[]): AskItem[] {
+function viewBase(list: AskItem[]): AskItem[] {
   // The board shows EVERY session's cards, whatever tag view the tabs/timeline hold (the user's
   // 2026-08-25 ruling, superseding the 2026-08-24 feed-follows-the-view coupling after living with
   // it): the feed is the attention/clearing surface — hidden-elsewhere work still lands and clears
-  // here. Its ONLY narrowing is its own local scoping below (the combobox exact filter + search).
-  // A tracked delegation's satellite lives under its delegator's PRIMARY card: the default board
-  // hides it, and picking its session in the filter is the one-click path back. INSIDE this helper
-  // on purpose — the hover-freeze churn badges count through it, so they see exactly what the
-  // board shows (a filter outside would paint +N for cards that never appear).
+  // here. Its ONLY narrowing is its own local scoping below (the combobox exact filter + search)
+  // plus the team-internals lens (viewFiltered). A tracked delegation's satellite lives under its
+  // delegator's PRIMARY card: the default board hides it, and picking its session in the filter is
+  // the one-click path back.
   let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list.filter((a) => !a.satellite);
   const sMatch = searchSids(feedSearchQ, sessionsMeta);
   if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
   return shown;
+}
+
+// The team-internals lens (the user 2026-08-25, option (iii) of the provenance audit): the DEFAULT
+// board shows cards rooted in the user's own asks; kernel-stamped `internal` cards fold behind the
+// footer's "N team-internal" word-button. Needs-you ALWAYS breaks through (interrupt only when the
+// human is the bottleneck — the same rule the satellite wears), and an unstamped card always shows.
+// Persisted in the shared romp:settings like every footer view pref.
+function internalLensOn(): boolean {
+  try { return JSON.parse(localStorage.getItem("romp:settings") || "{}").teamInternals === true; }
+  catch { return false; }
+}
+
+function viewFiltered(list: AskItem[]): AskItem[] {
+  // INSIDE this helper on purpose — the hover-freeze churn badges count through it, so they see
+  // exactly what the board shows (a filter outside would paint +N for cards that never appear).
+  const base = viewBase(list);
+  if (internalLensOn()) return base;
+  return base.filter((a) => !a.internal || a.column === "needs_input");
+}
+
+// The lens button's honest count: every card the lens GOVERNS under the current session/search
+// scoping (needs-you cards are outside its jurisdiction — they show either way).
+function internalLensCount(list: AskItem[]): number {
+  return viewBase(list).filter((a) => a.internal && a.column !== "needs_input").length;
 }
 
 // The per-host loading strip (the user 2026-08-25): while an attached host's cards are pending,
@@ -4124,6 +4166,17 @@ function render() {
   const showCA = !!asks.length;
   ensureViewMenuBtn().style.display = showCA ? "" : "none";       // sort + layout menu (the user 2026-08-24)
   ensureSessionBox().style.display = showCA ? "" : "none";        // session combobox: type-or-pick filter (the user 2026-08-24)
+  // the team-internals lens (the user 2026-08-25): label carries the honest count of what it governs
+  const lensN = internalLensCount(asks);
+  const lensOn = internalLensOn();
+  const lensBtn = ensureInternalLens();
+  lensBtn.style.display = (showCA && (lensN > 0 || lensOn)) ? "" : "none";
+  lensBtn.textContent = lensN + " team-internal";
+  lensBtn.classList.toggle("on", lensOn);
+  lensBtn.setAttribute("aria-pressed", lensOn ? "true" : "false");
+  lensBtn.title = lensOn
+    ? "team-internal cards (peer-to-peer work, not your asks) are showing — click to fold them back off the default board"
+    : "cards rooted in team-internal work (peer-to-peer, not your asks) are folded — click to show them; needs-you cards always surface";
   ensureClearAll().style.display = showCA ? "" : "none";
   ensureUndoClear().style.display = canUndoClear ? "" : "none";
   const foot = document.getElementById("feed-foot");


### PR DESCRIPTION
## What

Option (iii) of the 2026-08-25 provenance audit, the user's pick: the DEFAULT board shows cards whose evidence chain roots in a user prompt; team-internal cards live one click away behind a footer lens. Mint machinery untouched; fully reversible.

**Kernel** — `build_feed` classifies each top card at build time (`_ProvenanceWalk`): self-then-ancestors within its store, hopping stores through courier `origin` links (`origin.goalId` is the sender's tracking node, parented under the sender's linked ask), to the nearest record that reads confidently `user` (a human prompt) or `internal` (coordinate/question mail, romp-authored notices, interrupt artifacts, machine-injected input; delegate mail defers to the origin chain). A confident `internal` stamps the row; anything unclassifiable stamps NOTHING — **false-quiet is the failure this option was chosen to avoid, so unknown always shows**. Deterministic and cache-only: records come from the parse cache (a cold cache classifies nothing and self-heals on the next warm push — the working-dot idiom); stores are raw stat-keyed reads (build_feed runs every push; re-parsing every goals-archive that often is real money); cross-host origins are unclassifiable by design (their kernel classifies its own rows; the field rides the federation merge); cycle-safe and hop-capped.

**Feed** — the lens layers INSIDE `viewFiltered`'s slot family, after the satellite/session-filter/search slots, so the hover-freeze churn badges, the combobox, search, and the incoming tag lens (T70) all compose structurally. **Needs-you cards break through regardless of class** (the satellite's rule). The footer wears one new word-button in the session combobox's exact mode-toggle vocabulary: `N team-internal`, accent `.on` while showing, hidden entirely when it governs zero cards, ensure-once (click-safe across re-renders), persisted via the shared `romp:settings`.

## Live effect (the audited team's board, measured with this walk)

Over the audit's 48h window (124 top cards in a `notes-api`-style manager+workers world): 65 fold behind the lens, 59 stay (21 confidently user-rooted + 38 unclassifiable-defaults-shown). Today's live board: 4 shown, 1 folded.

Known edge, stated honestly: a card whose STORE chain lost its user root (e.g. consolidation re-parented a tracking node under a promptless umbrella) folds even when transcript-side evidence would have recovered a user ask — the audit found a handful of these. They stay one click away (the lens, or the session filter), needs-you still breaks through, and the courier link-precision work reduces the class at the source.

## Tests

`tests/test_feed_provenance_split.py` — the walk's truth table over synthetic worlds: atom classes (human / interrupt / romp / sdk / mail kinds / attachment markers), direct user and internal roots, origin chains to both, delegate-anchor deferring to the chain, archive-only senders, unclassifiable-defaults-shown (missing node, missing record, cold cache), cross-host refusal, nearest-evidence climb, parent- and origin-cycle termination.
`ui/webview/feed-internal-lens.test.ts` — wiring pins: additive stamp + type, cache-only + cross-host refusal, the viewFiltered layering with the needs-you breakthrough, honest count, button vocabulary/persistence/ensure-once, zero-card hiding.

Suites: UI 2399/2399 green. Python: full-suite runs on this loaded box flake in the known tunnel/timeline family (21 then 5 different files across two runs); every failing file passes in isolation, and the new files pass everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)