### PR TITLE
The feed mounts the shared tag lens: its own filter, All by default

### DIFF
--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -56,7 +56,8 @@ test("the filter defaults to NOTHING selected and only ever narrows the RENDER, 
 
 test("the combobox sits right of the view-menu icon, lists sessions in tab order, canonical form, click-safe", () => {
   // one control since 2026-08-24: the session picker and the search box merged into the combobox
-  assert.match(FEED, /ensureViewMenuBtn\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionBox\(\)\.style\.display = showCA \? "" : "none";/);
+  // the tag-lens button (T70, 2026-08-25) sits between the view menu and the combobox now
+  assert.match(FEED, /ensureViewMenuBtn\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureTagLensBtn\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionBox\(\)\.style\.display = showCA \? "" : "none";/);
   // the list is built ONCE per open; typing only toggles row display — a keystroke can never
   // rebuild a row out from under a press (click-safety)
   assert.match(FEED, /r\.style\.display = name === null \|\| searchMatches\(q, name\) \? "" : "none";/);

--- a/ui/webview/feed-tagmount.test.ts
+++ b/ui/webview/feed-tagmount.test.ts
@@ -1,0 +1,82 @@
+// The feed's LOCAL tag lens (the user 2026-08-25, T70): the shared multi-select model (tag-lens.ts)
+// and menu (tag-menu.ts) mounted as THIS board's own deliberate narrowing — independent of the
+// shared session view (the decoupling ruling stands; the payload's blob feeds tag DEFINITIONS
+// only). The model's own semantics (All exclusive, union visibility, last-off→All) execute in
+// tag-lens's suite; here the COMPOSITION executes and the mount is source-pinned (the repo
+// convention). Disclosure lineage: the 665 outside-view treatments, revived under the user's own
+// lens. Synthetic fixtures only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { lensVisible, lensAll, toggleLens } from "./tag-lens";
+import type { TagUnion } from "./session-views";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
+const PIPE = fs.readFileSync(path.join(ROOT, "vscode-extension", "src", "pipe-intent.ts"), "utf8");
+
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+const unions: TagUnion[] = [
+  { name: "infra", color: "", members: [U], ids: ["t1"], localId: "t1", remotes: [] },
+  { name: "web", color: "", members: [V], ids: ["TESTHOST:t2"], localId: null, remotes: [] },
+];
+
+test("arbitrary combinations union-filter; All is exclusive and the default board is byte-identical", () => {
+  // the model executes in tag-lens's own suite; this is the FEED's contract with it
+  const both = toggleLens(toggleLens({ all: true }, { tag: "infra" }), "none");
+  assert.equal(lensVisible(both, unions, U), true, "tagged infra — in the union");
+  assert.equal(lensVisible(both, unions, "77777777-0000-0000-0000-000000000000"), true, "untagged — the none bucket");
+  assert.equal(lensVisible(both, unions, V), false, "tagged web only — outside the combination");
+  assert.equal(lensAll(toggleLens(both, "all")), true, "All is exclusive — one pick clears the rest");
+  // default All short-circuits before any union math — today's board, byte-identical
+  assert.match(FEED, /if \(lensAll\(feedLens\)\) return s;   \/\/ default All = today's board, byte-identical/);
+});
+
+test("the lens is its own slot in the view family; needs-you passes (the family's interrupt rule)", () => {
+  assert.match(FEED, /function viewScope\(list: AskItem\[\]\): AskItem\[\]/,
+    "the combobox/search scoping kept its own layer");
+  assert.match(FEED, /return s\.filter\(\(a\) => lensVisible\(feedLens, u, a\.sid\) \|\| a\.column === "needs_input"\);/,
+    "the same breakthrough the satellite and internals lens wear");
+  // hover-freeze counts through viewFiltered = viewBase (+ internals) — the badges stay honest free
+  assert.match(FEED, /const base = viewBase\(list\);/);
+  assert.match(FEED, /function outsideLensCount\(list: AskItem\[\]\): number \{\s*\n\s*return lensAll\(feedLens\) \? 0 : viewScope\(list\)\.length - viewBase\(list\)\.length;/,
+    "the disclosure counts exactly what the lens alone hides — breakthroughs already show");
+});
+
+test("persistence: sessionStorage round-trip, All clears the key, the dialog's set-for-all adopts", () => {
+  assert.match(FEED, /sessionStorage\.getItem\("romp:feedTags"\)/);
+  assert.match(FEED, /if \(lensAll\(l\)\) sessionStorage\.removeItem\("romp:feedTags"\);/,
+    "All is the default — never persisted as a filter");
+  assert.match(FEED, /sessionStorage\.setItem\("romp:feedTags", JSON\.stringify\(l\)\);/);
+  // the PR-B adoption contract: the tags dialog's set-for-all lands via a localStorage write
+  assert.match(FEED, /if \(e\.key !== "romp:feedTags-set" \|\| !e\.newValue\) return;/);
+  assert.match(FEED, /if \(v && v\.lens\) \{ setFeedLens\(v\.lens as TagLens\); render\(\); \}/);
+});
+
+test("the mount is the SHARED component: tag glyph button, stay-open menu, Configure routes to the dialog", () => {
+  assert.match(FEED, /b = tagMenuButton\("filter this board by tag — combinations union; All shows everything", \(btn\) => \{/,
+    "the shared monochrome tag glyph — identical across surfaces");
+  assert.match(FEED, /openTagMenu\(btn, \{/);
+  assert.match(FEED, /scopeCaption: "filters this feed",/, "the captioned divider names the surface");
+  assert.match(FEED, /onApply: \(l\) => \{ setFeedLens\(l\); render\(\); \},/);
+  assert.match(FEED, /onConfigure: \(\) => vscodeApi\?\.postMessage\(\{ type: "openTagsDialog" \}\),/,
+    "one management entry; creation lives in the dialog");
+  assert.match(PIPE, /"openTagsDialog"/, "the VS Code pipe whitelists the route the kernel already carries");
+  assert.match(FEED, /ensureTagLensBtn\(\)\.style\.display = showCA \? "" : "none";/, "footer-gated like its siblings");
+  assert.match(FEED, /b\.style\.color = active \? "var\(--accent\)" : "";/, "active wears the accent, never re-hardcoded");
+});
+
+test("what the lens hides stays one glance away: whisper, promoted banner, click-to-All (665 lineage)", () => {
+  assert.match(FEED, /const lensOutN = outsideLensCount\(asks\);/);
+  assert.match(FEED, /lmore\.classList\.toggle\("prominent", lensOutN > lensShownN\);/,
+    "the exact promotion rule: the lens hides more than the board shows");
+  assert.match(FEED, /"Showing \\u201c" \+ lensLabel\(feedLens\) \+ "\\u201d \\u2014 " \+ lensOutN/,
+    "the promoted line NAMES the lens");
+  assert.match(FEED, /lmore\.onclick = \(\) => \{ setFeedLens\(\{ all: true \}\); render\(\); \};/,
+    "the way out is purely local — no kernel round-trip");
+  assert.match(CSS, /#feed-lensmore\.prominent \{ margin: 6px 8px 2px; padding: 10px 14px; background: #252526;/,
+    "the judge-limit banner's card chrome — neutral, a narrowed board is a choice");
+});

--- a/ui/webview/feed-unscoped.test.ts
+++ b/ui/webview/feed-unscoped.test.ts
@@ -16,14 +16,15 @@ const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8"
 const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
 const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
 
-test("the feed reads NO view state for card gating — all sessions' cards render under ANY active view", () => {
-  // structural proof: with no views input anywhere in the feed bundle, no tag-home shape (local,
-  // remote, union — the fixtures the tab-side deciders still execute against in session-views.test)
-  // can narrow the board; only the combobox exact filter and the search do.
-  assert.doesNotMatch(FEED, /session-views|feed-view"|viewVisible|cardInView|outsideView|feedViews/,
-    "no import, no decider, no adopted blob");
+test("the SHARED active view never gates the feed — the blob feeds tag DEFINITIONS only (T70)", () => {
+  // the decoupling ruling stands: the shared `active` is the tabs'/timeline's business. The feed's
+  // OWN local tag lens (T70, same day) legitimately reads the blob's tag definitions (lensUnions) —
+  // definitions, never the shared selection: no viewVisible, no `.active` read, anywhere.
+  assert.doesNotMatch(FEED, /viewVisible|cardInView|feedTagViews\.active|views\.active/,
+    "no shared-view decider, no read of the blob's active selection");
+  assert.match(FEED, /feedTagViews = m\.views as SessionViews;   \/\/ tag DEFINITIONS only — never `active`/);
   assert.match(FEED, /let shown = feedOnlySid \? list\.filter\(\(a\) => a\.sid === feedOnlySid\) : list\.filter\(\(a\) => !a\.satellite\);/,
-    "viewFiltered's whole composition: the board's own local scoping only");
+    "the board's own local scoping (viewScope) unchanged");
   assert.match(FEED, /the user's\s*\n\s*\/\/ 2026-08-25 ruling, superseding the 2026-08-24 feed-follows-the-view coupling/,
     "the ruling is cited where the gate used to live");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -904,6 +904,16 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-undoclear .undo-dots i:nth-child(3) { animation-delay: 0.36s; }
 @keyframes undo-dot { 0%, 100% { opacity: 0.25; } 40% { opacity: 1; } }
 @media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; } }
+/* The tag lens's disclosure line (the user 2026-08-25, T70; lineage: the 665 outside-view whisper
+   + promoted banner, revived under the user's OWN lens): dim one-liner after the columns; when the
+   lens hides MORE than the board shows, the judge-limit banner's card chrome + the lens named.
+   Neutral chrome — a narrowed board is a choice, not an error. */
+#feed-lensmore { padding: 4px 14px 10px; color: var(--dim); font-size: 0.82em; cursor: pointer; }
+#feed-lensmore:hover { color: var(--accent); text-decoration: underline; }
+#feed-lensmore.prominent { margin: 6px 8px 2px; padding: 10px 14px; background: #252526;
+  border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 6px;
+  color: var(--fg); font-size: 0.9em; }
+#feed-lensmore.prominent:hover { color: var(--fg); text-decoration: none; border-color: var(--accent); }
 /* The per-host loading strip (the user 2026-08-25; round two same day): an attached host's sessions
    are on the tabs but its cards haven't merged yet — one quiet line per pending host, the SHARED
    reverse-spin swirl glyph (.fask-awaiting-swirl, the user's pick over the dots) LEFT of the text,

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -10,6 +10,9 @@ import { distillText, distillInputs, applyDistillLine, distillPending, distillSt
 import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
+import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
+import { openTagMenu, tagMenuButton } from "./tag-menu";
+import { SessionViews } from "./session-views";
 import { freezeDiff, contentSig } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
@@ -495,6 +498,33 @@ function syncHostloadBackstops(): void {
     }
   }
 }
+// The feed's LOCAL tag lens (the user 2026-08-25, T70): the shared TagLens model (tag-lens.ts, the
+// multi-select every surface speaks) applied as THIS board's own deliberate narrowing — never the
+// shared blob's `active` (the decoupling ruling stands); the payload's views blob feeds tag
+// DEFINITIONS only (lensUnions). Persistence is sessionStorage, the feed's storage-split convention
+// (romp:feedOnly's reasoning): reload-proof, but a fresh window starts on All — a lens persisting
+// for days would read as silently missing cards, and the disclosure line only mitigates. The tags
+// dialog's "set for all surfaces" writes localStorage romp:feedTags-set {lens,t}; the storage
+// listener below adopts it into this pane's own lens (the PR-B adoption contract).
+let feedTagViews: SessionViews | null = null;
+let feedLens: TagLens = { all: true };
+try { feedLens = JSON.parse(sessionStorage.getItem("romp:feedTags") || "") || { all: true }; } catch { /* default All */ }
+function setFeedLens(l: TagLens): void {
+  feedLens = l;
+  try {
+    if (lensAll(l)) sessionStorage.removeItem("romp:feedTags");
+    else sessionStorage.setItem("romp:feedTags", JSON.stringify(l));
+  } catch { /* storage blocked */ }
+}
+try {
+  window.addEventListener("storage", (e) => {
+    if (e.key !== "romp:feedTags-set" || !e.newValue) return;
+    try {
+      const v = JSON.parse(e.newValue);
+      if (v && v.lens) { setFeedLens(v.lens as TagLens); render(); }
+    } catch { /* malformed set-for-all — ignore */ }
+  });
+} catch { /* no storage events */ }
 // The one session the board is filtered to, or null — the DEFAULT, nothing selected, everything shows.
 // sessionStorage, deliberately: it survives this tab's reloads (webviews reload on updates) but a fresh
 // window always starts unfiltered — a filter that persisted for days would read as silently lost cards.
@@ -3326,6 +3356,33 @@ function ensureClearAll(): HTMLElement {
 // its label); the pref rides the shared romp:settings via setViewPref, whose romp:settings event
 // re-renders every same-doc listener. Hidden entirely when nothing is folded and the lens is off —
 // a control that governs zero cards is noise.
+// The feed's mount of the SHARED tag-lens menu (tag-menu.ts — one component every surface mounts;
+// the user's generalized design). The button is the shared monochrome tag glyph; active (a narrowed
+// lens) wears the accent like every footer .on state. The menu inherits cross-pane dismissal free
+// (romp:menu-echo). Configure routes to the tags dialog through the kernel (openTagsDialog).
+function ensureTagLensBtn(): HTMLElement {
+  let b = document.getElementById("feed-taglens") as HTMLElement | null;
+  if (!b) {
+    b = tagMenuButton("filter this board by tag — combinations union; All shows everything", (btn) => {
+      openTagMenu(btn, {
+        lens: () => feedLens,
+        unions: () => lensUnions(feedTagViews),
+        onApply: (l) => { setFeedLens(l); render(); },
+        scopeCaption: "filters this feed",
+        onConfigure: () => vscodeApi?.postMessage({ type: "openTagsDialog" }),
+      });
+    });
+    b.id = "feed-taglens";
+    b.classList.add("feed-modetoggle");
+    (document.getElementById("feed-foot") || document.body).appendChild(b);
+  }
+  const active = !lensAll(feedLens);
+  b.classList.toggle("on", active);
+  b.style.color = active ? "var(--accent)" : "";   // the shared button's own gray otherwise
+  b.setAttribute("aria-pressed", active ? "true" : "false");
+  return b;
+}
+
 function ensureInternalLens(): HTMLElement {
   let b = document.getElementById("feed-internal-lens");
   if (!b) {
@@ -4096,18 +4153,35 @@ function paintJudgeLimit(): void {
 // per-card label does, so a just-died session's cards keep matching after the meta list drops it).
 // Shared by render() and the hover-freeze badge painter, so the deferred-churn hint counts exactly
 // what the user would see move.
-function viewBase(list: AskItem[]): AskItem[] {
+function viewScope(list: AskItem[]): AskItem[] {
   // The board shows EVERY session's cards, whatever tag view the tabs/timeline hold (the user's
   // 2026-08-25 ruling, superseding the 2026-08-24 feed-follows-the-view coupling after living with
   // it): the feed is the attention/clearing surface — hidden-elsewhere work still lands and clears
-  // here. Its ONLY narrowing is its own local scoping below (the combobox exact filter + search)
-  // plus the team-internals lens (viewFiltered). A tracked delegation's satellite lives under its
-  // delegator's PRIMARY card: the default board hides it, and picking its session in the filter is
-  // the one-click path back.
+  // here. Its ONLY narrowing is its own local scoping (this combobox exact filter + search), the
+  // feed-local TAG LENS (viewBase), and the team-internals lens (viewFiltered). A tracked
+  // delegation's satellite lives under its delegator's PRIMARY card: the default board hides it,
+  // and picking its session in the filter is the one-click path back.
   let shown = feedOnlySid ? list.filter((a) => a.sid === feedOnlySid) : list.filter((a) => !a.satellite);
   const sMatch = searchSids(feedSearchQ, sessionsMeta);
   if (sMatch) shown = shown.filter((a) => sMatch.has(a.sid) || searchMatches(feedSearchQ, (a as { name?: string }).name));
   return shown;
+}
+
+// The feed-local TAG LENS slot (the user 2026-08-25, T70; disclosure lineage: the 665 outside-view
+// treatments, retired with the shared-view coupling, live again here under the user's OWN lens).
+// Needs-you always passes — the same interrupt rule the satellite and internals lens wear: a
+// view-hidden session that needs the human is this board's whole job.
+function viewBase(list: AskItem[]): AskItem[] {
+  const s = viewScope(list);
+  if (lensAll(feedLens)) return s;   // default All = today's board, byte-identical
+  const u = lensUnions(feedTagViews);
+  return s.filter((a) => lensVisible(feedLens, u, a.sid) || a.column === "needs_input");
+}
+
+// The disclosure count: what the TAG LENS alone hides (breakthroughs already show; counting them
+// would double-speak) — viewScope minus viewBase, by construction.
+function outsideLensCount(list: AskItem[]): number {
+  return lensAll(feedLens) ? 0 : viewScope(list).length - viewBase(list).length;
 }
 
 // The team-internals lens (the user 2026-08-25, option (iii) of the provenance audit): the DEFAULT
@@ -4171,6 +4245,7 @@ function render() {
   // footer pane (below the cards, no overlap): view menu · Session filter · Search | Clear all · Undo
   const showCA = !!asks.length;
   ensureViewMenuBtn().style.display = showCA ? "" : "none";       // sort + layout menu (the user 2026-08-24)
+  ensureTagLensBtn().style.display = showCA ? "" : "none";        // the feed-local tag lens (the user 2026-08-25, T70)
   ensureSessionBox().style.display = showCA ? "" : "none";        // session combobox: type-or-pick filter (the user 2026-08-24)
   // the team-internals lens (the user 2026-08-25): label carries the honest count of what it governs
   const lensN = internalLensCount(asks);
@@ -4320,6 +4395,28 @@ function render() {
   }
   for (const tid of Array.from(groupEls.keys())) if (!desired.has("g:" + tid) && undismissed(groupEls.get(tid))) { groupEls.get(tid)?.remove(); groupEls.delete(tid); }
 
+  // The tag lens's disclosure line (the user 2026-08-25, T70; lineage: the 665 outside-view line +
+  // promoted banner, retired with the shared-view coupling, revived under the user's OWN lens —
+  // what a filter hides stays one glance from reach, never silent, the 2026-08-11 rule). The click
+  // resets to All, purely local (no kernel round-trip: sessionStorage + render).
+  const lensOutN = outsideLensCount(asks);
+  let lmore = document.getElementById("feed-lensmore");
+  if (!lmore) {
+    lmore = el("div", "");
+    lmore.id = "feed-lensmore";
+    lmore.title = "cards the tag filter hides — click to show all";
+    lmore.onclick = () => { setFeedLens({ all: true }); render(); };
+    list.appendChild(lmore);
+  }
+  const lensShownN = viewFiltered(asks).length;
+  lmore.classList.toggle("prominent", lensOutN > lensShownN);
+  lmore.style.display = lensOutN ? "" : "none";
+  if (lensOutN) {
+    lmore.textContent = lensOutN > lensShownN
+      ? "Showing \u201c" + lensLabel(feedLens) + "\u201d \u2014 " + lensOutN
+        + (lensOutN === 1 ? " card is" : " cards are") + " outside this filter \u00b7 show all"
+      : lensOutN + (lensOutN === 1 ? " card" : " cards") + " outside this tag filter \u2014 show all";
+  }
   ensureHostLoad(list);
   list.scrollTop = prevScroll;
   // Stale-freeze heal (hover-freeze): a LOCAL render can detach or re-key the hovered element with
@@ -4818,6 +4915,7 @@ function applyFeedPayload(m: any): void {
   pendingHosts = Array.isArray(m.pendingHosts) ? m.pendingHosts.filter((h: any) => typeof h === "string") : [];
   pendingDead = Array.isArray(m.pendingDead) ? m.pendingDead.filter((h: any) => typeof h === "string") : [];
   syncHostloadBackstops();
+  if (m.views && typeof m.views === "object") feedTagViews = m.views as SessionViews;   // tag DEFINITIONS only — never `active`
   if (Array.isArray(m.sessions)) {
     sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");
     // a filter aimed at a session the tab strip no longer shows is moot — clear it (the deciding

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -14,7 +14,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "renameSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
-  "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews",
+  "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "openTagsDialog",
   "reorderTabs", "closeTab",
 ]);
 


### PR DESCRIPTION
The feed instance of the shared tag-lens package (T70): the shared monochrome tag-glyph button joins the footer's left cluster, opening the shared multi-select menu — stay-open toggles, the captioned divider ("filters this feed"), cross-pane dismissal inherited from the component, and one **Configure tags…** entry routing to the tags dialog through the kernel's `openTagsDialog` (the VS Code pipe now whitelists the intent the kernel already carries).

**Independent by construction.** The lens is the board's own deliberate narrowing, never the shared blob's active selection — the decoupling ruling stands, and the payload's views blob feeds tag **definitions only** (the doctrine pin sharpened accordingly). It composes as its own slot in the view family: `viewScope` (combobox + search + satellite) → `viewBase` (+ the tag lens) → `viewFiltered` (+ the internals lens) — so the hover-freeze churn badges and every counter stay honest for free. **Needs-you always passes**, the same interrupt rule the satellite and internals lens wear. **Default All is today's board, byte-identical** (pinned as a short-circuit before any union math).

**Persistence:** sessionStorage (`romp:feedTags`, the feed's storage-split convention — reload-proof, fresh windows start on All), plus the PR-B adoption contract: the dialog's set-for-all writes `romp:feedTags-set` and the mount adopts it.

**Disclosure (665 lineage, revived under the user's own lens):** the dim "N cards outside this tag filter" whisper, promoting to the judge-limit-chrome banner naming the lens combination whenever it hides more than the board shows, with a purely-local click back to All.

**Tests:** the union/exclusivity contract executed against the shared model; composition, breakthrough, and disclosure-count pins; persistence round-trip + set-for-all adoption; the mount pins (shared button, scopeCaption, Configure route + pipe whitelist); the banner treatments. 2414 extension tests green on the pushed head; footer + banner verified headlessly.

Coordination: built on romp_ui's PR-B component and romp_cards' view-family split, per the sanctioned pairings — no merge-order concerns, everything referenced is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
