### PR TITLE
A finished delegation closes its ask: the report-back reaches the closer, and only propagate ends a tracker

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -150,7 +150,22 @@ to narrate it. The closer supplies the missing verdicts; the unblocker retires t
 ones; the distiller and the briefer write what you read on the resolved card.
 
 **closer.** The turn-end completion backstop; it exists because agents
-rarely say "done". It audits only the goals the turn actually touched;
+rarely say "done". Since 2026-08-25 a delegated goal's report-back rides its
+audit: when a "delegated to" tracking item completes, the recipient's own
+resolution travels into the sender's tree (run_propagate) and the
+steps-finished nomination shows it to the closer as a marked
+"Delegation reports" section — before that, a delegated ask's only visible
+history was the dispatch, the closer correctly omitted, and the look-stamp
+sealed a finished question open forever (the auto-nudge then re-asked it
+seven times in 75 minutes). Two guardrails ride the same fix: the closer
+never completes a "delegated to" tracking item itself (its ending event is
+the recipient's completion — a dispatch-time done consumed the slot and
+starved the report), and on a status-reporting turn (nudge / follow-up /
+wrap-up) a cited UMBRELLA's open descendants ride the audit too — the
+umbrella's open leaf was otherwise reachable by no channel, since a nudge
+spliced into a busy session's running turn strips its own resolutions (a
+plain cited goal keeps the tops-only shape: the closer rules it directly).
+It audits only the goals the turn actually touched;
 verdict done, blocked, or omit, with "when in doubt, omit". Idempotent per
 turn. Its diary events carry src `closer`, so planner and closer verdicts
 stay distinguishable, and both defer to the user floor: a verdict computed

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8505,11 +8505,33 @@ def _subtree_done_candidates(store):
             continue
         if _sealed_above(nodes, nid) or _task_open_below(nodes, children, nid):
             continue
-        if not _filed_since(nodes, children, nid, _look_stamp(nd)):
+        if (not _filed_since(nodes, children, nid, _look_stamp(nd))
+                and not _deleg_unseen(nodes, children, nid, nd)):
             continue                                   # the closer already looked at this world
         out.append(nd)
     out.sort(key=lambda nd: nd.get("t", 0))
     return out
+
+
+def _deleg_unseen(nodes, children, nid, nd):
+    """A DONE handoff child whose completion filing no closer look has yet seen WITH the delegation
+    report in evidence (the user 2026-08-25, the re-asking umbrella): the closer used to omit a
+    delegated ask — its visible history was just the dispatch; the recipient's completion lived in
+    another session's store — and closerLookT then sealed it forever (nothing files in a finished
+    subtree again), leaving the ask open to feed the auto-nudge loop. delegLookT is the look that
+    HAD the report visible (_close_turn stamps it beside closerLookT now that the report rides the
+    menu), so every already-sealed specimen re-nominates exactly ONCE post-upgrade, and a future
+    handoff completion re-arms naturally by its own done filing. Event-keyed both ways; no clock."""
+    seen = int(nd.get("delegLookT") or 0)
+    for c in children.get(nid, []):
+        cd = nodes.get(c) or {}
+        if not (isinstance(cd.get("handoff"), dict) and cd.get("nodeComplete")):
+            continue
+        at = max((int(e.get("at") or 0) for e in (cd.get("log") or []) if e.get("kind") == "done"),
+                 default=0)
+        if at > seen:
+            return True
+    return False
 
 
 def _starved_candidates(store):
@@ -8616,6 +8638,37 @@ def _status_report_candidates(store, turn):
         if nd.get("umbrella") or _task_open_below(nodes, children, nid):
             continue
         out.append(nd)
+    # CITED-UMBRELLA OPEN DESCENDANTS (the user 2026-08-25, the re-asking umbrella): a nudge/
+    # follow-up names its goal and the reply accounts for THAT goal's work — and when the named
+    # goal is an UMBRELLA, the top itself is unrulable (a structural container, skipped above)
+    # while the open LEAF actually holding it at working rides NO channel: the turn menu needs
+    # placements (a nudge spliced into a busy session's running turn strips its dones, so nothing
+    # ever places), steps-finished needs all-children-done, starved needs an empty diary. Three
+    # "it's finished" replies filed nothing on the audited specimen. So a cited UMBRELLA's open
+    # descendants ride this same closer call, with the sibling channels' skips — handoff trackers
+    # stay run_propagate's (their ending event is the recipient's completion, not this reply),
+    # blocked stays the unblocker's, and an agentTask-open subtree stays the agent's own. A PLAIN
+    # cited goal keeps the 2026-07-26 shape exactly: the closer rules the goal itself, and its
+    # subs never ride (the widened-menu pin in test_judge StatusReportMenu).
+    seen_ids = {nd["id"] for nd in out}
+    cited = set()
+    for s in _segs(turn, store):
+        for tgt in _seg_followup_all(s) or []:
+            if tgt in nodes and (nodes[tgt] or {}).get("umbrella"):
+                cited.add(tgt)
+    for top in sorted(cited):
+        stack = list(children.get(top, []))
+        while stack:
+            cid = stack.pop()
+            stack.extend(children.get(cid, []))
+            cd = nodes.get(cid) or {}
+            if (cid in seen_ids or cd.get("nodeComplete") or cd.get("cleared") or cd.get("blocked")
+                    or cd.get("settledDone") or cd.get("umbrella")
+                    or isinstance(cd.get("handoff"), dict)
+                    or _task_open_below(nodes, children, cid)):
+                continue
+            seen_ids.add(cid)
+            out.append(cd)
     out.sort(key=lambda nd: nd.get("t", 0))
     return out
 
@@ -8637,6 +8690,48 @@ def _reply_reopened_ids(menu):
         if any(e.get("kind") == "reopen" and e.get("src") == "user" and e.get("msg")
                and not e.get("undo") for e in rows[k + 1:]):
             out.add(nd["id"])
+    return out
+
+
+def _deleg_report_lines(store, nid):
+    """The completion evidence of nid's DONE handoff children, one line each — the cross-session
+    report the steps-finished ruling was blind to (the user 2026-08-25): a delegated ask's own
+    history is just the dispatch; the recipient's resolution lives on ANOTHER session's tree. The
+    substance comes from the tracking node's enriched done-why (run_propagate carries the
+    recipient's doneWhy/summary across since this fix); a pre-fix bare why falls back to a
+    read-only fetch from the recipient's store (origin/links msgId join — the same pointer
+    run_propagate follows). Capped like every quoted why; cross-host peers skip the fetch (their
+    stores live on another kernel) and report the bare completion."""
+    nodes = store["nodes"]
+    out = []
+    for cid, cd in nodes.items():
+        if cd.get("parentId") != nid or not cd.get("nodeComplete"):
+            continue
+        h = cd.get("handoff")
+        if not isinstance(h, dict) or not h.get("peer"):
+            continue
+        peer = str(h.get("peerName") or h.get("peer") or "a peer session")
+        sub = str(cd.get("doneWhy") or "").strip()
+        if sub.startswith("completed by") and ": " in sub:
+            sub = sub.split(": ", 1)[1]                # the enriched form → keep just the substance
+        elif sub.startswith("completed by") or sub.startswith("reported back by"):
+            sub = ""                                   # the bare pre-fix form carries none
+        if not sub and ":" not in str(h.get("peer") or ""):
+            try:                                       # read-only recipient join (local peers only)
+                r_nodes = dict(load_goal_archive(h["peer"]).get("nodes") or {})
+                r_nodes.update(load_goals(h["peer"]).get("nodes") or {})
+                for rn in r_nodes.values():
+                    o = rn.get("origin")
+                    refs = [o] if isinstance(o, dict) else []
+                    refs += [l for l in (rn.get("links") or []) if isinstance(l, dict)]
+                    if any(r.get("msgId") == h.get("msgId") for r in refs):
+                        sub = str(rn.get("doneWhy") or "").strip() \
+                            or (str(rn.get("summary") or "").strip().splitlines() or [""])[0]
+                        break
+            except Exception:
+                sub = ""
+        out.append("was delegated (\u21aa %s) and the recipient completed it%s"
+                   % (cd.get("text") or peer, (": " + sub[:220]) if sub else "."))
     return out
 
 
@@ -8685,7 +8780,29 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
         # state row — so t_overrides carries that anchor. Anchoring a history ruling to the turn made
         # it pre-shadowed by the very lift that nominated it (the fold orders by evidence time).
         ev = (t_overrides or {}).get(i, t)
+        if i in done and isinstance(nd.get("handoff"), dict) and nd["handoff"].get("peer"):
+            # a '↪ delegated' tracking node's ending event is the RECIPIENT's completion
+            # (run_propagate, or the cross-host reply sweep) — never this session's own prose
+            # (2026-08-25, the re-asking umbrella): the closer done'd a tracker at DISPATCH time
+            # ("queued to the peer"), propagate's real completion then no-op'd on the already-done
+            # node, and the parent ask's nomination sealed on dispatched-only evidence. The
+            # stand-down files nothing in either direction; the authoritative writer's own filing
+            # lands untouched, and the same reply's verdicts on other menu nodes still apply.
+            continue
         if i in done:
+            if isinstance(nd.get("handoff"), dict):
+                # A '↪ delegated' TRACKING node's deciding event is the RECIPIENT's completion —
+                # run_propagate's back-link for a local peer, the reply sweep for a cross-host one —
+                # never this session's own dispatch-time prose (the user 2026-08-25, the re-asking
+                # umbrella): the closer done'd a tracker "queued to the peer" at send time, which
+                # CONSUMED the slot — propagate's real completion later no-op'd on the already-done
+                # node, so the recipient's resolution never filed, the parent ask's steps-finished
+                # nomination sealed on dispatched-only evidence, and the card above ping-ponged
+                # nudge-block ↔ unblocker-unblock for 75 minutes. Stand down at the write moment;
+                # the authoritative writer's filing carries the report and re-arms the parent's
+                # nomination for free. (Same posture as the peer-kind awaiting gate below: a claim
+                # whose ending event belongs to another writer is not this closer's to file.)
+                continue
             if not record_verdict(store, nd, "closer", "done", ev, why=done[i] or None):
                 continue                              # the user's follow-up/move postdates this turn's evidence
             if ev is not None:                        # (the event materialized the flags + doneWhy)
@@ -8783,6 +8900,19 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                       % ("s" if len(flagged) > 1 else "",
                          ", ".join("#%d" % i for i in flagged),
                          "each" if len(flagged) > 1 else "it"))
+    dlines = []
+    for i, nd in enumerate(menu, 1):
+        if nd["id"] in cand_ids:
+            for line in _deleg_report_lines(store, nd["id"]):
+                dlines.append("Goal #%d %s" % (i, line))
+    if dlines:
+        # the cross-session completion evidence the steps-finished ruling was blind to (2026-08-25):
+        # its own marked section, like the lift whys — recipient-written text never rides romp's
+        # instruction prose
+        menu_text += ("\n\nDelegation reports (a goal above was handed to another session; that "
+                      "session finished and this is its report — completion evidence for the "
+                      "steps-finished rule, unless the goal's own history shows unfinished scope "
+                      "beyond what was delegated):\n" + "\n".join(dlines))
     starved_ids = {c["id"] for c in starved}
     sflagged = [i for i, nd in enumerate(menu, 1) if nd["id"] in starved_ids]
     if sflagged:
@@ -8899,6 +9029,12 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     for nd in menu:
         if nd["id"] in store["nodes"]:
             nd["closerLookT"] = _newest_filed(store["nodes"], kidmap, nd["id"])
+            if any(isinstance((store["nodes"].get(c) or {}).get("handoff"), dict)
+                   and (store["nodes"].get(c) or {}).get("nodeComplete")
+                   for c in kidmap.get(nd["id"], [])):
+                # this look SAW the delegation report (the menu carries it now) — seal the
+                # _deleg_unseen re-arm the same way closerLookT seals filings (2026-08-25)
+                nd["delegLookT"] = int(time.time())
     segs = _segs(turn, store)                          # seam-aware: post-split, the recap lives in the tail
     if segs:                                           # anchor each resolved (done/blocked) TURN goal to the recap
         # …but ONLY the turn's own menu (i <= n_touched). The riders behind it — steps-finished,
@@ -11192,10 +11328,20 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                 a_node = a_store.get("nodes", {}).get(a_gid)
                 if not a_node or a_node.get("nodeComplete"):
                     continue                            # sender's tracking node gone or already done → idempotent
-                record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now,
-                               why="completed by %s (delegated)" % (name or fsid[:8]))
-                _mark_node_done(a_store, a_gid, "completed by %s (delegated)" % (name or fsid[:8]), now,
-                                src="courier")
+                # Carry the RECIPIENT'S OWN RESOLUTION across (the user 2026-08-25, the re-asking
+                # umbrella): the bare "completed by <peer>" why gave the sender-side closer nothing
+                # to rule a delegated ask done WITH — the steps-finished nomination saw an ask whose
+                # only visible history was the dispatch, omitted, and the look-stamp sealed it while
+                # the auto-nudge re-asked a finished question seven times in 75 minutes. The
+                # recipient's doneWhy (else its summary head) IS the report-back's substance; capped
+                # like every quoted why.
+                why = "completed by %s (delegated)" % (name or fsid[:8])
+                sub = str(nd.get("doneWhy") or "").strip() \
+                    or (str(nd.get("summary") or "").strip().splitlines() or [""])[0]
+                if sub:
+                    why += ": " + sub[:220]
+                record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now, why=why)
+                _mark_node_done(a_store, a_gid, why, now, src="courier")
                 rollup_status(a_store, False)           # sender just had work close → recompute its columns
                 save_goals(a_sid, a_store)
                 n += 1

--- a/tests/test_deleg_report_close.py
+++ b/tests/test_deleg_report_close.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""The re-asking finished delegation (the user 2026-08-25): a delegated ask whose tracking child
+completed via run_propagate stayed open forever — the steps-finished nomination showed the closer
+an ask whose only visible history was the DISPATCH (the recipient's resolution lives on another
+session's tree), the closer correctly omitted, and closerLookT sealed it (nothing files in a
+finished subtree again) while the auto-nudge re-asked the finished question and the spliced-done
+strip cut off every answer. Three pieces close the class:
+(1) run_propagate carries the RECIPIENT'S OWN RESOLUTION (doneWhy, else summary head) into the
+    sender-side tracking node's done-why — the report-back's substance travels at the report-back
+    event;
+(2) the closer's steps-finished nomination shows that report as a marked "Delegation reports"
+    section, so the ruling has the completion evidence;
+(3) _deleg_unseen re-arms the nomination for any candidate whose done handoff child no look has
+    seen WITH the report visible (delegLookT, stamped beside closerLookT) — the sealed backlog
+    re-nominates exactly once post-upgrade, future completions re-arm by their own done filing.
+SYNTHETIC fixtures only; private synthetic sids."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_deleg_report", os.path.join(BIN, "romp-judge")).load_module()
+
+T = 1_787_000_000
+SENDER = "d17a0001-1111-4222-8333-000000000001"   # private synthetic sids — never the shared placeholder
+RECIP = "d17a0001-1111-4222-8333-000000000002"
+MID = "1787000000.000000_1.TESTHOST"
+
+
+def _node(nid, text, parent, t=T, **kw):
+    return {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": [], **kw}
+
+
+class World(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.discover
+        jd.discover = lambda now, window=None, forks=True: [
+            (SENDER, "/tmp/none-a.jsonl", None, "mgr"),
+            (RECIP, "/tmp/none-b.jsonl", None, "api")]
+
+    def tearDown(self):
+        jd.discover = self._saved
+        for sid in (SENDER, RECIP):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+            try:
+                (jd.STATE / "overrides" / (sid + ".jsonl")).unlink()
+            except OSError:
+                pass
+
+    def _plant(self, done_why=None, summary=None):
+        """Sender ask X with a courier-planted tracking child; recipient completes its goal."""
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":g1"] = _node(SENDER + ":g1", "Show a cancellable finding indicator", None)
+        st["seq"] = 1
+        hid = jd._plant_handoff_track(st, SENDER + ":g1", "seek indicator plus silent-seek fix",
+                                      RECIP, "api", T + 20, MID)
+        jd.save_goals(SENDER, st)
+        rt = jd.load_goals(RECIP)
+        rn = _node(RECIP + ":g5", "Cancellable seek indicator", None,
+                   origin={"peer": SENDER, "goalId": hid, "msgId": MID})
+        if summary:
+            rn["summary"] = summary
+        rt["nodes"][RECIP + ":g5"] = rn
+        jd.record_verdict(rt, rt["nodes"][RECIP + ":g5"], "closer", "done", T + 100, why=done_why)
+        jd.save_goals(RECIP, rt)
+        return hid
+
+
+class PropagateCarriesTheResolution(World):
+    def test_done_why_travels(self):
+        hid = self._plant(done_why="Shipped the cancellable indicator; suite green; merged")
+        self.assertEqual(jd.run_propagate(now=T + 200), 1)
+        st = jd.load_goals(SENDER)
+        self.assertTrue(st["nodes"][hid].get("nodeComplete"))
+        self.assertIn("Shipped the cancellable indicator", st["nodes"][hid].get("doneWhy") or "",
+                      "the recipient's own resolution rides the sender-side why")
+
+    def test_summary_head_is_the_fallback(self):
+        hid = self._plant(summary="The indicator shipped with a cancel X.\nMore detail below.")
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        why = st["nodes"][hid].get("doneWhy") or ""
+        self.assertIn("The indicator shipped with a cancel X.", why)
+        self.assertNotIn("More detail below", why, "the head only — capped like every quoted why")
+
+    def test_bare_form_when_the_recipient_carries_nothing(self):
+        hid = self._plant()
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        self.assertTrue((st["nodes"][hid].get("doneWhy") or "").startswith("completed by api (delegated)"))
+
+
+class DelegUnseenReArm(World):
+    def _sealed_world(self):
+        hid = self._plant(done_why="Shipped it")
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        # pre-fix seal: the closer looked AFTER the propagate filing, without the report in view
+        st["nodes"][SENDER + ":g1"]["closerLookT"] = jd._newest_filed(
+            st["nodes"], {None: [SENDER + ":g1"], SENDER + ":g1": [hid]}, SENDER + ":g1") + 10
+        jd.save_goals(SENDER, st)
+        return hid, jd.load_goals(SENDER)
+
+    def test_a_sealed_candidate_re_nominates_exactly_once(self):
+        hid, st = self._sealed_world()
+        cands = {nd["id"] for nd in jd._subtree_done_candidates(st)}
+        self.assertIn(SENDER + ":g1", cands,
+                      "sealed pre-fix world: the report was never in view — nominate once")
+        # the post-fix look stamps delegLookT AT/after the done filing (production stamps now(),
+        # always >= every existing `at`) → sealed again on THIS evidence
+        done_at = max(e["at"] for e in st["nodes"][hid]["log"] if e.get("kind") == "done")
+        st["nodes"][SENDER + ":g1"]["delegLookT"] = done_at + 1
+        cands = {nd["id"] for nd in jd._subtree_done_candidates(st)}
+        self.assertNotIn(SENDER + ":g1", cands, "a look that saw the report seals the re-arm")
+
+    def test_plain_children_keep_the_old_gate_exactly(self):
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":g1"] = _node(SENDER + ":g1", "Plain parent", None)
+        st["nodes"][SENDER + ":g2"] = _node(SENDER + ":g2", "Plain step", SENDER + ":g1", t=T + 10)
+        jd.record_verdict(st, st["nodes"][SENDER + ":g2"], "closer", "done", T + 50)
+        st["nodes"][SENDER + ":g1"]["closerLookT"] = jd._newest_filed(
+            st["nodes"], {None: [SENDER + ":g1"], SENDER + ":g1": [SENDER + ":g2"]}, SENDER + ":g1") + 10
+        cands = {nd["id"] for nd in jd._subtree_done_candidates(st)}
+        self.assertNotIn(SENDER + ":g1", cands,
+                         "no handoff child → the closerLookT seal is byte-identical to before")
+
+    def test_a_future_completion_re_arms_naturally(self):
+        hid, st = self._sealed_world()
+        done_at = max(e["at"] for e in st["nodes"][hid]["log"] if e.get("kind") == "done")
+        st["nodes"][SENDER + ":g1"]["delegLookT"] = done_at + 1   # the first report was seen
+        # a SECOND delegation completes LATER (a plain-dict fixture, so the filing's arrival
+        # time is controlled — record_verdict stamps wall-clock `at`)
+        st["nodes"][SENDER + ":g9"] = _node(
+            SENDER + ":g9", "↪ delegated to api: follow-on", SENDER + ":g1", t=T + 600,
+            handoff={"peer": RECIP, "msgId": "m2"}, nodeComplete=True,
+            log=[{"ev_t": T + 700, "src": "courier", "kind": "done",
+                  "why": "completed by api (delegated): follow-on shipped", "at": done_at + 100}])
+        cands = {nd["id"] for nd in jd._subtree_done_candidates(st)}
+        self.assertIn(SENDER + ":g1", cands, "a new report is new information — nominate again")
+
+
+class ReportLines(World):
+    def test_enriched_why_supplies_the_substance(self):
+        hid = self._plant(done_why="Shipped the indicator")
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        lines = jd._deleg_report_lines(st, SENDER + ":g1")
+        self.assertEqual(len(lines), 1)
+        self.assertIn("Shipped the indicator", lines[0])
+
+    def test_bare_why_fetches_the_recipient_read_only(self):
+        hid = self._plant(done_why="Shipped the indicator with a cancel X")
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        # simulate a PRE-FIX store: strip the substance back to the bare form
+        with jd._authority():
+            st["nodes"][hid]["doneWhy"] = "completed by api (delegated)"
+        lines = jd._deleg_report_lines(st, SENDER + ":g1")
+        self.assertIn("Shipped the indicator with a cancel X", lines[0],
+                      "the recipient join recovers the report for pre-fix stores")
+
+    def test_missing_recipient_still_reports_the_completion(self):
+        hid = self._plant(done_why="Shipped")
+        jd.run_propagate(now=T + 200)
+        (jd.GOALDIR / (RECIP + ".json")).unlink()
+        st = jd.load_goals(SENDER)
+        with jd._authority():
+            st["nodes"][hid]["doneWhy"] = "completed by api (delegated)"
+        lines = jd._deleg_report_lines(st, SENDER + ":g1")
+        self.assertEqual(len(lines), 1)
+        self.assertTrue(lines[0].endswith("completed it."), "no substance, but never silence")
+
+    def test_cross_host_peer_skips_the_fetch(self):
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":g1"] = _node(SENDER + ":g1", "Remote ask", None)
+        st["nodes"][SENDER + ":g2"] = _node(SENDER + ":g2", "↪ delegated to web", SENDER + ":g1",
+                                            t=T + 10, handoff={"peer": "TESTHOST:" + RECIP, "msgId": "m3"})
+        jd.record_verdict(st, st["nodes"][SENDER + ":g2"], "courier", "done", T + 50,
+                          why="reported back by TESTHOST:" + RECIP + " (delegated cross-host)")
+        st["nodes"][SENDER + ":g2"]["nodeComplete"] = True
+        lines = jd._deleg_report_lines(st, SENDER + ":g1")
+        self.assertEqual(len(lines), 1)
+        self.assertTrue(lines[0].endswith("completed it."),
+                        "another kernel's stores are not ours to read")
+
+
+class CloseTurnCarriesTheReport(World):
+    def test_the_menu_block_and_the_ruling_complete_the_ask(self):
+        hid = self._plant(done_why="Shipped the cancellable indicator")
+        jd.run_propagate(now=T + 200)
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":g1"]["closerLookT"] = jd._newest_filed(
+            st["nodes"], {None: [SENDER + ":g1"], SENDER + ":g1": [hid]}, SENDER + ":g1") + 10
+        jd.save_goals(SENDER, st)
+        st = jd.load_goals(SENDER)
+        seen = {}
+        saved = jd.closer_llm
+        jd.closer_llm = lambda work, menu_text, hist, lifts=None: (
+            seen.__setitem__("menu", menu_text) or
+            '{"done":[{"goal":1,"why":"the delegate shipped it and reported back"}],"block":[]}')
+        try:
+            turn = {"id": SENDER + ":t9", "t": T + 900, "ended": True, "atoms": [],
+                    "end": T + 901, "trigger": None}
+            newly = jd._close_turn(st, turn, seg_by_id={})
+        finally:
+            jd.closer_llm = saved
+        self.assertIn("Delegation reports", seen.get("menu") or "",
+                      "the cross-session report is a marked evidence section")
+        self.assertIn("Shipped the cancellable indicator", seen["menu"])
+        self.assertIn(SENDER + ":g1", newly, "the closer's done lands on the nominated ask")
+        self.assertTrue(st["nodes"][SENDER + ":g1"].get("nodeComplete"))
+        self.assertTrue(int(st["nodes"][SENDER + ":g1"].get("delegLookT") or 0) > 0,
+                        "the look that saw the report seals the re-arm")
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _turn(records, rompuuid=SENDER):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / (rompuuid + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        s = jd.em.parse_session(str(p), rompuuid=rompuuid, candidate_files=[str(p)], now=T + 900)
+        return s["turns"][0]
+
+
+class CloserHandoffStandDown(World):
+    """apply_close leg: a done verdict aimed at a '↪ delegated' tracking node stands down — its
+    deciding event is the RECIPIENT's completion (run_propagate / the reply sweep), never this
+    session's own dispatch-time prose. The audited specimen: the closer done'd the tracker at send
+    time ('queued to the peer'), propagate's real completion then no-op'd on the already-done node,
+    and the parent ask's nomination sealed on dispatched-only evidence."""
+
+    def _sender(self):
+        st = {"rompUuid": SENDER, "seq": 3, "nodes": {}, "placements": {}, "status": {}}
+        st["nodes"]["t1"] = _node("t1", "\u21aa delegated to web: seek indicator", None, t=T + 10,
+                                  handoff={"peer": RECIP, "msgId": MID})
+        return st
+
+    def test_a_dispatch_time_done_is_refused_and_a_plain_done_lands(self):
+        hid = self._plant(done_why="indicator wired; suite green")
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":p1"] = _node(SENDER + ":p1", "write the release note", None, t=T + 5)
+        tracker = st["nodes"][hid]
+        menu = [tracker, st["nodes"][SENDER + ":p1"]]
+        newly = jd.apply_close(st, menu, {"done": {1: "queued to the peer (T67)", 2: "note written"},
+                                          "block": {}}, t=T + 500)
+        self.assertFalse(tracker.get("nodeComplete"),
+                         "the tracker's ending event belongs to run_propagate, not this closer")
+        self.assertEqual([r for r in tracker.get("log") or [] if r.get("kind") == "done"], [],
+                         "a stand-down files nothing in either direction")
+        self.assertIn(SENDER + ":p1", newly,
+                      "the same reply's verdict on a plain node still lands")
+
+    def test_propagate_still_owns_the_completion(self):
+        hid = self._plant(done_why="indicator wired; suite green")
+        st = jd.load_goals(SENDER)
+        jd.apply_close(st, [st["nodes"][hid]], {"done": {1: "queued"}, "block": {}}, t=T + 500)
+        self.assertFalse(st["nodes"][hid].get("nodeComplete"))
+        jd.save_goals(SENDER, st)
+        jd.run_propagate(now=T + 900)
+        st2 = jd.load_goals(SENDER)
+        self.assertTrue(st2["nodes"][hid].get("nodeComplete"),
+                        "the authoritative writer's filing still lands after the stand-down")
+        self.assertIn("indicator wired", st2["nodes"][hid].get("doneWhy") or "",
+                      "…and it carries the recipient's own resolution")
+
+
+NUDGE = ("<!-- romp-injected -->Status check please. <!-- romp-goal-id: U -->")
+
+
+class CitedLeafRide(World):
+    """_status_report_candidates leg: on a nudge/follow-up turn, the CITED goals' open descendants
+    ride the closer menu — the audited umbrella's open leaf was reachable by NO channel (turn menus
+    need placements and the spliced nudge reply's dones strip; steps-finished needs
+    all-children-done; starved needs an empty diary), so three 'it's finished' replies filed
+    nothing."""
+
+    def _store_with_umbrella(self):
+        st = {"rompUuid": SENDER, "seq": 9, "nodes": {}, "placements": {}, "status": {}}
+        st["nodes"]["U"] = _node("U", "Feed renders correctly", None, umbrella=True)
+        st["nodes"]["done1"] = _node("done1", "shipped piece", "U", nodeComplete=True)
+        st["nodes"]["leaf"] = _node("leaf", "Show cancellable seek indicator", "U",
+                                    trail=["seg1"], log=[{"ev_t": T, "src": "planner",
+                                                          "kind": "sub", "at": T}])
+        st["nodes"]["trk"] = _node("trk", "\u21aa delegated to web: seek indicator", "leaf",
+                                   handoff={"peer": RECIP, "msgId": MID})
+        st["nodes"]["blockedleaf"] = _node("blockedleaf", "decide the copy", "U", blocked=True)
+        return st
+
+    def _nudge_turn(self):
+        return _turn([
+            {"type": "user", "timestamp": _iso(T + 600), "uuid": "n1", "parentUuid": None,
+             "promptSource": "sdk", "message": {"role": "user", "content": NUDGE}},
+            {"type": "assistant", "timestamp": _iso(T + 610), "uuid": "a1", "parentUuid": "n1",
+             "message": {"role": "assistant", "content": [{"type": "text",
+                         "text": "The seek indicator shipped and merged; suite green."}],
+                         "stop_reason": "end_turn"}}])
+
+    def test_the_cited_umbrellas_open_leaf_rides(self):
+        st = self._store_with_umbrella()
+        got = [nd["id"] for nd in jd._status_report_candidates(st, self._nudge_turn())]
+        self.assertIn("leaf", got, "the open leaf holding the umbrella at working is now rulable")
+        self.assertNotIn("U", got, "the umbrella itself stays structural")
+        self.assertNotIn("trk", got, "handoff trackers stay run_propagate's")
+        self.assertNotIn("blockedleaf", got, "blocked stays the unblocker's")
+        self.assertNotIn("done1", got)
+
+    def test_a_plain_turn_rides_nothing_cited(self):
+        st = self._store_with_umbrella()
+        turn = _turn([
+            {"type": "user", "timestamp": _iso(T + 600), "uuid": "u1", "parentUuid": None,
+             "promptSource": "typed", "message": {"role": "user", "content": "carry on"}},
+            {"type": "assistant", "timestamp": _iso(T + 610), "uuid": "a1", "parentUuid": "u1",
+             "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}],
+                         "stop_reason": "end_turn"}}])
+        self.assertEqual(jd._status_report_candidates(st, turn), [],
+                         "no status trigger, no ride — the gate is unchanged")
+
+    def test_a_plain_cited_goal_keeps_the_tops_only_shape(self):
+        # the 2026-07-26 pin (test_judge StatusReportMenu): a PLAIN cited goal is rulable itself,
+        # so its subs never ride — only a cited UMBRELLA opens the descendant walk
+        st = self._store_with_umbrella()
+        st["nodes"]["U"].pop("umbrella")
+        got = [nd["id"] for nd in jd._status_report_candidates(st, self._nudge_turn())]
+        self.assertNotIn("leaf", got)
+
+    def test_an_agent_open_subtree_stays_the_agents(self):
+        st = self._store_with_umbrella()
+        st["nodes"]["leaf"]["agentTask"] = {"key": "3", "status": "open"}
+        got = [nd["id"] for nd in jd._status_report_candidates(st, self._nudge_turn())]
+        self.assertNotIn("leaf", got, "the authoritative tier: the agent says work is owed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3657,11 +3657,21 @@ class StatusReportMenu(unittest.TestCase):
         blocked = _mknode(store, "waiting on the user"); blocked["blocked"] = True
         owed = _mknode(store, "agent still owes work")
         owed["agentTask"] = {"key": "k1", "status": "open"}
-        sub = _mknode(store, "a sub, not a card", parent=g1["id"])
+        g1["umbrella"] = True                          # the cited goal is a CONTAINER here (see below)
+        cited_sub = _mknode(store, "the cited goals own open leaf", parent=g1["id"])
+        other_top = _mknode(store, "an unrelated top")
+        other_sub = _mknode(store, "a sub of an uncited top", parent=other_top["id"])
         captured = self._spy('{"done": []}')
         jd._close_turn(store, turn)
-        for absent in ("already finished", "waiting on the user", "agent still owes work", "a sub, not a card"):
+        for absent in ("already finished", "waiting on the user", "agent still owes work",
+                       "a sub of an uncited top"):
             self.assertNotIn(absent, captured["mt"], "%r must not ride the widened menu" % absent)
+        # a cited UMBRELLA's open descendants DO ride since 2026-08-25 (the re-asking umbrella):
+        # the reply accounts for the named goal's work, and a container's top is unrulable — its
+        # open leaf, the node holding it at working, was reachable by no channel at all. A PLAIN
+        # cited goal keeps the tops-only menu exactly (the closer rules the goal itself;
+        # tests/test_deleg_report_close.py pins that shape).
+        self.assertIn("the cited goals own open leaf", captured["mt"])
 
 
 class SweepSession(unittest.TestCase):


### PR DESCRIPTION
## The loop

A manager-session umbrella kept generating status re-asks — the auto-nudge asked seven times in 75 minutes, the transcript answered "finished" three times, and the card ping-ponged nudge-block ↔ unblocker-unblock. The delegated work (tracked in a `notes-api`-style manager→worker world) had merged an hour earlier.

Five composing failures, five legs — all in the judge, all event-keyed:

1. **run_propagate carries the recipient's own resolution.** The sender-side tracking node's done-why was the bare "completed by <peer> (delegated)"; the recipient's actual outcome never crossed the store boundary. It now rides the recipient's `doneWhy` (else its summary head), capped like every quoted why, at the report-back event.
2. **The closer sees the report.** The steps-finished nomination showed an ask whose only visible history was the DISPATCH, so the closer correctly omitted. `_deleg_report_lines` now rides the menu as a marked "Delegation reports" section — with a read-only recipient-store join recovering the substance for pre-fix rows (cross-host peers skip the fetch; their stores live on another kernel).
3. **The seal re-arms once.** The omission's look-stamp (`closerLookT`) sealed the candidate forever (nothing files in a finished subtree again). `_deleg_unseen` re-nominates any candidate whose done handoff child no look has seen WITH the report visible (`delegLookT`, stamped beside the look) — the sealed backlog re-nominates exactly once post-upgrade; future completions re-arm by their own done filing. Event-keyed both ways; no clock.
4. **Only propagate ends a tracker.** `apply_close` stands down a closer done aimed at a '↪ delegated' tracking node: its ending event is the recipient's completion (run_propagate, or the cross-host reply sweep), never this session's own dispatch-time prose. A premature "queued to the peer" done had CONSUMED the slot — propagate's real completion then no-op'd, and the parent's nomination sealed on dispatched-only evidence. Nothing files in either direction; the same reply's other verdicts land.
5. **A cited umbrella's open leaves become rulable.** On a nudge/follow-up turn, `_status_report_candidates` now rides a cited UMBRELLA's open descendants: the container's top is structural — unrulable — and the leaf holding it at working rode NO channel (turn menus need placements, and a nudge spliced into a busy session's running turn strips its own dones by design; steps-finished needs all-children-done; starved needs an empty diary). A PLAIN cited goal keeps the tops-only lean menu exactly (the closer rules the goal itself) — busy managers get nudged the most, so every menu row is real cost.

The spliced-done strip stands untouched — it is load-bearing against confabulated dones; legs 2/5 give the answer judged paths that don't ride the spliced segment. The ping-pong itself was machinery acting correctly on a card that could never close; it retires with the ask's completion.

**No hand-edits:** the live specimen re-nominates via leg 3 on the first closer pass after deploy, and a dry-run of leg 5 against the live store confirms the stuck leaf rides the very next nudge-reply audit.

## Tests

`tests/test_deleg_report_close.py` (synthetic two-session worlds, private sids): propagate substance (doneWhy / summary-head / bare), the sealed-candidate exactly-once re-arm + plain-children byte-identical gate + future-completion natural re-arm, report lines (enriched / pre-fix join / missing recipient / cross-host skip), the closer stand-down (refused dispatch-done + propagate still landing with substance), the cited-umbrella leaf ride (leaf rides; umbrella, trackers, blocked, agent-open, plain-cited-goal all stay off), and an end-to-end `_close_turn` whose menu carries the report and whose ruling completes the ask + stamps the seal. `tests/test_judge.py` StatusReportMenu updated to the narrowed leg-5 semantics.

Suites: Python 5653 passed / 0 failed; UI 2409/2409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)