### PR TITLE
The tag button rests in its siblings' gray; accent only while the lens narrows

### DIFF
--- a/ui/webview/feed-tagmount.test.ts
+++ b/ui/webview/feed-tagmount.test.ts
@@ -66,7 +66,16 @@ test("the mount is the SHARED component: tag glyph button, stay-open menu, Confi
     "one management entry; creation lives in the dialog");
   assert.match(PIPE, /"openTagsDialog"/, "the VS Code pipe whitelists the route the kernel already carries");
   assert.match(FEED, /ensureTagLensBtn\(\)\.style\.display = showCA \? "" : "none";/, "footer-gated like its siblings");
-  assert.match(FEED, /b\.style\.color = active \? "var\(--accent\)" : "";/, "active wears the accent, never re-hardcoded");
+  // resting state = the SIBLINGS' computed style by construction (the user 2026-08-25, round two:
+  // the shared component's inline dress made rest blue-outlined and All off-black): the inline
+  // style is stripped and the className IS the sibling vocabulary — equality pinned, so it can't
+  // drift dark again; active is the standard .on class only, no inline colour anywhere.
+  assert.match(FEED, /b\.removeAttribute\("style"\);/);
+  assert.match(FEED, /b\.className = "fdismiss ffollow feed-modetoggle";/,
+    "the exact class string the Sessions/View buttons wear");
+  assert.match(FEED, /b\.classList\.toggle\("on", active\);/, "accent ONLY while the lens narrows");
+  const mnt = FEED.slice(FEED.indexOf("function ensureTagLensBtn"), FEED.indexOf("function ensureInternalLens"));
+  assert.ok(!mnt.includes("style.color"), "no inline colour survives in the mount");
 });
 
 test("what the lens hides stays one glance away: whisper, promoted banner, click-to-All (665 lineage)", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -908,6 +908,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    + promoted banner, revived under the user's OWN lens): dim one-liner after the columns; when the
    lens hides MORE than the board shows, the judge-limit banner's card chrome + the lens named.
    Neutral chrome — a narrowed board is a choice, not an error. */
+/* the tag-glyph button sits flush with its word-button siblings: same .fdismiss dress (the shared
+   component's inline style is stripped at mount — the user 2026-08-25, whose resting button wore an
+   accent outline and an off-black All state); only the svg centering is its own. */
+#feed-taglens { display: inline-flex; align-items: center; }
+#feed-taglens svg { display: block; }
 #feed-lensmore { padding: 4px 14px 10px; color: var(--dim); font-size: 0.82em; cursor: pointer; }
 #feed-lensmore:hover { color: var(--accent); text-decoration: underline; }
 #feed-lensmore.prominent { margin: 6px 8px 2px; padding: 10px 14px; background: #252526;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3373,12 +3373,17 @@ function ensureTagLensBtn(): HTMLElement {
       });
     });
     b.id = "feed-taglens";
-    b.classList.add("feed-modetoggle");
+    // FOOTER DRESS (the user 2026-08-25, round two: at rest the button outlined blue, and All faded
+    // it darker than its neighbours): the shared component ships its own inline style, and inline
+    // beats every class rule — strip it and wear the EXACT sibling vocabulary, so the resting state
+    // is the neighbours' computed style by construction and can never drift dark again. Active is
+    // the standard .on accent ONLY — the class the siblings use, never an inline colour.
+    b.removeAttribute("style");
+    b.className = "fdismiss ffollow feed-modetoggle";
     (document.getElementById("feed-foot") || document.body).appendChild(b);
   }
   const active = !lensAll(feedLens);
   b.classList.toggle("on", active);
-  b.style.color = active ? "var(--accent)" : "";   // the shared button's own gray otherwise
   b.setAttribute("aria-pressed", active ? "true" : "false");
   return b;
 }


### PR DESCRIPTION
Round two on the feed's tag button: at rest it wore an accent outline, and All faded it darker than its neighbours. Root cause: the shared component's inline style beats every class rule, so the footer's `.fdismiss` dress never painted and the mount's inline colour toggle left rest in the component's alien state.

The mount strips the inline style and wears the exact sibling vocabulary (`className = "fdismiss ffollow feed-modetoggle"`) — the resting state is the neighbours' computed style **by construction**, pinned as class-string equality plus a no-inline-colour sweep of the mount so it can't drift dark again. Active is the standard `.on` class only. Verified headlessly: resting renders identical to View ▴ / Sessions ▴; active wears the standard accent. 2418 extension tests green on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)