### PR TITLE
The badge caret stays in its badge: the menu-row caret rule is scoped to the row

### DIFF
--- a/ui/webview/meta-caret-scope.test.ts
+++ b/ui/webview/meta-caret-scope.test.ts
@@ -1,0 +1,26 @@
+// The Fast toggle's caret floated mid-sidebar (the user 2026-08-25): the version-submenu work added
+// a LATER, bare `.meta-caret { position: absolute; … }` for menu rows — same specificity as the
+// statusline-badge caret rule above it, so source order won and every badge's ▾ absolutely
+// positioned against some distant ancestor. The row rule is now SCOPED to `.meta-item .meta-caret`
+// (the row is the position:relative anchor), and this pins the TIEBREAK, not just existence — the
+// css-state-rules-must-win-cascade lesson.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the badge caret stays in flow; only MENU-ROW carets are absolutely positioned", () => {
+  // the badge rule: in-flow, sized/dimmed only
+  assert.match(CSS, /\.meta-caret \{ font-size: 0\.78em; opacity: 0\.65; \}/);
+  // the row rule: scoped under .meta-item (its position:relative anchor)
+  assert.match(CSS, /\.meta-item \.meta-caret \{ position: absolute; right: 22px; top: 50%;/);
+  // the cascade pin: NO bare .meta-caret rule may carry position — a later unscoped one is exactly
+  // the regression this guards (scan every bare-selector block for the property)
+  for (const m of CSS.matchAll(/(^|\n)\.meta-caret \{([^}]*)\}/g)) {
+    assert.ok(!/position\s*:/.test(m[2]), "a bare .meta-caret rule must never set position: " + m[2].trim());
+  }
+  // …and .meta-item is the anchor the scoped rule assumes
+  assert.match(CSS, /\.meta-item \{[^}]*position: relative;/s);
+});

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -970,8 +970,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    0.82em / 0.6 opacity as .ctx-item-sub — one sub-line size across every romp menu. */
 .meta-item-sub { font-size: 0.82em; opacity: 0.6; }
 /* the version-submenu affordance on model families (the user 2026-08-25): a dim caret at the row's
-   right, sitting left of the current-check slot; the submenu itself is a second .meta-menu beside it */
-.meta-caret { position: absolute; right: 22px; top: 50%; transform: translateY(-50%); opacity: 0.55; }
+   right, sitting left of the current-check slot; the submenu itself is a second .meta-menu beside it.
+   SCOPED to menu rows (.meta-item is the position:relative anchor): the first cut wrote a bare
+   .meta-caret, which — being later in the sheet — beat the statusline-badge caret rule above and
+   sent every badge's ▾ absolutely positioning against some distant ancestor: the Fast toggle's
+   caret floated mid-sidebar (the user 2026-08-25). Same-property competing rules must have their
+   tiebreak pinned, not just their existence. */
+.meta-item .meta-caret { position: absolute; right: 22px; top: 50%; transform: translateY(-50%); opacity: 0.55; }
 .meta-sub { z-index: 61; }
 .meta-item.current::after {
   content: "✓"; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);


### PR DESCRIPTION
## The bug

The Fast toggle's caret displayed mid-sidebar. The version-submenu work added a **later, bare** `.meta-caret { position: absolute; right: 22px; top: 50%; … }` intended for menu rows — same specificity as the statusline-badge caret rule above it, so source order won and every badge's ▾ (mode/model/effort/fast, chat statusline and popover statusline alike) absolutely positioned against some distant ancestor instead of sitting in its badge.

## The fix

Scope the row rule to `.meta-item .meta-caret` — the row is the `position: relative` anchor its offsets were written for. The submenu's side-measurement math is untouched (it was never the problem).

## Verification

Headless, sidebar-shaped viewport (420×900): on main's sheet, the fast caret's rect **escapes** its badge; with the fix, all four badges' carets sit inside their badges (`caretInsideBadge: true` ×4).

## Test

`meta-caret-scope.test.ts` pins the **tiebreak**, not just existence (the standing competing-rules lesson): the badge rule stays in-flow, the scoped row rule alone carries `position`, `.meta-item` is pinned as the anchor, and a scan asserts no bare `.meta-caret` rule may ever set `position` again. npm suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)