### PR TITLE
Session rows wear their tag chips — grouping visible, the controls stay separate

### DIFF
--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -10,6 +10,7 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { prefixInbound, mergeHostFeeds } from "./federation";
+import { lensUnions } from "./tag-lens";
 
 const ROOT = path.resolve(process.cwd(), "..");
 const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
@@ -66,6 +67,27 @@ test("the combobox sits right of the view-menu icon, lists sessions in tab order
   assert.ok(FEED.includes("const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));"));
   // the menu lives on document.body — outside render()'s reconcile, so a push can't rebuild it mid-press
   assert.ok(FEED.includes("document.body.appendChild(menu);"));
+});
+
+test("session rows carry their tag chips — grouping visible, the pick untouched (2026-08-25)", () => {
+  // the union math executes against both tag-home shapes (the shared model's own function)
+  const views = { tags: [{ id: "t1", name: "infra", members: [U] }],
+    remoteTags: [{ id: "TESTHOST:t9", name: "infra", members: [V] }, { id: "TESTHOST:t8", name: "web", members: [V] }] };
+  const unions = lensUnions(views);
+  const chipsFor = (sid: string) => unions.filter((g: any) => g.members.includes(sid)).map((g: any) => g.name);
+  assert.deepEqual(chipsFor(U), ["infra"], "a locally-tagged session wears its union chip");
+  assert.deepEqual(chipsFor(V), ["infra", "web"], "a remote-homed member joins the SAME name-keyed union");
+  // the row wiring: chips appended only when the session has any, the dialog's outline vocabulary,
+  // non-interactive, ellipsizing in the row's leftover space
+  assert.match(FEED, /if \(!g\.members\.includes\(pick\)\) continue;/);
+  assert.match(FEED, /if \(chips\.childElementCount\) r\.appendChild\(chips\);/);
+  assert.match(FEED, /if \(g\.color\) \{ c\.style\.color = g\.color; c\.style\.borderColor = g\.color; \}/,
+    "the tag's own colour, outline-pill like the dialog");
+  const CSS2 = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
+  assert.match(CSS2, /\.fsm-chips \{ flex: 1 1 auto; min-width: 0; margin-left: 8px; text-align: right;\s*\n\s*overflow: hidden; text-overflow: ellipsis; white-space: nowrap; pointer-events: none; \}/,
+    "ellipsizes, never wraps the row; never a click target — the pick stays byte-identical");
+  assert.match(CSS2, /\.fsm-chip-tag \{ display: inline-block; font-style: normal; padding: 0 6px; margin-left: 4px;/,
+    "compact at the row's scale");
 });
 
 test("menu rows write a session the way the tabs do — coloured bold name + the shared status dot", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -945,6 +945,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   border-radius: 4px; cursor: pointer; font-size: 11.5px; white-space: nowrap; }
 .feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
 .feed-sessmenu .fsm-row.on { background: rgba(156, 210, 255, 0.12); }
+/* TAG CHIPS on the combobox's session rows (the user 2026-08-25 — the smaller unification variant):
+   the dialog's own outline-pill vocabulary at the row's scale, NON-interactive (grouping made
+   visible; the controls stay separate). The strip ellipsizes in the row's leftover space — names
+   stay primary and rows never wrap. */
+.fsm-chips { flex: 1 1 auto; min-width: 0; margin-left: 8px; text-align: right;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; pointer-events: none; }
+.fsm-chip-tag { display: inline-block; font-style: normal; padding: 0 6px; margin-left: 4px;
+  border: 1px solid var(--dim); border-radius: 9px; font-size: 0.82em; color: var(--dim); }
 /* the VIEW MENU (the user 2026-08-24): the sort + layout controls live behind one monochrome ordering
    glyph now (NOT a gear — the strip's ⛭ sits right below this footer on the kernel page). The popup
    wears the shared .ctx-menu vocabulary (chrome defined with the card menus below); these rules add

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3623,6 +3623,22 @@ function openSessList(): void {
     r.setAttribute("role", "option");
     if (pick !== null) r.setAttribute("data-sid", pick);
     if (name !== null) r.setAttribute("data-name", name);
+    // TAG CHIPS inline (the user 2026-08-25 — the unification call's smaller variant): the session's
+    // name-keyed union tags as compact outline chips, the dialog's own one-chip-per-name vocabulary,
+    // NON-interactive (grouping made visible; the two controls stay separate and the pick is
+    // untouched). The strip ellipsizes in the row's leftover space so names stay primary.
+    // (Deliberately NOT built, decided: search matching tag names — the pick list stays sessions-only.)
+    if (pick !== null) {
+      const chips = el("span", "fsm-chips");
+      for (const g of lensUnions(feedTagViews)) {
+        if (!g.members.includes(pick)) continue;
+        const c = el("i", "fsm-chip-tag");
+        c.textContent = g.name;
+        if (g.color) { c.style.color = g.color; c.style.borderColor = g.color; }
+        chips.appendChild(c);
+      }
+      if (chips.childElementCount) r.appendChild(chips);
+    }
     r.onclick = (ev) => {   // pick = the exact filter, worn as the bar's chip; the list closes, the bar stays
       ev.stopPropagation();
       const already = (r.getAttribute("data-sid") || null) === feedOnlySid;


### PR DESCRIPTION
The tags-vs-Sessions unification call, decided as the **smaller variant**: each session row in the feed's combobox renders that session's tag chips inline — the name-keyed union, one chip per name in the dialog's own outline-pill vocabulary, the tag's colour, compact at the row's scale. The strip is non-interactive and right-aligned, ellipsizing in the row's leftover space so session names stay primary and rows never wrap; untagged sessions render exactly as before. The two controls stay fully separate: no tag rows in the list, no lens toggling from here, and the pick semantics are byte-identical — the suite's existing pick pins stand untouched.

**Deliberately not built (decided):** the search-matching-tag-names variant — the pick list stays sessions-only; the shelf is recorded at the site and here.

Tests execute the union membership against both tag-home shapes (a remote-homed member joins the same name-keyed union) and pin the row wiring, the dialog vocabulary, the non-interactive ellipsizing strip, and the colour treatment. 2421 extension tests green on the pushed head; rows verified headlessly including the overflow case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)