### PR TITLE
The tag button wears one convention: gray alone at rest, accent + selection chips narrowed

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2706,26 +2706,32 @@ class TimelinePanel {
     const lens = timelineLens(v);
     const unions = viewTagUnion(v);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
-    // any non-All selection is a FILTER; the chip names the whole selection ("infra + no tags" —
-    // ONE combined chip, the honest one-line read inside the gutter's space; per-tag chips would
-    // ellipsize each other out at two picks). Its ✕ resets to All.
+    // any non-All selection is a FILTER shown as PER-SELECTION CHIPS (the user's 2026-08-25
+    // convention, retargeting the earlier one-combined-chip call): each selected tag as its own
+    // chip in its color, the no-tags bucket as its own chip, a dim ✕ per chip unselecting that
+    // one pick. Chips that don't fit the gutter collapse into a dim "+N" that opens the menu.
     const active = !lensAll(lens);
-    const firstTag = active ? unions.find((u) => (lens.tags || []).indexOf(u.name) >= 0) : null;
-    const gcol = (firstTag && firstTag.color) || MODEL_FG;   // a pure no-tags pick wears the line's own gray
-    const gdim = firstTag ? 1 : 0.7;
-    const PADH = 7, GAP = 6;   // the chip's horizontal padding; the space between the line's parts
+    const chips = active ? (lens.tags || []).map((n) => {
+      const u = unions.find((x) => x.name === n);
+      return { label: n, color: (u && u.color) || MODEL_FG, pick: { tag: n } };
+    }).concat(lens.none ? [{ label: 'no tags', color: MODEL_FG, pick: 'none' }] : []) : [];
+    const PADH = 7, GAP = 9;   // the chip's horizontal padding; the space between the line's parts (the user 2026-08-25: more air)
     // TWO monochrome icon buttons (the user 2026-08-25): display options (sliders) LEFT of the tag
     // filter (tag icon) — the display toggles left the tags menu for their own button. Icon-only,
     // MODEL_FG, 14px, drawn inline (no icon font in the Obsidian host); tooltips carry the words.
-    const ICONW = 18;
-    let name = active ? lensLabel(lens) : '';
+    const ICONW = 22;   // wider than the icon: the extra is the controls' breathing room (2026-08-25)
     const tailStr = more ? more + ' more' : '';
-    const XGAP = 6;                                  // between the name and its dim ✕ (the composer chip's read)
-    const width = (n) => ICONW * 2
-      + (active ? GAP + PADH * 2 + this.labelWidth(n) + XGAP + this.labelWidth('✕') : 0)
-      + (tailStr ? GAP + this.labelWidth(tailStr) : 0);
-    const fits = (n) => width(n) <= this.M.left - PADL - 6;
-    while (active && name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
+    const XGAP = 6;                                  // between a chip's name and its dim ✕ (the composer chip's read)
+    const chipW = (c) => PADH * 2 + this.labelWidth(c.label) + XGAP + this.labelWidth('✕');
+    const budget = this.M.left - PADL - 6 - ICONW * 2 - (tailStr ? GAP + this.labelWidth(tailStr) : 0);
+    let used = 0, shown = [];
+    for (const c of chips) {
+      const w = GAP + chipW(c);
+      const restW = chips.length - shown.length - 1 > 0 ? GAP + this.labelWidth('+' + (chips.length - shown.length - 1)) : 0;
+      if (used + w + restW > budget) break;
+      shown.push(c); used += w;
+    }
+    const hidden = chips.length - shown.length;
     const y = axisY + 14;
     const iconBtn = (dx, title, draw, open) => {
       const btn = el('g', {});
@@ -2749,50 +2755,60 @@ class TimelinePanel {
           stroke: MODEL_FG, 'stroke-width': 1.4 }));
       }
     }, (btn) => this._openDisplayMenu(btn));
-    // tag: the classic label outline with its hole — the filter-by-tag read (the user chose a tag icon)
+    // tag: the classic label outline with its hole — the filter-by-tag read (the user chose a tag
+    // icon). THE BUTTON CONVENTION (2026-08-25): GRAY at rest (All), the ACCENT while narrowed —
+    // the same values the shared webview renderer uses (#9aa0a6 / #9cd2ff, cross-mount equality)
+    const tagIconCol = active ? '#9cd2ff' : MODEL_FG;
     iconBtn(ICONW, 'filter these lanes by tag', (btn, bx, by) => {
       const ox = bx + 1, oy = by - 11;
       btn.appendChild(el('path', {
         d: 'M ' + ox + ' ' + (oy + 5.5) + ' l 5.5 -4.5 h 6.5 v 6.5 l -5.5 4.5 z',
-        fill: 'transparent', stroke: MODEL_FG, 'stroke-width': 1.4, 'stroke-linejoin': 'round' }));
-      btn.appendChild(el('circle', { cx: ox + 9.5, cy: oy + 3.5, r: 1.3, fill: MODEL_FG }));
+        fill: 'transparent', stroke: tagIconCol, 'stroke-width': 1.4, 'stroke-linejoin': 'round' }));
+      btn.appendChild(el('circle', { cx: ox + 9.5, cy: oy + 3.5, r: 1.3, fill: tagIconCol }));
     }, (btn) => this._openViewsMenu(btn));
     let x = PADL + ICONW * 2;
-    if (active) {
+    for (const c of shown) {
       x += GAP;
-      const cw = PADH * 2 + this.labelWidth(name) + XGAP + this.labelWidth('✕');
-      // the active tag as a removable filter chip (the user 2026-08-23; re-dressed 2026-08-24):
-      // OUTLINE only in the tag's colour on the page's own dark ground — the tinted fill was too
-      // much — with the ✕ dim and SEPARATE, the way the composer context chip draws its ✕. Taller
-      // than the text line so the chip breathes (the bottom margin grew with it). Its own
-      // pointerdown clears the filter — one click back to the default view, no menu trip.
+      const cw = chipW(c);
+      // each selected pick as its own chip (2026-08-25): OUTLINE in its colour on the dark ground,
+      // ✕ dim and SEPARATE (the composer chip's read) — the ✕ unselects THAT pick, not the filter
       const grp = el('g', {});
       grp.setAttribute('style', 'cursor:pointer;');
-      const box = el('rect', { x, y: y - 13, width: cw, height: 18, rx: 9,
-        fill: 'transparent',
-        stroke: gcol, 'stroke-width': 1, opacity: gdim });
-      grp.appendChild(box);
-      const ct = el('text', { x: x + PADH, y, 'font-size': 12, fill: gcol, 'font-weight': 650, opacity: gdim });
-      ct.textContent = name;
+      grp.appendChild(el('rect', { x, y: y - 13, width: cw, height: 18, rx: 9,
+        fill: 'transparent', stroke: c.color, 'stroke-width': 1 }));
+      const ct = el('text', { x: x + PADH, y, 'font-size': 12, fill: c.color, 'font-weight': 650 });
+      ct.textContent = c.label;
       ct.setAttribute('style', 'user-select:none;');
       grp.appendChild(ct);
-      const cx = el('text', { x: x + PADH + this.labelWidth(name) + XGAP, y, 'font-size': 11,
+      const cx = el('text', { x: x + PADH + this.labelWidth(c.label) + XGAP, y, 'font-size': 11,
         fill: MODEL_FG, opacity: 0.75 });
       cx.textContent = '✕';
       cx.setAttribute('style', 'user-select:none;');
       grp.appendChild(cx);
       const tt = el('title', {});
-      tt.textContent = 'this timeline shows only: ' + lensLabel(lens) + ' — click to remove the filter (back to All)';
+      tt.textContent = 'remove \u201c' + c.label + '\u201d from this timeline\u2019s filter';
       grp.appendChild(tt);
       grp.addEventListener('pointerdown', (e) => {
         e.preventDefault(); e.stopPropagation();
         const nv = JSON.parse(JSON.stringify(v));
-        nv.actives = Object.assign({}, nv.actives, { timeline: { all: true } });
+        nv.actives = Object.assign({}, nv.actives, { timeline: lensToggle(lens, c.pick) });
         this._setViews(nv);
       });
       grp.addEventListener('click', (e) => e.stopPropagation());
       svg.appendChild(grp);
       x += cw;
+    }
+    if (hidden > 0) {
+      // the picks that didn't fit the gutter — one dim count, one click from the menu
+      const hx = el('text', { x: x + GAP, y, 'font-size': 12, fill: MODEL_FG, opacity: 0.7 });
+      hx.textContent = '+' + hidden;
+      hx.setAttribute('style', 'user-select:none;cursor:pointer;');
+      const ht = el('title', {}); ht.textContent = hidden + ' more selected — open the tag filter';
+      hx.appendChild(ht);
+      hx.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(hx); });
+      hx.addEventListener('click', (e) => e.stopPropagation());
+      svg.appendChild(hx);
+      x += GAP + this.labelWidth('+' + hidden);
     }
     if (more) {
       const m = el('text', { x: x + GAP, y, 'font-size': 12, fill: MODEL_FG, opacity: 0.7 });

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -86,20 +86,22 @@ test("the trigger sits in the corner strip and opens on pointerdown, like every 
 test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separate ✕, air below (the user 2026-08-24)", () => {
   // the chip's own pointerdown clears the filter without a menu trip; stopPropagation keeps the
   // text element's menu handler out of it (both are pointerdown — the redraw-eats-click rule)
-  assert.match(SRC, /grp\.addEventListener\('pointerdown', \(e\) => \{\n\s*e\.preventDefault\(\); e\.stopPropagation\(\);\n\s*const nv = JSON\.parse\(JSON\.stringify\(v\)\);\n\s*nv\.actives = Object\.assign\(\{\}, nv\.actives, \{ timeline: \{ all: true \} \}\);/,
-    "the ✕ clears THIS surface's lens back to All");
+  assert.match(SRC, /nv\.actives = Object\.assign\(\{\}, nv\.actives, \{ timeline: lensToggle\(lens, c\.pick\) \}\);/,
+    "each chip's ✕ unselects THAT pick (per-selection chips, the user 2026-08-25)");
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
-  assert.match(SRC, /fill: 'transparent',\n\s*stroke: gcol, 'stroke-width': 1, opacity: gdim/);
+  assert.match(SRC, /fill: 'transparent', stroke: c\.color, 'stroke-width': 1/);
   // a SENTINEL view's chip dims to the corner line's own gray at the N-more opacity (the user
   // 2026-08-24: at #cccccc it read bright as a tag) — real tag chips keep their tag colors, full strength
-  assert.match(SRC, /const gcol = \(firstTag && firstTag\.color\) \|\| MODEL_FG;/);
-  assert.match(SRC, /const gdim = firstTag \? 1 : 0\.7;/);
+  // per-selection chips since 2026-08-25: each pick derives its own colour (no-tags in the gray)
+  assert.match(SRC, /return \{ label: n, color: \(u && u\.color\) \|\| MODEL_FG, pick: \{ tag: n \} \};/);
+  assert.match(SRC, /\.concat\(lens\.none \? \[\{ label: 'no tags', color: MODEL_FG, pick: 'none' \}\] : \[\]\)/);
   assert.match(SRC, /y: y - 13, width: cw, height: 18, rx: 9,/, "taller chip");
   assert.match(SRC, /cx\.textContent = '✕';/);
   assert.match(SRC, /fill: MODEL_FG, opacity: 0\.75/);
-  assert.match(SRC, /fill: gcol, 'font-weight': 650, opacity: gdim/);
-  assert.match(SRC, /click to remove the filter \(back to All\)/);
+  assert.match(SRC, /fill: c\.color, 'font-weight': 650/);
+  assert.match(SRC, /remove \\u201c' \+ c\.label \+ '\\u201d from this timeline/,
+    "the ✕ hover names the ONE pick it removes");
   // no chip on All — the unfiltered default; the untagged view IS a filter now, so it wears one
   assert.match(SRC, /const active = !lensAll\(lens\);/, "any non-All lens selection shows the chip (2026-08-25)");
   // …and the bottom strip grew so the taller chip has air
@@ -115,7 +117,7 @@ test("the corner line wears the LANE LABELS' typography — inherited family, me
   assert.doesNotMatch(TRIG, /font-family/, "corner texts inherit the host font exactly like lane labels");
   // …at the lane-label scale: the N-more at the lane 12px, the chip name at the lane-name 650
   // (the "Filter ▾" trigger TEXT retired 2026-08-25 — the corner is two icon buttons now)
-  assert.match(TRIG, /'font-size': 12, fill: gcol, 'font-weight': 650/);
+  assert.match(TRIG, /'font-size': 12, fill: c\.color, 'font-weight': 650/);
   assert.match(SRC, /'font-weight': 650, 'font-size': 12, fill: F\(s\.color\)/, "the lane-name reference the line matches");
   // …and the width/ellipsis math measures in the SAME family the text renders in: _font resolves
   // the wrap's computed family (FONT is only the unstyled/bare-node fallback), so box and ellipsis
@@ -249,8 +251,11 @@ test("executed: the dialog's membership mutation, pure (viewToggleHidden retired
 
 test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {
   // the fit measures the whole line as LAID OUT: trigger + gap + padded chip + gap + tail
-  assert.match(SRC, /const width = \(n\) => ICONW \* 2\n\s*\+ \(active \? GAP \+ PADH \* 2 \+ this\.labelWidth\(n\) \+ XGAP \+ this\.labelWidth\('✕'\) : 0\)\n\s*\+ \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
-  assert.match(SRC, /const fits = \(n\) => width\(n\) <= this\.M\.left - PADL - 6;/);
+  // per-chip budgeting since 2026-08-25: chips render while they fit; the rest collapse into +N
+  assert.match(SRC, /const chipW = \(c\) => PADH \* 2 \+ this\.labelWidth\(c\.label\) \+ XGAP \+ this\.labelWidth\('✕'\);/);
+  assert.match(SRC, /const budget = this\.M\.left - PADL - 6 - ICONW \* 2 - \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
+  assert.match(SRC, /if \(used \+ w \+ restW > budget\) break;/);
+
   assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
   assert.match(SRC, /this\._viewsDialogKey\.doc\.removeEventListener\('keydown', this\._viewsDialogKey\.fn\);/);
 });

--- a/ui/webview/feed-tagmount.test.ts
+++ b/ui/webview/feed-tagmount.test.ts
@@ -73,7 +73,10 @@ test("the mount is the SHARED component: tag glyph button, stay-open menu, Confi
   assert.match(FEED, /b\.removeAttribute\("style"\);/);
   assert.match(FEED, /b\.className = "fdismiss ffollow feed-modetoggle";/,
     "the exact class string the Sessions/View buttons wear");
-  assert.match(FEED, /b\.classList\.toggle\("on", active\);/, "accent ONLY while the lens narrows");
+  // the 696 instance toggle subsumed by the SHARED convention renderer (the user 2026-08-25):
+  // class mode keeps the footer's .on mechanics, and the selection chips render beside the button
+  assert.match(FEED, /syncTagFilter\(b, ch, feedLens, lensUnions\(feedTagViews\) as never, \(l\) => \{ setFeedLens\(l\); render\(\); \}, "class"\);/,
+    "accent ONLY while the lens narrows — via the shared renderer");
   const mnt = FEED.slice(FEED.indexOf("function ensureTagLensBtn"), FEED.indexOf("function ensureInternalLens"));
   assert.ok(!mnt.includes("style.color"), "no inline colour survives in the mount");
 });

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -11,7 +11,7 @@ import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
 import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
-import { openTagMenu, tagMenuButton } from "./tag-menu";
+import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
 import { SessionViews } from "./session-views";
 import { freezeDiff, contentSig } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
@@ -3382,9 +3382,17 @@ function ensureTagLensBtn(): HTMLElement {
     b.className = "fdismiss ffollow feed-modetoggle";
     (document.getElementById("feed-foot") || document.body).appendChild(b);
   }
-  const active = !lensAll(feedLens);
-  b.classList.toggle("on", active);
-  b.setAttribute("aria-pressed", active ? "true" : "false");
+  // THE BUTTON CONVENTION (the user 2026-08-25), shared renderer — subsumes the 696 instance
+  // toggle: same .on class mechanics (mode "class", so the footer's sibling dress stands), plus
+  // the chips of everything selected beside the button, identical to every other mount
+  let ch = document.getElementById("feed-tagchips") as HTMLElement | null;
+  if (!ch) {
+    ch = document.createElement("span");
+    ch.id = "feed-tagchips";
+    ch.setAttribute("style", "display:inline-flex;gap:5px;align-items:center;margin-left:2px;");
+    b.after(ch);
+  }
+  syncTagFilter(b, ch, feedLens, lensUnions(feedTagViews) as never, (l) => { setFeedLens(l); render(); }, "class");
   return b;
 }
 

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -7,7 +7,7 @@
 import { delegate } from "./actions";
 import { SessionViews, viewTagUnion } from "./session-views";
 import { lensVisible, surfaceLens } from "./tag-lens";
-import { openTagMenu, tagMenuButton } from "./tag-menu";
+import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
 import { fleetVisibleRoots } from "./fleet-roots";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostPrefix } from "./host-prefix";
@@ -38,6 +38,7 @@ let loaded = false;
 let emptyShown = false;   // the romp wordmark is currently showing → don't replay its fade-in every push
 let searchQuery = "";     // #fleet-search filter (the user 2026-06-29): show only sessions whose NAME matches
 let fleetViews: SessionViews | null = null;   // the rendered views blob off the feed payload — the outline lens reads it (2026-08-25)
+let syncFleetTagBtn: (() => void) | null = null;   // re-dress the tag button per the shared convention on each render
 // Provisional cards (the user 2026-06-29): a session working a brand-new prompt the planner hasn't classified
 // into a goal yet has NO ledger node, so it's invisible in the fleet — exactly the "things about to appear" the
 // user wants to track. They ride the SAME feed payload (feed.asks, provisional:true), so surface a dotted
@@ -346,6 +347,7 @@ function renderFleetNode(ctx: SessCtx, n: LedgerNode, depth: number, container: 
 }
 
 function render() {
+  syncFleetTagBtn?.();
   const list = document.getElementById("fleet-list");
   if (!list) return;
   list.replaceChildren();
@@ -845,6 +847,19 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
       });
     });
     barEl.appendChild(tagBtn);
+    const chipsHost = document.createElement("span");
+    chipsHost.id = "fleet-tagchips";
+    chipsHost.setAttribute("style", "display:inline-flex;gap:5px;align-items:center;margin-left:2px;");
+    barEl.appendChild(chipsHost);
+    // the shared convention: gray alone at rest, accent + selection chips when narrowed
+    syncFleetTagBtn = () => syncTagFilter(tagBtn, chipsHost, surfaceLens(fleetViews, "outline"), viewTagUnion(fleetViews), (l) => {
+      const v = JSON.parse(JSON.stringify(fleetViews || { active: "all", tags: [] }));
+      v.actives = Object.assign({}, v.actives, { outline: l });
+      fleetViews = v;
+      vscodeApi?.postMessage({ type: "setTimelineViews", views: v });
+      render();
+    });
+    syncFleetTagBtn();
   }
   const syncClear = () => { if (clear) clear.hidden = search.value === ""; };
   search.addEventListener("input", () => { searchQuery = search.value; syncClear(); render(); });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -15,7 +15,7 @@ import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { lensVisible, surfaceLens } from "./tag-lens";
-import { openTagMenu, tagMenuButton } from "./tag-menu";
+import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
@@ -4524,7 +4524,22 @@ function renderTabs() {
     });
   });
   tagBtn.classList.add("tab-tagfilter");
+  // vertically centered against the + tab's box (the user 2026-08-25 — it sat high)
+  tagBtn.style.alignSelf = "center";
   bar.appendChild(tagBtn);
+  // THE BUTTON CONVENTION (the user 2026-08-25): gray alone at rest; accent + the chips of
+  // everything selected when narrowed — the shared renderer, identical on every mount
+  const tagChipsHost = el("span", "tab-tagchips");
+  tagChipsHost.setAttribute("style", "display:inline-flex;gap:5px;align-items:center;align-self:center;margin-left:2px;");
+  bar.appendChild(tagChipsHost);
+  {
+    const v = effViews();
+    syncTagFilter(tagBtn, tagChipsHost, surfaceLens(v, "chat"), viewTagUnion(v), (l) => {
+      const nv = JSON.parse(JSON.stringify(v || { active: "all", tags: [] }));
+      nv.actives = Object.assign({}, nv.actives, { chat: l });
+      postViews(nv);
+    });
+  }
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
   if (refocusTab) focusActiveTab();
   syncNoSessionsPlaceholder(visibleIds.length, ids.length);

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -1,0 +1,57 @@
+// THE TAG BUTTON CONVENTION (the user 2026-08-25): at rest (All) the tag icon is GRAY and stands
+// alone; narrowed, it wears the ACCENT and the chips of everything selected — each tag in its
+// color, the no-tags bucket as its own chip — identical across the timeline, chat, outline, and
+// feed mounts. Equality is COMPUTED, not class-shared (the 678 lesson): the executed model is one
+// function; the color constants are asserted equal across every home that states them.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { lensChips } from "./tag-lens";
+import { TAG_BTN_GRAY, TAG_BTN_ACCENT } from "./tag-menu";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const FLEET = ui("webview", "fleet.ts");
+const FEED = ui("webview", "feed.ts");
+const FEEDCSS = ui("webview", "feed.css");
+const TL = ui("romp-timeline-view.js");
+
+const UNIONS = [
+  { name: "infra", color: "#DD42FF", members: [] },
+  { name: "workers", color: "#4EC9B0", members: [] },
+];
+
+test("executed: lensChips — All bare; narrowed = every selection incl. the no-tags chip", () => {
+  assert.deepEqual(lensChips({ all: true }, UNIONS as never), [], "All → the button stands alone");
+  assert.deepEqual(lensChips({ tags: ["infra"] }, UNIONS as never),
+    [{ label: "infra", color: "#DD42FF", pick: { tag: "infra" } }]);
+  assert.deepEqual(lensChips({ none: true, tags: ["workers"] }, UNIONS as never),
+    [{ label: "workers", color: "#4EC9B0", pick: { tag: "workers" } },
+     { label: "no tags", color: null, pick: "none" }],
+    "the no-tags bucket is its own chip, last");
+});
+
+test("cross-mount computed equality: one gray, one accent, everywhere", () => {
+  assert.equal(TAG_BTN_GRAY, "#9aa0a6");
+  assert.equal(TAG_BTN_ACCENT, "#9cd2ff");
+  // the timeline inlines the same values (it loads no modules — Obsidian host)
+  assert.match(TL, /const MODEL_FG = '#9aa0a6';/, "the timeline's gray IS the convention gray");
+  assert.match(TL, /const tagIconCol = active \? '#9cd2ff' : MODEL_FG;/, "gray at rest, accent narrowed");
+  // the feed's class mode resolves to the same accent (its own :root states the literal)
+  assert.match(FEEDCSS, /--accent: #9cd2ff;/, "feed.css's accent equals the convention accent");
+  assert.match(FEED, /"class"\);/, "the feed mounts in class mode — its .on carries that accent");
+});
+
+test("every JS mount renders through the ONE convention function", () => {
+  for (const [name, src] of [["render", RENDER], ["fleet", FLEET], ["feed", FEED]] as const)
+    assert.match(src, /syncTagFilter\(/, name + " mounts the shared renderer");
+  assert.match(RENDER, /tagBtn\.style\.alignSelf = "center";/,
+    "the chat button centers against the + tab's box (the user 2026-08-25 — it sat high)");
+});
+
+test("timeline spacing grew (the user 2026-08-25: the corner controls were cramped)", () => {
+  assert.match(TL, /const ICONW = 22;/, "wider button slots");
+  assert.match(TL, /const PADH = 7, GAP = 9;/, "more air between the line's parts");
+  assert.match(TL, /if \(hidden > 0\)/, "overflow chips collapse into a +N, one click from the menu");
+});

--- a/ui/webview/tag-lens.ts
+++ b/ui/webview/tag-lens.ts
@@ -76,3 +76,18 @@ export function surfaceLens(views: SessionViews | null | undefined, surface: str
   return g ? { tags: [g.name] } : { all: true };
 }
 
+/** The selection as display chips (the user 2026-08-25 convention: a narrowed button shows the
+ *  chips of everything selected — each tag in its color, the no-tags bucket as its own chip).
+ *  All → empty (the resting button stands alone). Per-selection chips, superseding the earlier
+ *  combined-label call (that documented design choice retargeted by this ruling). */
+export function lensChips(l: TagLens | null | undefined, unions: TagUnion[]): { label: string; color: string | null; pick: "none" | { tag: string } }[] {
+  if (lensAll(l)) return [];
+  const out: { label: string; color: string | null; pick: "none" | { tag: string } }[] = [];
+  for (const name of (l!.tags || [])) {
+    const u = unions.find((x) => x.name === name);
+    out.push({ label: name, color: (u && u.color) || null, pick: { tag: name } });
+  }
+  if (l!.none) out.push({ label: "no tags", color: null, pick: "none" });
+  return out;
+}
+

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -16,7 +16,7 @@
 // model-version submenus: carets always face right (▸), expansion prefers the right side and
 // falls left only when the right edge would clip (measured, never assumed).
 import { TagUnion } from "./session-views";
-import { TagLens, lensAll, toggleLens } from "./tag-lens";
+import { TagLens, lensAll, toggleLens, lensChips } from "./tag-lens";
 
 export interface TagMenuOpts {
   lens: () => TagLens;                       // the surface's current selection (re-read per repaint)
@@ -41,11 +41,15 @@ export function closeTagMenu(): void {
   openMenu?.remove();
   openMenu = null;
 }
-document.addEventListener("click", () => closeTagMenu());
-document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeTagMenu(); });
-try {
-  window.addEventListener("storage", (e) => { if (e.key === "romp:menu-echo" && e.newValue) closeTagMenu(); });
-} catch { /* no storage events (foreign host) — local closers still apply */ }
+// module-level closers, guarded: the model half of this module (and its constants) is importable
+// from non-DOM contexts (the node test runner) — only a real document wires the listeners
+if (typeof document !== "undefined") {
+  document.addEventListener("click", () => closeTagMenu());
+  document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeTagMenu(); });
+  try {
+    window.addEventListener("storage", (e) => { if (e.key === "romp:menu-echo" && e.newValue) closeTagMenu(); });
+  } catch { /* no storage events (foreign host) — local closers still apply */ }
+}
 
 /** Open (or toggle shut) the lens menu anchored under `anchor`. The ctx-family skin — the chat
  *  pane's .ctx-menu is the reference spec (CLAUDE.md menu vocabulary). */
@@ -137,3 +141,38 @@ export function tagMenuButton(title: string, open: (btn: HTMLElement) => void): 
   btn.addEventListener("click", (e) => e.stopPropagation());   // the click-and-hold rule: swallow the opener's own click
   return btn;
 }
+
+// THE BUTTON CONVENTION (the user 2026-08-25): at rest (All) the tag icon is GRAY and stands
+// alone; narrowed, it wears the ACCENT and the chips of everything selected render beside it —
+// each tag in its color, the no-tags bucket as its own chip, a dim ✕ per chip unselecting that
+// one pick. One renderer, so every mount is identical by construction; the feed's footer keeps
+// its class mechanics (mode: "class" — its .on/.--dim values are pinned equal to these literals).
+export const TAG_BTN_GRAY = "#9aa0a6";
+export const TAG_BTN_ACCENT = "#9cd2ff";   // the romp accent (--accent) — pinned equal in feed.css/styles.css
+
+export function syncTagFilter(btn: HTMLElement, chipsHost: HTMLElement,
+                              lens: TagLens, unions: { name: string; color?: string | null; members: string[]; }[],
+                              onApply: (l: TagLens) => void,
+                              mode: "inline" | "class" = "inline"): void {
+  const narrowed = !lensAll(lens);
+  if (mode === "class") btn.classList.toggle("on", narrowed);
+  else btn.style.color = narrowed ? TAG_BTN_ACCENT : TAG_BTN_GRAY;
+  btn.setAttribute("aria-pressed", narrowed ? "true" : "false");
+  chipsHost.textContent = "";
+  for (const c of lensChips(lens, unions as never)) {
+    const col = c.color || TAG_BTN_GRAY;
+    const chip = document.createElement("span");
+    chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:1px 8px;"
+      + "border-radius:9px;font-size:0.82em;border:1px solid " + col + ";color:" + col + ";"
+      + "background:transparent;white-space:nowrap;");
+    chip.appendChild(document.createTextNode(c.label));
+    const x = document.createElement("span");
+    x.textContent = "✕";
+    x.setAttribute("style", "cursor:pointer;opacity:0.75;color:" + TAG_BTN_GRAY + ";font-size:0.9em;");
+    x.title = "remove this from the filter";
+    x.addEventListener("click", (e) => { e.stopPropagation(); onApply(toggleLens(lens, c.pick)); });
+    chip.appendChild(x);
+    chipsHost.appendChild(chip);
+  }
+}
+


### PR DESCRIPTION
## What (user normalization asks, 2026-08-25)

**The convention, component-level** (user's words honored exactly): at rest (All) the tag icon is **gray and stands alone**; narrowed, it wears the **accent** and the **chips of everything selected** render beside it — each tag in its color, the **no-tags bucket as its own chip**, a dim ✕ per chip unselecting that one pick. Identical across the Sessions view, chat, outline, and feed.

- `lensChips` (pure) + `syncTagFilter` (the one renderer). Per-selection chips supersede the earlier combined-label design call — that documented choice retargeted by this ruling.
- **The feed's 696 instance fix is subsumed**: it mounts in class mode so its footer's `.on` sibling mechanics stand (their round-two concern preserved); `feed.css`'s `--accent` is pinned equal to the convention literal. Same visuals, one source.
- The timeline (module-less, Obsidian host) mirrors the same values — **cross-mount computed equality pinned** (the 678 lesson: equality asserted, never classes shared).
- **Chat button vertically centered** against the + tab's box (it sat high).
- **Timeline corner spacing**: wider button slots + more air between parts; its combined chip becomes the same per-selection chips, overflow collapsing into a dim +N that opens the menu.

Headless frames (ui-verify, synthetic): rest and narrowed states render to the convention — verified before shipping.

## Tests

Executed `lensChips` truth table (All bare; per-tag chips; no-tags chip last); cross-mount equality pins (gray + accent literals everywhere they're stated); every-mount-uses-the-renderer pins; centering + spacing pins; a DOM guard makes the component importable from the test runner. Six sibling anchors on the old combined chip retargeted in-commit. Suites green: 5655 python, 2423 JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)