### PR TITLE
The rename ping is its own machine record, and a fresh session is never pinged

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4232,19 +4232,23 @@ class SdkBackend:
         s = self._ensure(sid)
         if not s:
             return False
-        # RENAME PING (the user 2026-08-24): one line ahead of the next thing that enters the
-        # session, so it hears its own new name instead of inferring it. A slash-command send
-        # passes untouched (the CLI must see the bare command) and the note holds for the next
-        # real prompt. MARKER-FREE on purpose, unlike the standalone restart notices: this line
-        # joins an EXISTING message, and the romp-injected marker would re-author the host
-        # message's echo and transcript atom (a typed follow-up would render as a gray romp
-        # bubble). The [romp] prefix is the sanctioned family for mechanics notices — the session
-        # prompt's housekeeping note already tells every session what it means.
+        # RENAME PING (the user 2026-08-24; own-record form 2026-08-25): one line ahead of the
+        # next thing that enters the session, so it hears its own new name instead of inferring
+        # it. Its OWN record in the machine-sent dress — string-prepending it into the incoming
+        # text put the bookkeeping line inside the USER's bubble, rendered as if they typed it
+        # (the user 2026-08-25, on their very first message). The romp-injected markers are safe
+        # here precisely BECAUSE the record is separate: they author this line 'romp' (the gray
+        # machine bubble, the restart notices' dress) without touching the user's own record. It
+        # still rides the same wake — the recursive send enqueues back-to-back with the message
+        # that triggered it, and an idle session stays idle. A slash-command send passes untouched
+        # (the CLI must see the bare command) and the note holds for the next real prompt; the
+        # recursion terminates because the note is cleared before the ping is sent.
         if not text.lstrip().startswith("/"):
             _reg = read_reg(self.state_dir, sid) or {}
             if _reg.get("renameNote"):
-                text = "%s\n\n%s" % (RENAME_NUDGE % _reg["renameNote"], text)
+                _note = _reg["renameNote"]
                 self._update_reg(sid, renameNote=None)
+                self.send(sid, "<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % _note)
         if _is_compact_cmd(text):
             # Delivering /compact: mark the session compacting NOW (authoritative), covering the gap between
             # this send and the CLI actually starting the turn — so a drive op the producer tick checks in
@@ -4697,11 +4701,20 @@ class SdkBackend:
         reg = read_reg(self.state_dir, sid)
         if not reg:
             return False
-        # renameNote: the one-line "you were renamed" ping, delivered by send() ahead of whatever
-        # NEXT enters the session (the user 2026-08-24: a renamed worker learned its own new name
-        # only by inference from a peer's prose). Reg-persisted so it survives restarts; never a
-        # wake of its own — the queue wakes sessions, this rides a send that already happens.
-        self._update_reg(sid, name=new_name, renameNote=new_name)   # locked RMW — see set_effort's race note
+        # renameNote: the one-line "you were renamed" ping, delivered by send() as its OWN
+        # machine-dressed record ahead of whatever NEXT enters the session (the user 2026-08-24: a
+        # renamed worker learned its own new name only by inference from a peer's prose).
+        # Reg-persisted so it survives restarts; never a wake of its own — the queue wakes
+        # sessions, this rides a send that already happens. ONLY when prior turns exist under the
+        # old name (the transcript is the record of prior turns): a rename before the first turn
+        # has no stale self-knowledge to correct — the fresh session learns its name the normal
+        # way, and pinging it put bookkeeping ahead of the user's very first words (the user
+        # 2026-08-25).
+        _ls = reg.get("lastSid")
+        _tp = Path(transcript_path(reg.get("cwd") or "", _ls)) if _ls else None
+        _has_history = bool(_tp) and _tp.exists() and _tp.stat().st_size > 0
+        self._update_reg(sid, name=new_name,
+                         **({"renameNote": new_name} if _has_history else {}))   # locked RMW — see set_effort's race note
         # keep the shared names/ identity file in sync (preserve colours)
         try:
             parts = (Path(self.state_dir) / "names" / sid).read_text().rstrip("\n").split("\t")

--- a/tests/test_kernel_effort_reconnect.py
+++ b/tests/test_kernel_effort_reconnect.py
@@ -77,7 +77,7 @@ class EffortReconnect(unittest.TestCase):
                     'self._update_reg(sid, auth=value, authPending=True, apiKeyAuth=None)',
                     'self._update_reg(sid, mode=mode)',
                     'self._update_reg(sid, fast=(value == "on"), liveFast=value)',
-                    'self._update_reg(sid, name=new_name, renameNote=new_name)',   # + the rename ping (2026-08-24)
+                    'self._update_reg(sid, name=new_name,',   # + the rename ping rides the same locked RMW when owed (2026-08-24/25)
                     'self._update_reg(sid, model=value, modelPending=bool(s._model_pending))',
                     'self._update_reg(sid, model=value, liveModel=_alias_label(value), modelPending=False)'):
             self.assertIn(pin, BACKEND_SRC)

--- a/tests/test_sdk_rename_ping.py
+++ b/tests/test_sdk_rename_ping.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""The rename ping (the user 2026-08-24): a renamed session hears its OWN new name on its next
-wake — rename() stamps the reg (renameNote, restart-proof), and send() delivers RENAME_NUDGE one
-line ahead of whatever next enters the session, never a wake of its own. Voice pinned in
-test_injected_voice.py. Deterministic: reg-level + source pins, no real claude processes."""
+"""The rename ping (the user 2026-08-24; own-record form 2026-08-25): a renamed session hears its
+OWN new name on its next wake — rename() stamps the reg (renameNote, restart-proof, and ONLY when
+prior turns exist under the old name: a fresh session has no stale self-knowledge to correct), and
+send() delivers RENAME_NUDGE as its OWN machine-dressed record ahead of whatever next enters the
+session — never inside the user's bubble (the 2026-08-25 sighting: the bookkeeping line rendered as
+the user's very first words), never a wake of its own. Voice pinned in test_injected_voice.py.
+Deterministic: reg-level + source pins, no real claude processes."""
 import os
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -28,30 +32,56 @@ class RenamePing(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         self.be = _backend(self.td.name)
         (Path(self.td.name) / "names").mkdir(parents=True, exist_ok=True)
-        sb.write_reg(Path(self.td.name), SID, {"sid": SID, "name": "web", "cwd": "/tmp"})
+        self.cwd = str(Path(self.td.name) / "proj")
+        Path(self.cwd).mkdir()
+        sb.write_reg(Path(self.td.name), SID, {"sid": SID, "name": "web", "cwd": self.cwd,
+                                               "lastSid": SID})
 
     def tearDown(self):
         self.td.cleanup()
 
-    def test_rename_stamps_the_pending_note_beside_the_name(self):
+    def _write_history(self):
+        # one prior turn under the old name — the transcript IS the record of prior turns
+        tp = Path(sb.transcript_path(self.cwd, SID))
+        tp.parent.mkdir(parents=True, exist_ok=True)
+        tp.write_text('{"type": "user", "uuid": "u1"}\n')
+
+    def test_rename_with_history_stamps_the_pending_note_beside_the_name(self):
+        self._write_history()
         self.assertTrue(self.be.rename(SID, "tests"))
         reg = sb.read_reg(Path(self.td.name), SID)
         self.assertEqual(reg.get("name"), "tests")
         self.assertEqual(reg.get("renameNote"), "tests",
                          "reg-persisted, so the ping survives a kernel restart unspoken")
 
+    def test_rename_before_the_first_turn_pings_nothing(self):
+        # the 2026-08-25 sighting's second half: a brand-new session has no stale self-knowledge
+        # to correct — it learns its name the normal way, and its user's first words stay first
+        self.assertTrue(self.be.rename(SID, "tests"))
+        reg = sb.read_reg(Path(self.td.name), SID)
+        self.assertEqual(reg.get("name"), "tests", "the rename itself still lands")
+        self.assertIsNone(reg.get("renameNote"), "…but no ping is owed")
+
     def test_rename_of_an_unknown_sid_stamps_nothing(self):
         self.assertFalse(self.be.rename("99999999-0000-1111-2222-333333333333", "tests"))
 
-    def test_send_delivers_the_ping_once_and_skips_slash_commands(self):
-        # send()'s consume, pinned at source (driving a real send spawns a CLI): the ping rides
-        # ahead of the next NON-command text, clears after one delivery, and never re-authors the
-        # host message (marker-free — see RENAME_NUDGE's own comment and the voice test)
+    def test_send_delivers_the_ping_as_its_own_machine_record_once(self):
+        # send()'s consume, pinned at source (driving a real send spawns a CLI): the ping is its
+        # OWN record in the machine dress — NEVER string-prepended into the user's text (the
+        # 2026-08-25 sighting: the bookkeeping line rendered inside the user's first bubble) —
+        # delivered before the message that triggered it, once, and a slash command passes bare
         self.assertIn('if not text.lstrip().startswith("/"):', SRC, "a bare /compact must reach the CLI bare")
         self.assertIn('if _reg.get("renameNote"):', SRC)
-        self.assertIn('text = "%s\\n\\n%s" % (RENAME_NUDGE % _reg["renameNote"], text)', SRC)
+        self.assertIn('self.send(sid, "<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % _note)',
+                      SRC, "its own record, wearing the machine-sent dress (author 'romp', gray bubble)")
+        self.assertNotIn('text = "%s\\n\\n%s" % (RENAME_NUDGE', SRC,
+                         "the string-prepend form is GONE — it contaminated the user's own words")
         self.assertIn('self._update_reg(sid, renameNote=None)', SRC, "one delivery, then the note is spent")
-        self.assertNotIn("romp-injected", sb.RENAME_NUDGE, "marker-free: it joins an EXISTING message")
+        idx_clear = SRC.index('self._update_reg(sid, renameNote=None)')
+        idx_send = SRC.index('self.send(sid, "<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE')
+        self.assertLess(idx_clear, idx_send, "cleared BEFORE the recursive send — the recursion terminates")
+        self.assertNotIn("romp-injected", sb.RENAME_NUDGE,
+                         "the constant stays bare prose; the dress is added only on the separate record")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two fixes on the rename ping (user report with screenshot: the bookkeeping line rendered **inside the user's bubble**, ahead of their very first words on a brand-new session).

**Own record, machine dress.** The ping was string-prepended into the next incoming text — so it became part of the user's message: their echo, their transcript atom, their words. It is now delivered as its **own record** wearing the machine-sent dress: the `romp-injected` markers are safe precisely because the record is separate (they author this one line 'romp' — the restart notices' gray-bubble rendering — without touching the user's own record). The no-extra-wake property stands: the recursive send enqueues back-to-back with the message that triggered it, an idle session stays idle, the note clears before the ping sends (the recursion terminates), and slash commands still pass bare with the note holding.

**No ping without history.** A rename before the session's first turn has no stale self-knowledge to correct — the fresh session learns its name the normal way. The stamp now fires only when prior turns exist under the old name, keyed on the transcript file (the record of prior turns), resolved via `transcript_path(cwd, lastSid)` at rename time.

**Tests:** own-record delivery pinned at source, with the string-prepend form pinned **gone** and the clear-before-send ordering pinned; rename-with-history stamps while rename-before-first-turn does not (executed, reg-level); the setter-family pin follows the conditional stamp; the voice pin keeps the constant bare prose (the dress is added only on the separate record). Suites green on this head: pytest 5656 passed, npm 2419/2419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)