### PR TITLE
The tag buttons wear the feed's outline, and the Sessions one works again

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2716,14 +2716,17 @@ class TimelinePanel {
       return { label: n, color: (u && u.color) || MODEL_FG, pick: { tag: n } };
     }).concat(lens.none ? [{ label: 'no tags', color: MODEL_FG, pick: 'none' }] : []) : [];
     const PADH = 7, GAP = 9;   // the chip's horizontal padding; the space between the line's parts (the user 2026-08-25: more air)
-    // TWO monochrome icon buttons (the user 2026-08-25): display options (sliders) LEFT of the tag
-    // filter (tag icon) — the display toggles left the tags menu for their own button. Icon-only,
-    // MODEL_FG, 14px, drawn inline (no icon font in the Obsidian host); tooltips carry the words.
-    const ICONW = 22;   // wider than the icon: the extra is the controls' breathing room (2026-08-25)
+    // TWO icon buttons (the user 2026-08-25): display options (sliders) LEFT of the tag filter
+    // (tag icon) — the display toggles left the tags menu for their own button. Drawn inline (no
+    // icon font in the Obsidian host); tooltips carry the words. Each wears THE BUTTON OUTLINE
+    // (the user 2026-08-25, round two: the bare glyph read weird next to the feed's dressed
+    // button): the feed word-button's box in svg terms — 1px hairline, 6px radius, 9px side
+    // padding around the 14px glyph, accent border + faint wash while narrowed (the feed's .on).
+    const BTNW = 32, BTNH = 18;   // 14px glyph + 9px sides; chip-row height, so the line reads level
     const tailStr = more ? more + ' more' : '';
     const XGAP = 6;                                  // between a chip's name and its dim ✕ (the composer chip's read)
     const chipW = (c) => PADH * 2 + this.labelWidth(c.label) + XGAP + this.labelWidth('✕');
-    const budget = this.M.left - PADL - 6 - ICONW * 2 - (tailStr ? GAP + this.labelWidth(tailStr) : 0);
+    const budget = this.M.left - PADL - 6 - (BTNW * 2 + GAP) - (tailStr ? GAP + this.labelWidth(tailStr) : 0);
     let used = 0, shown = [];
     for (const c of chips) {
       const w = GAP + chipW(c);
@@ -2733,12 +2736,16 @@ class TimelinePanel {
     }
     const hidden = chips.length - shown.length;
     const y = axisY + 14;
-    const iconBtn = (dx, title, draw, open) => {
+    const iconBtn = (dx, title, narrowed, draw, open) => {
       const btn = el('g', {});
       btn.setAttribute('style', 'cursor:pointer;');
-      const hit = el('rect', { x: PADL + dx, y: y - 12, width: 16, height: 16, fill: 'transparent' });
-      btn.appendChild(hit);
-      draw(btn, PADL + dx, y);
+      // the box is the WHOLE hit target (transparent fill still catches pointevents; the glyph
+      // parts opt out) — the old bare 16x16 glyph pad was half the size and read unclickable
+      const box = el('rect', { x: PADL + dx, y: y - 13, width: BTNW, height: BTNH, rx: 6,
+        fill: narrowed ? 'rgba(156,210,255,0.12)' : 'transparent',
+        stroke: narrowed ? '#9cd2ff' : 'rgba(255,255,255,0.10)', 'stroke-width': 1 });
+      btn.appendChild(box);
+      draw(btn, PADL + dx + 9, y);
       const tt = el('title', {}); tt.textContent = title; btn.appendChild(tt);
       btn.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); open(btn); });
       // the follow-up click would bubble to the document's menu-closer and shut the menu the same
@@ -2747,26 +2754,27 @@ class TimelinePanel {
       svg.appendChild(btn);
     };
     // sliders: two horizontal rails with offset knobs — the display-options read
-    iconBtn(0, 'timeline display options', (btn, bx, by) => {
-      for (const [ry, kx] of [[-8, 9], [-3, 4]]) {
+    iconBtn(0, 'timeline display options', false, (btn, bx, by) => {
+      for (const [ry, kx] of [[-7, 9], [-2, 4]]) {
         btn.appendChild(el('line', { x1: bx + 1, y1: by + ry, x2: bx + 13, y2: by + ry,
-          stroke: MODEL_FG, 'stroke-width': 1.4, 'stroke-linecap': 'round' }));
+          stroke: MODEL_FG, 'stroke-width': 1.4, 'stroke-linecap': 'round', 'pointer-events': 'none' }));
         btn.appendChild(el('circle', { cx: bx + kx, cy: by + ry, r: 2.4, fill: '#1e1e1e',
-          stroke: MODEL_FG, 'stroke-width': 1.4 }));
+          stroke: MODEL_FG, 'stroke-width': 1.4, 'pointer-events': 'none' }));
       }
     }, (btn) => this._openDisplayMenu(btn));
     // tag: the classic label outline with its hole — the filter-by-tag read (the user chose a tag
     // icon). THE BUTTON CONVENTION (2026-08-25): GRAY at rest (All), the ACCENT while narrowed —
     // the same values the shared webview renderer uses (#9aa0a6 / #9cd2ff, cross-mount equality)
     const tagIconCol = active ? '#9cd2ff' : MODEL_FG;
-    iconBtn(ICONW, 'filter these lanes by tag', (btn, bx, by) => {
+    iconBtn(BTNW + GAP, 'filter these lanes by tag', active, (btn, bx, by) => {
       const ox = bx + 1, oy = by - 11;
       btn.appendChild(el('path', {
         d: 'M ' + ox + ' ' + (oy + 5.5) + ' l 5.5 -4.5 h 6.5 v 6.5 l -5.5 4.5 z',
-        fill: 'transparent', stroke: tagIconCol, 'stroke-width': 1.4, 'stroke-linejoin': 'round' }));
-      btn.appendChild(el('circle', { cx: ox + 9.5, cy: oy + 3.5, r: 1.3, fill: tagIconCol }));
+        fill: 'transparent', stroke: tagIconCol, 'stroke-width': 1.4, 'stroke-linejoin': 'round',
+        'pointer-events': 'none' }));
+      btn.appendChild(el('circle', { cx: ox + 9.5, cy: oy + 3.5, r: 1.3, fill: tagIconCol, 'pointer-events': 'none' }));
     }, (btn) => this._openViewsMenu(btn));
-    let x = PADL + ICONW * 2;
+    let x = PADL + BTNW * 2 + GAP;
     for (const c of shown) {
       x += GAP;
       const cw = chipW(c);
@@ -2878,7 +2886,12 @@ class TimelinePanel {
     // and the menu STAYS OPEN across toggles (a settings panel, not a command — the gear's rule),
     // repainting in place. Tag rows stay NAME-KEYED (kernels are plumbing).
     const build = () => {
-      menu.empty();
+      // plain-DOM clear, NOT the Obsidian-only empty helper: the browser and VS Code hosts
+      // install just createEl/createDiv/createSpan (timeline-boot's three), so the repaint threw a
+      // TypeError and every tag-button press died before the menu appeared (the 2026-08-25
+      // unclickable corner button; timeline-tagbtn-click.test.ts executes this path under a
+      // three-helper host so an Obsidian-only call can never land again).
+      while (menu.firstChild) menu.removeChild(menu.firstChild);
       const v = this._curViews();
       const lens = timelineLens(v);
       const apply = (nl, close) => {

--- a/ui/timeline-tagbtn-click.test.ts
+++ b/ui/timeline-tagbtn-click.test.ts
@@ -1,0 +1,144 @@
+// The corner tag button must OPEN ITS MENU under a host that installs only the three DOM helpers
+// (createEl/createDiv/createSpan — all the browser and VS Code boots provide; timeline-boot.ts /
+// the kernel's _TIMELINE_BOOT). The 2026-08-25 "can't click on it": the menu repaint called
+// Obsidian's .empty(), which exists in neither host, so every press threw a TypeError before the
+// menu appeared — the button looked fine and did nothing. This test EXECUTES the press over the
+// house fake-DOM shim (which, like the real boots, has no Obsidian extras) and asserts the menu
+// builds; the source scan below bans the whole class of Obsidian-only helper calls.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+// ---- the house fake-DOM shim (timeline-hidden-stub.test.ts's, + createTextNode: the menu rows
+// write real text nodes, and the real hosts of course have it) ----
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) {   // real-DOM semantics: appending an attached node MOVES it (the menu is created on body, then re-appended to the menu host)
+      if (c.parentNode) { const i = c.parentNode.children.indexOf(c); if (i >= 0) c.parentNode.children.splice(i, 1); }
+      c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    _listeners: {} as any,
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 32, height: 18, left: 8, top: 400, right: 40, bottom: 418 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  createTextNode(text: string) { const n = makeNode("#text"); n.textContent = text; return n; },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+g.requestAnimationFrame = () => 0;
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+const SRC = fs.readFileSync(viewPath, "utf8");
+
+function drawnPanel(): any {
+  const now = 1_781_000_000;
+  const sess = (id: string, name: string, color: string) => ({
+    id, name, color, state: "working", live: true, model: "Opus", effort: "high",
+    context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+  });
+  const panel = new TimelinePanel(makeNode("div"));
+  panel.update({
+    now,
+    sessions: [sess("s1", "web", "#f7768e"), sess("s2", "api", "#7aa2f7")],
+    // turns present so draw() runs for real (an empty warm-up keeps the loader up and no corner draws)
+    turns: { s1: [{ id: "t1", start: now - 400, end: now - 100, prompt: "do the thing", tid: "f1", mids: [] }] },
+    messages: [], judging: [],
+    views: { active: "all", tags: [{ id: "g1", name: "infra", color: "#DD42FF", members: ["s2"] }], actives: { timeline: { all: true } } },
+  });
+  return panel;
+}
+
+function findByTitle(root: any, txt: string): any {
+  for (const c of root.children || []) {
+    if (c.tag === "title" && String(c.textContent).includes(txt)) return root;
+    const hit = findByTitle(c, txt);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+test("executed: a tag-button press BUILDS the menu under a three-helper host (the 2026-08-25 dead button)", () => {
+  const panel = drawnPanel();
+  const btn = findByTitle(panel.svg, "filter these lanes by tag");
+  assert.ok(btn, "the corner tag button drew");
+  const before = g.document.body.children.length;
+  btn._listeners.pointerdown({ preventDefault() {}, stopPropagation() {} });   // the press — must not throw
+  assert.ok(panel._viewsMenu, "the views menu opened");
+  assert.equal(g.document.body.children.length, before + 1, "the menu landed in the host body");
+  const labels: string[] = [];
+  (function walk(x: any) { for (const c of x.children || []) { if (c.tag === "#text" || c.tag === "span") labels.push(String(c.textContent)); walk(c); } })(panel._viewsMenu);
+  for (const want of ["All", "(no tags)", "infra", "Configure tags…"])
+    assert.ok(labels.some((l) => l.includes(want)), "menu row present: " + want);
+  // a second press on the open menu's button toggles it shut, still without throwing
+  btn._listeners.pointerdown({ preventDefault() {}, stopPropagation() {} });
+  assert.equal(panel._viewsMenu, null, "re-press toggles shut");
+  panel._closeViewsMenu();
+});
+
+test("executed: the outlined box is the button's hit geometry — it spans the glyph, not a bare 16x16 pad", () => {
+  const panel = drawnPanel();
+  const btn = findByTitle(panel.svg, "filter these lanes by tag");
+  const box = btn.children[0];
+  assert.equal(box.tag, "rect", "the box is the button's base layer");
+  assert.equal(box._attrs.width, 32, "full box width (14px glyph + 9px sides)");
+  assert.equal(box._attrs.height, 18, "chip-row height");
+  assert.equal(box._attrs.rx, 6, "the feed's radius");
+  assert.equal(box._attrs.fill, "transparent", "at rest transparent — still pointer-catching in svg");
+  assert.equal(box._attrs.stroke, "rgba(255,255,255,0.10)", "the feed's hairline at rest");
+  // every glyph part opts out of hits, so the box is the ONE hit surface (the lock's pattern)
+  for (const part of btn.children.slice(1))
+    if (part.tag !== "title") assert.equal(part._attrs["pointer-events"], "none", part.tag + " opts out of hits");
+  // the glyph sits INSIDE the box — the press target covers everything the eye reads as the button
+  const glyph = btn.children.find((c: any) => c.tag === "path");
+  assert.ok(glyph, "tag glyph drew");
+  const d = String(glyph._attrs.d);
+  const mx = Number(d.split(" ")[1]);
+  assert.ok(mx > Number(box._attrs.x) && mx < Number(box._attrs.x) + 32, "glyph starts inside the box");
+});
+
+test("executed: narrowed, the box wears the accent border + the feed .on wash", () => {
+  const panel = drawnPanel();
+  const v = { active: "all", tags: [{ id: "g1", name: "infra", color: "#DD42FF", members: ["s2"] }], actives: { timeline: { tags: ["infra"] } } };
+  panel.update(Object.assign({}, panel.data, { views: v }));
+  const btn = findByTitle(panel.svg, "filter these lanes by tag");
+  const box = btn.children[0];
+  assert.equal(box._attrs.stroke, "#9cd2ff", "accent border while narrowed");
+  assert.equal(box._attrs.fill, "rgba(156,210,255,0.12)", "the .on wash while narrowed");
+});
+
+test("the view speaks plain DOM: no Obsidian-only helper calls (the hosts install only the three)", () => {
+  // .empty()/.setText()/.addClass()/.removeClass()/.toggleClass()/.detach() exist only under
+  // Obsidian; a call to any of them is a crash on the web and VS Code timelines — exactly how the
+  // tag button died. createEl/createDiv/createSpan stay fine: every boot installs those three.
+  for (const bad of [/\.empty\(\)/, /\.setText\(/, /\.addClass\(/, /\.removeClass\(/, /\.toggleClass\(/, /\.detach\(\)/])
+    assert.doesNotMatch(SRC, bad, "Obsidian-only helper in the shared view: " + bad);
+});

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -79,7 +79,7 @@ test("the trigger sits in the corner strip and opens on pointerdown, like every 
   // two monochrome icon buttons since 2026-08-25 (display options + the tag filter), both
   // pointerdown-opened with tooltips carrying the words
   assert.match(SRC, /btn\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); open\(btn\); \}\);/);
-  assert.match(SRC, /iconBtn\(ICONW, 'filter these lanes by tag'/);
+  assert.match(SRC, /iconBtn\(BTNW \+ GAP, 'filter these lanes by tag'/);
   assert.match(SRC, /const tailStr = more \? more \+ ' more' : '';/, "a filtered-out live session is always one glance away");
 });
 
@@ -253,7 +253,7 @@ test("the trigger measures its WHOLE string against the gutter, and the dialog's
   // the fit measures the whole line as LAID OUT: trigger + gap + padded chip + gap + tail
   // per-chip budgeting since 2026-08-25: chips render while they fit; the rest collapse into +N
   assert.match(SRC, /const chipW = \(c\) => PADH \* 2 \+ this\.labelWidth\(c\.label\) \+ XGAP \+ this\.labelWidth\('✕'\);/);
-  assert.match(SRC, /const budget = this\.M\.left - PADL - 6 - ICONW \* 2 - \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
+  assert.match(SRC, /const budget = this\.M\.left - PADL - 6 - \(BTNW \* 2 \+ GAP\) - \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
   assert.match(SRC, /if \(used \+ w \+ restW > budget\) break;/);
 
   assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
@@ -420,7 +420,7 @@ test("executed: the timeline lens — toggles, All exclusivity, last-off→All, 
 test("the corner grew two icon buttons and the menus split (the user 2026-08-25)", () => {
   // display options (sliders) LEFT of the tag filter (tag icon); both monochrome, tooltip-worded
   assert.match(SRC, /iconBtn\(0, 'timeline display options'/, "sliders sit left");
-  assert.match(SRC, /iconBtn\(ICONW, 'filter these lanes by tag'/, "the tag button beside it");
+  assert.match(SRC, /iconBtn\(BTNW \+ GAP, 'filter these lanes by tag'/, "the tag button beside it");
   assert.match(SRC, /_openDisplayMenu\(btn\)/);
   assert.match(SRC, /capSep\('filters this timeline'\)/,
     "the captioned divider says which surface the selection governs");

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -8,7 +8,7 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { lensChips } from "./tag-lens";
-import { TAG_BTN_GRAY, TAG_BTN_ACCENT } from "./tag-menu";
+import { TAG_BTN_GRAY, TAG_BTN_ACCENT, TAG_BTN_BORDER, TAG_BTN_WASH } from "./tag-menu";
 
 const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
 const RENDER = ui("webview", "render.ts");
@@ -16,6 +16,7 @@ const FLEET = ui("webview", "fleet.ts");
 const FEED = ui("webview", "feed.ts");
 const FEEDCSS = ui("webview", "feed.css");
 const TL = ui("romp-timeline-view.js");
+const TAGMENU = ui("webview", "tag-menu.ts");
 
 const UNIONS = [
   { name: "infra", color: "#DD42FF", members: [] },
@@ -50,8 +51,37 @@ test("every JS mount renders through the ONE convention function", () => {
     "the chat button centers against the + tab's box (the user 2026-08-25 — it sat high)");
 });
 
+test("THE BUTTON OUTLINE (the user 2026-08-25, round two): every mount wears the feed word-button's box", () => {
+  // the box, by value: 1px hairline in the feed's --card-border, 6px radius, the footer's 1px 9px
+  // padding; narrowed = accent border + the .on wash. COMPUTED equality (the 678 lesson): the feed
+  // states these through classes, the other mounts through the shared literals — assert the values
+  // equal, never share the class.
+  const flat = FEEDCSS.replace(/\s+/g, "");
+  assert.equal(TAG_BTN_BORDER, "rgba(255,255,255,0.10)");
+  assert.equal(TAG_BTN_WASH, "rgba(156,210,255,0.12)");
+  assert.ok(flat.includes("--card-border:rgba(255,255,255,0.10)"), "the feed's hairline is the shared border literal");
+  assert.ok(flat.includes("background:rgba(156,210,255,0.12)"), "the feed .on's wash is the shared wash literal");
+  assert.ok(flat.includes("border-radius:6px"), "the feed's radius");
+  assert.ok(flat.includes("#feed-foot.fdismiss{font-size:10.5px;padding:1px9px"), "the feed footer instance's padding");
+  // the chat/outline builder states the same box inline (inline beats classes, so it must carry it itself)
+  assert.match(TAGMENU, /border:1px solid " \+ TAG_BTN_BORDER \+ ";"\s*\n\s*\+ "border-radius:6px;padding:1px 9px;/,
+    "tagMenuButton wears the box by the shared literals");
+  assert.match(TAGMENU, /btn\.style\.borderColor = narrowed \? TAG_BTN_ACCENT : TAG_BTN_BORDER;/,
+    "narrowed = accent border, at rest the hairline");
+  assert.match(TAGMENU, /btn\.style\.background = narrowed \? TAG_BTN_WASH : "transparent";/,
+    "narrowed = the .on wash");
+  // the timeline draws the same box in svg terms, and the BOX is the hit target (the bare 16x16
+  // glyph pad read unclickable — the user 2026-08-25)
+  assert.match(TL, /const box = el\('rect', \{ x: PADL \+ dx, y: y - 13, width: BTNW, height: BTNH, rx: 6,/,
+    "the corner buttons draw the outlined box as their hit rect");
+  assert.match(TL, /stroke: narrowed \? '#9cd2ff' : 'rgba\(255,255,255,0\.10\)', 'stroke-width': 1 \}\);/,
+    "same hairline at rest, same accent narrowed");
+  assert.match(TL, /fill: narrowed \? 'rgba\(156,210,255,0\.12\)' : 'transparent',/,
+    "same wash narrowed, transparent (still hit-catching) at rest");
+});
+
 test("timeline spacing grew (the user 2026-08-25: the corner controls were cramped)", () => {
-  assert.match(TL, /const ICONW = 22;/, "wider button slots");
+  assert.match(TL, /const BTNW = 32, BTNH = 18;/, "the outlined boxes replaced the bare icon slots (round two)");
   assert.match(TL, /const PADH = 7, GAP = 9;/, "more air between the line's parts");
   assert.match(TL, /if \(hidden > 0\)/, "overflow chips collapse into a +N, one click from the menu");
 });

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -128,12 +128,17 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
   openMenu = menu;
 }
 
-/** The shared monochrome tag-icon button (the user chose a tag glyph): identical across surfaces. */
+/** The shared tag-icon button (the user chose a tag glyph): identical across surfaces. It wears
+ * THE BUTTON OUTLINE (the user 2026-08-25, round two: the bare glyph read weird next to the feed's
+ * dressed buttons) — the feed word-button's box, stated in the same literals the feed's classes
+ * resolve to (--card-border, 6px radius, the #feed-foot 1px 9px padding), so a chat/outline mount
+ * computes equal to the feed instance by value, not by shared class (the 678 lesson). */
 export function tagMenuButton(title: string, open: (btn: HTMLElement) => void): HTMLElement {
   const btn = document.createElement("button");
   btn.type = "button";
   btn.title = title;
-  btn.setAttribute("style", "background:transparent;border:0;padding:2px 4px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;");
+  btn.setAttribute("style", "background:transparent;border:1px solid " + TAG_BTN_BORDER + ";"
+    + "border-radius:6px;padding:1px 9px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;");
   btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none">'
     + '<path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>'
     + '<circle cx="11" cy="5.5" r="1.2" fill="currentColor"/></svg>';
@@ -149,6 +154,8 @@ export function tagMenuButton(title: string, open: (btn: HTMLElement) => void): 
 // its class mechanics (mode: "class" — its .on/.--dim values are pinned equal to these literals).
 export const TAG_BTN_GRAY = "#9aa0a6";
 export const TAG_BTN_ACCENT = "#9cd2ff";   // the romp accent (--accent) — pinned equal in feed.css/styles.css
+export const TAG_BTN_BORDER = "rgba(255,255,255,0.10)";   // the feed's --card-border, stated by value
+export const TAG_BTN_WASH = "rgba(156,210,255,0.12)";     // the feed .on's faint accent wash, ditto
 
 export function syncTagFilter(btn: HTMLElement, chipsHost: HTMLElement,
                               lens: TagLens, unions: { name: string; color?: string | null; members: string[]; }[],
@@ -156,7 +163,12 @@ export function syncTagFilter(btn: HTMLElement, chipsHost: HTMLElement,
                               mode: "inline" | "class" = "inline"): void {
   const narrowed = !lensAll(lens);
   if (mode === "class") btn.classList.toggle("on", narrowed);
-  else btn.style.color = narrowed ? TAG_BTN_ACCENT : TAG_BTN_GRAY;
+  else {
+    // inline mode mirrors the feed's .on by VALUE: accent glyph + accent border + the faint wash
+    btn.style.color = narrowed ? TAG_BTN_ACCENT : TAG_BTN_GRAY;
+    btn.style.borderColor = narrowed ? TAG_BTN_ACCENT : TAG_BTN_BORDER;
+    btn.style.background = narrowed ? TAG_BTN_WASH : "transparent";
+  }
   btn.setAttribute("aria-pressed", narrowed ? "true" : "false");
   chipsHost.textContent = "";
   for (const c of lensChips(lens, unions as never)) {


### PR DESCRIPTION
Two fixes on the just-landed tag-button convention (user request, round two).

**The dead Sessions button.** The timeline's tag button did nothing when clicked. The cause was not squish or an overlapping element: the menu repaint called Obsidian's `empty()` DOM helper, which exists in neither the browser nor the VS Code host — their boots install only `createEl`/`createDiv`/`createSpan` — so every press threw a TypeError before the menu appeared. It landed with the T69-A multi-select repaint (the menu began rebuilding in place). Diagnosed empirically: pressed the button in headless Chromium and read the pageerror. Fixed with a plain-DOM clear.

**The button outline.** The chat and Sessions tag buttons were bare glyphs beside the feed's dressed word-button. Both now wear the feed's box by value (computed equality, never a shared class): 1px `rgba(255,255,255,0.10)` hairline, 6px radius, `1px 9px` padding; narrowed = accent border + the feed `.on`'s `rgba(156,210,255,0.12)` wash. The shared builder states it inline for the chat/outline mounts; the timeline draws the same box in svg terms around both corner buttons — and the box is the whole hit target (the old 16×16 glyph pad was half the visible size), glyph parts opting out of hits like the lock toggle.

**Tests.** `timeline-tagbtn-click.test.ts` executes a press under a three-helper host and asserts the menu builds (the regression), asserts the box hit geometry and narrowed dress, and bans the whole Obsidian-only helper class from the shared view. `tag-button-convention.test.ts` pins every box literal against feed.css. Stale pins retargeted. Verified in headless Chromium: elementFromPoint at the button center resolves inside the button, a real mouse click opens the menu, and rest/narrowed/menu frames plus a feed-vs-inline parity frame were eyeballed.

Suites: pytest 5655 passed / 34 skipped; vscode-extension 2430/2430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)