### PR TITLE
The corner buttons are real HTML now, pixel-equal to the feed's and seated

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -793,6 +793,42 @@ class TimelinePanel {
       }
     } catch (e) {}
 
+    // THE CORNER BAR (the user 2026-08-25, round three: the SVG-drawn outlines still read awkward
+    // and missized live): the display-options + tag-filter buttons are REAL HTML <button>s in a
+    // persistent layer over the SVG's bottom-left strip — an SVG imitation of a CSS button is never
+    // the same picture, because the box comes from the LAYOUT ENGINE (the 10.5px line box, inside
+    // borders, its own AA), not from viewBox math. The values below are the feed footer's own
+    // (#feed-foot .fdismiss / .feed-modetoggle.on / the syncTagFilter chip), stated BY VALUE —
+    // computed equality with the feed instance, never a shared stylesheet (the 678 lesson). The
+    // layer persists across SVG wipes (click-safe by construction — the compact-bar precedent) and
+    // rebuilds only when its content signature changes.
+    this._cornerBar = document.createElement('div');
+    this._cornerBar.className = 'romp-tl-corner';
+    this.wrap.appendChild(this._cornerBar);
+    this._cornerSig = null;
+    try {
+      if (typeof document !== 'undefined' && document.head && !document.getElementById('tl-corner-css')) {
+        const bst = document.createElement('style'); bst.id = 'tl-corner-css';
+        bst.textContent =
+          '.romp-tl-corner{position:absolute;left:8px;bottom:4px;display:flex;align-items:center;gap:8px;'
+          + 'pointer-events:none;font-size:13px;'
+          + 'font-family:var(--vscode-font-family,-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif)}'
+          + '.romp-tl-corner>*{pointer-events:auto}'
+          + '.romp-tl-cbtn{display:inline-flex;align-items:center;font:inherit;font-size:10.5px;padding:1px 9px;'
+          + 'color:var(--vscode-descriptionForeground,#9a9a9a);background:transparent;'
+          + 'border:1px solid rgba(255,255,255,0.10);border-radius:6px;cursor:pointer;white-space:nowrap;opacity:0.95;'
+          + 'transition:color 0.12s ease,border-color 0.12s ease,background 0.12s ease}'
+          + '.romp-tl-cbtn svg{display:block}'
+          + '.romp-tl-cbtn:hover{border-color:var(--accent,#9cd2ff);color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12)}'
+          + '.romp-tl-cbtn.on{color:var(--accent,#9cd2ff);border-color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12);opacity:1}'
+          + '.romp-tl-chip{display:inline-flex;align-items:center;gap:5px;padding:1px 8px;border-radius:9px;'
+          + 'font-size:0.82em;border:1px solid;background:transparent;white-space:nowrap}'
+          + '.romp-tl-chipx{cursor:pointer;opacity:0.75;color:#9aa0a6;font-size:0.9em}'
+          + '.romp-tl-ctail{color:#9aa0a6;opacity:0.7;font-size:12px;cursor:pointer;user-select:none;white-space:nowrap}';
+        document.head.appendChild(bst);
+      }
+    } catch (e) {}
+
     // Click-safe redraws (the user 2026-06-24): the EXTERNAL redraw paths — the poll update() and the live-edge
     // _tickLive() (which rebuilds the SVG every animation frame while following now) — wipe and recreate every
     // SVG child (lane rows, bars, dots, hit-targets). A native `click` needs mousedown AND mouseup on the same
@@ -2701,33 +2737,33 @@ class TimelinePanel {
     this.draw();
   }
 
-  _drawViewsTrigger(svg, axisY) {
+  // ── THE CORNER BAR — real HTML over the SVG strip (the user 2026-08-25, round three) ─────────
+  // The 702 pass drew the feed button's anatomy in SVG and it STILL read awkward live: a CSS
+  // button's box is the layout engine's product, and copying its numbers into viewBox math gives a
+  // different picture. So the corner controls render as real HTML in the persistent layer the
+  // constructor mounts, and parity with the feed footer is the RENDERED image (verified by
+  // side-by-side crops), not just the computed numbers — the 702 lesson generalized. Any
+  // non-All selection is a FILTER shown as PER-SELECTION CHIPS (the 2026-08-25 convention): each
+  // selected tag as its own chip in its color, the no-tags bucket as its own chip, a dim ✕ per
+  // chip unselecting that one pick. Chips that don't fit the gutter collapse into a dim "+N"
+  // that opens the menu. Rebuilds only when the content signature changes, so a press can never
+  // land on a node a redraw just replaced.
+  _renderCornerBar() {
+    if (!this._cornerBar) return;
     const v = this._curViews();
     const lens = timelineLens(v);
     const unions = viewTagUnion(v);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
-    // any non-All selection is a FILTER shown as PER-SELECTION CHIPS (the user's 2026-08-25
-    // convention, retargeting the earlier one-combined-chip call): each selected tag as its own
-    // chip in its color, the no-tags bucket as its own chip, a dim ✕ per chip unselecting that
-    // one pick. Chips that don't fit the gutter collapse into a dim "+N" that opens the menu.
     const active = !lensAll(lens);
     const chips = active ? (lens.tags || []).map((n) => {
       const u = unions.find((x) => x.name === n);
       return { label: n, color: (u && u.color) || MODEL_FG, pick: { tag: n } };
     }).concat(lens.none ? [{ label: 'no tags', color: MODEL_FG, pick: 'none' }] : []) : [];
-    const PADH = 7, GAP = 9;   // the chip's horizontal padding; the space between the line's parts (the user 2026-08-25: more air)
-    // TWO icon buttons (the user 2026-08-25): display options (sliders) LEFT of the tag filter
-    // (tag icon) — the display toggles left the tags menu for their own button. Drawn inline (no
-    // icon font in the Obsidian host); tooltips carry the words. Each wears THE BUTTON OUTLINE
-    // (the user 2026-08-25, round two: the bare glyph read weird next to the feed's dressed
-    // button): the feed word-button's box in svg terms — 1px hairline, 6px radius, 9px side
-    // padding around the 14px glyph, accent border + faint wash while narrowed (the feed's .on).
-    const BTNW = 32, BTNH = 18;   // 14px glyph + 9px sides; chip-row height, so the line reads level
+    const GAP = 8, BTNW = 34;   // the bar's flex gap; the feed tag button's measured box width
     const tailStr = more ? more + ' more' : '';
-    const XGAP = 6;                                  // between a chip's name and its dim ✕ (the composer chip's read)
-    const chipW = (c) => PADH * 2 + this.labelWidth(c.label) + XGAP + this.labelWidth('✕');
-    const budget = this.M.left - PADL - 6 - (BTNW * 2 + GAP) - (tailStr ? GAP + this.labelWidth(tailStr) : 0);
-    let used = 0, shown = [];
+    const chipW = (c) => 18 + this.labelWidth(c.label) + 6 + 8;   // pad+border + name + gap + ✕ (the 12px measure over-covers the 10.7px render)
+    const budget = this.M.left - PADL - (BTNW * 2 + GAP) - (tailStr ? GAP + this.labelWidth(tailStr) : 0);
+    let used = 0; const shown = [];
     for (const c of chips) {
       const w = GAP + chipW(c);
       const restW = chips.length - shown.length - 1 > 0 ? GAP + this.labelWidth('+' + (chips.length - shown.length - 1)) : 0;
@@ -2735,101 +2771,74 @@ class TimelinePanel {
       shown.push(c); used += w;
     }
     const hidden = chips.length - shown.length;
-    const y = axisY + 14;
-    const iconBtn = (dx, title, narrowed, draw, open) => {
-      const btn = el('g', {});
-      btn.setAttribute('style', 'cursor:pointer;');
-      // the box is the WHOLE hit target (transparent fill still catches pointevents; the glyph
-      // parts opt out) — the old bare 16x16 glyph pad was half the size and read unclickable
-      const box = el('rect', { x: PADL + dx, y: y - 13, width: BTNW, height: BTNH, rx: 6,
-        fill: narrowed ? 'rgba(156,210,255,0.12)' : 'transparent',
-        stroke: narrowed ? '#9cd2ff' : 'rgba(255,255,255,0.10)', 'stroke-width': 1 });
-      btn.appendChild(box);
-      draw(btn, PADL + dx + 9, y);
-      const tt = el('title', {}); tt.textContent = title; btn.appendChild(tt);
-      btn.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); open(btn); });
+    const sig = JSON.stringify([active, shown, hidden, tailStr]);
+    if (sig === this._cornerSig) return;
+    this._cornerSig = sig;
+    const bar = this._cornerBar;
+    while (bar.firstChild) bar.removeChild(bar.firstChild);
+    const btn = (title, glyph, open, on) => {
+      const b = document.createElement('button');
+      b.type = 'button'; b.title = title;
+      b.className = 'romp-tl-cbtn' + (on ? ' on' : '');
+      b.innerHTML = glyph;
+      b.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); open(b); });
       // the follow-up click would bubble to the document's menu-closer and shut the menu the same
       // instant it opened (the click-and-hold bug, 2026-08-24). Swallow it here.
-      btn.addEventListener('click', (e) => e.stopPropagation());
-      svg.appendChild(btn);
+      b.addEventListener('click', (e) => e.stopPropagation());
+      bar.appendChild(b);
+      return b;
     };
     // sliders: two horizontal rails with offset knobs — the display-options read
-    iconBtn(0, 'timeline display options', false, (btn, bx, by) => {
-      for (const [ry, kx] of [[-7, 9], [-2, 4]]) {
-        btn.appendChild(el('line', { x1: bx + 1, y1: by + ry, x2: bx + 13, y2: by + ry,
-          stroke: MODEL_FG, 'stroke-width': 1.4, 'stroke-linecap': 'round', 'pointer-events': 'none' }));
-        btn.appendChild(el('circle', { cx: bx + kx, cy: by + ry, r: 2.4, fill: '#1e1e1e',
-          stroke: MODEL_FG, 'stroke-width': 1.4, 'pointer-events': 'none' }));
-      }
-    }, (btn) => this._openDisplayMenu(btn));
-    // tag: the classic label outline with its hole — the filter-by-tag read (the user chose a tag
-    // icon). THE BUTTON CONVENTION (2026-08-25): GRAY at rest (All), the ACCENT while narrowed —
-    // the same values the shared webview renderer uses (#9aa0a6 / #9cd2ff, cross-mount equality)
-    const tagIconCol = active ? '#9cd2ff' : MODEL_FG;
-    iconBtn(BTNW + GAP, 'filter these lanes by tag', active, (btn, bx, by) => {
-      const ox = bx + 1, oy = by - 11;
-      btn.appendChild(el('path', {
-        d: 'M ' + ox + ' ' + (oy + 5.5) + ' l 5.5 -4.5 h 6.5 v 6.5 l -5.5 4.5 z',
-        fill: 'transparent', stroke: tagIconCol, 'stroke-width': 1.4, 'stroke-linejoin': 'round',
-        'pointer-events': 'none' }));
-      btn.appendChild(el('circle', { cx: ox + 9.5, cy: oy + 3.5, r: 1.3, fill: tagIconCol, 'pointer-events': 'none' }));
-    }, (btn) => this._openViewsMenu(btn));
-    let x = PADL + BTNW * 2 + GAP;
+    btn('timeline display options',
+      '<svg width="14" height="14" viewBox="0 0 14 14" fill="none">'
+      + '<line x1="1" y1="4" x2="13" y2="4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>'
+      + '<circle cx="9" cy="4" r="2.4" fill="#1e1e1e" stroke="currentColor" stroke-width="1.4"/>'
+      + '<line x1="1" y1="10" x2="13" y2="10" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>'
+      + '<circle cx="4" cy="10" r="2.4" fill="#1e1e1e" stroke="currentColor" stroke-width="1.4"/></svg>',
+      (b) => this._openDisplayMenu(b), false);
+    // tag: the ONE shared glyph — the exact markup every other mount renders (tag-menu.ts, the feed)
+    btn('filter these lanes by tag',
+      '<svg width="14" height="14" viewBox="0 0 16 16" fill="none">'
+      + '<path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>'
+      + '<circle cx="11" cy="5.5" r="1.2" fill="currentColor"/></svg>',
+      (b) => this._openViewsMenu(b), active);
     for (const c of shown) {
-      x += GAP;
-      const cw = chipW(c);
-      // each selected pick as its own chip (2026-08-25): OUTLINE in its colour on the dark ground,
-      // ✕ dim and SEPARATE (the composer chip's read) — the ✕ unselects THAT pick, not the filter
-      const grp = el('g', {});
-      grp.setAttribute('style', 'cursor:pointer;');
-      grp.appendChild(el('rect', { x, y: y - 13, width: cw, height: 18, rx: 9,
-        fill: 'transparent', stroke: c.color, 'stroke-width': 1 }));
-      const ct = el('text', { x: x + PADH, y, 'font-size': 12, fill: c.color, 'font-weight': 650 });
-      ct.textContent = c.label;
-      ct.setAttribute('style', 'user-select:none;');
-      grp.appendChild(ct);
-      const cx = el('text', { x: x + PADH + this.labelWidth(c.label) + XGAP, y, 'font-size': 11,
-        fill: MODEL_FG, opacity: 0.75 });
-      cx.textContent = '✕';
-      cx.setAttribute('style', 'user-select:none;');
-      grp.appendChild(cx);
-      const tt = el('title', {});
-      tt.textContent = 'remove \u201c' + c.label + '\u201d from this timeline\u2019s filter';
-      grp.appendChild(tt);
-      grp.addEventListener('pointerdown', (e) => {
+      // each selected pick as its own chip: OUTLINE in its colour, ✕ dim and SEPARATE (the
+      // composer chip's read) — the ✕ unselects THAT pick, not the filter
+      const chip = document.createElement('span');
+      chip.className = 'romp-tl-chip';
+      chip.style.borderColor = c.color; chip.style.color = c.color;
+      // a span, not a text node: this runs on the DRAW path, which the node harnesses drive with
+      // a minimal DOM shim (menus open only on real input; draw runs in every headless test)
+      const lbl = document.createElement('span');
+      lbl.textContent = c.label;
+      chip.appendChild(lbl);
+      const x = document.createElement('span');
+      x.className = 'romp-tl-chipx';
+      x.textContent = '\u2715';
+      x.title = 'remove \u201c' + c.label + '\u201d from this timeline\u2019s filter';
+      x.addEventListener('pointerdown', (e) => {
         e.preventDefault(); e.stopPropagation();
         const nv = JSON.parse(JSON.stringify(v));
         nv.actives = Object.assign({}, nv.actives, { timeline: lensToggle(lens, c.pick) });
         this._setViews(nv);
       });
-      grp.addEventListener('click', (e) => e.stopPropagation());
-      svg.appendChild(grp);
-      x += cw;
+      x.addEventListener('click', (e) => e.stopPropagation());
+      chip.appendChild(x);
+      bar.appendChild(chip);
     }
-    if (hidden > 0) {
-      // the picks that didn't fit the gutter — one dim count, one click from the menu
-      const hx = el('text', { x: x + GAP, y, 'font-size': 12, fill: MODEL_FG, opacity: 0.7 });
-      hx.textContent = '+' + hidden;
-      hx.setAttribute('style', 'user-select:none;cursor:pointer;');
-      const ht = el('title', {}); ht.textContent = hidden + ' more selected — open the tag filter';
-      hx.appendChild(ht);
-      hx.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(hx); });
-      hx.addEventListener('click', (e) => e.stopPropagation());
-      svg.appendChild(hx);
-      x += GAP + this.labelWidth('+' + hidden);
-    }
-    if (more) {
-      const m = el('text', { x: x + GAP, y, 'font-size': 12, fill: MODEL_FG, opacity: 0.7 });
-      m.textContent = tailStr;   // a filtered-out live session is always one glance away
-      // …and one CLICK away (the user 2026-08-24): the count opens the same views menu, so "what am
-      // I not seeing?" answers itself with the list of tags to switch to
-      m.setAttribute('style', 'user-select:none;cursor:pointer;');
-      const mt = el('title', {}); mt.textContent = 'live sessions outside this view — click to switch views, or un-hide via Sessions & tags…';
-      m.appendChild(mt);
-      m.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(m); });
-      m.addEventListener('click', (e) => e.stopPropagation());
-      svg.appendChild(m);
-    }
+    const tail = (text, title) => {
+      const t = document.createElement('span');
+      t.className = 'romp-tl-ctail';
+      t.textContent = text; t.title = title;
+      t.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(t); });
+      t.addEventListener('click', (e) => e.stopPropagation());
+      bar.appendChild(t);
+    };
+    if (hidden > 0) tail('+' + hidden, hidden + ' more selected \u2014 open the tag filter');
+    // a filtered-out live session is always one glance away — and one CLICK away (the user
+    // 2026-08-24): the count opens the same views menu, so "what am I not seeing?" answers itself
+    if (more) tail(tailStr, 'live sessions outside this view \u2014 click to switch views, or un-hide via Sessions & tags\u2026');
   }
 
   _closeViewsMenu() { if (this._viewsMenu) { this._viewsMenu.remove(); this._viewsMenu = null; } }
@@ -4023,7 +4032,7 @@ class TimelinePanel {
           this.hideTip();
           this._openLaneMenu(s, ghit);
         });
-        // same latent close-on-own-click as the views trigger (see _drawViewsTrigger): the gear's
+        // same latent close-on-own-click as the views trigger (see _renderCornerBar): the gear's
         // follow-up click must not reach the document's menu-closer
         ghit.addEventListener('click', (e) => e.stopPropagation());
       }
@@ -4628,7 +4637,7 @@ class TimelinePanel {
 
     // 🔒 lock-to-now padlock at the now-edge (replaces the old toolbar checkbox, the user 2026-06-26)
     this._drawLockToggle(svg, lockCx, axisY);
-    this._drawViewsTrigger(svg, axisY);
+    this._renderCornerBar();
 
     // The svg is fully rebuilt above — restore the hover the rebuild just swallowed, so a tip under a
     // stationary cursor comes up at once instead of waiting for the next mouse move (see _rehover).

--- a/ui/timeline-tagbtn-click.test.ts
+++ b/ui/timeline-tagbtn-click.test.ts
@@ -77,19 +77,15 @@ function drawnPanel(): any {
   return panel;
 }
 
-function findByTitle(root: any, txt: string): any {
-  for (const c of root.children || []) {
-    if (c.tag === "title" && String(c.textContent).includes(txt)) return root;
-    const hit = findByTitle(c, txt);
-    if (hit) return hit;
-  }
-  return null;
+function cornerBtn(panel: any, txt: string): any {
+  return (panel._cornerBar.children || []).find((c: any) => String(c.title || "").includes(txt)) || null;
 }
 
 test("executed: a tag-button press BUILDS the menu under a three-helper host (the 2026-08-25 dead button)", () => {
   const panel = drawnPanel();
-  const btn = findByTitle(panel.svg, "filter these lanes by tag");
-  assert.ok(btn, "the corner tag button drew");
+  const btn = cornerBtn(panel, "filter these lanes by tag");
+  assert.ok(btn, "the corner tag button rendered in the persistent HTML layer");
+  assert.equal(btn.tag, "button", "a REAL button — round three moved the corner off the SVG");
   const before = g.document.body.children.length;
   btn._listeners.pointerdown({ preventDefault() {}, stopPropagation() {} });   // the press — must not throw
   assert.ok(panel._viewsMenu, "the views menu opened");
@@ -104,35 +100,44 @@ test("executed: a tag-button press BUILDS the menu under a three-helper host (th
   panel._closeViewsMenu();
 });
 
-test("executed: the outlined box is the button's hit geometry — it spans the glyph, not a bare 16x16 pad", () => {
+test("executed: the whole button IS the hit target, wearing the feed's box by value", () => {
   const panel = drawnPanel();
-  const btn = findByTitle(panel.svg, "filter these lanes by tag");
-  const box = btn.children[0];
-  assert.equal(box.tag, "rect", "the box is the button's base layer");
-  assert.equal(box._attrs.width, 32, "full box width (14px glyph + 9px sides)");
-  assert.equal(box._attrs.height, 18, "chip-row height");
-  assert.equal(box._attrs.rx, 6, "the feed's radius");
-  assert.equal(box._attrs.fill, "transparent", "at rest transparent — still pointer-catching in svg");
-  assert.equal(box._attrs.stroke, "rgba(255,255,255,0.10)", "the feed's hairline at rest");
-  // every glyph part opts out of hits, so the box is the ONE hit surface (the lock's pattern)
-  for (const part of btn.children.slice(1))
-    if (part.tag !== "title") assert.equal(part._attrs["pointer-events"], "none", part.tag + " opts out of hits");
-  // the glyph sits INSIDE the box — the press target covers everything the eye reads as the button
-  const glyph = btn.children.find((c: any) => c.tag === "path");
-  assert.ok(glyph, "tag glyph drew");
-  const d = String(glyph._attrs.d);
-  const mx = Number(d.split(" ")[1]);
-  assert.ok(mx > Number(box._attrs.x) && mx < Number(box._attrs.x) + 32, "glyph starts inside the box");
+  const btn = cornerBtn(panel, "filter these lanes by tag");
+  // a native <button> — the entire box takes the press; no glyph-pad geometry to get wrong
+  assert.equal(btn.tag, "button");
+  assert.match(String(btn.className), /romp-tl-cbtn/);
+  assert.match(String(btn.innerHTML), /svg width="14" height="14"/, "the shared 14px tag glyph, currentColor");
+  // the injected corner CSS states the feed footer's values — the executed style node carries them
+  const styles = (g.document.head.children || []).filter((c: any) => c.tag === "style").map((c: any) => c.textContent).join("");
+  for (const lit of [
+    ".romp-tl-cbtn{display:inline-flex;align-items:center;font:inherit;font-size:10.5px;padding:1px 9px;",
+    "border:1px solid rgba(255,255,255,0.10);border-radius:6px;",
+    "color:var(--vscode-descriptionForeground,#9a9a9a);",
+  ]) assert.ok(styles.includes(lit), "corner CSS carries: " + lit);
 });
 
-test("executed: narrowed, the box wears the accent border + the feed .on wash", () => {
+test("executed: narrowed, the button wears the feed's .on dress and the chip renders beside it", () => {
   const panel = drawnPanel();
   const v = { active: "all", tags: [{ id: "g1", name: "infra", color: "#DD42FF", members: ["s2"] }], actives: { timeline: { tags: ["infra"] } } };
   panel.update(Object.assign({}, panel.data, { views: v }));
-  const btn = findByTitle(panel.svg, "filter these lanes by tag");
-  const box = btn.children[0];
-  assert.equal(box._attrs.stroke, "#9cd2ff", "accent border while narrowed");
-  assert.equal(box._attrs.fill, "rgba(156,210,255,0.12)", "the .on wash while narrowed");
+  const btn = cornerBtn(panel, "filter these lanes by tag");
+  assert.match(String(btn.className), /\bon\b/, "the .on class — same mechanics as the feed mount");
+  const styles = (g.document.head.children || []).filter((c: any) => c.tag === "style").map((c: any) => c.textContent).join("");
+  assert.ok(styles.includes(".romp-tl-cbtn.on{color:var(--accent,#9cd2ff);border-color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12);opacity:1}"),
+    "narrowed = accent border + the feed .on wash, full strength");
+  const chip = (panel._cornerBar.children || []).find((c: any) => String(c.className || "") === "romp-tl-chip");
+  assert.ok(chip, "the selection's chip renders beside the button");
+  assert.equal(chip.style.borderColor, "#DD42FF", "in its tag's colour");
+});
+
+test("executed: the corner bar persists across redraws — same signature, same nodes (click-safe by construction)", () => {
+  // the SVG is wiped per poll and per live-edge frame; the corner layer is NOT — it rebuilds only
+  // when its content signature changes, so a press can never land on a node a redraw just replaced
+  const panel = drawnPanel();
+  const before = cornerBtn(panel, "filter these lanes by tag");
+  panel.update(JSON.parse(JSON.stringify(panel.data)));   // same content, fresh poll
+  const after = cornerBtn(panel, "filter these lanes by tag");
+  assert.equal(before, after, "an unchanged poll leaves the very same button element in place");
 });
 
 test("the view speaks plain DOM: no Obsidian-only helper calls (the hosts install only the three)", () => {

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -75,11 +75,11 @@ test("the lane gate composes the view filter first, and the all-quiet fallback r
 });
 
 test("the trigger sits in the corner strip and opens on pointerdown, like every timeline control", () => {
-  assert.match(SRC, /_drawViewsTrigger\(svg, axisY\);/);
-  // two monochrome icon buttons since 2026-08-25 (display options + the tag filter), both
-  // pointerdown-opened with tooltips carrying the words
-  assert.match(SRC, /btn\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); open\(btn\); \}\);/);
-  assert.match(SRC, /iconBtn\(BTNW \+ GAP, 'filter these lanes by tag'/);
+  assert.match(SRC, /this\._renderCornerBar\(\);/);
+  // two icon buttons since 2026-08-25 (display options + the tag filter) — REAL HTML <button>s in
+  // the persistent corner layer since round three — both pointerdown-opened, tooltips carry the words
+  assert.match(SRC, /b\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); open\(b\); \}\);/);
+  assert.match(SRC, /btn\('filter these lanes by tag',/);
   assert.match(SRC, /const tailStr = more \? more \+ ' more' : '';/, "a filtered-out live session is always one glance away");
 });
 
@@ -90,16 +90,17 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
     "each chip's ✕ unselects THAT pick (per-selection chips, the user 2026-08-25)");
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
-  assert.match(SRC, /fill: 'transparent', stroke: c\.color, 'stroke-width': 1/);
+  assert.match(SRC, /chip\.style\.borderColor = c\.color; chip\.style\.color = c\.color;/,
+    "outline + text in the pick's colour on the page's own ground");
+  assert.match(SRC, /\.romp-tl-chip\{display:inline-flex;align-items:center;gap:5px;padding:1px 8px;border-radius:9px;/,
+    "the chip anatomy is the shared syncTagFilter chip's, by value");
   // a SENTINEL view's chip dims to the corner line's own gray at the N-more opacity (the user
   // 2026-08-24: at #cccccc it read bright as a tag) — real tag chips keep their tag colors, full strength
   // per-selection chips since 2026-08-25: each pick derives its own colour (no-tags in the gray)
   assert.match(SRC, /return \{ label: n, color: \(u && u\.color\) \|\| MODEL_FG, pick: \{ tag: n \} \};/);
   assert.match(SRC, /\.concat\(lens\.none \? \[\{ label: 'no tags', color: MODEL_FG, pick: 'none' \}\] : \[\]\)/);
-  assert.match(SRC, /y: y - 13, width: cw, height: 18, rx: 9,/, "taller chip");
-  assert.match(SRC, /cx\.textContent = '✕';/);
-  assert.match(SRC, /fill: MODEL_FG, opacity: 0\.75/);
-  assert.match(SRC, /fill: c\.color, 'font-weight': 650/);
+  assert.match(SRC, /x\.textContent = '\\u2715';/);
+  assert.match(SRC, /\.romp-tl-chipx\{cursor:pointer;opacity:0\.75;/, "the ✕ dim and separate");
   assert.match(SRC, /remove \\u201c' \+ c\.label \+ '\\u201d from this timeline/,
     "the ✕ hover names the ONE pick it removes");
   // no chip on All — the unfiltered default; the untagged view IS a filter now, so it wears one
@@ -108,17 +109,13 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
   assert.match(SRC, /bottom: 27 \}/);
 });
 
-test("the corner line wears the LANE LABELS' typography — inherited family, measured as rendered", () => {
-  // the user 2026-08-24, who read the chip as the wrong font: the corner texts carried an explicit
-  // 'font-family: FONT' while the lane names inherit the host's UI font, so at the same nominal
-  // 12px the chip rendered visibly bigger. The whole corner line now inherits like the lanes do —
-  // no family override anywhere in the trigger drawing…
-  const TRIG = SRC.slice(SRC.indexOf("_drawViewsTrigger(svg, axisY) {"), SRC.indexOf("_closeViewsMenu() {"));
-  assert.doesNotMatch(TRIG, /font-family/, "corner texts inherit the host font exactly like lane labels");
-  // …at the lane-label scale: the N-more at the lane 12px, the chip name at the lane-name 650
-  // (the "Filter ▾" trigger TEXT retired 2026-08-25 — the corner is two icon buttons now)
-  assert.match(TRIG, /'font-size': 12, fill: c\.color, 'font-weight': 650/);
-  assert.match(SRC, /'font-weight': 650, 'font-size': 12, fill: F\(s\.color\)/, "the lane-name reference the line matches");
+test("the corner bar wears the FEED FOOTER's typography — stated, since the pane may live in a foreign document", () => {
+  // round three (the user 2026-08-25): the corner is the feed footer's control row now, so it
+  // carries the feed's own font stack EXPLICITLY (the menu rule: an adopted/foreign host would
+  // substitute its own family otherwise — how the gear menu once drifted off-brand)
+  assert.match(SRC, /\.romp-tl-corner\{[^}]*font-family:var\(--vscode-font-family,-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif\)/,
+    "the bar states the shared stack every romp surface resolves to");
+  assert.match(SRC, /'font-weight': 650, 'font-size': 12, fill: F\(s\.color\)/, "the lane-name reference is untouched");
   // …and the width/ellipsis math measures in the SAME family the text renders in: _font resolves
   // the wrap's computed family (FONT is only the unstyled/bare-node fallback), so box and ellipsis
   // can never drift from the rendered glyphs
@@ -135,9 +132,9 @@ test("a pointerdown-opened menu survives its OWN opening click (the user 2026-08
   // the browser fires a click after pointerup; unstopped it bubbles to the document's menu-closer
   // and shuts the menu the instant it opened — only a mid-press redraw (element swapped, no click
   // at all) let it survive, which read as "hold to open". Every pointerdown anchor swallows it.
-  assert.match(SRC, /open\(btn\); \}\);[\s\S]{0,400}btn\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
+  assert.match(SRC, /open\(b\); \}\);[\s\S]{0,400}b\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
   assert.match(SRC, /this\._openLaneMenu\(s, ghit\);\n\s*\}\);[\s\S]{0,300}ghit\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
-  assert.match(SRC, /grp\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
+  assert.match(SRC, /x\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/, "the chip ✕ swallows its own click too");
 });
 
 test("the dropdown and dialog wear the shared menu vocabulary and adopt into the menu host", () => {
@@ -247,8 +244,8 @@ test("federation, NAME-KEYED (user ruling 2026-08-24): one name = one row/label/
 });
 
 test("the N-more count opens the views menu — what am I not seeing answers itself (the user 2026-08-24)", () => {
-  assert.match(SRC, /m\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(m\); \}\);/);
-  assert.match(SRC, /m\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/, "and survives its own opening click");
+  assert.match(SRC, /t\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(t\); \}\);/);
+  assert.match(SRC, /t\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/, "and survives its own opening click");
 });
 
 test("the two display toggles write the host's own romp:settings — reachable in every host now", () => {
@@ -279,8 +276,8 @@ test("executed: the dialog's membership mutation, pure (viewToggleHidden retired
 test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {
   // the fit measures the whole line as LAID OUT: trigger + gap + padded chip + gap + tail
   // per-chip budgeting since 2026-08-25: chips render while they fit; the rest collapse into +N
-  assert.match(SRC, /const chipW = \(c\) => PADH \* 2 \+ this\.labelWidth\(c\.label\) \+ XGAP \+ this\.labelWidth\('✕'\);/);
-  assert.match(SRC, /const budget = this\.M\.left - PADL - 6 - \(BTNW \* 2 \+ GAP\) - \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
+  assert.match(SRC, /const chipW = \(c\) => 18 \+ this\.labelWidth\(c\.label\) \+ 6 \+ 8;/);
+  assert.match(SRC, /const budget = this\.M\.left - PADL - \(BTNW \* 2 \+ GAP\) - \(tailStr \? GAP \+ this\.labelWidth\(tailStr\) : 0\);/);
   assert.match(SRC, /if \(used \+ w \+ restW > budget\) break;/);
 
   assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
@@ -446,9 +443,9 @@ test("executed: the timeline lens — toggles, All exclusivity, last-off→All, 
 
 test("the corner grew two icon buttons and the menus split (the user 2026-08-25)", () => {
   // display options (sliders) LEFT of the tag filter (tag icon); both monochrome, tooltip-worded
-  assert.match(SRC, /iconBtn\(0, 'timeline display options'/, "sliders sit left");
-  assert.match(SRC, /iconBtn\(BTNW \+ GAP, 'filter these lanes by tag'/, "the tag button beside it");
-  assert.match(SRC, /_openDisplayMenu\(btn\)/);
+  assert.match(SRC, /btn\('timeline display options',[\s\S]{0,900}btn\('filter these lanes by tag',/,
+    "sliders sit left, the tag button beside it (append order = flex order)");
+  assert.match(SRC, /_openDisplayMenu\(b\)/);
   assert.match(SRC, /capSep\('filters this timeline'\)/,
     "the captioned divider says which surface the selection governs");
   assert.match(SRC, /font-size:0\.82em;opacity:0\.6;font-style:italic/,

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -36,9 +36,12 @@ test("executed: lensChips — All bare; narrowed = every selection incl. the no-
 test("cross-mount computed equality: one gray, one accent, everywhere", () => {
   assert.equal(TAG_BTN_GRAY, "#9aa0a6");
   assert.equal(TAG_BTN_ACCENT, "#9cd2ff");
-  // the timeline inlines the same values (it loads no modules — Obsidian host)
-  assert.match(TL, /const MODEL_FG = '#9aa0a6';/, "the timeline's gray IS the convention gray");
-  assert.match(TL, /const tagIconCol = active \? '#9cd2ff' : MODEL_FG;/, "gray at rest, accent narrowed");
+  // the timeline inlines the same values (it loads no modules — Obsidian host). Round three: the
+  // corner buttons' rest gray is the FEED INSTANCE's own computed chain (var(--dim) resolves this),
+  // narrowed is the .on accent — stated in the injected corner CSS, currentColor carries the glyph
+  assert.match(TL, /const MODEL_FG = '#9aa0a6';/, "the timeline's text gray (chip fallback) is the convention gray");
+  assert.match(TL, /color:var\(--vscode-descriptionForeground,#9a9a9a\)/, "rest = the feed's exact color chain");
+  assert.match(TL, /\.romp-tl-cbtn\.on\{color:var\(--accent,#9cd2ff\);/, "narrowed = the .on accent");
   // the feed's class mode resolves to the same accent (its own :root states the literal)
   assert.match(FEEDCSS, /--accent: #9cd2ff;/, "feed.css's accent equals the convention accent");
   assert.match(FEED, /"class"\);/, "the feed mounts in class mode — its .on carries that accent");
@@ -70,18 +73,19 @@ test("THE BUTTON OUTLINE (the user 2026-08-25, round two): every mount wears the
     "narrowed = accent border, at rest the hairline");
   assert.match(TAGMENU, /btn\.style\.background = narrowed \? TAG_BTN_WASH : "transparent";/,
     "narrowed = the .on wash");
-  // the timeline draws the same box in svg terms, and the BOX is the hit target (the bare 16x16
-  // glyph pad read unclickable — the user 2026-08-25)
-  assert.match(TL, /const box = el\('rect', \{ x: PADL \+ dx, y: y - 13, width: BTNW, height: BTNH, rx: 6,/,
-    "the corner buttons draw the outlined box as their hit rect");
-  assert.match(TL, /stroke: narrowed \? '#9cd2ff' : 'rgba\(255,255,255,0\.10\)', 'stroke-width': 1 \}\);/,
-    "same hairline at rest, same accent narrowed");
-  assert.match(TL, /fill: narrowed \? 'rgba\(156,210,255,0\.12\)' : 'transparent',/,
-    "same wash narrowed, transparent (still hit-catching) at rest");
+  // the timeline mounts REAL HTML buttons in the corner layer (round three — the SVG imitation
+  // of the same numbers still rendered differently; parity is the rendered image now, checked by
+  // side-by-side crops in review), wearing the identical literals:
+  assert.match(TL, /border:1px solid rgba\(255,255,255,0\.10\);border-radius:6px;cursor:pointer;white-space:nowrap;opacity:0\.95;/,
+    "the corner button carries the feed's hairline, radius, and footer opacity");
+  assert.match(TL, /font:inherit;font-size:10\.5px;padding:1px 9px;/,
+    "…and the footer instance's font scale and padding");
+  assert.match(TL, /\.romp-tl-cbtn\.on\{[^}]*background:rgba\(156,210,255,0\.12\);opacity:1\}/,
+    "narrowed = the .on wash at full strength");
 });
 
 test("timeline spacing grew (the user 2026-08-25: the corner controls were cramped)", () => {
-  assert.match(TL, /const BTNW = 32, BTNH = 18;/, "the outlined boxes replaced the bare icon slots (round two)");
-  assert.match(TL, /const PADH = 7, GAP = 9;/, "more air between the line's parts");
+  assert.match(TL, /const GAP = 8, BTNW = 34;/,
+    "round three: the button slot IS the feed tag button's measured box (34px), the bar's flex gap 8");
   assert.match(TL, /if \(hidden > 0\)/, "overflow chips collapse into a +N, one click from the menu");
 });


### PR DESCRIPTION
Round three on the Sessions-corner buttons (user report: still awkward and missized next to the rest of the software, floating over dead space).

**The rendering-context cause.** The previous pass drew the feed button's anatomy in SVG and pinned the numbers equal — but a CSS button's box is the layout engine's product (the 10.5px line box, borders drawn inside, its own antialiasing), and an SVG imitation of the same numbers renders a different picture. The measured tell: the feed's tag button is 34×18 because the engine derives it from content + padding + border; the SVG copy hand-drew 32×18 and seated 8px off the strip bottom, which read as squarish boxes floating over dead space.

**The fix.** The corner controls are real `<button>`s now, in a persistent HTML layer over the SVG's bottom-left strip (the compact-bar overlay precedent), wearing the feed footer's exact values by value: the `#feed-foot .fdismiss` box, the `.feed-modetoggle.on` narrowed dress, real `:hover`, and the `syncTagFilter` chip anatomy for selection chips. The layer persists across SVG wipes and rebuilds only when its content signature changes — click-safe by construction. Seated `bottom:4px`; the dead space under the buttons is gone.

**The bar, met as pixels.** Both surfaces rendered in one headless Chromium page; the two tag buttons crop-diffed: 34×18 both, identical computed color/border/radius/padding/font/opacity, worst pixel-channel delta 9/255 (that residue is the two panes' background shades, #252526 vs #1e1e1e), zero pixels above 24. `elementFromPoint` at the button center resolves to the button; a real click opens the menu.

**Tests.** The executed press-builds-menu regression retargeted to the HTML button; a new persistence pin (same signature → same nodes across polls); the injected corner CSS literals pinned against feed.css; the draw-path stays three-helper-shim safe (chip labels are spans, not text nodes); stale SVG-anatomy pins retargeted. Suites: pytest 5656 passed / 34 skipped; vscode-extension 2431/2431 plus the new pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)