### PR TITLE
The menus drop their captions — the button tooltip is the one scope carrier

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2879,17 +2879,9 @@ class TimelinePanel {
       const s = menu.createDiv();
       s.setAttribute('style', 'height:1px;margin:4px 6px;background:rgba(255,255,255,0.12);');
     };
-    // a CAPTIONED divider (the user 2026-08-25): the hairline carries a tiny italic dim label —
-    // the menu says which surface its selection governs. The sub-line scale (0.82em/0.6), never a
-    // new size; one shared idiom other menus adopt.
-    const capSep = (label) => {
-      const s = menu.createDiv();
-      s.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 6px;');
-      const l1 = s.createDiv(); l1.setAttribute('style', 'height:1px;flex:0 0 8px;background:rgba(255,255,255,0.12);');
-      const t = s.createSpan({ text: label });
-      t.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
-      const l2 = s.createDiv(); l2.setAttribute('style', 'height:1px;flex:1;background:rgba(255,255,255,0.12);');
-    };
+    // (the menu's scope caption retired 2026-08-25 — the user: the button's tooltip already says
+    // which surface this governs, so the menu opens straight onto its rows. The captioned-divider
+    // idiom itself lives on in the dialog's sections.)
     // MULTI-SELECT (the user 2026-08-25): rows are TOGGLES on this surface's lens — All exclusive
     // and a plain pick; (no tags) and every tag combine arbitrarily; the ✓ marks each selected row
     // and the menu STAYS OPEN across toggles (a settings panel, not a command — the gear's rule),
@@ -2909,7 +2901,6 @@ class TimelinePanel {
         this._setViews(nv);
         if (close) this._closeViewsMenu(); else build();
       };
-      capSep('filters this timeline');
       item('All', { current: lensAll(lens) }).addEventListener('click', () => apply({ all: true }, true));
       item('(no tags)', { current: !lensAll(lens) && !!lens.none })
         .addEventListener('click', () => apply(lensToggle(lens, 'none'), false));
@@ -2953,12 +2944,7 @@ class TimelinePanel {
       row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
       return row;
     };
-    const cap = menu.createDiv();
-    cap.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 6px;');
-    cap.createDiv().setAttribute('style', 'height:1px;flex:0 0 8px;background:rgba(255,255,255,0.12);');
-    const capT = cap.createSpan({ text: 'how this timeline draws' });
-    capT.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
-    cap.createDiv().setAttribute('style', 'height:1px;flex:1;background:rgba(255,255,255,0.12);');
+    // (no header — the user 2026-08-25: the menu is just its two entries)
     const flip = (key, cur) => {
       let s = {}; try { s = JSON.parse(localStorage.getItem('romp:settings') || '{}') || {}; } catch (e) {}
       s[key] = !cur;

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -446,10 +446,11 @@ test("the corner grew two icon buttons and the menus split (the user 2026-08-25)
   assert.match(SRC, /btn\('timeline display options',[\s\S]{0,900}btn\('filter these lanes by tag',/,
     "sliders sit left, the tag button beside it (append order = flex order)");
   assert.match(SRC, /_openDisplayMenu\(b\)/);
-  assert.match(SRC, /capSep\('filters this timeline'\)/,
-    "the captioned divider says which surface the selection governs");
-  assert.match(SRC, /font-size:0\.82em;opacity:0\.6;font-style:italic/,
-    "caption at the sub-line scale — no new font sizes");
+  // the menu scope captions retired 2026-08-25 (the user: the tooltip already says it) — the
+  // button TOOLTIP is the one scope carrier now, and the menus open straight onto their rows
+  assert.ok(!SRC.includes("capSep("), "the tag menu's scope caption is gone");
+  assert.ok(!SRC.includes("how this timeline draws"), "the display menu's header is gone");
+  assert.match(SRC, /btn\('filter these lanes by tag',/, "…the tooltip names the surface instead");
   assert.match(SRC, /item\('Configure tags…', \{ dim: true \}\)/, "one management entry");
   assert.ok(!/item\('New tag…', \{ dim: true \}\)/.test(SRC), "New tag left the menu…");
   assert.match(SRC, /text: '\+ New tag'/,

--- a/ui/webview/feed-tagmount.test.ts
+++ b/ui/webview/feed-tagmount.test.ts
@@ -60,7 +60,7 @@ test("the mount is the SHARED component: tag glyph button, stay-open menu, Confi
   assert.match(FEED, /b = tagMenuButton\("filter this board by tag — combinations union; All shows everything", \(btn\) => \{/,
     "the shared monochrome tag glyph — identical across surfaces");
   assert.match(FEED, /openTagMenu\(btn, \{/);
-  assert.match(FEED, /scopeCaption: "filters this feed",/, "the captioned divider names the surface");
+  assert.ok(!FEED.includes("scopeCaption"), "the menu scope caption retired 2026-08-25 — the button tooltip carries the scope");
   assert.match(FEED, /onApply: \(l\) => \{ setFeedLens\(l\); render\(\); \},/);
   assert.match(FEED, /onConfigure: \(\) => vscodeApi\?\.postMessage\(\{ type: "openTagsDialog" \}\),/,
     "one management entry; creation lives in the dialog");

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3368,7 +3368,6 @@ function ensureTagLensBtn(): HTMLElement {
         lens: () => feedLens,
         unions: () => lensUnions(feedTagViews),
         onApply: (l) => { setFeedLens(l); render(); },
-        scopeCaption: "filters this feed",
         onConfigure: () => vscodeApi?.postMessage({ type: "openTagsDialog" }),
       });
     });

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -842,7 +842,6 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
           vscodeApi?.postMessage({ type: "setTimelineViews", views: v });
           render();
         },
-        scopeCaption: "filters this outline",
         onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
       });
     });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4519,7 +4519,6 @@ function renderTabs() {
         v.actives = Object.assign({}, v.actives, { chat: l });
         postViews(v);
       },
-      scopeCaption: "filters these tabs",
       onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
     });
   });

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -22,7 +22,6 @@ export interface TagMenuOpts {
   lens: () => TagLens;                       // the surface's current selection (re-read per repaint)
   unions: () => TagUnion[];                  // the name-keyed union rows (re-read per repaint)
   onApply: (l: TagLens, done: boolean) => void;  // done=true → the pick closes the menu (All)
-  scopeCaption: string;                      // "filters these tabs" — which surface this governs
   onConfigure?: () => void;                  // the one management entry, when the surface has a route
 }
 
@@ -68,20 +67,8 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
   const build = () => {
     menu.textContent = "";
     const lens = opts.lens();
-    const cap = document.createElement("div");
-    cap.setAttribute("style", "display:flex;align-items:center;gap:6px;margin:4px 6px;");
-    const capMk = (grow: boolean) => {
-      const d = document.createElement("div");
-      d.setAttribute("style", "height:1px;" + (grow ? "flex:1;" : "flex:0 0 8px;") + "background:rgba(255,255,255,0.12);");
-      return d;
-    };
-    cap.appendChild(capMk(false));
-    const capT = document.createElement("span");
-    capT.textContent = opts.scopeCaption;
-    capT.setAttribute("style", "font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;");
-    cap.appendChild(capT);
-    cap.appendChild(capMk(true));
-    menu.appendChild(cap);
+    // (the scope caption retired 2026-08-25 — the user: the button tooltip already names the
+    // surface, so it is the ONE scope carrier and the menu opens straight onto its rows)
     const row = (label: string, current: boolean, dot?: string | null, dim?: boolean) => {
       const r = document.createElement("div");
       r.setAttribute("style", "padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;"

--- a/ui/webview/tag-mounts.test.ts
+++ b/ui/webview/tag-mounts.test.ts
@@ -47,11 +47,11 @@ test("the chat strip and the outline both mount the shared component (source pin
   assert.match(RENDER, /function chatVisible\(id: string\): boolean/);
   assert.match(RENDER, /lensVisible\(surfaceLens\(v, "chat"\), viewTagUnion\(v\), id\)/,
     "tabs + peeks decide through actives.chat");
-  assert.match(RENDER, /tagMenuButton\("filter these tabs by tag"/);
-  assert.match(RENDER, /scopeCaption: "filters these tabs"/);
+  assert.match(RENDER, /tagMenuButton\("filter these tabs by tag"/,
+    "the tooltip names the surface — the ONE scope carrier since the menu caption retired (2026-08-25)");
   assert.match(RENDER, /Object\.assign\(\{\}, v\.actives, \{ chat: l \}\)/, "writes land on chat's lens only");
-  assert.match(FLEET, /tagMenuButton\("filter this outline by tag"/);
-  assert.match(FLEET, /scopeCaption: "filters this outline"/);
+  assert.match(FLEET, /tagMenuButton\("filter this outline by tag"/,
+    "ditto — the outline tooltip names its surface");
   assert.match(FLEET, /Object\.assign\(\{\}, v\.actives, \{ outline: l \}\)/);
   assert.match(FLEET, /if \(!lensVisible\(outlineLens, outlineUnions, s\.sid\)\) continue;/);
   assert.match(FLEET, /fleetViews = m\.views as SessionViews/, "the outline reads views off the feed payload");
@@ -66,11 +66,12 @@ test("every pane's Configure tags… routes to THE dialog on the timeline (sourc
     "routed to the SAME dashboard's timeline, like tagEditFailed");
 });
 
-test("the shared component: toggles stay open, scope caption, echo dismissal (source pins)", () => {
+test("the shared component: toggles stay open, no scope caption, echo dismissal (source pins)", () => {
   assert.match(MENU, /opts\.onApply\(toggleLens\(lens, \{ tag: u\.name \}\), false\); build\(\);/,
     "tag rows toggle and repaint in place");
   assert.match(MENU, /opts\.onApply\(\{ all: true \}, true\)/, "All is a plain pick");
-  assert.match(MENU, /font-size:0\.82em;opacity:0\.6;font-style:italic/, "the captioned divider, sub-line scale");
+  assert.ok(!MENU.includes("scopeCaption"),
+    "the scope caption retired 2026-08-25 (the user: the tooltip already says it) — the menu opens straight onto its rows");
   assert.match(MENU, /localStorage\.setItem\("romp:menu-echo"/, "every pane writes the pointerdown echo");
   assert.match(MENU, /e\.key === "romp:menu-echo" && e\.newValue/, "every open menu listens");
   assert.match(MENU, /btn\.addEventListener\("click", \(e\) => e\.stopPropagation\(\)\)/,


### PR DESCRIPTION
Two menu-copy removals per user request.

**The display menu's header goes.** "how this timeline draws" is gone; the menu is just its two entries (Collapse idle gaps / Active sessions only).

**The tag menus' scope captions go.** "filters this timeline" and its siblings are retired at the component level: `openTagMenu` no longer takes a `scopeCaption`, so the chat, outline, and feed mounts drop it together, and the timeline's inline menu drops its `capSep` (whose only use this was). The button tooltip is now the one scope carrier — each mount's tooltip verified to name its surface (filter these tabs / this outline / this board / these lanes by tag) and pinned as such.

The captioned-divider idiom itself survives in the dialog's sections; only the menu scope captions retire. Caption-presence pins became absence pins plus tooltip pins, ruling cited. Verified headlessly: both menus open straight onto their rows.

Suites: vscode-extension 2432/2432; pytest 5656 passed / 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)