### PR TITLE
The rename ping delivers at the turn's settle — where its record cannot fold

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2313,7 +2313,7 @@ class SdkSession:
         append_state(self.backend.state_dir, self.sid, state)
 
     def _on_message(self, msg, AssistantMessage, ResultMessage, SystemMessage):
-        if self._ping_feeding:
+        if getattr(self, "_ping_feeding", False):   # getattr: __new__-built test doubles skip __init__
             # the ping's turn is streaming — the CLI demonstrably started it, so a message fed from
             # here on lands MID-TURN as its own record (the CLI's designed forward behavior); the
             # queue can flow again

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -866,6 +866,8 @@ BOOT_RESUME_SLOT_S = float(os.environ.get("ROMP_BOOT_RESUME_SLOT_S", "180"))
 # meaning), but MARKER-FREE: this line joins an EXISTING message, and the romp-injected marker
 # would re-author the host message's echo and transcript atom.
 RENAME_NUDGE = "[romp] This session was renamed: it is now '%s'. A note for your own records — carry on."
+# the dressed ping's detectable head — the drain's feed-hold keys on it (see _deliver_rename_ping)
+RENAME_PING_HEAD = "<!-- romp-injected --><!-- romp-system -->[romp] This session was renamed"
 
 # Same recovery, different death: the session's OWN claude process died mid-turn (killed or crashed)
 # while the kernel stayed up, so the kernel itself resumes it (_heal_cut_session) instead of waiting
@@ -1498,6 +1500,10 @@ class SdkSession:
         # so a kernel death can DELAY queued messages but never lose them; the boot reconcile
         # resumes any session with a non-empty persisted queue and this seed delivers it.
         self._pending: list[str] = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+        self._ping_feeding = False   # a rename ping was fed and its turn hasn't streamed yet: hold the
+        #                              queue so no message can share its pre-turn window (the CLI batches
+        #                              everything pre-start into ONE record — the 2026-08-25 fold); cleared
+        #                              by the turn's first streamed message, an exact event, or a reconnect
         # A RESTORED /compact must light the compacting bracket too (the user 2026-07-22). send() sets
         # _compacting when it enqueues a compact command, but a persisted queue lands here INSTEAD of
         # going through send() — any /compact still queued when the kernel died arrives this way. Without
@@ -2038,6 +2044,7 @@ class SdkSession:
                     # up (_rewind_armed, set by _options) — feeding the edit turn to the CURRENT client
                     # would land it on the un-rewound branch (the exact wrong-branch delivery this guards)
                     blocked = blocked or bool(self._rewind_to and not self._rewind_armed)
+                    blocked = blocked or self._ping_feeding   # the ping's record must not share its window
                     item = self._pending.pop(0) if (self._pending and not blocked) else None
                     fresh = item is not None and self.inflight == 0     # starting from idle, not mid-turn
                 if item is None:
@@ -2050,6 +2057,8 @@ class SdkSession:
                     self._intr_level = 0             #   ...and its escalation episode (a new stop starts polite)
                 self.inflight += 1
                 self._inflight_texts.append(item)   # the fed-turn twin — see its init comment
+                if item.startswith(RENAME_PING_HEAD):
+                    self._ping_feeding = True       # hold feeds until this turn's first streamed message
                 self._mark("working")
                 self.backend._poke()
                 yield {"type": "user",
@@ -2073,6 +2082,7 @@ class SdkSession:
         while not self.ended:
             self._wake.clear()
             self._reconnect = False
+            self._ping_feeding = False   # a reconnect restarts the feed — a stale hold must not wedge it
             # settle + recover anything the abandoned client stranded — see _reconcile_stranded
             self._reconcile_stranded()
             opts = self.backend._options(self, ClaudeAgentOptions)
@@ -2303,6 +2313,13 @@ class SdkSession:
         append_state(self.backend.state_dir, self.sid, state)
 
     def _on_message(self, msg, AssistantMessage, ResultMessage, SystemMessage):
+        if self._ping_feeding:
+            # the ping's turn is streaming — the CLI demonstrably started it, so a message fed from
+            # here on lands MID-TURN as its own record (the CLI's designed forward behavior); the
+            # queue can flow again
+            self._ping_feeding = False
+            if self._input_wake is not None:
+                self._input_wake.set()   # same-loop thread — the settle path sets it the same way
         if isinstance(msg, SystemMessage) and msg.subtype == "init":
             self._fire_boot_settled()   # the CLI is up and streaming — its transcript catch-up burst
             #                             is over, so the boot-stagger slot (if any) frees NOW
@@ -2541,6 +2558,9 @@ class SdkSession:
             self.backend._poke()
             if self._input_wake is not None:   # turn done → release the next queued turn, if any
                 self._input_wake.set()
+            # a pending rename ping delivers HERE, as its own turn (the user answered first; the
+            # empty-queue guard + the feed-hold make its record unfoldable — see _deliver_rename_ping)
+            self.backend._deliver_rename_ping(self)
             if self._reconnect_when_idle and not self.ended:   # an effort change waited for this turn to end
                 self._reconnect_when_idle = False
                 self._reconnect = True
@@ -4232,23 +4252,6 @@ class SdkBackend:
         s = self._ensure(sid)
         if not s:
             return False
-        # RENAME PING (the user 2026-08-24; own-record form 2026-08-25): one line ahead of the
-        # next thing that enters the session, so it hears its own new name instead of inferring
-        # it. Its OWN record in the machine-sent dress — string-prepending it into the incoming
-        # text put the bookkeeping line inside the USER's bubble, rendered as if they typed it
-        # (the user 2026-08-25, on their very first message). The romp-injected markers are safe
-        # here precisely BECAUSE the record is separate: they author this line 'romp' (the gray
-        # machine bubble, the restart notices' dress) without touching the user's own record. It
-        # still rides the same wake — the recursive send enqueues back-to-back with the message
-        # that triggered it, and an idle session stays idle. A slash-command send passes untouched
-        # (the CLI must see the bare command) and the note holds for the next real prompt; the
-        # recursion terminates because the note is cleared before the ping is sent.
-        if not text.lstrip().startswith("/"):
-            _reg = read_reg(self.state_dir, sid) or {}
-            if _reg.get("renameNote"):
-                _note = _reg["renameNote"]
-                self._update_reg(sid, renameNote=None)
-                self.send(sid, "<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % _note)
         if _is_compact_cmd(text):
             # Delivering /compact: mark the session compacting NOW (authoritative), covering the gap between
             # this send and the CLI actually starting the turn — so a drive op the producer tick checks in
@@ -5173,6 +5176,32 @@ class SdkBackend:
                         "echo": bool(a.get("_echo_text")), "command": bool(a.get("command")),
                         "apiError": bool(a.get("isApiError")), "hasText": bool(_atom_text(a).strip())})
         return out
+
+    def _deliver_rename_ping(self, s) -> bool:
+        """Deliver a pending rename ping (reg renameNote) as its OWN turn, at a turn's SETTLE — the
+        only window where its record cannot fold into anyone else's (the user 2026-08-25: the
+        enqueue-AHEAD form fed the ping and the user's message back-to-back, and the CLI batches
+        every message that arrives before a turn starts into ONE user record — the user's own words
+        rendered inside the ping's machine bubble, worse than the bug it replaced). Three gates make
+        the fold unreachable: delivery only at settle (the user is answered first), only when the
+        queue is EMPTY (a queued message would share the pre-turn window), and the drain's feed-hold
+        (RENAME_PING_HEAD) keeps the next item back until the ping's turn demonstrably starts — its
+        first streamed message, an exact event — after which a racing send lands mid-turn as its own
+        record by the CLI's own design. A held note simply waits for a later settle; it survives
+        restarts in the reg."""
+        try:
+            reg = read_reg(self.state_dir, s.sid) or {}
+        except Exception:
+            return False
+        note = reg.get("renameNote")
+        if not note:
+            return False
+        with s._lock:
+            if s._pending:
+                return False               # a queued turn would share the pre-turn window — hold the note
+        self._update_reg(s.sid, renameNote=None)
+        s.enqueue("<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % note)
+        return True
 
     def _update_reg(self, sid: str, **fields):
         with self._reg_lock:                       # kernel + loop threads both write (queue mirror);

--- a/tests/test_model_fallback_card.py
+++ b/tests/test_model_fallback_card.py
@@ -110,6 +110,9 @@ class SidechainNeverLearns(unittest.TestCase):
             def _update_reg(self, sid, **kw):
                 calls["reg"].append(kw)
 
+            def _deliver_rename_ping(self, s):
+                return False   # settle hook (2026-08-25); no ping in these worlds
+
             def _poke(self):
                 pass
 

--- a/tests/test_sdk_api_retry_detail.py
+++ b/tests/test_sdk_api_retry_detail.py
@@ -61,6 +61,9 @@ class _Backend:
     def __init__(self):
         self.forwarded = []
 
+    def _deliver_rename_ping(self, s):
+        return False   # settle hook (2026-08-25); no ping in these worlds
+
     def _poke(self):
         pass
 

--- a/tests/test_sdk_compacting_signal.py
+++ b/tests/test_sdk_compacting_signal.py
@@ -39,6 +39,7 @@ class _FakeBackend:
     def _turn_completed(self, sid): pass
     def retire_live_work(self, sid): pass
     def _poke(self): pass
+    def _deliver_rename_ping(self, s): return False   # settle hook (2026-08-25); no ping in these worlds
     def _record_spend(self, cost, usage=None): pass   # the settle folds cost+tokens into spend.json; irrelevant here
     def _update_reg(self, *a, **k): pass
     def _forward(self, s, msg): pass

--- a/tests/test_sdk_rename_ping.py
+++ b/tests/test_sdk_rename_ping.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""The rename ping (the user 2026-08-24; own-record form 2026-08-25): a renamed session hears its
-OWN new name on its next wake — rename() stamps the reg (renameNote, restart-proof, and ONLY when
-prior turns exist under the old name: a fresh session has no stale self-knowledge to correct), and
-send() delivers RENAME_NUDGE as its OWN machine-dressed record ahead of whatever next enters the
-session — never inside the user's bubble (the 2026-08-25 sighting: the bookkeeping line rendered as
-the user's very first words), never a wake of its own. Voice pinned in test_injected_voice.py.
-Deterministic: reg-level + source pins, no real claude processes."""
+"""The rename ping (the user 2026-08-24; settle-boundary form 2026-08-25 pm): a renamed session
+hears its OWN new name — rename() stamps the reg (renameNote, restart-proof, ONLY when prior turns
+exist under the old name), and the ping delivers at a turn's SETTLE as its own machine-dressed
+turn. The enqueue-AHEAD form folded: the CLI batches every message that arrives before a turn
+starts into ONE user record, so the user's own words rendered inside the ping's machine bubble
+(the 2026-08-25 screenshot: one romp-badged bubble holding the ping + the user's reply-quote +
+their whole message). Three gates make that fold unreachable: settle-only delivery (the user is
+answered first), the empty-queue guard (a queued message would share the pre-turn window), and the
+drain's feed-hold until the ping's turn streams its first message — an exact event — after which a
+racing send lands mid-turn as its own record by the CLI's own design. Voice pinned in
+test_injected_voice.py. Deterministic: reg-level + a stub session, no real claude processes."""
 import os
 import tempfile
 import unittest
@@ -65,21 +69,49 @@ class RenamePing(unittest.TestCase):
     def test_rename_of_an_unknown_sid_stamps_nothing(self):
         self.assertFalse(self.be.rename("99999999-0000-1111-2222-333333333333", "tests"))
 
-    def test_send_delivers_the_ping_as_its_own_machine_record_once(self):
-        # send()'s consume, pinned at source (driving a real send spawns a CLI): the ping is its
-        # OWN record in the machine dress — NEVER string-prepended into the user's text (the
-        # 2026-08-25 sighting: the bookkeeping line rendered inside the user's first bubble) —
-        # delivered before the message that triggered it, once, and a slash command passes bare
-        self.assertIn('if not text.lstrip().startswith("/"):', SRC, "a bare /compact must reach the CLI bare")
-        self.assertIn('if _reg.get("renameNote"):', SRC)
-        self.assertIn('self.send(sid, "<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % _note)',
-                      SRC, "its own record, wearing the machine-sent dress (author 'romp', gray bubble)")
-        self.assertNotIn('text = "%s\\n\\n%s" % (RENAME_NUDGE', SRC,
-                         "the string-prepend form is GONE — it contaminated the user's own words")
-        self.assertIn('self._update_reg(sid, renameNote=None)', SRC, "one delivery, then the note is spent")
-        idx_clear = SRC.index('self._update_reg(sid, renameNote=None)')
-        idx_send = SRC.index('self.send(sid, "<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE')
-        self.assertLess(idx_clear, idx_send, "cleared BEFORE the recursive send — the recursion terminates")
+    class _StubSession:
+        def __init__(self, sid, pending=()):
+            import threading
+            self.sid = sid
+            self._lock = threading.Lock()
+            self._pending = list(pending)
+            self.sent = []
+
+        def enqueue(self, text):
+            self.sent.append(text)
+
+    def test_settle_delivery_ships_the_dressed_ping_alone_and_once(self):
+        self._write_history()
+        self.be.rename(SID, "tests")
+        s = self._StubSession(SID)
+        self.assertTrue(self.be._deliver_rename_ping(s))
+        self.assertEqual(len(s.sent), 1, "one turn of its own")
+        self.assertTrue(s.sent[0].startswith(sb.RENAME_PING_HEAD), "the machine dress leads the record")
+        self.assertIn("'tests'", s.sent[0], "…and it names the new name")
+        self.assertIsNone(sb.read_reg(Path(self.td.name), SID).get("renameNote"), "the note is spent")
+        self.assertFalse(self.be._deliver_rename_ping(s), "…and a second settle delivers nothing")
+
+    def test_a_queued_turn_holds_the_note_for_a_later_settle(self):
+        # the empty-queue guard: a queued message would share the ping's pre-turn window, which is
+        # exactly the fold that put the user's words in the machine bubble
+        self._write_history()
+        self.be.rename(SID, "tests")
+        s = self._StubSession(SID, pending=["already queued"])
+        self.assertFalse(self.be._deliver_rename_ping(s))
+        self.assertEqual(s.sent, [], "nothing fed beside a queued turn")
+        self.assertEqual(sb.read_reg(Path(self.td.name), SID).get("renameNote"), "tests",
+                         "the note survives for a later, empty-queue settle")
+
+    def test_the_fold_gates_are_pinned_at_source(self):
+        # the fold's mechanics live in async plumbing a unit test can't drive — pin the three gates
+        self.assertNotIn("RENAME_NUDGE % _reg", SRC, "no send()-time delivery of any form remains")
+        self.assertNotIn('text = "%s\\n\\n%s" % (RENAME_NUDGE', SRC, "the string-prepend form stays gone")
+        self.assertIn("self.backend._deliver_rename_ping(self)", SRC, "delivery hooks the turn's settle")
+        self.assertIn("blocked = blocked or self._ping_feeding", SRC,
+                      "the drain holds every feed while the ping's turn has not started")
+        self.assertIn("if item.startswith(RENAME_PING_HEAD):", SRC, "…armed exactly when a ping is fed")
+        self.assertIn("self._ping_feeding = False   # a reconnect restarts the feed", SRC,
+                      "…and a reconnect clears a stale hold instead of wedging the queue")
         self.assertNotIn("romp-injected", sb.RENAME_NUDGE,
                          "the constant stays bare prose; the dress is added only on the separate record")
 

--- a/tests/test_sdk_spawn_pin_send.py
+++ b/tests/test_sdk_spawn_pin_send.py
@@ -43,6 +43,7 @@ class _FakeBackend:
         self.retired = 0
     def retire_live_work(self, sid): self.retired += 1
     def _poke(self): pass
+    def _deliver_rename_ping(self, s): return False   # settle hook (2026-08-25); no ping in these worlds
     def _update_reg(self, *a, **k): pass
     def _mark_dropped_echoes(self, sid, surviving): self.dropped_calls.append((sid, list(surviving)))
     # the ResultMessage settle's other hooks (mirrors test_sdk_compacting_signal's fake)


### PR DESCRIPTION
Urgent fix on the rename-ping separation, which had **inverted** (user report with screenshot): one romp-badged bubble containing the ping, the user's reply-quote block, and their entire multi-paragraph message — their words rendered as romp-authored.

**The seam:** the enqueue-ahead form fed the ping and the triggering message back-to-back into the same **pre-turn window**, and the claude CLI batches every message that arrives before a turn starts into ONE user record (the live folded record shows `content: list[2]` — ping block + user block; this is the same CLI merge behavior the phantom-working fix documented). The kernel-side drain was innocent — it yields one record per item — so no enqueue-ahead variant can ever guarantee separation.

**The fix — three gates that make the fold unreachable, for every trigger shape:**
- the ping delivers only at a turn's **settle**, as its own turn (the user's message is answered first, untouched — `send()` no longer touches the note at all);
- only when the queue is **empty** (a queued message would share the pre-turn window; a held note waits for a later settle and survives restarts in the reg);
- the drain **holds every subsequent feed** until the ping's turn streams its first message — an exact event — after which a racing send lands mid-turn as its own record by the CLI's own design. A reconnect clears a stale hold rather than wedging the queue.

**Live damage, stated:** exactly one folded record exists across all transcripts (the sighting itself). Transcripts are immutable, so that record's user text remains romp-authored in history — including for feed provenance/human-root tracing over that one record; go-forward records are clean, and this bug class can no longer corrupt minting.

**Tests:** settle delivery ships the dressed ping alone and once (executed, stub session); a queued turn holds the note; the three gates pinned at source with the send-time and string-prepend forms pinned gone; history-gate and voice pins unchanged; the four sdk test worlds grow the settle hook's no-op and the hold check reads through getattr for `__new__`-built doubles. Suites green on this head: pytest 5664 passed, npm 2426/2426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)