### PR TITLE
A wrapped tag-controls line reserves the + tab's exact box

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4523,14 +4523,18 @@ function renderTabs() {
     });
   });
   tagBtn.classList.add("tab-tagfilter");
-  // vertically centered against the + tab's box (the user 2026-08-25 — it sat high)
-  tagBtn.style.alignSelf = "center";
-  bar.appendChild(tagBtn);
+  // button + chips ride ONE box that reserves the + tab's exact height (.tab-tagbox, 31px) and
+  // centers them in it — a wrapped controls-only line used to stand only pill-tall and sat nearly
+  // flush under the row above (the user 2026-08-25); the box makes every line the controls form
+  // as tall as a line the + is on, wherever the strip wraps them
+  const tagBox = el("span", "tab-tagbox");
+  tagBox.appendChild(tagBtn);
   // THE BUTTON CONVENTION (the user 2026-08-25): gray alone at rest; accent + the chips of
   // everything selected when narrowed — the shared renderer, identical on every mount
   const tagChipsHost = el("span", "tab-tagchips");
-  tagChipsHost.setAttribute("style", "display:inline-flex;gap:5px;align-items:center;align-self:center;margin-left:2px;");
-  bar.appendChild(tagChipsHost);
+  tagChipsHost.setAttribute("style", "display:inline-flex;gap:5px;align-items:center;margin-left:2px;");
+  tagBox.appendChild(tagChipsHost);
+  bar.appendChild(tagBox);
   {
     const v = effViews();
     syncTagFilter(tagBtn, tagChipsHost, surfaceLens(v, "chat"), viewTagUnion(v), (l) => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -358,7 +358,13 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-tip-recent-list { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .tab-tip-recent-item { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tab-close:hover { opacity: 1; background: rgba(255, 255, 255, 0.12); }
-.tab-add { color: var(--dim); font-size: 1.1em; padding: 6px 10px; border-radius: 6px; }
+.tab-add { color: var(--dim); font-size: 1.1em; padding: 6px 10px; border-radius: 6px; line-height: 18px; }
+/* the tag controls reserve the + tab's EXACT vertical box — 18px line + 12px padding + 1px border
+   = 31px (the line-height above pins the +'s content box so this arithmetic is exact, checked by
+   tag-mounts.test.ts): a wrapped controls-only flex line otherwise stood only as tall as the 18px
+   pill and landed nearly flush under the tab row above, while a line the + shared had air (the
+   user 2026-08-25). Inner centering keeps the pill and chips at their own sizes. */
+.tab-tagbox { display: inline-flex; align-items: center; flex-wrap: wrap; min-height: 31px; }
 .tab-add:hover { color: var(--fg); background: rgba(255, 255, 255, 0.04); }
 /* (The .tab-fleet pill was removed 2026-06-24 — Fleet/Chat are now the rotated toggles in the chat pane's
    vertical strip, so the tab-bar pill was redundant.) */

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -50,8 +50,8 @@ test("cross-mount computed equality: one gray, one accent, everywhere", () => {
 test("every JS mount renders through the ONE convention function", () => {
   for (const [name, src] of [["render", RENDER], ["fleet", FLEET], ["feed", FEED]] as const)
     assert.match(src, /syncTagFilter\(/, name + " mounts the shared renderer");
-  assert.match(RENDER, /tagBtn\.style\.alignSelf = "center";/,
-    "the chat button centers against the + tab's box (the user 2026-08-25 — it sat high)");
+  assert.match(RENDER, /const tagBox = el\("span", "tab-tagbox"\);/,
+    "the chat button + chips ride the .tab-tagbox, which reserves the + tab's box and centers them (the user 2026-08-25 — a wrapped controls line sat flush under the row above)");
 });
 
 test("THE BUTTON OUTLINE (the user 2026-08-25, round two): every mount wears the feed word-button's box", () => {

--- a/ui/webview/tag-mounts.test.ts
+++ b/ui/webview/tag-mounts.test.ts
@@ -66,6 +66,25 @@ test("every pane's Configure tags… routes to THE dialog on the timeline (sourc
     "routed to the SAME dashboard's timeline, like tagEditFailed");
 });
 
+test("a wrapped tag-controls line reserves the + tab's exact box — the arithmetic, from the stylesheet", () => {
+  // the user 2026-08-25: chips wrapping WITHOUT the + sat nearly flush under the tab row above,
+  // because a flex line is only as tall as its tallest item and the pill is 18px to the +'s ~31.
+  // The fix pins the +'s content box (line-height) and reserves the SAME total on the controls'
+  // box, so line height never depends on which elements land on the line. This test recomputes
+  // the equality from the stylesheet literals, so neither side can drift alone.
+  const CSS = ui("webview", "styles.css");
+  const addRule = CSS.match(/\.tab-add \{[^}]*\}/)![0];
+  const lineH = Number(addRule.match(/line-height: (\d+)px/)![1]);
+  const padV = Number(addRule.match(/padding: (\d+)px/)![1]);   // vertical padding, both sides
+  const tabRule = CSS.match(/^\.tab \{[\s\S]*?\n\}/m)![0];
+  const borderV = tabRule.includes("border: 1px solid") && tabRule.includes("border-bottom: none") ? 1 : 2;
+  const boxRule = CSS.match(/\.tab-tagbox \{[^}]*\}/)![0];
+  const minH = Number(boxRule.match(/min-height: (\d+)px/)![1]);
+  assert.equal(minH, lineH + padV * 2 + borderV,
+    "the .tab-tagbox floor equals the + tab's rendered box (content line + padding + border)");
+  assert.match(boxRule, /align-items: center/, "…with the pill and chips centered inside it");
+});
+
 test("the shared component: toggles stay open, no scope caption, echo dismissal (source pins)", () => {
   assert.match(MENU, /opts\.onApply\(toggleLens\(lens, \{ tag: u\.name \}\), false\); build\(\);/,
     "tag rows toggle and repaint in place");


### PR DESCRIPTION
User report: when the tag button and its selection chips wrap onto their own line in the chat strip, they sit nearly flush under the tab row above — but when the + wraps with them, the spacing is right. The diagnosis in the report was exactly right: a flex line is only as tall as its tallest item, and the controls (18px pill, ~17px chips) stood 13px shorter than the + tab's box.

**Fix.** The button and chips ride one `.tab-tagbox` that reserves the + tab's exact height and centers them inside it, so every line the controls form is as tall as a line the + is on, wherever the strip wraps. The +'s content box is pinned (`line-height: 18px`) so the equality is exact arithmetic: 18px line + 12px padding + 1px border = the box's 31px floor.

**Pins.** A new test recomputes that equality from the stylesheet literals (line-height + paddings + border vs the box floor), so neither side can drift alone. Verified headless at both wrap widths with the real stylesheet: a controls-only wrapped line measures 31px = a +-sharing line's 31px, pill clearance 6.5px in both shapes (was 18px line, ~0 clearance). The alignSelf pin retargeted to the box mechanism.

Suites: vscode-extension green; pytest 5664 passed / 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)