### PR TITLE
The Sessions & tags dialog sizes to the screen, padded, wrap only when narrow

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2983,9 +2983,17 @@ class TimelinePanel {
       + 'display:flex;align-items:center;justify-content:center;');
     const card = back.createDiv();
     // the dialog is a FORM, not a menu: it reads at 13px (the page's standard reading size, the
-    // user 2026-08-25: the menu 12px read too small here) — sub-lines keep the one 0.82em scale
-    card.setAttribute('style', 'width:min(560px,94vw);max-height:78vh;overflow:hidden;display:flex;flex-direction:column;padding:14px 16px;'
-      + MENU_STYLE + 'font-size:13px;');
+    // user 2026-08-25: the menu 12px read too small here) — sub-lines keep the one 0.82em scale.
+    // It sizes to the SCREEN (the user 2026-08-25, round two: 560px read cramped and made rows
+    // wrap for no reason): up to 90% of the viewport both axes — the big panels' family norm —
+    // capped at 1200px so a huge monitor doesn't stretch a form unreadably wide, with real
+    // breathing room inside the card's edges. The centered-card-over-dim treatment stands.
+    // the card's own declarations come AFTER the shared menu spec: MENU_STYLE opens with the
+    // MENU padding (4px), and in one style string the later declaration wins — with the paddings
+    // stated first the dialog had been rendering 4px edges all along, which IS the claustrophobia
+    // the user reported (2026-08-25); the 14px/22px in the source never applied.
+    card.setAttribute('style', MENU_STYLE + 'box-sizing:border-box;width:min(1200px,90vw);max-height:90vh;'
+      + 'overflow:hidden;display:flex;flex-direction:column;padding:22px 26px;font-size:13px;');
     card.addEventListener('click', (e) => e.stopPropagation());
     // the open [+] menu's key rides the INSTANCE (this._tagAddFor: sid, or '*' for the bulk bar)
     // so the shared join builder can close it from either surface — the dialog or the lane gear

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -220,6 +220,25 @@ test("membership rows drag-reorder into the SHARED session order (the user 2026-
     "the rebuild happens on the drop, after the persist");
 });
 
+test("the dialog sizes to the screen: 90% ceiling both axes, padded edges, wrap only when narrow (the user 2026-08-25)", () => {
+  // 560px read cramped — no padding at the edges, rows wrapping with plenty of screen left. The
+  // card grows with the window to the big panels' ~90% family norm (capped 1200px so a huge
+  // monitor doesn't stretch a form unreadably wide) with real breathing room inside the edges.
+  // the card declarations come AFTER MENU_STYLE: the menu spec opens with ITS padding (4px), and
+  // in one style string the later declaration wins — stated first, the dialog's padding had been
+  // silently 4px all along (found by headless computed-style measurement, 2026-08-25)
+  assert.match(SRC, /MENU_STYLE \+ 'box-sizing:border-box;width:min\(1200px,90vw\);max-height:90vh;'\s*\n\s*\+ 'overflow:hidden;display:flex;flex-direction:column;padding:22px 26px;font-size:13px;'/,
+    "the card's screen-sized border-box footprint + edge padding, declared after the menu spec");
+  // wrap stays GRACEFUL, not needless: the wide card lays the rows out on their lines; these
+  // containers wrap only when the window genuinely narrows
+  assert.match(SRC, /row\.setAttribute\('style', 'display:flex;align-items:center;gap:6px;margin:2px 0;flex-wrap:wrap;'\);/,
+    "the five filter rows fold only under real pressure");
+  assert.match(SRC, /chips\.setAttribute\('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;min-width:0;'\);/,
+    "membership chip cells ditto");
+  assert.match(SRC, /gridBox\.setAttribute\('style', 'flex:1 1 auto;min-height:0;overflow-y:auto;'\);/,
+    "only the session rows pan when height runs out — the card itself never scrolls whole");
+});
+
 test("federation, NAME-KEYED (user ruling 2026-08-24): one name = one row/label/union — kernels are plumbing", () => {
   // the ruling superseded the v0 host-marked two-rows render: "if the UX requires understanding
   // that tags exist across different kernels, it is not good". Executed on the mirror:
@@ -470,7 +489,8 @@ test("cross-pane dismissal rides the storage echo (the user 2026-08-25)", () => 
 
 test("dialog polish + reachable tag management (the user 2026-08-25)", () => {
   // the dialog reads at the page's 13px form scale (the menu 12px was the too-small complaint)
-  assert.match(SRC, /MENU_STYLE \+ 'font-size:13px;'/);
+  assert.match(SRC, /padding:22px 26px;font-size:13px;'/,
+    "the 13px form scale rides the card's own declarations (after MENU_STYLE, whose 4px padding they beat)");
   // the session table scrolls WITHIN the modal — chrome stays put
   assert.match(SRC, /gridBox\.setAttribute\('style', 'flex:1 1 auto;min-height:0;overflow-y:auto;'\)/);
   // [+] is a rounded RECTANGLE in its own column between name and tags


### PR DESCRIPTION
User report: the dialog was cramped — a small fixed footprint, no padding at the edges, rows wrapping despite plenty of horizontal space.

**Sizes to the screen.** `width:min(1200px,90vw)`, `max-height:90vh` — the big panels' ~90% family norm on both axes, capped so a huge monitor doesn't stretch a form unreadably wide. `border-box`, so the ceiling counts the padded box (with content-box the narrow card measured 100vw). The centered card-over-dimmed-backdrop treatment stands per the panels rule.

**Breathing room — and the bug behind the claustrophobia.** The card's declarations now come after the shared `MENU_STYLE`: the menu spec opens with its own `padding:4px`, and in one style string the later declaration wins — so the dialog had been rendering 4px edges all along; the padding in the source never applied. Found by headless computed-style measurement. Now 22px 26px, applied for real.

**No needless wrapping.** With real width, the five filter rows, the tag table, and the membership rows lay out on their lines (the flex-wrap containers were already single-line-first); wrap remains only for genuinely narrow windows.

**Geometry, verified headless with the real view.** At 1280×900: card exactly 90vw, computed padding 22px 26px, all five filter rows one line each (19px). At 380×700: card exactly 90vw, rows fold gracefully to two lines (44px). Pins cover the border-box footprint + declaration order, the graceful-wrap containers, and the inner scroller.

Suites: vscode-extension 2427/2427; pytest 5664 passed / 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)