### PR TITLE
A time-only link lands at the nearest moment and says so — the fifth can't-locate shape

### DIFF
--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -83,9 +83,27 @@ test("a scrolled-up append restores by turn ANCHOR (data-uuid), raw scrollTop on
 // the time fallback). Prompt-intent jumps resolve by id (promptAnchorUuid → a user turn OR a peer's postal
 // card, see the kind-guard test below); the genuinely-unanchorable (autonomous / pruned-or-compacted) honest-
 // fail with a toast. The whole time-nearest mechanism (scrollToNearestT) is deleted.
-test("scrollToNearestT is GONE — no time-based navigation remains in the chat", () => {
-  assert.doesNotMatch(RENDER, /function scrollToNearestT/, "the time-nearest helper is deleted");
+test("scrollToNearestT is GONE — time never silently substitutes for an ID anchor", () => {
+  assert.doesNotMatch(RENDER, /function scrollToNearestT\b/, "the time-nearest helper is deleted");
   assert.doesNotMatch(RENDER, /scrollToNearestT\(/, "nothing calls it");
+  // landNearestMoment (2026-08-25) is NOT that tier reborn: it fires only when the navigation
+  // carries NO id at all (anchorT-only producers — timeline lane clicks, deep links), so there is
+  // no right turn for time to impersonate — and it announces itself with the honest note instead
+  // of posing as an exact jump. An ID anchor that fails still never falls back to time:
+  assert.match(RENDER, /if \(!scrolled && !att\.anchor && att\.t != null\) scrolled = landNearestMoment\(att\.t\);/);
+});
+
+test("a time-only navigation lands at the nearest moment and SAYS so — never the bare toast", () => {
+  // the fifth can't-locate shape (the user 2026-08-25): anchor null + anchorT set dead-ended with
+  // "couldn't locate" and an empty trail — the whole producer class (timeline/deep links/atomless
+  // cards) could never land after the id-only hardening
+  const fn = RENDER.split("function landNearestMoment(")[1].split("\nfunction ")[0];
+  assert.ok(fn.includes("const d = Math.abs(ep - t);"), "nearest by the anchor's own datum");
+  assert.ok(fn.includes('landTrail.push("time-nearest");'), "the audit names the landing kind");
+  assert.ok(fn.includes('"that link points at a time, not a message — landed at the closest one"'), "the honest note");
+  assert.ok(fn.includes('"that link points at a moment before the loaded history — landed at the oldest loaded message"'),
+    "…and the pre-history case names itself too");
+  assert.ok(fn.includes("renderWindowItems(v, s, items,"), "off-window moments re-window like the id recovery");
 });
 
 test("the PROMPT-tier time fallback is removed — an unresolvable prompt anchor honest-fails (no clock-nearest)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7560,6 +7560,39 @@ function scrollToAnchor(uuid: string): boolean {
   return true;
 }
 
+/** The time-only landing (see landActive): the event whose epoch sits nearest `t` among the
+ *  RESIDENT events, landed with the honest note. Returns true when it landed. */
+function landNearestMoment(t: number): boolean {
+  const v = activeId ? views.get(activeId) : null;
+  const s = activeId ? sessions.get(activeId) : null;
+  if (!v || !s || !s.events.length) return false;
+  let best = -1, bestD = Infinity, headEp: number | null = null;
+  for (let i = 0; i < s.events.length; i++) {
+    const ep = eventEpoch(s.events[i]);
+    if (ep == null) continue;
+    if (headEp == null) headEp = ep;
+    const d = Math.abs(ep - t);
+    if (d < bestD) { bestD = d; best = i; }
+  }
+  if (best < 0) return false;
+  const uuid = (s.events[best] as { uuid?: string }).uuid || "";
+  const items = displayItems(s);
+  let u = items.findIndex((it) => it.kind === "toolgroup" ? it.indices.includes(best) : it.index === best);
+  if (u < 0) u = Math.max(0, items.findIndex((it) => itemFirstEvent(it) >= best));
+  const working = s.status.state === "working" || s.status.state === "compacting";
+  renderWindowItems(v, s, items, Math.max(0, u - WINDOW_RADIUS), Math.min(items.length, u + WINDOW_RADIUS), working);
+  const target = (uuid ? v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`) : null)
+    || (v.el.querySelector(`[data-unit="${u}"]`) as HTMLElement | null);
+  if (!target) { landTrail.push("time-nearest-miss"); return false; }
+  landTrail.push("time-nearest");
+  landOn(target as HTMLElement, uuid || undefined);
+  const beforeHead = headEp != null && t < headEp && (s.headFrom ?? 0) > 0;
+  landToast(beforeHead
+    ? "that link points at a moment before the loaded history — landed at the oldest loaded message"
+    : "that link points at a time, not a message — landed at the closest one");
+  return true;
+}
+
 // Land on a turn at the TOP of the viewport and KEEP it landed while the chrome
 // above the scroll container settles. Top-align (not center) so a jump lands on
 // the START of the thing and you read DOWN into it — a long work period isn't
@@ -8271,6 +8304,15 @@ function landActive(content: HTMLElement | null, v: View): void {
   const att = { anchor: pendingAnchor, t: pendingAnchorT, kind: pendingAnchorKind, keep: pendingAnchorKeepY != null };   // this pass's landing attempt, for diagnostics
   if (att.anchor || att.t != null) landTrail = [];
   let scrolled = pendingAnchor ? scrollToAnchor(pendingAnchor) : false;
+  // TIME-ONLY navigation (the user 2026-08-25, the fifth can't-locate shape): some producers — the
+  // timeline's lane clicks, deep links, cards minted from segments with no anchorable atom — send
+  // anchorT with NO uuid, and the by-id-only landing left the whole class dead-ending in the bare
+  // toast (audit rows: anchor null, empty trail). When the TIME is the anchor's only datum it is
+  // the datum, not a proxy (the 2026-06-20 removal was about silently substituting time for a
+  // KNOWN id): land at the event nearest that moment and SAY SO, never impersonating an exact jump
+  // and never dead-ending. If the moment predates the loaded history, the oldest loaded message is
+  // the nearest reachable point — the note names that too (fail loudly, land nearest).
+  if (!scrolled && !att.anchor && att.t != null) scrolled = landNearestMoment(att.t);
   if (seek && att.anchor === seek.uuid) {
     if (scrolled) clearSeek();             // the landing event — the indicator dies with the seek
     else showSeekNote();                   // outlived the immediate landing → say the search is on


### PR DESCRIPTION
## The shape (from the audit trail)

The failing rows: `anchor: null, anchorT: set, trail: []` — a navigation carrying **only a time**. Producers mint these deliberately (the timeline's lane clicks fall back to the event's moment when no uuid is known; deep links; cards minted from segments with no anchorable atom), but the chat's landing became id-only when the old time tier was removed — the whole class could never land and dead-ended in the bare couldn't-locate toast. None of the earlier fixes (settle alias, substantive-atom mint, attachment skip, durable seek) covers it: the seek only arms on an id.

## The fix — not the deleted tier reborn

`scrollToNearestT` silently substituted time for a **known** id and impersonated an exact jump onto unrelated turns; that stays deleted, and an id anchor that fails still never falls back to time (both pinned). `landNearestMoment` fires **only when no id exists at all** — the time is the anchor's own datum, not a proxy. It lands at the event whose epoch sits nearest (re-windowing like the id recovery when the moment is off the rendered window) and **announces itself**: "that link points at a time, not a message — landed at the closest one" (or the oldest-loaded-message wording when the moment predates loaded history). The audit row files `ok: true` with trail `["time-nearest"]`, so a nearest landing is never mistaken for exact.

## Verification (headless, built bundle)

An `anchorT`-only focus into an 80-event transcript lands on the nearest turn (anchor-flash on the right uuid), shows the honest note, and files trail `["time-nearest"]`.

## Tests

`render-scroll.test.ts`: the tombstone pin sharpened (`scrollToNearestT\b` still absent; id-anchors never fall back to time), plus the new tier's pins — no-id-only gate, nearest-by-datum, the audit trail name, both honest notes, the re-window path. npm 2427 + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)