### PR TITLE
A delegated card speaks the requester's language: the frame travels from mail to summary

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -264,7 +264,15 @@ goal-independent hard-block floor), while the sender's "delegated to"
 tracking node plants either way — so the delegation stays one glance away on
 the sender's board. At mint time uncertainty files quiet; the burden of
 proof is on the mint, the inverse of a display filter's. Coordinating makes
-no card, ever. The companion `run_propagate` is deterministic: when the
+no card, ever. A planted goal also stores the delegating mail's cleaned
+first line as the additive node field `frame` (2026-08-25, part of the
+goal-node consumer contract): the distiller and briefer prepend it — with
+the sender's linked-ask title — to their prompts as a marked
+`<delegating-request>` section, so a delegated card's summary opens in the
+requester's phrasing (usually the user's own words) instead of the worker's
+implementation nouns. A goal without a frame (a session's own work, or a
+node minted before the field existed) distills byte-identically to before.
+The companion `run_propagate` is deterministic: when the
 recipient completes the plant, the sender's tracker checks itself off
 through the origin pointer; a quiet-filed delegation's tracker (which no
 recipient goal can ever back-link) completes on the recipient's reply — the

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9818,7 +9818,7 @@ DISTILL_SYS = (
     "closely it names the goal. This line is parsed off and never shown.")
 
 
-def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None):
+def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None, frame=None):
     """The distiller's key-takeaway for one completed goal from the TRIAGE-tier model (Sonnet). '' on
     failure. done_why = the closer's completion verdict (the node's doneWhy), fed as <completed> ground
     truth so the summary reflects what was ACCOMPLISHED even when the work history is thin or mostly the
@@ -9830,6 +9830,17 @@ def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None)
     count-match gate stamps per-paragraph ages only when the model actually split."""
     mk = _mark()
     user = "%s\n%s" % (_sec("goal", goal_text, mk), _sec("work", work_text, mk))
+    if frame:
+        # the delegating request's framing (the user 2026-08-25): the card belongs to work HANDED
+        # to this session, and <work> speaks in the worker's implementation nouns — the frame is
+        # how the request was actually put (usually the user's own phrasing). Marked section, like
+        # every quoted why: sender-written text never rides romp's instruction prose.
+        user += ("\n%s"
+                 "\n<note>The <delegating-request> is how this work was framed when it was handed "
+                 "to this session — usually the requester's own words. Open the takeaway in those "
+                 "terms: what the request asked for and how it ended. Keep implementation nouns to "
+                 "the supporting detail; never open with them.</note>"
+                 % _sec("delegating-request", frame, mk))
     if done_why:
         user += "\n%s" % _sec("completed", done_why, mk)
     if items and len(items) > 1:
@@ -10048,7 +10059,7 @@ BLOCK_BRIEF_SYS = (
     "must be exactly SOURCE: mN. Do not stop at the takeaway; the SOURCE line always comes last.")
 
 
-def brief_llm(goal_text, work_text, owed):
+def brief_llm(goal_text, work_text, owed, frame=None):
     """The briefer's decision brief for one blocked goal from the TRIAGE-tier model (Sonnet). '' on
     failure. Logged as judge='briefer' — its own name, its own prompt (the user 2026-07-08). Its timeline
     mark still rides the distiller row: the kernel folds fine labels to role-family rows (_JUDGE_FAMILY),
@@ -10066,6 +10077,14 @@ def brief_llm(goal_text, work_text, owed):
     mk = _mark()
     user = "%s\n%s\n%s" % (_sec("goal", goal_text, mk), _sec("work", work_text, mk),
                            _sec("owed", owed_block, mk))
+    if frame:
+        # same enrichment as the distiller (the user 2026-08-25): state the owed decision in the
+        # delegating request's terms, not the worker's build vocabulary
+        user += ("\n%s"
+                 "\n<note>The <delegating-request> is how this work was framed when it was handed "
+                 "to this session — usually the requester's own words. State what is owed in those "
+                 "terms; keep implementation nouns to the supporting detail.</note>"
+                 % _sec("delegating-request", frame, mk))
     return _judge_run(_distill_model(), BLOCK_BRIEF_SYS, user, judge="briefer", tier="distill",
                       mark=mk).strip()   # caller splits SOURCE, then caps
 
@@ -10199,6 +10218,33 @@ def _live_prompt_since(fsid):
     except OSError:
         return None
     return since
+
+
+def _deleg_frame(store, nid):
+    """The context a delegated goal's summary writer should open with (the user 2026-08-25): the
+    mint-time `frame` (the delegating mail's cleaned first line, stored by apply_courier), plus the
+    SENDER's linked-ask title — the goal the dispatch was filed under on the sender's board — when
+    the origin points at a LOCAL sender whose store still holds the chain. "" for a non-delegated
+    goal (the enrichment never touches a session's own work), for cross-host origins (that kernel's
+    stores are not ours to read), and for pre-fix nodes minted before the frame existed (they
+    re-distill unchanged — absent frame is byte-identical to today)."""
+    nd = store.get("nodes", {}).get(nid) or {}
+    o = nd.get("origin")
+    if not isinstance(o, dict) or not o.get("peer") or not nd.get("frame"):
+        return ""                                      # no mint-time frame → BYTE-IDENTICAL to today,
+        #                                                including pre-fix delegated nodes re-distilling
+    parts = [str(nd["frame"])]
+    if o.get("goalId") and not o.get("peerHost"):
+        try:
+            snodes = dict(load_goal_archive(o["peer"]).get("nodes") or {})
+            snodes.update(load_goals(o["peer"]).get("nodes") or {})
+            tr = snodes.get(o["goalId"]) or {}
+            ask = (snodes.get(tr.get("parentId") or "") or {}).get("text") or ""
+            if ask and not str(ask).startswith("\u21aa"):
+                parts.append("the sender filed it under: %s" % str(ask)[:120])
+        except Exception:
+            pass                                       # a missing sender store just means less context
+    return " | ".join(p for p in parts if p)[:360]
 
 
 def _distill_due_t(store, nid, blocked):
@@ -10532,7 +10578,8 @@ def _distill_session(fsid, path, now):
             # direction"), and STALL_BRIEF_SYS restates <holding> faithfully rather than inventing an owed
             # decision from <work>. Stored as the card's blockSummary through the same fail/retry path.
             out = (stall_llm(nodes[top].get("text", ""), work, proc_whys[-1]) if proc_only
-                   else brief_llm(nodes[top].get("text", ""), work, owed))
+                   else brief_llm(nodes[top].get("text", ""), work, owed,
+                                  frame=_deleg_frame(store, top)))
             if not out:
                 if getattr(_judge_ctx, "paused", False):   # the call was SKIPPED (global retry-pause on), not
                     continue                               # tried — never count a pause-skip toward give-up, else
@@ -10613,7 +10660,8 @@ def _distill_session(fsid, path, now):
             # real re-distills: filtering loses no post-boundary coverage.
             _dsubs = [d for d in _dsubs if _done_since(d) > boundary_t]
         out = distill_llm(nodes[top].get("text", ""), work, nodes[top].get("doneWhy") or "", prior_summary=prior,
-                          items=[(d.get("text", ""), d.get("doneWhy", "")) for d in _dsubs])
+                          items=[(d.get("text", ""), d.get("doneWhy", "")) for d in _dsubs],
+                          frame=_deleg_frame(store, top))
         if not out:
             if getattr(_judge_ctx, "paused", False):   # pause-skip, not a real failure — don't count it toward
                 continue                               # give-up (leave summary null → re-enters once unpaused)
@@ -11154,15 +11202,16 @@ def _postal_row(mid):
     consumer contract). The sender may be a session of ANOTHER kernel (federated mail), so the local
     names registry cannot resolve it; the log row carries the name the sender wore, the origin host
     the bus stamped on cross-host delivery (2026-07-26), and the tracked report-back flag
-    (2026-08-24 — read off the row, never off message prose). ("", "", False) for None/unknown mids.
-    Memoized on the log file's (mtime, size)."""
+    (2026-08-24 — read off the row, never off message prose), and since 2026-08-25 the BODY —
+    whose cleaned first line is the delegating frame the card enrichment stores at mint.
+    ("", "", False, "") for None/unknown mids. Memoized on the log file's (mtime, size)."""
     if not mid:
-        return ("", "", False)
+        return ("", "", False, "")
     try:
         st = os.stat(MESSAGES)
         key = (st.st_mtime, st.st_size)
     except OSError:
-        return ("", "", False)
+        return ("", "", False, "")
     if _postal_from_memo["key"] != key:
         mp = {}
         try:
@@ -11172,11 +11221,31 @@ def _postal_row(mid):
                 except Exception:
                     continue
                 if r.get("ev") == "sent" and r.get("id"):
-                    mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "", bool(r.get("tracked")))
+                    mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "", bool(r.get("tracked")),
+                                   str(r.get("body") or ""))
         except OSError:
-            return ("", "", False)
+            return ("", "", False, "")
         _postal_from_memo["key"], _postal_from_memo["map"] = key, mp
-    return _postal_from_memo["map"].get(mid, ("", "", False))
+    return _postal_from_memo["map"].get(mid, ("", "", False, ""))
+
+
+def _frame_head(s):
+    """The delegating request's FIRST LINE, cleaned for card use: romp markers stripped (plumbing,
+    never display — the _provisional_card rule), whitespace collapsed, capped. The framing a
+    delegating manager writes in its opening line is usually the USER's own phrasing of the round
+    ("user asks (dictated): …"), which is exactly what the recipient card's summary should open
+    with (the user 2026-08-25: worker cards read as insider jargon because the summary writer
+    never saw the delegating thread)."""
+    s = re.sub(r"<!--.*?-->", "", str(s or ""), flags=re.S)
+    line = next((l.strip() for l in s.splitlines() if l.strip()), "")
+    line = re.sub(r"^USER ASKED:\s*", "", line)       # the unit-text framing prefix (segment-fallback
+    #                                                    path) is plumbing, never the request's words
+    return " ".join(line.split())[:220]
+
+
+def _postal_body_head(mid):
+    """The delegating mail's cleaned first line from its ledger row, "" when the row is unknown."""
+    return _frame_head(_postal_row(mid)[3])
 
 
 def _postal_from(mid):
@@ -11184,11 +11253,15 @@ def _postal_from(mid):
     return _postal_row(mid)[:2]
 
 
-def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None):
+def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None, frame=None):
     """Plant a top-level goal in the recipient's tree for a delegating message, with origin
     provenance. Idempotent by seg_id and origin.msgId (one planted goal per message). Returns nid.
     `prompt_uuid` (the user 2026-07-20, g200): the peer segment's anchor (its head record), so the
-    planted card's summary is landable like any other card — None left it silently unlinkable."""
+    planted card's summary is landable like any other card — None left it silently unlinkable.
+    `frame` (the user 2026-08-25, the confusing-worker-cards round): the delegating mail's cleaned
+    first line — usually the USER's own phrasing of the round — stored as the ADDITIVE node field
+    `frame` so the distiller/briefer open the card's summary in the user's terms instead of the
+    worker's implementation nouns. Absent on non-delegated goals; old payloads render unchanged."""
     nodes, placements = store["nodes"], store["placements"]
     mid = origin.get("msgId")
     if mid:
@@ -11198,9 +11271,12 @@ def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None):
                 return nid
     store["seq"] = store.get("seq", 0) + 1
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-    nodes[nid] = GuardedNode({"id": nid, "text": (text or "(delegation)")[:120], "parentId": None,
-                  "nodeComplete": False, "blocked": False, "cleared": False,
-                  "trail": [seg_id], "t": seg_t, "origin": origin, "promptUuid": prompt_uuid, "log": []})
+    payload = {"id": nid, "text": (text or "(delegation)")[:120], "parentId": None,
+               "nodeComplete": False, "blocked": False, "cleared": False,
+               "trail": [seg_id], "t": seg_t, "origin": origin, "promptUuid": prompt_uuid, "log": []}
+    if frame:
+        payload["frame"] = frame
+    nodes[nid] = GuardedNode(payload)
     placements[seg_id] = nid
     store["lastNode"] = nid                            # the delegation is now the active focus
     return nid
@@ -11710,7 +11786,11 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                 origin["peerName"] = pn
             if frm_host:                               # stamped only on cross-host delivery
                 origin["peerHost"] = frm_host
-            apply_courier(store, seg_id, seg_t, edit["text"], origin, prompt_uuid=anchor_uuid)
+            apply_courier(store, seg_id, seg_t, edit["text"], origin, prompt_uuid=anchor_uuid,
+                          frame=_postal_body_head(mid) or _frame_head(text))
+            #             ^ the ledger row's body is authoritative; a row the local ledger lacks
+            #               (some cross-host deliveries) falls back to the delivered segment's own
+            #               head — same content, one hop later
         else:
             store["placements"][seg_id] = "fyi"        # coordinating: no goal, but mark processed
         rollup_status(store, closed.get(fsid, False))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28915,6 +28915,18 @@ class Handler(BaseHTTPRequestHandler):
                 _dok, _derr = False, (str(_e) or _e.__class__.__name__)
                 sys.stderr.write("redistill: %s\n" % traceback.format_exc())
             _send_to_app("feed", {"type": "redistillResult", "itemId": _dnid, "ok": _dok, "error": _derr})
+        elif msg and msg.get("type") == "cardOpened" and msg.get("itemId"):
+            # the card-open event (the user 2026-08-25, the metrics round): one append-only row per
+            # modal open, so cleared-WITHOUT-open — the confusion signal the clear log alone cannot
+            # see — becomes measurable. Best-effort: a failed write loses one metric row, never a
+            # gesture.
+            try:
+                p = jd.STATE / "card-opens.jsonl"
+                with open(p, "a") as f:
+                    f.write(json.dumps({"t": int(time.time()), "itemId": str(msg["itemId"])[:200],
+                                        "sid": str(msg.get("sid") or "")[:64]}) + "\n")
+            except OSError:
+                pass
         elif msg and msg.get("type") == "clearAll":
             d = build_feed(int(time.time()))
             _clear_all([a["itemId"] for a in d["asks"]] + [c["itemId"] for c in d["items"]])

--- a/tests/test_context_frames.py
+++ b/tests/test_context_frames.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Context-enriched summaries (the user 2026-08-25, from the confusing-worker-cards round): a
+delegated card's summary should open in the REQUESTER's phrasing — usually the user's own words —
+not the worker's implementation nouns. Two seams, both mechanical: at MINT, apply_courier stores
+the delegating mail's cleaned first line as the additive node field `frame` (ledger body first,
+the delivered segment's head as the fallback; zero LLM calls); at DISTILL, the distiller/briefer
+prompts for a frame-carrying goal gain a marked <delegating-request> section plus the sender's
+linked-ask title. A goal WITHOUT a frame — a session's own work, or any node minted before the
+field existed — composes byte-identically to before (the pin). The 671 title clamp still governs
+the planted title. SYNTHETIC fixtures only; private synthetic sids."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_ctxframe", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1_787_200_000
+T0 = NOW - 3600
+MGR = "f20a0001-1111-4222-8333-000000000001"   # private synthetic sids — never the shared placeholder
+WKR = "f20a0001-1111-4222-8333-000000000002"
+MID = "1787199000.000001_1.TESTHOST"
+FRAME_LINE = "user asks (dictated): the color workflow round, four items, one worktree"
+BODY = (FRAME_LINE + "\n(1) drag-range selection over run rows\n"
+        "<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID)
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _node(nid, text, parent, t=T0, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return base
+
+
+class FrameHead(unittest.TestCase):
+    def test_markers_strip_and_first_line_wins(self):
+        self.assertEqual(jd._frame_head(BODY), FRAME_LINE)
+
+    def test_whitespace_collapses_and_caps(self):
+        self.assertEqual(jd._frame_head("  a \t b  \n second line"), "a b")
+        self.assertEqual(len(jd._frame_head("x" * 500)), 220)
+
+    def test_empty_and_marker_only_are_empty(self):
+        self.assertEqual(jd._frame_head(""), "")
+        self.assertEqual(jd._frame_head("<!-- romp-msg-id: x -->"), "")
+
+
+class ApplyCourierFrame(unittest.TestCase):
+    def _plant(self, **kw):
+        st = {"rompUuid": WKR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        nid = jd.apply_courier(st, "seg1", T0, "verify the staged refs",
+                               {"peer": MGR, "goalId": "t1", "msgId": MID}, **kw)
+        return st, nid
+
+    def test_frame_is_stored_additively(self):
+        st, nid = self._plant(frame=FRAME_LINE)
+        self.assertEqual(st["nodes"][nid].get("frame"), FRAME_LINE)
+
+    def test_absent_frame_writes_no_field(self):
+        st, nid = self._plant()
+        self.assertNotIn("frame", st["nodes"][nid], "old shape byte-identical — additive field only")
+
+    def test_the_title_clamp_still_governs(self):
+        st, nid = self._plant(frame=FRAME_LINE)
+        st2 = {"rompUuid": WKR, "seq": 5, "nodes": {}, "placements": {}, "status": {}}
+        nid2 = jd.apply_courier(st2, "seg2", T0, "y" * 400,
+                                {"peer": MGR, "goalId": "t1", "msgId": "m2"}, frame="z")
+        self.assertLessEqual(len(st2["nodes"][nid2]["text"]), 120, "the 671 clamp is untouched")
+
+
+class PostalBodyHead(unittest.TestCase):
+    def test_ledger_body_head_and_unknown_mid(self):
+        with tempfile.TemporaryDirectory() as td:
+            saved = jd.MESSAGES
+            jd.MESSAGES = Path(td) / "messages.jsonl"
+            jd.MESSAGES.write_text(json.dumps(
+                {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+                 "to_id": WKR, "kind": "delegate", "body": BODY}) + "\n")
+            try:
+                self.assertEqual(jd._postal_body_head(MID), FRAME_LINE)
+                self.assertEqual(jd._postal_body_head("nope"), "")
+                self.assertEqual(jd._postal_row(MID)[:3][2], False, "the row contract's prefix holds")
+            finally:
+                jd.MESSAGES = saved
+
+
+class CourierMintCarriesTheFrame(unittest.TestCase):
+    """run_courier end to end: the planted recipient goal carries the delegating mail's first line —
+    from the ledger row when present, from the delivered segment when not (the cross-host relay
+    shape, whose row the local ledger may lack)."""
+
+    def setUp(self):
+        self._rooted = jd._delegate_user_rooted
+        jd._delegate_user_rooted = lambda *a, **k: True   # rooting is orthogonal here (its own suite)
+        self.td = tempfile.TemporaryDirectory()
+        d = Path(self.td.name)
+        self.wpath = d / (WKR + ".jsonl")
+        self.wpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, BODY, "m1", ps="sdk"),
+            aline(T0 + 60, "On it.", "a1", "m1")]) + "\n")
+        self.mpath = d / (MGR + ".jsonl")
+        self.mpath.write_text(json.dumps(uline(T0 - 600, "kick off the color round", "hu")) + "\n")
+        self._msgs = jd.MESSAGES
+        jd.MESSAGES = d / "messages.jsonl"
+        self._disc = jd.discover
+        fleet = [(WKR, str(self.wpath), None, "api"), (MGR, str(self.mpath), None, "web")]
+        jd.discover = lambda now, window=None, forks=True: fleet
+        self._llm = jd.courier_llm
+        jd.courier_llm = lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 0, "text": "verify refs"}'
+        jd._PARSE_CACHE.clear()
+
+    def tearDown(self):
+        jd._delegate_user_rooted = self._rooted
+        jd.MESSAGES = self._msgs
+        jd.discover = self._disc
+        jd.courier_llm = self._llm
+        for sid in (MGR, WKR):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+        self.td.cleanup()
+
+    def _planted(self):
+        w = jd.load_goals(WKR)
+        return next((nd for nd in w["nodes"].values()
+                     if isinstance(nd.get("origin"), dict) and nd["origin"].get("msgId") == MID), None)
+
+    def test_the_ledger_body_is_the_frame(self):
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate", "body": BODY}) + "\n")
+        jd.run_courier(now=NOW)
+        nd = self._planted()
+        self.assertIsNotNone(nd)
+        self.assertEqual(nd.get("frame"), FRAME_LINE)
+
+    def test_a_bodyless_ledger_row_falls_back_to_the_delivered_head(self):
+        # the relay shape: the row exists (the bus logs delivery, so the sender resolves) but
+        # carries no body — the frame falls back to the delivered segment's own head
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate"}) + "\n")
+        jd.run_courier(now=NOW)
+        nd = self._planted()
+        self.assertIsNotNone(nd)
+        self.assertTrue((nd.get("frame") or "").startswith("user asks (dictated)"),
+                        "the delivered segment's own head carries the same framing")
+
+
+class LlmBuildersCarryTheFrame(unittest.TestCase):
+    def _capture(self, fn, *args, **kw):
+        seen = {}
+        saved = jd._judge_run
+        jd._judge_run = lambda model, sys_p, user, **k: seen.__setitem__("user", user) or ""
+        try:
+            fn(*args, **kw)
+        finally:
+            jd._judge_run = saved
+        return seen.get("user") or ""
+
+    def test_distill_gains_the_marked_section(self):
+        u = self._capture(jd.distill_llm, "goal", "work", "done", frame=FRAME_LINE)
+        self.assertIn("delegating-request", u)
+        self.assertIn(FRAME_LINE, u)
+        self.assertIn("Open the takeaway in those", u)
+
+    def test_distill_without_frame_is_byte_identical(self):
+        u0 = self._capture(jd.distill_llm, "goal", "work", "done")
+        self.assertNotIn("delegating-request", u0)
+        u1 = self._capture(jd.distill_llm, "goal", "work", "done", frame=None)
+        self.assertEqual(u0.replace(jd._mark() if False else "", ""), u0)   # sanity
+        # marks differ per call; compare shape by stripping the random mark
+        import re as _re
+        norm = lambda s: _re.sub(r"[0-9a-f]{8}", "MK", s)
+        self.assertEqual(norm(u0), norm(u1))
+
+    def test_brief_gains_the_marked_section(self):
+        u = self._capture(jd.brief_llm, "goal", "work", "owed thing", frame=FRAME_LINE)
+        self.assertIn("delegating-request", u)
+        self.assertIn(FRAME_LINE, u)
+        u0 = self._capture(jd.brief_llm, "goal", "work", "owed thing")
+        self.assertNotIn("delegating-request", u0)
+
+
+class DelegFrameJoin(unittest.TestCase):
+    def tearDown(self):
+        for sid in (MGR, WKR):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+
+    def _world(self, frame=FRAME_LINE, host=None):
+        o = {"peer": MGR, "goalId": "t1", "msgId": MID}
+        if host:
+            o["peerHost"] = host
+        st = {"rompUuid": WKR, "nodes":
+              {"g1": _node("g1", "verify refs", None, origin=o,
+                           **({"frame": frame} if frame else {}))},
+              "placements": {}, "status": {}}
+        jd.save_goals(MGR, {"rompUuid": MGR, "nodes":
+                            {"ask": _node("ask", "Ship the color round", None),
+                             "t1": _node("t1", "↪ delegated to api: verify refs", "ask")},
+                            "placements": {}, "status": {}})
+        return st
+
+    def test_frame_plus_sender_ask(self):
+        st = self._world()
+        out = jd._deleg_frame(st, "g1")
+        self.assertIn(FRAME_LINE, out)
+        self.assertIn("Ship the color round", out)
+
+    def test_no_frame_is_empty_even_with_origin(self):
+        st = self._world(frame=None)
+        self.assertEqual(jd._deleg_frame(st, "g1"), "",
+                         "pre-fix delegated nodes re-distill byte-identically")
+
+    def test_cross_host_keeps_the_frame_and_skips_the_store_read(self):
+        st = self._world(host="TESTHOST")
+        out = jd._deleg_frame(st, "g1")
+        self.assertIn(FRAME_LINE, out)
+        self.assertNotIn("Ship the color round", out)
+
+    def test_non_delegated_is_empty(self):
+        st = {"rompUuid": WKR, "nodes": {"g1": _node("g1", "own work", None)},
+              "placements": {}, "status": {}}
+        self.assertEqual(jd._deleg_frame(st, "g1"), "")
+
+
+class OpenEventWiring(unittest.TestCase):
+    """The card-open metric row (go-forward half of cleared-without-open): the kernel appends one
+    row per modal open; the feed posts at all three open sites."""
+
+    KERNEL = Path(os.path.join(BIN, "romp-kernel")).resolve().read_text()
+    FEED = (Path(HERE).parent / "ui" / "webview" / "feed.ts").read_text()
+
+    def test_the_kernel_route_appends_one_row(self):
+        self.assertIn('msg.get("type") == "cardOpened"', self.KERNEL)
+        self.assertIn('card-opens.jsonl', self.KERNEL)
+
+    def test_the_feed_posts_on_every_open_path(self):
+        self.assertEqual(self.FEED.count('type: "cardOpened"'), 3,
+                         "single-card click, group click, and the rail-dot open")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -4431,7 +4431,7 @@ class DeltaScopedDistill(unittest.TestCase):
             store["nodes"][g]["deltaSince"] = deltaSince
         jd.save_goals(SID, store)
         captured = {}
-        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None: (
+        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None, frame=None: (
             captured.update(work=work_text, prior=prior_summary) or "BACKGROUND: b.\nTAKEAWAY: t.\nSOURCE: m2")
         jd._distill_session(SID, str(path), NOW)
         return captured.get("work", ""), jd.load_goals(SID)["nodes"][g]
@@ -4471,7 +4471,7 @@ class DeltaScopedDistill(unittest.TestCase):
                                "settledAt": T0 + 200, "deltaSince": T0 + 50, "doneWhy": "finished it"}}}
         jd.save_goals(SID, store)
         captured = {}
-        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None: (
+        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None, frame=None: (
             captured.update(work=work_text, prior=prior_summary) or "BACKGROUND: b.\nTAKEAWAY: t2.\nSOURCE: m1")
         jd._distill_session(SID, str(path), NOW)
         return captured, jd.load_goals(SID)["nodes"][g]
@@ -4528,7 +4528,7 @@ class DeltaScopedDistill(unittest.TestCase):
                  "status": {g: "completed"}, "nodes": nodes}
         jd.save_goals(SID, store)
         captured = {}
-        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None: (
+        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None, frame=None: (
             captured.update(work=work_text, prior=prior_summary, items=items)
             or "BACKGROUND: b.\nTAKEAWAY: t3.\nSOURCE: m1")
         jd._distill_session(SID, str(path), NOW)
@@ -4757,7 +4757,7 @@ class ProceduralBlockStillSpeaks(unittest.TestCase):
         jd.stall_llm = lambda goal_text, work_text, holding: (
             calls["stall"].append(holding) or
             ("BACKGROUND: b.\nTAKEAWAY: stall take.\nSOURCE: m1" if stall_ret is None else stall_ret))
-        jd.brief_llm = lambda goal_text, work_text, owed: (
+        jd.brief_llm = lambda goal_text, work_text, owed, frame=None: (
             calls["brief"].append(owed) or
             ("BACKGROUND: b.\nTAKEAWAY: brief take.\nSOURCE: m1" if brief_ret is None else brief_ret))
         jd._distill_session(SID, str(path), NOW)
@@ -4890,7 +4890,7 @@ class DeadBlockNeverPinsTheBrief(unittest.TestCase):
     def test_the_owed_decision_reaches_the_briefer_past_a_dead_interrupt(self):
         path, _store, top = self._store()
         calls = []
-        jd.brief_llm = lambda goal_text, work_text, owed: (
+        jd.brief_llm = lambda goal_text, work_text, owed, frame=None: (
             calls.append(owed) or "BACKGROUND: b.\nTAKEAWAY: decide the gate.\nSOURCE: m1")
         jd.stall_llm = lambda *a, **k: self.fail("the staller does not speak for a substantive block")
         jd._distill_session(SID, path, NOW)
@@ -5022,7 +5022,7 @@ class DistillSections(unittest.TestCase):
                                 "nodes": {gid: {"id": gid, "text": "Faster export", "parentId": None,
                                                 "nodeComplete": True, "blocked": False, "cleared": False,
                                                 "trail": [s1], "t": T0, "mt": T0 + 10}}})
-            jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: ("BACKGROUND: You asked for a faster export.\n"
+            jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: ("BACKGROUND: You asked for a faster export.\n"
                                                   "TAKEAWAY: It ships gzip now.\nSOURCE: m1")
             self.assertEqual(jd.run_distill(now=now), 1)
             nd = jd.load_goals(SID)["nodes"][gid]
@@ -5045,7 +5045,7 @@ class DistillSections(unittest.TestCase):
                                 "nodes": {gid: {"id": gid, "text": "Ship the feature", "parentId": None,
                                                 "nodeComplete": False, "blocked": True, "cleared": False,
                                                 "blockWhy": "A or B?", "trail": [s1], "t": T0, "mt": T0 + 10}}})
-            jd.brief_llm = lambda g, w, ow="": "BACKGROUND: You asked to ship the feature.\nTAKEAWAY: Decide A or B."
+            jd.brief_llm = lambda g, w, ow="", frame=None: "BACKGROUND: You asked to ship the feature.\nTAKEAWAY: Decide A or B."
             self.assertEqual(jd.run_distill(now=now), 1)
             nd = jd.load_goals(SID)["nodes"][gid]
             self.assertEqual(nd["blockSummary"], "Decide A or B.")
@@ -5066,7 +5066,7 @@ class DistillSections(unittest.TestCase):
                                 "nodes": {gid: {"id": gid, "text": "Do it", "parentId": None,
                                                 "nodeComplete": True, "blocked": False, "cleared": False,
                                                 "trail": [s1], "t": T0, "mt": T0 + 10}}})
-            jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "Delivered."       # an older-style reply
+            jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "Delivered."       # an older-style reply
             self.assertEqual(jd.run_distill(now=now), 1)
             nd = jd.load_goals(SID)["nodes"][gid]
             self.assertEqual(nd["summary"], "Delivered.")
@@ -5236,7 +5236,7 @@ class Distiller(unittest.TestCase):
                                             "doneWhy": "Both parts shipped and verified"}}})
         captured = {}
 
-        def fake_distill(goal_text, work_text, done_why="", prior_summary="", items=None):
+        def fake_distill(goal_text, work_text, done_why="", prior_summary="", items=None, frame=None):
             captured["goal"], captured["work"], captured["done"] = goal_text, work_text, done_why
             return "Part one and part two delivered."
         jd.distill_llm = fake_distill
@@ -5250,7 +5250,7 @@ class Distiller(unittest.TestCase):
         self.assertEqual(captured["done"], "Both parts shipped and verified",
                          "the closer's doneWhy is fed to the distiller as <completed> ground truth")
         calls = []                                          # event-gated: re-running distills nothing
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: (calls.append(1), "x")[1]
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: (calls.append(1), "x")[1]
         self.assertEqual(jd.run_distill(now=now), 0)
         self.assertEqual(calls, [], "a goal already distilled at this mt is not re-distilled")
 
@@ -5274,7 +5274,7 @@ class Distiller(unittest.TestCase):
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": trail, "t": T0, "mt": T0 + 210}}})
         seen = {}
-        def fake_distill(goal_text, work_text, done_why="", prior_summary="", items=None):
+        def fake_distill(goal_text, work_text, done_why="", prior_summary="", items=None, frame=None):
             seen["work"] = work_text
             return "Both parts delivered.\nSOURCE: m2"
         jd.distill_llm = fake_distill
@@ -5298,7 +5298,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "Build the thing", "parentId": None,
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": [s1], "t": T0, "mt": T0 + 10}}})
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "Delivered without a citation."
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "Delivered without a citation."
         self.assertEqual(jd.run_distill(now=now), 1)
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd["summary"], "Delivered without a citation.")
@@ -5320,7 +5320,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "Build the thing", "parentId": None,
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": [s1], "t": T0, "mt": T0 + 10}}})
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "Delivered, but no citation line."
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "Delivered, but no citation line."
         d = Path(tempfile.mkdtemp()); saved_errors = jd.ERRORS
         try:
             jd.ERRORS = d / "judge-errors.jsonl"
@@ -5353,7 +5353,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "Build the thing", "parentId": None,
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": [s1], "t": T0, "mt": T0 + 10}}})
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "Delivered.\nSOURCE: m99"
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "Delivered.\nSOURCE: m99"
         d = Path(tempfile.mkdtemp()); saved_errors = jd.ERRORS
         try:
             jd.ERRORS = d / "judge-errors.jsonl"
@@ -5383,7 +5383,7 @@ class Distiller(unittest.TestCase):
                                             "trail": [s1], "t": T0, "mt": T0 + 10,
                                             "warns": [{"kind": "cite-miss", "t": T0, "msg": "m",
                                                        "detail": "d"}]}}})
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "Delivered.\nSOURCE: m1"
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "Delivered.\nSOURCE: m1"
         self.assertEqual(jd.run_distill(now=now), 1)
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd["summaryAnchor"], "a1")
@@ -5405,7 +5405,7 @@ class Distiller(unittest.TestCase):
                                             "nodeComplete": False, "blocked": True, "cleared": False,
                                             "blockWhy": "Which approach?", "trail": [s1],
                                             "t": T0, "mt": T0 + 10}}})
-        jd.brief_llm = lambda g, w, ow="": "Decide the approach, options laid out."
+        jd.brief_llm = lambda g, w, ow="", frame=None: "Decide the approach, options laid out."
         d = Path(tempfile.mkdtemp()); saved_errors = jd.ERRORS
         try:
             jd.ERRORS = d / "judge-errors.jsonl"
@@ -5434,7 +5434,7 @@ class Distiller(unittest.TestCase):
                                             "nodeComplete": False, "blocked": True, "cleared": False,
                                             "blockWhy": "Which approach — A or B?", "trail": [s1],
                                             "t": T0, "mt": T0 + 10}}})
-        jd.brief_llm = lambda g, w, ow="": "Decide A or B.\nSOURCE: [m1]"
+        jd.brief_llm = lambda g, w, ow="", frame=None: "Decide A or B.\nSOURCE: [m1]"
         self.assertEqual(jd.run_distill(now=now), 1)
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd["blockSummary"], "Decide A or B.", "the SOURCE line is parsed off the brief")
@@ -5465,7 +5465,7 @@ class Distiller(unittest.TestCase):
         self.assertEqual(store["status"][gid], "blocked", "the open-todo block rolls the top to blocked")
         jd.save_goals(SID, store)
         seen = {}
-        def fake_brief(goal_text, work_text, block_why):
+        def fake_brief(goal_text, work_text, block_why, frame=None):
             seen["owed"] = block_why
             return "Provide the staging credentials so the migration can run."
         jd.brief_llm = fake_brief
@@ -5502,7 +5502,7 @@ class Distiller(unittest.TestCase):
         self.assertEqual(store["status"][gid], "blocked", "two blocked subs roll the top to blocked")
         jd.save_goals(SID, store)
         seen = {}
-        def fake_brief(goal_text, work_text, owed):
+        def fake_brief(goal_text, work_text, owed, frame=None):
             seen["owed"] = owed
             return "Decide the screencast: record it now.\n\nDecide the Internals: merge or leave."
         jd.brief_llm = fake_brief
@@ -5531,7 +5531,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "Build the thing", "parentId": None,
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": [s1], "t": T0, "mt": T0 + 10}}})
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: ""             # the call always fails (empty)
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: ""             # the call always fails (empty)
         for i in range(1, jd.DISTILL_FAIL_CAP):             # the pre-cap passes: keep retrying, count climbs
             jd.run_distill(now=now)
             nd = jd.load_goals(SID)["nodes"][gid]
@@ -5544,7 +5544,7 @@ class Distiller(unittest.TestCase):
         self.assertEqual(nd.get("distilledMt"), T0 + 10, "distilledMt stamped → never re-enters")
         self.assertEqual(nd.get("distillFails"), 0, "counter reset for a future re-open")
         ran = []                                            # the sentinel is non-null → no more distills
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: (ran.append(1), "late")[1]
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: (ran.append(1), "late")[1]
         jd.run_distill(now=now)
         self.assertEqual(ran, [], "a settled card is not re-distilled — the loop is broken")
 
@@ -5562,7 +5562,7 @@ class Distiller(unittest.TestCase):
                                             "nodeComplete": False, "blocked": True, "cleared": False,
                                             "blockWhy": "Which approach — A or B?", "trail": [s1],
                                             "t": T0, "mt": T0 + 10}}})
-        jd.brief_llm = lambda g, w, ow="": ""               # the brief call always fails
+        jd.brief_llm = lambda g, w, ow="", frame=None: ""               # the brief call always fails
         for i in range(1, jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
             nd = jd.load_goals(SID)["nodes"][gid]
@@ -5592,14 +5592,14 @@ class Distiller(unittest.TestCase):
                                             "blockWhy": "Which approach — A or B?", "trail": [s1],
                                             "t": T0, "mt": T0 + 10}}})
         # simulate a pause-skip exactly as _judge_run does: mark _judge_ctx.paused and return "" (API not asked)
-        jd.brief_llm = lambda g, w, ow="": (setattr(jd._judge_ctx, "paused", True), "")[1]
+        jd.brief_llm = lambda g, w, ow="", frame=None: (setattr(jd._judge_ctx, "paused", True), "")[1]
         for _ in range(jd.DISTILL_FAIL_CAP + 2):            # MORE passes than the cap — still must not give up
             jd.run_distill(now=now)
             nd = jd.load_goals(SID)["nodes"][gid]
             self.assertIsNone(nd.get("blockSummary"), "a pause-skip leaves the brief null → re-enters next pass")
             self.assertIn(nd.get("briefFails"), (None, 0), "a pause-skip never increments the give-up counter")
             self.assertIsNone(nd.get("briefedMt"), "never stamped → never a permanent give-up while paused")
-        jd.brief_llm = lambda g, w, ow="": (setattr(jd._judge_ctx, "paused", False), "Decide A or B.")[1]
+        jd.brief_llm = lambda g, w, ow="", frame=None: (setattr(jd._judge_ctx, "paused", False), "Decide A or B.")[1]
         jd.run_distill(now=now)                             # pause cleared → the brief lands normally
         self.assertEqual(jd.load_goals(SID)["nodes"][gid].get("blockSummary"), "Decide A or B.",
                          "once the pause clears the brief lands — the card was never permanently blanked")
@@ -5624,7 +5624,7 @@ class Distiller(unittest.TestCase):
         (jd.STATE).mkdir(parents=True, exist_ok=True)       # no maxed account window → the generic cause
         (jd.STATE / "usage.json").write_text(json.dumps({"five_hour": {"pct": 20}, "seven_day": {"pct": 40}}))
         gid, now = self._blocked_goal()
-        jd.brief_llm = lambda g, w, ow="": ""               # every call fails (real, not a pause-skip)
+        jd.brief_llm = lambda g, w, ow="", frame=None: ""               # every call fails (real, not a pause-skip)
         for _ in range(jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
         nd = jd.load_goals(SID)["nodes"][gid]
@@ -5644,7 +5644,7 @@ class Distiller(unittest.TestCase):
             "seven_day": {"pct": 40, "resets_at": FUT},
             "fable": {"pct": 100, "resets_at": FUT}}))
         gid, now = self._blocked_goal()
-        jd.brief_llm = lambda g, w, ow="": ""
+        jd.brief_llm = lambda g, w, ow="", frame=None: ""
         for _ in range(jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
         det = [w for w in jd.load_goals(SID)["nodes"][gid].get("warns") or []
@@ -5655,14 +5655,14 @@ class Distiller(unittest.TestCase):
 
     def test_a_successful_summary_clears_the_failed_warn(self):
         gid, now = self._blocked_goal()
-        jd.brief_llm = lambda g, w, ow="": ""
+        jd.brief_llm = lambda g, w, ow="", frame=None: ""
         for _ in range(jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
         self.assertTrue(any(w.get("kind") == "brief-failed"
                             for w in jd.load_goals(SID)["nodes"][gid].get("warns") or []))
         # re-arm + a working brief → the warn clears
         st = jd.load_goals(SID); st["nodes"][gid]["blockSummary"] = None; jd.save_goals(SID, st)
-        jd.brief_llm = lambda g, w, ow="": "Decide A or B."
+        jd.brief_llm = lambda g, w, ow="", frame=None: "Decide A or B."
         jd.run_distill(now=now)
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd.get("blockSummary"), "Decide A or B.")
@@ -5673,7 +5673,7 @@ class Distiller(unittest.TestCase):
         # the chip's hover/modal history (the user 2026-08-18): every failed try lands as when + model +
         # literal error, and the line's eventual success clears its rows
         gid, now = self._blocked_goal()
-        jd.brief_llm = lambda g, w, ow="": (setattr(jd._judge_ctx, "last_call_fail",
+        jd.brief_llm = lambda g, w, ow="", frame=None: (setattr(jd._judge_ctx, "last_call_fail",
             {"note": "API Error: Repeated 529 Overloaded errors.", "model": "opus"}), "")[1]
         for _ in range(jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
@@ -5682,7 +5682,7 @@ class Distiller(unittest.TestCase):
         self.assertTrue(all(e["model"] == "opus" and "529" in e["note"] and e["line"] == "brief"
                             for e in log), "each row carries the model and the literal error")
         st = jd.load_goals(SID); st["nodes"][gid]["blockSummary"] = None; jd.save_goals(SID, st)
-        jd.brief_llm = lambda g, w, ow="": (setattr(jd._judge_ctx, "last_call_fail", None), "Decide A or B.")[1]
+        jd.brief_llm = lambda g, w, ow="", frame=None: (setattr(jd._judge_ctx, "last_call_fail", None), "Decide A or B.")[1]
         jd.run_distill(now=now)
         self.assertNotIn("failLog", jd.load_goals(SID)["nodes"][gid],
                          "the landed brief clears its line's attempt history")
@@ -5692,14 +5692,14 @@ class Distiller(unittest.TestCase):
         # the whole suite still passed — so pin them through the REAL path: an auto-re-armed line whose
         # retry succeeds must drop its era mark, or the health edge is one-per-lifetime per card
         gid, now = self._blocked_goal()
-        jd.brief_llm = lambda g, w, ow="": ""
+        jd.brief_llm = lambda g, w, ow="", frame=None: ""
         for _ in range(jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
         st = jd.load_goals(SID)                          # the health edge re-armed it (as rearm would):
         st["nodes"][gid]["blockSummary"] = None          # line owed again, era spent
         st["nodes"][gid]["autoRearmed"] = {"brief-failed": True}
         jd.save_goals(SID, st)
-        jd.brief_llm = lambda g, w, ow="": "Decide A or B."
+        jd.brief_llm = lambda g, w, ow="", frame=None: "Decide A or B."
         jd.run_distill(now=now)
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd.get("blockSummary"), "Decide A or B.")
@@ -5708,7 +5708,7 @@ class Distiller(unittest.TestCase):
 
     def test_scan_counts_failures_and_rearm_reopens_only_warned_cards(self):
         gid, now = self._blocked_goal()
-        jd.brief_llm = lambda g, w, ow="": ""
+        jd.brief_llm = lambda g, w, ow="", frame=None: ""
         for _ in range(jd.DISTILL_FAIL_CAP):
             jd.run_distill(now=now)
         scan = jd.judge_failure_scan()
@@ -5736,7 +5736,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "G", "parentId": None, "nodeComplete": True,
                                             "blocked": False, "cleared": False, "trail": [s1], "t": T0,
                                             "mt": T0 + 10, "distilledMt": T0 + 10, "summary": "old"}}})
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "fresh"
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "fresh"
         self.assertEqual(jd.run_distill(now=now), 0, "already distilled at this mt -> no-op")
         st = jd.load_goals(SID); st["nodes"][gid]["mt"] = T0 + 999; jd.save_goals(SID, st)   # reopened + re-completed
         self.assertEqual(jd.run_distill(now=now), 1, "mt advanced (re-completed) -> re-distill")
@@ -5755,7 +5755,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "Build and verify the feature", "parentId": None,
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": [], "t": T0, "mt": T0 + 10}}})   # empty trail → no work
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: (_ for _ in ()).throw(AssertionError("no work → distill_llm must not run"))
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: (_ for _ in ()).throw(AssertionError("no work → distill_llm must not run"))
         jd.run_distill(now=now)
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd["summary"], "", "no-work top settles to the \"\" sentinel, not a null/'(generating…)'")
@@ -5774,11 +5774,11 @@ class Distiller(unittest.TestCase):
                                             "nodeComplete": True, "blocked": False, "cleared": False,
                                             "trail": [], "t": T0, "mt": T0 + 10,
                                             "distilledMt": T0 + 10, "summary": None}}})   # stamped but null
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "should-not-run"
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "should-not-run"
         jd.run_distill(now=now)
         self.assertEqual(jd.load_goals(SID)["nodes"][gid]["summary"], "", "stuck null summary heals to \"\"")
         calls = []
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: (calls.append(1), "x")[1]
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: (calls.append(1), "x")[1]
         jd.run_distill(now=now)
         self.assertEqual(calls, [], "once settled to \"\" (non-null), the goal is not reprocessed")
 
@@ -5811,11 +5811,11 @@ class Distiller(unittest.TestCase):
                                             "blockWhy": "Redis or Postgres for sessions?"}}})
         captured = {}
 
-        def fake_brief(goal_text, work_text, owed):
+        def fake_brief(goal_text, work_text, owed, frame=None):
             captured["goal"], captured["work"], captured["owed"] = goal_text, work_text, owed
             return "Decide: Redis or Postgres for the session store."
         jd.brief_llm = fake_brief
-        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None: "should-not-run"
+        jd.distill_llm = lambda g, w, dw="", prior_summary="", items=None, frame=None: "should-not-run"
         self.assertEqual(jd.run_distill(now=now), 1, "the blocked top is briefed")
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertEqual(nd["blockSummary"], "Decide: Redis or Postgres for the session store.")
@@ -5824,7 +5824,7 @@ class Distiller(unittest.TestCase):
         self.assertEqual(captured["owed"], "Redis or Postgres for sessions?", "the owed question is fed in")
         self.assertIn("two options", captured["work"], "the goal's work history is fed in")
         calls = []                                          # event-gated: re-running briefs nothing
-        jd.brief_llm = lambda g, w, o: (calls.append(1), "x")[1]
+        jd.brief_llm = lambda g, w, o, frame=None: (calls.append(1), "x")[1]
         self.assertEqual(jd.run_distill(now=now), 0)
         self.assertEqual(calls, [], "a block already briefed at this mt is not re-briefed")
 
@@ -5840,7 +5840,7 @@ class Distiller(unittest.TestCase):
                             "nodes": {gid: {"id": gid, "text": "G", "parentId": None, "nodeComplete": False,
                                             "blocked": True, "cleared": False, "trail": [s1], "t": T0,
                                             "mt": T0 + 10, "blockWhy": "which way?"}}})
-        jd.brief_llm = lambda g, w, o: ""              # permanent failure
+        jd.brief_llm = lambda g, w, o, frame=None: ""              # permanent failure
         self.assertEqual(jd.run_distill(now=now), 0, "a failed brief produced nothing")
         nd = jd.load_goals(SID)["nodes"][gid]
         self.assertNotIn("blockSummary", nd, "NO fallback — blockSummary stays null")
@@ -6124,7 +6124,7 @@ class LivePickerBrief(unittest.TestCase):
 
     def test_live_picker_briefs_a_working_focus_top(self):
         path, g = self._setup("picker")
-        jd.brief_llm = lambda goal, work, owed: "Decide: option A or B. Context provided."
+        jd.brief_llm = lambda goal, work, owed, frame=None: "Decide: option A or B. Context provided."
         jd.distill_llm = lambda *a, **k: self.fail("a working goal must not take the DONE-distiller path")
         n = jd._distill_session(SID, path, NOW)
         nd = jd.load_goals(SID)["nodes"][g]
@@ -6136,14 +6136,14 @@ class LivePickerBrief(unittest.TestCase):
 
     def test_permission_also_briefs(self):
         path, g = self._setup("permission")
-        jd.brief_llm = lambda goal, work, owed: "Approve the edit to keep going?"
+        jd.brief_llm = lambda goal, work, owed, frame=None: "Approve the edit to keep going?"
         n = jd._distill_session(SID, path, NOW)
         self.assertEqual(n, 1, "a live PERMISSION prompt briefs its focus top too, like a picker")
 
     def test_idempotent_while_parked(self):
         path, g = self._setup("picker")
         calls = []
-        jd.brief_llm = lambda goal, work, owed: (calls.append(1), "brief")[1]
+        jd.brief_llm = lambda goal, work, owed, frame=None: (calls.append(1), "brief")[1]
         jd._distill_session(SID, path, NOW)
         jd._distill_session(SID, path, NOW)            # a 2nd pass while STILL parked
         self.assertEqual(len(calls), 1, "briefed ONCE per episode (promptBriefedT gate), not every producer pass")
@@ -6168,7 +6168,7 @@ class LivePickerBrief(unittest.TestCase):
         path, g = self._setup("picker")
         briefs = iter(["Pick the retry budget: 3 or 5?", "Name the config key: timeout or deadline?"])
         calls = []
-        jd.brief_llm = lambda goal, work, owed: (calls.append(1), next(briefs))[1]
+        jd.brief_llm = lambda goal, work, owed, frame=None: (calls.append(1), next(briefs))[1]
         jd._distill_session(SID, path, NOW)
         self._append_states((NOW - 15, "working"), (NOW - 10, "picker"))   # answered → NEW question
         jd._distill_session(SID, path, NOW)
@@ -6181,7 +6181,7 @@ class LivePickerBrief(unittest.TestCase):
     def test_one_park_spanning_picker_and_permission_is_one_episode(self):
         path, g = self._setup("picker")
         calls = []
-        jd.brief_llm = lambda goal, work, owed: (calls.append(1), "brief")[1]
+        jd.brief_llm = lambda goal, work, owed, frame=None: (calls.append(1), "brief")[1]
         jd._distill_session(SID, path, NOW)
         self._append_states((NOW - 15, "permission"))   # the same park, another prompt flavor — no exit between
         jd._distill_session(SID, path, NOW)
@@ -6200,7 +6200,7 @@ class LivePickerBrief(unittest.TestCase):
         store["status"][g] = "blocked"
         jd.save_goals(SID, store)
         calls = []
-        jd.brief_llm = lambda goal, work, owed: (calls.append(1), "Pick the port.")[1]
+        jd.brief_llm = lambda goal, work, owed, frame=None: (calls.append(1), "Pick the port.")[1]
         jd._distill_session(SID, path, NOW)
         jd._distill_session(SID, path, NOW)
         nd = jd.load_goals(SID)["nodes"][g]
@@ -7100,7 +7100,7 @@ class OrphanedHistory(unittest.TestCase):
                                "summary": None, "doneWhy": "finished it"}}}
         jd.save_goals(SID, store)
         captured = {}
-        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None: (
+        jd.distill_llm = lambda goal_text, work_text, done_why="", prior_summary="", items=None, frame=None: (
             captured.update(work=work_text) or "TAKEAWAY: t.\nSOURCE: m1")
         jd._distill_session(SID, str(path), NOW)
         return captured, jd.load_goals(SID)["nodes"][g]

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1231,6 +1231,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     pending = window.setTimeout(() => {
       pending = undefined;
       fullscreenAskId = it.itemId;
+      vscodeApi?.postMessage({ type: "cardOpened", itemId: it.itemId, sid: it.sid });   // the open-metric row (2026-08-25)
       vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, locate: false });
       render();
     }, 220);
@@ -2317,7 +2318,8 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     pending = window.setTimeout(() => {
       pending = undefined;
       fullscreenAskId = fkey;
-      const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, locate: false });
+      const m = m0(); if (m) vscodeApi?.postMessage({ type: "cardOpened", itemId: m.itemId, sid: m.sid });   // the open-metric row (2026-08-25)
+      if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, locate: false });
       render();
     }, 220);
   });
@@ -4981,6 +4983,7 @@ window.addEventListener("message", (e: MessageEvent) => {
     // ask itemId, "i:<itemId>" standalone, "g:<turnId>" group). hl = the clicked
     // turn's event id: ring its row(s) and scroll the first one into view.
     fullscreenAskId = m.key;
+    vscodeApi?.postMessage({ type: "cardOpened", itemId: m.key, sid: "" });   // rail-dot opens count too (2026-08-25)
     if (typeof m.hl === "string" && m.hl) extHoverEid = m.hl;
     renderModal();
     applyExtHover();


### PR DESCRIPTION
## What

From the confusing-worker-cards investigation: worker cards' titles/summaries are written from the worker's build segments, leading with implementation nouns — while the delegating mail's first line carries the requester's (usually the user's) own framing, which the summary writer never saw. Two mechanical seams, zero added LLM calls, no skill or team-behavior change (in the examples: a `notes-api` manager delegating to `web`/`api` workers).

**Mint** — `apply_courier` stores the delegating mail's cleaned first line as the additive node field `frame` (documented in the goal-node consumer contract, docs/judges.md). The ledger row's body is authoritative (`_postal_row`'s memo now carries it; `_postal_body_head`); the delivered segment's own head is the fallback for rows the local ledger lacks. `_frame_head` strips romp markers and the unit-text "USER ASKED:" framing prefix (plumbing, never the request's words), collapses whitespace, caps at 220.

**Distill** — the distiller and briefer prompts for a frame-carrying goal gain a marked `<delegating-request>` section (sender-written text rides a marked section, never romp's instruction prose) plus the sender's linked-ask title (`_deleg_frame`: origin → sender store, local senders only), with a note to open the takeaway / owed decision in the request's terms. **A goal without a frame — a session's own work, or any node minted before the field existed — composes byte-identically to before** (pinned). The title-shaping clamp is untouched.

**Measurement half** — the feed posts `cardOpened` at all three modal-open paths and the kernel appends one row per open to `card-opens.jsonl`, so cleared-WITHOUT-open (the confusion signal the clear log alone cannot see) becomes measurable go-forward. Pre-change baselines were captured read-only and travel in the dispatch report, not the repo.

## Tests

`tests/test_context_frames.py`: frame-head matrix (markers, framing prefix, collapse, cap), additive storage + absent-field + clamp, ledger-body head + unknown mid + row-contract prefix, courier end-to-end (ledger body as frame; bodyless row falls back to the delivered head), the LLM builders' marked section + byte-identical no-frame prompts, the `_deleg_frame` join (frame + sender ask; no frame = ""; cross-host skips the store read; non-delegated = ""), and the open-event wiring pins. Existing distill/brief stubs across the suite widened to the new keyword.

Suites: Python 5682 passed / 0 failed; UI 2429/2429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)