### PR TITLE
Tags drag into the user's order, which flows everywhere; no-tags sits leftmost

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1686,7 +1686,21 @@ def _norm_timeline_views(d):
     for sf in _LENS_SURFACES:
         actives[sf] = _norm_lens(posted.get(sf), tags) if posted and isinstance(posted.get(sf), dict) \
             else (_lens_seed(active, tags) if posted is None else {"all": True})
-    return {"active": active, "actives": actives, "tags": tags}
+    out = {"active": active, "actives": actives, "tags": tags}
+    # TAG ORDER (the user 2026-08-25): the union DISPLAY order — a NAME list, viewer-side, so a
+    # remote-homed tag holds its dragged position without any cross-kernel write (a display
+    # preference must not need another kernel up; the lane order's viewer-side philosophy). Local
+    # tags ALSO keep their array order (the drag rewrites both); this list extends the same order
+    # across the whole name-keyed union. Names are not validated against the local store — a
+    # remote name is unknowable here by design; junk entries cost nothing and age out on the next
+    # drag. Absent stays absent, so pre-order blobs round-trip byte-identical.
+    order = []
+    for n in _lst(d.get("tagOrder"))[:_VIEWS_MAX_TAGS * 2]:
+        if isinstance(n, str) and n and n[:_VIEWS_MAX_NAME] not in order:
+            order.append(n[:_VIEWS_MAX_NAME])
+    if order:
+        out["tagOrder"] = order
+    return out
 
 
 def _timeline_views():

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -29,6 +29,41 @@ jd = km.jd
 G1 = {"id": "g1", "name": "pool", "color": "#DD42FF", "members": ["s2", "s3"]}
 
 
+class TagOrderRoundTrip(unittest.TestCase):
+    """The union DISPLAY order (the user 2026-08-25): a NAME list on the views blob, viewer-side —
+    so a dragged remote-homed tag holds its position without any cross-kernel write. The normalizer
+    passes it through (clamped, deduped); pre-order blobs round-trip without the key."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def test_order_survives_normalize_and_store(self):
+        blob = {"active": "all", "tags": [G1], "tagOrder": ["experiments", "pool", "remotename"]}
+        n = km._norm_timeline_views(blob)
+        self.assertEqual(n["tagOrder"], ["experiments", "pool", "remotename"],
+                         "names pass through unvalidated — a remote-homed name is unknowable here by design")
+        km._set_timeline_views(blob)
+        self.assertEqual(km._timeline_views()["tagOrder"], ["experiments", "pool", "remotename"],
+                         "the drag persists: the stored blob re-reads with the order intact")
+        self.assertEqual(km._views_client()["tagOrder"], ["experiments", "pool", "remotename"],
+                         "…and the rendered blob every client holds carries it")
+
+    def test_absent_stays_absent_and_junk_drops(self):
+        n = km._norm_timeline_views({"active": "all", "tags": [G1]})
+        self.assertNotIn("tagOrder", n, "pre-order blobs round-trip without the key")
+        n = km._norm_timeline_views({"tags": [G1], "tagOrder": [3, "", None, "pool", "pool"]})
+        self.assertEqual(n["tagOrder"], ["pool"], "junk entries drop quietly; duplicates collapse")
+        n = km._norm_timeline_views({"tags": [G1], "tagOrder": "pool"})
+        self.assertNotIn("tagOrder", n, "a wrong-typed order drops whole, never raises")
+
+
 class TimelineViews(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -64,6 +64,17 @@ function viewTagUnion(views) {
     for (const m of (rt.members || [])) if (g.members.indexOf(m) < 0) g.members.push(m);
     if (out.indexOf(g) < 0) out.push(g);
   }
+  // THE ordering rule, stated once per mirror (the user 2026-08-25; session-views.ts is the
+  // typed twin): unions render in the user's dragged order (views.tagOrder, name-keyed — a
+  // remote-homed name holds its position too); unlisted names follow in natural order (stable
+  // sort, so a new tag lands at the end). Every chip list, menu row list, and dialog row list
+  // here renders through this union, so the order flows everywhere from this line.
+  const ord = (views && views.tagOrder) || [];
+  if (ord.length) {
+    const ix = {};
+    ord.forEach((n, i) => { if (!(n in ix)) ix[n] = i; });
+    out.sort((a, b) => (a.name in ix ? ix[a.name] : ord.length) - (b.name in ix ? ix[b.name] : ord.length));
+  }
   return out;
 }
 function viewVisible(views, id) {
@@ -2543,6 +2554,7 @@ class TimelinePanel {
   // may clamp names, so compare shapes, not object identity
   _viewsKey(v) {
     return JSON.stringify({ active: v.active || 'all',
+      order: v.tagOrder || [],   // the dragged union order is client-posted state (2026-08-25)
       hidden: (v.hidden || []).slice().sort(),
       tags: viewTags(v).map((t) => ({ id: t.id, name: t.name, color: t.color,
                                       members: (t.members || []).slice().sort() })) });
@@ -2755,10 +2767,21 @@ class TimelinePanel {
     const unions = viewTagUnion(v);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
     const active = !lensAll(lens);
-    const chips = active ? (lens.tags || []).map((n) => {
-      const u = unions.find((x) => x.name === n);
-      return { label: n, color: (u && u.color) || MODEL_FG, pick: { tag: n } };
-    }).concat(lens.none ? [{ label: 'no tags', color: MODEL_FG, pick: 'none' }] : []) : [];
+    // "no tags" sits LEFTMOST, the tags following in the USER'S order (the user 2026-08-25):
+    // the unions arrive ordered (viewTagUnion's one rule), so walking them IS the order; a
+    // selected name missing from the unions (a stale lens) appends last in the gray.
+    const chips = [];
+    if (active) {
+      if (lens.none) chips.push({ label: 'no tags', color: MODEL_FG, pick: 'none' });
+      const picked = {};
+      (lens.tags || []).forEach((n) => { picked[n] = true; });
+      for (const u of unions) {
+        if (!picked[u.name]) continue;
+        delete picked[u.name];
+        chips.push({ label: u.name, color: u.color || MODEL_FG, pick: { tag: u.name } });
+      }
+      for (const n of (lens.tags || [])) if (picked[n]) chips.push({ label: n, color: MODEL_FG, pick: { tag: n } });
+    }
     const GAP = 8, BTNW = 34;   // the bar's flex gap; the feed tag button's measured box width
     const tailStr = more ? more + ' more' : '';
     const chipW = (c) => 18 + this.labelWidth(c.label) + 6 + 8;   // pad+border + name + gap + ✕ (the 12px measure over-covers the 10.7px render)
@@ -3056,8 +3079,60 @@ class TimelinePanel {
         for (const tg of viewTagUnion(v)) {
           const editable = tg.localId || canEdit;
           const tc = tg.color || MODEL_FG;
-          // the tag itself: the normal pill, NO ✕ — actions live beside it, never on it
+          // the tag itself: the normal pill, NO ✕ — actions live beside it, never on it.
+          // DRAGGABLE (the user 2026-08-25): grab a pill to reorder the tags — the drop writes
+          // tagOrder (the union display order, viewer-side) AND re-sorts the local tags array to
+          // match (the natural store for local-only readers). The membership drag's discipline:
+          // pointer capture, an accent border cue that moves WITHOUT rebuilding mid-drag (the
+          // redraw-eats-pointer rule); the rebuild and the write happen on the drop. The rename
+          // input keeps the cell — no drag while editing.
           const pillCell = tgrid.createDiv();
+          pillCell._tname = tg.name;
+          if (this._tagEditorFor !== tg.name || !editable) {
+            pillCell.style.cursor = 'grab';
+            pillCell.addEventListener('pointerdown', (e) => {
+              e.preventDefault();
+              const cells = Array.from(tgrid.children).filter((c) => c._tname);
+              const fromIdx = cells.indexOf(pillCell);
+              if (fromIdx < 0) return;
+              let toIdx = fromIdx;
+              try { pillCell.setPointerCapture(e.pointerId); } catch (e2) {}
+              pillCell.style.opacity = '0.45';
+              const clearCues = () => cells.forEach((c) => { c.style.borderTop = ''; c.style.borderBottom = ''; });
+              const onMove = (ev) => {
+                const ys = cells.map((c) => { const r = c.getBoundingClientRect(); return (r.top + r.bottom) / 2; });
+                let idx = ys.findIndex((y) => ev.clientY < y);
+                if (idx < 0) idx = cells.length - 1;
+                if (idx !== toIdx) {
+                  toIdx = idx;
+                  clearCues();
+                  if (toIdx !== fromIdx) cells[toIdx].style[toIdx > fromIdx ? 'borderBottom' : 'borderTop'] = '2px solid #9cd2ff';
+                }
+              };
+              const onUp = () => {
+                pillCell.removeEventListener('pointermove', onMove);
+                pillCell.removeEventListener('pointerup', onUp);
+                pillCell.removeEventListener('pointercancel', onUp);
+                pillCell.style.opacity = '';
+                clearCues();
+                if (toIdx === fromIdx) return;
+                const names = cells.map((c) => c._tname);
+                names.splice(toIdx, 0, names.splice(fromIdx, 1)[0]);
+                const nv = JSON.parse(JSON.stringify(this._curViews()));
+                nv.tagOrder = names;                       // the union display order, remote-homed names included
+                const pos = {};
+                names.forEach((n, i) => { pos[n] = i; });
+                nv.tags = viewTags(nv).slice().sort((a, b) =>
+                  ((a.name in pos) ? pos[a.name] : names.length) - ((b.name in pos) ? pos[b.name] : names.length));
+                delete nv.groups;
+                this._setViews(nv);
+                build();
+              };
+              pillCell.addEventListener('pointermove', onMove);
+              pillCell.addEventListener('pointerup', onUp);
+              pillCell.addEventListener('pointercancel', onUp);
+            });
+          }
           if (this._tagEditorFor === tg.name && editable) {
             const nameIn = document.createElement('input');
             nameIn.value = tg.name; nameIn.maxLength = 40;

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -45,7 +45,11 @@ function viewTags(views) { return (views && (views.tags || views.groups)) || [];
 // stored duplicates stay separate under the hood (no automatic store merges — the anti-clobber
 // rule); this is PRESENTATION, and the mirrors (session-views.ts, kernel _view_visible) agree.
 function viewTagUnion(views) {
-  const out = [], byName = {};
+  // byName is null-prototype: a user-typed tag NAME can be "constructor"/"toString", which a
+  // plain {} resolves through the prototype chain — the lookup returned a Function and the
+  // union builder crashed on it (found in adversarial review 2026-08-25; the ordering lookups
+  // below wear the same guard)
+  const out = [], byName = Object.create(null);
   for (const t of viewTags(views)) {
     const g = byName[t.name] || (byName[t.name] = { name: t.name || 'tag', color: '', members: [],
                                                     ids: [], localId: null, homes: [], remotes: [] });
@@ -71,7 +75,9 @@ function viewTagUnion(views) {
   // here renders through this union, so the order flows everywhere from this line.
   const ord = (views && views.tagOrder) || [];
   if (ord.length) {
-    const ix = {};
+    // null-prototype lookup: a user-typed tag NAME can be "constructor"/"toString", which a plain
+    // {} would resolve through the prototype chain (the TS twin uses a Map for the same reason)
+    const ix = Object.create(null);
     ord.forEach((n, i) => { if (!(n in ix)) ix[n] = i; });
     out.sort((a, b) => (a.name in ix ? ix[a.name] : ord.length) - (b.name in ix ? ix[b.name] : ord.length));
   }
@@ -2773,7 +2779,7 @@ class TimelinePanel {
     const chips = [];
     if (active) {
       if (lens.none) chips.push({ label: 'no tags', color: MODEL_FG, pick: 'none' });
-      const picked = {};
+      const picked = Object.create(null);   // null-prototype: a tag named "constructor" must not read as picked
       (lens.tags || []).forEach((n) => { picked[n] = true; });
       for (const u of unions) {
         if (!picked[u.name]) continue;
@@ -3120,7 +3126,7 @@ class TimelinePanel {
                 names.splice(toIdx, 0, names.splice(fromIdx, 1)[0]);
                 const nv = JSON.parse(JSON.stringify(this._curViews()));
                 nv.tagOrder = names;                       // the union display order, remote-homed names included
-                const pos = {};
+                const pos = Object.create(null);           // null-prototype (the prototype-key name hazard)
                 names.forEach((n, i) => { pos[n] = i; });
                 nv.tags = viewTags(nv).slice().sort((a, b) =>
                   ((a.name in pos) ? pos[a.name] : names.length) - ((b.name in pos) ? pos[b.name] : names.length));

--- a/ui/timeline-tagorder-drag.test.ts
+++ b/ui/timeline-tagorder-drag.test.ts
@@ -1,0 +1,126 @@
+// TAG DRAG-TO-REORDER (the user 2026-08-25): grab a pill in the Sessions & tags dialog's tag
+// table to put the tags in your order. The drop writes tagOrder — the union DISPLAY order,
+// viewer-side, so a REMOTE-HOMED tag holds its dragged position without any cross-kernel write —
+// and re-sorts the local tags array to match (the natural store for local-only readers). This
+// EXECUTES the drag over the house fake-DOM shim: dialog open, pointer capture, cue math, drop,
+// and asserts the posted blob + that a rebuild from that blob (the reload) keeps the order.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) {
+      if (c.parentNode) { const i = c.parentNode.children.indexOf(c); if (i >= 0) c.parentNode.children.splice(i, 1); }
+      c.parentNode = n; this.children.push(c); return c;
+    },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    _listeners: {} as any,
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener(t: string) { delete n._listeners[t]; },
+    setPointerCapture() {}, releasePointerCapture() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return n._rect || { width: 200, height: 20, left: 0, top: 0, right: 200, bottom: 20 }; },
+    closest() { return null; }, focus() {}, select() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  createTextNode(text: string) { const n = makeNode("#text"); n.textContent = text; return n; },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)", fontFamily: "sans-serif" });
+g.requestAnimationFrame = () => 0;
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel, viewTagUnion } = createRequire(__filename)(viewPath);
+
+const now = 1_781_000_000;
+const sess = (id: string, name: string, color: string) => ({
+  id, name, color, state: "working", live: true, model: "Opus", effort: "high",
+  context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+});
+// three local tags + one REMOTE-homed one (read-only union entry) — the drag must position it too
+const VIEWS = {
+  active: "all",
+  tags: [
+    { id: "g1", name: "alpha", color: "#DD42FF", members: ["s1"] },
+    { id: "g2", name: "beta", color: "#4EC9B0", members: ["s2"] },
+    { id: "g3", name: "gamma", color: "#e0af68", members: [] },
+  ],
+  remoteTags: [{ id: "TESTHOST-A:r1", host: "TESTHOST-A", name: "remotepool", color: "#7aa2f7", members: ["m1"] }],
+  actives: { timeline: { all: true } },
+};
+
+function drawnPanel(): any {
+  const panel = new TimelinePanel(makeNode("div"));
+  panel.update({
+    now, sessions: [sess("s1", "web", "#f7768e"), sess("s2", "api", "#7aa2f7")],
+    turns: { s1: [{ id: "t1", start: now - 400, end: now - 100, prompt: "do the thing", tid: "f1", mids: [] }] },
+    messages: [], judging: [], views: JSON.parse(JSON.stringify(VIEWS)),
+  });
+  return panel;
+}
+
+test("executed: dragging a tag pill writes tagOrder + re-sorts the local array; a remote-homed tag holds its dragged spot", () => {
+  const posted: any[] = [];
+  g.__rompTimelineSetViews = (v: any) => posted.push(v);
+  g.__rompTimelineEditTag = () => {};   // marks remote tags editable-capable; the drag itself never routes an edit
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  const dlg = panel._viewsDialog;
+  assert.ok(dlg, "the dialog opened");
+  // the pill cells, in render order — the union's order: alpha, beta, gamma, remotepool
+  const cells: any[] = [];
+  (function walk(x: any) { for (const c of x.children || []) { if (c._tname) cells.push(c); walk(c); } })(dlg);
+  assert.deepEqual(cells.map((c) => c._tname), ["alpha", "beta", "gamma", "remotepool"], "table renders the union order");
+  // seat each cell at a distinct y so the drop math has real geometry
+  cells.forEach((c, i) => { c._rect = { top: i * 30, bottom: i * 30 + 28, left: 0, right: 200, width: 200, height: 28 }; });
+  // grab REMOTEPOOL (index 3) and drop it between alpha and beta (index 1)
+  const grab = cells[3];
+  grab._listeners.pointerdown({ preventDefault() {}, pointerId: 7 });
+  grab._listeners.pointermove({ clientY: 31 });   // over beta's slot
+  assert.equal(cells[1].style.borderTop, "2px solid #9cd2ff", "the accent insertion cue rides the target, no rebuild mid-drag");
+  grab._listeners.pointerup({});
+  assert.equal(posted.length, 1, "the drop posts ONE views write");
+  const blob = posted[0];
+  assert.deepEqual(blob.tagOrder, ["alpha", "remotepool", "beta", "gamma"],
+    "tagOrder carries the union display order — the remote-homed name holds its dragged spot, no cross-kernel write");
+  assert.deepEqual(blob.tags.map((t: any) => t.name), ["alpha", "beta", "gamma"],
+    "the local array re-sorts to the same order (remote names simply aren't in it)");
+  // RELOAD: a rebuild from the posted blob renders the dragged order — the order survives
+  const reloaded = JSON.parse(JSON.stringify(blob));
+  reloaded.remoteTags = VIEWS.remoteTags;   // the kernel re-joins remoteTags on every push
+  assert.deepEqual(viewTagUnion(reloaded).map((u: any) => u.name), ["alpha", "remotepool", "beta", "gamma"],
+    "the union renders the persisted order after reload");
+  delete g.__rompTimelineSetViews;
+  delete g.__rompTimelineEditTag;
+});
+
+test("executed: the ordering rule, both mirrors — tagOrder governs, unlisted names follow naturally", () => {
+  const v = JSON.parse(JSON.stringify(VIEWS));
+  v.tagOrder = ["remotepool", "gamma"];
+  assert.deepEqual(viewTagUnion(v).map((u: any) => u.name), ["remotepool", "gamma", "alpha", "beta"],
+    "listed names lead in order; unlisted keep natural order after (stable sort)");
+});

--- a/ui/timeline-tagorder-drag.test.ts
+++ b/ui/timeline-tagorder-drag.test.ts
@@ -123,4 +123,13 @@ test("executed: the ordering rule, both mirrors — tagOrder governs, unlisted n
   v.tagOrder = ["remotepool", "gamma"];
   assert.deepEqual(viewTagUnion(v).map((u: any) => u.name), ["remotepool", "gamma", "alpha", "beta"],
     "listed names lead in order; unlisted keep natural order after (stable sort)");
+  // a user-typed name CAN be a prototype key — the lookup must be null-prototype (found in
+  // adversarial review 2026-08-25: `"constructor" in {}` is true via the chain, so a tag named
+  // constructor read as always-listed/always-picked through a plain object)
+  const proto = { active: "all", tags: [
+    { id: "p1", name: "constructor", color: "#DD42FF", members: [] },
+    { id: "p2", name: "zed", color: "#4EC9B0", members: [] },
+  ], tagOrder: ["zed"] };
+  assert.deepEqual(viewTagUnion(proto).map((u: any) => u.name), ["zed", "constructor"],
+    "a prototype-key name sorts as UNLISTED (after the ordered), never as index-of-Function");
 });

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -97,8 +97,12 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
   // a SENTINEL view's chip dims to the corner line's own gray at the N-more opacity (the user
   // 2026-08-24: at #cccccc it read bright as a tag) — real tag chips keep their tag colors, full strength
   // per-selection chips since 2026-08-25: each pick derives its own colour (no-tags in the gray)
-  assert.match(SRC, /return \{ label: n, color: \(u && u\.color\) \|\| MODEL_FG, pick: \{ tag: n \} \};/);
-  assert.match(SRC, /\.concat\(lens\.none \? \[\{ label: 'no tags', color: MODEL_FG, pick: 'none' \}\] : \[\]\)/);
+  // ORDER (the user 2026-08-25): "no tags" leftmost, then the tags in the USER'S order — the
+  // chips walk the ordered unions instead of the raw selection (superseding the none-last form)
+  assert.match(SRC, /if \(lens\.none\) chips\.push\(\{ label: 'no tags', color: MODEL_FG, pick: 'none' \}\);/,
+    "no-tags sits leftmost in the corner's selection render");
+  assert.match(SRC, /if \(lens\.none\) chips\.push[\s\S]{0,400}for \(const u of unions\) \{/,
+    "…and the tag chips follow by walking the ORDERED unions");
   assert.match(SRC, /x\.textContent = '\\u2715';/);
   assert.match(SRC, /\.romp-tl-chipx\{cursor:pointer;opacity:0\.75;/, "the ✕ dim and separate");
   assert.match(SRC, /remove \\u201c' \+ c\.label \+ '\\u201d from this timeline/,

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -10,7 +10,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { viewVisible, viewsKey, revealIn } from "../../ui/webview/session-views";
+import { viewVisible, viewsKey, revealIn, viewTagUnion } from "../../ui/webview/session-views";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
@@ -147,3 +147,22 @@ test("executed: untagged excludes by the UNION — a remote-homed tag counts (th
   assert.equal(viewVisible(v, "other"), true);
 });
 
+
+test("executed: the union renders in the USER'S order — tagOrder governs, remote-homed names hold position (the user 2026-08-25)", () => {
+  const v = {
+    active: "all",
+    tags: [
+      { id: "g1", name: "alpha", color: "#DD42FF", members: [] },
+      { id: "g2", name: "beta", color: "#4EC9B0", members: [] },
+    ],
+    remoteTags: [{ id: "TESTHOST-A:r1", host: "TESTHOST-A", name: "remotepool", color: "#7aa2f7", members: [] }],
+  };
+  assert.deepEqual(viewTagUnion(v).map((u) => u.name), ["alpha", "beta", "remotepool"],
+    "no order yet → natural (array, then remotes) order");
+  assert.deepEqual(viewTagUnion({ ...v, tagOrder: ["remotepool", "alpha"] }).map((u) => u.name),
+    ["remotepool", "alpha", "beta"],
+    "the dragged order governs — the remote-homed name holds its position, viewer-side; unlisted names follow naturally");
+  // the echo key carries the order, so an optimistic drag clears on the kernel's echo and never flaps
+  assert.notEqual(viewsKey({ ...v, tagOrder: ["remotepool", "alpha"] }), viewsKey(v),
+    "tagOrder is part of the canonical echo compare");
+});

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -165,4 +165,8 @@ test("executed: the union renders in the USER'S order — tagOrder governs, remo
   // the echo key carries the order, so an optimistic drag clears on the kernel's echo and never flaps
   assert.notEqual(viewsKey({ ...v, tagOrder: ["remotepool", "alpha"] }), viewsKey(v),
     "tagOrder is part of the canonical echo compare");
+  // a user-typed name CAN be a prototype key (adversarial review 2026-08-25): the name-keyed
+  // builder crashed on {}["constructor"] resolving to Function — null-prototype lookups now
+  assert.deepEqual(viewTagUnion({ tags: [{ id: "p1", name: "constructor", members: [] }], tagOrder: ["constructor"] })
+    .map((u) => u.name), ["constructor"], "a prototype-key tag name builds and orders cleanly");
 });

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -21,6 +21,10 @@ export interface SessionViews {
   /** per-surface multi-select lenses (the user 2026-08-25) — the shared TagLens shape; the legacy
    *  scalar `active` stays for old clients and seeds these on migration (kernel-normalized) */
   actives?: { [surface: string]: { all?: boolean; none?: boolean; tags?: string[] } };
+  /** the union DISPLAY order (the user 2026-08-25): tag NAMES in the user's dragged order,
+   *  viewer-side so remote-homed names hold position without cross-kernel writes; locals also
+   *  keep array order (the drag rewrites both). Unlisted names follow, in natural order. */
+  tagOrder?: string[];
 }
 // One union group = one tag NAME across every kernel defining it (user ruling 2026-08-24: kernels
 // are plumbing — no host prefixes in any tag presentation). The typed mirror of the timeline's
@@ -46,7 +50,19 @@ export function viewTagUnion(views: SessionViews | null | undefined): TagUnion[]
     for (const m of (rt.members || [])) if (!g.members.includes(m)) g.members.push(m);
     if (!out.includes(g)) out.push(g);
   }
-  return out;
+  return orderUnions(out, views);
+}
+
+/** THE ordering rule, stated once (the user 2026-08-25): unions render in the user's dragged
+ *  order (views.tagOrder, name-keyed — remote-homed names hold position too); names not yet
+ *  ordered follow in their natural (array/arrival) order — sort() is stable, so a new tag lands
+ *  at the end without disturbing anything. Every chip list, menu row list, and dialog row list
+ *  renders through viewTagUnion, so the order flows everywhere from here. */
+function orderUnions(out: TagUnion[], views: SessionViews | null | undefined): TagUnion[] {
+  const ord = views?.tagOrder || [];
+  if (!ord.length) return out;
+  const ix = new Map(ord.map((n, i) => [n, i]));
+  return out.sort((a, b) => (ix.has(a.name) ? ix.get(a.name)! : ord.length) - (ix.has(b.name) ? ix.get(b.name)! : ord.length));
 }
 
 // the one place the legacy key is honored, so every rule below reads through it
@@ -78,6 +94,7 @@ export function viewsKey(v: SessionViews | null | undefined): string {
   if (!v) return "";
   return JSON.stringify({ active: v.active || "all",
     actives: v.actives || {},   // per-surface lenses are client-posted state — the echo compares them (2026-08-25)
+    order: v.tagOrder || [],    // the dragged union order is client-posted state too (2026-08-25)
     tags: viewTags(v).map((t) => ({ id: t.id, name: t.name, color: t.color,
                                     members: (t.members || []).slice().sort() })) });
 }

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -32,7 +32,10 @@ export interface SessionViews {
 // The chat's tab-menu Tags section reads and edits through this exact shape.
 export interface TagUnion { name: string; color: string; members: string[]; ids: string[]; localId: string | null; remotes: SessionTag[] }
 export function viewTagUnion(views: SessionViews | null | undefined): TagUnion[] {
-  const out: TagUnion[] = [], byName: Record<string, TagUnion> = {};
+  // byName is null-prototype: a user-typed tag NAME can be "constructor"/"toString", which a
+  // plain {} resolves through the prototype chain (the lookup returned a Function and the
+  // builder crashed on it — adversarial review 2026-08-25)
+  const out: TagUnion[] = [], byName: Record<string, TagUnion> = Object.create(null);
   for (const t of viewTags(views)) {
     const key = t.name || "tag";
     const g = byName[key] || (byName[key] = { name: key, color: "", members: [], ids: [], localId: null, remotes: [] });

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -23,14 +23,20 @@ const UNIONS = [
   { name: "workers", color: "#4EC9B0", members: [] },
 ];
 
-test("executed: lensChips — All bare; narrowed = every selection incl. the no-tags chip", () => {
+test("executed: lensChips — All bare; no-tags LEFTMOST; tags follow in the unions' (user) order", () => {
   assert.deepEqual(lensChips({ all: true }, UNIONS as never), [], "All → the button stands alone");
   assert.deepEqual(lensChips({ tags: ["infra"] }, UNIONS as never),
     [{ label: "infra", color: "#DD42FF", pick: { tag: "infra" } }]);
   assert.deepEqual(lensChips({ none: true, tags: ["workers"] }, UNIONS as never),
-    [{ label: "workers", color: "#4EC9B0", pick: { tag: "workers" } },
-     { label: "no tags", color: null, pick: "none" }],
-    "the no-tags bucket is its own chip, last");
+    [{ label: "no tags", color: null, pick: "none" },
+     { label: "workers", color: "#4EC9B0", pick: { tag: "workers" } }],
+    "no-tags sits LEFTMOST in every selection render (the user 2026-08-25, superseding the none-last form)");
+  // the tags render in the UNIONS' order (the user's dragged order), not the selection's insertion order
+  assert.deepEqual(lensChips({ tags: ["workers", "infra"] }, UNIONS as never).map((c) => c.label),
+    ["infra", "workers"], "selection insertion order yields to the user's tag order");
+  // a stale selected name (no union) still shows, dressless, after the ordered ones
+  assert.deepEqual(lensChips({ tags: ["ghost", "infra"] }, UNIONS as never).map((c) => c.label),
+    ["infra", "ghost"]);
 });
 
 test("cross-mount computed equality: one gray, one accent, everywhere", () => {

--- a/ui/webview/tag-lens.ts
+++ b/ui/webview/tag-lens.ts
@@ -83,11 +83,18 @@ export function surfaceLens(views: SessionViews | null | undefined, surface: str
 export function lensChips(l: TagLens | null | undefined, unions: TagUnion[]): { label: string; color: string | null; pick: "none" | { tag: string } }[] {
   if (lensAll(l)) return [];
   const out: { label: string; color: string | null; pick: "none" | { tag: string } }[] = [];
-  for (const name of (l!.tags || [])) {
-    const u = unions.find((x) => x.name === name);
-    out.push({ label: name, color: (u && u.color) || null, pick: { tag: name } });
-  }
+  // "no tags" sits LEFTMOST in every selection render, the tags following in the USER'S order —
+  // the unions arrive ordered (viewTagUnion's one ordering rule), so emitting selected names by
+  // walking the unions IS the order (the user 2026-08-25, superseding the chips-then-none-last
+  // form). A selected name missing from the unions (a stale lens) appends last, dressless.
   if (l!.none) out.push({ label: "no tags", color: null, pick: "none" });
+  const picked = new Set(l!.tags || []);
+  for (const u of unions) {
+    if (!picked.has(u.name)) continue;
+    picked.delete(u.name);
+    out.push({ label: u.name, color: u.color || null, pick: { tag: u.name } });
+  }
+  for (const name of (l!.tags || [])) if (picked.has(name)) out.push({ label: name, color: null, pick: { tag: name } });
   return out;
 }
 


### PR DESCRIPTION
Two user asks.

**Drag-to-reorder in the tag table.** Grab a pill to put the tags in your order — the membership drag's discipline (pointer capture, accent insertion cue that moves without rebuilding mid-drag, write on the drop). The order lives in `tagOrder`, a name list on the views blob, **viewer-side** — so a remote-homed tag holds its dragged position without any cross-kernel write (a display preference must not need another kernel up; the lane order's philosophy). The local tags array re-sorts to match on every drag, staying the natural store for local-only readers. The kernel normalizer passes `tagOrder` through clamped and deduped; pre-order blobs round-trip without the key; both echo keys carry it so an optimistic drag clears on the kernel's echo instead of flapping.

**The order flows everywhere, and "no tags" is always leftmost.** The ordering rule is stated once per mirror inside `viewTagUnion` (session-views.ts and the timeline's copy): every chip list, menu row list, and dialog row list renders through the union, so the user's order reaches the corner chips, the bar chips on all four surfaces, the tag menus, the gear menus, and the dialog's filter rows and tables from that one line. `lensChips` (and the corner's mirror) emit the no-tags chip first, then selected tags by walking the ordered unions — selection insertion order yields to the user's order; a stale selected name appends last, dressless.

**Adversarial-review finds.** (1) A user-typed tag name can be a prototype key ("constructor"): the name-keyed union builders crashed on it via the `{}` prototype chain (pre-existing, both mirrors, exposed by the new regression test), and the new lookups would have mis-read such names — every name-keyed lookup on the path is null-prototype now, with executed regressions. (2) `bin/romp-kernel` became a symlink to `kernel/kernel.py` in the restructure; the kernel edit landed through it and the second commit carries the real file.

**Tests.** Kernel round-trip (persist + client render + junk drops + absent-stays-absent); executed drag over the fake-DOM dialog (one posted write, `tagOrder` + re-sorted array, the remote-homed name in its dragged spot, the union re-rendering the order after reload); both mirrors' ordering executed; no-tags-leftmost expectations retargeted with the ruling cited; prototype-key regressions in both mirrors. Suites: vscode-extension 2432/2432 + new files green; pytest 5684 passed / 34 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)