### PR TITLE
A tracker's ending survives the recipient's card moving or dying: archive scan + dismissal report-back

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -11456,8 +11456,14 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
         now = int(time.time())
     n = 0
     for fsid, path, anchor, name in discover(now)[:sessions_cap]:
-        store = load_goals(fsid)
-        for nid, nd in list(store.get("nodes", {}).items()):
+        # live + ARCHIVE merged for the RECIPIENT-side scan (2026-08-26, the working-column audit):
+        # a recipient goal that completed and was then ARCHIVED (the user cleared the done card)
+        # vanished from the live-only scan, so the sender's tracker never checked off — a live
+        # specimen sat open seven hours with its completion event already fired and recorded.
+        # Read-only on this side: propagate writes SENDER stores only.
+        rnodes = dict(load_goal_archive(fsid).get("nodes") or {})
+        rnodes.update(load_goals(fsid).get("nodes") or {})
+        for nid, nd in list(rnodes.items()):
             if not nd.get("nodeComplete"):
                 continue                                # B hasn't finished it yet
             o = nd.get("origin")
@@ -11499,6 +11505,24 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     # re-derive from the stored toName exactly as the wait maps do: the alias when the peer has
     # spoken (it must have, to reply), else the raw relay key.
     last_any, _la, alias = _postal_ask_maps()
+    _rmemo = {}                                        # recipient sid -> merged nodes (per-pass, read-only)
+
+    def _ref_goal(peer_sid, mid):
+        """The recipient goal a tracker's msgId joins to (origin or links), live+archive merged."""
+        if peer_sid not in _rmemo:
+            m = dict(load_goal_archive(peer_sid).get("nodes") or {})
+            m.update(load_goals(peer_sid).get("nodes") or {})
+            _rmemo[peer_sid] = m
+        for rd in _rmemo[peer_sid].values():
+            if not isinstance(rd, dict):
+                continue
+            o = rd.get("origin")
+            refs = ([o] if isinstance(o, dict) else []) + [l for l in (rd.get("links") or [])
+                                                           if isinstance(l, dict)]
+            if any(r.get("msgId") == mid for r in refs):
+                return rd
+        return None
+
     for fsid, path, anchor, name in discover(now)[:sessions_cap]:
         store = load_goals(fsid)
         changed = False
@@ -11507,14 +11531,26 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
             if not (isinstance(h, dict) and h.get("peer") and not nd.get("nodeComplete")):
                 continue
             pk = str(h["peer"])
-            if ":" not in pk and not h.get("quiet"):   # a LOCAL linked recipient: the origin back-link owns it
-                continue
+            dismissed = False
+            if ":" not in pk and not h.get("quiet"):
+                # a LOCAL LINKED recipient: the origin back-link owns it — UNLESS the user DISMISSED
+                # the recipient's card without completion (2026-08-26, the working-column audit: two
+                # trackers sat open 8.3h and 2.6h under a Working hub because the cleared recipient
+                # goal could never reach nodeComplete). A dismissal kills the back-link's event
+                # forever, so the recipient's reply becomes the honest report-back ending — the
+                # exact quiet/cross-host rule, why-stamped as the dismissal shape it is. A LIVE
+                # linked recipient still defers to the back-link: a reply alone must never end a
+                # delegation whose card is still being worked.
+                rg = _ref_goal(pk, h.get("msgId"))
+                if not (isinstance(rg, dict) and rg.get("cleared") and not rg.get("nodeComplete")):
+                    continue
+                dismissed = True
             if ":" not in pk:
                 # a LOCAL QUIET handoff (chain-rooted minting, the user 2026-08-25): no recipient
                 # goal exists BY DESIGN, so the origin back-link can never fire — the recipient's
                 # reply (any kind, at/after the send) is the report-back event, exactly the
                 # cross-host rule. Same coarseness, same honesty: completing on the reply, never on
-                # delivery.
+                # delivery. (The dismissed-linked shape above ends the same way.)
                 reply = last_any.get((pk, fsid), 0)
             else:
                 keys = {"peer:" + pk}
@@ -11522,8 +11558,10 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                     keys.add(alias[pk])
                 reply = max((last_any.get((k, fsid), 0) for k in keys), default=0)
             if reply and reply >= (nd.get("t") or 0):
-                why = ("reported back by %s (delegated, quiet-filed)" % pk[:8] if ":" not in pk
-                       else "reported back by %s (delegated cross-host)" % pk)
+                why = (("reported back by %s (delegated; the recipient's card was dismissed)" % pk[:8])
+                       if dismissed else
+                       ("reported back by %s (delegated, quiet-filed)" % pk[:8] if ":" not in pk
+                        else "reported back by %s (delegated cross-host)" % pk))
                 if record_verdict(store, nd, "courier", "done", reply, why=why):
                     _mark_node_done(store, nid, why, reply, src="courier")
                     changed = True

--- a/tests/test_tracker_endings.py
+++ b/tests/test_tracker_endings.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Tracker endings, two gaps from the working-column audit (the user 2026-08-26: audit that all
+Working cards should be working — the non-real evidence isolated to sender-side delegation trackers
+whose ending event could no longer fire):
+(1) ARCHIVED-DONE RECIPIENT — run_propagate's back-link scanned recipient stores live-only, so a
+    recipient goal that completed and was then archived (the user cleared the done card) vanished
+    from the scan and the sender's tracker never checked off. The recipient-side scan now reads
+    live+archive merged (read-only on that side; propagate writes SENDER stores only).
+(2) CLEARED-UNDONE RECIPIENT — the user dismissed the recipient's card without completion, killing
+    the back-link's event forever; the reply sweep now covers a linked local tracker whose
+    ref-joined recipient goal is cleared-without-done — the recipient's reply at/after the send is
+    the report-back event (the exact quiet/cross-host rule), why-stamped as the dismissal shape it
+    is. A LIVE linked recipient still defers to the back-link: a reply alone never ends a
+    delegation whose card is still being worked. SYNTHETIC fixtures only; private synthetic sids."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_trkend", os.path.join(BIN, "romp-judge")).load_module()
+
+T = 1_787_300_000
+SENDER = "a21e0001-1111-4222-8333-000000000001"   # private synthetic sids — never the shared placeholder
+RECIP = "a21e0001-1111-4222-8333-000000000002"
+MID = "1787299000.000001_1.TESTHOST"
+
+
+def _node(nid, text, parent, t=T, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return base
+
+
+class World(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.discover
+        jd.discover = lambda now, window=None, forks=True: [
+            (SENDER, "/dev/null", None, "web"), (RECIP, "/dev/null", None, "api")]
+        self.td = tempfile.TemporaryDirectory()
+        self._msgs = jd.MESSAGES
+        jd.MESSAGES = Path(self.td.name) / "messages.jsonl"
+        jd.MESSAGES.write_text("")
+
+    def tearDown(self):
+        jd.discover = self._saved
+        jd.MESSAGES = self._msgs
+        for sid in (SENDER, RECIP):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+        self.td.cleanup()
+
+    def _sender_with_tracker(self):
+        st = {"rompUuid": SENDER, "seq": 2, "nodes":
+              {SENDER + ":g1": _node(SENDER + ":g1", "Ship the staged verification", None),
+               SENDER + ":t1": _node(SENDER + ":t1", "↪ delegated to api: verify refs", SENDER + ":g1",
+                                     handoff={"peer": RECIP, "msgId": MID})},
+              "placements": {}, "status": {}}
+        jd.save_goals(SENDER, st)
+
+    def _recipient(self, done, cleared, archive):
+        rn = _node(RECIP + ":g5", "Verify the staged refs", None,
+                   origin={"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID})
+        st = {"rompUuid": RECIP, "nodes": {RECIP + ":g5": rn}, "placements": {}, "status": {}}
+        if done:
+            jd.record_verdict(st, st["nodes"][RECIP + ":g5"], "closer", "done", T + 100,
+                              why="refs verified; drift zero")
+        if cleared:
+            st["nodes"][RECIP + ":g5"]["cleared"] = True
+        (jd.save_goal_archive if archive else jd.save_goals)(RECIP, st)
+        if archive:
+            jd.save_goals(RECIP, {"rompUuid": RECIP, "nodes": {}, "placements": {}, "status": {}})
+
+    def _reply(self, at):
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": at, "ev": "sent", "id": "r1", "from_id": RECIP, "to_id": SENDER,
+             "kind": "coordinate", "body": "verified; drift is zero"}) + "\n")
+
+    def _tracker(self):
+        return jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]
+
+
+class ArchivedDoneRecipient(World):
+    def test_the_back_link_reaches_an_archived_completion(self):
+        self._sender_with_tracker()
+        self._recipient(done=True, cleared=True, archive=True)
+        jd.run_propagate(now=T + 900)
+        nd = self._tracker()
+        self.assertTrue(nd.get("nodeComplete"),
+                        "the completion event FIRED — moving files must not erase it")
+        self.assertIn("refs verified", nd.get("doneWhy") or "",
+                      "the recipient's own resolution still travels")
+
+    def test_a_live_done_recipient_is_byte_identical(self):
+        self._sender_with_tracker()
+        self._recipient(done=True, cleared=False, archive=False)
+        jd.run_propagate(now=T + 900)
+        self.assertTrue(self._tracker().get("nodeComplete"))
+
+
+class DismissedRecipient(World):
+    def test_a_cleared_undone_recipient_ends_on_the_reply(self):
+        self._sender_with_tracker()
+        self._recipient(done=False, cleared=True, archive=False)
+        self._reply(T + 500)
+        jd.run_propagate(now=T + 900)
+        nd = self._tracker()
+        self.assertTrue(nd.get("nodeComplete"))
+        self.assertIn("dismissed", nd.get("doneWhy") or "",
+                      "the why says what happened — a dismissal-shaped ending, not a completion claim")
+
+    def test_no_reply_stays_open(self):
+        self._sender_with_tracker()
+        self._recipient(done=False, cleared=True, archive=False)
+        jd.run_propagate(now=T + 900)
+        self.assertFalse(self._tracker().get("nodeComplete"),
+                         "no report-back event yet — the standing wait machinery owns it")
+
+    def test_a_reply_before_the_send_does_not_count(self):
+        self._sender_with_tracker()
+        self._recipient(done=False, cleared=True, archive=False)
+        self._reply(T - 500)
+        jd.run_propagate(now=T + 900)
+        self.assertFalse(self._tracker().get("nodeComplete"))
+
+    def test_a_live_linked_recipient_never_ends_on_a_reply(self):
+        self._sender_with_tracker()
+        self._recipient(done=False, cleared=False, archive=False)
+        self._reply(T + 500)
+        jd.run_propagate(now=T + 900)
+        self.assertFalse(self._tracker().get("nodeComplete"),
+                         "the back-link owns a live linked delegation — a reply alone is not its end")
+
+    def test_an_archived_cleared_undone_recipient_also_ends_on_the_reply(self):
+        self._sender_with_tracker()
+        self._recipient(done=False, cleared=True, archive=True)
+        self._reply(T + 500)
+        jd.run_propagate(now=T + 900)
+        self.assertTrue(self._tracker().get("nodeComplete"),
+                        "the dismissal shape resolves through the archive too")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

From the working-column audit (2026-08-26): of nine live Working cards, seven were genuinely advancing and none were misfiled — the non-real evidence isolated to sender-side delegation trackers whose ending event could no longer fire. Two mechanical gaps in `run_propagate`, three live specimens (2.6–8.3h, in a `notes-api`-style manager→worker world):

**1. Archived-done recipient.** The back-link scanned recipient stores via `load_goals` — live nodes only — so a recipient goal that completed and was then ARCHIVED (the user cleared the done card) vanished from the scan, and the sender's tracker never checked off even though its completion event had fired and been recorded. The recipient-side scan now reads live+archive merged. Read-only on that side: propagate writes SENDER stores only, so the archive's no-rev-discipline caveat is untouched.

**2. Cleared-undone recipient.** The user DISMISSED the recipient's card without completion, killing the back-link's event forever — a linked local tracker then waited on nothing. The reply sweep now covers a linked local tracker whose ref-joined recipient goal (origin/links msgId join, live+archive) is cleared-without-done: the recipient's reply at/after the send is the report-back event — the exact rule quiet-filed and cross-host handoffs already use — why-stamped as the dismissal shape it is ("the recipient's card was dismissed"), never a completion claim. A LIVE linked recipient still defers to the back-link (a reply alone never ends a delegation whose card is still being worked); no reply → the tracker stays open and the standing wait machinery owns it.

The three live specimens retire through the fixed sweep's first pass — no hand-edits, per the standing rule.

## Tests

`tests/test_tracker_endings.py`: the archived completion reaches the tracker (carrying the recipient's own resolution), the live-done path byte-identical, the dismissal ending on a reply plus the archived-dismissed shape, no-reply and pre-send-reply stay open, and a live linked recipient never ends on a reply.

Suites: Python 5691 passed / 0 failed; UI 2432/2432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)