### PR TITLE
Spend rows attribute per session: bySid sub-maps with the keyed split (T100)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2513,7 +2513,7 @@ class SdkSession:
                     last = self._last_usage_totals.get(k, 0)
                     turn_u[k] = v - last if v >= last else v
                     self._last_usage_totals[k] = v
-                self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth)   # the rail's spend
+                self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth, sid=self.sid)   # the rail's spend
                 #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
                 #   honest on a mixed host (see _record_spend)
             self.retrying = False
@@ -3518,7 +3518,7 @@ class SdkBackend:
         self._log("usage refresh: %d live session(s), none with a loop to run it on — the rail bars "
                   "keep their last reading" % len(live), problem=True)
 
-    def _record_spend(self, cost, usage=None, keyed=False) -> None:
+    def _record_spend(self, cost, usage=None, keyed=False, sid=None) -> None:
         """Accumulate a turn's total_cost_usd AND its token counts into spend.json, keyed by LOCAL date —
         the rail's spend readout where the subscription bars sat, under API-key auth (the user
         2026-08-04; tokens added the same day, who wanted them beside the dollars). Recorded on every
@@ -3529,7 +3529,14 @@ class SdkBackend:
         rail's API readout must sum ONLY the key's turns — a login turn's computed cost there would be
         dollars nobody is billed (the user 2026-08-08). Token fields mirror the ResultMessage usage
         dict: input/output plus the two cache flavors, kept separately so the tooltip can break them
-        down. Pruned to the last 90 days; atomic."""
+        down. Pruned to the last 90 days; atomic.
+        PER-SESSION ATTRIBUTION (T100, the nightly optimizer's accepted ask 2026-08-24: key-billed
+        cost per session — 63%% of a day was untraceable): each bucket carries a `bySid` sub-map,
+        {sid: {usd, turns, tok, key:{usd,turns,tok}}} — SID-keyed (rename-proof; names flap), the
+        keyed split carried PER SID because that split is the point. Living inside the buckets, the
+        maps inherit the prune and the atomic write; rows without bySid stay readable (lossless
+        legacy, the T18 discipline). Inherited edge, unrecoverable here: a restart-killed turn
+        never emits its ResultMessage, so its cost is missing from every dimension alike."""
         if not isinstance(cost, (int, float)) or cost <= 0:
             return
         u = usage if isinstance(usage, dict) else {}
@@ -3556,12 +3563,26 @@ class SdkBackend:
                      "tokCacheR": int(e.get("tokCacheR") or 0) + _tok("cache_read_input_tokens"),
                      "tokCacheW": int(e.get("tokCacheW") or 0) + _tok("cache_creation_input_tokens")}
                 ke = e.get("key") if isinstance(e.get("key"), dict) else {}
+                tok_total = sum(_tok(k) for k in ("input_tokens", "output_tokens",
+                                                  "cache_read_input_tokens", "cache_creation_input_tokens"))
                 if keyed or ke:   # carry an existing key split forward even on a login turn
                     n["key"] = {"usd": round(float(ke.get("usd") or 0) + (float(cost) if keyed else 0), 6),
                                 "turns": int(ke.get("turns") or 0) + (1 if keyed else 0),
-                                "tok": int(ke.get("tok") or 0) + (sum(_tok(k) for k in (
-                                    "input_tokens", "output_tokens", "cache_read_input_tokens",
-                                    "cache_creation_input_tokens")) if keyed else 0)}
+                                "tok": int(ke.get("tok") or 0) + (tok_total if keyed else 0)}
+                by = e.get("bySid") if isinstance(e.get("bySid"), dict) else {}
+                if sid:
+                    se = by.get(sid) if isinstance(by.get(sid), dict) else {}
+                    sn = {"usd": round(float(se.get("usd") or 0) + float(cost), 6),
+                          "turns": int(se.get("turns") or 0) + 1,
+                          "tok": int(se.get("tok") or 0) + tok_total}
+                    ske = se.get("key") if isinstance(se.get("key"), dict) else {}
+                    if keyed or ske:   # the keyed split rides each sid too — carried forward on login turns
+                        sn["key"] = {"usd": round(float(ske.get("usd") or 0) + (float(cost) if keyed else 0), 6),
+                                     "turns": int(ske.get("turns") or 0) + (1 if keyed else 0),
+                                     "tok": int(ske.get("tok") or 0) + (tok_total if keyed else 0)}
+                    by[sid] = sn
+                if by:   # a sid-less fold (a non-rail caller) must not drop the attribution already there
+                    n["bySid"] = by
                 buckets[key] = n
                 for k in sorted(buckets)[:-keep]:
                     buckets.pop(k, None)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1885,12 +1885,69 @@ class SpendRecord(unittest.TestCase):
         self.assertLessEqual(len(kept), 90)
         self.assertIn(self._today(), kept)
 
+    def test_by_sid_attribution_with_keyed_split(self):
+        # T100 (the nightly optimizer's accepted ask): key-billed cost PER SESSION. Two sids, one
+        # keyed and one login — the bucket totals stay whole, and each sid carries its own keyed
+        # dimension. Private synthetic sids (the goal-store fixture rule).
+        self.be._record_spend(0.02, {"input_tokens": 100, "output_tokens": 40}, keyed=True,
+                              sid="aaaa1111-spend-attr-1")
+        self.be._record_spend(0.03, {"input_tokens": 10, "output_tokens": 5}, keyed=False,
+                              sid="aaaa1111-spend-attr-2")
+        self.be._record_spend(0.05, {"input_tokens": 1, "output_tokens": 1}, keyed=True,
+                              sid="aaaa1111-spend-attr-1")
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertAlmostEqual(d["usd"], 0.10)
+        by = d["bySid"]
+        s1, s2 = by["aaaa1111-spend-attr-1"], by["aaaa1111-spend-attr-2"]
+        self.assertAlmostEqual(s1["usd"], 0.07)
+        self.assertEqual((s1["turns"], s1["tok"]), (2, 142))
+        self.assertAlmostEqual(s1["key"]["usd"], 0.07, msg="the keyed split rides the sid — the optimizer's dimension")
+        self.assertEqual((s1["key"]["turns"], s1["key"]["tok"]), (2, 142))
+        self.assertAlmostEqual(s2["usd"], 0.03)
+        self.assertNotIn("key", s2, "a login-only sid carries no keyed split — its cost is dollars nobody is billed")
+        h = json.loads(self.p.read_text())["hours"][time.strftime("%Y-%m-%dT%H")]
+        self.assertAlmostEqual(h["bySid"]["aaaa1111-spend-attr-1"]["usd"], 0.07, msg="the hour buckets attribute too")
+
+    def test_legacy_rows_and_sidless_folds_stay_lossless(self):
+        # a pre-T100 bucket (no bySid) folds cleanly, and a sid-less fold never drops attribution
+        # already there (lossless legacy, the T18 discipline)
+        self.p.write_text(json.dumps({"days": {self._today(): {"usd": 1.0, "turns": 3}}}))
+        self.be._record_spend(0.02, keyed=True, sid="aaaa1111-spend-attr-3")
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertAlmostEqual(d["usd"], 1.02)
+        self.assertAlmostEqual(d["bySid"]["aaaa1111-spend-attr-3"]["usd"], 0.02,
+                               msg="attribution begins mid-history without touching the legacy totals")
+        self.be._record_spend(0.01)   # a sid-less caller
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertAlmostEqual(d["usd"], 1.03)
+        self.assertAlmostEqual(d["bySid"]["aaaa1111-spend-attr-3"]["usd"], 0.02,
+                               msg="the sid-less fold carried the existing bySid forward")
+
+    def test_by_sid_prunes_with_its_bucket(self):
+        # the maps live INSIDE the buckets, so the 90d prune takes them with it — no second ledger
+        # to sweep and no orphaned attribution
+        days = {"2020-04-%02d" % (i % 30 + 1): {"usd": 1, "turns": 1,
+                                                "bySid": {"aaaa1111-spend-attr-4": {"usd": 1, "turns": 1, "tok": 0}}}
+                for i in range(30)}
+        days.update({"2020-%02d-01" % (m + 1): {"usd": 1, "turns": 1} for m in range(12)})
+        days.update({"2021-%02d-01" % (m + 1): {"usd": 1, "turns": 1} for m in range(12)})
+        days.update({"2022-%02d-%02d" % (m + 1, d + 1): {"usd": 1, "turns": 1}
+                     for m in range(12) for d in range(4)})
+        self.assertGreater(len(days), 90, "the fixture really overflows the window")
+        self.p.write_text(json.dumps({"days": days}))
+        self.be._record_spend(0.01, sid="aaaa1111-spend-attr-5")
+        kept = json.loads(self.p.read_text())["days"]
+        self.assertLessEqual(len(kept), 90)
+        self.assertIn(self._today(), kept)
+        self.assertNotIn("2020-04-01", kept, "the oldest bucket left — and its bySid map with it, atomically")
+        self.assertIn("bySid", kept[self._today()])
+
     def test_result_message_records_and_the_kernel_serves_it(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth)", src,
+        self.assertIn("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth, sid=self.sid)", src,
                       "the settle folds THIS turn's DELTAS — cost AND tokens are cumulative per process — "
-                      "tagged with the session's own auth so the API sum stays honest on a mixed host")
+                      "tagged with the session's own auth AND its sid (T100: per-session attribution)")
         self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero",
                       src, "each connect resets the watermark with its new process")
         self.assertIn("self._last_usage_totals = {}  # …and its cumulative token counters", src,

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -47,7 +47,8 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   // the accumulator: cumulative-per-process DELTAS, and each bucket splits out the key's own turns
   assert.ok(BACKEND.includes("delta = total - self._last_cost_total if total >= self._last_cost_total else total"));
   assert.ok(BACKEND.includes("turn_u[k] = v - last if v >= last else v"));
-  assert.ok(BACKEND.includes("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth)"));
+  assert.ok(BACKEND.includes("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth, sid=self.sid)"),
+    "the settle threads the session sid — per-session attribution (T100)");
   assert.ok(BACKEND.includes("if keyed or ke:   # carry an existing key split forward even on a login turn"));
   assert.ok(BACKEND.includes("_fold(days, day, 90)"));
   assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");


### PR DESCRIPTION
The nightly optimizer's accepted ask: key-billed cost per session — 63% of a day was untraceable.

**Shape.** Each day/hour bucket in spend.json carries a `bySid` sub-map, `{sid: {usd, turns, tok, key:{usd,turns,tok}}}`. SID-keyed (rename-proof; names stay out entirely). The keyed split rides each sid — the point of the ask: with per-session auth a host holds both kinds at once, and the optimizer needs the key-billed dimension per session. A login-only sid carries no `key` sub-map (its computed cost is dollars nobody is billed), carried forward once present.

**Home: bucket sub-map, not a parallel file.** Inside the buckets the maps inherit the 90d/192h prune and the atomic tmp+replace — one file, no second ledger to sweep, no orphaned attribution, and the optimizer keeps reading the same place.

**Lossless legacy.** Pre-T100 rows fold cleanly without `bySid`; a sid-less fold carries existing attribution forward untouched.

**Wiring.** The rail's settle threads `sid=self.sid` into the fold — the call site already knew its session; no re-architecture.

**Inherited edge, stated not fixed.** A restart-killed turn never emits its ResultMessage, so its cost is missing from every dimension alike (the T16 finding); attribution cannot recover those turns.

**Tests.** Two-sid keyed/login attribution across day and hour buckets; legacy rows and sid-less folds lossless; a prune fixture that actually overflows the 90-day window and takes the `bySid` maps with their buckets; the call-site pins (python and the rail-spend TS mirror) retargeted to the sid-threaded form. Hermetic XDG_STATE_HOME, private synthetic sids.

Suites: pytest 5701 passed / 34 skipped; vscode-extension 2432/2432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)