### PR TITLE
One explicit gear Billing pick makes ROMP_EXPECTED_AUTH inert (Q3)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -176,7 +176,10 @@ every init, permanently. Declaring the intent fixes it: set
 on the declared side is quiet while one landing on the other side is flagged,
 naming the declaration. The check inverts rather than disappearing; unset (or
 any other value), it compares against what the session was launched with, as
-before.
+before. One explicit gear **Billing** pick supersedes the declaration from then
+on: the remembered pick becomes the box's expectation and the env var goes
+inert (it described the unpicked design), so re-seeded spawns are judged
+against your pick, never against stale doctrine.
 
 The usage rail reflects a mixed machine: the window bars (5 hours / 7 days /
 Fable 5) are drawn once, aggregated across every connected host's login as the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1228,6 +1228,28 @@ def _expected_auth() -> str:
     return v if v in ("key", "login") else ""
 
 
+def _declared_auth(state_dir) -> tuple:
+    """The EFFECTIVE box-wide auth expectation and where it came from: ("key"|"login"|"", "pick"|"env"|"").
+    One explicit gear Billing pick makes ROMP_EXPECTED_AUTH INERT (Q3, 2026-08-26): set_auth is the
+    ONLY writer of the remembered auth default, so that entry existing IS "the user has picked
+    billing by hand at least once" — from then on the remembered pick is the box's expectation and
+    the env declaration stops speaking (it described the box's unpicked design; once billing is
+    hand-managed it is stale doctrine, and its per-init alarms fought the user's own choice on
+    every re-seeded spawn). A SPAWN re-seeding reg.auth from the remembered default never counts
+    as explicit — inertness keys on the PICK EVENT's durable trace (the defaults entry), never on
+    any session's seeded state; hand-editing sdk-defaults.json stays the sanctioned escape hatch
+    (the mode precedent)."""
+    try:
+        d = read_sdk_defaults(Path(state_dir))
+    except Exception:
+        d = {}
+    a = d.get("auth")
+    if a in ("key", "login"):
+        return a, "pick"
+    v = _expected_auth()
+    return v, ("env" if v else "")
+
+
 # ---------------------------------------------------------------------------
 # Fast-mode permission for key-billed sessions — ask the account that PAYS.
 # ---------------------------------------------------------------------------
@@ -3506,7 +3528,7 @@ class SdkBackend:
                 self._usage_all_keyed = True
                 self._log("usage refresh: %d live session(s), all billing API keys — no session can "
                           "poll the subscription windows, so rate-limit telemetry is unavailable"
-                          % len(connected), problem=_expected_auth() != "key")
+                          % len(connected), problem=_declared_auth(self.state_dir)[0] != "key")
             return
         if any(s.auth_live == "login" for s in live):
             # Re-armed only by an init that CONFIRMED a login — a fresh spawn's default-False flag
@@ -3631,12 +3653,14 @@ class SdkBackend:
         # the box's UNPICKED design, while set_auth's contract is that the next init confirms the
         # PICK — judged (and worded) against what the pick launched, so a landing honoring the pick
         # stays quiet whatever the box declares, and one contradicting it still rings.
-        exp = "" if sess.auth in ("login", "key") else _expected_auth()
+        exp, exp_src = ("", "") if sess.auth in ("login", "key") else _declared_auth(self.state_dir)
         if keyed != ((exp == "key") if exp else sess._launched_keyed):
             if exp:
-                self._log("auth (%s): ROMP_EXPECTED_AUTH=%s but the CLI reports apiKeySource=%r — this "
+                what = ("ROMP_EXPECTED_AUTH=%s" % exp) if exp_src == "env" \
+                    else ("the remembered Billing pick is %s" % exp)
+                self._log("auth (%s): %s but the CLI reports apiKeySource=%r — this "
                           "session is billing the %s. Check the helper and service.env."
-                          % (sess.name, exp, source, "API key" if keyed else "login"), problem=True)
+                          % (sess.name, what, source, "API key" if keyed else "login"), problem=True)
             else:
                 self._log("auth (%s): launched for %s but the CLI reports apiKeySource=%r — this session "
                           "is billing the %s. Check the login (claude /login) and service.env."

--- a/tests/test_expected_auth.py
+++ b/tests/test_expected_auth.py
@@ -160,6 +160,65 @@ class AllKeyedUsageLineHonorsTheDeclaration(_Declared):
         self.assertTrue(self._usage_problems(), "undeclared all-keyed stays the surprising case")
 
 
+class GearPickMakesTheDeclarationInert(_Declared):
+    """Q3 (2026-08-26): ONE explicit gear Billing pick supersedes ROMP_EXPECTED_AUTH from then on —
+    the env var described the box's UNPICKED design, and once billing is hand-managed its per-init
+    alarms fought the user's own choice on every spawn re-seeded from the remembered default. The
+    pick's durable trace is the remembered auth default (set_auth is its only writer), so inertness
+    keys on the PICK EVENT — a spawn's seeded reg.auth never counts as explicit."""
+
+    def test_the_pick_supersedes_the_env_declaration(self):
+        os.environ["ROMP_EXPECTED_AUTH"] = "key"
+        sb.write_sdk_default(Path(self.d), auth="login")   # set_auth's durable trace — the gear pick
+        s = self._sess(11)
+        s._launched_keyed = True
+        self.be._note_auth_source(s, "none")               # a login landing: contradicts the ENV, honors the PICK
+        self.assertFalse([t for t in self._problem_texts() if "billing" in t],
+                         "the env declaration is INERT after the pick — no false alarm")
+        s2 = self._sess(12)
+        s2._launched_keyed = False
+        self.be._note_auth_source(s2, "apiKeyHelper")      # a keyed landing: contradicts the PICK
+        texts = self._problem_texts()
+        self.assertTrue(any("the remembered Billing pick is login" in t and "billing the API key" in t
+                            for t in texts),
+                        "a landing contradicting the pick rings, NAMING THE PICK not the env var: %r" % texts)
+        self.assertFalse(any("ROMP_EXPECTED_AUTH" in t for t in texts),
+                         "the env var no longer speaks anywhere once picked")
+
+    def test_a_seeded_spawn_never_makes_the_declaration_inert(self):
+        # the remembered default SEEDS reg.auth on a spawn — that seed must not count as explicit:
+        # with no pick trace in the defaults, the env declaration still governs
+        os.environ["ROMP_EXPECTED_AUTH"] = "key"
+        s = self._sess(13, auth="key")                     # a spawn re-seeded from some remembered default
+        s._launched_keyed = True
+        self.be._note_auth_source(s, "none")               # lands on login — contradicts its own seed
+        texts = self._problem_texts()
+        self.assertTrue(any("billing the login" in t for t in texts),
+                        "the seeded session is still judged (against its own pick side): %r" % texts)
+        self.assertFalse(any("remembered Billing pick" in t for t in texts),
+                         "…but nothing pretends a remembered default was an explicit box-wide pick")
+
+    def test_all_keyed_gate_follows_the_pick(self):
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        sb.write_sdk_default(Path(self.d), auth="key")     # the user picked key billing by hand
+        be2 = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        s = sb.SdkSession(be2, {"sid": "11111111-2222-3333-4444-%012d" % 14, "name": "s14", "cwd": "/tmp"})
+        s.connected = True
+        s.api_key_auth = True
+        be2.sessions[s.sid] = s
+        be2.refresh_usage()
+        probs = [p for p in be2.problems(20) if "telemetry is unavailable" in p["text"]]
+        self.assertFalse(probs, "all-keyed under a KEY pick is the design — an info line, not a problem "
+                                "(the env =login is inert)")
+
+    def test_the_real_set_auth_leaves_the_trace(self):
+        # end to end: the gear pick itself writes the durable trace _declared_auth keys on
+        sb.write_reg(Path(self.d), "11111111-2222-3333-4444-%012d" % 15,
+                     {"sid": "11111111-2222-3333-4444-%012d" % 15, "name": "s15", "cwd": "/tmp"})
+        self.assertTrue(self.be.set_auth("11111111-2222-3333-4444-%012d" % 15, "login"))
+        self.assertEqual(sb._declared_auth(Path(self.d)), ("login", "pick"))
+
+
 class PickOutranksTheDeclaration(_Declared):
     """An explicit per-session Billing pick (sess.auth) beats the box-wide declaration: the
     declaration describes the box's UNPICKED design, and set_auth's contract is that the next


### PR DESCRIPTION
The env declaration describes the box's unpicked design — but after the user hand-picks billing in the gear, every spawn re-seeded from the remembered default landed on the picked side and contradicted the declaration, ringing a per-init false alarm forever.

**Mechanism.** The remembered gear pick supersedes the declaration (`_declared_auth`): `set_auth` is the only writer of the remembered auth default, so that entry existing IS "the user has picked billing by hand at least once" — from then on the pick is the box's expectation and the env var stops speaking. Supersession (rather than mere muting) keeps the never-silent property at both call sites: a landing contradicting the pick still rings — naming the pick, not the env var — and the all-keyed refresh line is info under a key pick, a problem under a login pick.

**A remembered default never counts as explicit.** A spawn re-seeding `reg.auth` from the remembered default cannot flip the declaration inert — inertness keys on the pick event's durable trace (the defaults entry), never on any session's seeded state. Hand-editing sdk-defaults.json stays the sanctioned escape hatch (the mode precedent). The per-session rule is unchanged: an explicit per-session pick still outranks everything.

**Tests.** The pick supersedes the env at the mismatch check (quiet when honored; ringing and naming the pick when contradicted; the env var silent everywhere once picked); a seeded spawn never makes the declaration inert; the all-keyed gate follows the pick; the real `set_auth` leaves the trace end to end. Env-only behavior is pinned unchanged by the existing suite. Docs updated where the var is documented.

Suites: pytest 5705 passed / 34 skipped; vscode-extension 2432/2432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)