### PR TITLE
T101: the card unit is the dictated ask — dispatches link into it, containers retire

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -229,23 +229,30 @@ the distiller.
 
 ## Board shape: the grouper and the consolidator
 
-As cards accumulate, related tops nest under umbrellas so the board stays
-glanceable. Both judges move whole subtrees and append no diary events:
+Since 2026-08-26 (T101, the user's ruling) the board's unit is the
+INDIVIDUAL ASK: every top-level goal is its own card, tops never nest under
+other tops, and container ("umbrella") goals are retired — a store-level
+container is unavoidably a tracked unit (it owns rollup and, measured in the
+provenance audit, swallowed the chain evidence of every stranded ask), while
+the visual-grouping job belongs to the feed's display-side group fold, which
+has no store footprint. Both judges keep only the housekeeping that serves
+the ask-unit rule, move whole subtrees, and append no diary events:
 structure, never status.
 
-**grouper.** Given the open top-level cards: nest one under another, or
-mint an umbrella when several serve one outcome, and "doing nothing is a
-valid, common outcome". Called only when the open-top set actually changed.
-Hard rules in `apply_group`: never touch a view-cleared card, no cycles,
-depth clamp 4, same-session only. A to-do-mirror top (planted flat by
-plan-sync) is explicitly the grouper's to nest.
+**grouper.** Given the open top-level cards: merge true twins into one line,
+split a drifted tangent out to its own card, retitle a card its thread
+outgrew — and "doing nothing is a valid, common outcome". Called only when
+the open-top set actually changed. Hard rules in `apply_group`: never touch
+a view-cleared card, same-session only; the retired `mint`/`group` ops are
+parsed away and ignored if hand-built. A to-do-mirror top that duplicates a
+line already inside another card is explicitly the grouper's to merge.
 
-**consolidator.** The same prompt over the completed column: it groups
-related all-completed sibling tops under a done umbrella. It exists because
-the grouper only ever sees open tops, so related goals that finish before
-they get grouped would pile up flat in Completed forever, and an umbrella
-minted over already-done tops adopts nothing. Safe by construction: every child is done, so the umbrella rolls up
-completed. Gated by its own signature, logged under its own name.
+**consolidator.** The same prompt over the completed column, now merge/
+retitle housekeeping only. Legacy umbrellas from either judge DISSOLVE in
+every writer's rollup (the pre-pass beside the handoff-children lift):
+children re-parent to top level with their own provenance intact, the empty
+container leaves the store, and placements that pointed at it retire —
+idempotent, self-healing against save-rebase republishes.
 
 ## Peer mail: the courier
 
@@ -257,7 +264,14 @@ CHAIN-ROOTED (the user's verdict, replacing a one-day view-side split):
 delegating plants a real goal in the recipient's tree (origin-stamped) only
 when the sender's linked goal traces to a human prompt — self-then-ancestors
 in the sender's store, origin hops into a local grand-sender's chain, the
-root record read against the sender's own session. An untraceable delegate
+root record read against the sender's own session — AND no ask card already
+exists: since 2026-08-26 (T101) a dispatch whose chain roots to an ask the
+courier LINKED (the sender's ask node) never mints a recipient top — the
+tracking node plants under that ask, fan-out lives inside the ask card
+(several dispatches, one card; several asks to one worker, several cards),
+and the recipient files quietly with the reply-sweep ending. Only a rooted
+dispatch with no resolvable ask node still mints the recipient top: there
+the recipient card IS the ask's card. An untraceable delegate
 files quietly instead: no recipient top (its work lives in that session's
 view and transcript, and a needs-you state still surfaces through the
 goal-independent hard-block floor), while the sender's "delegated to"

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4046,6 +4046,36 @@ def rollup_status(store, session_closed, now=None):
         _hn = nodes[_hid]
         if isinstance(_hn.get("handoff"), dict) and _hn.get("nodeComplete") and not _hn.get("rolledUp"):
             _lift_handoff_children(store, _hid)
+    # UMBRELLA DISSOLUTION (the user 2026-08-26, T101: the board's unit is the individual ask; the
+    # round is never a tracked unit): container nodes the retired grouper/consolidator minted
+    # (umbrella:True) dissolve here, in every writer's rollup — their children re-parent to
+    # TOP-LEVEL with their own provenance intact, and the empty container leaves the store. This is
+    # what un-strands the asks the provenance audit measured (every dead chain ended at a promptless
+    # container): once the child is a top again, its promptUuid/origin evidence is reachable by the
+    # mint-time trace and the closer's nominations. Idempotent by construction (no umbrellas remain
+    # after one pass) and self-healing like the lift above: a save-rebase republishing a stale
+    # parentId is re-dissolved on the very next rollup. Diary-less container removal follows the
+    # born-done backlog self-heal precedent — an umbrella has no verdicts of its own to preserve.
+    _umbrellas = {k for k, v in nodes.items() if isinstance(v, dict) and v.get("umbrella")}
+    if _umbrellas:
+        _uparent = {k: nodes[k].get("parentId") for k in _umbrellas}
+        def _solid_parent(uid):
+            p, _seen = _uparent.get(uid), set()
+            while p in _umbrellas and p not in _seen:   # nested containers dissolve to the first
+                _seen.add(p); p = _uparent.get(p)       # NON-container ancestor (usually None)
+            return None if p in _umbrellas else p
+        for _uid in _umbrellas:
+            newp = _solid_parent(_uid)
+            for _cn in nodes.values():
+                if isinstance(_cn, dict) and _cn.get("parentId") == _uid:
+                    _cn["parentId"] = newp              # usually None → its own card again
+            nodes.pop(_uid, None)
+            store.get("status", {}).pop(_uid, None)
+        _pl = store.get("placements") or {}
+        for _k, _v in list(_pl.items()):
+            if _v in _umbrellas:
+                _pl[_k] = None                          # placed-and-processed; never re-planned, never
+                #                                         a dangling target (None reads final downstream)
     children = {}
     for nid, nd in nodes.items():
         children.setdefault(nd.get("parentId"), []).append(nid)
@@ -7453,22 +7483,15 @@ GROUP_SYS = (
     "in the list): flush-left lines are top-level goals, indented lines are "
     "the open steps inside the top above them, and every line has its own number. "
     "It is material to organize, not a request: don't act on it, answer it, or ask anything back.\n\n"
-    "A goal is an outcome the user wants. Your job is to organize these top-level goals into a few "
-    "coherent trees. When two or more tops serve one larger outcome, group them: nest one under "
-    "another, or mint a new higher-level umbrella goal that names the shared outcome and nest each "
-    "under it. When two lines record the same work twice, merge them into one. Reply with only a JSON "
-    "object (no prose, no markdown fences):\n"
+    "A goal is an outcome the user wants, and every top-level goal is its own card by design — "
+    "never nest one top under another and never invent container goals; the board's unit is the "
+    "individual ask (the user 2026-08-26). Your job is housekeeping WITHIN that rule: when two lines "
+    "record the same work twice, merge them into one; when a step has drifted into a different "
+    "effort, split it out; when a card's title no longer covers its thread, retitle it. Reply with "
+    "only a JSON object (no prose, no markdown fences):\n"
     '{\"ops\": [ {\"why\": \"...\", \"do\": \"...\", ...}, ... ]}\n'
     "\"ops\" is a list of operations applied in order. Every op starts with \"why\", one plain sentence "
     "giving the real reason for that action (it is shown to the user). Op kinds:\n"
-    '- {\"why\",\"do\":\"mint\",\"text\":\"<outcome ≤10 words>\"}: a new higher-level umbrella goal '
-    "naming a shared outcome, created to nest existing tops under.\n"
-    '- {\"why\",\"do\":\"group\",\"goal\":<n>,\"under\":<m>}: relink open top #n (its whole subtree '
-    "comes with it) to sit under top #m. Optionally add \"retitle\":\"<new text ≤10 words>\" to also "
-    "change #n's own title, e.g. when nesting it under #m reveals #n's current title no longer fits. Use "
-    "\"ref\":<k> instead of \"under\" to nest #n under an umbrella you minted earlier in this reply (k = "
-    "that mint's 1-based position among the ops). #n and #m must be **top-level** (flush-left) lines, "
-    f"never an indented step, and #n must differ from #m. Keep trees shallow: do not nest more than {MAX_DEPTH} levels deep.\n"
     '- {\"why\",\"do\":\"merge\",\"goal\":<n>,\"into\":<m>}: lines #n and #m record the **same** work '
     "twice — one restates or covers the other. Fold #n into #m: #m keeps its own title and state, "
     "absorbs #n's steps and history, and #n leaves the board. Either line may be a top or an indented "
@@ -7492,15 +7515,10 @@ GROUP_SYS = (
     "**receives** work too: after nesting tops under #m (or as a card quietly accretes steps), reread "
     "#m's title against everything now inside it — a title that names one narrow fix while the tree "
     "runs a whole campaign misleads, so retitle #m to the outcome that covers its steps.\n"
-    "Be aggressive about grouping a real shared purpose, since a few real trees beat a flat list of "
-    "every request, but never group on look-alike wording alone, and leave a standalone goal as its "
-    "own top. A top marked \"from the agent's own to-do list\" is a to-do mirror: it always starts "
-    "flat by design, and placing it is your job — when it records the same work as a line already "
-    "inside another top, merge it into that line; when it reads as its own distinct step of another "
-    "open top's outcome (wrap-up, verification, a task the agent queued for that work), group it under "
-    "that top. Reuse an existing umbrella rather than minting a duplicate. Doing nothing is a valid, "
-    "common outcome: if no clear cluster stands out, because the tops are already well-organized or "
-    'simply unrelated, return {\"ops\": []} and change nothing. Never invent a grouping just to act.\n'
+    "A top marked \"from the agent's own to-do list\" is a to-do mirror: when it records the same "
+    "work as a line already inside another top, merge it into that line; otherwise leave it as its "
+    "own card. Doing nothing is a valid, common outcome: if there are no twins, no drifted tangents, "
+    'and no outgrown titles, return {\"ops\": []} and change nothing. Never invent an op just to act.\n'
     "Write each \"why\" plainly: the real reason first, concrete verbs, the words a person actually "
     "says, cut filler (\"in order to\", \"it is worth noting\", \"notably\"), no em dashes, say it "
     "once. Output only the JSON object: nothing before it, and nothing after the closing brace. No "
@@ -7625,23 +7643,14 @@ def _parse_group(raw, menu_len):
         do = str(o.get("do", "")).strip().lower()
         why = " ".join(str(o.get("why", "")).split())[:300]
         text = " ".join(str(o.get("text", "")).split())[:120]
-        if do == "mint":
-            if re.sub(r"[^A-Za-z]", "", text):                          # an umbrella needs real text
-                ops.append({"do": "mint", "why": why, "text": text})
-        elif do == "group":
-            g, n, r = _int(o, "goal"), _int(o, "under"), _int(o, "ref")
-            retitle = " ".join(str(o.get("retitle", "")).split())[:120]
-            retitle = retitle if re.sub(r"[^A-Za-z]", "", retitle) else ""
-            if g and 1 <= g <= menu_len:                                # relink an open top under another node
-                if n and 1 <= n <= menu_len and n != g:
-                    op = {"do": "group", "why": why, "goal": g, "under": n}
-                elif r and r >= 1:
-                    op = {"do": "group", "why": why, "goal": g, "ref": r}
-                else:
-                    continue
-                if retitle:
-                    op["retitle"] = retitle
-                ops.append(op)
+        if do in ("mint", "group"):
+            # RETIRED (the user 2026-08-26, T101): the board's unit is the individual ask — no
+            # container goals, no nesting one top under another. A store-level umbrella is
+            # unavoidably a TRACKED unit (it owns rollup and swallowed chain provenance: every
+            # stranded ask in the provenance audit died at a promptless container), and the
+            # visual-grouping job has a display-side owner with no store footprint. A model that
+            # still emits these ops (an older cached reply) is silently ignored, never applied.
+            continue
         elif do == "merge":
             g, m = _int(o, "goal"), _int(o, "into")
             if g and m and 1 <= g <= menu_len and 1 <= m <= menu_len and g != m:
@@ -7681,26 +7690,12 @@ def _tie_pivot(store, ytop, cited, now):
     is untouched — the dismiss already restored it, so a done card stays done inside the umbrella while the
     pivot works beside it, and the umbrella's rollup carries the live story. Deterministic and idempotent;
     cleared cards never reach here (a follow-up to a cleared card is a fresh goal by rule)."""
-    nodes = store["nodes"]
-    if cited not in nodes or ytop not in nodes:
-        return
-    xtop = _top_ancestor(nodes, cited)
-    if xtop == ytop or xtop not in nodes:
-        return                                        # routed into the cited card's tree already
-    x, y = nodes[xtop], nodes[ytop]
-    if x.get("cleared") or y.get("parentId"):
-        return                                        # sealed thread, or Y already nested by routing
-    if x.get("umbrella"):
-        apply_group(store, [x, y], [{"do": "group", "goal": 2, "under": 1,
-                                     "why": "follow-up work stays with the card it replied to"}], now)
-    else:
-        apply_group(store, [x, y],
-                    [{"do": "mint", "text": x.get("text") or "Follow-up thread",
-                      "why": "follow-up work stays with the card it replied to"},
-                     {"do": "group", "goal": 1, "ref": 1,
-                      "why": "follow-up work stays with the card it replied to"},
-                     {"do": "group", "goal": 2, "ref": 1,
-                      "why": "follow-up work stays with the card it replied to"}], now)
+    # T101 (the user 2026-08-26): the STRUCTURAL tie retired with the umbrella — a container over
+    # the cited card and the pivot was exactly the round-shaped tracked unit the ruling removes,
+    # and the dissolution sweep would undo it on the next rollup anyway. The tie survives as pure
+    # PROVENANCE: ytop already carries pivotFrom (set by the caller before this), which display
+    # layers may group on with no store footprint. Nothing structural to do.
+    return
 
 
 def _merge_nodes(store, dupe_id, surv_id, t, why):
@@ -7806,30 +7801,12 @@ def apply_group(store, menu, ops, t):
     re-merged; the candidate forests still keep the columns apart (the working grouper sees only OPEN
     tops, the consolidator only ALL-COMPLETED ones)."""
     nodes = store["nodes"]
-    created = []
-
-    def new_umbrella(text, why):
-        store["seq"] = store.get("seq", 0) + 1
-        nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-        nodes[nid] = GuardedNode({"id": nid, "text": text or "(umbrella)", "parentId": None, "nodeComplete": False,
-                      "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "why": why,
-                      "umbrella": True, "log": []})
-        created.append(nid)
-        return nid
-
-    def _is_ancestor(a, b):                            # is node a AT or ABOVE node b? (cycle/self guard)
-        x, seen = b, set()
-        while x and x not in seen:
-            if x == a:
-                return True
-            seen.add(x); x = nodes.get(x, {}).get("parentId")
-        return False
 
     relinks = 0
     for o in ops:
-        if o["do"] == "mint":
-            new_umbrella(o["text"], o["why"])
-            continue
+        if o["do"] in ("mint", "group"):
+            continue                                   # retired ops (T101) — the parser drops them; this
+            #                                            is the second lock for hand-built op lists
         if o["do"] == "merge":                         # fold twin #goal into #into (_merge_nodes refuses
             relinks += _merge_nodes(store, menu[o["goal"] - 1]["id"],   # gone / double-mirror targets)
                                     menu[o["into"] - 1]["id"], t, o.get("why") or "")
@@ -7851,37 +7828,6 @@ def apply_group(store, menu, ops, t):
                 nodes[tgt]["mt"] = t
                 relinks += 1                           # counts as a change: the caller persists + re-rolls
             continue
-        # group: relink top #goal under #under (a menu top) or a same-reply umbrella (ref)
-        child = menu[o["goal"] - 1]["id"]
-        if child not in nodes or nodes[child].get("parentId") is not None:
-            continue                                   # merged away this reply, or an indented step —
-        #                                                grouping moves TOPS only; a placed step stays put
-        if "under" in o:
-            parent = menu[o["under"] - 1]["id"]
-            if parent in nodes:                        # a step parent walks up to its card (the intent —
-                parent = _top_ancestor(nodes, parent)  # "nest under that card" — is preserved)
-        else:
-            r = o.get("ref")
-            parent = created[r - 1] if (r and 1 <= r <= len(created)) else None
-        if not parent or parent not in nodes or parent == child or _is_ancestor(child, parent):
-            continue                                   # missing/merged parent / self / would cycle → skip
-        while _depth(nodes, parent) >= MAX_DEPTH:      # keep trees shallow; clamp the parent up
-            parent = nodes[parent]["parentId"]
-        nodes[child]["parentId"] = parent
-        if o.get("retitle"):                           # the user 2026-07-01: a relink may also correct the
-            nodes[child]["text"] = o["retitle"]         # child's own title, now that it sits under `parent`
-        nodes[child]["mt"] = t
-        relinks += 1
-
-    kids = {}                                          # umbrella anchor backfill (so it deep-links to its work)
-    for nd in nodes.values():
-        kids.setdefault(nd.get("parentId"), []).append(nd)
-    for uid in created:
-        ch = sorted(kids.get(uid, []), key=lambda c: c.get("t", 0))
-        anchor_seg = next((c["trail"][0] for c in ch if c.get("trail")), None)
-        if anchor_seg is not None:
-            nodes[uid]["trail"] = [anchor_seg]
-            nodes[uid]["t"] = ch[0].get("t", t)
     return relinks
 
 
@@ -11453,7 +11399,7 @@ def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
     seen = _seen if _seen is not None else set()
     nodes = dict(load_goal_archive(sender).get("nodes") or {})
     nodes.update(load_goals(sender).get("nodes") or {})
-    x = link_id
+    x, last = link_id, None
     while x is not None and (sender, x) not in seen:
         seen.add((sender, x))
         nd = nodes.get(x)
@@ -11467,7 +11413,32 @@ def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
         pu = nd.get("promptUuid")
         if pu and sender in paths and _session_user_prompt_record(sender, paths[sender], pu, now):
             return True
+        last = nd
         x = nd.get("parentId")
+    # CONTAINER-SIBLING RESCUE (the user 2026-08-26, T101): live umbrellas dissolve now, but
+    # ARCHIVED history keeps its containers — and the provenance audit measured that a chain
+    # dead-ending at a promptless container almost always has the dictated-round evidence sitting
+    # in the container's OTHER children (22 of 23 stranded asks). When the climb exhausts at an
+    # evidence-free container, one bounded look at its children recovers exactly that class —
+    # still a CONFIDENT rule (a sibling's human record IS the round's evidence), never a guess.
+    if last is not None and last.get("umbrella"):
+        cap = 0
+        for cid, cd in nodes.items():
+            if not isinstance(cd, dict) or cd.get("parentId") != last.get("id"):
+                continue
+            cap += 1
+            if cap > 40:
+                break
+            if (sender, cid) in seen:
+                continue
+            pu = cd.get("promptUuid")
+            if pu and sender in paths and _session_user_prompt_record(sender, paths[sender], pu, now):
+                return True
+            o = cd.get("origin")
+            if (isinstance(o, dict) and o.get("peer") and o.get("goalId")
+                    and not o.get("peerHost") and o["peer"] in paths
+                    and _delegate_user_rooted(o["peer"], o["goalId"], paths, now, _depth + 1, seen)):
+                return True
     return False
 
 
@@ -11813,24 +11784,34 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # state still reaches the board through the hard-block floor/placeholder, which need no
             # goal node. Uncertainty quiets by design (the trace's docstring names the surface).
             rooted = _delegate_user_rooted(sender, link_id, paths_map, now)
+            # THE ASK IS THE CARD UNIT (the user 2026-08-26, T101): a dispatch whose chain roots to
+            # an ask that ALREADY HAS A CARD — link_id resolved to the sender's ask node — LINKS
+            # instead of minting: the tracking node below plants under that ask (fan-out lives
+            # INSIDE the ask card, per-dispatch progress one click down), and the recipient gets NO
+            # standalone top (one ask fanned to three workers used to mint three near-duplicate
+            # cards). Only a rooted dispatch with NO resolvable ask node still mints the recipient
+            # top — there the recipient card IS the ask's card, the fallback that keeps every user
+            # ask carded somewhere. Linking alone never moves the ask card's column: planting a
+            # tracking child writes no verdict on the ask.
+            mint_recipient = rooted and not link_id
             # Mint the sender's precise '↪ delegated to <recipient>' tracking node (the user 2026-06-22) and
             # point B's goal at IT — so run_propagate checks off only the handed-off piece, never the sender's
             # broader linked goal. Saved to the sender's tree before planting G on the recipient's.
             track_id = _plant_handoff_track(sender_store, link_id, edit["text"], fsid, id2name.get(fsid), seg_t, mid,
-                                            tracked=trk and rooted)
-            if not rooted:
+                                            tracked=trk and mint_recipient)
+            if not mint_recipient:
                 h = sender_store["nodes"][track_id].get("handoff")
                 if isinstance(h, dict) and not h.get("quiet"):
                     # QUIET mark: no recipient goal will ever carry this msgId, so run_propagate's
                     # origin back-link can never end this tracker — the recipient's REPLY (any kind,
                     # at/after the send) is its report-back event instead, the same rule the
-                    # cross-host arm has always used. Also the breadcrumb for "where is the card?":
-                    # the delegation chose quiet filing because its chain roots in team-internal
-                    # work, not a user ask.
+                    # cross-host arm has always used. Both no-recipient-top shapes wear it: an
+                    # untraceable dispatch (team-internal chain) and, since T101, a LINKED dispatch
+                    # (the ask card carries the fan-out; the tracker under it is the unit that ends).
                     h["quiet"] = True
             rollup_status(sender_store, False)
             save_goals(sender, sender_store)
-            if not rooted:
+            if not mint_recipient:
                 store["placements"][seg_id] = "fyi"    # quiet: processed, no recipient top (the #d
                 #                                        delegation phase retires on this, exactly the
                 #                                        coordinate treatment)

--- a/tests/test_ask_unit_cards.py
+++ b/tests/test_ask_unit_cards.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""T101 (the user 2026-08-26): the board's unit is the individual ASK — the planner's decomposition
+of the dictated prompt, in the user's own phrasing, with a definite done. Rounds are never a
+tracked unit and dispatches never multiply an ask into near-duplicate cards:
+- a dispatch whose chain roots to an ask that ALREADY HAS A CARD (the courier's link resolved)
+  LINKS — the tracking node plants under the ask, fan-out lives INSIDE the ask card, the recipient
+  gets NO standalone top, and the tracker wears the quiet mark so the reply-sweep owns its ending;
+- one ask fanned to two workers = ONE card with two handoff children; two asks to one worker =
+  TWO cards; a rooted dispatch with NO resolvable ask still mints the recipient top (the fallback
+  that keeps every user ask carded somewhere), frame intact;
+- linking alone never moves the ask card's column (planting a tracking child writes no verdict);
+- the grouper/consolidator lose the umbrella-mint and group-relink ops (merge/split/retitle stay),
+  and legacy umbrellas DISSOLVE idempotently in every writer's rollup — children re-parent to top
+  level with their provenance intact, placements at the container retire.
+SYNTHETIC fixtures only; private synthetic sids; per-sid override journals cleaned in tearDown."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_askunit", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1_787_500_000
+T0 = NOW - 3600
+MGR = "a23f0001-1111-4222-8333-000000000001"   # private synthetic sids — never the shared placeholder
+WK1 = "a23f0001-1111-4222-8333-000000000002"
+WK2 = "a23f0001-1111-4222-8333-000000000003"
+MID1 = "1787499000.000001_1.TESTHOST"
+MID2 = "1787499000.000002_1.TESTHOST"
+BODY1 = ("DELEGATE: drag-range selection over run rows (user ask, dictated)\n"
+         "<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID1)
+BODY2 = ("DELEGATE: drag-range selection, the table half (user ask, dictated)\n"
+         "<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID2)
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _node(nid, text, parent, t=T0, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return base
+
+
+class CourierWorld(unittest.TestCase):
+    """run_courier end to end over a manager + two workers, the courier's link resolving to the
+    manager's ask node (menu #1)."""
+
+    def setUp(self):
+        self._rooted = jd._delegate_user_rooted
+        jd._delegate_user_rooted = lambda *a, **k: True   # rooting has its own suite; the LINK is under test
+        self.td = tempfile.TemporaryDirectory()
+        d = Path(self.td.name)
+        self.paths = {}
+        for sid, records in ((WK1, [uline(T0, BODY1, "m1", ps="sdk"), aline(T0 + 60, "On it.", "a1", "m1")]),
+                             (WK2, [uline(T0 + 5, BODY2, "m2", ps="sdk"), aline(T0 + 65, "On it.", "a2", "m2")]),
+                             (MGR, [uline(T0 - 600, "the drag-range round, dictated", "hu")])):
+            p = d / (sid + ".jsonl")
+            p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            self.paths[sid] = p
+        self._msgs = jd.MESSAGES
+        jd.MESSAGES = d / "messages.jsonl"
+        jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in [
+            {"t": T0, "ev": "sent", "id": MID1, "from": "web", "from_id": MGR,
+             "to_id": WK1, "kind": "delegate", "body": BODY1},
+            {"t": T0 + 5, "ev": "sent", "id": MID2, "from": "web", "from_id": MGR,
+             "to_id": WK2, "kind": "delegate", "body": BODY2}]) + "\n")
+        self._disc = jd.discover
+        fleet = [(WK1, str(self.paths[WK1]), None, "api"), (WK2, str(self.paths[WK2]), None, "tests"),
+                 (MGR, str(self.paths[MGR]), None, "web")]
+        jd.discover = lambda now, window=None, forks=True: fleet
+        self._llm = jd.courier_llm
+        jd.courier_llm = lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 1, "text": "drag-range selection"}'
+        jd._PARSE_CACHE.clear()
+
+    def tearDown(self):
+        jd._delegate_user_rooted = self._rooted
+        jd.MESSAGES = self._msgs
+        jd.discover = self._disc
+        jd.courier_llm = self._llm
+        for sid in (MGR, WK1, WK2):
+            for dd in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (dd / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+            try:
+                (jd.STATE / "overrides" / (sid + ".jsonl")).unlink()
+            except OSError:
+                pass
+        self.td.cleanup()
+
+    def _mgr(self, asks=1):
+        nodes = {MGR + ":g1": _node(MGR + ":g1", "Drag-range selection over run rows", None,
+                                    promptUuid="hu")}
+        if asks > 1:
+            nodes[MGR + ":g2"] = _node(MGR + ":g2", "Drag-range selection, the table half", None,
+                                       promptUuid="hu")
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 2, "nodes": nodes, "placements": {}, "status": {}})
+
+    def _trackers_under(self, ask):
+        m = jd.load_goals(MGR)
+        return [nd for nd in m["nodes"].values()
+                if isinstance(nd.get("handoff"), dict) and nd.get("parentId") == ask]
+
+    def test_one_ask_two_workers_is_one_card(self):
+        self._mgr()
+        jd.run_courier(now=NOW)
+        trackers = self._trackers_under(MGR + ":g1")
+        self.assertEqual(len(trackers), 2, "the fan-out lives INSIDE the ask card")
+        self.assertTrue(all(t["handoff"].get("quiet") for t in trackers),
+                        "no recipient goal will carry these msgIds — the reply-sweep owns the endings")
+        for wk in (WK1, WK2):
+            w = jd.load_goals(wk)
+            self.assertEqual([nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)], [],
+                             "no near-duplicate recipient top")
+            self.assertIn("fyi", set(w["placements"].values()), "the recipient files quietly")
+
+    def test_two_asks_one_worker_is_two_cards(self):
+        self._mgr(asks=2)
+        # both mails go to WK1; the courier links each mail to ITS ask, found by title in the
+        # menu text (menu numbering shifts as trackers plant — resolve like the model would)
+        def link_by_title(text, menu, declared=None):
+            want = "table half" if "table half" in text else "run rows"
+            for line in menu.splitlines():
+                if want in line and line.strip().startswith("#"):
+                    num = line.strip().split(".")[0].lstrip("#")
+                    return '{"verdict": "delegating", "goal": %s, "text": "drag-range"}' % num
+            for line in menu.splitlines():
+                if want in line:
+                    import re as _re
+                    m = _re.search(r"(\d+)", line)
+                    if m:
+                        return '{"verdict": "delegating", "goal": %s, "text": "drag-range"}' % m.group(1)
+            return '{"verdict": "delegating", "goal": 0, "text": "drag-range"}'
+        jd.courier_llm = link_by_title
+        self.paths[WK1].write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, BODY1, "m1", ps="sdk"), aline(T0 + 60, "On it.", "a1", "m1"),
+            uline(T0 + 120, BODY2, "m2", "a1", ps="sdk"), aline(T0 + 180, "And that.", "a2", "m2")]) + "\n")
+        self.paths[WK2].write_text(json.dumps(aline(T0, "idle.", "z1")) + "\n")   # WK2 out of this world
+        jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in [
+            {"t": T0, "ev": "sent", "id": MID1, "from": "web", "from_id": MGR,
+             "to_id": WK1, "kind": "delegate", "body": BODY1},
+            {"t": T0 + 120, "ev": "sent", "id": MID2, "from": "web", "from_id": MGR,
+             "to_id": WK1, "kind": "delegate", "body": BODY2}]) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd.run_courier(now=NOW)
+        self.assertEqual(len(self._trackers_under(MGR + ":g1")), 1)
+        self.assertEqual(len(self._trackers_under(MGR + ":g2")), 1,
+                         "several asks to one worker stay several cards")
+        w = jd.load_goals(WK1)
+        self.assertEqual([nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)], [])
+
+    def test_a_rooted_linkless_dispatch_still_mints_the_fallback_card(self):
+        self._mgr()
+        jd.courier_llm = lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 0, "text": "drag-range selection"}'
+        jd.run_courier(now=NOW)
+        w1 = jd.load_goals(WK1)
+        planted = [nd for nd in w1["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(len(planted), 1, "no ask node resolved → the recipient card IS the ask's card")
+        self.assertTrue(planted[0].get("frame"), "the fallback mint keeps the frame enrichment")
+
+    def test_linking_never_moves_the_ask_cards_column(self):
+        self._mgr()
+        st = jd.load_goals(MGR)
+        jd.rollup_status(st, False)
+        before = st["status"].get(MGR + ":g1")
+        jd.save_goals(MGR, st)
+        jd.run_courier(now=NOW)
+        st2 = jd.load_goals(MGR)
+        jd.rollup_status(st2, False)
+        self.assertEqual(st2["status"].get(MGR + ":g1"), before,
+                         "planting tracking children writes no verdict — the column stands")
+
+
+class GrouperRetirement(unittest.TestCase):
+    def test_mint_and_group_ops_parse_away(self):
+        raw = ('{"ops":[{"why":"w","do":"mint","text":"Umbrella"},'
+               '{"why":"w","do":"group","goal":1,"under":2},'
+               '{"why":"w","do":"retitle","goal":1,"text":"Better title"}]}')
+        ops = jd._parse_group(raw, 3)
+        self.assertEqual([o["do"] for o in ops], ["retitle"],
+                         "the retired ops never reach apply; housekeeping ops survive")
+
+    def test_apply_group_ignores_hand_built_retired_ops(self):
+        st = {"rompUuid": MGR, "seq": 2, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "Ask one", None),
+            MGR + ":g2": _node(MGR + ":g2", "Ask two", None)}, "placements": {}, "status": {}}
+        menu = [st["nodes"][MGR + ":g1"], st["nodes"][MGR + ":g2"]]
+        n = jd.apply_group(st, menu, [{"do": "mint", "why": "w", "text": "Umbrella"},
+                                      {"do": "group", "why": "w", "goal": 1, "under": 2}], T0)
+        self.assertEqual(n, 0)
+        self.assertEqual(len(st["nodes"]), 2, "no container minted")
+        self.assertIsNone(st["nodes"][MGR + ":g1"].get("parentId"), "no nesting applied")
+
+    def test_the_prompt_teaches_no_containers(self):
+        self.assertNotIn('\\"do\\":\\"mint\\"', jd.GROUP_SYS)
+        self.assertNotIn('\\"do\\":\\"group\\"', jd.GROUP_SYS)
+        self.assertIn("its own card by design", jd.GROUP_SYS)
+
+
+class UmbrellaDissolution(unittest.TestCase):
+    def tearDown(self):
+        for dd in (jd.GOALDIR, jd.GOALARCHDIR):
+            try:
+                (dd / (MGR + ".json")).unlink()
+            except OSError:
+                pass
+        try:
+            (jd.STATE / "overrides" / (MGR + ".jsonl")).unlink()
+        except OSError:
+            pass
+
+    def _legacy(self):
+        st = {"rompUuid": MGR, "seq": 5, "nodes": {
+            MGR + ":u1": _node(MGR + ":u1", "Improve the runs dashboard", None, umbrella=True),
+            MGR + ":u2": _node(MGR + ":u2", "Nested container", MGR + ":u1", umbrella=True),
+            MGR + ":a1": _node(MGR + ":a1", "Fix the color rows", MGR + ":u1", promptUuid="hu"),
+            MGR + ":a2": _node(MGR + ":a2", "Cap the scroll pane", MGR + ":u2", promptUuid="hu2"),
+            MGR + ":s1": _node(MGR + ":s1", "a step of a1", MGR + ":a1")},
+            "placements": {"segX": MGR + ":u1"}, "status": {}}
+        return st
+
+    def test_legacy_umbrellas_dissolve_idempotently(self):
+        st = self._legacy()
+        jd.rollup_status(st, False)
+        self.assertNotIn(MGR + ":u1", st["nodes"])
+        self.assertNotIn(MGR + ":u2", st["nodes"])
+        self.assertIsNone(st["nodes"][MGR + ":a1"].get("parentId"), "the ask is its own card again")
+        self.assertIsNone(st["nodes"][MGR + ":a2"].get("parentId"),
+                          "a nested container's child re-parents to the first NON-container ancestor")
+        self.assertEqual(st["nodes"][MGR + ":s1"].get("parentId"), MGR + ":a1",
+                         "real subtrees keep their shape — only containers dissolve")
+        self.assertIsNone(st["placements"].get("segX"),
+                          "a placement at the container retires processed, never dangles")
+        snap = json.dumps(st["nodes"], sort_keys=True, default=dict)
+        jd.rollup_status(st, False)
+        self.assertEqual(json.dumps(st["nodes"], sort_keys=True, default=dict), snap,
+                         "second pass is a no-op — idempotent")
+
+    def test_archived_container_sibling_rescue(self):
+        # archives keep their containers (dissolution is live-store only) — the TRACE recovers the
+        # stranded class there: a chain dead-ending at an archived umbrella looks once at the
+        # container's children for the round's evidence (the audit's 22/23 predicate, now in-walk)
+        saved = jd.parsed_session
+        jd.parsed_session = lambda sid, files, now: {"turns": [{"atoms": [
+            {"uuid": "hu", "type": "user", "author": "human",
+             "message": {"role": "user", "content": "the dictated round"}}]}]}
+        try:
+            jd.save_goal_archive(MGR, {"rompUuid": MGR, "nodes": {
+                "u1": _node("u1", "Round container", None, umbrella=True),
+                "ask": _node("ask", "Fix the color rows", "u1", promptUuid="hu"),
+                "trk": _node("trk", "tracking node", "u1")}, "placements": {}, "status": {}})
+            jd.save_goals(MGR, {"rompUuid": MGR, "nodes": {}, "placements": {}, "status": {}})
+            self.assertTrue(jd._delegate_user_rooted(MGR, "trk", {MGR: "/dev/null"}, NOW),
+                            "the dead-end container's sibling holds the round's human record")
+            # and WITHOUT a user-rooted sibling it stays quiet — the rescue is confident, not a guess
+            jd.save_goal_archive(MGR, {"rompUuid": MGR, "nodes": {
+                "u1": _node("u1", "Round container", None, umbrella=True),
+                "trk": _node("trk", "tracking node", "u1")}, "placements": {}, "status": {}})
+            self.assertFalse(jd._delegate_user_rooted(MGR, "trk", {MGR: "/dev/null"}, NOW))
+        finally:
+            jd.parsed_session = saved
+
+    def test_provenance_survives_dissolution(self):
+        st = self._legacy()
+        jd.rollup_status(st, False)
+        self.assertEqual(st["nodes"][MGR + ":a1"].get("promptUuid"), "hu",
+                         "the un-stranded ask carries its own evidence — the trace can reach it now")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chain_rooted_minting.py
+++ b/tests/test_chain_rooted_minting.py
@@ -234,21 +234,27 @@ class CourierMintMatrix(unittest.TestCase):
         jd.save_goals(MGR, st)
         self.mpath.write_text("\n".join(json.dumps(r) for r in records) + "\n")
 
-    def test_a_user_rooted_delegate_mints_exactly_as_before(self):
+    def test_a_user_rooted_linked_delegate_links_into_the_ask_card(self):
+        # T101 (the user 2026-08-26) supersedes the mint here: the courier's link resolved to the
+        # sender's ask node, so the ASK CARD carries the dispatch — the tracker plants under it
+        # (quiet: the reply-sweep owns its ending) and the recipient gets NO standalone top. The
+        # mint survives only for the LINKLESS rooted shape (tests/test_ask_unit_cards.py holds
+        # that fallback plus the fan-out matrix).
         self._mgr_store("hu", [uline(T0 - 600, "please verify the staged run references", "hu"),
                                aline(T0 - 540, "Dispatching.", "ha", "hu")])
         jd.run_courier(now=NOW)
         w = jd.load_goals(WKR)
-        planted = [nd for nd in w["nodes"].values()
-                   if isinstance(nd.get("origin"), dict) and nd["origin"].get("msgId") == MID]
-        self.assertEqual(len(planted), 1, "the ask flowing down still mints the recipient top")
-        self.assertIsNone(planted[0].get("parentId"))
+        self.assertEqual([nd for nd in w["nodes"].values()
+                          if isinstance(nd.get("origin"), dict)], [],
+                         "no recipient top — the ask card is the unit")
+        self.assertIn("fyi", set(w["placements"].values()))
         m = jd.load_goals(MGR)
         trackers = [nd for nd in m["nodes"].values()
                     if isinstance(nd.get("handoff"), dict) and nd["handoff"].get("msgId") == MID]
         self.assertEqual(len(trackers), 1, "the sender tracking node plants either way")
-        self.assertFalse(trackers[0]["handoff"].get("quiet"),
-                         "a linked recipient goal exists — the origin back-link owns completion")
+        self.assertEqual(trackers[0].get("parentId"), MGR + ":g1", "…under the ask it serves")
+        self.assertTrue(trackers[0]["handoff"].get("quiet"),
+                        "no recipient goal will carry this msgId — the reply-sweep owns the ending")
 
     def test_an_untraceable_delegate_files_quiet(self):
         # the sender's linked goal roots at a COORDINATE mail record — team-internal, not the user

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1425,10 +1425,10 @@ class PlanSubRef(unittest.TestCase):
 
 
 class Grouper(unittest.TestCase):
-    """The grouper judge (the user 2026-06-17): a separate pass after the planner that reshapes a
-    session's OPEN top goals into coherent trees — relinking one top under another, or minting a fresh
-    higher-level umbrella and nesting tops under it. Event-gated per session (groupedSig) so a stable
-    board is never re-grouped."""
+    """The grouper judge, post-T101 (the user 2026-08-26: the board's unit is the individual ask —
+    tops never nest, containers never mint): housekeeping only — merge true twins, split drifted
+    tangents, retitle outgrown cards. The retired mint/group ops parse away and are ignored if
+    hand-built. Event-gated per session (groupedSig) so a stable board is never re-examined."""
 
     def setUp(self):
         # _group_tops now consults STATE/cleared.jsonl (the view-cleared set) — sandbox STATE to a fresh
@@ -1444,85 +1444,52 @@ class Grouper(unittest.TestCase):
         return s, s["placements"]["s1"], s["placements"]["s2"]
 
     # ── parse ──
-    def test_parse_mint_group_and_empty(self):
-        self.assertEqual(jd._parse_group('{"ops":[{"why":"x","do":"group","goal":2,"under":1}]}', 3),
-                         [{"do": "group", "why": "x", "goal": 2, "under": 1}])
+    def test_parse_drops_the_retired_container_ops(self):
+        # T101 (the user 2026-08-26): mint + group parse away — an older cached reply that still
+        # emits them applies NOTHING; the housekeeping ops survive beside them
         ops = jd._parse_group('{"ops":[{"why":"u","do":"mint","text":"Umbrella"},'
-                              '{"why":"x","do":"group","goal":1,"ref":1}]}', 2)
-        self.assertEqual(ops[0], {"do": "mint", "why": "u", "text": "Umbrella"})
-        self.assertEqual(ops[1], {"do": "group", "why": "x", "goal": 1, "ref": 1}, "group via a same-reply ref")
-        self.assertEqual(jd._parse_group('{"ops":[{"why":"x","do":"group","goal":1,"under":1}]}', 3), [],
-                         "self-group (goal == under) is dropped")
-        self.assertEqual(jd._parse_group('{"ops":[]}', 3), [], "empty ops is valid: nothing to group")
+                              '{"why":"x","do":"group","goal":1,"under":2},'
+                              '{"why":"r","do":"retitle","goal":1,"text":"A, clarified"}]}', 3)
+        self.assertEqual([o["do"] for o in ops], ["retitle"])
+        self.assertEqual(jd._parse_group('{"ops":[]}', 3), [], "empty ops is valid: nothing to do")
         self.assertIsNone(jd._parse_group("not json", 3), "unusable JSON → None (retry)")
 
-    def test_parse_group_with_optional_retitle(self):
-        # the user 2026-07-01: a relink may ALSO retitle the child, now that continuous card identity in
-        # the UI (it visibly moves under the new parent) means a title change no longer reads as a new card.
-        ops = jd._parse_group('{"ops":[{"why":"x","do":"group","goal":2,"under":1,'
-                              '"retitle":"a clearer title"}]}', 3)
-        self.assertEqual(ops, [{"do": "group", "why": "x", "goal": 2, "under": 1, "retitle": "a clearer title"}])
-        # blank/whitespace-only retitle is dropped, same as an empty mint/sub text
-        ops2 = jd._parse_group('{"ops":[{"why":"x","do":"group","goal":2,"under":1,"retitle":"   "}]}', 3)
-        self.assertNotIn("retitle", ops2[0], "a blank retitle is dropped, not applied as an empty title")
-
     # ── apply ──
-    def test_relinks_a_top_under_another(self):
-        s, a, b = self._two_tops()
-        tops = jd._group_tops(s)                                  # [A, B] oldest-first
-        ai = next(i for i, nd in enumerate(tops, 1) if nd["id"] == a)
-        bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
-        n = jd.apply_group(s, tops, [{"do": "group", "why": "both serve X", "goal": bi, "under": ai}], T0 + 20)
-        self.assertEqual(n, 1, "one relink applied")
-        self.assertEqual(s["nodes"][b]["parentId"], a, "B is relinked under A (its subtree moves with it)")
-        self.assertIsNone(s["nodes"][a]["parentId"], "A stays a top")
-
-    def test_relink_can_retitle_the_child(self):
+    def test_apply_ignores_the_retired_container_ops(self):
+        # T101: every top stays its own card — a hand-built group/mint op list applies NOTHING
         s, a, b = self._two_tops()
         tops = jd._group_tops(s)
         ai = next(i for i, nd in enumerate(tops, 1) if nd["id"] == a)
         bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
-        jd.apply_group(s, tops, [{"do": "group", "why": "both serve X", "goal": bi, "under": ai,
-                                  "retitle": "B, narrowed"}], T0 + 20)
-        self.assertEqual(s["nodes"][b]["text"], "B, narrowed", "the relink also retitled the child")
+        n = jd.apply_group(s, tops, [{"do": "mint", "why": "x", "text": "Umbrella X"},
+                                     {"do": "group", "why": "x", "goal": bi, "under": ai}], T0 + 20)
+        self.assertEqual(n, 0, "nothing applied")
+        self.assertIsNone(s["nodes"][a]["parentId"], "A stays its own card")
+        self.assertIsNone(s["nodes"][b]["parentId"], "B stays its own card")
+        self.assertFalse(any(nd.get("umbrella") for nd in s["nodes"].values()), "no container minted")
+
+    def test_retitle_still_applies_standalone(self):
+        s, a, b = self._two_tops()
+        tops = jd._group_tops(s)
+        bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
+        n = jd.apply_group(s, tops, [{"do": "retitle", "why": "outgrown", "goal": bi,
+                                      "text": "B, narrowed"}], T0 + 20)
+        self.assertEqual(n, 1)
+        self.assertEqual(s["nodes"][b]["text"], "B, narrowed")
         self.assertEqual(s["nodes"][b]["mt"], T0 + 20)
 
-    def test_relink_without_retitle_leaves_the_childs_title_alone(self):
-        s, a, b = self._two_tops()
-        tops = jd._group_tops(s)
-        ai = next(i for i, nd in enumerate(tops, 1) if nd["id"] == a)
-        bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
-        jd.apply_group(s, tops, [{"do": "group", "why": "both serve X", "goal": bi, "under": ai}], T0 + 20)
-        self.assertEqual(s["nodes"][b]["text"], "Goal B", "no retitle in the op -> title unchanged")
-
-    def test_two_tops_under_a_fresh_umbrella_with_anchor_backfill(self):
-        s, a, b = self._two_tops()
-        s["nodes"][a]["trail"] = ["s1"]                           # A has a real anchor seg; B has none
-        tops = jd._group_tops(s)
-        ai = next(i for i, nd in enumerate(tops, 1) if nd["id"] == a)
-        bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
-        jd.apply_group(s, tops, [{"do": "mint", "why": "both serve X", "text": "Umbrella X"},
-                                 {"do": "group", "why": "x", "goal": ai, "ref": 1},
-                                 {"do": "group", "why": "x", "goal": bi, "ref": 1}], T0 + 20)
-        um = next(nd for nd in s["nodes"].values() if nd["text"] == "Umbrella X")
-        self.assertEqual(s["nodes"][a]["parentId"], um["id"], "A grouped under the fresh umbrella")
-        self.assertEqual(s["nodes"][b]["parentId"], um["id"], "B grouped under the fresh umbrella")
-        self.assertIsNone(um["parentId"], "the umbrella is the new top")
-        self.assertTrue(um.get("umbrella"), "a minted umbrella is tagged")
-        self.assertEqual(um["trail"], ["s1"], "umbrella inherits its earliest grouped child's anchor seg")
-
-    def test_refuses_a_cycle(self):
+    def test_group_ops_cannot_create_cycles_because_they_apply_nothing(self):
         s = _store()
         jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "Parent"}], [])
         jd.apply_plan(s, "s2", T0 + 10, [{"do": "sub", "why": "x", "under": 1, "text": "Child"}], jd.open_menu(s))
         parent, child = s["placements"]["s1"], s["placements"]["s2"]
-        tops = [s["nodes"][parent], s["nodes"][child]]            # force Child into the candidate list to exercise the guard
+        tops = [s["nodes"][parent], s["nodes"][child]]
         n = jd.apply_group(s, tops, [{"do": "group", "why": "x", "goal": 1, "under": 2}], T0 + 20)
-        self.assertEqual(n, 0, "the cyclic relink is refused")
-        self.assertIsNone(s["nodes"][parent]["parentId"], "grouping Parent under its own Child is refused (no cycle)")
+        self.assertEqual(n, 0, "retired op — nothing applies, no cycle possible")
+        self.assertIsNone(s["nodes"][parent]["parentId"])
         self.assertEqual(s["nodes"][child]["parentId"], parent, "Child stays under Parent")
 
-    def test_relink_clamps_at_max_depth(self):
+    def test_retired_group_op_never_deepens_a_tree(self):
         s = _store()
         jd.apply_plan(s, "s0", T0, [{"do": "mint", "why": "x", "text": "A"}], [])
         for i in range(1, jd.MAX_DEPTH + 1):                     # chain A -> step1 -> ... down to MAX_DEPTH
@@ -1535,9 +1502,9 @@ class Grouper(unittest.TestCase):
         b = s["placements"]["sb"]
         tops = [deepest, s["nodes"][b]]                          # group B under the deepest node
         jd.apply_group(s, tops, [{"do": "group", "why": "x", "goal": 2, "under": 1}], T0 + 60)
-        self.assertLessEqual(jd._depth(s["nodes"], b), jd.MAX_DEPTH, "B's relink is clamped to MAX_DEPTH")
+        self.assertIsNone(s["nodes"][b]["parentId"], "the retired op applies nothing — B stays a top")
 
-    def test_reopened_once_done_node_is_groupable_again(self):
+    def test_reopened_once_done_node_is_mergeable_again(self):
         # INVERTED 2026-07-06 (the user): the old never-move-an-everDone-node guard is REMOVED — a reopened
         # once-done top is live work again, so an erroneously split pair the user pushes back into Working
         # can be re-merged by the grouper. (The guard's original motive — a done card vanishing under an
@@ -1554,13 +1521,13 @@ class Grouper(unittest.TestCase):
         tops = jd._group_tops(s)                                  # B is an open top again
         ai = next(i for i, nd in enumerate(tops, 1) if nd["id"] == a)
         bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
-        n = jd.apply_group(s, tops, [{"do": "group", "why": "both serve X", "goal": bi, "under": ai}], T0 + 30)
-        self.assertEqual(n, 1, "a reopened once-done top relinks like any other open top")
-        self.assertEqual(s["nodes"][b]["parentId"], a, "B nests under A — the split re-merges")
+        n = jd.apply_group(s, tops, [{"do": "merge", "why": "same work twice", "goal": bi, "into": ai}], T0 + 30)
+        self.assertEqual(n, 1, "a reopened once-done top merges like any other open top (T101: merge, not nest)")
+        self.assertNotIn(b, s["nodes"], "the twin folded into the keeper")
 
-    def test_once_done_node_can_still_be_an_umbrella_parent(self):
-        # the exemption blocks MOVING a once-done node, not nesting OTHERS under it: A (never done) groups
-        # under B (once done, reopened) fine — B is a valid relink TARGET, just never a source.
+    def test_nesting_stays_retired_even_onto_a_reopened_top(self):
+        # T101: no relink target exists at all — a once-done reopened top is live work again, but
+        # nothing nests under it (the ask-unit rule has no exceptions)
         s, a, b = self._two_tops()
         di = next(i for i, nd in enumerate(jd.open_menu(s), 1) if nd["id"] == b)
         jd.apply_plan(s, "sd", T0 + 15, [{"do": "done", "why": "shipped", "goal": di}], jd.open_menu(s))
@@ -1569,8 +1536,8 @@ class Grouper(unittest.TestCase):
         ai = next(i for i, nd in enumerate(tops, 1) if nd["id"] == a)
         bi = next(i for i, nd in enumerate(tops, 1) if nd["id"] == b)
         n = jd.apply_group(s, tops, [{"do": "group", "why": "x", "goal": ai, "under": bi}], T0 + 30)
-        self.assertEqual(n, 1, "A (never done) is relinked under B")
-        self.assertEqual(s["nodes"][a]["parentId"], b, "the once-done node serves as the parent")
+        self.assertEqual(n, 0)
+        self.assertIsNone(s["nodes"][a]["parentId"], "A stays its own card")
 
     def test_a_bottom_up_completed_top_is_not_a_grouper_candidate(self):
         # the user 2026-06-25: a goal the board shows as DONE must never be a grouper source/target — else it
@@ -1648,12 +1615,13 @@ class Grouper(unittest.TestCase):
 
         def fake_group(menu):
             calls.append(menu)
-            return '{"ops":[{"why":"both serve X","do":"group","goal":2,"under":1}]}'   # B under A
+            bi = 2 if "Goal B" in menu.splitlines()[1] else 1     # retitle B wherever it landed
+            return '{"ops":[{"why":"outgrown","do":"retitle","goal":%d,"text":"Goal B, narrowed"}]}' % bi
         jd.group_llm = fake_group
         now = T0 + 5000
         jd.run_group(now=now)
         st = jd.load_goals(SID)
-        self.assertEqual(st["nodes"][b]["parentId"], a, "B nested under A")
+        self.assertEqual(st["nodes"][b]["text"], "Goal B, narrowed", "the housekeeping op applied")
         self.assertEqual(len(calls), 1, "the grouper called the model once")
         self.assertTrue(st.get("groupedSig"), "groupedSig recorded")
         jd.run_group(now=now)
@@ -1676,10 +1644,12 @@ class Grouper(unittest.TestCase):
         self.assertEqual(len(calls), 0, "fewer than two tops → nothing to group, model not called")
         self.assertIsNotNone(jd.load_goals(SID).get("groupedSig"), "the (single-top) set is still recorded")
 
-    def test_prompt_carries_the_grouping_steer(self):
-        for phrase in ('"do":"group"', '"do":"mint"', "relink open top", "umbrella",
-                       "aggressive about grouping", "look-alike wording"):
+    def test_prompt_carries_the_ask_unit_steer(self):
+        # T101: the prompt no longer teaches containers or nesting; the ask-unit rule is explicit
+        for phrase in ("its own card by design", '"do":"merge"', '"do":"split"', '"do":"retitle"'):
             self.assertIn(phrase, jd.GROUP_SYS, phrase)
+        for gone in ('"do":"group"', '"do":"mint"', "umbrella"):
+            self.assertNotIn(gone, jd.GROUP_SYS, gone)
         self.assertNotIn("genuine", jd.GROUP_SYS.lower(), "the grouper prompt avoids 'genuine' too")
 
     def test_prompt_allows_doing_nothing(self):
@@ -1719,12 +1689,12 @@ class Grouper(unittest.TestCase):
 
             def fake_group(menu):
                 gcalls.append(menu)
-                return '{"ops":[{"why":"both serve X","do":"group","goal":2,"under":1}]}'   # B under A
+                return '{"ops":[{"why":"same work twice","do":"merge","goal":2,"into":1}]}'   # twins fold
             jd.group_llm = fake_group
             jd.run_plan(now=T0 + 5000)
             st = jd.load_goals(SID)
             tops = [nd for nd in st["nodes"].values() if nd["parentId"] is None]
-            self.assertEqual(len(tops), 1, "2nd top grouped under the 1st INLINE — no separate run_group needed")
+            self.assertEqual(len(tops), 1, "the twin merged INLINE after placement — no separate run_group needed")
             self.assertGreaterEqual(len(gcalls), 1, "the planner invoked the grouper after a placement")
         finally:
             (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.group_llm) = saved
@@ -1798,19 +1768,18 @@ class Consolidator(unittest.TestCase):
         self.assertEqual(ids, {SID + ":g2"}, "a top the user crossed off the feed is never re-grouped")
 
     # ── apply-level: done nodes relink unconditionally (the allow_done lift is gone with its guard) ──
-    def test_apply_group_moves_a_once_done_node(self):
-        # 2026-07-06 (the user): apply_group no longer carries the once-done guard or the allow_done
-        # parameter — the consolidator (all-done candidates) and the working grouper (open candidates,
-        # possibly reopened-once-done) both relink through the same unconditional path.
+    def test_apply_group_never_nests_done_cards_either(self):
+        # T101: the retired group op applies nothing in the done column too
         s = self._completed_store([("g1", "A", ["sA"]), ("g2", "B", ["sB"])])
         tops = jd._consolidate_tops(s)
         ops = [{"do": "group", "why": "both done parts of X", "goal": 2, "under": 1}]
-        self.assertEqual(jd.apply_group(s, tops, ops, T0 + 20), 1,
-                         "a completed node relinks with no special lift")
-        self.assertEqual(s["nodes"][SID + ":g2"]["parentId"], SID + ":g1")
+        self.assertEqual(jd.apply_group(s, tops, ops, T0 + 20), 0)
+        self.assertIsNone(s["nodes"][SID + ":g2"].get("parentId"), "B stays its own done card")
 
     # ── the session pass ──
-    def test_groups_completed_siblings_under_a_completed_umbrella(self):
+    def test_completed_siblings_stay_their_own_cards(self):
+        # T101: the consolidator no longer containers the done column — an older cached reply that
+        # still asks for it applies nothing, and both cards keep their own identity and status row
         s = self._completed_store([("g1", "A", ["sA"]), ("g2", "B", ["sB"])])
         self._setup(s, self._RECORDS)
         jd.group_llm = lambda menu, **k: ('{"ops":[{"why":"both finish X","do":"mint","text":"Umbrella X"},'
@@ -1818,32 +1787,31 @@ class Consolidator(unittest.TestCase):
                                      '{"why":"x","do":"group","goal":2,"ref":1}]}')
         jd.run_consolidate(now=T0 + 5000)
         st = jd.load_goals(SID)
-        um = next((nd for nd in st["nodes"].values() if nd.get("umbrella")), None)
-        self.assertIsNotNone(um, "a completed umbrella was minted")
-        self.assertEqual(st["nodes"][SID + ":g1"]["parentId"], um["id"], "A nested under the umbrella")
-        self.assertEqual(st["nodes"][SID + ":g2"]["parentId"], um["id"], "B nested under the umbrella")
-        self.assertEqual(st["status"].get(um["id"]), "completed",
-                         "the umbrella rolls up to completed (all children done) — nothing reverts to working")
-        self.assertNotIn(SID + ":g1", st["status"], "the grouped children drop off the top-level status map")
-        self.assertNotIn(SID + ":g2", st["status"])
-        self.assertEqual(um["trail"], ["sA"], "the umbrella inherits its earliest child's anchor (deep-links to the work)")
+        self.assertIsNone(next((nd for nd in st["nodes"].values() if nd.get("umbrella")), None),
+                          "no container minted")
+        self.assertIsNone(st["nodes"][SID + ":g1"].get("parentId"), "A stays its own card")
+        self.assertIsNone(st["nodes"][SID + ":g2"].get("parentId"), "B stays its own card")
+        self.assertEqual(st["status"].get(SID + ":g1"), "completed")
+        self.assertEqual(st["status"].get(SID + ":g2"), "completed")
 
-    def test_reopened_child_reverts_the_whole_umbrella_to_working(self):
-        # the user's choice 2026-06-19: re-poking a child of a completed group reverts the umbrella to working,
-        # together — driven entirely by rollup_status (an umbrella is complete only while ALL kids are).
+    def test_a_legacy_umbrella_dissolves_and_its_children_stand_alone(self):
+        # T101: the dissolution sweep (rollup pre-pass) un-containers legacy stores — a reopened
+        # child then moves only ITSELF back to working; its done sibling rests untouched
         s = self._completed_store([("g1", "A", ["sA"]), ("g2", "B", ["sB"])])
-        tops = jd._consolidate_tops(s)
-        jd.apply_group(s, tops, [{"do": "mint", "why": "x", "text": "Umb"},
-                                 {"do": "group", "why": "x", "goal": 1, "ref": 1},
-                                 {"do": "group", "why": "x", "goal": 2, "ref": 1}], T0 + 20)
+        uid = SID + ":u9"
+        s["nodes"][uid] = {"id": uid, "text": "Umb", "parentId": None, "nodeComplete": False,
+                           "blocked": False, "cleared": False, "trail": [], "t": T0, "mt": T0,
+                           "umbrella": True, "log": []}
+        s["nodes"][SID + ":g1"]["parentId"] = uid
+        s["nodes"][SID + ":g2"]["parentId"] = uid
         jd.rollup_status(s, True)
-        um = next(nd for nd in s["nodes"].values() if nd.get("umbrella"))
-        self.assertEqual(s["status"][um["id"]], "completed", "all children done → umbrella completed")
-        jd._reopen(s, SID + ":g1", by="followup")     # a follow-up reopens child A — the REAL reopen:
-        jd.rollup_status(s, True)                     # post-P3.3, a hand-flipped flag with no event is
-        #                                               simply restored from the verdict log
-        self.assertEqual(s["status"][um["id"]], "working",
-                         "one reopened child reverts the whole umbrella to working")
+        self.assertNotIn(uid, s["nodes"], "the container dissolved")
+        self.assertEqual(s["status"].get(SID + ":g1"), "completed")
+        self.assertEqual(s["status"].get(SID + ":g2"), "completed")
+        jd._reopen(s, SID + ":g1", by="followup")
+        jd.rollup_status(s, True)
+        self.assertEqual(s["status"].get(SID + ":g1"), "working", "the reopened ask moves alone")
+        self.assertEqual(s["status"].get(SID + ":g2"), "completed", "its sibling rests — no shared fate")
 
     # ── empty-umbrella cleanup ──
     def test_empty_umbrella_is_cleared_but_a_populated_one_is_not(self):
@@ -4134,16 +4102,14 @@ class FollowUp(unittest.TestCase):
                          "nothing was buried under the cited goal itself")
         top = next(nd for nd in st["nodes"].values() if nd.get("pivotFrom") == gid)
         self.assertEqual(top["text"], "Rework the export flow")
-        umb = st["nodes"][top["parentId"]]
-        self.assertTrue(umb.get("umbrella"), "the pivot goal lives under an umbrella, not loose on the board")
-        self.assertEqual(st["nodes"][gid]["parentId"], umb["id"],
-                         "the cited card sits under the same umbrella — followed-up work stays together")
-        self.assertEqual(umb["text"], "Ship the release", "the umbrella wears the cited card's title")
-        self.assertIsNone(umb["parentId"])
+        # T101 (the user 2026-08-26): the STRUCTURAL tie retired with the umbrella — the pivot's
+        # goal is its own card, and pivotFrom is the provenance display layers may group on
+        self.assertIsNone(top.get("parentId"), "the pivot goal is its own card")
+        self.assertFalse(any(nd.get("umbrella") for nd in st["nodes"].values()), "no container minted")
 
-    def test_followup_pivot_joins_the_cited_cards_existing_umbrella(self):
-        # the tie reuses an existing roof: when the cited card already lives under an umbrella, the pivot's
-        # goal relinks under THAT umbrella — no umbrella-of-umbrellas.
+    def test_a_pivot_on_a_legacy_umbrella_child_dissolves_the_container(self):
+        # T101: a legacy umbrella around the cited card dissolves on the pass's own rollup — the
+        # cited card and the pivot goal both end as their own cards, tied by pivotFrom provenance
         gid, uid = SID + ":g1", SID + ":g9"
         store = self._completed_top(gid)
         store["nodes"][uid] = {"id": uid, "text": "Release work", "parentId": None, "umbrella": True,
@@ -4158,9 +4124,9 @@ class FollowUp(unittest.TestCase):
         jd.run_plan(now=T0 + 5000)
         st = jd.load_goals(SID)
         top = next(nd for nd in st["nodes"].values() if nd.get("pivotFrom") == gid)
-        self.assertEqual(top["parentId"], uid, "the pivot goal joined the existing umbrella")
-        self.assertEqual(sum(1 for nd in st["nodes"].values() if nd.get("umbrella")), 1,
-                         "no second umbrella was minted")
+        self.assertIsNone(top.get("parentId"), "the pivot goal is its own card")
+        self.assertNotIn(uid, st["nodes"], "the legacy container dissolved on the pass's rollup")
+        self.assertIsNone(st["nodes"][gid].get("parentId"), "the cited card stands alone again")
 
     def test_pivot_clears_followup_pending_on_a_blocked_cited_goal(self):
         # the user 2026-07-03: the track card sat in Working with a "Re-judging…" swirl for 8+ hours.
@@ -4182,9 +4148,10 @@ class FollowUp(unittest.TestCase):
         self.assertNotIn("followupPending", st["nodes"][gid],
                          "the pivot verdict processed the follow-up — the optimistic flag drops")
         self.assertTrue(st["nodes"][gid]["blocked"], "the block stands on the cited goal")
-        umb = st["nodes"][st["nodes"][gid]["parentId"]]   # the 07-09 tie grouped the pivot with the cited card
-        self.assertEqual(st["status"][umb["id"]], "blocked",
-                         "the umbrella card carries the block to Needs-You, not a permanent Re-judging swirl")
+        self.assertIsNone(st["nodes"][gid].get("parentId"),
+                          "T101: no umbrella tie — the cited card is its own card")
+        self.assertEqual(st["status"][gid], "blocked",
+                         "the cited card itself carries the block to Needs-You, not a permanent Re-judging swirl")
 
     def test_followup_parse_failure_keeps_the_forced_sub_floor(self):
         # ambiguity never pivots: an unparseable planner reply falls to the forced-sub default, so an

--- a/tests/test_judge_board_dedup.py
+++ b/tests/test_judge_board_dedup.py
@@ -162,8 +162,6 @@ class MergeOp(unittest.TestCase):
         self.assertIn("true twins", jd.GROUP_SYS)
         self.assertIn("never merge two lines that are both from the agent's own to-do list",
                       jd.GROUP_SYS.replace("\n", " "))
-        self.assertIn("**top-level** (flush-left) lines", jd.GROUP_SYS,
-                      "group is told it moves tops only, now that steps are numbered too")
 
     # ── apply ──
     def test_merge_folds_the_mirror_into_the_users_step(self):
@@ -223,16 +221,16 @@ class MergeOp(unittest.TestCase):
         self.assertEqual(s["nodes"][gid(3)]["parentId"], gid(2), "siblings moved under the survivor")
         self.assertEqual(jd._top_ancestor(s["nodes"], gid(3)), gid(2), "no cycle: the walk terminates")
 
-    def test_group_skips_a_step_child_and_walks_a_step_parent_up(self):
+    def test_group_ops_apply_nothing_anywhere(self):
+        # T101: the group op is retired outright — steps stay put and tops stay tops
         s = audit_store()
         menu = jd._group_menu(s, jd._group_tops(s))            # [card, wide(step), tall(step), mirror(top)]
         n = jd.apply_group(s, menu, [{"do": "group", "why": "x", "goal": 2, "under": 4}], T0 + 50)
-        self.assertEqual(n, 0, "a placed step is never relinked by the grouper")
+        self.assertEqual(n, 0)
         self.assertEqual(s["nodes"][gid(2)]["parentId"], gid(1), "the step stayed put")
         n = jd.apply_group(s, menu, [{"do": "group", "why": "x", "goal": 4, "under": 3}], T0 + 60)
-        self.assertEqual(n, 1, "a step parent walks up to its card")
-        self.assertEqual(s["nodes"][gid(4)]["parentId"], gid(1),
-                         "nesting 'under the step' lands under the step's card")
+        self.assertEqual(n, 0, "no walk-up either — nothing nests")
+        self.assertIsNone(s["nodes"][gid(4)].get("parentId"), "the mirror top stays its own card")
 
     def test_group_op_on_a_merged_away_target_is_skipped(self):
         s = audit_store()

--- a/tests/test_judge_card_first.py
+++ b/tests/test_judge_card_first.py
@@ -305,10 +305,10 @@ class PromptAndGrouperPins(unittest.TestCase):
 
     def test_grouper_marks_and_owns_todo_mirrors(self):
         self.assertIn("to-do mirror", jd.GROUP_SYS)
-        # "nesting it is your job" until 2026-07-11: the grouper now MERGES a mirror that duplicates an
-        # existing line and nests only a distinct one, so the pin follows the widened ownership
-        self.assertIn("placing it is your job", jd.GROUP_SYS)
+        # T101 (2026-08-26): nesting retired — a mirror that duplicates an existing line MERGES;
+        # a distinct one stays its own card
         self.assertIn("merge it into that line", jd.GROUP_SYS)
+        self.assertIn("otherwise leave it as its", jd.GROUP_SYS)
         st = store(node(gid(1), "Tests green, merge, push", t=100, agentTask={"key": "k1", "status": "open"}),
                    node(gid(2), "Build the widget", t=200))
         text = jd._group_menu_text(st, jd._group_tops(st))

--- a/tests/test_judge_one_completion_truth.py
+++ b/tests/test_judge_one_completion_truth.py
@@ -65,7 +65,9 @@ class DuplicateKeyHeals(unittest.TestCase):
     """The live g17 shape: umbrella + open twin shadowing a completed item, healed with no surgery."""
 
     def _incident_store(self):
-        top = _node(SID + ":g1", umbrella=True, nodeComplete=True)
+        # T101 note: containers dissolve in rollup now, so the shape uses a PLAIN parent — the
+        # subject here (duplicate to-do keys healing) never depended on the umbrella tag
+        top = _node(SID + ":g1", nodeComplete=True)
         done_twin = _node(SID + ":g2", parentId=SID + ":g1",
                           agentTask={"key": "5", "status": "done", "raw": "completed"},
                           agentBornOpen=True, agentDone=True, nodeComplete=True)

--- a/tests/test_judge_reopen_floor.py
+++ b/tests/test_judge_reopen_floor.py
@@ -168,17 +168,18 @@ class GrouperMovesOnceDone(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.td, ignore_errors=True)
 
-    def test_group_relinks_everdone_top(self):
+    def test_group_never_relinks_anything_anymore(self):
+        # T101: the once-done guard question is moot — the group op itself is retired
         store = {"rompUuid": SID, "seq": 3, "placements": {}, "status": {},
-                 "nodes": {G1: node(G1, "Fix the parser",                   # reopened once-done top —
+                 "nodes": {G1: node(G1, "Fix the parser",
                                     log=[{"ev_t": NOW - 400, "src": "closer", "kind": "done", "at": NOW - 400},
                                          {"ev_t": NOW - 200, "src": "user", "kind": "reopen", "at": NOW - 200}]),
-                           G2: node(G2, "Parser rewrite umbrella"),
+                           G2: node(G2, "Parser rewrite effort"),
                            G3: node(G3, "Add parser tests")}}
         tops = [store["nodes"][G1], store["nodes"][G2], store["nodes"][G3]]
         ops = [{"do": "group", "goal": 1, "under": 2, "why": "same parser effort"}]
-        self.assertEqual(jd.apply_group(store, tops, ops, NOW), 1)
-        self.assertEqual(store["nodes"][G1]["parentId"], G2)
+        self.assertEqual(jd.apply_group(store, tops, ops, NOW), 0)
+        self.assertIsNone(store["nodes"][G1].get("parentId"), "every top stays its own card")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The ruling

A dictated round contains multiple asks; each ask fans to possibly-multiple workers. The round is never the relevant unit for anything, and a dispatch-card multiplies one ask into near-duplicates on fan-out. Target structure: **round → asks → dispatches**, where the CARD is the ask — the planner's decomposition of the dictated prompt, in the user's own phrasing, with a definite done — and fan-out lives INSIDE the card (per-dispatch progress one click down, never sibling cards).

## What changed (all on existing rails, in a `notes-api` manager→workers world)

**Courier — link, never mint, when the ask is carded.** A dispatch whose chain roots to an ask the courier linked (oldest-wins, unchanged) plants its tracking node UNDER that ask; the recipient files quietly through the existing machinery (fyi placement + the `handoff.quiet` reply-sweep ending — no recipient goal will ever carry the msgId). One ask to two workers = one card with two handoff children; two asks to one worker = two cards. Only a rooted dispatch with NO resolvable ask still mints the recipient top (there the recipient card IS the ask's card; the frame enrichment rides). Linking alone never moves the ask card's column — planting a tracking child writes no verdict.

**Grouper/consolidator — containers RETIRE (not demote).** A store-level container is unavoidably a tracked unit: it owns rollup, and the provenance audit measured that it swallowed the chain evidence of every stranded ask. The visual-grouping job already has a display-side owner with no store footprint (the feed's group fold). `merge`/`split`/`retitle` stay; the retired `mint`/`group` ops parse away and are ignored if hand-built; the follow-up pivot's structural umbrella tie retires with them (pivotFrom provenance stays). **Legacy containers dissolve idempotently in every writer's rollup**: children re-parent to the first non-container ancestor with their provenance intact, placements at the container retire processed, nested containers resolve transitively.

**Trace — the container-sibling rescue.** Archives keep their containers (dissolution is live-store only), so a chain dead-ending at an evidence-free archived container now looks once — bounded, one level, cap 40 — at the container's children for the round's human record: the audit's own measured predicate, now in-walk, still a confident rule (a sibling's human record IS the round's evidence).

**Rescue, measured** over the dashboard team's real 36-hour chains: **40 of 41 origin-minted tops now trace user-rooted** (was 7 of 30 at audit time). The one miss is a parentless tracking top with no evidence anywhere — the known worst shape, genuinely untraceable.

## Tests

`tests/test_ask_unit_cards.py`: the courier fan-out matrix both directions (one-ask-two-workers = one card; two-asks-one-worker = two cards), the linkless fallback minting with frame, link-never-moves-the-column, retired-op parse/apply pins, the prompt steer, dissolution idempotency on legacy stores (nested containers, placement retirement, provenance survival), and the archived-container sibling rescue both ways. The grouper/consolidator/pivot suites reworked to the ask-unit semantics with retired behaviors pinned as no-ops. Private synthetic sids, journal cleanup in tearDown throughout.

Suites: Python 5712 passed / 0 failed; UI 2432/2432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)