### PR TITLE
The comment pulse is exchange-scoped: latched at the send, cleared by the reply record

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6523,16 +6523,9 @@ def _comments_frame(sid, tmux=None):
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
         reg = _thread_reg(tsid)
-        # the settle count (see _comment_settle_step): raw_busy mirrors the client's threadInFlight
-        # (comments.ts) exactly — live work or an owed reply, on an open unstuck thread
-        tid = str(th.get("tid") or "")
-        raw_busy = (status == "open" and not err and state not in ("permission", "picker")
-                    and (state in ("working", "retrying", "compacting")
-                         or bool(msgs and msgs[-1]["who"] == "you")))
-        quiet = _comment_settle_step(_comment_settle.get(tid), raw_busy, status != "open" or bool(err))
-        _comment_settle[tid] = quiet
-        if len(_comment_settle) > 512:
-            _comment_settle.clear()
+        # (T102: the push-count settle — settledPushes — is RETIRED. The client's pulse is exchange-
+        # scoped now: latched at the send gesture, cleared by the reply RECORD arriving in msgs; the
+        # frame's msgs already carry that event, so no per-push counter rides here anymore.)
         # sinceEpoch (MILLISECONDS, the client convention): when the thread's current state began —
         # the popover's working chip counts from it, exactly as the chat's statusline does
         since_ms = 0
@@ -6556,7 +6549,7 @@ def _comments_frame(sid, tmux=None):
                         "unread": unread, "promotedName": th.get("promotedName") or "",
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
-                        "settledPushes": quiet, "sinceEpoch": since_ms,
+                        "sinceEpoch": since_ms,
                         "mode": str(meta.get("mode") or ""), "fast": str(meta.get("fast") or ""),
                         # the same rank tints the chat statusline's badges wear (the user 2026-08-25,
                         # color rider: the popover's model/effort rendered plain gray — metaColor
@@ -6567,26 +6560,6 @@ def _comments_frame(sid, tmux=None):
                                                      cm.stops_for(_colormap())),
                         "msgs": msgs, "events": events})
     return {"type": "comments", "id": sid, "threads": threads}
-
-
-# The client's green→yellow settle needs TWO CONFIRMING PUSHES (comments.ts latchBusy), but
-# _send_client's dedup withholds unchanged frames — so after a reply landed, the second confirming
-# frame never arrived and the passage stayed green until some unrelated change minted one (the user
-# 2026-08-25: it didn't flip until clicking back into the main chat). The frame now carries the
-# count ITSELF: pushes since the thread last read busy, clamped at 2 — each step is a real pusher
-# cycle (an event, never a timer), the frame changes at most twice after settling, and then the
-# dedup resumes. tid → count; pure step logic split out for the test.
-_comment_settle = {}
-
-
-def _comment_settle_step(prev, raw_busy, decided):
-    """One pusher cycle's step of the settle count: busy → 0; a decided status (closed/errored)
-    settles immediately; otherwise count up, clamped at 2 (the client's SETTLE_CONFIRM_PUSHES)."""
-    if decided:
-        return 2
-    if raw_busy:
-        return 0
-    return min(2, (2 if prev is None else prev) + 1)
 
 
 def _comment_markers(sid):

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -703,31 +703,27 @@ class CommentOps(CommentBase):
             self.assertIn('"%s"' % op, src)
 
 
-class SettleStepCarriesTheConfirm(unittest.TestCase):
-    """The client's green→yellow settle needs two confirming pushes, but the wire dedup withholds
-    unchanged frames — so the kernel counts pushes-since-busy ON the frame (_comment_settle_step),
-    clamped so the frame changes at most twice after settling and the dedup resumes (the user
-    2026-08-25: the passage stayed green until clicking back into the main chat)."""
+class ExchangeLatchReplacedThePushCount(unittest.TestCase):
+    """T102 (the user 2026-08-26): the push-count settle (settledPushes / _comment_settle_step) is
+    RETIRED — it was a proxy for the real ending event, and it broke both ends: the fork-birth
+    frames read all-quiet so the create-window pulse died until the CLI booted, and any stall in
+    the 0→1→2 stepping parked the pulse green forever. The client's pulse is exchange-scoped now —
+    latched at the send gesture, cleared by the agent's reply RECORD arriving in msgs — so the
+    frame carries the exchange's records (msgs) and no per-push counter."""
 
-    def test_busy_pins_zero_and_settle_counts_up_clamped(self):
-        q = km._comment_settle_step(None, True, False)
-        self.assertEqual(q, 0, "busy → 0")
-        q = km._comment_settle_step(q, False, False)
-        self.assertEqual(q, 1, "first quiet push confirms once")
-        q = km._comment_settle_step(q, False, False)
-        self.assertEqual(q, 2, "second quiet push settles")
-        self.assertEqual(km._comment_settle_step(q, False, False), 2, "clamped — the frame stops changing")
-
-    def test_a_fresh_quiet_thread_is_settled_and_a_decided_status_settles_immediately(self):
-        self.assertEqual(km._comment_settle_step(None, False, False), 2, "never-busy starts settled")
-        self.assertEqual(km._comment_settle_step(0, False, True), 2, "resolved/errored decides at once")
-
-    def test_the_frame_carries_count_and_epoch(self):
+    def test_the_push_count_is_gone_root_and_branch(self):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
-        self.assertIn('"settledPushes": quiet, "sinceEpoch": since_ms,', src)
-        # raw_busy mirrors the client threadInFlight exactly: open + unstuck + (live work or owed reply)
-        self.assertIn('state in ("working", "retrying", "compacting")', src)
-        self.assertIn('bool(msgs and msgs[-1]["who"] == "you")', src)
+        self.assertNotIn("settledPushes", src.replace("settledPushes — is RETIRED", ""),
+                         "no counter rides the frame (the tombstone comment is the one mention)")
+        self.assertNotIn("_comment_settle_step", src)
+        ui = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "comments.ts")).read()
+        self.assertNotIn("settledPushes", ui)
+        self.assertNotIn("SETTLE_CONFIRM_PUSHES", ui)
+
+    def test_the_frame_still_carries_the_exchange_records_and_epoch(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('"sinceEpoch": since_ms,', src)
+        self.assertIn('"msgs": msgs, "events": events', src)
 
 
 if __name__ == "__main__":

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -45,7 +45,7 @@ test("the popover's bottom row IS a statusline: the chat's chip anatomy + counti
   assert.ok(!/\.cmt-meta \{/.test(CSSs), "no popover-local meta dress");
   assert.match(CSSs, /\.cmt-pop \.statusline \{[^}]*font-family: var\(--vscode-font-family\); font-size: var\(--vscode-font-size, 13px\); \}/);
   // …and the comments frame carries the epoch (milliseconds, the client convention)
-  assert.match(KERNEL, /"settledPushes": quiet, "sinceEpoch": since_ms,/);
+  assert.match(KERNEL, /"sinceEpoch": since_ms,/);   // (the push-count field is retired — T102)
   // the in-place refresh keeps chip + timer live per frame (chips carry no listeners — click-safe)
   assert.match(RENDER, /if \(th && cs\) cs\.replaceWith\(cmtStateChip\(th\)\);/);
 });
@@ -78,21 +78,17 @@ test("a fresh thread boots on the romp loader, then renders its final format ONC
   assert.ok(gate.includes('commentMsgEl("you", pb.text)'), "pending bubbles ride the boot view");
 });
 
-test("green→yellow settles LIVE: the kernel carries the confirm the dedup used to withhold", () => {
-  // the client latch needed two confirming FRAMES; unchanged frames never arrive (wire dedup), so
-  // the flip waited for an unrelated change (the user: it didn't flip until clicking back). The
-  // kernel counts pushes-since-busy on the frame, clamped so dedup resumes once decided.
-  assert.match(KERNEL, /def _comment_settle_step\(prev, raw_busy, decided\):/);
-  assert.match(COMMENTS, /export function settleConfirmed\(th: CommentThread\): boolean \| null \{/);
-  assert.match(COMMENTS, /return typeof sp === "number" \? sp >= SETTLE_CONFIRM_PUSHES : null;/);
-  // commentInFlight prefers the kernel's confirm; the client latch stays as the old-kernel fallback
-  assert.match(RENDER, /const confirmed = settleConfirmed\(th\);/);
-  assert.match(RENDER, /if \(confirmed !== null\) return raw \|\| \(th\.status === "open" && !th\.error && !confirmed\);/);
-  assert.match(RENDER, /return raw \|\| !!commentBusyLatch\.get\(th\.tid\)\?\.green;/);
+test("the pulse is exchange-scoped (T102): send-gesture latch, reply-record clear — no push counts", () => {
+  // the old kernel-carried confirm counter is retired root and branch: its all-quiet fork-birth
+  // frames killed the create-window green, and a stall in its stepping parked green forever. The
+  // pulse now latches at the SEND gesture and clears on the agent's reply RECORD in msgs
+  // (comments.test.ts carries the full lifecycle pins; this guards the retirement on this surface).
+  assert.doesNotMatch(KERNEL, /_comment_settle/);
+  assert.doesNotMatch(RENDER, /settleConfirmed|commentBusyLatch/);
+  assert.match(RENDER, /const cmtAwaitBase = new Map<string, number>\(\);/);
   // the frame handler already repaints marks AND the open popover per frame — the live wire
   assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) \{/);
 });
-
 test("the model meta-menu exposes VERSIONS: submenu, remembered default, keyboard (the user 2026-08-25)", () => {
   // families with >1 live version wear a side submenu (leftward — the menu anchors bottom-right):
   // hover or an arrow key reveals every version, each pickable with the current-✓; clicking the

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { threadsByAnchor, threadBusy, threadStuck, threadInFlight, replyOwed, latchBusy, type BusyLatch, SETTLE_CONFIRM_PUSHES, findExact, findAnchorRange, sliceRanges, prunePending,
+import { threadsByAnchor, threadBusy, threadStuck, replyOwed, agentCount, findExact, findAnchorRange, sliceRanges, prunePending,
          type CommentThread } from "./comments";
 import { compactDisplay } from "./compact";
 
@@ -465,59 +465,48 @@ test("the popover's typing dots are retired — the green highlight is the only 
   assert.match(UI, /the pending bubble IS the acknowledgement/);
 });
 
-// ── the in-flight color keys on the EXCHANGE, not the worker session's state (the user 2026-08-24,
-// second report): create → green for a second → YELLOW while the thread CLI booted (its live state
-// read idle) → green once generation started. The exact reported sequence, executed: ─────────────
-test("the mark stays green from send to landed reply, through the CLI-boot state wobble", () => {
+// ── THE EXCHANGE LATCH (T102, the user 2026-08-26 — replacing the push-count settle): busy latches
+// at the SEND GESTURE (cmtAwaitBase.set in render.ts, before any kernel round-trip — thread-open is
+// never the start trigger) and clears ONLY on the reply-arrived event: th.msgs holding MORE
+// who==="agent" records than at the send. No push counting (the banned proxy: its all-quiet
+// fork-birth frames killed the create-window green, and a stall in its stepping parked green
+// forever), no thread-state proxy, no clocks. ────────────────────────────────────────────────────
+test("agentCount is the reply-arrived detector's datum — records of the exchange itself", () => {
   const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
-  // 1) optimistic create: a synthetic working thread — green
-  assert.ok(threadInFlight(th({ state: "working", msgs: [] })), "optimistic create reads in-flight");
-  // 2) the kernel's frame replaces it mid-boot: state idle/empty, the comment is the newest message —
-  //    the reply is OWED, so STILL green (this is the wobble that flashed yellow)
-  assert.ok(threadInFlight(th({ state: "", msgs: [msg("you")] })), "boot window: owed reply keeps it green");
-  // 3) the reply lands: agent message newest, state settled — yellow
-  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you"), msg("agent")] })), "landed reply settles to yellow");
-  // 4) a follow-up from the user re-arms it
-  assert.ok(threadInFlight(th({ state: "", msgs: [msg("you"), msg("agent"), msg("you")] })), "a follow-up re-owes");
-  // live work still counts even with the agent's message newest (a continuing turn)
-  assert.ok(threadInFlight(th({ state: "working", msgs: [msg("you"), msg("agent")] })));
-  // …but never on a blocked, errored, or closed thread — green must not lie
-  assert.ok(!threadInFlight(th({ state: "permission", msgs: [msg("you")] })), "a stuck reply is NOT on the way");
-  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)), "errored: the note speaks, not the green");
-  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], status: "resolved" })), "resolved threads are done");
+  assert.equal(agentCount(th({ msgs: [] })), 0);
+  assert.equal(agentCount(th({ msgs: [msg("you")] })), 0, "the send alone arrives no reply");
+  assert.equal(agentCount(th({ msgs: [msg("you"), msg("agent")] })), 1, "the reply record raises the count");
+  assert.equal(agentCount(th({ msgs: [msg("you"), msg("agent"), msg("you")] })), 1, "a follow-up send does not");
   assert.equal(replyOwed(th({ msgs: [] })), false, "an empty thread owes nothing");
+  assert.equal(replyOwed(th({ msgs: [msg("you")] })), true, "…the durable owed half survives reloads");
 });
 
-// ── the SETTLE LATCH (the user 2026-08-24, third report: green → a ~1s YELLOW blip mid-churn →
-// green → correct settle). At a turn boundary inside a continuing thread one push reads
-// quiet-state + agent-tail — frame-locally identical to the true end — so the green now holds until
-// TWO consecutive pushes confirm the settle (pushes are events; the pendingSessionViews idiom).
-// The user's exact sequence, executed: the state changes at most ONCE across it. ────────────────
-test("the mark never blips: the user's churn sequence yields exactly one green→yellow transition", () => {
-  const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
-  const frames = [
-    th({ state: "working", msgs: [msg("you")] }),                    // churn
-    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // the boundary frame that blipped
-    th({ state: "working", msgs: [msg("you"), msg("agent")] }),      // churn resumes
-    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // quiet 1
-    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // quiet 2 → settle
-  ];
-  let l: BusyLatch | undefined;
-  const seen: boolean[] = [];
-  for (const f of frames) { l = latchBusy(l, f); seen.push(l.green); }
-  assert.deepEqual(seen, [true, true, true, true, false], "green held through the boundary, settled on confirmation");
-  assert.equal(seen.filter((s, i) => i && s !== seen[i - 1]).length, 1, "at most one change per deciding event");
-  assert.equal(SETTLE_CONFIRM_PUSHES, 2, "two consecutive confirming pushes decide the settle");
+test("busy latches at the SEND gesture and clears exactly on the reply-arrived record (source pins)", () => {
+  // create: the gesture latches under the synth tid, before any kernel round-trip
+  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, 0\);\s+\/\/ the SEND gesture latches the pulse/);
+  // follow-up: re-latches at ITS send, with the agent count at that moment as the base
+  assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, agentCount\(cur\.th\)\);/);
+  // the create's latch carries onto the real thread at adopt (the synth tid retires)
+  assert.match(UI, /if \(k\.startsWith\("pending:"\)\) \{ cmtAwaitBase\.set\(tid, cmtAwaitBase\.get\(k\)!\); cmtAwaitBase\.delete\(k\); \}/);
+  // the ONE clearing site: the comments frame whose msgs carry MORE agent records than the base —
+  // or the thread leaving "open"/erroring (green would lie about a reply no longer on the way)
+  assert.match(UI, /if \(base !== undefined && \(agentCount\(t\) > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/);
+  // the mark's predicate: the latch, or (post-reload) the records' own owed reading; never state
+  assert.match(UI, /return cmtAwaitBase\.has\(th\.tid\) \|\| replyOwed\(th\);/);
+  assert.match(UI, /if \(th\.status !== "open" \|\| !!th\.error \|\| threadStuck\(th\.state\)\) return false;/);
+  // the push-count proxy is GONE root and branch
+  assert.doesNotMatch(UI, /settledPushes|commentBusyLatch|latchBusy|SETTLE_CONFIRM_PUSHES/);
 });
 
-test("status flips decide IMMEDIATELY — resolve/merge/error never wait out the confirmation window", () => {
+test("stuck-green regression: a stalled or missing later frame can never park the pulse", () => {
+  // the old settle needed the 0→1→2 stepping to arrive; a parent dropping out of the pushed set (or
+  // any withheld frame) left !confirmed true with nothing to clear it. The new clear is the reply
+  // RECORD itself: the frame that shows the reply clears the latch in the same breath, and a thread
+  // with no latch entry and an agent-tail msgs reads settled with NO further frames needed.
   const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
-  let l = latchBusy(undefined, th({ state: "working", msgs: [msg("you")] }));
-  assert.equal(l.green, true);
-  assert.equal(latchBusy(l, th({ state: "working", msgs: [msg("you")], status: "resolved" })).green, false, "resolved drops the green on ITS event");
-  assert.equal(latchBusy(l, th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)).green, false, "an errored thread is never green");
-  // an optimistic pending send (alsoBusy) arms the latch like any busy reading
-  assert.equal(latchBusy(undefined, th({ state: "", msgs: [] }), true).green, true, "a just-typed reply reads busy immediately");
+  assert.equal(replyOwed(th({ msgs: [msg("you"), msg("agent")] })), false,
+    "the reply record alone reads settled — no confirmation pushes exist to stall");
+  assert.doesNotMatch(UI, /settleConfirmed/);
 });
 
 // ── LEG C (the user 2026-08-24): the popover ignored the chat's display settings — thinking blocks

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -18,7 +18,6 @@ export type CommentThread = {
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
   error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // an agent reply newer than the read watermark
-  settledPushes?: number;     // kernel pushes since the thread last read busy, clamped at 2 (settleConfirmed)
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   mode?: string;              // the thread's permission mode — the popover statusline's Auto badge
   fast?: string;              // fast-mode state ("on"/"off"/"cooldown"; "" = unknown → no badge)
@@ -60,43 +59,20 @@ export function replyOwed(th: CommentThread): boolean {
   const last = th.msgs.length ? th.msgs[th.msgs.length - 1] : null;
   return !!last && last.who === "you";
 }
-// The ONE in-flight predicate every busy surface reads (the passage mark, the rail tick): live work
-// OR an owed reply, on an open, non-errored thread that isn't blocked on the user — a stuck thread's
-// reply is NOT on the way, and green would lie.
-export function threadInFlight(th: CommentThread): boolean {
-  return th.status === "open" && !th.error && !threadStuck(th.state)
-    && (threadBusy(th.state) || replyOwed(th));
-}
-// SETTLE LATCH (the user 2026-08-24, second report: the passage went green, blipped YELLOW for a
-// second mid-churn, then back to green). At a turn boundary inside a continuing thread, one push can
-// read quiet-state + agent-tail — frame-locally indistinguishable from the true end, so no predicate
-// over a single frame can avoid the flap. The repo rule: transient states latch until the deciding
-// event. Here the deciding evidence is CONSECUTIVE confirming pushes (the pendingSessionViews idiom:
-// pushes are events, never timers): the green holds until TWO pushes in a row read settled; any busy
-// or owed reading resets the count; a status flip (resolved/merged/error) decides IMMEDIATELY — those
-// are real events, never held. The state changes at most once per deciding event by construction.
-export type BusyLatch = { green: boolean; quiet: number };
-export const SETTLE_CONFIRM_PUSHES = 2;
-export function latchBusy(prev: BusyLatch | undefined, th: CommentThread, alsoBusy = false): BusyLatch {
-  if (th.status !== "open" || th.error) return { green: false, quiet: 0 };
-  const raw = alsoBusy || (!threadStuck(th.state) && (threadBusy(th.state) || replyOwed(th)));
-  if (raw) return { green: true, quiet: 0 };
-  if (!prev || !prev.green) return { green: false, quiet: 0 };
-  const quiet = prev.quiet + 1;
-  return quiet >= SETTLE_CONFIRM_PUSHES ? { green: false, quiet: 0 } : { green: true, quiet };
+// THE EXCHANGE LATCH (T102, the user 2026-08-26 — replacing the push-count settle): the busy pulse
+// is exchange-scoped. It LATCHES at the user's SEND gesture (client-side, optimistic — before any
+// kernel round-trip; thread-open must never be the start trigger) and CLEARS only on the
+// REPLY-ARRIVED event for that send: the agent's reply RECORD landing in the thread's projected
+// msgs — concretely, th.msgs holding MORE who==="agent" entries than it held at the send. Counts of
+// the exchange's own records: never wall clocks (cross-host transcripts skew) and never push counts
+// (the banned proxy — the old two-quiet-pushes settle counter killed the create-window green
+// while the fork booted, and any stall in its 0→1→2 stepping parked green forever with no event to
+// clear it). agentCount is the reply-arrived detector's datum; render.ts holds the per-send base.
+export function agentCount(th: CommentThread): number {
+  return (th.msgs || []).filter((m) => m.who === "agent").length;
 }
 export function threadStuck(state: string): boolean {
   return state === "permission" || state === "picker";
-}
-// The kernel-carried settle confirmation (2026-08-25): the latch above needs two confirming PUSHES,
-// but the wire dedup withholds unchanged frames — the second confirm never arrived, and the green
-// held until an unrelated change minted a frame (the user: it didn't flip until clicking back into
-// the main chat). The kernel now counts pushes-since-busy on the frame itself (settledPushes,
-// clamped at SETTLE_CONFIRM_PUSHES so dedup resumes once decided). null = an older kernel without
-// the field — callers fall back to the client latch.
-export function settleConfirmed(th: CommentThread): boolean | null {
-  const sp = (th as { settledPushes?: number }).settledPushes;
-  return typeof sp === "number" ? sp >= SETTLE_CONFIRM_PUSHES : null;
 }
 
 // ── exact-text re-anchoring ────────────────────────────────────────────────────────────────────

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -47,7 +47,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
-import { threadInFlight, latchBusy, settleConfirmed, type BusyLatch, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -6123,19 +6123,20 @@ function showForkPrompt(sid: string, uuid: string): void {
 // re-render (the transcript rebuilds constantly) reapplies it — the openFolds pattern.
 const commentThreads = new Map<string, CommentThread[]>();          // parent sid → last frame's threads
 const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
-// the one busy answer for the mark + rail tick: the LIVE reading (the pure predicate plus this
-// pane's own optimistic sends) OR the settle latch — a turn boundary inside a continuing thread can
-// read settled for one push, and the green must not blip yellow on it (the user 2026-08-24, second
-// report; comments.ts latchBusy has the rule). The latch advances once per comments FRAME (the
-// event); the live OR keeps optimistic sends instant between frames.
-const commentBusyLatch = new Map<string, BusyLatch>();
+// THE EXCHANGE LATCH (T102, the user 2026-08-26): tid → the agent-message count at the newest SEND.
+// Set at the send GESTURE (create seeds 0 under the synth tid, transferred on adopt; a reply stamps
+// the count at its send), cleared ONLY by the reply-arrived event — the agent's reply record landing
+// in th.msgs (agentCount rising past the base; see the comments frame handler). Follow-ups re-latch
+// identically, each until ITS reply arrives. No push counting, no thread-state proxy: the old
+// push-count settle killed the create-window green while the fork booted (its frames read
+// all-quiet) and any stall in its stepping parked green forever — both ends of the reported bug.
+const cmtAwaitBase = new Map<string, number>();
+// the one busy answer for the mark + rail tick: an in-flight EXCHANGE (the gesture latch above), or
+// — after a reload lost the client latch — the exchange's own records still saying a reply is owed
+// (msgs ending with the user's message). A stuck/errored/closed thread never pulses: green would lie.
 const commentInFlight = (th: CommentThread): boolean => {
-  const raw = threadInFlight(th) || (th.status === "open" && !!(commentPending.get(th.tid) || []).length);
-  // the kernel-carried confirm makes the settle LIVE (the user 2026-08-25: green→yellow waited for a
-  // click): green holds until the frame says two pushes read settled; older kernels → the client latch
-  const confirmed = settleConfirmed(th);
-  if (confirmed !== null) return raw || (th.status === "open" && !th.error && !confirmed);
-  return raw || !!commentBusyLatch.get(th.tid)?.green;
+  if (th.status !== "open" || !!th.error || threadStuck(th.state)) return false;
+  return cmtAwaitBase.has(th.tid) || replyOwed(th);
 };
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 // The popover-boot hold (fillCommentMsgs): tid → when the loader first held the list. Held until the
@@ -6468,6 +6469,10 @@ function openCommentPopover(sid: string, tid: string, _x?: number, _y?: number):
  *  kernel sends the frame first, then the ack naming the tid). When the frame hasn't landed yet
  *  (a dropped/reordered leg), the tid parks in pendingAdoptTid and the next frame adopts it. */
 function adoptCommentThread(sid: string, tid: string): void {
+  // the create's gesture latch carries onto the real thread (the synth tid retires with the anchor)
+  for (const k of Array.from(cmtAwaitBase.keys())) {
+    if (k.startsWith("pending:")) { cmtAwaitBase.set(tid, cmtAwaitBase.get(k)!); cmtAwaitBase.delete(k); }
+  }
   if (pendingCommentAnchor && pendingCommentAnchor.sid === sid) {
     commentDrafts.delete("new:" + pendingCommentAnchor.uuid);
     commentDrafts.delete("newname:" + pendingCommentAnchor.uuid);
@@ -6765,6 +6770,7 @@ function commentSendFromPop(pop: HTMLElement): void {
       unread: false, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
+    cmtAwaitBase.set(synth.tid, 0);   // the SEND gesture latches the pulse — before any kernel round-trip (T102)
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
@@ -6774,7 +6780,8 @@ function commentSendFromPop(pop: HTMLElement): void {
   const cur = openCommentThread();
   if (!cur) return;
   vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
-  cur.th.state = "working";                     // optimistic: the ants march on the SEND, not the
+  cmtAwaitBase.set(cur.th.tid, agentCount(cur.th));   // a follow-up RE-LATCHES at its own send, until ITS reply (T102)
+  cur.th.state = "working";                     // optimistic: the pulse rides the SEND, not the
   applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
   const pl = commentPending.get(cur.th.tid) || [];
   pl.push({ text, t: Date.now() / 1000 });
@@ -11406,9 +11413,16 @@ window.addEventListener("message", (e: MessageEvent) => {
     const sid = String(m.id);
     const threads = (m.threads || []) as CommentThread[];
     commentThreads.set(sid, threads);
-    // the settle latch steps ONCE per frame — the deciding events are pushes (see comments.ts)
-    for (const t of threads) commentBusyLatch.set(t.tid, latchBusy(commentBusyLatch.get(t.tid), t, !!(commentPending.get(t.tid) || []).length));
-    for (const k of Array.from(commentBusyLatch.keys())) if (!threads.some((t) => t.tid === k)) commentBusyLatch.delete(k);
+    // THE REPLY-ARRIVED EVENT (T102): a frame whose msgs hold MORE agent records than the send's
+    // base means THAT send's reply landed — the exchange latch clears here and nowhere else. A
+    // thread that left "open" (or errored) drops its latch too: green would lie about a reply
+    // that is no longer on the way.
+    for (const t of threads) {
+      const base = cmtAwaitBase.get(t.tid);
+      if (base !== undefined && (agentCount(t) > base || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
+    }
+    for (const k of Array.from(cmtAwaitBase.keys()))
+      if (!k.startsWith("pending:") && !threads.some((t) => t.tid === k)) cmtAwaitBase.delete(k);
     const live = new Set(threads.filter((t) => t.status !== "promoted").map((t) => t.tid));
     for (const k of Array.from(commentPending.keys())) if (!live.has(k)) commentPending.delete(k);
     for (const k of Array.from(commentDrafts.keys())) if (!k.startsWith("new:") && !live.has(k)) commentDrafts.delete(k);


### PR DESCRIPTION
## Three symptoms, one proxy (T102)

The busy pulse was governed by a **push-count settle**: the comments frame carried "pushes since the thread last read busy" and the client held green until it read 2 — a proxy for the real ending event, broken at both ends:

1. **Yellow until the thread opened**: the fork-birth frames read all-quiet (CLI not booted, `state ""`, msgs projecting empty behind the fork gate), so the count settled instantly and killed the pulse the send should have started.
2. **Follow-ups didn't pulse** reliably — same faults inherited.
3. **Stuck green after the reply**: the 0→1→2 stepping needed further frames; a parent dropping out of the pushed chat set, a reconnect eating tail frames — any withheld push parked green with **no event to clear it**.

## The machine now — events, no counting

- **Latch = the SEND gesture**: `cmtAwaitBase` stamps the agent-message count at the send (create seeds 0 under the synth tid *before any kernel round-trip*; the adopt transfers it — thread-open is never the start trigger).
- **Clear = the REPLY-ARRIVED record**: the comments frame whose `msgs` hold **more `who === "agent"` records than the send's base** — the agent's reply landing in the thread's projected transcript is the exact named event. Counts of the exchange's own records: no wall clocks (cross-host skew), no push counts.
- Follow-ups re-latch at their own send, each until **its** reply. Stuck/errored/non-open threads never pulse; `replyOwed` stays as the reload-surviving half.
- The kernel counter, its frame field, the client latch, and `threadInFlight` are deleted root and branch. CSS untouched (`mark.cmt-hl.busy` pulse + yellow settled, per the standing pins).

## Verification (headless, built bundle, real gestures)

Select → context-menu **Comment** → type → Enter: busy TRUE at the send; **holds** through the all-quiet fork-birth frame (the reproduced bug frame); clears **immediately** on the reply record; re-latches at a follow-up send; **holds** through a lagging quiet frame; clears on its reply; stays settled with zero further frames — the stuck shape is structurally impossible.

## Tests

`comments.test.ts`: the exchange-latch lifecycle (gesture pins at all three send sites, the single clearing site, the predicate shape, proxy-gone sweeps) + `agentCount`/`replyOwed` executable semantics + a stuck-green regression. `comment-popover-parity.test.ts` retargeted. `tests/test_comment_threads.py`: the kernel counter gone root-and-branch, the frame still carrying the exchange records. npm 2432 + typecheck + Python 5704 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)