### PR TITLE
The popover's pending echo is the chat's queued idiom — inherited, not restyled

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6523,16 +6523,9 @@ def _comments_frame(sid, tmux=None):
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
         reg = _thread_reg(tsid)
-        # the settle count (see _comment_settle_step): raw_busy mirrors the client's threadInFlight
-        # (comments.ts) exactly — live work or an owed reply, on an open unstuck thread
-        tid = str(th.get("tid") or "")
-        raw_busy = (status == "open" and not err and state not in ("permission", "picker")
-                    and (state in ("working", "retrying", "compacting")
-                         or bool(msgs and msgs[-1]["who"] == "you")))
-        quiet = _comment_settle_step(_comment_settle.get(tid), raw_busy, status != "open" or bool(err))
-        _comment_settle[tid] = quiet
-        if len(_comment_settle) > 512:
-            _comment_settle.clear()
+        # (T102: the push-count settle — settledPushes — is RETIRED. The client's pulse is exchange-
+        # scoped now: latched at the send gesture, cleared by the reply RECORD arriving in msgs; the
+        # frame's msgs already carry that event, so no per-push counter rides here anymore.)
         # sinceEpoch (MILLISECONDS, the client convention): when the thread's current state began —
         # the popover's working chip counts from it, exactly as the chat's statusline does
         since_ms = 0
@@ -6556,7 +6549,7 @@ def _comments_frame(sid, tmux=None):
                         "unread": unread, "promotedName": th.get("promotedName") or "",
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
-                        "settledPushes": quiet, "sinceEpoch": since_ms,
+                        "sinceEpoch": since_ms,
                         "mode": str(meta.get("mode") or ""), "fast": str(meta.get("fast") or ""),
                         # the same rank tints the chat statusline's badges wear (the user 2026-08-25,
                         # color rider: the popover's model/effort rendered plain gray — metaColor
@@ -6567,26 +6560,6 @@ def _comments_frame(sid, tmux=None):
                                                      cm.stops_for(_colormap())),
                         "msgs": msgs, "events": events})
     return {"type": "comments", "id": sid, "threads": threads}
-
-
-# The client's green→yellow settle needs TWO CONFIRMING PUSHES (comments.ts latchBusy), but
-# _send_client's dedup withholds unchanged frames — so after a reply landed, the second confirming
-# frame never arrived and the passage stayed green until some unrelated change minted one (the user
-# 2026-08-25: it didn't flip until clicking back into the main chat). The frame now carries the
-# count ITSELF: pushes since the thread last read busy, clamped at 2 — each step is a real pusher
-# cycle (an event, never a timer), the frame changes at most twice after settling, and then the
-# dedup resumes. tid → count; pure step logic split out for the test.
-_comment_settle = {}
-
-
-def _comment_settle_step(prev, raw_busy, decided):
-    """One pusher cycle's step of the settle count: busy → 0; a decided status (closed/errored)
-    settles immediately; otherwise count up, clamped at 2 (the client's SETTLE_CONFIRM_PUSHES)."""
-    if decided:
-        return 2
-    if raw_busy:
-        return 0
-    return min(2, (2 if prev is None else prev) + 1)
 
 
 def _comment_markers(sid):

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5196,7 +5196,17 @@ class SdkBackend:
                     # /clear streams one) — nothing the user watched, nothing to salvage. Persisted, it
                     # resurfaced as a worked reply on the bare command turn (the user 2026-07-27); the
                     # parse-side guard in synthesize_orphans covers markers already written.
-                    if txt.strip() and txt.strip() != "(no content)":
+                    # VERIFIED AT THE WRITE MOMENT (the user 2026-08-26): a marker claims "this reply
+                    # is on disk nowhere", and the claim's precondition — prune_live retired every
+                    # landed atom — holds only for sessions the chat BUILDS. A comment thread is never
+                    # built (hidden by design), so its landed replies were still live at settle and
+                    # EVERY thread reply minted a spurious marker: states/ litter, and the judge's
+                    # per-push marker scan grows with it. One tail read of the sid's own transcript
+                    # per would-be marker (settles are rare; healthy sessions already pruned) keeps
+                    # the salvage honest for every hidden-session shape, threads and future ones. A
+                    # genuinely-lost reply (the API-error discard) is on disk nowhere and still mints.
+                    if txt.strip() and txt.strip() != "(no content)" \
+                            and not self._reply_on_disk(sid, a.get("uuid") or ""):
                         try:
                             append_orphan_reply(self.state_dir, sid, a.get("uuid") or "", txt, t=a.get("t"))
                         except Exception:
@@ -5204,6 +5214,24 @@ class SdkBackend:
                 del d[k]
         if not d:
             self._live.pop(sid, None)
+
+    def _reply_on_disk(self, sid: str, uuid: str) -> bool:
+        """Does the sid's transcript already hold this uuid? The orphan salvage's own precondition,
+        checked against the file it makes claims about (see retire_live_work). Tail-windowed: the
+        settle runs moments after the write, so a landed reply sits near the end; a discarded one's
+        uuid appears nowhere at any offset that matters."""
+        if not uuid:
+            return False
+        try:
+            reg = read_reg(self.state_dir, sid) or {}
+            p = transcript_path(reg.get("cwd") or "", reg.get("lastSid") or sid)
+            size = os.path.getsize(p)
+            with open(p, "rb") as f:
+                if size > 4_000_000:
+                    f.seek(size - 4_000_000)
+                return uuid.encode() in f.read()
+        except OSError:
+            return False
 
     def live_atom_kinds(self, sid: str) -> list:
         """Read-only DEBUG summary of the sid's live-tail atoms: uuid/type + the flags that decide their

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -703,31 +703,27 @@ class CommentOps(CommentBase):
             self.assertIn('"%s"' % op, src)
 
 
-class SettleStepCarriesTheConfirm(unittest.TestCase):
-    """The client's green→yellow settle needs two confirming pushes, but the wire dedup withholds
-    unchanged frames — so the kernel counts pushes-since-busy ON the frame (_comment_settle_step),
-    clamped so the frame changes at most twice after settling and the dedup resumes (the user
-    2026-08-25: the passage stayed green until clicking back into the main chat)."""
+class ExchangeLatchReplacedThePushCount(unittest.TestCase):
+    """T102 (the user 2026-08-26): the push-count settle (settledPushes / _comment_settle_step) is
+    RETIRED — it was a proxy for the real ending event, and it broke both ends: the fork-birth
+    frames read all-quiet so the create-window pulse died until the CLI booted, and any stall in
+    the 0→1→2 stepping parked the pulse green forever. The client's pulse is exchange-scoped now —
+    latched at the send gesture, cleared by the agent's reply RECORD arriving in msgs — so the
+    frame carries the exchange's records (msgs) and no per-push counter."""
 
-    def test_busy_pins_zero_and_settle_counts_up_clamped(self):
-        q = km._comment_settle_step(None, True, False)
-        self.assertEqual(q, 0, "busy → 0")
-        q = km._comment_settle_step(q, False, False)
-        self.assertEqual(q, 1, "first quiet push confirms once")
-        q = km._comment_settle_step(q, False, False)
-        self.assertEqual(q, 2, "second quiet push settles")
-        self.assertEqual(km._comment_settle_step(q, False, False), 2, "clamped — the frame stops changing")
-
-    def test_a_fresh_quiet_thread_is_settled_and_a_decided_status_settles_immediately(self):
-        self.assertEqual(km._comment_settle_step(None, False, False), 2, "never-busy starts settled")
-        self.assertEqual(km._comment_settle_step(0, False, True), 2, "resolved/errored decides at once")
-
-    def test_the_frame_carries_count_and_epoch(self):
+    def test_the_push_count_is_gone_root_and_branch(self):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
-        self.assertIn('"settledPushes": quiet, "sinceEpoch": since_ms,', src)
-        # raw_busy mirrors the client threadInFlight exactly: open + unstuck + (live work or owed reply)
-        self.assertIn('state in ("working", "retrying", "compacting")', src)
-        self.assertIn('bool(msgs and msgs[-1]["who"] == "you")', src)
+        self.assertNotIn("settledPushes", src.replace("settledPushes — is RETIRED", ""),
+                         "no counter rides the frame (the tombstone comment is the one mention)")
+        self.assertNotIn("_comment_settle_step", src)
+        ui = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "comments.ts")).read()
+        self.assertNotIn("settledPushes", ui)
+        self.assertNotIn("SETTLE_CONFIRM_PUSHES", ui)
+
+    def test_the_frame_still_carries_the_exchange_records_and_epoch(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('"sinceEpoch": since_ms,', src)
+        self.assertIn('"msgs": msgs, "events": events', src)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_orphan_reply.py
+++ b/tests/test_kernel_orphan_reply.py
@@ -21,6 +21,51 @@ km = SourceFileLoader("romp_kernel_orphan", os.path.join(BIN, "romp-kernel")).lo
 sb = SourceFileLoader("romp_sdk_backend_orphan_k", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 
+class SalvageVerifiesTheDiskFirst(unittest.TestCase):
+    """The user 2026-08-26: every comment-thread reply minted a spurious orphanReply marker. The
+    salvage's precondition — prune_live retired landed atoms — holds only for sessions the chat
+    BUILDS; a thread is never built, so its landed replies were still live at settle. The marker's
+    claim ("this reply is on disk nowhere") is now verified against the transcript at the write
+    moment: a landed uuid refuses the marker, a genuinely-discarded one (the API-error case, the
+    salvage's whole point) is on disk nowhere and still mints."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        from pathlib import Path
+        self.be = sb.SdkBackend(Path(self.td), "/bin/true", lambda *a, **k: None)
+        self.sid = "11111111-2222-3333-4444-555555555555"
+        self.be.spawn("t", os.path.join(self.td, "cwd"), sid=self.sid)
+        # the session's transcript, holding the LANDED reply record
+        import json
+        reg = sb.read_reg(self.be.state_dir, self.sid)
+        p = sb.transcript_path(reg.get("cwd") or "", reg.get("lastSid") or self.sid)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as f:
+            f.write(json.dumps({"type": "assistant", "uuid": "aaaa1111-0000-0000-0000-000000000001",
+                                "message": {"content": [{"type": "text", "text": "the landed reply"}]}}) + "\n")
+
+    def _live_reply(self, uuid, text):
+        self.be._live.setdefault(self.sid, {})[uuid] = {
+            "type": "assistant", "uuid": uuid, "t": 1,
+            "message": {"content": [{"type": "text", "text": text}]}}
+
+    def _markers(self):
+        f = os.path.join(self.td, "states", self.sid + ".jsonl")
+        if not os.path.exists(f):
+            return []
+        return [l for l in open(f) if '"orphanReply"' in l]
+
+    def test_a_landed_reply_mints_no_marker(self):
+        self._live_reply("aaaa1111-0000-0000-0000-000000000001", "the landed reply")
+        self.be.retire_live_work(self.sid)
+        self.assertEqual(self._markers(), [], "the uuid is on disk — the claim would be false")
+
+    def test_a_genuinely_lost_reply_still_mints(self):
+        self._live_reply("bbbb2222-0000-0000-0000-000000000002", "the discarded partial")
+        self.be.retire_live_work(self.sid)
+        self.assertEqual(len(self._markers()), 1, "on disk nowhere — the salvage's whole point stands")
+
+
 class OrphanReplyReader(unittest.TestCase):
     def test_write_then_read_returns_orphans_oldest_first(self):
         sid = "TESTHOST-orphan-1"

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -73,9 +73,10 @@ test("a fresh thread boots on the romp loader, then renders its final format ONC
   // …with the can't-trap backstop: past it, the hold releases and the projection paints after all
   assert.match(RENDER, /const CMT_BOOT_BACKSTOP_MS = 8000;/);
   assert.match(RENDER, /window\.setTimeout\(\(\) => \{ if \(openCommentKey\?\.tid === tid\) refillOpenCommentPop\(\); \}, CMT_BOOT_BACKSTOP_MS \+ 50\);/);
-  // the user's own pending sends still acknowledge under the loader
+  // the user's own pending sends still acknowledge under the loader — through the CHAT'S queued
+  // idiom (T104: the one-off gray pill is gone; cmtPendingQueued IS renderQueued's bare group)
   const gate = RENDER.split("cmtBootHolds(th.tid)) {")[1].split("return;")[0];
-  assert.ok(gate.includes('commentMsgEl("you", pb.text)'), "pending bubbles ride the boot view");
+  assert.ok(gate.includes("cmtPendingQueued(pend)"), "pending bubbles ride the boot view, chat-idiom");
 });
 
 test("the pulse is exchange-scoped (T102): send-gesture latch, reply-record clear — no push counts", () => {

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -45,7 +45,7 @@ test("the popover's bottom row IS a statusline: the chat's chip anatomy + counti
   assert.ok(!/\.cmt-meta \{/.test(CSSs), "no popover-local meta dress");
   assert.match(CSSs, /\.cmt-pop \.statusline \{[^}]*font-family: var\(--vscode-font-family\); font-size: var\(--vscode-font-size, 13px\); \}/);
   // …and the comments frame carries the epoch (milliseconds, the client convention)
-  assert.match(KERNEL, /"settledPushes": quiet, "sinceEpoch": since_ms,/);
+  assert.match(KERNEL, /"sinceEpoch": since_ms,/);   // (the push-count field is retired — T102)
   // the in-place refresh keeps chip + timer live per frame (chips carry no listeners — click-safe)
   assert.match(RENDER, /if \(th && cs\) cs\.replaceWith\(cmtStateChip\(th\)\);/);
 });
@@ -78,21 +78,17 @@ test("a fresh thread boots on the romp loader, then renders its final format ONC
   assert.ok(gate.includes('commentMsgEl("you", pb.text)'), "pending bubbles ride the boot view");
 });
 
-test("green→yellow settles LIVE: the kernel carries the confirm the dedup used to withhold", () => {
-  // the client latch needed two confirming FRAMES; unchanged frames never arrive (wire dedup), so
-  // the flip waited for an unrelated change (the user: it didn't flip until clicking back). The
-  // kernel counts pushes-since-busy on the frame, clamped so dedup resumes once decided.
-  assert.match(KERNEL, /def _comment_settle_step\(prev, raw_busy, decided\):/);
-  assert.match(COMMENTS, /export function settleConfirmed\(th: CommentThread\): boolean \| null \{/);
-  assert.match(COMMENTS, /return typeof sp === "number" \? sp >= SETTLE_CONFIRM_PUSHES : null;/);
-  // commentInFlight prefers the kernel's confirm; the client latch stays as the old-kernel fallback
-  assert.match(RENDER, /const confirmed = settleConfirmed\(th\);/);
-  assert.match(RENDER, /if \(confirmed !== null\) return raw \|\| \(th\.status === "open" && !th\.error && !confirmed\);/);
-  assert.match(RENDER, /return raw \|\| !!commentBusyLatch\.get\(th\.tid\)\?\.green;/);
+test("the pulse is exchange-scoped (T102): send-gesture latch, reply-record clear — no push counts", () => {
+  // the old kernel-carried confirm counter is retired root and branch: its all-quiet fork-birth
+  // frames killed the create-window green, and a stall in its stepping parked green forever. The
+  // pulse now latches at the SEND gesture and clears on the agent's reply RECORD in msgs
+  // (comments.test.ts carries the full lifecycle pins; this guards the retirement on this surface).
+  assert.doesNotMatch(KERNEL, /_comment_settle/);
+  assert.doesNotMatch(RENDER, /settleConfirmed|commentBusyLatch/);
+  assert.match(RENDER, /const cmtAwaitBase = new Map<string, number>\(\);/);
   // the frame handler already repaints marks AND the open popover per frame — the live wire
   assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) \{/);
 });
-
 test("the model meta-menu exposes VERSIONS: submenu, remembered default, keyboard (the user 2026-08-25)", () => {
   // families with >1 live version wear a side submenu (leftward — the menu anchors bottom-right):
   // hover or an arrow key reveals every version, each pickable with the current-✓; clicking the

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -465,6 +465,20 @@ test("the popover's typing dots are retired — the green highlight is the only 
   assert.match(UI, /the pending bubble IS the acknowledgement/);
 });
 
+// ── T104 (the user 2026-08-26, screenshot): the popover's pending echo wore a one-off washed-gray
+// pill — the "third look" the chat killed 2026-07-16, reborn thread-locally — while the chip read
+// Ready off one stale relayed frame, so it read as a stuck queued thing with no queued dress. The
+// echo now RIDES the chat's own component: renderQueued's bare optimistic group, inherited. ──────
+test("the popover's pending echo IS the chat's queued idiom — one component, both boot and live", () => {
+  assert.match(UI, /function cmtPendingQueued\(pend: \{ text: string; t: number \}\[\]\): HTMLElement \{\s*\n\s*return renderQueued\(\{ kind: "queued", bare: true,/);
+  assert.match(UI, /texts: pend\.map\(\(p\) => \(\{ md: p\.text, optimistic: true, cancelable: false \}\)\),/);
+  const sites = (UI.match(/cmtPendingQueued\(pend\)/g) || []).length;
+  assert.equal(sites, 2, "both render sites — the boot view and the live list — share it");
+  // the one-off is gone root and branch: no .pending class minted, no washed-gray CSS
+  assert.doesNotMatch(UI, /classList\.add\("pending"\)/);
+  assert.doesNotMatch(CSS, /\.cmt-msg\.pending/);
+});
+
 // ── THE EXCHANGE LATCH (T102, the user 2026-08-26 — replacing the push-count settle): busy latches
 // at the SEND GESTURE (cmtAwaitBase.set in render.ts, before any kernel round-trip — thread-open is
 // never the start trigger) and clears ONLY on the reply-arrived event: th.msgs holding MORE

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { threadsByAnchor, threadBusy, threadStuck, threadInFlight, replyOwed, latchBusy, type BusyLatch, SETTLE_CONFIRM_PUSHES, findExact, findAnchorRange, sliceRanges, prunePending,
+import { threadsByAnchor, threadBusy, threadStuck, replyOwed, agentCount, findExact, findAnchorRange, sliceRanges, prunePending,
          type CommentThread } from "./comments";
 import { compactDisplay } from "./compact";
 
@@ -465,59 +465,48 @@ test("the popover's typing dots are retired — the green highlight is the only 
   assert.match(UI, /the pending bubble IS the acknowledgement/);
 });
 
-// ── the in-flight color keys on the EXCHANGE, not the worker session's state (the user 2026-08-24,
-// second report): create → green for a second → YELLOW while the thread CLI booted (its live state
-// read idle) → green once generation started. The exact reported sequence, executed: ─────────────
-test("the mark stays green from send to landed reply, through the CLI-boot state wobble", () => {
+// ── THE EXCHANGE LATCH (T102, the user 2026-08-26 — replacing the push-count settle): busy latches
+// at the SEND GESTURE (cmtAwaitBase.set in render.ts, before any kernel round-trip — thread-open is
+// never the start trigger) and clears ONLY on the reply-arrived event: th.msgs holding MORE
+// who==="agent" records than at the send. No push counting (the banned proxy: its all-quiet
+// fork-birth frames killed the create-window green, and a stall in its stepping parked green
+// forever), no thread-state proxy, no clocks. ────────────────────────────────────────────────────
+test("agentCount is the reply-arrived detector's datum — records of the exchange itself", () => {
   const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
-  // 1) optimistic create: a synthetic working thread — green
-  assert.ok(threadInFlight(th({ state: "working", msgs: [] })), "optimistic create reads in-flight");
-  // 2) the kernel's frame replaces it mid-boot: state idle/empty, the comment is the newest message —
-  //    the reply is OWED, so STILL green (this is the wobble that flashed yellow)
-  assert.ok(threadInFlight(th({ state: "", msgs: [msg("you")] })), "boot window: owed reply keeps it green");
-  // 3) the reply lands: agent message newest, state settled — yellow
-  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you"), msg("agent")] })), "landed reply settles to yellow");
-  // 4) a follow-up from the user re-arms it
-  assert.ok(threadInFlight(th({ state: "", msgs: [msg("you"), msg("agent"), msg("you")] })), "a follow-up re-owes");
-  // live work still counts even with the agent's message newest (a continuing turn)
-  assert.ok(threadInFlight(th({ state: "working", msgs: [msg("you"), msg("agent")] })));
-  // …but never on a blocked, errored, or closed thread — green must not lie
-  assert.ok(!threadInFlight(th({ state: "permission", msgs: [msg("you")] })), "a stuck reply is NOT on the way");
-  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)), "errored: the note speaks, not the green");
-  assert.ok(!threadInFlight(th({ state: "", msgs: [msg("you")], status: "resolved" })), "resolved threads are done");
+  assert.equal(agentCount(th({ msgs: [] })), 0);
+  assert.equal(agentCount(th({ msgs: [msg("you")] })), 0, "the send alone arrives no reply");
+  assert.equal(agentCount(th({ msgs: [msg("you"), msg("agent")] })), 1, "the reply record raises the count");
+  assert.equal(agentCount(th({ msgs: [msg("you"), msg("agent"), msg("you")] })), 1, "a follow-up send does not");
   assert.equal(replyOwed(th({ msgs: [] })), false, "an empty thread owes nothing");
+  assert.equal(replyOwed(th({ msgs: [msg("you")] })), true, "…the durable owed half survives reloads");
 });
 
-// ── the SETTLE LATCH (the user 2026-08-24, third report: green → a ~1s YELLOW blip mid-churn →
-// green → correct settle). At a turn boundary inside a continuing thread one push reads
-// quiet-state + agent-tail — frame-locally identical to the true end — so the green now holds until
-// TWO consecutive pushes confirm the settle (pushes are events; the pendingSessionViews idiom).
-// The user's exact sequence, executed: the state changes at most ONCE across it. ────────────────
-test("the mark never blips: the user's churn sequence yields exactly one green→yellow transition", () => {
-  const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
-  const frames = [
-    th({ state: "working", msgs: [msg("you")] }),                    // churn
-    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // the boundary frame that blipped
-    th({ state: "working", msgs: [msg("you"), msg("agent")] }),      // churn resumes
-    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // quiet 1
-    th({ state: "", msgs: [msg("you"), msg("agent")] }),             // quiet 2 → settle
-  ];
-  let l: BusyLatch | undefined;
-  const seen: boolean[] = [];
-  for (const f of frames) { l = latchBusy(l, f); seen.push(l.green); }
-  assert.deepEqual(seen, [true, true, true, true, false], "green held through the boundary, settled on confirmation");
-  assert.equal(seen.filter((s, i) => i && s !== seen[i - 1]).length, 1, "at most one change per deciding event");
-  assert.equal(SETTLE_CONFIRM_PUSHES, 2, "two consecutive confirming pushes decide the settle");
+test("busy latches at the SEND gesture and clears exactly on the reply-arrived record (source pins)", () => {
+  // create: the gesture latches under the synth tid, before any kernel round-trip
+  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, 0\);\s+\/\/ the SEND gesture latches the pulse/);
+  // follow-up: re-latches at ITS send, with the agent count at that moment as the base
+  assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, agentCount\(cur\.th\)\);/);
+  // the create's latch carries onto the real thread at adopt (the synth tid retires)
+  assert.match(UI, /if \(k\.startsWith\("pending:"\)\) \{ cmtAwaitBase\.set\(tid, cmtAwaitBase\.get\(k\)!\); cmtAwaitBase\.delete\(k\); \}/);
+  // the ONE clearing site: the comments frame whose msgs carry MORE agent records than the base —
+  // or the thread leaving "open"/erroring (green would lie about a reply no longer on the way)
+  assert.match(UI, /if \(base !== undefined && \(agentCount\(t\) > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/);
+  // the mark's predicate: the latch, or (post-reload) the records' own owed reading; never state
+  assert.match(UI, /return cmtAwaitBase\.has\(th\.tid\) \|\| replyOwed\(th\);/);
+  assert.match(UI, /if \(th\.status !== "open" \|\| !!th\.error \|\| threadStuck\(th\.state\)\) return false;/);
+  // the push-count proxy is GONE root and branch
+  assert.doesNotMatch(UI, /settledPushes|commentBusyLatch|latchBusy|SETTLE_CONFIRM_PUSHES/);
 });
 
-test("status flips decide IMMEDIATELY — resolve/merge/error never wait out the confirmation window", () => {
+test("stuck-green regression: a stalled or missing later frame can never park the pulse", () => {
+  // the old settle needed the 0→1→2 stepping to arrive; a parent dropping out of the pushed set (or
+  // any withheld frame) left !confirmed true with nothing to clear it. The new clear is the reply
+  // RECORD itself: the frame that shows the reply clears the latch in the same breath, and a thread
+  // with no latch entry and an agent-tail msgs reads settled with NO further frames needed.
   const msg = (who: "you" | "agent") => ({ who, text: "x", t: 1 });
-  let l = latchBusy(undefined, th({ state: "working", msgs: [msg("you")] }));
-  assert.equal(l.green, true);
-  assert.equal(latchBusy(l, th({ state: "working", msgs: [msg("you")], status: "resolved" })).green, false, "resolved drops the green on ITS event");
-  assert.equal(latchBusy(l, th({ state: "", msgs: [msg("you")], error: "spawn failed" } as any)).green, false, "an errored thread is never green");
-  // an optimistic pending send (alsoBusy) arms the latch like any busy reading
-  assert.equal(latchBusy(undefined, th({ state: "", msgs: [] }), true).green, true, "a just-typed reply reads busy immediately");
+  assert.equal(replyOwed(th({ msgs: [msg("you"), msg("agent")] })), false,
+    "the reply record alone reads settled — no confirmation pushes exist to stall");
+  assert.doesNotMatch(UI, /settleConfirmed/);
 });
 
 // ── LEG C (the user 2026-08-24): the popover ignored the chat's display settings — thinking blocks

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -18,7 +18,6 @@ export type CommentThread = {
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
   error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // an agent reply newer than the read watermark
-  settledPushes?: number;     // kernel pushes since the thread last read busy, clamped at 2 (settleConfirmed)
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   mode?: string;              // the thread's permission mode — the popover statusline's Auto badge
   fast?: string;              // fast-mode state ("on"/"off"/"cooldown"; "" = unknown → no badge)
@@ -60,43 +59,20 @@ export function replyOwed(th: CommentThread): boolean {
   const last = th.msgs.length ? th.msgs[th.msgs.length - 1] : null;
   return !!last && last.who === "you";
 }
-// The ONE in-flight predicate every busy surface reads (the passage mark, the rail tick): live work
-// OR an owed reply, on an open, non-errored thread that isn't blocked on the user — a stuck thread's
-// reply is NOT on the way, and green would lie.
-export function threadInFlight(th: CommentThread): boolean {
-  return th.status === "open" && !th.error && !threadStuck(th.state)
-    && (threadBusy(th.state) || replyOwed(th));
-}
-// SETTLE LATCH (the user 2026-08-24, second report: the passage went green, blipped YELLOW for a
-// second mid-churn, then back to green). At a turn boundary inside a continuing thread, one push can
-// read quiet-state + agent-tail — frame-locally indistinguishable from the true end, so no predicate
-// over a single frame can avoid the flap. The repo rule: transient states latch until the deciding
-// event. Here the deciding evidence is CONSECUTIVE confirming pushes (the pendingSessionViews idiom:
-// pushes are events, never timers): the green holds until TWO pushes in a row read settled; any busy
-// or owed reading resets the count; a status flip (resolved/merged/error) decides IMMEDIATELY — those
-// are real events, never held. The state changes at most once per deciding event by construction.
-export type BusyLatch = { green: boolean; quiet: number };
-export const SETTLE_CONFIRM_PUSHES = 2;
-export function latchBusy(prev: BusyLatch | undefined, th: CommentThread, alsoBusy = false): BusyLatch {
-  if (th.status !== "open" || th.error) return { green: false, quiet: 0 };
-  const raw = alsoBusy || (!threadStuck(th.state) && (threadBusy(th.state) || replyOwed(th)));
-  if (raw) return { green: true, quiet: 0 };
-  if (!prev || !prev.green) return { green: false, quiet: 0 };
-  const quiet = prev.quiet + 1;
-  return quiet >= SETTLE_CONFIRM_PUSHES ? { green: false, quiet: 0 } : { green: true, quiet };
+// THE EXCHANGE LATCH (T102, the user 2026-08-26 — replacing the push-count settle): the busy pulse
+// is exchange-scoped. It LATCHES at the user's SEND gesture (client-side, optimistic — before any
+// kernel round-trip; thread-open must never be the start trigger) and CLEARS only on the
+// REPLY-ARRIVED event for that send: the agent's reply RECORD landing in the thread's projected
+// msgs — concretely, th.msgs holding MORE who==="agent" entries than it held at the send. Counts of
+// the exchange's own records: never wall clocks (cross-host transcripts skew) and never push counts
+// (the banned proxy — the old two-quiet-pushes settle counter killed the create-window green
+// while the fork booted, and any stall in its 0→1→2 stepping parked green forever with no event to
+// clear it). agentCount is the reply-arrived detector's datum; render.ts holds the per-send base.
+export function agentCount(th: CommentThread): number {
+  return (th.msgs || []).filter((m) => m.who === "agent").length;
 }
 export function threadStuck(state: string): boolean {
   return state === "permission" || state === "picker";
-}
-// The kernel-carried settle confirmation (2026-08-25): the latch above needs two confirming PUSHES,
-// but the wire dedup withholds unchanged frames — the second confirm never arrived, and the green
-// held until an unrelated change minted a frame (the user: it didn't flip until clicking back into
-// the main chat). The kernel now counts pushes-since-busy on the frame itself (settledPushes,
-// clamped at SETTLE_CONFIRM_PUSHES so dedup resumes once decided). null = an older kernel without
-// the field — callers fall back to the client latch.
-export function settleConfirmed(th: CommentThread): boolean | null {
-  const sp = (th as { settledPushes?: number }).settledPushes;
-  return typeof sp === "number" ? sp >= SETTLE_CONFIRM_PUSHES : null;
 }
 
 // ── exact-text re-anchoring ────────────────────────────────────────────────────────────────────

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6485,6 +6485,18 @@ function adoptCommentThread(sid: string, tid: string): void {
   applyCommentMarks(sid);
 }
 
+/** The popover's unconfirmed sends, rendered through the CHAT'S OWN queued idiom — renderQueued's
+ *  bare optimistic group, the exact component an unconfirmed chat send wears (T104, the user
+ *  2026-08-26: the thread-local echo was a washed-gray one-off pill, the "third look" the chat
+ *  killed 2026-07-16 reborn in the popover; "I really want to be inheriting all the stuff for how
+ *  the chat normally renders"). Inherited, never restyled: the dashed bubble, the sent-just-now
+ *  title, the no-header bare form all come from the one code path. */
+function cmtPendingQueued(pend: { text: string; t: number }[]): HTMLElement {
+  return renderQueued({ kind: "queued", bare: true,
+    texts: pend.map((p) => ({ md: p.text, optimistic: true, cancelable: false })),
+    uuid: OPT_PREFIX + pend[0].t } as Extract<ChatEvent, { kind: "queued" }>);
+}
+
 function commentMsgEl(who: "you" | "agent", text: string): HTMLElement {
   const n = el("div", "cmt-msg " + who);
   if (who === "agent") n.innerHTML = md(text);
@@ -6523,11 +6535,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
     const boot = el("div", "cmt-boot");
     boot.appendChild(rompLoaderInner("opening the thread…", { wordmark: false }));
     list.appendChild(boot);
-    for (const pb of pend) {
-      const n = commentMsgEl("you", pb.text);
-      n.classList.add("pending");
-      list.appendChild(n);
-    }
+    if (pend.length) list.appendChild(cmtPendingQueued(pend));
     list.scrollTop = list.scrollHeight;
     return;
   }
@@ -6594,11 +6602,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
       list.closest(".cmt-pop")?.querySelector(":scope > .cmt-quote")?.remove();
     }
   } else for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
-  for (const p of pend) {
-    const n = commentMsgEl("you", p.text);
-    n.classList.add("pending");
-    list.appendChild(n);
-  }
+  if (pend.length) list.appendChild(cmtPendingQueued(pend));
   // (the typing dots that rendered here while the thread was busy are RETIRED — the user 2026-08-24:
   // the await-green highlight carries the in-flight signal, and the reply's arrival is announced by
   // the green→yellow settle; the pending bubble still acknowledges the user's own send)

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -47,7 +47,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
-import { threadInFlight, latchBusy, settleConfirmed, type BusyLatch, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -6123,19 +6123,20 @@ function showForkPrompt(sid: string, uuid: string): void {
 // re-render (the transcript rebuilds constantly) reapplies it — the openFolds pattern.
 const commentThreads = new Map<string, CommentThread[]>();          // parent sid → last frame's threads
 const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
-// the one busy answer for the mark + rail tick: the LIVE reading (the pure predicate plus this
-// pane's own optimistic sends) OR the settle latch — a turn boundary inside a continuing thread can
-// read settled for one push, and the green must not blip yellow on it (the user 2026-08-24, second
-// report; comments.ts latchBusy has the rule). The latch advances once per comments FRAME (the
-// event); the live OR keeps optimistic sends instant between frames.
-const commentBusyLatch = new Map<string, BusyLatch>();
+// THE EXCHANGE LATCH (T102, the user 2026-08-26): tid → the agent-message count at the newest SEND.
+// Set at the send GESTURE (create seeds 0 under the synth tid, transferred on adopt; a reply stamps
+// the count at its send), cleared ONLY by the reply-arrived event — the agent's reply record landing
+// in th.msgs (agentCount rising past the base; see the comments frame handler). Follow-ups re-latch
+// identically, each until ITS reply arrives. No push counting, no thread-state proxy: the old
+// push-count settle killed the create-window green while the fork booted (its frames read
+// all-quiet) and any stall in its stepping parked green forever — both ends of the reported bug.
+const cmtAwaitBase = new Map<string, number>();
+// the one busy answer for the mark + rail tick: an in-flight EXCHANGE (the gesture latch above), or
+// — after a reload lost the client latch — the exchange's own records still saying a reply is owed
+// (msgs ending with the user's message). A stuck/errored/closed thread never pulses: green would lie.
 const commentInFlight = (th: CommentThread): boolean => {
-  const raw = threadInFlight(th) || (th.status === "open" && !!(commentPending.get(th.tid) || []).length);
-  // the kernel-carried confirm makes the settle LIVE (the user 2026-08-25: green→yellow waited for a
-  // click): green holds until the frame says two pushes read settled; older kernels → the client latch
-  const confirmed = settleConfirmed(th);
-  if (confirmed !== null) return raw || (th.status === "open" && !th.error && !confirmed);
-  return raw || !!commentBusyLatch.get(th.tid)?.green;
+  if (th.status !== "open" || !!th.error || threadStuck(th.state)) return false;
+  return cmtAwaitBase.has(th.tid) || replyOwed(th);
 };
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 // The popover-boot hold (fillCommentMsgs): tid → when the loader first held the list. Held until the
@@ -6468,6 +6469,10 @@ function openCommentPopover(sid: string, tid: string, _x?: number, _y?: number):
  *  kernel sends the frame first, then the ack naming the tid). When the frame hasn't landed yet
  *  (a dropped/reordered leg), the tid parks in pendingAdoptTid and the next frame adopts it. */
 function adoptCommentThread(sid: string, tid: string): void {
+  // the create's gesture latch carries onto the real thread (the synth tid retires with the anchor)
+  for (const k of Array.from(cmtAwaitBase.keys())) {
+    if (k.startsWith("pending:")) { cmtAwaitBase.set(tid, cmtAwaitBase.get(k)!); cmtAwaitBase.delete(k); }
+  }
   if (pendingCommentAnchor && pendingCommentAnchor.sid === sid) {
     commentDrafts.delete("new:" + pendingCommentAnchor.uuid);
     commentDrafts.delete("newname:" + pendingCommentAnchor.uuid);
@@ -6765,6 +6770,7 @@ function commentSendFromPop(pop: HTMLElement): void {
       unread: false, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
+    cmtAwaitBase.set(synth.tid, 0);   // the SEND gesture latches the pulse — before any kernel round-trip (T102)
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
@@ -6774,7 +6780,8 @@ function commentSendFromPop(pop: HTMLElement): void {
   const cur = openCommentThread();
   if (!cur) return;
   vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
-  cur.th.state = "working";                     // optimistic: the ants march on the SEND, not the
+  cmtAwaitBase.set(cur.th.tid, agentCount(cur.th));   // a follow-up RE-LATCHES at its own send, until ITS reply (T102)
+  cur.th.state = "working";                     // optimistic: the pulse rides the SEND, not the
   applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
   const pl = commentPending.get(cur.th.tid) || [];
   pl.push({ text, t: Date.now() / 1000 });
@@ -11406,9 +11413,16 @@ window.addEventListener("message", (e: MessageEvent) => {
     const sid = String(m.id);
     const threads = (m.threads || []) as CommentThread[];
     commentThreads.set(sid, threads);
-    // the settle latch steps ONCE per frame — the deciding events are pushes (see comments.ts)
-    for (const t of threads) commentBusyLatch.set(t.tid, latchBusy(commentBusyLatch.get(t.tid), t, !!(commentPending.get(t.tid) || []).length));
-    for (const k of Array.from(commentBusyLatch.keys())) if (!threads.some((t) => t.tid === k)) commentBusyLatch.delete(k);
+    // THE REPLY-ARRIVED EVENT (T102): a frame whose msgs hold MORE agent records than the send's
+    // base means THAT send's reply landed — the exchange latch clears here and nowhere else. A
+    // thread that left "open" (or errored) drops its latch too: green would lie about a reply
+    // that is no longer on the way.
+    for (const t of threads) {
+      const base = cmtAwaitBase.get(t.tid);
+      if (base !== undefined && (agentCount(t) > base || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
+    }
+    for (const k of Array.from(cmtAwaitBase.keys()))
+      if (!k.startsWith("pending:") && !threads.some((t) => t.tid === k)) cmtAwaitBase.delete(k);
     const live = new Set(threads.filter((t) => t.status !== "promoted").map((t) => t.tid));
     for (const k of Array.from(commentPending.keys())) if (!live.has(k)) commentPending.delete(k);
     for (const k of Array.from(commentDrafts.keys())) if (!k.startsWith("new:") && !live.has(k)) commentDrafts.delete(k);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2777,7 +2777,6 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-msg.agent { background: rgba(255, 255, 255, 0.05); align-self: flex-start; max-width: 96%; }
 .cmt-msg.agent > *:first-child { margin-top: 0; }
 .cmt-msg.agent > *:last-child { margin-bottom: 0; }
-.cmt-msg.pending { opacity: 0.55; }
 .cmt-note { font-size: 0.92em; opacity: 0.7; padding: 2px 6px; }
 /* the popover's message row mirrors the CHAT composer (the user 2026-08-17): clip left, ➤ right,
    pill input — the attach/send buttons share the chat's own selectors above, so they stay in sync */


### PR DESCRIPTION
## The shown state, diagnosed first (T104)

The send was healthy: the thread's transcript holds the follow-up **and** its reply (landed within seconds of the screenshot), and the state settled right after. The screenshot caught **one stale relayed frame** — the echo not yet pruned, the chip pre-working from the same frame; it heals on the next push. Not a delivery bug, not the T102 reconcile. What made it *read* broken: the popover's pending echo wore a one-off washed-gray style — the "third look" the chat killed on 2026-07-16 (an unconfirmed send must ride the queued idiom), reborn thread-locally.

## The fix — inherited, not restyled

`cmtPendingQueued` wraps **`renderQueued`'s bare optimistic group** — the dashed bubble, the "sent just now — romp hasn't confirmed the session has it yet" title, the no-header bare form, all from the chat's one code path — at **both** render sites (the boot view under the loader, and the live list). The one-off `.pending` class and its CSS are deleted. `prunePending` and the T102 exchange latch are untouched: the landed frame prunes the echo and clears the pulse exactly as before.

## Parity inventory (the "more broadly")

**Shared-path** (the chat's own renderers via `th.events` → `renderEvent`): markdown, user/assistant turns, rail dots, tool rows/folds/groups (compact + `expandedGroups` honored), thinking visibility, notice cards, slash chips, interrupt seams, path links + previews (owner-sid correct), branch divider, quote-as-context; **now also the unconfirmed-send echo**; the statusline chip/timer/meta badges (shared builders); the boot loader (shared `rompLoaderInner`).
**Re-implemented, deliberately**: the msgs-projection fallback bubbles (`commentMsgEl`, only for threads without events); the stuck-on-a-prompt note (Break out — the popover can't answer asks); the thread error note.
**Missing vs the chat** (named for deliberate queueing): (1) echo image thumbnails (the chat's `imgPaths` ride); (2) kernel-side queued/held groups for a busy thread's queue; (3) day dividers; (4) live-ask widgets (today deliberately the Break-out note); (5) API-error/retry cards + controls for the thread session; (6) the "worked Ns" elapsed footers.

## Verification

Headless over the built bundle: the popover follow-up renders as `.turn-queued`/`.queued-bubble` with the sent-just-now title (no bare-group header, no one-off pill), the T102 pulse latches beside it, and the landed frame prunes the echo, renders the real turn, and settles the mark.

## Tests

`comments.test.ts`: the shared-component pins (one builder, both sites, one-off gone root-and-branch); `comment-popover-parity.test.ts`'s boot pin retargeted. npm 2433 + typecheck + Python 5704 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)