### PR TITLE
UI aesthetic polish: one vocabulary per visual family, modern browser fonts, a soft identity palette

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26612,7 +26612,7 @@ def _landing():
             # A mismatched pair is the state that used to be invisible until mail quarantined, so it
             # wears a warm tint; matched reads as quiet metadata.
             ".rnet-back{color:#6e7681;font-size:11px;white-space:nowrap}"
-            ".rnet-back.rnet-mismatch{color:#d29922}"
+            ".rnet-back.rnet-mismatch{color:#d7a23a}"
             ".rnet-mirror{background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:1px 7px;font-size:11px;cursor:pointer}"
             ".rnet-mirror:disabled{opacity:0.55;cursor:default}"
             ".rnet-dot{width:7px;height:7px;border-radius:50%;flex:0 0 auto}"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -625,7 +625,7 @@ _TOKEN_LOGIN_HTML = """<!doctype html>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>romp</title>
 <body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;\
-background:#101418;color:#dfe7ee;font:15px/1.5 -apple-system,system-ui,sans-serif">
+background:#101418;color:#dfe7ee;font:15px/1.5 system-ui,-apple-system,sans-serif">
 <form style="text-align:center;max-width:26em;padding:2em" onsubmit="\
 location.replace('/?token='+encodeURIComponent(document.getElementById('t').value.trim()));return false">
   <div style="font-size:1.6em;letter-spacing:.04em;margin-bottom:.4em">romp</div>
@@ -23983,8 +23983,8 @@ def _pusher():
 
 
 # ───────────────────────── HTTP / page serving ─────────────────────────
-THEME_CSS = """:root{--vscode-font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
---vscode-editor-font-family:Menlo,Monaco,"Courier New",monospace;--vscode-chat-font-family:var(--vscode-font-family);
+THEME_CSS = """:root{--vscode-font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+--vscode-editor-font-family:ui-monospace,"SF Mono",Menlo,Consolas,"DejaVu Sans Mono",monospace;--vscode-chat-font-family:var(--vscode-font-family);
 --vscode-chat-font-size:13px;--vscode-foreground:#cccccc;--vscode-descriptionForeground:rgba(204,204,204,.7);
 --vscode-errorForeground:#f48771;--vscode-editor-background:#1e1e1e;--vscode-editorWidget-background:#252526;
 --vscode-editorHoverWidget-border:#454545;--vscode-sideBar-background:#252526;--vscode-widget-border:#303031;
@@ -24023,7 +24023,7 @@ function netState(s){try{if(window.parent!==window)window.parent.postMessage({ro
 // directly) has no shell, so self-inject a minimal top bar with the same Reload action.
 function selfBar(t,kind){try{if(document.getElementById("romp-stale-self"))return;
 var b=document.createElement("div");b.id="romp-stale-self";b.dataset.kind=kind||"conn";
-b.style.cssText="position:fixed;top:0;left:0;right:0;z-index:99999;display:flex;gap:12px;align-items:center;justify-content:center;background:#2b2d30;color:#e6e6e6;border-bottom:1px solid #4a4d51;padding:9px 14px;font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif";
+b.style.cssText="position:fixed;top:0;left:0;right:0;z-index:99999;display:flex;gap:12px;align-items:center;justify-content:center;background:#2b2d30;color:#e6e6e6;border-bottom:1px solid #4a4d51;padding:9px 14px;font:13px/1.4 system-ui,-apple-system,'Segoe UI',Roboto,sans-serif";
 var m=document.createElement("span");m.textContent=t;b.appendChild(m);
 var r=document.createElement("button");r.textContent="Reload";
 r.style.cssText="font:inherit;cursor:pointer;border-radius:6px;padding:4px 11px;font-weight:600;background:#54B204;color:#0c1a00;border:1px solid #3f8a00";
@@ -24142,7 +24142,7 @@ _CHAT_MOBILE_CSS = (
     "#mhdr{display:flex;align-items:stretch;gap:6px;width:100%}"
     "#mcur{flex:1 1 auto;min-width:0;display:flex;align-items:center;gap:8px;cursor:pointer;"
     "background:#2a2a2a;color:#dddddd;border:1px solid #3a3a3a;border-radius:6px;padding:7px 10px;"
-    "font:600 13px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
+    "font:600 13px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     # colored session: the identity color reads as the NAME (bold) on the same grey chip as the +/madd
     # button, with a hairline color border, not the color as a fill (the user 2026-07-22).
     "#mcur.colored{background:#2a2a2a;color:var(--cbg);border-color:var(--cbg)}"
@@ -24158,7 +24158,7 @@ _CHAT_MOBILE_CSS = (
     "box-shadow:0 8px 24px #000000aa}"
     "#mlist.open{display:block}"
     ".mrow{display:flex;align-items:center;gap:9px;padding:10px 12px;cursor:pointer;"
-    "border-bottom:1px solid #ffffff12;font:600 13px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
+    "border-bottom:1px solid #ffffff12;font:600 13px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     ".mrow:last-child{border-bottom:0}"
     # match desktop: the session's identity color tints the NAME text (set inline, like the Fleet list and
     # the colored tab label), and the only dot is the gold WORKING dot, shown just for working sessions.
@@ -24302,7 +24302,7 @@ _LOADER_CSS = (
     # (baseline + x-height/2). Geometry from assets/make_wordmark.py: the swirl-o glyph is the
     # CENTERED 102..820 crop, sized SWIRL_EM=0.65em, with side margins -(0.65-0.583)/2 = -0.0335em so its
     # advance equals Anta's 'o' (0.583em) and m/p land where a real "o" puts them.
-    ".rl-word{font-family:'RompAnta',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:38px;"
+    ".rl-word{font-family:'RompAnta',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;font-size:38px;"
     "line-height:1;white-space:nowrap}"
     ".rl-o{width:.65em;height:.65em;vertical-align:middle;margin:0 -.0335em;animation:rl-spin 7s linear infinite}"
     ".rl-dots{display:flex;gap:7px}"
@@ -24420,7 +24420,7 @@ def _fleet_page():
     try:
         fleet_css = (UI / "webview" / "fleet-pane.css").read_text()
     except OSError:
-        return ("<!DOCTYPE html><html><body style='font-family:-apple-system,sans-serif;color:#999;"
+        return ("<!DOCTYPE html><html><body style='font-family:system-ui,-apple-system,sans-serif;color:#999;"
                 "background:#1e1e1e;padding:12px'>romp outline needs the ui/ modules "
                 "(webview/fleet-pane.css).</body></html>")
     v = _dist_ver()
@@ -24495,7 +24495,7 @@ def _timeline_page():
         view_js = (UI / "romp-timeline-view.js").read_text()
         tl_css = (UI / "webview" / "timeline-pane.css").read_text()
     except OSError:
-        return ("<!DOCTYPE html><html><body style='font-family:-apple-system,sans-serif;color:#999;"
+        return ("<!DOCTYPE html><html><body style='font-family:system-ui,-apple-system,sans-serif;color:#999;"
                 "background:#1e1e1e;padding:12px'>romp timeline needs the ui/ modules "
                 "(romp-timeline-view.js + webview/timeline-pane.css).</body></html>")
     v = _dist_ver()
@@ -26097,7 +26097,7 @@ _STALE_CSS = (
     "#rstale{position:fixed;top:14px;left:50%;transform:translateX(-50%);z-index:99999;display:none;"
     "align-items:center;gap:12px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
     "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
-    "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
+    "font:13px/1.4 system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     "#rstale.show{display:flex}#rstale .rs-msg{font-weight:500}"
     "#rstale button{font:inherit;cursor:pointer;border-radius:6px;padding:5px 11px;"
     "border:1px solid transparent;white-space:nowrap}"
@@ -26203,7 +26203,7 @@ _UPD_CSS = (
     "#rupd{position:fixed;top:56px;left:50%;transform:translateX(-50%);z-index:99999;display:none;"
     "align-items:center;gap:12px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
     "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
-    "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
+    "font:13px/1.4 system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     "#rupd.show{display:flex}#rupd .rup-msg{font-weight:500}"
     "#rupd button{font:inherit;cursor:pointer;border-radius:6px;padding:5px 11px;"
     "border:1px solid transparent;white-space:nowrap}"
@@ -26295,7 +26295,7 @@ _RDRIFT_CSS = (
     "#rdrift{position:fixed;top:104px;left:50%;transform:translateX(-50%);z-index:99998;display:none;"
     "align-items:center;gap:10px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
     "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
-    "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
+    "font:13px/1.4 system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     "#rdrift.show{display:flex}#rdrift .rd-msg{font-weight:500}"
     "#rdrift .rd-spin{width:14px;height:14px;flex:0 0 auto;display:none;"
     "background:url(/media/romp-swirl-glyph.svg) center/contain no-repeat;animation:rd-spin 2.4s linear infinite}"
@@ -26514,7 +26514,7 @@ def _landing():
             ".rail-scroll::-webkit-scrollbar{width:0;height:0}"
             ".rail-acts{flex:0 0 auto;display:flex;flex-direction:row;align-items:center;gap:6px;margin-left:auto}"   # compact: tight row of refresh/network/settings   # pinned to the RIGHT of the bottom bar, always visible
             ".rail-btn{flex:0 0 auto;letter-spacing:.04em;line-height:1;"
-            "font:600 11px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#8a8a8a;margin:0;"
+            "font:600 11px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#8a8a8a;margin:0;"
             "padding:4px 9px;border-radius:5px;cursor:pointer;user-select:none;display:flex;align-items:center;"
             "justify-content:center;transition:color .1s,background .1s}"
             ".rail-btn:hover{color:#cfe6ff;background:rgba(255,255,255,0.06)}"
@@ -26710,7 +26710,7 @@ def _landing():
             # the windows sit side-by-side. Full detail (elapsed %, reset countdown, age) stays in the hover panel.
             "#rail-usage{flex:0 0 auto;display:flex;flex-direction:row;align-items:center;gap:16px}"
             ".ru-w{display:flex;flex-direction:row;align-items:center;gap:7px;cursor:default}"
-            ".ru-name{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#9aa4ad;letter-spacing:.02em;white-space:nowrap}"
+            ".ru-name{font:600 10px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#9aa4ad;letter-spacing:.02em;white-space:nowrap}"
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
             ".ru-track{position:relative;width:54px;height:5px;background:rgba(255,255,255,0.12);border-radius:3px;overflow:hidden;flex:0 0 auto}"
             ".ru-fill{position:absolute;left:0;top:0;height:100%;border-radius:3px;transition:width .3s ease}"
@@ -26718,7 +26718,7 @@ def _landing():
             # drawn on the bar AT ALL — only what we know shows there. The last-known reading survives in
             # the tooltip, labelled "last known" and faded, which is honest because it says what it is.
             ".ru-tip-row.ru-unk i{opacity:.3}.ru-tip-row.ru-unk .ru-tip-k,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
-            ".ru-pct{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
+            ".ru-pct{font:600 10px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)
             # over an "elapsed" bar (slate) with the % + reset countdown, and nothing else (no prose).
@@ -26738,7 +26738,7 @@ def _landing():
             "#ru-back{position:fixed;inset:0;z-index:290;display:none;background:rgba(0,0,0,0.4)}"
             "#ru-back.on{display:block}"
             "#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
-            "padding:8px 10px;font:500 11px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#cfd6dd;"
+            "padding:8px 10px;font:500 11px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfd6dd;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45);pointer-events:none;line-height:1.4}"
             ".ru-tip-win{margin-bottom:8px}#ru-tip .ru-tip-win:last-child{margin-bottom:0}"
             # Multi-host breakdown: one COLUMN per host, side by side (the user 2026-08-08 — not one
@@ -26770,13 +26770,13 @@ def _landing():
             # aggregates one set of bars + one API cell, and the per-host story lives in the hover, whose
             # .ru-tip-host heading keeps the quiet lowercase-italic treatment a federated session's name
             # wears in the chat tabs.)
-            ".ru-tip-host{font:italic 400 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+            ".ru-tip-host{font:italic 400 10px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "color:#9aa0a6;text-transform:lowercase;margin:0 0 4px}"
             "#ru-tip .ru-tip-host:not(:first-child){margin-top:10px;padding-top:8px;"
             "border-top:1px solid rgba(255,255,255,0.08)}"
             # the login the window bars belong to (the user 2026-08-09) — quiet, above the sections,
             # the host heading's size without its lowercase-italic host vocabulary
-            ".ru-tip-acct{font:400 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+            ".ru-tip-acct{font:400 10px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "color:#9aa0a6;margin:0 0 4px}"
             # the three TOP panes flex-grow by a per-pane var (resized by the gutters, persisted); toggling one
             # off hides it AND the now-orphaned gutters. Fixed order: chat, fleet, feed. Timeline is the band.
@@ -26858,7 +26858,7 @@ def _landing():
             # which includes this padding, so .col's reservation tracks it for free.
             "html.ios-standalone #mtabs{padding-bottom:env(safe-area-inset-bottom,0px)}"
             "#mtabs button{flex:1;border:0;background:none;cursor:pointer;-webkit-tap-highlight-color:transparent;"
-            "color:#9aa0a6;font:600 12px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+            "color:#9aa0a6;font:600 12px system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "padding:6px 0;display:flex;align-items:center;justify-content:center}"
             "#mtabs button.on{color:#4da4ff}"
             # action buttons: dimmer + fixed-width so the four pane tabs keep the room; thin divider between

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26095,8 +26095,8 @@ try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.sea
 # version only). Self-contained block (own style + node + script) so it injects at one point.
 _STALE_CSS = (
     "#rstale{position:fixed;top:14px;left:50%;transform:translateX(-50%);z-index:99999;display:none;"
-    "align-items:center;gap:12px;max-width:92vw;background:#2b2d30;border:1px solid #4a4d51;"
-    "border-radius:10px;padding:10px 14px;color:#e6e6e6;box-shadow:0 10px 30px #0000008a;"
+    "align-items:center;gap:12px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
+    "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
     "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
     "#rstale.show{display:flex}#rstale .rs-msg{font-weight:500}"
     "#rstale button{font:inherit;cursor:pointer;border-radius:6px;padding:5px 11px;"
@@ -26201,8 +26201,8 @@ def _stale_block(v):
 # "Not now" is page-scoped on purpose — the next kernel start re-offers (what the user asked for).
 _UPD_CSS = (
     "#rupd{position:fixed;top:56px;left:50%;transform:translateX(-50%);z-index:99999;display:none;"
-    "align-items:center;gap:12px;max-width:92vw;background:#2b2d30;border:1px solid #4a4d51;"
-    "border-radius:10px;padding:10px 14px;color:#e6e6e6;box-shadow:0 10px 30px #0000008a;"
+    "align-items:center;gap:12px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
+    "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
     "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
     "#rupd.show{display:flex}#rupd .rup-msg{font-weight:500}"
     "#rupd button{font:inherit;cursor:pointer;border-radius:6px;padding:5px 11px;"
@@ -26293,8 +26293,8 @@ _RDRIFT_CSS = (
 # used to overlap at 56/60px when a self-update offer and a remote-drift ask were both live (the user
 # 2026-08-15, whose screenshot showed exactly that pileup) — three claims, three targets, one spot.
     "#rdrift{position:fixed;top:104px;left:50%;transform:translateX(-50%);z-index:99998;display:none;"
-    "align-items:center;gap:10px;max-width:92vw;background:#2b2d30;border:1px solid #4a4d51;"
-    "border-radius:10px;padding:10px 14px;color:#e6e6e6;box-shadow:0 10px 30px #0000008a;"
+    "align-items:center;gap:10px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
+    "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
     "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
     "#rdrift.show{display:flex}#rdrift .rd-msg{font-weight:500}"
     "#rdrift .rd-spin{width:14px;height:14px;flex:0 0 auto;display:none;"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26518,7 +26518,7 @@ def _landing():
             "padding:4px 9px;border-radius:5px;cursor:pointer;user-select:none;display:flex;align-items:center;"
             "justify-content:center;transition:color .1s,background .1s}"
             ".rail-btn:hover{color:#cfe6ff;background:rgba(255,255,255,0.06)}"
-            ".rail-btn.on{color:var(--accent);background:rgba(156,210,255,0.10)}"
+            ".rail-btn.on{color:var(--accent);background:rgba(156,210,255,0.12)}"
             # the ↻ refresh + ⛭ settings actions sit in .rail-acts, pinned to the RIGHT (margin-left:auto on the
             # wrapper) of the bottom bar and ALWAYS visible — settings (⛭, last in the DOM) at the far right.
             ".rail-act{flex:0 0 auto;display:flex;align-items:center;justify-content:center;margin:1px 4px;padding:4px 0;"

--- a/kernel/palette.py
+++ b/kernel/palette.py
@@ -61,6 +61,16 @@ PALETTES = {
         "fg": ["white", "black", "black", "white", "white",
                "white", "black", "white", "black"],
     },
+    # pastel — a soft high-lightness set (all-black text) for anyone who finds the saturated sets
+    # loud across many tabs (2026-08-26). Hand-tuned like the romp set, same colorblind-tuned
+    # order (blue, green, teal first); every swatch stays under the mid-tone luminance cap.
+    "pastel": {
+        "label": "pastel — romp soft",
+        "bg": ["#8FC7F2", "#9AD48A", "#7ED4C8", "#D9A7EC", "#F2B27C",
+               "#C9CBB0", "#F2A09E", "#EBD584", "#B4AFF2"],
+        "fg": ["black", "black", "black", "black", "black",
+               "black", "black", "black", "black"],
+    },
 }
 
 

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -50,6 +50,12 @@ class PaletteShapes(unittest.TestCase):
         self.assertEqual(next(iter(pal.PALETTES)), "romp")
         self.assertEqual(pal.PALETTES["romp"]["bg"], ROMP_BG, "the historical set is the default, unchanged")
 
+    def test_pastel_is_the_soft_all_black_text_set(self):
+        # the 2026-08-26 addition: a high-lightness identity set for anyone who finds the saturated
+        # palettes loud across many tabs — soft by construction, so every fg must be black
+        self.assertIn("pastel", pal.PALETTES)
+        self.assertEqual(pal.PALETTES["pastel"]["fg"], ["black"] * 9)
+
     def test_crameri_and_cmocean_sets_are_curated_mid_tone(self):
         # The raw Crameri "S" orderings include near-black (#011959) and near-white entries — built for
         # white paper, unusable as identity chrome on the dark UI. Every shipped color must be mid-tone.

--- a/tools/ui-verify/fixtures/feed-card-badges.html
+++ b/tools/ui-verify/fixtures/feed-card-badges.html
@@ -1,0 +1,29 @@
+<!-- SYNTHETIC fixture: one ask card whose row carries every status badge side by side —
+     .fask-blocked, .fask-apierror (+ Retry), .fask-retrying, .fask-jauth — plus the column head's
+     .fcol-chip, for eyeballing the same-row badge metric set (they claim "same information type";
+     before 2026-08-26 .fask-blocked alone wore 0.72em/700/6px/1px 8px). Invented content
+     (notes-api demo domain). Run:
+       tools/ui-verify/shot.sh --css ui/webview/feed.css --body tools/ui-verify/fixtures/feed-card-badges.html \
+           --out /tmp/feed-badges.png --size 760x240 --extra-css '#feed-list { min-height: 170px; }'
+-->
+<div id="feed-head"></div>
+<div id="feed-list">
+  <div class="feed-cols">
+    <div class="feed-col col-asks">
+      <div class="feed-col-head"><span class="feed-col-name fcol-chip fcol-chip-blocked">Blocked</span><span class="feed-col-count">1</span></div>
+      <div class="feed-col-list">
+        <div class="fitem ask" style="background:#26262e;border-color:rgba(192,57,43,.5)"><div class="fitem-main">
+          <div class="fask-row1"><div class="fcard-title nav">ship the notes-api exporter</div><span class="ftime">2m ago</span></div>
+          <div class="fask-row2">
+            <div class="fask-id"><a class="fname" style="color:#E0A030">api</a></div>
+            <span class="fask-blocked">⏸ permission</span>
+            <span class="fask-apierror">⚠ API error</span>
+            <button class="fdismiss fretry">Retry</button>
+            <span class="fask-retrying">⚠ retrying since 14:02</span>
+            <span class="fask-jauth">⚠ Can’t analyze · API key</span>
+          </div>
+        </div></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/tools/ui-verify/fixtures/loader.html
+++ b/tools/ui-verify/fixtures/loader.html
@@ -1,0 +1,16 @@
+<!-- SYNTHETIC fixture: the romp loader anatomy exactly as rompLoaderInner (render.ts) builds it —
+     the revive loader's DOM on the VS Code chat surface, which loads styles.css ALONE. Run:
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/loader.html \
+           --out /tmp/loader.png --size 500x300
+     shot.sh copies only the stylesheet into its temp page, so the swirl <img> 404s here and falls
+     back to its alt "o", and the RompAnta @font-face falls back to var(--sans) — geometry and the
+     dots' pulse are what this fixture verifies. To see the real glyph, copy this file to /tmp and
+     point src at an absolute file:// path of vscode-extension/media/romp-swirl-o.svg (never commit
+     that copy). Caption text is invented (notes-api demo domain). -->
+<div id="revive-loader" style="left: 10px; top: 10px; width: 480px; height: 280px;">
+  <div class="rl-in">
+    <div class="rl-word"><span style="color:#1EA1EB">R</span><img class="rl-o" src="romp-swirl-o.svg" alt="o"><span style="color:#54B204">m</span><span style="color:#4EA8A9">p</span></div>
+    <div class="rl-dots"><i></i><i></i><i></i></div>
+    <div class="revive-cap">reviving “web”…</div>
+  </div>
+</div>

--- a/tools/ui-verify/fixtures/menus-chat.html
+++ b/tools/ui-verify/fixtures/menus-chat.html
@@ -1,0 +1,29 @@
+<!-- SYNTHETIC fixture: the chat pane's dropdown/tooltip family side by side, for eyeballing the ONE
+     menu vocabulary (CLAUDE.md): #252526 card, hairline, --radius-menu, --shadow-menu. All content
+     invented (notes-api demo domain). These elements are position:fixed (and .tab-tip display:none)
+     in real life — the runner statically places them (body must be re-flexed to a ROW: the chat
+     sheet's own body is a flex column):
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/menus-chat.html \
+           --out /tmp/menus-chat.png --size 940x260 --extra-css '.ctx-menu,.meta-menu,.tab-tip,.slash-pop{position:static;display:block} body{background:#1e1e1e;padding:24px;display:flex;flex-direction:row;align-items:flex-start;gap:28px}'
+-->
+<div class="ctx-menu">
+  <div class="ctx-item">Rename</div>
+  <div class="ctx-item">Change color</div>
+  <div class="ctx-item">Close tab</div>
+</div>
+<div class="meta-menu">
+  <div class="meta-item current">sonnet</div>
+  <div class="meta-item">opus</div>
+  <div class="meta-item">haiku</div>
+</div>
+<div class="tab-tip">
+  <b style="color:#1EA1EB">sdk</b><br>
+  ~/notes-api<br>
+  main · sonnet · high<br>
+  context 41%
+</div>
+<div class="slash-pop">
+  <div class="slash-row sel"><span class="slash-name">/review</span><span class="slash-desc">review the current diff</span></div>
+  <div class="slash-row"><span class="slash-name">/tests</span><span class="slash-desc">run the test suite</span></div>
+  <div class="slash-row"><span class="slash-name">/deploy</span><span class="slash-desc">ship to staging</span></div>
+</div>

--- a/tools/ui-verify/fixtures/modals-feed.html
+++ b/tools/ui-verify/fixtures/modals-feed.html
@@ -1,0 +1,24 @@
+<!-- SYNTHETIC fixture: the feed pane's dialog/modal card family side by side — resume dialog,
+     confirm box, the card modal's shell, the file viewer's shell — for eyeballing the ONE
+     centered-modal card (--radius-modal, --shadow-modal, --overlay-dim). Invented content
+     (notes-api demo domain). The wrappers are fixed inset-0 backdrops in real life — the runner
+     statically places the CARDS only:
+       tools/ui-verify/shot.sh --css ui/webview/feed.css --body tools/ui-verify/fixtures/modals-feed.html \
+           --out /tmp/modals-feed.png --size 1000x330 \
+           --extra-css '.pickdlg-box,.fconfirm-box,.feed-modal-inner,.fileview{position:static;width:220px;height:auto;min-height:120px} body{background:#1e1e1e;padding:30px;display:flex;flex-direction:row;align-items:flex-start;gap:30px}'
+-->
+<div class="pickdlg-box">
+  <div class="pickdlg-title">Resume “web”?</div>
+  <div>Pick where to continue from.</div>
+</div>
+<div class="fconfirm-box">
+  <div class="fconfirm-msg">Revive “tests” and re-run the failing suite?</div>
+  <div class="fconfirm-btns"><button class="fconfirm-btn">Cancel</button><button class="fconfirm-btn primary">Revive</button></div>
+</div>
+<div class="feed-modal-inner">
+  <div class="feed-modal-head"><span class="feed-modal-title">ship the notes-api exporter</span></div>
+</div>
+<div class="fileview">
+  <div class="fileview-bar"><span class="fileview-name"><span class="fileview-dir">src/</span><span class="fileview-base">exporter.ts</span></span><span class="fileview-acts"><button class="fileview-btn">Raw</button></span></div>
+  <div class="fileview-body"></div>
+</div>

--- a/tools/ui-verify/fixtures/outline-header.html
+++ b/tools/ui-verify/fixtures/outline-header.html
@@ -1,0 +1,12 @@
+<!-- SYNTHETIC fixture: the sessions pane's header row — search box + the shared tag button + a
+     selection chip — for eyeballing the one-row flex layout (the button used to drop to a second
+     line) and the icon button's box. The button/chip inline styles mirror tag-menu.ts's literals.
+     Run at TWO widths to see the row hold and then wrap gracefully:
+       tools/ui-verify/shot.sh --css ui/webview/fleet-pane.css --body tools/ui-verify/fixtures/outline-header.html \
+           --out /tmp/outline-header.png --size 420x90
+-->
+<div id="fleet-search-bar">
+  <div id="fleet-search-wrap"><input id="fleet-search" type="search" placeholder="filter sessions…"></div>
+  <button style="background:transparent;border:1px solid rgba(255,255,255,0.10);border-radius:6px;padding:4px 6px;cursor:pointer;color:#9cd2ff;display:inline-flex;align-items:center;"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/><circle cx="11" cy="5.5" r="1.2" fill="currentColor"/></svg></button>
+  <span id="fleet-tagchips" style="display:inline-flex;gap:5px;align-items:center;margin-left:2px;"><span style="display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0.82em;border:1px solid #DD42FF;color:#DD42FF;background:transparent;white-space:nowrap;">infra <span style="cursor:pointer;opacity:0.75;color:#9aa0a6;font-size:0.9em;">✕</span></span></span>
+</div>

--- a/tools/ui-verify/fixtures/toasts-chat.html
+++ b/tools/ui-verify/fixtures/toasts-chat.html
@@ -1,0 +1,11 @@
+<!-- SYNTHETIC fixture: the chat pane's transient-notice family side by side — locate-toast,
+     seek-note, warn-toast — for eyeballing the ONE toast vocabulary (--surface-raised,
+     --radius-toast, --shadow-toast; semantic border colors stay per notice). Invented content
+     (notes-api demo domain). All are position:fixed in real life — the runner statically places
+     them (body re-flexed to a row: the chat sheet's body is a flex column):
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/toasts-chat.html \
+           --out /tmp/toasts-chat.png --size 940x180 --extra-css '.locate-toast,.warn-toast,#seek-note{position:static;transform:none} body{background:#1e1e1e;padding:24px;display:flex;flex-direction:row;align-items:flex-start;gap:28px}'
+-->
+<div class="locate-toast">showing the last session before the filter</div>
+<div id="seek-note"><span class="seek-note-label">jumped to</span> the exporter question <span class="seek-note-x">✕</span></div>
+<div class="warn-toast">could not revive “tests” — the worktree is gone <span class="warn-toast-x">✕</span></div>

--- a/tools/ui-verify/fixtures/transcript-density.html
+++ b/tools/ui-verify/fixtures/transcript-density.html
@@ -1,0 +1,10 @@
+<!-- SYNTHETIC fixture: a short chat exchange — user bubble, agent prose, romp follow-up bubble —
+     for eyeballing the transcript's vertical rhythm (turn padding, bubble padding). Invented
+     content (notes-api demo domain). Run:
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/transcript-density.html \
+           --out /tmp/transcript.png --size 700x420 --extra-css 'body{display:block;padding:10px 20px}'
+-->
+<div class="turn turn-user"><div class="user-bubble">Can you ship the notes-api exporter today?</div></div>
+<div class="turn"><div class="md"><p>Working on it — the failing suite in <code>tests/</code> is the blocker. Two cases assume the old CSV header; I'm updating the fixtures now and will re-run the full suite before pushing.</p></div></div>
+<div class="turn turn-user"><div class="user-bubble">Great — ping me when CI is green.</div></div>
+<div class="turn"><div class="md"><p>Will do. The branch is <code>exporter-v2</code>; the PR opens as soon as the suite passes.</p></div></div>

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -831,14 +831,14 @@ class TimelinePanel {
           + 'pointer-events:none;font-size:13px;'
           + 'font-family:var(--vscode-font-family,-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif)}'
           + '.romp-tl-corner>*{pointer-events:auto}'
-          + '.romp-tl-cbtn{display:inline-flex;align-items:center;font:inherit;font-size:10.5px;padding:1px 9px;'
+          + '.romp-tl-cbtn{display:inline-flex;align-items:center;font:inherit;font-size:10.5px;padding:4px 6px;'
           + 'color:var(--vscode-descriptionForeground,#9a9a9a);background:transparent;'
           + 'border:1px solid rgba(255,255,255,0.10);border-radius:6px;cursor:pointer;white-space:nowrap;opacity:0.95;'
           + 'transition:color 0.12s ease,border-color 0.12s ease,background 0.12s ease}'
           + '.romp-tl-cbtn svg{display:block}'
           + '.romp-tl-cbtn:hover{border-color:var(--accent,#9cd2ff);color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12)}'
           + '.romp-tl-cbtn.on{color:var(--accent,#9cd2ff);border-color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12);opacity:1}'
-          + '.romp-tl-chip{display:inline-flex;align-items:center;gap:5px;padding:1px 8px;border-radius:9px;'
+          + '.romp-tl-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;'
           + 'font-size:0.82em;border:1px solid;background:transparent;white-space:nowrap}'
           + '.romp-tl-chipx{cursor:pointer;opacity:0.75;color:#9aa0a6;font-size:0.9em}'
           + '.romp-tl-ctail{color:#9aa0a6;opacity:0.7;font-size:12px;cursor:pointer;user-select:none;white-space:nowrap}';
@@ -2788,7 +2788,7 @@ class TimelinePanel {
       }
       for (const n of (lens.tags || [])) if (picked[n]) chips.push({ label: n, color: MODEL_FG, pick: { tag: n } });
     }
-    const GAP = 8, BTNW = 34;   // the bar's flex gap; the feed tag button's measured box width
+    const GAP = 8, BTNW = 28;   // the bar's flex gap; the icon button's measured box (14 glyph + 12 pad + 2 border)
     const tailStr = more ? more + ' more' : '';
     const chipW = (c) => 18 + this.labelWidth(c.label) + 6 + 8;   // pad+border + name + gap + ✕ (the 12px measure over-covers the 10.7px render)
     const budget = this.M.left - PADL - (BTNW * 2 + GAP) - (tailStr ? GAP + this.labelWidth(tailStr) : 0);

--- a/ui/timeline-tagbtn-click.test.ts
+++ b/ui/timeline-tagbtn-click.test.ts
@@ -110,7 +110,7 @@ test("executed: the whole button IS the hit target, wearing the feed's box by va
   // the injected corner CSS states the feed footer's values — the executed style node carries them
   const styles = (g.document.head.children || []).filter((c: any) => c.tag === "style").map((c: any) => c.textContent).join("");
   for (const lit of [
-    ".romp-tl-cbtn{display:inline-flex;align-items:center;font:inherit;font-size:10.5px;padding:1px 9px;",
+    ".romp-tl-cbtn{display:inline-flex;align-items:center;font:inherit;font-size:10.5px;padding:4px 6px;",
     "border:1px solid rgba(255,255,255,0.10);border-radius:6px;",
     "color:var(--vscode-descriptionForeground,#9a9a9a);",
   ]) assert.ok(styles.includes(lit), "corner CSS carries: " + lit);

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -92,7 +92,7 @@ test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separ
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
   assert.match(SRC, /chip\.style\.borderColor = c\.color; chip\.style\.color = c\.color;/,
     "outline + text in the pick's colour on the page's own ground");
-  assert.match(SRC, /\.romp-tl-chip\{display:inline-flex;align-items:center;gap:5px;padding:1px 8px;border-radius:9px;/,
+  assert.match(SRC, /\.romp-tl-chip\{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;/,
     "the chip anatomy is the shared syncTagFilter chip's, by value");
   // a SENTINEL view's chip dims to the corner line's own gray at the N-more opacity (the user
   // 2026-08-24: at #cccccc it read bright as a tag) — real tag chips keep their tag colors, full strength

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -52,7 +52,7 @@ test("the popover's bottom row IS a statusline: the chat's chip anatomy + counti
 
 test("the action buttons wear the chat's under-bubble family; Fork stays out by the user's call", () => {
   assert.match(CSS, /\.cmt-act \{\s*\n\s*background: rgba\(255, 255, 255, 0\.06\);\s*\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\); border-radius: 5px; font-size: 0\.78em;\s*\n\s*padding: 1px 8px; cursor: pointer;\s*\n\}/);
-  assert.match(CSS, /\.cmt-act:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: rgba\(156, 210, 255, 0\.12\); \}/);   // the feed word-button hover (2026-08-25): text+outline accent, never a fill
+  assert.match(CSS, /\.cmt-act:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);   // the feed word-button hover (2026-08-25): text+outline accent, never a fill
   // the popover's verbs stay Break out / Merge / Delete — the chat's Fork button is deliberately absent
   const pop = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
   assert.ok(!/data-act="fork"|showForkPrompt/.test(pop), "no fork button in the popover");

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -236,7 +236,7 @@ test("context stages ALONE, and the chips strip carries the visible Stage button
   // neutral at rest (the user 2026-08-23): an accent outline beside the accent-blue chips read as
   // already-pressed. Rest = the button family's dress; the accent appears only on hover.
   assert.match(CSS, /\.composer-stage-btn \{ background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
-  assert.match(CSS, /\.composer-stage-btn:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: rgba\(156, 210, 255, 0\.12\); \}/);   // the feed word-button hover (2026-08-25)
+  assert.match(CSS, /\.composer-stage-btn:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);   // the feed word-button hover (2026-08-25)
   assert.doesNotMatch(CSS, /\.composer-stage-btn \{ position: absolute/,
     "no absolute pin — the button flows in the strip, immediately after what it acts on");
   assert.match(RENDER, /st\.title = "hold this context \(and anything typed\) for one combined send later — ⌘⏎ does the same";/);

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -36,7 +36,14 @@ test("on a phone (coarse pointer) Enter is a newline, not send — the Send butt
   // the resting placeholder drops every hint on mobile (⏎/⇧⏎ is wrong there, and even the "/" hint
   // wrapped and clipped the one-line pill)
   assert.match(RENDER, /function composerRestingPlaceholder\(\)/);
-  assert.match(RENDER, /isCoarsePointer\(\)\s*\?\s*"Message this session…"/);
+  assert.match(RENDER, /if \(isCoarsePointer\(\)\) return "Message this session…";/);
+  // …and on a NARROW desktop pane (the user 2026-08-26: the full hint wrapped onto a clipped second
+  // line) the resting hint adapts to the box's width: under 620px it keeps only the core prompt +
+  // the one undiscoverable key. Re-fitted event-based on resize, and ONLY while a resting form is
+  // showing — a picker's "add your own answer…" or the closed-session notice is never clobbered.
+  assert.match(RENDER, /if \(ta && ta\.clientWidth > 0 && ta\.clientWidth < 620\) return "Message this session…  \(\/ for commands\)";/);
+  assert.match(RENDER, /if \(ta\.placeholder\.startsWith\("Message this session…"\)\) ta\.placeholder = composerRestingPlaceholder\(\);/);
+  assert.match(RENDER, /\}\)\.observe\(ta\);/, "the re-fit is a ResizeObserver, not a poll");
 });
 
 test("on a phone the resting box is ONE line — the Signal-style pill — with a placeholder that fits it (the user 2026-07-30)", () => {

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -65,6 +65,34 @@ test("menus wear ONE vocabulary (CLAUDE.md): --radius-menu 6px + --shadow-menu o
   assert.match(CHAT, /\.meta-menu \{[^}]*font-family: var\(--sans\)/s, "the meta menus read in the menus' sans");
 });
 
+test("transient notices wear ONE treatment: --surface-raised + --radius-toast + --shadow-toast", () => {
+  // five toast variants had drifted (6/7/8/10px radii, four backgrounds, shadows from none to
+  // 0 10px 30px); the semantic BORDER colors stay per notice (locate amber, warn red). The
+  // kernel's #rstale/#rupd/#rdrift banners carry the same values as literals (no :root there).
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.match(css, /--surface-raised: #252526;/, name);
+    assert.match(css, /--radius-toast: 8px;/, name);
+    assert.match(css, /--shadow-toast: 0 8px 28px rgba\(0, 0, 0, 0\.45\);/, name);
+  }
+  for (const sel of [".locate-toast", ".warn-toast", "#seek-note"]) {
+    const at = CHAT.indexOf(sel + " {");
+    const rule = CHAT.slice(at, CHAT.indexOf("}", at));
+    assert.ok(rule.includes("var(--radius-toast)"), sel + " radius through the token");
+    assert.ok(rule.includes("var(--shadow-toast)"), sel + " shadow through the token");
+  }
+  {
+    const at = FEED.indexOf(".feed-toast {");
+    const rule = FEED.slice(at, FEED.indexOf("}", at));
+    assert.ok(rule.includes("var(--radius-toast)"), ".feed-toast radius through the token");
+    assert.ok(rule.includes("var(--shadow-toast)"), ".feed-toast shadow through the token");
+    assert.ok(rule.includes("var(--vscode-menu-background, var(--surface-raised))"), ".feed-toast surface");
+  }
+  // the retired one-off toast surfaces are gone from the sheets
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.doesNotMatch(css, /rgba\(28, 28, 28, 0\.9[46]\)|#26262a/, name);
+  }
+});
+
 test("ONE accent wash: every selected/hovered accent chrome resolves through --accent-wash at 0.12", () => {
   // 0.10 and 0.14 washes had drifted in beside the dominant 0.12 (three alphas for one meaning);
   // the token is declared in both self-sufficient :roots, and no bare wash literal remains in the

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -1,0 +1,40 @@
+// The UI's color/metric vocabulary — pins the dedupes of 2026-08-26 so near-twin values cannot
+// creep back in. Each block names ONE vocabulary decision and the drift it retired; a failure here
+// means a new rule re-introduced a value the vocabulary already names (use the token / the named
+// hex instead). CLAUDE.md Design is the spec these instances serve.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const CHAT = read("styles.css");
+const FEED = read("feed.css");
+const GEAR = read("gear.css");
+const STRIP = read("strip.css");
+const SHORTCUTS = read("shortcuts-modal.ts");
+
+test("--warn is a real token, one heads-up amber: defined in BOTH self-sufficient :roots", () => {
+  // it was a phantom for months — referenced with fallbacks, defined nowhere — while two more
+  // ambers one hex digit apart (#e0a020, #e0b341) grew nine lines from each other in feed.css
+  assert.match(CHAT, /--warn: #d7a23a;/);
+  assert.match(FEED, /--warn: #d7a23a;/);
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.doesNotMatch(css, /#e0a020|#e0b341|#d29922/i, name + " uses var(--warn), not a near-twin amber");
+  }
+  assert.doesNotMatch(SHORTCUTS, /#d29922/, "the shortcuts dialog's conflict amber is the warn amber");
+});
+
+test("one elevated small-button gray (#2a2a2a) and one dropdown shadow alpha (#000000aa)", () => {
+  // #2a2a2b differed from its sibling #2a2a2a by one digit across gear/strip; the two settings
+  // dropdowns (colormap / session palette, 11 lines apart) wore #000000aa vs #00000088
+  for (const [name, css] of [["gear.css", GEAR], ["strip.css", STRIP]] as const) {
+    assert.doesNotMatch(css, /#2a2a2b/, name);
+    assert.doesNotMatch(css, /#00000088/, name);
+  }
+});
+
+test("gear.css accent chrome references var(--accent) — never a re-hardcoded bare hex (CLAUDE.md)", () => {
+  assert.doesNotMatch(GEAR, /outline: 2px solid #9cd2ff/);
+  assert.match(GEAR, /outline: 2px solid var\(--accent, #9cd2ff\)/);
+});

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -118,6 +118,31 @@ test("centered modals wear ONE card (CLAUDE.md): --radius-modal 10px + --shadow-
   assert.match(GEAR, /#ranalytics \{[^}]*box-shadow: 0 12px 36px #000000aa/s, "analytics shadow joins the card");
 });
 
+test("same-row badges wear the SAME metric set; micro-labels wear the section-header spec", () => {
+  // an ask card's status badges sit in ONE row and their comments claim 'same information type' —
+  // yet .fask-blocked alone wore 0.72em/700/6px/1px 8px against its siblings' 0.7em/800/5px/1px 6px
+  for (const sel of [".fask-blocked", ".fask-apierror", ".fask-retrying", ".fask-jauth"]) {
+    const esc = sel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(FEED, new RegExp(esc + " \\{[^}]*font-size: 0\\.7em; font-weight: 800;"), sel + " size/weight");
+    assert.match(FEED, new RegExp(esc + " \\{[^}]*border-radius: 5px; padding: 1px 6px;"), sel + " box");
+  }
+  // .fcol-chip's comment says it reproduces the chat .chip — now its padding does too
+  assert.match(FEED, /\.fcol-chip \{[^}]*padding: 3px 10px;/s);
+  assert.match(CHAT, /\.chip \{[^}]*padding: 3px 10px;/s);
+  // uppercase section micro-labels: 10.5px/700/.08em (the .rs-sec spec, documented at the kernel's
+  // .rnet-khead) — .sn-khead is the same feature in the VS Code strip and had drifted off it
+  assert.match(STRIP, /\.sn-khead \{[^}]*font-weight: 700; letter-spacing: 0\.08em;/);
+  assert.match(GEAR, /\.rs-sec \{[^}]*font-weight: 700; letter-spacing: 0\.08em;/s);
+  // no px letter-spacing (an em value scales with its label; 0.4px was the one outlier)
+  const FLEET = read("fleet-pane.css");
+  assert.doesNotMatch(FLEET, /letter-spacing:0\.4px/);
+  // true pills resolve through --radius-pill (the .fitem:hover inset-999px fill trick is not a radius)
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.match(css, /--radius-pill: 999px;/, name);
+    assert.doesNotMatch(css, /border-radius: 999px/, name + " pills use the token");
+  }
+});
+
 test("ONE accent wash: every selected/hovered accent chrome resolves through --accent-wash at 0.12", () => {
   // 0.10 and 0.14 washes had drifted in beside the dominant 0.12 (three alphas for one meaning);
   // the token is declared in both self-sufficient :roots, and no bare wash literal remains in the

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -93,6 +93,31 @@ test("transient notices wear ONE treatment: --surface-raised + --radius-toast + 
   }
 });
 
+test("centered modals wear ONE card (CLAUDE.md): --radius-modal 10px + --shadow-modal + --overlay-dim 0.55", () => {
+  // the picker card wore 8px + its own shadow, the feed's card modal 12px, the confirm and resume
+  // dialogs their own shadows and a 0.5 dim, the file viewer 8px + 0 12px 44px, the analytics
+  // modal a 0.73 dim + 40px blur. All resolve through the vocabulary now (gear.css keeps unified
+  // literals — it loads standalone). The lightbox's 0.72 dim is a LIGHTBOX, deliberately darker.
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.match(css, /--radius-modal: 10px;/, name);
+    assert.match(css, /--shadow-modal: 0 12px 36px #000000aa;/, name);
+    assert.match(css, /--overlay-dim: rgba\(0, 0, 0, 0\.55\);/, name);
+    assert.doesNotMatch(css, /0 10px 36px|0 10px 40px|0 12px 44px/, name + " retired modal shadows gone");
+  }
+  for (const [sel, css, name] of [
+    [".picker-box", CHAT, "styles.css"], [".fileview", CHAT, "styles.css"],
+    [".fileview", FEED, "feed.css"], [".fconfirm-box", FEED, "feed.css"],
+    [".feed-modal-inner", FEED, "feed.css"], [".pickdlg-box", FEED, "feed.css"],
+  ] as const) {
+    // regex, not indexOf: a selector may have a second (e.g. mobile) rule that skips the box chrome
+    const esc = sel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(css, new RegExp(esc + " \\{[^}]*var\\(--radius-modal\\)"), sel + " radius through the token (" + name + ")");
+    assert.match(css, new RegExp(esc + " \\{[^}]*var\\(--shadow-modal\\)"), sel + " shadow through the token (" + name + ")");
+  }
+  assert.match(GEAR, /#ranalytics-back \{[^}]*background: rgba\(0, 0, 0, 0\.55\)/, "analytics dim joins 0.55");
+  assert.match(GEAR, /#ranalytics \{[^}]*box-shadow: 0 12px 36px #000000aa/s, "analytics shadow joins the card");
+});
+
 test("ONE accent wash: every selected/hovered accent chrome resolves through --accent-wash at 0.12", () => {
   // 0.10 and 0.14 washes had drifted in beside the dominant 0.12 (three alphas for one meaning);
   // the token is declared in both self-sufficient :roots, and no bare wash literal remains in the

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -143,6 +143,26 @@ test("same-row badges wear the SAME metric set; micro-labels wear the section-he
   }
 });
 
+test("the transcript's rhythm: 7px turns, 11px user turns, ONE bubble padding, dots on the first line", () => {
+  // slightly-more-compact pass (the user 2026-08-26): turn padding 9→7 and user turns 14→11, with
+  // the rail dots/time markers moved the same distance so they keep sitting on the first line;
+  // the outgoing-bubble family (user / romp / follow-up / queued) had three paddings for one
+  // shape (9px 14px / 7px 14px / 7px 13px) and now wears one.
+  assert.match(CHAT, /\.turn \{ position: relative; padding-left: 24px; padding-top: 7px; padding-bottom: 7px;/);
+  assert.match(CHAT, /\.dot \{ position: absolute; left: 6px; top: 13px;/);
+  assert.match(CHAT, /\.time-marker \{\n  position: absolute; top: 13px;/);
+  assert.match(CHAT, /\.turn-user \{ padding-top: 11px; padding-bottom: 11px; \}/);
+  assert.match(CHAT, /\.turn-user \.dot, \.turn-user \.time-marker \{ top: 17px; \}/);
+  assert.equal((CHAT.match(/border-radius: 14px; padding: 7px 12px;/g) || []).length, 4,
+    "user, follow-up, romp, queued bubbles share the one padding");
+});
+
+test("the sessions-pane header is ONE flex row: search shrinks, the tag button never drops alone", () => {
+  const SESSIONS = read("fleet-pane.css");   // the Sessions pane sheet (file keeps its legacy name)
+  assert.match(SESSIONS, /#fleet-search-bar\{flex:0 0 auto;display:flex;align-items:center;flex-wrap:wrap;gap:6px;/);
+  assert.match(SESSIONS, /#fleet-search-wrap\{position:relative;flex:1 1 140px;min-width:140px\}/);
+});
+
 test("ONE accent wash: every selected/hovered accent chrome resolves through --accent-wash at 0.12", () => {
   // 0.10 and 0.14 washes had drifted in beside the dominant 0.12 (three alphas for one meaning);
   // the token is declared in both self-sufficient :roots, and no bare wash literal remains in the

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -134,8 +134,8 @@ test("same-row badges wear the SAME metric set; micro-labels wear the section-he
   assert.match(STRIP, /\.sn-khead \{[^}]*font-weight: 700; letter-spacing: 0\.08em;/);
   assert.match(GEAR, /\.rs-sec \{[^}]*font-weight: 700; letter-spacing: 0\.08em;/s);
   // no px letter-spacing (an em value scales with its label; 0.4px was the one outlier)
-  const FLEET = read("fleet-pane.css");
-  assert.doesNotMatch(FLEET, /letter-spacing:0\.4px/);
+  const SESSIONS = read("fleet-pane.css");   // the Sessions pane sheet (file keeps its legacy name)
+  assert.doesNotMatch(SESSIONS, /letter-spacing:0\.4px/);
   // true pills resolve through --radius-pill (the .fitem:hover inset-999px fill trick is not a radius)
   for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
     assert.match(css, /--radius-pill: 999px;/, name);

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -38,3 +38,22 @@ test("gear.css accent chrome references var(--accent) — never a re-hardcoded b
   assert.doesNotMatch(GEAR, /outline: 2px solid #9cd2ff/);
   assert.match(GEAR, /outline: 2px solid var\(--accent, #9cd2ff\)/);
 });
+
+test("ONE accent wash: every selected/hovered accent chrome resolves through --accent-wash at 0.12", () => {
+  // 0.10 and 0.14 washes had drifted in beside the dominant 0.12 (three alphas for one meaning);
+  // the token is declared in both self-sufficient :roots, and no bare wash literal remains in the
+  // sheets. The CodeMirror .cm-selectionMatch (editor-chunk.ts) keeps 0.14 — a text-match marker,
+  // not chrome — and shell-page inline CSS keeps unified 0.12 literals (no :root to share).
+  assert.match(CHAT, /--accent-wash: rgba\(156, 210, 255, 0\.12\);/);
+  assert.match(FEED, /--accent-wash: rgba\(156, 210, 255, 0\.12\);/);
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    const bare = css.replace(/--accent-wash: rgba\(156, 210, 255, 0\.12\);/g, "");
+    assert.doesNotMatch(bare, /rgba\(156, ?210, ?255, ?0?\.1[024]\)/, name + " has no bare wash literal");
+  }
+  // the selected fileview toggle wears the app's ONE selected language in BOTH sheets: wash at
+  // rest, reverse-highlight on hover (styles.css's copy had drifted to a wash hover, 2026-08-25)
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.match(css, /\.fileview-btn\.on:hover \{ background: var\(--accent\); color: var\(--accent-fg\); border-color: var\(--accent\); \}/,
+      name + " reverse-highlights the selected viewer toggle");
+  }
+});

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -39,6 +39,32 @@ test("gear.css accent chrome references var(--accent) — never a re-hardcoded b
   assert.match(GEAR, /outline: 2px solid var\(--accent, #9cd2ff\)/);
 });
 
+test("menus wear ONE vocabulary (CLAUDE.md): --radius-menu 6px + --shadow-menu on every dropdown", () => {
+  // .meta-menu and .tab-tip had drifted onto 0 4px 16px/0.45; .slash-pop onto 8px + 0 6px 22px;
+  // .feed-sessmenu onto 0 6px 24px. All resolve through the tokens now. .tab-tip keeps its mono
+  // (a statusline tooltip, not a dropdown); .meta-menu joins the menus' sans per the spec.
+  assert.match(CHAT, /--radius-menu: 6px;\n  --shadow-menu: 0 4px 12px rgba\(0, 0, 0, 0\.35\);/);
+  assert.match(FEED, /--radius-menu: 6px;/);
+  assert.match(FEED, /--shadow-menu: 0 4px 12px rgba\(0, 0, 0, 0\.35\);/);
+  for (const sel of [".ctx-menu", ".meta-menu", ".tab-tip", ".slash-pop"]) {
+    const at = CHAT.indexOf(sel + " {");
+    const rule = CHAT.slice(at, CHAT.indexOf("}", at));
+    assert.ok(rule.includes("var(--radius-menu)"), sel + " radius through the token");
+    assert.ok(rule.includes("var(--shadow-menu)"), sel + " shadow through the token");
+  }
+  for (const sel of [".ctx-menu", ".feed-sessmenu"]) {
+    const at = FEED.indexOf(sel + " {");
+    const rule = FEED.slice(at, FEED.indexOf("}", at));
+    assert.ok(rule.includes("var(--radius-menu)"), sel + " radius through the token (feed)");
+    assert.ok(rule.includes("var(--shadow-menu)"), sel + " shadow through the token (feed)");
+  }
+  // the retired drift shadows appear nowhere in the sheets
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.doesNotMatch(css, /0 4px 16px rgba\(0, 0, 0, 0\.45\)|0 6px 2[24]px rgba\(0, 0, 0, 0\.45\)/, name);
+  }
+  assert.match(CHAT, /\.meta-menu \{[^}]*font-family: var\(--sans\)/s, "the meta menus read in the menus' sans");
+});
+
 test("ONE accent wash: every selected/hovered accent chrome resolves through --accent-wash at 0.12", () => {
   // 0.10 and 0.14 washes had drifted in beside the dominant 0.12 (three alphas for one meaning);
   // the token is declared in both self-sufficient :roots, and no bare wash literal remains in the

--- a/ui/webview/distill-background.test.ts
+++ b/ui/webview/distill-background.test.ts
@@ -36,7 +36,7 @@ test("the buttons ARE the toggles: pressed state reads at a glance, mutually exc
   assert.match(FEED, /a\._takeBtn\.classList\.toggle\("on", choice === "summary"\);/);
   assert.match(FEED, /a\._bgBtn\.setAttribute\("aria-pressed", choice === "bg" \? "true" : "false"\);/);
   // selected = the rail toggles' accent language: blue text, accent border, faint accent wash, bolder
-  assert.match(CSS, /\.fask-secbtn\.on \{ color: var\(--accent\); border-color: var\(--accent\);\n  background: rgba\(156, 210, 255, 0\.10\); font-weight: 600; \}/);
+  assert.match(CSS, /\.fask-secbtn\.on \{ color: var\(--accent\); border-color: var\(--accent\);\n  background: var\(--accent-wash\); font-weight: 600; \}/);
   assert.match(CSS, /--accent: #9cd2ff;/, "feed.css defines --accent in its own :root");
   assert.doesNotMatch(FEED, /fask-less/, "the less control is gone");
 });

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -38,5 +38,5 @@ test("the tooltip explains what happens next in the user's terms", () => {
 test("the pill wears the done-check blue family, same shape as its sibling pills", () => {
   assert.match(CSS, /\.fask-doneconfirming \{[^}]*color: var\(--check-bg\)/, "the ✓ family's blue, no new color");
   assert.match(CSS, /\.fask-doneconfirming \{[^}]*font-size: 0\.64em/, "same size as its sibling pills");
-  assert.match(CSS, /\.fask-doneconfirming \{[^}]*border-radius: 999px/);
+  assert.match(CSS, /\.fask-doneconfirming \{[^}]*border-radius: var\(--radius-pill\)/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -16,6 +16,8 @@
   --accent: #9cd2ff;  /* the romp accent (CLAUDE.md Design) — feed.css has its OWN :root, so selected-state
                        chrome here needs it defined locally or var(--accent) silently falls back */
   --accent-fg: #0c1a2e;  /* dark text ON the accent (CLAUDE.md) — for the reverse-highlight on a selected toggle */
+  --accent-wash: rgba(156, 210, 255, 0.12);  /* THE faint accent wash — mirrors styles.css; one alpha
+                       behind every selected/hovered accent chrome */
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -325,7 +327,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    line; the "✓ Done — I did it" button greens on hover (it's a check-off). */
 .fq-send { flex: 0 0 auto; font: inherit; font-size: 0.85em; cursor: pointer; color: var(--fg);
   background: rgba(255, 255, 255, 0.08); border: 1px solid var(--card-border); border-radius: 6px; padding: 5px 12px; }
-.fq-send:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }
+.fq-send:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* "didn't need me" — the false-awaiting teaching dismissal */
 
 /* drop-point lines on an asks-column card: where the work is currently parked */
@@ -371,7 +373,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    selected-state language across the whole app; gray = off, accent blue = on). Same wash alpha as the
    rail's .rail-btn.on. */
 .fask-secbtn.on { color: var(--accent); border-color: var(--accent);
-  background: rgba(156, 210, 255, 0.10); font-weight: 600; }
+  background: var(--accent-wash); font-weight: 600; }
 /* STALLED — the one toggle that keeps its OWN colour in every state. The others turn accent-blue when
    selected, which is the app's "this is the one you picked" language; a stall is not a preference, it
    is something wrong. It wears the PROBLEM-CHIP outline the card's other trouble chips wear (yellow
@@ -565,7 +567,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ftree-act-done:hover,
 .ftree-act-status:hover,
 .ftree-act-fup:hover,
-.ftree-act-drop:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }
+.ftree-act-drop:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 .ftree-act-btn:disabled { opacity: 0.55; cursor: default; }
 /* On a phone the modal row is too narrow to hold the reply text AND the nowrap Done/Drop/Check-status/
    Follow-up group on one line: .ftree-node has no flex-wrap, so the buttons kept their full width and the
@@ -878,7 +880,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fdismiss { padding: 2px 10px; }
 /* One accent hover for every action button (the user 2026-07-21): Clear, Move to Working, Follow up,
    Clear all, Undo all share it — no red on any action, only on error/blocked STATUS. */
-.fdismiss:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }
+.fdismiss:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* Undo — restorative, so it hovers BLUE like Follow up, not Clear's red. */
 /* The feed's DOCKED control bar (the user 2026-06-29): its own dedicated rectangle in normal flow at the
    bottom of the pane, NOT a floating overlay. The body is a column flex, so #feed-list flexes to fill above
@@ -932,7 +934,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    (blue text + border + faint wash), the same selected-state look the card section toggles use (the
    user 2026-07-07) */
 #feed-foot .feed-modetoggle.on { color: var(--accent); border-color: var(--accent);
-  background: rgba(156, 210, 255, 0.12); opacity: 1; }
+  background: var(--accent-wash); opacity: 1; }
 /* the SESSION list + chip identity treatment (the user 2026-08-08, now the combobox's list): one row
    per tab-order session written the way the tabs and session headers write it — .fsm-name BOLD in the
    session's identity colour (inline, from the payload), host: prefix quiet (.host-prefix, shared), the
@@ -946,7 +948,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .feed-sessmenu .fsm-row { display: flex; align-items: center; gap: 7px; padding: 4px 9px;
   border-radius: 4px; cursor: pointer; font-size: 11.5px; white-space: nowrap; }
 .feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
-.feed-sessmenu .fsm-row.on { background: rgba(156, 210, 255, 0.12); }
+.feed-sessmenu .fsm-row.on { background: var(--accent-wash); }
 /* TAG CHIPS on the combobox's session rows (the user 2026-08-25 — the smaller unification variant):
    the dialog's own outline-pill vocabulary at the row's scale, NON-interactive (grouping made
    visible; the controls stay separate). The strip ellipsizes in the row's leftover space — names
@@ -1235,7 +1237,7 @@ a.fileview-btn[hidden] { display: none; }
    border + faint wash, gray = off (the .fask-secbtn.on / .feed-modetoggle.on treatment) — with the same
    reverse-highlight hover so a selected toggle never reads as dead. */
 .fileview-btn.on { color: var(--accent); border-color: var(--accent);
-  background: rgba(156, 210, 255, 0.10); font-weight: 600; }
+  background: var(--accent-wash); font-weight: 600; }
 .fileview-btn.on:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 
 /* Wrap mode (the Wrap toggle, persisted per browser): long lines soft-wrap instead of scrolling
@@ -1503,7 +1505,7 @@ body.filebrowse-open { overflow: hidden; }
    name + working dot + ✕ back to typing. The accent-wash pill the .on state already wears
    everywhere; the footer's own 10.5px, no new sizes. */
 #feed-sess-chip { display: inline-flex; align-items: center; gap: 5px; padding: 1px 4px 1px 7px;
-  border: 1px solid var(--accent); border-radius: 6px; background: rgba(156, 210, 255, 0.12);
+  border: 1px solid var(--accent); border-radius: 6px; background: var(--accent-wash);
   font-size: 10.5px; white-space: nowrap; }
 #feed-sess-chip[hidden] { display: none; }
 #feed-search:not(.open) #feed-sess-chip { display: none; }   /* same backstop as the ✕: chips live on an open bar */

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -26,6 +26,7 @@
   --radius-modal: 10px;  /* the centered-modal vocabulary (CLAUDE.md) — mirrors styles.css */
   --shadow-modal: 0 12px 36px #000000aa;
   --overlay-dim: rgba(0, 0, 0, 0.55);
+  --radius-pill: 999px;  /* the true-pill radius — mirrors styles.css */
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -177,7 +178,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    webview, no shared :root). The neutral count sits dim beside the chip. */
 .fcol-chip {
   display: inline-flex; align-items: center;
-  padding: 2px 9px; border-radius: 11px;
+  padding: 3px 10px; border-radius: 11px;
   font-weight: 700; letter-spacing: 0.07em;
 }
 .fcol-chip-working   { background: #e0b020; color: #332600; }
@@ -436,43 +437,43 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 
 /* "Followed up" — optimistic reopen pending the judge's re-file (judges delegation, 2026-06-17); blue pill */
 .fask-followedup { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
   color: #5aa2ff; border: 1px solid rgba(90, 162, 255, 0.6); }
 /* "done, confirming" — the done verdict is in, only the settle event is pending (the user 2026-07-24):
    a steady cue on the Working card, never an early column move (that flicker is what the settle gate
    prevents). Outline pill in the done-check blue (--check-bg), the same family as the ✓ it will wear. */
 .fask-doneconfirming { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
   color: var(--check-bg); border: 1px solid rgba(30, 161, 235, 0.55); }
 /* "nudge failed" — the one auto-nudge didn't resolve the stall and is never re-asked (design/
    stalled-open-todos-nudge.md); red pill: this thread is waiting on the human now */
 .fask-nudgefailed { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
   color: #ff6a6a; border: 1px solid rgba(255, 106, 106, 0.6); }
 /* "interrupted" — the user stopped this session mid-turn and hasn't re-engaged; auto-nudge holds
    off until their next message. WARNING yellow (the user 2026-07-06, was neutral gray and too easy
    to miss): the pause is user-chosen but the thread IS dangling — same yellow as the warn chip,
    one warning treatment across the card (see .fask-warnchip) */
 .fask-interrupted { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
   color: #ffd166; border: 1px solid rgba(255, 209, 102, 0.6); }
 /* "interrupting…" — a stop is IN FLIGHT (the user 2026-07-07): the turn is still winding down, so this
    wears the WORKING treatment (filled yellow, faded) exactly like the chat chip's .chip-interrupting —
    an active state, visually distinct from the interrupted OUTLINE badge (paused/done). It holds steady
    from the click until the interrupt settles, then yields to .fask-interrupted. */
 .fask-interrupting { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
   background: var(--st-working-bg); color: var(--st-working-fg); opacity: 0.75; }
 /* "warning" — a judge stamped an anomaly on this goal (judge _node_warn; the user 2026-07-02): yellow
    pill, a BUTTON — click opens the warn-detail overlay (what happened + why it's unexpected) */
 .fask-warnchip { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4; font-family: inherit;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4; font-family: inherit;
   color: #ffd166; border: 1px solid rgba(255, 209, 102, 0.6); background: transparent; cursor: pointer; }
 .fask-warnchip:hover { background: rgba(255, 209, 102, 0.14); }
 /* "waiting on <peer>" — an unanswered message out to a live peer; held in Working, not stalled (the user
    2026-06-22); teal pill, red for a mutual-wait deadlock cycle */
 .fask-waiton { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
-  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
   color: #4ec9b0; border: 1px solid rgba(78, 201, 176, 0.6); }
 .fask-waiton-cycle { color: #ff6a6a; border-color: rgba(255, 106, 106, 0.7); }
 /* the chip's elapsed readout (" · 42m") — same size as the chip text, dimmed like a sub-line so the
@@ -614,7 +615,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ftree-log-when { flex: 0 0 auto; color: var(--dim); white-space: nowrap; }
 .ftree-log-what { overflow-wrap: anywhere; }
 .ftree-followedup { flex: 0 0 auto; margin-left: 8px; font-size: 0.68em; font-weight: 700; letter-spacing: 0.03em;
-  padding: 0 6px; border-radius: 999px; line-height: 1.6; color: #5aa2ff; border: 1px solid rgba(90, 162, 255, 0.6); white-space: nowrap; }
+  padding: 0 6px; border-radius: var(--radius-pill); line-height: 1.6; color: #5aa2ff; border: 1px solid rgba(90, 162, 255, 0.6); white-space: nowrap; }
 .ftree-node.repeat { opacity: 0.5; }
 
 /* grouped sibling-asks card: a member line per sub-ask under the title, each with
@@ -757,11 +758,13 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    permission prompt / picker for THIS card's work; click opens the session.
    Same red as the BLOCKED column header. */
 .fask-blocked {
-  flex: 0 0 auto; font-size: 0.72em; font-weight: 700; letter-spacing: 0.03em;
+  flex: 0 0 auto; font-size: 0.7em; font-weight: 800; letter-spacing: 0.03em;
   color: #c0392b; cursor: pointer; white-space: nowrap;
-  /* a rounded-rect outline in the badge's own red, mirroring the Clear button's chrome (.fdismiss)
-     so the permission/picker block reads as a contained pill, not loose text (the user 2026-06-16) */
-  border: 1px solid #c0392b; border-radius: 6px; padding: 1px 8px;
+  /* a rounded-rect outline in the badge's own red so the permission/picker block reads as a
+     contained pill, not loose text (the user 2026-06-16) — wearing the SAME metric set as its
+     same-row api-trouble siblings (.fask-apierror/.fask-retrying/.fask-jauth: same information
+     type, same size; it alone wore 0.72em/700/6px/1px 8px until 2026-08-26) */
+  border: 1px solid #c0392b; border-radius: 5px; padding: 1px 6px;
 }
 .fask-blocked:hover { color: #fff; background: #c0392b; border-color: #c0392b; }
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -23,6 +23,9 @@
   --surface-raised: #252526;  /* the transient-notice vocabulary — mirrors styles.css */
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(0, 0, 0, 0.45);
+  --radius-modal: 10px;  /* the centered-modal vocabulary (CLAUDE.md) — mirrors styles.css */
+  --shadow-modal: 0 12px 36px #000000aa;
+  --overlay-dim: rgba(0, 0, 0, 0.55);
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -651,10 +654,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* ⛶ full-screen tree modal (deep hierarchies) */
 /* feedConfirm() overlay — a small yes/no (e.g. revive a closed session). Above
    #feed-modal so it can sit over an open card modal. */
-.fconfirm-back { position: fixed; inset: 0; z-index: 200; background: rgba(0, 0, 0, 0.55);
+.fconfirm-back { position: fixed; inset: 0; z-index: 200; background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; padding: 4vh 4vw; }
 .fconfirm-box { background: var(--bg); border: 1px solid var(--card-border, rgba(255, 255, 255, 0.18));
-  border-radius: 10px; padding: 18px 20px; max-width: 380px; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5); }
+  border-radius: var(--radius-modal); padding: 18px 20px; max-width: 380px; box-shadow: var(--shadow-modal); }
 .fconfirm-msg { color: var(--fg); line-height: 1.45; margin-bottom: 14px; overflow-wrap: anywhere; }
 .fconfirm-btns { display: flex; justify-content: flex-end; gap: 8px; }
 .fconfirm-btn { font: inherit; padding: 5px 13px; border-radius: 6px; cursor: pointer;
@@ -673,10 +676,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fwarn-meta { color: var(--dim); font-size: 0.78em; letter-spacing: 0.04em; margin-bottom: 6px; }
 .fwarn-detail { color: var(--fg); line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 0.92em; }
 
-#feed-modal { position: fixed; inset: 0; z-index: 100; background: rgba(0, 0, 0, 0.55);
+#feed-modal { position: fixed; inset: 0; z-index: 100; background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; padding: 4vh 4vw; }
 .feed-modal-inner { display: flex; flex-direction: column; width: 100%; max-width: 1280px; max-height: 92vh;
-  background: var(--bg); border: 1px solid var(--card-border); border-radius: 12px; overflow: hidden; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5); }
+  background: var(--bg); border: 1px solid var(--card-border); border-radius: var(--radius-modal); overflow: hidden; box-shadow: var(--shadow-modal); }
 .feed-modal-head { display: flex; align-items: baseline; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--card-border); }
 .feed-modal-title { flex: 1 1 auto; min-width: 0; font-weight: 600; overflow-wrap: anywhere; }
 /* the modal title is a locate link, same affordance as the card title */
@@ -1122,7 +1125,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* ---- in-page resume-picker dialog (answerPicker without a native QuickPick) ---- */
 .pickdlg-overlay {
   position: fixed; inset: 0; z-index: 1200;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; padding: 16px;
 }
 .pickdlg-box {
@@ -1130,8 +1133,8 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   display: flex; flex-direction: column; gap: 8px;
   background: var(--vscode-editorWidget-background, #252526);
   border: 1px solid var(--vscode-widget-border, #303031);
-  border-radius: 8px; padding: 16px 18px;
-  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.55);
+  border-radius: var(--radius-modal); padding: 16px 18px;
+  box-shadow: var(--shadow-modal);
 }
 .pickdlg-title { font-weight: 700; color: var(--vscode-foreground, #ccc); margin-bottom: 4px; }
 /* the quarantine dialog's title IS the card's route line, so opening a held message never re-words who
@@ -1181,11 +1184,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    file BROWSER (file-browse.ts) opens files through the same module. One treatment, two sheets: the
    ~95% card and dimmed backdrop mirror styles.css exactly (the panels treatment: the listing behind
    stays visible, never hidden). `body.fileview-open` stops the cards underneath scrolling behind it. */
-#romp-fileview { position: fixed; inset: 0; z-index: 1200; background: rgba(0, 0, 0, 0.55);
+#romp-fileview { position: fixed; inset: 0; z-index: 1200; background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; }
 .fileview { width: 95%; height: 95%; display: flex; flex-direction: column; overflow: hidden;
-  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 8px;
-  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.6); }
+  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: var(--radius-modal);
+  box-shadow: var(--shadow-modal); }
 body.fileview-open { overflow: hidden; }
 .fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
   padding: 7px 10px; border-bottom: 1px solid var(--box-border); }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -18,6 +18,8 @@
   --accent-fg: #0c1a2e;  /* dark text ON the accent (CLAUDE.md) — for the reverse-highlight on a selected toggle */
   --accent-wash: rgba(156, 210, 255, 0.12);  /* THE faint accent wash — mirrors styles.css; one alpha
                        behind every selected/hovered accent chrome */
+  --radius-menu: 6px;  /* the menu vocabulary (CLAUDE.md) — mirrors styles.css */
+  --shadow-menu: 0 4px 12px rgba(0, 0, 0, 0.35);
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -942,9 +944,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    untouched. The list opens UPWARD from the bar (position from the wrap rect, feed.ts). */
 .fsm-name { font-weight: 600; }
 .feed-sessmenu { position: fixed; z-index: 60; min-width: 150px; max-height: 60vh; overflow-y: auto;
-  padding: 4px; border: 1px solid var(--card-border); border-radius: 6px;
+  padding: 4px; border: 1px solid var(--card-border); border-radius: var(--radius-menu);
   background: var(--vscode-editorWidget-background, #252526);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45); }
+  box-shadow: var(--shadow-menu); }
 .feed-sessmenu .fsm-row { display: flex; align-items: center; gap: 7px; padding: 4px 9px;
   border-radius: 4px; cursor: pointer; font-size: 11.5px; white-space: nowrap; }
 .feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
@@ -1367,8 +1369,8 @@ a.fileview-btn[hidden] { display: none; }
   position: fixed; z-index: 100; min-width: 110px; padding: 4px;
   background: var(--vscode-menu-background, #252526);
   color: var(--vscode-menu-foreground, var(--fg));
-  border: 1px solid var(--box-border); border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--box-border); border-radius: var(--radius-menu);
+  box-shadow: var(--shadow-menu);
   font-size: 0.92em;
 }
 .ctx-item { padding: 4px 10px; border-radius: 4px; cursor: pointer; white-space: nowrap; }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1192,6 +1192,11 @@ body.fileview-open { overflow: hidden; }
   padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.08); color: var(--fg);
   border: 1px solid var(--box-border); }
 .fileview-btn:hover { border-color: var(--accent); }
+/* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
+a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
+/* an author `display` beats the UA's [hidden] rule — without this the anchor shows hrefless
+   before the kernel ever answers */
+a.fileview-btn[hidden] { display: none; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
    and because they are a sibling element a selection of the code copies without dragging them along */

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -8,6 +8,8 @@
   --green: #74c991;
   --err: #c0392b;   /* the block-red — mirrors styles.css; feed.css has its OWN :root, so the ⏸ block marks
                        (and the modal's red ⏸-ring) need it defined HERE or var(--err) falls back to gray */
+  --warn: #d7a23a;  /* the heads-up amber — mirrors styles.css; ONE amber for "attention, not an error":
+                       the toast's left rule, the judge-warnings head (two near-twin hexes before 2026-08-26) */
   --box-border: rgba(255, 255, 255, 0.12);  /* mirrors styles.css — same trap as --err: an undefined var()
                        in a border SHORTHAND voids the whole declaration, so the section-toggle circles and
                        the await-paused outline rendered with NO border at all (the user 2026-07-02) */
@@ -1148,7 +1150,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%) translateY(8px);
   z-index: 200; max-width: min(440px, 90vw); padding: 9px 13px;
   background: var(--vscode-menu-background, #26262a); color: var(--fg);
-  border: 1px solid rgba(255, 255, 255, 0.12); border-left: 3px solid #e0a020; border-radius: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.12); border-left: 3px solid var(--warn); border-radius: 7px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45); font-size: 0.86em; line-height: 1.35;
   opacity: 0; transition: opacity 0.18s ease, transform 0.18s ease; pointer-events: none;
 }
@@ -1157,7 +1159,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* debug-mode judge warnings (the user 2026-07-09): the card modal's failure-inspection section.
    0.72em heads, 0.82em body rows (labels match labels). */
 .fmodal-warns { margin-top: 12px; padding-top: 8px; border-top: 1px solid rgba(255, 255, 255, 0.08); }
-.fmodal-warns-head { font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; color: #e0b341; margin-bottom: 6px; }
+.fmodal-warns-head { font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--warn); margin-bottom: 6px; }
 .fmodal-warn-row { margin-bottom: 6px; }
 .fmodal-warn-line { font-size: 0.82em; color: var(--fg); overflow-wrap: anywhere; }
 .fmodal-warn-det { margin: 2px 0 0 14px; }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -20,6 +20,9 @@
                        behind every selected/hovered accent chrome */
   --radius-menu: 6px;  /* the menu vocabulary (CLAUDE.md) — mirrors styles.css */
   --shadow-menu: 0 4px 12px rgba(0, 0, 0, 0.35);
+  --surface-raised: #252526;  /* the transient-notice vocabulary — mirrors styles.css */
+  --radius-toast: 8px;
+  --shadow-toast: 0 8px 28px rgba(0, 0, 0, 0.45);
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -1153,9 +1156,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .feed-toast {
   position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%) translateY(8px);
   z-index: 200; max-width: min(440px, 90vw); padding: 9px 13px;
-  background: var(--vscode-menu-background, #26262a); color: var(--fg);
-  border: 1px solid rgba(255, 255, 255, 0.12); border-left: 3px solid var(--warn); border-radius: 7px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45); font-size: 0.86em; line-height: 1.35;
+  background: var(--vscode-menu-background, var(--surface-raised)); color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.12); border-left: 3px solid var(--warn); border-radius: var(--radius-toast);
+  box-shadow: var(--shadow-toast); font-size: 0.86em; line-height: 1.35;
   opacity: 0; transition: opacity 0.18s ease, transform 0.18s ease; pointer-events: none;
 }
 .feed-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
@@ -1339,9 +1342,9 @@ a.fileview-btn[hidden] { display: none; }
    marks) is its own section under a hairline. pointer-events:none — it can never eat a click. */
 #age-tip {
   position: fixed; z-index: 210; display: none; max-width: min(440px, 92vw);
-  background: var(--vscode-menu-background, #26262a); color: var(--fg);
-  border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 7px; padding: 7px 10px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45); font-size: 0.86em; line-height: 1.45;
+  background: var(--vscode-menu-background, var(--surface-raised)); color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.12); border-radius: var(--radius-toast); padding: 7px 10px;
+  box-shadow: var(--shadow-toast); font-size: 0.86em; line-height: 1.45;
   pointer-events: none;
 }
 .age-tip-row { display: flex; column-gap: 10px; align-items: baseline; }

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -61,7 +61,7 @@ test("the viewer is a singleton MODAL over its pane: ~95% card, dimmed backdrop,
   assert.match(VIEW, /close\.addEventListener\("click", closeFileView\);/);
   assert.match(VIEW, /if \(e\.key !== "Escape" \|\| !document\.getElementById\("romp-fileview"\)\) return;/);
   // the panels treatment on the CHAT sheet: dimmed rgba(0,0,0,0.55) backdrop, the content behind visible
-  assert.match(CHAT_CSS, /#romp-fileview \{ position: fixed; inset: 0; z-index: 1200; background: rgba\(0, 0, 0, 0\.55\);/);
+  assert.match(CHAT_CSS, /#romp-fileview \{ position: fixed; inset: 0; z-index: 1200; background: var\(--overlay-dim\);/);
   assert.match(CHAT_CSS, /\.fileview \{ width: 95%; height: 95%;/);
   // …and mirrored on the FEED sheet, which still hosts the viewer when the file BROWSER opens a file
   // (one treatment, two sheets — the hljs-palette precedent below)

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -1,0 +1,34 @@
+// The file VIEWER mounts in both documents (file-view.ts is one shared module), but the chat page
+// loads styles.css alone and the feed page feed.css alone — so its dress is declared in BOTH sheets
+// (the .romp-acted / filebrowse precedent). The copies had already drifted once (feed.css lacked the
+// a.fileview-btn anchor rules, so the GitHub link rendered hrefless-underlined there, 2026-08-26).
+// This pins the shared chrome byte-equal so it cannot drift again. Rules that are deliberately
+// pane-specific (the md body, wrap mode, load cue) are not pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const CHAT = read("styles.css");
+const FEED = read("feed.css");
+
+const RULES = [
+  "#romp-fileview {", ".fileview {", "body.fileview-open {", ".fileview-bar {", ".fileview-name {",
+  ".fileview-dir {", ".fileview-base {", ".fileview-acts {", ".fileview-btn {", ".fileview-btn:hover {",
+  "a.fileview-btn {", "a.fileview-btn[hidden] {", ".fileview-body {",
+  ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {",
+  ".fileview-dir-link {", ".fileview-dir-link:hover {",
+];
+
+function ruleOf(css: string, head: string): string {
+  const at = css.indexOf(head);
+  assert.ok(at >= 0, head + " present");
+  return css.slice(at, css.indexOf("}", at) + 1);
+}
+
+test("the viewer's shared chrome exists in BOTH sheets, byte-equal", () => {
+  for (const head of RULES) {
+    assert.equal(ruleOf(CHAT, head), ruleOf(FEED, head), head + " mirrors exactly");
+  }
+});

--- a/ui/webview/fleet-pane.css
+++ b/ui/webview/fleet-pane.css
@@ -78,7 +78,7 @@ color:var(--vscode-descriptionForeground,#9a9a9a);font-size:12px;user-select:non
 .fl-hover-state{color:var(--vscode-descriptionForeground,#9a9a9a);margin-bottom:3px}
 .fl-hover-title{font-weight:600;margin-bottom:2px;white-space:normal}
 .fl-hover-sec{margin-top:7px}
-.fl-hover-lab{font-size:10.5px;text-transform:uppercase;letter-spacing:0.4px;
+.fl-hover-lab{font-size:10.5px;text-transform:uppercase;letter-spacing:0.04em;
   color:var(--vscode-descriptionForeground,#9a9a9a);margin-bottom:2px}
 .fl-hover-body{white-space:pre-wrap}
 .fl-hover-sub{display:flex;gap:6px;align-items:baseline;margin-top:1px}

--- a/ui/webview/fleet-pane.css
+++ b/ui/webview/fleet-pane.css
@@ -7,8 +7,8 @@ html,body{margin:0;height:100%;background:var(--vscode-editor-background,#1e1e1e
 color:var(--vscode-foreground,#cccccc);font-family:var(--vscode-font-family,system-ui,-apple-system,'Segoe UI',sans-serif);
 font-size:13px;display:flex;flex-direction:column;overflow:hidden}
 /* docked search bar at the TOP (the user 2026-06-29): filter the fleet to sessions whose NAME matches. */
-#fleet-search-bar{flex:0 0 auto;padding:8px 12px;border-bottom:1px solid var(--vscode-editorHoverWidget-border,rgba(255,255,255,0.12))}
-#fleet-search-wrap{position:relative}
+#fleet-search-bar{flex:0 0 auto;display:flex;align-items:center;flex-wrap:wrap;gap:6px;padding:8px 12px;border-bottom:1px solid var(--vscode-editorHoverWidget-border,rgba(255,255,255,0.12))}
+#fleet-search-wrap{position:relative;flex:1 1 140px;min-width:140px}
 #fleet-search{width:100%;box-sizing:border-box;background:var(--vscode-input-background,#3c3c3c);
 color:var(--vscode-input-foreground,#ccc);border:1px solid var(--vscode-input-border,#3c3c3c);
 border-radius:6px;padding:5px 28px 5px 10px;font:inherit;font-size:12.5px;outline:none}

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -108,13 +108,13 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 .ra-openbtn { margin-top: 8px; width: 100%; background: #2d2d2f; border: 1px solid #3a3a3a; border-radius: 6px;
   color: #cdd3da; font: 600 12px/1.4 -apple-system, sans-serif; padding: 7px; cursor: pointer; }
 .ra-openbtn:hover { background: #343436; color: #fff; }
-#ranalytics-back { position: fixed; inset: 0; z-index: 70; background: #000000bb; display: flex;
+#ranalytics-back { position: fixed; inset: 0; z-index: 70; background: rgba(0, 0, 0, 0.55); display: flex;
   align-items: center; justify-content: center; }
 /* an explicit display rule beats the UA [hidden]{display:none}; restore hiding at higher
    specificity so the close / backdrop-click / Esc (which set .hidden) actually dismiss the modal */
 #ranalytics-back[hidden] { display: none; }
 #ranalytics { width: min(520px, 94vw); max-height: 90vh; overflow: auto; background: #252526;
-  border: 1px solid #3a3a3a; border-radius: 10px; padding: 14px 16px; box-shadow: 0 12px 40px #000000aa;
+  border: 1px solid #3a3a3a; border-radius: 10px; padding: 14px 16px; box-shadow: 0 12px 36px #000000aa;
   font: 12px/1.5 -apple-system, sans-serif; color: #ccc; }
 #ranalytics .ra-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
 #ranalytics .ra-title { font-weight: 600; font-size: 14px; color: #e8eaed; }

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -106,7 +106,7 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
   border-radius: 4px; padding: 1px 6px; font: 600 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; color: #e6e6e6; }
 /* token-usage analytics: a button in the gear panel opens a centered modal with the chart. */
 .ra-openbtn { margin-top: 8px; width: 100%; background: #2d2d2f; border: 1px solid #3a3a3a; border-radius: 6px;
-  color: #cdd3da; font: 600 12px/1.4 -apple-system, sans-serif; padding: 7px; cursor: pointer; }
+  color: #cdd3da; font: 600 12px/1.4 system-ui, -apple-system, 'Segoe UI', sans-serif; padding: 7px; cursor: pointer; }
 .ra-openbtn:hover { background: #343436; color: #fff; }
 #ranalytics-back { position: fixed; inset: 0; z-index: 70; background: rgba(0, 0, 0, 0.55); display: flex;
   align-items: center; justify-content: center; }
@@ -115,14 +115,14 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #ranalytics-back[hidden] { display: none; }
 #ranalytics { width: min(520px, 94vw); max-height: 90vh; overflow: auto; background: #252526;
   border: 1px solid #3a3a3a; border-radius: 10px; padding: 14px 16px; box-shadow: 0 12px 36px #000000aa;
-  font: 12px/1.5 -apple-system, sans-serif; color: #ccc; }
+  font: 12px/1.5 system-ui, -apple-system, 'Segoe UI', sans-serif; color: #ccc; }
 #ranalytics .ra-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
 #ranalytics .ra-title { font-weight: 600; font-size: 14px; color: #e8eaed; }
 #ra-close { background: none; border: none; color: #9aa0a6; font-size: 16px; cursor: pointer; line-height: 1; }
 #ra-close:hover { color: #fff; }
 .ra-periods, .ra-group, .ra-metric { display: flex; gap: 4px; margin-bottom: 8px; flex-wrap: wrap; }
 .ra-periods button, .ra-group button, .ra-metric button { background: #2a2a2a; border: 1px solid #3a3a3a;
-  border-radius: 5px; color: #9aa0a6; font: 12px/1 -apple-system, sans-serif; padding: 5px 9px; cursor: pointer; }
+  border-radius: 5px; color: #9aa0a6; font: 12px/1 system-ui, -apple-system, 'Segoe UI', sans-serif; padding: 5px 9px; cursor: pointer; }
 .ra-periods button:hover, .ra-group button:hover, .ra-metric button:hover { background: #333; color: #ddd; }
 .ra-periods button.on, .ra-group button.on, .ra-metric button.on { background: #0e639c; border-color: #1177bb; color: #fff; }
 .ra-chart { margin: 6px 0 10px; min-height: 120px; }

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -2,10 +2,10 @@
    that hosts the modal can link it: the kernel's /feed page, and the VS Code feed AND chat
    panels (the modal opens over whichever pane the strip's gear was clicked in,
    the user 2026-07-13). */
-#rgear { position: fixed; top: 6px; right: 8px; z-index: 60; background: #2a2a2b; border: 1px solid #3a3a3a;
+#rgear { position: fixed; top: 6px; right: 8px; z-index: 60; background: #2a2a2a; border: 1px solid #3a3a3a;
   border-radius: 6px; color: #9aa0a6; font-size: 15px; cursor: pointer; opacity: .7; line-height: 1; padding: 3px 6px; }
 #rgear:hover { opacity: 1; background: #333; }
-#rrefresh { position: fixed; top: 6px; right: 42px; z-index: 60; background: #2a2a2b; border: 1px solid #3a3a3a;
+#rrefresh { position: fixed; top: 6px; right: 42px; z-index: 60; background: #2a2a2a; border: 1px solid #3a3a3a;
   border-radius: 6px; color: #9aa0a6; font-size: 14px; cursor: pointer; opacity: .7; line-height: 1; padding: 3px 6px; }
 #rrefresh:hover { opacity: 1; background: #333; color: #fff; }
 #rrefresh:disabled { opacity: .4; cursor: default; }
@@ -56,7 +56,7 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
    floats below the row on hover (absolute → no layout shift). */
 #rsettings .rs-sub { display: none; }
 #rsettings .rs-row:hover .rs-sub { display: block; position: absolute; left: 0; right: 0; top: 100%; z-index: 10;
-  margin-top: 2px; color: #cdd3da; font-size: .92em; line-height: 1.35; background: #1b1b1c; border: 1px solid #3a3a3a;
+  margin-top: 2px; color: #cdd3da; font-size: 0.92em; line-height: 1.35; background: #1b1b1c; border: 1px solid #3a3a3a;
   border-radius: 6px; padding: 6px 9px; box-shadow: 0 4px 14px #000000aa; pointer-events: none; }
 #rsettings .rs-sub code { background: #0d0d0d; border-radius: 3px; padding: 0 3px; }
 /* A setting whose value differs between the connected machines: the checkbox goes tri-state, and this
@@ -72,24 +72,24 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #rs-cmap { position: relative; margin-top: 5px; }
 #rs-cmap-btn { width: 100%; height: 20px; border-radius: 5px; border: 1px solid #3a3a3a; cursor: pointer; padding: 0; display: block; }
 #rs-cmap-list { position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px; z-index: 20; background: #1e1e1e;
-  border: 1px solid #3a3a3a; border-radius: 6px; padding: 5px; box-shadow: 0 8px 24px #000000aa; }
+  border: 1px solid #3a3a3a; border-radius: 6px; padding: 4px; box-shadow: 0 8px 24px #000000aa; }
 #rs-cmap-list[hidden] { display: none; }
 .rs-cmap-opt { height: 18px; border-radius: 4px; border: 1px solid #3a3a3a; cursor: pointer; margin: 4px 0; }
 .rs-cmap-opt:first-child { margin-top: 0; }
 .rs-cmap-opt:last-child { margin-bottom: 0; }
-.rs-cmap-opt.sel { outline: 2px solid #9cd2ff; outline-offset: 1px; border-color: transparent; }
+.rs-cmap-opt.sel { outline: 2px solid var(--accent, #9cd2ff); outline-offset: 1px; border-color: transparent; }
 /* Session-colors picker (the user 2026-07-12): same dropdown mechanics, options = 9 identity dots + name. */
 #rs-pal { position: relative; margin-top: 5px; }
 #rs-pal-btn { width: 100%; border: 1px solid #3a3a3a; border-radius: 5px; cursor: pointer; background: #1e1e1e;
   display: flex; gap: 5px; align-items: center; padding: 4px 7px; min-height: 20px; }
 #rs-pal-list { position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px; z-index: 20; background: #1e1e1e;
-  border: 1px solid #3a3a3a; border-radius: 6px; padding: 4px; box-shadow: 0 8px 24px #00000088; }
+  border: 1px solid #3a3a3a; border-radius: 6px; padding: 4px; box-shadow: 0 8px 24px #000000aa; }
 #rs-pal-list[hidden] { display: none; }
 .rs-pal-opt { display: flex; gap: 5px; align-items: center; border: 1px solid #3a3a3a; border-radius: 4px;
   cursor: pointer; margin: 4px 0; padding: 4px 7px; }
 .rs-pal-opt:first-child { margin-top: 0; }
 .rs-pal-opt:last-child { margin-bottom: 0; }
-.rs-pal-opt.sel { outline: 2px solid #9cd2ff; outline-offset: 1px; border-color: transparent; }
+.rs-pal-opt.sel { outline: 2px solid var(--accent, #9cd2ff); outline-offset: 1px; border-color: transparent; }
 .rs-pal-dot { width: 11px; height: 11px; border-radius: 50%; flex: 0 0 auto; }
 .rs-pal-name { color: #9aa0a6; font-size: 11px; margin-left: auto; padding-left: 8px; white-space: nowrap; }
 #rsettings .rs-sep { border-top: 1px solid #3a3a3a; margin-top: 6px; padding-top: 8px; }
@@ -121,7 +121,7 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #ra-close { background: none; border: none; color: #9aa0a6; font-size: 16px; cursor: pointer; line-height: 1; }
 #ra-close:hover { color: #fff; }
 .ra-periods, .ra-group, .ra-metric { display: flex; gap: 4px; margin-bottom: 8px; flex-wrap: wrap; }
-.ra-periods button, .ra-group button, .ra-metric button { background: #2a2a2b; border: 1px solid #3a3a3a;
+.ra-periods button, .ra-group button, .ra-metric button { background: #2a2a2a; border: 1px solid #3a3a3a;
   border-radius: 5px; color: #9aa0a6; font: 12px/1 -apple-system, sans-serif; padding: 5px 9px; cursor: pointer; }
 .ra-periods button:hover, .ra-group button:hover, .ra-metric button:hover { background: #333; color: #ddd; }
 .ra-periods button.on, .ra-group button.on, .ra-metric button.on { background: #0e639c; border-color: #1177bb; color: #fff; }

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -191,7 +191,7 @@ test("settings lift does the same via rs-lifted / rs-pane-gone", () => {
 });
 
 test("overlay dims are the one standard 0.55", () => {
-  assert.match(CSS, /\.picker-overlay \{[\s\S]*?background: rgba\(0, 0, 0, 0\.55\);/);
+  assert.match(CSS, /\.picker-overlay \{[\s\S]*?background: var\(--overlay-dim\);/);
   assert.match(GEAR_CSS, /#rsettings \{ position: fixed; inset: 0; z-index: 60; background: rgba\(0, 0, 0, 0\.55\);/);
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8946,9 +8946,14 @@ function isCoarsePointer(): boolean {
 function composerRestingPlaceholder(): string {
   // the one canonical hint line (the user 2026-08-15): send, newline, stage, commands — and just
   // "/ for commands", not "type / for commands". The static skeletons carry the same string.
-  return isCoarsePointer()
-    ? "Message this session…"
-    : "Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)";
+  // WIDTH-ADAPTIVE (the user 2026-08-26, whose narrow pane wrapped the full hint onto a clipped
+  // second line): below ~620px of box the hint drops to the core prompt + the one undiscoverable
+  // key ("/"); the full key chart stays a wide-desktop hint. Re-fitted event-based on pane resize
+  // (the ResizeObserver beside the composer's other wiring), never re-measured per keystroke.
+  if (isCoarsePointer()) return "Message this session…";
+  const ta = document.getElementById("composer-input");
+  if (ta && ta.clientWidth > 0 && ta.clientWidth < 620) return "Message this session…  (/ for commands)";
+  return "Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)";
 }
 
 // How a message typed into the NORMAL composer should be routed while a live picker is up — the picker's
@@ -11748,6 +11753,15 @@ function setupComposer() {
     // a double-click on the handle resets to auto (one line) — a quick escape hatch without sending
     grip.addEventListener("dblclick", () => { composerManualH = null; growComposer(ta); });
   }
+
+  // ── width-adaptive resting placeholder (the user 2026-08-26) ── the pane resized across the
+  // short/long hint threshold → re-fit the placeholder, but ONLY while it is showing a resting
+  // form: a picker's "add your own answer…" or the closed-session notice must never be clobbered.
+  try {
+    new ResizeObserver(() => {
+      if (ta.placeholder.startsWith("Message this session…")) ta.placeholder = composerRestingPlaceholder();
+    }).observe(ta);
+  } catch (e) { /* tests: no ResizeObserver in the DOM shim */ }
 
   // ── slash-command autocomplete (the user 2026-06-29) ── a "/" at the START of the box opens a filterable,
   // arrow-navigable menu of THIS session's slash commands (name + description + arg hint), sourced from the

--- a/ui/webview/revive-loader.test.ts
+++ b/ui/webview/revive-loader.test.ts
@@ -23,7 +23,7 @@ test("the loader is the romp treatment: wordmark + swirl + pulsing dots + captio
   // ONE shared builder (rompLoaderInner) carries the anatomy — the revive loader and the comment
   // popover's boot both wear it, per the loading-states rule
   assert.match(RENDER, /function rompLoaderInner\(caption: string, opts\?: \{ wordmark\?: boolean \}\): HTMLElement/);   // parameterized, never forked (the popover drops the wordmark; everything else keeps it)
-  assert.match(RENDER, /const word = el\("div", "rl-word"\)/, "reuses the boot-splash .rl-* styles already on the page");
+  assert.match(RENDER, /const word = el\("div", "rl-word"\)/, "the shared .rl-* anatomy");
   assert.match(RENDER, /swirl\.src = mediaSrc\("romp-swirl-o\.svg"\)/);
   assert.match(RENDER, /const dots = el\("div", "rl-dots"\)/);
   assert.match(RENDER, /o\.appendChild\(rompLoaderInner\(`reviving “\$\{name\}”…`\)\);/);
@@ -74,4 +74,16 @@ test("the loader has styles: dimming backdrop + caption; the error-box family is
   assert.match(CSS, /#revive-loader \{ position: fixed; z-index: 65; display: flex;/);
   assert.match(CSS, /#revive-loader \.revive-cap \{/);
   assert.doesNotMatch(CSS, /revive-err/);
+});
+
+test("the .rl-* anatomy lives in styles.css itself — the VS Code chat page loads this sheet ALONE", () => {
+  // kernel-served pages also inject _LOADER_CSS, but the VS Code webview never sees that block:
+  // without these rules the revive loader rendered as an unstyled div stack there (2026-08-26)
+  assert.match(CSS, /\.rl-in \{ display: flex; flex-direction: column; align-items: center; gap: 18px; \}/);
+  assert.match(CSS, /\.rl-word \{ font-family: 'RompAnta', var\(--sans\);/);
+  assert.match(CSS, /\.rl-o \{[^}]*animation: rl-spin 7s linear infinite/);
+  assert.match(CSS, /\.rl-dots i \{[^}]*background: var\(--accent\)/);
+  assert.match(CSS, /@keyframes rl-bnc/);
+  assert.match(CSS, /@keyframes rl-spin/);
+  assert.match(CSS, /@font-face \{ font-family: 'RompAnta'; src: url\(\.\.\/media\/Anta-Regular\.ttf\)/);
 });

--- a/ui/webview/shortcuts-modal.ts
+++ b/ui/webview/shortcuts-modal.ts
@@ -48,7 +48,7 @@ const CSS =
   // recording / conflict states: the accent marks "the dialog is listening", never a status color
   ".rkeys-row.recording{background:rgba(156,210,255,0.10);outline:1px solid var(--accent,#9cd2ff)}" +
   ".rkeys-hint{flex:0 0 auto;color:var(--accent,#9cd2ff);font-size:11px}" +
-  ".rkeys-conflict{flex:0 0 auto;color:#d29922;font-size:11px}" +
+  ".rkeys-conflict{flex:0 0 auto;color:var(--warn,#d7a23a);font-size:11px}" +
   "#rkeys-fixed{flex:0 0 auto;margin-top:10px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.08)}" +
   "#rkeys-fixed .rkeys-sec{color:#9aa0a6;font-size:11px;margin-bottom:2px}" +
   "#rkeys-fixed .rkeys-row{padding:2px 8px}" +

--- a/ui/webview/shortcuts-modal.ts
+++ b/ui/webview/shortcuts-modal.ts
@@ -46,7 +46,7 @@ const CSS =
   ".rkeys-row:hover .rkeys-act{visibility:visible}" +
   ".rkeys-act:hover{background:#333;color:#e8eaed}" +
   // recording / conflict states: the accent marks "the dialog is listening", never a status color
-  ".rkeys-row.recording{background:rgba(156,210,255,0.10);outline:1px solid var(--accent,#9cd2ff)}" +
+  ".rkeys-row.recording{background:rgba(156,210,255,0.12);outline:1px solid var(--accent,#9cd2ff)}" +
   ".rkeys-hint{flex:0 0 auto;color:var(--accent,#9cd2ff);font-size:11px}" +
   ".rkeys-conflict{flex:0 0 auto;color:var(--warn,#d7a23a);font-size:11px}" +
   "#rkeys-fixed{flex:0 0 auto;margin-top:10px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.08)}" +

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -77,7 +77,7 @@
 #strip-refresh:disabled { opacity: .35; cursor: default; }
 #strip-net.on { color: var(--accent, #9cd2ff); opacity: 1; }
 /* the popover-open acknowledgment: the button reacts the instant it's clicked */
-#strip-net.open { color: var(--accent, #9cd2ff); opacity: 1; background: rgba(156, 210, 255, 0.12); }
+#strip-net.open { color: var(--accent, #9cd2ff); opacity: 1; background: var(--accent-wash, rgba(156, 210, 255, 0.12)); }
 /* the remotes popover, anchored above the strip */
 #strip-net-pop { position: fixed; right: 8px; bottom: 34px; z-index: 80; width: min(340px, 92vw);
   background: #1e1e1e; border: 1px solid #3a3a3a; border-radius: 8px; padding: 8px;

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -34,7 +34,7 @@
    their own class so the tiers never hide them on a key-billed machine: tier 2 folds the token halves,
    tier 3 folds the labels like every other row, the value stays at every tier. */
 .ru-w.ru-api { gap: 6px; }
-.ru-apiv { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #cfe6ff;
+.ru-apiv { font: 600 10px system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #cfe6ff;
   font-variant-numeric: tabular-nums; white-space: nowrap; }
 #romp-strip[data-tier="2"] .ru-apitok, #romp-strip[data-tier="3"] .ru-apitok { display: none; }
 #strip-gear { flex: 0 0 auto; background: transparent; border: 1px solid transparent; border-radius: 5px;
@@ -43,7 +43,7 @@
 #strip-gear:hover { opacity: 1; background: rgba(255, 255, 255, 0.08); color: var(--vscode-foreground, #ccc); }
 .ru-w { display: flex; flex-direction: row; align-items: center; gap: 7px; cursor: default;
   flex: 0 1 auto; min-width: 0; }
-.ru-name { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #9aa4ad;
+.ru-name { font: 600 10px system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #9aa4ad;
   letter-spacing: .02em; white-space: nowrap; }
 /* fluid: 54px with room, compressing continuously to an 18px floor without one.
    width (not flex-basis) on purpose: the tracks are empty spans, so a bare basis
@@ -58,14 +58,14 @@
 /* UNKNOWN (the user 2026-08-13; supersedes the 2026-07-31 '?' slot): a window whose reading no longer
    describes the present is not drawn at all — the bar shows only what we know, and the last-known
    number rides the usage wrap's hover title, labelled as such. */
-.ru-pct { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #cfe6ff;
+.ru-pct { font: 600 10px system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; color: #cfe6ff;
   font-variant-numeric: tabular-nums; white-space: nowrap; }
 
 /* pane quick-opens: text labels for the panes NOT currently on screen */
 #strip-panes { flex: 0 0 auto; display: flex; flex-direction: row; align-items: center; gap: 6px; }
 .strip-pane { background: rgba(255, 255, 255, 0.06); color: var(--vscode-foreground, #ccc);
   border: 1px solid var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.14)); border-radius: 5px;
-  cursor: pointer; font: 600 10.5px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; padding: 2px 8px;
+  cursor: pointer; font: 600 10.5px system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; padding: 2px 8px;
   white-space: nowrap; }
 .strip-pane:hover { background: rgba(255, 255, 255, 0.12); }
 /* refresh + network buttons share the gear's quiet chrome */
@@ -81,14 +81,14 @@
 /* the remotes popover, anchored above the strip */
 #strip-net-pop { position: fixed; right: 8px; bottom: 34px; z-index: 80; width: min(340px, 92vw);
   background: #1e1e1e; border: 1px solid #3a3a3a; border-radius: 8px; padding: 8px;
-  box-shadow: 0 10px 30px #000000aa; font: 12px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  box-shadow: 0 10px 30px #000000aa; font: 12px/1.5 system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   color: #ccc; }
 #strip-net-pop[hidden] { display: none; }
 #strip-net-pop .sn-attach { display: flex; gap: 6px; margin-bottom: 8px; }
 #strip-net-pop select { flex: 1 1 auto; min-width: 0; background: #2a2a2a; color: #ccc;
   border: 1px solid #3a3a3a; border-radius: 5px; padding: 3px 4px; }
 #strip-net-pop button { background: #2a2a2a; border: 1px solid #3a3a3a; border-radius: 5px; color: #cdd3da;
-  font: 600 11px -apple-system, sans-serif; padding: 3px 9px; cursor: pointer; white-space: nowrap; }
+  font: 600 11px system-ui, -apple-system, sans-serif; padding: 3px 9px; cursor: pointer; white-space: nowrap; }
 #strip-net-pop button:hover { background: #333; color: #fff; }
 #strip-net-pop button:disabled { opacity: .5; cursor: default; }
 .sn-row { display: flex; align-items: center; gap: 7px; padding: 3px 0; }

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -104,7 +104,7 @@
 .sn-pend { color: var(--accent, #9cd2ff); font-size: 11px; flex: 0 0 auto; }
 /* "Previously attached": a quiet header + dimmed rows, so remembered hosts read as history you can act
    on and never as something currently connected. Hover restores full opacity (they're interactive). */
-.sn-khead { color: #6e7681; font-size: 10.5px; letter-spacing: .04em; text-transform: uppercase;
+.sn-khead { color: #6e7681; font-size: 10.5px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
   margin: 10px 0 2px; padding-top: 8px; border-top: 1px solid var(--vscode-widget-border, #2a2a2a); }
 .sn-known { opacity: 0.62; }
 .sn-known:hover { opacity: 1; }

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -85,9 +85,9 @@
   color: #ccc; }
 #strip-net-pop[hidden] { display: none; }
 #strip-net-pop .sn-attach { display: flex; gap: 6px; margin-bottom: 8px; }
-#strip-net-pop select { flex: 1 1 auto; min-width: 0; background: #2a2a2b; color: #ccc;
+#strip-net-pop select { flex: 1 1 auto; min-width: 0; background: #2a2a2a; color: #ccc;
   border: 1px solid #3a3a3a; border-radius: 5px; padding: 3px 4px; }
-#strip-net-pop button { background: #2a2a2b; border: 1px solid #3a3a3a; border-radius: 5px; color: #cdd3da;
+#strip-net-pop button { background: #2a2a2a; border: 1px solid #3a3a3a; border-radius: 5px; color: #cdd3da;
   font: 600 11px -apple-system, sans-serif; padding: 3px 9px; cursor: pointer; white-space: nowrap; }
 #strip-net-pop button:hover { background: #333; color: #fff; }
 #strip-net-pop button:disabled { opacity: .5; cursor: default; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -81,6 +81,9 @@ body.scheme-solarized-dark {
   --radius-modal: 10px;
   --shadow-modal: 0 12px 36px #000000aa;
   --overlay-dim: rgba(0, 0, 0, 0.55);
+  /* the true-pill radius (filter pills, the loading pill) — one name so new pills don't mint
+     another magic number. Mirrored in feed.css (own :root). */
+  --radius-pill: 999px;
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
@@ -1095,7 +1098,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .tx-loading-pill {
   position: fixed; top: 10px; left: 50%; transform: translateX(-50%); z-index: 50;
   background: rgba(20, 24, 33, 0.92); color: var(--accent, #9cd2ff); font-size: 12px; font-weight: 600;
-  padding: 4px 12px; border-radius: 999px; pointer-events: none;
+  padding: 4px 12px; border-radius: var(--radius-pill); pointer-events: none;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4); border: 1px solid rgba(156, 210, 255, 0.25);
 }
 /* tool + thinking rows pack tighter than prose turns (the user: ~half the spacing) */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -54,6 +54,8 @@ body.scheme-solarized-dark {
   --box-bg: rgba(255, 255, 255, 0.03);
   --box-border: var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.12));
   --err: #c0392b;   /* unified with the awaiting/blocked red (the user 2026-06-24): one "needs you" red. API-error (--st-blocked-bg #e5484d) stays distinct. */
+  --warn: #d7a23a;  /* the heads-up amber — "attention, not an error". Was referenced with fallbacks but never
+                       defined (a phantom token) until 2026-08-26; mirrored in feed.css (own :root). */
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1085,7 +1085,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* scroll-margin-top: a jump lands the turn at the TOP of the viewport (landOn uses
    block:"start") — a few px of breathing room so it isn't glued to the edge and the
    anchor-flash border isn't clipped. */
-.turn { position: relative; padding-left: 24px; padding-top: 9px; padding-bottom: 9px; scroll-margin-top: 10px; }   /* text indent from the rail; tightened 30→24 for more prose width (the user 2026-07-05) — the dot/rail (left:6/10.5) are unaffected */
+.turn { position: relative; padding-left: 24px; padding-top: 7px; padding-bottom: 7px; scroll-margin-top: 10px; }   /* text indent from the rail; tightened 30→24 for more prose width (the user 2026-07-05) — the dot/rail (left:6/10.5) are unaffected */
 /* Tail-windowing spacer (render.ts): stands in for the older head [0, winStart) that isn't rendered as real
    .turn nodes, sized to its estimated height so the scrollbar is honest. Invisible, non-interactive — it's
    pure vertical space. (content-visibility:auto was tried here first but REVERTED: it made content.scrollHeight
@@ -1205,13 +1205,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    glow appends .rail-band divs to the same container, and with :last-child the stub selector stopped
    matching mid-hover, snapping a full-height line over the final text (the user 2026-07-03). */
 .turn:not(:has(~ .turn))::before { bottom: auto; height: 16px; }
-.dot { position: absolute; left: 6px; top: 15px; width: 11px; height: 11px; border-radius: 50%; box-sizing: border-box; }
+.dot { position: absolute; left: 6px; top: 13px; width: 11px; height: 11px; border-radius: 50%; box-sizing: border-box; }
 /* timeline-rail TIME MARKER — the time label that REPLACES the hollow per-turn dots
    (the user 2026-06-10): floated in the gap above a turn, on the rail, when the clock
    minute/day advanced since the previous timed event. Absolute (no layout shift), bg
    interrupts the rail so it reads as a tick on the timeline. .day adds the date+bold. */
 .time-marker {
-  position: absolute; top: 15px; left: -45px; width: 48px; z-index: 2;
+  position: absolute; top: 13px; left: -45px; width: 48px; z-index: 2;
   text-align: right; white-space: nowrap; line-height: 1;       /* right edge sits ~3px LEFT of the dot (dot is at 6px); text fills the empty gutter to its left, aligned to the dot's row */
   font-size: 0.76em; font-variant-numeric: tabular-nums; letter-spacing: 0.02em;
   color: var(--dim);
@@ -1308,9 +1308,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   content: ""; position: absolute; inset: 0; border-radius: 50%;
   background: url(../media/romp-swirl-glyph.svg) center / contain no-repeat;
 }
-/* user turns pad 14px on top (vs 9px for assistant), so nudge their dot + rail marker
+/* user turns pad 11px on top (vs 7px for assistant), so nudge their dot + rail marker
    down to sit on the bubble's first line */
-.turn-user .dot, .turn-user .time-marker { top: 20px; }
+.turn-user .dot, .turn-user .time-marker { top: 17px; }
 
 /* deep-link target: brief highlight when the dashboard scrolls us to an event */
 @keyframes anchor-flash {
@@ -1323,13 +1323,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    solid saturated blue + white text, right-aligned, so "your voice" is unmistakable.
    The blue (#2b6cef, royal/indigo) is deliberately distinct from --rel-decision
    (#1EA1EB, cyan), --st-ready-bg (#2b7fb8, steel), and peer identity blues. */
-.turn-user { padding-top: 14px; padding-bottom: 14px; }
+.turn-user { padding-top: 11px; padding-bottom: 11px; }
 /* GENUINE prompts only: right-align the outgoing bubble. Injected lines stay full-width left. */
 .turn-user:not(.injected) { display: flex; flex-direction: column; align-items: flex-end; }
 .user-bubble {
   max-width: 72%;
   background: #2b6cef; border: 1px solid #2b6cef;
-  border-radius: 14px; padding: 9px 14px; color: #ffffff;
+  border-radius: 14px; padding: 7px 12px; color: #ffffff;
   display: flow-root;   /* contain inner floats (e.g. image captions) */
 }
 /* (A just-sent message renders as the dashed .queued-bubble via the QUEUED idiom — see render.ts's
@@ -1418,7 +1418,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .user-bubble.cont-row {
   max-width: 72%;
   background: rgba(43, 108, 239, 0.16); border: 1px solid rgba(43, 108, 239, 0.42);
-  border-radius: 14px; padding: 7px 14px;
+  border-radius: 14px; padding: 7px 12px;
 }
 .user-bubble.cont-row .followup-tag { max-width: none; }
 .user-bubble.cont-row .cont-tri::before { content: "▸"; }
@@ -1438,7 +1438,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .romp-bubble {
   max-width: 72%;
   background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 14px; padding: 9px 14px; color: var(--fg);
+  border-radius: 14px; padding: 7px 12px; color: var(--fg);
   display: flow-root;
 }
 .romp-bubble a { color: var(--fg); text-decoration: underline; text-underline-offset: 2px; }
@@ -1469,7 +1469,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .queued-bubble {
   max-width: 72%; overflow-wrap: anywhere; display: flow-root;
   background: rgba(43, 108, 239, 0.10); border: 1px dashed rgba(43, 108, 239, 0.65);
-  border-radius: 14px; padding: 7px 13px; color: var(--fg); opacity: 0.85;
+  border-radius: 14px; padding: 7px 12px; color: var(--fg); opacity: 0.85;
 }
 /* A CANCELABLE queued bubble carries an explicit ✕ (the user 2026-07-08 — the old whole-bubble click was
    undiscoverable and re-render-fragile). The bubble itself is no longer clickable; only the ✕ acts. It sits

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -60,6 +60,9 @@ body.scheme-solarized-dark {
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
   --accent: #9cd2ff; --accent-fg: #0c1a2e;
+  /* THE faint accent wash — the one alpha behind every selected/hovered accent chrome (0.10 and 0.14
+     variants drifted in before 2026-08-26). Mirrored in feed.css (own :root). */
+  --accent-wash: rgba(156, 210, 255, 0.12);
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
@@ -668,7 +671,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .held-head { flex: 1 1 100%; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
-.staged-head .staged-go:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }   /* the feed word-button hover (2026-08-25) */
+.staged-head .staged-go:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }   /* the feed word-button hover (2026-08-25) */
 /* the chips strip's Stage button (the user 2026-08-23; moved 2026-08-24): it FOLLOWS the blue
    context chips in the strip's column — immediately after what it acts on, where its meaning reads;
    right-justified it floated detached. Exists exactly while context is held (the strip renders it,
@@ -681,7 +684,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* hover = the FEED's word-button treatment exactly (the user 2026-08-25: text + outline light up
    blue, like Clear/Undo — never a background fill; the wash values are the feed's .ftree-act-btn
    family, referenced not re-derived) */
-.composer-stage-btn:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }
+.composer-stage-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 .staged-chip { display: flex; flex-direction: column; gap: 2px; border: 1px dashed rgba(156, 210, 255, 0.45);
   border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg);
   cursor: pointer; }
@@ -2238,7 +2241,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .picker-dir-row:hover { background: rgba(255, 255, 255, 0.08); }
-.picker-dir-row.active { background: rgba(156, 210, 255, 0.14); color: var(--accent); }
+.picker-dir-row.active { background: var(--accent-wash); color: var(--accent); }
 .picker-dir-more { padding: 4px 10px; color: var(--dim); font-size: 0.82em; }
 /* per-session backend toggle in the + dialog (the user 2026-06-23): a tmux | SDK segmented control */
 .picker-backend { display: flex; align-items: center; gap: 6px; padding: 6px 14px 8px; }
@@ -2820,7 +2823,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.78em;
   padding: 1px 8px; cursor: pointer;
 }
-.cmt-act:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }   /* the feed word-button hover (2026-08-25): Break out / Merge / Delete light up like Clear/Undo */
+.cmt-act:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }   /* the feed word-button hover (2026-08-25): Break out / Merge / Delete light up like Clear/Undo */
 .cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
 .cmt-note.cmt-err { color: var(--st-blocked-bg, #c94f4f); opacity: 0.9; }
 
@@ -3020,8 +3023,8 @@ body.filebrowse-open { overflow: hidden; }
    border + faint wash, gray = off (the .fask-secbtn.on / .feed-modetoggle.on treatment) — with the same
    reverse-highlight hover so a selected toggle never reads as dead. */
 .fileview-btn.on { color: var(--accent); border-color: var(--accent);
-  background: rgba(156, 210, 255, 0.10); font-weight: 600; }
-.fileview-btn.on:hover { border-color: var(--accent); color: var(--accent); background: rgba(156, 210, 255, 0.12); }   /* the feed word-button hover (2026-08-25) */
+  background: var(--accent-wash); font-weight: 600; }
+.fileview-btn.on:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 
 /* Wrap mode (the Wrap toggle, persisted per browser): long lines soft-wrap instead of scrolling
    sideways. The flat sibling gutter cannot survive that — one logical line becomes several visual lines

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -74,6 +74,13 @@ body.scheme-solarized-dark {
   --surface-raised: #252526;
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(0, 0, 0, 0.45);
+  /* the centered-modal vocabulary (CLAUDE.md "Panels open as centered modals over a dimmed,
+     UNCHANGED dashboard") — one card radius/shadow and ONE backdrop dim; the picker, the feed's
+     dialogs and the file viewer had each drifted a step off it before 2026-08-26. Mirrored in
+     feed.css (own :root); gear.css and the shell panels carry the same values as literals. */
+  --radius-modal: 10px;
+  --shadow-modal: 0 12px 36px #000000aa;
+  --overlay-dim: rgba(0, 0, 0, 0.55);
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
@@ -2082,7 +2089,7 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
 /* ---------- session picker overlay (colored, Claude-Code-history style) ---------- */
 .picker-overlay {
   position: fixed; inset: 0;
-  background: rgba(0, 0, 0, 0.55);   /* the one modal dim — same as the shell's network/Log/palette backdrops */
+  background: var(--overlay-dim);   /* the one modal dim — same as the shell's network/Log/palette backdrops */
   display: none; align-items: flex-start; justify-content: center;
   z-index: 1000; padding: 56px 16px 16px;
 }
@@ -2174,8 +2181,8 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   display: flex; flex-direction: column;
   background: var(--vscode-editorWidget-background, #252526);
   border: 1px solid var(--vscode-widget-border, var(--box-border));
-  border-radius: 8px;
-  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.55);
+  border-radius: var(--radius-modal);
+  box-shadow: var(--shadow-modal);
   overflow: hidden;
 }
 .picker-search {
@@ -2570,7 +2577,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   display: flex; align-items: center; justify-content: center; }
 .romp-lightbox-inner { display: flex; flex-direction: column; gap: 8px; max-width: 92vw; max-height: 90vh; }
 .romp-lightbox-img { max-width: 92vw; max-height: 82vh; object-fit: contain; border-radius: 8px;
-  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.6); }
+  box-shadow: var(--shadow-modal); }
 .romp-lightbox-inner.pdf { width: 88vw; height: 88vh; }
 .romp-lightbox-frame { flex: 1 1 auto; width: 100%; border: 0; border-radius: 8px; background: #fff; }
 .romp-lightbox-bar { display: flex; align-items: center; gap: 10px; min-width: 0; }
@@ -2923,11 +2930,11 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    pane, dimmed backdrop (the panels treatment: content behind stays visible, never hidden), ✕ top
    right, Esc/backdrop closes. Under the lightbox (1300) so an image opened FROM a viewed markdown
    file still presents above it. `body.fileview-open` stops the chat scrolling underneath. */
-#romp-fileview { position: fixed; inset: 0; z-index: 1200; background: rgba(0, 0, 0, 0.55);
+#romp-fileview { position: fixed; inset: 0; z-index: 1200; background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; }
 .fileview { width: 95%; height: 95%; display: flex; flex-direction: column; overflow: hidden;
-  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 8px;
-  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.6); }
+  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: var(--radius-modal);
+  box-shadow: var(--shadow-modal); }
 body.fileview-open { overflow: hidden; }
 .fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
   padding: 7px 10px; border-bottom: 1px solid var(--box-border); }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -68,6 +68,12 @@ body.scheme-solarized-dark {
      2026-08-26. Mirrored in feed.css (own :root). */
   --radius-menu: 6px;
   --shadow-menu: 0 4px 12px rgba(0, 0, 0, 0.35);
+  /* the transient-notice (toast/banner) vocabulary — one raised surface, radius and shadow for
+     every self-dismissing notice; five variants had drifted in before 2026-08-26. Mirrored in
+     feed.css (own :root); the kernel's banners carry the same values as literals. */
+  --surface-raised: #252526;
+  --radius-toast: 8px;
+  --shadow-toast: 0 8px 28px rgba(0, 0, 0, 0.45);
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
@@ -2331,8 +2337,9 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    bad jump announces itself instead of impersonating a successful one */
 .locate-toast {
   position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%);
-  max-width: 82%; padding: 6px 14px; border-radius: 8px; z-index: 60;
-  background: rgba(28, 28, 28, 0.94); border: 1px solid rgba(224, 176, 32, 0.55);
+  max-width: 82%; padding: 6px 14px; border-radius: var(--radius-toast); z-index: 60;
+  background: var(--surface-raised); border: 1px solid rgba(224, 176, 32, 0.55);
+  box-shadow: var(--shadow-toast);
   color: var(--fg); font-size: 0.85em; pointer-events: none;
   transition: opacity 0.7s ease;
 }
@@ -2343,9 +2350,9 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    vocabulary, never a window blocker; it dies on the landing event, the ✕, or the backstop. */
 #seek-note {
   position: fixed; left: 50%; bottom: 86px; transform: translateX(-50%); z-index: 60;
-  display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 6px;
-  background: var(--vscode-menu-background, #252526); border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35); font-size: 12px; color: var(--fg);
+  display: flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: var(--radius-toast);
+  background: var(--vscode-menu-background, var(--surface-raised)); border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow-toast); font-size: 12px; color: var(--fg);
 }
 #seek-note .seek-note-label { color: var(--dim); }
 #seek-note .seek-note-x {
@@ -2363,8 +2370,9 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 }
 .warn-toast {
   display: flex; align-items: flex-start; gap: 8px;
-  padding: 8px 12px; border-radius: 8px; cursor: pointer;
-  background: rgba(28, 28, 28, 0.96);
+  padding: 8px 12px; border-radius: var(--radius-toast); cursor: pointer;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-toast);
   border: 1px solid var(--vscode-errorForeground, #f48771);
   color: var(--fg); font-size: 0.85em;
   transition: opacity 0.7s ease;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2459,8 +2459,26 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 @keyframes fl-prov-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .fl-prov-swirl { animation: none; } }
 
+/* ── the romp loader anatomy (.rl-*) — swirl spinning as the wordmark's "o" + three pulsing accent
+   dots, ONE look for every wait state (CLAUDE.md "Loading/waiting states"). Values mirror the
+   kernel's _LOADER_CSS (through this sheet's tokens — same resolved values; kernel-served pages
+   inject that block too, identical rules, harmless): they must ALSO live here because the VS Code
+   webview links only this sheet, and
+   rompLoaderInner (render.ts) builds .rl-* DOM on that surface too — before 2026-08-26 the revive
+   loader rendered as an unstyled div stack there. Geometry notes live with _LOADER_CSS. */
+@font-face { font-family: 'RompAnta'; src: url(../media/Anta-Regular.ttf) format('truetype'); font-display: swap; }
+.rl-in { display: flex; flex-direction: column; align-items: center; gap: 18px; }
+.rl-word { font-family: 'RompAnta', var(--sans); font-size: 38px; line-height: 1; white-space: nowrap; }
+.rl-o { width: .65em; height: .65em; vertical-align: middle; margin: 0 -.0335em; animation: rl-spin 7s linear infinite; }
+.rl-dots { display: flex; gap: 7px; }
+.rl-dots i { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); animation: rl-bnc 1.1s ease-in-out infinite; }
+.rl-dots i:nth-child(2) { animation-delay: .16s; }
+.rl-dots i:nth-child(3) { animation-delay: .32s; }
+@keyframes rl-bnc { 0%, 75%, 100% { opacity: .25; transform: translateY(0); } 38% { opacity: 1; transform: translateY(-5px); } }
+@keyframes rl-spin { to { transform: rotate(-360deg); } }
+
 /* ── revive loader (the user 2026-07-05; PANE-LOCAL 2026-08-25): the romp loader (swirl + wordmark +
-   dots, .rl-* styles from the page's boot-splash block) while a dead session revives. It covers ONLY
+   dots, the .rl-* anatomy above) while a dead session revives. It covers ONLY
    the reviving session's thread area — geometry set inline by placeReviveLoader over #content's box,
    shown only while that session is the active tab — so the tab strip and composer stay live and every
    other tab is fully interactive (the old inset-0 overlay blocked the whole window). Cleared

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -63,6 +63,11 @@ body.scheme-solarized-dark {
   /* THE faint accent wash — the one alpha behind every selected/hovered accent chrome (0.10 and 0.14
      variants drifted in before 2026-08-26). Mirrored in feed.css (own :root). */
   --accent-wash: rgba(156, 210, 255, 0.12);
+  /* the menu vocabulary (CLAUDE.md "Menus and dropdowns wear ONE vocabulary") — every dropdown's
+     radius and shadow resolve through these; two menus had drifted onto their own shadows before
+     2026-08-26. Mirrored in feed.css (own :root). */
+  --radius-menu: 6px;
+  --shadow-menu: 0 4px 12px rgba(0, 0, 0, 0.35);
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
@@ -288,8 +293,8 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
   position: fixed; z-index: 100; min-width: 110px; padding: 4px;
   background: var(--vscode-menu-background, #252526);
   color: var(--vscode-menu-foreground, var(--fg));
-  border: 1px solid var(--box-border); border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--box-border); border-radius: var(--radius-menu);
+  box-shadow: var(--shadow-menu);
   font-size: 0.92em;
 }
 .ctx-item { padding: 4px 10px; border-radius: 4px; cursor: pointer; white-space: nowrap; }
@@ -346,8 +351,9 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-tip {
   position: fixed; z-index: 70; display: none; pointer-events: none;
   background: var(--vscode-editorWidget-background, #252526);
-  border: 1px solid var(--box-border); border-radius: 6px;
-  padding: 7px 10px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+  border: 1px solid var(--box-border); border-radius: var(--radius-menu);
+  padding: 7px 10px; box-shadow: var(--shadow-menu);
+  /* mono ON PURPOSE (unlike the menus' sans): the body is paths/branch/model, the statusline's own voice */
   font-family: var(--mono); font-size: 0.82em; line-height: 1.55;
   /* span the full chat pane width (the user 2026-06-25) so the recent-activity names don't get clipped — the
      positioner (render.ts) clamps it to a small left margin once it's this wide; short tips stay content-sized. */
@@ -727,8 +733,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .slash-pop {
   position: fixed; z-index: 120; max-height: 46vh; overflow-y: auto;
   background: var(--vscode-menu-background, #252526);
-  border: 1px solid var(--box-border); border-radius: 8px;
-  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.45); padding: 4px;
+  border: 1px solid var(--box-border); border-radius: var(--radius-menu);
+  box-shadow: var(--shadow-menu); padding: 4px;
   font-size: 12.5px;
 }
 .slash-row { display: flex; align-items: baseline; gap: 9px; padding: 5px 9px; border-radius: 5px; cursor: pointer; }
@@ -968,9 +974,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .meta-menu {
   position: fixed; z-index: 60; min-width: 96px;
   background: var(--vscode-editorWidget-background, #252526);
-  border: 1px solid var(--box-border); border-radius: 6px;
-  padding: 4px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
-  font-family: var(--mono); font-size: 0.92em;
+  border: 1px solid var(--box-border); border-radius: var(--radius-menu);
+  padding: 4px; box-shadow: var(--shadow-menu);
+  font-family: var(--sans); font-size: 0.92em;
 }
 .meta-item {
   padding: 4px 22px 4px 8px; border-radius: 4px; cursor: pointer;

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -76,8 +76,11 @@ test("THE BUTTON OUTLINE (the user 2026-08-25, round two): every mount wears the
   assert.ok(flat.includes("border-radius:6px"), "the feed's radius");
   assert.ok(flat.includes("#feed-foot.fdismiss{font-size:10.5px;padding:1px9px"), "the feed footer instance's padding");
   // the chat/outline builder states the same box inline (inline beats classes, so it must carry it itself)
-  assert.match(TAGMENU, /border:1px solid " \+ TAG_BTN_BORDER \+ ";"\s*\n\s*\+ "border-radius:6px;padding:1px 9px;/,
-    "tagMenuButton wears the box by the shared literals");
+  // the GLYPH button keeps the outline dress (border/radius/colors) but wears an ICON box —
+  // 4px 6px, taller and narrower than the word-buttons' 1px 9px, which read wide-and-short
+  // around the 14px glyph next to inputs and tabs (the user 2026-08-26)
+  assert.match(TAGMENU, /border:1px solid " \+ TAG_BTN_BORDER \+ ";"\s*\n\s*\+ "border-radius:6px;padding:4px 6px;/,
+    "tagMenuButton wears the outline dress with the icon box");
   assert.match(TAGMENU, /btn\.style\.borderColor = narrowed \? TAG_BTN_ACCENT : TAG_BTN_BORDER;/,
     "narrowed = accent border, at rest the hairline");
   assert.match(TAGMENU, /btn\.style\.background = narrowed \? TAG_BTN_WASH : "transparent";/,
@@ -87,14 +90,14 @@ test("THE BUTTON OUTLINE (the user 2026-08-25, round two): every mount wears the
   // side-by-side crops in review), wearing the identical literals:
   assert.match(TL, /border:1px solid rgba\(255,255,255,0\.10\);border-radius:6px;cursor:pointer;white-space:nowrap;opacity:0\.95;/,
     "the corner button carries the feed's hairline, radius, and footer opacity");
-  assert.match(TL, /font:inherit;font-size:10\.5px;padding:1px 9px;/,
-    "…and the footer instance's font scale and padding");
+  assert.match(TL, /font:inherit;font-size:10\.5px;padding:4px 6px;/,
+    "…and the footer's font scale with the icon box (glyph buttons, 2026-08-26)");
   assert.match(TL, /\.romp-tl-cbtn\.on\{[^}]*background:rgba\(156,210,255,0\.12\);opacity:1\}/,
     "narrowed = the .on wash at full strength");
 });
 
 test("timeline spacing grew (the user 2026-08-25: the corner controls were cramped)", () => {
-  assert.match(TL, /const GAP = 8, BTNW = 34;/,
-    "round three: the button slot IS the feed tag button's measured box (34px), the bar's flex gap 8");
+  assert.match(TL, /const GAP = 8, BTNW = 28;/,
+    "round three: the button slot IS the icon button's measured box (28px since the 2026-08-26 icon box), the bar's flex gap 8");
   assert.match(TL, /if \(hidden > 0\)/, "overflow chips collapse into a +N, one click from the menu");
 });

--- a/ui/webview/tag-button-convention.test.ts
+++ b/ui/webview/tag-button-convention.test.ts
@@ -69,7 +69,10 @@ test("THE BUTTON OUTLINE (the user 2026-08-25, round two): every mount wears the
   assert.equal(TAG_BTN_BORDER, "rgba(255,255,255,0.10)");
   assert.equal(TAG_BTN_WASH, "rgba(156,210,255,0.12)");
   assert.ok(flat.includes("--card-border:rgba(255,255,255,0.10)"), "the feed's hairline is the shared border literal");
-  assert.ok(flat.includes("background:rgba(156,210,255,0.12)"), "the feed .on's wash is the shared wash literal");
+  // the feed's .on rules resolve through var(--accent-wash) since 2026-08-26 — its :root literal
+  // is what must equal the shared constant
+  assert.ok(flat.includes("--accent-wash:rgba(156,210,255,0.12)"), "the feed's wash token is the shared wash literal");
+  assert.ok(flat.includes("background:var(--accent-wash)"), "the feed .on's wash resolves through the token");
   assert.ok(flat.includes("border-radius:6px"), "the feed's radius");
   assert.ok(flat.includes("#feed-foot.fdismiss{font-size:10.5px;padding:1px9px"), "the feed footer instance's padding");
   // the chat/outline builder states the same box inline (inline beats classes, so it must carry it itself)

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -125,7 +125,7 @@ export function tagMenuButton(title: string, open: (btn: HTMLElement) => void): 
   btn.type = "button";
   btn.title = title;
   btn.setAttribute("style", "background:transparent;border:1px solid " + TAG_BTN_BORDER + ";"
-    + "border-radius:6px;padding:1px 9px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;");
+    + "border-radius:6px;padding:4px 6px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;");
   btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none">'
     + '<path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>'
     + '<circle cx="11" cy="5.5" r="1.2" fill="currentColor"/></svg>';
@@ -161,7 +161,7 @@ export function syncTagFilter(btn: HTMLElement, chipsHost: HTMLElement,
   for (const c of lensChips(lens, unions as never)) {
     const col = c.color || TAG_BTN_GRAY;
     const chip = document.createElement("span");
-    chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:1px 8px;"
+    chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;"
       + "border-radius:9px;font-size:0.82em;border:1px solid " + col + ";color:" + col + ";"
       + "background:transparent;white-space:nowrap;");
     chip.appendChild(document.createTextNode(c.label));


### PR DESCRIPTION
A consistency-first polish pass: no redesign, no layout changes — the existing look, applied consistently. Each commit unifies one visual family toward its documented spec (CLAUDE.md Design) or dominant value, lands with a vocabulary-pinning test, and was verified with before/after headless screenshots of new synthetic fixtures (`tools/ui-verify/fixtures/`).

**Bug fixes found along the way**
- The romp loader (`.rl-in/.rl-word/.rl-dots`, built by `rompLoaderInner`) had no CSS on the VS Code chat surface — the revive loader rendered as an unstyled div stack. The anatomy now lives in styles.css (kernel pages carry both copies, identical).
- feed.css lacked the `a.fileview-btn` anchor rules (the GitHub link rendered hrefless there); a new fileview-parity test pins the viewer chrome byte-equal across the sheets.
- `--warn` was a phantom token — referenced with fallbacks, defined nowhere — while two more ambers one hex digit apart sat nine lines from each other in feed.css.

**Vocabulary unifications** (new tokens in both self-sufficient `:root`s; inline surfaces carry the same values as literals; `css-vocab.test.ts` pins each family)
- Menus: `--radius-menu`/`--shadow-menu` — `.meta-menu` and `.tab-tip` were off the documented spec (heavier shadow, and `.meta-menu` wore mono where the spec says menus read in the romp sans; `.tab-tip` keeps mono on purpose, now said in a comment).
- Toasts/banners: `--surface-raised`/`--radius-toast`/`--shadow-toast` — five variants of one component (incl. the kernel's #rstale/#rupd/#rdrift) share one box; semantic border colors stay.
- Modals: `--radius-modal`/`--shadow-modal`/`--overlay-dim` — three radii, five shadows and four backdrop dims collapse to the documented centered-card treatment.
- Accent wash: `--accent-wash` at the dominant 0.12 (0.10/0.14 strays unified); the selected file-viewer toggle's hover reverts to the app-wide reverse-highlight both sheets' comments already describe.
- Same-row feed badges wear the same metric set; uppercase micro-labels join the 10.5px/700/.08em section-header spec; `--radius-pill`.
- Near-twin colors deduped (one heads-up amber, one small-button gray, one dropdown shadow alpha).

**Going a bit further**
- Browser font stacks modernized in the kernel's THEME_CSS (+ its inline copies, strip.css, gear.css): sans leads with `system-ui`, mono with `ui-monospace`/`SF Mono` — Linux browsers no longer fall to raw DejaVu, and the mono chain loses `"Courier New"`. VS Code surface untouched (its theme vars always won).
- A new opt-in session-identity palette, `pastel — romp soft`: high-lightness, all-black-text, in the romp set's colorblind-tuned order. Purely additive; nobody's current colors change.

Deliberate exemptions preserved and documented: the usage panel's faint 0.4 dim, the lightbox's darker 0.72 dim, `.tab-tip` mono, CodeMirror's 0.14 selection match, the full-width top bars.

Verified: typecheck + 2442 webview tests + full pytest (5706) + build, per commit; before/after PNG pairs per family (kept in /tmp per the privacy rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)