### PR TITLE
The menu-echo writer installs at module load — every pane broadcasts before it ever opens a menu

### DIFF
--- a/ui/webview/menu-echo.test.ts
+++ b/ui/webview/menu-echo.test.ts
@@ -1,0 +1,71 @@
+// T107 (the user 2026-08-26): the cross-pane menu-echo WRITER installs at MODULE LOAD in every
+// pane document — never lazily inside openTagMenu. The repro: a tag menu opened from the sessions
+// panel stood through clicks in the chat, because the chat imports tag-menu.ts but had never
+// opened a menu of its own, so its document held no pointerdown broadcast. The listener half was
+// already module-level; these tests pin the writer half to the same place, per pane document.
+//
+// NO static tag-menu import here: the executed test requires the module AFTER mocking the DOM
+// globals, so the module-level guard runs against the mocks (esbuild wraps bundled modules in
+// lazy factories — require() at call site is the load).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const MENU = ui("webview", "tag-menu.ts");
+const RENDER = ui("webview", "render.ts");
+const FLEET = ui("webview", "fleet.ts");
+const FEED = ui("webview", "feed.ts");
+const PALETTE = ui("webview", "palette-main.ts");
+const TIMELINE = ui("romp-timeline-view.js");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("executed: loading tag-menu in a real-DOM context installs the writer — no open call needed", () => {
+  const writes: Array<[string, string]> = [];
+  const listeners: Record<string, Array<{ fn: (e: unknown) => void; capture: unknown }>> = {};
+  const g = globalThis as any;
+  g.document = {
+    addEventListener: (k: string, fn: (e: unknown) => void, capture?: unknown) => {
+      (listeners[k] ||= []).push({ fn, capture });
+    },
+  };
+  g.window = { addEventListener: () => { /* storage listener — not under test */ } };
+  g.localStorage = { setItem: (k: string, v: string) => writes.push([k, v]) };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require("./tag-menu");   // the LOAD is the install
+    const pd = listeners["pointerdown"];
+    assert.ok(pd && pd.length === 1, "the pointerdown writer is wired by the module guard at load");
+    assert.equal(pd[0].capture, true, "capture phase — fires even when a target swallows the bubble");
+    assert.equal(writes.length, 0, "no write before any pointerdown");
+    pd[0].fn({});
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0][0], "romp:menu-echo", "the shared key every listener watches");
+    const body = JSON.parse(writes[0][1]);
+    assert.equal(typeof body.t, "number", "the { t } shape — a fresh value so same-tick echoes still fire");
+  } finally {
+    delete g.document; delete g.window; delete g.localStorage;
+  }
+});
+
+test("the writer lives in the module guard, and openTagMenu no longer installs anything", () => {
+  const guard = MENU.slice(MENU.indexOf('if (typeof document !== "undefined")'), MENU.indexOf("export function openTagMenu"));
+  assert.ok(guard.includes("installMenuEcho();"), "install sits beside the module-level closers");
+  const open = MENU.slice(MENU.indexOf("export function openTagMenu"), MENU.indexOf("export function tagMenuButton"));
+  assert.ok(!open.includes("installMenuEcho"), "the lazy call is gone — opening a menu is not the install");
+});
+
+test("every pane document the dashboard composes carries the writer at load", () => {
+  // chat, outline/sessions, feed: the pane bundles import tag-menu — the module guard is the writer
+  for (const [name, src] of [["render", RENDER], ["fleet", FLEET], ["feed", FEED]] as const)
+    assert.match(src, /from "\.\/tag-menu"/, name + " bundles the module (writer rides the guard)");
+  // the shell page mounts no tag menu but must still broadcast (palette/log backdrops, statusline)
+  assert.match(PALETTE, /import \{ installMenuEcho \} from "\.\/tag-menu";/);
+  assert.match(PALETTE, /^installMenuEcho\(\);$/m, "module-level — before boot()'s in-iframe early return");
+  assert.match(KERNEL, /dist\/palette-main\.js/, "the shell page loads the bundle that broadcasts");
+  // the timeline pane loads romp-timeline-view.js, not tag-menu — its constructor is its page boot
+  const ctorWriter = /document\.addEventListener\('pointerdown', \(\) => \{\s*\n\s*try \{ localStorage\.setItem\('romp:menu-echo', JSON\.stringify\(\{ t: Date\.now\(\) \}\)\); \} catch \(e\) \{ \/\* storage blocked \*\/ \}\s*\n\s*\}, true\);/;
+  assert.match(TIMELINE, ctorWriter,
+    "same key, same shape, capture phase, try/catch kept (Obsidian's localStorage may be foreign)");
+});

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -11,8 +11,15 @@ import { initPalette, PickItem } from "./palette";
 import { initShortcutsModal } from "./shortcuts-modal";
 import { chordMap, chordOf, dispatchable, displayChord, effectiveChord, keyHint, loadOverrides, titleWithKey, KEYS_EVENT } from "./keybindings";
 import { hostPrefix } from "./host-prefix";   // pure display helper — safe here (never federation.ts, which boots a manager on import)
+import { installMenuEcho } from "./tag-menu";   // model deps only (tag-lens/session-views) — no manager, no DOM cost
 
 type SessionRow = { id: string; name: string; dir: string; bg: string };
+
+// The SHELL document must broadcast the menu echo too: it mounts no tag menu, but a click on its
+// chrome (statusline, pane rail, the palette/log/remote backdrops) has to dismiss a menu open
+// inside any pane. Module-level and before boot()'s in-iframe early return — the writer is
+// per-document plumbing, not palette behavior. Idempotent (the module guard already ran it).
+installMenuEcho();
 
 (function boot() {
   // The shell page only, never inside a pane: the pane documents get the KEY wiring below

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -26,7 +26,11 @@ export interface TagMenuOpts {
 }
 
 let echoInstalled = false;
-/** Every pane writes the pointerdown echo ONCE per document — sibling panes' open menus close on it. */
+/** Every pane writes the pointerdown echo ONCE per document — sibling panes' open menus close on it.
+ *  Installed AT MODULE LOAD by the guard below, never lazily (the user 2026-08-26: a menu opened
+ *  from the sessions panel stood through clicks in the chat — the chat imports this module but had
+ *  never opened a menu, so its document held no writer). Exported for documents that mount no tag
+ *  menu at all (the shell page's palette-main) to compose the same writer explicitly. */
 export function installMenuEcho(): void {
   if (echoInstalled) return;
   echoInstalled = true;
@@ -43,6 +47,7 @@ export function closeTagMenu(): void {
 // module-level closers, guarded: the model half of this module (and its constants) is importable
 // from non-DOM contexts (the node test runner) — only a real document wires the listeners
 if (typeof document !== "undefined") {
+  installMenuEcho();   // the WRITER rides every bundle at load — a pane must broadcast before it ever opens a menu
   document.addEventListener("click", () => closeTagMenu());
   document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeTagMenu(); });
   try {
@@ -53,7 +58,6 @@ if (typeof document !== "undefined") {
 /** Open (or toggle shut) the lens menu anchored under `anchor`. The ctx-family skin — the chat
  *  pane's .ctx-menu is the reference spec (CLAUDE.md menu vocabulary). */
 export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
-  installMenuEcho();
   const reopen = !!openMenu && openMenu.dataset.tagMenu === "1";
   closeTagMenu();
   if (reopen) return;


### PR DESCRIPTION
**Root cause** (verified in source): `installMenuEcho()` was called only inside `openTagMenu()` — a pane wrote the `romp:menu-echo` pointerdown broadcast only after that pane had opened a tag menu once. The chat imports the module, but until its own tag button was used its document had no writer, so its clicks were silent to sibling panes' open menus (the user's repro: tags menu opened from the sessions panel stood through clicks in the chat). The listener half was already module-level.

**Fix, the class not the instance:**
- `tag-menu.ts`: the writer moves into the existing `typeof document` guard beside the click/Escape/storage closers — installed at module load; the lazy call in `openTagMenu` is gone.
- Pane enumeration, each document broadcasting at load: **chat / feed / outline (fleet)** import the module, so the guard covers them free; **timeline** loads `romp-timeline-view.js` (not this module) and already writes in the `TimelinePanel` constructor — its page boot — with the try/catch swallow kept for Obsidian's foreign localStorage; the **shell page** mounts no tag menu at all and was the remaining silent document — it now installs the shared writer via `palette-main.ts`, module-level and before `boot()`'s in-iframe early return, so clicks on the statusline, pane rail, and the palette/log/remote backdrops dismiss menus open inside any pane.
- Out of scope, stated: the PDF lightbox iframe is browser-native content (unscriptable); VS Code webviews are origin-isolated, so the storage echo cannot cross there (pre-existing, unchanged).

**Tests** (`ui/webview/menu-echo.test.ts`): an executed require of the module against mocked DOM globals proves the writer wires at load (capture phase, no write before a pointerdown, the `romp:menu-echo` key and `{ t }` shape); source pins hold the install inside the module guard and out of `openTagMenu`, the tag-menu import in each pane bundle, palette-main's module-level call, the shell page's script tag, and the timeline constructor's writer with its swallow. A headless two-pane dismissal check was considered and skipped: the screenshot harness has no cross-frame assertion mode, and it would exercise the browser's storage-event plumbing rather than this fix — the load-time install is what the executed test pins.

2436/2436 extension tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)