### PR TITLE
romp-lab: a hermetic headless full romp, and the three seams its first loop caught

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6270,7 +6270,7 @@ def _comment_cut_target(path, sid, anchor_uuid):
     context the anchor asked for; the quote still names the passage exactly."""
     ad = _anchor_adapter(path, sid)
     if anchor_uuid not in ad.by_uuid:
-        return None, 0, "that message isn't in the transcript yet; try again in a moment"
+        return None, 0, ANCHOR_LAG_ERR
     is_boundary = lambda r: r is not None and r.get("type") == "system" and r.get("subtype") == "compact_boundary"
     u, hops, on_active = ad.leaf_uuid, 0, False
     while u is not None and hops < 500000:
@@ -6579,6 +6579,14 @@ def _comment_markers(sid):
                     "uuid": th.get("anchorUuid") or "", "tid": th.get("tid"),
                     "status": th.get("status") or "open"})
     return out
+
+
+# The one TRANSIENT create refusal (T106 lab find, 2026-08-26): the anchor record streamed to the
+# client but this kernel's parse hasn't caught up yet. The ws handler sends a typed nack with
+# transient=True for exactly this string; the client keeps its optimistic mark and re-posts when the
+# next session frame proves the parse caught up — so a comment made seconds after a reply lands is
+# never dropped on the floor with a try-again toast.
+ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"
 
 
 def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", color="", now=None):
@@ -7817,7 +7825,13 @@ def _drive(msg, client):
                                    model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""),
                                    color=str(msg.get("color") or ""))
         if err:
-            client["send"](json.dumps({"type": "warn", "text": err}))
+            # a TRANSIENT refusal (parse lag) is the client's cue to hold + retry — no toast for
+            # plumbing the retry makes moot; every real refusal stays loud (fail loudly)
+            if err != ANCHOR_LAG_ERR:
+                client["send"](json.dumps({"type": "warn", "text": err}))
+            client["send"](json.dumps({"type": "commentCreateFailed", "id": sid,
+                                       "uuid": str(msg["uuid"]), "transient": err == ANCHOR_LAG_ERR,
+                                       "text": err}))
         else:
             # the FRAME rides ahead of the ack: the ack's handler adopts the new thread from the
             # client's thread map, so the thread must be in it first (reversed, the popover looked

--- a/tools/romp-lab/README.md
+++ b/tools/romp-lab/README.md
@@ -1,0 +1,46 @@
+# romp-lab — a full, hermetic, headless romp you can drive in a loop
+
+The standing capability T106 asked for (the user 2026-08-26): run a COMPLETE romp —
+real kernel, real SDK sessions replying on the cheapest usable model, the real
+dashboard in a headless browser — entirely in the background, reproduce a reported
+behavior by scripting the user's exact flow, and iterate until it demonstrably
+matches intent. ui-verify (next door) renders static fixtures; romp-lab runs the
+whole stack.
+
+## Hermeticity (non-negotiable)
+
+`lab.sh` exports `XDG_STATE_HOME` into a fresh temp root BEFORE anything loads —
+the never-load-romp-modules-against-live-state rule: a kernel booted against live
+state reconciles it (resumes turns, spawns writers). Its own `ROMP_SERVE_TOKEN`,
+its own free port, `ROMP_KERNEL_NO_OPEN=1` (nothing pops up), headless Chromium
+(the playwright cache vscode-extension pins). Live state, live postal, and every
+visible display stay untouched. Session content is SYNTHETIC ONLY: invented
+prompts, never anything from live transcripts.
+
+## Run
+
+```sh
+tools/romp-lab/lab.sh                      # full highlight loop, screenshots + verdicts
+tools/romp-lab/lab.sh --keep               # keep the temp root + kernel log for forensics
+LAB_MODEL="Haiku 4.5" tools/romp-lab/lab.sh   # pick the reply model (default: the cheapest Haiku the menu offers)
+```
+
+The driver (`highlight-loop.mjs`) scripts the user's exact flow through the real
+dashboard — create a session from the + picker, drop the model to the lab default,
+send a prompt, get a REAL reply, select rendered text, Comment, send, follow up —
+and asserts the comment-mark state at EVERY event boundary of the T102 contract:
+
+1. send gesture → the busy pulse latches immediately (before any thread exists)
+2. thread-open → no state change (sampled continuously: zero flicker)
+3. the reply record lands → the pulse clears to settled yellow
+4. a follow-up send → re-latches until ITS reply
+5. after → nothing sticks (sampled well past the last push)
+
+Screenshots land in the temp root's `shots/` per phase; the script exits non-zero
+on the first divergence with the phase named, so it loops cleanly in a
+fix → re-run cycle.
+
+## Cost
+
+A lab run spends a handful of short turns on the configured model (default Haiku)
+against the machine's own key — the same key live sessions bill.

--- a/tools/romp-lab/highlight-loop.mjs
+++ b/tools/romp-lab/highlight-loop.mjs
@@ -1,0 +1,139 @@
+// The scripted highlight loop (T106): drive the REAL dashboard through the user's exact flow and
+// assert the comment-mark state at every event boundary of the T102 contract. Synthetic content
+// only. Exits non-zero naming the first diverging phase, so a fix → re-run cycle loops cleanly.
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const require2 = createRequire(path.join(ROOT, "vscode-extension", "package.json"));
+const { chromium } = require2("playwright");
+
+const PORT = process.env.PORT, TOKEN = process.env.TOKEN, LAB = process.env.LAB_DIR, PROJ = process.env.PROJECT_DIR;
+const MODEL = process.env.LAB_MODEL || "Haiku";
+const PASSAGE = "the moon has no weather to speak of";
+const shots = path.join(LAB, "shots");
+let phaseN = 0;
+const fails = [];
+
+const b = await chromium.launch();
+const page = await b.newPage({ viewport: { width: 1280, height: 850 } });
+page.on("pageerror", (e) => console.log("PAGEERR", String(e)));
+const shot = async (name) => page.screenshot({ path: path.join(shots, `${String(++phaseN).padStart(2, "0")}-${name}.png`) });
+const busy = () => page.evaluate(() => !!document.querySelector("mark.cmt-hl.busy"));
+const marked = () => page.evaluate(() => !!document.querySelector("mark.cmt-hl"));
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}${detail ? " — " + detail : ""}`);
+  if (!ok) fails.push(name);
+};
+// continuous flicker sampling between two moments: the pulse must not blip through thread-open
+let flickerStop = null;
+const sampleFlicker = () => {
+  const seen = { falses: 0, samples: 0 };
+  const t = setInterval(async () => {
+    try { seen.samples++; if (!(await busy())) seen.falses++; } catch { /* page busy */ }
+  }, 60);
+  flickerStop = () => { clearInterval(t); return seen; };
+};
+
+await page.goto(`http://127.0.0.1:${PORT}/chat?token=${TOKEN}`);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+
+// ── create the lab session through the + picker, exactly as a user would ──
+await page.click(".tab.tab-add", { timeout: 8000 });
+await page.waitForSelector("#picker-search", { timeout: 8000 });
+await shot("picker");
+await page.fill("#picker-search", "lab-moon");
+await page.fill("#picker-dir", PROJ);
+await page.click("#picker-new-btn");
+await page.waitForSelector(".tab", { timeout: 30000 });
+// wait until the session is REAL (composer live, statusline shows a state chip)
+await page.waitForSelector("#statusline .chip, #statusline .compacting-line", { timeout: 60000 });
+await shot("session-open");
+
+// ── drop the model to the lab default (cheapest) via the statusline menu ──
+await page.waitForSelector('#statusline .meta-btn[data-kind="model"]', { timeout: 60000 });
+const dropped = await page.evaluate(async (want) => {
+  const btn = document.querySelector('#statusline .meta-btn[data-kind="model"]');
+  if (!btn) return "no-model-badge";
+  btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 200));
+  const item = Array.from(document.querySelectorAll(".meta-menu .meta-item"))
+    .find((i) => i.textContent.toLowerCase().includes(want.toLowerCase()));
+  if (!item) return "no-menu-item";
+  item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  return "ok";
+}, MODEL);
+console.log("model drop:", dropped);
+
+// ── a REAL turn: ask for a stable, selectable sentence ──
+await page.fill("#composer-input", `Reply with exactly this sentence and nothing else: ${PASSAGE}`);
+await page.keyboard.press("Enter");
+await page.waitForFunction((p) => Array.from(document.querySelectorAll(".turn-assistant .md"))
+  .some((e) => e.textContent.includes(p)), PASSAGE, { timeout: 180000 });
+await shot("reply-landed");
+
+// ── the COMMENT flow: select the passage → context menu → Comment → send ──
+await page.evaluate((p) => {
+  const el = Array.from(document.querySelectorAll(".turn-assistant .md")).find((e) => e.textContent.includes(p));
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let tn; while ((tn = walker.nextNode())) if (tn.data.includes(p)) break;
+  const r = document.createRange();
+  const off = tn.data.indexOf(p);
+  r.setStart(tn, off); r.setEnd(tn, off + p.length);
+  const sel = getSelection(); sel.removeAllRanges(); sel.addRange(r);
+  document.dispatchEvent(new Event("selectionchange"));
+  el.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 420, clientY: 300 }));
+}, PASSAGE);
+await page.waitForSelector(".ctx-menu", { timeout: 5000 });
+await page.evaluate(() => {
+  for (const it of document.querySelectorAll(".ctx-menu .ctx-item")) if (it.textContent === "Comment") it.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+});
+await page.waitForSelector(".cmt-pop .cmt-input", { timeout: 5000 });
+await page.fill(".cmt-pop .cmt-input", "Why is that the case? One short sentence.");
+const preSend = await busy();
+await page.keyboard.press("Enter");
+// PHASE 1: the send gesture latches the pulse IMMEDIATELY — before any thread exists
+await page.waitForTimeout(250);
+check("1-latch-at-send", (await busy()) === true, `pre-send busy was ${preSend}`);
+await shot("send-latched");
+sampleFlicker();
+
+// PHASE 2+3: hold through thread-open, clear exactly when the reply text renders in the popover
+await page.waitForFunction(() => {
+  const msgs = document.querySelector(".cmt-pop .cmt-msgs");
+  return msgs && Array.from(msgs.querySelectorAll(".turn-assistant, .cmt-msg.agent"))
+    .some((e) => e.textContent.trim().length > 0);
+}, undefined, { timeout: 240000 });
+const flick = flickerStop();
+check("2-no-flicker-through-thread-open", flick.falses === 0, `${flick.falses}/${flick.samples} false samples before the reply`);
+await shot("reply-in-thread");
+// the clear rides the same frame that rendered the reply — allow one push
+await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), undefined, { timeout: 12000 })
+  .then(() => check("3-clear-on-reply-record", true))
+  .catch(async () => check("3-clear-on-reply-record", false, "still busy 12s after the reply rendered"));
+await shot("settled-yellow");
+
+// PHASE 4: a follow-up re-latches until ITS reply
+await page.fill(".cmt-pop .cmt-input", "And one more short sentence about it?");
+await page.keyboard.press("Enter");
+await page.waitForTimeout(250);
+check("4-follow-up-relatch", (await busy()) === true);
+await shot("followup-latched");
+const agentTurns = () => page.evaluate(() => document.querySelectorAll(".cmt-pop .cmt-msgs .turn-assistant, .cmt-pop .cmt-msgs .cmt-msg.agent").length);
+const before = await agentTurns();
+await page.waitForFunction((n) => document.querySelectorAll(".cmt-pop .cmt-msgs .turn-assistant, .cmt-pop .cmt-msgs .cmt-msg.agent").length > n, before, { timeout: 240000 });
+await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), undefined, { timeout: 12000 })
+  .then(() => check("4b-follow-up-clears-on-its-reply", true))
+  .catch(async () => check("4b-follow-up-clears-on-its-reply", false, "still busy after the follow-up's reply"));
+await shot("followup-settled");
+
+// PHASE 5: nothing sticks — sample well past several pushes
+await page.waitForTimeout(10000);
+check("5-nothing-sticks", (await busy()) === false, "busy after 10s quiet");
+check("mark-still-present", await marked(), "the settled yellow mark must remain");
+await shot("final");
+
+await b.close();
+if (fails.length) { console.log("DIVERGED:", fails.join(", ")); process.exit(1); }
+console.log("ALL PHASES GREEN");

--- a/tools/romp-lab/lab.sh
+++ b/tools/romp-lab/lab.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# romp-lab: a hermetic, headless, full-stack romp + the scripted highlight loop (see README.md).
+# HERMETICITY FIRST: the state root moves to a temp dir BEFORE any romp code runs — the
+# never-load-romp-modules-against-live-state rule. Nothing here may touch live state, live
+# postal, or any visible display.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+KEEP=0
+for a in "$@"; do case "$a" in --keep) KEEP=1 ;; esac; done
+
+LAB="$(mktemp -d /tmp/romp-lab-XXXXXX)"
+mkdir -p "$LAB/state" "$LAB/shots" "$LAB/project"
+echo "# a synthetic scratch project for the lab session" > "$LAB/project/README.md"
+
+export XDG_STATE_HOME="$LAB/state"
+unset ROMP_STATE_DIR || true
+# the SDK venv is PACKAGES, not state — symlink the machine's real one into the hermetic root so
+# lab sessions can actually run their CLI (without it every SDK session reports unable to start).
+# A symlink shares bytes only; nothing here writes into the venv.
+REAL_VENV="${HOME}/.local/state/romp/sdkvenv"
+if [ -d "$REAL_VENV" ]; then
+  mkdir -p "$LAB/state/romp"
+  ln -s "$REAL_VENV" "$LAB/state/romp/sdkvenv"
+fi
+export ROMP_KERNEL_NO_OPEN=1
+export ROMP_SERVE_TOKEN="labtok-$(head -c8 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+# a free port: bind 0 and read it back
+PORT=$(python3 - <<'PY'
+import socket
+s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()
+PY
+)
+export ROMP_KERNEL_PORT="$PORT"
+
+# serve the FRESH build, never a stale bundle (the T106 triage's first lesson)
+( cd "$ROOT/vscode-extension" && node esbuild.js >/dev/null 2>&1 )
+
+"$ROOT/bin/romp-kernel" > "$LAB/kernel.log" 2>&1 &
+KPID=$!
+cleanup() {
+  kill "$KPID" 2>/dev/null || true
+  wait "$KPID" 2>/dev/null || true
+  if [ "$KEEP" = 1 ]; then echo "kept: $LAB (kernel.log, shots/)"; else rm -rf "$LAB"; fi
+}
+trap cleanup EXIT
+
+for i in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then break; fi
+  sleep 0.5
+  kill -0 "$KPID" 2>/dev/null || { echo "kernel died at boot — $LAB/kernel.log:"; tail -20 "$LAB/kernel.log"; exit 1; }
+done
+curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null || { echo "kernel never became healthy"; exit 1; }
+echo "lab kernel up on :$PORT (state: $LAB/state)"
+
+LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" PROJECT_DIR="$LAB/project" \
+  node "$ROOT/tools/romp-lab/highlight-loop.mjs"
+RC=$?
+echo "highlight loop exit: $RC (shots: $LAB/shots)"
+[ "$RC" = 0 ] || KEEP=1
+exit "$RC"

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -556,3 +556,33 @@ test("everything that re-renders the chat's units refills the open popover live"
   assert.match(UI, /refillOpenCommentPop\(\);   \/\/ the popover renders the same units — its copy of this run must flip too/);
   assert.match(UI, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\); rerenderAll\(\); refillOpenCommentPop\(\); \}\);/);
 });
+
+// ── T106 (the user 2026-08-26, found by the romp-lab loop's first full pass): three seam fixes ────
+test("a create refused by parse lag holds its mark and retries on the frame event — never dropped", () => {
+  // the kernel's typed nack: transient (the anchor record hasn't hit its parse yet) vs real
+  const KERNELSRC = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNELSRC, /ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"/);
+  assert.match(KERNELSRC, /"transient": err == ANCHOR_LAG_ERR,/);
+  assert.match(KERNELSRC, /if err != ANCHOR_LAG_ERR:\s*\n\s*client\["send"\]\(json\.dumps\(\{"type": "warn", "text": err\}\)\)/,
+    "no toast for plumbing the retry makes moot; real refusals stay loud");
+  // the client holds the payload at send and re-posts when a session frame proves the parse caught up
+  assert.match(UI, /cmtCreateInFlight\.set\(create\.uuid, \{ sid: create\.sid,/);
+  assert.match(UI, /retryCmtCreates\(String\(msg\.id \|\| ""\)\);\s+\/\/ a session frame = the kernel re-parsed/);
+  assert.match(UI, /const CMT_CREATE_MAX_TRIES = 12;/);
+  // the ack retires the hold; a REAL refusal drops the synth honestly
+  assert.match(UI, /if \(m\.uuid\) cmtCreateInFlight\.delete\(String\(m\.uuid\)\);\s+\/\/ the ack retires the retry hold/);
+  assert.match(UI, /else \{ cmtCreateInFlight\.delete\(String\(m\.uuid\)\); dropSynthThread\(held\.sid, held\.uuid\); \}/);
+});
+
+test("the optimistic synth thread survives comments frames until superseded or failed", () => {
+  // the frame used to WIPE it: every create's mark blinked between the gesture and the real
+  // thread's first frame, and a lag-refused create erased the comment entirely
+  assert.match(UI, /const synths = \(commentThreads\.get\(sid\) \|\| \[\]\)\.filter\(\(t\) =>\s*\n\s*t\.tid\.startsWith\("pending:"\) && cmtCreateInFlight\.has\(t\.tid\.slice\("pending:"\.length\)\)/);
+  assert.match(UI, /&& !threads\.some\(\(r\) => r\.anchorUuid === t\.anchorUuid\)\);/,
+    "a real thread on the same anchor supersedes the synth");
+});
+
+test("the pending echo prunes against EVENTS too — a landed user turn never double-shows", () => {
+  assert.match(UI, /const evUserMsgs = \(\(th\.events \|\| \[\]\) as ChatEvent\[\]\)/);
+  assert.match(UI, /prunePending\(commentPending\.get\(th\.tid\) \|\| \[\], \[\.\.\.th\.msgs, \.\.\.evUserMsgs\]\);/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6131,6 +6131,38 @@ const commentPending = new Map<string, { text: string; t: number }[]>(); // tid 
 // push-count settle killed the create-window green while the fork booted (its frames read
 // all-quiet) and any stall in its stepping parked green forever — both ends of the reported bug.
 const cmtAwaitBase = new Map<string, number>();
+// Creates in flight (T106 lab find, 2026-08-26): a comment made seconds after a reply lands can be
+// refused by the kernel's parse lag ("isn't in the transcript yet"). The payload holds here from the
+// send; a TRANSIENT nack keeps the optimistic mark + latch alive and the create RE-POSTS when the
+// next session frame for the sid arrives (frames are built from the kernel's parse — a new frame IS
+// the parse catching up). Bounded by attempts, not time; a real refusal or the ack drops the hold.
+const cmtCreateInFlight = new Map<string, { sid: string; uuid: string; exact: string; text: string;
+  name: string; model: string; effort: string; color: string; tries: number }>();
+const CMT_CREATE_MAX_TRIES = 12;
+
+function retryCmtCreates(sid: string): void {
+  for (const [u, c] of Array.from(cmtCreateInFlight.entries())) {
+    if (c.sid !== sid || c.tries < 1) continue;            // tries starts counting after the first transient nack
+    if (c.tries > CMT_CREATE_MAX_TRIES) {                  // the can't-trap bound: give up honestly
+      cmtCreateInFlight.delete(u);
+      dropSynthThread(c.sid, u);
+      warnToast("couldn't anchor the comment — the message never appeared in the kernel's transcript.");
+      continue;
+    }
+    c.tries++;
+    vscodeApi?.postMessage({ type: "commentCreate", id: c.sid, uuid: c.uuid, exact: c.exact,
+      text: c.text, name: c.name, model: c.model, effort: c.effort, color: c.color });
+  }
+}
+
+/** Drop a refused create's optimistic synth thread + latch + mark — the honest retreat. */
+function dropSynthThread(sid: string, uuid: string): void {
+  const tid = "pending:" + uuid;
+  const cur = commentThreads.get(sid) || [];
+  if (cur.some((t) => t.tid === tid)) commentThreads.set(sid, cur.filter((t) => t.tid !== tid));
+  cmtAwaitBase.delete(tid);
+  applyCommentMarks(sid);
+}
 // the one busy answer for the mark + rail tick: an in-flight EXCHANGE (the gesture latch above), or
 // — after a reload lost the client latch — the exchange's own records still saying a reply is owed
 // (msgs ending with the user's message). A stuck/errored/closed thread never pulses: green would lie.
@@ -6522,7 +6554,13 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
   const overflowed = list.scrollHeight > list.clientHeight + 2;
   const atTail = overflowed && list.scrollTop >= list.scrollHeight - list.clientHeight - 8;
   list.replaceChildren();
-  const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
+  // pruned against BOTH projections (T106 lab, screenshot: the follow-up double-showed — its
+  // landed user TURN rendered from th.events while the echo, pruned only against th.msgs, waited
+  // for the slower projection to catch up). A user event's md is the same landed fact.
+  const evUserMsgs = ((th.events || []) as ChatEvent[])
+    .filter((e): e is Extract<ChatEvent, { kind: "user" }> => e.kind === "user" && typeof (e as { md?: string }).md === "string")
+    .map((e) => ({ who: "you" as const, text: e.md, t: 0 }));
+  const pend = prunePending(commentPending.get(th.tid) || [], [...th.msgs, ...evUserMsgs]);
   commentPending.set(th.tid, pend);
   const evs = (th.events || []) as ChatEvent[];
   // ONE final format (the user 2026-08-25: a fresh thread flashed the plain msgs projection for a
@@ -6779,6 +6817,9 @@ function commentSendFromPop(pop: HTMLElement): void {
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
       color: create.color || "" });
+    cmtCreateInFlight.set(create.uuid, { sid: create.sid, uuid: create.uuid, exact: create.exact,
+      text, name: nm, model: create.model || "", effort: create.effort || "",
+      color: create.color || "", tries: 0 });
     return;
   }
   const cur = openCommentThread();
@@ -10779,6 +10820,7 @@ function sharesAnyUuid(a: ChatEvent[], b: ChatEvent[]): boolean {
 }
 
 function upsert(msg: any) {
+  retryCmtCreates(String(msg.id || ""));   // a session frame = the kernel re-parsed → retry a lag-refused create (T106)
   const existed = sessions.has(msg.id);
   const prev = sessions.get(msg.id);
   awaitingFull.delete(msg.id);   // a full session landed → this session is re-based; a later gap may ask again
@@ -10869,6 +10911,7 @@ function upsert(msg: any) {
 }
 
 function update(msg: any) {
+  retryCmtCreates(String(msg.id || ""));   // ditto for the delta path (T106)
   const s = sessions.get(msg.id);
   if (!s) return;
   s.events = msg.events || s.events;
@@ -11416,7 +11459,14 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "comments" && m.id) {
     const sid = String(m.id);
     const threads = (m.threads || []) as CommentThread[];
-    commentThreads.set(sid, threads);
+    // an OPTIMISTIC synth thread (a create still in flight) survives the frame rebuild until its
+    // real thread supersedes it (same anchor) or its create fails — the frame used to wipe it, so
+    // every create's mark BLINKED between the gesture and the thread's first frame, and a
+    // parse-lag refusal erased the comment entirely (the T106 lab's first catch, 2026-08-26)
+    const synths = (commentThreads.get(sid) || []).filter((t) =>
+      t.tid.startsWith("pending:") && cmtCreateInFlight.has(t.tid.slice("pending:".length))
+      && !threads.some((r) => r.anchorUuid === t.anchorUuid));
+    commentThreads.set(sid, synths.length ? [...threads, ...synths] : threads);
     // THE REPLY-ARRIVED EVENT (T102): a frame whose msgs hold MORE agent records than the send's
     // base means THAT send's reply landed — the exchange latch clears here and nowhere else. A
     // thread that left "open" (or errored) drops its latch too: green would lie about a reply
@@ -11447,7 +11497,19 @@ window.addEventListener("message", (e: MessageEvent) => {
   // frame first; if this ack somehow beat it, park the tid and the next frame adopts. The draft is
   // spent UNCONDITIONALLY off the echoed anchor uuid — a popover closed before the ack otherwise
   // leaves its sent words to resurface in the next composer on the same passage.
+  else if (m.type === "commentCreateFailed" && m.id && m.uuid) {
+    // the typed nack (T106): a TRANSIENT refusal (the kernel's parse hasn't caught the anchor
+    // record up yet) keeps the optimistic mark + latch and arms the frame-keyed retry — the next
+    // session frame for the sid IS the parse catching up (retryCmtCreates). A real refusal drops
+    // the synth honestly; the kernel's warn already said why.
+    const held = cmtCreateInFlight.get(String(m.uuid));
+    if (held) {
+      if (m.transient) { if (held.tries === 0) held.tries = 1; }
+      else { cmtCreateInFlight.delete(String(m.uuid)); dropSynthThread(held.sid, held.uuid); }
+    }
+  }
   else if (m.type === "commentCreated" && m.id && m.tid) {
+    if (m.uuid) cmtCreateInFlight.delete(String(m.uuid));   // the ack retires the retry hold
     if (m.uuid) commentDrafts.delete("new:" + String(m.uuid));
     if (pendingCommentAnchor && pendingCommentAnchor.sid === m.id) {
       const tid = String(m.tid);


### PR DESCRIPTION
## The harness (`tools/romp-lab` — a standing capability)

A COMPLETE romp, hermetic and headless: `lab.sh` moves `XDG_STATE_HOME` into a temp root **before anything loads** (the never-load-against-live-state rule), takes its own token + a free port, **rebuilds dist fresh** (the staleness triage's first lesson), boots the real kernel, and drives the real dashboard in headless Chromium through the user's exact flow — + picker create, model drop to Haiku via the statusline menu, a REAL reply, select → Comment → send → follow-up — asserting the mark state at every T102 event boundary with continuous flicker sampling and per-phase screenshots. The SDK venv (packages, not state) symlinks in read-only; live state/postal/displays untouched; synthetic content only. Exits non-zero naming the first diverging phase, so fix → re-run loops cleanly.

## What the loop caught (all fixed + pinned)

1. **A comment created seconds after a reply lands was dropped**: the kernel's parse lag refused the create ("isn't in the transcript yet") and the user's comment evaporated behind a toast. The refusal now carries a **typed nack** (`commentCreateFailed`, `transient` for exactly the lag case); the client holds the payload from the send and **re-posts when the next session frame arrives** — frames are built from the parse, so a new frame *is* the catch-up event. Attempt-bounded; real refusals stay loud and drop the optimistic state honestly.
2. **The optimistic synth thread was wiped** by any comments frame not yet carrying the real thread — every create's mark blinked between the gesture and the thread's first frame. Frames now preserve in-flight synths until a same-anchor real thread supersedes them or the create fails.
3. **The follow-up double-showed**: the landed user turn rendered from `th.events` while the echo pruned only against the slower `th.msgs` projection. It prunes against both now.

## The verdicts

Final run on the fixed build, real kernel + real Haiku replies: latch-at-send ✓, zero flicker through thread-open (84 samples) ✓, clear-on-the-reply-record ✓, follow-up re-latch + clear ✓, nothing sticks ✓, mark persists ✓ — **ALL PHASES GREEN**. (The staleness triage that preceded this: the serving stack was fresh within 13s of the 719 merge; the user's sighting was an open tab awaiting its reload banner, per their own click-to-reload rule.)

## Tests

`comments.test.ts`: the nack lifecycle (typed kernel nack + transient split, the hold, the frame-keyed retry + bound, the honest drop), synth preservation + supersession, the dual-projection prune. npm 2436 + typecheck + Python 5706 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)