### PR TITLE
Every peer-kind wait names the actual session — one identity ladder, identities on every arm

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3017,8 +3017,9 @@ def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
 
 
 def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
-    """(awaitingAt, why, kind) of the freshest live ⏳ stamp in `top`'s subtree, or None —
-    _goal_awaiting_stamp with the ANCHOR and the wait's KIND (jd.AWAIT_KINDS or None) alongside the why.
+    """(awaitingAt, why, kind, peer keys) of the freshest live ⏳ stamp in `top`'s subtree, or None —
+    _goal_awaiting_stamp with the ANCHOR, the wait's KIND (jd.AWAIT_KINDS or None) and the stamp's own
+    awaitingPeers (the judge's pair-aware keys; () when unrecorded) alongside the why.
     The awaiting wake's due-check needs the anchor (see the awaiting branch of _auto_nudge_session's
     goal walk); display consumers that only word the wait keep the why-only twin above."""
     if children is None:
@@ -3045,10 +3046,10 @@ def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
             # 2026-08-19 audit. `answered_at` here may be the pair-aware _peer_answered(sid) tuple
             # or a legacy scalar (tests, older callers) — the predicate normalizes both.
             if not _peer_stamp_superseded(nd, answered_at):
-                cand = (at, nd["awaitingWhy"], kind or "")   # "" keeps max() comparable
+                cand = (at, nd["awaitingWhy"], kind or "", tuple(nd.get("awaitingPeers") or ()))   # "" keeps max() comparable
                 best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
-    return (best[0], best[1], best[2] or None) if best else None
+    return (best[0], best[1], best[2] or None, best[3]) if best else None
 
 
 def _mark_nudge_failed(gid, ev_t=None, wake=False):
@@ -4188,7 +4189,8 @@ def _dead_handoff_block(sid, nid, h, nd, nudged, now):
         cur = store.get("nodes", {}).get(nid)
         if not cur or cur.get("nodeComplete") or cur.get("blocked"):
             return False
-        peer = _name_of(h.get("peer") or "") or (h.get("peer") or "")[:8] or "a peer"
+        _pid = _peer_identity(h.get("peer") or "")
+        peer = (("%s:%s" % (_pid["host"], _pid["name"])) if _pid["host"] else _pid["name"]) or "a peer"
         blkwhy = jd.dead_wait_block_why("the delegation to %s (%s)"
                                         % (peer, (cur.get("text") or "").replace("↪ ", "")[:80]))
         _ev = int(max(anchor, last_t or 0) or now)
@@ -12761,7 +12763,7 @@ def _session_stamp_read(sid):
         gs = (jd.GOALDIR / (sid + ".json")).stat()
         gkey = (gs.st_mtime, gs.st_size)
     except Exception:
-        return ((None, None, None, None), frozenset(), ())   # no store yet → nothing to stamp, nothing delegated
+        return ((None, None, None, None, ()), frozenset(), ())   # no store yet → nothing to stamp, nothing delegated
     try:
         ostt = (jd._overrides_dir() / (sid + ".jsonl")).stat()
         okey = (ostt.st_mtime, ostt.st_size)
@@ -12776,7 +12778,7 @@ def _session_stamp_read(sid):
     hit = _SESSION_STAMP_CACHE.get(sid)
     if hit and hit[0] == key:
         return hit[1]
-    full, tops, deleg = (None, None, None, None), set(), ()
+    full, tops, deleg = (None, None, None, None, ()), set(), ()
     try:                                               # load_goals (not a raw read) so overrides replay —
         store = jd.load_goals(sid)                     # the same view _goal_awaiting_stamp sees on the card
         nodes = store.get("nodes", {})
@@ -12809,10 +12811,10 @@ def _session_stamp_read(sid):
                 # The TOPS SET above stays status-blind on purpose: it feeds _bg_split's awaited-vs-
                 # service classification, where a temporarily blocked top's live task is still awaited.
                 if status.get(top, "working") == "working":
-                    cand = (at, nid, nd["awaitingWhy"], kind)
+                    cand = (at, nid, nd["awaitingWhy"], kind, tuple(nd.get("awaitingPeers") or ()))
                     best = cand if best is None else max(best, cand)
         if best:
-            full = (best[1], best[0], best[2], best[3])   # (gid, at, why, kind)
+            full = (best[1], best[0], best[2], best[3], best[4])   # (gid, at, why, kind, awaited peer keys)
         # DELEGATION, the same pass (the user 2026-08-08, whose fully-delegated session wore the feed's
         # green awaiting dot while chat/timeline/rail read plain ready): a top whose every OPEN leaf is a
         # courier handoff node is work handed to PEERS — the exact evidence the feed's per-card flavor
@@ -12832,15 +12834,16 @@ def _session_stamp_read(sid):
                     peers.add(str(h["peer"]))
         deleg = tuple(sorted(peers))
     except Exception:
-        full, tops, deleg = (None, None, None, None), set(), ()
+        full, tops, deleg = (None, None, None, None, ()), set(), ()
     val = (full, frozenset(tops), deleg)
     _SESSION_STAMP_CACHE[sid] = (key, val)
     return val
 
 
 def _session_stamp_full(sid):
-    """(gid, awaitingAt, why, kind) of the freshest durable ⏳ awaiting stamp across ALL of a session's
-    goals, or (None, None, None, None)."""
+    """(gid, awaitingAt, why, kind, peer keys) of the freshest durable ⏳ awaiting stamp across ALL of a
+    session's goals, or (None, None, None, None, ()) — the 5th slot is the stamp's own awaitingPeers
+    (the judge's pair-aware keys), so the session surfaces can NAME the wait (2026-08-26)."""
     return _session_stamp_read(sid)[0]
 
 
@@ -12849,6 +12852,32 @@ def _session_stamped_tops(sid):
     (_bg_split): a placed launch owned by one of these tops is AWAITED, any other placed launch is a
     SERVICE."""
     return _session_stamp_read(sid)[1]
+
+
+_UUIDISH_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+def _peer_identity(psid):
+    """ONE identity ladder for every peer reference romp records (the user 2026-08-26: a peer-kind
+    wait names the ACTUAL session — 'a peer' is a bug to trace, not a style). Accepts the three
+    recorded shapes — a bare sid, the courier's cross-host "<host>:<tail>" composite, the wait map's
+    "peer:<host>:<name>" key — and resolves {name, host, sid, color}: the names REGISTRY first
+    (identity persists for DORMANT sessions; liveness is never a prerequisite for naming), else the
+    composite's own parts (display-join on the canonical pair, per the federation rule — a name tail
+    reads whole, a sid tail stubs to 8), else the sid stub. Color is registry-only: a peer another
+    kernel owns keeps color None (its identity colors live on its home kernel), so the UIs render an
+    uncolored host-prefixed name rather than a guessed hue."""
+    raw = str(psid or "")
+    if raw.startswith("peer:"):
+        raw = raw[len("peer:"):]
+    pn = _name_of(raw)
+    if pn:
+        return {"name": pn, "host": "", "sid": raw, "color": _name_color(raw)}
+    if ":" in raw:
+        h, _, tail = raw.partition(":")
+        return {"name": (tail[:8] if _UUIDISH_RE.match(tail) else tail) or raw[:8],
+                "host": h, "sid": raw, "color": _name_color(raw)}
+    return {"name": raw[:8], "host": "", "sid": raw, "color": _name_color(raw)}
 
 
 def _handoff_peer_identities(nodes, hnodes):
@@ -12864,10 +12893,7 @@ def _handoff_peer_identities(nodes, hnodes):
         psid = str((nodes.get(x, {}).get("handoff") or {}).get("peer") or "")
         if not psid or psid in seen:
             continue
-        pn = _name_of(psid)
-        seen[psid] = {"name": pn or psid.split(":")[-1][:8],
-                      "host": ("" if pn or ":" not in psid else psid.split(":", 1)[0]),
-                      "sid": psid, "color": _name_color(psid)}
+        seen[psid] = _peer_identity(psid)     # the ONE ladder (2026-08-26) — same resolve everywhere
     return sorted(seen.values(), key=lambda d: d["name"]) or None
 
 
@@ -13003,11 +13029,22 @@ def _session_delegated_why(sid):
     awaiting dot while every session-scoped surface read plain ready (the user 2026-08-08, who asked why
     three surfaces disagreed on one fact). Peer SIDS ride the mtime cache; names resolve here so a
     renamed peer reads fresh."""
+    idents = _session_delegated_identities(sid)
+    if not idents:
+        return None
+    names = sorted({("%s:%s" % (d["host"], d["name"])) if d["host"] else d["name"] for d in idents})
+    return "delegated to %s; waiting on their result" % ", ".join(names)
+
+
+def _session_delegated_identities(sid):
+    """The STRUCTURED identities behind the session-scoped delegation wait, or None. Sids ride the
+    mtime cache; names/colors resolve HERE at read time (a renamed peer reads fresh) through the one
+    _peer_identity ladder — before this, a cross-host "<host>:<name>" composite fell to a bare
+    registry read and every such delegation was announced as 'a peer' (the user 2026-08-26)."""
     peers = _session_stamp_read(sid)[2]
     if not peers:
         return None
-    names = sorted(_name_of(p) or "a peer" for p in peers)
-    return "delegated to %s; waiting on their result" % ", ".join(names)
+    return sorted((_peer_identity(p) for p in peers), key=lambda d: d["name"])
 
 
 def _session_awaiting(sid, path, idle, stamp=False):
@@ -13132,12 +13169,21 @@ def _session_awaiting(sid, path, idle, stamp=False):
         y = _owned_yield_why(sid, path)
         if y:
             return {"kind": "task", "why": y, "since": None}   # a live owned dispatch — in-harness work (no single event time to show)
-        _gid, _at, st_why, st_kind = _session_stamp_full(sid)
+        _gid, _at, st_why, st_kind, st_peers = _session_stamp_full(sid)
         if st_why:
-            return {"kind": st_kind, "why": st_why, "since": _at or None}   # the judge's own classification rides the stamp, with its awaitingAt
+            out = {"kind": st_kind, "why": st_why, "since": _at or None}   # the judge's own classification rides the stamp, with its awaitingAt
+            if st_kind == "peer" and st_peers:
+                # the stamp RECORDS who the wait is on (judge awaitPeers) — name them (2026-08-26);
+                # `peers` rides only when known, so every other arm's shape is byte-identical
+                out["peers"] = sorted((_peer_identity(p) for p in st_peers), key=lambda d_: d_["name"])
+            return out
         d = _session_delegated_why(sid)
         if d:
-            return {"kind": "peer", "why": d, "since": None}   # the courier handoff graph is peer by construction
+            out = {"kind": "peer", "why": d, "since": None}   # the courier handoff graph is peer by construction
+            pi = _session_delegated_identities(sid)
+            if pi:
+                out["peers"] = pi
+            return out
     return None
 
 
@@ -17504,6 +17550,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # pill), so a multi-task wait can list them all on hover.
                   "awaitingWhy": awaiting_why or None,
                   "awaitingKind": awaiting_kind,   # WHAT the wait is on (jd.AWAIT_KINDS; None = kindless)
+                  # WHO a peer-kind wait is on — [{name, host, sid, color}], the same identities the feed
+                  # box wears, so the chat chip + awaiting box name the actual session (2026-08-26)
+                  "awaitingPeers": ((_aw or {}).get("peers") or None),
                   "awaitingTasks": (_awaiting_task_descs(sid, sess["path"]) if awaiting_why else []),
                   # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
                   # rows in the chip's await-green (the user 2026-08-19)
@@ -19027,6 +19076,7 @@ def build_feed(now, tmux=None):
         sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
         sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
         sess_awaiting_since = _sess_aw.get("since") if _sess_aw else None   # the wait's own event time (the user 2026-08-23)
+        sess_awaiting_peers = _sess_aw.get("peers") if _sess_aw else None   # named identities when the arm knows them (2026-08-26)
         if sess_awaiting_why and not who_working:
             awaiting.append(name)                    # the AWAITING dot list (await-green, the user 2026-07-13) — the
             #                                          same split _session_chip makes; feed/chat dots match the chip
@@ -19129,6 +19179,11 @@ def build_feed(now, tmux=None):
             _stamp_why = _sf[1] if _sf else None
             _stamp_kind = _sf[2] if _sf else None
             _stamp_since = (_sf[0] or None) if _sf else None   # the stamp's awaitingAt — when the judge filed the wait
+            # the stamp arm NAMES its peers too (2026-08-26): the judge's awaitPeers keys resolve through
+            # the one identity ladder, so a judge-classified peer wait wears the same identity chips the
+            # delegation arm always has — before this the or-chain hardcoded peers=None on this arm
+            _stamp_peers = (sorted((_peer_identity(p) for p in _sf[3]), key=lambda d_: d_["name"])
+                            if _sf and _stamp_kind == "peer" and _sf[3] else None)
             # DELEGATION-derived awaiting (the courier's durable handoff graph, not the question-regex):
             # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
             # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
@@ -19141,9 +19196,13 @@ def build_feed(now, tmux=None):
             _deleg_peers = None
             if col == "working" and not _stamp_why and not _await_ok \
                     and _all_outstanding_delegated(nodes, nid):
-                _hnodes = [x for x in _subtree(nid)
-                           if isinstance(nodes[x].get("handoff"), dict)
-                           and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
+                # the SAME open test the gate used (2026-08-26): _all_outstanding_delegated proved every
+                # OPEN LEAF is a handoff via _open_leaves (whose agent-open pierce ignores a done marker),
+                # so the peers/since read here must walk the same set — the raw nodeComplete filter this
+                # replaces could see an EMPTY set the gate saw as non-empty, minting a nameless, durationless
+                # "delegated to a peer" card
+                _hnodes = [x for x in _open_leaves(nodes, nid)
+                           if isinstance(nodes[x].get("handoff"), dict)]
                 _deleg_peers = _handoff_peer_identities(nodes, _hnodes)
                 _peers = sorted({d["name"] for d in (_deleg_peers or [])} or {"a peer"})
                 _deleg_why = "delegated to %s; waiting on their result" % ", ".join(_peers)
@@ -19198,8 +19257,8 @@ def build_feed(now, tmux=None):
             await_since = None                       # mirroring the or-chain exactly (a kindless winner
             await_peers = None                       # stays kindless; since = the wait's own event time).
             if col == "awaiting":                    # peers = structured identities, delegation arm only
-                for _w, _k, _s, _p in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, None),
-                                       (_stamp_why, _stamp_kind, _stamp_since, None),
+                for _w, _k, _s, _p in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers),
+                                       (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers),
                                        (_deleg_why, "peer", _deleg_since, _deleg_peers),
                                        (_owned_why, "task", _owned_since, None)):
                     if _w:
@@ -21382,6 +21441,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         sessions.append({
             "id": sid, "name": name, "live": live, "state": state, "awaitingBg": awaiting_bg,
             "awaitingKind": awaiting_kind,
+            "awaitingPeers": ((_aw_bg or {}).get("peers") or None),   # named identities for a peer wait (2026-08-26)
             # the live bg-task descriptions behind awaitingBg (the user 2026-07-13): the lane draws the
             # idle-but-waiting stretch as a thin dashed segment whose hover lists exactly what's pending
             "awaitingTasks": (_awaiting_task_descs(sid, s["path"]) if awaiting_bg else []),

--- a/tests/test_awaiting_since.py
+++ b/tests/test_awaiting_since.py
@@ -36,7 +36,7 @@ class SessionAwaitingSince(unittest.TestCase):
         km._bg_pending = lambda sid, path, tasks: []
         km._states_awaiting_overlay = lambda sid: None
         km._owned_yield_why = lambda sid, path: None
-        km._session_stamp_full = lambda sid: (None, 0, None, None)
+        km._session_stamp_full = lambda sid: (None, 0, None, None, ())
         km._session_delegated_why = lambda sid: None
 
     def tearDown(self):
@@ -66,7 +66,7 @@ class SessionAwaitingSince(unittest.TestCase):
         self.assertEqual(aw["since"], 4321)
 
     def test_judge_stamp_rides_its_awaitingAt(self):
-        km._session_stamp_full = lambda sid: ("g1", 8765, "waiting on the test suite", "task")
+        km._session_stamp_full = lambda sid: ("g1", 8765, "waiting on the test suite", "task", ())
         aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
         self.assertEqual(aw["why"], "waiting on the test suite")
         self.assertEqual(aw["since"], 8765)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7564,7 +7564,7 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
         # the peer's reply lands (also busts the postal-key on the stamp cache) → the stamp view lifts
         self._log(self._msg(self.B, self.A, NOW - 100, "coordinate", body="built and merged"))
         full, tops, _deleg = km._session_stamp_read(self.A)
-        self.assertEqual(full, (None, None, None, None), "the answered handoff supersedes the older stamp")
+        self.assertEqual(full, (None, None, None, None, ()), "the answered handoff supersedes the older stamp")
         self.assertEqual(tops, frozenset())
 
 

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -157,7 +157,7 @@ class SessionLevelStamp(unittest.TestCase):
                          {"kind": "job", "why": "slurm 4821 regenerating the parts",
                           "since": 200})   # the stamp's awaitingAt → the chips' elapsed readout (the user 2026-08-23)
         self.assertEqual(km._session_stamp_full(SID),
-                         ("g1", 200, "slurm 4821 regenerating the parts", "job"))
+                         ("g1", 200, "slurm 4821 regenerating the parts", "job", ()))
 
     def test_session_stamp_takes_the_freshest_across_ALL_tops(self):
         # session-level, so it scans every goal (not one subtree like _goal_awaiting_stamp) for the newest
@@ -256,7 +256,8 @@ class SessionLevelDelegation(unittest.TestCase):
         self._seed(self._delegated_store())
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": "peer", "why": "delegated to probe; waiting on their result",
-                          "since": None})   # the handoff graph has no single event time here → no duration
+                          "since": None,   # the handoff graph has no single event time here → no duration
+                          "peers": [{"name": "probe", "host": "", "sid": self.PEER, "color": None}]})
 
     def test_handoff_peer_identities_carry_name_host_and_colour_for_the_card(self):
         # the card's awaiting box names the peers the way the origin line does (the user 2026-08-23):
@@ -376,7 +377,7 @@ class KindScopedRules(unittest.TestCase):
     def test_the_goal_level_read_scopes_the_same_way(self):
         nodes = {"g1": dict(_node("g1", why="the wait", at=200), awaitingKind="job")}
         self.assertEqual(km._goal_awaiting_stamp_full(nodes, "g1", answered_at=900),
-                         (200, "the wait", "job"))
+                         (200, "the wait", "job", ()))
         nodes["g1"]["awaitingKind"] = "peer"
         self.assertIsNone(km._goal_awaiting_stamp_full(nodes, "g1", answered_at=900))
         nodes["g1"].pop("awaitingKind")
@@ -523,7 +524,7 @@ class AwaitingWake(unittest.TestCase):
     def test_stamp_full_exposes_gid_and_at(self):
         self._seed(at=500)
         self.assertEqual(km._session_stamp_full(SID),
-                         (self.gid, 500, "the trace it dispatched; reports when it returns", None))
+                         (self.gid, 500, "the trace it dispatched; reports when it returns", None, ()))
 
     def test_fires_past_the_window_and_records_the_episode(self):
         now = 1_000_000

--- a/tests/test_peer_identity_naming.py
+++ b/tests/test_peer_identity_naming.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Every peer-kind wait names the ACTUAL session (the user 2026-08-26, screenshot of an 'Awaiting
+peer · delegated to a peer' chip): 'a peer' is a bug to trace, not a style. The traced class — three
+writer arms could ship a peer wait nameless: the session-scoped delegation why resolved through a
+bare registry read (so every cross-host "<host>:<name>" composite fell to 'a peer'), the judge-stamp
+arm hardcoded peers=None even when the stamp recorded its awaitPeers, and build_feed's handoff scan
+filtered on raw nodeComplete while its gate pierced done-markers for agent-open nodes (an empty scan
+minted a nameless, durationless wait the gate saw as real). One identity ladder (_peer_identity) now
+resolves every recorded shape: the names REGISTRY first — identity persists for DORMANT sessions,
+liveness is never a prerequisite for naming — else the composite's own parts (display-join on the
+canonical pair, per the federation rule), else the sid stub. All fixtures SYNTHETIC."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_peerid", os.path.join(BIN, "romp-kernel")).load_module()
+
+# PRIVATE synthetic sid (the goal-store fixture rule, CLAUDE.md 2026-08-24): stores minted under the
+# shared placeholder sid get re-flagged by other modules' journaled overrides on load_goals replay.
+SID = "aaaa1108-bbbb-cccc-dddd-eeeeffff0001"
+PEER = "aaaa1108-bbbb-cccc-dddd-eeeeffff0002"   # a local peer with a registry entry (dormant)
+FARSID = "aaaa1108-bbbb-cccc-dddd-eeeeffff0003"
+
+
+def _node(nid, parent=None, complete=False):
+    return {"id": nid, "text": "work " + nid, "parentId": parent, "nodeComplete": complete,
+            "blocked": False, "cleared": False, "trail": [], "t": 100, "mt": 100, "log": []}
+
+
+class _Base(unittest.TestCase):
+    """Registry + goal store in a temp root; a live-but-idle session so every live source falls
+    through to the durable arms (the SessionLevelStamp idiom)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km.NAMES, km._tmux_sessions,
+                       km._states_awaiting_overlay)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        km.NAMES = td / "names"
+        km.NAMES.mkdir()
+        # a DORMANT peer's registry entry: written at launch, PERSISTS after the session dies —
+        # the authoritative identity source, no liveness involved
+        (km.NAMES / PEER).write_text("web\t/tmp/notes-api\t#1EA1EB\twhite\n")
+        km._SESSION_STAMP_CACHE.clear()
+        km._states_awaiting_overlay = lambda sid: None
+        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+
+    def tearDown(self):
+        (km.jd.STATE, km.jd.GOALDIR, km.NAMES, km._tmux_sessions,
+         km._states_awaiting_overlay) = self._saved
+        km._SESSION_STAMP_CACHE.clear()
+        self.td.cleanup()
+
+    def _seed(self, nodes, status=None):
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 9, "placements": {}, "status": status or {}, "nodes": nodes}))
+
+
+class PeerIdentityLadder(_Base):
+    """_peer_identity — the ONE resolve for every recorded peer shape."""
+
+    def test_registry_names_a_dormant_session(self):
+        # no live session anywhere in this fixture: the registry file alone names it, with colours
+        self.assertEqual(km._peer_identity(PEER),
+                         {"name": "web", "host": "", "sid": PEER,
+                          "color": {"bg": "#1EA1EB", "fg": "#ffffff"}})
+
+    def test_cross_host_name_composite_splits_on_the_canonical_pair(self):
+        # the courier's remote arm records toName ("<host>:<name>") — display-join, never 'a peer'
+        self.assertEqual(km._peer_identity("TESTHOST:api"),
+                         {"name": "api", "host": "TESTHOST", "sid": "TESTHOST:api", "color": None})
+
+    def test_wait_map_key_shape_resolves_too(self):
+        # the judge's awaitPeers record "peer:<host>:<name>" for an unresolved cross-host recipient
+        self.assertEqual(km._peer_identity("peer:TESTHOST:api"),
+                         {"name": "api", "host": "TESTHOST", "sid": "TESTHOST:api", "color": None})
+
+    def test_uuid_tail_keeps_the_sid_stub(self):
+        got = km._peer_identity("TESTHOST:" + FARSID)
+        self.assertEqual((got["name"], got["host"]), (FARSID[:8], "TESTHOST"),
+                         "a uuid tail is a sid, not a name — stub it like one")
+
+    def test_bare_unknown_sid_stubs(self):
+        got = km._peer_identity(FARSID)
+        self.assertEqual((got["name"], got["host"], got["color"]), (FARSID[:8], "", None))
+
+
+class DelegatedWaitNames(_Base):
+    """The session-scoped delegation arm — the traced specimen's writer (_session_delegated_why)."""
+
+    def _delegated(self, peer):
+        h = _node("h1", parent="g1")
+        h["handoff"] = {"peer": peer, "msgId": "1111111111.00000_00000.TESTHOST"}
+        done = _node("s1", parent="g1", complete=True)
+        self._seed({"g1": _node("g1"), "s1": done, "h1": h})
+
+    def test_cross_host_delegation_names_the_pair_not_a_peer(self):
+        # the specimen's path: handoff.peer = "<host>:<name>"; the bare registry read said 'a peer'
+        self._delegated("TESTHOST:api")
+        aw = km._session_awaiting(SID, "/p", True, stamp=True)
+        self.assertEqual(aw["why"], "delegated to TESTHOST:api; waiting on their result")
+        self.assertEqual(aw["peers"],
+                         [{"name": "api", "host": "TESTHOST", "sid": "TESTHOST:api", "color": None}])
+
+    def test_local_dormant_peer_names_from_the_registry(self):
+        self._delegated(PEER)
+        aw = km._session_awaiting(SID, "/p", True, stamp=True)
+        self.assertEqual(aw["why"], "delegated to web; waiting on their result")
+        self.assertEqual(aw["peers"][0]["color"], {"bg": "#1EA1EB", "fg": "#ffffff"},
+                         "identity colour rides from the registry — no live session exists here")
+
+
+class StampArmNamesPeers(_Base):
+    """The judge-stamp arm — its awaitPeers record now reaches every surface as identities."""
+
+    def _stamped(self, kind="peer", peers=(PEER,)):
+        g1 = _node("g1")
+        g1["awaitingWhy"] = "asked the manager which port"
+        g1["awaitingAt"] = 200
+        g1["awaitingKind"] = kind
+        if peers is not None:
+            g1["awaitingPeers"] = list(peers)
+        self._seed({"g1": g1})
+
+    def test_goal_reader_carries_the_recorded_keys(self):
+        self._stamped()
+        self.assertEqual(km._goal_awaiting_stamp_full({"g1": dict(_node("g1"), awaitingWhy="w",
+                                                                  awaitingAt=200, awaitingKind="job",
+                                                                  awaitingPeers=[PEER])}, "g1"),
+                         (200, "w", "job", (PEER,)))
+
+    def test_session_arm_resolves_the_stamp_peers(self):
+        self._stamped()
+        aw = km._session_awaiting(SID, "/p", True, stamp=True)
+        self.assertEqual(aw["kind"], "peer")
+        self.assertEqual(aw["peers"][0]["name"], "web")
+
+    def test_non_peer_and_recordless_stamps_keep_the_legacy_shape(self):
+        # byte-identical dicts for every arm that has nothing to name — no key, not a null
+        self._stamped(kind="job", peers=None)
+        self.assertNotIn("peers", km._session_awaiting(SID, "/p", True, stamp=True))
+        km._SESSION_STAMP_CACHE.clear()
+        self._stamped(kind="peer", peers=None)
+        self.assertNotIn("peers", km._session_awaiting(SID, "/p", True, stamp=True))
+
+
+class OpenLeavesAlignment(_Base):
+    """build_feed's handoff scan walks the SAME open set its gate proved non-empty — the raw
+    nodeComplete filter it replaces could see nothing where the gate (whose agent-open pierce
+    ignores a done marker) saw the delegation, minting a nameless, durationless wait."""
+
+    def test_agent_open_pierced_handoff_is_in_both_reads(self):
+        h = _node("h1", parent="g1", complete=True)          # done marker…
+        h["agentTask"] = {"status": "open"}                  # …pierced: the agent's own list says open
+        h["handoff"] = {"peer": PEER, "msgId": "1111111111.00000_00001.TESTHOST"}
+        nodes = {"g1": _node("g1"), "h1": h}
+        self.assertTrue(km._all_outstanding_delegated(nodes, "g1"), "the gate fires")
+        aligned = [x for x in km._open_leaves(nodes, "g1")
+                   if isinstance(nodes[x].get("handoff"), dict)]
+        self.assertEqual(aligned, ["h1"], "the aligned scan names the peer the gate saw")
+        legacy = [x for x in nodes
+                  if isinstance(nodes[x].get("handoff"), dict)
+                  and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
+        self.assertEqual(legacy, [], "the raw filter this replaces was blind here — the bug window")
+
+    def test_legacy_blank_peer_is_the_only_honest_fallback(self):
+        # a record with NO peer sid at all is truly unknowable — identities stay None and the card
+        # keeps the 'a peer' prose (with the UI's explanatory tooltip); nothing else may reach it
+        h = _node("h1", parent="g1")
+        h["handoff"] = {"peer": "", "msgId": "1111111111.00000_00002.TESTHOST"}
+        self.assertIsNone(km._handoff_peer_identities({"g1": _node("g1"), "h1": h}, ["h1"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -1,0 +1,60 @@
+// Every peer-kind awaiting stamp names the ACTUAL session (the user 2026-08-26): 'a peer' is a bug
+// to trace, not a style. The kernel now resolves identities through ONE ladder (_peer_identity:
+// registry first — dormant sessions keep their names — then the cross-host pair, then the sid stub)
+// and ships them on every arm; these pins hold the render half: the feed box's chips open the
+// session, the chat box + chip name the peer in identity colour, and the fallback says WHY a name
+// is missing instead of presenting 'peer' as a style.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const FEED = ui("webview", "feed.ts");
+const RENDER = ui("webview", "render.ts");
+const CSS = ui("webview", "styles.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the feed box's peer chips are the standard session chip — click opens the session", () => {
+  const box = FEED.slice(FEED.indexOf("const awPeers ="), FEED.indexOf("a._awaitSpin.title"));
+  assert.match(box, /hostPartsNodes\(p\.host, p\.name\)/, "quiet host: prefix, the ↪ from treatment");
+  assert.match(box, /nm\.style\.color = p\.color\.bg/, "identity colour");
+  assert.match(box, /postMessage\(\{ type: "openSession", id: p\.sid \}\)/, "the handoffTo click idiom");
+  assert.match(box, /nm\.style\.cursor = "pointer"/);
+});
+
+test("the feed's nameless peer wait explains itself — honest fallback, not a style", () => {
+  assert.match(FEED,
+    /if \(awaitingBg && !awPeers\.length && it\.awaiting && it\.awaiting\.kind === "peer"\)\s*\n\s*a\._awaitSpin\.title \+=/,
+    "peer-kind with no names → the tooltip says the record predates capture or an older kernel shipped it");
+});
+
+test("the chat pane names the peer: box in identity colour, pill with the colour dot", () => {
+  assert.match(RENDER, /awaitingPeers\?: PeerIdent\[\] \| null;/, "the payload field beside awaitingKind");
+  assert.match(RENDER, /type PeerIdent = \{ name: string; host\?: string; sid\?: string; color\?: \{ bg: string; fg: string \} \| null \};/,
+    "named alias — the Status interface line stays brace-free for its other pins");
+  const boxAt = RENDER.indexOf("const awPeers = s!.status.awaitingPeers");
+  const box = RENDER.slice(boxAt, RENDER.indexOf("head.appendChild(lab);", boxAt));
+  assert.match(box, /el\("span", "bg-await-peer"\)/);
+  assert.match(box, /\(pr\.host \? pr\.host \+ ":" : ""\) \+ pr\.name/, "host-prefixed when cross-host");
+  assert.match(box, /nm\.style\.color = pr\.color\.bg/);
+  const chipAt = RENDER.indexOf("const chipPeers = s.status.awaitingPeers");
+  const chip = RENDER.slice(chipAt, RENDER.indexOf("chip.title =", chipAt));
+  assert.match(chip, /el\("span", "chip-peer-dot"\)/, "'Awaiting <name>' wears the identity dot");
+  assert.match(chip, /dot\.style\.background = chipPeers\[0\]\.color\.bg/);
+  assert.match(chip, /chipPeers\.length \+ " peers"/, "several peers keep the one-line rule as a count");
+  assert.match(CSS, /\.chip-peer-dot \{ display: inline-block; width: 7px; height: 7px; border-radius: 50%;/);
+});
+
+test("the kernel ships identities on every arm — the or-chain's hardcoded Nones are gone", () => {
+  assert.match(KERNEL, /\(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers\)/, "the judge-stamp arm");
+  assert.match(KERNEL, /\(sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers\)/,
+    "the session-snapshot arm");
+  assert.match(KERNEL, /"awaitingPeers": \(\(_aw or \{\}\)\.get\("peers"\) or None\)/, "the chat status payload");
+  assert.match(KERNEL, /"awaitingPeers": \(\(_aw_bg or \{\}\)\.get\("peers"\) or None\)/, "the timeline sessions payload");
+  assert.match(KERNEL, /def _peer_identity\(psid\):/, "the ONE identity ladder");
+  assert.ok(!/_name_of\(p\) or "a peer"/.test(KERNEL),
+    "the bare registry read that named every cross-host delegation 'a peer' is gone");
+  assert.match(KERNEL, /_hnodes = \[x for x in _open_leaves\(nodes, nid\)/,
+    "the handoff scan walks the same open set its gate proved non-empty");
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1858,11 +1858,22 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
         const nm = el("span", "fask-waiton-name");
         nm.replaceChildren(...hostPartsNodes(p.host, p.name));
         if (p.color && p.color.bg) nm.style.color = p.color.bg;
+        if (p.sid) {
+          // the standard session-chip gesture (the handoffTo idiom above): click opens the session
+          nm.title = "waiting on " + p.name + " — click opens the session";
+          nm.style.cursor = "pointer";
+          nm.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: p.sid }); };
+        }
         a._awaitWhy.appendChild(nm);
       });
       a._awaitWhy.append(waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000));
     } else a._awaitWhy.textContent = spinCaption;
     a._awaitSpin.title = spinTip || spinCaption;
+    // HONEST fallback (the user 2026-08-26): a peer-kind wait with no named session says WHY the
+    // name is missing, instead of presenting "peer" as a style — identity is only truly unknowable
+    // when the record predates identity capture or an older/offline kernel shipped the payload.
+    if (awaitingBg && !awPeers.length && it.awaiting && it.awaiting.kind === "peer")
+      a._awaitSpin.title += " (No session is named in this wait's record — it predates identity capture, or an older kernel shipped it.)";
   }
   // The swirl's "Analyzing…" caption + tooltip REPLACES the separate "↩ re-judging" chip (the user
   // 2026-06-29: don't show both) — drop the chip the recheck branch set above when the swirl is saying it.

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -224,7 +224,8 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -8948,7 +8949,23 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
   // the kernel's why leads with the verb ("waiting on a background task: …") — strip it so the
   // labeled header doesn't stutter; the expanded body keeps the full sentence
   const kw = KIND_WORD[(s!.status.awaitingKind || "")] || "";
-  lab.textContent = "Awaiting" + (kw ? " " + kw : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+  const awPeers = s!.status.awaitingPeers || [];
+  if (awPeers.length) {
+    // a peer-kind wait NAMES the actual session (the user 2026-08-26) — identity colour, quiet
+    // host: prefix, the feed box's own treatment; the why tail keeps the wait's verb without
+    // restating the names ("delegated to X; " is the names, already rendered)
+    lab.append("Awaiting ");
+    awPeers.forEach((pr, i) => {
+      if (i) lab.append(", ");
+      const nm = el("span", "bg-await-peer");
+      nm.textContent = (pr.host ? pr.host + ":" : "") + pr.name;
+      if (pr.color && pr.color.bg) nm.style.color = pr.color.bg;
+      lab.appendChild(nm);
+    });
+    lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
+  } else {
+    lab.textContent = "Awaiting" + (kw ? " " + kw : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+  }
   head.appendChild(lab);
   host.appendChild(head);
   if (!open) return;
@@ -9922,7 +9939,20 @@ function updateStatusline() {
     // dead on the touch PWA, so the word must be visible; the subject stays in the #bg-tasks box
     const kw = KIND_WORD[s.status.awaitingKind || ""] || "";
     chip.classList.add("chip-awaiting-" + (s.status.awaitingKind || "untyped"));   // per-kind hook, one hue today
-    chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kw : "");
+    const chipPeers = s.status.awaitingPeers || [];
+    if (chipPeers.length) {
+      // the pill names the actual session (the user 2026-08-26): "Awaiting <name>" with the peer's
+      // identity-colour dot; several peers keep the one-line rule as a count, names on the tooltip
+      chip.append(CHIP_LABEL.awaitingBg + " ");
+      if (chipPeers.length === 1) {
+        if (chipPeers[0].color && chipPeers[0].color.bg) {
+          const dot = el("span", "chip-peer-dot");
+          dot.style.background = chipPeers[0].color.bg;
+          chip.appendChild(dot);
+        }
+        chip.append((chipPeers[0].host ? chipPeers[0].host + ":" : "") + chipPeers[0].name);
+      } else chip.append(chipPeers.length + " peers");
+    } else chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kw : "");
     chip.title = (s.status.awaitingWhy || "idle, waiting on background work it dispatched")
                + " — clears when the result lands";
     sl.appendChild(chip);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -869,6 +869,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .chip-ready { background: var(--st-ready-bg); color: var(--st-ready-fg); }
 .chip-needsInput { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }
 .chip-awaiting { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }   /* legacy name — an older remote kernel */
+/* the awaiting chip's peer-identity dot (2026-08-26): the named session's colour beside its name */
+.chip-peer-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin: 0 4px 0 1px; }
 .chip-awaitingBg { background: var(--st-awaitbg-bg); color: var(--st-awaitbg-fg); }
 /* retrying = a SOFT 'blocked on the API' (rate-limit / overload auto-retry) — not a hang, not working. Amber/
    orange, deliberately distinct from working-yellow and blocked-red (the user via api 2026-06-23). */


### PR DESCRIPTION
**The user's specimen** ('Awaiting peer · delegated to a peer; waiting on their result' + an 'Awaiting peer' pill at 1h 10m): traced to the chat pane's awaiting box (`renderAwaitWhy`) and status chip, fed by the session-scoped delegation why — whose bare registry read (`_name_of(p) or "a peer"`) can never resolve the cross-host `<host>:<name>` composites the courier records. The local kernel's live cards all carried resolved identities at trace time, and the duration in the pill rules out the empty-scan window (which ships no since) — the shape matches a federated kernel's payload plus the standing composite hole, both closed here.

**The traced class — every path that mints or serves a peer-kind wait:**
1. **Session-scoped delegation why** (`_session_delegated_why`) — bare `_name_of`, fell to 'a peer' on every cross-host composite and registry miss. The specimen's writer.
2. **Judge-stamp arm** of build_feed's or-chain — hardcoded `peers=None` even when the stamp recorded its `awaitingPeers`; the recorded keys never reached a surface.
3. **Session-snapshot arm** — same hardcoded None (no identities existed to ship; now wired through).
4. **build_feed's handoff scan** — filtered raw `nodeComplete` while its gate (`_all_outstanding_delegated`) pierces done markers for agent-open nodes: an empty scan where the gate saw the delegation minted a nameless, durationless 'delegated to a peer'.
5. **Dead-handoff block why** — named the peer via the same bare read; now the ladder.
6. **Card path** (`_handoff_peer_identities`) — was already correct; now delegates to the shared ladder so there is exactly one resolve.

**The fix:** one identity ladder, `_peer_identity` — the names REGISTRY first (identity persists for DORMANT sessions; liveness is never a prerequisite for naming), else the composite's own parts (display-join on the canonical pair per the federation rule; a name tail reads whole, a sid tail stubs), else the sid stub. Identities ride every arm: the feed or-chain ships `peers[]` on the stamp and session arms too, and the chat status + timeline sessions payloads carry `awaitingPeers`.

**Rendered:** feed box peer chips click-open the session (the handoffTo idiom); the chat awaiting box names the peer in identity colour with the quiet host: prefix; the chat chip reads 'Awaiting <name>' with the peer's identity-colour dot (several → a count, one-line rule). **Honest fallback only** where identity is truly unknowable (a record with no peer sid; an older kernel's payload): 'a peer' survives there and the feed tooltip now says why the name is missing.

**Tests:** a fixture per traced path — registry-dormant naming, cross-host composite, wait-map `peer:<host>:<name>` key, uuid-tail stub, stamp-arm resolution end to end, legacy-blank honest fallback, and the open-leaves divergence window (gate fires, legacy filter blind) — plus render pins for the chips, the dot, the fallback tooltip, and the or-chain arms. Synthetic sids throughout (private-sid rule). Python 5724 passed / extension 2443 passed on the pushed head.

Out of scope, stated: the timeline lane still words the kind only (its payload now carries the identities for a follow-up); VS Code webview origin isolation unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)