### PR TITLE
Every board number counts cards, bare, through one rule — sections and folds can no longer disagree

### DIFF
--- a/ui/webview/feed-counts.test.ts
+++ b/ui/webview/feed-counts.test.ts
@@ -1,0 +1,48 @@
+// ONE counting rule for every number on the board (the user 2026-08-26, verbatim intent): the
+// number ALWAYS shows next to the Working/Blocked/Completed section headers AND next to collapsed
+// thread headers; just the number, never the word 'cards'; zero shows nothing. The traced bug: the
+// section chip counted a turn-group as ONE row while other reads spoke in cards, so expanded and
+// collapsed states could disagree (the user's 34-vs-'27 cards' screenshot). Both counters now read
+// entryCards — a turn-group is worth its members, a folded header the cards it hides — so the
+// section number is INVARIANT under grouping, group expansion, and thread folds by construction.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const FEED = ui("webview", "feed.ts");
+
+test("one counting rule: sections and folds read the SAME cards-not-rows helper", () => {
+  assert.match(FEED, /function entryCards\(e: Entry\): number \{\s*\n\s*return e\.kind === "sess" \? e\.folded : e\.kind === "group" \? e\.group\.members\.length : 1;/,
+    "a turn-group is worth its members; a folded header the cards it stands in for");
+  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ entryCards\(e\), 0\);/,
+    "the section chip counts through the rule");
+  assert.match(FEED, /if \(head\) head\.folded \+= entryCards\(e\); continue;/,
+    "the fold accumulator counts through the SAME rule — expansion invariance by construction");
+});
+
+test("expansion invariance, executed: folding moves cards onto the header without changing the total", () => {
+  // the rule as pure math, run on a synthetic bucket: 1 ask + a 3-member turn-group = 4 cards
+  const entryCards = (e: { kind: string; folded?: number; members?: number }) =>
+    e.kind === "sess" ? e.folded! : e.kind === "group" ? e.members! : 1;
+  const run = [{ kind: "ask" }, { kind: "group", members: 3 }];
+  const expanded = [{ kind: "sess", folded: 0 }, ...run];
+  const total = (es: { kind: string; folded?: number; members?: number }[]) =>
+    es.reduce((n, e) => n + entryCards(e), 0);
+  const folded = [{ kind: "sess", folded: run.reduce((n, e) => n + entryCards(e), 0) }];
+  assert.equal(total(expanded), 4);
+  assert.equal(total(folded), 4, "the same number, expanded or collapsed — the user's 34 stays 34");
+});
+
+test("just the number — the word 'cards' never renders; words live on hover", () => {
+  assert.match(FEED, /foldn\.textContent = String\(e\.folded\);/);
+  assert.ok(!/foldn\.textContent = [^;]*card/.test(FEED), "no wording variant survives");
+  assert.match(FEED, /foldn\.title = e\.folded === 1 \? "1 card folded under this session"/,
+    "the tooltip keeps the words the visible chip dropped");
+});
+
+test("zero shows nothing at all — on the section chips and the fold stand-in alike", () => {
+  assert.match(FEED, /const setCount = \(elc: HTMLElement, n: number\) => \{ elc\.textContent = n \? String\(n\) : ""; elc\.style\.display = n \? "" : "none"; \};/);
+  assert.match(FEED, /foldn\.style\.display = shut && e\.folded \? "" : "none";/);
+});

--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -44,7 +44,7 @@ test("a name+dot header entry opens each session's run; only runs that exist get
   assert.match(FEED, /setWorkDot\(nm, dotFor\(e\.name\)\);/);   // work OR awaiting dot — await-green when idle-but-awaiting (the user 2026-07-13)
   // headers aren't cards — but a FOLDED one stands in for its run, so the chip counts what it hides;
   // the column must report the board, not what the reader happens to have open (2026-07-31)
-  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ \(e\.kind === "sess" \? e\.folded : 1\), 0\);/);
+  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ entryCards\(e\), 0\);/);
   // flex-wrap: the header hosts the background-process chip's expandable list on its own full-width
   // line (feed-bg-service-chip.test.ts, the user 2026-07-24)
   assert.match(CSS, /\.feed-sess-head \{ display: flex; flex-wrap: wrap; align-items: center;/);

--- a/ui/webview/feed-thread-fold.test.ts
+++ b/ui/webview/feed-thread-fold.test.ts
@@ -28,14 +28,14 @@ test("it is a caret, and it says which way it will go", () => {
 
 test("folding hides that thread's cards and counts them onto the header", () => {
   // the header stands in for the run: entries are counted, not rendered
-  assert.match(FEED, /if \(collapsedThreads\.has\(s\)\) \{ if \(head\) head\.folded\+\+; continue; \}/);
-  assert.match(FEED, /foldn\.textContent = e\.folded === 1 \? "1 card" : e\.folded \+ " cards";/);
+  assert.match(FEED, /if \(collapsedThreads\.has\(s\)\) \{ if \(head\) head\.folded \+= entryCards\(e\); continue; \}/);
+  assert.match(FEED, /foldn\.textContent = String\(e\.folded\);/, "bare number (the user 2026-08-26) — words on hover only");
   assert.match(FEED, /foldn\.style\.display = shut && e\.folded \? "" : "none";/);
 });
 
 test("the column count reports the BOARD, not what you have open", () => {
   // folding a thread must not read as its work having left the column
-  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ \(e\.kind === "sess" \? e\.folded : 1\), 0\);/);
+  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ entryCards\(e\), 0\);/);
 });
 
 test("the fold is per-SESSION, so a card that does not exist yet inherits it", () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3205,6 +3205,14 @@ type Entry =
   // `folded` = how many of this run's cards the header is standing in for (0 when the thread is expanded)
   | { kind: "sess"; t: number; sid: string; name: string; color: { bg: string; fg: string } | null; live: boolean; folded: number };
 
+// ONE counting rule (the user 2026-08-26): every number on the board counts CARDS, never rows — a
+// turn-group entry is worth its members, a folded session header is worth the cards it stands in for.
+// Both the section chips and the fold accumulator read THIS, so expanded and collapsed can never
+// disagree (the traced bug: the chip counted a group as 1 row while the fold header said "cards").
+function entryCards(e: Entry): number {
+  return e.kind === "sess" ? e.folded : e.kind === "group" ? e.group.members.length : 1;
+}
+
 // Grouped-mode session headers, one reused element per (column, sid) — same keyed-incremental treatment as
 // cards so re-renders never rebuild a header mid-press. Pruned when a reconcile drops them from the DOM.
 const sessHeadEls = new Map<string, HTMLElement>();
@@ -3246,7 +3254,9 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   fold.setAttribute("aria-expanded", shut ? "false" : "true");
   fold.setAttribute("aria-label", (shut ? "expand " : "collapse ") + e.name);
   foldn.style.display = shut && e.folded ? "" : "none";
-  foldn.textContent = e.folded === 1 ? "1 card" : e.folded + " cards";
+  // just the number (the user 2026-08-26) — the section chips' own vocabulary; the words live on hover
+  foldn.textContent = String(e.folded);
+  foldn.title = e.folded === 1 ? "1 card folded under this session" : e.folded + " cards folded under this session";
   fold.onclick = (ev) => {
     ev.stopPropagation();   // the fold IS the acknowledgement: local state + an immediate re-render
     if (collapsedThreads.has(e.sid)) collapsedThreads.delete(e.sid); else collapsedThreads.add(e.sid);
@@ -4319,8 +4329,9 @@ function render() {
           withHeads.push(head);
         }
         // A COLLAPSED thread contributes its header and nothing else — the run's cards are counted onto the
-        // header instead of rendered, so the folded row still says how much is under it.
-        if (collapsedThreads.has(s)) { if (head) head.folded++; continue; }
+        // header instead of rendered, so the folded row still says how much is under it. CARDS, not rows
+        // (entryCards): a turn-group folds as its member count, the same rule the section chip reads.
+        if (collapsedThreads.has(s)) { if (head) head.folded += entryCards(e); continue; }
         withHeads.push(e);
       }
       buckets[k] = withHeads;
@@ -4352,8 +4363,11 @@ function render() {
   const setCount = (elc: HTMLElement, n: number) => { elc.textContent = n ? String(n) : ""; elc.style.display = n ? "" : "none"; };
   // Headers aren't cards — but a FOLDED header stands in for its run, so its cards count. The column chip
   // reports what is on the board, never what you happen to have open: folding a thread must not read as
-  // work having left the column (the user 2026-07-31).
-  const nCards = (es: Entry[]) => es.reduce((n, e) => n + (e.kind === "sess" ? e.folded : 1), 0);
+  // work having left the column (the user 2026-07-31). ONE counting rule (the user 2026-08-26): a number
+  // is always CARDS, never rows — a turn-group row is its members, a folded header is the cards it hides
+  // (entryCards, which the fold accumulator uses too) — so a section's number cannot move on any fold or
+  // grouping, only when cards actually enter or leave the column.
+  const nCards = (es: Entry[]) => es.reduce((n, e) => n + entryCards(e), 0);
   setCount(cols.asksCount, nCards(buckets.asks));
   setCount(cols.needsInputCount, nCards(buckets.needsInput));
   setCount(cols.completedCount, nCards(buckets.completed));


### PR DESCRIPTION
**The traced bug** (the user's 34-vs-'27 cards' report): the board's numbers spoke two dialects. The section chips counted ROWS — a turn-group as 1, whatever its member count — while the collapsed thread header spelled its own count as "N cards". The two derive from the same buckets but through different arithmetic, so any turn-group in a column made expanded and collapsed reads provably diverge, and the worded fold stand-in sat directly under the section header where it reads as the section's own number.

**One counting rule:** `entryCards` — a turn-group entry is worth its members, a folded session header is worth the cards it stands in for, an ask is 1 — and BOTH the section chips (`nCards`) and the fold accumulator read it. A section's number is now invariant under grouping, group expansion, and thread folds **by construction**: it moves only when cards actually enter or leave the column (the cards-move rule, applied to numbers).

**Presentation per the ask:** the number always shows next to the Working/Blocked/Completed headers and next to collapsed thread headers; just the number, never the word 'cards' (the words moved to the fold chip's hover title); zero shows nothing at all — on the chips and the stand-in alike.

**Tests:** the one-rule pins (both counters through `entryCards`), an executed expansion-invariance check (folding moves cards onto the header without changing the total), the no-word pin, and the zero-hides pins; two existing pins retargeted. 2443/2443 extension tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)