### PR TITLE
T111: no judge driver fails silently — every swallowed per-session exception files a pass-crash row

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -5136,8 +5136,10 @@ def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURREN
             task = futs[fut]
             try:
                 cap, cap_paused = fut.result()
-            except Exception:
+            except Exception as e:
                 cap, cap_paused = "", True                # a crashed worker is not the model's verdict
+                _log_judge_error("captioner", str(task.get("fsid") or ""), "pass-crash",
+                                 note=repr(e))            # …but its REASON must not vanish (T111)
             if not cap:
                 # A LIVE task retries by design (the open segment's text grows — the chunk cadence
                 # gates it) and a paused/rate-gated skip is not a verdict. A CLOSED unit's empty
@@ -5186,8 +5188,9 @@ def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURREN
             fsid, nturns = futs[fut]
             try:
                 rec = fut.result()
-            except Exception:
+            except Exception as e:
                 rec = None
+                _log_judge_error("archiver", fsid, "pass-crash", note=repr(e))   # reason kept (T111)
             if not rec:
                 # archive_llm already logged the DISTINCT error (call vs parse). Bump the per-turn-set
                 # fail counter on the EXISTING record (keeping the old headline/abstract serving the TOC)
@@ -7324,8 +7327,8 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verb
             try:
                 placed += fut.result()
                 pass_done("plan", futs[fut])          # the pass over THIS fsid completed (W2c's event)
-            except Exception:
-                pass
+            except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
+                _log_judge_error("planner", futs[fut], "pass-crash", note=repr(e))
     if verbose:
         sys.stderr.write("romp-judge: planner placed %d segments across %d sessions\n" % (placed, len(fleet)))
     return placed
@@ -7944,8 +7947,8 @@ def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ver
         for fut in as_completed(futs):
             try:
                 n += fut.result()
-            except Exception:
-                pass
+            except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
+                _log_judge_error("grouper", futs[fut], "pass-crash", note=repr(e))
     if verbose:
         sys.stderr.write("romp-judge: grouper relinked %d top goals\n" % n)
     return n
@@ -8038,8 +8041,8 @@ def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENC
         for fut in as_completed(futs):
             try:
                 n += fut.result()
-            except Exception:
-                pass
+            except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
+                _log_judge_error("consolidator", futs[fut], "pass-crash", note=repr(e))
     if verbose:
         sys.stderr.write("romp-judge: consolidator reorganized %d completed columns\n" % n)
     return n
@@ -9241,8 +9244,8 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ver
             try:
                 n += len(fut.result())
                 pass_done("close", futs[fut])         # the pass over THIS fsid completed (W2c's event)
-            except Exception:
-                pass
+            except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
+                _log_judge_error("closer", futs[fut], "pass-crash", note=repr(e))
     if verbose:
         sys.stderr.write("romp-judge: closer completed %d nodes\n" % n)
     return n
@@ -9517,8 +9520,8 @@ def run_unblock(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         for fut in as_completed(futs):
             try:
                 n += len(fut.result())
-            except Exception:
-                pass
+            except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
+                _log_judge_error("unblocker", futs[fut], "pass-crash", note=repr(e))
     if verbose:
         sys.stderr.write("romp-judge: unblocker lifted %d stale blocks\n" % n)
     return n
@@ -11724,7 +11727,8 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     for fsid, path, anchor, name in fleet:
         try:
             session = parsed_session(fsid, [str(path)], now)   # states-aware + cached, so _session_closed is correct
-        except Exception:
+        except Exception as e:                         # a poisoned transcript must not skip silently (T111)
+            _log_judge_error("courier", fsid, "pass-crash", note="parse: %r" % e)
             continue
         cstore = load_goals(fsid)
         closed[fsid] = _session_settled(fsid, str(path), session, cstore)
@@ -11743,8 +11747,8 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                         pm0 = _seg_peer(seg)
                         if pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate":
                             _attach_courier_link(cstore, seg["id"], pm0[1])
-                    except Exception:
-                        pass
+                    except Exception as e:             # bookkeeping, but its failure is not nothing (T111)
+                        _log_judge_error("courier", fsid, "pass-crash", note="link-attach: %r" % e)
                     continue
                 if floor and seg["t"] < floor:
                     # pre-episode: conversation the agent can no longer see. The planner retires these

--- a/tests/test_loud_driver_failures.py
+++ b/tests/test_loud_driver_failures.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""No judge driver may fail silently (the user 2026-08-26, T111 — the fail-loudly house rule
+applied to the pattern the T110 report exposed: one poisoned goal killed a whole store's distills
+with zero calls and zero errors, undiagnosable from the log). Every per-session swallow leg in the
+judge drivers now files a `pass-crash` judge-error row: the five fleet loops verbatim
+(planner/grouper/consolidator/closer/unblocker, matching the distiller's T110 shape), the index
+tier's captioner/archiver legs (their designed fallbacks preserved — a fallback that hides its
+trigger is the same black hole one tier down), and the courier's two sequential swallows (the
+per-session parse skip and the courier-link attach). Behavior is unchanged beyond logging.
+SYNTHETIC fixtures only; private synthetic sids."""
+import os
+import re
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from inspect import getsource
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_loudfail", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1_787_800_000
+SID = "a55f0001-1111-4222-8333-000000000001"    # private synthetic sid — never the shared placeholder
+
+
+class RepresentativeCrashRow(unittest.TestCase):
+    """One driver pinned end to end: a _plan_session that dies files ('planner', sid, 'pass-crash')
+    with the reason in the note — and the driver itself neither raises nor changes its return."""
+
+    def test_a_poisoned_plan_session_logs_and_the_pass_survives(self):
+        saved = (jd._plan_session, jd.discover, jd._log_judge_error)
+        rows = []
+        try:
+            jd.discover = lambda now, window=None, forks=True: [(SID, Path("/dev/null"), SID, "web")]
+            jd._plan_session = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("poisoned goal"))
+            jd._log_judge_error = lambda judge, fsid, err, note=None, goal=None, seg=None: \
+                rows.append((judge, fsid, err, note))
+            placed = jd.run_plan(now=NOW)
+        finally:
+            jd._plan_session, jd.discover, jd._log_judge_error = saved
+        self.assertEqual(placed, 0, "the pass survives the crash — behavior unchanged beyond logging")
+        self.assertEqual(len(rows), 1)
+        judge, fsid, err, note = rows[0]
+        self.assertEqual((judge, fsid, err), ("planner", SID, "pass-crash"))
+        self.assertIn("poisoned goal", note or "")
+
+
+class SourceSweep(unittest.TestCase):
+    """The pattern itself is pinned at the source level, so a future driver written with the old
+    idiom fails here, not in production: no `for fut in as_completed(futs)` loop may carry a bare
+    `except Exception: pass` (or a bare-continue), and the courier's two sequential swallows carry
+    their named rows."""
+
+    def test_no_fleet_loop_swallows_bare(self):
+        lines = getsource(jd).splitlines()
+        loops = [i for i, ln in enumerate(lines) if "as_completed(futs)" in ln]
+        self.assertGreaterEqual(len(loops), 7, "the driver loops are all visible to the sweep")
+        for i in loops:
+            for j in range(i, min(i + 12, len(lines))):
+                if re.match(r"^\s+except Exception\b.*:\s*$", lines[j]):
+                    body = lines[j + 1].strip()
+                    self.assertNotIn(body, ("pass", "continue"),
+                                     "a driver loop at source line ~%d swallows bare — every "
+                                     "swallow leg files a judge-error row (T111)" % (j + 1))
+
+    def test_the_courier_swallows_carry_their_rows(self):
+        src = getsource(jd)
+        self.assertIn('"pass-crash", note="parse: %r"', src,
+                      "the per-session parse skip names its reason")
+        self.assertIn('"pass-crash", note="link-attach: %r"', src,
+                      "the courier-link attach names its reason")
+
+    def test_the_index_legs_keep_their_fallbacks_and_add_the_reason(self):
+        src = getsource(jd)
+        self.assertIn('cap, cap_paused = "", True', src, "the captioner fallback is preserved")
+        i = src.index('cap, cap_paused = "", True')
+        self.assertIn('_log_judge_error("captioner"', src[i:i + 300],
+                      "…and the crash reason no longer vanishes")
+        self.assertIn('_log_judge_error("archiver"', src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The fail-loudly house rule applied to the pattern the T110 report exposed: one poisoned goal killed a whole store's distills with zero calls and zero errors, and the same bare `except Exception: pass` sat in every other driver. Nine swallow legs, logging-only:

- **The five fleet loops** (run_plan, run_group, run_consolidate, run_close, run_unblock) get the distiller's T110 treatment verbatim: `('<judge>', fsid, 'pass-crash', note=repr(e))` where they used to pass. `pass_done` placement and counter arithmetic unchanged.
- **The index tier's two legs** keep their designed fallbacks (crashed captioner worker still degrades to a retry; crashed archiver call still bumps the record's fail counter) and now also file the crash reason — a fallback that hides its trigger is the same black hole one tier down.
- **The courier's two sequential swallows** (per-session parse skip, courier-link attach) keep their control flow and name their reasons.

Adversarially verified hunk-by-hunk (scoping of `futs[fut]`/`fsid`/`task["fsid"]` per loop, fallback tuples byte-identical, no existing test pins the old silent behavior).

Tests: a poisoned `_plan_session` files the row and the pass survives; a source sweep pins the pattern itself (no `as_completed` driver loop may carry a bare except-pass — a future driver written with the old idiom fails in CI); the index legs' fallbacks pinned alongside their rows.

Suites: Python 5747/0 (+301 subtests), UI 2439/2439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)