### PR TITLE
The popover inherits the chat's remaining passive states — and lag-parked creates retry kernel-side

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6583,12 +6583,45 @@ def _comment_markers(sid):
     return out
 
 
-# The one TRANSIENT create refusal (T106 lab find, 2026-08-26): the anchor record streamed to the
-# client but this kernel's parse hasn't caught up yet. The ws handler sends a typed nack with
-# transient=True for exactly this string; the client keeps its optimistic mark and re-posts when the
-# next session frame proves the parse caught up — so a comment made seconds after a reply lands is
-# never dropped on the floor with a try-again toast.
+# The one TRANSIENT create refusal (T106 lab find, 2026-08-26): the reply the user just commented
+# on rendered from the LIVE STREAM, and the CLI flushes the transcript file a beat later — so the
+# kernel's (fresh) file read genuinely lacks the record for a second or two. The ws handler parks
+# the create HERE and the pusher retries it each cycle until the file catches up (the kernel owns
+# the file it is waiting on — a settled session emits no further frames, so a client-side retry
+# alone starves; the client's frame-keyed re-post stays as the belt for a kernel restart that loses
+# this in-memory park). The typed transient nack keeps the client's optimistic mark alive meanwhile.
 ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"
+_parked_creates = []                       # [{sid,uuid,exact,text,name,model,effort,color,tries}]
+_PARK_MAX_TRIES = 30                       # pusher cycles (~15-90s) — past this the record isn't coming
+
+
+def _retry_parked_creates():
+    """One pusher cycle's pass over lag-parked comment creates: re-run each against the (now
+    possibly caught-up) transcript; success acks commentCreated + a fresh comments frame to every
+    chat client (the creating client's socket may be gone — the adopt keys on the uuid, and clients
+    without a matching pending simply ignore it). Still lagging → keep, bounded; any OTHER error →
+    drop (the client's own attempt cap surfaces the failure honestly)."""
+    if not _parked_creates:
+        return
+    for pk in list(_parked_creates):
+        pk["tries"] += 1
+        err, tid = _comment_create(pk["sid"], pk["uuid"], pk["exact"], pk["text"], name=pk["name"],
+                                   model=pk["model"], effort=pk["effort"], color=pk["color"])
+        if err == ANCHOR_LAG_ERR and pk["tries"] < _PARK_MAX_TRIES:
+            continue
+        _parked_creates.remove(pk)
+        if not err:
+            fr = _comments_frame(pk["sid"])
+            with _clients_lock:
+                targets = [c for c in _clients if c.get("app") == "chat"]
+            for c in targets:
+                try:
+                    if fr:
+                        c["send"](json.dumps(fr))
+                    c["send"](json.dumps({"type": "commentCreated", "id": pk["sid"], "tid": tid,
+                                          "uuid": pk["uuid"]}))
+                except Exception:
+                    pass
 
 
 def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", color="", now=None):
@@ -7827,9 +7860,17 @@ def _drive(msg, client):
                                    model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""),
                                    color=str(msg.get("color") or ""))
         if err:
-            # a TRANSIENT refusal (parse lag) is the client's cue to hold + retry — no toast for
-            # plumbing the retry makes moot; every real refusal stays loud (fail loudly)
-            if err != ANCHOR_LAG_ERR:
+            # a TRANSIENT refusal (the live-streamed reply's file flush lagging) PARKS the create —
+            # the pusher retries it each cycle until the transcript catches up — and the typed nack
+            # keeps the client's optimistic mark alive; no toast for plumbing the retry makes moot.
+            # Every real refusal stays loud (fail loudly).
+            if err == ANCHOR_LAG_ERR:
+                _parked_creates.append({"sid": sid, "uuid": str(msg["uuid"]), "exact": str(msg["exact"]),
+                                        "text": str(msg["text"]), "name": str(msg.get("name") or ""),
+                                        "model": str(msg.get("model") or ""),
+                                        "effort": str(msg.get("effort") or ""),
+                                        "color": str(msg.get("color") or ""), "tries": 0})
+            else:
                 client["send"](json.dumps({"type": "warn", "text": err}))
             client["send"](json.dumps({"type": "commentCreateFailed", "id": sid,
                                        "uuid": str(msg["uuid"]), "transient": err == ANCHOR_LAG_ERR,
@@ -23144,6 +23185,7 @@ def _push(targets, connect=False, tmux=None):
                     _built_chat.pop(sid, None)
                     _prev_chat_events.pop(sid, None)
                     _prev_chat_ledger.pop(sid, None)
+            _retry_parked_creates()   # lag-parked comment creates ride every pusher cycle (T106)
             # COMMENT THREADS: one {type:"comments"} frame per session that has ever had one (its
             # comments/ store exists — an ~free stat for everyone else). Each frame rides its OWN
             # per-sid dedup slot, never the chat delta baseline (the 2026-07-28 stranded-delta rule):

--- a/ui/webview/apierror-retry-now.test.ts
+++ b/ui/webview/apierror-retry-now.test.ts
@@ -14,7 +14,7 @@ const H = (RENDER.match(/const retry = el\("button", "apierror-retry"\)[\s\S]*?h
 
 test("Retry now posts an explicit MANUAL override so it fires even when auto-retry is paused/suppressed", () => {
   assert.ok(H, "found the Retry button block");
-  assert.match(H, /vscodeApi\.postMessage\(\{ type: "apiRetry", id: activeId, manual: true \}\)/);
+  assert.match(H, /vscodeApi\.postMessage\(\{ type: "apiRetry", id: own, manual: true \}\)/);   // owner-scoped: inside the popover the card acts on the THREAD (the parity bundle, 2026-08-26)
 });
 
 test("Retry now acknowledges the click immediately (disabled + 'Retrying…'), then self-restores", () => {

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -385,7 +385,7 @@ test("while the thread is WRITING the passage holds the await-green tint and NOT
 
 test("the popover renders the thread with the CHAT's own renderer from the branch point", () => {
   assert.match(UI, /renderingSid = th\.tid;/);
-  assert.match(UI, /const node = renderEvent\(ev, prev, null\);\s*\n\s*list\.appendChild\(node\);/);
+  assert.match(UI, /const node = renderEvent\(ev, prev, turnWorkedSecs\(evs, it\.index, thWorking\)\);\s*\n\s*list\.appendChild\(node\);/);   // + the chat's worked footers (the parity bundle, 2026-08-26)
   assert.match(KERNEL, /def _thread_events\(tsid, cut_uuid, now, tmux\):/);
   assert.match(KERNEL, /evs = evs\[at \+ 1:\]/, "sliced to AFTER the branch point — the head system card never rides");
   // the thread's own statusline posts the chat's own ops through the SHARED menu, keyed to the
@@ -470,8 +470,12 @@ test("the popover's typing dots are retired — the green highlight is the only 
 // Ready off one stale relayed frame, so it read as a stuck queued thing with no queued dress. The
 // echo now RIDES the chat's own component: renderQueued's bare optimistic group, inherited. ──────
 test("the popover's pending echo IS the chat's queued idiom — one component, both boot and live", () => {
-  assert.match(UI, /function cmtPendingQueued\(pend: \{ text: string; t: number \}\[\]\): HTMLElement \{\s*\n\s*return renderQueued\(\{ kind: "queued", bare: true,/);
-  assert.match(UI, /texts: pend\.map\(\(p\) => \(\{ md: p\.text, optimistic: true, cancelable: false \}\)\),/);
+  assert.match(UI, /function cmtPendingQueued\(pend: \{ text: string; t: number; imgPaths\?: string\[\] \}\[\]\): HTMLElement \{\s*\n\s*return renderQueued\(\{ kind: "queued", bare: true,/);
+  assert.match(UI, /texts: pend\.map\(\(p\) => \(\{ md: p\.text, optimistic: true, cancelable: false, imgPaths: p\.imgPaths \}\)\),/);
+  // the parity bundle (2026-08-26): a shipped image rides the pending entry, so the echo renders
+  // the SAME thumbnails the chat's echo does — event-sourced from the drop ack, never text-parsed
+  assert.match(UI, /if \(previewKind\(m\.path\) === "img"\) cmtShippedImgs\.push\(m\.path\);/);
+  assert.match(UI, /imgPaths: cmtShippedImgs\.filter\(\(p2\) => text\.includes\(p2\)\) \}\);/);
   const sites = (UI.match(/cmtPendingQueued\(pend\)/g) || []).length;
   assert.equal(sites, 2, "both render sites — the boot view and the live list — share it");
   // the one-off is gone root and branch: no .pending class minted, no washed-gray CSS
@@ -563,8 +567,15 @@ test("a create refused by parse lag holds its mark and retries on the frame even
   const KERNELSRC = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
   assert.match(KERNELSRC, /ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"/);
   assert.match(KERNELSRC, /"transient": err == ANCHOR_LAG_ERR,/);
-  assert.match(KERNELSRC, /if err != ANCHOR_LAG_ERR:\s*\n\s*client\["send"\]\(json\.dumps\(\{"type": "warn", "text": err\}\)\)/,
+  assert.match(KERNELSRC, /else:\s*\n\s*client\["send"\]\(json\.dumps\(\{"type": "warn", "text": err\}\)\)/,
     "no toast for plumbing the retry makes moot; real refusals stay loud");
+  // …and the kernel PARKS the lag-refused create and retries it per pusher cycle (the file it is
+  // waiting on is its own): a settled session emits no further frames, so the client-side re-post
+  // alone starved — the park covers that; the client's frame-keyed belt covers a restart's lost park
+  assert.match(KERNELSRC, /_parked_creates\.append\(\{"sid": sid, "uuid": str\(msg\["uuid"\]\)/);
+  assert.match(KERNELSRC, /def _retry_parked_creates\(\):/);
+  assert.match(KERNELSRC, /_retry_parked_creates\(\)   # lag-parked comment creates ride every pusher cycle \(T106\)/);
+  assert.match(KERNELSRC, /_PARK_MAX_TRIES = 30/);
   // the client holds the payload at send and re-posts when a session frame proves the parse caught up
   assert.match(UI, /cmtCreateInFlight\.set\(create\.uuid, \{ sid: create\.sid,/);
   assert.match(UI, /retryCmtCreates\(String\(msg\.id \|\| ""\)\);\s+\/\/ a session frame = the kernel re-parsed/);
@@ -585,4 +596,15 @@ test("the optimistic synth thread survives comments frames until superseded or f
 test("the pending echo prunes against EVENTS too — a landed user turn never double-shows", () => {
   assert.match(UI, /const evUserMsgs = \(\(th\.events \|\| \[\]\) as ChatEvent\[\]\)/);
   assert.match(UI, /prunePending\(commentPending\.get\(th\.tid\) \|\| \[\], \[\.\.\.th\.msgs, \.\.\.evUserMsgs\]\);/);
+});
+
+test("the parity bundle (2026-08-26): dividers, owner-scoped in-turn controls, the sid stamp", () => {
+  // day dividers open new days in the popover exactly as in the chat (same helper, same idiom)
+  assert.match(UI, /const dayOpen = eventEpoch\(evs\[itemFirstEvent\(it\)\]\);\s*\n\s*if \(dayOpen != null\) \{\s*\n\s*const dv = dayDividerFor\(dayOpen, prev\);/);
+  // the popover's list is stamped with the THREAD sid, and in-turn controls resolve their owner
+  // from the DOM at click time — queued ✕ and the api-error card act on the thread, never the tab
+  assert.match(UI, /list\.dataset\.session = th\.tid;/);
+  assert.match(UI, /function owningSidOf\(el0: HTMLElement \| null\): string \| null \{/);
+  assert.match(UI, /\{ type: "cancelQueued", id: owningSidOf\(el\), md: qmd \}/);
+  assert.match(UI, /\{ type: "dismissDialog", id: owningSidOf\(dismiss\) \}/);
 });

--- a/ui/webview/day-divider.test.ts
+++ b/ui/webview/day-divider.test.ts
@@ -34,10 +34,11 @@ test("the divider is a sibling of the turn, never a child (the dot anchors to th
 });
 
 test("every append path emits the divider, so scrolling back can't disagree with the live tail", () => {
-  // three call sites: windowed rebuild, incremental tail append, cleared-episode fold
+  // four call sites: windowed rebuild, incremental tail append, cleared-episode fold, and the
+  // comment popover's chat-parity loop (the parity bundle, 2026-08-26)
   // (the `function dayDividerFor(` definition is excluded, hence the negative lookbehind)
   const calls = RENDER.match(/(?<!function )dayDividerFor\(/g) ?? [];
-  assert.equal(calls.length, 3, `expected 3 dayDividerFor() call sites, found ${calls.length}`);
+  assert.equal(calls.length, 4, `expected 4 dayDividerFor() call sites, found ${calls.length}`);
 });
 
 test("the windowed divider carries data-unit so the scroll-to-unit map still resolves it", () => {

--- a/ui/webview/dismiss-dialog.test.ts
+++ b/ui/webview/dismiss-dialog.test.ts
@@ -24,7 +24,7 @@ test("a tmux spend cap offers Dismiss dialog, posting the dismissDialog op", () 
   // refusal-gated: the Esc-sender is for the CLI's spend-limit dialog — a refusal parks no menu
   assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{/);
   assert.match(apiErr, /dismiss\.textContent = "Dismiss dialog";/);
-  assert.match(apiErr, /vscodeApi\.postMessage\(\{ type: "dismissDialog", id: activeId \}\)/);
+  assert.match(apiErr, /vscodeApi\.postMessage\(\{ type: "dismissDialog", id: owningSidOf\(dismiss\) \}\)/);   // owner-scoped (the parity bundle, 2026-08-26)
   // acknowledges the click at once (disable + "Dismissing…"), like every other card control
   assert.match(apiErr, /dismiss\.textContent = "Dismissing…";/);
 });

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -60,7 +60,7 @@ test("a cancelable queued bubble carries an explicit ✕ — messages AND parked
 test("the delegated qx handler cancels click-safely: kernel op + composer restore for messages only", () => {
   // one handler on document.body (stable across every per-push rebuild) — never a per-render listener
   assert.match(RENDER, /qx: \(el\) => \{/);
-  assert.match(RENDER, /\{ type: "cancelQueued", id: activeId, md: qmd \}/, "the body rides along as the kernel's drift guard");
+  assert.match(RENDER, /\{ type: "cancelQueued", id: owningSidOf\(el\), md: qmd \}/, "the body rides along as the kernel's drift guard; owner-scoped for the popover (2026-08-26)");
   assert.match(RENDER, /if \(el\.dataset\.qidx !== undefined\) msg\.idx = Number\(el\.dataset\.qidx\);/);
   assert.match(RENDER, /if \(el\.dataset\.qpark !== undefined\) msg\.park = Number\(el\.dataset\.qpark\);/);
   // a MESSAGE returns to the composer to re-edit; a slash COMMAND (qcmd) just cancels

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3493,8 +3493,9 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
       // (the kernel gate is for the auto-loop only); without it "Retry now" was a dead no-op on a suppressed
       // session (the user 2026-07-06). Acknowledge the click AT ONCE — disable + "Retrying…" — so it never
       // reads as unresponsive; the next render (a fresh error card, or the turn resuming) restores it.
-      if (vscodeApi) vscodeApi.postMessage({ type: "apiRetry", id: activeId, manual: true });
-      if (activeId) apiRetryNext.set(activeId, Date.now() + API_RETRY_MS);   // restart the countdown
+      const own = owningSidOf(retry);
+      if (vscodeApi) vscodeApi.postMessage({ type: "apiRetry", id: own, manual: true });
+      if (own) apiRetryNext.set(own, Date.now() + API_RETRY_MS);   // restart the countdown
       retry.disabled = true;
       retry.textContent = "Retrying…";
       setTimeout(() => { if (retry.isConnected) { retry.disabled = false; retry.textContent = "Retry now"; } }, 2500);
@@ -3506,7 +3507,7 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
     dismiss.textContent = "Dismiss dialog";
     dismiss.title = "the terminal is showing the spend-limit menu — send Esc to close it (cancels; changes no billing setting)";
     dismiss.addEventListener("click", () => {
-      if (vscodeApi) vscodeApi.postMessage({ type: "dismissDialog", id: activeId });
+      if (vscodeApi) vscodeApi.postMessage({ type: "dismissDialog", id: owningSidOf(dismiss) });
       dismiss.disabled = true;
       dismiss.textContent = "Dismissing…";
       setTimeout(() => { if (dismiss.isConnected) { dismiss.disabled = false; dismiss.textContent = "Dismiss dialog"; } }, 2500);
@@ -6123,7 +6124,10 @@ function showForkPrompt(sid: string, uuid: string): void {
 // drifts, so a thread is never unreachable. State lives in module maps keyed by sid/tid, so every
 // re-render (the transcript rebuilds constantly) reapplies it — the openFolds pattern.
 const commentThreads = new Map<string, CommentThread[]>();          // parent sid → last frame's threads
-const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
+const commentPending = new Map<string, { text: string; t: number; imgPaths?: string[] }[]>(); // tid → optimistic sends (+ shipped image paths → echo thumbnails, the parity bundle 2026-08-26)
+// image paths shipped into the OPEN popover's box (the droppedPath ack) and not yet sent — the next
+// send attaches them to its pending entry so the echo renders the same thumbnails the chat's does
+let cmtShippedImgs: string[] = [];
 // THE EXCHANGE LATCH (T102, the user 2026-08-26): tid → the agent-message count at the newest SEND.
 // Set at the send GESTURE (create seeds 0 under the synth tid, transferred on adopt; a reply stamps
 // the count at its send), cleared ONLY by the reply-arrived event — the agent's reply record landing
@@ -6524,9 +6528,9 @@ function adoptCommentThread(sid: string, tid: string): void {
  *  killed 2026-07-16 reborn in the popover; "I really want to be inheriting all the stuff for how
  *  the chat normally renders"). Inherited, never restyled: the dashed bubble, the sent-just-now
  *  title, the no-header bare form all come from the one code path. */
-function cmtPendingQueued(pend: { text: string; t: number }[]): HTMLElement {
+function cmtPendingQueued(pend: { text: string; t: number; imgPaths?: string[] }[]): HTMLElement {
   return renderQueued({ kind: "queued", bare: true,
-    texts: pend.map((p) => ({ md: p.text, optimistic: true, cancelable: false })),
+    texts: pend.map((p) => ({ md: p.text, optimistic: true, cancelable: false, imgPaths: p.imgPaths })),
     uuid: OPT_PREFIX + pend[0].t } as Extract<ChatEvent, { kind: "queued" }>);
 }
 
@@ -6547,7 +6551,16 @@ function openCommentThread(): { sid: string; th: CommentThread } | null {
 
 /** The popover's conversation area, (re)filled in place — shared by the full build and the
  *  frame-driven refresh so an update never rebuilds the composer under the user's caret. */
+/** The OWNING session of a control's DOM at click time: the thread root (chat views) or the
+ *  popover's list (stamped with the THREAD sid below) — so in-turn controls rendered through the
+ *  shared path (queued ✕, api-error Retry) act on the session that owns them, never on whichever
+ *  tab is active (the parity bundle, 2026-08-26; the render-time twin is renderingOwnerSid). */
+function owningSidOf(el0: HTMLElement | null): string | null {
+  return (el0?.closest("[data-session]") as HTMLElement | null)?.dataset.session || activeId;
+}
+
 function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): void {
+  list.dataset.session = th.tid;   // the THREAD owns its queue/errors — in-turn controls resolve to it
   const prevScroll = list.scrollTop;
   // the slack rule (the user 2026-08-25, same word as the chat's appendActive): while the thread's
   // content hasn't overflowed the fixed box, streaming writes in place — no follow, no jump; once
@@ -6599,7 +6612,15 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
     const items: DisplayItem[] = settings.compact
       ? compactDisplay(evs.map((e) => e.kind), evs.map((e) => e.kind === "tool" ? e.name : undefined))
       : evs.map((_, i) => ({ kind: "event", index: i } as DisplayItem));
+    const thWorking = threadBusy(th.state);
     for (const it of items) {
+      // a new day opens with the chat's own divider (the parity bundle, 2026-08-26) — same helper,
+      // same placement idiom as appendItem
+      const dayOpen = eventEpoch(evs[itemFirstEvent(it)]);
+      if (dayOpen != null) {
+        const dv = dayDividerFor(dayOpen, prev);
+        if (dv) list.appendChild(dv);
+      }
       if (it.kind === "toolgroup") {
         const tools = it.indices.map((ix) => evs[ix]) as Extract<ChatEvent, { kind: "tool" }>[];
         const key = toolGroupKey(tools[0]);
@@ -6607,7 +6628,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
         list.appendChild(renderToolGroup(tools, prev, key, open));
         if (open) {
           it.indices.forEach((ix, j) => {   // the tools only — it.indices already excludes thinking
-            const child = renderEvent(evs[ix], prev, null);
+            const child = renderEvent(evs[ix], prev, turnWorkedSecs(evs, ix, thWorking));
             child.classList.add("tg-child"); if (j === it.indices.length - 1) child.classList.add("tg-last");
             list.appendChild(child);
             const ep = eventEpoch(evs[ix]); if (ep != null) prev = ep;
@@ -6618,7 +6639,9 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
         continue;
       }
       const ev = evs[it.index];
-      const node = renderEvent(ev, prev, null);
+      // the "worked Ns" footer rides exactly as in the chat (the parity bundle) — the same
+      // turnWorkedSecs, with the thread session's own busy reading standing in for `working`
+      const node = renderEvent(ev, prev, turnWorkedSecs(evs, it.index, thWorking));
       list.appendChild(node);
       if (!quoteHost && ev.kind === "user") quoteHost = node;
       const ep = eventEpoch(ev);
@@ -6830,7 +6853,9 @@ function commentSendFromPop(pop: HTMLElement): void {
   cur.th.state = "working";                     // optimistic: the pulse rides the SEND, not the
   applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
   const pl = commentPending.get(cur.th.tid) || [];
-  pl.push({ text, t: Date.now() / 1000 });
+  pl.push({ text, t: Date.now() / 1000,
+            imgPaths: cmtShippedImgs.filter((p2) => text.includes(p2)) });   // only paths still in the sent text
+  cmtShippedImgs = [];
   commentPending.set(cur.th.tid, pl);
   commentDrafts.delete(cur.th.tid);
   box.value = "";
@@ -11452,6 +11477,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       retirePendingShip(m.path);
       cbox.value = (cbox.value ? cbox.value.trimEnd() + " " : "") + m.path + " ";
       cbox.dispatchEvent(new Event("input"));   // the draft listener persists it
+      if (previewKind(m.path) === "img") cmtShippedImgs.push(m.path);   // the echo's thumbnail ride
       cbox.focus();
       return;
     }
@@ -12478,7 +12504,7 @@ setupSettings();
     qx: (el) => {
       if (!activeId || !vscodeApi) return;
       const qmd = (el as any)._qmd as string | undefined;
-      const msg: Record<string, unknown> = { type: "cancelQueued", id: activeId, md: qmd };
+      const msg: Record<string, unknown> = { type: "cancelQueued", id: owningSidOf(el), md: qmd };
       if (el.dataset.qidx !== undefined) msg.idx = Number(el.dataset.qidx);
       if (el.dataset.qpark !== undefined) msg.park = Number(el.dataset.qpark);
       vscodeApi.postMessage(msg);


### PR DESCRIPTION
## The parity bundle (the T104 missing-list's passive five, shared-path only)

- **Day dividers + worked footers**: the popover's chat-parity loop opens new days with the chat's own `dayDividerFor` (divider census → four call sites) and passes `turnWorkedSecs` into `renderEvent` (the thread's busy reading standing in for `working`).
- **Queued groups + api-error cards** were already inherited — they are EVENTS and `_thread_events` runs the full `build_session`. The real gap was their **controls' scoping**: the queued ✕ and the api-error Retry/Dismiss posted `id: activeId`, acting on whichever tab was active. The popover's list is stamped with the thread sid and the controls resolve their owner from the DOM at click time (`owningSidOf` — the `renderingOwnerSid` idiom's click-side twin).
- **Echo image thumbnails**: an image shipped into the popover's box rides the pending entry's `imgPaths`, so the queued echo renders the same thumbnails the chat's does — event-sourced from the ship ack, never text-parsed; `renderQueued` already carries the ride.
- Live-ask widgets stay excluded by design (the Break-out note).

## The lab's next catch: lag-parked creates now retry kernel-side

A lag-refused create **starved** when the session settled: the reply renders from the live stream before the CLI flushes the transcript file (the kernel's fresh read genuinely lacks the record), and a settled session emits no further frames for the client's frame-keyed re-post to ride. The kernel now **parks** the lag-refused create and retries it every pusher cycle until the file catches up — it owns the file it's waiting on — acking `commentCreated` + a fresh comments frame on success, bounded at 30 cycles. The client's re-post stays as the belt for a restart that loses the in-memory park.

## Verification

romp-lab on the built bundle: **ALL PHASES GREEN** — latch at send, zero flicker through thread-open, clear on the reply record, follow-up re-latch + clear, nothing sticks — with this run's create riding the park (the previous run reproduced the starvation exactly).

## Tests

`comments.test.ts` (the park + nack lifecycle, the thumbnails ride, dividers/footers/stamp/owner-scoping pins), `day-divider.test.ts` census updated, `apierror-retry-now`/`dismiss-dialog`/`queued-indicator` pins retargeted to the owner-scoped posts. npm 2460 + typecheck + Python 5760 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)