### PR TITLE
The pulse clears when the reply is VISIBLE — the reply-completed event, not the first record

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5229,7 +5229,24 @@ class SdkBackend:
             with open(p, "rb") as f:
                 if size > 4_000_000:
                     f.seek(size - 4_000_000)
-                return uuid.encode() in f.read()
+                data = f.read()
+            if uuid.encode() not in data:
+                return False
+            # TEXT-AWARE (T112, guarding the 2026-07-28 textless-twin class): the CLI can persist a
+            # record under the SAME uuid with EMPTY text (a thinking-only twin) while the text the
+            # user watched streamed only. Byte-containment alone then refused the salvage marker and
+            # the reply vanished everywhere. Only a record that actually CARRIES text counts as
+            # landed — mirroring landed_text_uuids, the build-time dedup's own rule.
+            for ln in data.split(b"\n"):
+                if uuid.encode() not in ln or not ln.strip():
+                    continue
+                try:
+                    r = json.loads(ln)
+                except ValueError:
+                    continue
+                if r.get("uuid") == uuid and r.get("type") == "assistant" and _atom_text(r).strip():
+                    return True
+            return False
         except OSError:
             return False
 

--- a/tests/test_kernel_orphan_reply.py
+++ b/tests/test_kernel_orphan_reply.py
@@ -60,6 +60,21 @@ class SalvageVerifiesTheDiskFirst(unittest.TestCase):
         self.be.retire_live_work(self.sid)
         self.assertEqual(self._markers(), [], "the uuid is on disk — the claim would be false")
 
+    def test_a_textless_twin_on_disk_does_not_eat_the_salvage(self):
+        # T112, guarding the 2026-07-28 class: the CLI persists a record under the SAME uuid with
+        # EMPTY text (a thinking-only twin) while the reply's text streamed only. Byte-containment
+        # alone refused the marker and the watched reply vanished everywhere; the check is
+        # text-aware now, mirroring landed_text_uuids.
+        import json
+        reg = sb.read_reg(self.be.state_dir, self.sid)
+        p = sb.transcript_path(reg.get("cwd") or "", reg.get("lastSid") or self.sid)
+        with open(p, "a") as f:
+            f.write(json.dumps({"type": "assistant", "uuid": "cccc3333-0000-0000-0000-000000000003",
+                                "message": {"content": [{"type": "thinking", "thinking": ""}]}}) + "\n")
+        self._live_reply("cccc3333-0000-0000-0000-000000000003", "the streamed text the twin dropped")
+        self.be.retire_live_work(self.sid)
+        self.assertEqual(len(self._markers()), 1, "the twin carries no text — the streamed reply must salvage")
+
     def test_a_genuinely_lost_reply_still_mints(self):
         self._live_reply("bbbb2222-0000-0000-0000-000000000002", "the discarded partial")
         self.be.retire_live_work(self.sid)

--- a/tools/romp-lab/highlight-loop.mjs
+++ b/tools/romp-lab/highlight-loop.mjs
@@ -65,6 +65,20 @@ const dropped = await page.evaluate(async (want) => {
   return "ok";
 }, MODEL);
 console.log("model drop:", dropped);
+// bypass permissions in the HERMETIC lab so the thread's tool step never parks on an ask — the
+// thread inherits the parent's mode at fork, and the clear-timing phase needs a real tool pause
+const moded = await page.evaluate(async () => {
+  const btn = document.querySelector('#statusline .meta-btn[data-kind="mode"]');
+  if (!btn) return "no-mode-badge";
+  btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 200));
+  const item = Array.from(document.querySelectorAll(".meta-menu .meta-item"))
+    .find((i) => i.textContent.toLowerCase().includes("bypass"));
+  if (!item) return "no-bypass-item";
+  item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  return "ok";
+});
+console.log("mode bypass:", moded);
 
 // ── a REAL turn: ask for a stable, selectable sentence ──
 await page.fill("#composer-input", `Reply with exactly this sentence and nothing else: ${PASSAGE}`);
@@ -114,16 +128,38 @@ await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), un
   .catch(async () => check("3-clear-on-reply-record", false, "still busy 12s after the reply rendered"));
 await shot("settled-yellow");
 
-// PHASE 4: a follow-up re-latches until ITS reply
-await page.fill(".cmt-pop .cmt-input", "And one more short sentence about it?");
+// PHASE 4 (T112's specimen shape, permanent): the follow-up forces an INTERIM text record, a real
+// tool pause, then the final answer — the clear must wait for the reply to be VISIBLE, never firing
+// on the interim record the way the specimen did.
+const FINAL = "FINAL ANSWER: the moon is airless.";
+await page.fill(".cmt-pop .cmt-input",
+  "Do exactly this, in order: first reply with only the sentence 'checking the sources first.' — then run the bash command `echo verified` — then give a final message containing exactly this phrase: " + FINAL);
 await page.keyboard.press("Enter");
 await page.waitForTimeout(250);
 check("4-follow-up-relatch", (await busy()) === true);
 await shot("followup-latched");
-const agentTurns = () => page.evaluate(() => document.querySelectorAll(".cmt-pop .cmt-msgs .turn-assistant, .cmt-pop .cmt-msgs .cmt-msg.agent").length);
-const before = await agentTurns();
-await page.waitForFunction((n) => document.querySelectorAll(".cmt-pop .cmt-msgs .turn-assistant, .cmt-pop .cmt-msgs .cmt-msg.agent").length > n, before, { timeout: 240000 });
-await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), undefined, { timeout: 12000 })
+// CLEAR-TIMING (permanent, T112): sample continuously — the mark may never read settled while the
+// rendered thread lacks the final answer text (the reader's own view is the arbiter).
+const violations = { count: 0, samples: 0 };
+const timer = setInterval(async () => {
+  try {
+    violations.samples++;
+    const st = await page.evaluate((f) => ({
+      busy: !!document.querySelector("mark.cmt-hl.busy"),
+      hasFinal: Array.from(document.querySelectorAll(".cmt-pop .cmt-msgs .turn-assistant"))
+        .some((e) => e.textContent.includes(f)) }), FINAL);
+    if (!st.busy && !st.hasFinal) violations.count++;
+  } catch { /* page busy */ }
+}, 100);
+// FULL-TEXT (permanent, T112): the rendered thread must converge to the complete reply
+await page.waitForFunction((f) => Array.from(document.querySelectorAll(".cmt-pop .cmt-msgs .turn-assistant"))
+  .some((e) => e.textContent.includes(f)), FINAL, { timeout: 300000 })
+  .then(() => check("4c-full-text-renders", true))
+  .catch(() => check("4c-full-text-renders", false, "the final answer text never rendered in the thread"));
+clearInterval(timer);
+check("4d-clear-never-precedes-visible-reply", violations.count === 0,
+  `${violations.count}/${violations.samples} samples read settled before the answer was visible`);
+await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), undefined, { timeout: 15000 })
   .then(() => check("4b-follow-up-clears-on-its-reply", true))
   .catch(async () => check("4b-follow-up-clears-on-its-reply", false, "still busy after the follow-up's reply"));
 await shot("followup-settled");

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -508,7 +508,10 @@ test("busy latches at the SEND gesture and clears exactly on the reply-arrived r
   assert.match(UI, /if \(k\.startsWith\("pending:"\)\) \{ cmtAwaitBase\.set\(tid, cmtAwaitBase\.get\(k\)!\); cmtAwaitBase\.delete\(k\); \}/);
   // the ONE clearing site: the comments frame whose msgs carry MORE agent records than the base —
   // or the thread leaving "open"/erroring (green would lie about a reply no longer on the way)
-  assert.match(UI, /if \(base !== undefined && \(agentCount\(t\) > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/);
+  assert.match(UI, /if \(base !== undefined && \(\(agentCount\(t\) > base && !threadBusy\(t\.state\)\) \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/,
+    "T112: the clear is the reply-COMPLETED event — a new agent record AND the turn settled; a "
+    + "mid-turn interim (the specimen's 'checking…' text) must never clear the pulse early. "
+    + "threadBusy on the CLEAR side only delays; the latch side never re-derives from state.");
   // the mark's predicate: the latch, or (post-reload) the records' own owed reading; never state
   assert.match(UI, /return cmtAwaitBase\.has\(th\.tid\) \|\| replyOwed\(th\);/);
   assert.match(UI, /if \(th\.status !== "open" \|\| !!th\.error \|\| threadStuck\(th\.state\)\) return false;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11528,13 +11528,17 @@ window.addEventListener("message", (e: MessageEvent) => {
       t.tid.startsWith("pending:") && cmtCreateInFlight.has(t.tid.slice("pending:".length))
       && !threads.some((r) => r.anchorUuid === t.anchorUuid));
     commentThreads.set(sid, synths.length ? [...threads, ...synths] : threads);
-    // THE REPLY-ARRIVED EVENT (T102): a frame whose msgs hold MORE agent records than the send's
-    // base means THAT send's reply landed — the exchange latch clears here and nowhere else. A
-    // thread that left "open" (or errored) drops its latch too: green would lie about a reply
-    // that is no longer on the way.
+    // THE REPLY-COMPLETED EVENT (T102, sharpened by T112): a frame whose msgs hold MORE agent
+    // records than the send's base AND whose thread reads settled — the turn that produced the
+    // reply has ENDED, so what the reader sees is the answer, not a mid-turn interim. Counting
+    // records alone cleared 40s early on the specimen: the model wrote "checking…" first, ran
+    // tools, then answered — the interim record raised the count while the turn was still working
+    // and the pulse went yellow before the answer existed. threadBusy here can only DELAY the
+    // clear (the latch side never re-derives from state), so the boot-flap class T102 removed
+    // cannot re-green anything. Leaving "open" (or erroring) still clears immediately.
     for (const t of threads) {
       const base = cmtAwaitBase.get(t.tid);
-      if (base !== undefined && (agentCount(t) > base || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
+      if (base !== undefined && ((agentCount(t) > base && !threadBusy(t.state)) || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
     }
     for (const k of Array.from(cmtAwaitBase.keys()))
       if (!k.startsWith("pending:") && !threads.some((t) => t.tid === k)) cmtAwaitBase.delete(k);


### PR DESCRIPTION
## The specimen, traced on disk (T112)

The thread's turn was an interim text, two tool calls, then the final answer — and the transcript holds **exactly what rendered**: the events build omitted nothing. The clear was the bug: counting agent records alone, the **interim** record raised the count while the turn still had 40 seconds of tools to run — the pulse went yellow, the user looked, and what they saw was a stub plus folded tool output. The "incomplete thread" was that early look (compounded by wrap-up phrasing referencing work behind the fold).

## The clear event, named

**The reply-completed event**: a comments frame whose msgs hold a new agent record beyond the send's base **and** whose thread reads settled (`!threadBusy`) — the turn that produced the reply has ended, so what the reader sees is the answer. On the clear side `threadBusy` can only *delay* (the latch side never re-derives from state), so the boot-flap class T102 removed cannot re-green anything. Leaving "open"/erroring still clears immediately.

## Also fixed, found re-tracing the seam

The orphan-salvage disk check (719's third commit) used byte-containment — a **textless twin** (the CLI persisting a same-uuid record with empty text while the watched text streamed only; the 2026-07-28 class) would satisfy it, refusing the salvage and losing the reply everywhere. The check is text-aware now, mirroring `landed_text_uuids`' own rule; regression test added.

## The loop's two permanent phases (the T112 bar)

**full-text** (the rendered thread converges to the complete reply) and **clear-timing** (continuous sampling: the mark may never read settled while the rendered thread lacks the answer). The follow-up prompt forces the specimen's exact shape — interim text record, a real bash pause, final answer — with the hermetic lab bypassing permissions so the tool step never parks. **ALL PHASES GREEN** on the built bundle: zero clear-before-visible violations across the tool pause.

## Staleness verdict

The user's kernel + dist restarted onto 729 at 22:13 (sighting ~22:46). Tab age is moot here: the record-count clear semantics predate and postdate 729 unchanged, so the sighting reflects real current-code behavior — now fixed.

npm 2460 + typecheck + Python 5761 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)