### PR TITLE
File viewer: images and PDFs render as themselves, not line-numbered mojibake

### DIFF
--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -51,6 +51,14 @@ class FilePreviewEndpoint(unittest.TestCase):
         cls.txt = os.path.join(cls.tmp.name, "notes.txt")
         with open(cls.txt, "w") as f:
             f.write("not renderable")
+        # a synthetic SVG — XML on disk, but SERVED as an image (an <img> never runs its scripts)
+        cls.svg = os.path.join(cls.tmp.name, "diagram.svg")
+        with open(cls.svg, "w") as f:
+            f.write('<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>')
+        # a minimal synthetic PDF — the media contract's OTHER half (the viewer's isPdf branch)
+        cls.pdf = os.path.join(cls.tmp.name, "report.pdf")
+        with open(cls.pdf, "wb") as f:
+            f.write(b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n")
         # …and something served NEITHER as media nor as text, which is what "off the allowlist" means
         # now that source/text is ON it (2026-08-08 — see tests/test_file_view.py)
         cls.bin = os.path.join(cls.tmp.name, "archive.zip")
@@ -76,6 +84,27 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(code, 200)
         self.assertEqual(hdrs.get("Content-Type"), "image/png")
         self.assertEqual(body, PNG)
+
+    def test_a_media_200_carries_its_mime_and_no_text_utf8_marker(self):
+        # The viewer's media branches (ui/webview/file-view.ts) key on exactly this contract: a media
+        # 200 wears its locally-derived mime — image/* for the isImage branch, application/pdf for
+        # the isPdf one — and NOT the text pipeline's X-Romp-Text-Utf8 marker; that header belongs
+        # to the text branch alone, and its absence tells the client no text decode happened. SVG is
+        # the load-bearing image case: XML on disk, image on the wire, nosniff so the browser never
+        # reinterprets it as a document. The PDF trio (mime + marker absence + nosniff) is what the
+        # viewer's iframe arm believes without a client-side extension re-test.
+        for p, mime in ((self.png, "image/png"), (self.svg, "image/svg+xml"),
+                        (self.pdf, "application/pdf")):
+            code, hdrs, _ = self._req("/file?path=" + urllib.parse.quote(p))
+            self.assertEqual(code, 200)
+            self.assertEqual(hdrs.get("Content-Type"), mime)
+            self.assertIsNone(hdrs.get("X-Romp-Text-Utf8"),
+                              "the text marker must never ride a media response")
+            self.assertEqual(hdrs.get("X-Content-Type-Options"), "nosniff")
+        code, hdrs, _ = self._req("/file?path=" + urllib.parse.quote(self.txt))
+        self.assertEqual(code, 200)
+        self.assertEqual(hdrs.get("X-Romp-Text-Utf8"), "1",
+                         "…while the text branch carries its marker — the asymmetry is the signal")
 
     def _req_range(self, path, rng):
         url = "http://127.0.0.1:%d%s&token=%s" % (self.port, path, TOKEN)

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1307,6 +1307,17 @@ a.fileview-btn[hidden] { display: none; }
 .fileview-md th { background: rgba(255, 255, 255, 0.03); }
 .fileview-md img { max-width: 100%; }
 
+/* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
+   wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the
+   same radius + shadow) so media presents one way everywhere; the frame is the lightbox's PDF
+   iframe filling the card. Mirrored from styles.css — the viewer mounts in both documents (the
+   .romp-acted precedent). */
+.fileview-imgbox { display: flex; align-items: center; justify-content: center;
+  min-height: 100%; padding: 14px; box-sizing: border-box; }
+.fileview-img { max-width: 100%; max-height: 82vh; object-fit: contain; border-radius: 8px;
+  box-shadow: var(--shadow-modal); }
+.fileview-frame { display: block; width: 100%; height: 100%; border: 0; background: #fff; }
+
 /* ---------- syntax highlighting (warm, restrained) ----------
    The hljs token palette, mirrored from styles.css (one treatment, two sheets — the .romp-acted
    precedent: each page loads only its own sheet). The viewer wraps every token in .hljs-* spans, and

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -98,9 +98,12 @@ test("the chip lands in the session the file was opened FOR — the posted sid b
 test("the label's line is minted against a FRESH read, and a failed re-read falls back to the snapshot", () => {
   // agents edit these same trees while you read: the open-time snapshot's numbering may have moved,
   // so the line is anchored at selection time — and a failed re-read must not fabricate drift
-  // nobody observed (the retired Submit guard's rule), so it anchors the snapshot instead
+  // nobody observed (the retired Submit guard's rule), so it anchors the snapshot instead. The
+  // snapshot is viewText, not text: the SVG Source view's snapshot is the decoded blob and `text`
+  // stays null in media mode, so falling back to it would strip every SVG quote's line label.
   assert.match(VIEW, /const seq = \+\+seedSeq;/);
-  assert.match(VIEW, /fetch\(fileUrl\(path, sid\), \{ cache: "no-store" \}\)\n\s*\.then\(\(r\) => \(r\.ok \? r\.text\(\) : Promise\.reject\(new Error\(String\(r\.status\)\)\)\)\)\n\s*\.catch\(\(\) => text\)/);
+  assert.match(VIEW, /fetch\(fileUrl\(path, sid\), \{ cache: "no-store" \}\)\n\s*\.then\(\(r\) => \(r\.ok \? r\.text\(\) : Promise\.reject\(new Error\(String\(r\.status\)\)\)\)\)\n\s*\.catch\(\(\) => viewText\(\)\)/);
+  assert.match(VIEW, /const viewText = \(\): string \| null => \(svgSource && svgText !== null \? svgText : text\);/);
   assert.match(VIEW, /if \(seq !== seedSeq\) return;/, "two racing reads: the last gesture wins");
 });
 
@@ -358,6 +361,239 @@ test("Edit is consent-gated, and the gate is the KERNEL's flag, not the button (
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
   assert.match(KERNEL, /if not _file_editing_on\(\):/);
   assert.match(KERNEL, /dashboard file editing is off on this machine/);
+});
+
+// ── inline images + PDFs: a clicked .png used to open as line-numbered mojibake — the fetch pipeline
+// called r.text() unconditionally on any 200. The viewer branches on the KERNEL'S OWN Content-Type
+// verdict (the authoritative-source rule; the kernel derives mime locally and the relay re-derives
+// it, so the header is a verdict, never an echo — no client-side extension re-test), takes the
+// already-fetched bytes as a blob (no second request), and renders media as media. ──
+
+// executed: the routing replica — which body call a 200 gets, by the kernel's header alone
+test("the media branch keys on the kernel's Content-Type verdict, never the extension", () => {
+  const mediaKind = (ct: string): "img" | "pdf" | null =>
+    ct.startsWith("image/") ? "img" : ct.startsWith("application/pdf") ? "pdf" : null;
+  assert.equal(mediaKind("image/png"), "img");
+  assert.equal(mediaKind("image/svg+xml"), "img", "SVG is an image here — the <img> surface");
+  assert.equal(mediaKind("application/pdf"), "pdf");
+  assert.equal(mediaKind("text/plain; charset=utf-8"), null, "text keeps the r.text() pipeline unchanged");
+  assert.equal(mediaKind(""), null, "no header → the text path, exactly the pre-image behavior");
+  // replica ↔ source: the flags read the kernel's header, and blob is taken ONLY for media
+  assert.match(VIEW, /const ct = r\.headers\.get\("Content-Type"\) \|\| "";/);
+  assert.match(VIEW, /isImage = ct\.startsWith\("image\/"\);/);
+  assert.match(VIEW, /isPdf = ct\.startsWith\("application\/pdf"\);/);
+  assert.match(VIEW, /return isImage \|\| isPdf \? r\.blob\(\) : r\.text\(\);/);
+  // never a client-side extension re-test: preview.ts's extension probe stays out of this module
+  assert.doesNotMatch(VIEW, /previewKind\(/);
+  assert.doesNotMatch(VIEW, /IMG_EXT/);
+});
+
+test("a 200 image renders ONE <img> at an object URL; the quote gesture stays off RENDERED media", () => {
+  const openFn = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+  // the blob becomes an object URL only AFTER the still-open/still-this-viewer checks — a viewer
+  // closed or replaced mid-flight creates nothing to leak
+  assert.ok(openFn.indexOf('if (!document.getElementById("romp-fileview")) return;')
+            < openFn.indexOf("URL.createObjectURL"),
+    "no URL is minted for a viewer that is already gone");
+  assert.match(openFn, /if \(!wrap\.isConnected\) return;/);
+  // renderBody's img/PDF arm renders and returns — an <img>/iframe body has no honest text to
+  // quote (affordance honesty: no real target, no affordance), so the mouseup seed gates off
+  // RENDERED media too. The SVG SOURCE view is the deliberate exception — a text view, covered by
+  // the media-gate test below.
+  const mediaBranch = VIEW.split("if (isImage || isPdf) {")[1].split("if (text === null || editing) return;")[0];
+  const renderedArm = mediaBranch.slice(mediaBranch.indexOf("body.replaceChildren(isPdf"));
+  assert.ok(renderedArm.length > 0, "the img/PDF render arm exists");
+  assert.match(mediaBranch, /imgBlock\(objUrl, path, imgFailed\)/);
+  assert.match(VIEW, /if \(\(isImage \|\| isPdf\) && !\(svgSource && svgText !== null\)\) return;/);
+  // the romp loader holds the body until the bytes land (the loading-state rule)
+  assert.match(mediaBranch, /if \(objUrl === null\) return;/);
+  // the <img> itself: one element, src = the object URL, capped like the lightbox's image on BOTH
+  // sheets (the viewer mounts in both documents — the .romp-acted precedent)
+  const imgFn = VIEW.split("function imgBlock")[1].split("// The PDF body")[0];
+  assert.match(imgFn, /el\("img", "fileview-img"\)/);
+  assert.match(imgFn, /img\.src = objUrl;/);
+  for (const SHEET of [FEED_CSS, CHAT_CSS]) {
+    assert.match(SHEET, /\.fileview-img \{[^}]*object-fit: contain[^}]*\}/);
+    assert.match(SHEET, /\.fileview-imgbox \{/);
+  }
+});
+
+// ── media gating is RENDERED-media gating: the gate's rationale — "no honest text to quote" — is
+// true of the img/PDF surfaces only. The SVG SOURCE view is codeBlock output, real text nodes, so
+// a selection there seeds a labeled quote chip exactly as in any text view; a blanket media gate
+// would make an .svg's XML unquotable. ──
+test("the quote seed gates off RENDERED media only — the SVG Source view is a text view like any other", () => {
+  // executed: the seed offer across the view states
+  const seedable = (isImage: boolean, isPdf: boolean, srcView: boolean): boolean =>
+    !((isImage || isPdf) && !srcView);
+  assert.equal(seedable(true, false, true), true, "SVG Source view: the selection seeds a chip");
+  assert.equal(seedable(true, false, false), false, "the img view has no honest text to quote");
+  assert.equal(seedable(false, true, false), false, "the PDF iframe owns its own surface");
+  assert.equal(seedable(false, false, false), true, "plain text views are untouched");
+  // source: the media arm of the mouseup gate carves out the Source view, sitting right after the
+  // edit-mode gate (CodeMirror selections are edit gestures, not quotes)
+  assert.match(VIEW, /if \(editing\) return;[^\n]*\n(\s*\/\/[^\n]*\n)*\s*if \(\(isImage \|\| isPdf\) && !\(svgSource && svgText !== null\)\) return;/);
+  // anchoring reads the text THE VIEW SHOWS — the Source view's decoded XML, never the text
+  // pipeline's null — so a quote on the XML earns its path:line label (viewText, pinned with the
+  // fresh-read test above); renderBody's Source arm builds those text nodes through codeBlock
+  const mediaBranch = VIEW.split("if (isImage || isPdf) {")[1].split("if (text === null || editing) return;")[0];
+  const srcArm = (mediaBranch.split("if (svgSource && svgText !== null) {")[1] || "").split("\n      }")[0];
+  assert.ok(srcArm, "the Source-view arm exists inside the media branch");
+  assert.match(srcArm, /body\.replaceChildren\(codeBlock\(svgText, path, true\)\);/);
+});
+
+test("image mode hides Edit; Download, Copy path, GitHub, ✕ and the dir-link survive", () => {
+  const mediaBranch = VIEW.split("if (isImage || isPdf) {")[1].split("if (text === null || editing) return;")[0];
+  // (Wrap needs no hiding — the toggle button is gone everywhere, its stored key pinned away above)
+  // Edit was ALREADY gated on the kernel's text verdict — an image/* response sets isText false, so
+  // the existing arm hides it; both halves stay pinned (file-edit.test.ts pins the isText line too)
+  assert.match(VIEW, /isText = \(r\.headers\.get\("Content-Type"\) \|\| ""\)\.startsWith\("text\/plain"\)/);
+  assert.match(VIEW, /editBtn\.hidden = editing \|\| text === null \|\| !isText \|\| !mtimeNs;/);
+  // the media branch touches NONE of the keepers — they are built unconditionally before the fetch
+  // (the dir-link rides the title bar, outside renderBody entirely)
+  for (const keeper of ["dl.", "copy.", "close.", "gh."])
+    assert.ok(!mediaBranch.includes(keeper), keeper + " must not be re-hidden for images");
+  // markdown's Rendered/Raw segs exist only for .md files (the isMd gate, pinned above), and an .md
+  // is never served image/* — so the segs cannot coexist with an image body by construction
+});
+
+test("SVG renders via <img> ONLY — never innerHTML, never an iframe: its scripts must never run", () => {
+  // the kernel serves .svg as image/svg+xml on purpose (an <img> never runs SVG scripts — kernel.py's
+  // preview comment), and the relay re-derives the type locally; the viewer must keep that surface
+  const imgFn = VIEW.split("function imgBlock")[1].split("// The PDF body")[0];
+  assert.doesNotMatch(imgFn, /innerHTML/, "the XSS property: SVG bytes never become live DOM");
+  assert.doesNotMatch(imgFn, /iframe/, "an iframed SVG is a document — scripts would run");
+  assert.match(imgFn, /el\("img", "fileview-img"\)/);
+  // THE MEDIA BRANCH ITSELF is the surface a mutation actually hits (a proven mutation: a
+  // `body.innerHTML = svgText` swapped into the branch kept every test green — the innerHTML pin
+  // above covers only imgBlock, and a codeBlock string pin matched its own commented-out corpse).
+  // So the branch source is audited directly: no HTML-parsing sink of ANY kind, in code or comment.
+  const mediaBranch = VIEW.split("if (isImage || isPdf) {")[1].split("if (text === null || editing) return;")[0];
+  assert.ok(mediaBranch.length > 0, "media-branch anchors moved — re-anchor this extraction");
+  assert.doesNotMatch(mediaBranch, /innerHTML/, "the XSS property, on the branch that holds the bytes");
+  assert.doesNotMatch(mediaBranch, /insertAdjacentHTML/);
+  assert.doesNotMatch(mediaBranch, /outerHTML|document\.write|DOMParser|createContextualFragment/);
+  // …its only writes to the body element are replaceChildren of BUILT elements (the safe sink) —
+  // a new sink added to the branch must show up here and be argued for
+  const sinks = mediaBranch.match(/body\.\w+\s*[(=]/g) || [];
+  assert.ok(sinks.length > 0 && sinks.every((s) => /^body\.replaceChildren\s*\($/.test(s)),
+    "the media branch's only body writes are replaceChildren(...): " + JSON.stringify(sinks));
+  // …and the Source toggle's codeBlock render — the same escape/highlight path every text file
+  // takes (textContent / escapeHtml), never a parse into live DOM — is LIVE CODE, not a comment
+  const live = mediaBranch.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+  assert.match(live, /body\.replaceChildren\(codeBlock\(svgText, path, true\)\)/,
+    "the SVG Source view renders through codeBlock, uncommented (born wrapped, like every code view)");
+  assert.match(VIEW, /isSvgImage = ct === "image\/svg\+xml";/, "the toggle keys on the kernel's verdict too");
+  assert.match(VIEW, /mediaBlob\.text\(\)/, "the source view decodes the SAME fetched bytes — no second request");
+});
+
+// executed: the object-URL lifecycle — every teardown revokes
+test("the object URL is revoked on close AND on replace-open — none leaks, one live at a time", () => {
+  const sim = () => {
+    let live: string | null = null;
+    let seq = 0;
+    const revoked: string[] = [];
+    const dropMediaUrl = () => { if (live) { revoked.push(live); live = null; } };
+    const openView = () => { dropMediaUrl(); live = "blob:" + ++seq; };  // replace-teardown, then the fetch lands
+    const closeView = () => dropMediaUrl();
+    openView();          // an image opens
+    openView();          // Reload / a second click replaces it — blob:1 must go
+    closeView();         // ✕ — blob:2 must go
+    return { revoked, live };
+  };
+  const r = sim();
+  assert.deepEqual(r.revoked, ["blob:1", "blob:2"], "the replaced URL AND the closed URL both go");
+  assert.equal(r.live, null, "nothing outlives the viewer");
+  // replica ↔ source: ONE module-level registration, dropped by BOTH exits (the editHooks/gitHooks
+  // precedent), revoking through URL.revokeObjectURL
+  assert.match(VIEW, /let mediaUrlLive: string \| null = null;/);
+  assert.match(VIEW, /URL\.revokeObjectURL\(mediaUrlLive\)/);
+  const closeFn = VIEW.split("export function closeFileView")[1].split("/** Show `path`")[0];
+  assert.match(closeFn, /dropMediaUrl\(\);/, "close revokes");
+  const openFn = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+  assert.match(openFn, /dropMediaUrl\(\);/, "the replace path revokes (the conflict Reload re-opens through here)");
+  assert.ok(openFn.indexOf("dropMediaUrl();") < openFn.indexOf('document.getElementById("romp-fileview")?.remove();'),
+    "…before the old viewer is torn down, beside the other module-level drops");
+  assert.match(openFn, /mediaUrlLive = objUrl;/, "the minted URL is exactly what the teardowns revoke");
+});
+
+test("an oversize image lands on the kernel's words + Download — a 413 never reaches the media branch", () => {
+  // executed: the pipeline model — !ok throws (status attached) BEFORE any Content-Type branching
+  const route = (ok: boolean, ct: string): "error" | "img" | "pdf" | "text" => {
+    if (!ok) return "error";
+    return ct.startsWith("image/") ? "img" : ct.startsWith("application/pdf") ? "pdf" : "text";
+  };
+  assert.equal(route(false, "text/plain"), "error",
+    "the kernel 413s an oversize image with a text/plain body naming the size and the cap");
+  assert.equal(route(true, "image/png"), "img");
+  const offersDownload = (status: number | undefined): boolean => status === 413 || status === 415;
+  assert.equal(offersDownload(413), true, "…and the error pane still offers the Download the view could not be");
+  // source ordering: the throw sits before the media flags are ever assigned
+  assert.ok(VIEW.indexOf("if (!r.ok) return r.text().then((t) => {")
+            < VIEW.indexOf('isImage = ct.startsWith("image/");'));
+});
+
+test("a PDF takes the lightbox's exact iframe treatment, aimed at the already-fetched blob", () => {
+  const PREVIEW = web("preview.ts");
+  // the reference: openLightbox's pdf arm is a PLAIN iframe — className, src, title, no sandbox
+  // attributes to mirror or forget
+  assert.match(PREVIEW, /frame\.className = "romp-lightbox-frame";\s*\n\s*frame\.src = fileUrl\(path, sid\);\s*\n\s*frame\.title = path;/);
+  const pdfFn = VIEW.split("function pdfBlock")[1].split("/** Bind the pane's WS poster")[0];
+  assert.match(pdfFn, /el\("iframe", "fileview-frame"\)/);
+  assert.match(pdfFn, /frame\.src = objUrl;/, "the blob URL — the bytes were already fetched once");
+  assert.match(pdfFn, /frame\.title = path;/);
+  assert.doesNotMatch(pdfFn, /sandbox/, "the lightbox sets none; inventing one here would be a different surface");
+  const mediaBranch = VIEW.split("if (isImage || isPdf) {")[1].split("if (text === null || editing) return;")[0];
+  assert.match(mediaBranch, /isPdf \? pdfBlock\(objUrl, path\) : imgBlock\(objUrl, path, imgFailed\)/);
+  for (const SHEET of [FEED_CSS, CHAT_CSS]) assert.match(SHEET, /\.fileview-frame \{[^}]*height: 100%/);
+});
+
+// ── decode failure: a zero-byte or mid-write/truncated image is a 200 whose BYTES will not decode —
+// the browser fires the img's error event and used to leave its mute broken-image glyph: no reason,
+// no way out. The viewer answers with the 413/415 pane idiom instead: plain words naming what
+// happened, the path, and the Download the view could not be. The img's own error event is the
+// exact deciding signal (never a timer, never a byte sniff). The PDF iframe has NO equivalent
+// failure event — the browser's own viewer owns that surface and reports inside it — so this
+// covers images only, deliberately. ──
+
+test("an image 200 that fails to DECODE swaps to the failure pane: plain words + Download, never a mute glyph", () => {
+  // executed: the handler's continuation — an object URL of garbage bytes fires `error` once, and
+  // the pane replaces the glyph; a decodable image never invokes it
+  const sim = (decodes: boolean) => {
+    let pane: string[] = [];
+    let armed: (() => void) | null = null;
+    const imgBlock = (onDecodeFail: () => void): string => { armed = onDecodeFail; return "img"; };
+    const imgFailed = () => { pane = ["this image failed to decode — it may be mid-write or truncated", "Download"]; };
+    pane = [imgBlock(imgFailed)];              // the media branch renders the img, handler armed
+    if (!decodes) armed!();                    // garbage bytes: the browser fires the img's error event
+    return pane;
+  };
+  assert.deepEqual(sim(true), ["img"], "a decodable image just shows");
+  assert.deepEqual(sim(false),
+    ["this image failed to decode — it may be mid-write or truncated", "Download"],
+    "garbage bytes land on words + the way out");
+  // source: the handler rides the img itself, armed BEFORE src so no event can slip past it
+  const imgFn = VIEW.split("function imgBlock")[1].split("// The PDF body")[0];
+  assert.match(imgFn, /^\(objUrl: string, path: string, onDecodeFail: \(\) => void\)/);
+  assert.match(imgFn, /img\.addEventListener\("error", onDecodeFail, \{ once: true \}\);\s*\n\s*img\.src = objUrl;/);
+  // …and the continuation builds the EXACT failure idiom the 413/415 catch renders: fileview-err
+  // words + the path hint + the fileview-err-dl Download wired through startDownload
+  const openFn = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+  const failFn = (openFn.split("const imgFailed = ")[1] || "").split("\n  };")[0];
+  assert.ok(failFn, "imgFailed lives in the open viewer's closure — it needs body and dlUrl");
+  assert.match(failFn, /el\("div", "fileview-err"\)/);
+  assert.match(failFn, /failed to decode/);
+  assert.match(failFn, /mid-write or truncated/);
+  assert.match(failFn, /el\("div", "fileview-err-hint"\)/);
+  assert.match(failFn, /hint\.textContent = path;/);
+  assert.match(failFn, /el\("button", "fileview-btn fileview-err-dl"\)/);
+  assert.match(failFn, /startDownload\(dlUrl, offer\)/);
+  assert.match(failFn, /body\.replaceChildren\(why\);/);
+  // a decode failure that settles after the viewer was closed or replaced paints nothing
+  assert.match(failFn, /if \(!wrap\.isConnected\) return;/);
+  // the PDF arm stays bare — an iframe fires no decode-failure event to key on
+  const pdfFn = VIEW.split("function pdfBlock")[1].split("/** Bind the pane's WS poster")[0];
+  assert.doesNotMatch(pdfFn, /addEventListener/, "no synthetic failure signal invented for the iframe");
 });
 
 // executed: the gutter is a SIBLING of the code, so selecting the code copies it without line numbers

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -121,6 +121,18 @@ let editHooks: { reqId: number; saved: (mtimeNs: string) => void; failed: (err: 
 // first). The guard must live in closeFileView itself, because the browser overlay and the Escape
 // handler both close through it without knowing an edit is in progress.
 let closeGuard: (() => boolean) | null = null;
+// ONE live media object URL at a time (images used to render as line-numbered mojibake; now an
+// image/PDF view holds its bytes in an object URL). The URL is per-open state, but — like editHooks
+// and gitHooks above — the teardown must be reachable from BOTH exits (closeFileView and the replace
+// path), so the open viewer registers its URL here and each exit revokes it. Without the revoke
+// every image view leaks its blob for the page's life.
+let mediaUrlLive: string | null = null;
+function dropMediaUrl(): void {
+  if (mediaUrlLive) {
+    try { URL.revokeObjectURL(mediaUrlLive); } catch { /* already gone */ }
+    mediaUrlLive = null;
+  }
+}
 
 // ── viewer action registry (the user 2026-08-22) ── INTERNAL SEAM, no compatibility promise:
 // reshape freely. Anything acting on the OPEN file declares itself here instead of hand-wiring into
@@ -183,6 +195,7 @@ export function closeFileView(): void {
   closeGuard = null;
   editHooks = null;
   gitHooks = null;                                     // a reply landing after the close decorates nothing
+  dropMediaUrl();                                      // an image/PDF view's bytes leave with the viewer
   wrap.remove();
   document.body.classList.remove("fileview-open");
 }
@@ -195,6 +208,7 @@ export function openFileView(path: string, sid?: string | null): void {
   closeGuard = null;
   editHooks = null;
   gitHooks = null;                                     // the replace path skips closeFileView — same drop
+  dropMediaUrl();                                      // …and the old viewer's image bytes (the Reload path)
   document.getElementById("romp-fileview")?.remove();
   // backdrop (the whole overlay carries the id every open/closed check targets) + the ~95% card.
   // The backdrop treatment matches the lightbox: dimmed, click outside the card closes, content
@@ -252,6 +266,22 @@ export function openFileView(path: string, sid?: string | null): void {
   //   saveFile's conflict floor (ns because whole seconds let a same-second agent write slip the
   //   guard; a string because ~1.7e18 exceeds JS's safe-integer range and a number would round)
   let isText = false;                         // the kernel's verdicts (text/plain AND faithful UTF-8)
+  // ── the media verdicts: a .png used to open as line-numbered mojibake — the fetch pipeline called
+  // r.text() on ANY 200. All read from the KERNEL's Content-Type, never a client-side extension
+  // re-test (the authoritative-source rule; the kernel derives the mime locally and the relay
+  // re-derives it, so the header is a verdict, not an echo).
+  let isImage = false;                        // image/* → one <img> at an object URL
+  let isPdf = false;                          // application/pdf → the lightbox's iframe treatment
+  let isSvgImage = false;                     // image/svg+xml exactly — unlocks the Source toggle
+  let svgSource = false;                      // the SVG Source view is up (the highlighted XML)
+  let svgText: string | null = null;          // the decoded SVG bytes, read once on first toggle
+  let mediaBlob: Blob | null = null;          // the fetched bytes — the Source toggle decodes THESE
+  let objUrl: string | null = null;           // this open's object URL (registered as mediaUrlLive)
+  // The text the CURRENT view shows: the SVG Source view reads the decoded blob, every other text
+  // view reads the fetch pipeline's text. The quote seed's failed-re-read fallback anchors against
+  // THIS (a selection in the Source view must find its line in that XML; falling back to `text` —
+  // null the whole time media mode is up — would strip every SVG quote's line label).
+  const viewText = (): string | null => (svgSource && svgText !== null ? svgText : text);
   let editing = false;
   let dirty = false;
   let eolCRLF = false;                        // the file's dominant line ending — textareas normalize
@@ -272,6 +302,22 @@ export function openFileView(path: string, sid?: string | null): void {
       acts.appendChild(b);
     }
   }
+  // ── the SVG Source toggle ── an SVG is served (and shown) as an image, but it IS also XML worth
+  // reading; the toggle swaps in the existing highlighted-code view (langFor maps svg → xml) built
+  // from the SAME fetched bytes — no second request. Appears only once an image/svg+xml body landed.
+  const srcBtn = el("button", "fileview-btn") as HTMLButtonElement;
+  srcBtn.type = "button"; srcBtn.textContent = "Source"; srcBtn.title = "The SVG's XML, highlighted";
+  srcBtn.hidden = true;
+  srcBtn.addEventListener("click", () => {
+    if (svgText === null) {
+      if (!mediaBlob) return;
+      void mediaBlob.text().then((t) => { svgText = t; svgSource = true; renderBody(); });
+      return;
+    }
+    svgSource = !svgSource;
+    renderBody();
+  });
+  acts.appendChild(srcBtn);
 
   // ── edit (the raw-mode slice) ── exactly what raw mode can show is what Edit can touch: the
   // button arms only when the kernel served text/plain WITH a Last-Modified to anchor the save's
@@ -358,6 +404,28 @@ export function openFileView(path: string, sid?: string | null): void {
   wrap.appendChild(box);
   document.body.appendChild(wrap);
 
+  // A 200 whose bytes will not DECODE — a zero-byte file, a mid-write/truncated image — fires the
+  // img's error event and used to leave the browser's mute broken-image glyph: no reason, no way
+  // out. This is the 413/415 pane idiom instead: plain words naming what happened, the path, and
+  // the Download the view could not be. Keyed on the img's own error event, the exact deciding
+  // signal (never a timer, never a byte sniff). The PDF iframe has no equivalent failure event —
+  // the browser's viewer owns that surface and reports inside it — so this covers images only,
+  // deliberately.
+  const imgFailed = () => {
+    if (!wrap.isConnected) return;              // settled after a close/replace — paint nothing
+    const why = el("div", "fileview-err");
+    why.textContent = "this image failed to decode — it may be mid-write or truncated";
+    const hint = el("div", "fileview-err-hint");
+    hint.textContent = path;
+    why.appendChild(hint);
+    const offer = el("button", "fileview-btn fileview-err-dl") as HTMLButtonElement;
+    offer.type = "button"; offer.textContent = "Download";
+    offer.title = "Save this file to your device";
+    offer.addEventListener("click", () => startDownload(dlUrl, offer));
+    why.appendChild(offer);
+    body.replaceChildren(why);
+  };
+
   // Chooses the body for the current prefs and syncs the buttons. The pressed state flips SYNCHRONOUSLY
   // in the click handler — the immediate acknowledgement ui/CLAUDE.md requires — and so does the content
   // swap, since the text is already in memory.
@@ -372,6 +440,25 @@ export function openFileView(path: string, sid?: string | null): void {
     editBtn.hidden = editing || text === null || !isText || !mtimeNs;
     saveBtn.hidden = !editing;
     cancelBtn.hidden = !editing;
+    if (isImage || isPdf) {
+      // Media mode. The quote gesture gates off the RENDERED views only: a chip's label anchors to
+      // text and an <img>/iframe body has none (affordance honesty: no real target, no affordance —
+      // the mouseup seed below gates the same way). The SVG SOURCE view is a TEXT view — codeBlock
+      // output, real text nodes — so selections there quote like any text view (a blanket media
+      // gate would make an .svg's XML unquotable). Edit is already off through the isText arm
+      // above; the md segs cannot exist (an .md is never served image/*); Download, Copy path, the
+      // GitHub link, ✕ and the dir-link all keep working — none of them needs the text.
+      srcBtn.hidden = !(isSvgImage && objUrl !== null);
+      srcBtn.classList.toggle("on", svgSource);
+      srcBtn.setAttribute("aria-pressed", String(svgSource));
+      if (objUrl === null) return;            // the romp loader holds the body until the bytes land
+      if (svgSource && svgText !== null) {
+        body.replaceChildren(codeBlock(svgText, path, true));   // long lines always soft-wrap (the user 2026-08-24)
+        return;
+      }
+      body.replaceChildren(isPdf ? pdfBlock(objUrl, path) : imgBlock(objUrl, path, imgFailed));
+      return;
+    }
     if (text === null || editing) return;   // loading, or the textarea owns the body right now
     body.replaceChildren(rendered ? mdBlock(text) : codeBlock(text, path, true));   // long lines always soft-wrap (the user 2026-08-24)
   };
@@ -385,6 +472,10 @@ export function openFileView(path: string, sid?: string | null): void {
   let seedSeq = 0;                                 // last gesture wins if two fresh reads race
   box.addEventListener("mouseup", () => {
     if (editing) return;   // CodeMirror selections are edit gestures, not quotes
+    // RENDERED media has no honest text to quote — an <img>/iframe body owns its own selection
+    // surface; the SVG SOURCE view is a real text view and quotes like any other (renderBody's
+    // media gate, same rule).
+    if ((isImage || isPdf) && !(svgSource && svgText !== null)) return;
     const sel = window.getSelection();
     if (!sel || sel.isCollapsed || !sel.anchorNode || !box.contains(sel.anchorNode)) return;
     const picked = sel.toString().trim();
@@ -392,12 +483,13 @@ export function openFileView(path: string, sid?: string | null): void {
     // The label's line is minted NOW, not at open: agents edit these same trees, so the open-time
     // snapshot's numbering may have quietly moved. Anchor against a fresh read; a FAILED re-read
     // falls back to the snapshot rather than fabricating drift nobody observed (the old Submit
-    // guard's rule). quoteSrcLabel itself degrades to the bare path when the passage cannot be
-    // honestly found in whichever bytes it gets.
+    // guard's rule) — viewText, not text, because the SVG Source view's snapshot is the decoded
+    // blob and `text` stays null in media mode. quoteSrcLabel itself degrades to the bare path
+    // when the passage cannot be honestly found in whichever bytes it gets.
     const seq = ++seedSeq;
     fetch(fileUrl(path, sid), { cache: "no-store" })
       .then((r) => (r.ok ? r.text() : Promise.reject(new Error(String(r.status)))))
-      .catch(() => text)
+      .catch(() => viewText())
       .then((doc) => {
         if (seq !== seedSeq) return;
         try { window.postMessage({ type: "editorSelection", text: picked, sid: sid || undefined, src: quoteSrcLabel(path, doc, picked) }, "*"); }
@@ -542,7 +634,7 @@ export function openFileView(path: string, sid?: string | null): void {
   };
   document.addEventListener("keydown", onKey);
 
-  fetch(fileUrl(path, sid), { cache: "no-store" }).then((r) => {
+  fetch(fileUrl(path, sid), { cache: "no-store" }).then((r): Promise<string | Blob> => {
     // Every failure says WHY, in the pane, rather than leaving a blank one: the kernel distinguishes
     // "not a type I serve" from "too big" from "not text after all", and that is exactly what the
     // person who clicked needs to know (a 413 names the size and the cap). The status rides along so
@@ -557,9 +649,26 @@ export function openFileView(path: string, sid?: string | null): void {
     isText = (r.headers.get("Content-Type") || "").startsWith("text/plain")
       && r.headers.get("X-Romp-Text-Utf8") !== "0";
     mtimeNs = r.headers.get("X-Romp-Mtime-Ns") || "";
-    return r.text();
+    // Media branches on the SAME kernel verdict (an image 200 wears image/* and no X-Romp-Text-Utf8 —
+    // tests/test_kernel_preview.py pins that contract server-side). The bytes below are the one fetch
+    // either way: media takes them as a blob for an object URL, never a second request.
+    const ct = r.headers.get("Content-Type") || "";
+    isImage = ct.startsWith("image/");
+    isPdf = ct.startsWith("application/pdf");
+    isSvgImage = ct === "image/svg+xml";
+    return isImage || isPdf ? r.blob() : r.text();
   }).then((t) => {
     if (!document.getElementById("romp-fileview")) return;    // closed while it was in flight
+    if (t instanceof Blob) {
+      // Minted only now — a viewer closed (above) or REPLACED mid-flight creates nothing to leak,
+      // and never clobbers the new open's mediaUrlLive registration.
+      if (!wrap.isConnected) return;
+      mediaBlob = t;
+      objUrl = URL.createObjectURL(t);
+      mediaUrlLive = objUrl;                   // registered so close/replace can revoke (dropMediaUrl)
+      renderBody();
+      return;
+    }
     text = t;
     renderBody();
   }).catch((err) => {
@@ -700,6 +809,33 @@ function mdBlock(text: string): HTMLElement {
     } catch { /* leave plain */ }
   });
   return box;
+}
+
+// The image body: ONE <img> aimed at the object URL — never innerHTML, never an iframe. That is the
+// whole SVG-safety story (an <img> never runs SVG scripts — the same surface the kernel's preview
+// comments and the relay's local type re-derivation rely on), and for every other image it is simply
+// the right element. Centered and capped like the lightbox's image (.romp-lightbox-img), so a huge
+// plot fits the card and a small icon renders at its own size. Bytes that will not decode fire the
+// img's error event into onDecodeFail (armed before src, so no event can slip past), where the open
+// viewer swaps in its failure pane — the caller owns the pane; this stays a pure element builder.
+function imgBlock(objUrl: string, path: string, onDecodeFail: () => void): HTMLElement {
+  const box = el("div", "fileview-imgbox");
+  const img = el("img", "fileview-img") as HTMLImageElement;
+  img.addEventListener("error", onDecodeFail, { once: true });
+  img.src = objUrl;
+  img.alt = path;
+  box.appendChild(img);
+  return box;
+}
+
+// The PDF body mirrors the lightbox's treatment exactly (openLightbox's pdf arm, preview.ts): the
+// browser's own viewer in a PLAIN iframe — className, src, title, nothing more — aimed at the
+// already-fetched bytes instead of a second network fetch.
+function pdfBlock(objUrl: string, path: string): HTMLElement {
+  const frame = el("iframe", "fileview-frame") as HTMLIFrameElement;
+  frame.src = objUrl;
+  frame.title = path;
+  return frame;
 }
 
 /** Bind the pane's WS poster and route saveFile + fileGitLink replies back to the open viewer.

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -19,6 +19,7 @@ const RULES = [
   "a.fileview-btn {", "a.fileview-btn[hidden] {", ".fileview-body {",
   ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {",
   ".fileview-dir-link {", ".fileview-dir-link:hover {",
+  ".fileview-imgbox {", ".fileview-img {", ".fileview-frame {",
 ];
 
 function ruleOf(css: string, head: string): string {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3107,6 +3107,17 @@ body.filebrowse-open { overflow: hidden; }
 .fileview-md th { background: rgba(255, 255, 255, 0.03); }
 .fileview-md img { max-width: 100%; }
 
+/* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
+   wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the
+   same radius + shadow) so media presents one way everywhere; the frame is the lightbox's PDF
+   iframe filling the card. Mirrored in feed.css — the viewer mounts in both documents (the
+   .romp-acted precedent). */
+.fileview-imgbox { display: flex; align-items: center; justify-content: center;
+  min-height: 100%; padding: 14px; box-sizing: border-box; }
+.fileview-img { max-width: 100%; max-height: 82vh; object-fit: contain; border-radius: 8px;
+  box-shadow: var(--shadow-modal); }
+.fileview-frame { display: block; width: 100%; height: 100%; border: 0; background: #fff; }
+
 /* a MACHINE-sent message's notch (romp injections, ⚙-tagged sends — the same senderKind verdict the
    bubble wears): light gray, visibly quieter than the user's blue, so the scroll map separates "you
    spoke" from "something was injected" at a glance (the user 2026-08-18) */


### PR DESCRIPTION
Open any image from the file browser or a file link (a screenshot, a plot, a PDF report) and the viewer renders line-numbered garbage: the load pipeline calls `r.text()` on every 200 and hands the result to the code view, and no test covers a media 200. Synthetic repro: point the viewer at a `.png`. The kernel answers with a correct `image/png` 200; the viewer decodes the bytes as UTF-8 text and numbers the lines.

The kernel side already does the right thing: `/file` serves media with a locally derived Content-Type, nosniff, the 50 MB cap (the 413 names the size and the limit), and suffix-range 206s, and the relay re-derives the type for remote sessions, so the header can be trusted as a verdict. The viewer never read it.

**The fix** branches on that verdict, never a client-side extension re-test:
- `image/*` renders one `<img>` aimed at an object URL minted from the already-fetched bytes (no second request).
- `application/pdf` takes the lightbox's existing plain-iframe treatment, aimed at the same blob.
- The object URL is registered at module level and revoked on both teardowns, close and replace-open (the editHooks precedent), and minted only after the closed- and replaced-mid-flight guards: nothing leaks, and a stale flight cannot clobber a new open.
- Content-Type is a CORS-safelisted response header, so the verdict is readable even where custom headers are not exposed.

**SVG safety.** An `.svg` is served `image/svg+xml` on purpose and renders via `<img>` only (never innerHTML, never an iframe), so its scripts never run. A test extracts the media branch's source and audits it for every parser sink (innerHTML, insertAdjacentHTML, outerHTML, document.write, DOMParser, createContextualFragment), requires `replaceChildren` as the only body write, and checks that the safe `codeBlock` call survives comment-stripping; a tried mutation (`body.innerHTML = svgText` swapped in with the safe call commented out) goes red. A Source toggle decodes the same blob into the existing highlighted-XML view (LANG already maps svg to xml), so the XML stays readable, and quotable: the quote gesture gates off rendered media (an `<img>`/iframe body has no honest text to select) but works in the Source view, whose snapshot the label-anchoring fallback now reads (`viewText`; `text` stays null in media mode).

**Buttons stay honest.** Edit stays hidden through the existing isText arm (a media 200 never carries text/plain); Download, Copy path, the GitHub link, ✕, and the directory link keep working. An oversize image still lands on the kernel's own 413 words plus the Download offer; the error path is untouched and ordered before any media branching. A 200 whose bytes will not decode (zero-byte, mid-write, truncated) fires the img's error event, keyed on that event alone (no timer, no byte sniff), and swaps to the same words-plus-Download pane instead of the browser's mute broken-image glyph. The PDF iframe gains no synthetic failure signal on purpose: the browser's viewer owns that surface and reports inside it.

**Tests.**
- Kernel: one contract pin in `tests/test_kernel_preview.py`, green before this change by design. It pins what the viewer now relies on: a media 200 (png, svg, pdf) carries its mime and nosniff and never `X-Romp-Text-Utf8`, while the text branch carries the marker. The asymmetry is the signal.
- Webview: nine executed-replica plus source-pin tests (routing by header, the object-URL lifecycle including both revokes, the XSS audit, the quote-gate matrix, 413 ordering, the lightbox-parity iframe, the decode-failure pane), all red on the unfixed file; the existing fresh-read label test updated for `viewText`.
- The three new CSS rules land in both sheets and in `fileview-parity.test.ts`'s RULES, so the byte-equal pin covers them.

One design note: the PDF iframe aims at the blob URL rather than a second `fileUrl` fetch, so the browser's PDF viewer cannot lazy range-request, but the bytes are already fully local and nothing is lost. If you prefer the lightbox's fetch-URL form for consistency, `frame.src = fileUrl(path, sid)` is a one-line change that keeps the rest intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)