### PR TITLE
The timeline's lens-echo key matches its webview twin — actives in, retired hidden out, and a parity pin

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2556,12 +2556,17 @@ class TimelinePanel {
     return v;
   }
 
-  // one canonical serialization for echo comparison: the kernel normalizer sorts hidden/members and
-  // may clamp names, so compare shapes, not object identity
+  // one canonical serialization for echo comparison — the hand-copy of session-views.ts viewsKey
+  // (the timeline can't import TS; timeline-views-panel.test.ts pins the two shapes equal): the
+  // kernel normalizer re-sorts lists and may clamp names, so compare shapes, not object identity.
+  // The retired hidden set (2026-08-24) stays OUT — the kernel drops it, so serializing it held
+  // every echo hostage — and omitting `actives` let a stale views frame clear a pending lens-only
+  // edit, flapping the tag filter (revert-then-jump-back).
   _viewsKey(v) {
+    if (!v) return '';
     return JSON.stringify({ active: v.active || 'all',
-      order: v.tagOrder || [],   // the dragged union order is client-posted state (2026-08-25)
-      hidden: (v.hidden || []).slice().sort(),
+      actives: v.actives || {},   // per-surface lenses are client-posted state — the echo compares them (2026-08-25)
+      order: v.tagOrder || [],    // the dragged union order is client-posted state too (2026-08-25)
       tags: viewTags(v).map((t) => ({ id: t.id, name: t.name, color: t.color,
                                       members: (t.members || []).slice().sort() })) });
   }

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -66,6 +66,63 @@ test("executed: an optimistic edit holds until the kernel echoes it — then yie
   assert.equal(p._pendingViews, null, "the third silent push adopts the kernel's blob");
 });
 
+test("executed: the echo key compares per-surface lenses and ignores the retired hidden set", () => {
+  // a LENS-ONLY edit (same tags, this surface's lens added): a stale views-bearing frame still
+  // carrying the PRE-EDIT blob must NOT clear the pending copy — with `actives` missing from the
+  // key the first stale frame compared equal, the optimistic filter reverted, and the tag filter
+  // visibly flapped (revert-then-jump-back) until the kernel's real echo arrived
+  const p: any = Object.create(TimelinePanel.prototype);
+  p._pendingViews = { active: "all", tags: [G], actives: { timeline: { tags: ["pool"] } } };
+  p._pendingViewsAge = 0;
+  p._views = { active: "all", tags: [G] };   // the pre-edit blob — no lens on it yet
+  p._reconcileViews();
+  assert.ok(p._pendingViews, "a stale frame without the lens edit must not clear the pending copy");
+  // the kernel's genuine echo (lists re-sorted, the lens present) clears it
+  p._views = { active: "all", tags: [{ id: "g1", name: "pool", color: "#DD42FF", members: ["s3", "s2"] }],
+               actives: { timeline: { tags: ["pool"] } } };
+  p._reconcileViews();
+  assert.equal(p._pendingViews, null, "the echo carrying the lens clears the pending edit");
+  // …and the RETIRED hidden set (2026-08-24) is OUT of the key: the kernel drops it, so a local
+  // copy still carrying a legacy hidden entry must compare EQUAL to the echo that shed it —
+  // serializing hidden made every such edit ride the 3-push yield instead of clearing on echo
+  p._pendingViews = { active: "all", hidden: ["s9"], tags: [] }; p._pendingViewsAge = 0;
+  p._views = { active: "all", tags: [] };
+  p._reconcileViews();
+  assert.equal(p._pendingViews, null, "hidden is retired — it cannot hold an echo hostage");
+});
+
+test("pin: _viewsKey serializes the SAME shape as its twin, session-views.ts viewsKey", () => {
+  // the timeline cannot import TS, so _viewsKey is a hand-copy of the webview's viewsKey — this
+  // pin compares the two serializations at the source level (comments/quotes/whitespace
+  // normalized) so the copies cannot drift apart again (the 2026-08-25 lens fix landed in the
+  // twin and left the hand-copy behind)
+  const TS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "session-views.ts"), "utf8");
+  const norm = (s: string) => s.replace(/\/\/[^\n]*/g, "").replace(/'/g, '"').replace(/\s+/g, " ").trim();
+  const grab = (src: string, marker: string) => {
+    const i = src.indexOf(marker);
+    assert.ok(i >= 0, marker + " found");
+    // the slice STARTS at the null guard, not at JSON.stringify — the guard's return value is part
+    // of the key's contract too (a drifted `if (!v) return ...` sat outside the old compared slice)
+    const j = src.indexOf("if (!v)", i);
+    assert.ok(j > i, "the null guard heads " + marker);
+    const body = src.slice(j, src.indexOf("});", j) + 3);
+    return norm(body);
+  };
+  assert.equal(grab(SRC, "_viewsKey(v)"), grab(TS, "export function viewsKey("),
+    "the timeline's hand-copied echo key drifted from ui/webview/session-views.ts viewsKey");
+  // viewTags is the key's one FREE identifier, and it is ITSELF an independent hand-copy (the
+  // timeline's function viewTags vs session-views.ts's export) — identical key bodies still
+  // serialize different shapes if the two viewTags diverge, so the pin covers that twin pair too
+  const grabReturn = (src: string, marker: string) => {
+    const i = src.indexOf(marker);
+    assert.ok(i >= 0, marker + " found");
+    const j = src.indexOf("return", i);
+    return norm(src.slice(j, src.indexOf(";", j) + 1));
+  };
+  assert.equal(grabReturn(SRC, "function viewTags(views)"), grabReturn(TS, "export function viewTags("),
+    "the timeline's hand-copied viewTags drifted from ui/webview/session-views.ts viewTags");
+});
+
 test("the lane gate composes the view filter first, and the all-quiet fallback respects it", () => {
   assert.match(SRC, /const inView = \(s\) => \{ const v = this\._curViews\(\); return lensVisible\(timelineLens\(v\), viewTagUnion\(v\), s\.id\); \};/,
     "lanes key on THIS surface's lens (per-surface selections, 2026-08-25)");


### PR DESCRIPTION
### What breaks

On the timeline, changing the tag filter visibly flaps: the filter reverts on the next data push, then jumps back when the kernel's echo arrives. A tag-filter change is a lens-only edit (same tags; only this surface's selection under `actives` changes), and those are the edits the timeline mishandles.

### Root cause

`_viewsKey` in `ui/romp-timeline-view.js` is a hand-copy of `viewsKey` in `ui/webview/session-views.ts` (the timeline can't import TS), and two twin updates never reached it:

- 93f4cc35 dropped the retired `hidden` set from the twin's key.
- 15dd5540 added `actives` to it, in the same commit that mounted the lens on the timeline, so the surface left with the stale key is the one posting lens edits.

(`order` did land in both keys in d45dbe02, which shows how easily the hand-copy drifts: one of three updates made it across.)

Two concrete failures at `_reconcileViews`:

1. **`actives` missing from the key.** After a lens edit, the first views-bearing push still carrying the pre-edit blob compares equal to the pending copy and clears it. `_curViews()` then renders the stale blob (the filter reverts) until the kernel's true echo lands and it jumps back.
2. **`hidden` still in the key.** The kernel's normalizer drops `hidden` from every stored or echoed blob, so a client blob still carrying a legacy hidden entry can never match any echo; every such edit rides the three-push yield instead of clearing on the echo that confirms it.

### Reproduction

Pick a tag in the timeline's corner filter while a kernel is connected. The views blob rides every push, so the next push still carrying the pre-edit blob reverts the chip, and the kernel's echo restores it a beat later. Deterministically: the new executed test drives the same frames through `_reconcileViews` on a bare `TimelinePanel` prototype.

### The fix

Bring `_viewsKey` to the twin's exact shape, null guard included.

### Tests (both red on main before the fix)

- An executed test on the bare prototype (the file's existing house pattern) proving a stale frame no longer clears a lens-only edit, the genuine echo does clear it, and a legacy `hidden` entry can't hold an echo hostage. Synthetic fixtures throughout.
- A source-parity pin that normalizes (comments, quote style, whitespace) and compares the two key bodies, plus the `viewTags` pair (the key's one free identifier, itself an independent hand-copy), so the next edit that lands in one file and not the other fails CI in the existing vscode-extension test job. No workflow changes: the esbuild test bundle already picks up `ui/*.test.ts`.

Maintenance note the pin implies: any future change to either `viewsKey` must now touch both files; that is its purpose. Comment-only edits don't trip it; a structural reshape of either function (say, extracting a helper) needs the pin's marker strings updated alongside. If you'd rather not carry the pin, the executed test stands alone.

Found while folding the recent tags-era changes into a downstream fork, where the same flap reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)