### PR TITLE
_patch_rows: degrade every malformed structuredPatch shape instead of raising out of the push loop

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14102,13 +14102,27 @@ def _patch_rows(sp):
     "@@ -old +new @@" header. Removed lines carry only an old number, added lines only a new one, context both.
     Capped so a huge MultiEdit can't bloat the payload. Returns [] when there's nothing usable."""
     rows = []
-    for h in (sp or []):
+    if not isinstance(sp, list):
+        return rows                                  # the CONTAINER is external input too: a truthy
+                                                     # non-iterable (int/bool/float) TypeError'd at
+                                                     # the for itself, OUTSIDE the per-hunk try —
+                                                     # the same escape to the push loop's outer
+                                                     # except, the same permanent push-cycle abort
+    for h in sp:
         try:
             o = int(h["oldStart"]); n = int(h["newStart"])
+            lines = h.get("lines") or []
+            if not isinstance(lines, list) or not all(isinstance(ln, str) for ln in lines):
+                continue                             # a non-list lines (a STRING's chars pass the
+                                                     # per-entry check — one garbage row per char) or
+                                                     # a non-string line entry (the record is external
+                                                     # input) degrades its hunk like every other bad
+                                                     # shape — a TypeError here escaped the chat build
+                                                     # and aborted every push cycle permanently
         except Exception:
             continue
         rows.append({"sign": "@", "text": "@@ -%d +%d @@" % (o, n), "oldNo": None, "newNo": None})
-        for ln in (h.get("lines") or []):
+        for ln in lines:
             mark = ln[:1]
             if mark == "+":
                 rows.append({"sign": "+", "text": ln[1:], "oldNo": None, "newNo": n}); n += 1

--- a/tests/test_kernel_patch_rows.py
+++ b/tests/test_kernel_patch_rows.py
@@ -62,6 +62,36 @@ class PatchRows(unittest.TestCase):
         rows = km._patch_rows(big)
         self.assertLessEqual(len(rows), 601)
 
+    def test_a_non_string_line_entry_degrades_the_hunk_never_raises(self):
+        # The record is external input and the chat-build consumer has no guard: a lines array
+        # carrying an int/None used to raise TypeError (ln[:1]) out of the view build, and the
+        # escape aborted EVERY push cycle permanently (the record is permanent). A bad line shape
+        # degrades its hunk to no rows, exactly like every other malformed patch here.
+        bad = [{"oldStart": 3, "newStart": 3, "lines": ["-old_line", 5, "+new_line"]}]
+        self.assertEqual(km._patch_rows(bad), [])
+        self.assertEqual(km._patch_rows([{"oldStart": 1, "newStart": 1, "lines": [None]}]), [])
+        self.assertEqual(km._patch_rows([{"oldStart": 1, "newStart": 1, "lines": 7}]), [])
+        # …and a good hunk beside a bad one still renders — the degrade is per-hunk
+        rows = km._patch_rows(bad + [{"oldStart": 9, "newStart": 9, "lines": ["+kept"]}])
+        self.assertEqual([r["text"] for r in rows], ["@@ -9 +9 @@", "kept"])
+
+    def test_a_non_list_container_degrades_never_raises(self):
+        # The CONTAINER is external input too: a truthy non-iterable structuredPatch (int/bool/
+        # float) used to TypeError at the `for` itself, OUTSIDE the per-hunk try — the same escape
+        # to the push loop's outer except, the same permanent abort of every push cycle.
+        self.assertEqual(km._patch_rows(7), [])
+        self.assertEqual(km._patch_rows(True), [])
+        self.assertEqual(km._patch_rows(2.5), [])
+
+    def test_a_string_lines_field_degrades_the_hunk_like_every_other_bad_shape(self):
+        # A STRING lines value slips the per-entry check (the chars of a str are strs themselves)
+        # and used to render one garbage row per character; a non-list lines degrades its hunk to
+        # no rows, and a good sibling hunk still renders.
+        bad = [{"oldStart": 1, "newStart": 1, "lines": "+ab"}]
+        self.assertEqual(km._patch_rows(bad), [])
+        rows = km._patch_rows(bad + [{"oldStart": 4, "newStart": 4, "lines": ["+kept"]}])
+        self.assertEqual([r["text"] for r in rows], ["@@ -4 +4 @@", "kept"])
+
 
 NOW = 1781100000
 SID = "11111111-2222-3333-4444-555555555555"


### PR DESCRIPTION
## Problem

`_patch_rows` (kernel/kernel.py) treats a `structuredPatch` record as trusted, but `toolUseResult` is external input — whatever the CLI wrote into the transcript (and, since #576 wired the live tail to carry `toolUseResult` onto atoms, whatever it streams; the gap itself predates that and has been present since the function's birth). The per-hunk `try` covers only the `oldStart`/`newStart` int casts. Three malformed shapes raise `TypeError` straight out of the function:

- a non-string entry in a `lines` array — `ln[:1]` on an int or `None`;
- a truthy non-iterable `lines` value (e.g. `7`) — the inner `for`;
- a truthy non-iterable container (e.g. `7`, `True`, `2.5`) — the outer `for`, outside the `try` entirely.

A fourth shape — a **string** `lines` value — doesn't raise but renders one garbage row per character, since the chars of a str are strs.

## Impact

The consumer in `build_session` (`pr = _patch_rows(tur["structuredPatch"])`) has no guard, so the escape propagates out of the chat build into `_push`'s outer `except`, which logs `push build:` and returns — aborting the **entire push** (chat, feed, and timeline, for every connected client). The bad record is permanent in the transcript, so every subsequent pusher cycle aborts at the same point: one malformed record freezes the whole dashboard until the transcript is edited by hand. Every other odd shape (missing `oldStart`, a dict hunk, a `None`/empty container) already degrades to no rows; these were the gaps.

Synthetic repro shape: `[{"oldStart": 3, "newStart": 3, "lines": ["-old_line", 5, "+new_line"]}]` in a tool_result record's `toolUseResult.structuredPatch`.

## Fix

Three lines plus comments, inside `_patch_rows`' existing bad-shape idiom: a non-list container returns `[]` up front, and a hunk whose `lines` is not a list of strings degrades via the same `continue` the int casts use. The degrade is per-hunk — a well-formed sibling hunk still renders its rows.

Notes for review: the container guard requires exactly a list; `structuredPatch` is JSON-parsed, so no real record can be a tuple or other iterable. `_patch_rows(None)`/`[]` behavior is unchanged (pinned by the existing `test_empty_or_malformed_patch_is_safe`), and nothing on the path catches `TypeError` specifically, so no caller depended on the exception. The only observable change is raise→degrade (and garbage-rows→degrade) for malformed shapes.

## Tests

Three new tests in `tests/test_kernel_patch_rows.py`, red on the parent commit (two `TypeError`s, one garbage-row assertion) and green with the fix, including the good-hunk-beside-a-bad-one case. The file's existing tests — the empty/malformed pin, the 600-row cap, and the end-to-end `build_session` diffRows chain — stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)