### PR TITLE
Resolve the manager port before the /restart ack; floor ROMP_MANAGER_PORT in the test suite

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2598,11 +2598,22 @@ def _main_drift_check():
                                "cur": _kernel_sha() or "", "tag": target, "boot": _BOOT_ID})
 
 
-def _run_main_update(kind, immediate=False):
+# HTTP-triggered restarts resolve ROMP_MANAGER_PORT BEFORE their ack goes out (2026-08-27): the
+# env read used to trail the ack by a thread hop, so a caller that set the var for the duration
+# of its request — a test suite fencing off a live deployment does exactly this — could have the
+# RESTORED value read instead of the one in force when the kernel answered. The handlers now read
+# the env once, pre-ack, and hand the value down. _PORT_FROM_ENV keeps every non-HTTP caller
+# exactly as before: the env is read at use time, absent still meaning "no manager" in
+# _restart_this_kernel and "the default port" in _run_main_update.
+_PORT_FROM_ENV = object()
+
+
+def _run_main_update(kind, immediate=False, manager_port=_PORT_FROM_ENV):
     """Converge on newest main: advance the checkout (fast-forward only; a DIRTY shared tree refuses
     LOUDLY — peer sessions' uncommitted work is never discarded) and bounce every kernel through the
     manager. `kind` "restart" skips the pull (the checkout is already ahead). Unattended (auto mode)
-    the bounce rides the quiet window; a banner CLICK is the user's own deliberate cut → immediate."""
+    the bounce rides the quiet window; a banner CLICK is the user's own deliberate cut → immediate.
+    `manager_port` is the value the /update handler resolved before its ack (see _PORT_FROM_ENV)."""
     if kind == "pull":
         try:
             dirty = subprocess.run(["git", "status", "--porcelain"], cwd=str(ROOT),
@@ -2635,10 +2646,12 @@ def _run_main_update(kind, immediate=False):
             return
         _sync_notice("UI-only update failed to build in place (%s) — taking the restart path" % err,
                      ok=False)
+    if manager_port is _PORT_FROM_ENV:
+        manager_port = os.environ.get("ROMP_MANAGER_PORT")
     try:
         import urllib.request
         req = urllib.request.Request("http://127.0.0.1:%d/restart-all%s"
-                                     % (int(os.environ.get("ROMP_MANAGER_PORT") or 7432),
+                                     % (int(manager_port or 7432),
                                         "" if immediate else "?when=quiet"), method="POST")
         urllib.request.urlopen(req, timeout=5).read()
     except Exception as e:
@@ -11423,10 +11436,12 @@ def _fleet_restart_plan(r):
     return "skip", "its build isn't in this repo's history, so nothing can be proven safe to sync"
 
 
-def _fleet_restart_run():
+def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
     """Do the remote half of a fleet restart, write the report, then restart this machine's kernel last —
     the local restart kills this process, so anything that must be REPORTED has to be on disk before it.
-    The page reads the report back after it reloads."""
+    The page reads the report back after it reloads. `manager_port` carries the /restart handler's
+    ack-time resolution through to the local restart (see _PORT_FROM_ENV) — this thread runs for
+    seconds of network first, so a use-time env read here would be even further from the ack."""
     rows = []
     with _remotes_lock:
         remotes = [dict(x) for x in _remotes.values()]
@@ -11456,7 +11471,7 @@ def _fleet_restart_run():
         _atomic_write(FLEET_REPORT, json.dumps(report))
     except OSError:
         sys.stderr.write("fleet-restart: could not write the report: %s\n" % traceback.format_exc())
-    _restart_this_kernel("fleet-restart: the local half of the fleet Restart")
+    _restart_this_kernel("fleet-restart: the local half of the fleet Restart", manager_port=manager_port)
 
 
 def _audit_restart_request(action, **kw):
@@ -11474,12 +11489,14 @@ def _audit_restart_request(action, **kw):
         pass
 
 
-def _restart_this_kernel(reason=""):
+def _restart_this_kernel(reason="", manager_port=_PORT_FROM_ENV):
     """Ask the manager to restart-all (it SIGTERMs this kernel; its exit handler spawns a fresh one).
     Standalone (no manager) → nothing to restart, which is not an error. `reason` lands in
-    restart-audit.jsonl so the manager hop is never an anonymous SIGTERM (see _audit_restart_request)."""
+    restart-audit.jsonl so the manager hop is never an anonymous SIGTERM (see _audit_restart_request).
+    `manager_port` is the value an HTTP handler resolved BEFORE its ack went out (see _PORT_FROM_ENV);
+    the default reads the env here, for callers with no ack to sequence against."""
     _audit_restart_request("kernel-asks-manager-restart-all", reason=reason, pid=os.getpid())
-    mport = os.environ.get("ROMP_MANAGER_PORT")
+    mport = os.environ.get("ROMP_MANAGER_PORT") if manager_port is _PORT_FROM_ENV else manager_port
     if not mport:
         return
     try:
@@ -27959,12 +27976,20 @@ class Handler(BaseHTTPRequestHandler):
                                        addr=str(self.client_address[0]),
                                        origin=str(self.headers.get("Origin") or ""),
                                        ua=str(self.headers.get("User-Agent") or ""))
+                # Resolve the manager port BEFORE the ack (2026-08-27): the read used to sit inside
+                # _restart_this_kernel, AFTER _send returned — so a caller that set ROMP_MANAGER_PORT
+                # for exactly the request window (a test suite fencing a live deployment off does
+                # this) raced its restore against this thread, and the RESTORED value could win.
+                # The value in force when the kernel acks is the value acted on; absent still means
+                # what it always meant (no manager → nothing to restart).
+                _mport = os.environ.get("ROMP_MANAGER_PORT")
                 self._send(200, json.dumps({"ok": True, "restarting": True, "boot": _BOOT_ID,
                                             "fleet": bool(_fleet)}), "application/json")
                 if _fleet and _remotes:
-                    threading.Thread(target=_fleet_restart_run, daemon=True).start()
+                    threading.Thread(target=_fleet_restart_run,
+                                     kwargs={"manager_port": _mport}, daemon=True).start()
                 else:
-                    _restart_this_kernel("http /restart (local-only)")
+                    _restart_this_kernel("http /restart (local-only)", manager_port=_mport)
                 return
             if u.path == "/fleet-restart":
                 # What the last fleet restart did, read back by the page AFTER it reloads (the restart
@@ -27989,7 +28014,11 @@ class Handler(BaseHTTPRequestHandler):
                 if kind:
                     _audit_restart_request("main-converge", tag=_MAIN_DRIFT[0] or _MAIN_DRIFT[1],
                                            addr=str(self.client_address[0]))
-                    threading.Thread(target=_run_main_update, args=(kind, True), daemon=True).start()
+                    # same ack-time port resolution as /restart: the daemon thread's env read could
+                    # otherwise land after this response, on a value the caller has already restored
+                    threading.Thread(target=_run_main_update, args=(kind, True),
+                                     kwargs={"manager_port": os.environ.get("ROMP_MANAGER_PORT")},
+                                     daemon=True).start()
                     _send_to_app("shell", {"type": "updateAvail", "state": "running", "boot": _BOOT_ID})
                     return self._send(200, json.dumps({"ok": True, "state": "converging"}), "application/json")
                 return self._send(409, "no newer release or main commit known to this kernel", "text/plain")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,27 @@ import pytest
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
 
+# No test may reach a REAL manager control port (2026-08-27): on a machine running a live romp,
+# every shell the manager tree spawns inherits ROMP_MANAGER_PORT, and any test kernel that dials
+# "the manager" through the inherited value restarts the ACTUAL deployment — the serve-layer
+# restart test's pop-then-restore raced the /restart handler's post-ack env read and took a
+# self-hosted instance down mid-suite, repeatedly. POISONED to a dead port, never popped: an
+# absent var is the one unsafe state, because _restart_this_kernel treats absent as "no manager"
+# but _run_main_update maps absent to the DEFAULT port — the live one — so only a dead value is
+# safe against every consumer. Import-time, so collection-time code is floored too.
+os.environ["ROMP_MANAGER_PORT"] = "1"
+
+
+@pytest.fixture(autouse=True)
+def _dead_manager_port():
+    """The import-time poison above covers collection, but a module-level env write in a test file
+    ALSO executes during collection — so one module's write (or pop) would otherwise hold for the
+    entire run phase, erasing the floor for every test after it. Re-assert per test: no
+    module-level write can outlive collection against this."""
+    os.environ["ROMP_MANAGER_PORT"] = "1"
+    yield
+
+
 # No test may reach the REAL `claude` CLI (2026-08-12): _judge_claude_bin honors ROMP_CLAUDE_BIN
 # first, so this floors every judge call a test forgot to stub at /bin/false — empty stdout, the
 # dead-CLI row, byte-for-byte what a claude-less CI runner produces. Found when an unstubbed

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -127,7 +127,8 @@ class ReportSurvivesTheRestart(unittest.TestCase):
                                             "_restart_this_kernel", "_local_head", "_local_branch")}
         km._fleet_restart_plan = lambda r: ("restart", "already on this build")
         km._restart_remote_kernel = lambda h: (_ for _ in ()).throw(RuntimeError("ssh exploded"))
-        km._restart_this_kernel = lambda reason="": None   # audits its reason since 2026-07-31
+        # audits its reason since 2026-07-31; carries the handler's ack-time port since 2026-08-27
+        km._restart_this_kernel = lambda reason="", manager_port=None: None
         km._local_head = lambda short=False: "abc1234"
         km._local_branch = lambda: "main"
         km._remotes.clear()
@@ -151,7 +152,9 @@ class ReportSurvivesTheRestart(unittest.TestCase):
         src = inspect.getsource(km.Handler)
         self.assertIn('if u.path == "/fleet-restart":', src)
         self.assertIn("FLEET_REPORT.read_text()", src)
-        self.assertIn("threading.Thread(target=_fleet_restart_run, daemon=True).start()", src)
+        self.assertIn("threading.Thread(target=_fleet_restart_run,", src)
+        self.assertIn('kwargs={"manager_port": _mport}, daemon=True).start()', src,
+                      "the remote leg carries the port resolved before the ack, like the local one")
         # the page reads it back AFTER reloading and shows it exactly once (keyed on the report's stamp).
         # It rides the block that owns the Restart button itself, so the two can never drift apart.
         js = km._LANDING_SETTINGS_JS
@@ -163,7 +166,8 @@ class ReportSurvivesTheRestart(unittest.TestCase):
     def test_a_kernel_with_no_remotes_restarts_exactly_as_before(self):
         src = inspect.getsource(km.Handler)
         self.assertIn("if _fleet and _remotes:", src)
-        self.assertIn("else:\n                    _restart_this_kernel(\"http /restart (local-only)\")", src)
+        self.assertIn("else:\n                    _restart_this_kernel(\"http /restart (local-only)\", "
+                      "manager_port=_mport)", src)
 
 
 class GlyphSaysTheFleetState(unittest.TestCase):

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -408,8 +408,9 @@ class Routes(Fresh):
         km._UPDATE_AVAIL[0] = ""
         km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = "aaaa1111", ""
         ran = []
-        with mock.patch.object(km, "_run_main_update",
-                               side_effect=lambda kind, immediate=False: ran.append((kind, immediate))):
+        with mock.patch.object(km, "_run_main_update",   # the route hands over its ack-time port too
+                               side_effect=lambda kind, immediate=False, manager_port=None:
+                                   ran.append((kind, immediate))):
             code, body = self._post("/update")
             self.assertEqual(code, 200)
             self.assertIn("converging", body)

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -65,7 +65,7 @@ class DriftWiring(unittest.TestCase):
         src = inspect.getsource(km._run_main_update)
         self.assertIn('"" if immediate else "?when=quiet"', src)
         route = inspect.getsource(km)
-        self.assertIn('threading.Thread(target=_run_main_update, args=(kind, True), daemon=True)', route,
+        self.assertIn('threading.Thread(target=_run_main_update, args=(kind, True),', route,
                       "the banner click is the user's own deliberate cut")
 
     def test_auto_converges_batch_behind_the_cool_down(self):

--- a/tests/test_restart_audit.py
+++ b/tests/test_restart_audit.py
@@ -31,7 +31,10 @@ SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
-os.environ.pop("ROMP_MANAGER_PORT", None)   # no manager → _restart_this_kernel audits, then no-ops
+os.environ["ROMP_MANAGER_PORT"] = "1"   # dead port → _restart_this_kernel audits, then its dial is
+#   refused (its except: pass). NEVER pop: pytest imports this module at COLLECTION, so a pop here
+#   would erase conftest's suite-wide floor before any test runs — and an ABSENT var is the one
+#   unsafe state (_run_main_update maps absent to the DEFAULT port: the live manager).
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 def _audit_path():

--- a/tests/test_restart_port_at_ack.py
+++ b/tests/test_restart_port_at_ack.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""POST /restart resolves ROMP_MANAGER_PORT BEFORE the ack goes out (2026-08-27).
+
+The read used to sit inside _restart_this_kernel, which runs only after the handler's _send
+returned — so a caller that installed a value for exactly the duration of the request (a test
+suite fencing a live self-hosted deployment off its real manager does precisely this: set, POST,
+restore in `finally`) raced its restore against the handler thread, and the RESTORED value could
+be the one read. On a machine whose environment carries a live manager port, losing that race
+restarts the real deployment. The contract pinned here: the value in force when the kernel ACKS
+is the value acted on.
+
+Deterministic by construction — the "restore after the ack" is not a sleep this test could lose,
+it is an event sequenced in the handler's own thread: _send is wrapped so the moment the ack is
+written, the env flips to a dead port. Pre-fix the post-ack read sees the flipped (dead) value and
+the recorded manager hears nothing; post-fix the pre-ack resolution governs and the manager hop
+lands. Synthetic only: the real Handler and a recording fake manager, both on ephemeral loopback
+ports, invented token.
+"""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# A dead manager port at module level — NEVER pop: a pop here executes at collection time and
+# erases any suite-wide floor for the rest of the run, and an ABSENT var is the one unsafe state
+# (_run_main_update maps absent to the DEFAULT port: a live manager, if one is running).
+os.environ["ROMP_MANAGER_PORT"] = "1"
+km = SourceFileLoader("romp_kernel_port_ack", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _RecordingManager(BaseHTTPRequestHandler):
+    """A fake manager: records every POST path, answers 200. What a real manager's /restart-all
+    door looks like to the kernel, minus the SIGTERM."""
+    hits = []
+
+    def do_POST(self):
+        type(self).hits.append(self.path)
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, *a):
+        pass
+
+
+class RestartPortResolvedAtAck(unittest.TestCase):
+    def setUp(self):
+        _RecordingManager.hits = []
+        self.mgr = ThreadingHTTPServer(("127.0.0.1", 0), _RecordingManager)
+        self.mgr_port = self.mgr.server_address[1]
+        threading.Thread(target=self.mgr.serve_forever, daemon=True).start()
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self._saved_env = os.environ.get("ROMP_MANAGER_PORT")
+        self._real_send = km.Handler._send
+
+    def tearDown(self):
+        km.Handler._send = self._real_send
+        if self._saved_env is None:
+            os.environ.pop("ROMP_MANAGER_PORT", None)
+        else:
+            os.environ["ROMP_MANAGER_PORT"] = self._saved_env
+        self.srv.shutdown()
+        self.srv.server_close()
+        self.mgr.shutdown()
+        self.mgr.server_close()
+
+    def test_the_value_in_force_at_the_ack_governs_the_restart(self):
+        # The fake manager's port is installed only for the request window. The restore-after-ack
+        # is sequenced ON the ack itself: the wrapped _send writes the response, then flips the env
+        # to a dead port — in the handler's own thread, so the pre-fix read (which follows _send)
+        # ALWAYS sees the flipped value, and the post-fix read (which precedes it) never does.
+        os.environ["ROMP_MANAGER_PORT"] = str(self.mgr_port)
+        real_send = self._real_send
+
+        def send_then_restore(handler, *a, **kw):
+            r = real_send(handler, *a, **kw)
+            os.environ["ROMP_MANAGER_PORT"] = "1"   # the caller's `finally` restore, as an event
+            return r
+
+        km.Handler._send = send_then_restore
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/restart" % self.port,
+            data=json.dumps({"fleet": False}).encode(),
+            headers={"X-Romp-Token": km.TOKEN, "Content-Type": "application/json"},
+            method="POST")
+        with urllib.request.urlopen(req, timeout=10) as r:
+            self.assertTrue(json.loads(r.read()).get("restarting"))
+        # the manager hop runs after the ack — wait (bounded) for the handler thread to finish it
+        deadline = time.time() + 10
+        while not _RecordingManager.hits and time.time() < deadline:
+            time.sleep(0.01)
+        self.assertEqual(_RecordingManager.hits, ["/restart-all"],
+                         "the port resolved at the ack, not the restored one, takes the hop")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/romp-lab/lab.sh
+++ b/tools/romp-lab/lab.sh
@@ -15,6 +15,10 @@ echo "# a synthetic scratch project for the lab session" > "$LAB/project/README.
 
 export XDG_STATE_HOME="$LAB/state"
 unset ROMP_STATE_DIR || true
+# never the machine's real manager: an inherited ROMP_MANAGER_PORT would let the lab kernel
+# restart the live deployment. Poisoned to a dead port, not unset — absent maps to the DEFAULT
+# (live) port in the update path, so only a dead value is safe against every consumer.
+export ROMP_MANAGER_PORT=1
 # the SDK venv is PACKAGES, not state — symlink the machine's real one into the hermetic root so
 # lab sessions can actually run their CLI (without it every SDK session reports unable to start).
 # A symlink shares bytes only; nothing here writes into the venv.


### PR DESCRIPTION
## Summary

`POST /restart` acks the request and only afterwards reads `ROMP_MANAGER_PORT`: the read sits in `_restart_this_kernel`, on the handler thread after `_send` returns. A caller that sets the variable for the duration of the request (set, POST, restore in `finally`) races its restore against that read, so the restored value can be the one acted on. Commit 1 makes the HTTP handlers resolve the port before the ack, closing the class for every caller. Commit 2 floors the variable at a dead port for the whole test suite, because the suite is the caller that loses this race in practice.

## The incident

On a machine that self-hosts a live romp deployment, every shell under the manager tree inherits the live `ROMP_MANAGER_PORT`. `ServeSecurity.test_restart_endpoint_acks_post` pops the variable, POSTs `/restart`, and restores it after the ack. When the restore beat the handler's env read, the kernel under test relayed `/restart-all` to the real manager and the live deployment went down mid-suite, cutting every in-flight turn. One deployment restarted three times in one evening this way (2026-08-26/27, suite runs in a worktree without a guard); an equivalent incident with four firings predates it (2026-08-19).

## Commit 1: resolve the port at the ack

- The `/restart` handler reads `ROMP_MANAGER_PORT` once, before `_send`, and hands the value down: to `_restart_this_kernel` on the local branch and through `_fleet_restart_run` on the remote branch. `/update` does the same for `_run_main_update`'s daemon thread.
- Semantics for real callers are unchanged. Absent at ack time still means "no manager" in `_restart_this_kernel` and the default port in `_run_main_update`; non-HTTP callers (boot paths, auto-converge) still read the env at use time via the `_PORT_FROM_ENV` sentinel default.
- The new `tests/test_restart_port_at_ack.py` pins the ordering deterministically. A recording fake manager's port is installed only during the request, and the restore rides the ack itself: a wrapped `_send` flips the env to a dead port the moment the response is written, in the handler's own thread. Pre-fix, the post-ack read always sees the flipped value and the fake manager hears nothing (verified failing against the base commit); post-fix, the ack-time value governs. No sleep decides the outcome.
- Three test files pinned the old call text at source level and are updated to the new text in the same commit: `tests/test_fleet_restart.py` (the exact `_restart_this_kernel("http /restart (local-only)")` call, the `_fleet_restart_run` thread start, and a monkeypatch stub that needed the new keyword), `tests/test_main_drift_notice.py` (the `/update` thread start), and `tests/test_kernel_update.py` (a `_run_main_update` stub's signature). None of these pinned the race on purpose; they pinned literal call shapes the fix changes.
- `ServeSecurity.test_restart_endpoint_acks_post` needs no change and now passes deterministically: its pop is in force for the whole request window, so the ack-time read always sees "no manager".

## Commit 2: floor the suite on any machine

- `tests/conftest.py` writes `ROMP_MANAGER_PORT = "1"` at import time and re-asserts it from an autouse fixture. Two parts are needed because module-level env writes in test files execute during collection and then hold for the whole run phase, which would erase a bare import-time floor. The value is poisoned rather than popped because absent is the one unsafe state: `_restart_this_kernel` treats absent as "no manager", but `_run_main_update` maps absent to the default port, i.e. a live manager.
- `tests/test_restart_audit.py`'s module-level pop becomes the same dead-port write; the pop erased the floor at collection time.
- Rider: `tools/romp-lab/lab.sh` exports the same dead port next to its state-root rebinding, so its hermetic kernel cannot inherit a live manager port either. The script has no bats coverage today; the rider is one export in its existing idiom.

The two halves stand alone: the kernel fix protects every caller of the HTTP doors, and the floor keeps the suite safe on a machine running a live deployment even when the kernel under test predates the fix.

## Testing

- `tests/test_restart_port_at_ack.py`: fails against the base commit (the restored dead value wins and the fake manager records nothing), passes with the fix.
- Targeted: `test_restart_port_at_ack.py`, `test_restart_audit.py`, `test_fleet_restart.py`, `test_main_drift_notice.py`, `test_kernel_update.py`, `test_kernel.py::ServeSecurity` all pass.
- Full pytest suite with the floor in place: 5756 passed, 40 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)