### PR TITLE
The queued header counts only what is actually queued — popAll resolves, an overtaken echo says it was lost

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8411,9 +8411,34 @@ class TmuxBackend(sb.SessionBackend):
         return _tmux_echo_atoms(str(sid))
 
     def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
-        # human_floor is SDK-only: a tmux echo must SURVIVE a later turn to keep a dropped send visible, so it
-        # keeps the text/uuid-only prune (the SDK's FIFO-floor echo retirement doesn't apply here).
+        # The floor never PRUNES a plain tmux echo: it must SURVIVE a later turn to keep a dropped send
+        # visible, so retirement stays text/uuid-only. It does SETTLE it — an echo the transcript has
+        # overtaken is marked dropped (the "never delivered" treatment), which is what keeps a two-day-old
+        # loss from posing as a pending queued message (_tmux_echo_settle).
         _tmux_echo_prune(str(sid), tx_uuids, tx_user_texts)
+        _tmux_echo_settle(str(sid), human_floor)
+
+    def dismiss_echo(self, sid, uuid=None, t=None):
+        """Drop ONE settled echo on the user's ✕ (the chat's echodismiss), by synthetic uuid or send time.
+        Without this the "never delivered" bubble's dismiss button was a fake affordance on tmux — the
+        kernel's drive op is gated on hasattr(be, "dismiss_echo"), so the click acknowledged and the bubble
+        came straight back on the next push. Only a DROPPED echo is dismissible: an in-flight send is not
+        the user's to clear, and mirroring sdk_backend.dismiss_echo keeps one rule across both backends.
+        Matched exactly as sdk_backend.dismiss_echo matches — store key first, else the echo's send time,
+        as an OR so a client whose handle came from a different paint still lands. Returns the dismissed
+        text (idempotent: None when it's already gone)."""
+        d = _tmux_echo.get(str(sid))
+        if not d:
+            return None
+        for k, a in list(d.items()):
+            if not (a.get("_echo_text") and a.get("dropped")):
+                continue
+            if (uuid is not None and k == uuid) or (t is not None and int(a.get("t") or 0) == t):
+                d.pop(k, None)
+                if not d:
+                    _tmux_echo.pop(str(sid), None)
+                return a.get("_echo_text")
+        return None
 
     # ask picker — translate a webview action into pane keystrokes (AskDriver); current_ask SCRAPES the pane
     # (the SDK answers its own callback / reads its stored ask instead).
@@ -12588,12 +12613,31 @@ def _split_followup(text):
 
 
 def _pending_queued(path):
-    """Still-pending queued messages, folded FIFO from the transcript's queue-operation records
-    (type:"queue-operation"; operation enqueue/dequeue/remove; content on enqueue). enqueue appends; each
-    dequeue/remove resolves the oldest pending one; the unresolved genuine tail is what's still queued, in
-    submission order. Claude Code writes these the instant a message is queued (while busy/compacting), so
-    they show before reaching the turn DAG — the archive's foldQueue, event-based instead of pane-scraped
-    (the pane scrape mis-parsed a second queued message and dropped both — the user 2026-06-16)."""
+    """Still-pending queued messages, folded from the transcript's queue-operation records
+    (type:"queue-operation"; operation enqueue/dequeue/remove/popAll; content on enqueue, and usually on a
+    remove/popAll too). enqueue appends; a content-bearing `remove` discards exactly the entry carrying that
+    text (the CLI's removes are content-addressed single-item discards — measured live 2026-08-18, see
+    _undelivered_wake_tail, which resolves this same ledger for the idle-queue drive); a content-less remove
+    and every `dequeue` resolve the OLDEST pending entry; a `popAll` is the whole queue recalled at once, so
+    it clears everything pending. The unresolved genuine tail is what's still queued, in submission order.
+    Claude Code writes these the instant a message is queued (while busy/compacting), so they show before
+    reaching the turn DAG — the archive's foldQueue, event-based instead of pane-scraped (the pane scrape
+    mis-parsed a second queued message and dropped both — the user 2026-06-16).
+
+    popAll WAS UNHANDLED until 2026-08-26, and an unrecognized clear is no harmless no-op: its enqueues
+    stayed pending forever, so every later dequeue resolved an entry one slot too old and the newest
+    DELIVERED message sat in the chat as a queued bubble for good — a session showed a slash command it had
+    already finished running, and the same phantom held the queue-aware nudge gate (_backend_queued) shut.
+    Content-addressed removes land in the same pass for the same reason: the FIFO pairing is the fragile
+    part, and one missing or extra resolution shifts every later one (the failure that made the event model
+    drop this ledger for placement altogether — see event_model._absorbed).
+
+    One DELIBERATE divergence from _undelivered_wake_tail: a content-bearing remove naming text that isn't
+    pending here (this fold credits dequeues, so a dequeue may already have taken it) still resolves the
+    oldest, where the drive's reader resolves nothing. The two failure directions are not symmetric for a
+    DISPLAY — an unresolved entry is a bubble that never leaves, the bug this whole pass exists to end,
+    while an over-resolved one self-heals at the next record — and the case is vanishingly rare besides
+    (live corpus: one such remove in 305, and it is where a credited dequeue had already taken the entry)."""
     try:
         st = os.stat(path)
         key = (st.st_mtime, st.st_size)
@@ -12602,7 +12646,7 @@ def _pending_queued(path):
     hit = _queued_parse_cache.get(path)
     if hit is not None and key is not None and hit[0] == key:
         return hit[1]
-    texts, resolved = [], 0
+    pending = []
     try:
         with open(path, errors="replace") as f:
             for line in f:
@@ -12615,13 +12659,18 @@ def _pending_queued(path):
                 if o.get("type") != "queue-operation":
                     continue
                 op = o.get("operation")
+                content = o.get("content") if isinstance(o.get("content"), str) else None
                 if op == "enqueue":
-                    texts.append(o.get("content") if isinstance(o.get("content"), str) else "")
-                elif op in ("dequeue", "remove") and resolved < len(texts):
-                    resolved += 1                            # FIFO: this dequeue clears the oldest enqueue
+                    pending.append(content or "")
+                elif op == "popAll":                         # the whole queue recalled — nothing is left owed
+                    pending.clear()
+                elif op == "remove" and content is not None and content in pending:
+                    pending.remove(content)                  # that entry only; the rest keep their places
+                elif op in ("dequeue", "remove") and pending:
+                    del pending[0]                           # anonymous resolution: the oldest is the one taken
     except OSError:
         return []
-    out = [t.strip() for t in texts[resolved:] if _genuine_queued(t)]
+    out = [t.strip() for t in pending if _genuine_queued(t)]
     if key is not None:
         if len(_queued_parse_cache) > 256:                   # bounded by fleet size; never unbounded
             _queued_parse_cache.clear()
@@ -12679,7 +12728,10 @@ def _undelivered_wake_tail(path):
     CLI actually writes (measured live 2026-08-18 — the comment block above):
       * a `remove` carrying content discards exactly the entry with that text (the CLI's removes are
         content-addressed single-item discards, routinely of a NON-oldest entry while others stay
-        pending); a content-less remove discards the oldest, matching _pending_queued's FIFO fold;
+        pending); a content-less remove discards the oldest, matching _pending_queued's fold;
+      * a `popAll` discards EVERY pending entry — the whole queue withdrawn in one record, so none of it
+        is still owed a turn (unhandled until 2026-08-26: a recalled queue went on reading as undriven
+        signals indefinitely, one session holding twelve of them);
       * a `dequeue` alone clears NOTHING — the CLI's idle deliveries write no dequeue at all, and an
         agent notification's instant dequeue must not wipe an older undriven signal; the delivery
         evidence is the user record it produces;
@@ -12741,6 +12793,10 @@ def _undelivered_wake_tail(path):
                                 del tail[i]                  # the CLI's call on THAT entry only
                         elif tail:
                             del tail[0]                      # content-less: the oldest, as _pending_queued folds
+                    elif op == "popAll":                     # the whole queue recalled at once: every entry is
+                        tail.clear()                         # withdrawn, so nothing here is owed a turn any more
+                        #                                      (unhandled until 2026-08-26 — a recalled queue kept
+                        #                                      reading as undriven signals, one session holding 12)
                     #      a `dequeue` clears nothing — its delivery evidence is the user record it produces
                     continue
                 if not tail:
@@ -16448,6 +16504,60 @@ def _tmux_echo_prune(sid, tx_uuids, tx_texts):
         _tmux_echo.pop(sid, None)
 
 
+def _human_turn_floor(session):
+    """The newest GENUINE-HUMAN user atom's timestamp in the parsed session, or 0. The one event that says
+    "the transcript has moved past anything typed before this": read by the SDK's echo floor
+    (sdk_backend.prune_live), by the tmux echo's settle below, and by the queued fold.
+
+    EXCLUDES the interrupt record (the user 2026-07-07): it authors 'human' but is a STOP event, not a
+    message that landed and processed the echo. When a just-sent message hadn't hit disk yet, the
+    interrupt's timestamp floored past the echo and retired it — so an interrupted send that got a partial
+    reply then VANISHED on the next push. Mirrors _last_genuine_turn_t, which floors on genuine turns only."""
+    return max((a.get("t", 0) for turn in session["turns"] for a in turn["atoms"]
+                if a.get("type") == "user" and a.get("author") == "human"
+                and not em.is_interrupt_record(a)), default=0)
+
+
+def _echo_overtaken(atom, human_floor):
+    """True when the transcript has taken a genuine-human turn STRICTLY LATER than this echo's send — the
+    event that settles whether the send is still in flight. The pane is FIFO, so a message the CLI still
+    held could not be overtaken by one typed after it: past this point the echo is a LOSS, not a pending
+    message. Strictly later, never at-or-later, so a send landing in the same second as another turn keeps
+    the optimistic queued treatment (the no-flicker path the 2026-06-29 fold bought)."""
+    return bool(atom.get("_echo_text")) and bool(human_floor) and human_floor > atom.get("t", 0)
+
+
+def _tmux_echo_settle(sid, human_floor):
+    """Mark every overtaken tmux echo `dropped`, so the chat draws the shipped "never delivered" treatment
+    (dashed bubble + restore/dismiss, renderQueued's sibling) instead of an ordinary sent bubble, and the
+    queued fold stops enlisting it as a pending message (the user 2026-08-26: a session's queued header
+    counted sends from two days earlier, which it had long since answered — one of them genuinely lost at
+    the pane, two delivered under text the transcript recorded differently, all three indistinguishable
+    from a message actually waiting in the CLI's queue).
+
+    Marking, NOT pruning: a tmux echo is the only record of a send the pane dropped, and that loss must
+    stay on screen — the whole reason the echo outlives a later turn (see TmuxBackend.prune_live). The one
+    exception mirrors the SDK's own floor: a PATH-BEARING echo can fail the text match STRUCTURALLY,
+    because the transcript extracts image paths out of the user text, so that flavor is retired the way
+    sdk_backend.prune_live retires it rather than labelled a loss it may not be. With the SDK module
+    unavailable the predicate is simply unavailable too, and marking (the visible, reversible outcome)
+    covers every echo."""
+    d = _tmux_echo.get(sid)
+    if not d:
+        return
+    path_bearing = getattr(sys.modules.get("romp_sdk_backend"), "_path_bearing", None)
+    for k in list(d.keys()):
+        a = d[k]
+        if not _echo_overtaken(a, human_floor):
+            continue
+        if path_bearing is not None and path_bearing(a.get("_echo_text") or ""):
+            d.pop(k, None)
+        else:
+            a["dropped"] = True
+    if not d:
+        _tmux_echo.pop(sid, None)
+
+
 def _sendvis_diag(sid):
     """Send-visibility snapshot for /diag/sendvis (the user 2026-07-20): the exact inputs the chat build
     consults to render an in-flight send. When a sent message is invisible, this names the layer that
@@ -16477,7 +16587,10 @@ def _sendvis_diag(sid):
                             for a in (be.live_atoms(sid) if be else [])]
     except Exception as e:
         out["liveAtoms"] = "error: %s" % e
-    out["tmuxEchoes"] = [{"t": a.get("t"), "echo": (a.get("_echo_text") or "")[:120]}
+    # `dropped` is the whole diagnosis for a stale echo (the user 2026-08-26): without it a settled loss and
+    # a genuinely in-flight send read identically here, which is how three days-old echoes went unexplained.
+    out["tmuxEchoes"] = [{"t": a.get("t"), "echo": (a.get("_echo_text") or "")[:120],
+                          "dropped": bool(a.get("dropped"))}
                          for a in _tmux_echo_atoms(sid)]
     try:
         out["compacting"] = bool(_compacting_now(sid))
@@ -16521,17 +16634,7 @@ def _merge_live_atoms(session, sid, shown_texts=()):
                        and _atom_prose_chars(a) > 0}
     tx_uuids -= (live_text_uuids - tx_text_uuids)
     tx_texts = {t for turn in session["turns"] for a in turn["atoms"] for t in _atom_user_texts(a)}
-    # FIFO floor: the newest GENUINE-HUMAN turn the transcript has — retires an input echo whose text can't
-    # match because the transcript extracted an image path out of it (screenshots piling up at the bottom, the
-    # user 2026-06-25). SDK-only semantics: TmuxBackend.prune_live IGNORES the floor, since a tmux echo must
-    # SURVIVE a later turn to keep a dropped send visible (it keeps the text/uuid-only prune).
-    # EXCLUDE the interrupt record (the user 2026-07-07): it authors 'human' but is a STOP event, not a message
-    # that landed and processed the echo. When a just-sent message hadn't hit disk yet, the interrupt's
-    # timestamp floored past the echo and retired it — so an interrupted send that got a partial reply then
-    # VANISHED on the next push. Mirror _last_genuine_turn_t, which floors on genuine turns only.
-    human_floor = max((a.get("t", 0) for turn in session["turns"] for a in turn["atoms"]
-                       if a.get("type") == "user" and a.get("author") == "human"
-                       and not em.is_interrupt_record(a)), default=0)
+    human_floor = _human_turn_floor(session)
     be.prune_live(sid, tx_uuids, tx_texts, human_floor)
     hide = tx_texts | {t.strip() for t in shown_texts if t}    # transcript dups + already-shown queued msgs
     fresh = [a for a in live if a.get("uuid") not in tx_uuids
@@ -16874,12 +16977,19 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     compacting_now = (False if path_override else
                       _compacting(sid, (tm0 or {}).get("state", ""), parsed, now, (tm0 or {}).get("since")))
     busy = not path_override and (_session_working(parsed["turns"]) or compacting_now)
+    # The fold takes only echoes STILL IN FLIGHT — one the transcript has already overtaken with a later
+    # genuine-human turn is a loss, not a pending message, and enlisting it here was how sends from days
+    # earlier kept inflating the queued header on a busy session (the user 2026-08-26). _echo_overtaken is
+    # the same event TmuxBackend.prune_live settles them on, read directly rather than off the `dropped`
+    # mark, since the mark is written by the merge BELOW this fold (one build later would be one build of
+    # phantom).
     if not hasattr(be, "unqueue") and busy:
         already = {q.strip() for q in queued}
         tx_user = {t for turn in parsed["turns"] for a in turn["atoms"] for t in _atom_user_texts(a)}
+        echo_floor = _human_turn_floor(parsed)
         for a in be.live_atoms(sid):
             et = (a.get("_echo_text") or "").strip()
-            if et and et not in already and et not in tx_user:
+            if et and et not in already and et not in tx_user and not _echo_overtaken(a, echo_floor):
                 queued = queued + [et]; already.add(et)
     session = parsed if path_override else _merge_live_atoms(parsed, sid, shown_texts=queued)
     caps = _captions(sid)

--- a/tests/test_idle_queue_drive.py
+++ b/tests/test_idle_queue_drive.py
@@ -121,7 +121,10 @@ def _backlog(count=3, minute0=14):
 
 class WakeTail(unittest.TestCase):
     """kernel._undelivered_wake_tail — the trailing unconsumed enqueues, from the transcript's own
-    queue-operation records (the authoritative queue; the display fold _pending_queued is untouched)."""
+    queue-operation records (the authoritative queue). The display fold _pending_queued is a SEPARATE
+    reader with its own semantics — it credits a dequeue, which this one deliberately does not — and the
+    two agree only on the record kinds whose meaning is unambiguous: a content-addressed remove, a
+    content-less remove taking the oldest, and popAll withdrawing everything."""
 
     def setUp(self):
         self.dir = tempfile.mkdtemp()
@@ -157,6 +160,21 @@ class WakeTail(unittest.TestCase):
                                            _qop("enqueue", _wrap(1), ts=TS % (15, 0)), _qop("remove")])
         self.assertEqual([e["text"] for e in entries], [_wrap(1)],
                          "no content → FIFO, exactly as _pending_queued folds the same records")
+
+    def test_popAll_withdraws_the_whole_tail(self):
+        # popAll — the whole queue recalled in one record — was unhandled here too (the user 2026-08-26),
+        # so a recalled backlog went on reading as signals still owed a turn and kept the session a drive
+        # candidate indefinitely (one live session was holding twelve).
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap(0)),
+                                              _qop("enqueue", _wrap(1), ts=TS % (15, 0)),
+                                              _qop("popAll", _wrap(0))])
+        self.assertEqual((entries, mark), ([], None), "a withdrawn queue owes no turn")
+
+    def test_an_enqueue_after_popAll_is_still_owed_a_turn(self):
+        entries, mark = self._tail(_turn() + [_qop("enqueue", _wrap(0)), _qop("popAll", _wrap(0)),
+                                              _qop("enqueue", _wrap(1), ts=TS % (15, 0))])
+        self.assertEqual([e["text"] for e in entries], [_wrap(1)], "the recall clears only what preceded it")
+        self.assertIsNotNone(mark)
 
     def test_a_remove_matching_nothing_drops_nothing(self):
         entries, _ = self._tail(_turn() + [_qop("enqueue", _wrap(0)), _qop("remove", _wrap(7))])

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1096,6 +1096,31 @@ class ViewBuilder(unittest.TestCase):
         sent = [e for e in events if e["kind"] == "user" and e.get("md") == "and also fix the header"]
         self.assertEqual(sent, [], "it must NOT also show as a sent (solid) user bubble — that was the flip")
 
+    def test_tmux_echo_the_transcript_OVERTOOK_is_not_counted_as_queued(self):
+        # The reported bug (the user 2026-08-26): a busy session's queued header counted sends from DAYS
+        # earlier — echoes whose text never landed verbatim (one lost at the pane, two delivered under text
+        # the transcript recorded differently), sitting in _tmux_echo forever and folded in as "queued" on
+        # every push. The pane is FIFO, so a genuine-human turn landing AFTER a send settles it: that send
+        # is a loss, not a pending message. It stays VISIBLE (the whole point of the tmux echo) but as the
+        # "never delivered" treatment, which carries a ✕ — never as one of N queued messages.
+        with self.tpath.open("a") as f:                  # an OPEN turn → the session reads busy
+            f.write(json.dumps(uline(NOW, "keep working on the strip", "uOpen", parent="a2")) + "\n")
+        km._parse_cache.clear()
+        km._tmux_echo.pop(SID, None)
+        stale = "does the notes-api build still fail"
+        km._tmux_echo_add(SID, stale)
+        for echo_atom in km._tmux_echo[SID].values():
+            echo_atom["t"] = NOW - 3600                  # typed before the turn the transcript has since taken
+        try:
+            events = km.build_session(SID, NOW)["events"]
+        finally:
+            km._tmux_echo.pop(SID, None)
+        qmsgs = [m["md"] for e in events if e["kind"] == "queued" for m in e["texts"]]
+        self.assertNotIn(stale, qmsgs, "an overtaken send is a loss, not a message waiting in the queue")
+        lost = [e for e in events if e["kind"] == "user" and e.get("md") == stale]
+        self.assertEqual(len(lost), 1, "it stays on screen — the loss must not vanish silently")
+        self.assertTrue(lost[0].get("undelivered"), "and reads as never delivered, with the dismiss affordance")
+
     def test_tmux_send_while_IDLE_echoes_as_a_sent_bubble_not_queued(self):
         # the gate: when the session is IDLE (default fixture ends on an ended turn), the SAME echo is a
         # genuine sent message — it shows as a solid user bubble, never the dotted queued indicator.
@@ -6196,6 +6221,44 @@ class TestPendingQueued(unittest.TestCase):
         self._write(("enqueue", "first"), ("enqueue", "second"), ("remove",), ("remove",))
         self.assertEqual(km._pending_queued(self.p), [], "remove drains like dequeue")
 
+    def test_popAll_clears_the_whole_queue(self):
+        # The phantom (the user 2026-08-26): popAll — the CLI's record for the whole queue being recalled
+        # at once — was UNHANDLED, so its enqueues stayed pending forever. Nothing here is still owed.
+        self._write(("enqueue", "first"), ("enqueue", "second"), ("popAll", "first"))
+        self.assertEqual(km._pending_queued(self.p), [], "a recalled queue owes nothing")
+
+    def test_popAll_does_not_shift_later_resolutions(self):
+        # The DAMAGE the unhandled op did, and the actual bug reported: with popAll ignored, its two
+        # enqueues stayed on the pending list, so the dequeue below resolved one of THEM instead of the
+        # message it actually delivered — leaving the delivered one on screen as a queued bubble for good.
+        self._write(("enqueue", "recalled one"), ("enqueue", "recalled two"), ("popAll", "recalled one"),
+                    ("enqueue", "typed after the recall"), ("dequeue",))
+        self.assertEqual(km._pending_queued(self.p), [],
+                         "the dequeue resolves the message that followed the recall, not a recalled one")
+
+    def test_enqueue_after_popAll_is_still_pending(self):
+        # the other direction: a recall clears what was queued THEN, never what arrives after it
+        self._write(("enqueue", "recalled"), ("popAll", "recalled"), ("enqueue", "still waiting"))
+        self.assertEqual(km._pending_queued(self.p), ["still waiting"])
+
+    def test_remove_with_content_takes_that_entry_not_the_oldest(self):
+        # The CLI's removes are content-addressed single-item discards, routinely of a NON-oldest entry
+        # (measured live 2026-08-18 — _undelivered_wake_tail resolves the same ledger this way). Folding
+        # one as "the oldest went" mispairs every later resolution, which is the same class of drift popAll
+        # caused: the survivor shown is not the message still waiting.
+        self._write(("enqueue", "first"), ("enqueue", "second"), ("enqueue", "third"),
+                    ("remove", "second"))
+        self.assertEqual(km._pending_queued(self.p), ["first", "third"])
+
+    def test_a_content_remove_naming_nothing_pending_still_resolves_the_oldest(self):
+        # The deliberate split from _undelivered_wake_tail, which resolves nothing here. This fold credits
+        # dequeues, so a dequeue may already have taken the named entry — and for a DISPLAY the two errors
+        # are not symmetric: an unresolved entry is a bubble that never leaves (the reported bug), while an
+        # over-resolved one self-heals at the next record.
+        self._write(("enqueue", "first"), ("enqueue", "second"), ("dequeue",), ("remove", "first"))
+        self.assertEqual(km._pending_queued(self.p), [],
+                         "the CLI resolved something; the display must not strand the survivor")
+
     def test_drops_postal_and_harness_injections(self):
         # romp delivers a peer message by ENQUEUEing it (carries romp-msg-id / 📬 / a #### banner); those
         # must not masquerade as the user's pending input — only the genuine typed message remains.
@@ -7152,6 +7215,91 @@ class TmuxInputEcho(unittest.TestCase):
         merged = km._merge_live_atoms(self._session([]), SID, shown_texts=["padded message"])
         texts = [km._atom_user_text(a) for a in merged["turns"][-1]["atoms"]]
         self.assertNotIn("padded message", texts, "stripped-text match suppresses the echo against the queued bubble")
+
+
+class TmuxEchoSettledByALaterTurn(unittest.TestCase):
+    """A tmux echo the transcript has OVERTAKEN (the user 2026-08-26). The echo outlives a later turn on
+    purpose — that is how a send the pane dropped stays visible — but "still visible" had come to mean
+    "still posing as pending": days-old echoes were folded into the queued indicator on every busy push,
+    and off it they drew as ordinary sent bubbles with no way to clear them. The settling EVENT is a
+    genuine-human turn landing strictly later than the send: the pane is FIFO, so nothing typed after a
+    message the CLI still held could overtake it. Past that, the echo is marked dropped — the shipped
+    "never delivered" treatment, restore + dismiss — and never pruned out from under the user. Synthetic
+    only; the SDK's own floor semantics live in test_sdk_echo_durability.py."""
+
+    LANDED_AT = T0 + 500
+    SENT_BEFORE = T0 + 100          # overtaken: the transcript took a human turn after this
+    SENT_AFTER = T0 + 900           # still in flight: nothing has overtaken it
+
+    def setUp(self):
+        self._saved_sdk = km._sdk
+        km._sdk = lambda: None                 # tmux path: no SDK backend owns the sid
+        km._tmux_echo.clear()
+
+    def tearDown(self):
+        km._sdk = self._saved_sdk
+        km._tmux_echo.clear()
+
+    def _session_with_landed_human_turn(self):
+        return {"turns": [{"id": "t", "trigger": None, "t": T0, "end": T0, "ended": True,
+                           "atoms": [{"type": "user", "uuid": "real-1", "author": "human",
+                                      "t": self.LANDED_AT,
+                                      "message": {"role": "user",
+                                                  "content": [{"type": "text", "text": "a later ask"}]}}]}]}
+
+    def _echo_at(self, text, sent_at):
+        km._tmux_echo_add(SID, text)
+        for echo_atom in km._tmux_echo[SID].values():
+            if echo_atom.get("_echo_text") == text:
+                echo_atom["t"] = sent_at
+                return echo_atom
+        raise AssertionError("the echo was not stored")
+
+    def test_overtaken_echo_is_MARKED_dropped_and_kept_visible(self):
+        echo_atom = self._echo_at("this one never made it in", self.SENT_BEFORE)
+        km._merge_live_atoms(self._session_with_landed_human_turn(), SID)
+        self.assertTrue(echo_atom.get("dropped"), "an overtaken send reads as the loss it is")
+        self.assertIn(SID, km._tmux_echo, "marked, never pruned — the only copy of the text is in here")
+
+    def test_in_flight_echo_is_left_untouched(self):
+        echo_atom = self._echo_at("just typed, still going out", self.SENT_AFTER)
+        km._merge_live_atoms(self._session_with_landed_human_turn(), SID)
+        self.assertFalse(echo_atom.get("dropped"), "nothing has overtaken it — it is still in flight")
+
+    def test_a_send_in_the_SAME_second_as_a_landed_turn_stays_in_flight(self):
+        # Strictly later, never at-or-later: the equality case is a send racing the turn that happens to
+        # share its second, and treating that as overtaken would put the 2026-06-29 solid-then-dotted
+        # flicker back for it.
+        echo_atom = self._echo_at("same second as the turn", self.LANDED_AT)
+        km._merge_live_atoms(self._session_with_landed_human_turn(), SID)
+        self.assertFalse(echo_atom.get("dropped"))
+
+    def test_an_interrupt_record_does_not_settle_an_echo(self):
+        # _human_turn_floor excludes the interrupt record (the user 2026-07-07): it authors human but is a
+        # STOP event, not a message that landed and processed the send.
+        session = self._session_with_landed_human_turn()
+        session["turns"][0]["atoms"] = [
+            {"type": "user", "uuid": "int-1", "author": "human", "t": self.LANDED_AT,
+             "message": {"role": "user", "content": [{"type": "text",
+                                                      "text": "[Request interrupted by user]"}]}}]
+        echo_atom = self._echo_at("sent just before the stop", self.SENT_BEFORE)
+        km._merge_live_atoms(session, SID)
+        self.assertFalse(echo_atom.get("dropped"), "a stop is not a delivered turn")
+
+    def test_dismiss_echo_clears_a_settled_one_and_refuses_an_in_flight_one(self):
+        # Without a tmux dismiss_echo the ✕ on the "never delivered" bubble was a fake affordance: the
+        # kernel's drive op is gated on hasattr(be, "dismiss_echo"), so the click acknowledged and the
+        # bubble returned on the next push.
+        backend = km.TmuxBackend()
+        in_flight = self._echo_at("still going out", self.SENT_AFTER)
+        settled = self._echo_at("gone for good", self.SENT_BEFORE)
+        km._merge_live_atoms(self._session_with_landed_human_turn(), SID)
+        self.assertIsNone(backend.dismiss_echo(SID, uuid=in_flight["uuid"]),
+                          "an in-flight send is not the user's to clear")
+        self.assertEqual(backend.dismiss_echo(SID, uuid=settled["uuid"]), "gone for good")
+        self.assertIsNone(backend.dismiss_echo(SID, uuid=settled["uuid"]), "idempotent: a miss is a no-op")
+        remaining = [a.get("_echo_text") for a in km._tmux_echo_atoms(SID)]
+        self.assertEqual(remaining, ["still going out"], "only the dismissed one goes")
 
 
 class TestCloserSettledGate(unittest.TestCase):

--- a/tests/test_kernel_sendvis_diag.py
+++ b/tests/test_kernel_sendvis_diag.py
@@ -58,6 +58,22 @@ class SendVisDiag(unittest.TestCase):
         self.assertIn("compacting", out)
         self.assertIn("tmuxEchoes", out)
 
+    def test_a_tmux_echo_row_says_whether_it_is_settled(self):
+        # A settled loss and an in-flight send read identically here until `dropped` was carried (the user
+        # 2026-08-26): the diagnostic's job is naming the layer, and "which of these is still going out"
+        # was the exact question it could not answer.
+        km._tmux_echo.clear()
+        km._tmux_echo_add(SID, "sent and still going out")
+        km._tmux_echo_add(SID, "overtaken, never delivered")
+        try:
+            for echo_atom in km._tmux_echo[SID].values():
+                if echo_atom["_echo_text"].startswith("overtaken"):
+                    echo_atom["dropped"] = True
+            rows = {r["echo"]: r["dropped"] for r in km._sendvis_diag(SID)["tmuxEchoes"]}
+        finally:
+            km._tmux_echo.clear()
+        self.assertEqual(rows, {"sent and still going out": False, "overtaken, never delivered": True})
+
     def test_route_is_wired_and_read_only(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('if p == "/diag/sendvis":', src)


### PR DESCRIPTION
Three separate ways a delivered or lost message kept reading as "queued", all visible at once on one session's header: four items, of which one had already run and three were sends from days earlier.

## What was wrong

- **`_pending_queued` ignored `popAll`.** Its enqueues stayed pending, so every later `dequeue` resolved an entry one slot too old and the newest *delivered* message sat in the chat as a queued bubble for good — holding the queue-aware nudge gate (`_backend_queued`) shut with it. Live corpus: 11 `popAll` records, 5 sessions each stuck with one phantom; handling the op clears all 5 and hides nothing new.
- **`_undelivered_wake_tail` ignored it too**, so the idle-queue drive read a recalled backlog as signals still owed a turn (one session was holding twelve).
- **The busy-session echo fold enlisted any unlanded tmux echo, with no bound.** An echo the transcript has overtaken with a later genuine-human turn cannot still be waiting in a FIFO pane — it is a loss. It now settles as `dropped`, which draws the already-shipped "never delivered" treatment instead of an ordinary sent bubble.

## Changes

- `_pending_queued`: `popAll` clears the queue; a content-bearing `remove` discards that entry (the rule `_undelivered_wake_tail` measured live 2026-08-18) instead of shifting the FIFO. The one deliberate divergence between the two readers — an unmatched content-remove still resolves the oldest here, because for a *display* a stranded bubble is the worse error — is documented at both ends.
- `_undelivered_wake_tail`: `popAll` withdraws the tail.
- `_human_turn_floor` extracted from `_merge_live_atoms`, so the SDK floor, the tmux echo's settle and the queued fold read one rule. `_echo_overtaken` is strictly-later, never at-or-later, so a send sharing a second with a landed turn keeps the no-flicker queued treatment.
- `TmuxBackend.dismiss_echo`: the ✕ on a never-delivered bubble was posting into a `hasattr(be, "dismiss_echo")` gate only the SDK satisfied, so the click came undone on the next push. Matching mirrors `sdk_backend.dismiss_echo`.
- `/diag/sendvis` reports each tmux echo's `dropped` — the question it could not answer while this was being diagnosed.

## Tests

New coverage in `tests/test_kernel.py` (`TestPendingQueued`, `TmuxEchoSettledByALaterTurn`, one `ViewBuilder` case), `tests/test_idle_queue_drive.py` and `tests/test_kernel_sendvis_diag.py`: `popAll` clears / does not shift later resolutions / spares what follows it; content-addressed remove; overtaken echo marked but never pruned; in-flight and same-second echoes untouched; an interrupt record does not settle an echo; dismiss clears a settled echo and refuses an in-flight one. All synthetic.

Replaces #731, which was branched off a fork branch and carried unrelated commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)