### PR TITLE
The clear before a pane paste actually clears — Ctrl+A never selected, so every send onto a held input was concatenated

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12058,28 +12058,52 @@ def _clear_pane_input(name):
     prompt the user never wrote. Ctrl+U measurably empties the box (the killed text stays in the CLI's own
     kill ring — Ctrl+Y — so this destroys nothing the human cannot get back).
 
-    Verified EVENT-BASED per press (the box text changing), never a fixed sleep; an empty box costs one
+    Verified EVENT-BASED per press (the box REGION changing), never a fixed sleep; an empty box costs one
     capture and zero keystrokes, so the ordinary send is cheaper than it was before. False when the box
     cannot be READ at all (no locatable prompt box) — the caller must not paste on a maybe — and false
-    once presses stop moving the box, which is the shape the Ctrl+A regression itself had."""
+    once presses stop moving the box, which is the shape the Ctrl+A regression itself had.
+
+    The change detector compares the RAW box region (lines, count included), never the stripped text: a
+    press that pops an emptied or blank LINE moves the region but not the text, so the stripped compare
+    read two structural pops in a row — any draft holding a blank line — as a dead binding and refused a
+    perfectly clearable box (PR-741 review, 2026-08-27). Raw-region compares also return the instant a
+    pop lands instead of burning the full wait on an 'unchanged' press, so a multi-line clear is fast
+    again."""
     if not name:
         return False
     unchanged = 0
     for _ in range(_CLEAR_KILL_PRESSES):
         cap = _TMUX.capture(name, colour=True)
-        if _box_region(cap) is None:
+        region = _box_region(cap)
+        if region is None:
             return False                                            # can't see the box → can't claim it's clear
-        held = _box_text(cap)
-        if not held:
+        if not _box_text(cap):
             return True
+        held = list(region)
         _TMUX.send_keys(name, "C-u")
-        if _deliver_wait(lambda: _box_text(_TMUX.capture(name, colour=True)) != held, 1.0):
+        if _deliver_wait(lambda: _box_region(_TMUX.capture(name, colour=True)) != held, 1.0):
             unchanged = 0
         else:
             unchanged += 1
             if unchanged >= _CLEAR_UNCHANGED_GIVE_UP:
                 return False
     return False
+
+
+# One lock per pane serializing the read-decide-keystroke sequences: _interrupt's post-Esc wipe and
+# _tmux_send's clear+paste+Enter ran as unserialized daemon threads on the same pane, so an interrupt's
+# kill loop still draining a restored prompt could read a send's JUST-PASTED message as leftover and
+# C-u it away inside the pre-Enter gap — Enter then submitted an empty box (PR-741 review, 2026-08-27:
+# Stop, then Send within the drain window). Whichever sequence acquires second now rules on the pane's
+# true state instead of a snapshot the other thread is mid-way through changing. Never pruned — a lock
+# is a few bytes and the key space is the live session list.
+_pane_io_locks = {}
+_pane_io_locks_guard = threading.Lock()
+
+
+def _pane_io_lock(name):
+    with _pane_io_locks_guard:
+        return _pane_io_locks.setdefault(str(name), threading.Lock())
 
 
 def _interrupt(name, _async=True):
@@ -12091,11 +12115,14 @@ def _interrupt(name, _async=True):
         return
 
     def go():
+        # Esc itself rides OUTSIDE the pane lock: stopping the turn must not wait behind a send mid-paste
+        # (the user's Stop is the higher-priority gesture), and the restore beat gives the lock a window.
         _TMUX.send_keys(name, "Escape")
         time.sleep(0.15)                              # let Claude Code restore the recalled prompt before we wipe it
-        if not _clear_pane_input(name):               # loud, but nothing is pasted here — the next send's own
-            #                                           guard is what refuses to concatenate onto the leftover
-            sys.stderr.write("interrupt: %s still holds the recalled prompt after the input clear\n" % name)
+        with _pane_io_lock(name):
+            if not _clear_pane_input(name):           # loud, but nothing is pasted here — the next send's own
+                #                                       guard is what refuses to concatenate onto the leftover
+                sys.stderr.write("interrupt: %s still holds the recalled prompt after the input clear\n" % name)
     threading.Thread(target=go, daemon=True).start() if _async else go()
 
 
@@ -12295,6 +12322,10 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
         return
 
     def go():
+      # The whole clear→paste→Enter sequence holds the pane lock: an interrupt's kill loop running beside
+      # it read the just-pasted message as leftover and C-u'd it away in the pre-Enter gap, so Enter
+      # submitted an empty box (PR-741 review, 2026-08-27). Under the lock the paste cannot be sniped.
+      with _pane_io_lock(name):
         if _TMUX.pane_in_mode(name):
             _TMUX.send_keys(name, "-X", "cancel", t=2)              # exit copy-mode so paste+Enter land
         # Leftover in the box (an interrupt-restored prompt, or text typed straight into the terminal) must

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12031,18 +12031,55 @@ def _picker_check(sid):
         time.sleep(0.5)
 
 
+# Ctrl+U kills ONE line of the CLI's input box, and a multi-line box takes TWO presses per line (the text,
+# then the emptied line itself), so the clear below presses until the box READS empty. Bounded so a box that
+# will not empty — a keystroke the pane never applies, a CLI that stopped honoring the binding — ends as a
+# refusal instead of a spin: 40 presses covers a 20-line draft, far past anything typed at a prompt.
+_CLEAR_KILL_PRESSES = 40
+# …and the outer bound is not the one that normally fires. A press that moves nothing means the binding
+# isn't landing, and pressing on cannot fix that — so two consecutive no-change presses end it. Two, not
+# one, because a single slow repaint is not evidence of a dead binding.
+_CLEAR_UNCHANGED_GIVE_UP = 2
+
+
 def _clear_pane_input(name):
-    """Select-all + delete the pane's input box. The romp composer and the tmux pane must agree on the
-    input: when a turn is INTERRUPTED (Esc), Claude Code RESTORES the in-progress prompt into the input —
-    invisible to the web composer — and our inject pastes by APPENDING, so Stop → type-and-send in the
-    composer concatenated the recalled prompt and the new message into ONE submission (the user
-    2026-06-19). Clearing first makes a paste REPLACE, never append. Ctrl+A selects the whole (possibly
-    multi-line) input in Claude Code >=2.1.18, Backspace deletes the selection — and BOTH are NO-OPS on an
-    already-empty input, so this is safe to send unconditionally before every paste (no regression to the
-    normal empty-input send)."""
+    """Empty the pane's input box, returning True ONLY when it is provably empty. The romp composer and the
+    tmux pane must agree on the input: when a turn is INTERRUPTED (Esc), Claude Code RESTORES the in-progress
+    prompt into the input — invisible to the web composer — and a paste APPENDS, so Stop → type-and-send in
+    the composer concatenated the recalled prompt and the new message into ONE submission (the user
+    2026-06-19). Clearing first makes a paste REPLACE, never append.
+
+    This used to send Ctrl+A + Backspace, on the understanding that Ctrl+A selects the whole input and
+    Backspace deletes the selection. Measured against Claude Code 2.1.223 (a scratch CLI in tmux, 2026-08-26)
+    that is NOT what happens: Ctrl+A does not select, and the Backspace deletes exactly ONE character — so
+    for two months the clear was a silent no-op on any non-empty input, and every composer send into a pane
+    holding text was concatenated onto it. The damage is worse than a cosmetic one: the joined submission
+    carries BOTH texts, so the delivered message never matches what romp echoed, and the CLI answers a
+    prompt the user never wrote. Ctrl+U measurably empties the box (the killed text stays in the CLI's own
+    kill ring — Ctrl+Y — so this destroys nothing the human cannot get back).
+
+    Verified EVENT-BASED per press (the box text changing), never a fixed sleep; an empty box costs one
+    capture and zero keystrokes, so the ordinary send is cheaper than it was before. False when the box
+    cannot be READ at all (no locatable prompt box) — the caller must not paste on a maybe — and false
+    once presses stop moving the box, which is the shape the Ctrl+A regression itself had."""
     if not name:
-        return
-    _TMUX.send_keys(name, "C-a", "BSpace")
+        return False
+    unchanged = 0
+    for _ in range(_CLEAR_KILL_PRESSES):
+        cap = _TMUX.capture(name, colour=True)
+        if _box_region(cap) is None:
+            return False                                            # can't see the box → can't claim it's clear
+        held = _box_text(cap)
+        if not held:
+            return True
+        _TMUX.send_keys(name, "C-u")
+        if _deliver_wait(lambda: _box_text(_TMUX.capture(name, colour=True)) != held, 1.0):
+            unchanged = 0
+        else:
+            unchanged += 1
+            if unchanged >= _CLEAR_UNCHANGED_GIVE_UP:
+                return False
+    return False
 
 
 def _interrupt(name, _async=True):
@@ -12056,7 +12093,9 @@ def _interrupt(name, _async=True):
     def go():
         _TMUX.send_keys(name, "Escape")
         time.sleep(0.15)                              # let Claude Code restore the recalled prompt before we wipe it
-        _clear_pane_input(name)
+        if not _clear_pane_input(name):               # loud, but nothing is pasted here — the next send's own
+            #                                           guard is what refuses to concatenate onto the leftover
+            sys.stderr.write("interrupt: %s still holds the recalled prompt after the input clear\n" % name)
     threading.Thread(target=go, daemon=True).start() if _async else go()
 
 
@@ -12258,8 +12297,15 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
     def go():
         if _TMUX.pane_in_mode(name):
             _TMUX.send_keys(name, "-X", "cancel", t=2)              # exit copy-mode so paste+Enter land
-        _clear_pane_input(name)                                     # wipe any leftover (e.g. an interrupt-restored prompt) so the paste REPLACES, never appends
-        time.sleep(0.05)                                            # let the clear land before the paste
+        # Leftover in the box (an interrupt-restored prompt, or text typed straight into the terminal) must
+        # be GONE before the paste, which appends. Pasting anyway is not a lesser evil: the CLI receives the
+        # two texts joined, answers a prompt nobody wrote, and the delivered text no longer matches romp's
+        # echo — which is then indistinguishable from a lost send. So a clear that cannot finish REFUSES the
+        # send, loudly; the echo stays on screen and settles as never-delivered, which is the truth.
+        if not _clear_pane_input(name):
+            sys.stderr.write("tmux send: %s holds input that would not clear — NOT pasting, the message "
+                             "would have been concatenated onto it\n" % name)
+            return
         _TMUX.set_buffer(text)
         _TMUX.paste_buffer(name)                                    # bracketed (-p), delete buf (-d)
         paths = _injected_img_paths(text)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6264,8 +6264,13 @@ class CompactSessionRoute(unittest.TestCase):
 class TmuxInject(unittest.TestCase):
     def test_tmux_send_sequence(self):
         calls = []
+        # An EMPTY prompt box (the box sits between the last two ─── rules): the send's clear reads it,
+        # finds nothing to kill, and goes straight to the paste. A capture the send cannot PARSE is a
+        # refusal now, so the fake has to answer like a real pane rather than with a bare "".
+        empty_box = "\n".join(["  an earlier reply", "─" * 40, km.PROMPT_GLYPH + " ", "─" * 40])
         real_run, real_sleep = km.subprocess.run, km.time.sleep
-        km.subprocess.run = lambda args, **k: calls.append(list(args)) or type("R", (), {"stdout": ""})()
+        km.subprocess.run = lambda args, **k: calls.append(list(args)) or type(
+            "R", (), {"stdout": empty_box if args[:2] == ["tmux", "capture-pane"] else "", "returncode": 0})()
         km.time.sleep = lambda s: None
         try:
             km._tmux_send("mysess", "hello world", _async=False)

--- a/tests/test_kernel_inject.py
+++ b/tests/test_kernel_inject.py
@@ -25,16 +25,40 @@ km = SourceFileLoader("romp_kernel_inj", os.path.join(BIN, "romp-kernel")).load_
 
 
 class _Res:
-    def __init__(self, stdout=""):
+    def __init__(self, stdout="", returncode=0):
         self.stdout = stdout
+        self.returncode = returncode
+
+
+RULE = "─" * 40
+
+
+def _pane(box_lines):
+    """A capture shaped like the CLI's — the input box sits between the last two ─── rules."""
+    first, rest = (box_lines[0], box_lines[1:]) if box_lines else ("", [])
+    return "\n".join(["  an earlier reply", RULE, km.PROMPT_GLYPH + " " + first]
+                     + ["  " + line for line in rest] + [RULE])
 
 
 class Inject(unittest.TestCase):
+    """The fake tmux models the ONE pane behavior these paths depend on: Ctrl+U kills the last input line
+    (its text first, then the emptied line), which is what a live Claude Code 2.1.223 does. The clear used
+    to be Ctrl+A + Backspace on the belief that Ctrl+A selects all — measured 2026-08-26, it does not, and
+    the clear silently did nothing to a non-empty box for two months."""
+
     def setUp(self):
         self.calls = []
+        self.box_lines = []            # per-test: the input box the fake pane is holding
 
         def rec(args, **kw):
             self.calls.append(list(args))
+            if args[:2] == ["tmux", "capture-pane"]:
+                return _Res(_pane(self.box_lines))
+            if args[1:2] == ["send-keys"] and args[-1] == "C-u" and self.box_lines:
+                if self.box_lines[-1]:
+                    self.box_lines[-1] = ""
+                else:
+                    self.box_lines.pop()
             return _Res("")            # stdout "" → not in copy-mode, no image paths left in the input
         self.p_run = mock.patch.object(km.subprocess, "run", side_effect=rec)
         self.p_sleep = mock.patch.object(km.time, "sleep", lambda *a, **k: None)
@@ -48,32 +72,53 @@ class Inject(unittest.TestCase):
     def _cmds(self):
         return [c[1:] for c in self.calls if c and c[0] == "tmux"]   # the tmux sub-command sequence
 
-    CLEAR = ["send-keys", "-t", "sess", "C-a", "BSpace"]
+    KILL = ["send-keys", "-t", "sess", "C-u"]
 
-    def test_clear_selects_all_then_deletes(self):
-        km._clear_pane_input("sess")
-        self.assertEqual(self._cmds(), [self.CLEAR], "Ctrl+A selects the whole input, Backspace deletes it")
+    def test_clear_kills_until_the_box_is_empty(self):
+        self.box_lines = ["a recalled prompt", "and its second line"]
+        self.assertTrue(km._clear_pane_input("sess"))
+        self.assertEqual(km._box_text(_pane(self.box_lines)), "",
+                         "the box READS empty, not merely one character shorter")
+        self.assertEqual([c for c in self._cmds() if c == self.KILL], [self.KILL] * 3,
+                         "one press per line, plus one for the emptied line left behind")
+
+    def test_clear_on_an_empty_box_presses_nothing(self):
+        self.assertTrue(km._clear_pane_input("sess"))
+        self.assertNotIn(self.KILL, self._cmds(), "the ordinary send costs one capture and no keystrokes")
 
     def test_clear_is_a_noop_without_a_name(self):
-        km._clear_pane_input("")
+        self.assertFalse(km._clear_pane_input(""))
         self.assertEqual(self.calls, [])
 
     def test_interrupt_stops_then_wipes_the_restored_prompt(self):
+        self.box_lines = ["the prompt Claude Code restored on Esc"]
         km._interrupt("sess", _async=False)
         cmds = self._cmds()
         esc = ["send-keys", "-t", "sess", "Escape"]
         self.assertIn(esc, cmds, "Esc stops the turn")
-        self.assertIn(self.CLEAR, cmds, "then the restored prompt is cleared")
-        self.assertLess(cmds.index(esc), cmds.index(self.CLEAR), "stop BEFORE clear (let the restore land first)")
+        self.assertIn(self.KILL, cmds, "then the restored prompt is cleared")
+        self.assertLess(cmds.index(esc), cmds.index(self.KILL), "stop BEFORE clear (let the restore land first)")
+        self.assertEqual(km._box_text(_pane(self.box_lines)), "")
 
     def test_inject_clears_before_pasting_so_it_replaces_not_appends(self):
+        self.box_lines = ["leftover typed straight into the terminal"]
         km._tmux_send("sess", "hello", _async=False)
         cmds = self._cmds()
         paste = next(c for c in cmds if c[:1] == ["paste-buffer"])
-        self.assertIn(self.CLEAR, cmds, "the input is cleared as part of the inject")
-        self.assertLess(cmds.index(self.CLEAR), cmds.index(paste),
+        self.assertIn(self.KILL, cmds, "the input is cleared as part of the inject")
+        self.assertLess(cmds.index(self.KILL), cmds.index(paste),
                         "clear happens BEFORE the paste — a paste REPLACES, never appends to leftover text")
         self.assertEqual(cmds[-1], ["send-keys", "-t", "sess", "Enter"], "Enter submits after the paste")
+
+    def test_inject_refuses_when_the_box_will_not_clear(self):
+        # the regression's own shape: presses land, the box does not move. Pasting here would deliver the
+        # leftover and the message JOINED as one prompt, so the send is refused instead (loud on stderr).
+        self.box_lines = ["text this pane will never let go of"]
+        with mock.patch.object(km, "_box_text", lambda cap: "text this pane will never let go of"):
+            km._tmux_send("sess", "hello", _async=False)
+        cmds = self._cmds()
+        self.assertEqual([c for c in cmds if c[:1] == ["paste-buffer"]], [], "nothing is pasted")
+        self.assertNotIn(["send-keys", "-t", "sess", "Enter"], cmds, "and nothing is submitted")
 
     def test_inject_without_a_name_or_text_does_nothing(self):
         km._tmux_send("", "hello", _async=False)

--- a/tests/test_kernel_pane_clear.py
+++ b/tests/test_kernel_pane_clear.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""The clear-before-paste that stopped clearing (the user 2026-08-26).
+
+Every romp send into a tmux pane pastes, and a paste APPENDS — so the input box has to be emptied first or
+the CLI receives the leftover and the new message JOINED. `_clear_pane_input` was written for that
+(2026-06-19) as Ctrl+A + Backspace, on the understanding that Ctrl+A selects the whole input. Measured
+against Claude Code 2.1.223 in a scratch tmux CLI, it does not: Ctrl+A does not select, the Backspace
+deletes ONE character, and the clear was a silent no-op on any non-empty box. The joined submission then
+carries both texts — the CLI answers a prompt nobody wrote, and the delivered text no longer matches the
+echo romp is showing, which makes a corrupted send indistinguishable from a lost one.
+
+Ctrl+U empties the box, one line per press (two per line: the text, then the emptied line), so the clear
+presses until the box READS empty and REFUSES when it cannot get there — a refusal keeps the leftover and
+the message apart, which is the only safe outcome. The fake pane below models exactly those Ctrl+U
+semantics; the live-CLI measurement is what it stands in for. Synthetic pane text throughout.
+
+XDG_STATE_HOME is redirected before the kernel loads so no test state leaks into the live store."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+km = SourceFileLoader("romp_kernel_pane_clear", os.path.join(BIN, "romp-kernel")).load_module()
+
+RULE = "─" * 40
+SESSION = "web"
+
+
+def _pane(box_lines):
+    """A capture shaped like the CLI's: the input box sits between the last two ─── rules."""
+    body = ["  an earlier reply", RULE]
+    first, rest = (box_lines[0], box_lines[1:]) if box_lines else ("", [])
+    body.append(km.PROMPT_GLYPH + " " + first)
+    body.extend("  " + line for line in rest)
+    body.append(RULE)
+    return "\n".join(body)
+
+
+class _FakePane:
+    """The two raw-tmux primitives `_clear_pane_input` uses, over a modelled input box.
+
+    `honors_kill` off is the regression itself: a CLI that ignores the keystroke, where the clear must end
+    as a refusal rather than a spin or a false "cleared"."""
+
+    def __init__(self, box_lines, honors_kill=True):
+        self.box_lines = list(box_lines)
+        self.honors_kill = honors_kill
+        self.keys_sent = []
+        self.captures = 0
+
+    def capture(self, name, join=False, colour=False, t=2.5):
+        self.captures += 1
+        return _pane(self.box_lines)
+
+    def send_keys(self, name, *keys, t=3):
+        self.keys_sent.append(keys)
+        if not self.honors_kill or keys != ("C-u",):
+            return
+        if not self.box_lines:                      # nothing left to kill
+            return
+        if self.box_lines[-1]:
+            self.box_lines[-1] = ""                 # the CLI kills the line's TEXT first…
+        else:
+            self.box_lines.pop()                    # …then the emptied line itself
+
+
+class ClearPaneInput(unittest.TestCase):
+    def setUp(self):
+        self._saved_tmux = km._TMUX
+
+    def tearDown(self):
+        km._TMUX = self._saved_tmux
+
+    def _run_clear(self, pane):
+        km._TMUX = pane
+        return km._clear_pane_input(SESSION)
+
+    def test_a_multi_line_leftover_is_fully_cleared(self):
+        pane = _FakePane(["https://example.com/pull/123 ", "and a second line", ""])
+        self.assertTrue(self._run_clear(pane))
+        self.assertEqual(km._box_text(_pane(pane.box_lines)), "", "the box is provably empty at the end")
+
+    def test_an_empty_box_costs_one_capture_and_no_keystrokes(self):
+        # the ordinary send's path: cheaper than the two keystrokes it used to fire unconditionally
+        pane = _FakePane([""])
+        self.assertTrue(self._run_clear(pane))
+        self.assertEqual(pane.keys_sent, [])
+        self.assertEqual(pane.captures, 1)
+
+    def test_a_box_that_will_not_empty_is_a_REFUSAL_not_a_false_clear(self):
+        # the regression's shape — the keystroke lands and nothing changes. Answering True here is what
+        # let a send paste onto the leftover for two months.
+        pane = _FakePane(["text the CLI will not kill"], honors_kill=False)
+        self.assertFalse(self._run_clear(pane))
+        self.assertEqual(len(pane.keys_sent), km._CLEAR_UNCHANGED_GIVE_UP,
+                         "presses that move nothing stop early — the press cap is only the outer guard")
+        self.assertEqual(set(pane.keys_sent), {("C-u",)})
+        self.assertLess(km._CLEAR_UNCHANGED_GIVE_UP, km._CLEAR_KILL_PRESSES)
+
+    def test_an_unreadable_box_is_a_refusal_and_sends_nothing(self):
+        # no locatable prompt box (a loading screen, a picker): the box may hold anything, so a clear that
+        # cannot READ it must not claim it, and must not fire keystrokes into whatever IS up
+        km._TMUX = _FakePane([""])
+        km._TMUX.capture = lambda name, join=False, colour=False, t=2.5: "no rules here at all"
+        self.assertFalse(km._clear_pane_input(SESSION))
+        self.assertEqual(km._TMUX.keys_sent, [])
+
+    def test_no_session_name_is_a_refusal(self):
+        self.assertFalse(km._clear_pane_input(""))
+
+
+class SendRefusesToConcatenate(unittest.TestCase):
+    """The caller's half: a send whose clear failed must not paste. Pasting anyway is not the lesser evil —
+    it delivers two texts joined as one prompt."""
+
+    def setUp(self):
+        self._saved_tmux = km._TMUX
+
+    def tearDown(self):
+        km._TMUX = self._saved_tmux
+
+    class _RecordingPane(_FakePane):
+        def __init__(self, box_lines, honors_kill=True):
+            super().__init__(box_lines, honors_kill)
+            self.buffers, self.pastes = [], []
+
+        def pane_in_mode(self, name, t=2):
+            return False
+
+        def set_buffer(self, text):
+            self.buffers.append(text)
+
+        def paste_buffer(self, name):
+            self.pastes.append(name)
+
+    def test_an_unclearable_box_blocks_the_paste_and_the_Enter(self):
+        pane = self._RecordingPane(["a draft typed straight into the terminal"], honors_kill=False)
+        km._TMUX = pane
+        km._tmux_send(SESSION, "the composer message", _async=False)
+        self.assertEqual(pane.buffers, [], "nothing is staged")
+        self.assertEqual(pane.pastes, [], "nothing is pasted onto the leftover")
+        self.assertNotIn(("Enter",), pane.keys_sent, "and nothing is submitted")
+
+    def test_a_clearable_box_sends_normally(self):
+        pane = self._RecordingPane(["an interrupt-restored prompt"])
+        km._TMUX = pane
+        km._tmux_send(SESSION, "the composer message", _async=False)
+        self.assertEqual(pane.buffers, ["the composer message"])
+        self.assertEqual(pane.pastes, [SESSION])
+        self.assertIn(("Enter",), pane.keys_sent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_pane_clear.py
+++ b/tests/test_kernel_pane_clear.py
@@ -17,6 +17,7 @@ semantics; the live-CLI measurement is what it stands in for. Synthetic pane tex
 XDG_STATE_HOME is redirected before the kernel loads so no test state leaks into the live store."""
 import os
 import tempfile
+import threading
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -93,6 +94,17 @@ class ClearPaneInput(unittest.TestCase):
         self.assertEqual(pane.keys_sent, [])
         self.assertEqual(pane.captures, 1)
 
+    def test_a_draft_with_a_BLANK_line_still_clears(self):
+        # The change detector compares the RAW box region, not the stripped text: a press that pops an
+        # emptied or blank LINE moves the region but not the text, and a blank line in the draft produces
+        # two such presses in a row — which the stripped compare read as a dead binding, refusing a
+        # perfectly clearable box (PR-741 review, 2026-08-27). A multi-paragraph restored prompt is the
+        # exact shape the clear exists for, so this is the case that must never refuse.
+        pane = _FakePane(["paragraph one", "", "paragraph two"])
+        self.assertTrue(self._run_clear(pane))
+        self.assertEqual(km._box_text(_pane(pane.box_lines)), "")
+        self.assertEqual(set(pane.keys_sent), {("C-u",)}, "nothing but the kill was ever pressed")
+
     def test_a_box_that_will_not_empty_is_a_REFUSAL_not_a_false_clear(self):
         # the regression's shape — the keystroke lands and nothing changes. Answering True here is what
         # let a send paste onto the leftover for two months.
@@ -154,6 +166,60 @@ class SendRefusesToConcatenate(unittest.TestCase):
         self.assertEqual(pane.buffers, ["the composer message"])
         self.assertEqual(pane.pastes, [SESSION])
         self.assertIn(("Enter",), pane.keys_sent)
+
+
+class PaneLockSerializesInterruptAndSend(unittest.TestCase):
+    """The interrupt's post-Esc kill loop and a send's clear+paste+Enter ran unserialized on one pane, so
+    the loop could read a just-pasted message as leftover and C-u it away in the pre-Enter gap — Enter
+    then submitted an empty box (PR-741 review, 2026-08-27). Both sequences now hold the pane's lock;
+    these pin that each side actually waits for it."""
+
+    def setUp(self):
+        self._saved_tmux = km._TMUX
+        km._pane_io_locks.clear()
+
+    def tearDown(self):
+        km._TMUX = self._saved_tmux
+        km._pane_io_locks.clear()
+
+    def test_a_send_waits_out_the_lock_holder_and_the_paste_is_never_sniped(self):
+        pane = SendRefusesToConcatenate._RecordingPane(["an interrupt-restored prompt"])
+        km._TMUX = pane
+        lock = km._pane_io_lock(SESSION)
+        lock.acquire()                                  # stand in for an interrupt mid-drain
+        t = threading.Thread(target=km._tmux_send, args=(SESSION, "the composer message"),
+                             kwargs={"_async": False}, daemon=True)
+        try:
+            t.start()
+            t.join(0.4)
+            self.assertTrue(t.is_alive(), "the send is waiting on the pane lock")
+            self.assertEqual(pane.pastes, [], "nothing pastes while another sequence owns the pane")
+        finally:
+            lock.release()
+        t.join(5)
+        self.assertFalse(t.is_alive())
+        self.assertEqual(pane.buffers, ["the composer message"])
+        self.assertIn(("Enter",), pane.keys_sent, "released → the send completes intact")
+
+    def test_an_interrupt_stops_the_turn_at_once_but_clears_under_the_lock(self):
+        # Esc rides OUTSIDE the lock on purpose — the user's Stop must not wait behind a send mid-paste —
+        # while the wipe of the restored prompt serializes like any other read-decide-keystroke sequence.
+        pane = _FakePane(["a restored prompt"])
+        km._TMUX = pane
+        lock = km._pane_io_lock(SESSION)
+        lock.acquire()                                  # stand in for a send mid-sequence
+        t = threading.Thread(target=km._interrupt, args=(SESSION,), kwargs={"_async": False}, daemon=True)
+        try:
+            t.start()
+            t.join(0.6)                                 # past the 0.15s restore beat
+            self.assertIn(("Escape",), pane.keys_sent, "the Stop lands immediately")
+            self.assertNotIn(("C-u",), pane.keys_sent, "the wipe waits for the pane")
+        finally:
+            lock.release()
+        t.join(5)
+        self.assertFalse(t.is_alive())
+        self.assertIn(("C-u",), pane.keys_sent, "released → the wipe runs")
+        self.assertEqual(km._box_text(_pane(pane.box_lines)), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A paste APPENDS, so the CLI's input box has to be empty before romp injects a message. `_clear_pane_input` was written for that in June as `Ctrl+A` + `Backspace`, on the understanding that Ctrl+A selects the whole input and Backspace deletes the selection.

**Measured against Claude Code 2.1.223** (a scratch CLI in tmux, 2026-08-26): Ctrl+A does not select, and the Backspace deletes exactly ONE character. Seeded box `https://example.com/pull/123␤` → after the clear: `https://example.com/pull/123`. The clear has been a silent no-op on any non-empty box, and every composer send into a pane holding text went in joined onto it.

The damage is not cosmetic: the CLI receives two texts as one prompt and answers something nobody wrote, and the delivered text no longer matches the echo romp is showing — so the send becomes indistinguishable from a lost one.

## Changes

- `Ctrl+U` empties the box, one line per press (two per line: the text, then the emptied line). `_clear_pane_input` presses until the box READS empty and returns whether it got there — event-based per press, not a sleep. An empty box costs one capture and zero keystrokes, so the ordinary send is cheaper than before.
- It gives up after two presses that move nothing (the shape the Ctrl+A regression itself had), with the press cap only as an outer guard.
- A clear that cannot finish **refuses the send**, loudly, rather than pasting anyway. Keeping the leftover and the message apart is the only safe outcome, and a refused send surfaces as never-delivered instead of as a message that vanished. `_interrupt` reports the same failure without pasting anything.

## Tests

`tests/test_kernel_inject.py` and `test_kernel.py::TmuxInject` pinned the old keystroke pair and faked every capture as `""`, so they were asserting a sequence the CLI no longer honors; both now drive a stateful fake pane modelling real Ctrl+U semantics. New `tests/test_kernel_pane_clear.py` covers the multi-line clear, the no-keystroke empty case, the refusal on a box that will not move, and the refusal on a box that cannot be read.

Verified end-to-end against the live CLI as well as in unit tests: with a leftover URL in the box, a send now leaves only the new message.

Replaces #739, which was branched off a fork branch and carried unrelated commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)