### PR TITLE
Chat tabs: Classic returns as the tuned default; PR 730's look becomes the Yatharth theme

### DIFF
--- a/ui/webview/chat-affordances.test.ts
+++ b/ui/webview/chat-affordances.test.ts
@@ -23,14 +23,19 @@ test("session identity: rail (2px, 70%) + the soft 1px pane ring in the SAME col
   assert.match(CSS, /#winframe \{ display: block; position: fixed; inset: 0; z-index: 900; pointer-events: none;\n  border: 1px solid color-mix\(in srgb, var\(--active-accent, transparent\) 30%, transparent\); \}/);
   assert.doesNotMatch(CSS, /#winframe \{[^}]*border: 2px solid/);
   assert.match(CSS, /\.turn::before \{[^}]*width: 2px[^}]*background: var\(--active-accent[^}]*opacity: 0\.7/);
-  // the tab wears the identity as a FLAT soft tint (no more harsh 1.5px inset ring; the gradient
-  // cut read old-school — the user 2026-08-26), strongest when active, with a soft border whose
-  // open bottom fuses into the identity-tinted #tabbar line
-  assert.doesNotMatch(CSS, /inset 0 0 0 1\.5px var\(--chip-bg\)/);
+  // T113 (the user 2026-08-27): CLASSIC is the default — the thick 1.5px selected ring returns,
+  // the identity wash drops to the user's 5% (vars, trivially tunable), and the strip has NO
+  // bottom line (transparent keeps geometry). PR 730's aesthetic lives on, exactly, as the opt-in
+  // Yatharth theme scoped under body.chat-theme-yatharth.
+  assert.match(CSS, /#tabbar \{ --tab-tint-rest: 5%; --tab-tint-hover: 8%; --tab-tint-active: 5%; \}/);
+  assert.match(CSS, /\.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\);/s,
+    "the classic selected ring — the user: the thicker outline makes the selected tab easy to tell");
+  assert.match(CSS, /\.tab\.colored:not\(\.tab-blocked\) \{ background: color-mix\(in srgb, var\(--chip-bg\) var\(--tab-tint-rest\), transparent\); \}/);
+  assert.match(CSS, /border-bottom: 1px solid transparent;/, "no line under the strip in Classic (multi-row strips)");
   assert.doesNotMatch(CSS, /\.tab[^{]*\{[^}]*linear-gradient\(180deg/, "no glossy tab gradients");
-  assert.match(CSS, /\.tab\.colored:not\(\.tab-blocked\) \{ background: color-mix\(in srgb, var\(--chip-bg\) 9%, transparent\); \}/);
-  assert.match(CSS, /\.tab\.active\.colored:not\(\.tab-blocked\) \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 22%, transparent\);/);
-  assert.match(CSS, /#tabbar \{[^}]*border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, rgba\(255, 255, 255, 0\.3\)\) 40%, transparent\);/s);
+  // the Yatharth scope carries 730's values verbatim: tinted line, 9/15/22 wash, soft border, no ring
+  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{\n  --tab-tint-rest: 9%; --tab-tint-hover: 15%; --tab-tint-active: 22%;\n  border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, rgba\(255, 255, 255, 0\.3\)\) 40%, transparent\);/);
+  assert.match(CSS, /body\.chat-theme-yatharth \.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*border-color: color-mix\(in srgb, var\(--chip-bg\) 55%, transparent\);[^}]*box-shadow: none;/s);
 });
 
 test("dot colors are decoupled from the session (no ring, absolute hues)", () => {
@@ -59,10 +64,10 @@ test("a SELECTED blocked tab blends the selection white OVER the red, so it read
   assert.match(rule, /rgba\(229, 72, 77, 0\.42\)/, "over a stronger red than the unselected fill");
 });
 
-test("identity stands down on a blocked tab, so it can't mask the red (structural :not now)", () => {
-  // the old form was a box-shadow:none override on the ring; the 2026-08-26 gradient tint bakes the
-  // stand-down into every identity rule's selector instead — blocked outranks identity by construction
-  assert.doesNotMatch(CSS, /box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\)/);
+test("identity stands down on a blocked tab, so it can't mask the red (both mechanisms)", () => {
+  // the tint family keeps the structural :not — AND the classic ring (restored by T113) carries the
+  // 2026-07-24 stand-down override again, since a ring near red painted over the dashed state outline
+  assert.match(CSS, /\.tab\.tab-blocked\.active\.colored \{ box-shadow: none; \}/);
   // matched on the DECLARATION as written (background: color-mix(... var(--chip-bg) ...)) and
   // COUNTED: the first form of this loop required var(--chip-bg) BEFORE the word background, an
   // order the sheet never uses, so it matched zero rules and asserted nothing (PR-730 review,

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -100,6 +100,10 @@ var GEAR_HTML =
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
   '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
   '</select></span></div>' +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Chat tabs</b>" +
+  "<span class=rs-sub>The tab strip's look. Classic keeps the thick outline on the selected tab with a faint per-session tint; Yatharth is the contributed flat-wash aesthetic with the tinted line under the strip.</span>" +
+  "<div id=rs-tabtheme style='margin-top:5px;display:flex;flex-direction:column;gap:4px'></div>" +
+  '</span></div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Text scheme</b>" +
   "<span class=rs-sub>Chat text colors only. Each row previews its own tiers — prose, the dimmer tool text, code. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
   "<div id=rs-chatscheme style='margin-top:5px;display:flex;flex-direction:column;gap:4px'></div>" +
@@ -174,6 +178,7 @@ function initGear(post) {
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
     cs = document.getElementById('rs-chatscheme'),
+    tt = document.getElementById('rs-tabtheme'),
     cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
     fc = document.getElementById('rs-feedcollapsed'),
     jm = document.getElementById('rs-judgemodel'),
@@ -231,6 +236,27 @@ function initGear(post) {
       cs.appendChild(row);
     });
   }
+  var TABTHEMES = [
+    { id: 'classic', name: 'Classic', sub: 'thick selected outline \u00b7 faint 5% session tint \u00b7 no line under the strip' },
+    { id: 'yatharth', name: 'Yatharth', sub: 'flat session wash \u00b7 soft selected border \u00b7 tinted line under the strip' }
+  ];
+  function ttPaint() {
+    if (!tt) return;
+    var cur = load().chatTabTheme === 'yatharth' ? 'yatharth' : 'classic';
+    tt.innerHTML = '';
+    TABTHEMES.forEach(function (th) {
+      var row = document.createElement('button');
+      row.type = 'button'; row.dataset.tabtheme = th.id;
+      row.style.cssText = 'display:flex;align-items:center;gap:8px;text-align:left;background:#1e1e1e;' +
+        'border:1px solid ' + (th.id === cur ? '#1EA1EB' : '#3a3a3a') + ';border-radius:5px;padding:5px 8px;cursor:pointer;font:inherit;color:#ccc';
+      row.innerHTML = '<span style="flex:0 0 auto;width:15px;color:#1EA1EB">' + (th.id === cur ? '\u2713' : '') + '</span>' +
+        '<span style="flex:0 0 auto;min-width:96px;color:#ccc">' + th.name + '</span>' +
+        '<span style="flex:1 1 auto;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#8a8a8a">' + th.sub + '</span>';
+      row.addEventListener('click', function () { var s = load(); s.chatTabTheme = th.id; save(s); ttPaint(); });
+      tt.appendChild(row);
+    });
+  }
+  ttPaint();
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4002,6 +4002,7 @@ function bgRgb(): [number, number, number] {
 // its luminance hits a uniform low target, so a bright hue (yellow) fades as much
 // as a dim one (blue) — consistent "faded-ness" regardless of color. Never
 // touches the bright color (only used for at-rest tabs).
+const CLASSIC_FADE_SCALE = 0.8;   // the user's ~20% brighter faded tab labels (T113) — one tunable knob
 function fadedColor(hex: string): string {
   const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
   if (!m) return hex;
@@ -4011,7 +4012,10 @@ function fadedColor(hex: string): string {
   const lum = (x: number, y: number, z: number) => 0.2126 * x + 0.7152 * y + 0.0722 * z;
   const Lc = lum(r, g, b), Lb = lum(br, bgc, bb), Lt = Lb + 38;
   if (Lc <= Lt) return hex; // already dim — leave it
-  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb));
+  // CLASSIC brightens the faded labels ~20% (T113 item 4 — unselected tabs were hard to read, a
+  // complaint predating 730): fade 20% less far toward the background. Yatharth keeps the full fade.
+  const scale = settings.chatTabTheme === "yatharth" ? 1 : CLASSIC_FADE_SCALE;
+  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb)) * scale;
   const hx = (a: number, c: number) => Math.round(a * (1 - t) + c * t).toString(16).padStart(2, "0");
   return `#${hx(r, br)}${hx(g, bgc)}${hx(b, bb)}`;
 }
@@ -12387,6 +12391,9 @@ function shipFileToHost(f: File, sidAt: string | null = activeId) {
 function applyChatScheme(s: RompSettings): void {
   document.body.classList.toggle("scheme-high-contrast", s.chatScheme === "high-contrast");
   document.body.classList.toggle("scheme-solarized-dark", s.chatScheme === "solarized-dark");
+  // the chat-tab appearance theme (T113): Classic is the unscoped default; Yatharth scopes PR 730's
+  // strip aesthetic under this class. Applies live — onExternalSettingsChange re-runs this + renderTabs.
+  document.body.classList.toggle("chat-theme-yatharth", s.chatTabTheme === "yatharth");
 }
 function setupSettings(): void {
   applyChatScheme(settings);   // the persisted pick applies at startup — it survives reloads

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -18,11 +18,16 @@ export interface RompSettings {
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
+  chatTabTheme: ChatTabTheme;   // the chat TAB STRIP's appearance (T113, the user 2026-08-27): "classic" = the tuned default (no bottom line, the thick selected ring, a 5% identity wash, brighter faded labels); "yatharth" = PR 730's aesthetic as merged, named for its contributor at the user's ask. Tab strip only — never a global reskin.
 }
 // Solarized LIGHT is deliberately absent (the user allowed skipping it): its text tiers are designed
 // for a paper-light ground and invert into mud on romp's dark canvas — an unreadable preset is worse
 // than none.
 export type ChatScheme = "default" | "high-contrast" | "solarized-dark";
+export type ChatTabTheme = "classic" | "yatharth";
+export function chatTabTheme(v: unknown): ChatTabTheme {
+  return v === "yatharth" ? "yatharth" : "classic";
+}
 export function chatScheme(v: unknown): ChatScheme {
   return v === "high-contrast" || v === "solarized-dark" ? v : "default";
 }
@@ -40,7 +45,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", chatScheme: "default" };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", chatScheme: "default", chatTabTheme: "classic" };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {
@@ -50,6 +55,7 @@ export function loadSettings(): RompSettings {
       const s = { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
       s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
       s.chatScheme = chatScheme(s.chatScheme);   // unknown/legacy values normalize to "default"
+      s.chatTabTheme = chatTabTheme(s.chatTabTheme);   // unknown/legacy values normalize to "classic"
       return s;
     }
   } catch { /* corrupt / unavailable → defaults */ }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -145,9 +145,10 @@ body { display: flex; flex-direction: column; overflow-x: hidden; }   /* the cha
      #tabbar-resize drag can move it while the mobile page's max-height:none still wins over it
      (an inline max-height would override that media rule and clip the mobile header) */
   max-height: var(--tabbar-cap, 150px); overflow-y: auto; overflow-x: hidden;
-  /* the line the tabs sit on wears the ACTIVE session's color (40%) — the tab's tint fuses into it,
-     so tab and pane read as one object (the user 2026-08-26). Neutral (= --box-border) with no color. */
-  border-bottom: 1px solid color-mix(in srgb, var(--active-accent, rgba(255, 255, 255, 0.3)) 40%, transparent);
+  /* CLASSIC (T113, the user 2026-08-27): NO line under the tabs — with multiple tab rows it read
+     wrong. Transparent (not none) so the strip's geometry is identical across themes. The Yatharth
+     theme (body.chat-theme-yatharth, below the strip rules) restores PR 730's identity-tinted line. */
+  border-bottom: 1px solid transparent;
   background: var(--vscode-sideBar-background, var(--bg));
 }
 /* #tabs fills the bar width and wraps its tabs across multiple rows. gap: a hair of air between
@@ -297,18 +298,39 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-ph-swirl { width: 12px; height: 12px; border-radius: 2px; flex: none;
   animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with its own gap, so no margin needed */
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
-/* SELECTED: gray fill; a COLORED session wears its identity as a FLAT soft tint instead of the old
-   harsh 1.5px inset ring. (First cut was a vertical gradient — the user 2026-08-26: old-school and
-   ugly; a single flat wash is the modern read.) A whisper at rest, warmer on hover, strongest when
-   active plus a soft top/side border in the same color — its bottom is open, so it fuses with the
-   identity-tinted #tabbar line below and the pane frame (#winframe): one color, one object.
+/* CLASSIC (the default; T113, the user 2026-08-27 reacting to PR 730): the pre-730 SELECTED
+   treatment returns — the thicker 1.5px inset identity ring ("makes it really easy to tell which
+   one is selected") — while the one keeper from 730, per-tab identity distinguishability, stays as
+   a FAINT background wash at the user's ~5% ("way too strong" at 730's 9/15/22). The percentages
+   are CSS vars so the tuning stays trivial; body.chat-theme-yatharth (below) restores 730's values
+   and treatment exactly, as the opt-in theme named for its contributor.
    :not(.tab-blocked) throughout — the blocked red fill outranks identity (the user 2026-07-24). */
+#tabbar { --tab-tint-rest: 5%; --tab-tint-hover: 8%; --tab-tint-active: 5%; }
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
-.tab.colored:not(.tab-blocked) { background: color-mix(in srgb, var(--chip-bg) 9%, transparent); }
-.tab.colored:not(.tab-blocked):hover { background: color-mix(in srgb, var(--chip-bg) 15%, transparent); }
+.tab.colored:not(.tab-blocked) { background: color-mix(in srgb, var(--chip-bg) var(--tab-tint-rest), transparent); }
+.tab.colored:not(.tab-blocked):hover { background: color-mix(in srgb, var(--chip-bg) var(--tab-tint-hover), transparent); }
 .tab.active.colored:not(.tab-blocked) {
-  background: color-mix(in srgb, var(--chip-bg) 22%, transparent);
+  /* the gray selected fill OVER the faint identity wash, ringed in the identity color */
+  background: linear-gradient(rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.14)),
+              color-mix(in srgb, var(--chip-bg) var(--tab-tint-active), transparent);
+  box-shadow: inset 0 0 0 1.5px var(--chip-bg);
+}
+/* the identity ring STANDS DOWN while blocked (the user 2026-07-24, restored with the ring): the
+   dashed red state outline occupies the same band, and blocked outranks identity */
+.tab.tab-blocked.active.colored { box-shadow: none; }
+
+/* ── the YATHARTH theme (opt-in via settings, named for its contributor at the user's ask): PR
+   730's tab-strip aesthetic exactly as merged — the identity-tinted bottom line, the flat soft
+   wash instead of the ring (9% rest / 15% hover / 22% active + a 55% top/side border whose open
+   bottom fuses with the line below). Scoped to the CHAT TAB STRIP only, per the T113 seam. ── */
+body.chat-theme-yatharth #tabbar {
+  --tab-tint-rest: 9%; --tab-tint-hover: 15%; --tab-tint-active: 22%;
+  border-bottom: 1px solid color-mix(in srgb, var(--active-accent, rgba(255, 255, 255, 0.3)) 40%, transparent);
+}
+body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
+  background: color-mix(in srgb, var(--chip-bg) var(--tab-tint-active), transparent);
   border-color: color-mix(in srgb, var(--chip-bg) 55%, transparent);
+  box-shadow: none;
 }
 /* tab title in the session's romp identity color (bold), like the dashboard */
 .tab.colored .tab-label { color: var(--chip-bg); font-weight: 600; }

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,0 +1,56 @@
+// The chat-tab appearance themes (T113, the user 2026-08-27, reacting to PR 730's strip pass):
+// CLASSIC is the tuned default — no line under the strip (multi-row strips made it read wrong),
+// the pre-730 thick selected ring back ("really easy to tell which one is selected"), the one
+// keeper from 730 (per-tab identity distinguishability) at the user's ~5% wash, and faded tab
+// labels ~20% brighter (an older complaint). YATHARTH is 730's aesthetic exactly as merged,
+// opt-in via settings and named for its contributor at the user's explicit ask. The seam is the
+// CHAT TAB STRIP only. Source pins per the repo convention; the round-trip is executable.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { chatTabTheme, DEFAULT_SETTINGS } from "./settings";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const CSS = ui("webview", "styles.css");
+const GEAR = ui("webview", "gear.js");
+
+test("the setting round-trips: classic default, yatharth opt-in, junk normalizes", () => {
+  assert.equal(DEFAULT_SETTINGS.chatTabTheme, "classic");
+  assert.equal(chatTabTheme("yatharth"), "yatharth");
+  assert.equal(chatTabTheme("classic"), "classic");
+  assert.equal(chatTabTheme(undefined), "classic");
+  assert.equal(chatTabTheme("sparkles"), "classic");
+});
+
+test("the theme applies LIVE through the scheme plumbing — a body class, no reload", () => {
+  assert.match(RENDER, /document\.body\.classList\.toggle\("chat-theme-yatharth", s\.chatTabTheme === "yatharth"\);/);
+  // onExternalSettingsChange already re-runs applyChatScheme + renderTabs on every settings write
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\);/);
+});
+
+test("Classic: no strip line, the thick ring, the 5% wash (tunable vars), the stand-down", () => {
+  assert.match(CSS, /#tabbar \{ --tab-tint-rest: 5%; --tab-tint-hover: 8%; --tab-tint-active: 5%; \}/);
+  assert.match(CSS, /border-bottom: 1px solid transparent;/);
+  assert.match(CSS, /\.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\);/s);
+  assert.match(CSS, /\.tab\.tab-blocked\.active\.colored \{ box-shadow: none; \}/, "blocked outranks the ring (2026-07-24)");
+});
+
+test("Classic: faded tab labels brighten ~20% — one tunable knob, yatharth keeps the full fade", () => {
+  assert.match(RENDER, /const CLASSIC_FADE_SCALE = 0\.8;/);
+  assert.match(RENDER, /const scale = settings\.chatTabTheme === "yatharth" \? 1 : CLASSIC_FADE_SCALE;/);
+  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
+});
+
+test("Yatharth: PR 730's strip values verbatim, scoped to the theme class", () => {
+  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{\n  --tab-tint-rest: 9%; --tab-tint-hover: 15%; --tab-tint-active: 22%;/);
+  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{[^}]*border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, rgba\(255, 255, 255, 0\.3\)\) 40%, transparent\);/s);
+  assert.match(CSS, /body\.chat-theme-yatharth \.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*box-shadow: none;/s);
+});
+
+test("the gear offers the picker in the one menu vocabulary, Classic first", () => {
+  assert.match(GEAR, /\{ id: 'classic', name: 'Classic',/);
+  assert.match(GEAR, /\{ id: 'yatharth', name: 'Yatharth',/);
+  assert.match(GEAR, /s\.chatTabTheme = th\.id; save\(s\); ttPaint\(\);/);
+});


### PR DESCRIPTION
## Classic (the default), the user's exact tuning

- **No line under the tabs** (transparent, geometry preserved) — multiple tab rows made it read wrong.
- **The thick selected ring returns** (the pre-730 1.5px inset identity ring) over the gray fill — with the 2026-07-24 blocked stand-down override restored alongside it.
- **The keeper from the new look** — per-tab identity distinguishability — stays at the user's **~5% wash** (was 9/15/22). Percentages are CSS vars on `#tabbar`: trivially tunable.
- **Faded tab labels brighten ~20%** (a pre-730 complaint): `fadedColor` fades 20% less far toward the background under Classic — one named knob (`CLASSIC_FADE_SCALE`).

## Yatharth (opt-in, named for its contributor at the user's ask)

PR 730's strip aesthetic **exactly as merged** — the identity-tinted bottom line, the 9/15/22 flat wash, the soft 55% border, no ring — scoped under `body.chat-theme-yatharth`.

**The seam**: chat tab strip only. Nothing resisted the split; 730's `#winframe` accent border and the Inter typography are pane/global concerns outside the reacted-to surface and deliberately stay as merged under both themes (noted, not silently widened).

## The picker

In the gear beside the Text scheme row, same row vocabulary (Classic first, one-line sub each). Persists like every other setting; applies **live** through the scheme plumbing (body class; `onExternalSettingsChange` re-runs `applyChatScheme` + `renderTabs`) — no reload.

## Verification

Screenshots over the built bundle, both themes: Classic shows the ring + faint washes + the dashed blocked state unmasked + no strip line; Yatharth shows the flat wash + soft border + tinted line. `tab-theme.test.ts` pins both themes' key properties + the setting round-trip (junk normalizes to classic); the 730-era affordance pins retargeted to the two-theme contract. npm 2467 + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)