### PR TITLE
The awaiting chip's name wears the identity colour itself — the dot retires

### DIFF
--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -40,10 +40,13 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
   assert.match(box, /nm\.style\.color = pr\.color\.bg/);
   const chipAt = RENDER.indexOf("const chipPeers = s.status.awaitingPeers");
   const chip = RENDER.slice(chipAt, RENDER.indexOf("chip.title =", chipAt));
-  assert.match(chip, /el\("span", "chip-peer-dot"\)/, "'Awaiting <name>' wears the identity dot");
-  assert.match(chip, /dot\.style\.background = chipPeers\[0\]\.color\.bg/);
+  assert.ok(!chip.includes("chip-peer-dot"), "the dot retired (the user 2026-08-26, round two) — the name wears the colour");
+  assert.match(chip, /el\("span", "chip-peer-name"\)/, "'Awaiting <name>' — the NAME itself in identity colour");
+  assert.match(chip, /nm\.style\.color = chipPeers\[0\]\.color\.bg/);
   assert.match(chip, /chipPeers\.length \+ " peers"/, "several peers keep the one-line rule as a count");
-  assert.match(CSS, /\.chip-peer-dot \{ display: inline-block; width: 7px; height: 7px; border-radius: 50%;/);
+  assert.match(CSS, /\.chip-peer-name \{ background: rgba\(0, 0, 0, 0\.85\); color: #fff; border-radius: 7px;/,
+    "the ~85% black backing — any colour reads on it, the chip hue still glows around it");
+  assert.ok(!/\.chip-peer-dot/.test(CSS), "the dot's CSS goes with it");
 });
 
 test("the kernel ships identities on every arm — the or-chain's hardcoded Nones are gone", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9971,16 +9971,18 @@ function updateStatusline() {
     chip.classList.add("chip-awaiting-" + (s.status.awaitingKind || "untyped"));   // per-kind hook, one hue today
     const chipPeers = s.status.awaitingPeers || [];
     if (chipPeers.length) {
-      // the pill names the actual session (the user 2026-08-26): "Awaiting <name>" with the peer's
-      // identity-colour dot; several peers keep the one-line rule as a count, names on the tooltip
+      // the pill names the actual session (the user 2026-08-26): "Awaiting <name>", the NAME itself
+      // in the peer's identity colour — the dot it launched with retired the same day (round two:
+      // it read stupid). The name sits on an always-on ~85% black backing (.chip-peer-name), mostly
+      // opaque so ANY identity colour reads against any chip hue (their green-on-green example),
+      // translucent enough that the chip's own colour still glows through around it. Several peers
+      // keep the one-line rule as a count, names on the tooltip.
       chip.append(CHIP_LABEL.awaitingBg + " ");
       if (chipPeers.length === 1) {
-        if (chipPeers[0].color && chipPeers[0].color.bg) {
-          const dot = el("span", "chip-peer-dot");
-          dot.style.background = chipPeers[0].color.bg;
-          chip.appendChild(dot);
-        }
-        chip.append((chipPeers[0].host ? chipPeers[0].host + ":" : "") + chipPeers[0].name);
+        const nm = el("span", "chip-peer-name");
+        nm.textContent = (chipPeers[0].host ? chipPeers[0].host + ":" : "") + chipPeers[0].name;
+        if (chipPeers[0].color && chipPeers[0].color.bg) nm.style.color = chipPeers[0].color.bg;
+        chip.appendChild(nm);
       } else chip.append(chipPeers.length + " peers");
     } else chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kw : "");
     chip.title = (s.status.awaitingWhy || "idle, waiting on background work it dispatched")

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -917,8 +917,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .chip-ready { background: var(--st-ready-bg); color: var(--st-ready-fg); }
 .chip-needsInput { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }
 .chip-awaiting { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }   /* legacy name — an older remote kernel */
-/* the awaiting chip's peer-identity dot (2026-08-26): the named session's colour beside its name */
-.chip-peer-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin: 0 4px 0 1px; }
+/* the awaiting chip's peer NAME wears the identity colour itself (the user 2026-08-26, round two —
+   the dot retired). The backing is ~85% black: opaque enough that any colour reads on it regardless
+   of the chip hue behind (their green-on-green case), translucent enough to keep the chip's flavor.
+   #fff default = the no-identity (cross-host) name stays legible on the dark backing. */
+.chip-peer-name { background: rgba(0, 0, 0, 0.85); color: #fff; border-radius: 7px; padding: 0 5px; margin-left: 1px; }
 .chip-awaitingBg { background: var(--st-awaitbg-bg); color: var(--st-awaitbg-fg); }
 /* retrying = a SOFT 'blocked on the API' (rate-limit / overload auto-retry) — not a hang, not working. Amber/
    orange, deliberately distinct from working-yellow and blocked-red (the user via api 2026-06-23). */


### PR DESCRIPTION
Round two on the awaiting-chip identity treatment (the user 2026-08-26, screenshot): keeping the name was right, the little dot beside it was not. The chip now reads **Awaiting <name>** with the NAME text in the session's identity colour; the dot element and its CSS are gone.

Contrast is the user's prescribed mechanism: the name sits on a small rounded **~85%-alpha black backing** — mostly opaque so any identity colour reads against any chip hue (their green-on-green example), translucent enough that the chip's own colour still glows through around it. The backing is **always on** (their refined framing: whatever is in front must have enough contrast regardless of its colour), verified headlessly as the cleaner uniform look across green-named, blue-named, and uncoloured cross-host specimens. The no-identity name defaults to white so it stays legible on the dark backing. Multi-peer chips keep the plain count (no name shown, nothing to colour); font and size unchanged.

Pins updated in the same test that held the dot: no `chip-peer-dot` in the branch or the stylesheet, the name span carries the identity colour, the backing rule pins its alpha and radius. 2461/2461 extension tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)