### PR TITLE
The never-delivered note tells only what is known, and the settle's side arms get their pins

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8417,9 +8417,11 @@ class TmuxBackend(sb.SessionBackend):
         # The floor never PRUNES a plain tmux echo: it must SURVIVE a later turn to keep a dropped send
         # visible, so retirement stays text/uuid-only. It does SETTLE it — an echo the transcript has
         # overtaken is marked dropped (the "never delivered" treatment), which is what keeps a two-day-old
-        # loss from posing as a pending queued message (_tmux_echo_settle).
+        # loss from posing as a pending queued message (_tmux_echo_settle). The settle also sees what the
+        # queue ledger still OWES (pending_queued is mtime-cached, so the read is free on a quiet
+        # transcript): a send still listed there is waiting, not lost.
         _tmux_echo_prune(str(sid), tx_uuids, tx_user_texts)
-        _tmux_echo_settle(str(sid), human_floor)
+        _tmux_echo_settle(str(sid), human_floor, still_queued=self.pending_queued(sid))
 
     def dismiss_echo(self, sid, uuid=None, t=None):
         """Drop ONE settled echo on the user's ✕ (the chat's echodismiss), by synthetic uuid or send time.
@@ -16530,7 +16532,7 @@ def _echo_overtaken(atom, human_floor):
     return bool(atom.get("_echo_text")) and bool(human_floor) and human_floor > atom.get("t", 0)
 
 
-def _tmux_echo_settle(sid, human_floor):
+def _tmux_echo_settle(sid, human_floor, still_queued=()):
     """Mark every overtaken tmux echo `dropped`, so the chat draws the shipped "never delivered" treatment
     (dashed bubble + restore/dismiss, renderQueued's sibling) instead of an ordinary sent bubble, and the
     queued fold stops enlisting it as a pending message (the user 2026-08-26: a session's queued header
@@ -16544,15 +16546,26 @@ def _tmux_echo_settle(sid, human_floor):
     because the transcript extracts image paths out of the user text, so that flavor is retired the way
     sdk_backend.prune_live retires it rather than labelled a loss it may not be. With the SDK module
     unavailable the predicate is simply unavailable too, and marking (the visible, reversible outcome)
-    covers every echo."""
+    covers every echo.
+
+    STANDS DOWN for an echo whose text the queue ledger still lists as pending (`still_queued`,
+    2026-08-27): the floor is a per-SESSION clock, so an OLDER queued sibling delivering raises it past
+    a younger send still genuinely waiting in the CLI's queue — overtaken by the floor, but not lost.
+    Marking it would have /diag/sendvis call one message both pending and dropped, the exact
+    misdiagnosis the dropped field exists to prevent. The queue ledger is the authoritative "still
+    owed" record, so it outranks the floor here; once the ledger releases the text (delivery or
+    recall), the next settle rules on it normally."""
     d = _tmux_echo.get(sid)
     if not d:
         return
+    owed = {t.strip() for t in still_queued if isinstance(t, str)}
     path_bearing = getattr(sys.modules.get("romp_sdk_backend"), "_path_bearing", None)
     for k in list(d.keys()):
         a = d[k]
         if not _echo_overtaken(a, human_floor):
             continue
+        if (a.get("_echo_text") or "").strip() in owed:
+            continue                                     # still owed by the queue ledger → waiting, not lost
         if path_bearing is not None and path_bearing(a.get("_echo_text") or ""):
             d.pop(k, None)
         else:
@@ -17179,11 +17192,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             # interrupt marker on the rail instead of a person-blue bubble (the user 2026-07-02).
                             if prompt.strip().startswith("[Request interrupted by user"):
                                 ev["interruptMarker"] = True
-                            # A provably-LOST send (a live echo whose CLI died holding it — the backend's
-                            # dropped-echo marking): the client renders "never delivered" with restore/
-                            # dismiss instead of a sent-looking bubble that poses as history (the user
-                            # 2026-07-29). echoT is the dismiss handle that survives kernel restarts —
-                            # the echo uuid regenerates on every boot reseed; its send time does not.
+                            # A send that never made the transcript (the backend's dropped-echo marking:
+                            # an SDK echo whose CLI died holding it, or a tmux echo the session moved past
+                            # — a pane-dropped keystroke, or a delivery the transcript recorded under
+                            # different text; the population widened 2026-08-26): the client renders
+                            # "never delivered" with restore/dismiss instead of a sent-looking bubble that
+                            # poses as history (the user 2026-07-29). echoT is the dismiss handle that
+                            # survives kernel restarts — the echo uuid regenerates on every boot reseed;
+                            # its send time does not.
                             if a.get("dropped") and a.get("_echo_text"):
                                 ev["undelivered"] = True
                                 ev["echoT"] = a.get("t")

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7,6 +7,7 @@ UUIDs; no real session data.
 import json
 import os
 import re
+import sys
 import tempfile
 import time
 import types
@@ -7300,6 +7301,55 @@ class TmuxEchoSettledByALaterTurn(unittest.TestCase):
         self.assertIsNone(backend.dismiss_echo(SID, uuid=settled["uuid"]), "idempotent: a miss is a no-op")
         remaining = [a.get("_echo_text") for a in km._tmux_echo_atoms(SID)]
         self.assertEqual(remaining, ["still going out"], "only the dismissed one goes")
+
+    # ── the settle's two side arms, previously untested (PR-740 review follow-up, 2026-08-27) ──
+    # Direct _tmux_echo_settle calls: the arms live there, and the merge path's threading is one line
+    # (TmuxBackend.prune_live passes still_queued=self.pending_queued(sid)).
+
+    def test_path_bearing_overtaken_echo_is_RETIRED_when_the_predicate_resolves(self):
+        # The pop arm mirrors sdk_backend.prune_live: a path-bearing echo fails the text match
+        # STRUCTURALLY (the transcript extracts image paths out of the user text), so "overtaken" is not
+        # evidence of loss — labelling it "never delivered" would libel a delivered screenshot send.
+        echo_atom = self._echo_at("see /tmp/shot.png", self.SENT_BEFORE)
+        fake = types.ModuleType("romp_sdk_backend")
+        fake._path_bearing = lambda t: "/tmp/shot.png" in t
+        saved = sys.modules.get("romp_sdk_backend")
+        sys.modules["romp_sdk_backend"] = fake
+        try:
+            km._tmux_echo_settle(SID, human_floor=self.LANDED_AT)
+        finally:
+            if saved is None:
+                sys.modules.pop("romp_sdk_backend", None)
+            else:
+                sys.modules["romp_sdk_backend"] = saved
+        self.assertNotIn(SID, km._tmux_echo, "retired the SDK way, not labelled a loss it may not be")
+        self.assertFalse(echo_atom.get("dropped"))
+
+    def test_path_bearing_echo_is_MARKED_when_the_sdk_module_is_absent(self):
+        # With the predicate unavailable the settle cannot tell path-bearing from plain, and marking is
+        # the visible, reversible outcome — the dashed bubble's ✕ undoes a wrong call, a silent retire
+        # cannot be undone.
+        echo_atom = self._echo_at("see /tmp/shot.png", self.SENT_BEFORE)
+        saved = sys.modules.pop("romp_sdk_backend", None)
+        try:
+            km._tmux_echo_settle(SID, human_floor=self.LANDED_AT)
+        finally:
+            if saved is not None:
+                sys.modules["romp_sdk_backend"] = saved
+        self.assertTrue(echo_atom.get("dropped"), "marked, the reversible outcome")
+        self.assertIn(SID, km._tmux_echo)
+
+    def test_a_still_queued_echo_stands_down_and_settles_on_release(self):
+        # The floor is a per-SESSION clock: an older queued sibling delivering raises it past a younger
+        # send still genuinely waiting in the CLI's queue. The queue ledger is the authoritative "still
+        # owed" record, so the settle defers to it — marking would have /diag/sendvis call one message
+        # both pending and dropped. Once the ledger releases the text, the next settle rules normally.
+        echo_atom = self._echo_at("the younger queued send", self.SENT_BEFORE)
+        km._tmux_echo_settle(SID, human_floor=self.LANDED_AT,
+                             still_queued=["the younger queued send"])
+        self.assertFalse(echo_atom.get("dropped"), "still owed by the queue ledger — waiting, not lost")
+        km._tmux_echo_settle(SID, human_floor=self.LANDED_AT, still_queued=[])
+        self.assertTrue(echo_atom.get("dropped"), "the ledger released it — the floor's ruling stands")
 
 
 class TestCloserSettledGate(unittest.TestCase):

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2404,7 +2404,12 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         turn.classList.add("undelivered");
         bubble.classList.add("undelivered-bubble");
         const note = el("div", "undelivered-note");
-        note.title = "This message never reached the session: its process died holding it before it was written to the conversation.";
+        // covers BOTH dropped-echo populations (the copy predated the 2026-08-26 widening and claimed a
+        // process death for every loss): an SDK echo really is a send its CLI died holding, but a tmux
+        // echo settles dropped when the session simply moved past it — a keystroke the pane dropped, or
+        // a delivery the transcript recorded under different text. Say what is KNOWN (it never made the
+        // conversation), not a cause that is only sometimes true.
+        note.title = "This message never made it into the conversation: the session moved on without recording it (a dropped keystroke, a process that died holding it, or a delivery recorded under different text).";
         const label = el("span", "undelivered-label");
         label.textContent = "never delivered";
         note.appendChild(label);


### PR DESCRIPTION
Follow-ups from the queued-header fix's adversarial review (three findings, none blocking, all confirmed by refute-verification):

- **The undelivered tooltip stopped asserting a cause that is only sometimes true.** The copy claimed every loss was a process death; that was written for the SDK population and became wrong for most cases when overtaken tmux echoes joined it (a pane-dropped keystroke, or a delivery the transcript recorded under different text, on a session that is alive). It now says what is known: the message never made the conversation. The kernel-side comment widens the same way.
- **The settle defers to the queue ledger.** The human-turn floor is a per-session clock, so an older queued sibling's delivery raised it past a younger send still genuinely waiting in the CLI's queue, and /diag/sendvis called one message both pending and dropped. An echo whose text pending_queued still lists now stands down; the ledger's release hands it back to the floor's ruling.
- **The settle's two side arms are pinned**: the path-bearing retirement (predicate available), the marking fallback (SDK module absent), and the stand-down plus its release each have a test; none did before.

Verified at ea31ecb3: full pytest 5,779 passed (34 skipped, the usual), webview suite 2,470/2,470 with typecheck and build clean. Touches kernel/kernel.py, ui/webview/render.ts, tests/test_kernel.py only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)