### PR TITLE
The awaiting chip's reference wears the house session idiom — shared renderer, no copy

### DIFF
--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -42,7 +42,10 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
   const chip = RENDER.slice(chipAt, RENDER.indexOf("chip.title =", chipAt));
   assert.ok(!chip.includes("chip-peer-dot"), "the dot retired (the user 2026-08-26, round two) — the name wears the colour");
   assert.match(chip, /el\("span", "chip-peer-name"\)/, "'Awaiting <name>' — the NAME itself in identity colour");
+  assert.match(chip, /nm\.replaceChildren\(\.\.\.hostPartsNodes\(chipPeers\[0\]\.host, chipPeers\[0\]\.name\)\)/,
+    "the HOUSE idiom via the SHARED renderer (the user 2026-08-26, round three) — host in .host-prefix italic gray, never a restyled copy");
   assert.match(chip, /nm\.style\.color = chipPeers\[0\]\.color\.bg/);
+  assert.ok(!/nm\.textContent = .*host/.test(chip), "no one-string concatenation of host and name");
   assert.match(chip, /chipPeers\.length \+ " peers"/, "several peers keep the one-line rule as a count");
   assert.match(CSS, /\.chip-peer-name \{ background: rgba\(0, 0, 0, 0\.85\); color: #fff; border-radius: 7px;/,
     "the ~85% black backing — any colour reads on it, the chip hue still glows around it");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -41,7 +41,7 @@ import { openFileView } from "./file-view";
 import { initFileView } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
-import { hostNameNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
+import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
@@ -9984,7 +9984,11 @@ function updateStatusline() {
       chip.append(CHIP_LABEL.awaitingBg + " ");
       if (chipPeers.length === 1) {
         const nm = el("span", "chip-peer-name");
-        nm.textContent = (chipPeers[0].host ? chipPeers[0].host + ":" : "") + chipPeers[0].name;
+        // the HOUSE session-reference idiom (the user 2026-08-26, round three — one undifferentiated
+        // string read wrong): the shared renderer, so the host prefix wears .host-prefix (italic
+        // gray) and the NAME text takes the identity colour — the card headers' own treatment,
+        // never a restyled copy
+        nm.replaceChildren(...hostPartsNodes(chipPeers[0].host, chipPeers[0].name));
         if (chipPeers[0].color && chipPeers[0].color.bg) nm.style.color = chipPeers[0].color.bg;
         chip.appendChild(nm);
       } else chip.append(chipPeers.length + " peers");


### PR DESCRIPTION
Round three on the awaiting chip (the user 2026-08-26, screenshot of 'devbox:romp_manager' as one undifferentiated string on the backing): inside the T114 backing, the reference now renders exactly like the card headers' session idiom — the host prefix in `.host-prefix` (italic gray, a step smaller), the session name in its identity colour, local sessions unprefixed as always.

One code path, per the ask: the chip calls the **shared `hostPartsNodes` renderer** (the same helper the feed's awaiting box and delegation chips use), so the host token wears the one `.host-prefix` class every surface styles — no restyled copy. The identity colour rides the containing span as before, colouring the NAME text node while the house class keeps the prefix gray. Backing, alpha, and radius stay as T114 shipped them.

Pins retargeted: the shared-renderer call (and no one-string host+name concatenation), the identity colour on the span, the backing rule unchanged. 2478/2478 extension tests green; typecheck clean. States screenshot (cross-host magenta, cross-host green-on-green, local) verified against the idiom headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)