### PR TITLE
Classic tab theme is the pre-720 strip verbatim, typography excepted

### DIFF
--- a/ui/webview/chat-affordances.test.ts
+++ b/ui/webview/chat-affordances.test.ts
@@ -23,18 +23,14 @@ test("session identity: rail (2px, 70%) + the soft 1px pane ring in the SAME col
   assert.match(CSS, /#winframe \{ display: block; position: fixed; inset: 0; z-index: 900; pointer-events: none;\n  border: 1px solid color-mix\(in srgb, var\(--active-accent, transparent\) 30%, transparent\); \}/);
   assert.doesNotMatch(CSS, /#winframe \{[^}]*border: 2px solid/);
   assert.match(CSS, /\.turn::before \{[^}]*width: 2px[^}]*background: var\(--active-accent[^}]*opacity: 0\.7/);
-  // T113 (the user 2026-08-27): CLASSIC is the default — the thick 1.5px selected ring returns,
-  // the identity wash drops to the user's 5% (vars, trivially tunable), and the strip has NO
-  // bottom line (transparent keeps geometry). PR 730's aesthetic lives on, exactly, as the opt-in
-  // Yatharth theme scoped under body.chat-theme-yatharth.
-  assert.match(CSS, /#tabbar \{ --tab-tint-rest: 5%; --tab-tint-hover: 8%; --tab-tint-active: 5%; \}/);
-  assert.match(CSS, /\.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\);/s,
+  // T113→T115 (the user 2026-08-27): CLASSIC is the default and is the PRE-720 strip verbatim,
+  // typography excepted — the thick 1.5px selected ring, NO identity tint at any state, the
+  // neutral line under the strip. The contributor's aesthetic lives on, exactly, as the opt-in
+  // Yatharth theme scoped under body.chat-theme-yatharth (tab-theme.test.ts pins both in full).
+  assert.match(CSS, /\.tab\.active\.colored \{ box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\); \}/,
     "the classic selected ring — the user: the thicker outline makes the selected tab easy to tell");
-  assert.match(CSS, /\.tab\.colored:not\(\.tab-blocked\) \{ background: color-mix\(in srgb, var\(--chip-bg\) var\(--tab-tint-rest\), transparent\); \}/);
-  assert.match(CSS, /border-bottom: 1px solid transparent;/, "no line under the strip in Classic (multi-row strips)");
+  assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/, "the pre-720 neutral line under the strip");
   assert.doesNotMatch(CSS, /\.tab[^{]*\{[^}]*linear-gradient\(180deg/, "no glossy tab gradients");
-  // the Yatharth scope carries 730's values verbatim: tinted line, 9/15/22 wash, soft border, no ring
-  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{\n  --tab-tint-rest: 9%; --tab-tint-hover: 15%; --tab-tint-active: 22%;\n  border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, rgba\(255, 255, 255, 0\.3\)\) 40%, transparent\);/);
   assert.match(CSS, /body\.chat-theme-yatharth \.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*border-color: color-mix\(in srgb, var\(--chip-bg\) 55%, transparent\);[^}]*box-shadow: none;/s);
 });
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -237,7 +237,7 @@ function initGear(post) {
     });
   }
   var TABTHEMES = [
-    { id: 'classic', name: 'Classic', sub: 'thick selected outline \u00b7 faint 5% session tint \u00b7 no line under the strip' },
+    { id: 'classic', name: 'Classic', sub: 'the original high-contrast strip \u00b7 thick selected outline \u00b7 no session tint' },
     { id: 'yatharth', name: 'Yatharth', sub: 'flat session wash \u00b7 soft selected border \u00b7 tinted line under the strip' }
   ];
   function ttPaint() {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4002,7 +4002,6 @@ function bgRgb(): [number, number, number] {
 // its luminance hits a uniform low target, so a bright hue (yellow) fades as much
 // as a dim one (blue) — consistent "faded-ness" regardless of color. Never
 // touches the bright color (only used for at-rest tabs).
-const CLASSIC_FADE_SCALE = 0.8;   // the user's ~20% brighter faded tab labels (T113) — one tunable knob
 function fadedColor(hex: string): string {
   const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
   if (!m) return hex;
@@ -4012,10 +4011,7 @@ function fadedColor(hex: string): string {
   const lum = (x: number, y: number, z: number) => 0.2126 * x + 0.7152 * y + 0.0722 * z;
   const Lc = lum(r, g, b), Lb = lum(br, bgc, bb), Lt = Lb + 38;
   if (Lc <= Lt) return hex; // already dim — leave it
-  // CLASSIC brightens the faded labels ~20% (T113 item 4 — unselected tabs were hard to read, a
-  // complaint predating 730): fade 20% less far toward the background. Yatharth keeps the full fade.
-  const scale = settings.chatTabTheme === "yatharth" ? 1 : CLASSIC_FADE_SCALE;
-  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb)) * scale;
+  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb));
   const hx = (a: number, c: number) => Math.round(a * (1 - t) + c * t).toString(16).padStart(2, "0");
   return `#${hx(r, br)}${hx(g, bgc)}${hx(b, bb)}`;
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -145,17 +145,14 @@ body { display: flex; flex-direction: column; overflow-x: hidden; }   /* the cha
      #tabbar-resize drag can move it while the mobile page's max-height:none still wins over it
      (an inline max-height would override that media rule and clip the mobile header) */
   max-height: var(--tabbar-cap, 150px); overflow-y: auto; overflow-x: hidden;
-  /* CLASSIC (T113, the user 2026-08-27): NO line under the tabs — with multiple tab rows it read
-     wrong. Transparent (not none) so the strip's geometry is identical across themes. The Yatharth
-     theme (body.chat-theme-yatharth, below the strip rules) restores PR 730's identity-tinted line. */
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid var(--box-border);
   background: var(--vscode-sideBar-background, var(--bg));
 }
-/* #tabs fills the bar width and wraps its tabs across multiple rows. gap: a hair of air between
-   tabs (the user 2026-08-26) — the flat identity tints turned the strip into touching colored
-   blocks with no seam. 3px, not the old 4px the 2026-08-08 gauge-room trade removed: most of that
-   trade's room stays. */
-#tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0 3px; }
+/* #tabs fills the bar width and wraps its tabs across multiple rows. gap 0 (was 4px, the user
+   2026-08-08): the strip trades its empty inter-tab space for room for the per-tab context gauge —
+   the active/hover fills and per-tab padding still separate neighbours visually. (The Yatharth
+   theme reopens a 3px seam — its flat tints need one; see its block below.) */
+#tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; }
 /* Drag handle straddling the tab strip's bottom border (the user 2026-08-18): the strip scrolls past
    its max-height cap, which clipped the fifth row of a many-session strip with no way to see more.
    Drag DOWN for more rows, UP for fewer; double-click resets; the strip stays a scroll pane at every
@@ -298,40 +295,41 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-ph-swirl { width: 12px; height: 12px; border-radius: 2px; flex: none;
   animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with its own gap, so no margin needed */
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
-/* CLASSIC (the default; T113, the user 2026-08-27 reacting to PR 730): the pre-730 SELECTED
-   treatment returns — the thicker 1.5px inset identity ring ("makes it really easy to tell which
-   one is selected") — while the one keeper from 730, per-tab identity distinguishability, stays as
-   a FAINT background wash at the user's ~5% ("way too strong" at 730's 9/15/22). The percentages
-   are CSS vars so the tuning stays trivial; body.chat-theme-yatharth (below) restores 730's values
-   and treatment exactly, as the opt-in theme named for its contributor.
-   :not(.tab-blocked) throughout — the blocked red fill outranks identity (the user 2026-07-24). */
-#tabbar { --tab-tint-rest: 5%; --tab-tint-hover: 8%; --tab-tint-active: 5%; }
+/* CLASSIC (the default; T113 then tightened by T115, the user 2026-08-27): the tab strip is the
+   PRE-720 strip, byte-for-byte — verified by pixel-diffing a real pre-720 build — with typography
+   the ONE permitted difference (the strip inherits the global Inter/type ladder; the user is fine
+   with any font changes, nothing else). No identity tint at any state, the thick 1.5px inset
+   identity ring on the selected tab, full-contrast faded labels (fadedColor, render.ts), the
+   neutral line under the strip. The Yatharth theme below is the opt-in restoration of the
+   contributor's merged strip aesthetic. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
-.tab.colored:not(.tab-blocked) { background: color-mix(in srgb, var(--chip-bg) var(--tab-tint-rest), transparent); }
-.tab.colored:not(.tab-blocked):hover { background: color-mix(in srgb, var(--chip-bg) var(--tab-tint-hover), transparent); }
-.tab.active.colored:not(.tab-blocked) {
-  /* the gray selected fill OVER the faint identity wash, ringed in the identity color */
-  background: linear-gradient(rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.14)),
-              color-mix(in srgb, var(--chip-bg) var(--tab-tint-active), transparent);
-  box-shadow: inset 0 0 0 1.5px var(--chip-bg);
-}
-/* the identity ring STANDS DOWN while blocked (the user 2026-07-24, restored with the ring): the
-   dashed red state outline occupies the same band, and blocked outranks identity */
+.tab.active.colored { box-shadow: inset 0 0 0 1.5px var(--chip-bg); }
+/* the identity ring STANDS DOWN while blocked (the user 2026-07-24): the dashed red state outline
+   occupies the same band, and blocked outranks identity */
 .tab.tab-blocked.active.colored { box-shadow: none; }
 
-/* ── the YATHARTH theme (opt-in via settings, named for its contributor at the user's ask): PR
-   730's tab-strip aesthetic exactly as merged — the identity-tinted bottom line, the flat soft
-   wash instead of the ring (9% rest / 15% hover / 22% active + a 55% top/side border whose open
-   bottom fuses with the line below). Scoped to the CHAT TAB STRIP only, per the T113 seam. ── */
+/* ── the YATHARTH theme (opt-in via settings, named for its contributor at the user's ask): the
+   tab strip exactly as his PRs merged it — the flat identity wash instead of the ring (9% rest /
+   15% hover / 22% active, a 55% top/side border on the selected tab), the identity-tinted line
+   under the strip, and the 3px seam of air between tabs (his call: the flat tints turned the
+   strip into touching colored blocks with no seam). Scoped to the CHAT TAB STRIP only, per the
+   T113 seam: global typography is not themed here. ── */
 body.chat-theme-yatharth #tabbar {
-  --tab-tint-rest: 9%; --tab-tint-hover: 15%; --tab-tint-active: 22%;
   border-bottom: 1px solid color-mix(in srgb, var(--active-accent, rgba(255, 255, 255, 0.3)) 40%, transparent);
 }
+body.chat-theme-yatharth #tabs { gap: 0 3px; }
+body.chat-theme-yatharth .tab.colored:not(.tab-blocked) {
+  background: color-mix(in srgb, var(--chip-bg) 9%, transparent);
+}
+body.chat-theme-yatharth .tab.colored:not(.tab-blocked):hover {
+  background: color-mix(in srgb, var(--chip-bg) 15%, transparent);
+}
 body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
-  background: color-mix(in srgb, var(--chip-bg) var(--tab-tint-active), transparent);
+  background: color-mix(in srgb, var(--chip-bg) 22%, transparent);
   border-color: color-mix(in srgb, var(--chip-bg) 55%, transparent);
   box-shadow: none;
 }
+
 /* tab title in the session's romp identity color (bold), like the dashboard */
 .tab.colored .tab-label { color: var(--chip-bg); font-weight: 600; }
 /* inactive (at rest) sessions fade their color, like the romp timeline */

--- a/ui/webview/tab-ctx-gauge.test.ts
+++ b/ui/webview/tab-ctx-gauge.test.ts
@@ -43,8 +43,9 @@ test("the gauge is a slim VERTICAL bar and the strip tightened to make room for 
   assert.ok(g, ".tab-ctx must declare width+height");
   assert.ok(+g![1] < +g![2], `gauge must be vertical (w ${g![1]} < h ${g![2]})`);
   assert.match(CSS, /\.tab-ctx-fill \{ position: absolute; left: 0; right: 0; bottom: 0/);
-  // the strip's spacing trade (the user 2026-08-08): inter-tab gap 0; in-tab gap/padding shrunk
-  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0 3px; \}/);
+  // the strip's spacing trade (the user 2026-08-08): inter-tab gap 0; in-tab gap/padding shrunk.
+  // (The Yatharth theme reopens a 3px seam under its scope — tab-theme.test.ts pins that.)
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
   assert.match(CSS, /\.tab \{[\s\S]{0,400}gap: 4px;[^\n]*\n\s*padding: 6px 7px;/);
 });
 

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,10 +1,12 @@
-// The chat-tab appearance themes (T113, the user 2026-08-27, reacting to PR 730's strip pass):
-// CLASSIC is the tuned default — no line under the strip (multi-row strips made it read wrong),
-// the pre-730 thick selected ring back ("really easy to tell which one is selected"), the one
-// keeper from 730 (per-tab identity distinguishability) at the user's ~5% wash, and faded tab
-// labels ~20% brighter (an older complaint). YATHARTH is 730's aesthetic exactly as merged,
-// opt-in via settings and named for its contributor at the user's explicit ask. The seam is the
-// CHAT TAB STRIP only. Source pins per the repo convention; the round-trip is executable.
+// The chat-tab appearance themes (T113, tightened by T115 — the user 2026-08-27, reacting to the
+// contributor's strip pass): CLASSIC, the default, is the PRE-720 tab strip byte-for-byte, with
+// typography the ONE permitted difference — the user's amended words: fine with any font changes,
+// nothing else. So: NO identity tint at any state, the thick 1.5px selected ring, the neutral
+// line under the strip, gap 0, and the full pre-720 label fade. T115 verified this by pixel-diffing
+// a real pre-720 build: with fonts normalized, zero differing pixels outside the (out-of-scope)
+// tag-controls box. YATHARTH is the contributor's merged strip aesthetic exactly, opt-in via
+// settings and named for him at the user's explicit ask. The seam is the CHAT TAB STRIP only.
+// Source pins per the repo convention; the round-trip is executable.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -30,23 +32,34 @@ test("the theme applies LIVE through the scheme plumbing — a body class, no re
   assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\);/);
 });
 
-test("Classic: no strip line, the thick ring, the 5% wash (tunable vars), the stand-down", () => {
-  assert.match(CSS, /#tabbar \{ --tab-tint-rest: 5%; --tab-tint-hover: 8%; --tab-tint-active: 5%; \}/);
-  assert.match(CSS, /border-bottom: 1px solid transparent;/);
-  assert.match(CSS, /\.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\);/s);
+test("Classic: the pre-720 strip verbatim — line, gap 0, gray active fill, ring, stand-down", () => {
+  assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/);
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
+  assert.match(CSS, /\.tab\.active \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.14\); \}/);
+  assert.match(CSS, /\.tab\.active\.colored \{ box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\); \}/);
   assert.match(CSS, /\.tab\.tab-blocked\.active\.colored \{ box-shadow: none; \}/, "blocked outranks the ring (2026-07-24)");
 });
 
-test("Classic: faded tab labels brighten ~20% — one tunable knob, yatharth keeps the full fade", () => {
-  assert.match(RENDER, /const CLASSIC_FADE_SCALE = 0\.8;/);
-  assert.match(RENDER, /const scale = settings\.chatTabTheme === "yatharth" \? 1 : CLASSIC_FADE_SCALE;/);
-  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
+test("Classic: NO identity tint — every tint rule lives under the theme class", () => {
+  // The user revoked the at-rest wash (T115 amendment): outside the yatharth block there must be
+  // no identity-tinted tab background at all. Every tinted background in the stylesheet is scoped.
+  const tintRules = CSS.split("\n").filter((l) => /\.tab[^{]*\{[^}]*color-mix\(in srgb, var\(--chip-bg\)/.test(l));
+  for (const l of tintRules) assert.match(l, /^body\.chat-theme-yatharth /, "tint rule must be theme-scoped: " + l);
+  const ringLine = CSS.match(/^\.tab\.active\.colored \{.*$/m)![0];
+  assert.ok(!ringLine.includes("color-mix"), "the classic selected tab is the gray fill + ring, no tint layer");
 });
 
-test("Yatharth: PR 730's strip values verbatim, scoped to the theme class", () => {
-  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{\n  --tab-tint-rest: 9%; --tab-tint-hover: 15%; --tab-tint-active: 22%;/);
-  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{[^}]*border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, rgba\(255, 255, 255, 0\.3\)\) 40%, transparent\);/s);
-  assert.match(CSS, /body\.chat-theme-yatharth \.tab\.active\.colored:not\(\.tab-blocked\) \{[^}]*box-shadow: none;/s);
+test("Classic: the label fade is the pre-720 formula — no theme branch, no brightening scale", () => {
+  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\);/);
+  assert.doesNotMatch(RENDER, /chatTabTheme[^\n]*\? 1 :/, "fadedColor no longer branches on the theme");
+});
+
+test("Yatharth: his strip verbatim, scoped to the theme class", () => {
+  assert.match(CSS, /body\.chat-theme-yatharth #tabbar \{\n  border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, rgba\(255, 255, 255, 0\.3\)\) 40%, transparent\);\n\}/);
+  assert.match(CSS, /body\.chat-theme-yatharth #tabs \{ gap: 0 3px; \}/, "his 3px seam of air between the flat tints");
+  assert.match(CSS, /body\.chat-theme-yatharth \.tab\.colored:not\(\.tab-blocked\) \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 9%, transparent\);\n\}/);
+  assert.match(CSS, /body\.chat-theme-yatharth \.tab\.colored:not\(\.tab-blocked\):hover \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 15%, transparent\);\n\}/);
+  assert.match(CSS, /body\.chat-theme-yatharth \.tab\.active\.colored:not\(\.tab-blocked\) \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 22%, transparent\);\n  border-color: color-mix\(in srgb, var\(--chip-bg\) 55%, transparent\);\n  box-shadow: none;\n\}/);
 });
 
 test("the gear offers the picker in the one menu vocabulary, Classic first", () => {


### PR DESCRIPTION
The user's tightened spec for the tab-strip restoration: **Classic (the default) must equal the pre-720 strip pixel-for-pixel, with typography the only permitted difference** (any font change is fine, nothing else). This lands that, verified against a real pre-720 build rather than restored from memory.

## Method
A throwaway worktree on the last pre-720 main, built; an identical synthetic six-tab harness (mixed selected/faded/blocked/colored states, placeholder UUIDs) rendered per tree; every strip property computed-style-diffed; then a Chromium-canvas pixel diff.

**Result after this change:** the computed-style diff between the pre-720 baseline and Classic is exactly `font-family` (Inter from the global typography pass — permitted) on every probed element, and the pixel diff with typography normalized is **zero differing pixels** outside the tag-controls box (whose 36→30px width is the user's own later tag-strip change, out of scope).

## What was still different before this change
- Identity tint at rest/hover/active (the earlier 5/8/5% wash) — **removed**: no tint at any state; selected = plain gray fill + the 1.5px identity ring
- `#tabs` gap `0 3px` (the contributor's seam of air) — **back to `gap: 0`**
- `#tabbar` transparent border-bottom — **back to the neutral `--box-border` line**
- `fadedColor`'s 0.8 brightening scale on faded labels — **back to the pre-720 formula**, no theme branch (themes are pure CSS now; JS only toggles the body class)
- Inter inside the strip — **kept** (typography is the sanctioned seam)

## Yatharth theme (opt-in) unchanged in look
His strip exactly as merged, now fully scoped under `body.chat-theme-yatharth`: 9/15/22% flat washes, 55% selected border, no ring, identity-tinted line, 3px seam.

## Tests
`tab-theme.test.ts` repinned to the new contract (baseline-verbatim Classic rules, every `color-mix` tint rule proven theme-scoped, fade formula unbranched); `chat-affordances.test.ts` and `tab-ctx-gauge.test.ts` pins updated. Full webview suite 2479/2479, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)