### PR TITLE
Every restart writes a cut ledger row: what it interrupted, by sid (T121 part 3)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11519,6 +11519,62 @@ def _audit_restart_request(action, **kw):
         pass
 
 
+RESTART_CUTS_FILE = jd.STATE / "restart-cuts.jsonl"
+
+
+def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None):
+    """One ledger row per restart — what THIS restart cut (T121: the drain's effect is measurable
+    only if every restart writes its row, so a clean drain's row with an empty cutTurns list is the
+    success metric, not noise). cutTurns names the sessions whose in-flight turns the drain
+    interrupted (sid-keyed, rename-proof); watchesArmed counts the PERSISTED kernel watches at cut
+    time — those SURVIVE by construction (pr-watches.json + the generic store re-arm at boot) and
+    ride along as context. In-session background watchers and Claude-side workflows are INVISIBLE
+    to the kernel and cannot be counted here — moving waits into the kernel watch primitive is what
+    makes them survivable AND countable. NOTE on the false interrupted-by-user transcript stamps:
+    those records are written by the CLI into its own transcript when the SDK client closes
+    mid-turn; romp does not rewrite CLI transcripts (ever), and romp's OWN records already
+    distinguish machine cuts (the INTR_RESTART_SIG resume notice + the machine-cut stop record) —
+    so the ledger documents the cut honestly on our side and the stamps stay a documented CLI
+    artifact."""
+    d = drain_res if isinstance(drain_res, dict) else {}
+    return {"t": int(now if now is not None else time.time()),
+            "pid": os.getpid(),
+            "cutTurns": list(d.get("cutTurns") or []),
+            "stopped": int(d.get("stopped") or 0),
+            "unjoined": int(d.get("unjoined") or 0),
+            "reaped": int(d.get("reaped") or 0),
+            "watchesArmed": int(watches_armed or 0),
+            "reason": str(audit_reason or "")}
+
+
+def _append_restart_cut(row):
+    """Best-effort append in a dying process: flushed line-buffered write, never raises — the
+    ledger must not be able to break the restart itself (the audit's discipline)."""
+    try:
+        with open(RESTART_CUTS_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(row) + "\n")
+            f.flush()
+    except Exception:
+        pass
+
+
+def _recent_restart_reason(window=90, now=None):
+    """The most recent restart-audit action within `window` seconds — joins the cut row to WHO asked
+    (deploy refresh, self-update, the rail button…). Best-effort: an anonymous SIGTERM has no row
+    and reads as ""."""
+    try:
+        tail = (jd.STATE / "restart-audit.jsonl").read_text().strip().splitlines()
+        if not tail:
+            return ""
+        rec = json.loads(tail[-1])
+        t0 = int(now if now is not None else time.time())
+        if isinstance(rec, dict) and isinstance(rec.get("t"), int) and t0 - rec["t"] <= window:
+            return str(rec.get("action") or "") + (": " + str(rec["reason"]) if rec.get("reason") else "")
+    except Exception:
+        pass
+    return ""
+
+
 def _restart_this_kernel(reason="", manager_port=_PORT_FROM_ENV):
     """Ask the manager to restart-all (it SIGTERMs this kernel; its exit handler spawns a fresh one).
     Standalone (no manager) → nothing to restart, which is not an error. `reason` lands in
@@ -30104,8 +30160,14 @@ def _graceful_term(signum, frame):
     try:
         sys.stderr.write("romp-kernel: SIGTERM — draining SDK sessions\n")
         be = _sdk_backend or None
+        res = {}
         if be is not None and hasattr(be, "drain"):
-            be.drain(2.0)
+            res = be.drain(2.0)
+        # the restart-cut ledger (T121): one row per restart, empty cutTurns included — a clean
+        # drain's row IS the metric. Written after the drain (the cutter knows what it cut) and
+        # before exit; best-effort like the audit.
+        _append_restart_cut(_restart_cut_row(res, watches_armed=len(_pr_watches),
+                                             audit_reason=_recent_restart_reason()))
     except Exception:
         sys.stderr.write("romp-kernel: drain failed: %s\n" % traceback.format_exc())
     finally:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3437,7 +3437,10 @@ class SdkBackend:
         test seam."""
         with self._lock:
             sessions = list(self.sessions.values())
-        inflight = sum(1 for s in sessions if s.inflight)
+        # the identities of the turns this drain is about to cut — the restart-cut ledger's rows
+        # (T121: the drain's effect is measured by what still gets cut; sid-keyed like spend)
+        cut = [{"sid": s.sid, "name": s.name} for s in sessions if s.inflight and not s.ended]
+        inflight = len(cut)
         for s in sessions:
             try:
                 s.shutdown()
@@ -3474,7 +3477,7 @@ class SdkBackend:
                          "; still closing: " + ", ".join(names) if names else "",
                          "; reaped: " + ", ".join(reaped) if reaped else ""))
         return {"stopped": len(sessions), "inflight": inflight, "unjoined": len(unjoined),
-                "reaped": len(reaped)}
+                "reaped": len(reaped), "cutTurns": cut}
 
     def available(self) -> bool:
         """Can this backend actually RUN a session? False when claude_agent_sdk isn't importable.

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""The per-restart CUT LEDGER (T121, 2026-08-27): every restart writes ONE row to
+restart-cuts.jsonl naming what it cut — the drain's effect is measurable only if clean restarts
+write rows too (an empty cutTurns list is the success metric, not noise). The row joins the
+restart-audit tail for WHO asked, counts the persisted kernel watches (which SURVIVE restarts by
+construction — they ride as context, not cuts), and its docstring documents the two things the
+kernel cannot do: count in-session watchers/Claude-side workflows (invisible here — the kernel
+watch primitive is the fix), and un-write the CLI's own interrupted-by-user transcript stamps
+(romp never rewrites CLI transcripts; romp's own records already distinguish machine cuts).
+Hermetic state; synthetic sids only."""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — module import runs boot reconcile against the state root.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_cuts", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-00000000c001"
+
+
+class CutRow(unittest.TestCase):
+    def test_row_shape_from_a_cutting_drain(self):
+        row = km._restart_cut_row({"stopped": 3, "inflight": 2, "unjoined": 1, "reaped": 1,
+                                   "cutTurns": [{"sid": SID, "name": "web"}]},
+                                  watches_armed=4, audit_reason="kernel-asks-manager-restart-all: self-update",
+                                  now=1_781_000_000)
+        self.assertEqual(row["t"], 1_781_000_000)
+        self.assertEqual(row["cutTurns"], [{"sid": SID, "name": "web"}])
+        self.assertEqual((row["stopped"], row["unjoined"], row["reaped"]), (3, 1, 1))
+        self.assertEqual(row["watchesArmed"], 4, "persisted watches SURVIVE — context, never cuts")
+        self.assertIn("self-update", row["reason"])
+
+    def test_a_clean_drain_still_writes_its_row(self):
+        # the success metric: a restart that cut NOTHING is a row with an empty list
+        row = km._restart_cut_row({"stopped": 5, "inflight": 0, "unjoined": 0, "reaped": 0,
+                                   "cutTurns": []}, now=1)
+        self.assertEqual(row["cutTurns"], [])
+        row = km._restart_cut_row(None, now=1)   # no backend at all — still a row
+        self.assertEqual(row["cutTurns"], [])
+
+    def test_append_is_jsonl_and_never_raises(self):
+        km._append_restart_cut(km._restart_cut_row({"cutTurns": []}, now=2))
+        km._append_restart_cut(km._restart_cut_row({"cutTurns": [{"sid": SID, "name": "api"}]}, now=3))
+        rows = [json.loads(l) for l in km.RESTART_CUTS_FILE.read_text().strip().splitlines()]
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[1]["cutTurns"][0]["sid"], SID)
+        km.RESTART_CUTS_FILE.unlink()
+
+    def test_reason_joins_the_recent_audit_tail_only(self):
+        audit = jd.STATE / "restart-audit.jsonl"
+        audit.write_text(json.dumps({"t": 1000, "action": "kernel-asks-manager-restart-all",
+                                     "reason": "self-update"}) + "\n")
+        self.assertIn("self-update", km._recent_restart_reason(window=90, now=1050))
+        self.assertEqual(km._recent_restart_reason(window=90, now=5000), "",
+                         "a stale audit row is not this restart's cause")
+        audit.unlink()
+        self.assertEqual(km._recent_restart_reason(now=1050), "", "no audit → anonymous, honestly")
+
+    def test_sigterm_handler_writes_the_ledger(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        block = src[src.index("def _graceful_term"):src.index("def main():")]
+        self.assertIn("_append_restart_cut(_restart_cut_row(res, watches_armed=len(_pr_watches),",
+                      block, "the SIGTERM drain writes one ledger row before exit")
+        self.assertIn("audit_reason=_recent_restart_reason()", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -401,6 +401,8 @@ class Drain(unittest.TestCase):
         be.sessions[sid] = s
         r = be.drain(1.0)
         self.assertEqual((r["stopped"], r["inflight"]), (1, 1))
+        self.assertEqual(r["cutTurns"], [{"sid": sid, "name": reg.get("name", sid)}],
+                         "the drain names what it cuts — the restart-cut ledger's rows (T121)")
         self.assertTrue(s.ended, "shutdown was requested on the session")
         self.assertEqual(sb.last_state_value(Path(d), sid), "working",
                          "drain writes no idle/waiting — the trailing 'working' IS the boot "
@@ -408,7 +410,8 @@ class Drain(unittest.TestCase):
 
     def test_drain_with_nothing_running_is_a_quiet_noop(self):
         be = _backend()
-        self.assertEqual(be.drain(0.1), {"stopped": 0, "inflight": 0, "unjoined": 0, "reaped": 0})
+        self.assertEqual(be.drain(0.1), {"stopped": 0, "inflight": 0, "unjoined": 0, "reaped": 0,
+                                         "cutTurns": []})
 
     def test_drain_reaps_the_cli_of_a_session_that_wont_close(self):
         # The 2026-07-25 twin incident: the drain's bound expired on a busy session ("still


### PR DESCRIPTION
Part 3 of T121 (landing first — it is the metric for the drain work in part 1).

**The ledger.** The SIGTERM drain writes one row to `restart-cuts.jsonl` before exit: `{t, pid, cutTurns:[{sid,name}], stopped, unjoined, reaped, watchesArmed, reason}`. A clean drain's row with an empty `cutTurns` list is the success metric, not noise — the drain's effect is measurable only if every restart reports. `reason` joins the restart-audit tail (who asked: deploy refresh, self-update, the rail button) within a 90s window; an anonymous SIGTERM reads as `""` honestly. `drain()` now names what it cuts (sid-keyed, rename-proof) instead of only counting; `watchesArmed` counts the persisted kernel watches, which survive restarts by construction and ride as context.

**Stated limits (per the dispatch's annotate-or-document latitude).** In-session background watchers and Claude-side workflows are invisible to the kernel and cannot be counted here — moving waits into the kernel watch primitive (part 2) is what makes them survivable and countable. The false interrupted-by-user transcript stamps are CLI-written records in the CLI's own transcript; romp never rewrites CLI transcripts, and romp's own records already distinguish machine cuts (the INTR_RESTART_SIG resume notice + the machine-cut stop record) — documented in the ledger's docstring.

**Discipline.** Best-effort flushed append in a dying process — the ledger can never break the restart (the restart-audit's rule). Hermetic tests (state root isolated before module load, synthetic sids); the existing drain pins extended to the named-cuts shape.

Suites: pytest 5806 passed / 34 skipped; vscode-extension 2479/2479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)