### PR TITLE
A restart serves bundles that match its checkout, or says loudly that it cannot

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28,7 +28,10 @@ pal = SourceFileLoader("romp_palette", str(HERE / "palette.py")).load_module()  
 ap = SourceFileLoader("romp_askparse", str(HERE / "askparse.py")).load_module()  # tmux-pane → live AskUserQuestion picker
 sb = SourceFileLoader("romp_session_backend", str(HERE / "session_backend.py")).load_module()  # the SessionBackend ABC
 CHAT_VIEW = ROOT / "vscode-extension"               # the tuned UI, current in this worktree via `git merge main`
-DIST = CHAT_VIEW / "dist"                    # bundles built from ui/webview sources (the human's tuned render layer)
+# ROMP_DIST_DIR: test seam (romp-lab serves a COPY of the built bundles, so its rebuild simulations —
+# mtime bumps that must raise the reload banner — never touch the dist the LIVE kernel serves).
+DIST = (Path(os.environ["ROMP_DIST_DIR"]) if os.environ.get("ROMP_DIST_DIR")
+        else CHAT_VIEW / "dist")                 # bundles built from ui/webview sources (the human's tuned render layer)
 MEDIA = CHAT_VIEW / "media"
 UI = ROOT / "ui"                             # the browser UI: timeline view + webview sources (served/built from here)
 NAMES = jd.STATE / "names"
@@ -2555,6 +2558,56 @@ def _rebuild_dist():
         return False, str(e)
 
 
+_DIST_CONVERGE_TRIED = [0.0]
+
+
+def _dist_src_newest():
+    """Newest mtime across the served bundles' INPUTS (the ui/ tree + the esbuild config) — the exact
+    staleness _rebuild_dist cures. Cheap stat sweep, _dist_ver's twin on the source side."""
+    newest = 0.0
+    try:
+        cfg = CHAT_VIEW / "esbuild.js"
+        if cfg.is_file():
+            newest = cfg.stat().st_mtime
+        for pth in UI.rglob("*"):
+            if pth.suffix in (".ts", ".js", ".css") and pth.is_file():
+                m = pth.stat().st_mtime
+                if m > newest:
+                    newest = m
+    except OSError:
+        pass
+    return newest
+
+
+def _dist_converge_check():
+    """Serve bundles that MATCH the checkout, or say LOUDLY that we cannot (T119, the user 2026-08-27:
+    a restart onto real UI changes served the OLD dist for 15 minutes — a restart execs new kernel code
+    but nothing on that path rebuilds the bundles, and the sha-based drift check sees checkout == running
+    == origin, so `dv` stayed equal to every open page's LOADEDV and NO raiser owed the reload banner.
+    The exact silent-degrade the house rule forbids: the staleness that matters — dist older than the
+    checkout's UI sources — was checked nowhere). Runs at boot and every drift pass, regardless of
+    update MODE: serving bundles that match one's own checkout is correctness, not update policy.
+    One rebuild attempt per distinct source state (the in-memory latch): a failure stays visible in its
+    notice and on stderr, retries on the next source change or the next boot — never a 5-minute storm.
+    The ROMP_DIST_DIR seam disables it: a redirected dist is the test's own to control."""
+    if os.environ.get("ROMP_DIST_DIR"):
+        return
+    newest = _dist_src_newest()
+    if not newest or newest <= _dist_ver():
+        return
+    if newest == _DIST_CONVERGE_TRIED[0]:
+        return
+    _DIST_CONVERGE_TRIED[0] = newest
+    ok, err = _rebuild_dist()
+    if ok:
+        _sync_notice("new build served in place (the running bundles predated the checkout's UI "
+                     "sources — a restart doesn't rebuild them) — reload the dashboard to pick it up")
+    else:
+        _sync_notice("the served UI bundles are OLDER than the checkout's sources and the in-place "
+                     "rebuild failed (%s) — dashboards are running stale UI until this builds" % err,
+                     ok=False)
+
+
 def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
@@ -2673,6 +2726,10 @@ def _update_check_loop():
                 _update_check()
         except Exception:
             sys.stderr.write("update check pass: %s\n" % traceback.format_exc())
+        try:
+            _dist_converge_check()                # bundles-vs-checkout staleness — the restart path's gap (T119)
+        except Exception:
+            sys.stderr.write("dist converge pass: %s\n" % traceback.format_exc())
         try:
             _main_drift_check()
         except Exception:

--- a/tests/test_dist_converge.py
+++ b/tests/test_dist_converge.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""The kernel serves bundles that MATCH its checkout, or says loudly that it cannot (T119, the user
+2026-08-27: a restart onto real UI changes served the OLD dist for 15 minutes — a restart execs new
+kernel code but nothing on that path rebuilds the bundles, and the sha-based drift check sees
+checkout == running == origin, so `dv` stayed equal to every open page's LOADEDV and no raiser owed
+the reload banner). _dist_converge_check runs at boot and every drift pass: dist older than the
+checkout's UI sources → one in-place rebuild per distinct source state, an ok notice on success and
+a LOUD one on failure — never a silent stale serve, never a retry storm. All fixtures SYNTHETIC."""
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ.pop("ROMP_DIST_DIR", None)   # the seam under test — must be absent at load
+km = SourceFileLoader("romp_kernel_distcv", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class DistConverge(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved = (km.UI, km.DIST, km.CHAT_VIEW, km._rebuild_dist, km._sync_notice)
+        km.UI = td / "ui"; km.UI.mkdir()
+        km.CHAT_VIEW = td / "ext"; km.CHAT_VIEW.mkdir()
+        km.DIST = km.CHAT_VIEW / "dist"; km.DIST.mkdir()
+        self.rebuilds, self.notices = [], []
+        self.rebuild_ok = True
+        def fake_rebuild():
+            self.rebuilds.append(1)
+            if self.rebuild_ok:
+                # a real rebuild rewrites the bundles — their mtimes move past the sources
+                (km.DIST / "feed.js").write_text("fresh")
+                now = time.time() + 5
+                os.utime(km.DIST / "feed.js", (now, now))
+                return True, ""
+            return False, "esbuild exploded"
+        km._rebuild_dist = fake_rebuild
+        km._sync_notice = lambda text, ok=True: self.notices.append((ok, text))
+        km._DIST_CONVERGE_TRIED[0] = 0.0
+
+    def tearDown(self):
+        (km.UI, km.DIST, km.CHAT_VIEW, km._rebuild_dist, km._sync_notice) = self._saved
+        km._DIST_CONVERGE_TRIED[0] = 0.0
+        self.td.cleanup()
+
+    def _dist(self, age=100):
+        (km.DIST / "feed.js").write_text("old")
+        t = time.time() - age
+        os.utime(km.DIST / "feed.js", (t, t))
+
+    def _src(self, age=50):
+        (km.UI / "feed.ts").write_text("newer source")
+        t = time.time() - age
+        os.utime(km.UI / "feed.ts", (t, t))
+
+    def test_stale_dist_rebuilds_in_place_with_the_ok_notice(self):
+        self._dist(age=100); self._src(age=50)          # sources newer than the served bundles
+        km._dist_converge_check()
+        self.assertEqual(len(self.rebuilds), 1)
+        self.assertTrue(self.notices and self.notices[0][0] is True)
+        self.assertIn("restart doesn't rebuild", self.notices[0][1])
+
+    def test_fresh_dist_is_left_alone(self):
+        self._src(age=100); self._dist(age=50)          # bundles newer than every source
+        km._dist_converge_check()
+        self.assertEqual(self.rebuilds, [])
+        self.assertEqual(self.notices, [])
+
+    def test_failure_is_loud_and_never_a_retry_storm(self):
+        self.rebuild_ok = False
+        self._dist(age=100); self._src(age=50)
+        km._dist_converge_check()
+        self.assertEqual(len(self.rebuilds), 1)
+        self.assertTrue(self.notices and self.notices[0][0] is False, "a failed build surfaces, never silent")
+        self.assertIn("stale UI", self.notices[0][1])
+        km._dist_converge_check()                        # same source state → one attempt only
+        self.assertEqual(len(self.rebuilds), 1)
+        self._src(age=1)                                 # the sources CHANGED → a fresh attempt is owed
+        km._dist_converge_check()
+        self.assertEqual(len(self.rebuilds), 2)
+
+    def test_success_self_clears_no_second_rebuild(self):
+        self._dist(age=100); self._src(age=50)
+        km._dist_converge_check()
+        km._dist_converge_check()
+        self.assertEqual(len(self.rebuilds), 1, "the rebuilt dist is newer than the sources — settled")
+
+    def test_the_lab_seam_stands_the_converge_down(self):
+        self._dist(age=100); self._src(age=50)
+        os.environ["ROMP_DIST_DIR"] = self.td.name
+        try:
+            km._dist_converge_check()
+        finally:
+            os.environ.pop("ROMP_DIST_DIR", None)
+        self.assertEqual(self.rebuilds, [], "a redirected dist is the test's own to control")
+
+
+class BannerRaiserPins(unittest.TestCase):
+    """The two raiser invariants the T119 trace verified, pinned so they hold: the shim's per-frame
+    dv compare, and the shell's wsFresh handler PRESERVING a latched build prompt (a resync delivers
+    state, never new code)."""
+    KERNEL = Path(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read_text()
+
+    def test_shim_compares_dv_on_every_keepalive(self):
+        self.assertIn('if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();', self.KERNEL)
+
+    def test_wsfresh_keeps_a_latched_build_prompt(self):
+        self.assertIn("else if(m&&m.romp==='wsFresh'){connStale=false;if(buildStale)show(BUILDMSG);", self.KERNEL)
+
+    def test_dist_seam_is_env_keyed(self):
+        self.assertIn('Path(os.environ["ROMP_DIST_DIR"]) if os.environ.get("ROMP_DIST_DIR")', self.KERNEL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/romp-lab/README.md
+++ b/tools/romp-lab/README.md
@@ -40,6 +40,20 @@ Screenshots land in the temp root's `shots/` per phase; the script exits non-zer
 on the first divergence with the phase named, so it loops cleanly in a
 fix → re-run cycle.
 
+## Phases
+
+The default run drives TWO phases, banner first (it spends no model turns):
+
+- **banner-loop.mjs** (T119) — the reload-banner contract on the real stack: a fresh
+  page shows no banner; a dist rebuild (an mtime bump on the lab's own dist copy —
+  `ROMP_DIST_DIR`, so live viewers never see it) raises the shell's `#rstale` within
+  one heartbeat via the shim's keepalive dv-compare; the prompt latches across live
+  pushes (`wsFresh` never retires a build prompt); Reload answers it; and after a
+  real kernel kill + relaunch the reconnected page still banners on the next drift.
+  `--banner-only` runs just this phase.
+- **highlight-loop.mjs** (T102/T106) — the comment-mark contract described above.
+  `--highlight-only` skips the banner phase.
+
 ## Cost
 
 A lab run spends a handful of short turns on the configured model (default Haiku)

--- a/tools/romp-lab/banner-loop.mjs
+++ b/tools/romp-lab/banner-loop.mjs
@@ -1,0 +1,106 @@
+// The scripted RELOAD-BANNER loop (T119, the user 2026-08-27: a restart onto real UI changes never
+// raised the banner — the restart path rebuilt nothing, so no drift existed for any raiser). This
+// phase asserts the banner CONTRACT end to end on the real stack, with zero model spend:
+//   1. a fresh page shows no banner
+//   2. a dist rebuild (simulated: an mtime bump on the LAB's OWN dist copy — ROMP_DIST_DIR) raises
+//      the shell's #rstale within one heartbeat via the shim's ka dv-compare (the window is kept
+//      tighter than the shell's 30s /version poll, so it proves the EVENT path, not the poll)
+//   3. the banner LATCHES across live pushes (wsFresh must never retire a build prompt)
+//   4. Reload answers it: the reloaded page (fresh LOADEDV) shows no banner — click-to-reload only,
+//      never auto (the standing rule)
+//   5. the RECONNECT shape: the kernel is killed and relaunched (a real restart severing every ws);
+//      after the page reconnects, a fresh dist bump must banner again — the reconnected socket's
+//      drift detection, the T119 candidate (b)
+// Exits non-zero naming the first diverging phase; screenshots per phase in $LAB/shots.
+import { createRequire } from "node:module";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const require2 = createRequire(path.join(ROOT, "vscode-extension", "package.json"));
+const { chromium } = require2("playwright");
+
+const PORT = process.env.PORT, TOKEN = process.env.TOKEN, LAB = process.env.LAB_DIR;
+const KPID = Number(process.env.KPID || 0);
+const KERNEL_BIN = process.env.KERNEL_BIN || path.join(ROOT, "bin", "romp-kernel");
+const DIST = process.env.ROMP_DIST_DIR;   // the lab's own copy — bumps here never touch live viewers
+const KA = Number(process.env.ROMP_WS_KEEPALIVE || 10);
+const shots = path.join(LAB, "shots");
+let phaseN = 0;
+const fails = [];
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const b = await chromium.launch();
+const page = await b.newPage({ viewport: { width: 1280, height: 850 } });
+page.on("pageerror", (e) => console.log("PAGEERR", String(e)));
+const shot = async (name) => page.screenshot({ path: path.join(shots, `bn${String(++phaseN).padStart(2, "0")}-${name}.png`) });
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"} banner:${name}${detail ? " — " + detail : ""}`);
+  if (!ok) fails.push(name);
+};
+const bannerShown = () => page.evaluate(() => {
+  const box = document.getElementById("rstale");
+  return !!box && box.classList.contains("show") ? box.querySelector(".rs-msg").textContent : "";
+});
+const bumpDist = () => {
+  const now = new Date();
+  for (const f of fs.readdirSync(DIST)) if (f.endsWith(".js")) fs.utimesSync(path.join(DIST, f), now, now);
+};
+const waitBanner = async (ms) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    const m = await bannerShown();
+    if (m) return m;
+    await sleep(200);
+  }
+  return "";
+};
+const healthy = async () => {
+  try { const r = await fetch(`http://127.0.0.1:${PORT}/healthz`); return r.ok; } catch { return false; }
+};
+
+// ── 1. fresh page: no banner ──
+await page.goto(`http://127.0.0.1:${PORT}/?token=${TOKEN}`);
+await page.waitForSelector("#rstale", { state: "attached", timeout: 20000 });
+await sleep(2 * KA * 1000 + 1000);            // two heartbeats of quiet — nothing may raise on a fresh page
+check("fresh-page-quiet", !(await bannerShown()), await bannerShown());
+await shot("fresh");
+
+// ── 2. dist bump → banner within one heartbeat (the shim's ka path, tighter than the 30s poll) ──
+bumpDist();
+const raised = await waitBanner(2 * KA * 1000 + 3000);
+check("raise-on-drift", raised.includes("newer romp build"), raised || "(never shown)");
+await shot("raised");
+
+// ── 3. the build prompt LATCHES across live pushes (wsFresh keeps it) ──
+await sleep(3000);
+check("latch-across-pushes", (await bannerShown()).includes("newer romp build"));
+
+// ── 4. click-to-reload answers it — and only a click ever does ──
+await page.click("#rstale-reload");
+await page.waitForSelector("#rstale", { state: "attached", timeout: 20000 });
+await sleep(2 * KA * 1000 + 1000);
+check("reload-answers", !(await bannerShown()), await bannerShown());
+await shot("reloaded");
+
+// ── 5. the reconnect shape: kernel killed + relaunched, then a fresh drift must still banner ──
+process.kill(KPID, "SIGTERM");
+const log2 = fs.openSync(path.join(LAB, "kernel.log"), "a");
+const k2 = spawn(KERNEL_BIN, [], { env: process.env, stdio: ["ignore", log2, log2], detached: true });
+k2.unref();
+fs.writeFileSync(path.join(LAB, "kernel.pid"), String(k2.pid));
+const t0 = Date.now();
+while (!(await healthy()) && Date.now() - t0 < 30000) await sleep(500);
+check("kernel-relaunched", await healthy());
+// let the page's shims notice the drop and reconnect (onclose → retry), and the resync land
+await sleep(8000);
+bumpDist();
+const raised2 = await waitBanner(2 * KA * 1000 + 3000);
+check("raise-after-reconnect", raised2.includes("newer romp build"), raised2 || "(never shown)");
+await shot("raised-after-reconnect");
+
+await b.close();
+if (fails.length) { console.log("banner loop FAILED:", fails.join(", ")); process.exit(1); }
+console.log("banner loop: all phases green");

--- a/tools/romp-lab/lab.sh
+++ b/tools/romp-lab/lab.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 KEEP=0
-for a in "$@"; do case "$a" in --keep) KEEP=1 ;; esac; done
+MODE=all
+for a in "$@"; do case "$a" in
+  --keep) KEEP=1 ;;
+  --banner-only) MODE=banner ;;       # the T119 reload-banner phase alone (no model spend)
+  --highlight-only) MODE=highlight ;; # the T102/T106 highlight loop alone
+esac; done
 
 LAB="$(mktemp -d /tmp/romp-lab-XXXXXX)"
 mkdir -p "$LAB/state" "$LAB/shots" "$LAB/project"
@@ -40,9 +45,23 @@ export ROMP_KERNEL_PORT="$PORT"
 # serve the FRESH build, never a stale bundle (the T106 triage's first lesson)
 ( cd "$ROOT/vscode-extension" && node esbuild.js >/dev/null 2>&1 )
 
+# …and serve a COPY of it (T119): the banner phase simulates rebuilds by bumping dist mtimes, and
+# the repo's real dist is what the LIVE kernel serves — a lab run must never raise reload banners
+# on the user's real dashboard. ROMP_DIST_DIR is the kernel's test seam for exactly this; it also
+# stands the kernel's own dist-vs-source converge down, so the lab controls every mtime it asserts.
+mkdir -p "$LAB/dist"
+cp "$ROOT/vscode-extension/dist/"*.js "$LAB/dist/" 2>/dev/null || true
+cp "$ROOT/vscode-extension/dist/"*.css "$LAB/dist/" 2>/dev/null || true
+if [ -d "$ROOT/vscode-extension/dist/fonts" ]; then cp -r "$ROOT/vscode-extension/dist/fonts" "$LAB/dist/fonts"; fi
+export ROMP_DIST_DIR="$LAB/dist"
+# a fast heartbeat so the banner phase's one-heartbeat assertions run in seconds, not tens of them
+export ROMP_WS_KEEPALIVE=2
+
 "$ROOT/bin/romp-kernel" > "$LAB/kernel.log" 2>&1 &
 KPID=$!
 cleanup() {
+  # the banner phase restarts the kernel (its reconnect assertion) and records the new pid
+  [ -f "$LAB/kernel.pid" ] && KPID="$(cat "$LAB/kernel.pid")"
   kill "$KPID" 2>/dev/null || true
   wait "$KPID" 2>/dev/null || true
   if [ "$KEEP" = 1 ]; then echo "kept: $LAB (kernel.log, shots/)"; else rm -rf "$LAB"; fi
@@ -57,9 +76,22 @@ done
 curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null || { echo "kernel never became healthy"; exit 1; }
 echo "lab kernel up on :$PORT (state: $LAB/state)"
 
-LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" PROJECT_DIR="$LAB/project" \
-  node "$ROOT/tools/romp-lab/highlight-loop.mjs"
-RC=$?
-echo "highlight loop exit: $RC (shots: $LAB/shots)"
+RC=0
+if [ "$MODE" != "highlight" ]; then
+  # the reload-banner contract (T119) — first, because it spends no model turns
+  LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" KPID="$KPID" KERNEL_BIN="$ROOT/bin/romp-kernel" \
+    node "$ROOT/tools/romp-lab/banner-loop.mjs" || RC=$?
+  echo "banner loop exit: $RC (shots: $LAB/shots)"
+  [ -f "$LAB/kernel.pid" ] && KPID="$(cat "$LAB/kernel.pid")"
+fi
+if [ "$MODE" != "banner" ] && [ "$RC" = 0 ]; then
+  # the kernel may have been bounced by the banner phase — wait for health before driving it
+  for i in $(seq 1 60); do
+    curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && break; sleep 0.5
+  done
+  LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" PROJECT_DIR="$LAB/project" \
+    node "$ROOT/tools/romp-lab/highlight-loop.mjs" || RC=$?
+  echo "highlight loop exit: $RC (shots: $LAB/shots)"
+fi
 [ "$RC" = 0 ] || KEEP=1
 exit "$RC"


### PR DESCRIPTION
**The found failure path (T119, evidence not assumption):** the banner machinery is sound — the shim compares the keepalive's `dv` against the page's baked `LOADEDV` on every frame, the shell polls `/version` every 30s as a second raiser, and `wsFresh` preserves a latched build prompt. What failed is upstream: **nothing on the restart path rebuilds the bundles** (romp-serve's header claims it; the script has no build step), and the boot drift check compares SHAs only — after a restart onto an advanced checkout, checkout == running == origin, so it sees no drift. dist-vs-source staleness was checked **nowhere**: after the 14:44:39Z restart onto real UI changes, `dv` stayed equal to every open page's `LOADEDV` and no raiser *owed* a banner — 15 minutes of silently stale UI, until the NEXT merge happened to be UI-only and the drift pass rebuilt in place at 14:59:33 (the accidental cure that dates the gap; dist mtimes + the merge sequence confirm it). The relay topology is not implicated: each host's pages compare against their own kernel's dv, which this fix keeps fresh per host.

**Fix — close the class at the source:** `_dist_converge_check` runs at boot and on every drift pass, regardless of update mode (serving bundles that match one's own checkout is correctness, not update policy). dist older than the checkout's UI sources (a stat sweep, `_dist_ver`'s twin on the source side) → the existing in-place rebuild + ok notice; a failed build → a **loud** notice naming the error; one attempt per distinct source state, retried on the next source change or boot — never a silent stale serve, never a retry storm. Banner stays click-to-reload; nothing auto-reloads.

**The lab gains the banner contract as a permanent phase** (`banner-loop.mjs`, zero model spend, runs first by default): fresh page quiet → a dist bump raises `#rstale` within one heartbeat (window tighter than the 30s poll — proves the event path) → the prompt latches across live pushes → Reload answers it → a real kernel kill + relaunch, and the reconnected page banners on the next drift. **All six phases green on the real stack.** The lab serves a COPY of dist via the new `ROMP_DIST_DIR` seam so its mtime games can never raise banners on live viewers; the seam also stands the converge down. `lab.sh` grew `--banner-only` / `--highlight-only`, a `set -e` hazard on the fonts copy was fixed, and cleanup follows the relaunched kernel's recorded pid.

**Tests:** the converge matrix (stale→rebuild+notice, fresh no-op, loud failure without retry storm, success self-clears, seam stand-down), the seam's env keying, and pins on the two raiser invariants the trace verified. Python 5797 passed / extension 2479 passed on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)