### PR TITLE
Deploy restarts drain first: parked polls hold new turn starts (T121 part 1)

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -325,8 +325,12 @@ function quietGate(st, busy, now, opts) {
 
 let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer}
 
-function fetchBusy(port, cb) {
-  const req = http.get({ host: HOST, port, path: '/busy', timeout: 2000 }, (res) => {
+function fetchBusy(port, cb, path) {
+  // the PARKED quiet poll passes '/busy?drain=1' (T121): the same probe that reads the count also
+  // refreshes the kernel's drain lease, so new turn starts hold while the restart is parked and
+  // the count falls on turn-end events. The lease dies by itself (~12s) when this manager stops
+  // polling — no off-switch to forget — and a fresh kernel boots clear by construction.
+  const req = http.get({ host: HOST, port, path: path || '/busy', timeout: 2000 }, (res) => {
     let b = ''; res.on('data', (d) => (b += d));
     res.on('end', () => { let n = null; try { const v = JSON.parse(b).busy; n = Number.isFinite(v) ? v : null; } catch { n = null; } cb(n); });
   });
@@ -379,7 +383,7 @@ function queueQuietRestart(mode) {
   log(`refresh queued — applying at the next quiet window (no SDK turn in flight; backstop ${Math.round(QUIET_MAX_DEFER_MS / 60000)} min)`);
   const tick = () => quietTick({
     pending: () => pendingQuiet,
-    fetchBusy: (cb) => fetchBusy(KERNEL_PORT, cb),
+    fetchBusy: (cb) => fetchBusy(KERNEL_PORT, cb, '/busy?drain=1'),   // parked → hold new turn starts (T121)
     now: Date.now,
     opts: { maxDeferMs: QUIET_MAX_DEFER_MS },
     log,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2370,7 +2370,11 @@ def _run_update(tag):
     q = shlex.quote
     log, rep = q(str(jd.STATE / "update.log")), q(str(jd.STATE / "update-report.json"))
     mport = os.environ.get("ROMP_MANAGER_PORT") or ""
-    restart = ("  curl -s -X POST http://127.0.0.1:%d/restart-all >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
+    # ?when=quiet (T121): the self-update is a DEPLOY — it rides the manager's quiet-window gate
+    # (drain first, backstop-capped) exactly like `romp refresh`, instead of cutting every in-flight
+    # turn immediately. The human Restart buttons (_restart_this_kernel) stay immediate on purpose:
+    # a person pressing Restart wants it now.
+    restart = ("  curl -s -X POST 'http://127.0.0.1:%d/restart-all?when=quiet' >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
         else "  : # no manager — the new code arms on the next romp start (the report says so)\n"
     ok_rep = {"ok": True, "tag": tag, "restarted": bool(mport.isdigit())}
     script = (
@@ -27988,9 +27992,18 @@ class Handler(BaseHTTPRequestHandler):
                 # In-flight SDK turn count — the manager's quiet-window gate for deferred deploy
                 # refreshes (it polls this only while a refresh is pending). Auth-exempt like
                 # /healthz: the manager holds no token, and a bare count leaks nothing.
+                # ?drain=1 (T121): the PARKED poll also refreshes the kernel's drain lease — new
+                # turn starts hold so this count falls to 0 on turn-end events instead of only via
+                # the manager's backstop cut. One round-trip arms both; a plain /busy never holds.
                 be = _sdk()
                 n = be.busy_count() if be and hasattr(be, "busy_count") else 0
-                return self._send(200, json.dumps({"busy": n}), "application/json", cache="no-cache")
+                draining = False
+                if be is not None and hasattr(be, "refresh_drain_hold"):
+                    if parse_qs(urlparse(self.path).query).get("drain", [""])[0] == "1":
+                        be.refresh_drain_hold()
+                    draining = be.drain_holding()
+                return self._send(200, json.dumps({"busy": n, "draining": draining}),
+                                  "application/json", cache="no-cache")
             if p == "/manifest.webmanifest":
                 # the install manifest — auth-exempt like /healthz, and for a hard reason: the
                 # browser's manifest fetch sends NO credentials, so behind the gate it 403s at the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2067,6 +2067,11 @@ class SdkSession:
                     # would land it on the un-rewound branch (the exact wrong-branch delivery this guards)
                     blocked = blocked or bool(self._rewind_to and not self._rewind_armed)
                     blocked = blocked or self._ping_feeding   # the ping's record must not share its window
+                    # a parked deploy restart is DRAINING (T121): hold NEW turn starts — the queued
+                    # prompt persists (the checkpoint) and /busy falls to 0 on this box's own
+                    # turn-end events. Mid-turn forwards keep flowing (inflight > 0), so the
+                    # in-flight turn can still finish; the wedged/rewind holds above are untouched.
+                    blocked = blocked or (self.inflight == 0 and self.backend.drain_holding())
                     item = self._pending.pop(0) if (self._pending and not blocked) else None
                     fresh = item is not None and self.inflight == 0     # starting from idle, not mid-turn
                 if item is None:
@@ -3030,6 +3035,10 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
+        self._drain_hold_until = 0.0              # deploy-drain lease (T121): RUNTIME-ONLY — a fresh boot starts clear by construction
+        self._drain_hold_since = 0.0
+        self._drain_hold_rang = False
+        self._drain_wake_timer = None
         self._usage_all_keyed = False             # refresh_usage's one-shot: the last refresh found only
         #                                           keyed candidates (already logged); reset when a
         #                                           pollable session exists again, so the 60s rail timer
@@ -3500,6 +3509,66 @@ class SdkBackend:
         with self._lock:
             sessions = list(self.sessions.values())
         return sum(1 for s in sessions if s.inflight and not s.ended)
+
+    # ── deploy-drain hold (T121 part 1) ─────────────────────────────────────
+    # While a quiet deploy restart is PARKED at the manager, this kernel holds NEW turn starts so
+    # /busy genuinely drains to 0 on its own turn-end events (before this, kernels kept starting
+    # queued turns and a busy box only ever "drained" via the manager's backstop cut). A LEASE, not
+    # a latch: the manager's quiet poll refreshes it every ~3s (/busy?drain=1), it expires seconds
+    # after the holder dies, and it is RUNTIME-ONLY — a freshly booted kernel starts clear by
+    # construction (the restart the hold served already happened), the manager-approved stale-flag
+    # guard. Mid-turn forwards keep flowing (the in-flight turn must be able to finish); queued
+    # prompts persist to disk — that IS the checkpoint. Visibility: arming logs the parked state
+    # once per episode, and a drain that outlives DRAIN_LOUD_S escalates to the problems ring so a
+    # long-held box never reads as mysteriously idle.
+    DRAIN_HOLD_TTL = 12.0     # seconds; ~4 manager polls — the lease outlives a missed poll, not a dead manager
+    DRAIN_LOUD_S = 300.0      # a drain still holding after 5 min rings — visible, never mysterious
+
+    def refresh_drain_hold(self) -> None:
+        """Arm/extend the drain lease (the manager's parked quiet poll calls this each tick)."""
+        now = time.time()
+        with self._lock:
+            first = self._drain_hold_until <= now
+            self._drain_hold_until = now + self.DRAIN_HOLD_TTL
+            if first:
+                self._drain_hold_since = now
+                self._drain_hold_rang = False
+            t = self._drain_wake_timer
+            self._drain_wake_timer = threading.Timer(self.DRAIN_HOLD_TTL + 0.5, self._wake_all_inputs)
+            self._drain_wake_timer.daemon = True
+            nt = self._drain_wake_timer
+        if t is not None:
+            t.cancel()
+        nt.start()
+        if first:
+            self._log("deploy restart parked: draining — %d in-flight turn(s); new turn starts held "
+                      "until this box quiets (queued prompts persist and start after the bounce)"
+                      % self.busy_count())
+        elif now - self._drain_hold_since > self.DRAIN_LOUD_S and not self._drain_hold_rang:
+            with self._lock:
+                self._drain_hold_rang = True
+            self._log("deploy restart still parked after %d min — %d in-flight turn(s) have not "
+                      "finished; new turn starts remain held (the manager's backstop will apply "
+                      "the restart regardless)" % (int((now - self._drain_hold_since) / 60),
+                                                   self.busy_count()), problem=True)
+
+    def drain_holding(self) -> bool:
+        """Whether new turn starts are currently held for a parked deploy restart."""
+        with self._lock:
+            return self._drain_hold_until > time.time()
+
+    def _wake_all_inputs(self) -> None:
+        """Nudge every session's input generator to re-check its gate — the lease just expired
+        (holder gone), so held fresh turns must start without waiting for another event."""
+        with self._lock:
+            sessions = list(self.sessions.values())
+        for s in sessions:
+            try:
+                loop, wake = s.loop, s._input_wake
+                if loop is not None and wake is not None:
+                    loop.call_soon_threadsafe(wake.set)
+            except Exception:
+                pass
 
     def refresh_usage(self):
         """Ask a live connected session for the exact /usage snapshot (get_usage control request). The

--- a/tests/manager-restart.test.js
+++ b/tests/manager-restart.test.js
@@ -118,3 +118,15 @@ test('quietTick: a quiet fleet applies through the injected apply', () => {
               opts: QOPTS, log: () => {}, schedule: () => {}, apply: (g) => { applied = g; } });
   assert.equal(applied && applied.reason, 'quiet');
 });
+
+// T121: the PARKED quiet poll is also the kernel's drain-lease refresher — one probe reads the
+// count AND holds new turn starts, and the lease dies by itself when this manager stops polling
+// (no off-switch to forget; a fresh kernel boots clear by construction).
+test('the parked quiet poll refreshes the kernel drain lease in the same probe', () => {
+  const fs = require('node:fs');
+  const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
+  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')"),
+    'the quiet tick binds the drain-refresh spelling of the probe');
+  assert.ok(src.includes('path: path || \'/busy\''),
+    'a plain /busy stays side-effect free — only the parked poll holds');
+});

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""The deploy-drain hold (T121 part 1, 2026-08-27): while a quiet deploy restart is PARKED at the
+manager, the kernel holds NEW turn starts so /busy falls to 0 on its own turn-end events — before
+this, kernels kept starting queued turns and a busy box only ever "drained" via the manager's
+backstop cut. The hold is a LEASE (refreshed by the parked poll, self-expiring when the holder
+dies) and RUNTIME-ONLY (a fresh boot starts clear by construction — the manager-approved
+stale-flag guard); arming is visible once per episode and a long hold escalates to the problems
+ring. Mid-turn forwards keep flowing so the in-flight turn can finish; queued prompts persist —
+that IS the checkpoint. Hermetic state; synthetic sids only."""
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_drainhold", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+
+def _backend(d=None):
+    return sb.SdkBackend(d or tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+
+
+class DrainLease(unittest.TestCase):
+    def test_a_fresh_backend_never_holds(self):
+        # boot-clear BY CONSTRUCTION: the lease is runtime-only, so the restart it served can never
+        # leave a standing flag behind — the manager-approved stale-drain guard
+        self.assertFalse(_backend().drain_holding())
+
+    def test_refresh_arms_and_expiry_releases(self):
+        be = _backend()
+        be.DRAIN_HOLD_TTL = 0.15
+        be.refresh_drain_hold()
+        self.assertTrue(be.drain_holding(), "the parked poll's refresh arms the hold")
+        time.sleep(0.25)
+        self.assertFalse(be.drain_holding(),
+                         "the lease dies by itself when the holder stops refreshing — no off-switch to forget")
+
+    def test_expiry_wakes_held_inputs(self):
+        be = _backend()
+        be.DRAIN_HOLD_TTL = 0.1
+        woken = []
+        be._wake_all_inputs = lambda: woken.append(1)
+        be.refresh_drain_hold()
+        time.sleep(0.9)   # the wake timer fires at TTL + 0.5s
+        self.assertTrue(woken, "the lease-end timer nudges every input generator — a held fresh "
+                               "turn starts without waiting for another event")
+
+    def test_arming_is_visible_and_a_long_hold_rings(self):
+        logs = []
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=logs.append)
+        be.refresh_drain_hold()
+        self.assertTrue(any("deploy restart parked" in str(l) for l in logs),
+                        "arming says so once — a draining box never reads as a hung one")
+        be._drain_hold_since = time.time() - be.DRAIN_LOUD_S - 1
+        be.refresh_drain_hold()
+        self.assertTrue(any("still parked" in str(l) for l in logs),
+                        "a hold outliving the loud bound escalates rather than reading as idle sessions")
+
+    def test_the_turn_start_gate_holds_fresh_starts_only(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        self.assertIn("blocked = blocked or (self.inflight == 0 and self.backend.drain_holding())", src,
+                      "the inputs() gate holds NEW turn starts while draining; mid-turn forwards "
+                      "(inflight > 0) keep flowing so the in-flight turn can finish")
+
+    def test_the_kernel_route_and_the_deploy_paths_ride_the_gate(self):
+        ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('parse_qs(urlparse(self.path).query).get("drain", [""])[0] == "1"', ksrc,
+                      "/busy?drain=1 refreshes the lease in the same round-trip that reads the count")
+        self.assertIn('json.dumps({"busy": n, "draining": draining})', ksrc,
+                      "the payload says when the box is draining — glanceable, never mysterious")
+        self.assertIn("'http://127.0.0.1:%d/restart-all?when=quiet'", ksrc,
+                      "the self-update deploy rides the quiet gate instead of cutting immediately")
+        msrc = open(os.path.join(BIN, "romp-manager")).read()
+        self.assertIn("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')", msrc,
+                      "the manager's PARKED poll is the lease's refresher")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -287,7 +287,9 @@ class RunUpdate(Fresh):
         # the restart rides the SUCCESS branch only: everything after `if` up to `else` has it,
         # the failure branch does not
         ok_branch, fail_branch = script.split("else\n", 1)
-        self.assertIn("/restart-all", ok_branch)
+        self.assertIn("/restart-all?when=quiet", ok_branch,
+                      "the self-update is a DEPLOY: it rides the quiet-window gate (drain first, "
+                      "backstop-capped) instead of cutting every in-flight turn (T121)")
         self.assertNotIn("/restart-all", fail_branch)
         self.assertEqual(km._UPDATE_STATE[0], "running")
 


### PR DESCRIPTION
Part 1 of T121, measured by part 3's ledger (cuts per restart, before/after).

**What was leaking.** The quiet-window gate already parked deploy refreshes until `/busy` read 0 — but kernels kept starting queued turns while parked, so a busy box only ever "drained" via the backstop cut. And the self-update deploy skipped the gate entirely: its curl posted `/restart-all` without `?when=quiet`, cutting every in-flight turn immediately on every self-update.

**The hold.** While a quiet restart is parked, the manager's poll rides `/busy?drain=1` — one probe reads the count and refreshes a kernel-side drain lease that holds new turn starts. Mid-turn forwards keep flowing (the in-flight turn must be able to finish; turn-end is the drain's event), queued prompts stay persisted (the checkpoint), and `/busy` genuinely falls to 0. The manager's backstop cap remains the hung-turn bound; the restart notice still covers whatever the cap cuts.

**Stale-flag guards (the approved acceptance items).** The lease is runtime-only — a fresh boot starts clear by construction. It self-expires ~12s after the holder stops polling (a dead manager can never freeze the box), with a wake timer so held turns start the moment it lapses. Arming logs "deploy restart parked: draining — N in-flight turn(s)" once per episode; a hold outliving 5 minutes escalates to the problems ring. `/busy` carries `draining` for glanceable surfaces.

**Deploy paths.** The self-update curl gains `?when=quiet`. The human Restart buttons stay immediate on purpose — a person pressing Restart wants it now.

**Tests.** Hermetic: lease arm/expiry/self-release, expiry wake, episode visibility + loud escalation, fresh-start-only gate pin, the `/busy?drain=1` route + manager probe + quiet curl pins; the update-script pin extended to the quiet spelling; a manager JS pin that a plain `/busy` stays side-effect free.

Suites: pytest 5820 passed / 34 skipped; vscode-extension 2479/2479; manager node tests 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)