### PR TITLE
Classic strip: 2% neutral rest wash + 0.9 label fade; the gauge picker joins the house menus

### DIFF
--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -94,12 +94,13 @@ var GEAR_HTML =
   '<span><b>Show git branch</b>' +
   "<span class=rs-sub>Show the session's git branch (when it's in a repo) in the chat bottom bar, beside the directory.</span>" +
   '</span></label>' +
-  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Context gauge in tabs</b>" +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>Context gauge in tabs</b>" +
   "<span class=rs-sub>A slim vertical bar beside each session's name in the tab strip, filling as its context fills — the same colors as the context battery, no number. By default it appears only once a session is half full, so quiet tabs stay clean.</span>" +
-  "<select id=rs-tabctx style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
-  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
+  "<select id=rs-tabctx style='display:none'>" +
   '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
-  '</select></span></div>' +
+  '</select>' +
+  "<div id=rs-tabctx-pick style='position:relative;margin-top:5px'></div>" +
+  '</span></div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>Chat tabs</b>" +
   "<span class=rs-sub>The tab strip's look. Classic is the original high-contrast strip; Yatharth is the contributed flat-wash aesthetic with the tinted line under the strip.</span>" +
   "<div id=rs-tabtheme style='position:relative;margin-top:5px'></div>" +
@@ -311,6 +312,28 @@ function initGear(post) {
     ttDrop(TABTHEMES, load().chatTabTheme === 'yatharth' ? 'yatharth' : 'classic');
   }
   ttPaint();
+  // The Context-gauge picker joins the same builder (the user 2026-08-27, approving the flagged
+  // migration: one menu vocabulary across the whole panel — the native select stuck out beside
+  // the two house menus). Plain-text options, so the rows are just labels; the HIDDEN select
+  // stays the VALUE holder (the versionMenu pattern): fill()/openSettings keep writing tc.value,
+  // and the pick fires the select's own change event so persistence is the existing handler.
+  var TABCTX = [
+    { id: 'over50', name: 'When above 50%' },
+    { id: 'always', name: 'Always' },
+    { id: 'never', name: 'Never' }
+  ];
+  function tabCtxRowHTML(o) {
+    return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#ccc">' + o.name + '</span>';
+  }
+  var tcDrop = housePick(document.getElementById('rs-tabctx-pick'), 'tabctx', tabCtxRowHTML, function (id) {
+    if (tc) { tc.value = id; tc.dispatchEvent(new Event('change')); }
+    tcPaint();
+  });
+  function tcPaint() {
+    if (!tcDrop) return;
+    tcDrop(TABCTX, tc ? tc.value : 'over50');
+  }
+  tcPaint();
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -645,7 +668,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4007,6 +4007,7 @@ function bgRgb(): [number, number, number] {
 // its luminance hits a uniform low target, so a bright hue (yellow) fades as much
 // as a dim one (blue) — consistent "faded-ness" regardless of color. Never
 // touches the bright color (only used for at-rest tabs).
+const CLASSIC_FADE_SCALE = 0.9;   // T118 (the user 2026-08-27): +10% brighter faded tab labels under Classic — one tunable knob (half the parked T113 number)
 function fadedColor(hex: string): string {
   const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
   if (!m) return hex;
@@ -4016,7 +4017,9 @@ function fadedColor(hex: string): string {
   const lum = (x: number, y: number, z: number) => 0.2126 * x + 0.7152 * y + 0.0722 * z;
   const Lc = lum(r, g, b), Lb = lum(br, bgc, bb), Lt = Lb + 38;
   if (Lc <= Lt) return hex; // already dim — leave it
-  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb));
+  // Classic fades 10% less far toward the background (T118); Yatharth keeps his full fade.
+  const scale = settings.chatTabTheme === "yatharth" ? 1 : CLASSIC_FADE_SCALE;
+  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb)) * scale;
   const hx = (a: number, c: number) => Math.round(a * (1 - t) + c * t).toString(16).padStart(2, "0");
   return `#${hx(r, br)}${hx(g, bgc)}${hx(b, bb)}`;
 }

--- a/ui/webview/settings-dropdown.test.ts
+++ b/ui/webview/settings-dropdown.test.ts
@@ -75,10 +75,17 @@ test("dismissal is event-based: outside click, Escape, the sibling dropdown, and
 test("both pickers build on the ONE dropdown, and repaint on every settings open", () => {
   assert.match(GEAR, /var csDrop = housePick\(cs, 'scheme', schemeRowHTML,/);
   assert.match(GEAR, /var ttDrop = housePick\(tt, 'tabtheme', tabThemeRowHTML,/);
-  assert.match(GEAR, /csPaint\(\); ttPaint\(\); if \(cg\)/,
-    "openSettings repaints BOTH closed rows — a pick made in another pane shows current on open");
+  assert.match(GEAR, /tcPaint\(\); csPaint\(\); ttPaint\(\); if \(cg\)/,
+    "openSettings repaints ALL closed rows — a pick made in another pane shows current on open");
 });
 
-test("the Context-gauge picker stays a native select — plain-text options need no rich rows", () => {
-  assert.match(GEAR, /<select id=rs-tabctx/);
+test("the Context-gauge picker rides the same builder; its hidden select stays the value holder", () => {
+  // The user (2026-08-27) approved the flagged migration: one menu vocabulary across the panel.
+  // The select persists invisibly (the versionMenu pattern) so fill()/openSettings keep writing
+  // tc.value and the existing change handler keeps persisting — the pick fires that same event.
+  assert.match(GEAR, /<select id=rs-tabctx style='display:none'>/);
+  assert.match(GEAR, /var tcDrop = housePick\(document\.getElementById\('rs-tabctx-pick'\), 'tabctx', tabCtxRowHTML,/);
+  assert.match(GEAR, /tc\.value = id; tc\.dispatchEvent\(new Event\('change'\)\);/);
+  assert.match(GEAR, /if \(tc\) tc\.value = tabCtxMode\(s\.tabCtx\); tcPaint\(\);/,
+    "openSettings writes the authoritative value THEN repaints the closed row");
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -295,14 +295,25 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-ph-swirl { width: 12px; height: 12px; border-radius: 2px; flex: none;
   animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with its own gap, so no margin needed */
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
-/* CLASSIC (the default; T113 then tightened by T115, the user 2026-08-27): the tab strip is the
-   PRE-720 strip, byte-for-byte — verified by pixel-diffing a real pre-720 build — with typography
-   the ONE permitted difference (the strip inherits the global Inter/type ladder; the user is fine
-   with any font changes, nothing else). No identity tint at any state, the thick 1.5px inset
-   identity ring on the selected tab, full-contrast faded labels (fadedColor, render.ts), the
-   neutral line under the strip. The Yatharth theme below is the opt-in restoration of the
-   contributor's merged strip aesthetic. */
+/* CLASSIC (the default; T113, tightened by T115, tuned by T118 — the user 2026-08-27): the tab
+   strip is the PRE-720 strip — verified by pixel-diffing a real pre-720 build — modulo exactly
+   three sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 2%
+   neutral rest wash below, and the 0.9 faded-label scale (fadedColor, render.ts; both T118, the
+   user partially restoring parked tunings with new numbers). No identity tint at any state, the
+   thick 1.5px inset identity ring on the selected tab, the neutral line under the strip. The
+   Yatharth theme below is the opt-in restoration of the contributor's merged strip aesthetic. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
+/* T118 (the user 2026-08-27, partially restoring a parked tuning with a NEW number): resting tabs
+   get the hover box's shape in "the slightest slightest lighter gray than the default nothing" —
+   a NEUTRAL 2% white wash, never identity-colored. Rest only: the :not chain excludes every state
+   that paints its own background (hover 0.06 / active 0.14 / blocked red), so there is no
+   same-specificity race to lose — the rule simply never matches those states (the cascade-tiebreak
+   lesson) — and excludes the + affordance (.tab-add, class "tab tab-add", which is not a session
+   tab). Scoped body:not(.chat-theme-yatharth): one rule instead of a Classic rule plus a Yatharth
+   cancel that would need its own specificity juggling. With this and the fadedColor scale in
+   render.ts, Classic = the pre-720 strip modulo exactly three sanctioned deltas: typography, this
+   2% rest wash, and the 0.9 label-fade scale. */
+body:not(.chat-theme-yatharth) .tab:not(.tab-blocked):not(.active):not(:hover):not(.tab-add) { background: rgba(255, 255, 255, 0.02); }
 .tab.active.colored { box-shadow: inset 0 0 0 1.5px var(--chip-bg); }
 /* the identity ring STANDS DOWN while blocked (the user 2026-07-24): the dashed red state outline
    occupies the same band, and blocked outranks identity */

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,10 +1,12 @@
-// The chat-tab appearance themes (T113, tightened by T115 — the user 2026-08-27, reacting to the
-// contributor's strip pass): CLASSIC, the default, is the PRE-720 tab strip byte-for-byte, with
-// typography the ONE permitted difference — the user's amended words: fine with any font changes,
-// nothing else. So: NO identity tint at any state, the thick 1.5px selected ring, the neutral
-// line under the strip, gap 0, and the full pre-720 label fade. T115 verified this by pixel-diffing
-// a real pre-720 build: with fonts normalized, zero differing pixels outside the (out-of-scope)
-// tag-controls box. YATHARTH is the contributor's merged strip aesthetic exactly, opt-in via
+// The chat-tab appearance themes (T113, tightened by T115, tuned by T118 — the user 2026-08-27):
+// CLASSIC, the default, is the PRE-720 tab strip modulo exactly THREE sanctioned deltas —
+// typography (the strip inherits the global Inter/type ladder), T118's 2% neutral rest wash, and
+// T118's 0.9 faded-label scale (the user partially restoring parked T113 tunings with new
+// numbers). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
+// selected ring, the neutral line under the strip, gap 0. T115 verified the baseline equality by
+// pixel-diffing a real pre-720 build: with fonts normalized, zero differing pixels outside the
+// (out-of-scope) tag-controls box — a re-run must subtract the two T118 washes the same way it
+// subtracts fonts. YATHARTH is the contributor's merged strip aesthetic exactly, opt-in via
 // settings and named for him at the user's explicit ask. The seam is the CHAT TAB STRIP only.
 // Source pins per the repo convention; the round-trip is executable.
 import { test } from "node:test";
@@ -41,17 +43,31 @@ test("Classic: the pre-720 strip verbatim — line, gap 0, gray active fill, rin
 });
 
 test("Classic: NO identity tint — every tint rule lives under the theme class", () => {
-  // The user revoked the at-rest wash (T115 amendment): outside the yatharth block there must be
+  // The user revoked the IDENTITY wash (T115 amendment): outside the yatharth block there must be
   // no identity-tinted tab background at all. Every tinted background in the stylesheet is scoped.
+  // (T118's rest wash is NEUTRAL white, not identity — pinned in its own test below.)
   const tintRules = CSS.split("\n").filter((l) => /\.tab[^{]*\{[^}]*color-mix\(in srgb, var\(--chip-bg\)/.test(l));
   for (const l of tintRules) assert.match(l, /^body\.chat-theme-yatharth /, "tint rule must be theme-scoped: " + l);
   const ringLine = CSS.match(/^\.tab\.active\.colored \{.*$/m)![0];
   assert.ok(!ringLine.includes("color-mix"), "the classic selected tab is the gray fill + ring, no tint layer");
 });
 
-test("Classic: the label fade is the pre-720 formula — no theme branch, no brightening scale", () => {
-  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\);/);
-  assert.doesNotMatch(RENDER, /chatTabTheme[^\n]*\? 1 :/, "fadedColor no longer branches on the theme");
+test("Classic: faded labels brighten 10% — one tunable knob, Yatharth keeps his full fade (T118)", () => {
+  assert.match(RENDER, /const CLASSIC_FADE_SCALE = 0\.9;/);
+  assert.match(RENDER, /const scale = settings\.chatTabTheme === "yatharth" \? 1 : CLASSIC_FADE_SCALE;/);
+  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
+});
+
+test("Classic: the 2% NEUTRAL rest wash — rest only, never a state, never the + tab, never Yatharth (T118)", () => {
+  const rule = CSS.match(/^body:not\(\.chat-theme-yatharth\) \.tab([^ ]*) \{ background: (rgba\([^)]*\)); \}$/m);
+  assert.ok(rule, "the rest-wash rule exists, body-scoped OUT of the Yatharth theme in one rule (no cancel rule to race)");
+  assert.equal(rule![2], "rgba(255, 255, 255, 0.02)", "the slightest lighter gray — neutral white, the user's ~2% starting number");
+  for (const excl of [":not(.tab-blocked)", ":not(.active)", ":not(:hover)", ":not(.tab-add)"]) {
+    assert.ok(rule![1].includes(excl), "rest only — the rule never MATCHES " + excl.slice(5, -1) +
+      ", so the stateful backgrounds keep winning without a specificity race (the cascade-tiebreak lesson)");
+  }
+  // hover keeps its existing stronger gray exactly
+  assert.match(CSS, /\.tab:hover \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.06\); \}/);
 });
 
 test("Yatharth: his strip verbatim, scoped to the theme class", () => {


### PR DESCRIPTION
MERGED CONTENT (title/body restored after a mid-flight retitle raced the auto-merge; the retitle described follow-up work that ships separately):

## 1. Faded labels brighten 10% under Classic
`CLASSIC_FADE_SCALE` returns at **0.9** (half the parked number), one tunable knob; Yatharth keeps his full fade via the theme branch.

## 2. A neutral 2% rest wash on Classic tabs
`rgba(255,255,255,0.02)` on resting tabs — one `body:not(.chat-theme-yatharth)`-scoped rule whose `:not` chain excludes hover/active/blocked/`+`. (Superseded in the immediate follow-up: the user redirected resting-tab distinction to a 1px outline, no fill.)

## 3. Context-gauge picker joins the house dropdowns
Hidden select stays the value holder (the `versionMenu` pattern); persistence is the existing change handler.

Suite 2487/2487 at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)