### PR TITLE
T120: the nudge cap escalates to a fresh judgment, and the send moment re-reads the world

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3379,9 +3379,12 @@ def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None):
     """Append one auto-nudge event to STATE/nudge-events.jsonl — {sid, gid, t, count, verdict, evT} —
     for the timeline's DEBUG judging band (per-nudge ⚡ marker) AND the redundancy accounting (the
     user 2026-08-25): every decision the gate takes is a row — fired / skipped-redundant /
-    held-fresh-re-judged / force-fired-at-cap — carrying the evidence snapshot's timestamp, so
-    redundant fires are countable from the log alone (this decides later whether the freshness
-    guard must extend to the cap path). Additive fields; older readers key on sid/gid/t/count."""
+    held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap / resolved-at-send /
+    blocked-on-user-at-send — carrying the evidence snapshot's timestamp, so redundant fires are
+    countable from the log alone. That accounting is what extended the freshness guard to the cap
+    path (the user 2026-08-27, T120: the pre-T120 force-fired-at-cap rows measured the blind fire
+    at 56% of deliveries; the cap now escalates to a fresh judgment instead). Additive fields;
+    older readers key on sid/gid/t/count."""
     try:
         p = jd.STATE / "nudge-events.jsonl"
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -5210,28 +5213,35 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             def _judge_batch(cands, report, report_ts, held_pass):
                 keep = []
                 for f in cands:
-                    if held_pass and _verdicts.get(f[0], ("",))[0] == "force-fired-at-cap":
-                        keep.append(f)               # the cap path is UNCHANGED: it fires regardless,
-                        continue                     #   and never re-judges — only its log row says so
                     gtxt = (_nodes.get(f[0]) or {}).get("text") or ""
                     rec0 = nudged.get(f[0]) or {}
                     skips = rec0.get("redundantSkips") or 0
                     try:
-                        # CAPPED at two consecutive skips (the user 2026-08-23, the same day the gate
-                        # shipped: on a status-heavy session every due nudge can read as redundant, and
-                        # each skip restarting the patience window is a forever-pause with no reviver —
-                        # the exact suppressed-without-reviver class the ladder exists to prevent). Past
-                        # the cap the nudge fires regardless; any real fire or answer resets the count.
-                        if skips < 2 and gtxt and jd.nudge_redundant(gtxt, report):
+                        # THE CAP ESCALATES TO A FRESH JUDGMENT, NEVER PAST ONE (the user 2026-08-27,
+                        # T120, superseding the 2026-08-23 blind third fire). The cap exists because a
+                        # skip restarts the patience window — a forever-pause with no reviver on a
+                        # status-heavy session — but the in-window measurement showed the blind fire
+                        # delivering the MAJORITY of nudges (38 of 68), re-asking questions the
+                        # transcript had already answered (one specimen drew two more nudges AFTER the
+                        # report they asked about). Past two consecutive skips the judge is now
+                        # consulted once more on the freshest evidence instead of short-circuited: a
+                        # not-redundant verdict still fires (the forever-pause still ends, and
+                        # fired-at-cap says how), a still-redundant one skips — the report IS the
+                        # answer, and its skipped-redundant-at-cap row keeps the case countable so the
+                        # optimizer can see a wedge this would hide. The held-pass re-judge applies to
+                        # capped candidates exactly as to organic ones: the old early-keep was the
+                        # second half of the blind fire.
+                        if gtxt and jd.nudge_redundant(gtxt, report):
                             nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1)
                             _put_nudged(f[0], nudged[f[0]])
-                            _v = "held-fresh-re-judged" if held_pass else "skipped-redundant"
+                            _v = ("skipped-redundant-at-cap" if skips >= 2
+                                  else "held-fresh-re-judged" if held_pass else "skipped-redundant")
                             _log_nudge_event(sid, f[0], now, f[1], verdict=_v, ev_t=report_ts)
                             continue
                     except Exception:
                         pass
                     if skips >= 2:
-                        _verdicts[f[0]] = ("force-fired-at-cap", report_ts)
+                        _verdicts[f[0]] = ("fired-at-cap", report_ts)
                     if skips:
                         nudged[f[0]] = dict(rec0, redundantSkips=0)   # firing (or an unjudgeable check) resets
                         _put_nudged(f[0], nudged[f[0]])
@@ -5252,6 +5262,35 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                 if _fresh and _fresh_ts and _fresh_ts > recent_ts:
                     to_fire = _judge_batch(to_fire, _fresh, _fresh_ts, held_pass=True)
                     recent_ts = _fresh_ts             # the fired rows carry the evidence they survived
+    _bnodes = nodes
+    if to_fire:
+        # SEND-MOMENT FRESHNESS (the user 2026-08-27, T120): the fire list read the store BEFORE the
+        # redundancy judge deliberated for seconds, and the card body rendered the tick's snapshot
+        # from before even that — so a verdict landing in the gap left already-resolved items on the
+        # delivered card (the measured specimen: a bundle whose items had all been ruled on by send
+        # time). One fresh read at the send moment, the wake re-key's own idiom: an item the fresh
+        # rollup exports no longer call working has been ruled on since the walk — it leaves the
+        # card with a row saying why (resolved-at-send for a completion/confirming/clear;
+        # blocked-on-user-at-send for a landed block: the user IS the pending event, and nudging the
+        # session re-asks a question already parked on the human). An empty card sends nothing.
+        # Event-keyed on the fresh exports' verdicts — status + confirming, never raw flags, and
+        # never an age window.
+        try:
+            _fr = jd.load_goals(sid)
+            _fst, _fcf = _fr.get("status") or {}, set(_fr.get("confirming") or ())
+            _keep = []
+            for f in to_fire:
+                _s = _fst.get(f[0], "working")
+                if _s == "working" and f[0] not in _fcf:
+                    _keep.append(f)
+                    continue
+                _log_nudge_event(sid, f[0], now, f[1],
+                                 verdict=("blocked-on-user-at-send" if _s == "blocked"
+                                          else "resolved-at-send"), ev_t=recent_ts)
+            to_fire = _keep
+            _bnodes = _fr.get("nodes") or nodes      # the bundle body renders the same fresh world
+        except Exception:
+            pass
     if len(to_fire) == 1:
         gid, count, stalled = to_fire[0]
         text = _nudge_text(count, stalled)             # variant by escalation count — a repeat re-asks in fresh words
@@ -5260,7 +5299,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         # BUNDLE (the user 2026-07-24): several goals due in the SAME tick → ONE message naming them all,
         # instead of N separate status checks the SDK queue would fold into concatenated boilerplate anyway.
         Sessions.backend_for(sid).send(sid, _nudge_bundle_body(
-            [f[0] for f in to_fire], nodes, {f[0] for f in to_fire if f[2]}))
+            [f[0] for f in to_fire], _bnodes, {f[0] for f in to_fire if f[2]}))
     for gid, count, stalled in to_fire:
         _nudge_deferred_ok(gid, "", now, sid)        # the hold is over — drop any deferral record so a stale
         #                                              why can never outlive the wait it described

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -351,6 +351,24 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         self.assertIn(G1, recs)
         self.assertNotIn(G2, recs, "a dropped goal gets no record — it never fired")
 
+    def test_the_bundle_body_renders_the_send_moment_world(self):
+        # T120 (the user 2026-08-27): the card body used to render the tick's snapshot while the
+        # redundancy judge deliberated for seconds — a retitle landing in that gap shipped stale.
+        # The send-moment re-read that drops resolved items also hands the body the fresh nodes.
+        snap = self.store
+        fresh = _store({G1: _node(G1, "Ship the auth refactor, retitled by the planner"),
+                        G2: _node(G2, "Write the migration guide")})
+        calls = {"n": 0}
+
+        def load(sid):
+            calls["n"] += 1
+            return snap if calls["n"] == 1 else fresh
+        jd.load_goals = load
+        self._tick()
+        self.assertEqual(len(self.sent), 1)
+        self.assertIn("retitled by the planner", self.sent[0],
+                      "the delivered card speaks the send-moment world, not the snapshot")
+
 
 class PromptPins(unittest.TestCase):
     def test_plan_sys_sweeps_other_cards_the_segment_resolved(self):

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -7,8 +7,14 @@ session stopped its own loop 11:18:32, the nudge fired 11:18:33 asking where the
 guard is the writer-yields family at the fire moment: the transcript's newest assistant timestamp
 moving past the snapshot's IS the world outrunning the evidence — hold, re-judge ONCE against the
 fresh report (never a loop), fire only what survives. Every gate decision is now a nudge-events row
-(fired / skipped-redundant / held-fresh-re-judged / force-fired-at-cap, each carrying the evidence
-timestamp), so redundant fires are countable from the log alone. SYNTHETIC fixtures only."""
+(fired / skipped-redundant / held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap /
+resolved-at-send / blocked-on-user-at-send, each carrying the evidence timestamp), so redundant
+fires are countable from the log alone. That accounting is what re-shaped the cap (the user
+2026-08-27, T120): the blind third fire measured at 56% of deliveries, re-asking answered
+questions — the cap now ESCALATES to one more judgment on the freshest evidence, never past it.
+And the send moment re-reads the store: an item the fresh rollup no longer calls working leaves
+the card (resolved-at-send / blocked-on-user-at-send) — the redundancy judge deliberates for
+seconds, and verdicts land in that gap. SYNTHETIC fixtures only."""
 import json
 import os
 import tempfile
@@ -152,18 +158,76 @@ class FreshGuard(unittest.TestCase):
         self.assertEqual(self.sent, [])
         self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant"])
 
-    def test_the_cap_path_is_unchanged_and_now_distinguishable(self):
-        # two consecutive skips already recorded → the fire goes out with NO judging at all —
-        # even when the world moved mid-tick, the held pass never re-judges a cap-fire
+    def test_the_cap_consults_the_judge_and_a_fresh_answer_skips(self):
+        # T120 (the user 2026-08-27): past two consecutive skips the judge is CONSULTED once more
+        # instead of short-circuited — a still-redundant verdict skips, because the report IS the
+        # answer (the measured blind fire delivered 38 of 68 nudges, two of them AFTER the report
+        # they asked about).
+        self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
+                        "redundantSkips": 2})
+        self.reports = [("all done — merged and reported", ARM_T + 50)]
+        self.judge_replies = [True]
+        self._tick()
+        self.assertEqual(self.sent, [], "the judge ruled the ask answered — no fire at the cap")
+        self.assertEqual(len(self.judge_calls), 1, "the cap consulted the judge, never bypassed it")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant-at-cap"])
+        rec = km._auto_nudge_data()["nudged"][G1]
+        self.assertEqual(rec.get("answeredAt"), NOW, "the report is recorded as the answer")
+
+    def test_the_cap_fires_when_the_judge_says_the_ask_is_live(self):
+        # the forever-pause the cap was built against still ends: a not-redundant verdict at the
+        # cap fires — now as a JUDGED fire, and its row says how
+        self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
+                        "redundantSkips": 2})
+        self.judge_replies = [False]
+        self.assertTrue(self._tick())
+        self.assertEqual(len(self.sent), 1)
+        self.assertEqual(len(self.judge_calls), 1)
+        self.assertEqual([r["verdict"] for r in self._rows()], ["fired-at-cap"])
+        self.assertEqual(km._auto_nudge_data()["nudged"][G1].get("redundantSkips", 0), 0,
+                         "a real fire resets the count")
+
+    def test_a_capped_candidate_rides_the_held_pass_re_judge(self):
+        # the old early-keep was the second half of the blind fire: a report landing DURING
+        # deliberation now re-judges a capped candidate exactly like an organic one
         self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
                         "redundantSkips": 2})
         self.reports = [("working through the queue", ARM_T + 50),
                         ("all done — merged and reported", ARM_T + 590)]
-        self.judge_replies = [False]                 # would be consulted only by a bug
-        self.assertTrue(self._tick())
-        self.assertEqual(len(self.sent), 1, "past the cap the nudge fires regardless")
-        self.assertEqual(self.judge_calls, [], "…without asking the judge")
-        self.assertEqual([r["verdict"] for r in self._rows()], ["force-fired-at-cap"])
+        self.judge_replies = [False, True]           # live on the snapshot; answered by the fresh report
+        self._tick()
+        self.assertEqual(self.sent, [], "the fresh report answered the ask mid-tick")
+        self.assertEqual(len(self.judge_calls), 2, "snapshot consult + held-pass re-judge")
+        # the verdict is the ORDINARY freshness hold, deliberately: the cap's escalated consult
+        # ruled the ask live (resetting the consecutive count), so the held-pass yield is exactly
+        # an organic writer-yields — the at-cap names mark only decisions taken AT the cap
+        self.assertEqual([r["verdict"] for r in self._rows()], ["held-fresh-re-judged"])
+        self.assertEqual(self._rows()[0]["evT"], ARM_T + 590,
+                         "the row carries the fresh evidence it yielded to")
+
+    def test_an_item_resolved_mid_deliberation_leaves_at_the_send_moment(self):
+        # SEND-MOMENT FRESHNESS (T120): the fire list read the store before the redundancy judge
+        # deliberated — a verdict landing in that gap used to leave a resolved item on the card
+        test = self
+        working, resolved = self.store, _store()
+        resolved["status"][G1] = "completed"
+        jd.load_goals = lambda sid: resolved if test.judge_calls else working
+        self.judge_replies = [False]
+        self._tick()
+        self.assertEqual(self.sent, [], "nothing survives → nothing sends")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["resolved-at-send"])
+
+    def test_a_block_landing_mid_deliberation_suppresses_the_send(self):
+        # blocked-on-user (T120): the user IS the pending event — nudging the session re-asks a
+        # question already parked on the human; the unblocker's verdict is what re-enables
+        test = self
+        working, blocked = self.store, _store()
+        blocked["status"][G1] = "blocked"
+        jd.load_goals = lambda sid: blocked if test.judge_calls else working
+        self.judge_replies = [False]
+        self._tick()
+        self.assertEqual(self.sent, [])
+        self.assertEqual([r["verdict"] for r in self._rows()], ["blocked-on-user-at-send"])
 
 
 if __name__ == "__main__":

--- a/tests/test_nudge_redundancy.py
+++ b/tests/test_nudge_redundancy.py
@@ -77,9 +77,12 @@ class NudgeRedundancy(unittest.TestCase):
         self.assertIn("jd.nudge_redundant(gtxt, report)", src)
         self.assertIn('recent, recent_ts = _last_assistant_report(s["path"])', src)
         self.assertIn("redundantSkips=skips + 1", src)
-        self.assertIn("if skips < 2 and gtxt", src,
-                      "two consecutive skips max — past that the nudge fires regardless, so the "
-                      "gate can never become a forever-pause with no reviver")
+        self.assertIn("if gtxt and jd.nudge_redundant", src,
+                      "the judge is consulted on EVERY due fire — past two consecutive skips the "
+                      "cap escalates to one more judgment on the freshest evidence (T120), never "
+                      "past one; fired-at-cap is how the forever-pause still ends")
+        self.assertIn('"skipped-redundant-at-cap" if skips >= 2', src,
+                      "a still-redundant verdict at the cap skips with its own countable row")
         self.assertIn("redundantSkips=0", src, "a real fire resets the count")
 
 


### PR DESCRIPTION
The 08-25 freshness guard skipped 94 redundant nudges in the measured window, but the force-fire cap then delivered the majority of what got through (38 of 68) by firing the third due nudge blind after two consecutive skips — one specimen drew two more nudges after the report they asked about.

**The cap consults, never bypasses.** Past two consecutive skips the redundancy judge is consulted once more on the freshest evidence instead of short-circuited: not-redundant still fires (`fired-at-cap` — the forever-pause the cap was built against still ends), still-redundant skips with its own countable row (`skipped-redundant-at-cap`). The held-pass early-keep — the second half of the blind fire — is gone: capped candidates yield to mid-tick evidence exactly like organic ones. **Replayed on the window's own 46 cap fires: the consult would have skipped 25 of the 38 with surviving evidence (66%), fired 13.**

**The send moment re-reads the store.** Verdicts landing during the redundancy judge's seconds-long deliberation left already-resolved items on delivered cards (measured: 7 of 89 delivered nudges targeted goals already done or cleared; one specimen card carried three items, all resolved by send time). One fresh read at the send moment: resolved/confirming items leave as `resolved-at-send`, blocked ones as `blocked-on-user-at-send` (the user IS the pending event). An empty card sends nothing, and the bundle body renders the same fresh world. The wake path already stood down on non-working goals at its own re-key (pinned pre-existing).

Tests: cap consult skip/fire shapes, capped candidates riding the held-pass re-judge, send-moment drops (both flavors), bundle body freshness, retargeted source anchors.

Suites: Python 5806/0 (+301 subtests), UI 2479/2479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)