### PR TITLE
romp watch: a kernel-owned predicate watch for ANY background wait (T121 part 2)

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -660,6 +660,7 @@ EOF
     _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
     _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the no-tags view); --host <kernel> edits an attached kernel's tag; --rename renames"
     _romp_cmd "romp watch-pr <n> [--repo o/r]" -        "One mail here when the PR lands or fails — the kernel owns the watch, so it survives restarts (replaces the mortal shell loop)"
+    _romp_cmd "romp watch --cmd '<pred>' [...]" -       "One mail when the command exits 0 (or the timeout passes) — kernel-owned like watch-pr, for ANY background wait (--every Ns --timeout Ns --note '...' | --list | --cancel <id>)"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> [--tag <label>] <text>" - "Hand a session a message; scripts/cron SHOULD pass --tag so it renders machine-sent, not as your typed words"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -954,6 +955,77 @@ fi
 # The SESSION defaults to the caller (ROMP_SID, spawn-frozen in SDK sessions; --session overrides);
 # the REPO defaults to the caller's checkout (gh resolves it from cwd; --repo overrides). Both
 # resolve CLIENT-side so the kernel route stays explicit.
+if [[ "${1:-}" == "watch" ]]; then
+    shift
+    _w_usage="usage: romp watch --cmd '<predicate>' [--every <s>] [--timeout <s>] [--note '<what>'] [--session <name>]
+       romp watch --list
+       romp watch --cancel <id>"
+    _w_cmd=""; _w_every=""; _w_timeout=""; _w_note=""; _w_sess=""; _w_list=0; _w_cancel=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cmd)     shift; [[ $# -eq 0 || -z "$1" ]] && { echo "$_w_usage" >&2; exit 2; }; _w_cmd="$1"; shift ;;
+            --every)   shift; [[ $# -eq 0 || ! "$1" =~ ^[0-9]+$ ]] && { echo "$_w_usage" >&2; exit 2; }; _w_every="$1"; shift ;;
+            --timeout) shift; [[ $# -eq 0 || ! "$1" =~ ^[0-9]+$ ]] && { echo "$_w_usage" >&2; exit 2; }; _w_timeout="$1"; shift ;;
+            --note)    shift; [[ $# -eq 0 ]] && { echo "$_w_usage" >&2; exit 2; }; _w_note="$1"; shift ;;
+            --session) shift; [[ $# -eq 0 || -z "$1" || "$1" == -* ]] && { echo "$_w_usage" >&2; exit 2; }; _w_sess="$1"; shift ;;
+            --list)    _w_list=1; shift ;;
+            --cancel)  shift; [[ $# -eq 0 || -z "$1" ]] && { echo "$_w_usage" >&2; exit 2; }; _w_cancel="$1"; shift ;;
+            *)         echo "$_w_usage" >&2; exit 2 ;;
+        esac
+    done
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp watch: the kernel isn't running (no serve token). Start romp first." >&2
+        exit 1
+    fi
+    if [[ "$_w_list" == "1" ]]; then
+        _romp_token_cfg | curl -sf -m 15 --config - "http://127.0.0.1:$_kport/watches" \
+            | python3 -c 'import json,sys
+rows = json.load(sys.stdin).get("watches") or []
+if not rows: print("romp watch: nothing registered"); raise SystemExit
+for r in rows:
+    print("%s  every %ss  timeout %ss  %s" % (r["id"], r["every"], r["timeoutS"], r.get("note") or r["cmd"]))' \
+            || { echo "romp watch: kernel not reachable on :$_kport" >&2; exit 1; }
+    exit 0
+    fi
+    if [[ -n "$_w_cancel" ]]; then
+        _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/watch" \
+                     -H 'Content-Type: application/json' -d "{\"cancel\": \"$_w_cancel\"}")" \
+            || { echo "romp watch: kernel not reachable on :$_kport" >&2; exit 1; }
+        [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]] \
+            && { echo "romp watch: cancelled $_w_cancel"; exit 0; }
+        echo "romp watch: refused — $_resp" >&2; exit 1
+    fi
+    if [[ -z "$_w_cmd" ]]; then echo "$_w_usage" >&2; exit 2; fi
+    _w_who="$_w_sess"
+    if [[ -z "$_w_who" ]]; then
+        if [[ -z "${ROMP_SID:-}" ]]; then
+            echo "romp watch: --session <name> required outside a romp SDK session (ROMP_SID is not set)" >&2
+            exit 2
+        fi
+        _w_who="$ROMP_SID"
+    fi
+    _w_key="id"; [[ -n "$_w_sess" ]] && _w_key="name"
+    _payload="$(python3 -c 'import json,sys
+b = {"cmd": sys.argv[1], sys.argv[2]: sys.argv[3]}
+if sys.argv[4]: b["every"] = int(sys.argv[4])
+if sys.argv[5]: b["timeoutS"] = int(sys.argv[5])
+if sys.argv[6]: b["note"] = sys.argv[6]
+print(json.dumps(b))' "$_w_cmd" "$_w_key" "$_w_who" "$_w_every" "$_w_timeout" "$_w_note")"
+    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/watch" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp watch: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        _wid="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["watch"]["id"])' "$_resp" 2>/dev/null || true)"
+        echo "romp watch: registered${_wid:+ ($_wid)} — one mail here when the condition holds or the timeout passes"
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp watch: refused — $_err" >&2
+    exit 1
+fi
+
 if [[ "${1:-}" == "watch-pr" ]]; then
     shift
     _wp_usage="usage: romp watch-pr <number> [--repo <owner/name>] [--session <name>]"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10807,6 +10807,178 @@ def _pr_watch_tick(now):
         _pr_watches_save()
 
 
+# ── kernel-owned GENERIC watches (T121 part 2, 2026-08-27): the pr-watch machinery, generalized —
+# sessions kept arming IN-PROCESS background watchers for every other kind of wait (a CI run, a
+# file appearing, a remote queue), and every kernel restart killed them mid-wait (the optimizer
+# measured 15+ in one window, plus ~40 near-empty re-arm wakes in a single watcher session). A
+# generic watch is a PREDICATE COMMAND the KERNEL runs on a cadence: exit 0 means the condition
+# holds → ONE [romp] mail to the registering session (with the predicate's output tail) and the
+# watch retires. Anything else means "not yet" — except an exec failure (127/126) on the FIRST
+# run, which retires LOUDLY at once (a typo'd command must not wait silently for its timeout).
+# Every watch carries a TIMEOUT (default 24h): the giving-up mail is the other end of the standing
+# watcher rule — never a silent dead loop. Same discipline as pr-watches end to end: persisted
+# (watches.json), boot re-armed, one mail through the park-aware injector, rate-gated per row.
+# pr-watches stays its OWN store on purpose: its verdicts are structured gh reads (merged/closed/
+# failed + the busy cadence hint), not a predicate exit — the two share the delivery and the
+# discipline, not a row shape; nothing migrates.
+
+WATCH_FILE = jd.STATE / "watches.json"
+WATCH_MIN_EVERY = 15          # floor: a predicate is a subprocess — never let a watch hammer
+WATCH_DEFAULT_EVERY = 60
+WATCH_DEFAULT_TIMEOUT = 24 * 3600   # a watch with no bound is a leak; the giving-up mail names it
+WATCH_RUN_TIMEOUT = 45        # one predicate run's own bound
+WATCH_MAX = 200               # registration cap — a runaway loop's backstop, far above real use
+_watches = []                 # [{id, cmd, every, timeoutS, sid, note, at} + runtime {_next, _ran}]
+_watch_lock = threading.Lock()
+_WATCH_KEYS = ("id", "cmd", "every", "timeoutS", "sid", "note", "at")
+
+
+def _watches_load():
+    try:
+        rows = json.loads(WATCH_FILE.read_text())
+    except Exception:
+        return
+    if not isinstance(rows, list):
+        return
+    with _watch_lock:
+        _watches[:] = [dict(r) for r in rows
+                       if isinstance(r, dict) and r.get("id") and r.get("cmd") and r.get("sid")]
+        for r in _watches:          # boot re-arm (the pr-watch idiom): fresh counters, poll soon
+            r["_next"], r["_ran"] = 0, True   # a re-armed watch is never "first run" — no exec-fail retire on a boot blip
+    if _watches:
+        sys.stderr.write("romp-kernel: re-armed %d generic watch(es)\n" % len(_watches))
+
+
+def _watches_save():
+    with _watch_lock:
+        rows = [{k: r.get(k) for k in _WATCH_KEYS} for r in _watches]
+    try:
+        _atomic_write(WATCH_FILE, json.dumps(rows))
+    except Exception:
+        sys.stderr.write("watches save: %s\n" % traceback.format_exc())
+
+
+def add_watch(cmd, sid, every=None, timeout_s=None, note="", now=None):
+    """Register a generic watch. Returns (row, error): the persisted row on success, else a
+    human-readable refusal — loud, never a silent drop."""
+    cmd = str(cmd or "").strip()
+    if not cmd:
+        return None, "a watch needs a command (the predicate: exit 0 = condition met)"
+    if len(cmd) > 4000:
+        return None, "that command is too long to be a predicate (4000 chars max)"
+    try:
+        every = max(WATCH_MIN_EVERY, int(every)) if every else WATCH_DEFAULT_EVERY
+    except Exception:
+        return None, "every must be seconds (a number)"
+    try:
+        timeout_s = max(every, int(timeout_s)) if timeout_s else WATCH_DEFAULT_TIMEOUT
+    except Exception:
+        return None, "timeout must be seconds (a number)"
+    with _watch_lock:
+        if len(_watches) >= WATCH_MAX:
+            return None, "too many watches are registered (%d) — cancel some first" % WATCH_MAX
+        wid = os.urandom(4).hex()
+        row = {"id": wid, "cmd": cmd, "every": every, "timeoutS": timeout_s,
+               "sid": str(sid), "note": str(note or "")[:200],
+               "at": int(now if now is not None else time.time()),
+               "_next": 0, "_ran": False}
+        _watches.append(row)
+    _watches_save()
+    return {k: row[k] for k in _WATCH_KEYS}, None
+
+
+def cancel_watch(wid):
+    with _watch_lock:
+        hit = next((r for r in _watches if r.get("id") == wid), None)
+        if hit:
+            _watches.remove(hit)
+    if hit:
+        _watches_save()
+    return bool(hit)
+
+
+def list_watches():
+    with _watch_lock:
+        return [{k: r.get(k) for k in _WATCH_KEYS} for r in _watches]
+
+
+def _watch_notice(kind, row, detail=""):
+    """The one mail a generic watch sends — the [romp] mechanics-notice family (ABOUT romp's own
+    watch service, like the pr-watch and restart notices). PURE for the voice test. The session's
+    own `note` leads when present — the user's words for what they were waiting on."""
+    what = row.get("note") or ("`%s`" % str(row.get("cmd") or "")[:120])
+    if kind == "met":
+        body = ("[romp] The condition you asked romp to watch now HOLDS: %s. This watch is done."
+                % what)
+        tail = (detail or "").strip()
+        if tail:
+            body += "\n\nThe check's last output:\n" + tail[:800]
+    elif kind == "timeout":
+        body = ("[romp] romp gave up watching after %s: %s never held (the check kept saying not-yet). "
+                "This watch is done — re-register with `romp watch` if you still need it."
+                % (_fmt_span_s(int(row.get("timeoutS") or 0)), what))
+    else:   # execfail — the first run could not even execute
+        body = ("[romp] The watch command could not run at all (%s): %s. This watch was dropped — "
+                "fix the command and re-register with `romp watch`."
+                % (detail or "exec failed", what))
+    return body + "\n\n<!-- romp-tag: watch -->"
+
+
+def _fmt_span_s(s):
+    if s >= 3600:
+        return "%dh%s" % (s // 3600, ("%02dm" % (s % 3600 // 60)) if s % 3600 else "")
+    if s >= 60:
+        return "%dm" % (s // 60)
+    return "%ds" % s
+
+
+def _watch_run(cmd):
+    """One predicate run → (exitcode, output tail). Bounded; a timeout reads as not-yet (the
+    predicate gets another try — its own bound is the watch timeout)."""
+    try:
+        r = subprocess.run(["/bin/sh", "-c", cmd], capture_output=True, text=True,
+                           timeout=WATCH_RUN_TIMEOUT)
+        out = ((r.stdout or "") + (("\n" + r.stderr) if r.stderr else "")).strip()
+        return r.returncode, out[-1000:]
+    except subprocess.TimeoutExpired:
+        return None, "the check ran past %ds" % WATCH_RUN_TIMEOUT
+    except Exception as e:
+        return 127, str(e)[:200]
+
+
+def _watch_tick(now):
+    """One supervisor-pass sweep (rate-gated per row) — the pr-watch pump's twin."""
+    with _watch_lock:
+        rows = list(_watches)
+    done = []
+    for r in rows:
+        if now < r.get("_next", 0):
+            continue
+        if now - int(r.get("at") or 0) >= int(r.get("timeoutS") or WATCH_DEFAULT_TIMEOUT):
+            _pr_watch_deliver(r["sid"], _watch_notice("timeout", r))
+            done.append(r)
+            continue
+        code, out = _watch_run(r["cmd"])
+        first = not r.get("_ran")
+        r["_ran"] = True
+        if code == 0:
+            _pr_watch_deliver(r["sid"], _watch_notice("met", r, out))
+            done.append(r)
+            continue
+        if first and code in (126, 127):
+            # a command that cannot exec at all must not wait silently for its timeout
+            _pr_watch_deliver(r["sid"], _watch_notice("execfail", r, out or ("exit %s" % code)))
+            done.append(r)
+            continue
+        r["_next"] = now + int(r.get("every") or WATCH_DEFAULT_EVERY)
+    if done:
+        with _watch_lock:
+            for r in done:
+                if r in _watches:
+                    _watches.remove(r)
+        _watches_save()
+
+
 def _fleet_usage():
     """One row per HOST whose usage is known — local always first (the notices read off it), each row
     {host, acct, usage}.
@@ -11965,6 +12137,7 @@ def _tunnel_supervisor():
                 # Once per (host, level); a failed push retries next pass.
                 _push_origin_trust_rows()
             _pr_watch_tick(now)          # PR-landing watches (rate-gated per row; loud on gh failure)
+            _watch_tick(now)             # generic predicate watches (T121 part 2) — same pump discipline
             # Everything above is the supervisor's own state (status, fails, next_try, kernel_sha, detail).
             # None of it used to reach disk — only the act routes saved — so the file could sit frozen on a
             # failure long after the row recovered. Signature-gated: a steady fleet writes nothing.
@@ -28109,6 +28282,11 @@ class Handler(BaseHTTPRequestHandler):
                               "records": {k: v for k, v in (nd.get("nudged") or {}).items() if mine(k)},
                               "walkGates": {k: v for k, v in (nd.get("walkGates") or {}).items() if mine(k)}},
                 }), "application/json", cache="no-cache")
+            if p == "/watches":
+                # the registered generic watches, for `romp watch --list` — AUTHED (rows carry
+                # user-written commands; nothing here is exempt-safe like the bare /busy count)
+                return self._send(200, json.dumps({"watches": list_watches()}), "application/json",
+                                  cache="no-cache")
             if p == "/views":                             # the session-views blob (active view, hidden set,
                 # tags) for scripts/agents: the read half of POST /tag, AND the remote-poll source of
                 # tag federation v0. CANONICAL shape (member pairs), remoteTags absent on purpose:
@@ -28755,6 +28933,35 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": False, "error":
                         'no session answers to "%s"' % who}), "application/json")
                 row = add_pr_watch(prn, repo, tsid)
+                return self._send(200, json.dumps({"ok": True, "watch": row}), "application/json")
+            if u.path == "/watch":
+                # Register a GENERIC predicate watch (T121 part 2): the kernel runs `cmd` on a
+                # cadence; exit 0 = the condition holds → one [romp] mail to the session and the
+                # watch retires; a timeout mails the giving-up notice (never a silent dead loop).
+                # Body: {"cmd": "...", "id"|"name": <session>, "every"?: s, "timeoutS"?: s,
+                # "note"?: "..."} — or {"cancel": <watch id>} to retire one early.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                if b.get("cancel"):
+                    ok = cancel_watch(str(b["cancel"]).strip())
+                    return self._send(200, json.dumps({"ok": ok} if ok else
+                        {"ok": False, "error": "no watch with that id (see `romp watch --list`)"}),
+                        "application/json")
+                who = str(b.get("id") or b.get("name") or "").strip()
+                if not str(b.get("cmd") or "").strip() or not who:
+                    return self._send(400, json.dumps({"ok": False, "error":
+                        "cmd (the predicate: exit 0 = met) and id|name (the session to mail) required"}),
+                        "application/json")
+                tsid = _sid_of(who)
+                if not tsid:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'no session answers to "%s"' % who}), "application/json")
+                row, err = add_watch(b.get("cmd"), tsid, every=b.get("every"),
+                                     timeout_s=b.get("timeoutS"), note=b.get("note"))
+                if err:
+                    return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "watch": row}), "application/json")
             if u.path in ("/tag", "/group"):
                 # Headless tag edit (`romp tag`, the user 2026-08-23, the manager/worker workflow:
@@ -30288,6 +30495,7 @@ def main():
     _known_load()                                              # remembered past hosts (popover's re-attach rows)
     _remotes_load()                                            # re-attach remote kernels from a prior run
     _pr_watches_load()                                         # re-arm PR-landing watches (same intent rule)
+    _watches_load()                                            # …and the generic watches (T121 part 2)
     _consume_update_report()                                   # last self-update's outcome → the Log, once
     threading.Thread(target=_update_check_loop, daemon=True).start()   # newer release? boot + every 6h (mode-gated inside)
     threading.Thread(target=_ensure_postal_bus, daemon=True).start()   # a sessionless machine still needs its bus

--- a/tests/test_generic_watch.py
+++ b/tests/test_generic_watch.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Kernel-owned GENERIC watches (T121 part 2, 2026-08-27): sessions kept arming in-process
+background watchers for every non-PR wait, and kernel restarts killed them mid-wait. A generic
+watch is a PREDICATE COMMAND the kernel runs on a cadence — exit 0 = the condition holds → ONE
+[romp] mail (with the check's output tail) and the watch retires; the TIMEOUT mails the giving-up
+notice (the standing watcher rule's other end); a first-run exec failure (127/126) retires loudly
+at once. Persisted (watches.json), boot re-armed, the pr-watch pump's discipline end to end.
+Synthetic only; hermetic state; predicates are stubbed at _watch_run."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_gw", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-6666666666aa"
+
+
+class _Watches(unittest.TestCase):
+    def setUp(self):
+        with km._watch_lock:
+            km._watches[:] = []
+        try:
+            km.WATCH_FILE.unlink()
+        except OSError:
+            pass
+        self.mails = []
+        self._saved_deliver = km._pr_watch_deliver
+        self._saved_run = km._watch_run
+        km._pr_watch_deliver = lambda sid, text: self.mails.append((sid, text)) or True
+
+    def tearDown(self):
+        km._pr_watch_deliver = self._saved_deliver
+        km._watch_run = self._saved_run
+        with km._watch_lock:
+            km._watches[:] = []
+        try:
+            km.WATCH_FILE.unlink()
+        except OSError:
+            pass
+
+
+class Register(_Watches):
+    def test_add_persists_and_boot_rearms(self):
+        row, err = km.add_watch("test -f /tmp/x", SID, every=30, timeout_s=600, note="the file", now=100)
+        self.assertIsNone(err)
+        self.assertEqual((row["every"], row["timeoutS"], row["note"]), (30, 600, "the file"))
+        # the store survives a "restart": clear runtime, reload from disk
+        with km._watch_lock:
+            km._watches[:] = []
+        km._watches_load()
+        rows = km.list_watches()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], row["id"], "the watch re-arms on boot — a restart moves it, never kills it")
+
+    def test_refusals_are_loud_and_floors_hold(self):
+        row, err = km.add_watch("", SID)
+        self.assertIsNotNone(err)
+        row, err = km.add_watch("true", SID, every=1)
+        self.assertEqual(row["every"], km.WATCH_MIN_EVERY, "the cadence floor — a watch never hammers")
+        row, err = km.add_watch("true", SID)
+        self.assertEqual(row["timeoutS"], km.WATCH_DEFAULT_TIMEOUT, "an unbounded watch is a leak — 24h default")
+
+    def test_cancel_retires_early(self):
+        row, _ = km.add_watch("true", SID)
+        self.assertTrue(km.cancel_watch(row["id"]))
+        self.assertFalse(km.cancel_watch(row["id"]))
+        self.assertEqual(km.list_watches(), [])
+
+
+class Tick(_Watches):
+    def test_met_mails_once_with_the_output_tail_and_retires(self):
+        km.add_watch("check thing", SID, note="the deploy finished", now=0)
+        km._watch_run = lambda cmd: (1, "not yet")
+        km._watch_tick(10.0)
+        self.assertEqual(self.mails, [], "not-yet keeps waiting quietly")
+        km._watch_run = lambda cmd: (0, "deployed v2 OK")
+        km._watch_tick(100.0)
+        self.assertEqual(len(self.mails), 1)
+        sid, text = self.mails[0]
+        self.assertEqual(sid, SID)
+        self.assertIn("now HOLDS: the deploy finished", text, "the user's note leads — their words for the wait")
+        self.assertIn("deployed v2 OK", text, "the check's output rides along")
+        self.assertIn("<!-- romp-tag: watch -->", text)
+        self.assertEqual(km.list_watches(), [], "one mail, then the watch retires")
+
+    def test_timeout_mails_the_giving_up_notice(self):
+        km.add_watch("never", SID, every=15, timeout_s=60, now=0)
+        km._watch_run = lambda cmd: (1, "")
+        km._watch_tick(30.0)
+        self.assertEqual(self.mails, [])
+        km._watch_tick(61.0)
+        self.assertEqual(len(self.mails), 1)
+        self.assertIn("gave up watching", self.mails[0][1])
+        self.assertIn("never held", self.mails[0][1])
+        self.assertEqual(km.list_watches(), [], "the standing watcher rule: never a silent dead loop")
+
+    def test_first_run_exec_failure_retires_loudly_at_once(self):
+        km.add_watch("nosuchbinary --flag", SID, now=0)
+        km._watch_run = lambda cmd: (127, "sh: nosuchbinary: not found")
+        km._watch_tick(1.0)
+        self.assertEqual(len(self.mails), 1)
+        self.assertIn("could not run at all", self.mails[0][1])
+        self.assertEqual(km.list_watches(), [], "a typo'd command must not wait silently for its timeout")
+
+    def test_a_rearmed_watch_never_takes_the_first_run_retire(self):
+        km.add_watch("flaky", SID, now=0)
+        with km._watch_lock:
+            km._watches[:] = []
+        km._watches_load()   # the boot path marks rows as already-run
+        km._watch_run = lambda cmd: (127, "transient PATH blip on boot")
+        km._watch_tick(1.0)
+        self.assertEqual(self.mails, [], "a boot blip is not a typo — the re-armed watch keeps waiting")
+        self.assertEqual(len(km.list_watches()), 1)
+
+    def test_rate_gate_and_cadence(self):
+        km.add_watch("slow", SID, every=60, now=0)
+        runs = []
+        km._watch_run = lambda cmd: runs.append(1) or (1, "")
+        km._watch_tick(1.0)
+        km._watch_tick(2.0)
+        self.assertEqual(len(runs), 1, "the per-row gate holds between polls")
+        km._watch_tick(62.0)
+        self.assertEqual(len(runs), 2)
+
+
+class Wiring(_Watches):
+    def test_pump_and_boot_are_wired_beside_the_pr_watch(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn("_watch_tick(now)             # generic predicate watches (T121 part 2)", src,
+                      "the generic tick rides the same supervisor pass as the pr-watch pump")
+        self.assertIn("_watches_load()                                            # …and the generic watches", src,
+                      "…and the same boot re-arm")
+
+    def test_the_real_watch_run_contract(self):
+        code, out = km._watch_run("exit 3")
+        self.assertEqual(code, 3)
+        code, out = km._watch_run("echo held; exit 0")
+        self.assertEqual((code, out), (0, "held"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part 2 of T121. Sessions kept arming in-process background watchers for every non-PR wait, and kernel restarts killed them mid-wait — watch-pr proved the kernel-owned shape; this generalizes it.

**The primitive.** A generic watch is a predicate command the kernel runs on a cadence: exit 0 = the condition holds → one `[romp]` mail to the registering session (the check's output tail rides along; the session's own `--note` leads when present) and the watch retires. Anything else = not yet — except an exec failure (127/126) on the first run, which retires loudly at once (a typo'd command must not wait silently for its timeout), and never on a re-armed row (a boot PATH blip is not a typo). Every watch carries a timeout (default 24h): the giving-up mail is the standing watcher rule's other end — never a silent dead loop.

**Same discipline as pr-watches end to end.** Persisted (`watches.json`), boot re-armed, delivered through the same park-aware injector, rate-gated per row on the same supervisor pass. pr-watches stays its own store on purpose: its verdicts are structured gh reads (merged/closed/failed + the busy cadence hint), not a predicate exit — the two share the delivery and the discipline, not a row shape; nothing migrates.

**Surface.** `romp watch --cmd '<predicate>' [--every s] [--timeout s] [--note '...'] [--session name] | --list | --cancel <id>`. Routes: POST `/watch` (register/cancel; the session resolves like `/send`'s), GET `/watches` — authed deliberately (rows carry user-written commands), not in the exempt block beside `/busy`. Floors: 15s cadence minimum, 200-watch cap, 45s per predicate run.

**Tests.** Hermetic: register/persist/boot-rearm; met/timeout/execfail mails with the voice tag; the rearmed-row exec-fail exemption; the per-row rate gate; the real `/bin/sh` contract; pump/boot wiring pins.

Suites: pytest 5830 passed / 34 skipped; vscode-extension 2486/2486; manager node tests 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)