### PR TITLE
Classic rest outline replaces the wash; winframe leaves Classic; house menus across the panel

### DIFF
--- a/ui/webview/chat-affordances.test.ts
+++ b/ui/webview/chat-affordances.test.ts
@@ -16,11 +16,12 @@ test("the fold toggle and file links have a persistent dotted-underline link aff
   assert.match(CSS, /\.tool-file \{[^}]*text-decoration: underline dotted/);
 });
 
-test("session identity: rail (2px, 70%) + the soft 1px pane ring in the SAME color", () => {
-  // 2026-06-23 removed the old 2px decorative frame; 2026-08-26 the user asked for the identity
-  // color to go all the way around the current session, linked to its tab — re-introduced at a
-  // third of the weight (1px, 30% tint), transparent when no session color. Never 2px again.
-  assert.match(CSS, /#winframe \{ display: block; position: fixed; inset: 0; z-index: 900; pointer-events: none;\n  border: 1px solid color-mix\(in srgb, var\(--active-accent, transparent\) 30%, transparent\); \}/);
+test("session identity: rail (2px, 70%) + the pane ring THEMED under Yatharth, none in Classic", () => {
+  // 2026-06-23 removed the old 2px decorative frame; PR 730 re-introduced a 1px/30% linkage ring;
+  // T122 (the user 2026-08-27: there never used to be an outline around the chat, and there
+  // wasn't) scopes it under the Yatharth theme — Classic is frameless, byte-equal to pre-730.
+  assert.match(CSS, /#winframe \{ display: none; \}/);
+  assert.match(CSS, /body\.chat-theme-yatharth #winframe \{ display: block; position: fixed; inset: 0; z-index: 900; pointer-events: none;\n  border: 1px solid color-mix\(in srgb, var\(--active-accent, transparent\) 30%, transparent\); \}/);
   assert.doesNotMatch(CSS, /#winframe \{[^}]*border: 2px solid/);
   assert.match(CSS, /\.turn::before \{[^}]*width: 2px[^}]*background: var\(--active-accent[^}]*opacity: 0\.7/);
   // T113→T115 (the user 2026-08-27): CLASSIC is the default and is the PRE-720 strip verbatim,

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -67,14 +67,12 @@ var GEAR_HTML =
   '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
   '<span class=rs-sub>romp watches for new tagged releases (every 6 hours) AND new commits on main (origin polled every few minutes, plus a restart offer when updated code sits on disk unbooted) — one banner covers both, and acting on it converges every attached machine. Check and ask (the default) offers the banner with an Update button; Install automatically converges by itself, restarting at the next quiet moment; Off never checks. Kernel-side setting.</span>' +
-  "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
-  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
+  "<select id=rs-updates style='display:none'>" +
   '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +
   '</select></span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
   '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK. Both kinds run side by side; this only sets the default.</span>' +
-  "<select id=rs-backend style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
-  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
+  "<select id=rs-backend style='display:none'>" +
   '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option>' +
   '</select></span></div>' +
   '<div class=rs-sec>Judges</div>' +
@@ -254,9 +252,16 @@ function initGear(post) {
     try { window.addEventListener('storage', function (e) { if (e.key === 'romp:menu-echo' && e.newValue) close(); }); } catch (e) {}
     // paint(options, curId): the closed row shows the CURRENT option, the menu one row per option
     return function (options, curId) {
-      var cur = options[0];
+      // options can be EMPTY: the swept effort selects start blank until /models resolves
+      // (fillChoices) — paint a quiet placeholder row instead of dying on options[0].name,
+      // which would abort the whole initGear before anything else wired (caught in the
+      // Playwright harness pre-merge; kernel tests also pin this file clear of retired option
+      // words, so keep comments plain here).
+      var cur = null;
       options.forEach(function (o) { if (o.id === curId) cur = o; });
-      btn.innerHTML = rowHTML(cur) + '<span style="flex:0 0 auto;margin-left:auto;opacity:0.55">\u25BE</span>';
+      if (!cur) cur = options.length ? options[0] : null;
+      btn.innerHTML = (cur ? rowHTML(cur) : '<span style="flex:1 1 auto;min-width:0;color:#8a8a8a">\u2026</span>') +
+        '<span style="flex:0 0 auto;margin-left:auto;opacity:0.55">\u25BE</span>';
       menu.innerHTML = '';
       options.forEach(function (o) {
         var row = document.createElement('div');
@@ -264,7 +269,7 @@ function initGear(post) {
         row.style.cssText = 'display:flex;align-items:center;gap:8px;min-width:0;position:relative;' +
           'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer';
         row.innerHTML = rowHTML(o);
-        if (o.id === cur.id) {
+        if (cur && o.id === cur.id) {
           var ck = document.createElement('span'); ck.textContent = '\u2713';
           ck.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
           row.appendChild(ck);
@@ -334,6 +339,42 @@ function initGear(post) {
     tcDrop(TABCTX, tc ? tc.value : 'over50');
   }
   tcPaint();
+  // The remaining native selects sweep onto the same builder (the user 2026-08-27, closing the
+  // 3-house/3-native split the gauge migration left): a generic adapter over ANY hidden select —
+  // options snapshot from sel.options (so the effort selects, whose options arrive from /models
+  // in fillChoices, stay correct), the pick writes sel.value and fires the select's own change
+  // event, so every existing persistence path (setUpdateMode / s.backend / setJudgeEffort / ...)
+  // and the fillMixedMarks row lookup keep working untouched. Repaints ride the same events the
+  // value rides: the change event, a childList mutation (fillChoices rewriting options), and the
+  // end of fill() (which sets values silently — repaintSelectPicks below). The model pickers keep
+  // versionMenu (they need family→version submenus); tabctx/scheme/theme have their own rows.
+  var selectPickPaints = [];
+  function repaintSelectPicks() { selectPickPaints.forEach(function (fn) { fn(); }); }
+  function selectPick(sel, wrapStyle) {
+    if (!sel) return;
+    sel.style.display = 'none';
+    var wrap = document.createElement('div');
+    wrap.setAttribute('style', 'position:relative;' + wrapStyle);
+    sel.parentNode.insertBefore(wrap, sel.nextSibling);
+    var rowHTML = function (o) {
+      return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#ccc">' + o.name + '</span>';
+    };
+    var drop = housePick(wrap, 'val', rowHTML, function (id) {
+      sel.value = id; sel.dispatchEvent(new Event('change')); paint();
+    });
+    function paint() {
+      drop(Array.prototype.map.call(sel.options, function (o) { return { id: o.value, name: o.textContent }; }), sel.value);
+    }
+    sel.addEventListener('change', paint);
+    new MutationObserver(paint).observe(sel, { childList: true });
+    selectPickPaints.push(paint);
+    paint();
+  }
+  selectPick(upm, 'margin-top:5px');
+  selectPick(bk, 'margin-top:5px');
+  selectPick(je, 'flex:0 0 auto;width:45%');
+  selectPick(ie, 'flex:0 0 auto;width:45%');
+  selectPick(de, 'flex:0 0 auto;width:45%');
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -629,6 +670,7 @@ function initGear(post) {
     // field takes a typed path, which is what that machine has. An older kernel sends no verdict and
     // keeps the button it always had.
     if (ddb && typeof v.nativeDialogs === 'boolean') ddb.style.display = v.nativeDialogs ? '' : 'none';
+    repaintSelectPicks();   // fill() writes sel.value directly (no change event) — the closed rows follow
     var x = lv(); b.innerHTML = 'kernel ' + (v.kernel_sha || '?') + '\nserving v' + v.dist_ver + '\nthis tab v' + (x || '?');
   }).catch(function () { b.textContent = '(version unavailable)'; }); }
   // The settings modal is full-WINDOW in the web shell — ask it to expand the

--- a/ui/webview/settings-dropdown.test.ts
+++ b/ui/webview/settings-dropdown.test.ts
@@ -23,7 +23,7 @@ const pickBody = (() => {
 })();
 
 test("closed state is ONE row: a full-width button with the current option + caret, no option list", () => {
-  assert.match(pickBody, /btn\.innerHTML = rowHTML\(cur\) \+ '<span style="flex:0 0 auto;margin-left:auto;opacity:0\.55">\\u25BE<\/span>'/,
+  assert.match(pickBody, /btn\.innerHTML = \(cur \? rowHTML\(cur\) : '<span style="flex:1 1 auto;min-width:0;color:#8a8a8a">\\u2026<\/span>'\) \+\n\s*'<span style="flex:0 0 auto;margin-left:auto;opacity:0\.55">\\u25BE<\/span>'/,
     "the button re-paints to the CURRENT option each paint — name + description in one row, caret at the end");
   assert.match(pickBody, /width:100%;min-width:0/, "the button fills the row and can shrink — the ellipsis engages instead of overrunning");
   assert.match(pickBody, /menu\.hidden = true;?\n/, "the option menu starts hidden — options are one click away, never always-expanded");
@@ -77,6 +77,24 @@ test("both pickers build on the ONE dropdown, and repaint on every settings open
   assert.match(GEAR, /var ttDrop = housePick\(tt, 'tabtheme', tabThemeRowHTML,/);
   assert.match(GEAR, /tcPaint\(\); csPaint\(\); ttPaint\(\); if \(cg\)/,
     "openSettings repaints ALL closed rows — a pick made in another pane shows current on open");
+});
+
+test("an empty option list paints a placeholder, never a crash — the effort selects start blank", () => {
+  // The swept effort pickers have NO options until /models resolves; options[0].name on an empty
+  // list threw inside initGear and took the whole settings panel down (caught headless, pre-merge).
+  assert.match(GEAR, /if \(!cur\) cur = options\.length \? options\[0\] : null;/);
+  assert.match(GEAR, /cur \? rowHTML\(cur\) : '<span style="flex:1 1 auto;min-width:0;color:#8a8a8a">\\u2026<\/span>'/);
+  assert.match(GEAR, /if \(cur && o\.id === cur\.id\) \{/);
+});
+
+test("every remaining native select rides the adapter — one vocabulary across the panel", () => {
+  assert.match(GEAR, /selectPick\(upm, 'margin-top:5px'\);/);
+  assert.match(GEAR, /selectPick\(bk, 'margin-top:5px'\);/);
+  assert.match(GEAR, /selectPick\(je, 'flex:0 0 auto;width:45%'\);/);
+  assert.match(GEAR, /selectPick\(ie, 'flex:0 0 auto;width:45%'\);/);
+  assert.match(GEAR, /selectPick\(de, 'flex:0 0 auto;width:45%'\);/);
+  assert.match(GEAR, /repaintSelectPicks\(\);   \/\/ fill\(\) writes sel\.value directly/,
+    "fill() sets values with no change event — the closed rows repaint at its end");
 });
 
 test("the Context-gauge picker rides the same builder; its hidden select stays the value holder", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -126,14 +126,16 @@ html, body {
 }
 body { display: flex; flex-direction: column; overflow-x: hidden; }   /* the chat pane NEVER scrolls
    sideways (the user 2026-08-16) — a wide child is a layout bug to fix, not a scroll to offer */
-/* The active session's identity color goes ALL THE WAY AROUND its pane (the user 2026-08-26, who
-   wanted the current session unmistakably linked to its tab) — a whisper-thin tinted ring, drawn as
-   a fixed overlay ON TOP so the tab bar / composer backgrounds can't paint over it, pointer-events:
-   none so it never blocks. History: a 2px frame here was removed on 2026-06-23 as decorative noise;
-   this re-introduction is that user's own later call, at a third of the weight (1px, 30% tint) and
-   CARRYING MEANING — it is the same color as the active tab's tint and the transcript rail, so the
-   three read as one linked object. No session color → transparent, no frame at all. */
-#winframe { display: block; position: fixed; inset: 0; z-index: 900; pointer-events: none;
+/* The whole-pane session-color ring is the CONTRIBUTOR's linkage piece, themed (T122, the user
+   2026-08-27, who confirmed there never used to be a thin session-color outline around the chat —
+   and there wasn't): Classic renders NO frame, byte-equal to pre-730. History: a 2px frame here
+   was removed 2026-06-23 as decorative noise; PR 730 re-introduced the idea at a third of the
+   weight (1px, 30% tint, the same color as the active tab + transcript rail so the three read as
+   one linked object); T122 scopes that re-introduction under the Yatharth theme, where the rest
+   of his aesthetic lives. Fixed overlay ON TOP, pointer-events:none; no session color →
+   transparent even there. */
+#winframe { display: none; }
+body.chat-theme-yatharth #winframe { display: block; position: fixed; inset: 0; z-index: 900; pointer-events: none;
   border: 1px solid color-mix(in srgb, var(--active-accent, transparent) 30%, transparent); }
 
 /* ---------- tab bar ---------- */
@@ -297,23 +299,25 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
 /* CLASSIC (the default; T113, tightened by T115, tuned by T118 — the user 2026-08-27): the tab
    strip is the PRE-720 strip — verified by pixel-diffing a real pre-720 build — modulo exactly
-   three sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 2%
-   neutral rest wash below, and the 0.9 faded-label scale (fadedColor, render.ts; both T118, the
-   user partially restoring parked tunings with new numbers). No identity tint at any state, the
+   three sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
+   hover-gray rest outline below (T123), and the 0.9 faded-label scale (fadedColor, render.ts;
+   T118 — both are the user restoring parked tunings, renumbered). No identity tint at any state, the
    thick 1.5px inset identity ring on the selected tab, the neutral line under the strip. The
    Yatharth theme below is the opt-in restoration of the contributor's merged strip aesthetic. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
-/* T118 (the user 2026-08-27, partially restoring a parked tuning with a NEW number): resting tabs
-   get the hover box's shape in "the slightest slightest lighter gray than the default nothing" —
-   a NEUTRAL 2% white wash, never identity-colored. Rest only: the :not chain excludes every state
-   that paints its own background (hover 0.06 / active 0.14 / blocked red), so there is no
-   same-specificity race to lose — the rule simply never matches those states (the cascade-tiebreak
-   lesson) — and excludes the + affordance (.tab-add, class "tab tab-add", which is not a session
-   tab). Scoped body:not(.chat-theme-yatharth): one rule instead of a Classic rule plus a Yatharth
-   cancel that would need its own specificity juggling. With this and the fadedColor scale in
-   render.ts, Classic = the pre-720 strip modulo exactly three sanctioned deltas: typography, this
-   2% rest wash, and the 0.9 label-fade scale. */
-body:not(.chat-theme-yatharth) .tab:not(.tab-blocked):not(.active):not(:hover):not(.tab-add) { background: rgba(255, 255, 255, 0.02); }
+/* T123 (the user 2026-08-27, redirecting T118's resting-tab distinction — the merged 2% fill
+   came out for this): resting tabs wear a SUPER-THIN outline at all times, no fill — the tab body
+   stays the dark background, ringed by 1px in EXACTLY the gray the hover fill uses
+   (rgba(255,255,255,0.06) — keep the two in lockstep if either is tuned; the width rides .tab's
+   existing 1px border, so there is zero layout shift and both are one-line tunables). It rides
+   border-color, a DIFFERENT property from the state backgrounds, so hover's fill needs no
+   exclusion — the outline stays under the fill, same color, and the tab reads as one object
+   filling in. The :not chain stands down for the states that own their border/ring band: active
+   (the identity ring + baseline transparent border), blocked (the dashed red outline), and the +
+   affordance, which is not a session tab. Yatharth untouched via the body scope. With this and
+   fadedColor's 0.9 scale (render.ts), Classic = the pre-720 strip modulo exactly three sanctioned
+   deltas: typography, this rest outline, and the label-fade scale. */
+body:not(.chat-theme-yatharth) .tab:not(.tab-blocked):not(.active):not(.tab-add) { border-color: rgba(255, 255, 255, 0.06); }
 .tab.active.colored { box-shadow: inset 0 0 0 1.5px var(--chip-bg); }
 /* the identity ring STANDS DOWN while blocked (the user 2026-07-24): the dashed red state outline
    occupies the same band, and blocked outranks identity */

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,8 +1,7 @@
 // The chat-tab appearance themes (T113, tightened by T115, tuned by T118 — the user 2026-08-27):
 // CLASSIC, the default, is the PRE-720 tab strip modulo exactly THREE sanctioned deltas —
-// typography (the strip inherits the global Inter/type ladder), T118's 2% neutral rest wash, and
-// T118's 0.9 faded-label scale (the user partially restoring parked T113 tunings with new
-// numbers). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
+// typography (the strip inherits the global Inter/type ladder), T123's 1px hover-gray rest
+// outline, and T118's 0.9 faded-label scale (the user restoring parked tunings, redirected). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
 // selected ring, the neutral line under the strip, gap 0. T115 verified the baseline equality by
 // pixel-diffing a real pre-720 build: with fonts normalized, zero differing pixels outside the
 // (out-of-scope) tag-controls box — a re-run must subtract the two T118 washes the same way it
@@ -45,7 +44,7 @@ test("Classic: the pre-720 strip verbatim — line, gap 0, gray active fill, rin
 test("Classic: NO identity tint — every tint rule lives under the theme class", () => {
   // The user revoked the IDENTITY wash (T115 amendment): outside the yatharth block there must be
   // no identity-tinted tab background at all. Every tinted background in the stylesheet is scoped.
-  // (T118's rest wash is NEUTRAL white, not identity — pinned in its own test below.)
+  // (T123's rest OUTLINE is neutral hover-gray, not identity — pinned in its own test below.)
   const tintRules = CSS.split("\n").filter((l) => /\.tab[^{]*\{[^}]*color-mix\(in srgb, var\(--chip-bg\)/.test(l));
   for (const l of tintRules) assert.match(l, /^body\.chat-theme-yatharth /, "tint rule must be theme-scoped: " + l);
   const ringLine = CSS.match(/^\.tab\.active\.colored \{.*$/m)![0];
@@ -58,16 +57,19 @@ test("Classic: faded labels brighten 10% — one tunable knob, Yatharth keeps hi
   assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
 });
 
-test("Classic: the 2% NEUTRAL rest wash — rest only, never a state, never the + tab, never Yatharth (T118)", () => {
-  const rule = CSS.match(/^body:not\(\.chat-theme-yatharth\) \.tab([^ ]*) \{ background: (rgba\([^)]*\)); \}$/m);
-  assert.ok(rule, "the rest-wash rule exists, body-scoped OUT of the Yatharth theme in one rule (no cancel rule to race)");
-  assert.equal(rule![2], "rgba(255, 255, 255, 0.02)", "the slightest lighter gray — neutral white, the user's ~2% starting number");
-  for (const excl of [":not(.tab-blocked)", ":not(.active)", ":not(:hover)", ":not(.tab-add)"]) {
-    assert.ok(rule![1].includes(excl), "rest only — the rule never MATCHES " + excl.slice(5, -1) +
-      ", so the stateful backgrounds keep winning without a specificity race (the cascade-tiebreak lesson)");
+test("Classic: the rest OUTLINE — 1px in the hover gray, no fill, states stand down (T123)", () => {
+  const rule = CSS.match(/^body:not\(\.chat-theme-yatharth\) \.tab([^ ]*) \{ border-color: (rgba\([^)]*\)); \}$/m);
+  assert.ok(rule, "the rest-outline rule exists, body-scoped OUT of the Yatharth theme");
+  assert.equal(rule![2], "rgba(255, 255, 255, 0.06)", "EXACTLY the hover fill's gray — tune them in lockstep");
+  for (const excl of [":not(.tab-blocked)", ":not(.active)", ":not(.tab-add)"]) {
+    assert.ok(rule![1].includes(excl), "the outline stands down for " + excl.slice(5, -1) +
+      " — those states own their border/ring band");
   }
-  // hover keeps its existing stronger gray exactly
+  // border-color is a different property from the state FILLS, so hover needs no exclusion — the
+  // outline stays under hover's fill (same color, one object filling in) and the fill itself…
   assert.match(CSS, /\.tab:hover \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.06\); \}/);
+  // …and no resting FILL remains: the T118 2% wash was replaced by this outline (T123).
+  assert.doesNotMatch(CSS, /\.tab[^{]*\{ background: rgba\(255, 255, 255, 0\.0[24]\); \}/);
 });
 
 test("Yatharth: his strip verbatim, scoped to the theme class", () => {


### PR DESCRIPTION
Three calls from the user, folded into one follow-up to the just-merged strip-tuning PR.

## 1. Resting-tab distinction redirected: outline, not fill (T123)
The just-merged 2% rest wash comes **out**. Every resting tab wears a **super-thin 1px outline in exactly the gray the hover fill uses** (`rgba(255,255,255,0.06)` — tune the two in lockstep), riding `.tab`'s existing 1px border so there is **zero layout shift**; color and width stay one-line tunables. It rides `border-color`, a different property from the state fills, so hover needs no exclusion — the outline stays under hover's unchanged fill and the tab reads as one object filling in. The `:not` chain stands down for active (identity ring), blocked (dashed red), and `+`; Yatharth untouched via the body scope.

**Classic = pre-720 modulo exactly three sanctioned deltas**: typography, this rest outline, the 0.9 fade — pins and block comments carry the swapped list.

## 2. The whole-pane session ring leaves Classic (T122)
The user confirmed there never used to be an outline around the chat — and there wasn't (2px removed 2026-06-23 as noise; PR 730 re-introduced 1px/30%). Classic renders **no frame, byte-equal to pre-730** (`display:none`); the ring lives on under `body.chat-theme-yatharth` exactly as merged.

## 3. House menus across the whole panel
The remaining native selects (updates, backend, three effort pickers) sweep onto the `housePick` dropdowns via a generic hidden-select adapter — options snapshot from `sel.options` (effort options arrive async from `/models`: childList observer + a repaint at the end of `fill()`), the pick writes `sel.value` and fires the select's own `change` event, so every persistence path and `fillMixedMarks` keep working untouched. Model pickers keep `versionMenu`.

**Empty-options safety, caught headless pre-merge**: the effort selects start blank until `/models` resolves; `options[0].name` on an empty list threw inside `initGear` and took the whole settings panel down. The closed row paints a quiet `…` placeholder instead, pinned by test.

## Verification
Headless over built bundles: rest background transparent with the 1px outline rendering; hover 0.06 fill unchanged and continuous over the outline; active ring untouched; `+` excluded; Yatharth 9% tint + his winframe ring intact (Classic `display:none`); backend/updates picks round-trip through the hidden selects; effort dropdown paints placeholder when blank, repaints on option arrival; jrow layout holds. Suite 2489/2489, tsc clean. Comparison screenshots (rest/hover/selected) in the task report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)