### PR TITLE
The multi-row tab strip becomes a band, the way polished multi-tab UIs ground theirs

### DIFF
--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -155,6 +155,16 @@ body.chat-theme-yatharth #winframe { display: block; position: fixed; inset: 0; 
    the active/hover fills and per-tab padding still separate neighbours visually. (The Yatharth
    theme reopens a 3px seam — its flat tints need one; see its block below.) */
 #tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; }
+/* T125 (the user 2026-08-27, screenshot: with wrapped rows the tabs read as floating boxes): the
+   strip is a BAND — its own background plane a hair above the page, containing every wrapped row,
+   closed by the existing --box-border hairline at its bottom edge. This is how tab strips are
+   grounded in the polished multi-tab precedents (browser frame bands, editor tab-group headers,
+   design-system "tabs on a surface + divider"): the plane says "one control", the hairline says
+   "it ends here" — per-row separator lines were rejected as clutter. 3% white over the page bg
+   (tunable one-liner); background only, so zero layout shift, and the selected ring / blocked
+   dashed / rest outline / hover fill all read as before, now against the band. Classic only:
+   Yatharth keeps his merged look via the body scope. */
+body:not(.chat-theme-yatharth) #tabbar { background: linear-gradient(rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.03)), var(--vscode-sideBar-background, var(--bg)); }
 /* Drag handle straddling the tab strip's bottom border (the user 2026-08-18): the strip scrolls past
    its max-height cap, which clipped the fifth row of a many-session strip with no way to see more.
    Drag DOWN for more rows, UP for fewer; double-click resets; the strip stays a scroll pane at every
@@ -299,9 +309,9 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
 /* CLASSIC (the default; T113, tightened by T115, tuned by T118 — the user 2026-08-27): the tab
    strip is the PRE-720 strip — verified by pixel-diffing a real pre-720 build — modulo exactly
-   three sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
-   hover-gray rest outline below (T123), and the 0.9 faded-label scale (fadedColor, render.ts;
-   T118 — both are the user restoring parked tunings, renumbered). No identity tint at any state, the
+   four sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
+   hover-gray rest outline below (T123), the 0.9 faded-label scale (fadedColor, render.ts; T118),
+   and the strip band (T125, below). No identity tint at any state, the
    thick 1.5px inset identity ring on the selected tab, the neutral line under the strip. The
    Yatharth theme below is the opt-in restoration of the contributor's merged strip aesthetic. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,7 +1,7 @@
 // The chat-tab appearance themes (T113, tightened by T115, tuned by T118 — the user 2026-08-27):
 // CLASSIC, the default, is the PRE-720 tab strip modulo exactly THREE sanctioned deltas —
 // typography (the strip inherits the global Inter/type ladder), T123's 1px hover-gray rest
-// outline, and T118's 0.9 faded-label scale (the user restoring parked tunings, redirected). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
+// outline, T118's 0.9 faded-label scale, and T125's strip band (the multi-row grounding). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
 // selected ring, the neutral line under the strip, gap 0. T115 verified the baseline equality by
 // pixel-diffing a real pre-720 build: with fonts normalized, zero differing pixels outside the
 // (out-of-scope) tag-controls box — a re-run must subtract the two T118 washes the same way it
@@ -78,6 +78,17 @@ test("Yatharth: his strip verbatim, scoped to the theme class", () => {
   assert.match(CSS, /body\.chat-theme-yatharth \.tab\.colored:not\(\.tab-blocked\) \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 9%, transparent\);\n\}/);
   assert.match(CSS, /body\.chat-theme-yatharth \.tab\.colored:not\(\.tab-blocked\):hover \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 15%, transparent\);\n\}/);
   assert.match(CSS, /body\.chat-theme-yatharth \.tab\.active\.colored:not\(\.tab-blocked\) \{\n  background: color-mix\(in srgb, var\(--chip-bg\) 22%, transparent\);\n  border-color: color-mix\(in srgb, var\(--chip-bg\) 55%, transparent\);\n  box-shadow: none;\n\}/);
+});
+
+test("Classic: the strip is a BAND — a 3% plane over the page bg, closed by the hairline (T125)", () => {
+  // The user (2026-08-27, screenshot): wrapped rows read as floating boxes. The survey verdict
+  // across editors (VS Code wrapTabs, JetBrains multi-row), browsers/terminals, and design-system
+  // specs (Material's mandatory divider, Carbon/Ant contained tabs) is unanimous: containment
+  // comes from the strip owning a background PLANE, closed by ONE bottom hairline — not from
+  // per-row lines. 3% white over --bg reproduces VS Code's canonical #252526-over-#1E1E1E band.
+  assert.match(CSS, /^body:not\(\.chat-theme-yatharth\) #tabbar \{ background: linear-gradient\(rgba\(255, 255, 255, 0\.03\), rgba\(255, 255, 255, 0\.03\)\), var\(--vscode-sideBar-background, var\(--bg\)\); \}$/m,
+    "the band: one Classic-scoped background line, tunable in place; Yatharth keeps his merged look");
+  assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/, "…closed by the ONE existing hairline at the band's bottom edge");
 });
 
 test("the gear offers the picker in the one menu vocabulary, Classic first", () => {


### PR DESCRIPTION
The user (screenshot): with a couple of wrapped rows the tabs read as floating boxes — and their words deferred the mechanism to good precedent ('the same way that other visually aesthetically pleasing softwares do').

## Survey verdict (3 domains, unanimous)
- **Editors/IDEs**: VS Code `wrapTabs` — the real multi-row precedent — grounds wrapped rows with the tabs-band background (+ optional bottom border); JetBrains multi-row = band + bottom border.
- **Browsers/terminals**: Chrome/Firefox/Safari/tmux all ground tabs as flat elements ON a distinct band plane.
- **Design systems**: Material mandates surface + bottom divider; Carbon contained / Ant card tabs bound the group with a band + one nav-level hairline that survives wrapping unchanged. The hairline-under-last-row alone is the Fluent/Atlassian minimal treatment — viable only because their strips are guaranteed ONE row. It demonstrably fails at three (the screenshot).

**Containment comes from the plane change, not lines.** Per-row hairlines (JetBrains' extra move) were rejected: their tabs are flat and need row definition; ours already carry the rest outlines.

## The change
One Classic-scoped rule: `#tabbar` paints a **3% white plane over the page background** — which lands exactly on VS Code's canonical tabs-band contrast (`#252526` over `#1E1E1E`) — beneath the existing `--box-border` hairline at the band's bottom edge. Background only: **zero layout shift**; the selected ring / blocked dashed / rest outline / hover fill all read exactly as before, now against the band. Yatharth untouched via the body scope. Tunable in place (one line).

Classic = pre-720 modulo exactly **four** sanctioned deltas now: typography, the rest outline, the 0.9 fade, and this band — pins and block comments carry the list.

## Verification
Headless over built bundles at 1 and 3 rows, before/after screenshots in the task report. Webview suite 2490/2490 (new band pin included), tsc clean; kernel settings-sections + the styles.css-reading kernel test files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)