### PR TITLE
T126: tracking ids are jargon to every writer, and the origin kernel walks the chain at relay time

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1300,7 +1300,8 @@ GIST_SYS = (
     "settings'; 'the feed card recency tint'; 'why the parser drops compaction boundaries'; 'a regression "
     "test for the planner'.\n"
     "Keep the request's own vocabulary: never import a coined or internal name the request itself "
-    "does not use.\n"
+    "does not use. A ticket-shaped lead token (T120, ABC-42) is an id, not the topic: name what "
+    "the request is about instead.\n"
     "When the request rambles or bundles several things, name the single most salient topic. Output only "
     "the phrase.")
 
@@ -2015,7 +2016,8 @@ PLAN_SYS = (
     "\"it is worth noting\", \"notably\"), no em dashes, state facts plainly and hedge only actual "
     "guesses, say it once. Goal text speaks the requester's vocabulary: never a coined or internal "
     "name (an engine, a module, a codename, a team shorthand) unless the user's own message uses "
-    "it; say what the work is in plain words. Most segments do one thing, but emit more ops when the segment actually did "
+    "it; say what the work is in plain words. A ticket-shaped lead token in the message (T120, "
+    "ABC-42) is an id, not the ask: never open goal text with it. Most segments do one thing, but emit more ops when the segment actually did "
     "more (e.g. finished one goal and started another). Op kinds:\n"
     '- {\"why\",\"do\":\"mint\",\"text\":\"<outcome ≤10 words>\"}: a new top-level request from the '
     "user. Be selective: only a real new ask mints a top-level goal — but a **distinct deliverable** "
@@ -9760,7 +9762,9 @@ DISTILL_SYS = (
     "present, it is their ask in their own words: anchor on its vocabulary. Never use a coined or "
     "internal name (an engine, a module, a codename, a team shorthand) in an opening sentence "
     "unless the <user-ask> itself uses it; gloss any internal noun you keep in plain words, and a "
-    "noun you cannot explain from the material given stays out.\n\n"
+    "noun you cannot explain from the material given stays out. A bare tracking id (T120, ABC-42: "
+    "an opaque ticket token) is an internal name like any other: never open with one, and never "
+    "treat it as the work's proper name.\n\n"
     "When <work> contains a message the assistant wrote to the person as its finished report, a "
     "wrap-up addressed to them rather than to a teammate, condense that report as the takeaway's "
     "primary source: it was already written for their eyes, and it outranks your own reading of "
@@ -10046,7 +10050,9 @@ BLOCK_BRIEF_SYS = (
     "present, it is their ask in their own words: anchor on its vocabulary. Never use a coined or "
     "internal name (an engine, a module, a codename, a team shorthand) in an opening sentence "
     "unless the <user-ask> itself uses it; gloss any internal noun you keep in plain words, and a "
-    "noun you cannot explain from the material given stays out.\n\n"
+    "noun you cannot explain from the material given stays out. A bare tracking id (T120, ABC-42: "
+    "an opaque ticket token) is an internal name like any other: never open with one, and never "
+    "treat it as the work's proper name.\n\n"
     "When <work> contains a message the assistant wrote to the person about this decision, laid "
     "out for their eyes rather than a teammate's, condense it as the primary source; the owed "
     "decision still leads. Prefer sources in this order: that message, then the <user-ask>, then "
@@ -10232,6 +10238,42 @@ def _live_prompt_since(fsid):
     except OSError:
         return None
     return since
+
+
+_TICKET_SEP_RE = re.compile(r"^\s*[\[\(]?(?:T\d{1,6}|#\d{1,6})[\]\)]?\s*[:,\-—–]+\s*")
+_TICKET_BARE_RE = re.compile(r"^\s*[\[\(]?T\d{2,6}[\]\)]?\s+")
+
+
+def _strip_ticket_lead(s):
+    """Drop a ticket-shaped LEAD token from card-bound text (the user 2026-08-27, T126: a
+    dispatch led with an opaque tracking id, the courier compressed that first line into goal
+    text, and every writer thereafter treated the id as the work's proper name — the jargon gate
+    read it as the title, not as jargon). MECHANICAL scope is deliberately narrow: T<digits> and
+    #<digits> with an explicit separator, or T<2+ digits> on bare space — shapes that cannot be
+    natural language. The GENERAL shape (bare alphanumeric ids) is the writers' judgment call via
+    their prompt lines: a mechanical rule wide enough to catch ABC-42 also beheads real titles
+    about GPT-4 or COVID-19. A title that IS only the token keeps it (better a bare id than an
+    empty card); the raw line survives in the stored frame for provenance either way."""
+    t = str(s or "")
+    out = _TICKET_SEP_RE.sub("", t, count=1)
+    if out == t:
+        out = _TICKET_BARE_RE.sub("", t, count=1)
+    out = out.strip()
+    return out if out else t.strip()
+
+
+_CARRIED_ASK_RE = re.compile(r"<user-ask>\s*(.*?)\s*</user-ask>", re.S | re.I)
+
+
+def _carried_user_ask(body):
+    """A delegating mail's EXPLICIT quoted requester ask — the sender-declared <user-ask> block
+    (the user 2026-08-27, T126): a chain that routes through a FOREIGN kernel rightly refuses the
+    root walk's hops, so no walk-resolved record can ever ride along, and the writers anchored on
+    the intermediary's framing. Same trust class as the frame (sender-declared, stored verbatim-
+    shaped); a walk-RESOLVED root always outranks a carried claim. '' when the body carries no
+    block."""
+    m = _CARRIED_ASK_RE.search(str(body or ""))
+    return m.group(1).strip() if m else ""
 
 
 def _ask_head(s, cap=700):
@@ -11387,13 +11429,14 @@ def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None, frame=No
                 return nid
     store["seq"] = store.get("seq", 0) + 1
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-    payload = {"id": nid, "text": (text or "(delegation)")[:120], "parentId": None,
+    payload = {"id": nid, "text": (_strip_ticket_lead(text) or "(delegation)")[:120], "parentId": None,
                "nodeComplete": False, "blocked": False, "cleared": False,
                "trail": [seg_id], "t": seg_t, "origin": origin, "promptUuid": prompt_uuid, "log": []}
     if frame:
         payload["frame"] = frame
     if isinstance(user_ask, dict) and str(user_ask.get("text") or "").strip():
-        payload["userAsk"] = {"text": _ask_head(str(user_ask["text"])), "sid": user_ask.get("sid")}
+        payload["userAsk"] = {"text": _ask_head(str(user_ask["text"])), "sid": user_ask.get("sid"),
+                              **({"carried": True} if user_ask.get("carried") else {})}
     nodes[nid] = GuardedNode(payload)
     placements[seg_id] = nid
     store["lastNode"] = nid                            # the delegation is now the active focus
@@ -11458,7 +11501,7 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
         parent_id = None                                # linked goal vanished → file as a top, never orphan
     store["seq"] = store.get("seq", 0) + 1
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-    label = "↪ delegated to %s: %s" % (peer_name or peer_sid[:8], text or "(work)")
+    label = "↪ delegated to %s: %s" % (peer_name or peer_sid[:8], _strip_ticket_lead(text) or "(work)")
     handoff = {"peer": peer_sid, "msgId": mid}
     if tracked:
         handoff["tracked"] = True
@@ -11946,6 +11989,14 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # state still reaches the board through the hard-block floor/placeholder, which need no
             # goal node. Uncertainty quiets by design (the trace's docstring names the surface).
             rooted = _delegate_user_rooted(sender, link_id, paths_map, now)
+            # CARRIED USER-ASK (the user 2026-08-27, T126): a dispatch may QUOTE the requester in
+            # an explicit <user-ask> block — the cross-host shape, where the walk rightly refuses
+            # foreign-kernel hops and could never resolve a local record. Sender-declared, the
+            # frame's trust class; consulted only when the walk resolves nothing (a walk-resolved
+            # root outranks a carried claim), and it LICENSES the mint below: an explicit quote of
+            # the requester is the ask flowing down in the sender's own hand, not the uncertainty
+            # T101 quiets on.
+            carried = "" if rooted else _carried_user_ask(_postal_row(mid)[3] or text)
             # THE ASK IS THE CARD UNIT (the user 2026-08-26, T101): a dispatch whose chain roots to
             # an ask that ALREADY HAS A CARD — link_id resolved to the sender's ask node — LINKS
             # instead of minting: the tracking node below plants under that ask (fan-out lives
@@ -11955,7 +12006,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # top — there the recipient card IS the ask's card, the fallback that keeps every user
             # ask carded somewhere. Linking alone never moves the ask card's column: planting a
             # tracking child writes no verdict on the ask.
-            mint_recipient = rooted and not link_id
+            mint_recipient = (rooted or carried) and not link_id
             # Mint the sender's precise '↪ delegated to <recipient>' tracking node (the user 2026-06-22) and
             # point B's goal at IT — so run_propagate checks off only the handed-off piece, never the sender's
             # broader linked goal. Saved to the sender's tree before planting G on the recipient's.
@@ -11995,7 +12046,9 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                 origin["peerHost"] = frm_host
             apply_courier(store, seg_id, seg_t, edit["text"], origin, prompt_uuid=anchor_uuid,
                           frame=_postal_body_head(mid) or _frame_head(text),
-                          user_ask=rooted if isinstance(rooted, dict) else None)
+                          user_ask=(rooted if isinstance(rooted, dict)
+                                    else {"text": carried, "sid": sender, "carried": True}
+                                    if carried else None))
             #             ^ the ledger row's body is authoritative; a row the local ledger lacks
             #               (some cross-host deliveries) falls back to the delivered segment's own
             #               head — same content, one hop later

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10240,42 +10240,6 @@ def _live_prompt_since(fsid):
     return since
 
 
-_TICKET_SEP_RE = re.compile(r"^\s*[\[\(]?(?:T\d{1,6}|#\d{1,6})[\]\)]?\s*[:,\-—–]+\s*")
-_TICKET_BARE_RE = re.compile(r"^\s*[\[\(]?T\d{2,6}[\]\)]?\s+")
-
-
-def _strip_ticket_lead(s):
-    """Drop a ticket-shaped LEAD token from card-bound text (the user 2026-08-27, T126: a
-    dispatch led with an opaque tracking id, the courier compressed that first line into goal
-    text, and every writer thereafter treated the id as the work's proper name — the jargon gate
-    read it as the title, not as jargon). MECHANICAL scope is deliberately narrow: T<digits> and
-    #<digits> with an explicit separator, or T<2+ digits> on bare space — shapes that cannot be
-    natural language. The GENERAL shape (bare alphanumeric ids) is the writers' judgment call via
-    their prompt lines: a mechanical rule wide enough to catch ABC-42 also beheads real titles
-    about GPT-4 or COVID-19. A title that IS only the token keeps it (better a bare id than an
-    empty card); the raw line survives in the stored frame for provenance either way."""
-    t = str(s or "")
-    out = _TICKET_SEP_RE.sub("", t, count=1)
-    if out == t:
-        out = _TICKET_BARE_RE.sub("", t, count=1)
-    out = out.strip()
-    return out if out else t.strip()
-
-
-_CARRIED_ASK_RE = re.compile(r"<user-ask>\s*(.*?)\s*</user-ask>", re.S | re.I)
-
-
-def _carried_user_ask(body):
-    """A delegating mail's EXPLICIT quoted requester ask — the sender-declared <user-ask> block
-    (the user 2026-08-27, T126): a chain that routes through a FOREIGN kernel rightly refuses the
-    root walk's hops, so no walk-resolved record can ever ride along, and the writers anchored on
-    the intermediary's framing. Same trust class as the frame (sender-declared, stored verbatim-
-    shaped); a walk-RESOLVED root always outranks a carried claim. '' when the body carries no
-    block."""
-    m = _CARRIED_ASK_RE.search(str(body or ""))
-    return m.group(1).strip() if m else ""
-
-
 def _ask_head(s, cap=700):
     """A dictated ask shaped for the <user-ask> section (T105): romp comment markers stripped, a
     quoted `> …` context block dropped, the courier's "USER ASKED:" prefix removed, blank runs
@@ -11090,7 +11054,8 @@ COURIER_SYS = (
     "the body and decide by whether B actually ends up owning work. Write text in plain concrete words "
     "(the outcome itself, no filler or stock AI phrasing, no em dashes). When the body names its "
     "subject by a coined or internal name, prefer the plain words around it: the outcome in words "
-    "anyone can read. Output only the JSON object.")
+    "anyone can read. A ticket-shaped lead token in the body (T120, ABC-42) is an id, not the "
+    "outcome: never open text with it. Output only the JSON object.")
 
 
 def _seg_peer(seg):
@@ -11351,21 +11316,24 @@ _postal_from_memo = {"key": None, "map": {}}   # messages.jsonl (mtime,size) -> 
 
 
 def _postal_row(mid):
-    """(from_name, from_host, tracked) for a delivered postal message id, from the messages log's
+    """(from_name, from_host, tracked, body, userAsk) for a delivered postal message id, from the
     "sent" row — the AUTHORITATIVE record of who sent it and how (the row schema is the postal
     consumer contract). The sender may be a session of ANOTHER kernel (federated mail), so the local
     names registry cannot resolve it; the log row carries the name the sender wore, the origin host
     the bus stamped on cross-host delivery (2026-07-26), and the tracked report-back flag
-    (2026-08-24 — read off the row, never off message prose), and since 2026-08-25 the BODY —
-    whose cleaned first line is the delegating frame the card enrichment stores at mint.
-    ("", "", False, "") for None/unknown mids. Memoized on the log file's (mtime, size)."""
+    (2026-08-24 — read off the row, never off message prose), since 2026-08-25 the BODY — whose
+    cleaned first line is the delegating frame the card enrichment stores at mint — and since
+    2026-08-27 (T126) the origin kernel's WALKED root-ask record ({text, sid, host} or None): the
+    sending kernel ran its local chain walk at relay time and the bus carried the proof, so a
+    cross-host delegate reads user-anchored though the local walk rightly refuses foreign hops.
+    ("", "", False, "", None) for None/unknown mids. Memoized on the log file's (mtime, size)."""
     if not mid:
-        return ("", "", False, "")
+        return ("", "", False, "", None)
     try:
         st = os.stat(MESSAGES)
         key = (st.st_mtime, st.st_size)
     except OSError:
-        return ("", "", False, "")
+        return ("", "", False, "", None)
     if _postal_from_memo["key"] != key:
         mp = {}
         try:
@@ -11375,12 +11343,14 @@ def _postal_row(mid):
                 except Exception:
                     continue
                 if r.get("ev") == "sent" and r.get("id"):
+                    ua = r.get("userAsk")
                     mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "", bool(r.get("tracked")),
-                                   str(r.get("body") or ""))
+                                   str(r.get("body") or ""),
+                                   ua if isinstance(ua, dict) and str(ua.get("text") or "").strip() else None)
         except OSError:
-            return ("", "", False, "")
+            return ("", "", False, "", None)
         _postal_from_memo["key"], _postal_from_memo["map"] = key, mp
-    return _postal_from_memo["map"].get(mid, ("", "", False, ""))
+    return _postal_from_memo["map"].get(mid, ("", "", False, "", None))
 
 
 def _frame_head(s):
@@ -11429,14 +11399,14 @@ def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None, frame=No
                 return nid
     store["seq"] = store.get("seq", 0) + 1
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-    payload = {"id": nid, "text": (_strip_ticket_lead(text) or "(delegation)")[:120], "parentId": None,
+    payload = {"id": nid, "text": (text or "(delegation)")[:120], "parentId": None,
                "nodeComplete": False, "blocked": False, "cleared": False,
                "trail": [seg_id], "t": seg_t, "origin": origin, "promptUuid": prompt_uuid, "log": []}
     if frame:
         payload["frame"] = frame
     if isinstance(user_ask, dict) and str(user_ask.get("text") or "").strip():
         payload["userAsk"] = {"text": _ask_head(str(user_ask["text"])), "sid": user_ask.get("sid"),
-                              **({"carried": True} if user_ask.get("carried") else {})}
+                              **({"host": str(user_ask["host"])} if user_ask.get("host") else {})}
     nodes[nid] = GuardedNode(payload)
     placements[seg_id] = nid
     store["lastNode"] = nid                            # the delegation is now the active focus
@@ -11501,7 +11471,7 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
         parent_id = None                                # linked goal vanished → file as a top, never orphan
     store["seq"] = store.get("seq", 0) + 1
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-    label = "↪ delegated to %s: %s" % (peer_name or peer_sid[:8], _strip_ticket_lead(text) or "(work)")
+    label = "↪ delegated to %s: %s" % (peer_name or peer_sid[:8], text or "(work)")
     handoff = {"peer": peer_sid, "msgId": mid}
     if tracked:
         handoff["tracked"] = True
@@ -11603,6 +11573,16 @@ def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
         nd = nodes.get(x)
         if not isinstance(nd, dict):
             return None
+        ua = nd.get("userAsk")
+        if isinstance(ua, dict) and str(ua.get("text") or "").strip():
+            # KERNEL-PROVED ROOT ON THE NODE (the user 2026-08-27, T126): only apply_courier writes
+            # userAsk, from a record either walked locally at mint or walked at RELAY time by the
+            # kernel that held the evidence — so a chain reaching such a node is resolved. This is
+            # the arm that lets a walked-remote chain RE-DELEGATE onward: the planted top's own
+            # promptUuid is the mail segment (refused as a human record) and its origin hop is
+            # cross-host (refused as a foreign read); the stored proof is the surviving evidence.
+            return {"text": ua["text"], "sid": ua.get("sid"),
+                    **({"host": ua["host"]} if ua.get("host") else {})}
         o = nd.get("origin")
         if (isinstance(o, dict) and o.get("peer") and o.get("goalId")
                 and not o.get("peerHost") and o["peer"] in paths):
@@ -11989,14 +11969,15 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # state still reaches the board through the hard-block floor/placeholder, which need no
             # goal node. Uncertainty quiets by design (the trace's docstring names the surface).
             rooted = _delegate_user_rooted(sender, link_id, paths_map, now)
-            # CARRIED USER-ASK (the user 2026-08-27, T126): a dispatch may QUOTE the requester in
-            # an explicit <user-ask> block — the cross-host shape, where the walk rightly refuses
-            # foreign-kernel hops and could never resolve a local record. Sender-declared, the
-            # frame's trust class; consulted only when the walk resolves nothing (a walk-resolved
-            # root outranks a carried claim), and it LICENSES the mint below: an explicit quote of
-            # the requester is the ask flowing down in the sender's own hand, not the uncertainty
-            # T101 quiets on.
-            carried = "" if rooted else _carried_user_ask(_postal_row(mid)[3] or text)
+            # WALKED-AT-RELAY ROOT (the user 2026-08-27, T126): a cross-host dispatch carries the
+            # record the ORIGIN kernel walked at send time — the evidence (stores + transcripts)
+            # lives on that machine's disk, so the local walk rightly refuses the hop, but at the
+            # relay moment the origin kernel held everything and stamped the proof onto the mail
+            # (kernel-written, never agent prose — the same trust class as a local walk). Consulted
+            # only when the local walk resolves nothing (fresher local proof outranks), and it
+            # LICENSES the mint below exactly like a local root: every link of the chain was proved
+            # by the kernel that held its evidence, not the uncertainty T101 quiets on.
+            wired = None if rooted else _postal_row(mid)[4]
             # THE ASK IS THE CARD UNIT (the user 2026-08-26, T101): a dispatch whose chain roots to
             # an ask that ALREADY HAS A CARD — link_id resolved to the sender's ask node — LINKS
             # instead of minting: the tracking node below plants under that ask (fan-out lives
@@ -12006,7 +11987,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # top — there the recipient card IS the ask's card, the fallback that keeps every user
             # ask carded somewhere. Linking alone never moves the ask card's column: planting a
             # tracking child writes no verdict on the ask.
-            mint_recipient = (rooted or carried) and not link_id
+            mint_recipient = (rooted or wired) and not link_id
             # Mint the sender's precise '↪ delegated to <recipient>' tracking node (the user 2026-06-22) and
             # point B's goal at IT — so run_propagate checks off only the handed-off piece, never the sender's
             # broader linked goal. Saved to the sender's tree before planting G on the recipient's.
@@ -12046,9 +12027,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                 origin["peerHost"] = frm_host
             apply_courier(store, seg_id, seg_t, edit["text"], origin, prompt_uuid=anchor_uuid,
                           frame=_postal_body_head(mid) or _frame_head(text),
-                          user_ask=(rooted if isinstance(rooted, dict)
-                                    else {"text": carried, "sid": sender, "carried": True}
-                                    if carried else None))
+                          user_ask=rooted if isinstance(rooted, dict) else wired)
             #             ^ the ledger row's body is authoritative; a row the local ledger lacks
             #               (some cross-host deliveries) falls back to the delivered segment's own
             #               head — same content, one hop later

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3436,6 +3436,28 @@ def _interrupt_block_tick(now, tmux):
         _push_all()
 
 
+def _walk_root_record(sid):
+    """Kernel side of the bus's send-time enrichment (the user 2026-08-27, T126): walk the SENDING
+    session's chain on THIS kernel, where the evidence is local, so a cross-host delegate can carry
+    a walk-proved root-ask record the receiving kernel could never resolve (its walk rightly
+    refuses foreign hops at read time). Start node = the sender's active focus chain (lastNode):
+    the round the session is serving when it dispatches — a positional proxy for the courier's
+    later semantic link, tolerant of error in the safe direction (a wrong-chain start usually
+    dead-ends to None, which enriches nothing; T101's quiet-on-uncertainty). None when the chain
+    resolves no human record — the mail relays unenriched, never blocked."""
+    try:
+        store = jd.load_goals(sid)
+        start = store.get("lastNode")
+        if not start:
+            return None
+        now = int(time.time())
+        paths = {f: str(p) for f, p, _a, _n in jd.discover(now)}
+        rec = jd._delegate_user_rooted(sid, start, paths, now)
+        return rec if isinstance(rec, dict) and str(rec.get("text") or "").strip() else None
+    except Exception:
+        return None
+
+
 def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None):
     """Append one auto-nudge event to STATE/nudge-events.jsonl — {sid, gid, t, count, verdict, evT} —
     for the timeline's DEBUG judging band (per-nudge ⚡ marker) AND the redundancy accounting (the
@@ -29026,6 +29048,16 @@ class Handler(BaseHTTPRequestHandler):
                 if pub is None:
                     return self._send(404, json.dumps({"ok": False, "error": "no attached host '%s' — attach it first" % host}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "tunnel": pub}), "application/json")
+            if u.path == "/walk-root":
+                # the postal bus asks for the sending session's walked root-ask record at relay
+                # time (T126) — best-effort: {} when the chain resolves nothing, and the bus
+                # degrades to an unenriched relay either way
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = {}
+                rec = _walk_root_record(str((body or {}).get("sid") or ""))
+                return self._send(200, json.dumps(rec or {}), "application/json")
             if u.path == "/redial":
                 # A CONSUMER just needed a host and found it unreachable (the postal bus parking mail,
                 # the composer refusing a send to a downed host): user demand, so re-send the connect

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -264,8 +264,25 @@ def _tl_append(fname, obj):
     except Exception:
         pass
 
+def _walk_root_record(frm_id):
+    """The sending session's kernel-walked root-ask record, fetched at SEND time for a cross-host
+    delegate (the user 2026-08-27, T126): the receiving kernel's chain walk rightly refuses
+    foreign-kernel hops because the evidence (goal stores + transcripts) lives on THIS machine's
+    disk — but at send time that evidence and the outgoing payload share a disk and the host is
+    definitionally online, so the origin kernel walks its own chain and the proof rides the wire.
+    The bus is stdlib-only by design, so the walk is a kernel HTTP ask (the /redial pattern):
+    best-effort, and an unreachable kernel enriches nothing — mail never blocks on enrichment.
+    The record is KERNEL-written (never agent prose), which is what earns it the walk-proved trust
+    class on the receiving side."""
+    r = _kernel_post("/walk-root", {"sid": frm_id}) or {}
+    txt = str((r or {}).get("text") or "").strip()
+    if not txt:
+        return None
+    return {"text": txt[:1200], "sid": str(r.get("sid") or frm_id), "host": self_host()}
+
+
 def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
-            relay_mid="", relay_via="", tracked=False):
+            relay_mid="", relay_via="", tracked=False, user_ask=None):
     # park=True marks a HANDOFF parked for a session that's currently dead. The
     # maildir is keyed by the session UUID (which `romp resume` reuses), so the
     # message simply waits on disk until that session is revived — delivered then,
@@ -324,6 +341,11 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         #                                              no header, no prose (the recipient reads nothing)
     if from_host:
         ev["from_host"] = from_host                  # additive (consumer contract above)
+    if isinstance(user_ask, dict) and str(user_ask.get("text") or "").strip():
+        # the origin kernel's walked root-ask record (T126) — whitelisted copy, additive: the
+        # receiving courier reads it off this row (_postal_row) as walk-proved provenance
+        ev["userAsk"] = {"text": str(user_ask["text"])[:1200], "sid": str(user_ask.get("sid") or ""),
+                         "host": str(user_ask.get("host") or "")}
     _tl_append("messages.jsonl", ev)
     return name   # the message id (maildir filename); joins to the log + status-bar prefix
 
@@ -1318,9 +1340,16 @@ class Handler(BaseHTTPRequestHandler):
                 tnote = (" — report-back tracking does not cross hosts yet; sent as a plain handoff"
                          if tracked else "")
                 mid = "px-" + _unique()
-                outbox_put(phost, {"mid": mid, "to": hit.get("name") or to, "frm": frm,
-                                   "frm_id": frm_id, "body": body, "kind": kind,
-                                   "t": int(time.time())})
+                relay_msg = {"mid": mid, "to": hit.get("name") or to, "frm": frm,
+                             "frm_id": frm_id, "body": body, "kind": kind,
+                             "t": int(time.time())}
+                if kind == "delegate":
+                    # kernel-walked-at-relay provenance (the user 2026-08-27, T126): park time IS
+                    # send time (this write), so the walk always runs where the evidence is local
+                    ua = _walk_root_record(frm_id)
+                    if ua:
+                        relay_msg["userAsk"] = ua
+                outbox_put(phost, relay_msg)
                 _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "sent", "id": mid,
                                               "from": frm, "from_id": frm_id,
                                               "to_id": "peer:%s" % phost,
@@ -2051,6 +2080,8 @@ def _quarantine_put(origin, m, to_id, via=""):
     rec = {"mid": mid, "to": m.get("to") or "", "toId": to_id, "frm": m.get("frm") or "?",
            "frmId": m.get("frm_id") or "", "body": m.get("body") or "", "kind": m.get("kind") or "",
            "origin": origin, "via": via or origin, "at": int(time.time())}
+    if isinstance(m.get("userAsk"), dict):
+        rec["userAsk"] = m["userAsk"]                # held with its provenance; approve replays it (T126)
     try:
         QUARANTINE.mkdir(parents=True, exist_ok=True)
         tmp = QUARANTINE / (mid + ".tmp")
@@ -2129,7 +2160,8 @@ def quarantine_decide(mid, action, text=None, feedback=None):
             to_id = match[0]["id"]
         deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
                 from_host=rec.get("origin") or "",
-                relay_mid=rec.get("mid") or "", relay_via=rec.get("via") or rec.get("origin") or "")
+                relay_mid=rec.get("mid") or "", relay_via=rec.get("via") or rec.get("origin") or "",
+                user_ask=rec.get("userAsk"))
         quarantine_del(mid)
         return True, None
     return False, "unknown action '%s' (approve|deny)" % action
@@ -2182,7 +2214,8 @@ def _relay_in(host, m, token_proven=False):
         if trust == "trusted":
             deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
                     kind=m.get("kind") or "", from_host=origin,
-                    relay_mid=mid, relay_via=host)       # read-receipt route: back through the direct peer
+                    relay_mid=mid, relay_via=host,       # read-receipt route: back through the direct peer
+                    user_ask=m.get("userAsk"))           # origin-kernel walked record rides through (T126)
         elif trust == "directed":
             _quarantine_put(origin, m, match[0]["id"], via=host)   # HELD for human approve/deny/edit; never injects
         # else isolated → drop: ack so the sender stops resending, but deliver nothing (no communication).

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -359,7 +359,10 @@ class CrossHostDelegation(_Base):
         self.assertEqual(hs[0]["handoff"]["peer"], "TESTHOST-B:web",
                          "the identity is toName — displays resolve it, the remote arm re-keys from it")
         self.assertIn("↪ delegated to TESTHOST-B:web", hs[0]["text"])
-        self.assertNotIn("tracked", hs[0]["handoff"], "tracked never rides the relay — the boundary")
+        self.assertNotIn("tracked", hs[0]["handoff"],
+                         "tracked never rides the relay (its primary view lives on the sender's "
+                         "kernel); the ONE thing that crosses beyond the mail itself is the "
+                         "kernel-walked root-ask record, T126 — proof, not machinery")
         jd.run_courier(now=T0 + 200)
         self.assertEqual(len(self._handoffs()), 1, "idempotent by msgId — one plant per message ever")
 

--- a/tests/test_postal_walked_ask.py
+++ b/tests/test_postal_walked_ask.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Kernel-walked-at-relay provenance rides the postal wire (the user 2026-08-27, T126): a
+cross-host delegate's chain evidence lives on the ORIGIN machine's disk, so the receiving walk
+rightly refuses the hop — but at send time the origin kernel holds everything, walks its own
+chain, and the bus stamps the proof ({text, sid, host}, kernel-written, never agent prose) onto
+the relayed mail. Pins: the /send helper degrades to nothing when the kernel can't answer; the
+receiving deliver() whitelists the record into the recipient's ledger row; the trusted relay
+branch passes it through; a directed-host hold keeps it and the approve replay re-delivers it.
+SYNTHETIC fixtures only; hostname TESTHOST; private synthetic sids."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+pm = SourceFileLoader("romp_postal_walkedask", os.path.join(BIN, "romp-postal-service")).load_module()
+
+SND = "b66a0001-1111-4222-8333-000000000001"    # private synthetic sids — never the shared placeholder
+RCP = "b66a0001-1111-4222-8333-000000000002"
+ASK = "make the two graph views draw identically"
+REC = {"text": ASK, "sid": SND, "host": "TESTHOST"}
+
+
+class WalkHelper(unittest.TestCase):
+    """_walk_root_record: one kernel HTTP ask, degrade-to-nothing — mail never blocks on it."""
+
+    def setUp(self):
+        self.saved = pm._kernel_post
+
+    def tearDown(self):
+        pm._kernel_post = self.saved
+
+    def test_a_kernel_record_is_shaped_and_host_stamped(self):
+        pm._kernel_post = lambda path, body, timeout=2: {"text": ASK, "sid": SND}
+        rec = pm._walk_root_record(SND)
+        self.assertEqual(rec["text"], ASK)
+        self.assertEqual(rec["sid"], SND)
+        self.assertTrue(rec["host"], "the proving kernel names itself")
+
+    def test_no_kernel_or_no_record_enriches_nothing(self):
+        pm._kernel_post = lambda path, body, timeout=2: None
+        self.assertIsNone(pm._walk_root_record(SND))
+        pm._kernel_post = lambda path, body, timeout=2: {}
+        self.assertIsNone(pm._walk_root_record(SND))
+
+    def test_the_relay_branch_attaches_it_to_delegates_only(self):
+        src = open(os.path.join(BIN, "romp-postal-service")).read()
+        self.assertIn('if kind == "delegate":', src)
+        self.assertIn('relay_msg["userAsk"] = ua', src,
+                      "the walked record rides the outbox payload, never the body prose")
+
+
+class DeliverRow(unittest.TestCase):
+    """deliver() whitelists the record into the recipient-side ledger row — the surface the
+    receiving courier reads (_postal_row)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._tl, self._md = pm.TLDIR, pm.MAILROOT
+        pm.TLDIR = type(pm.TLDIR)(self.td.name)
+        pm.MAILROOT = type(pm.MAILROOT)(self.td.name) / "mail"
+
+    def tearDown(self):
+        pm.TLDIR, pm.MAILROOT = self._tl, self._md
+        self.td.cleanup()
+
+    def _rows(self):
+        p = pm.TLDIR / "messages.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+    def test_the_record_lands_whitelisted_on_the_row(self):
+        pm.deliver(RCP, "web", SND, "please do the thing", kind="delegate",
+                   from_host="TESTHOST", user_ask=dict(REC, junk="never-copied"))
+        row = self._rows()[-1]
+        self.assertEqual(row["userAsk"], REC, "a whitelisted copy — no foreign keys ride along")
+
+    def test_absent_or_textless_records_write_nothing(self):
+        pm.deliver(RCP, "web", SND, "hello", kind="coordinate")
+        pm.deliver(RCP, "web", SND, "hello again", kind="delegate", user_ask={"text": "  "})
+        for row in self._rows():
+            self.assertNotIn("userAsk", row)
+
+
+class RelayInPassesItThrough(unittest.TestCase):
+    """The trusted relay branch hands the wire record to deliver(); a directed hold keeps it and
+    the approve replay re-delivers it — the record survives every receive-side path."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (pm.deliver, pm.local_agents, pm._postal_off, pm.peer_seen_check,
+                       pm.peer_seen_add, dict(pm.PEERS), pm.QUARANTINE)
+        self.delivered = []
+        pm.deliver = lambda *a, **k: self.delivered.append((a, k)) or "m-local"
+        pm.local_agents = lambda threads=False: [{"id": RCP, "name": "api", "remote": False}]
+        pm._postal_off = lambda sid: False
+        pm.peer_seen_check = lambda mid: False
+        pm.peer_seen_add = lambda mid: None
+        pm.QUARANTINE = type(pm.QUARANTINE)(self.td.name) / "q"
+
+    def tearDown(self):
+        (pm.deliver, pm.local_agents, pm._postal_off, pm.peer_seen_check,
+         pm.peer_seen_add, peers, pm.QUARANTINE) = self._saved
+        pm.PEERS.clear()
+        pm.PEERS.update(peers)
+        self.td.cleanup()
+
+    def _mail(self):
+        return {"mid": "px-1", "to": "api", "frm": "web", "frm_id": SND,
+                "body": "please do the thing", "kind": "delegate", "userAsk": dict(REC)}
+
+    def test_trusted_delivery_carries_the_record(self):
+        pm.PEERS["TESTHOST"] = {"trust": "trusted", "up": True}
+        verdict, _ = pm._relay_in("TESTHOST", self._mail())
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(self.delivered[0][1].get("user_ask"), REC)
+
+    def test_a_directed_hold_keeps_it_and_the_approve_replay_re_delivers(self):
+        pm.PEERS["TESTHOST"] = {"trust": "directed", "up": True}
+        verdict, _ = pm._relay_in("TESTHOST", self._mail())
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(self.delivered, [], "directed → held, nothing injected")
+        rec = pm.quarantine_get("px-1")
+        self.assertEqual(rec.get("userAsk"), REC, "the hold keeps the provenance")
+        ok, err = pm.quarantine_decide("px-1", "approve")
+        self.assertTrue(ok, err)
+        self.assertEqual(self.delivered[0][1].get("user_ask"), REC,
+                         "the approve replay re-delivers with the proof intact")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_root_ask_anchor.py
+++ b/tests/test_root_ask_anchor.py
@@ -247,35 +247,39 @@ class CourierStoresTheAsk(unittest.TestCase):
         self.assertIsNotNone(nd)
         self.assertNotIn("userAsk", nd)
 
-    def test_a_carried_quote_licenses_the_mint_when_the_walk_resolves_nothing(self):
-        # the cross-host shape (T126): the walk rightly refuses foreign hops — the sender's
-        # explicit <user-ask> block is the ask flowing down in their own hand, and it mints
+    def test_a_walked_at_relay_record_licenses_the_mint_when_the_local_walk_resolves_nothing(self):
+        # the cross-host shape (T126): the local walk rightly refuses foreign hops — the ORIGIN
+        # kernel walked the chain at relay time and the bus stamped the proof onto the ledger row;
+        # kernel-proved, it licenses the mint exactly like a local root
         jd._delegate_user_rooted = lambda *a, **k: None
-        body = (BODY + "\n<user-ask>\n" + DICTATION + "\n</user-ask>")
         jd.MESSAGES.write_text(json.dumps(
             {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
-             "to_id": WKR, "kind": "delegate", "body": body}) + "\n")
+             "to_id": WKR, "kind": "delegate", "body": BODY, "from_host": "TESTHOST",
+             "userAsk": {"text": DICTATION, "sid": MGR, "host": "TESTHOST"}}) + "\n")
         jd.run_courier(now=NOW)
         nd = self._planted()
-        self.assertIsNotNone(nd, "the carried quote licenses the mint")
+        self.assertIsNotNone(nd, "the walked-at-relay record licenses the mint")
         self.assertEqual(nd["userAsk"]["text"], DICTATION)
-        self.assertTrue(nd["userAsk"].get("carried"))
+        self.assertEqual(nd["userAsk"]["host"], "TESTHOST", "provenance names the proving kernel")
+        self.assertNotIn("carried", nd["userAsk"], "kernel-proved needs no trust asterisk")
 
-    def test_without_the_block_an_unresolvable_delegate_still_files_quiet(self):
+    def test_without_the_record_an_unresolvable_delegate_still_files_quiet(self):
         jd._delegate_user_rooted = lambda *a, **k: None
         jd.run_courier(now=NOW)
         self.assertIsNone(self._planted(), "T101's quiet-on-uncertainty stands")
 
-    def test_a_walk_resolved_root_outranks_a_carried_claim(self):
+    def test_a_local_walk_resolved_root_outranks_the_wire_record(self):
         jd._delegate_user_rooted = lambda *a, **k: {"text": DICTATION, "sid": MGR}
-        body = (BODY + "\n<user-ask>\nsomething the sender claims instead\n</user-ask>")
         jd.MESSAGES.write_text(json.dumps(
             {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
-             "to_id": WKR, "kind": "delegate", "body": body}) + "\n")
+             "to_id": WKR, "kind": "delegate", "body": BODY,
+             "userAsk": {"text": "an older claim from the wire", "sid": MGR,
+                         "host": "TESTHOST"}}) + "\n")
         jd.run_courier(now=NOW)
         nd = self._planted()
-        self.assertEqual(nd["userAsk"]["text"], DICTATION)
-        self.assertNotIn("carried", nd["userAsk"])
+        self.assertEqual(nd["userAsk"]["text"], DICTATION,
+                         "the fresher local proof wins")
+        self.assertNotIn("host", nd["userAsk"])
 
 
 class UserAskText(unittest.TestCase):
@@ -373,68 +377,53 @@ class BuildersCarryTheAsk(unittest.TestCase):
                          "nothing of it in the unmarked (romp-authored) half")
 
 
-class TicketLeadStrip(unittest.TestCase):
-    """A ticket-shaped LEAD token never titles a card (the user 2026-08-27, T126: a dispatch led
-    with an opaque tracking id, the courier compressed it into goal text, and every writer treated
-    the id as the work's proper name). The mechanical rule is deliberately narrow — shapes that
-    cannot be natural language; the general shape is the writers' prompt-level call."""
+class WalkedAtRelay(unittest.TestCase):
+    """Kernel-walked-at-relay provenance (the user 2026-08-27, T126): the local walk rightly
+    refuses foreign-kernel hops because the EVIDENCE lives on the origin machine's disk — but at
+    send time the origin kernel holds everything, so it walks its own chain and the proof rides
+    the wire ({text, sid, host}, kernel-written, never agent prose). Stored on the minted top, it
+    is ALSO how re-delegation continues the chain: the planted node's own promptUuid is the mail
+    segment (refused as a human record) and its origin hop is cross-host (refused as a foreign
+    read), so the stored proof is the surviving evidence the walk resolves."""
 
-    def test_ticket_leads_strip(self):
-        for raw, want in (("T120: nudge cap re-judges at fire time", "nudge cap re-judges at fire time"),
-                          ("T120 — the nudge cap escalates", "the nudge cap escalates"),
-                          ("[T99] fix the tint", "fix the tint"),
-                          ("#752: merge it", "merge it"),
-                          ("T12 verify the refs", "verify the refs")):
-            self.assertEqual(jd._strip_ticket_lead(raw), want, raw)
-
-    def test_natural_leads_survive(self):
-        for raw in ("Test the parser end to end", "T-shirt mockups for the launch",
-                    "GPT-4 evaluation results", "COVID-19 response plan",
-                    "2026 planning doc", "B2 bomber history page",
-                    "T5 fine-tuning run"):
-            self.assertEqual(jd._strip_ticket_lead(raw), raw, raw)
-
-    def test_a_bare_token_title_keeps_itself(self):
-        self.assertEqual(jd._strip_ticket_lead("T120:"), "T120:",
-                         "better a bare id than an empty card")
-
-    def test_the_courier_mint_strips_but_the_frame_keeps_the_raw_line(self):
-        st = {"rompUuid": MGR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
-        nid = jd.apply_courier(st, "s1", NOW, "T120: factor the layout engine",
-                               {"peer": WKR, "goalId": "t1", "msgId": MID},
-                               frame="T120 — factor the layout engine into a shared module")
-        self.assertEqual(st["nodes"][nid]["text"], "factor the layout engine")
-        self.assertEqual(st["nodes"][nid]["frame"],
-                         "T120 — factor the layout engine into a shared module",
-                         "provenance survives in the frame, verbatim")
-
-    def test_the_sender_tracker_label_is_stripped_too(self):
-        st = {"rompUuid": MGR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
-        nid = jd._plant_handoff_track(st, None, "T99: verify the refs", WKR, "api", NOW, MID)
-        self.assertEqual(st["nodes"][nid]["text"], "\u21aa delegated to api: verify the refs")
-
-
-class CarriedUserAsk(unittest.TestCase):
-    """A delegating mail may CARRY the requester's quoted ask (the user 2026-08-27, T126): a chain
-    routed through a FOREIGN kernel rightly refuses the walk's hops, so no walk-resolved record can
-    ride along — the sender-declared <user-ask> block (the frame's trust class) fills the seat, and
-    it LICENSES the mint: an explicit quote of the requester is the ask flowing down in the
-    sender's own hand, not the uncertainty T101 quiets on. A walk-resolved root outranks it."""
-
-    def test_extraction(self):
-        self.assertEqual(jd._carried_user_ask(
-            "Do the thing.\n<user-ask>\nmake the two views identical\n</user-ask>\nrest"),
-            "make the two views identical")
-        self.assertEqual(jd._carried_user_ask("no block here"), "")
-
-    def test_carried_ask_stores_with_its_flag(self):
+    def test_the_walked_record_stores_with_its_host(self):
         st = {"rompUuid": MGR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
         nid = jd.apply_courier(st, "s1", NOW, "factor the engine",
                                {"peer": WKR, "goalId": "t1", "msgId": MID},
-                               user_ask={"text": DICTATION, "sid": WKR, "carried": True})
+                               user_ask={"text": DICTATION, "sid": WKR, "host": "TESTHOST"})
         ua = st["nodes"][nid]["userAsk"]
         self.assertEqual(ua["text"], DICTATION)
-        self.assertTrue(ua.get("carried"), "sender-declared, distinguishable from walk-proved")
+        self.assertEqual(ua["host"], "TESTHOST")
+        self.assertNotIn("carried", ua)
+
+    def test_a_node_wearing_the_proof_resolves_the_walk_for_re_delegation(self):
+        saved = jd.parsed_session
+        jd.parsed_session = lambda sid, files, now: {"turns": []}
+        try:
+            st = {"rompUuid": MGR, "nodes": {
+                "top": _node("top", "the planted cross-host ask", None,
+                             origin={"peer": WKR, "goalId": "t1", "msgId": MID,
+                                     "peerHost": "TESTHOST"},
+                             promptUuid="mail-seg",
+                             userAsk={"text": DICTATION, "sid": WKR, "host": "TESTHOST"}),
+                "kid": _node("kid", "a step under it", "top")},
+                  "placements": {}, "status": {}}
+            jd.save_goals(MGR, st)
+            rec = jd._delegate_user_rooted(MGR, "kid", {MGR: "/dev/null"}, NOW)
+            self.assertEqual(rec["text"], DICTATION,
+                             "the stored kernel proof is the surviving evidence")
+            self.assertEqual(rec["host"], "TESTHOST")
+        finally:
+            jd.parsed_session = saved
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (MGR + ".json")).unlink()
+                except OSError:
+                    pass
+            try:
+                (jd._overrides_dir() / (MGR + ".jsonl")).unlink()
+            except OSError:
+                pass
 
 
 class PromptGates(unittest.TestCase):
@@ -455,7 +444,7 @@ class PromptGates(unittest.TestCase):
                       "the <delegating-request>, then the rest of <work>.", jd.BLOCK_BRIEF_SYS)
 
     def test_tracking_ids_are_jargon_in_every_writer_that_titles_or_opens(self):
-        for name in ("DISTILL_SYS", "BLOCK_BRIEF_SYS", "PLAN_SYS", "GIST_SYS"):
+        for name in ("DISTILL_SYS", "BLOCK_BRIEF_SYS", "PLAN_SYS", "GIST_SYS", "COURIER_SYS"):
             with self.subTest(prompt=name):
                 self.assertIn("ticket", getattr(jd, name).lower(),
                               "a tracking id is jargon-gated like any coined name (T126)")

--- a/tests/test_root_ask_anchor.py
+++ b/tests/test_root_ask_anchor.py
@@ -247,6 +247,36 @@ class CourierStoresTheAsk(unittest.TestCase):
         self.assertIsNotNone(nd)
         self.assertNotIn("userAsk", nd)
 
+    def test_a_carried_quote_licenses_the_mint_when_the_walk_resolves_nothing(self):
+        # the cross-host shape (T126): the walk rightly refuses foreign hops — the sender's
+        # explicit <user-ask> block is the ask flowing down in their own hand, and it mints
+        jd._delegate_user_rooted = lambda *a, **k: None
+        body = (BODY + "\n<user-ask>\n" + DICTATION + "\n</user-ask>")
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate", "body": body}) + "\n")
+        jd.run_courier(now=NOW)
+        nd = self._planted()
+        self.assertIsNotNone(nd, "the carried quote licenses the mint")
+        self.assertEqual(nd["userAsk"]["text"], DICTATION)
+        self.assertTrue(nd["userAsk"].get("carried"))
+
+    def test_without_the_block_an_unresolvable_delegate_still_files_quiet(self):
+        jd._delegate_user_rooted = lambda *a, **k: None
+        jd.run_courier(now=NOW)
+        self.assertIsNone(self._planted(), "T101's quiet-on-uncertainty stands")
+
+    def test_a_walk_resolved_root_outranks_a_carried_claim(self):
+        jd._delegate_user_rooted = lambda *a, **k: {"text": DICTATION, "sid": MGR}
+        body = (BODY + "\n<user-ask>\nsomething the sender claims instead\n</user-ask>")
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate", "body": body}) + "\n")
+        jd.run_courier(now=NOW)
+        nd = self._planted()
+        self.assertEqual(nd["userAsk"]["text"], DICTATION)
+        self.assertNotIn("carried", nd["userAsk"])
+
 
 class UserAskText(unittest.TestCase):
     """_user_ask_text: the stored mint-time record wins; a board's own prompt-minted top falls
@@ -343,6 +373,70 @@ class BuildersCarryTheAsk(unittest.TestCase):
                          "nothing of it in the unmarked (romp-authored) half")
 
 
+class TicketLeadStrip(unittest.TestCase):
+    """A ticket-shaped LEAD token never titles a card (the user 2026-08-27, T126: a dispatch led
+    with an opaque tracking id, the courier compressed it into goal text, and every writer treated
+    the id as the work's proper name). The mechanical rule is deliberately narrow — shapes that
+    cannot be natural language; the general shape is the writers' prompt-level call."""
+
+    def test_ticket_leads_strip(self):
+        for raw, want in (("T120: nudge cap re-judges at fire time", "nudge cap re-judges at fire time"),
+                          ("T120 — the nudge cap escalates", "the nudge cap escalates"),
+                          ("[T99] fix the tint", "fix the tint"),
+                          ("#752: merge it", "merge it"),
+                          ("T12 verify the refs", "verify the refs")):
+            self.assertEqual(jd._strip_ticket_lead(raw), want, raw)
+
+    def test_natural_leads_survive(self):
+        for raw in ("Test the parser end to end", "T-shirt mockups for the launch",
+                    "GPT-4 evaluation results", "COVID-19 response plan",
+                    "2026 planning doc", "B2 bomber history page",
+                    "T5 fine-tuning run"):
+            self.assertEqual(jd._strip_ticket_lead(raw), raw, raw)
+
+    def test_a_bare_token_title_keeps_itself(self):
+        self.assertEqual(jd._strip_ticket_lead("T120:"), "T120:",
+                         "better a bare id than an empty card")
+
+    def test_the_courier_mint_strips_but_the_frame_keeps_the_raw_line(self):
+        st = {"rompUuid": MGR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        nid = jd.apply_courier(st, "s1", NOW, "T120: factor the layout engine",
+                               {"peer": WKR, "goalId": "t1", "msgId": MID},
+                               frame="T120 — factor the layout engine into a shared module")
+        self.assertEqual(st["nodes"][nid]["text"], "factor the layout engine")
+        self.assertEqual(st["nodes"][nid]["frame"],
+                         "T120 — factor the layout engine into a shared module",
+                         "provenance survives in the frame, verbatim")
+
+    def test_the_sender_tracker_label_is_stripped_too(self):
+        st = {"rompUuid": MGR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        nid = jd._plant_handoff_track(st, None, "T99: verify the refs", WKR, "api", NOW, MID)
+        self.assertEqual(st["nodes"][nid]["text"], "\u21aa delegated to api: verify the refs")
+
+
+class CarriedUserAsk(unittest.TestCase):
+    """A delegating mail may CARRY the requester's quoted ask (the user 2026-08-27, T126): a chain
+    routed through a FOREIGN kernel rightly refuses the walk's hops, so no walk-resolved record can
+    ride along — the sender-declared <user-ask> block (the frame's trust class) fills the seat, and
+    it LICENSES the mint: an explicit quote of the requester is the ask flowing down in the
+    sender's own hand, not the uncertainty T101 quiets on. A walk-resolved root outranks it."""
+
+    def test_extraction(self):
+        self.assertEqual(jd._carried_user_ask(
+            "Do the thing.\n<user-ask>\nmake the two views identical\n</user-ask>\nrest"),
+            "make the two views identical")
+        self.assertEqual(jd._carried_user_ask("no block here"), "")
+
+    def test_carried_ask_stores_with_its_flag(self):
+        st = {"rompUuid": MGR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        nid = jd.apply_courier(st, "s1", NOW, "factor the engine",
+                               {"peer": WKR, "goalId": "t1", "msgId": MID},
+                               user_ask={"text": DICTATION, "sid": WKR, "carried": True})
+        ua = st["nodes"][nid]["userAsk"]
+        self.assertEqual(ua["text"], DICTATION)
+        self.assertTrue(ua.get("carried"), "sender-declared, distinguishable from walk-proved")
+
+
 class PromptGates(unittest.TestCase):
     """The jargon gate rides every prose/title writer, and the source preference names its order:
     the session's own report to the person outranks everything, then the root ask, then the
@@ -359,6 +453,12 @@ class PromptGates(unittest.TestCase):
                       "<delegating-request>, then the rest of <work>.", jd.DISTILL_SYS)
         self.assertIn("Prefer sources in this order: that message, then the <user-ask>, then "
                       "the <delegating-request>, then the rest of <work>.", jd.BLOCK_BRIEF_SYS)
+
+    def test_tracking_ids_are_jargon_in_every_writer_that_titles_or_opens(self):
+        for name in ("DISTILL_SYS", "BLOCK_BRIEF_SYS", "PLAN_SYS", "GIST_SYS"):
+            with self.subTest(prompt=name):
+                self.assertIn("ticket", getattr(jd, name).lower(),
+                              "a tracking id is jargon-gated like any coined name (T126)")
 
     def test_the_prose_gates_key_on_the_user_ask_section(self):
         for name in ("DISTILL_SYS", "BLOCK_BRIEF_SYS"):

--- a/tests/test_walk_root_endpoint.py
+++ b/tests/test_walk_root_endpoint.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""The kernel side of send-time relay enrichment (the user 2026-08-27, T126): _walk_root_record
+runs the chain walk where the evidence is local — start node = the sending session's active focus
+chain (lastNode), the round it was serving when it dispatched — and returns the root record or
+None (unenriched relay; T101's quiet-on-uncertainty). The /walk-root HTTP handler wraps exactly
+this function for the stdlib-only bus. SYNTHETIC fixtures only; private synthetic sids."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_walkroot", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+NOW = 1_787_900_000
+SID = "c77b0001-1111-4222-8333-000000000001"    # private synthetic sid — never the shared placeholder
+ASK = "make the two graph views draw identically"
+
+
+class WalkRootRecord(unittest.TestCase):
+    def setUp(self):
+        self._saved = (jd.load_goals, jd.discover, jd._delegate_user_rooted)
+
+    def tearDown(self):
+        jd.load_goals, jd.discover, jd._delegate_user_rooted = self._saved
+
+    def test_the_focus_chain_resolves_to_the_record(self):
+        jd.load_goals = lambda sid: {"rompUuid": SID, "nodes": {}, "lastNode": SID + ":g3"}
+        jd.discover = lambda now, window=None, forks=True: [(SID, "/dev/null", SID, "web")]
+        seen = {}
+        jd._delegate_user_rooted = lambda sid, start, paths, now: (
+            seen.update(sid=sid, start=start) or {"text": ASK, "sid": SID})
+        rec = km._walk_root_record(SID)
+        self.assertEqual(rec, {"text": ASK, "sid": SID})
+        self.assertEqual(seen["start"], SID + ":g3", "the walk starts at the active focus chain")
+
+    def test_no_focus_or_no_record_or_a_crash_enriches_nothing(self):
+        jd.load_goals = lambda sid: {"rompUuid": SID, "nodes": {}}
+        rec = km._walk_root_record(SID)
+        self.assertIsNone(rec, "no lastNode → no start → unenriched")
+        jd.load_goals = lambda sid: {"rompUuid": SID, "nodes": {}, "lastNode": SID + ":g3"}
+        jd.discover = lambda now, window=None, forks=True: []
+        jd._delegate_user_rooted = lambda *a: None
+        self.assertIsNone(km._walk_root_record(SID))
+        jd.load_goals = lambda sid: (_ for _ in ()).throw(RuntimeError("boom"))
+        self.assertIsNone(km._walk_root_record(SID), "a crash degrades, never raises into the bus")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two holes the jargon gate exposed (a card titled by an internal tracking id; cross-host chains anchoring on the intermediary's framing), fixed per the user's amended design — prompt-only id treatment, kernel-proved cross-host provenance.

**Tracking ids are jargon, prompt-only.** No mechanical strip (a token-shape regex is a heuristic, and its wider forms behead GPT-4/COVID-19 titles). Every writer that titles or opens (DISTILL/BRIEF/PLAN/GIST/COURIER) carries one explicit line: a bare tracking id is an internal name like any coined one. Measured at the courier (the seam that produced the specimen): 0/4 minted texts carried the token on a synthetic ticket-led dispatch.

**The origin kernel walks the chain at relay time.** The local walk refuses foreign hops because the evidence lives on the origin machine's disk — but at send time the origin kernel holds everything. The bus (stdlib-only) asks its kernel over HTTP (`/walk-root`, the `/redial` pattern) to walk the sending session's focus chain and stamps the proof ({text, sid, host}, kernel-written) onto the relayed payload. Park time is send time, so offline hosts need nothing extra. The record rides the schemaless outbox through forward hops, is whitelist-copied into the recipient's ledger row, survives quarantine hold + approve replay, and the receiving courier reads it off the row: consulted only when the local walk resolves nothing, licensing the mint exactly like a local root.

**Re-delegation continues the chain**: the walk gains one arm — a node wearing a kernel-proved userAsk IS a resolved root — so a multi-hop cross-kernel chain reads user-anchored end to end, every link proved by the kernel that held its evidence. Degrade-to-nothing everywhere: unreachable kernel or empty walk relays unenriched, never blocked.

Tests: wire pins (deliver whitelist, trusted relay pass-through, quarantine hold/replay), kernel walk unit, retargeted courier licensing pins, the re-delegation arm, and the relay-boundary pin re-worded.

Suites: Python 5840/0 (+306 subtests), UI 2489/2489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)