### PR TITLE
The Billing row tells the truth in every landing shape; a login pick needs a login (T124)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7119,6 +7119,10 @@ def _sdk_locked():
             # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
             # only as good as that file); the backend picks any live login session to ask
             jd._USAGE_REFRESH_FN = getattr(_sdk_backend, "refresh_usage", None)   # best-effort hook (judge guards None)
+            # the Billing pick's login gate (T124): set_auth refuses 'login' when the credential
+            # store names no signed-in account — the same authority the usage bars trust, so the
+            # pick can never sit in the UI as applied fact on a box that demonstrably cannot apply it
+            _sdk_backend.login_ok = lambda: bool(_claude_account())
             # silent mid-turn model swaps mint a completed card (the user 2026-08-23) — the backend
             # observes the transition; the judge store owns the card; the kernel wires the two
             type(_sdk_backend).on_model_fallback = staticmethod(
@@ -7937,7 +7941,8 @@ def _drive(msg, client):
         if not _set_auth_or_park(be, sid, str(msg["value"])):
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't switch the account this session bills — "
-                                               "it isn't an SDK session, or no API key is configured."}))
+                                               "it isn't an SDK session, no API key is configured, "
+                                               "or this machine has no Claude login to switch to."}))
         _push_soon()
     elif t == "stopTask" and msg.get("taskId"):
         # the SDK's designed stop_task control request, addressed by the id the bg-task box shows.

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3039,6 +3039,7 @@ class SdkBackend:
         self._drain_hold_since = 0.0
         self._drain_hold_rang = False
         self._drain_wake_timer = None
+        self.login_ok = lambda: True              # the kernel wires its credential-store probe (T124); permissive unwired
         self._usage_all_keyed = False             # refresh_usage's one-shot: the last refresh found only
         #                                           keyed candidates (already logged); reset when a
         #                                           pollable session exists again, so the 60s rail timer
@@ -5032,6 +5033,13 @@ class SdkBackend:
             return False
         if value == "key" and not self.work_key:
             return False   # nothing to inject — the UI never offers this; refuse rather than half-apply
+        if value == "login" and not self.login_ok():
+            # the SAME bar the key side always had (T124: set_auth accepted 'login' unconditionally,
+            # so on a login-less box the pick sat in the UI as applied fact while the reconnect
+            # errored or landed keyed via an apiKeyHelper — the silent-degrade class). login_ok is
+            # the kernel's credential-store probe (the authority the usage bars trust); the default
+            # is permissive so a bare backend (tests, no kernel wiring) keeps the old behavior.
+            return False
         if not read_reg(self.state_dir, sid):
             return False
         # authPending: the applying reconnect hasn't completed → badge dots. Locked RMW — see set_effort.

--- a/tests/test_expected_auth.py
+++ b/tests/test_expected_auth.py
@@ -219,6 +219,42 @@ class GearPickMakesTheDeclarationInert(_Declared):
         self.assertEqual(sb._declared_auth(Path(self.d)), ("login", "pick"))
 
 
+class LoginPickNeedsALogin(_Declared):
+    """T124 (2026-08-27): set_auth accepted 'login' UNCONDITIONALLY while gating 'key' on work_key —
+    so on a box with no Claude login the pick sat in the UI as applied fact while the applying
+    reconnect errored or landed keyed through an apiKeyHelper (the silent-degrade class). The pick
+    now refuses at pick time via the kernel-wired credential probe; a bare backend stays
+    permissive (tests, no kernel), and a REFUSED pick writes nothing — no reg flip, no remembered
+    default, no pending window."""
+
+    def _reg(self, n):
+        sid = "11111111-2222-3333-4444-%012d" % n
+        sb.write_reg(Path(self.d), sid, {"sid": sid, "name": "s%d" % n, "cwd": "/tmp"})
+        return sid
+
+    def test_refused_when_the_probe_says_no_login(self):
+        self.be.login_ok = lambda: False
+        sid = self._reg(21)
+        self.assertFalse(self.be.set_auth(sid, "login"),
+                         "refuse loudly at pick time — the box demonstrably lacks the credential")
+        reg = sb.read_reg(Path(self.d), sid)
+        self.assertNotIn("auth", reg or {}, "a refused pick flips nothing")
+        self.assertFalse((reg or {}).get("authPending"), "…and opens no pending window")
+        self.assertNotEqual(sb._declared_auth(Path(self.d))[1], "pick",
+                            "…and leaves no remembered-default trace (the Q3 marker stays honest)")
+
+    def test_accepted_when_the_probe_says_yes(self):
+        self.be.login_ok = lambda: True
+        sid = self._reg(22)
+        self.assertTrue(self.be.set_auth(sid, "login"))
+        self.assertEqual((sb.read_reg(Path(self.d), sid) or {}).get("auth"), "login")
+
+    def test_unwired_backend_stays_permissive(self):
+        sid = self._reg(23)
+        self.assertTrue(self.be.set_auth(sid, "login"),
+                        "no kernel probe wired → the pre-T124 behavior stands (bare backends, old tests)")
+
+
 class PickOutranksTheDeclaration(_Declared):
     """An explicit per-session Billing pick (sess.auth) beats the box-wide declaration: the
     declaration describes the box's UNPICKED design, and set_auth's contract is that the next

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -489,6 +489,60 @@ class Availability(unittest.TestCase):
         self.assertIn('"authAvail": _auth_avail()', src)
 
 
+class SwitchCycleTruthTable(_Keyed):
+    """T124 (2026-08-27, the user's key->login switch where 'the UI is not what is happening'):
+    the full switch cycle, every landing shape, asserted at the session state dict — the exact
+    fields the Billing row renders from (auth/authLive/authPending; the render mapping is pinned
+    in ui/webview/auth-selector.test.ts). The contract: intent shows AS PENDING intent through the
+    reconnect window (never as applied fact), a confirmed contradiction is visible, and a pick the
+    box cannot apply refuses at pick time."""
+
+    def _state(self, s):
+        d = s.snapshot()
+        return (d["auth"], d["authLive"], d["authPending"])
+
+    def test_the_cycle_on_a_logged_in_box(self):
+        self.be.login_ok = lambda: True                      # the simulated logged-in box
+        sid = "11111111-2222-3333-4444-00000000t124"
+        sb.write_reg(Path(self.d), sid, {"sid": sid, "name": "misc", "cwd": "/tmp"})
+        s = self._sess(41, sid=sid)
+        self.be.sessions[sid] = s
+        # rest: keyed (the env key), confirmed by an init
+        self.be._note_auth_source(s, "ANTHROPIC_API_KEY")
+        self.assertEqual(self._state(s), ("key", "key", False), "rest: confirmed key, row says API key")
+        # SWITCH key->login: the pending window renders as pending — never applied fact
+        self.assertTrue(self.be.set_auth(sid, "login"))
+        self.assertEqual(self._state(s), ("login", "", True),
+                         "the pick shows as PENDING intent (authLive cleared, authPending up) until an init confirms")
+        # landing shape 1: the CLI confirms the login → truth within one init
+        s._auth_pending = ""                                  # the connect clears the dots (event-based)
+        self.be._note_auth_source(s, "none")
+        self.assertEqual(self._state(s), ("login", "login", False), "confirmed login — plain Login")
+        # SWITCH login->key, landing shape 2: the CLI lands on the WRONG side (an apiKeyHelper world:
+        # picked login again later, but a helper re-injects the key) — the contradiction is VISIBLE
+        self.assertTrue(self.be.set_auth(sid, "key"))
+        s._launched_keyed = True                              # the applying reconnect injected the key (_options)
+        s._auth_pending = ""
+        self.be._note_auth_source(s, "none")                  # picked key; the CLI reports login
+        auth, live, pending = self._state(s)
+        self.assertEqual((auth, pending), ("key", False))
+        self.assertEqual(live, "login", "the wrong-side landing rides authLive → the row's ⚠ shape")
+        self.assertTrue(any("billing the login" in p["text"] for p in self.be.problems(20)),
+                        "…and the problems ring names it")
+
+    def test_the_cycle_on_a_login_less_box(self):
+        self.be.login_ok = lambda: False                     # THIS devbox's real shape (env-key-only)
+        sid = "11111111-2222-3333-4444-00000000t125"
+        sb.write_reg(Path(self.d), sid, {"sid": sid, "name": "misc2", "cwd": "/tmp"})
+        s = self._sess(42, sid=sid)
+        self.be.sessions[sid] = s
+        self.be._note_auth_source(s, "ANTHROPIC_API_KEY")
+        self.assertFalse(self.be.set_auth(sid, "login"),
+                         "the pick the box cannot apply refuses AT PICK TIME — never accept-then-fail")
+        self.assertEqual(self._state(s), ("key", "key", False),
+                         "nothing moved: no pending window, no intent shown, the row keeps the truth")
+
+
 class DrivePlumbing(unittest.TestCase):
     """setAuth rides the same drive/park path as the other per-session switches (source pins)."""
 

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -92,12 +92,31 @@ test("the chat tab hover says Billing whenever the backend reports it, naming th
   // ungated on machine shape (the user 2026-08-09: one-auth machines included; only a tmux session,
   // whose CLI env romp does not control, reports nothing) — and 'Login (account)' when known
   assert.match(RENDER, /s\.status\.auth === "key" \? "API key"\s*\n\s*: \(s\.status\.authAcct \? `Login \(\$\{s\.status\.authAcct\}\)` : "Login"\)\]\);/);
-  // …and when the CLI's own init landed on the OTHER side (authLive — a key found via apiKeyHelper
-  // on a login launch), the row carries the live truth beside the intent instead of wearing the lie,
-  // and the account name yields its parenthetical — it is not the account being billed (2026-08-15).
+  // …and the row tells the TRUTH in every landing shape (T124, superseding the quiet-parenthetical
+  // form: after a switch the row showed the pick as applied fact through the whole reconnect
+  // window, and a wrong-side landing read as an aside). A PENDING pick says "applying — not
+  // confirmed yet"; a CONFIRMED contradiction (authLive on the other side — a key found via
+  // apiKeyHelper on a login launch) LEADS with the warning and names what is actually billed.
   // Anchored at the gate + label: a no-auth session (tmux — the exclusion above) must never grow a
   // fabricated Billing row, so the `if (s.status.auth)` guard is part of the pinned behavior.
-  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing",\s*\n\s*s\.status\.authLive && s\.status\.authLive !== s\.status\.auth\s*\n\s*\? \(s\.status\.auth === "key" \? "API key" : "Login"\)\s*\n\s*\+ ` \(CLI reports \$\{s\.status\.authLive === "key" \? "API key" : "login"\}\)`/);
+  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing",\s*\n\s*s\.status\.authPending\s*\n\s*\? \(s\.status\.auth === "key" \? "API key" : "Login"\) \+ " \(applying — not confirmed yet\)"/,
+    "the reconnect window renders as pending intent, never as applied fact");
+  assert.match(RENDER, /⚠ \$\{s\.status\.auth === "key" \? "API key" : "Login"\} picked, but the CLI reports `\s*\n\s*\+ `\$\{s\.status\.authLive === "key" \? "the API key" : "the login"\} — this session bills that`/,
+    "a confirmed contradiction leads with the warning");
+  // the SWITCH CONTROL (the Billing submenu) carries the same truth where the pick lives
+  assert.match(RENDER, /sb\.textContent = st\.authPending \? "applying…"\s*\n\s*: st\.authLive && st\.authLive !== st\.auth\s*\n\s*\? `⚠ CLI reports \$\{st\.authLive === "key" \? "API key" : "login"\}`/,
+    "the submenu sub-line shows the contradiction, not the unapplied pick");
+});
+
+test("set_auth refuses a login pick on a box with no login — the same bar the key side always had (T124)", () => {
+  const BACKEND = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+  assert.ok(BACKEND.includes('if value == "login" and not self.login_ok():'),
+    "refuse loudly at pick time when the box demonstrably lacks the credential");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.ok(KERNEL.includes("_sdk_backend.login_ok = lambda: bool(_claude_account())"),
+    "the probe is the credential store — the authority the usage bars trust");
+  assert.ok(KERNEL.includes("or this machine has no Claude login to switch to."),
+    "the warn toast names the login case");
 });
 
 test("setAuth is an intent op — held through a kernel-restart window, never dropped", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4177,12 +4177,17 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   // on a session launched for the login), the row carries the live truth beside the intent instead
   // of wearing the lie (the user 2026-08-15). The account name yields its parenthetical then: it is
   // not the account being billed.
+  // the row tells the TRUTH in every landing shape (T124: after a switch it showed the pick as
+  // applied fact through the whole reconnect window, and a wrong-side landing read as a quiet
+  // parenthetical): a pending pick says so, a confirmed contradiction leads with the warning.
   if (s.status.auth) rows.push(["Billing",
-    s.status.authLive && s.status.authLive !== s.status.auth
-      ? (s.status.auth === "key" ? "API key" : "Login")
-        + ` (CLI reports ${s.status.authLive === "key" ? "API key" : "login"})`
-      : s.status.auth === "key" ? "API key"
-        : (s.status.authAcct ? `Login (${s.status.authAcct})` : "Login")]);
+    s.status.authPending
+      ? (s.status.auth === "key" ? "API key" : "Login") + " (applying — not confirmed yet)"
+      : s.status.authLive && s.status.authLive !== s.status.auth
+        ? `⚠ ${s.status.auth === "key" ? "API key" : "Login"} picked, but the CLI reports `
+          + `${s.status.authLive === "key" ? "the API key" : "the login"} — this session bills that`
+        : s.status.auth === "key" ? "API key"
+          : (s.status.authAcct ? `Login (${s.status.authAcct})` : "Login")]);
   for (const [k, v] of rows) {
     const r = el("div", "tab-tip-row");
     const ke = el("span", "tab-tip-k"); ke.textContent = k;
@@ -4762,7 +4767,9 @@ function showTabMenu(e: MouseEvent, id: string) {
     const l = el("span", "ctx-item-label"); l.textContent = "Billing"; bodyEl.appendChild(l);
     const sb = el("span", "ctx-item-sub");
     sb.textContent = st.authPending ? "applying…"
-      : (st.auth === "key" ? "API key" : (st.authAcct ? `Login (${st.authAcct})` : "Login"));
+      : st.authLive && st.authLive !== st.auth
+        ? `⚠ CLI reports ${st.authLive === "key" ? "API key" : "login"}`   // the pick did not take — say so where the switch lives (T124)
+        : (st.auth === "key" ? "API key" : (st.authAcct ? `Login (${st.authAcct})` : "Login"));
     bodyEl.appendChild(sb);
     item.appendChild(bodyEl);
     const caret = el("span", "ctx-caret"); caret.textContent = "▸"; item.appendChild(caret);


### PR DESCRIPTION
User report: after switching a session key→login, "what's represented in the UI is not actually what's happening." Code-path analysis found three truth gaps.

**1. A login pick on a box that cannot apply it was accepted silently.** `set_auth` gated `key` on `work_key` but accepted `login` unconditionally — the pick then sat in the UI while the applying reconnect errored or landed keyed through an apiKeyHelper. It now refuses at pick time via a kernel-wired credential-store probe (`login_ok`, the same authority the usage bars trust; permissive when unwired, so bare backends and old tests keep the prior behavior). A refused pick flips nothing — no reg write, no pending window, no remembered-default trace (the Q3 marker stays honest) — and the warn toast names the login case.

**2. The pending window rendered as applied fact.** Through the whole applying reconnect the tab hover showed the plain pick ("Login"). It now reads "Login (applying — not confirmed yet)" until the CLI's init confirms.

**3. The contradiction was too quiet.** A wrong-side landing was a hover parenthetical plus a log-only problem line. The hover now leads with it ("⚠ Login picked, but the CLI reports the API key — this session bills that"), and the Billing submenu — where the switch lives — shows "⚠ CLI reports X" instead of the unapplied pick.

**The cycle, pinned as a truth table** at the session state dict (the exact fields the row renders from): confirmed key at rest → the pending window (intent as pending, never fact) → confirmed login within one init → a wrong-side landing (authLive carries it; the problems ring names it) → the login-less refusal that moves nothing. The render mapping is pinned beside the retargeted hover pins; the submenu's truth line is pinned too.

**The laptop's likely shape, honestly bounded** (no HTTP path from this devbox; T108 precedent): their box has a login, so the pick was accepted and the reconnect applied — the complaint window is either shape 2 (the hover asserting "Login" before any init confirmed, indefinitely if the session sat idle mid-reconnect) or shape 3 (an apiKeyHelper/project key landing the CLI back on the key with only a hover parenthetical saying so). Both now render the truth; which one their session hit is recoverable from their kernel log's mismatch line if needed.

Suites: pytest 5830 passed / 34 skipped (72 in the two auth files, five new); vscode-extension 2490/2490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)