### PR TITLE
Live tab-drag reorder; the scrollbar overlays' frame goes virtual (two strip fixes, one branch)

### DIFF
--- a/tools/romp-lab/README.md
+++ b/tools/romp-lab/README.md
@@ -58,3 +58,14 @@ The default run drives TWO phases, banner first (it spends no model turns):
 
 A lab run spends a handful of short turns on the configured model (default Haiku)
 against the machine's own key — the same key live sessions bill.
+
+## rail-drift.mjs — the scroll-marks invariance assertion (T129)
+
+Under pure scrolling, the transcript rail's notches must never move relative to each other (the
+user filmed exactly that, 2026-08-27). `node rail-drift.mjs [--dist <dir>]` renders a synthetic
+long mixed transcript over the built bundle (no kernel needed — file:// page, placeholder UUIDs),
+scrolls two full round trips sampling every notch per frame, and asserts the second round trip —
+the learned regime, after the height cache primes — shows zero pairwise drift (tolerance 1.5px for
+style rounding; the pre-fix map drifted 5.7px, endlessly). The first round trip's remaps are
+event-keyed cache learning and are reported but not gated. Run it after any change to
+contentOffsetFrame, the virtualization window, or the scroll-marks/comment-rail painters.

--- a/tools/romp-lab/rail-drift.mjs
+++ b/tools/romp-lab/rail-drift.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Permanent lab assertion (T129, the user 2026-08-27, screen recording: the transcript rail's
+// side marks moved RELATIVE TO EACH OTHER while scrolling — geometrically impossible for a linear
+// map): under PURE SCROLLING, every scroll-marks notch must hold its pairwise spacing — nothing
+// moves relative to anything else. The fix made contentOffsetFrame a fully VIRTUAL frame (one
+// cached-height prefix over all units), so a mark's rail position is independent of scrollTop and
+// the render window; it changes only when information arrives (a height first measured, events
+// appended). This script proves the invariant over the BUILT bundle:
+//   pass 1 (down+up) PRIMES the height cache — remaps here are event-keyed learning, allowed;
+//   pass 2 (down+up) is the assertion regime — zero drift, to sub-pixel rounding.
+// Metric: per animation frame, normalize all mark tops to [0,1] over their span (a global rescale
+// is legitimate — the native thumb does the same); drift = max over marks of the range of its
+// normalized position across frames. Fails loud above TOLERANCE_PX.
+//
+// Usage: node rail-drift.mjs [--dist <dir>]   (defaults to ../../vscode-extension/dist)
+// Hermetic: synthetic transcript (placeholder UUIDs, notes-api world), file:// page, no kernel.
+import { createRequire } from "node:module";
+import { mkdtempSync, writeFileSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distArg = process.argv.indexOf("--dist");
+const dist = resolve(distArg > 0 ? process.argv[distArg + 1] : join(here, "..", "..", "vscode-extension", "dist"));
+const require2 = createRequire(join(dist, "..", "package.json"));
+const { chromium } = require2("playwright");
+
+const TOLERANCE_PX = 1.5;   // sub-pixel style rounding only; real drift measured 5.7px before the fix
+
+const dir = mkdtempSync(join(tmpdir(), "rail-drift-"));
+copyFileSync(join(dist, "render.js"), join(dir, "render.js"));
+copyFileSync(join(dist, "styles.css"), join(dir, "styles.css"));
+writeFileSync(join(dir, "page.html"), `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><link href="styles.css" rel="stylesheet"></head><body>
+  <div id="winframe"></div>
+  <div id="tabbar"><span id="tabs"></span></div>
+  <div id="tabbar-resize"></div>
+  <div id="ledger" style="display:none"></div>
+  <div id="content"><div id="live-ask" style="display:none"></div></div>
+  <div id="footer"><div id="composer-resize"></div><div id="statusline" class="statusline"></div>
+  <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-staged" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1"></textarea><button id="composer-attach"></button><button id="composer-send">➤</button></div></div>
+<script>window.acquireVsCodeApi = function () { return { postMessage: function () {}, getState: function () { return {}; }, setState: function () {} }; };</script>
+<script src="render.js"></script>
+</body></html>`);
+
+const frame = (o) => `window.dispatchEvent(new MessageEvent("message", { data: ${JSON.stringify(o)} }))`;
+const S = "aaaaaaaa-1111-2222-3333-444444440001";
+const events = [];
+let u = 0;
+const uid = () => "u-" + (++u);
+for (let i = 0; i < 120; i++) {   // long MIXED transcript: virtualization + folds + height variety
+  events.push({ kind: "user", md: "question " + i + " about the api behavior?", uuid: uid(), human: true });
+  events.push({ kind: "assistant", md: i % 3 === 0
+    ? ("A long answer. " + "The quick brown fox jumps over the lazy dog and explains the tradeoff in detail. ".repeat(6 + (i % 5)))
+    : "Short answer " + i + ".", uuid: uid() });
+  if (i % 2 === 0) for (let k = 0; k < 3; k++)
+    events.push({ kind: "tool", name: "Bash", input: { command: "echo step-" + i + "-" + k }, output: "ok " + "line\n".repeat(1 + (k * 3)), uuid: uid() });
+  if (i % 4 === 1) events.push({ kind: "assistant", md: "```python\n" + "x = compute(" + i + ")\nprint(x)\n".repeat(4) + "```", uuid: uid() });
+}
+
+const b = await chromium.launch();
+const p = await b.newPage({ viewport: { width: 700, height: 600 }, deviceScaleFactor: 1 });
+p.on("pageerror", (e) => { console.error("PAGEERROR", e.message); process.exitCode = 1; });
+await p.goto("file://" + join(dir, "page.html"));
+await p.evaluate(frame({ type: "session", id: S, name: "web", cwd: "/home/demo/notes-api",
+  status: { state: "idle", sinceEpoch: null, faded: false }, events }));
+await p.evaluate(frame({ type: "tabOrder", order: [S], tabs: [{ id: S, name: "web", color: { bg: "#4dabf7", fg: "#111" } }] }));
+await p.waitForSelector(".turn", { timeout: 8000 });
+await p.waitForTimeout(500);
+const samples = await p.evaluate(async () => {
+  const content = document.getElementById("content");
+  const marks = () => Array.from(document.querySelectorAll(".scroll-marks .scroll-mark")).map((m) => parseFloat(m.style.top));
+  const raf = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+  const max = content.scrollHeight - content.clientHeight;
+  const out = [];
+  for (let dir2 = 0; dir2 < 4; dir2++) {           // two full round trips; the second is the assertion regime
+    for (let k = 0; k <= 60; k++) {
+      content.scrollTop = dir2 % 2 === 0 ? (max * k) / 60 : max - (max * k) / 60;
+      content.dispatchEvent(new Event("scroll"));
+      await raf(); await raf();
+      out.push(marks());
+    }
+  }
+  return out;
+});
+const railH = await p.evaluate(() => document.querySelector(".scroll-marks")?.getBoundingClientRect().height || 0);
+await b.close();
+
+const n = Math.min(...samples.map((s2) => s2.length));
+if (!(n > 10)) { console.error("rail-drift: too few marks rendered (" + n + ")"); process.exit(1); }
+const norm = samples.filter((s2) => s2.length === n).map((s2) => {
+  const lo = Math.min(...s2), hi = Math.max(...s2);
+  return s2.map((y) => (hi > lo ? (y - lo) / (hi - lo) : 0));
+});
+const driftOver = (frames) => {
+  let worst = 0;
+  for (let i = 0; i < n; i++) {
+    const vals = frames.map((f) => f[i]);
+    const d = Math.max(...vals) - Math.min(...vals);
+    if (d > worst) worst = d;
+  }
+  return worst * railH;
+};
+const learnedPx = driftOver(norm.slice(Math.floor(norm.length / 2)));
+const allPx = driftOver(norm);
+console.log(JSON.stringify({ marks: n, frames: samples.length, railH: Math.round(railH),
+  learnedRegimeDriftPx: +learnedPx.toFixed(2), allFramesDriftPx: +allPx.toFixed(2), tolerancePx: TOLERANCE_PX }));
+if (learnedPx > TOLERANCE_PX) {
+  console.error(`rail-drift FAIL: marks moved ${learnedPx.toFixed(2)}px relative to each other under pure scrolling (tolerance ${TOLERANCE_PX}px)`);
+  process.exit(1);
+}
+console.log("rail-drift OK: pairwise positions invariant under pure scrolling");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4130,6 +4130,37 @@ function auditTabOrder(ids: string[]) {
   lastTabIds = ids.slice();
 }
 let draggedId: string | null = null;
+let tabDragCommitted = false;   // set by the strip's drop handler; dragend without it = a cancel (Escape / dropped outside)
+// FLIP the strip around a DOM mutation (T127 live reorder): snapshot every tab's rect by id, run
+// the mutation, then play each moved tab from its old rect to its new one — an inverted transform
+// released a frame later. A row jump is just a bigger delta: the wrap layout reflows and the
+// animation follows, which is what makes true cross-row live reorder work. Under
+// prefers-reduced-motion the mutation still happens (the reorder IS the information, per the
+// spec) — only the transition is skipped, so positions update instantly. Duration is
+// presentation, not logic: nothing waits on it.
+function flipTabs(mutate: () => void): void {
+  const bar = document.getElementById("tabs");
+  if (!bar) { mutate(); return; }
+  const before = new Map<string, DOMRect>();
+  bar.querySelectorAll<HTMLElement>(".tab[data-id]").forEach((t) => { if (t.dataset.id) before.set(t.dataset.id, t.getBoundingClientRect()); });
+  mutate();
+  if (matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  bar.querySelectorAll<HTMLElement>(".tab[data-id]").forEach((t) => {
+    const a = t.dataset.id ? before.get(t.dataset.id) : undefined;
+    if (!a) return;
+    const b = t.getBoundingClientRect();
+    const dx = a.left - b.left, dy = a.top - b.top;
+    if (!dx && !dy) return;
+    t.style.transition = "none";
+    t.style.transform = `translate(${dx}px, ${dy}px)`;
+    requestAnimationFrame(() => {
+      t.style.transition = "transform 0.12s ease";
+      t.style.transform = "";
+      const done = () => { t.style.transition = ""; t.removeEventListener("transitionend", done); };
+      t.addEventListener("transitionend", done);
+    });
+  });
+}
 function reorderTo(dragId: string, targetId: string, after: boolean) {
   const di = order.indexOf(dragId);
   if (di < 0) return;
@@ -4266,6 +4297,14 @@ let renderPendingAfterRename = false;
 // dispatches right after pointerup, fires against the still-present node first.
 let tabPointerHeld = false;
 let renderPendingWhilePressed = false;
+// Release the press-hold and flush any deferred rebuild. Hoisted so the DRAG handlers can call it
+// too: a native drag swallows the pointerup, so without this a finished drag would leave the strip
+// frozen against pushes until the next unrelated press (see the dragend handler).
+function releaseTabStrip(): void {
+  if (!tabPointerHeld) return;
+  tabPointerHeld = false;
+  if (renderPendingWhilePressed) { renderPendingWhilePressed = false; setTimeout(() => renderTabs(), 0); }
+}
 // A loading PLACEHOLDER tab (the user 2026-06-26): name + identity color from the kernel's tabOrder push,
 // shown while the session's build_session is still in flight so the strip's full width is reserved up front
 // (no one-by-one pop-in). CLICKABLE (the user 2026-08-25: "I'd like to click it so when the session
@@ -4401,23 +4440,22 @@ function renderTabs() {
     tab.addEventListener("keydown", onTabKey);
     // drag-to-reorder (synced with the timeline via the shared session-order file)
     tab.draggable = true;
-    tab.addEventListener("dragstart", (e) => { draggedId = id; if (e.dataTransfer) e.dataTransfer.effectAllowed = "move"; tab.classList.add("dragging"); });
-    tab.addEventListener("dragend", () => { draggedId = null; document.querySelectorAll(".tab.dragging,.tab.drop-before,.tab.drop-after").forEach((t) => t.classList.remove("dragging", "drop-before", "drop-after")); });
-    tab.addEventListener("dragover", (e) => {
-      if (!draggedId || draggedId === id) return;
-      e.preventDefault();
-      const r = tab.getBoundingClientRect();
-      const after = e.clientX > r.left + r.width / 2;
-      tab.classList.toggle("drop-after", after);
-      tab.classList.toggle("drop-before", !after);
-    });
-    tab.addEventListener("dragleave", () => tab.classList.remove("drop-before", "drop-after"));
-    tab.addEventListener("drop", (e) => {
-      tab.classList.remove("drop-before", "drop-after");
-      if (!draggedId || draggedId === id) return;
-      e.preventDefault();
-      const r = tab.getBoundingClientRect();
-      reorderTo(draggedId, id, e.clientX > r.left + r.width / 2);
+    tab.addEventListener("dragstart", (e) => { draggedId = id; tabDragCommitted = false; if (e.dataTransfer) e.dataTransfer.effectAllowed = "move"; tab.classList.add("dragging"); });
+    // dragend closes EVERY drag (drop, Escape, released outside). The pointerdown that started the
+    // drag latched tabPointerHeld, and the drag swallowed the matching pointerup — so the hold is
+    // released here by hand, covering the whole gesture against pushes (the click-safe rule). A
+    // CANCELLED drag re-renders from the untouched order and everything FLIP-animates home — that
+    // render also folds in any push that arrived, deferred, mid-drag. A committed drop's reorderTo
+    // already asked for its render; it ran deferred, so flush it.
+    tab.addEventListener("dragend", () => {
+      const cancelled = !tabDragCommitted;
+      draggedId = null; tabDragCommitted = false;
+      tab.classList.remove("dragging");
+      tabPointerHeld = false;
+      const pending = renderPendingWhilePressed;
+      renderPendingWhilePressed = false;
+      if (cancelled) flipTabs(() => renderTabs());
+      else if (pending) setTimeout(() => renderTabs(), 0);
     });
     if (s.color) {
       tab.style.setProperty("--chip-bg", s.color.bg);
@@ -12698,14 +12736,42 @@ setupSettings();
   // may end in another frame / outside the window, where no pointerup reaches us). The flush is a setTimeout(0)
   // so the click — dispatched immediately after pointerup, before the timer — fires against the live node first.
   tabs.addEventListener("pointerdown", () => { tabPointerHeld = true; });
-  const releaseTabs = () => {
-    if (!tabPointerHeld) return;
-    tabPointerHeld = false;
-    if (renderPendingWhilePressed) { renderPendingWhilePressed = false; setTimeout(() => renderTabs(), 0); }
-  };
-  window.addEventListener("pointerup", releaseTabs);
-  window.addEventListener("pointercancel", releaseTabs);
-  window.addEventListener("blur", releaseTabs);
+  window.addEventListener("pointerup", releaseTabStrip);
+  window.addEventListener("pointercancel", releaseTabStrip);
+  window.addEventListener("blur", releaseTabStrip);
+  // LIVE REORDER (T127, the user 2026-08-27: dragging should push the other tabs into their new
+  // locations as you drag, the way browsers do): while a tab drags, its in-flow element moves
+  // through the strip's DOM as the pointer crosses the MIDPOINT of the tab under it — the
+  // slot-boundary event, never a timer — and the wrap layout reflows rows natively, so a tab
+  // pushed past a row's end wraps to the next row mid-drag; siblings FLIP to their new rects
+  // (flipTabs). The no-op guard (already sitting immediately before the reference node) is what
+  // keeps a pointer resting inside one slot from churning the DOM on every dragover tick.
+  tabs.addEventListener("dragover", (e) => {
+    if (!draggedId) return;
+    e.preventDefault();   // the whole strip is a valid drop target
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+    const over = (e.target as HTMLElement).closest?.(".tab[data-id]") as HTMLElement | null;
+    const dragged = tabs.querySelector<HTMLElement>(`.tab[data-id="${CSS.escape(draggedId)}"]`);
+    if (!over || !dragged || over === dragged) return;
+    const r = over.getBoundingClientRect();
+    const ref = e.clientX > r.left + r.width / 2 ? over.nextElementSibling : over;
+    if (ref !== dragged && dragged.nextElementSibling !== ref) flipTabs(() => tabs.insertBefore(dragged, ref));
+  });
+  // Drop commits the LIVE DOM position through the same reorderTo the strip has always used —
+  // neighbor id + side — so persistence and the kernel write are byte-identical, and ids that a
+  // filtered view HIDES (present in `order`, absent from the DOM) keep their places: a wholesale
+  // order-from-DOM write would silently drop them.
+  tabs.addEventListener("drop", (e) => {
+    if (!draggedId) return;
+    e.preventDefault();
+    const dragged = tabs.querySelector<HTMLElement>(`.tab[data-id="${CSS.escape(draggedId)}"]`);
+    if (!dragged) return;
+    const prev = dragged.previousElementSibling as HTMLElement | null;
+    const next = dragged.nextElementSibling as HTMLElement | null;
+    if (prev?.dataset?.id) reorderTo(draggedId, prev.dataset.id, true);
+    else if (next?.dataset?.id) reorderTo(draggedId, next.dataset.id, false);
+    tabDragCommitted = true;   // dragend must not treat this as a cancel (it fires next)
+  });
 })();
 // right-click a selection in the transcript → Reply (quote it) / Copy
 document.getElementById("content")?.addEventListener("contextmenu", showSelectionMenu);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1947,24 +1947,29 @@ function eventUnitIndex(s: Session): Int32Array {
 // ONE content-space frame for every scrollbar overlay (the user 2026-08-17, watching comment ticks
 // drift past message notches as history loaded): marks anchored to transcript positions share an
 // inherent monotonic order, so every overlay must place them with the SAME event-index → pixel
-// mapping — rendered turns by their true offset, spacer-covered turns by cumulative cached heights
-// normalized to the spacer's real height. The comment rail's old uniform index-fraction percents
-// were a second, disagreeing frame. Returns null while the pane is hidden or degenerate; offsetOf
-// returns null for an event mid-window-update — callers skip that mark, the next paint lands it.
+// mapping. Since T129 (the user 2026-08-27, filming marks moving RELATIVE TO EACH OTHER while
+// scrolling — geometrically impossible for a linear map) the frame is fully VIRTUAL: one
+// prefix-sum over ALL units, the cached measured height where a unit was ever rendered, the
+// renderer's average else. The old frame was PIECEWISE — live getBoundingClientRect offsets
+// inside the virtualization window, cache sums normalized to each spacer's rendered height
+// outside it — so pure scrolling changed the map every frame the window slid: marks flipped
+// basis crossing the window edge, the spacer denominators flapped, and first-render measurements
+// reshuffled the slots mid-scroll. In the virtual frame a mark's position does not depend on
+// scrollTop or the window AT ALL: under pure scrolling nothing moves, and a mark moves only when
+// information arrives — a height first measured (or remeasured: an image sizing in, a fold
+// toggling), events appending — the event-keyed remap the design rule asks for. The rendered
+// window still feeds the cache every paint, so the frame converges to truth as units are seen;
+// the scrollbar thumb lives in the real-pixel frame, whose totals the cache tracks to within the
+// average-height estimate for never-rendered units — same accuracy class as the spacers that
+// size that scrollbar in the first place. Returns null while the pane is hidden or degenerate;
+// offsetOf returns null out of range — callers skip that mark, the next paint lands it.
 function contentOffsetFrame(content: HTMLElement, v: View, s: Session):
     { sh: number; offsetOf: (i: number) => number | null } | null {
   const cRect = content.getBoundingClientRect();
-  const sh = content.scrollHeight;
-  if (!sh || cRect.height <= 40) return null;
-  const winStart = v.winStart ?? 0;
-  const winEnd = v.winEnd ?? s.events.length;
+  if (!content.scrollHeight || cRect.height <= 40) return null;
   const unitTotal = v.unitTotal ?? s.events.length;
-  const topSp = v.el.querySelector<HTMLElement>(".tx-spacer-top");
-  const botSp = v.el.querySelector<HTMLElement>(".tx-spacer-bot");
-  const topH = topSp ? topSp.offsetHeight : 0;
-  const botH = botSp ? botSp.offsetHeight : 0;
-  const scrollTop = content.scrollTop;
-  // remember every rendered unit's measured height — the spacer estimates below feed on them
+  if (!(unitTotal > 0)) return null;
+  // remember every rendered unit's measured height — the virtual frame feeds on them
   let uh = unitHeights.get(activeId!);
   if (!uh) { uh = new Map(); unitHeights.set(activeId!, uh); }
   for (const node of Array.from(v.el.querySelectorAll<HTMLElement>(".turn[data-unit]"))) {
@@ -1973,37 +1978,14 @@ function contentOffsetFrame(content: HTMLElement, v: View, s: Session):
     if (Number.isFinite(u) && h > 0) uh.set(u, h);
   }
   const avg = v.avgTurnH ?? 60;
-  // Cumulative-height slots within each spacer run, NORMALIZED to the spacer's actual rendered
-  // height (the frame the scrollbar itself stands on) — cached truth where a unit was ever
-  // rendered, the renderer's average for the rest. One prefix-sum pass per spacer per paint (O(n)
-  // total), then O(1) per mark. Normalizing keeps mark and thumb in one frame even when the
-  // cache disagrees with the spacer's uniform sizing.
-  const prefixOver = (from: number, to: number): number[] => {
-    const pre: number[] = [0];
-    let t = 0;
-    for (let u = from; u < to; u++) { t += uh!.get(u) ?? avg; pre.push(t); }
-    return pre;
-  };
-  const topPre = winStart > 0 ? prefixOver(0, winStart) : null;
-  const botPre = unitTotal > winEnd ? prefixOver(winEnd, unitTotal) : null;
-  const slotIn = (pre: number[], k: number, spanH: number): number => {
-    const total = pre[pre.length - 1];
-    if (!(total > 0)) return spanH / 2;
-    return spanH * ((pre[k] + (pre[k + 1] - pre[k]) / 2) / total);
-  };
-  const offsetOf = (i: number): number | null => {
-    let off: number | null = null;
-    if (i >= winStart && i < winEnd) {
-      const node = v.el.querySelector<HTMLElement>('.turn[data-unit="' + i + '"]');
-      if (node) off = node.getBoundingClientRect().top - cRect.top + scrollTop;
-    }
-    if (off == null) {
-      if (i < winStart && topPre) off = slotIn(topPre, i, topH);                        // inside the top spacer
-      else if (i >= winEnd && botPre) off = (sh - botH) + slotIn(botPre, i - winEnd, botH);
-    }
-    return off;                                      // null → window bookkeeping mid-update — skip this one, next paint has it
-  };
-  return { sh, offsetOf };
+  // one prefix-sum pass per paint (O(n)), then O(1) per mark
+  const pre: number[] = [0];
+  let t = 0;
+  for (let u = 0; u < unitTotal; u++) { t += uh.get(u) ?? avg; pre.push(t); }
+  if (!(t > 0)) return null;
+  const offsetOf = (i: number): number | null =>
+    (i >= 0 && i < unitTotal) ? pre[i] + (pre[i + 1] - pre[i]) / 2 : null;   // the unit's slot MIDDLE, uniform for every unit
+  return { sh: t, offsetOf };
 }
 
 function ensureScrollMarks(): HTMLElement {

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -13,25 +13,33 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("one notch per real user message across the WHOLE loaded conversation", () => {
   // the user 2026-08-17: the chat virtualizes (a rendered window between two estimated-height
-  // spacers), and window-only notches "forgot" the newer messages when scrolled back. Notches now
-  // come from the full resident events array: true pixels for rendered turns, a proportional slot
-  // inside the MEASURED spacer for the rest — the same estimate the scrollbar itself stands on.
+  // spacers), and window-only notches "forgot" the newer messages when scrolled back. Notches
+  // come from the full resident events array, placed by the one virtual frame (pinned below).
   assert.match(RENDER, /for \(let i = 0; i < s\.events\.length; i\+\+\) \{/);
   // the filter reads the ONE senderKind verdict (2026-08-18): user → blue, romp/tagged → the gray
   // machine notch, harness noise → none — the same classifier the bubble and rail dot wear
   assert.match(RENDER, /const kind = senderKind\(ev\);\s*\n\s*if \(kind === "injected"\) continue;/);
   assert.match(RENDER, /ev\.canned === "continue" \|\| SLASH_CMD_RE\.test\(md\)/,
     "a /command or Continue gesture is a doing, not words — no notch");
-  assert.match(RENDER, /'\.turn\[data-unit="' \+ i \+ '"\]'/, "rendered events use their true pixel offset");
-  // spacer slots feed on CACHED measured heights (the user 2026-08-17, video: uniform-average
-  // slots made notches wiggle as messages crossed the render-window boundary and corrected to
-  // truth) — cumulative cached heights, normalized to the spacer's actual height, one prefix-sum
-  // pass per spacer, O(1) per notch
+});
+
+test("the frame is VIRTUAL: one cached-height prefix over ALL units, independent of scroll and window", () => {
+  // T129 (the user 2026-08-27, filming marks moving RELATIVE TO EACH OTHER while scrolling —
+  // geometrically impossible for a linear map): the old frame was piecewise — live rect offsets
+  // inside the render window, cache sums normalized to each spacer's height outside — so pure
+  // scrolling changed the map every frame the window slid. The frame now depends on NOTHING the
+  // scroll moves: a mark's position changes only when information arrives (a height measured, an
+  // event appended). Lab proof: tools/romp-lab/rail-drift.mjs — learned-regime drift is 0.0px
+  // across a full scroll round trip (was 5.7px, endlessly, before).
   assert.match(RENDER, /const unitHeights = new Map<string, Map<number, number>>\(\);/);
   assert.match(RENDER, /if \(Number\.isFinite\(u\) && h > 0\) uh\.set\(u, h\);/, "every rendered unit's height is remembered");
-  assert.match(RENDER, /off = slotIn\(topPre, i, topH\);/, "top-spacer events slot by cumulative cached heights");
-  assert.match(RENDER, /off = \(sh - botH\) \+ slotIn\(botPre, i - winEnd, botH\);/,
-    "bottom-spacer events too — normalized to the spacer the scrollbar stands on");
+  assert.match(RENDER, /for \(let u = 0; u < unitTotal; u\+\+\) \{ t \+= uh\.get\(u\) \?\? avg; pre\.push\(t\); \}/,
+    "ONE prefix-sum over every unit — cached truth where seen, the renderer's average else");
+  assert.match(RENDER, /\(i >= 0 && i < unitTotal\) \? pre\[i\] \+ \(pre\[i \+ 1\] - pre\[i\]\) \/ 2 : null/,
+    "every unit slots at its virtual middle — uniform semantics, no per-basis seams");
+  const frameBody = RENDER.slice(RENDER.indexOf("function contentOffsetFrame("), RENDER.indexOf("function ensureScrollMarks("));
+  assert.ok(!/scrollTop|tx-spacer|winStart|slotIn/.test(frameBody),
+    "nothing scroll-coupled inside the frame — no live offsets, no spacer reads, no window bounds");
 });
 
 test("a history load rescales the map smoothly — moved notches are carried, never teleported", () => {
@@ -45,7 +53,6 @@ test("a history load rescales the map smoothly — moved notches are carried, ne
 });
 
 test("positions are proportional and pure scrolls do no DOM work", () => {
-  assert.match(RENDER, /node\.getBoundingClientRect\(\)\.top - cRect\.top \+ scrollTop/);
   assert.match(RENDER, /if \(sig !== scrollMarksSig\) \{/, "signature skip: rebuild only on real change");
   assert.match(RENDER, /paintRailSticky\(\); paintScrollMarks\(\);/, "rides the existing rAF scheduler");
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -198,13 +198,12 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
      dashed state outlines (.tab.tab-awaiting / .tab-blocked / .tab-retrying). */
   outline: none;
 }
-/* drag-to-reorder: dim the dragged tab, show an insertion line on the drop target */
+/* drag-to-reorder: dim the in-flow dragged tab — it marks the live landing slot while the native
+   drag image follows the pointer, and the OTHER tabs rearrange in real time around it (T127, the
+   user 2026-08-27: dragging should push the other tabs into their new locations as you drag, the
+   way browser tab strips do). The mechanics live in render.ts (flipTabs + the strip's dragover);
+   the old two-px landing marker and its classes are deleted with this. */
 .tab.dragging { opacity: 0.45; }
-.tab.drop-before::after, .tab.drop-after::after {
-  content: ""; position: absolute; top: 3px; bottom: 3px; width: 2px; background: var(--fg); border-radius: 1px;
-}
-.tab.drop-before::after { left: -3px; }
-.tab.drop-after::after { right: -3px; }
 .tab:hover { color: var(--fg); background: rgba(255, 255, 255, 0.06); }
 .tab.tab-awaiting { --state: var(--st-awaiting-bg); }
 /* RETRYING: an amber dashed ring (soft 'blocked on the API' auto-retry) — same dashed treatment as awaiting,

--- a/ui/webview/tab-close-clicksafe.test.ts
+++ b/ui/webview/tab-close-clicksafe.test.ts
@@ -22,9 +22,9 @@ test("renderTabs defers its rebuild while a pointer is pressed on the tab strip"
 
 test("the press guard is armed on #tabs pointerdown and released on pointerup/cancel/blur", () => {
   assert.match(RENDER, /tabs\.addEventListener\("pointerdown", \(\) => \{ tabPointerHeld = true; \}\)/);
-  assert.match(RENDER, /window\.addEventListener\("pointerup", releaseTabs\)/);
-  assert.match(RENDER, /window\.addEventListener\("pointercancel", releaseTabs\)/);
-  assert.match(RENDER, /window\.addEventListener\("blur", releaseTabs\)/);   // press may end off-strip / in another frame
+  assert.match(RENDER, /window\.addEventListener\("pointerup", releaseTabStrip\)/);
+  assert.match(RENDER, /window\.addEventListener\("pointercancel", releaseTabStrip\)/);
+  assert.match(RENDER, /window\.addEventListener\("blur", releaseTabStrip\)/);   // press may end off-strip / in another frame
 });
 
 test("release flushes a pending rebuild a tick LATER so the click fires against the live node first", () => {

--- a/ui/webview/tab-drag-live.test.ts
+++ b/ui/webview/tab-drag-live.test.ts
@@ -1,0 +1,81 @@
+// Tab drag is LIVE REORDER (T127, the user 2026-08-27): while a tab drags, the other tabs
+// rearrange in real time to make room, the way browser tab strips do — the old two-px landing
+// marker is gone. The deciding event is the pointer crossing the MIDPOINT of the tab under it
+// (never a timer); the dragged tab's in-flow element moves through the strip's DOM, the wrap
+// layout reflows rows natively (true cross-row reorder: a tab pushed past a row's end wraps
+// mid-drag), and siblings FLIP to their new rects. Verified end-to-end headless (synthetic drag
+// events over the built bundle): same-row displacement, cross-row reflow, a push deferred across
+// the whole drag, drop persistence surviving a forced re-render, and cancel animating home.
+// Source pins per the repo convention (render.ts builds the strip imperatively; no jsdom here).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+const between = (a: string, b: string) => {
+  const at = RENDER.indexOf(a);
+  assert.ok(at > 0, a + " must exist");
+  return RENDER.slice(at, RENDER.indexOf(b, at));
+};
+
+test("slot boundary is the event: midpoint compare moves the dragged element in DOM order", () => {
+  const body = between('tabs.addEventListener("dragover"', "});");
+  assert.match(body, /const ref = e\.clientX > r\.left \+ r\.width \/ 2 \? over\.nextElementSibling : over;/,
+    "crossing the midpoint of the tab under the pointer decides the slot — an event, not a timer");
+  assert.match(body, /if \(ref !== dragged && dragged\.nextElementSibling !== ref\) flipTabs\(\(\) => tabs\.insertBefore\(dragged, ref\)\);/,
+    "already-in-place is a no-op, so a pointer resting in one slot never churns the DOM");
+  assert.doesNotMatch(body, /setTimeout|debounce|Date\.now/, "no time-based logic in the reorder decision");
+});
+
+test("cross-row reflow is the wrap layout's own: DOM insertion, no per-row special case", () => {
+  // the strip wraps (flex-wrap) — moving the element IS the cross-row mechanism, so there must be
+  // no row math in the drag path
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
+  const body = between('tabs.addEventListener("dragover"', "});");
+  assert.doesNotMatch(body, /row|clientY/i, "no row bookkeeping — insertion order + wrap does it");
+});
+
+test("drop commits through the SAME reorderTo — neighbor + side, hidden-view ids keep their places", () => {
+  const body = between('tabs.addEventListener("drop"', "});");
+  assert.match(body, /if \(prev\?\.dataset\?\.id\) reorderTo\(draggedId, prev\.dataset\.id, true\);/);
+  assert.match(body, /else if \(next\?\.dataset\?\.id\) reorderTo\(draggedId, next\.dataset\.id, false\);/);
+  // …and reorderTo still persists exactly as before
+  const rt = between("function reorderTo(", "\n}");
+  assert.match(rt, /commitTabOrder\(\);/);
+  assert.match(rt, /renderTabs\(\);/);
+});
+
+test("the drag covers the whole gesture against pushes, and dragend releases the hold by hand", () => {
+  // pointerdown latches the hold BEFORE dragstart can fire; the drag swallows the pointerup, so
+  // dragend clears it and flushes anything a push deferred mid-drag
+  assert.match(RENDER, /tabs\.addEventListener\("pointerdown", \(\) => \{ tabPointerHeld = true; \}\);/);
+  const de = between('tab.addEventListener("dragend"', "});");
+  assert.match(de, /tabPointerHeld = false;/);
+  assert.match(de, /const pending = renderPendingWhilePressed;/);
+  assert.match(de, /else if \(pending\) setTimeout\(\(\) => renderTabs\(\), 0\);/);
+});
+
+test("cancel (Escape / dropped outside) re-renders from the untouched order, FLIP-animated home", () => {
+  const de = between('tab.addEventListener("dragend"', "});");
+  assert.match(de, /const cancelled = !tabDragCommitted;/);
+  assert.match(de, /if \(cancelled\) flipTabs\(\(\) => renderTabs\(\)\);/);
+  // the drop handler is what marks a commit, and it does so AFTER committing
+  const drop = between('tabs.addEventListener("drop"', "});");
+  assert.match(drop, /tabDragCommitted = true;/);
+});
+
+test("reduced motion: the mutation still happens, only the transition is skipped", () => {
+  const flip = between("function flipTabs(", "\n}");
+  assert.match(flip, /mutate\(\);\s*\n\s*if \(matchMedia\("\(prefers-reduced-motion: reduce\)"\)\.matches\) return;/,
+    "the guard sits AFTER the mutation — positions always update; the reorder IS the information");
+  assert.match(flip, /transform 0\.12s ease/, "duration is presentation, not logic — nothing waits on it");
+});
+
+test("the old landing marker is fully retired", () => {
+  for (const [name, src] of [["render.ts", RENDER], ["styles.css", CSS]] as const) {
+    assert.ok(!/drop-(?:before|after)/.test(src), name + " carries no landing-marker classes");
+  }
+});


### PR DESCRIPTION
Two independent, individually-verified changes that ended up on one branch (the first PR was still in CI when the second landed on the shared task branch — packaging noted in the task report; each has its own full commit message).

# 1. Tab drag becomes live reorder — siblings make room in real time
The user: dragging a chat tab should push the other tabs into their new locations as you drag, the way browsers do it — not just show a line where the tab will land.

- **The deciding event is the pointer crossing the midpoint of the tab under it** — never a timer. On each crossing the dragged element moves in DOM order (`insertBefore` on the stable `#tabs`) and siblings **FLIP-animate** by `data-id`.
- **True cross-row live reorder falls out by construction**: the strip is `flex-wrap`, so a tab pushed past a row's end wraps mid-drag. No row math (pinned).
- The old insertion-line marker and its classes are deleted. Drop commits through the **same `reorderTo`** (neighbor + side): persistence byte-identical, hidden-view ids keep their places. Escape re-renders from the untouched order, FLIP home. `tabPointerHeld` covers the whole gesture (pointerdown latches before dragstart; dragend releases + flushes by hand — the drag swallows the pointerup). Reduced motion: mutation always happens, transition skipped.
- Verified headless end-to-end (12 tabs / 3 rows): same-row displacement, cross-row wrap mid-drag, push-deferral mid-drag, drop persistence across a forced re-render, cancel restore.

# 2. The scrollbar overlays' content frame goes fully virtual — marks stop moving under scroll
The user (screen recording): the transcript rail's side marks moved **relative to each other** while scrolling — geometrically impossible for a linear map.

- **Mechanism**: `contentOffsetFrame` (shared by scroll-marks + comment rail) was piecewise — live rect offsets inside the virtualization window, spacer-normalized cache sums outside — so pure scrolling changed the map every frame the window slid.
- **Fix**: one prefix-sum over ALL units (cached measured truth where seen, renderer's average else). A mark's position no longer depends on scrollTop or the window at all; it moves only when information arrives — event-keyed. No consumer inverts rail y (comment ticks navigate by uuid).
- **Proof** (`tools/romp-lab/rail-drift.mjs`, new permanent assertion, gates at 1.5px): learned-regime drift across a full scroll round trip **5.7px endless before → 0.00px after**; all-frames 8.7px → 5.1px (first-pass cache learning, converges).
- `scroll-marks.test.ts` retargeted to the virtual-frame contract incl. an absence pin (nothing scroll-coupled inside the frame).

Suite 2499/2499, tsc clean; kernel-side neighbors green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)