### PR TITLE
The tab-strip band steps from 3% to 5% — the T128 triage's one-liner

### DIFF
--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -160,11 +160,14 @@ body.chat-theme-yatharth #winframe { display: block; position: fixed; inset: 0; 
    closed by the existing --box-border hairline at its bottom edge. This is how tab strips are
    grounded in the polished multi-tab precedents (browser frame bands, editor tab-group headers,
    design-system "tabs on a surface + divider"): the plane says "one control", the hairline says
-   "it ends here" — per-row separator lines were rejected as clutter. 3% white over the page bg
-   (tunable one-liner); background only, so zero layout shift, and the selected ring / blocked
+   "it ends here" — per-row separator lines were rejected as clutter. 5% white over the page bg
+   (tunable one-liner; shipped at 3%, stepped up 2026-08-27 after the T128 triage: on the user's
+   dark theme 3% was an ~11-gray-level delta that read as nothing at a glance — the eyeball
+   comparison lives in their drops, and 3%/6% stay one edit away); background only, so zero
+   layout shift, and the selected ring / blocked
    dashed / rest outline / hover fill all read as before, now against the band. Classic only:
    Yatharth keeps his merged look via the body scope. */
-body:not(.chat-theme-yatharth) #tabbar { background: linear-gradient(rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.03)), var(--vscode-sideBar-background, var(--bg)); }
+body:not(.chat-theme-yatharth) #tabbar { background: linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05)), var(--vscode-sideBar-background, var(--bg)); }
 /* Drag handle straddling the tab strip's bottom border (the user 2026-08-18): the strip scrolls past
    its max-height cap, which clipped the fifth row of a many-session strip with no way to see more.
    Drag DOWN for more rows, UP for fewer; double-click resets; the strip stays a scroll pane at every

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -85,8 +85,11 @@ test("Classic: the strip is a BAND — a 3% plane over the page bg, closed by th
   // across editors (VS Code wrapTabs, JetBrains multi-row), browsers/terminals, and design-system
   // specs (Material's mandatory divider, Carbon/Ant contained tabs) is unanimous: containment
   // comes from the strip owning a background PLANE, closed by ONE bottom hairline — not from
-  // per-row lines. 3% white over --bg reproduces VS Code's canonical #252526-over-#1E1E1E band.
-  assert.match(CSS, /^body:not\(\.chat-theme-yatharth\) #tabbar \{ background: linear-gradient\(rgba\(255, 255, 255, 0\.03\), rgba\(255, 255, 255, 0\.03\)\), var\(--vscode-sideBar-background, var\(--bg\)\); \}$/m,
+  // per-row lines. Shipped at 3% (VS Code's canonical #252526-over-#1E1E1E); stepped to 5% by the
+  // T128 triage (the user 2026-08-27: on their dark theme 3% read as nothing at a glance — the
+  // 3/5/6% eyeball comparison sits in their drops, and the placement of the ONE hairline at the
+  // strip's bottom edge stands per the precedent survey, the user's alone to overturn).
+  assert.match(CSS, /^body:not\(\.chat-theme-yatharth\) #tabbar \{ background: linear-gradient\(rgba\(255, 255, 255, 0\.05\), rgba\(255, 255, 255, 0\.05\)\), var\(--vscode-sideBar-background, var\(--bg\)\); \}$/m,
     "the band: one Classic-scoped background line, tunable in place; Yatharth keeps his merged look");
   assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/, "…closed by the ONE existing hairline at the band's bottom edge");
 });


### PR DESCRIPTION
The band-visibility triage (the user 2026-08-27, who saw no band or hairline on their two-row strip): pixel forensics on their own screenshot proved the band and its closing hairline WERE rendering — staleness ruled out (the served dist carried the band; their strip sampled ~11 gray levels above the page with a full-width hairline at its bottom edge). What failed is perception: a 3% wash over their dark theme, with no bare page plane adjacent for reference, reads as nothing at a glance. The 3/5/6% eyeball comparison (their exact strip shape rendered over the real served stylesheet) is in their drops; 5% reads as a surface at a glance, and 3%/6% stay one edit away.

The literal steps to 0.05, its comment carries the triage, and the pin follows. The hairline's placement — at the strip's very bottom edge, below the controls row, per the precedent survey the band shipped on — stands untouched: overturning that is the user's call alone and remains open to them.

2491/2491 extension tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)