### PR TITLE
Every romp injection wears the one machine rendering; the [romp] prefix strips for display

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10816,7 +10816,10 @@ def _pr_watch_notice(verdict, repo, pr, detail=""):
         body = ("[romp] romp could not read %s (gh said: %s) after several tries, so this watch was "
                 "dropped — check `gh auth status` on this machine and re-register with `romp watch-pr` "
                 "if you still need it." % (ref, detail or "an unknown error"))
-    return body + "\n\n<!-- romp-tag: pr-watch -->"
+    # romp-injected: the chat classifies by MARKER, never by prose (T130) — without it this notice
+    # rendered as a generic tagged machine message instead of wearing the romp attribution the
+    # nudges wear; romp-system marks the mechanics-notice family; the tag stays as the shape's id.
+    return body + "\n\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: pr-watch -->"
 
 
 def _pr_watch_read(pr, repo):
@@ -10987,7 +10990,8 @@ def _watch_notice(kind, row, detail=""):
         body = ("[romp] The watch command could not run at all (%s): %s. This watch was dropped — "
                 "fix the command and re-register with `romp watch`."
                 % (detail or "exec failed", what))
-    return body + "\n\n<!-- romp-tag: watch -->"
+    # same marker discipline as the pr-watch notice above (T130)
+    return body + "\n\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: watch -->"
 
 
 def _fmt_span_s(s):

--- a/tests/test_generic_watch.py
+++ b/tests/test_generic_watch.py
@@ -93,6 +93,8 @@ class Tick(_Watches):
         self.assertIn("now HOLDS: the deploy finished", text, "the user's note leads — their words for the wait")
         self.assertIn("deployed v2 OK", text, "the check's output rides along")
         self.assertIn("<!-- romp-tag: watch -->", text)
+        # T130: marker-classified like every romp injection (see test_pr_watch's twin pin)
+        self.assertIn("<!-- romp-injected --><!-- romp-system -->", text)
         self.assertEqual(km.list_watches(), [], "one mail, then the watch retires")
 
     def test_timeout_mails_the_giving_up_notice(self):

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -62,6 +62,10 @@ class Notice(unittest.TestCase):
             self.assertIn("TESTORG/testrepo#7", n)
             self.assertIn(must, n)
             self.assertIn("<!-- romp-tag: pr-watch -->", n, "machine-sent dress, never the user's words")
+            # T130 (the user 2026-08-27): the chat classifies by MARKER — without romp-injected this
+            # notice wore the generic tagged dress instead of the romp attribution the nudges wear
+            self.assertIn("<!-- romp-injected --><!-- romp-system -->", n,
+                          "the mechanics-notice family's markers, so the one machine-injected rendering applies")
             for word in ("card", "board", "goal", "column", "nudge"):
                 self.assertNotIn(word, n.lower(), "no board vocabulary in an injected body")
 

--- a/ui/webview/chat-nudge-compact.test.ts
+++ b/ui/webview/chat-nudge-compact.test.ts
@@ -21,7 +21,7 @@ test("a romp bubble renders a one-line gist by default, full text behind a keyed
   assert.match(fn, /: firstLine\.length > 90 \? firstLine\.slice\(0, 88\)\.replace\(\/\\s\+\\S\*\$\/, ""\) \+ "…" : firstLine;/);
   assert.match(fn, /lines\.find\(\(l\) => l && !l\.startsWith\(">"\)\)/, "the text gist never shows the quoted goal context");
   // the romp markers are stripped before the gist is cut (they'd read as literal comment text)
-  assert.match(fn, /ev\.md\.replace\(\/<!--\[\\s\\S\]\*\?-->\/g, ""\)\.trim\(\);/);
+  assert.match(fn, /ev\.md\.replace\(\/<!--\[\\s\\S\]\*\?-->\/g, ""\)\.replace\(\/\^\\s\*\\\[romp\\\]\\s\*\/, ""\)\.trim\(\);/);   // markers AND the [romp] source prefix strip for display (T130)
   // collapsible ONLY when there is more than the gist; the caret marks it
   assert.match(fn, /const more = collapseWs\(raw\) !== collapseWs\(gist\);/);
   assert.match(fn, /if \(more\) \{ const c = el\("span", "nudge-caret"\); c\.textContent = "▸"; gistEl\.appendChild\(c\); \}/);

--- a/ui/webview/injected-render.test.ts
+++ b/ui/webview/injected-render.test.ts
@@ -1,0 +1,63 @@
+// ONE machine-injected rendering for everything romp injects (T130, the user 2026-08-27: a nudge
+// says romp above it, but the PR-watch notice printed a literal square-bracket prefix inside the
+// bubble — the parser treated two romp-injected shapes differently). The contract, per shape:
+//
+//   MACHINE-VOICED (carry <!-- romp-injected --> at the injection site; classify "romp"; render
+//   the romp mark + swirl above a gray bubble, the source prefix stripped for display):
+//     kernel-restart resume · rename ping · process-died notice · dead-background-tasks notice ·
+//     pr-watch landing family · generic watch family (markers added by T130) · auto/fork nudges ·
+//     multi-goal bundles · awaiting backstop · debt reminders · the retry message · goal check-ins
+//   PERSON-VOICED BY DESIGN (no marker — they are written as the person's own words, per the
+//   2026-06-20 rule and the injected-voice test): typed follow-ups · the Continue gesture ·
+//   comment-thread merges · comment-thread openers · edit traces — these stay the user's blue.
+//   THIRD-PARTY TAGGED (romp-tag with no romp-injected): the ⚙-labelled tag bubble.
+//
+// The classifier is executable here; the display strip and the marker discipline are source pins.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { senderKind } from "./sender-identity";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+
+test("every machine-voiced shape classifies 'romp' — the flag the markers set, never prose matching", () => {
+  // the kernel authors 'romp' from the romp-injected marker; the classifier keys on that flag
+  for (const shape of [
+    { name: "kernel-restart resume", ev: { romp: true, md: "[romp] The romp kernel restarted…" } },
+    { name: "pr-watch landing", ev: { romp: true, md: "[romp] The pull request you asked romp to watch has MERGED…", tag: "pr-watch" } },
+    { name: "generic watch", ev: { romp: true, md: "[romp] The condition you asked romp to watch now HOLDS…", tag: "watch" } },
+    { name: "auto-nudge", ev: { romp: true, rompAuto: true, md: "Where does this stand?" } },
+    { name: "nudge button", ev: { romp: true, md: "Status update please?" } },
+  ]) assert.equal(senderKind(shape.ev as never), "romp", shape.name + " wears the one machine treatment");
+  // …and the romp flag OUTRANKS a tag: a tagged watch notice is romp's own voice, not a third party's
+  assert.equal(senderKind({ romp: true, tag: "pr-watch", md: "x" } as never), "romp");
+  // person-voiced injections stay the person's
+  assert.equal(senderKind({ human: true, md: "ship it" } as never), "user", "typed follow-up");
+  assert.equal(senderKind({ human: true, tag: "peer-ci", md: "build green" } as never), "tagged", "a third party's tag message (tag turns enter as human rows)");
+  assert.equal(senderKind({ md: "<system-reminder>…" } as never), "injected", "harness noise");
+});
+
+test("the visible source prefix strips for DISPLAY only, in the romp render branch", () => {
+  const at = RENDER.indexOf("} else if (romp && ev.md) {");
+  assert.ok(at > 0, "the romp render branch exists");
+  const branch = RENDER.slice(at, RENDER.indexOf("} else if (ev.md) {", at));
+  assert.match(branch, /const raw = ev\.md\.replace\(\/<!--\[\\s\\S\]\*\?-->\/g, ""\)\.replace\(\/\^\\s\*\\\[romp\\\]\\s\*\/, ""\)\.trim\(\);/,
+    "comments AND the literal source prefix strip from the displayed text");
+  assert.ok(!branch.includes("ev.md =") && !RENDER.includes("ev.md = ev.md.replace"),
+    "the transcript record is never mutated — the prefix still tells the AGENT where the message came from");
+  // the plain user branch renders md untouched — the strip is romp-only
+  const userBranch = RENDER.slice(RENDER.indexOf("} else if (ev.md) {", at));
+  assert.match(userBranch.slice(0, 200), /bubble\.innerHTML = md\(ev\.md\);/);
+});
+
+test("the watch notices carry the marker at the injection site — no prose pattern-matching anywhere", () => {
+  assert.match(KERNEL, /return body \+ "\\n\\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: pr-watch -->"/);
+  assert.match(KERNEL, /return body \+ "\\n\\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: watch -->"/);
+  // the restart family already wore them
+  assert.match(SDK, /<!-- romp-injected --><!-- romp-system -->\[romp\] The romp kernel restarted/);
+  // and nobody classifies by matching the visible prefix
+  assert.ok(!/startsWith\(["']\[romp\]/.test(RENDER), "no prose matching in the renderer");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2337,7 +2337,13 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         // The gist SAYS WHAT ROMP DID, not the message's first line (the user 2026-07-17 ×2: a follow-up
         // opens with the goal-context "> …" quote, so the text gist read as the user's own words — pure
         // confusion). Known flavors get a semantic label; the text fallback skips quoted "> " lines.
-        const raw = ev.md.replace(/<!--[\s\S]*?-->/g, "").trim();
+        // display-only strip of the literal "[romp] " source prefix (T130, the user 2026-08-27: a
+        // nudge says romp above it, but a mechanics notice ALSO printed "[romp]" inside the bubble —
+        // two shapes for one sender). The prefix exists for the AGENT (the housekeeping-note design:
+        // it tells a model that has never heard of the dashboard where the message came from) and
+        // stays in the transcript record untouched; the romp attribution mark above the bubble
+        // already says the same thing to the READER, so showing both was double-labelling.
+        const raw = ev.md.replace(/<!--[\s\S]*?-->/g, "").replace(/^\s*\[romp\]\s*/, "").trim();
         const lines = raw.split("\n").map((l) => l.trim());
         const firstLine = lines.find((l) => l && !l.startsWith(">")) || lines.find((l) => l) || raw;
         const gist = ev.followUp ? "follow-up" + (ev.goal ? " · " + ev.goal : "")


### PR DESCRIPTION
The user: a nudge renders with the romp attribution above it, but the PR-watch notice printed a literal `[romp]` square-bracket prefix inside a plain bubble — the parser treated two romp-injected shapes differently.

## The enumeration (injected-voice render list + every injection site, verified shape by shape)
- **Machine-voiced, marker-carrying, already classified `romp`** (mark + swirl over the gray bubble): kernel-restart resume, rename ping, process-died notice, dead-background-tasks notice, auto/fork nudges + variants, multi-goal bundles, awaiting backstop, debt reminders, the retry message, goal check-ins.
- **The two marker-less shapes — the bug**: the pr-watch landing family and the generic watch family (`[romp]`-prefixed, tailed only with their `romp-tag`) classified `tagged` and wore the third-party ⚙ dress. Their injection sites now append `<!-- romp-injected --><!-- romp-system -->` beside the tag — **the classifier keys on markers, never prose**; `senderKind` puts romp above tag, so the tag stays as the shape's id without owning the dress.
- **Person-voiced by design, deliberately untouched**: typed follow-ups, Continue, comment-thread merges/openers, edit traces — written as the person's own words per the standing injected-voice rule (2026-06-20). Flipping those to machine dress would contradict that design; scope call noted.

## Display
The romp render branch strips the leading `[romp] ` from the bubble text only (beside the marker strip it already did). The prefix stays in the transcript record: it exists for the **agent** (housekeeping-note design); the attribution mark already tells the **reader** the same thing. Gist lines inherit the strip.

## Tests
`injected-render.test.ts`: per-shape classifier verdicts executable via `senderKind`, the display-only strip (record never mutated), marker discipline at both kernel sites, and an absence pin that nothing classifies by prose. `test_pr_watch` / `test_generic_watch` pin the markers server-side. The injected-voice suite passes untouched (markers ride after the prose it audits). Webview 2502/2502, tsc clean; kernel selections green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)