### PR TITLE
Pre-clear side-notes stay in their episode — the /clear boundary floors the note merge

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17501,14 +17501,27 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # Persistent "effort set to X" notes (the user 2026-07-16): same time-anchored durable-note mechanism as
     # the recovery markers — the /effort reconnect leaves no transcript atom, so this pins when the new effort
     # took effect and survives scroll-back (and the next message, which pruned the ephemeral /effort chip).
-    recoveries = _retry_recoveries(sid); _ri = 0
-    gaveups = _retry_gaveups(sid); _gi = 0            # the storm that DIDN'T recover → "gave up after N retries"
-    efforts = _effort_changes(sid); _ei = 0
+    # T131 (the user 2026-08-27, screenshot: seventeen pre-clear "Recovered after N retries" rows
+    # standing in a freshly /clear-ed thread): side-store notes are time-anchored against TRANSCRIPT
+    # atoms, and a /clear re-points the transcript to a fresh file — so the first new atom's flush
+    # dumped every note older than the clear into the new conversation's top. The floor is the last
+    # episode boundary's time: notes at/before it belong to the PREVIOUS episode's render (the
+    # boundary card's fold reads the same stores with tail_cap_t as its upper bound and no floor —
+    # nothing is lost, it moves where the rest of the pre-clear conversation lives). Live render
+    # only: an episode render (path_override) must keep its own era's notes.
+    _epi_rows_for_notes = [] if path_override else jd.episode_rows(sid)
+    _note_floor = (_epi_rows_for_notes[-1].get("t")
+                   if len(_epi_rows_for_notes) >= 2 and _epi_rows_for_notes[-1].get("t") else None)
+    def _past_floor(rows):
+        return rows if _note_floor is None else [r for r in rows if r.get("t") and r["t"] > _note_floor]
+    recoveries = _past_floor(_retry_recoveries(sid)); _ri = 0
+    gaveups = _past_floor(_retry_gaveups(sid)); _gi = 0   # the storm that DIDN'T recover → "gave up after N retries"
+    efforts = _past_floor(_effort_changes(sid)); _ei = 0
     # Persistent command-gesture chips (the user 2026-08-14): the synthesized /model-/effort-/auth chip lives
     # only in the backend's _live tail and stale_cmd prunes it on the next human turn — the durable marker
     # takes over here. DEDUP'd by (t, text) against a still-live chip so the same gesture never doubles;
     # flushed BEFORE the efforts loop so a same-second "/effort X" gesture sits above its "effort set to X".
-    gestures = _cmd_gestures(sid); _cgi = 0
+    gestures = _past_floor(_cmd_gestures(sid)); _cgi = 0
     _live_cmd_keys = set()
     for _t in session["turns"]:
         for _a in _t["atoms"]:
@@ -17518,7 +17531,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # (an API-errored try). Interleave it back at its timestamp, DEDUP'd against what the disk DID keep — a
     # retry that re-replied must not double. Match exact, and either-way prefix (a partial stream vs its full
     # retry). NB: build the disk-text set from the SAME session["turns"] atoms this loop renders.
-    orphans = _orphan_replies(sid); _oi = 0
+    orphans = _past_floor(_orphan_replies(sid)); _oi = 0
     _disk_texts = set()
     for _t in session["turns"]:
         for _a in _t["atoms"]:
@@ -18289,7 +18302,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # conversation on expand (loadEpisode → build_episode). It also guarantees a just-cleared session is
     # never events-empty, so the "No messages yet." placeholder can't lie about a conversation that DID
     # exist. Ordered ABOVE the system card: the cleared history predates the current conversation's frame.
-    _epi_rows = jd.episode_rows(sid)
+    _epi_rows = _epi_rows_for_notes   # loaded once above, with the note floor (T131)
     boundary = _epi_rows[-1] if len(_epi_rows) >= 2 else None
     if events or boundary:
         if docs or any(sysinfo[k] for k in ("model", "cwd", "gitBranch", "version", "mode")):

--- a/tests/test_clear_chat_view.py
+++ b/tests/test_clear_chat_view.py
@@ -221,3 +221,77 @@ class ClearChatViewTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PreClearNotesStayInTheirEpisode(unittest.TestCase):
+    """T131 (the user 2026-08-27, screenshot): seventeen pre-clear "Recovered after N retries"
+    rows stood in a freshly /clear-ed thread. The side-store notes (recoveries, gave-ups, command
+    gestures, effort notes, orphan replies) are time-anchored against transcript atoms, and the
+    /clear re-points the transcript to a fresh file — so the first new atom's flush dumped every
+    note older than the clear into the new conversation. The floor: the live render drops notes
+    at/before the last episode boundary; the EPISODE render keeps them (they live in the boundary
+    card's fold, with the rest of the pre-clear conversation). Synthetic data only."""
+
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        self.cwd = os.path.realpath(os.path.join(self._td, "notes-api"))
+        os.makedirs(self.cwd, exist_ok=True)
+        self.proj = jd._proj_dir(self.cwd)
+        self.proj.mkdir(parents=True)
+        (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "names" / SID).write_text("web\t" + self.cwd)
+        _write_jsonl(self.proj / (SID + ".jsonl"), [
+            _urec(NOW - 3600, "u1", "set up the api server"),
+            _arec(NOW - 3590, "a1", "done - the notes-api server runs on port 8080", "u1"),
+        ])
+        _write_jsonl(self.proj / (NEWFSID + ".jsonl"), [
+            _urec(NOW - 50, "n1", "hello again", fsid=NEWFSID),
+            _arec(NOW - 40, "n2", "fresh start - what next?", "n1", fsid=NEWFSID),
+        ])
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps(
+            {"sid": SID, "name": "web", "alive": True, "lastSid": NEWFSID}))
+        _write_jsonl(jd.STATE / "episodes" / (SID + ".jsonl"), [
+            {"head": "u1", "fsid": SID, "t": NOW - 3600},
+            {"head": "n1", "fsid": NEWFSID, "t": CLEAR_T},
+        ])
+        # the side-store: a pre-clear recovery storm + a pre-clear /auth gesture (the filmed pair),
+        # and one POST-clear recovery that must keep rendering live
+        _write_jsonl(jd.STATE / "states" / (SID + ".jsonl"), [
+            {"t": NOW - 3000, "retriesRecovered": 1},
+            {"t": NOW - 2900, "retriesRecovered": 3},
+            {"t": NOW - 2800, "cmdGesture": "/auth login"},
+            {"t": NOW - 30, "retriesRecovered": 2},
+        ])
+
+    def tearDown(self):
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def test_live_render_shows_only_the_current_episodes_notes(self):
+        events = km.build_session(SID, NOW)["events"]
+        retried = [e for e in events if e.get("kind") == "retried"]
+        self.assertEqual([e["retries"] for e in retried], [2],
+                         "pre-clear recoveries belong to the previous episode's render, not the fresh thread")
+        self.assertEqual([e for e in events if e.get("kind") == "cmdGesture"], [],
+                         "the pre-clear /auth gesture chip goes with them")
+
+    def test_the_episode_render_keeps_its_own_eras_notes(self):
+        got = km.build_episode(SID, NOW)
+        self.assertNotIn("error", got or {}, "the pre-clear transcript must resolve")
+        kinds = [(e.get("kind"), e.get("retries")) for e in got["events"] if e.get("kind") in ("retried", "cmdGesture")]
+        self.assertIn(("retried", 1), kinds, "the boundary card's fold is where the pre-clear notes live")
+        self.assertIn(("retried", 3), kinds)
+        self.assertIn(("cmdGesture", None), kinds)
+
+    def test_a_single_episode_session_keeps_every_note(self):
+        _write_jsonl(jd.STATE / "episodes" / (SID + ".jsonl"),
+                     [{"head": "u1", "fsid": SID, "t": NOW - 3600}])
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps(
+            {"sid": SID, "name": "web", "alive": True, "lastSid": SID}))
+        events = km.build_session(SID, NOW)["events"]
+        self.assertEqual([e["retries"] for e in events if e.get("kind") == "retried"], [1, 3, 2],
+                         "no boundary, no floor — the whole history is one episode")

--- a/tests/test_kernel_cmd_gesture.py
+++ b/tests/test_kernel_cmd_gesture.py
@@ -79,7 +79,9 @@ class CmdGestureSourcePins(unittest.TestCase):
 
     def test_build_session_interleaves_and_dedups_against_the_live_chip(self):
         src = inspect.getsource(km.build_session)
-        self.assertIn("gestures = _cmd_gestures(sid)", src)
+        # the durable store is still the source; since T131 the live render floors it at the last
+        # episode boundary so a /clear's fresh thread doesn't inherit the old episode's gestures
+        self.assertIn("gestures = _past_floor(_cmd_gestures(sid))", src)
         self.assertIn('if (_cg["t"], _cg["cmd"]) in _live_cmd_keys:', src)
         self.assertIn('events.append({"kind": "cmdGesture", "cmd": _cg["cmd"], "ts": iso(_cg["t"]),', src)
         # flushed by the SAME time-gate as the other durable notes, and BEFORE the efforts loop, so a

--- a/tests/test_kernel_effort_note.py
+++ b/tests/test_kernel_effort_note.py
@@ -78,7 +78,7 @@ class EffortNoteSourcePins(unittest.TestCase):
 
     def test_build_session_interleaves_the_durable_note_by_time(self):
         src = inspect.getsource(km.build_session)
-        self.assertIn("efforts = _effort_changes(sid)", src)
+        self.assertIn("efforts = _past_floor(_effort_changes(sid))", src)   # floored at the episode boundary since T131
         self.assertIn('events.append({"kind": "effortApplied", "effort": _e["effort"], "ts": iso(_e["t"]),', src)
         # flushed by the SAME time-gate as the recovery notes, so both stay ordered against the atoms
         self.assertIn("while _ei < len(efforts) and (upto is None or efforts[_ei][\"t\"] <= upto):", src)

--- a/tests/test_kernel_orphan_reply.py
+++ b/tests/test_kernel_orphan_reply.py
@@ -116,7 +116,7 @@ class OrphanReplyReader(unittest.TestCase):
 class OrphanInterleaveAndDedup(unittest.TestCase):
     def test_build_session_interleaves_the_orphan_as_an_assistant_bubble(self):
         src = inspect.getsource(km.build_session)
-        self.assertIn("orphans = _orphan_replies(sid)", src)
+        self.assertIn("orphans = _past_floor(_orphan_replies(sid))", src)   # floored at the episode boundary since T131
         # interleaved by timestamp in the same flush as the recovery note, as a normal assistant bubble
         self.assertIn('events.append({"kind": "assistant", "md": _o["text"], "orphaned": True,', src)
         self.assertIn('"uuid": "orphan:%s" % (_o["uuid"] or _o["t"]), "ts": iso(_o["t"])})', src)

--- a/tests/test_retry_gaveup.py
+++ b/tests/test_retry_gaveup.py
@@ -159,7 +159,7 @@ class KernelReaderAndInterleave(unittest.TestCase):
 
     def test_build_session_interleaves_the_gave_up_note_and_the_error_card(self):
         src = inspect.getsource(km.build_session)
-        self.assertIn("gaveups = _retry_gaveups(sid)", src)
+        self.assertIn("gaveups = _past_floor(_retry_gaveups(sid))", src)   # floored at the episode boundary since T131
         self.assertIn('"kind": "retryGaveUp", "retries": _g["retries"]', src)
         # the transcript's isApiError record becomes durable error CHROME, not an agent bubble
         self.assertIn('events.append({"kind": "apiErrorNote", "md": txt,', src)


### PR DESCRIPTION
The user (screenshot): a freshly `/clear`-ed session showed **seventeen** consecutive 'Recovered after N retries' rows from the previous day standing above the clear, plus a pre-clear `/auth` gesture chip.

## Mechanism
All five `states/<sid>.jsonl` side-note families — retry recoveries, retry gave-ups, command gestures, effort notes, orphan replies — merge into the served events **time-anchored against transcript atoms, with no lower bound**. A /clear re-points the transcript to a fresh file, so the first new atom's flush dumped every pre-clear note into the new conversation's top.

## Fix
The live render floors the note merge at the last episode boundary's time. Notes at/before it belong to the previous episode's render — and that's where they still appear: the boundary card's fold (`build_episode`) reads the same stores with `tail_cap_t` as its upper bound and **no floor**, so nothing is lost; the notes move to where the rest of the pre-clear conversation lives. The boundary-card insert reuses the episode rows the floor loaded (one file read, not two).

## Tests
`test_clear_chat_view.py` (synthetic world): live render shows only the current episode's notes (the filmed pair gone; a post-clear recovery stays); the episode render keeps its own era's notes; a single-episode session keeps everything. 14/14.

**Flagged follow-up, shipping separately**: collapsing consecutive recovery rows into one expandable row (toolgroup idiom) — a live retry storm still renders one row per recovery within its episode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)