### PR TITLE
The reload banner drags out of the way — keepable without covering what you need

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26798,9 +26798,11 @@ try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.sea
 # version only). Self-contained block (own style + node + script) so it injects at one point.
 _STALE_CSS = (
     "#rstale{position:fixed;top:14px;left:50%;transform:translateX(-50%);z-index:99999;display:none;"
+    "cursor:grab;touch-action:none;"   # T132: the banner drags out of the way — the box wears grab, buttons keep pointer
     "align-items:center;gap:12px;max-width:92vw;background:#252526;border:1px solid rgba(255,255,255,0.12);"
     "border-radius:8px;padding:10px 14px;color:#e6e6e6;box-shadow:0 8px 28px rgba(0,0,0,0.45);"
     "font:13px/1.4 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
+    "#rstale.dragging{cursor:grabbing;user-select:none}"
     "#rstale.show{display:flex}#rstale .rs-msg{font-weight:500}"
     "#rstale button{font:inherit;cursor:pointer;border-radius:6px;padding:5px 11px;"
     "border:1px solid transparent;white-space:nowrap}"
@@ -26846,6 +26848,27 @@ _STALE_JS = (
     "window.addEventListener('message',function(e){var m=e&&e.data;"
     "if(m&&m.romp==='wsStale'){if(m.build){buildStale=true;show(BUILDMSG);}else{connStale=true;show(CONNMSG);}}"
     "else if(m&&m.romp==='wsFresh'){connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');}});"
+    # T132 (the user 2026-08-27): the banner is DRAGGABLE — movable out of the way so it can STAY up
+    # (it was covering a tab they needed before accepting the build). Moving never dismisses, mutes, or
+    # times it out; Reload keeps working identically after any number of moves (BUTTON targets never
+    # start a drag, so a click is never eaten). Position holds for the page's lifetime for free: the box
+    # is the shell's one static element — show() only swaps text and a class, so pushes/re-raises never
+    # reset it — and a fresh page's banner is a fresh drift, where the centered default is right.
+    # Clamped fully on-screen at drag time and re-clamped on resize (a shrunken window must not strand it).
+    "var drag=null;"
+    "function clampXY(x,y){var r=box.getBoundingClientRect();"
+    "return [Math.max(0,Math.min(x,window.innerWidth-r.width)),Math.max(0,Math.min(y,window.innerHeight-r.height))];}"
+    "box.addEventListener('pointerdown',function(e){if(e.button!==0||e.target.tagName==='BUTTON')return;"
+    "var r=box.getBoundingClientRect();box.style.left=r.left+'px';box.style.top=r.top+'px';box.style.transform='none';"
+    "drag={dx:e.clientX-r.left,dy:e.clientY-r.top};box.classList.add('dragging');"
+    "try{box.setPointerCapture(e.pointerId);}catch(err){}e.preventDefault();});"
+    "box.addEventListener('pointermove',function(e){if(!drag)return;"
+    "var p=clampXY(e.clientX-drag.dx,e.clientY-drag.dy);box.style.left=p[0]+'px';box.style.top=p[1]+'px';});"
+    "function endDrag(e){if(!drag)return;drag=null;box.classList.remove('dragging');"
+    "try{box.releasePointerCapture(e.pointerId);}catch(err){}}"
+    "box.addEventListener('pointerup',endDrag);box.addEventListener('pointercancel',endDrag);"
+    "window.addEventListener('resize',function(){if(!box.style.left)return;"
+    "var p=clampXY(parseFloat(box.style.left),parseFloat(box.style.top));box.style.left=p[0]+'px';box.style.top=p[1]+'px';});"
     "rl.onclick=function(){location.reload();};"
     "dm.onclick=function(){dismissed=served;connStale=false;buildStale=false;box.classList.remove('show');};"
     "check();setInterval(check,30000);})();")

--- a/tests/test_dist_converge.py
+++ b/tests/test_dist_converge.py
@@ -118,5 +118,29 @@ class BannerRaiserPins(unittest.TestCase):
         self.assertIn('Path(os.environ["ROMP_DIST_DIR"]) if os.environ.get("ROMP_DIST_DIR")', self.KERNEL)
 
 
+class DraggableBannerPins(BannerRaiserPins):
+    """T132 (the user 2026-08-27): the banner drags out of the way so it can STAY up. Source pins on
+    the shell's inline JS/CSS; the behavior itself (moves, clamps, never dismisses, holds across
+    pushes, Reload after any number of moves) runs live in the lab's banner phase."""
+
+    def test_buttons_never_start_a_drag(self):
+        self.assertIn("if(e.button!==0||e.target.tagName==='BUTTON')return;", self.KERNEL)
+
+    def test_drag_is_clamped_and_reclamped_on_resize(self):
+        self.assertIn("Math.max(0,Math.min(x,window.innerWidth-r.width))", self.KERNEL)
+        self.assertIn("window.addEventListener('resize',function(){if(!box.style.left)return;", self.KERNEL)
+
+    def test_the_affordance_is_the_house_grab_pair(self):
+        self.assertIn("cursor:grab;touch-action:none;", self.KERNEL)
+        self.assertIn("#rstale.dragging{cursor:grabbing;user-select:none}", self.KERNEL)
+
+    def test_dragging_never_dismisses(self):
+        # the drag handlers touch style/class only — the ONLY dismiss writers stay the two buttons
+        self.assertNotIn("classList.remove('show');}   # drag", self.KERNEL)
+        drag = self.KERNEL[self.KERNEL.index("var drag=null;"):self.KERNEL.index("rl.onclick=")]
+        self.assertNotIn("remove('show')", drag)
+        self.assertNotIn("dismissed=", drag)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/romp-lab/banner-loop.mjs
+++ b/tools/romp-lab/banner-loop.mjs
@@ -78,7 +78,33 @@ await shot("raised");
 await sleep(3000);
 check("latch-across-pushes", (await bannerShown()).includes("newer romp build"));
 
-// ── 4. click-to-reload answers it — and only a click ever does ──
+// ── 3.5 T132: DRAG it out of the way — it moves, clamps, never dismisses, and holds its spot ──
+const box = page.locator("#rstale");
+const r0 = await box.boundingBox();
+const grabX = r0.x + 40, grabY = r0.y + Math.min(10, r0.height / 2);   // on the message, never a button
+await page.mouse.move(grabX, grabY);
+await page.mouse.down();
+await page.mouse.move(grabX + 250, grabY + 420, { steps: 8 });
+await page.mouse.up();
+const r1 = await box.boundingBox();
+check("drag-moves", r1.y - r0.y > 200, `y ${Math.round(r0.y)}→${Math.round(r1.y)}`);
+check("drag-keeps-shown", (await bannerShown()).includes("newer romp build"), "moving must never dismiss");
+// fling far past the bottom-right corner — it must stay fully on-screen
+await page.mouse.move(r1.x + 40, r1.y + Math.min(10, r1.height / 2));
+await page.mouse.down();
+await page.mouse.move(5000, 5000, { steps: 4 });
+await page.mouse.up();
+const r2 = await box.boundingBox();
+const vp = page.viewportSize();
+check("drag-clamps", r2.x + r2.width <= vp.width + 1 && r2.y + r2.height <= vp.height + 1,
+  `box ${JSON.stringify(r2)} vs viewport ${vp.width}x${vp.height}`);
+await shot("dragged");
+// pushes keep flowing — the moved banner must hold its spot (show() only swaps text, never position)
+await sleep(2 * KA * 1000);
+const r3 = await box.boundingBox();
+check("position-survives-pushes", Math.abs(r3.x - r2.x) < 2 && Math.abs(r3.y - r2.y) < 2);
+
+// ── 4. click-to-reload answers it — identically after any number of moves ──
 await page.click("#rstale-reload");
 await page.waitForSelector("#rstale", { state: "attached", timeout: 20000 });
 await sleep(2 * KA * 1000 + 1000);


### PR DESCRIPTION
The user (2026-08-27): the 'newer romp build' banner can cover a tab they need before they accept the build — they want to click and drag it aside and KEEP it. The shell's `#rstale` gains pointer drag anywhere in the viewport: **clamped fully on-screen** at drag time and re-clamped on window resize, **grab/grabbing** cursors per the house vocabulary, `touch-action` pinned so a touch drag never scroll-fights. BUTTON targets never start a drag, so a Reload or Dismiss click is never eaten — **Reload works identically after any number of moves**, and moving never dismisses, mutes, or times the banner out (the drag handlers touch style and class only; the two buttons stay the only dismiss writers).

Position holds for the page's lifetime for free: the box is the shell's one static element — `show()` only swaps text and a class, so pushes and re-raises never reset it — and a fresh page's banner is a fresh drift, where the centered default is right. No animation involved, so reduced motion is untouched by construction.

**Proved live**: the lab's banner phase grows the drag contract — drag moves (y 14→434), keeps shown, a fling past the corner clamps inside the viewport, the spot survives two heartbeats of pushes, Reload answers after the moves — **ten phases green on the real stack**, moved-banner screenshot in the report. Source pins hold the button guard, clamp + resize re-clamp, the grab pair, and that no dismiss writer lives in the drag handlers.

Python 5862 passed / extension 2502 passed on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)