### PR TITLE
Strip triple: one drag visual, a hairline under every row, tab bodies back to native dark

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4119,6 +4119,15 @@ function auditTabOrder(ids: string[]) {
 }
 let draggedId: string | null = null;
 let tabDragCommitted = false;   // set by the strip's drop handler; dragend without it = a cancel (Escape / dropped outside)
+let dragBlankEl: HTMLElement | null = null;
+function dragImageBlank(): HTMLElement {
+  if (!dragBlankEl || !dragBlankEl.isConnected) {
+    dragBlankEl = el("div", "");
+    dragBlankEl.style.cssText = "position:fixed;top:-10px;left:-10px;width:1px;height:1px;opacity:0;pointer-events:none";
+    document.body.appendChild(dragBlankEl);
+  }
+  return dragBlankEl;
+}
 // FLIP the strip around a DOM mutation (T127 live reorder): snapshot every tab's rect by id, run
 // the mutation, then play each moved tab from its old rect to its new one — an inverted transform
 // released a frame later. A row jump is just a bigger delta: the wrap layout reflows and the
@@ -4373,6 +4382,37 @@ function tabCtxGauge(ctxStr: string, ctxColor?: number[]): HTMLElement {
   return g;
 }
 
+// A hairline under EVERY row of tabs (T134, the user 2026-08-27, overturning the survey's
+// one-outer-line design — their call, flagged when it shipped: with three rows and a short third,
+// row 2's tabs "look like they're sitting there floating"). CSS cannot select flex-wrap rows, so
+// the painter groups the rendered tabs by offsetTop and lays one absolute full-bleed hairline
+// under each row but the last — the strip's existing bottom border already finishes the final row. Runs on
+// every strip rebuild and on wrap changes (a ResizeObserver on #tabs: width changes re-wrap rows
+// without a rebuild — event-keyed, no polling). Classic-scoped in CSS (the Yatharth theme hides
+// .tab-row-line), like every strip tuning.
+function paintTabRowLines(bar: HTMLElement): void {
+  for (const old of Array.from(bar.querySelectorAll(":scope > .tab-row-line"))) old.remove();
+  const rows = new Map<number, number>();   // rowTop → rowBottom (max tab bottom in that row)
+  for (const t of Array.from(bar.children) as HTMLElement[]) {
+    if (!t.classList.contains("tab")) continue;
+    const top = t.offsetTop, bot = t.offsetTop + t.offsetHeight;
+    rows.set(top, Math.max(rows.get(top) ?? 0, bot));
+  }
+  const bottoms = [...rows.values()].sort((a, b) => a - b);
+  bottoms.pop();   // the LAST row already has #tabbar's own border-bottom beneath it — no double line
+  for (const y of bottoms) {
+    const line = el("div", "tab-row-line");
+    line.style.top = y + "px";
+    bar.appendChild(line);
+  }
+}
+let tabRowObserver: ResizeObserver | null = null;
+function ensureTabRowObserver(bar: HTMLElement): void {
+  if (tabRowObserver) return;
+  tabRowObserver = new ResizeObserver(() => paintTabRowLines(bar));
+  tabRowObserver.observe(bar);
+}
+
 function renderTabs() {
   if (renameActive) { renderPendingAfterRename = true; return; }
   if (tabPointerHeld) { renderPendingWhilePressed = true; return; }   // don't destroy a tab mid-click (see tabPointerHeld)
@@ -4428,7 +4468,17 @@ function renderTabs() {
     tab.addEventListener("keydown", onTabKey);
     // drag-to-reorder (synced with the timeline via the shared session-order file)
     tab.draggable = true;
-    tab.addEventListener("dragstart", (e) => { draggedId = id; tabDragCommitted = false; if (e.dataTransfer) e.dataTransfer.effectAllowed = "move"; tab.classList.add("dragging"); });
+    // Exactly ONE thing on screen may look like the dragged tab (T133, the user 2026-08-27: the
+    // native drag image following the pointer PLUS the dimmed in-flow tab read as a ghost
+    // duplicate — "not how most softwares show it"). The native image is blanked, and the dimmed
+    // in-flow element — the one that live-reorders through the strip — is the single provisional
+    // visual, browser-style. dragImageBlank must be a rendered DOM node at dragstart (Chromium
+    // snapshots it), hence the fixed off-viewport 1px div installed once below.
+    tab.addEventListener("dragstart", (e) => {
+      draggedId = id; tabDragCommitted = false;
+      if (e.dataTransfer) { e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setDragImage(dragImageBlank(), 0, 0); }
+      tab.classList.add("dragging");
+    });
     // dragend closes EVERY drag (drop, Escape, released outside). The pointerdown that started the
     // drag latched tabPointerHeld, and the drag swallowed the matching pointerup — so the hold is
     // released here by hand, covering the whole gesture against pushes (the click-safe rule). A
@@ -4584,6 +4634,8 @@ function renderTabs() {
       postViews(nv);
     });
   }
+  paintTabRowLines(bar);
+  ensureTabRowObserver(bar);
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
   if (refocusTab) focusActiveTab();
   syncNoSessionsPlaceholder(visibleIds.length, ids.length);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -154,7 +154,15 @@ body.chat-theme-yatharth #winframe { display: block; position: fixed; inset: 0; 
    2026-08-08): the strip trades its empty inter-tab space for room for the per-tab context gauge —
    the active/hover fills and per-tab padding still separate neighbours visually. (The Yatharth
    theme reopens a 3px seam — its flat tints need one; see its block below.) */
-#tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; }
+#tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; }   /* relative: the per-row hairlines (T134) anchor to it */
+/* T134 (the user 2026-08-27, overturning the T125 survey's one-outer-line call — theirs to make):
+   a full-bleed hairline under EVERY row of tabs, so a row above a short row never floats. Painted
+   by paintTabRowLines (render.ts — CSS cannot select wrap rows); the last row is closed by
+   #tabbar's own border-bottom. The negative bleed spans the bar's 8px side padding so each line
+   runs the strip's full width, like the outer close. Classic only; Yatharth keeps his merged look. */
+body:not(.chat-theme-yatharth) #tabs .tab-row-line {
+  position: absolute; left: -8px; right: -8px; height: 1px; background: var(--box-border); pointer-events: none; }
+body.chat-theme-yatharth #tabs .tab-row-line { display: none; }
 /* T125 (the user 2026-08-27, screenshot: with wrapped rows the tabs read as floating boxes): the
    strip is a BAND — its own background plane a hair above the page, containing every wrapped row,
    closed by the existing --box-border hairline at its bottom edge. This is how tab strips are
@@ -311,12 +319,20 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
 /* CLASSIC (the default; T113, tightened by T115, tuned by T118 — the user 2026-08-27): the tab
    strip is the PRE-720 strip — verified by pixel-diffing a real pre-720 build — modulo exactly
-   four sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
+   five sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
    hover-gray rest outline below (T123), the 0.9 faded-label scale (fadedColor, render.ts; T118),
-   and the strip band (T125, below). No identity tint at any state, the
+   the strip band (T125, below), and the per-row hairlines (T134, above at #tabs). No identity tint at any state, the
    thick 1.5px inset identity ring on the selected tab, the neutral line under the strip. The
    Yatharth theme below is the opt-in restoration of the contributor's merged strip aesthetic. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
+/* T136 (the user 2026-08-27: every tab body reads lighter than four days ago — "restore it to
+   what it was"; they were right): the T125 band paints BEHIND the strip, and a transparent
+   resting tab let it show THROUGH the body, lightening every tab — the sanctioned delta was the
+   strip PLANE, never the tab fill. Resting tabs now paint the baseline body explicitly (the very
+   color the strip's background was before the band), so the band reads only between/around tabs.
+   Same :not chain as the retired T118 wash (hover/active/blocked own their fills; + is not a
+   session tab); pixel-verified against the pre-720 baseline in the T136 harness run. */
+body:not(.chat-theme-yatharth) .tab:not(.tab-blocked):not(.active):not(:hover):not(.tab-add) { background: var(--vscode-sideBar-background, var(--bg)); }
 /* T123 (the user 2026-08-27, redirecting T118's resting-tab distinction — the merged 2% fill
    came out for this): resting tabs wear a SUPER-THIN outline at all times, no fill — the tab body
    stays the dark background, ringed by 1px in EXACTLY the gray the hover fill uses

--- a/ui/webview/tab-ctx-gauge.test.ts
+++ b/ui/webview/tab-ctx-gauge.test.ts
@@ -45,7 +45,7 @@ test("the gauge is a slim VERTICAL bar and the strip tightened to make room for 
   assert.match(CSS, /\.tab-ctx-fill \{ position: absolute; left: 0; right: 0; bottom: 0/);
   // the strip's spacing trade (the user 2026-08-08): inter-tab gap 0; in-tab gap/padding shrunk.
   // (The Yatharth theme reopens a 3px seam under its scope — tab-theme.test.ts pins that.)
-  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; \}/);
   assert.match(CSS, /\.tab \{[\s\S]{0,400}gap: 4px;[^\n]*\n\s*padding: 6px 7px;/);
 });
 

--- a/ui/webview/tab-drag-live.test.ts
+++ b/ui/webview/tab-drag-live.test.ts
@@ -21,6 +21,18 @@ const between = (a: string, b: string) => {
   return RENDER.slice(at, RENDER.indexOf(b, at));
 };
 
+test("exactly ONE thing on screen looks like the dragged tab (T133)", () => {
+  // the user 2026-08-27: the native drag image following the pointer PLUS the dimmed in-flow tab
+  // read as a ghost duplicate. The native image is blanked at dragstart; the dimmed in-flow
+  // element — the one that live-reorders — is the single provisional visual, browser-style.
+  assert.match(RENDER, /e\.dataTransfer\.setDragImage\(dragImageBlank\(\), 0, 0\);/);
+  const at = RENDER.indexOf("function dragImageBlank(");
+  assert.ok(at > 0);
+  const body = RENDER.slice(at, RENDER.indexOf("\n}", at));
+  assert.match(body, /position:fixed;top:-10px;left:-10px;width:1px;height:1px;opacity:0/,
+    "a rendered but invisible node — Chromium snapshots the drag image at dragstart, so it must be in the DOM");
+});
+
 test("slot boundary is the event: midpoint compare moves the dragged element in DOM order", () => {
   const body = between('tabs.addEventListener("dragover"', "});");
   assert.match(body, /const ref = e\.clientX > r\.left \+ r\.width \/ 2 \? over\.nextElementSibling : over;/,
@@ -33,7 +45,7 @@ test("slot boundary is the event: midpoint compare moves the dragged element in 
 test("cross-row reflow is the wrap layout's own: DOM insertion, no per-row special case", () => {
   // the strip wraps (flex-wrap) — moving the element IS the cross-row mechanism, so there must be
   // no row math in the drag path
-  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; \}/);
   const body = between('tabs.addEventListener("dragover"', "});");
   assert.doesNotMatch(body, /row|clientY/i, "no row bookkeeping — insertion order + wrap does it");
 });

--- a/ui/webview/tab-row-lines.test.ts
+++ b/ui/webview/tab-row-lines.test.ts
@@ -1,0 +1,32 @@
+// A hairline under EVERY row of tabs (T134, the user 2026-08-27, overturning the T125 survey's
+// one-outer-line design — flagged then as their call to make, now made: with three rows and a
+// short third, row 2's tabs "look like they're sitting there floating"). CSS cannot select
+// flex-wrap rows, so render.ts paints them; these pins hold the mechanism and the scope.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the painter groups rendered tabs by row and lines every row but the last", () => {
+  const at = RENDER.indexOf("function paintTabRowLines(");
+  assert.ok(at > 0);
+  const body = RENDER.slice(at, RENDER.indexOf("\n}", at));
+  assert.match(body, /rows\.set\(top, Math\.max\(rows\.get\(top\) \?\? 0, bot\)\);/, "a row = the tabs sharing an offsetTop; its line sits at the tallest bottom");
+  assert.match(body, /bottoms\.pop\(\);/, "the LAST row already has #tabbar's own border-bottom beneath it — no double line");
+  assert.match(body, /el\("div", "tab-row-line"\)/);
+});
+
+test("repaints are event-keyed: every strip rebuild, plus wrap changes via ResizeObserver", () => {
+  assert.match(RENDER, /paintTabRowLines\(bar\);\s*\n\s*ensureTabRowObserver\(bar\);/, "renderTabs ends by painting + arming the observer once");
+  assert.match(RENDER, /tabRowObserver = new ResizeObserver\(\(\) => paintTabRowLines\(bar\)\);/, "a width resize re-wraps rows without a rebuild — the observer catches it, no polling");
+});
+
+test("full-bleed hairlines in the strip's own border color, Classic-scoped", () => {
+  assert.match(CSS, /body:not\(\.chat-theme-yatharth\) #tabs \.tab-row-line \{\n  position: absolute; left: -8px; right: -8px; height: 1px; background: var\(--box-border\); pointer-events: none; \}/,
+    "the negative bleed spans the bar's 8px side padding, like the outer close");
+  assert.match(CSS, /body\.chat-theme-yatharth #tabs \.tab-row-line \{ display: none; \}/, "Yatharth keeps his merged look");
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; \}/);
+});

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,7 +1,7 @@
 // The chat-tab appearance themes (T113, tightened by T115, tuned by T118 — the user 2026-08-27):
 // CLASSIC, the default, is the PRE-720 tab strip modulo exactly THREE sanctioned deltas —
 // typography (the strip inherits the global Inter/type ladder), T123's 1px hover-gray rest
-// outline, T118's 0.9 faded-label scale, and T125's strip band (the multi-row grounding). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
+// outline, T118's 0.9 faded-label scale, T125's strip band, and T134's per-row hairlines. Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
 // selected ring, the neutral line under the strip, gap 0. T115 verified the baseline equality by
 // pixel-diffing a real pre-720 build: with fonts normalized, zero differing pixels outside the
 // (out-of-scope) tag-controls box — a re-run must subtract the two T118 washes the same way it
@@ -35,7 +35,7 @@ test("the theme applies LIVE through the scheme plumbing — a body class, no re
 
 test("Classic: the pre-720 strip verbatim — line, gap 0, gray active fill, ring, stand-down", () => {
   assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/);
-  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; \}/);
   assert.match(CSS, /\.tab\.active \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.14\); \}/);
   assert.match(CSS, /\.tab\.active\.colored \{ box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\); \}/);
   assert.match(CSS, /\.tab\.tab-blocked\.active\.colored \{ box-shadow: none; \}/, "blocked outranks the ring (2026-07-24)");
@@ -57,6 +57,15 @@ test("Classic: faded labels brighten 10% — one tunable knob, Yatharth keeps hi
   assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
 });
 
+test("Classic: resting tab bodies paint the BASELINE color — the band never lightens them (T136)", () => {
+  // The user (2026-08-27): every tab body read lighter than four days before — and the harness
+  // proved it: the T125 band showed through transparent bodies, rgb(41,41,41) vs the pre-720
+  // baseline's rgb(30,30,30). The explicit body restores byte-equality (verified) while the band
+  // keeps reading between/around tabs. Same :not chain as the retired wash: hover/active/blocked
+  // own their fills, + is not a session tab, Yatharth untouched via the body scope.
+  assert.match(CSS, /^body:not\(\.chat-theme-yatharth\) \.tab:not\(\.tab-blocked\):not\(\.active\):not\(:hover\):not\(\.tab-add\) \{ background: var\(--vscode-sideBar-background, var\(--bg\)\); \}$/m);
+});
+
 test("Classic: the rest OUTLINE — 1px in the hover gray, no fill, states stand down (T123)", () => {
   const rule = CSS.match(/^body:not\(\.chat-theme-yatharth\) \.tab([^ ]*) \{ border-color: (rgba\([^)]*\)); \}$/m);
   assert.ok(rule, "the rest-outline rule exists, body-scoped OUT of the Yatharth theme");
@@ -68,7 +77,8 @@ test("Classic: the rest OUTLINE — 1px in the hover gray, no fill, states stand
   // border-color is a different property from the state FILLS, so hover needs no exclusion — the
   // outline stays under hover's fill (same color, one object filling in) and the fill itself…
   assert.match(CSS, /\.tab:hover \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.06\); \}/);
-  // …and no resting FILL remains: the T118 2% wash was replaced by this outline (T123).
+  // …and no resting WASH remains: the T118 2% white lift was replaced by this outline (T123).
+  // (T136's explicit baseline-color body is not a wash — it restores the pre-720 pixel exactly.)
   assert.doesNotMatch(CSS, /\.tab[^{]*\{ background: rgba\(255, 255, 255, 0\.0[24]\); \}/);
 });
 


### PR DESCRIPTION
Three user calls from live use of the fresh strip ships.

## 1. Drag shows exactly ONE provisional representation (T133)
The native drag image + the dimmed in-flow tab read as a ghost duplicate. The native image is blanked at dragstart (a rendered-but-invisible fixed 1px node — Chromium snapshots at dragstart), so the dimmed in-flow element — the one that live-reorders — is the single visual, browser-style. All T127 behavior stays pinned.

## 2. A full-bleed hairline under EVERY row (T134)
The user overturned the survey's one-outer-line design (their call, flagged when it shipped): with a short third row, row 2's tabs floated. CSS can't select wrap rows, so `paintTabRowLines` groups tabs by `offsetTop` and lays one absolute `--box-border` hairline under each row but the last (the strip's own border finishes that one). Event-keyed repaints: every rebuild + a ResizeObserver for re-wraps. Classic-scoped; Yatharth hides them.

## 3. Tab bodies back to native dark (T136)
The user: bodies read lighter than four days ago — **the pixel harness proved them right**. The band showed through transparent bodies:

| surface | baseline (pre-720) | live before | after |
|---|---|---|---|
| resting tab body | rgb(30,30,30) | **rgb(41,41,41)** | **rgb(30,30,30)** ✓ |
| strip gap (the band) | rgb(30,30,30) | rgb(41,41,41) | rgb(41,41,41) ✓ |

Bodies are byte-identical to baseline again; the band reads only between/around tabs. The user's in-app anchor (the feed's bottom button bar) paints no background over the page `--bg` — exactly the color bodies now wear.

## Verification + tests
Headless at the exact 3-row-short-third shape: rows−1 lines, Yatharth hidden, one `.dragging` visual, blank node present, three-way pixel probe. New `tab-row-lines.test.ts`; drag-invariant + baseline-body pins; suite 2507/2507, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)