### PR TITLE
Consecutive retry-recovery notes fold like a tool run — one expandable row per storm

### DIFF
--- a/ui/webview/chat-windowing.test.ts
+++ b/ui/webview/chat-windowing.test.ts
@@ -114,7 +114,7 @@ test("an oversized view (window grew past the cap) re-collapses to the tail on s
 });
 
 test("a deep-link off the current window renders a fresh window AROUND the target unit, then lands", () => {
-  assert.match(RENDER, /let u = items\.findIndex\(\(it\) => it\.kind === "toolgroup" \? it\.indices\.includes\(idx\) : it\.index === idx\);/);
+  assert.match(RENDER, /let u = items\.findIndex\(\(it\) => it\.kind === "toolgroup" \|\| it\.kind === "retrygroup" \? it\.indices\.includes\(idx\) : it\.index === idx\);/);
   assert.match(RENDER, /renderWindowItems\(v, s, items, Math\.max\(0, u - WINDOW_RADIUS\), Math\.min\(items\.length, u \+ WINDOW_RADIUS\), working\);/);
 });
 

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -542,8 +542,10 @@ test("the popover renders the chat's display units — thinking hidden, tool run
   const block = UI.slice(at, at + 2200);
   assert.ok(block.includes("? compactDisplay(evs.map((e) => e.kind), evs.map((e) => e.kind === \"tool\" ? e.name : undefined))"),
     "the SAME unit builder the chat uses, gated on the SAME settings.compact");
-  assert.ok(block.includes("const key = toolGroupKey(tools[0]);"), "the chat's group identity — expands survive refills");
-  assert.ok(block.includes("list.appendChild(renderToolGroup(tools, prev, key, open));"), "the chat's own folded line");
+  assert.ok(block.includes('const key = it.kind === "toolgroup" ? toolGroupKey(run[0]) : retryGroupKey(run[0]);'),
+    "the chat's group identities — tool runs AND retry runs (T131) — so expands survive refills");
+  assert.ok(block.includes("? renderToolGroup(run as Extract<ChatEvent, { kind: \"tool\" }>[], prev, key, open)"),
+    "the chat's own folded lines");
   assert.ok(block.includes('child.classList.add("tg-child");'), "expanded children wear the chat's classes");
 });
 

--- a/ui/webview/compact.test.ts
+++ b/ui/webview/compact.test.ts
@@ -88,7 +88,7 @@ test("every non-tool event owns exactly one display unit — the scroll-mark tra
   const items = compactDisplay(kinds, kinds.map((k) => (k === "tool" ? "Bash" : undefined)));
   const seen = new Map<number, number>();
   items.forEach((it, u) => {
-    if (it.kind === "toolgroup") for (const i of it.indices) seen.set(i, u);
+    if (it.kind === "toolgroup" || it.kind === "retrygroup") for (const i of it.indices) seen.set(i, u);
     else seen.set(it.index, u);
   });
   for (let i = 0; i < kinds.length; i++) {
@@ -99,4 +99,33 @@ test("every non-tool event owns exactly one display unit — the scroll-mark tra
       assert.equal(it.kind, "event", "a non-tool event is its OWN unit, never inside a fold");
     }
   }
+});
+
+test("consecutive retry-recovery notes fold like a tool run — a lone one stays first-class (T131)", () => {
+  // the user 2026-08-27: seventeen consecutive 'Recovered after N retries' rows are a flood; the
+  // collapsed-run idiom fits consecutive same-shape machine notices exactly.
+  const kinds = ["user", "retried", "retried", "retried", "assistant", "retried", "user"];
+  const items = compactDisplay(kinds);
+  assert.deepEqual(items, [
+    { kind: "event", index: 0 },
+    { kind: "retrygroup", indices: [1, 2, 3] },
+    { kind: "event", index: 4 },
+    { kind: "event", index: 5 },   // a lone recovery renders first-class, like a lone tool
+    { kind: "event", index: 6 },
+  ]);
+});
+
+test("retry runs and tool runs break each other — two folds, never one mixed group", () => {
+  const kinds = ["retried", "retried", "tool", "tool", "retried", "retried"];
+  const items = compactDisplay(kinds, kinds.map((k) => (k === "tool" ? "Bash" : undefined)));
+  assert.deepEqual(items, [
+    { kind: "retrygroup", indices: [0, 1] },
+    { kind: "toolgroup", indices: [2, 3] },
+    { kind: "retrygroup", indices: [4, 5] },
+  ]);
+});
+
+test("thinking hides without breaking a retry run, same as a tool run", () => {
+  const kinds = ["retried", "thinking", "retried"];
+  assert.deepEqual(compactDisplay(kinds), [{ kind: "retrygroup", indices: [0, 2] }]);
 });

--- a/ui/webview/compact.ts
+++ b/ui/webview/compact.ts
@@ -8,7 +8,8 @@
 
 export type DisplayItem =
   | { kind: "event"; index: number }            // a pass-through event, by its index in the source array
-  | { kind: "toolgroup"; indices: number[] };   // a collapsed run of ≥2 consecutive tool uses (a lone tool is an "event")
+  | { kind: "toolgroup"; indices: number[] }    // a collapsed run of ≥2 consecutive tool uses (a lone tool is an "event")
+  | { kind: "retrygroup"; indices: number[] };  // a collapsed run of ≥2 consecutive retry-recovery notes (T131 follow-up)
 
 // Tools that are an EXCEPTION to collapsing: they render FIRST-CLASS even in compact mode, never swept
 // into a toolgroup (the user 2026-06-17). AskUserQuestion is the "↳ You answered Claude's question" box —
@@ -21,6 +22,7 @@ export const STANDALONE_TOOLS = new Set<string>(["AskUserQuestion"]);
 export function compactDisplay(kinds: readonly string[], names?: readonly (string | undefined)[]): DisplayItem[] {
   const out: DisplayItem[] = [];
   let run: number[] | null = null;
+  let retryRun: number[] | null = null;           // consecutive "retried" recovery notes (T131 follow-up)
   // a LONE tool passes through as a normal event (its first-class inline tool line + fold); only a run of
   // TWO OR MORE collapses into a summary toolgroup (the user 2026-06-22)
   const flush = () => {
@@ -28,16 +30,26 @@ export function compactDisplay(kinds: readonly string[], names?: readonly (strin
     out.push(run.length === 1 ? { kind: "event", index: run[0] } : { kind: "toolgroup", indices: run });
     run = null;
   };
+  // same shape for retry-recovery runs (the user 2026-08-27, seventeen consecutive recovery rows):
+  // a lone recovery stays a first-class row; a storm of ≥2 collapses into one expandable line
+  const flushRetries = () => {
+    if (!retryRun) return;
+    out.push(retryRun.length === 1 ? { kind: "event", index: retryRun[0] } : { kind: "retrygroup", indices: retryRun });
+    retryRun = null;
+  };
   for (let i = 0; i < kinds.length; i++) {
     const k = kinds[i];
     if (k === "thinking") continue;                 // hidden — and does NOT break a tool run
     // A standalone tool (AskUserQuestion) is NOT collapsed: it breaks the run and passes through as its
     // own event, so renderTool → renderAsk draws the first-class box instead of "+1" inside a group.
-    if (k === "tool" && !STANDALONE_TOOLS.has(names?.[i] ?? "")) { (run ||= []).push(i); continue; }
+    if (k === "tool" && !STANDALONE_TOOLS.has(names?.[i] ?? "")) { flushRetries(); (run ||= []).push(i); continue; }
+    if (k === "retried") { flush(); (retryRun ||= []).push(i); continue; }
     flush();
+    flushRetries();
     out.push({ kind: "event", index: i });
   }
   flush();
+  flushRetries();
   return out;
 }
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1938,7 +1938,7 @@ function eventUnitIndex(s: Session): Int32Array {
   const items = displayItems(s);
   for (let u = 0; u < items.length; u++) {
     const it = items[u];
-    if (it.kind === "toolgroup") { for (const i of it.indices) map[i] = u; }
+    if (it.kind === "toolgroup" || it.kind === "retrygroup") { for (const i of it.indices) map[i] = u; }
     else map[it.index] = u;
   }
   return map;
@@ -6714,20 +6714,22 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
         const dv = dayDividerFor(dayOpen, prev);
         if (dv) list.appendChild(dv);
       }
-      if (it.kind === "toolgroup") {
-        const tools = it.indices.map((ix) => evs[ix]) as Extract<ChatEvent, { kind: "tool" }>[];
-        const key = toolGroupKey(tools[0]);
+      if (it.kind === "toolgroup" || it.kind === "retrygroup") {
+        const run = it.indices.map((ix) => evs[ix]);
+        const key = it.kind === "toolgroup" ? toolGroupKey(run[0]) : retryGroupKey(run[0]);
         const open = expandedGroups.has(key);
-        list.appendChild(renderToolGroup(tools, prev, key, open));
+        list.appendChild(it.kind === "toolgroup"
+          ? renderToolGroup(run as Extract<ChatEvent, { kind: "tool" }>[], prev, key, open)
+          : renderRetryGroup(run as Extract<ChatEvent, { kind: "retried" }>[], prev, key, open));
         if (open) {
-          it.indices.forEach((ix, j) => {   // the tools only — it.indices already excludes thinking
+          it.indices.forEach((ix, j) => {   // the run's own members — it.indices already excludes thinking
             const child = renderEvent(evs[ix], prev, turnWorkedSecs(evs, ix, thWorking));
             child.classList.add("tg-child"); if (j === it.indices.length - 1) child.classList.add("tg-last");
             list.appendChild(child);
             const ep = eventEpoch(evs[ix]); if (ep != null) prev = ep;
           });
         } else {
-          const ep = eventEpoch(tools[tools.length - 1]); if (ep != null) prev = ep;
+          const ep = eventEpoch(run[run.length - 1]); if (ep != null) prev = ep;
         }
         continue;
       }
@@ -7661,7 +7663,7 @@ function scrollToAnchor(uuid: string): boolean {
                                        || (((e as { settleUuids?: string[] }).settleUuids || []).includes(uuid))) : -1;
     if (s && idx >= 0) {
       const items = displayItems(s);
-      let u = items.findIndex((it) => it.kind === "toolgroup" ? it.indices.includes(idx) : it.index === idx);
+      let u = items.findIndex((it) => it.kind === "toolgroup" || it.kind === "retrygroup" ? it.indices.includes(idx) : it.index === idx);
       if (u < 0) u = Math.max(0, items.findIndex((it) => itemFirstEvent(it) >= idx));
       // The anchor can live INSIDE a collapsed tool run: the folded line carries only the run's FIRST
       // uuid, so the re-render below could never surface a mid-run member — the click honest-failed
@@ -7671,6 +7673,8 @@ function scrollToAnchor(uuid: string): boolean {
       const hit = items[u];
       if (hit && hit.kind === "toolgroup" && hit.indices.includes(idx))
         expandedGroups.add(toolGroupKey(s.events[hit.indices[0]]));
+      if (hit && hit.kind === "retrygroup" && hit.indices.includes(idx))
+        expandedGroups.add(retryGroupKey(s.events[hit.indices[0]]));
       const working = s.status.state === "working" || s.status.state === "compacting";
       renderWindowItems(v, s, items, Math.max(0, u - WINDOW_RADIUS), Math.min(items.length, u + WINDOW_RADIUS), working);
       // Re-query with the SAME three selectors the first lookup used. data-mids was missing here, so an
@@ -7752,7 +7756,7 @@ function landNearestMoment(t: number): boolean {
   if (best < 0) return false;
   const uuid = (s.events[best] as { uuid?: string }).uuid || "";
   const items = displayItems(s);
-  let u = items.findIndex((it) => it.kind === "toolgroup" ? it.indices.includes(best) : it.index === best);
+  let u = items.findIndex((it) => it.kind === "toolgroup" || it.kind === "retrygroup" ? it.indices.includes(best) : it.index === best);
   if (u < 0) u = Math.max(0, items.findIndex((it) => itemFirstEvent(it) >= best));
   const working = s.status.state === "working" || s.status.state === "compacting";
   renderWindowItems(v, s, items, Math.max(0, u - WINDOW_RADIUS), Math.min(items.length, u + WINDOW_RADIUS), working);
@@ -8037,7 +8041,7 @@ function displayItems(s: Session): DisplayItem[] {
   }
   return compactDisplay(s.events.map((e) => e.kind), s.events.map((e) => e.kind === "tool" ? e.name : undefined));
 }
-function itemFirstEvent(it: DisplayItem): number { return it.kind === "toolgroup" ? it.indices[0] : it.index; }
+function itemFirstEvent(it: DisplayItem): number { return it.kind === "toolgroup" || it.kind === "retrygroup" ? it.indices[0] : it.index; }
 
 // The display-unit index of the most recent compaction boundary in the loaded events, or 0 if none. The
 // default render window opens at (never below) this unit so pre-compaction history is scrubbed from the
@@ -8076,6 +8080,19 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
       // everywhere, so the expansion must too: iterate it.indices (the tools only), NOT the contiguous
       // start..end span, which would surface the thinking that sat between the tools (the user 2026-06-29).
       // it.indices already excludes thinking — compactDisplay skipped it while building the run.
+      it.indices.forEach((i, j) => {
+        const child = renderEvent(s.events[i], prevEpoch, turnWorkedSecs(s.events, i, working));
+        child.classList.add("tg-child"); if (j === it.indices.length - 1) child.classList.add("tg-last");
+        v.el.appendChild(tag(child)); adv(i);
+      });
+    }
+  } else if (it.kind === "retrygroup") {
+    const notes = it.indices.map((i) => s.events[i]) as Extract<ChatEvent, { kind: "retried" }>[];
+    const key = retryGroupKey(notes[0]);
+    const open = expandedGroups.has(key);
+    v.el.appendChild(tag(renderRetryGroup(notes, prevEpoch, key, open)));
+    adv(it.indices[0]);
+    if (open) {
       it.indices.forEach((i, j) => {
         const child = renderEvent(s.events[i], prevEpoch, turnWorkedSecs(s.events, i, working));
         child.classList.add("tg-child"); if (j === it.indices.length - 1) child.classList.add("tg-last");
@@ -8183,6 +8200,34 @@ function renderToolGroup(tools: Extract<ChatEvent, { kind: "tool" }>[], prevEpoc
   if (epoch != null) turn.insertBefore(timeMarker(epoch, prevEpoch ?? null), turn.firstChild);
   const railDot = turn.querySelector(".dot") as HTMLElement | null;
   if (anchorUuid || epoch != null) wireTurnHover(turn, railDot, anchorUuid, epoch ?? 0, tools[0].tlId ?? null);
+  return turn;
+}
+
+// A collapsed run of consecutive retry-recovery notes (T131 follow-up; the user 2026-08-27,
+// seventeen consecutive rows) → one rail line in the same fold grammar as the tool runs: caret +
+// "Recovered after retries ×N", expanding to the individual notes. Key rides expandedGroups like
+// a toolgroup, so the same toggle, persistence-across-rebuilds, and popover-flip machinery apply.
+function retryGroupKey(first: ChatEvent): string { return "rg:" + (first.uuid || String(eventEpoch(first) ?? "")); }
+function renderRetryGroup(notes: Extract<ChatEvent, { kind: "retried" }>[], prevEpoch: number | null, key: string, open: boolean): HTMLElement {
+  const turn = el("div", "turn turn-toolgroup turn-retrygroup" + (open ? " expanded" : ""));
+  turn.appendChild(dot("ring"));
+  const line = el("div", "toolgroup-line");
+  line.title = open ? "click to collapse" : "click to expand";
+  const caret = el("span", "toolgroup-caret"); caret.textContent = open ? "▾" : "▸"; line.appendChild(caret);
+  if (!open) {
+    const w = el("span", "retried-text");
+    w.textContent = ` Recovered after retries ×${notes.length}`;
+    line.appendChild(w);
+  }
+  line.addEventListener("click", (e) => { e.stopPropagation(); toggleToolGroup(key); });
+  turn.appendChild(line);
+  const epoch = eventEpoch(notes[0]);
+  const anchorUuid = notes[0].uuid ?? null;
+  if (anchorUuid) turn.dataset.uuid = anchorUuid;
+  if (epoch != null) turn.dataset.t = String(epoch);
+  if (epoch != null) turn.insertBefore(timeMarker(epoch, prevEpoch ?? null), turn.firstChild);
+  const railDot = turn.querySelector(".dot") as HTMLElement | null;
+  if (anchorUuid || epoch != null) wireTurnHover(turn, railDot, anchorUuid, epoch ?? 0, notes[0].tlId ?? null);
   return turn;
 }
 

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -69,7 +69,7 @@ test("marks translate EVENT indices to DISPLAY UNITS before asking the frame", (
   // one) and the mark silently vanished — worst exactly beside big tool runs, where replies to a
   // working session land. Both painters now translate through eventUnitIndex.
   assert.match(RENDER, /function eventUnitIndex\(s: Session\): Int32Array/);
-  assert.match(RENDER, /if \(it\.kind === "toolgroup"\) \{ for \(const i of it\.indices\) map\[i\] = u; \}/);
+  assert.match(RENDER, /if \(it\.kind === "toolgroup" \|\| it\.kind === "retrygroup"\) \{ for \(const i of it\.indices\) map\[i\] = u; \}/);
   assert.match(RENDER, /const evUnit = eventUnitIndex\(s\);/);
   assert.match(RENDER, /const u = evUnit\[i\];/);
   assert.match(RENDER, /const off = frame\.offsetOf\(u\);/, "notches ask the frame in unit space");


### PR DESCRIPTION
The T131 flagged follow-up: seventeen consecutive 'Recovered after N retries' rows are a flood regardless of clear — the collapsed-run idiom (tool groups) fits consecutive same-shape machine notices.

- `compactDisplay` gains a second run tracker: ≥2 consecutive `retried` notes fold to a `retrygroup` unit; a **lone recovery stays first-class** (like a lone tool); retry runs and tool runs **break each other**; hidden thinking splits neither (all pinned executable in `compact.test.ts`).
- The collapsed row wears the tool-run fold grammar — caret + 'Recovered after retries ×N' on the rail — expanding to the individual notes via the same `expandedGroups`/toggle machinery, so expands survive rebuilds and flip live in the comment popover.
- Every unit-machinery consumer follows the toolgroup precedent: `eventUnitIndex`, `itemFirstEvent`, `appendItem`, the deep-link ternaries + expand-on-anchor, the popover fold (now shared). The T129 virtual scroll-frame is unit-shaped already.

Verified headless: a 6-note storm renders one '×6' line, the post-storm lone note stays first-class, click expands 6 children in place. Suite 2510/2510, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)