### PR TITLE
Comment threads can be interrupted from the popover — the stop square, owner-scoped

### DIFF
--- a/tools/romp-lab/README.md
+++ b/tools/romp-lab/README.md
@@ -51,7 +51,12 @@ The default run drives TWO phases, banner first (it spends no model turns):
   pushes (`wsFresh` never retires a build prompt); Reload answers it; and after a
   real kernel kill + relaunch the reconnected page still banners on the next drift.
   `--banner-only` runs just this phase.
-- **highlight-loop.mjs** (T102/T106) — the comment-mark contract described above.
+- **highlight-loop.mjs** (T102/T106) — the comment-mark contract described above; its
+  permanent tail phases: 4c full-text (the rendered thread converges to the complete
+  reply), 4d clear-timing (the mark may never read settled while the final answer is
+  not visible — T112), and 4e thread-interrupt (T138: the popover's working state
+  offers the stop square, it targets the THREAD's own session, the ack is instant,
+  the pulse clears on the gesture — no reply record is coming — and the turn ends).
   `--highlight-only` skips the banner phase.
 
 ## Cost

--- a/tools/romp-lab/highlight-loop.mjs
+++ b/tools/romp-lab/highlight-loop.mjs
@@ -164,6 +164,45 @@ await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), un
   .catch(async () => check("4b-follow-up-clears-on-its-reply", false, "still busy after the follow-up's reply"));
 await shot("followup-settled");
 
+// PHASE 4e (T138, permanent): a thread's running turn can be INTERRUPTED from the popover — the
+// stop square renders beside the working chip, targets the THREAD's own session, the turn ends
+// mid-stream, the pulse clears on the gesture (no reply record is coming), and the partial thread
+// renders honestly (whatever landed stays; nothing poses as a full answer).
+await page.fill(".cmt-pop .cmt-input",
+  "Count slowly: write one line per number from 1 to 40, each on its own line, no tools.");
+await page.keyboard.press("Enter");
+await page.waitForTimeout(250);
+check("4e-relatch-for-interrupt-run", (await busy()) === true);
+// the stop affordance must appear with the working chip in the popover statusline
+await page.waitForSelector('.cmt-pop .cmt-state .stop-btn[data-act="cmtinterrupt"]', { timeout: 60000 })
+  .then(() => check("4e-stop-affordance-renders", true))
+  .catch(() => check("4e-stop-affordance-renders", false, "no stop square in the popover's working state"));
+await shot("interrupt-affordance");
+// interrupt MID-STREAM: wait for streaming text to start, then click the popover's own stop
+await page.waitForFunction(() => {
+  const msgs = document.querySelector(".cmt-pop .cmt-msgs");
+  return msgs && /\b3\b/.test(msgs.textContent || "");
+}, undefined, { timeout: 120000 }).catch(() => null);
+const hadStop = await page.evaluate(() => {
+  const b = document.querySelector('.cmt-pop .cmt-state .stop-btn[data-act="cmtinterrupt"]');
+  if (!b) return false;
+  b.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  return true;
+});
+check("4e-stop-clicked", hadStop, "the stop square vanished before the click");
+// the ack is instant: the chip flips to Interrupting… without waiting on the kernel
+const acked = await page.evaluate(() => !!document.querySelector(".cmt-pop .cmt-state .chip-interrupting"));
+check("4e-instant-ack", acked, "no Interrupting… chip right after the click");
+// the pulse clears on the GESTURE — no reply record is coming; never hangs green
+await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), undefined, { timeout: 12000 })
+  .then(() => check("4e-pulse-clears-on-interrupt", true))
+  .catch(() => check("4e-pulse-clears-on-interrupt", false, "pulse still green after the interrupt"));
+// the turn actually ENDS on the thread's CLI: the popover chip leaves working within a few pushes
+await page.waitForFunction(() => !document.querySelector(".cmt-pop .cmt-state .chip-working"), undefined, { timeout: 60000 })
+  .then(() => check("4e-turn-ends", true))
+  .catch(() => check("4e-turn-ends", false, "thread still working 60s after the interrupt"));
+await shot("interrupted-settled");
+
 // PHASE 5: nothing sticks — sample well past several pushes
 await page.waitForTimeout(10000);
 check("5-nothing-sticks", (await busy()) === false, "busy after 10s quiet");

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -513,7 +513,9 @@ test("busy latches at the SEND gesture and clears exactly on the reply-arrived r
     + "mid-turn interim (the specimen's 'checking…' text) must never clear the pulse early. "
     + "threadBusy on the CLEAR side only delays; the latch side never re-derives from state.");
   // the mark's predicate: the latch, or (post-reload) the records' own owed reading; never state
-  assert.match(UI, /return cmtAwaitBase\.has\(th\.tid\) \|\| replyOwed\(th\);/);
+  assert.match(UI, /if \(cmtAwaitBase\.has\(th\.tid\)\) return true;/);
+  assert.match(UI, /return replyOwed\(th\) && !cmtInterrupted\.has\(th\.tid\);/,
+    "the owed arm carries the T138 stop tombstone — an interrupted send owes nothing until the NEXT send");
   assert.match(UI, /if \(th\.status !== "open" \|\| !!th\.error \|\| threadStuck\(th\.state\)\) return false;/);
   // the push-count proxy is GONE root and branch
   assert.doesNotMatch(UI, /settledPushes|commentBusyLatch|latchBusy|SETTLE_CONFIRM_PUSHES/);
@@ -612,4 +614,38 @@ test("the parity bundle (2026-08-26): dividers, owner-scoped in-turn controls, t
   assert.match(UI, /function owningSidOf\(el0: HTMLElement \| null\): string \| null \{/);
   assert.match(UI, /\{ type: "cancelQueued", id: owningSidOf\(el\), md: qmd \}/);
   assert.match(UI, /\{ type: "dismissDialog", id: owningSidOf\(dismiss\) \}/);
+});
+
+test("the thread's running turn offers the chat's stop affordance, owner-scoped to the THREAD (T138)", () => {
+  // the user 2026-08-27: threads couldn't be interrupted from the UI at all — diagnosis (a), the
+  // affordance was simply absent from the popover statusline (the chat's stopButton never had a
+  // popover twin). The fix rides the stable body delegate (this statusline rebuilds per comments
+  // frame — press-safety) and pins the target to the thread's own session, never the active tab.
+  const at = UI.indexOf("function cmtStateChip(");
+  const chip = UI.slice(at, UI.indexOf("\n}", at));
+  assert.match(chip, /b\.dataset\.act = "cmtinterrupt";/);
+  assert.match(chip, /b\.dataset\.sid = th\.tid;/, "the thread's OWN sid rides the button");
+  assert.match(chip, /wrap\.append\(chip, timer, stopBtn\(\)\);/, "working offers it");
+  assert.match(chip, /wrap\.append\(chip, stopBtn\(\)\);/, "retrying offers it");
+});
+
+test("the popover interrupt posts the THREAD sid, clears the send-latch on the gesture, and acks instantly", () => {
+  const at = UI.indexOf("cmtinterrupt: (elx) => {");
+  assert.ok(at > 0, "the delegated handler exists (a direct listener would die in the per-frame rebuild)");
+  const body = UI.slice(at, UI.indexOf("},", at));
+  assert.match(body, /const sid = \(elx as HTMLElement\)\.dataset\.sid;/);
+  assert.match(body, /vscodeApi\.postMessage\(\{ type: "interrupt", id: sid \}\);/);
+  assert.ok(!body.includes("activeId"), "never the active tab — the owner-scoping class queued-x/Retry were fixed for");
+  // T102's latch contract at the interrupt edge: the exchange ends with NO reply record coming, so
+  // the pulse clears on the gesture itself — the deciding event — not on a reply that never lands.
+  assert.match(body, /cmtAwaitBase\.delete\(sid\);/);
+  // …and the OWED arm stands down too (lab phase 4e caught it: replyOwed's trailing-user shape held
+  // the mark green forever after a stop). The tombstone is record-count-keyed, never a clock, and a
+  // fresh send retires it (re-owed).
+  assert.match(body, /cmtInterrupted\.add\(sid\);/);
+  assert.match(UI, /return replyOwed\(th\) && !cmtInterrupted\.has\(th\.tid\);/,
+    "gesture-pair tombstone: stop sets it, ONLY the next send clears it — the CLI files the interrupt "
+    + "as a trailing user-kind record, so any record-shape re-derivation would re-fire (lab-caught)");
+  assert.match(UI, /cmtInterrupted\.delete\(cur\.th\.tid\);/);
+  assert.match(body, /chip chip-interrupting/, "instant acknowledgment: the chip flips before any kernel round-trip");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6264,9 +6264,19 @@ function dropSynthThread(sid: string, uuid: string): void {
 // the one busy answer for the mark + rail tick: an in-flight EXCHANGE (the gesture latch above), or
 // — after a reload lost the client latch — the exchange's own records still saying a reply is owed
 // (msgs ending with the user's message). A stuck/errored/closed thread never pulses: green would lie.
+// A thread whose trailing user message was ANSWERED BY A STOP (T138, found by lab phase 4e): the
+// user interrupted the turn, so no reply record is coming for that send — replyOwed's
+// trailing-user shape would otherwise hold the mark green forever. A plain until-the-next-send
+// tombstone: the only event that can OWE a new reply is the user's next send gesture, which
+// retires it (and latches the real base). A count-keyed first cut died in the lab: the CLI files
+// the interrupt itself as a trailing user-kind record, so any record-shape re-derivation re-fires
+// exactly like the flapping proxies the T102 rule bans — the gesture pair (stop sets, send
+// clears) is the event-true form.
+const cmtInterrupted = new Set<string>();
 const commentInFlight = (th: CommentThread): boolean => {
   if (th.status !== "open" || !!th.error || threadStuck(th.state)) return false;
-  return cmtAwaitBase.has(th.tid) || replyOwed(th);
+  if (cmtAwaitBase.has(th.tid)) return true;
+  return replyOwed(th) && !cmtInterrupted.has(th.tid);
 };
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 // The popover-boot hold (fillCommentMsgs): tid → when the loader first held the list. Held until the
@@ -6810,6 +6820,21 @@ function cmtStateChip(th: CommentThread): HTMLElement {
   wrap.id = "cmt-state";
   if (th.status !== "open") return wrap;                    // closed threads carry their status in the title
   const st = th.state || "";
+  // the stop square, exactly the chat statusline's affordance owner-scoped to the THREAD (T138,
+  // the user 2026-08-27: threads couldn't be interrupted from the UI at all — the popover chip
+  // rendered working/retrying with no stop). data-act rides the stable document.body delegate
+  // (this statusline rebuilds per comments frame — a direct listener would be press-unsafe), and
+  // data-sid pins the target to the thread's own session, never the active tab.
+  const stopBtn = () => {
+    const b = el("button", "stop-btn cmt-stop");
+    (b as HTMLButtonElement).type = "button";
+    b.title = "Stop — interrupt this thread's turn";
+    b.setAttribute("aria-label", "Interrupt this thread");
+    b.dataset.act = "cmtinterrupt";
+    b.dataset.sid = th.tid;
+    b.appendChild(el("span", "stop-icon"));
+    return b;
+  };
   if (st === "working") {
     const chip = el("span", "chip chip-working");
     const label = el("span", "chip-pulse");
@@ -6818,11 +6843,11 @@ function cmtStateChip(th: CommentThread): HTMLElement {
     const timer = el("span", "status-timer");
     timer.id = "cmt-work-timer";
     timer.textContent = elapsedMs(th.sinceEpoch || null);
-    wrap.append(chip, timer);
+    wrap.append(chip, timer, stopBtn());
   } else if (st === "retrying") {
     const chip = el("span", "chip chip-retrying");
     chip.textContent = CHIP_LABEL.retrying;
-    wrap.appendChild(chip);
+    wrap.append(chip, stopBtn());
   } else if (st === "compacting") {
     const c = el("span", "compacting-line");
     c.textContent = "⟳ Compacting context…";
@@ -6945,6 +6970,7 @@ function commentSendFromPop(pop: HTMLElement): void {
   if (!cur) return;
   vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
   cmtAwaitBase.set(cur.th.tid, agentCount(cur.th));   // a follow-up RE-LATCHES at its own send, until ITS reply (T102)
+  cmtInterrupted.delete(cur.th.tid);                  // a fresh send re-owes a reply — the stop tombstone retires (T138)
   cur.th.state = "working";                     // optimistic: the pulse rides the SEND, not the
   applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
   const pl = commentPending.get(cur.th.tid) || [];
@@ -12685,6 +12711,25 @@ setupSettings();
       openCommentPopover(activeId, tid, Math.min(r.left, window.innerWidth - 380), r.bottom + 6);
     },
     cmtclose: () => closeCommentPop(),
+    // Interrupt the THREAD's own turn (T138): the sid rides the button (the thread's session),
+    // never activeId — the exact owner-scoping class queued-x/Retry were fixed for. The gesture
+    // itself ENDS the exchange with no reply record coming, so the T102 send-latch clears on THIS
+    // event (a user gesture is a sanctioned mover; waiting for a reply-completed record would hang
+    // the pulse green forever). Acknowledge instantly per the buttons rule: the chip flips to
+    // Interrupting… and the timer + button go; the next comments frame rebuilds this statusline.
+    cmtinterrupt: (elx) => {
+      const sid = (elx as HTMLElement).dataset.sid;
+      if (!sid || !vscodeApi) return;
+      vscodeApi.postMessage({ type: "interrupt", id: sid });
+      cmtAwaitBase.delete(sid);
+      cmtInterrupted.add(sid);
+      const wrap = document.getElementById("cmt-state");
+      if (wrap) {
+        const chip = el("span", "chip chip-interrupting");
+        chip.textContent = CHIP_LABEL.interrupting;
+        wrap.replaceChildren(chip);
+      }
+    },
     // a scroll-rail tick: jump the chat to the commented message (fresh navigation → one flash)
     // and open its thread beside it
     cmtjump: (elx) => {


### PR DESCRIPTION
The user: sessions inside a comment thread could not be interrupted from the UI.

## Diagnosis: (a) — absent entirely
The popover statusline rendered the working chip + timer with **no stop affordance**, and every existing interrupt sender hardcodes `activeId`. The kernel route accepts thread sids unchanged (`be.interrupt(sid)` is sid-agnostic — verified).

## The fix
The popover's working and retrying states render the chat's stop square:
- **delegated** (`data-act=cmtinterrupt` on the stable body delegate) — the statusline rebuilds per comments frame; a direct listener would die mid-press;
- **owner-scoped**: `data-sid` carries the thread's own session, never the active tab (the queued-x/Retry class);
- **instant ack**: the chip flips to Interrupting… before any round-trip.

## The T102 latch at the interrupt edge — lab-caught, twice
An interrupt ends the exchange with **no reply record coming**: the gesture clears the send-latch, and the `replyOwed` arm gets a **stop tombstone**. A count-keyed first cut re-fired because the CLI files the interrupt itself as a trailing user-kind record — so the tombstone is the event-true gesture pair: stop sets it, only the next send clears it (which latches that send's real base).

## Proof
Permanent lab phase 4e (real kernel, real streaming reply): stop square renders → mid-stream interrupt → instant ack → pulse clears on the gesture → the turn ends on the thread's CLI → nothing sticks. **Full run: all 17 checks green**, phases 1–5 intact. Suite 2512/2512, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)