### PR TITLE
T137: the to-do mirror joins the ask-unit principle — serving steps fold into the ask card

### DIFF
--- a/docs/judge-pipeline.md
+++ b/docs/judge-pipeline.md
@@ -170,7 +170,7 @@ cards: one in each tree, linked, and the link checks itself off.
 |---|---|
 | why is this card in this state? | the node's `log` in `goals/<sid>.json`: every event has source, kind, reason, time |
 | why was this work filed here? | `placements` in the store, plus the node's `why` and `trail` |
-| why did this mint at top level? | the node's `why`: "declared in the agent's own to-do list" means the plan-sync mirror, and nesting it is the grouper's job; anything else is the planner |
+| why did this mint at top level? | the node's `why`: "declared in the agent's own to-do list" means the plan-sync mirror — a step declared while serving a dispatch carries `serving` and folds into the sender's ask card at render (T137); the grouper may merge a duplicate; anything else is the planner |
 | did a judge fail or get skipped? | `judge-errors.jsonl`: every row carries judge, session, kind (parse, call, give-up, cite-miss, rate-limited, task-store, history-unreadable, drift-skip), and the evidence (reply tail, API message, re-arm event) |
 | what did a judge call cost, and when? | `judge-usage.jsonl`, per judge and session |
 | what happened to a peer message? | `timeline/messages.jsonl` by message id, plus the delivered markers in the transcript |

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -376,7 +376,14 @@ permission/API-error floors: one interrupt at a time, the present event first.
   holds the authoritative tier: an open item on the agent's own to-do list
   pins the card in Working over any judge verdict.
 - **plan-sync**: pure code. Mirrors the agent's own to-do list as flat top
-  cards ("declared in the agent's own to-do list"); the grouper nests them.
+  cards ("declared in the agent's own to-do list"). A step declared while
+  the session serves a linked dispatch is stamped `serving` ({peer, msgId,
+  goalId}, latched at mint on the newest delegate-kind segment at or before
+  the declaration) plus the dispatch's frame and root-ask, and the feed
+  folds it into the sender's ask card at render — fan-out inside the ask
+  card, with needs-you breaking through (T137). A dispatch-less step
+  threads the session's own prompt record instead. The grouper may still
+  merge a duplicate mirror.
   It reads the live task store (`~/.claude/tasks/<fsid>/`, the same source
   the chat TO-DO card reads) — never the transcript, whose record of a
   TaskUpdate can fall off the live chain when an api-error retry forks the

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4369,7 +4369,7 @@ def rollup_status(store, session_closed, now=None):
     store["confirming"] = confirming
 
 
-def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
+def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None, ctx=None):
     """DETERMINISTIC (no LLM): mirror the agent's live to-do list (Claude Code's Task tool) into the goal
     graph as `agentTask:{key,status}` nodes — the authoritative tier rollup_status honors.
     `prompt_uuid` (the user 2026-07-11): the syncing segment's trigger uuid, stamped on every node
@@ -4390,7 +4390,20 @@ def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
     record fell off the transcript's live chain (an api-error retry fork orphaned the completing update
     for a mirror that then stayed phantom-open and re-minted after every clear — g204, 2026-07-09).
     The fold remains only for a session with NO store dir; a store that exists but can't be read skips
-    the sync loudly (judge-errors row) instead of silently degrading to the lossy fold (repo policy)."""
+    the sync loudly (judge-errors row) instead of silently degrading to the lossy fold (repo policy).
+
+    `ctx` (the user 2026-08-28, T137: the mirror joins the ask-unit principle) — a lazy callable
+    returning (serving, user_ask), resolved once per pass and only when a mint needs it:
+    a step declared while the session serves a linked dispatch is that dispatch's fan-out, not a
+    standalone ask — the mint stamps the caller-resolved `serving` ref ({peer, msgId, goalId}, a
+    DISTINCT field from origin/links, which carry run_propagate's complete-the-tracker semantics)
+    plus the dispatch's frame and root-ask record so the prose writers anchor; the feed folds a
+    serving-marked top into the ask card at render (view-side join — the mirror stays in THIS
+    store, where plan-sync completion, nudge freshness, and clears all live). A dispatch-less
+    declaration threads the session's own prompt-chain record as `user_ask` instead. Both are
+    LATCHED at mint, never re-derived (cards move on new information, not on inference flaps);
+    the one-shot arm below back-fills existing OPEN un-stamped mirrors ONCE, resolving the same
+    event as-of each mirror's own declaring segment."""
     try:
         plan = em.task_store_plan(session.get("leafFsid") or "")
     except OSError as e:
@@ -4475,13 +4488,58 @@ def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
             continue
         store["seq"] = store.get("seq", 0) + 1
         nid = "%s:g%d" % (store["rompUuid"], store["seq"])
-        nodes[nid] = GuardedNode({"id": nid, "text": it["text"] or it.get("activeForm") or "(declared step)",
-                      "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
-                      "trail": [seg_id] if seg_id else [], "promptUuid": prompt_uuid, "t": seg_t, "mt": seg_t,
-                      "why": "declared in the agent's own to-do list",
-                      "agentTask": {"key": key, "status": "open", "raw": it["status"]}, "agentBornOpen": True, "log": []})
+        payload = {"id": nid, "text": it["text"] or it.get("activeForm") or "(declared step)",
+                   "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
+                   "trail": [seg_id] if seg_id else [], "promptUuid": prompt_uuid, "t": seg_t, "mt": seg_t,
+                   "why": "declared in the agent's own to-do list",
+                   "agentTask": {"key": key, "status": "open", "raw": it["status"]}, "agentBornOpen": True,
+                   "servingT": seg_t, "log": []}
+        serving, user_ask = ctx() if ctx else (None, None)
+        if isinstance(serving, dict) and serving.get("msgId"):
+            payload["serving"] = dict(serving)
+            fr = _postal_body_head(serving["msgId"])
+            if fr:
+                payload["frame"] = fr
+        if isinstance(user_ask, dict) and str(user_ask.get("text") or "").strip():
+            payload["userAsk"] = {"text": _ask_head(str(user_ask["text"])), "sid": user_ask.get("sid"),
+                                  **({"host": user_ask["host"]} if user_ask.get("host") else {})}
+        nodes[nid] = GuardedNode(payload)
         key_nodes[key] = [nid]
         changed = True
+
+    # ONE-SHOT BACK-FILL (T137's deploy arm, the dissolution precedent): an OPEN mirror minted
+    # before the stamp existed resolves the SAME event as-of its OWN declaring segment (trail[0]
+    # position, not the current pass's — resolving as-of-now would re-attribute old steps to
+    # whatever dispatch arrived since). Latched by servingT whether or not anything resolves: a
+    # mirror whose transcript no longer holds its segment stays standalone forever rather than
+    # flapping between attributions.
+    for key, nids in list(key_nodes.items()):
+        for nid in nids:
+            nd = nodes.get(nid)
+            if (not isinstance(nd, dict) or nd.get("servingT")
+                    or (nd.get("agentTask") or {}).get("status") != "open"):
+                continue
+            nd["servingT"] = seg_t
+            changed = True
+            decl = (nd.get("trail") or [None])[0]
+            serv = _serving_dispatch(session, store, store.get("rompUuid") or "", decl) if decl else None
+            if not serv:
+                continue
+            serv = _serving_ref(serv)
+            nd["serving"] = serv
+            if not nd.get("frame"):
+                fr = _postal_body_head(serv["msgId"])
+                if fr:
+                    nd["frame"] = fr
+            if not nd.get("userAsk") and serv.get("goalId"):
+                try:
+                    paths = {f: str(p) for f, p, _a, _nm in discover(int(seg_t))}
+                    rec = _delegate_user_rooted(serv["peer"], serv["goalId"], paths, int(seg_t))
+                    if isinstance(rec, dict):
+                        nd["userAsk"] = {"text": _ask_head(str(rec["text"])), "sid": rec.get("sid"),
+                                         **({"host": rec["host"]} if rec.get("host") else {})}
+                except Exception:
+                    pass
 
     # 3) BACKSTOP (the user 2026-07-21): an OPEN to-do link belongs on a LEAF the card can render, never
     # on a CONTAINER that is not itself a to-do row — the root goal or an umbrella, whose done sub-goals
@@ -6834,6 +6892,36 @@ def _queued_sibling(store, seg_by_id, seg_id):
     return None
 
 
+def _mirror_mint_ctx(session, store, fsid, path, latest_seg, now):
+    """The lazy (serving, user_ask) resolver for mirror mints (T137) — memoized, so the transcript
+    walk, the sender-store join, and the chain walk run at most once per pass, and only on a pass
+    that actually mints. serving present → user_ask is the DISPATCH chain's root (the sender
+    tracker walked on this kernel; cross-host trackers degrade to None and the mirror anchors on
+    nothing rather than a guess). No dispatch → the session's own prompt-chain record when the
+    vetted anchor is a human prompt (autonomous declarations anchor on nothing — honest)."""
+    memo = {}
+
+    def ctx():
+        if "v" in memo:
+            return memo["v"]
+        serv = _serving_dispatch(session, store, fsid, (latest_seg or {}).get("id")) if latest_seg else None
+        serv = _serving_ref(serv) if serv else None
+        ua = None
+        if serv and serv.get("goalId"):
+            try:
+                paths = {f: str(p) for f, p, _a, _nm in discover(now)}
+                rec = _delegate_user_rooted(serv["peer"], serv["goalId"], paths, now)
+                ua = rec if isinstance(rec, dict) else None
+            except Exception:
+                ua = None
+        elif not serv and latest_seg is not None:
+            anch = _mint_anchor_uuid(latest_seg)
+            ua = _session_user_prompt_record(fsid, path, anch, now) if anch else None
+        memo["v"] = (serv, ua)
+        return memo["v"]
+    return ctx
+
+
 def _plan_session(fsid, path, now):
     """Advance ONE session's goal tree: place its un-placed planner UNITS oldest-first (each sees the prior
     tree's open menu) and GROUP after every placement (the user 2026-06-17: planner + grouper are both
@@ -7310,7 +7398,8 @@ def _plan_session(fsid, path, now):
         _log_judge_error("planner", fsid, "rewind-stand-down",
                          note="plan-sync skipped this pass: the latest segment was rewound away mid-pass")
     elif _sync_declared_plan(store, session, (latest_seg or {}).get("id"), (latest_seg or {}).get("t") or now,
-                             prompt_uuid=_mint_anchor_uuid(latest_seg) if latest_seg else None):
+                             prompt_uuid=_mint_anchor_uuid(latest_seg) if latest_seg else None,
+                             ctx=_mirror_mint_ctx(session, store, fsid, path, latest_seg, now)):
         # ^ the VETTED anchor, not the raw trigger (the user 2026-08-25, the audited g-specimen): the
         #   mirror stamps its promptUuid off whatever segment happens to be syncing, and when that
         #   segment was opened by a coordinate/question mail or a romp notice, the raw trigger made
@@ -10313,7 +10402,7 @@ def _deleg_frame(store, nid):
     stores are not ours to read), and for pre-fix nodes minted before the frame existed (they
     re-distill unchanged — absent frame is byte-identical to today)."""
     nd = store.get("nodes", {}).get(nid) or {}
-    o = nd.get("origin")
+    o = nd.get("origin") or nd.get("serving")          # a serving mirror's dispatch frames it (T137)
     if not isinstance(o, dict) or not o.get("peer") or not nd.get("frame"):
         return ""                                      # no mint-time frame → BYTE-IDENTICAL to today,
         #                                                including pre-fix delegated nodes re-distilling
@@ -11456,6 +11545,55 @@ def _attach_courier_link(store, seg_id, mid):
     nodes[top].setdefault("links", []).append({"peer": peer_sid, "goalId": peer_gid, "msgId": mid})
     save_goals(store["rompUuid"], store)
     return True
+
+
+def _serving_dispatch(session, store, fsid, upto_seg_id):
+    """The dispatch this session is SERVING at a given segment (the user 2026-08-28, T137): the
+    newest delegate-kind peer segment at or before `upto_seg_id` in TRANSCRIPT ORDER (segment
+    start times shift when a states-overlay atom lands before the trigger, so parse position is
+    the stable order), within the current episode. Returns {"peer", "msgId"} or None — the same
+    discriminator pair the courier files dispatches by (_seg_peer + _seg_peer_kind), read from the
+    delivered trigger record, never from placements (a linked dispatch leaves only an
+    indistinguishable 'fyi' there). Multi-dispatch honesty: newest-at-or-before misattributes only
+    when the agent declares steps for an OLDER dispatch after a newer one arrived — no event can
+    distinguish that without content heuristics, and the miss is bounded to a sibling dispatch."""
+    floor = episode_floor(fsid)
+    last = None
+    for turn in session.get("turns") or []:
+        for sg in _segs(turn, store):
+            if not (floor and (sg.get("t") or 0) < floor):
+                pm = _seg_peer(sg)
+                if pm and pm[0] and pm[1] and _seg_peer_kind(sg) == "delegate":
+                    last = {"peer": pm[0], "msgId": pm[1]}
+            if sg.get("id") == upto_seg_id:
+                return last
+    return None                                        # the declaring segment is not in this parse →
+    #                                                    no confident attribution (a newest-overall
+    #                                                    fallback would re-attribute a gone-segment
+    #                                                    mirror to whatever dispatch arrived since)
+
+
+def _serving_ref(serving):
+    """Complete a {"peer","msgId"} serving pair with the SENDER's tracking-node id (goalId) — a
+    read-only join on handoff.msgId in the sender's own store, the durable record the plant wrote
+    at dispatch time. Deliberately NOT _handoff_backref: that helper filters complete trackers
+    out, and a serving mirror's tracker is COMMONLY complete already (a quiet tracker ends on any
+    reply, so a worker that acked its dispatch closed it while still serving). Returns the ref
+    with goalId (or None when the sender's store no longer holds the tracker — cross-host, or
+    archived away) — a distinct field from origin/links ON PURPOSE: those carry run_propagate's
+    complete-the-tracker semantics, and a per-step mirror completing must never check off the
+    whole dispatch."""
+    ref = dict(serving)
+    ref["goalId"] = None
+    try:
+        for nid, nd in load_goals(serving["peer"]).get("nodes", {}).items():
+            h = nd.get("handoff")
+            if isinstance(h, dict) and h.get("msgId") == serving["msgId"]:
+                ref["goalId"] = nid
+                break
+    except Exception:
+        pass
+    return ref
 
 
 def _handoff_backref(mid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19424,6 +19424,7 @@ def build_feed(now, tmux=None):
     # Zero cost when off: no rows read, no key emitted.
     dbg_rows = _judge_error_rows(now) if jd._debug_mode() else None
     asks, working, awaiting = [], [], []
+    serving_folds = []                                # T137: worker mirror cards awaiting the view-side fold
     bg_services = {}          # session name -> live SERVICE descs (judge-classified, _bg_split) → the neutral chip
     alive = _alive_sessions(now, tmux)               # hard filter: living sessions only
     wmap = _wait_for_graph(now, {s["sid"] for s in alive})   # per-session 'waiting on a live peer' (the user 2026-06-22)
@@ -20162,7 +20163,7 @@ def build_feed(now, tmux=None):
                 # serve the distiller's stored citation raw — the chat's own landing handles a bad uuid
                 # honestly, and the validated tiers take back over on the first warm push.
                 _sa_u = _cited
-            asks.append({
+            card = {
                 "itemId": nid, "sid": fsid, "name": name, "color": color, "text": card_text,
                 "t": disp_t, "live": live,
                 "trgb": list(cm.age_rgb(now - disp_t, _colormap())),
@@ -20262,7 +20263,22 @@ def build_feed(now, tmux=None):
                 "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
                                              store.get("placements") or {}) or None)
                             if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section
-                "tree": flatten(nid, [], boundary=jd.review_boundary(nodes[nid]))})
+                "tree": flatten(nid, [], boundary=jd.review_boundary(nodes[nid]))}
+            # THE SERVING FOLD, candidate side (the user 2026-08-28, T137: fan-out lives inside the
+            # ask card — the T101 ruling applied to the mirror, view-side): a to-do mirror top the
+            # sync stamped as SERVING a dispatch folds into the sender's ask card instead of
+            # standing alone on the board. Candidate only — the fold commits in the post-pass IFF
+            # the sender's tracker row actually rendered this build (never orphan rows into an
+            # unrendered card; the candidate falls back to its own card). NEEDS-YOU BREAKS THROUGH:
+            # a serving mirror folds ONLY from the quiet columns (working/completed) — any
+            # needs-input state stands on the board like any needs-you card until it lifts, the
+            # store-independent breakthrough rule.
+            _srv = nodes[nid].get("serving")
+            if (isinstance(_srv, dict) and _srv.get("goalId")
+                    and column in ("working", "completed")):
+                serving_folds.append({"tracker": _srv["goalId"], "card": card})
+            else:
+                asks.append(card)
         # A session actively working a brand-new ask shows NO card until the planner classifies the held
         # segment at turn-end — surface a live-prompt placeholder so it isn't invisible. Only when nothing
         # already covers it (no working card); replaced by the real card once the planner places it.
@@ -20297,6 +20313,28 @@ def build_feed(now, tmux=None):
                 # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
                 asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
                                            kind=sess_awaiting_kind, since=sess_awaiting_since))
+    # THE SERVING FOLD, commit side (T137): join each candidate's rows under its dispatch's
+    # tracker row — a read-only render-time join across stores (the node itself stays in the
+    # WORKER's store, where plan-sync completion, nudge freshness, and clears live; node ids are
+    # globally unique, so the tracker id is the whole key). A candidate whose tracker row is not
+    # on this build's board keeps its own card — suppression without a rendered home would
+    # silently hide live work.
+    if serving_folds:
+        _byrow = {}
+        for _c in asks:
+            for _r in _c.get("tree") or []:
+                if _r.get("kind") == "handoff":
+                    _byrow[_r["id"]] = (_c, _r)
+        for _f in serving_folds:
+            _hit = _byrow.get(_f["tracker"])
+            if not _hit:
+                asks.append(_f["card"])
+                continue
+            _c, _r = _hit
+            _rows = _f["card"].get("tree") or []
+            if _rows:
+                _r.setdefault("children", []).append(_rows[0]["id"])
+                _c["tree"].extend(_rows)
     if cold_parse:
         _warm_fleet_bg(now)                          # a living session wasn't parsed yet → warm it + re-push (dots/anchors)
     # NO caption stream. The feed's cards are TOP-LEVEL GOALS ONLY (read-side.md: Inbox = goal cards;

--- a/tests/test_serving_mirror.py
+++ b/tests/test_serving_mirror.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""The to-do mirror joins the ask-unit principle (the user 2026-08-28, T137): a step declared
+while the session serves a linked dispatch is that dispatch's fan-out, not a standalone ask.
+The sync stamps a kernel-resolved `serving` ref ({peer, msgId, goalId} — a DISTINCT field from
+origin/links, which carry run_propagate's complete-the-tracker semantics) latched at mint on a
+named event: the newest delegate-kind peer segment at or before the declaring segment, in
+transcript order, within the episode. The dispatch's frame and root-ask thread into the node so
+the prose writers anchor; a dispatch-less declaration threads the session's own prompt record.
+The FEED folds a serving-marked top into the sender's ask card at render (a read-only cross-store
+join — the node stays in the worker's store, where plan-sync completion, nudge freshness, and
+clears all live), with the needs-you breakthrough: a BLOCKED serving mirror never folds silently.
+SYNTHETIC fixtures only; private synthetic sids."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_servmir", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+em = jd.em
+
+NOW = 1_788_000_000
+T0 = NOW - 3600
+SND = "d88c0001-1111-4222-8333-000000000001"    # private synthetic sids — never the shared placeholder
+WKR = "d88c0001-1111-4222-8333-000000000002"
+MID = "1787999000.000001_1.TESTHOST"
+MID2 = "1787999100.000001_2.TESTHOST"
+ASK = "the metric panels should pick sensible ranges on their own"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def dmail(t, uuid, mid, kind="delegate", parent=None):
+    body = ("do the panels piece\n<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: %s -->" % (mid, kind))
+    return uline(t, body, uuid, parent=parent, ps="sdk")
+
+
+ROWS = [{"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": SND,
+         "to_id": WKR, "kind": "delegate", "body": "pick per-metric ranges for the panels"},
+        {"t": T0 + 100, "ev": "sent", "id": MID2, "from": "web", "from_id": SND,
+         "to_id": WKR, "kind": "delegate", "body": "then wire the picker into settings"}]
+
+
+class ServingResolver(unittest.TestCase):
+    """_serving_dispatch: transcript-positional, delegate-kind only, honest about a gone segment."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._msgs = (jd.MESSAGES, em.MESSAGES_LOG)
+        p = Path(self.td.name) / "messages.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in ROWS) + "\n")
+        jd.MESSAGES = em.MESSAGES_LOG = p
+
+    def tearDown(self):
+        jd.MESSAGES, em.MESSAGES_LOG = self._msgs
+        self.td.cleanup()
+
+    def _sess(self, recs):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / (WKR + ".jsonl")
+            p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+            return em.parse_session(str(p), rompuuid=WKR, candidate_files=[str(p)], now=NOW)
+
+    def _segids(self, s):
+        st = {"rompUuid": WKR, "nodes": {}, "placements": {}, "status": {}}
+        return [(sg["id"], sg) for turn in s["turns"] for sg in jd._segs(turn, st)], st
+
+    def test_the_newest_delegate_at_or_before_the_declaration_wins(self):
+        s = self._sess([dmail(T0, "m1", MID), aline(T0 + 30, "on it", "a1", "m1"),
+                        dmail(T0 + 100, "m2", MID2, parent="a1"),
+                        aline(T0 + 130, "and this", "a2", "m2"),
+                        uline(T0 + 200, "carry on", "u3", "a2"), aline(T0 + 230, "ok", "a3", "u3")])
+        segs, st = self._segids(s)
+        self.assertEqual(jd._serving_dispatch(s, st, WKR, segs[-1][0]),
+                         {"peer": SND, "msgId": MID2}, "declared after the second dispatch → it")
+        self.assertEqual(jd._serving_dispatch(s, st, WKR, segs[0][0])["msgId"], MID,
+                         "declared in the first dispatch's own segment → the first (at-or-before)")
+
+    def test_no_delegate_or_coordinate_only_resolves_nothing(self):
+        s = self._sess([uline(T0, "work on my own thing", "u1"), aline(T0 + 30, "ok", "a1", "u1")])
+        segs, st = self._segids(s)
+        self.assertIsNone(jd._serving_dispatch(s, st, WKR, segs[-1][0]))
+        s2 = self._sess([dmail(T0, "m1", MID, kind="coordinate"), aline(T0 + 30, "noted", "a1", "m1")])
+        segs2, st2 = self._segids(s2)
+        self.assertIsNone(jd._serving_dispatch(s2, st2, WKR, segs2[-1][0]),
+                          "a coordinate is not a dispatch")
+
+    def test_a_gone_declaring_segment_attributes_nothing(self):
+        s = self._sess([dmail(T0, "m1", MID), aline(T0 + 30, "on it", "a1", "m1")])
+        _, st = self._segids(s)
+        self.assertIsNone(jd._serving_dispatch(s, st, WKR, "seg-that-no-longer-exists"),
+                          "no confident placement → no attribution, never newest-overall")
+
+
+def _mail_atom_peer(recs):
+    return recs
+
+
+class SyncStamps(unittest.TestCase):
+    """The mint stamps serving + frame + userAsk from the lazy ctx, latched; the one-shot
+    back-fill resolves existing open mirrors as-of their own declaring segment, once."""
+
+    def setUp(self):
+        self._plan = em.task_store_plan
+        self._msgs = (jd.MESSAGES, em.MESSAGES_LOG)
+        self.td = tempfile.TemporaryDirectory()
+        p = Path(self.td.name) / "messages.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in ROWS) + "\n")
+        jd.MESSAGES = em.MESSAGES_LOG = p
+
+    def tearDown(self):
+        em.task_store_plan = self._plan
+        jd.MESSAGES, em.MESSAGES_LOG = self._msgs
+        self.td.cleanup()
+        for d in (jd.GOALDIR, jd.GOALARCHDIR):
+            try:
+                (d / (WKR + ".json")).unlink()
+            except OSError:
+                pass
+        try:
+            (jd._overrides_dir() / (WKR + ".jsonl")).unlink()
+        except OSError:
+            pass
+
+    def _store(self):
+        return {"rompUuid": WKR, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+
+    def test_a_serving_mint_carries_ref_frame_and_root_ask(self):
+        em.task_store_plan = lambda fsid: [{"key": "1", "text": "probe the axes",
+                                            "activeForm": "", "status": "pending"}]
+        st = self._store()
+        ref = {"peer": SND, "msgId": MID, "goalId": SND + ":g2"}
+        ua = {"text": ASK, "sid": SND}
+        self.assertTrue(jd._sync_declared_plan(st, {"turns": [], "leafFsid": WKR}, "s1", T0 + 50,
+                                               prompt_uuid="pu1", ctx=lambda: (ref, ua)))
+        nd = next(iter(st["nodes"].values()))
+        self.assertEqual(nd["serving"], ref)
+        self.assertEqual(nd["frame"], "pick per-metric ranges for the panels",
+                         "the dispatch's ledger head frames the step")
+        self.assertEqual(nd["userAsk"]["text"], ASK, "the dispatch chain's root anchors the prose")
+        self.assertEqual(nd["servingT"], T0 + 50)
+
+    def test_the_stamp_is_latched_never_rederived(self):
+        em.task_store_plan = lambda fsid: [{"key": "1", "text": "probe the axes",
+                                            "activeForm": "", "status": "pending"}]
+        st = self._store()
+        jd._sync_declared_plan(st, {"turns": [], "leafFsid": WKR}, "s1", T0 + 50,
+                               ctx=lambda: ({"peer": SND, "msgId": MID, "goalId": SND + ":g2"}, None))
+        jd._sync_declared_plan(st, {"turns": [], "leafFsid": WKR}, "s2", T0 + 900,
+                               ctx=lambda: ({"peer": SND, "msgId": MID2, "goalId": SND + ":g9"}, None))
+        nd = next(iter(st["nodes"].values()))
+        self.assertEqual(nd["serving"]["msgId"], MID,
+                         "a later dispatch never re-attributes an existing step (no flap)")
+
+    def test_a_dispatchless_mint_anchors_on_the_sessions_own_record(self):
+        em.task_store_plan = lambda fsid: [{"key": "1", "text": "tidy my own backlog",
+                                            "activeForm": "", "status": "pending"}]
+        st = self._store()
+        self.assertTrue(jd._sync_declared_plan(st, {"turns": [], "leafFsid": WKR}, "s1", T0 + 50,
+                                               ctx=lambda: (None, {"text": "sort out my backlog",
+                                                                   "sid": WKR})))
+        nd = next(iter(st["nodes"].values()))
+        self.assertNotIn("serving", nd)
+        self.assertEqual(nd["userAsk"]["text"], "sort out my backlog")
+
+    def test_the_one_shot_backfill_resolves_as_of_the_declaring_segment_once(self):
+        em.task_store_plan = lambda fsid: [{"key": "7", "text": "old declared step",
+                                            "activeForm": "", "status": "pending"}]
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / (WKR + ".jsonl")
+            recs = [dmail(T0, "m1", MID), aline(T0 + 30, "on it", "a1", "m1"),
+                    uline(T0 + 60, "declare it", "u2", "a1"), aline(T0 + 90, "declared", "a2", "u2")]
+            p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+            session = em.parse_session(str(p), rompuuid=WKR, candidate_files=[str(p)], now=NOW)
+            st = {"rompUuid": WKR, "nodes": {}, "placements": {}, "status": {}}
+            segs = [sg["id"] for turn in session["turns"] for sg in jd._segs(turn, st)]
+            st["nodes"][WKR + ":g5"] = jd.GuardedNode(
+                {"id": WKR + ":g5", "text": "old declared step", "parentId": None,
+                 "nodeComplete": False, "blocked": False, "cleared": False,
+                 "trail": [segs[-1]], "t": T0 + 60, "mt": T0 + 60,
+                 "why": "declared in the agent's own to-do list",
+                 "agentTask": {"key": "7", "status": "open", "raw": "pending"},
+                 "agentBornOpen": True, "log": []})
+            st["seq"] = 5
+            jd._sync_declared_plan(st, session, segs[-1], NOW, ctx=lambda: (None, None))
+            nd = st["nodes"][WKR + ":g5"]
+            self.assertEqual(nd["serving"]["msgId"], MID, "back-filled as-of its own segment")
+            self.assertEqual(nd["servingT"], NOW, "latched — never re-attempted")
+
+    def test_frame_enrichment_treats_serving_as_origin(self):
+        st = self._store()
+        st["nodes"][WKR + ":g5"] = {"id": WKR + ":g5", "text": "t", "parentId": None,
+                                    "serving": {"peer": SND, "msgId": MID, "goalId": None},
+                                    "frame": "pick per-metric ranges for the panels"}
+        self.assertIn("pick per-metric ranges", jd._deleg_frame(st, WKR + ":g5"),
+                      "a serving mirror's dispatch frames its prose (T137)")
+
+
+class FoldMatrix(unittest.TestCase):
+    """The view-side fold: a serving-marked mirror top joins the sender's ask card at render —
+    read-only, cross-store, never orphaning — and needs-you BREAKS THROUGH (a blocked serving
+    mirror stands on the board like any needs-you card)."""
+
+    def setUp(self):
+        km._downtime[:] = []
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"
+        cdir.mkdir()
+        proj = td / "projects"
+        import re as _re
+        pdir = proj / _re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        for sid, nm in ((SND, "web"), (WKR, "api")):
+            recs = [uline(T0, "kick off the panels round", "hu-" + nm, ps="typed"),
+                    aline(T0 + 20, "On it.", "a-" + nm, "hu-" + nm)]
+            (pdir / (sid + ".jsonl")).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        names = td / "names"
+        names.mkdir()
+        (names / SND).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        (names / WKR).write_text("api\t%s\t#ffaa00\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
+        jd.gist_llm = lambda p: ""
+        km._autonudge_cache.clear()
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        jd.STATE = td
+        km.NAMES = names
+        km._tmux_sessions = lambda: {
+            SND: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                  "context": None, "compactPct": None, "color": None},
+            WKR: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                  "context": None, "compactPct": None, "color": None}}
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm) = self.saved
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _sender_store(self):
+        ask, trk, sub = SND + ":g1", SND + ":g2", SND + ":g3"
+        (jd.GOALDIR / (SND + ".json")).write_text(json.dumps({
+            "rompUuid": SND, "seq": 3, "lastNode": ask,
+            "nodes": {ask: {"id": ask, "text": "Ship the panels round", "parentId": None,
+                            "nodeComplete": False, "blocked": False, "cleared": False,
+                            "trail": [], "t": NOW - 300, "mt": NOW - 300, "log": []},
+                      trk: {"id": trk, "text": "\u21aa delegated to api: pick the ranges",
+                            "parentId": ask, "nodeComplete": False, "blocked": False,
+                            "cleared": False, "trail": [], "t": NOW - 250, "mt": NOW - 250,
+                            "handoff": {"peer": WKR, "msgId": MID}, "log": []},
+                      sub: {"id": sub, "text": "the round's own step", "parentId": ask,
+                            "nodeComplete": False, "blocked": False, "cleared": False,
+                            "trail": [], "t": NOW - 240, "mt": NOW - 240, "log": []}},
+            "placements": {}, "status": {ask: "working"}}))
+        return ask, trk
+
+    def _worker_store(self, serving=True, blocked=False, goal_id=None):
+        g = WKR + ":g5"
+        nd = {"id": g, "text": "probe the axes", "parentId": None,
+              "nodeComplete": False, "blocked": blocked, "cleared": False,
+              "trail": [], "t": NOW - 200, "mt": NOW - 200,
+              "why": "declared in the agent's own to-do list",
+              "agentTask": {"key": "1", "status": "open", "raw": "pending"},
+              "agentBornOpen": True, "log": []}
+        if blocked:
+            nd["blockWhy"] = "pick a range basis"
+        if serving:
+            nd["serving"] = {"peer": SND, "msgId": MID,
+                             "goalId": goal_id if goal_id is not None else SND + ":g2"}
+        (jd.GOALDIR / (WKR + ".json")).write_text(json.dumps({
+            "rompUuid": WKR, "seq": 5, "lastNode": g, "nodes": {g: nd},
+            "placements": {}, "status": {g: "blocked" if blocked else "working"}}))
+        return g
+
+    def test_a_working_serving_mirror_folds_into_the_ask_card(self):
+        ask, trk = self._sender_store()
+        g = self._worker_store()
+        asks = km.build_feed(NOW)["asks"]
+        self.assertNotIn(g, {a.get("itemId") for a in asks},
+                         "no standalone worker card — fan-out lives inside the ask card")
+        card = next(a for a in asks if a.get("itemId") == ask)
+        rows = {r["id"]: r for r in card["tree"]}
+        self.assertIn(g, rows, "the step rides the ask card's tree")
+        self.assertIn(g, rows[trk].get("children") or [],
+                      "…as a child of its dispatch's tracker row")
+        self.assertEqual(rows[g]["who"], "api", "the row wears the WORKER's identity")
+        self.assertEqual(rows[g]["auth"], "open", "authority disc intact across the join")
+
+    def test_a_blocked_serving_mirror_breaks_through(self):
+        self._sender_store()
+        g = self._worker_store(blocked=True)
+        asks = km.build_feed(NOW)["asks"]
+        card = next((a for a in asks if a.get("itemId") == g), None)
+        self.assertIsNotNone(card, "needs-you NEVER folds silently — the card stands")
+        self.assertEqual(card["column"], "needs_input")
+
+    def test_a_missing_tracker_keeps_the_standalone_card(self):
+        self._sender_store()
+        g = self._worker_store(goal_id=SND + ":gone")
+        asks = km.build_feed(NOW)["asks"]
+        self.assertIn(g, {a.get("itemId") for a in asks},
+                      "no rendered home → the card stays; suppression never hides live work")
+
+    def test_a_legacy_mirror_without_serving_is_untouched(self):
+        self._sender_store()
+        g = self._worker_store(serving=False)
+        asks = km.build_feed(NOW)["asks"]
+        self.assertIn(g, {a.get("itemId") for a in asks})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/reviewed-fold.test.ts
+++ b/ui/webview/reviewed-fold.test.ts
@@ -31,7 +31,7 @@ test("kernel: summaryStale = followupAt postdates the read summary; self-clears 
 });
 
 test("kernel: reviewedEarlier keys on the SHARED review boundary, never a second derivation", () => {
-  assert.match(KERNEL, /"tree": flatten\(nid, \[\], boundary=jd\.review_boundary\(nodes\[nid\]\)\)\}\)/);
+  assert.match(KERNEL, /"tree": flatten\(nid, \[\], boundary=jd\.review_boundary\(nodes\[nid\]\)\)\}/);
   assert.match(KERNEL, /"reviewedEarlier": bool\(boundary and out and done\s*\n\s*and jd\._done_since\(nd\) <= boundary\) or None,/);
   // the shared helper: settle boundary advanced to the summary watermark on a reopen past it
   assert.match(JUDGE, /def review_boundary\(nd\):/);


### PR DESCRIPTION
The last mint path outside the T101 ruling: the agent to-do mirror declared every step as a standalone worker-board top with zero ask context (97% of the two teams' 33 mirror tops followed a dispatch delivery). The dispatched attach-under-the-tracker shape was contradicted by six codified contracts (sender-owned tracker children, store-local plan-sync completion, quiet dispatches planting no recipient node, the lift expelling open children, suppression/nudge gates flipping on non-handoff leaves, card-level handoff opacity) — this is the constraint-fitting equivalent, approved as shaped.

**The serving stamp**: a step declared while serving a linked dispatch carries `serving` ({peer, msgId, goalId} — distinct from origin/links, which would let the first step-completion check off the whole tracker). Latched at mint on a named event: the newest delegate-kind segment at or before the declaration, transcript-positional, episode-bounded; a gone declaring segment attributes nothing. The dispatch's frame + walked root-ask thread into the node (the writers anchor); dispatch-less declarations thread the session's own prompt record. A one-shot back-fill stamps existing open mirrors as-of their own declaring segment.

**The view-side fold**: build_feed folds a serving-marked top out of the standalone board and joins its rows under the dispatch's tracker row inside the sender's ask card — read-only, render-time, cross-store; the node stays in the worker's store where completion/nudge/clear machinery lives. Candidate-commit: the fold commits only when the tracker row rendered this build, else the card stands (never orphan live work). **Needs-you breaks through**: folding only from quiet columns.

**Measured**: 33 mirror tops ever on the two teams, 32 serving-eligible (97%); 1 still open back-fills and folds on deploy.

Tests: resolver matrix, stamp + latch + back-fill, frame/root-ask anchoring, and the fold matrix incl. the breakthrough pin. Docs updated from the pre-ask-unit grouper-nests world.

Suites: Python 5879/0 (+313 subtests), UI 2502/2502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)