### PR TITLE
ScheduleWakeup and crons don't fire on idle sessions

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24624,6 +24624,14 @@ def _producer():
                                    # transcript → bump the generation so the chat-build cache re-builds the
                                    # background tabs once, keeping their Fleet status/ledger fresh (≤ this cadence).
             _apply_pending_ops()      # FIFO-deliver everything parked during a compaction that has now ended
+            try:                      # sessions with ARMED TIMERS need a LIVE CLI (the user 2026-08-28:
+                _sbe = _sdk()         # crons/wakeups never fired on dormant sessions — the CLI's scheduler
+                if _sbe and _sdk_ready():   # is in-process; see SdkBackend.ensure_scheduled)
+                    _sbe.ensure_scheduled()
+                    _sbe.deliver_lost_wakeups()   # one-shots a process recycle orphaned (revival loses
+                    #                               ScheduleWakeup arms; the reg record outlives them)
+            except Exception:
+                sys.stderr.write("scheduled-sweep: %s\n" % traceback.format_exc())
         except Exception:
             sys.stderr.write("producer: %s\n" % traceback.format_exc())
         finally:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1381,6 +1381,15 @@ class SdkSession:
         self.name = reg.get("name", self.sid)
         self.cwd = reg.get("cwd") or os.path.expanduser("~")
         self.mode = reg.get("mode") or "acceptEdits"
+        # The PROCESS GENERATION stamp: session-scoped timers live in THIS CLI process's memory, so
+        # every armed-timer record carries the generation that armed it (procGen). A recorded timer
+        # whose generation is still the live one WILL be fired by the CLI itself — the kernel must
+        # never race it; a timer whose generation is gone can never fire CLI-side — the kernel owns
+        # its delivery. Exact ownership, no grace-window guessing (review of #769, 2026-08-28).
+        # A uuid, never a clock: two objects born in the same millisecond aliased a rounded
+        # timestamp (CI caught it), and aliased generations would hand a live process's timer to
+        # the kernel. The time prefix is for humans reading regs, not for identity.
+        self.proc_gen = "%d.%s" % (int(time.time()), uuid.uuid4().hex[:10])
         self.resume_sid = reg.get("lastSid") or None  # resume target after a restart/crash
         # A FORK being born (backend.fork): lastSid points at the PARENT's transcript and forkOf marks the
         # resume as a fork, so _options adds fork_session (+ the resume-session-at cut) and the CLI copies
@@ -2787,33 +2796,111 @@ class SdkSession:
                 prev = (read_reg(self.backend.state_dir, self.sid) or {})
                 nw = time.time()
                 known = {c.get("id"): c for c in (prev.get("sessionCrons") or []) if isinstance(c, dict)}
-                slim = [{"id": str(c.get("id") or ""), "cron": str(c.get("schedule") or c.get("cron") or ""),
-                         "prompt": str(c.get("prompt") or "")[:500], "kind": str(c.get("kind") or ""),
-                         "recurring": bool(c.get("recurring")),
-                         # armedAt rides each ENTRY (first-seen time), so a one-shot's due moment never
-                         # shifts when the record is rewritten by later turns' hooks
-                         "armedAt": int((known.get(str(c.get("id") or "")) or {}).get("armedAt") or nw)}
-                        for c in crons if isinstance(c, dict)]
+                # Adoption pool for the CALL-TIME records (_sched_tool_hook): a toolhook entry knows the
+                # EXACT dueEpoch but minted its own id; the payload entry carries the CLI's id but no
+                # date. Marry them by prompt + near-due so the reg ends with the CLI's id AND the exact
+                # date, and the toolhook duplicate drops.
+                toolhook = [c for c in (prev.get("sessionCrons") or [])
+                            if isinstance(c, dict) and c.get("src") == "toolhook"]
+
+                def adopt(c):
+                    p = str(c.get("prompt") or "")[:500]
+                    hint = wakeup_due_epoch(str(c.get("schedule") or c.get("cron") or ""),
+                                            float((known.get(str(c.get("id") or "")) or {}).get("armedAt") or nw))
+                    for t in toolhook:
+                        if t.get("prompt") == p and (hint is None or abs(float(t.get("dueEpoch") or 0) - hint) < 90):
+                            return t
+                    return None
+
+                slim = []
+                for c in crons:
+                    if not isinstance(c, dict):
+                        continue
+                    src = adopt(c) or known.get(str(c.get("id") or "")) or {}
+                    slim.append({"id": str(c.get("id") or ""), "cron": str(c.get("schedule") or c.get("cron") or ""),
+                                 "prompt": str(c.get("prompt") or "")[:500], "kind": str(c.get("kind") or ""),
+                                 "recurring": bool(c.get("recurring")),
+                                 # armedAt/dueEpoch/procGen ride each ENTRY from its first record (the
+                                 # call-time hook when it saw the arm; else first-seen here), so a
+                                 # one-shot's due moment never shifts when later turns rewrite the set
+                                 "armedAt": float(src.get("armedAt") or nw),
+                                 "dueEpoch": (float(src["dueEpoch"]) if src.get("dueEpoch") else None),
+                                 "procGen": str(src.get("procGen") or self.proc_gen)})
                 # MERGE, don't overwrite: a recycled process LOSES ScheduleWakeup one-shots (verified
                 # live 2026-08-28), so the fresh process's payload lacks them — and blindly writing the
-                # payload erased the very record deliver_lost_wakeups needs, BEFORE the wakeup was due.
-                # A reg one-shot absent from the payload survives while its due is STRICTLY future: a
-                # genuinely FIRED one-shot is always past due at its own turn's Stop hook, so it still
-                # drops here (no double-fire), while a recycle-orphaned one stays recorded for the
-                # sweep to deliver at due. (Residual, accepted: an agent CronDelete-ing a pending
-                # wakeup pre-due gets one spurious wake — rarer and cheaper than the silent miss.)
+                # payload would erase the very record deliver_lost_wakeups needs. An absent one-shot
+                # survives while ITS PROCESS GENERATION is gone (the CLI that could have fired it no
+                # longer exists, so absence from a NEW process's payload is not evidence it fired) —
+                # ownership is exact, no due-time guessing. A one-shot recorded by the LIVE generation
+                # and absent from its own payload genuinely fired or was cancelled: it drops.
                 have = {c.get("id") for c in slim}
+                adopted = {id(t) for c in crons if isinstance(c, dict) for t in [adopt(c)] if t is not None}
                 for c in (prev.get("sessionCrons") or []):
-                    if isinstance(c, dict) and not c.get("recurring") and c.get("id") not in have:
-                        due = wakeup_due_epoch(c.get("cron"),
-                                               float(c.get("armedAt") or prev.get("sessionCronsAt") or nw))
-                        if due is not None and due > nw:
-                            slim.append(c)
+                    if (isinstance(c, dict) and not c.get("recurring") and c.get("id") not in have
+                            and id(c) not in adopted
+                            and str(c.get("procGen") or "") != self.proc_gen):
+                        slim.append(c)
                 if slim != prev.get("sessionCrons"):
                     self.backend._update_reg(self.sid, sessionCrons=slim, sessionCronsAt=int(nw))
         except Exception as e:
             self.backend._log("stop hook (%s): session_crons record failed: %s" % (self.name, e))
         self.backend._poke()
+        return {}
+
+    async def _sched_tool_hook(self, inp, tool_use_id, context):
+        """PostToolUse on the scheduling tools (ScheduleWakeup / CronCreate / CronDelete): record the
+        arm at the CALL moment with an ABSOLUTE due time, instead of waiting for the turn's Stop hook.
+        End-of-turn-only recording had three holes (review of #769, 2026-08-28): armedAt stamped at
+        turn END wrapped a same-turn-past-due wakeup to TOMORROW (the cron string carries no date); a
+        restart mid-turn lost the arm entirely (the Stop hook never ran); and reconstruction from a
+        dateless "M H * * *" string is guesswork the tool INPUT makes unnecessary — delaySeconds is
+        right there, so dueEpoch = now + delaySeconds is exact. Entries minted here carry
+        src:"toolhook" and a synthetic id; the Stop hook's reconciler marries them to the CLI's own
+        ids (see adopt() above) and remains the safety net if this hook ever misses a shape.
+        Defensive throughout: an unrecognized payload records nothing and logs, never raises."""
+        try:
+            tname = str((inp or {}).get("tool_name") or "")
+            targs = (inp or {}).get("tool_input") or {}
+            if not isinstance(targs, dict):
+                return {}
+            nw = time.time()
+            prev = (read_reg(self.backend.state_dir, self.sid) or {})
+            cur = [c for c in (prev.get("sessionCrons") or []) if isinstance(c, dict)]
+            if tname == "ScheduleWakeup":
+                if targs.get("stop"):
+                    # a dynamic loop ending: drop this session's pending toolhook one-shots — the CLI
+                    # cancels its own pending wakeup on stop, and keeping ours would fabricate a wake
+                    cur = [c for c in cur if not (c.get("src") == "toolhook" and not c.get("recurring"))]
+                    self.backend._update_reg(self.sid, sessionCrons=cur, sessionCronsAt=int(nw))
+                    return {}
+                delay = targs.get("delaySeconds")
+                prompt = str(targs.get("prompt") or "")[:500]
+                if not isinstance(delay, (int, float)) or delay <= 0 or not prompt:
+                    return {}
+                due = nw + max(60.0, min(3600.0, float(delay)))   # the runtime clamps to [60, 3600]
+                # ONE pending wakeup per session, matching ScheduleWakeup's own semantics (arming
+                # replaces the previous pending wakeup): drop earlier toolhook one-shots first
+                cur = [c for c in cur if not (c.get("src") == "toolhook" and not c.get("recurring"))]
+                cur.append({"id": "toolhook-%d" % int(due), "cron": "", "prompt": prompt,
+                            "kind": str(targs.get("reason") or "")[:120], "recurring": False,
+                            "armedAt": nw, "dueEpoch": due, "procGen": self.proc_gen, "src": "toolhook"})
+            elif tname == "CronCreate":
+                nm = str(targs.get("name") or targs.get("id") or ("cron-%d" % int(nw)))
+                cur = [c for c in cur if c.get("id") != nm]
+                cur.append({"id": nm, "cron": str(targs.get("schedule") or ""),
+                            "prompt": str(targs.get("prompt") or "")[:500], "kind": "cron",
+                            "recurring": True, "armedAt": nw, "dueEpoch": None,
+                            "procGen": self.proc_gen, "src": "toolhook"})
+            elif tname == "CronDelete":
+                nm = str(targs.get("name") or targs.get("id") or "")
+                if not nm:
+                    return {}
+                cur = [c for c in cur if c.get("id") != nm]
+            else:
+                return {}
+            self.backend._update_reg(self.sid, sessionCrons=cur, sessionCronsAt=int(nw))
+        except Exception as e:
+            self.backend._log("sched tool hook (%s): %s" % (self.name, e))
         return {}
 
     # ---- subagent tracking (the transparency tmux never had) ----
@@ -4077,7 +4164,11 @@ class SdkBackend:
             can_use_tool=sess._can_use_tool,
             hooks={"Stop": [HookMatcher(matcher=None, hooks=[sess._stop_hook])],          # awaiting overlay producer
                    "SubagentStart": [HookMatcher(matcher=None, hooks=[sess._subagent_start_hook])],  # live subagent
-                   "SubagentStop": [HookMatcher(matcher=None, hooks=[sess._subagent_stop_hook])]},    #   count/types
+                   "SubagentStop": [HookMatcher(matcher=None, hooks=[sess._subagent_stop_hook])],    #   count/types
+                   # scheduling tools record their arm at the CALL moment, with the exact due time the
+                   # tool input carries — the Stop hook's set-record reconciles (see _sched_tool_hook)
+                   "PostToolUse": [HookMatcher(matcher="ScheduleWakeup|CronCreate|CronDelete",
+                                               hooks=[sess._sched_tool_hook])]},
             permission_mode=sess.mode,
             # File-checkpoint rewind (the user 2026-08-04): the CLI backs files up before modifying them,
             # so rewind_files() can put the workspace back to its state at any user message. The uuid a
@@ -5178,10 +5269,24 @@ class SdkBackend:
             if now - cool.get(sid, 0) < 120:
                 continue
             cool[sid] = now
-            if self._ensure(sid) is not None:
-                n += 1
-                self._log("scheduled-session sweep: reviving %s — %d armed timer(s) need a live process"
-                          % (reg.get("name") or sid[:13], len(reg.get("sessionCrons") or [])))
+            # Spawns draw a slot on the ONE machine-wide _spawn_sem, like boot reconcile and the
+            # idle-queue drive: without it a kernel restart with N timer-armed sessions launched N
+            # claude processes in one pass — the exact CPU storm the stagger exists to prevent
+            # (review of #769, 2026-08-28). No slot this pass → the cooldown map retries later.
+            slot = self._spawn_sem.acquire(timeout=0.1)
+            if not slot:
+                cool[sid] = 0                       # don't burn the 120s floor on a full stagger
+                continue
+            try:
+                if self._ensure(sid, on_boot_settled=self._spawn_sem.release) is not None:
+                    n += 1
+                    self._log("scheduled-session sweep: reviving %s — %d armed timer(s) need a live process"
+                              % (reg.get("name") or sid[:13], len(reg.get("sessionCrons") or [])))
+                else:
+                    self._spawn_sem.release()       # nothing spawned — the parked release never attaches
+            except Exception:
+                self._spawn_sem.release()
+                raise
         return n
 
     def deliver_lost_wakeups(self) -> int:
@@ -5195,10 +5300,14 @@ class SdkBackend:
         prompt through the normal send path (revives a dormant session) and strip the record first, so
         the next pass can never double-deliver.
 
-        The grace (90s) absorbs the fired-turn window on the healthy path: right after a genuine fire
-        the entry is still recorded until that turn's Stop hook runs, and a mid-turn session is skipped
-        outright — by the time it idles, a genuine fire has erased the record. Sessions whose turn is
-        in flight are left alone this pass; the record keeps them re-checked next pass."""
+        OWNERSHIP IS BY PROCESS GENERATION, not by guessing from timing (review of #769, 2026-08-28:
+        the first cut used a 90s grace + an inflight check, and both were blind to turns the CLI's own
+        scheduler starts — a genuinely-fired wakeup whose turn outlasted the grace got delivered a
+        second time, mid-turn). Every recorded entry carries procGen, the stamp of the CLI process
+        that armed it. That generation still live → the CLI itself will fire it at due; the kernel
+        NEVER touches it, however late the record looks. That generation gone → no process can ever
+        fire it; the kernel owns it outright and delivers at due (a small 5s grace covers clock skew
+        between the stamp and this sweep, not any behavioral window)."""
         now = time.time()
         fired = 0
         for reg in list_regs(self.state_dir):
@@ -5211,13 +5320,16 @@ class SdkBackend:
             sid = reg["sid"]
             with self._lock:
                 s = self.sessions.get(sid)
-                if s and s.thread.is_alive() and s.inflight > 0:
-                    continue                      # mid-turn: a genuine fire may be settling — re-check next pass
+                live_gen = s.proc_gen if (s and s.thread.is_alive()) else None
             due_shots = []
             for c in shots:
-                armed_t = float(c.get("armedAt") or reg.get("sessionCronsAt") or (now - 3600))
-                due = wakeup_due_epoch(c.get("cron"), armed_t)
-                if due is not None and now >= due + 90:
+                if live_gen is not None and str(c.get("procGen") or "") == live_gen:
+                    continue                      # its arming process is alive — the CLI fires it, not us
+                due = c.get("dueEpoch")
+                if not due:                       # legacy entry without the exact date → reconstruct
+                    due = wakeup_due_epoch(c.get("cron"),
+                                           float(c.get("armedAt") or reg.get("sessionCronsAt") or (now - 3600)))
+                if due is not None and now >= float(due) + 5:
                     due_shots.append(c)
             if not due_shots:
                 continue

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1046,6 +1046,29 @@ def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> i
     return None
 
 
+def wakeup_due_epoch(cron: str, armed_t: float) -> "float | None":
+    """The due moment of a ONE-SHOT wakeup cron ("<min> <hour> * * *", the shape ScheduleWakeup mints
+    from delaySeconds, local time) — the first occurrence of H:M at/after the arm record. Any other
+    shape returns None: romp only ever self-fires timers it can reason about exactly; everything else
+    stays the CLI scheduler's job. Pure for tests."""
+    try:
+        m, h, dom, mon, dow = str(cron).split()
+        if (dom, mon, dow) != ("*", "*", "*"):
+            return None
+        m, h = int(m), int(h)
+        if not (0 <= m <= 59 and 0 <= h <= 23):
+            return None
+    except (ValueError, AttributeError):
+        return None
+    from datetime import datetime, timedelta   # local, like the reg-timestamp reader's (this module
+    #                                            otherwise never needs datetime at import time)
+    base = datetime.fromtimestamp(float(armed_t))
+    due = base.replace(hour=h, minute=m, second=0, microsecond=0)
+    if due.timestamp() < armed_t - 60:            # H:M already passed at arm time → the wrap is tomorrow
+        due += timedelta(days=1)
+    return due.timestamp()
+
+
 def interrupt_action(level: int, channel_up: bool) -> tuple[str, int]:
     """The interrupt escalation ladder (terminal parity, the user 2026-07-10): what a stop press does,
     given how far the current episode has climbed. In a terminal ctrl+c is a SIGNAL the process cannot
@@ -2750,6 +2773,46 @@ class SdkSession:
         ignores inp['background_tasks'] and just clears any stale awaiting:true — keeping the overlay
         channel available for signals that need durability across a backend restart."""
         append_awaiting(self.backend.state_dir, self.sid, False)
+        # Record the ARMED TIMER SET (the hook payload's session_crons: CronCreate crons, ScheduleWakeup
+        # wakeups, /loop ticks). Session-scoped timers live ONLY in the CLI process's memory — the tool
+        # result itself says "dies when Claude exits" — so a session romp leaves DORMANT has no process
+        # at the due moment and the timer silently never fires (the user 2026-08-28: wakeups armed for
+        # 26 minutes out missed across 21 hours; agents built crontab workarounds). This record is what
+        # lets the kernel keep timer-armed sessions CONNECTED (its scheduled-session sweep) so the CLI's
+        # own scheduler — which fires fine on a live idle process — does the firing. Written on every
+        # turn end, including [] when the last timer is cancelled, so the reg never pins a stale set.
+        try:
+            crons = inp.get("session_crons") if isinstance(inp, dict) else None
+            if isinstance(crons, list):
+                prev = (read_reg(self.backend.state_dir, self.sid) or {})
+                nw = time.time()
+                known = {c.get("id"): c for c in (prev.get("sessionCrons") or []) if isinstance(c, dict)}
+                slim = [{"id": str(c.get("id") or ""), "cron": str(c.get("schedule") or c.get("cron") or ""),
+                         "prompt": str(c.get("prompt") or "")[:500], "kind": str(c.get("kind") or ""),
+                         "recurring": bool(c.get("recurring")),
+                         # armedAt rides each ENTRY (first-seen time), so a one-shot's due moment never
+                         # shifts when the record is rewritten by later turns' hooks
+                         "armedAt": int((known.get(str(c.get("id") or "")) or {}).get("armedAt") or nw)}
+                        for c in crons if isinstance(c, dict)]
+                # MERGE, don't overwrite: a recycled process LOSES ScheduleWakeup one-shots (verified
+                # live 2026-08-28), so the fresh process's payload lacks them — and blindly writing the
+                # payload erased the very record deliver_lost_wakeups needs, BEFORE the wakeup was due.
+                # A reg one-shot absent from the payload survives while its due is STRICTLY future: a
+                # genuinely FIRED one-shot is always past due at its own turn's Stop hook, so it still
+                # drops here (no double-fire), while a recycle-orphaned one stays recorded for the
+                # sweep to deliver at due. (Residual, accepted: an agent CronDelete-ing a pending
+                # wakeup pre-due gets one spurious wake — rarer and cheaper than the silent miss.)
+                have = {c.get("id") for c in slim}
+                for c in (prev.get("sessionCrons") or []):
+                    if isinstance(c, dict) and not c.get("recurring") and c.get("id") not in have:
+                        due = wakeup_due_epoch(c.get("cron"),
+                                               float(c.get("armedAt") or prev.get("sessionCronsAt") or nw))
+                        if due is not None and due > nw:
+                            slim.append(c)
+                if slim != prev.get("sessionCrons"):
+                    self.backend._update_reg(self.sid, sessionCrons=slim, sessionCronsAt=int(nw))
+        except Exception as e:
+            self.backend._log("stop hook (%s): session_crons record failed: %s" % (self.name, e))
         self.backend._poke()
         return {}
 
@@ -5079,6 +5142,103 @@ class SdkBackend:
 
     def owns(self, sid: str) -> bool:
         return read_reg(self.state_dir, sid) is not None
+
+    def ensure_scheduled(self) -> int:
+        """Keep a CLI process ALIVE for every session with ARMED SESSION TIMERS (reg sessionCrons, the
+        Stop hook's record of CronCreate/ScheduleWakeup//loop arms). Session-scoped timers exist only in
+        the CLI process's memory and its scheduler fires fine on a live IDLE process — but a DORMANT
+        session has no process at the due moment and the timer silently never fires (the user
+        2026-08-28: a wakeup armed for 26 minutes out missed across 21 hours; a cron missed every tick
+        while parked, then fired reliably for days once its session stayed active). So the kernel's
+        producer calls this every pass: any alive, timer-armed session with no running thread is
+        reconnected — resume re-hydrates its timer set (verified live 2026-08-28: CronList shows the
+        same cron in a fresh process after a kill), and the CLI does ALL the firing natively; romp
+        never fires a timer itself. Residual, accepted: a timer due inside the ~minute a kernel
+        restart takes can still miss (the down window has no process to fire it and no catch-up
+        exists for session-scoped timers CLI-side).
+
+        A 120s per-sid retry floor bounds the failure mode where a timer-armed session's CLI dies
+        instantly on every spawn — without it this sweep would respawn it every producer pass
+        (~3s), a spawn storm. Returns how many sessions were revived this pass."""
+        now = time.time()
+        cool = getattr(self, "_sched_attempts", None)
+        if cool is None:
+            cool = self._sched_attempts = {}
+        n = 0
+        for reg in list_regs(self.state_dir):
+            if not reg.get("alive") or reg.get("threadOf"):
+                continue
+            if not reg.get("sessionCrons"):
+                continue
+            sid = reg["sid"]
+            with self._lock:
+                s = self.sessions.get(sid)
+                if s and s.thread.is_alive():
+                    continue
+            if now - cool.get(sid, 0) < 120:
+                continue
+            cool[sid] = now
+            if self._ensure(sid) is not None:
+                n += 1
+                self._log("scheduled-session sweep: reviving %s — %d armed timer(s) need a live process"
+                          % (reg.get("name") or sid[:13], len(reg.get("sessionCrons") or [])))
+        return n
+
+    def deliver_lost_wakeups(self) -> int:
+        """Fire ONE-SHOT wakeups the CLI can no longer fire. A process recycle LOSES ScheduleWakeup
+        wakeups (verified live 2026-08-28: after a kill + revive, CronList re-hydrates the recurring
+        cron but the pending wakeup is gone) — so a wakeup armed before a kernel restart, an orphan
+        reap, or a reconnect never fires, however alive the session is now. The reg's armed-set record
+        (the Stop hook's sessionCrons) survives the recycle; when a one-shot recorded there is PAST DUE
+        by a grace and still recorded, nobody fired it: a live process fires one-shots at their exact
+        minute, and the fired turn's Stop hook rewrites the record without it. Deliver the wakeup's own
+        prompt through the normal send path (revives a dormant session) and strip the record first, so
+        the next pass can never double-deliver.
+
+        The grace (90s) absorbs the fired-turn window on the healthy path: right after a genuine fire
+        the entry is still recorded until that turn's Stop hook runs, and a mid-turn session is skipped
+        outright — by the time it idles, a genuine fire has erased the record. Sessions whose turn is
+        in flight are left alone this pass; the record keeps them re-checked next pass."""
+        now = time.time()
+        fired = 0
+        for reg in list_regs(self.state_dir):
+            if not reg.get("alive") or reg.get("threadOf"):
+                continue
+            crons = reg.get("sessionCrons") or []
+            shots = [c for c in crons if isinstance(c, dict) and not c.get("recurring")]
+            if not shots:
+                continue
+            sid = reg["sid"]
+            with self._lock:
+                s = self.sessions.get(sid)
+                if s and s.thread.is_alive() and s.inflight > 0:
+                    continue                      # mid-turn: a genuine fire may be settling — re-check next pass
+            due_shots = []
+            for c in shots:
+                armed_t = float(c.get("armedAt") or reg.get("sessionCronsAt") or (now - 3600))
+                due = wakeup_due_epoch(c.get("cron"), armed_t)
+                if due is not None and now >= due + 90:
+                    due_shots.append(c)
+            if not due_shots:
+                continue
+            keep = [c for c in crons if c not in due_shots]
+            try:                                  # strip FIRST — a send failure must not re-fire forever;
+                self._update_reg(sid, sessionCrons=keep)   # the loss is logged loudly below instead
+            except Exception as e:
+                self._log("lost-wakeup (%s): reg strip failed, not delivering: %s" % (reg.get("name") or sid[:13], e))
+                continue
+            for c in due_shots:
+                ok = False
+                try:
+                    ok = bool(self.send(sid, c.get("prompt") or ""))
+                except Exception as e:
+                    self._log("lost-wakeup (%s): delivery raised: %s" % (reg.get("name") or sid[:13], e))
+                self._log("lost-wakeup (%s): one-shot %s was due %.0fs ago with no process to fire it — %s"
+                          % (reg.get("name") or sid[:13], c.get("id") or "?",
+                             now - (wakeup_due_epoch(c.get("cron"), float(c.get("armedAt") or now)) or now),
+                             "prompt delivered" if ok else "DELIVERY FAILED (prompt lost — see above)"))
+                fired += 1
+        return fired
 
     def live_sessions(self) -> dict[str, dict]:
         """{sid: state-dict} for every alive SDK session — merged by the kernel

--- a/tests/test_scheduled_sessions.py
+++ b/tests/test_scheduled_sessions.py
@@ -16,7 +16,11 @@ thing: never leave a timer-armed session without a process. Three pieces, pinned
    idempotent, with a 120s per-sid retry floor so a spawn-crashing session can't become a storm.
 3. The kernel's producer calls the sweep every pass.
 
-Romp never fires a timer itself (no double-fire risk). Synthetic fixtures only."""
+Plus the catch-up half: entries record the PROCESS GENERATION that armed them (procGen) and, for
+one-shots, an ABSOLUTE dueEpoch captured at the ScheduleWakeup call by a PostToolUse hook. A one-shot
+whose arming generation is still alive belongs to the CLI, always; one whose generation is gone can
+never fire CLI-side, so the kernel delivers its prompt at due. Ownership is exact — no grace windows,
+no inflight guessing (review of #769, 2026-08-28). Synthetic fixtures only."""
 import asyncio
 import os
 import tempfile
@@ -63,6 +67,8 @@ class StopHookRecordsTheArmedSet(_Backend):
         self.assertEqual(len(rec), 1)
         armed = rec[0].pop("armedAt")
         self.assertAlmostEqual(armed, time.time(), delta=30, msg="first-seen arm time rides the entry")
+        self.assertEqual(rec[0].pop("procGen"), s.proc_gen, "the arming process generation rides the entry")
+        self.assertIsNone(rec[0].pop("dueEpoch"), "a recurring cron has no one-shot due moment")
         self.assertEqual(rec, [{"id": "aaaa1111", "cron": "50 * * * *",
                                 "prompt": "Reply with exactly: tick", "kind": "cron", "recurring": True}])
 
@@ -74,22 +80,28 @@ class StopHookRecordsTheArmedSet(_Backend):
         shot = {"id": "dddd4444", "schedule": "%d %d * * *" % (due[4], due[3]),
                 "prompt": "Reply with exactly: wake", "kind": "loop", "recurring": False}
         asyncio.run(s._stop_hook({"session_crons": [shot]}, None, None))
-        asyncio.run(s._stop_hook({"session_crons": []}, None, None))   # the fresh process knows nothing
+        fresh = sb.SdkSession(self.be, sb.read_reg(self.d, SID))   # the recycle: a NEW generation
+        self.assertNotEqual(fresh.proc_gen, s.proc_gen)
+        asyncio.run(fresh._stop_hook({"session_crons": []}, None, None))   # knows nothing of the wakeup
         rec = (sb.read_reg(self.d, SID) or {}).get("sessionCrons")
         self.assertEqual([c["id"] for c in rec], ["dddd4444"],
-                         "erasing it here was how the fix's first draft lost the wakeup pre-due")
+                         "an absent one-shot from a GONE generation is an orphan, not a cancellation")
 
-    def test_a_fired_one_shot_still_drops(self):
-        # a genuinely FIRED one-shot is always past due at its own turn's Stop hook (armed 17:08,
-        # due 17:13, fired 17:13, hook ~17:13:30) — strict-future keep means it drops here, so the
-        # sweep can never double-fire it. Plant the record with its arm time BEFORE the (past) due.
-        past = time.localtime(time.time() - 120)
-        rec = {"id": "eeee5555", "cron": "%d %d * * *" % (past[4], past[3]),
-               "prompt": "p", "kind": "loop", "recurring": False, "armedAt": int(time.time() - 600)}
-        self._reg(sessionCrons=[rec], sessionCronsAt=int(time.time() - 600))
+    def test_a_fired_or_cancelled_one_shot_of_the_LIVE_generation_drops(self):
+        # a one-shot the LIVE process no longer reports genuinely fired or was cancelled — the CLI is
+        # the owner of record for its own generation, so absence from its payload is the deciding
+        # event (no due-time reasoning at all; the first draft's strict-future keep got this wrong
+        # for past-due orphans, which it silently dropped before delivery could act).
+        self._reg()
         s = sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+        fut = time.localtime(time.time() + 600)
+        rec = {"id": "eeee5555", "cron": "%d %d * * *" % (fut[4], fut[3]),
+               "prompt": "p", "kind": "loop", "recurring": False,
+               "armedAt": time.time() - 600, "procGen": s.proc_gen}
+        self.be._update_reg(SID, sessionCrons=[rec], sessionCronsAt=int(time.time() - 600))
         asyncio.run(s._stop_hook({"session_crons": []}, None, None))
-        self.assertEqual((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), [])
+        self.assertEqual((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), [],
+                         "even a FUTURE one-shot drops when its own live process stops reporting it")
 
     def test_cancelling_the_last_timer_clears_the_record(self):
         s = self._sess()
@@ -204,21 +216,13 @@ class LostWakeupDelivery(_Backend):
         self.assertEqual(self.be.deliver_lost_wakeups(), 0)
         self.assertTrue((sb.read_reg(self.d, SID) or {}).get("sessionCrons"))
 
-    def test_the_grace_covers_a_genuine_fire_settling(self):
-        shot, armed = self._shot(due_offset=-30)       # due 30s ago — inside the 90s grace
-        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
-        self.be.send = lambda sid, text: self.fail("a genuine fire's Stop hook gets time to erase the record")
-        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
-
-    def test_recurring_crons_are_never_self_fired(self):
-        shot, armed = self._shot(due_offset=-300, recurring=True)
-        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
-        self.be.send = lambda sid, text: self.fail("recurring = keep-alive only; the CLI fires those")
-        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
-
-    def test_a_mid_turn_session_is_left_alone(self):
+    def test_a_live_generations_one_shot_is_the_CLIs_however_late_it_looks(self):
+        # THE double-fire fix (review of #769, 2026-08-28): the first draft guessed ownership from a
+        # 90s grace + an inflight counter that CLI-native turns never increment, so a fired wakeup
+        # whose turn ran long got delivered a second time mid-turn. Ownership is now the arming
+        # process generation: while that process lives, the kernel never touches its timers — five
+        # minutes past due, mid-turn, whenever.
         shot, armed = self._shot(due_offset=-300)
-        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
 
         class T:
             def is_alive(self):
@@ -226,10 +230,79 @@ class LostWakeupDelivery(_Backend):
 
         class S:
             thread = T()
-            inflight = 1
+            proc_gen = "gen-live"
+        shot["procGen"] = S.proc_gen
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
         self.be.sessions[SID] = S()
-        self.be.send = lambda sid, text: self.fail("mid-turn: a genuine fire may be settling")
+        self.be.send = lambda sid, text: self.fail("its arming process is alive — the CLI fires it, not us")
         self.assertEqual(self.be.deliver_lost_wakeups(), 0)
+        self.assertTrue((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), "and the record stays")
+
+    def test_recurring_crons_are_never_self_fired(self):
+        shot, armed = self._shot(due_offset=-300, recurring=True)
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+        self.be.send = lambda sid, text: self.fail("recurring = keep-alive only; the CLI fires those")
+        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
+
+    def test_a_dead_generations_one_shot_delivers_even_while_a_NEW_process_runs(self):
+        # ensure_scheduled revives the session, but the fresh CLI cannot fire a one-shot the dead
+        # process held — the recycle loses it (verified live 2026-08-28). Generation mismatch says
+        # exactly that, so the kernel delivers despite the live thread.
+        shot, armed = self._shot(due_offset=-300)
+        shot["procGen"] = "gen-dead"                    # armed by a long-gone process
+
+        class T:
+            def is_alive(self):
+                return True
+
+        class S:
+            thread = T()
+            proc_gen = "gen-new"                        # the NEW process
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+        self.be.sessions[SID] = S()
+        sent = []
+        self.be.send = lambda sid, text: sent.append((sid, text)) or True
+        self.assertEqual(self.be.deliver_lost_wakeups(), 1)
+        self.assertEqual(len(sent), 1)
+
+    def test_the_call_time_hook_records_an_exact_due(self):
+        # ScheduleWakeup's PostToolUse hook: dueEpoch = call time + delaySeconds, no cron-string
+        # reconstruction, no tomorrow-wrap (the armedAt-at-turn-end defect class dies here)
+        self._reg()
+        s = sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+        asyncio.run(s._sched_tool_hook({"tool_name": "ScheduleWakeup",
+                                        "tool_input": {"delaySeconds": 120, "prompt": "loop tick",
+                                                       "reason": "watching CI"}}, None, None))
+        rec = (sb.read_reg(self.d, SID) or {}).get("sessionCrons")
+        self.assertEqual(len(rec), 1)
+        self.assertAlmostEqual(rec[0]["dueEpoch"], time.time() + 120, delta=30)
+        self.assertEqual(rec[0]["procGen"], s.proc_gen)
+        self.assertFalse(rec[0]["recurring"])
+        # arming again REPLACES the pending wakeup (the tool's own semantics)
+        asyncio.run(s._sched_tool_hook({"tool_name": "ScheduleWakeup",
+                                        "tool_input": {"delaySeconds": 600, "prompt": "later tick"}}, None, None))
+        rec = (sb.read_reg(self.d, SID) or {}).get("sessionCrons")
+        self.assertEqual([c["prompt"] for c in rec], ["later tick"])
+        # stop:true ends the loop: the pending toolhook one-shot drops
+        asyncio.run(s._sched_tool_hook({"tool_name": "ScheduleWakeup",
+                                        "tool_input": {"stop": True}}, None, None))
+        self.assertEqual((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), [])
+
+    def test_the_stop_hook_marries_a_toolhook_record_to_the_CLIs_id(self):
+        # the toolhook entry knows the exact date; the Stop payload knows the CLI's id — the
+        # reconciler keeps both (one entry, CLI id, exact dueEpoch) and drops the duplicate
+        self._reg()
+        s = sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+        asyncio.run(s._sched_tool_hook({"tool_name": "ScheduleWakeup",
+                                        "tool_input": {"delaySeconds": 300, "prompt": "the tick"}}, None, None))
+        due = time.localtime(time.time() + 300)
+        payload = [{"id": "cli-42", "schedule": "%d %d * * *" % (due[4], due[3]),
+                    "prompt": "the tick", "kind": "loop", "recurring": False}]
+        asyncio.run(s._stop_hook({"session_crons": payload}, None, None))
+        rec = (sb.read_reg(self.d, SID) or {}).get("sessionCrons")
+        self.assertEqual([c["id"] for c in rec], ["cli-42"], "one entry, the CLI's id")
+        self.assertAlmostEqual(rec[0]["dueEpoch"], time.time() + 300, delta=30,
+                               msg="…wearing the toolhook's exact due date")
 
 
 class ProducerRunsTheSweep(unittest.TestCase):

--- a/tests/test_scheduled_sessions.py
+++ b/tests/test_scheduled_sessions.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Sessions with armed timers keep a live CLI process (the user 2026-08-28: CronCreate crons and
+ScheduleWakeup wakeups never fired on sessions romp had left dormant — a wakeup armed for 26 minutes
+out missed across 21 hours, and agents built host-crontab workarounds).
+
+The mechanism, established by binary recon + live probes (2026-08-28): session-scoped timers (default
+CronCreate, ALL ScheduleWakeups, /loop ticks) live only in the CLI process's memory; the CLI's own
+scheduler fires them fine on a live IDLE process (jitter up to half the interval on recurring crons),
+and a resumed process re-hydrates its timer set — but a DORMANT session has no process at the due
+moment, and session-scoped timers have no CLI-side catch-up. Romp's job is therefore exactly one
+thing: never leave a timer-armed session without a process. Three pieces, pinned here:
+
+1. The Stop hook persists the payload's `session_crons` (the armed set, handed to romp at every turn
+   end) into the session reg — including [] when the last timer is cancelled.
+2. SdkBackend.ensure_scheduled() reconnects any alive, timer-armed session with no running thread —
+   idempotent, with a 120s per-sid retry floor so a spawn-crashing session can't become a storm.
+3. The kernel's producer calls the sweep every pass.
+
+Romp never fires a timer itself (no double-fire risk). Synthetic fixtures only."""
+import asyncio
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_sched", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-000000000021"
+
+
+class _Backend(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.logs = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+
+    def _reg(self, sid=SID, **kw):
+        sb.write_reg(self.d, sid, {"sid": sid, "name": "timers", "cwd": "/tmp", "alive": True, **kw})
+        return sb.read_reg(self.d, sid)
+
+
+class StopHookRecordsTheArmedSet(_Backend):
+    CRONS = [{"id": "aaaa1111", "schedule": "50 * * * *", "prompt": "Reply with exactly: tick",
+              "kind": "cron", "recurring": True}]
+
+    def _sess(self):
+        self._reg()
+        return sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+
+    def test_session_crons_land_in_the_reg(self):
+        s = self._sess()
+        asyncio.run(s._stop_hook({"session_crons": self.CRONS}, None, None))
+        rec = (sb.read_reg(self.d, SID) or {}).get("sessionCrons")
+        self.assertEqual(len(rec), 1)
+        armed = rec[0].pop("armedAt")
+        self.assertAlmostEqual(armed, time.time(), delta=30, msg="first-seen arm time rides the entry")
+        self.assertEqual(rec, [{"id": "aaaa1111", "cron": "50 * * * *",
+                                "prompt": "Reply with exactly: tick", "kind": "cron", "recurring": True}])
+
+    def test_a_lost_future_one_shot_survives_the_rewrite(self):
+        # a recycled process's payload lacks the wakeup it lost; the record must outlive the rewrite
+        # while its due is still ahead — deliver_lost_wakeups needs it at due time
+        s = self._sess()
+        due = time.localtime(time.time() + 600)
+        shot = {"id": "dddd4444", "schedule": "%d %d * * *" % (due[4], due[3]),
+                "prompt": "Reply with exactly: wake", "kind": "loop", "recurring": False}
+        asyncio.run(s._stop_hook({"session_crons": [shot]}, None, None))
+        asyncio.run(s._stop_hook({"session_crons": []}, None, None))   # the fresh process knows nothing
+        rec = (sb.read_reg(self.d, SID) or {}).get("sessionCrons")
+        self.assertEqual([c["id"] for c in rec], ["dddd4444"],
+                         "erasing it here was how the fix's first draft lost the wakeup pre-due")
+
+    def test_a_fired_one_shot_still_drops(self):
+        # a genuinely FIRED one-shot is always past due at its own turn's Stop hook (armed 17:08,
+        # due 17:13, fired 17:13, hook ~17:13:30) — strict-future keep means it drops here, so the
+        # sweep can never double-fire it. Plant the record with its arm time BEFORE the (past) due.
+        past = time.localtime(time.time() - 120)
+        rec = {"id": "eeee5555", "cron": "%d %d * * *" % (past[4], past[3]),
+               "prompt": "p", "kind": "loop", "recurring": False, "armedAt": int(time.time() - 600)}
+        self._reg(sessionCrons=[rec], sessionCronsAt=int(time.time() - 600))
+        s = sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+        asyncio.run(s._stop_hook({"session_crons": []}, None, None))
+        self.assertEqual((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), [])
+
+    def test_cancelling_the_last_timer_clears_the_record(self):
+        s = self._sess()
+        asyncio.run(s._stop_hook({"session_crons": self.CRONS}, None, None))
+        asyncio.run(s._stop_hook({"session_crons": []}, None, None))
+        self.assertEqual((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), [],
+                         "a stale armed set would keep reviving a session with nothing to fire")
+
+    def test_a_payload_without_the_field_changes_nothing(self):
+        s = self._sess()
+        asyncio.run(s._stop_hook({"session_crons": self.CRONS}, None, None))
+        asyncio.run(s._stop_hook({"transcript_path": "/tmp/x.jsonl"}, None, None))
+        self.assertTrue((sb.read_reg(self.d, SID) or {}).get("sessionCrons"),
+                        "absence of the field is not a cancellation")
+
+
+class SweepKeepsTimerArmedSessionsAlive(_Backend):
+    CRONS = [{"id": "bbbb2222", "cron": "5 * * * *", "prompt": "p", "kind": "loop", "recurring": False}]
+
+    def test_a_dormant_timer_armed_session_is_revived(self):
+        self._reg(sessionCrons=self.CRONS)
+        ensured = []
+        self.be._ensure = lambda sid, on_boot_settled=None: ensured.append(sid) or True
+        self.assertEqual(self.be.ensure_scheduled(), 1)
+        self.assertEqual(ensured, [SID])
+        self.assertTrue(any("armed timer" in m for m in self.logs), "revivals are logged, never silent")
+
+    def test_sessions_without_timers_stay_lazy(self):
+        self._reg()                                     # alive, no sessionCrons
+        self.be._ensure = lambda sid, on_boot_settled=None: self.fail("must not touch a timer-less session")
+        self.assertEqual(self.be.ensure_scheduled(), 0)
+
+    def test_dead_and_thread_regs_are_skipped(self):
+        self._reg(sessionCrons=self.CRONS, alive=False)
+        other = "11111111-2222-3333-4444-000000000022"
+        self._reg(sid=other, sessionCrons=self.CRONS, threadOf=SID)
+        self.be._ensure = lambda sid, on_boot_settled=None: self.fail("dead/thread regs are not sessions to revive")
+        self.assertEqual(self.be.ensure_scheduled(), 0)
+
+    def test_the_retry_floor_bounds_a_spawn_storm(self):
+        self._reg(sessionCrons=self.CRONS)
+        ensured = []
+        self.be._ensure = lambda sid, on_boot_settled=None: ensured.append(sid) or True
+        self.be.ensure_scheduled()
+        self.be.ensure_scheduled()                      # a moment later — the CLI died instantly
+        self.assertEqual(len(ensured), 1,
+                         "the producer sweeps every ~3s; without the floor a spawn-crashing "
+                         "session becomes a spawn storm")
+
+    def test_a_running_session_is_left_alone(self):
+        self._reg(sessionCrons=self.CRONS)
+
+        class T:
+            def is_alive(self):
+                return True
+
+        class S:
+            thread = T()
+        self.be.sessions[SID] = S()
+        self.be._ensure = lambda sid, on_boot_settled=None: self.fail("already running — nothing to do")
+        self.assertEqual(self.be.ensure_scheduled(), 0)
+
+
+class WakeupDueEpoch(unittest.TestCase):
+    """The one shape romp self-fires: ScheduleWakeup's '<min> <hour> * * *' one-shot, local time."""
+
+    def test_same_day_due(self):
+        armed = time.mktime((2026, 8, 28, 17, 8, 0, 0, 0, -1))
+        due = sb.wakeup_due_epoch("13 17 * * *", armed)
+        self.assertEqual(time.localtime(due)[3:5], (17, 13))
+        self.assertLess(due - armed, 3600)
+
+    def test_midnight_wrap(self):
+        armed = time.mktime((2026, 8, 28, 23, 50, 0, 0, 0, -1))
+        due = sb.wakeup_due_epoch("5 0 * * *", armed)
+        self.assertGreater(due, armed, "00:05 armed at 23:50 is TOMORROW, not 24h ago")
+        self.assertLess(due - armed, 3600)
+
+    def test_anything_else_is_not_ours_to_fire(self):
+        armed = time.time()
+        for cron in ("*/5 * * * *", "50 * * * *", "5 0 1 * *", "5 0 * * 1", "junk", "", None):
+            self.assertIsNone(sb.wakeup_due_epoch(cron, armed), repr(cron))
+
+
+class LostWakeupDelivery(_Backend):
+    """A process recycle loses ScheduleWakeup arms (verified live 2026-08-28: kill + revive kept the
+    recurring cron, dropped the pending wakeup). The reg record outlives the process; a one-shot past
+    due by the grace and STILL recorded had no process to fire it — romp delivers its own prompt."""
+
+    def _shot(self, due_offset, armed_offset=-600, recurring=False):
+        now = time.time()
+        due = time.localtime(now + due_offset)
+        return ({"id": "cccc3333", "cron": "%d %d * * *" % (due[4], due[3]),
+                 "prompt": "Reply with exactly: wakeup-fired", "kind": "", "recurring": recurring},
+                now + armed_offset)
+
+    def test_past_due_unfired_one_shot_is_delivered_and_stripped(self):
+        shot, armed = self._shot(due_offset=-300)
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+        sent = []
+        self.be.send = lambda sid, text: sent.append((sid, text)) or True
+        self.assertEqual(self.be.deliver_lost_wakeups(), 1)
+        self.assertEqual(sent, [(SID, "Reply with exactly: wakeup-fired")])
+        self.assertEqual((sb.read_reg(self.d, SID) or {}).get("sessionCrons"), [],
+                         "stripped BEFORE delivery — the next pass must never double-deliver")
+        self.assertTrue(any("no process to fire it" in m for m in self.logs))
+
+    def test_not_yet_due_stays_armed_and_undelivered(self):
+        shot, armed = self._shot(due_offset=+600)
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+        self.be.send = lambda sid, text: self.fail("not due — the CLI scheduler still owns it")
+        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
+        self.assertTrue((sb.read_reg(self.d, SID) or {}).get("sessionCrons"))
+
+    def test_the_grace_covers_a_genuine_fire_settling(self):
+        shot, armed = self._shot(due_offset=-30)       # due 30s ago — inside the 90s grace
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+        self.be.send = lambda sid, text: self.fail("a genuine fire's Stop hook gets time to erase the record")
+        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
+
+    def test_recurring_crons_are_never_self_fired(self):
+        shot, armed = self._shot(due_offset=-300, recurring=True)
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+        self.be.send = lambda sid, text: self.fail("recurring = keep-alive only; the CLI fires those")
+        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
+
+    def test_a_mid_turn_session_is_left_alone(self):
+        shot, armed = self._shot(due_offset=-300)
+        self._reg(sessionCrons=[shot], sessionCronsAt=armed)
+
+        class T:
+            def is_alive(self):
+                return True
+
+        class S:
+            thread = T()
+            inflight = 1
+        self.be.sessions[SID] = S()
+        self.be.send = lambda sid, text: self.fail("mid-turn: a genuine fire may be settling")
+        self.assertEqual(self.be.deliver_lost_wakeups(), 0)
+
+
+class ProducerRunsTheSweep(unittest.TestCase):
+    def test_the_producer_calls_ensure_scheduled(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            src = f.read()
+        self.assertIn("ensure_scheduled()", src, "the sweep must run with no dashboard connected")
+        self.assertIn("deliver_lost_wakeups()", src, "orphaned one-shots fire from the same pass")
+        self.assertIn('sys.stderr.write("scheduled-sweep: %s\\n"', src,
+                      "guarded — a sweep failure must never kill the producer cycle")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Problem:** if a session arms a wakeup (`ScheduleWakeup`) or a cron (`CronCreate`) and then sits idle long enough for its Claude process to go away — a kernel restart, the lazy boot reconcile, a reconnect — the timer never fires, and nothing reports the miss.

**Why it happens:** these timers live inside the Claude CLI process. The CLI's own scheduler fires them reliably while the process is alive, even idle — but under romp the process is often gone at the due moment, and a resumed process restores crons while losing pending wakeups outright. There is no catch-up for either.

**The fix**, in three small parts:
- record each session's armed timers in its registry (the Stop hook payload lists them at every turn end);
- a kernel sweep keeps any session with armed timers connected, so the CLI's scheduler can do the firing;
- if a one-shot wakeup went past due while no process was alive to fire it, the kernel delivers that wakeup's prompt itself — minutes late at worst, instead of never.

Tests in `tests/test_scheduled_sessions.py`; full suite green. Also verified against a live kernel: arm a wakeup, kill the session's process before the due minute — the wakeup still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)