### PR TITLE
Mode menu: 'Accept edits' becomes 'Accept', and every mode wears a tagline

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7954,7 +7954,7 @@ def _drive(msg, client):
         if not be.set_mode(sid, str(msg["value"])):
             client["send"](json.dumps({"type": "warn",
                                        "text": "A terminal session can only reach the modes in its "
-                                               "shift+tab cycle — Normal, Accept edits, Auto, Plan."}))
+                                               "shift+tab cycle — Normal, Accept, Auto, Plan."}))
         _push_soon()
     elif t == "setAuth" and msg.get("value") in ("login", "key"):
         # per-session billing (login vs the manager env's API key) — SDK-only, applied via reconnect

--- a/ui/webview/mode-selector.test.ts
+++ b/ui/webview/mode-selector.test.ts
@@ -37,3 +37,28 @@ test("Bypass carries a sub-line saying what it costs", () => {
   assert.match(CSS, /\.meta-item-sub \{ font-size: 0\.82em; opacity: 0\.6; \}/,
     "one sub-line size across every romp menu — same as .ctx-item-sub");
 });
+
+test("every mode wears a tagline, and 'Accept edits' reads 'Accept' everywhere (T140)", () => {
+  // the user 2026-08-28: where taglines exist under some entries, add analogous ones — each line
+  // states what the mode ENFORCES (worded from the plumbing, per the task), in the one menu
+  // vocabulary (.meta-item-sub, pinned above). The mode ids stay the wire's.
+  assert.match(RENDER, /\{ label: "Normal", value: "default", sub: "asks before edits and commands" \}/);
+  assert.match(RENDER, /\{ label: "Accept", value: "acceptEdits", sub: "file edits apply without asking; commands still ask" \}/);
+  assert.match(RENDER, /\{ label: "Auto", value: "auto", sub: "safe actions run unasked; risky ones still ask" \}/);
+  assert.match(RENDER, /\{ label: "Plan", value: "plan", sub: "reads and proposes only — changes nothing" \}/);
+  // the rename holds everywhere the mode name renders: the chip/badge…
+  assert.match(RENDER, /case "acceptedits": return "Accept";/);
+  assert.ok(!RENDER.includes('"Accept edits"'), "no surface still says the two-word label");
+  // …and the kernel's tmux-cycle refusal names the same four modes with the same word
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /shift\+tab cycle — Normal, Accept, Auto, Plan\./);
+});
+
+test("no width blowout: every new tagline is no longer than the accepted bypass line (T117 fit rule)", () => {
+  // the menu sizes to its longest line; the bypass sub shipped 2026-08-15 and set the accepted
+  // width — the new taglines must all fit inside it, so the menu gets no wider than it already was
+  const subs = [...RENDER.matchAll(/sub: "([^"]+)"/g)].map((m) => m[1]);
+  const bypass = "every tool runs unasked, and romp stops showing approvals";
+  assert.ok(subs.includes(bypass));
+  for (const sub of subs) assert.ok(sub.length <= bypass.length, `tagline wider than the accepted menu: ${sub}`);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9692,15 +9692,18 @@ fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d
 // An SDK session sets it outright over the control channel (set_permission_mode), which is what makes
 // Bypass offerable there and only there: on tmux the click would land on a mode the cycle cannot
 // express, and _cycle_mode would drop it. `sdkOnly` is the filter, applied in toggleMetaMenu.
+// Every mode wears a one-phrase sub-line (T140, the user 2026-08-28: where taglines exist under
+// some entries, add analogous ones saying what the other modes are — and 'Accept edits' reads
+// just 'Accept'; the mode ids stay the wire's). Each line states what the mode ENFORCES, worded
+// from the plumbing, not folklore: the SDK's permission engine owns the gate (romp's can_use_tool
+// only renders the asks it fires), auto's gate is the safety classifier (observed enforcement:
+// its outage refuses with "cannot determine the safety of"), and bypass's line keeps its 2026-08-15
+// cost warning — it never fires can_use_tool, so the approval RECORD goes too, not just the asking.
 const MODE_CHOICES: MetaChoice[] = [
-  { label: "Normal", value: "default" },
-  { label: "Accept edits", value: "acceptEdits" },
-  { label: "Auto", value: "auto" },
-  { label: "Plan", value: "plan" },
-  // The one mode that removes the gate rather than moving it, so it says what that costs right in the
-  // menu (the user 2026-08-15). Two things are worth the sub-line: every tool runs unasked, and romp's
-  // own approve/deny cards go with them — they are rendered from the SDK's can_use_tool callback, which
-  // bypass never fires, so you lose the RECORD of what ran, not just the asking.
+  { label: "Normal", value: "default", sub: "asks before edits and commands" },
+  { label: "Accept", value: "acceptEdits", sub: "file edits apply without asking; commands still ask" },
+  { label: "Auto", value: "auto", sub: "safe actions run unasked; risky ones still ask" },
+  { label: "Plan", value: "plan", sub: "reads and proposes only — changes nothing" },
   { label: "Bypass permissions", value: "bypassPermissions", sdkOnly: true,
     sub: "every tool runs unasked, and romp stops showing approvals" },
 ];
@@ -9744,7 +9747,7 @@ function fastAvailable(st: Status): boolean {
 function prettyMode(m: string | undefined): string {
   switch ((m || "").toLowerCase()) {
     case "plan": return "Plan";
-    case "acceptedits": return "Accept edits";
+    case "acceptedits": return "Accept";   // one word everywhere the mode renders (T140)
     case "auto": return "Auto";
     case "dontask": return "Don’t ask";
     case "bypasspermissions": return "Bypass";


### PR DESCRIPTION
The user: rename Accept edits to Accept, and where taglines exist under some entries (Bypass had one), add analogous ones concisely saying what the other modes are.

## The taglines — worded from enforcement, not folklore
The SDK's permission engine owns the gate (romp's `can_use_tool` only renders the asks it fires); auto's gate is the safety classifier (observed enforcement: its outage refuses with 'cannot determine the safety of').

| mode | tagline |
|---|---|
| Normal | asks before edits and commands |
| **Accept** (renamed) | file edits apply without asking; commands still ask |
| Auto | safe actions run unasked; risky ones still ask |
| Plan | reads and proposes only — changes nothing |
| Bypass | *(unchanged)* every tool runs unasked, and romp stops showing approvals |

## Consistency + fit
The rename holds at all three render sites: menu label, statusline badge (`prettyMode`), and the kernel's tmux-cycle refusal copy. Mode ids unchanged on the wire. Sub-lines ride the existing `.meta-item-sub` (0.82em / 0.6 — the house menu spec); every new tagline is shorter than the accepted Bypass line, so the menu gets **no wider than it already was** (T117 fit rule) — verified rendered at 288px.

## Tests
`mode-selector.test.ts` pins the five label+sub literals, the rename at all three sites with an absence pin on the two-word label, and an executable no-width-blowout check. Suite 2514/2514, tsc clean; kernel settings tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)