### PR TITLE
One dark background everywhere: the band is out, and every button wears the feed's rest

### DIFF
--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -51,7 +51,7 @@ test("the popover's bottom row IS a statusline: the chat's chip anatomy + counti
 });
 
 test("the action buttons wear the chat's under-bubble family; Fork stays out by the user's call", () => {
-  assert.match(CSS, /\.cmt-act \{\s*\n\s*background: rgba\(255, 255, 255, 0\.06\);\s*\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\); border-radius: 5px; font-size: 0\.82em;\s*\n\s*padding: 1px 8px; cursor: pointer;\s*\n\}/);
+  assert.match(CSS, /\.cmt-act \{\s*\n\s*background: transparent;[^\n]*\n\s*border: 1px solid var\(--card-border\); color: var\(--dim\); border-radius: 5px; font-size: 0\.82em;\s*\n\s*padding: 1px 8px; cursor: pointer;\s*\n\}/);   // T141: the one button rest — dark ground, the feed hairline
   assert.match(CSS, /\.cmt-act:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);   // the feed word-button hover (2026-08-25): text+outline accent, never a fill
   // the popover's verbs stay Break out / Merge / Delete — the chat's Fork button is deliberately absent
   const pop = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -235,7 +235,10 @@ test("context stages ALONE, and the chips strip carries the visible Stage button
   assert.ok(loop >= 0 && btn > loop, "the Stage button is appended AFTER the context chips");
   // neutral at rest (the user 2026-08-23): an accent outline beside the accent-blue chips read as
   // already-pressed. Rest = the button family's dress; the accent appears only on hover.
-  assert.match(CSS, /\.composer-stage-btn \{ background: rgba\(255, 255, 255, 0\.06\);\n\s*border: 1px solid var\(--box-border\); color: var\(--dim\);/);
+  // T141 (the user 2026-08-28): buttons are consistent — the feed word-buttons' rest exactly:
+  // dark ground (transparent over the page), the feed's --card-border hairline (mirrored token)
+  assert.match(CSS, /\.composer-stage-btn \{ background: transparent;[^\n]*\n\s*border: 1px solid var\(--card-border\); color: var\(--dim\);/);
+  assert.match(CSS, /--card-border: rgba\(255, 255, 255, 0\.10\);/, "byte-equal mirror of feed.css --card-border");
   assert.match(CSS, /\.composer-stage-btn:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);   // the feed word-button hover (2026-08-25)
   assert.doesNotMatch(CSS, /\.composer-stage-btn \{ position: absolute/,
     "no absolute pin — the button flows in the strip, immediately after what it acts on");

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -47,12 +47,14 @@ test("the fork button sits INLINE, right of the worked-seconds label — never i
   assert.match(CSS, /\.turn-assistant:hover \.msg-fork, \.msg-fork:focus-visible \{ opacity: 0\.9; \}/);
   assert.match(CSS, /\.msg-fork:hover \{ color: var\(--fg\); border-color: var\(--accent\); \}/);
   assert.doesNotMatch(CSS, /\.msg-fork\.armed/);
-  // the under-bubble button family wears NEUTRAL chrome (the user 2026-08-23): it sits on the page
-  // ground, where the terracotta code tint (--code-bg) read as a faint red button. Only .code-copy
-  // keeps the tint — it sits ON the tinted code block and blends there.
+  // the under-bubble button family wears the ONE button rest (the user 2026-08-23 made it neutral,
+  // never the terracotta code tint; T141 2026-08-28 unified all button rests to the feed's — dark
+  // ground, the mirrored --card-border hairline). Only .code-copy keeps the tint — it sits ON the
+  // tinted code block and blends there.
   for (const block of [".msg-edit {", ".msg-del, .msg-restorefiles, .msg-fork {", ".undelivered-act {"]) {
     const body = CSS.slice(CSS.indexOf(block), CSS.indexOf("}", CSS.indexOf(block)));
-    assert.ok(body.includes("background: rgba(255, 255, 255, 0.06)"), block + " wears the neutral ground");
+    assert.ok(body.includes("background: transparent"), block + " wears the one button rest");
+    assert.ok(body.includes("var(--card-border)"), block + " wears the feed hairline");
     assert.ok(!body.includes("--code-bg"), block + " must not borrow the code tint");
   }
   const copy = CSS.slice(CSS.indexOf(".code-copy {"), CSS.indexOf("}", CSS.indexOf(".code-copy {")));

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -62,6 +62,9 @@ body.scheme-solarized-dark {
   --code-bg: rgba(217, 119, 87, 0.10);
   --box-bg: rgba(255, 255, 255, 0.03);
   --box-border: var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.12));
+  /* the feed's button hairline, MIRRORED byte-equal from feed.css --card-border (T141: the chat's
+     button family wears the feed's exact rest treatment; the chat page cannot import feed.css) */
+  --card-border: rgba(255, 255, 255, 0.10);
   --err: #c0392b;   /* unified with the awaiting/blocked red (the user 2026-06-24): one "needs you" red. API-error (--st-blocked-bg #e5484d) stays distinct. */
   --warn: #d7a23a;  /* the heads-up amber — "attention, not an error". Was referenced with fallbacks but never
                        defined (a phantom token) until 2026-08-26; mirrored in feed.css (own :root). */
@@ -163,19 +166,12 @@ body.chat-theme-yatharth #winframe { display: block; position: fixed; inset: 0; 
 body:not(.chat-theme-yatharth) #tabs .tab-row-line {
   position: absolute; left: -8px; right: -8px; height: 1px; background: var(--box-border); pointer-events: none; }
 body.chat-theme-yatharth #tabs .tab-row-line { display: none; }
-/* T125 (the user 2026-08-27, screenshot: with wrapped rows the tabs read as floating boxes): the
-   strip is a BAND — its own background plane a hair above the page, containing every wrapped row,
-   closed by the existing --box-border hairline at its bottom edge. This is how tab strips are
-   grounded in the polished multi-tab precedents (browser frame bands, editor tab-group headers,
-   design-system "tabs on a surface + divider"): the plane says "one control", the hairline says
-   "it ends here" — per-row separator lines were rejected as clutter. 5% white over the page bg
-   (tunable one-liner; shipped at 3%, stepped up 2026-08-27 after the T128 triage: on the user's
-   dark theme 3% was an ~11-gray-level delta that read as nothing at a glance — the eyeball
-   comparison lives in their drops, and 3%/6% stay one edit away); background only, so zero
-   layout shift, and the selected ring / blocked
-   dashed / rest outline / hover fill all read as before, now against the band. Classic only:
-   Yatharth keeps his merged look via the body scope. */
-body:not(.chat-theme-yatharth) #tabbar { background: linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05)), var(--vscode-sideBar-background, var(--bg)); }
+/* T141 (the user 2026-08-28, explicit ruling): the T125/T128 band is OUT — one dark background
+   everywhere; the strip's plane is the page dark again (#tabbar's own background above), the same
+   color as the feed behind its cards and its bottom control bar. The grounding that survives the
+   band: the T134 per-row hairlines and the T123 rest outlines. (History: the band shipped for the
+   floating-rows read, stepped 3%→5% after T128, then lightened every surface it sat behind — the
+   extra shade is exactly what the ruling removes.) */
 /* Drag handle straddling the tab strip's bottom border (the user 2026-08-18): the strip scrolls past
    its max-height cap, which clipped the fifth row of a many-session strip with no way to see more.
    Drag DOWN for more rows, UP for fewer; double-click resets; the strip stays a scroll pane at every
@@ -319,20 +315,13 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
 /* CLASSIC (the default; T113, tightened by T115, tuned by T118 — the user 2026-08-27): the tab
    strip is the PRE-720 strip — verified by pixel-diffing a real pre-720 build — modulo exactly
-   five sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
+   four sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px
    hover-gray rest outline below (T123), the 0.9 faded-label scale (fadedColor, render.ts; T118),
-   the strip band (T125, below), and the per-row hairlines (T134, above at #tabs). No identity tint at any state, the
+   and the per-row hairlines (T134, above at #tabs; the T125 band was ruled OUT by T141 — one dark
+   background everywhere). No identity tint at any state, the
    thick 1.5px inset identity ring on the selected tab, the neutral line under the strip. The
    Yatharth theme below is the opt-in restoration of the contributor's merged strip aesthetic. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
-/* T136 (the user 2026-08-27: every tab body reads lighter than four days ago — "restore it to
-   what it was"; they were right): the T125 band paints BEHIND the strip, and a transparent
-   resting tab let it show THROUGH the body, lightening every tab — the sanctioned delta was the
-   strip PLANE, never the tab fill. Resting tabs now paint the baseline body explicitly (the very
-   color the strip's background was before the band), so the band reads only between/around tabs.
-   Same :not chain as the retired T118 wash (hover/active/blocked own their fills; + is not a
-   session tab); pixel-verified against the pre-720 baseline in the T136 harness run. */
-body:not(.chat-theme-yatharth) .tab:not(.tab-blocked):not(.active):not(:hover):not(.tab-add) { background: var(--vscode-sideBar-background, var(--bg)); }
 /* T123 (the user 2026-08-27, redirecting T118's resting-tab distinction — the merged 2% fill
    came out for this): resting tabs wear a SUPER-THIN outline at all times, no fill — the tab body
    stays the dark background, ringed by 1px in EXACTLY the gray the hover fill uses
@@ -784,8 +773,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    and the strip hides with the chips). NEUTRAL at rest (the under-bubble button family's dress): an
    accent outline next to the accent-blue chips read as already-pressed — accent is for
    hover/selected, never rest chrome */
-.composer-stage-btn { background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.82em;
+.composer-stage-btn { background: transparent;   /* T141: the feed word-buttons' rest — dark ground, hairline, no wash */
+  border: 1px solid var(--card-border); color: var(--dim); border-radius: 5px; font-size: 0.82em;
   padding: 1px 8px; cursor: pointer; }
 /* hover = the FEED's word-button treatment exactly (the user 2026-08-25: text + outline light up
    blue, like Clear/Undo — never a background fill; the wash values are the feed's .ftree-act-btn
@@ -1432,7 +1421,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
   /* neutral ground, neutral chrome (the user 2026-08-23): these sit on the page, not on a code
      block, so the code tint .code-copy blends with read here as a faint red button */
-  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--dim);
+  border: 1px solid var(--card-border); background: transparent; color: var(--dim);   /* T141: the one button rest — dark ground, hairline */
   cursor: pointer; opacity: 0; user-select: none;
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
@@ -1445,7 +1434,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .msg-del, .msg-restorefiles, .msg-fork {
   align-self: flex-end; margin-top: 3px;
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
-  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--dim);
+  border: 1px solid var(--card-border); background: transparent; color: var(--dim);   /* T141: the one button rest — dark ground, hairline */
   cursor: pointer; opacity: 0; user-select: none;
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
@@ -1589,7 +1578,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 .undelivered-act {
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
-  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--dim);
+  border: 1px solid var(--card-border); background: transparent; color: var(--dim);   /* T141: the one button rest */
   cursor: pointer; user-select: none;
   transition: color 0.12s ease, border-color 0.12s ease;
 }
@@ -1775,7 +1764,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .ask-actions { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
 .ask-btn {
   padding: 4px 13px; border-radius: 6px; font: inherit; cursor: pointer;
-  border: 1px solid var(--box-border); background: rgba(255, 255, 255, 0.06); color: var(--fg);
+  border: 1px solid var(--card-border); background: transparent; color: var(--fg);   /* T141: the one button rest */
 }
 .ask-btn:hover { background: rgba(255, 255, 255, 0.13); }
 /* keyboard focus ring on the Submit/Cancel buttons — they're part of the multi-select arrow-key nav now
@@ -2318,8 +2307,8 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-dir-input::placeholder { color: var(--dim); }
 .picker-browse {
   flex: 0 0 auto; cursor: pointer; white-space: nowrap;
-  background: rgba(255, 255, 255, 0.06); color: var(--fg);
-  border: 1px solid var(--box-border); border-radius: 5px; padding: 5px 9px; font-size: 0.82em;
+  background: transparent; color: var(--fg);   /* T141: the one button rest */
+  border: 1px solid var(--card-border); border-radius: 5px; padding: 5px 9px; font-size: 0.82em;
 }
 .picker-browse:hover { background: rgba(255, 255, 255, 0.12); }
 /* Disabled while a REMOTE host is selected — that machine's dialog can't open on this screen. It had no
@@ -2931,8 +2920,8 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    2026-08-25: the popover's buttons should be the chat's, one vocabulary): neutral at rest,
    accent on hover, the 0.78em label tier */
 .cmt-act {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--box-border); color: var(--dim); border-radius: 5px; font-size: 0.82em;
+  background: transparent;   /* T141: one dress with the stage button + the feed's word-buttons */
+  border: 1px solid var(--card-border); color: var(--dim); border-radius: 5px; font-size: 0.82em;
   padding: 1px 8px; cursor: pointer;
 }
 .cmt-act:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }   /* the feed word-button hover (2026-08-25): Break out / Merge / Delete light up like Clear/Undo */

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -1,7 +1,8 @@
 // The chat-tab appearance themes (T113, tightened by T115, tuned by T118 — the user 2026-08-27):
 // CLASSIC, the default, is the PRE-720 tab strip modulo exactly THREE sanctioned deltas —
 // typography (the strip inherits the global Inter/type ladder), T123's 1px hover-gray rest
-// outline, T118's 0.9 faded-label scale, T125's strip band, and T134's per-row hairlines. Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
+// outline, T118's 0.9 faded-label scale, and T134's per-row hairlines (the T125 band was
+// ruled OUT by T141 — one dark background everywhere). Everything else reads pre-720: NO identity tint at any state, the thick 1.5px
 // selected ring, the neutral line under the strip, gap 0. T115 verified the baseline equality by
 // pixel-diffing a real pre-720 build: with fonts normalized, zero differing pixels outside the
 // (out-of-scope) tag-controls box — a re-run must subtract the two T118 washes the same way it
@@ -57,13 +58,15 @@ test("Classic: faded labels brighten 10% — one tunable knob, Yatharth keeps hi
   assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
 });
 
-test("Classic: resting tab bodies paint the BASELINE color — the band never lightens them (T136)", () => {
-  // The user (2026-08-27): every tab body read lighter than four days before — and the harness
-  // proved it: the T125 band showed through transparent bodies, rgb(41,41,41) vs the pre-720
-  // baseline's rgb(30,30,30). The explicit body restores byte-equality (verified) while the band
-  // keeps reading between/around tabs. Same :not chain as the retired wash: hover/active/blocked
-  // own their fills, + is not a session tab, Yatharth untouched via the body scope.
-  assert.match(CSS, /^body:not\(\.chat-theme-yatharth\) \.tab:not\(\.tab-blocked\):not\(\.active\):not\(:hover\):not\(\.tab-add\) \{ background: var\(--vscode-sideBar-background, var\(--bg\)\); \}$/m);
+test("Classic: ONE dark background — no band, no explicit body fill, baseline transparency (T141)", () => {
+  // The user (2026-08-28, explicit ruling): the lighter gray behind/around the tabs goes; the
+  // strip's plane is the page dark, same as the feed behind its cards. The T125/T128 band and the
+  // T136 body rule (which existed only to fight the band showing through) are both out — resting
+  // tabs read the dark plane through baseline transparency again. Grounding = row lines + outlines.
+  assert.doesNotMatch(CSS, /#tabbar \{ background: linear-gradient/, "no band plane on the strip");
+  assert.doesNotMatch(CSS, /\.tab:not\(\.tab-blocked\):not\(\.active\):not\(:hover\):not\(\.tab-add\) \{ background:/,
+    "no explicit rest-body fill either — baseline transparency over the dark plane");
+  assert.match(CSS, /^  background: var\(--vscode-sideBar-background, var\(--bg\)\);$/m, "the strip's one background");
 });
 
 test("Classic: the rest OUTLINE — 1px in the hover gray, no fill, states stand down (T123)", () => {
@@ -99,8 +102,7 @@ test("Classic: the strip is a BAND — a 3% plane over the page bg, closed by th
   // T128 triage (the user 2026-08-27: on their dark theme 3% read as nothing at a glance — the
   // 3/5/6% eyeball comparison sits in their drops, and the placement of the ONE hairline at the
   // strip's bottom edge stands per the precedent survey, the user's alone to overturn).
-  assert.match(CSS, /^body:not\(\.chat-theme-yatharth\) #tabbar \{ background: linear-gradient\(rgba\(255, 255, 255, 0\.05\), rgba\(255, 255, 255, 0\.05\)\), var\(--vscode-sideBar-background, var\(--bg\)\); \}$/m,
-    "the band: one Classic-scoped background line, tunable in place; Yatharth keeps his merged look");
+
   assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/, "…closed by the ONE existing hairline at the band's bottom edge");
 });
 


### PR DESCRIPTION
The user (explicit ruling): the lighter gray behind/around the tabs must go — the strip's plane should be the same dark as the feed behind its cards and its bottom control bar; no extra shades of lighter gray; the thin outlines stay. And buttons should be consistent: Stage had a lighter background than the feed-bar buttons.

## 1. The band is out
`#tabbar` returns to the page dark. The T136 explicit tab-body rule goes with it (it existed only to fight the band showing through). Grounding = the per-row hairlines + rest outlines, which stay. **Sanctioned strip deltas drop to four**: typography, outline, fade, row lines.

## 2. One button rest
The whole under-bubble/control button family unifies on the feed's treatment — transparent over the dark, the feed's `--card-border` hairline (mirrored byte-equal, keep-in-sync note), hovers unchanged: `composer-stage-btn`, `.cmt-act`, `.msg-edit`, `.msg-del/.msg-restorefiles/.msg-fork`, `.undelivered-act`, `.ask-btn`, `.picker-browse`.

## 3. Bounded pass — semantic shades flagged, kept
Every `:hover` wash (highlight); the chat scrollbar track (verbatim exception); `.ctx-bar` track (gauge ground); `chip-idle/closed` (status); the ledger panel + its selected fill; `.tab-rename` (an input must read as a field); coarse-pointer attach fill (touch target); `.romp-bubble` (a message surface). Feed side already clean.

## Verification
Probes over the built bundle: `#tabbar` rgb(30,30,30), no background image; resting tab transparent; **Stage computed = the feed `.fdismiss` values exactly** (transparent + rgba(255,255,255,0.1) border); row lines painted. Suite 2514/2514, tsc clean, kernel styles-adjacent tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)