### PR TITLE
T142: the redundant verdict persists — a pair ruled redundant is never re-judged until the evidence moves

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -741,9 +741,17 @@ def active_runs():
         return [dict(v) for v in _active.values()]
 
 
-_USAGE_PRUNE_BYTES = 48 * 1024 * 1024   # prune trigger — never reached at healthy volume (a normal
-                                         # month is a few MB); the 2026-08-18 captioner storm grew the
-                                         # log to 59.5MB, which the kernel then re-read per timeline build
+_USAGE_PRUNE_BYTES = 128 * 1024 * 1024  # prune trigger — must sit comfortably ABOVE what the
+                                         # 31-day retention below keeps, or every prune is a full
+                                         # rewrite that lands back over the trigger and re-fires
+                                         # forever (the T142 finding: a 48MB trigger against a
+                                         # ~65MB retained month rewrote 67MB per pass and could
+                                         # never shrink the file). Retention is consumer-driven
+                                         # (the kernel's 30-day analytics view) and is the side
+                                         # that must NOT move; the trigger exists only for
+                                         # pathological growth beyond it — 2x the observed
+                                         # steady-state month, with T142's memo shrinking judge
+                                         # volume (and so the month) from here.
 _USAGE_RETAIN_S = 31 * 86400             # matches the kernel reader's widest consumer window
                                          # (_JUDGE_USAGE_RETAIN, the 30-day analytics view + slack)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3462,8 +3462,9 @@ def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None):
     """Append one auto-nudge event to STATE/nudge-events.jsonl — {sid, gid, t, count, verdict, evT} —
     for the timeline's DEBUG judging band (per-nudge ⚡ marker) AND the redundancy accounting (the
     user 2026-08-25): every decision the gate takes is a row — fired / skipped-redundant /
-    held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap / resolved-at-send /
-    blocked-on-user-at-send — carrying the evidence snapshot's timestamp, so redundant fires are
+    held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap / skipped-redundant-memo (the
+    T142 memo served a ruling already made on this exact evidence, no judge call) /
+    resolved-at-send / blocked-on-user-at-send — carrying the evidence snapshot's timestamp, so redundant fires are
     countable from the log alone. That accounting is what extended the freshness guard to the cap
     path (the user 2026-08-27, T120: the pre-T120 force-fired-at-cap rows measured the blind fire
     at 56% of deliveries; the cap now escalates to a fresh judgment instead). Additive fields;
@@ -5314,8 +5315,25 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                         # optimizer can see a wedge this would hide. The held-pass re-judge applies to
                         # capped candidates exactly as to organic ones: the old early-keep was the
                         # second half of the blind fire.
+                        #
+                        # THE MEMO (the user 2026-08-28, T142): a (goal, evidence) pair ruled
+                        # redundant is NEVER re-judged — a skip consumes no arm, so a capped goal
+                        # came due again every pusher tick and re-judged CONSTANT evidence
+                        # (measured: 464 of 510 judgments in one storm window were redundant
+                        # re-skips, one goal 147 times in 68 minutes, and 3 of 10 at-cap fires
+                        # were the judge FLIPPING on a pair it had just ruled redundant, i.e.
+                        # nondeterminism delivering the very stale nudge T120 exists to stop).
+                        # The ruling persists on the record as the evT it was judged against and
+                        # dies the moment the transcript's newest report moves or a fire replaces
+                        # the record. Consulted before ANY call, so the flip class dies by
+                        # construction. Event-true: no time backoff, no counter.
+                        if report_ts and rec0.get("redundantEvT") == report_ts:
+                            _log_nudge_event(sid, f[0], now, f[1],
+                                             verdict="skipped-redundant-memo", ev_t=report_ts)
+                            continue
                         if gtxt and jd.nudge_redundant(gtxt, report):
-                            nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1)
+                            nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1,
+                                                redundantEvT=report_ts)
                             _put_nudged(f[0], nudged[f[0]])
                             _v = ("skipped-redundant-at-cap" if skips >= 2
                                   else "held-fresh-re-judged" if held_pass else "skipped-redundant")

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -8,7 +8,8 @@ guard is the writer-yields family at the fire moment: the transcript's newest as
 moving past the snapshot's IS the world outrunning the evidence — hold, re-judge ONCE against the
 fresh report (never a loop), fire only what survives. Every gate decision is now a nudge-events row
 (fired / skipped-redundant / held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap /
-resolved-at-send / blocked-on-user-at-send, each carrying the evidence timestamp), so redundant
+skipped-redundant-memo / resolved-at-send / blocked-on-user-at-send, each carrying the evidence
+timestamp), so redundant
 fires are countable from the log alone. That accounting is what re-shaped the cap (the user
 2026-08-27, T120): the blind third fire measured at 56% of deliveries, re-asking answered
 questions — the cap now ESCALATES to one more judgment on the freshest evidence, never past it.
@@ -204,6 +205,48 @@ class FreshGuard(unittest.TestCase):
         self.assertEqual([r["verdict"] for r in self._rows()], ["held-fresh-re-judged"])
         self.assertEqual(self._rows()[0]["evT"], ARM_T + 590,
                          "the row carries the fresh evidence it yielded to")
+
+    def test_a_memoed_pair_serves_without_a_judge_call(self):
+        # THE MEMO (T142): a (goal, evidence) pair ruled redundant is never re-judged — a skip
+        # consumes no arm, so a capped goal came due every tick and re-judged constant evidence
+        # (147 re-judgments on one goal in 68 minutes; ~$1.92/day)
+        self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50})
+        self.judge_replies = [True]                   # would be consulted only by a bug
+        self._tick()
+        self.assertEqual(self.sent, [])
+        self.assertEqual(self.judge_calls, [], "the memo serves the ruling — no call")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant-memo"])
+        self.assertEqual(self._rows()[0]["evT"], ARM_T + 50)
+
+    def test_the_at_cap_flip_class_dies_by_construction(self):
+        # 3 of 10 measured fired-at-cap rows were the judge FLIPPING on a (gid, evT) it had just
+        # ruled redundant — nondeterminism delivering the stale nudge T120 exists to stop. The
+        # memo is consulted before the at-cap consult too, so the flip cannot happen.
+        self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
+                        "redundantSkips": 2, "redundantEvT": ARM_T + 50})
+        self.judge_replies = [False]                  # the flip verdict, never reachable
+        self._tick()
+        self.assertEqual(self.sent, [], "a pair ruled redundant can never fire on the same evidence")
+        self.assertEqual(self.judge_calls, [])
+        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant-memo"])
+
+    def test_a_judged_redundancy_stamps_the_memo(self):
+        self.judge_replies = [True]
+        self._tick()
+        rec = km._auto_nudge_data()["nudged"][G1]
+        self.assertEqual(rec.get("redundantEvT"), ARM_T + 50,
+                         "the ruling persists keyed on the evidence it judged")
+
+    def test_a_moved_report_kills_the_memo_and_re_enters_the_judge(self):
+        self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50})
+        self.reports = [("fresh words about new work", ARM_T + 800)]
+        self.judge_replies = [False]
+        self.assertTrue(self._tick())
+        self.assertEqual(len(self.sent), 1, "new evidence → a real judgment → a real fire")
+        self.assertEqual(len(self.judge_calls), 1)
+        self.assertEqual([r["verdict"] for r in self._rows()], ["fired"])
 
     def test_an_item_resolved_mid_deliberation_leaves_at_the_send_moment(self):
         # SEND-MOMENT FRESHNESS (T120): the fire list read the store before the redundancy judge


### PR DESCRIPTION
The T120 cap consult created a storm it could not see: a skip consumes no arm (the blind cap fire used to consume it), so a capped goal came due every pusher tick and re-judged constant evidence — 464/510 judgments redundant in the measured window, one goal 147x in 68 minutes, ~$1.92/day, and 3 of 10 `fired-at-cap` rows were the judge flipping on a (goal, evT) pair it had just ruled redundant.

**The memo, event-true**: a judged redundancy persists on the auto-nudge record as the evT it was judged against; the gate consults it before any judge call, capped candidates included. A pair ruled redundant is never re-judged until the transcript's newest report moves or a fire replaces the record — no time backoff, no counter; the flip class dies by construction. Memo serves log `skipped-redundant-memo` rows for the optimizer's accounting.

**Replayed on the live 48h window**: 511 of 674 gate decisions (76%) would have been memo-served with zero judge calls; 37 flip-class fires impossible under the memo.

**Fold-in**: judge-usage.jsonl's 48MB prune trigger sat below its own 31-day retention (~65MB kept), so every prune rewrote the 67MB file and landed back over the trigger forever. Retention is consumer-driven (the kernel's 30-day analytics view) and stays; the trigger rises to 128MB — twice the observed steady-state month — restoring its only-pathological-growth intent.

Tests: memo serves without a call, the at-cap flip pin, the ruling stamps the memo, a moved report kills it and re-enters the judge.

Suites: Python 5883/0 (+313 subtests), UI 2514/2514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)