### PR TITLE
Permission modes tell the truth: bypass never blocks, refusals revert, five-mode sweep (T139)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1662,11 +1662,13 @@ class SdkSession:
             self.loop.call_soon_threadsafe(
                 lambda: asyncio.ensure_future(self._do_set_model(model)))
 
-    def set_mode_live(self, mode):
-        """Change the permission mode on a CONNECTED session via the SDK control channel."""
+    def set_mode_live(self, mode, prev="default"):
+        """Change the permission mode on a CONNECTED session via the SDK control channel. `prev` is
+        the last CONFIRMED mode, captured by set_mode before its optimistic flip — the value every
+        layer reverts to if the CLI refuses the switch (T139)."""
         if self.loop and self.client:
             self.loop.call_soon_threadsafe(
-                lambda: asyncio.ensure_future(self._do_set_mode(mode)))
+                lambda: asyncio.ensure_future(self._do_set_mode(mode, prev)))
 
     def resolve_ask(self, kind: str, payload=None):
         """Deliver a picker/permission UI action (answer/toggle/submit/custom/
@@ -1808,11 +1810,22 @@ class SdkSession:
         await self._do_refresh_context()
         self.backend._poke()
 
-    async def _do_set_mode(self, mode):
+    async def _do_set_mode(self, mode, prev="default"):
         try:
             await self.client.set_permission_mode(mode)
         except Exception as e:
-            self.backend._log("set_permission_mode (%s -> %s) refused by the SDK: %s: %s" % (self.name, mode, type(e).__name__, e))
+            # the T124 rule, applied to modes (T139): set_mode flips the DISPLAYED mode
+            # optimistically — a refusal that only logged left the switcher asserting a mode the
+            # CLI never accepted, indefinitely. Revert every layer to the last confirmed mode
+            # (snapshot, session, registry — the next connect must not re-apply the refused pick
+            # either) and ring the problems so the failed switch is unmissable.
+            self.perm_mode = prev
+            self.mode = prev
+            self.backend._update_reg(self.sid, mode=prev)
+            self.backend._log("set_permission_mode (%s -> %s) refused by the SDK: %s: %s — the switch "
+                              "did NOT apply; the mode reverted to %s"
+                              % (self.name, mode, type(e).__name__, e, prev), problem=True)
+            self.backend._poke()
 
     async def _do_refresh_context(self):
         """Pull authoritative context-window usage from the SDK — the DESIGNED source. `get_context_usage()` is
@@ -2621,7 +2634,22 @@ class SdkSession:
                 updated_input={"questions": tool_input.get("questions", []), "answers": answers})
         if tool_name == "ExitPlanMode":
             return await self._approve_plan(tool_input)
-        # Ordinary tool permission. Options are Allow (1), optionally Allow-&-don't-ask-again (2 when the
+        # Ordinary tool permission. FIRST, the declared-intent guard (T139, the exp specimen): the
+        # SDK's own contract says bypassPermissions auto-approves every call before this callback
+        # is consulted (explicit deny rules aside) — yet CLI 2.1.221 consulted it once for a plain
+        # main-thread Bash, 30s after an equivalent command sailed through, and the session sat
+        # BLOCKED eleven hours on an ask the user had declared they never wanted. romp is the
+        # registered permission authority, so it re-imposes the declared intent: under bypass,
+        # auto-allow and ring the problems (the CLI broke its contract — visible, never silent),
+        # and never block a bypass session on an ask. Other modes keep asking: when the CLI
+        # consults under default/plan/acceptEdits, an ask IS the honest behavior for whatever its
+        # own evaluation could not auto-decide.
+        if self.perm_mode == "bypassPermissions":
+            self.backend._log("permission consult under bypassPermissions (%s, tool %s) — the CLI's "
+                              "contract says this cannot happen; auto-allowed per the declared mode"
+                              % (self.name, tool_name), problem=True)
+            return PermissionResultAllow(behavior="allow")
+        # Options are Allow (1), optionally Allow-&-don't-ask-again (2 when the
         # SDK supplied permission suggestions), then Deny (last). _next_ask_action returns the chosen
         # ordinal so we map it back to the action here.
         ask = permission_to_live(tool_name, tool_input, context)
@@ -4954,9 +4982,19 @@ class SdkBackend:
             write_sdk_default(self.state_dir, mode=mode)   # remember as the seed for the NEXT new session, like model/effort (the user 2026-06-27)
         s = self.sessions.get(sid)
         if s:
+            prev = s.perm_mode      # the last CONFIRMED mode — the revert target if the CLI refuses (T139)
             s.mode = mode
             s.perm_mode = mode      # snapshot reflects it immediately (clears the picker's meta-pending)
-            s.set_mode_live(mode)
+            if mode == "bypassPermissions" and prev != "bypassPermissions":
+                # the CLI REFUSES a live switch INTO bypass unless the process was LAUNCHED with
+                # --dangerously-skip-permissions (probed on CLI 2.1.221, T139: 'Cannot set permission
+                # mode to bypassPermissions because the session was not launched with…'). The honest
+                # apply is the RECONNECT (effort's pattern): the relaunch carries
+                # permission_mode=bypassPermissions, which the SDK maps to the launch flag — resume
+                # continues the conversation and the next init confirms perm_mode.
+                s.request_reconnect()
+            else:
+                s.set_mode_live(mode, prev=prev)
         return True
 
     def stop_task(self, sid: str, task_id: str) -> bool:

--- a/tests/test_mode_truth.py
+++ b/tests/test_mode_truth.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Permission-mode truth (T139, 2026-08-28; the exp specimen: a session in CONFIRMED
+bypassPermissions got a permission ask for a plain main-thread Bash and sat blocked eleven hours).
+
+Two truth rules, both the T124 family:
+  * THE DECLARED-INTENT GUARD: the SDK's contract says bypass auto-approves every call before
+    can_use_tool is consulted (deny rules aside) — when the CLI consults anyway (the specimen:
+    CLI 2.1.221, once, against its own contract), romp — the registered permission authority —
+    re-imposes the declared intent: auto-allow + a problems ring, never a block. Other modes keep
+    asking: a consult under default/plan/acceptEdits is the CLI honestly delegating what its own
+    evaluation could not auto-decide.
+  * A REFUSED LIVE SWITCH REVERTS: set_mode flips the displayed mode optimistically and fires
+    set_permission_mode; a refusal used to only log, leaving the switcher asserting a mode the CLI
+    never accepted. Every layer now reverts to the last CONFIRMED mode (snapshot, session, reg —
+    the next connect must not re-apply the refused pick) and the problems ring names it.
+
+Hermetic state; synthetic sids; the SDK client is stubbed."""
+import asyncio
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+# the callback imports PermissionResult* lazily — a hermetic box has no real SDK, so a stub module
+# stands in AT CALL TIME ONLY (installed per-test in _Harness.setUp, removed in tearDown): a
+# module-scope sys.modules entry leaked into the whole pytest process and made every real-SDK-gated
+# test elsewhere stop skipping and run against the stub (30 failures in the full suite).
+_fake = types.ModuleType("claude_agent_sdk")
+class _PRA:
+    def __init__(self, behavior="allow", updated_input=None, updated_permissions=None):
+        self.behavior, self.updated_input, self.updated_permissions = behavior, updated_input, updated_permissions
+class _PRD:
+    def __init__(self, behavior="deny", message="", interrupt=False):
+        self.behavior, self.message, self.interrupt = behavior, message, interrupt
+_fake.PermissionResultAllow = _PRA
+_fake.PermissionResultDeny = _PRD
+_fake.PermissionUpdate = lambda **kw: kw
+sb = SourceFileLoader("romp_sdk_backend_modetruth", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-00000000d139"
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self):
+        self._sdk_before = sys.modules.get("claude_agent_sdk")
+        if self._sdk_before is None:
+            sys.modules["claude_agent_sdk"] = _fake   # call-time only; removed in tearDown
+        self.d = tempfile.mkdtemp()
+        self.logs = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "spec", "cwd": "/tmp", "mode": "bypassPermissions"})
+        self.s = sb.SdkSession(self.be, sb.read_reg(Path(self.d), SID))
+        self.be.sessions[SID] = self.s
+
+    def tearDown(self):
+        if self._sdk_before is None:
+            sys.modules.pop("claude_agent_sdk", None)
+
+    def _problems(self):
+        return [p["text"] for p in self.be.problems(20)]
+
+
+class DeclaredIntentGuard(_Harness):
+    def test_a_consult_under_bypass_auto_allows_and_rings(self):
+        # the specimen, replayed: perm_mode is CONFIRMED bypass; the CLI consults anyway
+        self.s.perm_mode = "bypassPermissions"
+        res = asyncio.run(self.s._can_use_tool("Bash", {"command": "mkdir -p x"}, object()))
+        self.assertEqual(getattr(res, "behavior", None), "allow",
+                         "romp re-imposes the declared intent — never a block under bypass")
+        self.assertTrue(any("bypassPermissions" in t and "contract" in t for t in self._problems()),
+                        "…and the CLI's contract breach is VISIBLE, never silent: %r" % self._problems())
+
+    def test_other_modes_still_ask(self):
+        # a consult under default is the CLI honestly delegating — the ask machinery must engage.
+        # The ask blocks on user input, so run it with a pre-resolved answer future.
+        self.s.perm_mode = "default"
+        async def drive():
+            loop = asyncio.get_running_loop()
+            self.s.loop = loop
+            task = asyncio.ensure_future(self.s._can_use_tool("Bash", {"command": "x"}, object()))
+            await asyncio.sleep(0.05)          # let it park on the ask
+            self.assertIsNotNone(self.s._cur_ask_fut, "the ask engaged (the session marked permission)")
+            self.s.resolve_ask("answer", "1")  # the user allows
+            return await task
+        res = asyncio.run(drive())
+        self.assertEqual(getattr(res, "behavior", None), "allow")
+        self.assertFalse(any("contract" in t for t in self._problems()),
+                         "an honest consult rings nothing")
+
+
+class RefusedSwitchReverts(_Harness):
+    class _RefusingClient:
+        async def set_permission_mode(self, mode):
+            raise RuntimeError("control request rejected")
+
+    class _AckingClient:
+        async def set_permission_mode(self, mode):
+            return None
+
+    def test_refusal_reverts_every_layer_and_rings(self):
+        # the real refused-live fixture (probed on CLI 2.1.221): 'auto' is model-dependent —
+        # 'Cannot set permission mode to auto: auto mode unavailable for this model'
+        self.s.perm_mode = "acceptEdits"       # the last CONFIRMED mode
+        self.s.client = self._RefusingClient()
+        async def drive():
+            self.s.loop = asyncio.get_running_loop()
+            self.assertTrue(self.be.set_mode(SID, "auto"))
+            self.assertEqual(self.s.perm_mode, "auto", "the optimistic flip shows at once")
+            await asyncio.sleep(0.05)          # the control request refuses
+        asyncio.run(drive())
+        self.assertEqual(self.s.perm_mode, "acceptEdits", "the snapshot reverted to the last confirmed mode")
+        self.assertEqual(self.s.mode, "acceptEdits", "…and the connect-time mode")
+        self.assertEqual((sb.read_reg(Path(self.d), SID) or {}).get("mode"), "acceptEdits",
+                         "…and the registry — the next connect must not re-apply the refused pick")
+        self.assertTrue(any("did NOT apply" in t and "reverted" in t for t in self._problems()),
+                        "the failed switch is unmissable: %r" % self._problems())
+
+    def test_a_bypass_pick_applies_via_reconnect_never_the_live_call(self):
+        # probed on CLI 2.1.221 (T139): set_permission_mode INTO bypass is refused unless the
+        # process was LAUNCHED with --dangerously-skip-permissions — so the pick reconnects
+        # (effort's pattern; the relaunch carries the mode) instead of firing a doomed live call
+        self.s.perm_mode = "acceptEdits"
+        calls = []
+        self.s.set_mode_live = lambda mode, prev="default": calls.append(("live", mode))
+        self.s.request_reconnect = lambda: calls.append(("reconnect",))
+        self.assertTrue(self.be.set_mode(SID, "bypassPermissions"))
+        self.assertEqual(calls, [("reconnect",)], "bypass = reconnect, never the refused live call")
+        self.assertEqual(self.s.perm_mode, "bypassPermissions")
+        calls.clear()
+        self.s.perm_mode = "bypassPermissions"
+        self.assertTrue(self.be.set_mode(SID, "default"))
+        self.assertEqual(calls, [("live", "default")], "leaving bypass switches live (the flag only gates entry)")
+
+    def test_an_acked_switch_stays(self):
+        self.s.perm_mode = "acceptEdits"
+        self.s.client = self._AckingClient()
+        async def drive():
+            self.s.loop = asyncio.get_running_loop()
+            self.be.set_mode(SID, "plan")      # plan ACKs live (probed)
+            await asyncio.sleep(0.05)
+        asyncio.run(drive())
+        self.assertEqual(self.s.perm_mode, "plan")
+        self.assertEqual((sb.read_reg(Path(self.d), SID) or {}).get("mode"), "plan")
+        self.assertFalse(any("did NOT apply" in t for t in self._problems()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/romp-lab/lab.sh
+++ b/tools/romp-lab/lab.sh
@@ -12,6 +12,7 @@ for a in "$@"; do case "$a" in
   --keep) KEEP=1 ;;
   --banner-only) MODE=banner ;;       # the T119 reload-banner phase alone (no model spend)
   --highlight-only) MODE=highlight ;; # the T102/T106 highlight loop alone
+  --modes-only) MODE=modes ;;         # the T139 permission-mode sweep alone
 esac; done
 
 LAB="$(mktemp -d /tmp/romp-lab-XXXXXX)"
@@ -77,14 +78,14 @@ curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null || { echo "kernel never be
 echo "lab kernel up on :$PORT (state: $LAB/state)"
 
 RC=0
-if [ "$MODE" != "highlight" ]; then
+if [ "$MODE" != "highlight" ] && [ "$MODE" != "modes" ]; then
   # the reload-banner contract (T119) — first, because it spends no model turns
   LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" KPID="$KPID" KERNEL_BIN="$ROOT/bin/romp-kernel" \
     node "$ROOT/tools/romp-lab/banner-loop.mjs" || RC=$?
   echo "banner loop exit: $RC (shots: $LAB/shots)"
   [ -f "$LAB/kernel.pid" ] && KPID="$(cat "$LAB/kernel.pid")"
 fi
-if [ "$MODE" != "banner" ] && [ "$RC" = 0 ]; then
+if [ "$MODE" != "banner" ] && [ "$MODE" != "modes" ] && [ "$RC" = 0 ]; then
   # the kernel may have been bounced by the banner phase — wait for health before driving it
   for i in $(seq 1 60); do
     curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && break; sleep 0.5
@@ -92,6 +93,15 @@ if [ "$MODE" != "banner" ] && [ "$RC" = 0 ]; then
   LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" PROJECT_DIR="$LAB/project" \
     node "$ROOT/tools/romp-lab/highlight-loop.mjs" || RC=$?
   echo "highlight loop exit: $RC (shots: $LAB/shots)"
+fi
+if [ "$MODE" != "banner" ] && [ "$MODE" != "highlight" ] && [ "$RC" = 0 ]; then
+  # the T139 permission-mode sweep: every mode's ask contract on the real stack
+  for i in $(seq 1 60); do
+    curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && break; sleep 0.5
+  done
+  LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" PROJECT_DIR="$LAB/project" \
+    node "$ROOT/tools/romp-lab/modes-loop.mjs" || RC=$?
+  echo "modes loop exit: $RC (shots: $LAB/shots)"
 fi
 [ "$RC" = 0 ] || KEEP=1
 exit "$RC"

--- a/tools/romp-lab/modes-loop.mjs
+++ b/tools/romp-lab/modes-loop.mjs
@@ -1,0 +1,229 @@
+// The scripted PERMISSION-MODE sweep (T139, the user 2026-08-28: a session in confirmed
+// bypassPermissions got a permission ask and sat blocked eleven hours — 'maybe it's not working
+// properly; do a sweep to make sure that all of them are working as we would expect'). Drives the
+// REAL dashboard through every mode with the same action matrix (a Bash command + a file Write)
+// and asserts the CONTRACT per mode:
+//   * asks appear when the mode says so, never when it says not (bypass is sampled CONTINUOUSLY —
+//     one 'permission' blip fails the phase);
+//   * the switcher's DISPLAYED mode always matches what was picked (the badge is read back after
+//     every set — the T124 truth family);
+//   * a MID-SESSION switch is provably live on the very next action (default → accept: the same
+//     Write that asked before the switch must not ask after).
+// The per-mode ask EXPECTATIONS are the contract table below — plan is exercised via its Plan-ready
+// approval shape. Synthetic content only; cheapest model; exits non-zero naming the first divergence.
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const require2 = createRequire(path.join(ROOT, "vscode-extension", "package.json"));
+const { chromium } = require2("playwright");
+
+const PORT = process.env.PORT, TOKEN = process.env.TOKEN, LAB = process.env.LAB_DIR, PROJ = process.env.PROJECT_DIR;
+const MODEL = process.env.LAB_MODEL || "Haiku";
+const shots = path.join(LAB, "shots");
+let phaseN = 0;
+const fails = [];
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const b = await chromium.launch();
+const page = await b.newPage({ viewport: { width: 1280, height: 850 } });
+page.on("pageerror", (e) => console.log("PAGEERR", String(e)));
+const shot = async (name) => page.screenshot({ path: path.join(shots, `md${String(++phaseN).padStart(2, "0")}-${name}.png`) });
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"} modes:${name}${detail ? " — " + detail : ""}`);
+  if (!ok) fails.push(name);
+};
+
+// ── shared drivers (the highlight loop's idioms) ──────────────────────────
+const newSession = async (name) => {
+  // the pane loader intercepts pointer events while up (a reconnect re-shows it) — wait it out
+  await page.waitForFunction(() => {
+    const sp = document.getElementById("pane-spin");
+    return !sp || sp.classList.contains("gone");   // it hides via .gone (opacity+pointer-events), never display
+  }, { timeout: 30000 });
+  await page.click(".tab.tab-add", { timeout: 8000 });
+  await page.waitForSelector("#picker-search", { timeout: 8000 });
+  await page.fill("#picker-search", name);
+  await page.fill("#picker-dir", PROJ);
+  await page.click("#picker-new-btn");
+  await page.waitForSelector("#statusline .chip, #statusline .compacting-line", { timeout: 60000 });
+  // the meta badges land after the connect settles — picking before they exist is a silent no-op
+  // (the first sweep's every-mode failure); the highlight loop always waited for the model badge
+  await page.waitForSelector('#statusline .meta-btn[data-kind="model"]', { timeout: 60000 });
+  await page.waitForSelector('#statusline .meta-btn[data-kind="mode"]', { timeout: 60000 });
+};
+const pickMeta = async (kind, wantText) => page.evaluate(async ({ kind, wantText }) => {
+  document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));   // fold any open menu (a second pick toggled shut)
+  await new Promise((r) => setTimeout(r, 120));
+  const btn = document.querySelector(`#statusline .meta-btn[data-kind="${kind}"]`);
+  if (!btn) return "no-badge";
+  btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 250));
+  const item = Array.from(document.querySelectorAll(".meta-menu .meta-item"))
+    .find((i) => i.textContent.toLowerCase().includes(wantText.toLowerCase()));
+  if (!item) return "no-item:" + Array.from(document.querySelectorAll(".meta-menu .meta-item")).map((i) => i.textContent.trim().slice(0, 20)).join("|");
+  item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  return "ok";
+}, { kind, wantText });
+const modeBadge = () => page.evaluate(() => {
+  const btn = document.querySelector('#statusline .meta-btn[data-kind="mode"]');
+  return btn ? btn.textContent.trim() : "";
+});
+const askVisible = () => page.evaluate(() => {
+  const la = document.getElementById("live-ask");
+  // the LIVE picker's option rows are .ask-live-opt (the transcript's answered cards use .ask-opt —
+  // the round-4 lesson: the wrong class made every ask invisible to the driver)
+  return !!la && la.style.display !== "none" && !!la.querySelector(".ask-live-opt, .ask-opt");
+});
+const askHeader = () => page.evaluate(() => {
+  const la = document.getElementById("live-ask");
+  return la ? la.textContent.slice(0, 200) : "";
+});
+const answerAsk = async (labelMatch) => page.evaluate((m) => {
+  const la = document.getElementById("live-ask");
+  if (!la) return "no-ask";
+  const opts = Array.from(la.querySelectorAll(".ask-live-opt, .ask-opt"));
+  const hit = m ? opts.find((o) => o.textContent.toLowerCase().includes(m.toLowerCase())) : opts[0];
+  if (!hit) return "no-opt:" + opts.map((o) => o.textContent.trim().slice(0, 30)).join("|");
+  hit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  return "ok";
+}, labelMatch);
+const send = async (text) => {
+  await page.fill("#composer-input", text);
+  await page.keyboard.press("Enter");
+};
+// run one action turn, collecting every ask that appears (answering Allow each time) until the
+// turn settles; samples the state continuously so a bypass blip cannot hide between polls
+const runActions = async (label, { allowWith = "" } = {}) => {
+  const asks = [];
+  const t0 = Date.now();
+  let settledQuiet = 0, seenBusy = false;
+  while (Date.now() - t0 < 240000) {
+    if (await askVisible()) {
+      seenBusy = true;
+      const head = await askHeader();
+      asks.push(head.replace(/\s+/g, " ").slice(0, 120));
+      await shot(`${label}-ask${asks.length}`);
+      const a = await answerAsk(allowWith);
+      if (a !== "ok") { check(`${label}-answerable`, false, a); break; }
+      await sleep(600);
+      continue;
+    }
+    const busyNow = await page.evaluate(() => {
+      const sl = document.querySelector("#statusline");
+      return sl ? /working|permission|blocked|retrying|compacting/i.test(sl.textContent) : false;
+    });
+    if (busyNow) seenBusy = true;
+    // quiet only counts once the turn has demonstrably STARTED — the Working chip lags the send by
+    // up to a push (~3s), and the first sweep read that pre-push silence as "settled" (0 asks)
+    if (!busyNow && (seenBusy || Date.now() - t0 > 15000)) { if (++settledQuiet >= 4) break; }
+    else if (busyNow) settledQuiet = 0;
+    await sleep(400);
+  }
+  return asks;
+};
+
+import fs from "node:fs";
+const actionsFor = (label) => "Do exactly these two things, then stop: "
+  + `1) run this bash command: echo probe-${label}-ok. `
+  + `2) use the Write tool to create a file named probe-${label}.txt containing the single word: probe. `
+  + "No other tools, no questions.";
+const probeWritten = (label) => fs.existsSync(path.join(PROJ, `probe-${label}.txt`));
+
+await page.goto(`http://127.0.0.1:${PORT}/chat?token=${TOKEN}`);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+
+// ── the CONTRACT TABLE the sweep asserts (probed on CLI 2.1.221, T139) ──
+// default consults for BOTH actions (no shadowing rules in the lab); accept-edits auto-allows the
+// Write and consults for Bash; AUTO is MODEL-DEPENDENT — on the lab's Haiku the live switch
+// REFUSES ('auto mode unavailable for this model') and the truth contract is THE REVERT: the
+// badge must fall back to the pre-pick mode, never assert the refused one; BYPASS cannot apply
+// live (launch-flag-gated) — it applies via the RECONNECT, then nothing ever asks.
+const TABLE = [
+  { menu: "normal", match: /normal/i, min: 1, max: 4, label: "default" },
+  // probed round 5: sandbox-safe Bash (echo) auto-approves WITHOUT a consult in default and
+  // acceptEdits alike — default's one ask was the Write; under acceptEdits the Write auto-accepts
+  // too, so this benign matrix consults for NOTHING. A consult would still be answerable (0-1).
+  { menu: "accept", match: /accept/i, min: 0, max: 1, label: "acceptEdits" },
+  { menu: "auto", revertExpected: true, label: "auto" },
+  { menu: "bypass", match: /bypass/i, min: 0, max: 0, label: "bypass" },
+];
+const badgeSettles = async (re, ms = 12000) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    const b2 = await modeBadge();
+    if (re.test(b2)) return b2;
+    await sleep(400);
+  }
+  return await modeBadge();
+};
+
+for (const row of TABLE) {
+  await newSession(`mode-${row.label}`);
+  console.log(`— ${row.label} —`);
+  console.log("model:", await pickMeta("model", MODEL));
+  const preBadge = await modeBadge();
+  const set = await pickMeta("mode", row.menu);
+  check(`${row.label}-set`, set === "ok", set);
+  if (row.revertExpected) {
+    // the refused-live class (auto on the lab's model): the badge must NOT keep asserting the
+    // refused pick — it reverts to the pre-pick mode (the T124 truth family, live on the stack)
+    const back = await badgeSettles(new RegExp(preBadge.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace("▾", ""), "i"));
+    check(`${row.label}-refusal-reverts`, !/auto/i.test(back),
+      `badge settled at ${JSON.stringify(back)} (pre-pick ${JSON.stringify(preBadge)})`);
+    continue;   // the ask matrix is seed-mode-dependent after a revert — nothing more to assert here
+  }
+  const badge = await badgeSettles(row.match);
+  check(`${row.label}-switcher-truth`, row.match.test(badge),
+    `badge reads ${JSON.stringify(badge)} after picking ${row.menu}`);
+  await send(actionsFor(row.label));
+  let asks = await runActions(row.label);
+  if (asks.length === 0 && !probeWritten(row.label)) {
+    // the lab model occasionally settles without touching a tool (a compliance blip, not
+    // machinery — round 6's bypass session answered toollessly where round 5's ran both actions).
+    // ONE bounded retry, logged — never silent (the no-silent-caps rule).
+    console.log(`retry: ${row.label} settled toolless — re-sending the actions once`);
+    await send(actionsFor(row.label) + " You did not do them yet — do them now.");
+    asks = asks.concat(await runActions(row.label + "-retry"));
+  }
+  check(`${row.label}-ask-count`, asks.length >= row.min && asks.length <= row.max,
+    `${asks.length} ask(s): ${asks.join(" || ") || "none"}`);
+  if (row.label === "bypass")
+    check("bypass-never-blocks", asks.length === 0,
+      asks.length ? "an ask under bypass — the specimen class" : "");
+  check(`${row.label}-actions-ran`, probeWritten(row.label),
+    `probe-${row.label}.txt ${probeWritten(row.label) ? "written" : "missing"} (the filesystem is the ground truth)`);
+  await shot(`${row.label}-settled`);
+
+  if (row.label === "default") {
+    // MID-SESSION SWITCH truth: default → accept; the very next Write must not ask
+    const sw = await pickMeta("mode", "accept");
+    check("switch-live-set", sw === "ok", sw);
+    await sleep(700);
+    check("switch-live-badge", /accept/i.test(await modeBadge()), await modeBadge());
+    await send("Use the Write tool to overwrite probe.txt with the word: again. Nothing else.");
+    const asks2 = await runActions("default-after-switch");
+    check("switch-live-on-next-action", !asks2.some((a) => /write|probe.txt/i.test(a)),
+      asks2.length ? asks2.join(" || ") : "no asks (the Write auto-accepted)");
+  }
+}
+
+// ── PLAN mode: the approval shape, not the action matrix ──────────────────
+await newSession("mode-plan");
+console.log("— plan —");
+console.log("model:", await pickMeta("model", MODEL));
+const setPlan = await pickMeta("mode", "plan");
+check("plan-set", setPlan === "ok", setPlan);
+await sleep(700);
+check("plan-switcher-truth", /plan/i.test(await modeBadge()), await modeBadge());
+await send("Plan how you would create a file named probe.txt containing the word probe. "
+  + "When your plan is ready, use the ExitPlanMode tool to present it for approval.");
+const planAsks = await runActions("plan", { allowWith: "keep planning" });
+check("plan-approval-shape", planAsks.some((a) => /plan/i.test(a)),
+  planAsks.join(" || ") || "no Plan-ready approval appeared");
+
+await shot("sweep-done");
+await b.close();
+if (fails.length) { console.log("MODES SWEEP FAILURES:", fails.join(", ")); process.exit(1); }
+console.log("modes sweep: all green");


### PR DESCRIPTION
**The specimen** (a session in confirmed bypassPermissions blocked ~11 hours on a permission ask): no romp layer lied — reg, the CLI's own transcript stamps (97 seconds before the block), and the display all agreed on bypass. CLI 2.1.221 consulted the registered `can_use_tool` callback for a plain main-thread Bash against its own SDK-documented contract ("bypassPermissions auto-approves every tool call (except explicit deny rules) before the callback is consulted"; no deny/ask rules exist on the box), 30 seconds after an equivalent command sailed through unasked.

**Fixes, all the T124 truth family:**
- **The declared-intent guard**: when the CLI consults under bypass anyway, romp — the registered permission authority — re-imposes the declared intent: auto-allow plus a problems ring naming the contract breach. A bypass session can never again block on an ask the user declared they never wanted. Other modes keep asking (a consult there is honest delegation).
- **Bypass applies via reconnect**: probed live — the CLI refuses `set_permission_mode` into bypass unless the process was launched with `--dangerously-skip-permissions`. A bypass pick now reconnects (effort's pattern; the relaunch carries the mode) instead of firing a doomed live call whose failure left the switcher lying.
- **A refused live switch reverts**: probed — `auto` is model-dependent ("unavailable for this model" on Haiku). A refusal used to only log; now every layer reverts to the last confirmed mode (snapshot, session, registry) and the problems ring names it.

**The sweep** (`tools/romp-lab/modes-loop.mjs`, a permanent lab phase, `--modes-only`): drives the real dashboard through all five modes with one action matrix (Bash + Write) and asserts the probed contract — default consults for the Write (sandbox-safe Bash auto-approves without a consult in default and acceptEdits alike, measured); acceptEdits auto-accepts the Write; auto-on-Haiku asserts the revert; bypass applies via the reconnect then never asks (filesystem ground truth); plan presents the Plan-ready approval. A mid-session default→accept switch is provably live on the very next action, and the switcher's badge is read back after every pick. Final run: all green.

**Tests.** Hermetic coverage of all three fixes; the SDK stub is call-time-scoped (a module-scope `sys.modules` stub leaked process-wide and un-skipped 30 real-SDK-gated tests elsewhere — caught in the full run).

Suites: pytest 5884 passed / 34 skipped; vscode-extension 2512/2512; modes sweep exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)