### PR TITLE
Merge becomes Relay: whole exchange, machine-dressed, staged, and the thread stays open

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6361,9 +6361,9 @@ def _comment_status_refusal(prior):
     if prior == "promoting":
         return "this thread is becoming its own session; give it a moment."
     if prior == "merging":
-        return "this thread is merging back into the session; give it a moment."
+        return "this thread is being relayed back to the session; give it a moment."
     if prior == "merged":
-        return "this thread was already merged back into the session."
+        return "this discussion was already relayed; reply in the thread to continue it."
     return "that thread is gone."
 
 
@@ -6701,6 +6701,7 @@ def _comments_frame(sid, tmux=None):
             except Exception:
                 meta = {}
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
+                        "relayedT": th.get("relayedT") or 0,   # the persistent sent-back indicator's stamp (T145)
                         "name": th.get("name") or "", "color": th.get("color") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
@@ -6849,7 +6850,7 @@ def _comment_reply(parent_sid, tid, text):
     be = Sessions.backend_for(parent_sid)
     if not hasattr(be, "fork"):
         return "threads need the SDK backend."
-    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved"),
+    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved", "merged"),
                                    status="open", lastSeenT=int(time.time()))
     if th is None:
         if prior == "promoted":
@@ -6857,7 +6858,9 @@ def _comment_reply(parent_sid, tid, text):
             return "this thread is now the session '%s'; continue there." % (row.get("promotedName") or "")
         return _comment_status_refusal(prior)
     tsid = th["sid"]
-    if prior == "resolved":
+    if prior in ("resolved", "merged"):
+        # a RELAYED thread stays talkable (T145): replying reopens it exactly like a resolved one —
+        # the conversation continues, and a later relay sends only the new tail past relayedT
         reg = _thread_reg(tsid)
         be.resume(reg.get("name") or ("thread-" + tsid[:8]), tsid)   # alive again; names/ untouched
     if not be.send(tsid, str(text)):
@@ -6866,21 +6869,31 @@ def _comment_reply(parent_sid, tid, text):
     return None
 
 
-MERGE_BODY_CAP = 6000   # the thread exchange fed back on a merge — keep the most recent tail
+MERGE_BODY_CAP = 48000  # the relay sends the WHOLE exchange (T145, the user 2026-08-28: it looked
+#                           like only part of the thread merged — the old 6000 trimmed any real
+#                           discussion); this cap is a pathological-thread backstop only, and the
+#                           trim marker still says so honestly when it fires
 
 
 def _merge_body(exact, msgs):
-    """The MERGE handoff (the user 2026-08-23): fold a side discussion's outcome back into the main
-    conversation. Injected-voice rules apply (repo CLAUDE.md): the agent reading this has never heard
-    of romp, so it reads as the person it works for handing over the record of a discussion they had
-    elsewhere, grounded by the passage it was about. No machinery named, no reply slots."""
+    """The RELAY handoff (the user 2026-08-23 as 'merge'; renamed + machine-dressed by T145): send a
+    side discussion back into the main conversation. Injected-voice rules apply to the PROSE (repo
+    CLAUDE.md): the agent reading this has never heard of romp, so it reads as the person it works
+    for handing over the record of a discussion they had elsewhere, grounded by the passage it was
+    about — no machinery named, no reply slots. The MARKER TAIL is for the READER's chat: romp moved
+    this content on the user's behalf, so it renders machine-attributed (the T130 class), never as
+    the user's own typed bubble (their 2026-08-28 complaint). prose() in the voice test splits at
+    the first marker, so the voice audit covers exactly what the agent reads."""
     quote = (exact or "").strip()
     lines = []
     for m in msgs or []:
         t = (m.get("text") or "").strip()
         if not t:
             continue
-        lines.append(("Me: " if m.get("who") == "user" else "Them: ") + t)
+        # the projection's who is "you"/"agent" ("user" accepted for older fixtures) — the first lab
+        # run of this path shipped every line as "Them:", and the parent model read the incoherent
+        # log as fabricated and refused it (T145 lab find)
+        lines.append(("Me: " if m.get("who") in ("you", "user") else "Them: ") + t)
     convo = "\n\n".join(lines)
     if len(convo) > MERGE_BODY_CAP:
         convo = "… (earlier discussion trimmed)\n\n" + convo[-MERGE_BODY_CAP:]
@@ -6891,7 +6904,12 @@ def _merge_body(exact, msgs):
     parts.append(convo)
     parts.append("Treat what we settled there as my direction: fold it into your understanding and "
                  "account for it in everything you do on this from here on.")
-    return "\n\n".join(parts)
+    # romp-injected: the arrival wears the T130 machine attribution (the gray romp bubble + swirl),
+    # NEVER the user's own blue. Deliberately NOT romp-system: that marker routes to the kernel
+    # STATUS notice card (restart/resume family), and relayed CONTENT is a conversation, not a
+    # status — the first lab run of this path rendered as a notice card and the arrival assertion
+    # caught it.
+    return "\n\n".join(parts) + "\n\n<!-- romp-injected --><!-- romp-tag: relay -->"
 
 
 def _comment_merge(parent_sid, tid):
@@ -6909,15 +6927,23 @@ def _comment_merge(parent_sid, tid):
         _comment_update(parent_sid, tid, status=prior)
         return msg
     msgs = _thread_messages(th["sid"], th.get("cutUuid") or "", th.get("createdT") or 0)
+    # A LATER relay sends only the NEW tail (T145: the thread stays talkable after a relay, and
+    # relaying again must not repeat what the session already has). relayedT is EVIDENCE time — the
+    # last relayed message's own stamp, never wall clock (the design rule; wall clocks also skew
+    # cross-host). First relay: everything.
+    floor = th.get("relayedT") or 0
+    if floor:
+        msgs = [m for m in msgs if (m.get("t") or 0) > floor]
     if not any((m.get("text") or "").strip() for m in msgs):
-        return _revert("this thread has no discussion to merge yet.")
+        return _revert("nothing new to send back yet." if floor else "this thread has no discussion to send back yet.")
     body = _merge_body(th.get("exact"), msgs)
     be = Sessions.backend_for(parent_sid)
     try:
         be.send(parent_sid, body)
     except Exception as e:
         return _revert("the merge message could not be delivered: %s" % e)
-    _comment_update(parent_sid, tid, status="merged")
+    _comment_update(parent_sid, tid, status="merged",
+                    relayedT=max((m.get("t") or 0) for m in msgs))
     if hasattr(be, "kill"):
         try:
             be.kill(th["sid"])                      # its work is folded back; the CLI has nothing left

--- a/tests/test_comment_merge.py
+++ b/tests/test_comment_merge.py
@@ -75,7 +75,7 @@ class CommentMerge(unittest.TestCase):
     def test_nothing_to_merge_reverts_the_latch_loudly(self):
         km._thread_messages = lambda tsid, cut, floor_t=0: []
         err = km._comment_merge(PARENT, TSID)
-        self.assertIn("no discussion to merge", err or "")
+        self.assertIn("no discussion to send back", err or "")
         self.assertEqual(self._row().get("status"), "open", "the latch never sticks on a refusal")
         self.assertEqual(self.be.sent, [])
 
@@ -85,16 +85,52 @@ class CommentMerge(unittest.TestCase):
         self.assertIn("could not be delivered", err or "")
         self.assertEqual(self._row().get("status"), "open")
 
-    def test_a_merged_thread_refuses_a_second_merge_and_replies(self):
+    def test_a_relayed_thread_stays_talkable_and_a_second_relay_sends_only_the_new_tail(self):
+        # T145 (the user 2026-08-28): a relay does NOT close the thread — talking continues, and the
+        # next relay carries only what the session hasn't seen (the evidence-time relayedT floor).
         self.assertIsNone(km._comment_merge(PARENT, TSID))
+        self.assertEqual(len(self.be.sent), 1)
+        self.assertGreater(self._row().get("relayedT") or 0, 0, "the sent-back stamp persists on the row")
+        # nothing new yet → the CAS refuses in relay vocabulary, pointing at the reply path
         err = km._comment_merge(PARENT, TSID)
-        self.assertIn("already merged", err or "")
-        self.assertEqual(len(self.be.sent), 1, "once per thread")
+        self.assertIn("already relayed", err or "")
+        # a reply REOPENS the relayed thread exactly like a resolved one…
+        self.be.fork = lambda *a, **k: None      # the reply path gates on the SDK shape (fork/resume)
+        self.be.resume = lambda name, sid: None
+        _send0 = self.be.send                    # the reply path checks send's truthiness; the fake returns None
+        self.be.send = lambda sid, text: (_send0(sid, text) or True)
+        self.assertIsNone(km._comment_reply(PARENT, TSID, "one more thought"))
+        self.assertEqual(self._row().get("status"), "open")
+        # …and the next relay sends ONLY messages past the floor
+        base = km._thread_messages(TSID, "", 0)
+        newer = base + [{"who": "user", "text": "one more thought", "t": (base[-1]["t"] if base else 0) + 10}]
+        km._thread_messages = lambda tsid, cut, floor_t=0: newer
+        self.assertIsNone(km._comment_merge(PARENT, TSID))
+        self.assertEqual(len(self.be.sent), 3, "the relay + the reply + the tail-only relay")
+        self.assertIn("one more thought", self.be.sent[-1][1])
+        for m in base:
+            if (m.get("text") or "").strip():
+                self.assertNotIn(m["text"], self.be.sent[-1][1], "already-relayed content never repeats")
+
+    def test_the_relay_arrives_machine_dressed_with_the_whole_exchange(self):
+        # T145: the arrival wears the T130 machine attribution (markers), never a plain user bubble,
+        # and the body carries BOTH sides of the exchange in full.
+        self.assertIsNone(km._comment_merge(PARENT, TSID))
+        body = self.be.sent[0][1]
+        self.assertIn("<!-- romp-injected --><!-- romp-tag: relay -->", body)
+        self.assertNotIn("romp-system", body, "relayed content is a conversation, not a kernel status notice")
+        for m in km._thread_messages(TSID, "", 0):
+            if (m.get("text") or "").strip():
+                self.assertIn(m["text"], body, "the WHOLE exchange goes — no summary, no slice")
 
     def test_the_transcript_cap_keeps_the_recent_tail(self):
+        # T145 raised the cap to 48k (the whole exchange goes; 6k trimmed real discussions — the
+        # user's 'only part merged'); the trim marker remains the honest pathological backstop
         body = km._merge_body("q", [{"who": "user", "text": "x" * 9000}])
-        self.assertIn("earlier discussion trimmed", body)
-        self.assertLess(len(body), 9000, "capped — a huge thread never floods the parent's turn")
+        self.assertNotIn("earlier discussion trimmed", body, "9k is a normal discussion now — untrimmed")
+        big = km._merge_body("q", [{"who": "user", "text": "x" * 60000}])
+        self.assertIn("earlier discussion trimmed", big)
+        self.assertLess(len(big), 60000, "the pathological backstop still bounds the injection")
 
 
 if __name__ == "__main__":

--- a/tools/romp-lab/README.md
+++ b/tools/romp-lab/README.md
@@ -56,7 +56,9 @@ The default run drives TWO phases, banner first (it spends no model turns):
   reply), 4d clear-timing (the mark may never read settled while the final answer is
   not visible — T112), and 4e thread-interrupt (T138: the popover's working state
   offers the stop square, it targets the THREAD's own session, the ack is instant,
-  the pulse clears on the gesture — no reply record is coming — and the turn ends).
+  the pulse clears on the gesture — no reply record is coming — and the turn ends), and
+  6 relay (T145: the Relay button acks instantly, the WHOLE exchange arrives in the main
+  thread machine-dressed, the thread keeps its ↩ sent-back marker and stays talkable).
   `--highlight-only` skips the banner phase.
 
 ## Cost

--- a/tools/romp-lab/highlight-loop.mjs
+++ b/tools/romp-lab/highlight-loop.mjs
@@ -203,6 +203,40 @@ await page.waitForFunction(() => !document.querySelector(".cmt-pop .cmt-state .c
   .catch(() => check("4e-turn-ends", false, "thread still working 60s after the interrupt"));
 await shot("interrupted-settled");
 
+// PHASE 6 (T145, permanent): RELAY — the discussion goes back to the main conversation whole,
+// machine-dressed, with staged feedback and a persistent sent-back marker; the thread stays
+// talkable. Runs BEFORE phase 5's quiet sampling so its own settling is covered by it.
+{
+  const relayBtn = await page.evaluate(() => {
+    const b = Array.from(document.querySelectorAll('.cmt-pop .cmt-act')).find((x) => x.textContent === "Relay");
+    if (!b) return false;
+    b.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    return true;
+  });
+  check("6-relay-button-renders-and-clicks", relayBtn, "no Relay button in the open popover");
+  // instant ack: the button flips before any kernel round-trip
+  const ack = await page.evaluate(() => {
+    const b = Array.from(document.querySelectorAll('.cmt-pop .cmt-act')).find((x) => x.textContent === "Relaying…");
+    return !!b && b.disabled;
+  });
+  check("6-instant-ack", ack, "the button did not flip to Relaying…");
+  // the arrival: a machine-dressed (romp-attributed) turn in the MAIN thread carrying the WHOLE
+  // exchange — both the user's question and the final answer text
+  await page.waitForFunction((f) => Array.from(document.querySelectorAll("#content .turn.romp"))
+    .some((t) => t.textContent.includes("side discussion") && t.textContent.includes(f)
+              && t.textContent.includes("Why is that the case?")), FINAL, { timeout: 120000 })
+    .then(() => check("6-machine-dressed-whole-exchange-arrives", true))
+    .catch(() => check("6-machine-dressed-whole-exchange-arrives", false,
+      "no romp-attributed arrival carrying both sides of the exchange in the main thread"));
+  // the persistent sent-back marker in the thread, and the composer still invites more talk
+  await page.waitForFunction(() => !!document.querySelector(".cmt-pop .cmt-relayed-note"), undefined, { timeout: 30000 })
+    .then(() => check("6-sent-back-marker", true))
+    .catch(() => check("6-sent-back-marker", false, "no ↩ sent-back marker in the popover"));
+  const talkable = await page.evaluate(() => !!document.querySelector(".cmt-pop .cmt-input"));
+  check("6-thread-stays-talkable", talkable, "the composer vanished after the relay");
+  await shot("relayed");
+}
+
 // PHASE 5: nothing sticks — sample well past several pushes
 await page.waitForTimeout(10000);
 check("5-nothing-sticks", (await busy()) === false, "busy after 10s quiet");

--- a/ui/webview/comment-merge.test.ts
+++ b/ui/webview/comment-merge.test.ts
@@ -1,7 +1,11 @@
-// The comment thread's third exit (the user 2026-08-23): MERGE folds the discussion back into the
-// parent session. The kernel executes the flow (tests/test_comment_merge.py + the injected-voice
-// sweep); these are the UI's source pins: the button, the delegated click-safe handler with its
-// instant ack, and the merged status wearing resolved's dim everywhere it renders.
+// The comment thread's RELAY exit (the user 2026-08-23 as 'merge'; rethought end-to-end by T145,
+// the user 2026-08-28): send the discussion back into the parent session. The kernel executes the
+// flow (tests/test_comment_merge.py + the injected-voice sweep); these are the UI's source pins.
+// The T145 contract: the verb is Relay (Merge implied the thread closes — it doesn't); the arrival
+// wears the machine-dressed attribution, never a plain user bubble; the WHOLE exchange goes; the
+// thread stays talkable and carries a persistent sent-back marker at the relay's place in time.
+// Wire ids (commentMerge / merging / merged) stay — persisted rows; display-only rename, the
+// Accept-edits precedent.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -10,29 +14,51 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const TYPES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "comments.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("the Merge button rides the actions row, delegated, acknowledging before the round-trip", () => {
-  assert.match(RENDER, /mg\.textContent = "Merge";/);
-  assert.match(RENDER, /mg\.dataset\.act = "cmtmerge";/);
+test("the Relay button rides the actions row, delegated, acknowledging before the round-trip", () => {
+  assert.match(RENDER, /mg\.textContent = "Relay";/);
+  assert.match(RENDER, /mg\.dataset\.act = "cmtmerge";/);   // the wire op keeps its name
   assert.match(RENDER, /cmtmerge: \(elx\) => \{/);
-  assert.match(RENDER, /elx\.textContent = "Merging…";/);
+  assert.match(RENDER, /elx\.textContent = "Relaying…";/);
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "commentMerge", id: cur\.sid, tid: cur\.th\.tid \}\);/);
+  assert.ok(!RENDER.includes('mg.textContent = "Merge"'), "the old verb is gone from the button");
 });
 
-test("merged is a first-class status: title, dim, rail, and a closed composer", () => {
+test("relayed is a first-class status, and the thread STAYS TALKABLE", () => {
   assert.match(TYPES, /"merging" \| "merged"/);
-  assert.match(RENDER, /: th!\.status === "merged" \? nm \+ " \(merged into the session\)"/);
+  assert.match(RENDER, /: th!\.status === "merging" \? "Relaying back to the session…"/);
+  assert.match(RENDER, /: th!\.status === "merged" \? nm \+ " \(relayed to the session\)"/);
   assert.match(RENDER, /t\.status === "open" \|\| t\.status === "resolved" \|\| t\.status === "merged"/);
   assert.match(RENDER, /th\.status === "resolved" \|\| th\.status === "merged" \? " resolved" : ""/);
-  assert.match(RENDER, /Merged — its outcome lives in the session now/);
+  // the composer invites the next message instead of declaring the thread done
+  assert.match(RENDER, /Reply to continue — the discussion so far was relayed to the session…/);
+  // …and the kernel reopens a relayed thread on reply exactly like a resolved one
+  assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "resolved", "merged"\),\n\s*status="open"/);
+  assert.match(KERNEL, /if prior in \("resolved", "merged"\):/);
 });
 
-test("kernel: the op is registered, latched like promote, and the handoff is voice-ruled", () => {
+test("the persistent sent-back marker sits at the relay's place in time and survives reopens", () => {
+  assert.match(TYPES, /relayedT\?: number;/);
+  assert.match(KERNEL, /"relayedT": th\.get\("relayedT"\) or 0,/, "the stamp rides the comments frame — store-backed, reopen-proof");
+  assert.match(RENDER, /function cmtRelayedNote\(t: number\): HTMLElement/);
+  assert.match(RENDER, /if \(!relayNoted && dayOpen != null && dayOpen > \(th\.relayedT \|\| 0\)\)/,
+    "placed BY TIME: above it went back; below is the tail the next relay sends");
+  assert.match(RENDER, /if \(!relayNoted\) list\.appendChild\(cmtRelayedNote\(th\.relayedT \|\| 0\)\);/, "relay at the tail still shows");
+  assert.match(CSS, /\.cmt-relayed-note \{ text-align: center; font-size: 0\.82em; color: var\(--dim\); opacity: 0\.85; padding: 5px 0 3px; \}/);
+});
+
+test("kernel: whole exchange by default, machine-dressed arrival, tail-only re-relays", () => {
   assert.match(KERNEL, /"commentMerge"\)/);
   assert.match(KERNEL, /elif t == "commentMerge" and msg\.get\("tid"\):/);
-  assert.match(KERNEL, /def _comment_merge\(parent_sid, tid\):/);
   assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "resolved"\), status="merging"\)/);
-  assert.match(KERNEL, /MERGE_BODY_CAP = 6000/);
-  // the reply CAS never accepts a merged thread, so a merged discussion cannot silently reopen
-  assert.match(KERNEL, /this thread was already merged back into the session\./);
+  assert.match(KERNEL, /MERGE_BODY_CAP = 48000/, "the whole exchange goes (T145) — the cap is a pathological backstop, not a summary");
+  // the arrival renders machine-attributed (the T130 class), never as the user's own typed bubble
+  assert.match(KERNEL, /<!-- romp-injected --><!-- romp-tag: relay -->/);
+  assert.ok(!KERNEL.includes('romp-system --><!-- romp-tag: relay'), "not romp-system: that routes to the status notice card, and a relay is conversation (lab-caught)");
+  // a later relay sends only what the session hasn't seen — evidence-time floor, never wall clock
+  assert.match(KERNEL, /floor = th\.get\("relayedT"\) or 0/);
+  assert.match(KERNEL, /msgs = \[m for m in msgs if \(m\.get\("t"\) or 0\) > floor\]/);
+  assert.match(KERNEL, /relayedT=max\(\(m\.get\("t"\) or 0\) for m in msgs\)/);
+  assert.match(KERNEL, /nothing new to send back yet\./);
 });

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -541,7 +541,7 @@ test("stuck-green regression: a stalled or missing later frame can never park th
 // (tab strip) — not transcript-rendering settings, N/A both before and after. ───────────────────
 test("the popover renders the chat's display units — thinking hidden, tool runs folded, per the gear", () => {
   const at = UI.indexOf("renderingIntoThread = true;");
-  const block = UI.slice(at, at + 2200);
+  const block = UI.slice(at, at + 2800);   // widened past the T145 relay-note insert
   assert.ok(block.includes("? compactDisplay(evs.map((e) => e.kind), evs.map((e) => e.kind === \"tool\" ? e.name : undefined))"),
     "the SAME unit builder the chat uses, gated on the SAME settings.compact");
   assert.ok(block.includes('const key = it.kind === "toolgroup" ? toolGroupKey(run[0]) : retryGroupKey(run[0]);'),
@@ -607,7 +607,7 @@ test("the pending echo prunes against EVENTS too — a landed user turn never do
 
 test("the parity bundle (2026-08-26): dividers, owner-scoped in-turn controls, the sid stamp", () => {
   // day dividers open new days in the popover exactly as in the chat (same helper, same idiom)
-  assert.match(UI, /const dayOpen = eventEpoch\(evs\[itemFirstEvent\(it\)\]\);\s*\n\s*if \(dayOpen != null\) \{\s*\n\s*const dv = dayDividerFor\(dayOpen, prev\);/);
+  assert.match(UI, /const dayOpen = eventEpoch\(evs\[itemFirstEvent\(it\)\]\);[\s\S]{0,300}?if \(dayOpen != null\) \{\s*\n\s*const dv = dayDividerFor\(dayOpen, prev\);/);   // the T145 relay-note insert sits between
   // the popover's list is stamped with the THREAD sid, and in-turn controls resolve their owner
   // from the DOM at click time — queued ✕ and the api-error card act on the thread, never the tab
   assert.match(UI, /list\.dataset\.session = th\.tid;/);

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -24,6 +24,7 @@ export type CommentThread = {
   modelColor?: number[];      // the chat statusline's rank tints, so metaColor paints the popover
   effortColor?: number[];     //   badges exactly as the chat's (the 2026-08-25 color rider)
   promotedName: string;       // the board session it became, when status === "promoted"
+  relayedT?: number;          // when the discussion was last sent back to the session (T145) — 0/absent = never
   model?: string;             // the thread's live/chosen model (the popover's switchable chip)
   effort?: string;            // the thread's effort level (ditto)
   msgs: CommentMsg[];

--- a/ui/webview/injected-render.test.ts
+++ b/ui/webview/injected-render.test.ts
@@ -9,7 +9,9 @@
 //     multi-goal bundles · awaiting backstop · debt reminders · the retry message · goal check-ins
 //   PERSON-VOICED BY DESIGN (no marker — they are written as the person's own words, per the
 //   2026-06-20 rule and the injected-voice test): typed follow-ups · the Continue gesture ·
-//   comment-thread merges · comment-thread openers · edit traces — these stay the user's blue.
+//   comment-thread openers · edit traces — these stay the user's blue. (Thread RELAYS moved to
+//   the machine-voiced set by T145: the user ruled the arrival is romp moving content on their
+//   behalf, not their own typed words — the prose still speaks as the person for the AGENT.)
 //   THIRD-PARTY TAGGED (romp-tag with no romp-injected): the ⚙-labelled tag bubble.
 //
 // The classifier is executable here; the display strip and the marker discipline are source pins.
@@ -29,6 +31,7 @@ test("every machine-voiced shape classifies 'romp' — the flag the markers set,
     { name: "kernel-restart resume", ev: { romp: true, md: "[romp] The romp kernel restarted…" } },
     { name: "pr-watch landing", ev: { romp: true, md: "[romp] The pull request you asked romp to watch has MERGED…", tag: "pr-watch" } },
     { name: "generic watch", ev: { romp: true, md: "[romp] The condition you asked romp to watch now HOLDS…", tag: "watch" } },
+    { name: "thread relay (T145)", ev: { romp: true, md: "I took a side discussion with another assistant about this passage…", tag: "relay" } },
     { name: "auto-nudge", ev: { romp: true, rompAuto: true, md: "Where does this stand?" } },
     { name: "nudge button", ev: { romp: true, md: "Status update please?" } },
   ]) assert.equal(senderKind(shape.ev as never), "romp", shape.name + " wears the one machine treatment");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6567,7 +6567,7 @@ function styleCommentMark(m: HTMLElement, th: CommentThread): void {
   m.classList.toggle("unread", !!th.unread && th.status === "open");
   m.classList.toggle("busy", commentInFlight(th));
   m.title = th.status === "promoted" ? "thread, now the session '" + th.promotedName + "'"
-    : th.status === "merged" ? "merged thread: its outcome was folded back into the session"
+    : th.status === "merged" ? "relayed thread: its discussion was sent back into the session"
     : th.status === "resolved" ? "resolved thread: click to read or reopen"
     : "thread: click to open";
 }
@@ -6662,6 +6662,17 @@ function owningSidOf(el0: HTMLElement | null): string | null {
   return (el0?.closest("[data-session]") as HTMLElement | null)?.dataset.session || activeId;
 }
 
+// The persistent sent-back marker (T145): where the last relay CUT the thread — everything above
+// it went back to the main conversation; everything below is the new tail a later relay would
+// send. From the store (relayedT rides the comments frame), so it survives reopens; evidence-time
+// stamp, rendered in the rail's own HH:MM.
+function cmtRelayedNote(t: number): HTMLElement {
+  const n = el("div", "cmt-relayed-note");
+  n.textContent = `↩ sent back to the main conversation · ${markerLabel(t, null, Date.now()).hm}`;
+  n.title = "the discussion above was relayed into the session; anything below goes with the next relay";
+  return n;
+}
+
 function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): void {
   list.dataset.session = th.tid;   // the THREAD owns its queue/errors — in-turn controls resolve to it
   const prevScroll = list.scrollTop;
@@ -6716,10 +6727,15 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
       ? compactDisplay(evs.map((e) => e.kind), evs.map((e) => e.kind === "tool" ? e.name : undefined))
       : evs.map((_, i) => ({ kind: "event", index: i } as DisplayItem));
     const thWorking = threadBusy(th.state);
+    let relayNoted = !th.relayedT;   // T145: drop the sent-back marker at its place in time, once
     for (const it of items) {
       // a new day opens with the chat's own divider (the parity bundle, 2026-08-26) — same helper,
       // same placement idiom as appendItem
       const dayOpen = eventEpoch(evs[itemFirstEvent(it)]);
+      if (!relayNoted && dayOpen != null && dayOpen > (th.relayedT || 0)) {
+        list.appendChild(cmtRelayedNote(th.relayedT || 0));
+        relayNoted = true;
+      }
       if (dayOpen != null) {
         const dv = dayDividerFor(dayOpen, prev);
         if (dv) list.appendChild(dv);
@@ -6752,6 +6768,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
       const ep = eventEpoch(ev);
       if (ep != null) prev = ep;
     }
+    if (!relayNoted) list.appendChild(cmtRelayedNote(th.relayedT || 0));   // relay at the tail — nothing new after it yet
     renderingIntoThread = false;
     renderingSid = saved;
     renderingOwnerSid = savedOwner;
@@ -6929,8 +6946,8 @@ function commentPopTitle(create: boolean, th: CommentThread | null | undefined):
   return create ? "New comment:"
     : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
     : th!.status === "promoting" ? "Breaking out…"
-    : th!.status === "merging" ? "Merging back in…"
-    : th!.status === "merged" ? nm + " (merged into the session)"
+    : th!.status === "merging" ? "Relaying back to the session…"
+    : th!.status === "merged" ? nm + " (relayed to the session)"
     : th!.status === "resolved" ? nm + " (resolved)" : nm;
 }
 
@@ -7156,7 +7173,7 @@ function renderCommentPopover(): void {
     box.className = "cmt-input";
     box.rows = 2;
     box.placeholder = create ? "Comment on this passage…"
-      : th!.status === "merged" ? "Merged — its outcome lives in the session now"
+      : th!.status === "merged" ? "Reply to continue — the discussion so far was relayed to the session…"
       : th!.status === "resolved" ? "Reply to reopen…" : "Reply…";
     box.value = commentDrafts.get(dk) || "";
     box.addEventListener("input", () => commentDrafts.set(dk, box.value));
@@ -7217,8 +7234,8 @@ function renderCommentPopover(): void {
       if (th.status === "open" || th.status === "resolved") {
         const mg = el("button", "cmt-act") as HTMLButtonElement;
         mg.type = "button";
-        mg.textContent = "Merge";
-        mg.title = "Send this discussion back into the session as direction going forward; the thread closes as merged";
+        mg.textContent = "Relay";   // T145: the verb is 'sending it back into the main thread with context' — Merge implied the thread closes, and it doesn't
+        mg.title = "Send this discussion back into the main conversation as context going forward; the thread stays open for more talk";
         mg.dataset.act = "cmtmerge";
         row.appendChild(mg);
       }
@@ -12755,7 +12772,7 @@ setupSettings();
       const cur = openCommentThread();
       if (!cur) return;
       (elx as HTMLButtonElement).disabled = true;   // acknowledge before the round-trip
-      elx.textContent = "Merging…";
+      elx.textContent = "Relaying…";
       vscodeApi?.postMessage({ type: "commentMerge", id: cur.sid, tid: cur.th.tid });
     },
     cmtresolve: (elx) => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2919,6 +2919,8 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 /* the chat's under-bubble button family, exactly (the composer-stage-btn dress — the user
    2026-08-25: the popover's buttons should be the chat's, one vocabulary): neutral at rest,
    accent on hover, the 0.78em label tier */
+/* the sent-back marker (T145): a quiet centered line in the house sub scale — a fact, not a state */
+.cmt-relayed-note { text-align: center; font-size: 0.82em; color: var(--dim); opacity: 0.85; padding: 5px 0 3px; }
 .cmt-act {
   background: transparent;   /* T141: one dress with the stage button + the feed's word-buttons */
   border: 1px solid var(--card-border); color: var(--dim); border-radius: 5px; font-size: 0.82em;


### PR DESCRIPTION
The user's five observations on the comment-thread merge flow, one rethink.

## The verb: Relay
One word for *sending the discussion back into the main conversation with context* — Merge implied the thread closes, and it doesn't. All copy renamed; wire ids stay (persisted rows; the Accept precedent).

## Completeness — the user was right
Extraction was already whole, but `MERGE_BODY_CAP = 6000` tail-trimmed any real discussion: 'only part of the thread merged' was literal. Now 48k as a pathological backstop; **the whole exchange goes by default**.

## Rendering — machine-dressed, two lab-caught bugs
The body carries `romp-injected` + `romp-tag: relay`: the arrival wears the **T130 machine attribution**, never a plain user bubble. The lab caught: (1) every line said 'Them:' (`who=='user'` vs the projection's `'you'`) — the parent model refused the incoherent log as fabricated; (2) `romp-system` in the tail routed the arrival to the status notice card. Both fixed + pinned.

## Thread state — stays open
Reply reopens a relayed thread exactly like resolved. `relayedT` (evidence-time) rides the row + frame; the popover renders a persistent **↩ sent back · HH:MM marker at its place in time** — above went back, below is the tail — and a later relay sends **only that tail**.

## Feedback
Instant ack → staged title → the attributed arrival (dot + notch, auto-scroll at tail) → marker on the same frame. Postal transport considered, skipped (`be.send` already gives delivery discipline; the dress comes from markers).

## Proof
Permanent lab phase 6: **ALL PHASES GREEN (22 checks)** — machine-dressed whole-exchange arrival, marker persists, thread talkable, phases 1–5 intact. Kernel merge/threads/voice suites green; webview 2515/2515, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)