### PR TITLE
The cut ledger stops undercounting, and a stalled failed PR pings its manager (T143)

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1028,14 +1028,16 @@ fi
 
 if [[ "${1:-}" == "watch-pr" ]]; then
     shift
-    _wp_usage="usage: romp watch-pr <number> [--repo <owner/name>] [--session <name>]"
-    _wp_pr=""; _wp_repo=""; _wp_sess=""
+    _wp_usage="usage: romp watch-pr <number> [--repo <owner/name>] [--session <name>] [--escalate <session>]"
+    _wp_pr=""; _wp_repo=""; _wp_sess=""; _wp_esc=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --repo)    shift; [[ $# -eq 0 || -z "$1" || "$1" == -* ]] && { echo "$_wp_usage" >&2; exit 2; }
                        _wp_repo="$1"; shift ;;
             --session) shift; [[ $# -eq 0 || -z "$1" || "$1" == -* ]] && { echo "$_wp_usage" >&2; exit 2; }
                        _wp_sess="$1"; shift ;;
+            --escalate) shift; [[ $# -eq 0 || -z "$1" || "$1" == -* ]] && { echo "$_wp_usage" >&2; exit 2; }
+                       _wp_esc="$1"; shift ;;
             -*)        echo "$_wp_usage" >&2; exit 2 ;;
             *)         [[ -n "$_wp_pr" ]] && { echo "$_wp_usage" >&2; exit 2; }
                        _wp_pr="$1"; shift ;;
@@ -1064,8 +1066,11 @@ if [[ "${1:-}" == "watch-pr" ]]; then
         exit 1
     fi
     _wp_key="id"; [[ -n "$_wp_sess" ]] && _wp_key="name"
-    _payload="$(python3 -c 'import json,sys; print(json.dumps({"pr": int(sys.argv[1]), "repo": sys.argv[2], sys.argv[3]: sys.argv[4]}))' \
-        "$_wp_pr" "$_wp_repo" "$_wp_key" "$_wp_who")"
+    _payload="$(python3 -c 'import json,sys
+b = {"pr": int(sys.argv[1]), "repo": sys.argv[2], sys.argv[3]: sys.argv[4]}
+if len(sys.argv) > 5 and sys.argv[5]: b["escalate"] = sys.argv[5]
+print(json.dumps(b))' \
+        "$_wp_pr" "$_wp_repo" "$_wp_key" "$_wp_who" "$_wp_esc")"
     _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/watch-pr" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp watch-pr: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10744,12 +10744,25 @@ def _poll_remote_views(r):
 # USAGE_POLL precedent): modest cadence, a touch slower while checks visibly run. Terminal means
 # MERGED, CLOSED, or a FAILED check — both ends of the standing watcher rule — and a gh failure is
 # LOUD: three consecutive errors deliver a failure notice and retire the watch, never a silent dead
-# loop the worker discovers hours later.
+# loop the worker discovers hours later. (A FAILED CHECK stopped being terminal in T143: it mails
+# the owner once and HOLDS — see the stalled-failure escalation block below.)
 
 PR_WATCH_FILE = jd.STATE / "pr-watches.json"
 PR_WATCH_EVERY = 60          # the base poll cadence (seconds)
 PR_WATCH_BUSY_EVERY = 90     # …relaxed while checks are visibly still running
 PR_WATCH_MAX_FAILS = 3       # consecutive gh failures before the loud retire
+# STALLED-FAILURE ESCALATION (T143, the ~6h invisible-ask specimen: the worker's failure notice
+# landed in a session a restart had killed, and the USER discovered the stalled PR). A FAILED check
+# no longer retires the watch: the failure mail goes to the owner as before, but the watch HOLDS
+# and keeps polling — resolution is EVENT-keyed (checks re-running clears the held state; merged/
+# closed ends the watch normally). Only the gap with no event — nobody acted — takes the bounded
+# check-back: held-failed past PR_WATCH_ESCALATE_S with the failure still standing, ONE mail to the
+# escalation target. The target is NAMED, never inferred (the kernel cannot trace a PR to a user
+# ask): per-watch (`romp watch-pr --escalate <session>`) or the box default
+# (STATE/watch-escalate.json {"name": ...}); unset = no ping, no false alarms for non-user work.
+# failedAt/escalated PERSIST with the row — the specimen window held ~21 restarts, and a clock that
+# reset on each would never fire.
+PR_WATCH_ESCALATE_S = 2 * 3600
 _pr_watches = []             # [{pr, repo, sid, at} + runtime {_next, _fails, _busy}]
 _pr_watch_lock = threading.Lock()
 
@@ -10771,23 +10784,29 @@ def _pr_watches_load():
 
 def _pr_watches_save():
     with _pr_watch_lock:
-        rows = [{k: r[k] for k in ("pr", "repo", "sid", "at")} for r in _pr_watches]
+        rows = [{k: r[k] for k in ("pr", "repo", "sid", "at", "escalate", "failedAt", "escalated")
+                 if k in r} for r in _pr_watches]
     try:
         _atomic_write(PR_WATCH_FILE, json.dumps(rows))
     except Exception:
         sys.stderr.write("pr-watches save: %s\n" % traceback.format_exc())
 
 
-def add_pr_watch(pr, repo, sid, now=None):
+def add_pr_watch(pr, repo, sid, now=None, escalate=""):
     """Register (idempotently) a landing watch: one mail to `sid` when repo#pr reaches a terminal
-    state. Returns the row."""
+    state. `escalate` names the session pinged if a FAILED check sits unresolved past the bound
+    (T143 — the delegating manager registers itself; the kernel infers nothing). Returns the row."""
     pr, repo, sid = int(pr), str(repo).strip(), str(sid).strip()
     with _pr_watch_lock:
         for r in _pr_watches:
             if r["pr"] == pr and r["repo"] == repo and r["sid"] == sid:
+                if escalate and not r.get("escalate"):
+                    r["escalate"] = str(escalate).strip()
                 return {k: r[k] for k in ("pr", "repo", "sid", "at")}
         row = {"pr": pr, "repo": repo, "sid": sid, "at": int(now if now is not None else time.time()),
                "_next": 0, "_fails": 0, "_busy": False}
+        if escalate:
+            row["escalate"] = str(escalate).strip()
         _pr_watches.append(row)
     _pr_watches_save()
     return {k: row[k] for k in ("pr", "repo", "sid", "at")}
@@ -10840,6 +10859,28 @@ def _pr_watch_notice(verdict, repo, pr, detail=""):
     return body + "\n\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: pr-watch -->"
 
 
+def _watch_escalate_default():
+    """The box-default escalation target (STATE/watch-escalate.json {"name": ...}) — set once by
+    the managing session; absent = no default, no pings (the kernel never guesses a manager)."""
+    try:
+        d = json.loads((jd.STATE / "watch-escalate.json").read_text())
+        return str(d.get("name") or "").strip() if isinstance(d, dict) else ""
+    except Exception:
+        return ""
+
+
+def _pr_watch_stalled_notice(r, now):
+    """The ONE escalation mail (T143): a watched PR has sat failed past the bound — the owner was
+    mailed when it failed, and nothing has moved since. The [romp] mechanics family; PURE for the
+    voice test."""
+    hours = max(1, int((now - int(r.get("failedAt") or now)) // 3600))
+    return ("[romp] A pull request romp is watching has sat with a FAILED check for ~%dh with no "
+            "movement: %s#%s (the session that registered the watch, %s, was told when it failed). "
+            "It will not land on its own — someone needs to pick it up."
+            % (hours, r["repo"], r["pr"], r.get("sid", "?")[:8])
+            + "\n\n<!-- romp-tag: pr-watch -->")
+
+
 def _pr_watch_read(pr, repo):
     """One gh read → (verdict, detail) or ("error", why). Subprocess, bounded."""
     try:
@@ -10882,7 +10923,31 @@ def _pr_watch_tick(now):
             continue
         r["_fails"] = 0
         if verdict is None:
+            if r.get("failedAt"):
+                # the failure RESOLVED by event (checks re-running / a new push) — the held state
+                # clears and the watch continues normally; no clock involved (T143)
+                r.pop("failedAt", None)
+                r.pop("escalated", None)
+                _pr_watches_save()
             r["_next"] = now + (PR_WATCH_BUSY_EVERY if detail == "busy" else PR_WATCH_EVERY)
+            continue
+        if verdict == "failed":
+            # a failed check HOLDS the watch instead of retiring it (T143: the one failure mail
+            # died with a restarted worker and the PR sat invisible ~6h): the owner is mailed once,
+            # the row keeps polling for the resolution events, and ONLY the no-event gap — nobody
+            # acted — takes the bounded escalation to the NAMED target.
+            if not r.get("failedAt"):
+                r["failedAt"] = int(now)
+                _pr_watches_save()
+                _pr_watch_deliver(r["sid"], _pr_watch_notice(verdict, r["repo"], r["pr"], detail))
+            elif (not r.get("escalated")) and now - int(r["failedAt"]) >= PR_WATCH_ESCALATE_S:
+                target = str(r.get("escalate") or _watch_escalate_default() or "").strip()
+                tsid = _sid_of(target) if target else ""
+                if tsid:
+                    r["escalated"] = True
+                    _pr_watches_save()
+                    _pr_watch_deliver(tsid, _pr_watch_stalled_notice(r, now))
+            r["_next"] = now + PR_WATCH_EVERY
             continue
         _pr_watch_deliver(r["sid"], _pr_watch_notice(verdict, r["repo"], r["pr"], detail))
         done.append(r)
@@ -11847,9 +11912,9 @@ def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None):
     """One ledger row per restart — what THIS restart cut (T121: the drain's effect is measurable
     only if every restart writes its row, so a clean drain's row with an empty cutTurns list is the
     success metric, not noise). cutTurns names the sessions whose in-flight turns the drain
-    interrupted (sid-keyed, rename-proof); watchesArmed counts the PERSISTED kernel watches at cut
-    time — those SURVIVE by construction (pr-watches.json + the generic store re-arm at boot) and
-    ride along as context. In-session background watchers and Claude-side workflows are INVISIBLE
+    interrupted (sid-keyed, rename-proof); watchesArmed counts BOTH persisted watch stores
+    (pr-watches.json + watches.json — T143: the count covered only PR watches while the claim said
+    all) — those SURVIVE by construction and ride along as context. In-session background watchers and Claude-side workflows are INVISIBLE
     to the kernel and cannot be counted here — moving waits into the kernel watch primitive is what
     makes them survivable AND countable. NOTE on the false interrupted-by-user transcript stamps:
     those records are written by the CLI into its own transcript when the SDK client closes
@@ -29094,7 +29159,8 @@ class Handler(BaseHTTPRequestHandler):
                 if not tsid:
                     return self._send(200, json.dumps({"ok": False, "error":
                         'no session answers to "%s"' % who}), "application/json")
-                row = add_pr_watch(prn, repo, tsid)
+                esc = str(b.get("escalate") or "").strip()
+                row = add_pr_watch(prn, repo, tsid, escalate=esc)
                 return self._send(200, json.dumps({"ok": True, "watch": row}), "application/json")
             if u.path == "/watch":
                 # Register a GENERIC predicate watch (T121 part 2): the kernel runs `cmd` on a
@@ -30606,20 +30672,28 @@ def _graceful_term(signum, frame):
     mutation, and a cut turn keeps its 'working' state tail — the NEXT kernel's boot reconcile
     resumes exactly those. Bounded (~2s) so `romp refresh` stays snappy. Never construct the
     backend here — no SDK sessions were running if it doesn't exist."""
+    res = {}
+    err = ""
     try:
         sys.stderr.write("romp-kernel: SIGTERM — draining SDK sessions\n")
         be = _sdk_backend or None
-        res = {}
         if be is not None and hasattr(be, "drain"):
             res = be.drain(2.0)
-        # the restart-cut ledger (T121): one row per restart, empty cutTurns included — a clean
-        # drain's row IS the metric. Written after the drain (the cutter knows what it cut) and
-        # before exit; best-effort like the audit.
-        _append_restart_cut(_restart_cut_row(res, watches_armed=len(_pr_watches),
-                                             audit_reason=_recent_restart_reason()))
     except Exception:
-        sys.stderr.write("romp-kernel: drain failed: %s\n" % traceback.format_exc())
+        # log-and-record, never die recordless (T143: a raising drain lost 2 of 18 restarts' rows)
+        err = traceback.format_exc()
+        sys.stderr.write("romp-kernel: drain failed: %s\n" % err)
     finally:
+        # the restart-cut ledger (T121): one row per restart, ALWAYS — an empty cutTurns row is the
+        # clean-drain metric, and a drain that errored writes what it knew plus the error (T143).
+        try:
+            row = _restart_cut_row(res, watches_armed=len(_pr_watches) + len(_watches),
+                                   audit_reason=_recent_restart_reason())
+            if err:
+                row["drainError"] = err.strip().splitlines()[-1][:200]
+            _append_restart_cut(row)
+        except Exception:
+            sys.stderr.write("romp-kernel: cut ledger failed: %s\n" % traceback.format_exc())
         os._exit(0)
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3477,7 +3477,11 @@ class SdkBackend:
             sessions = list(self.sessions.values())
         # the identities of the turns this drain is about to cut — the restart-cut ledger's rows
         # (T121: the drain's effect is measured by what still gets cut; sid-keyed like spend)
-        cut = [{"sid": s.sid, "name": s.name} for s in sessions if s.inflight and not s.ended]
+        # EVERY session with an in-flight turn is a cut — including one already flagged `ended`
+        # (mid-shutdown with a live turn: its CLI is reaped below all the same). The old
+        # `and not s.ended` clause was a FILTER where a join was meant (T143: romp_cards counted 10
+        # transcript-verified cuts against 7 ledger rows — the missing three were mid-shutdown).
+        cut = [{"sid": s.sid, "name": s.name} for s in sessions if s.inflight]
         inflight = len(cut)
         for s in sessions:
             try:
@@ -3486,8 +3490,11 @@ class SdkBackend:
                 self._log("drain: shutdown failed for %s: %s" % (s.name, e))
         deadline = time.time() + timeout
         for s in sessions:
-            s.thread.join(max(0.05, deadline - time.time()))
-        unjoined = [s for s in sessions if s.thread.is_alive()]
+            if s.thread is not None:   # a constructed-but-never-started session has no thread —
+                #   joining None raised here and the WHOLE drain died recordless (T143: 2 of 18
+                #   restarts lost their ledger rows to exactly this)
+                s.thread.join(max(0.05, deadline - time.time()))
+        unjoined = [s for s in sessions if s.thread is not None and s.thread.is_alive()]
         reaped = []
         for s in unjoined:
             try:

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -146,13 +146,66 @@ class Tick(unittest.TestCase):
         km._pr_watch_tick(200.0)
         self.assertEqual(len(self.mail), 1, "…and never mails twice")
 
-    def test_a_failed_check_is_just_as_terminal(self):
-        km.add_pr_watch(8, "TESTORG/testrepo", SID, now=0)
-        km._pr_watch_read = lambda pr, repo: ("failed", "Shell (bats)")
+    def test_a_failed_check_holds_mails_once_and_escalates_on_the_bound(self):
+        # T143 (the ~6h invisible-ask specimen): a failed check MAILS THE OWNER ONCE and HOLDS —
+        # never a silent retire the owner's death can orphan. Resolution is event-keyed; only the
+        # no-event gap (nobody acted) takes the bounded escalation to the NAMED target.
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._sid_of_saved = getattr(km, "_sid_of")
+        km._sid_of = lambda who: "22222222-2222-3333-4444-555555555555" if who == "mgr" else ""
+        try:
+            km._pr_watch_read = lambda pr, repo: ("failed", "Shell (bats)")
+            km._pr_watch_tick(100.0)
+            self.assertEqual(len(self.mail), 1, "the owner is mailed once")
+            self.assertIn("FAILED check", self.mail[0][1])
+            self.assertEqual(len(km._pr_watches), 1, "…and the watch HOLDS instead of retiring")
+            km._pr_watch_tick(200.0)
+            self.assertEqual(len(self.mail), 1, "no re-mail while held")
+            # the bound passes with the failure still standing → ONE escalation to the named target
+            km._pr_watch_tick(100.0 + km.PR_WATCH_ESCALATE_S + 61)
+            self.assertEqual(len(self.mail), 2)
+            self.assertEqual(self.mail[1][0], "22222222-2222-3333-4444-555555555555")
+            self.assertIn("sat with a FAILED check", self.mail[1][1])
+            km._pr_watch_tick(100.0 + km.PR_WATCH_ESCALATE_S + 200)
+            self.assertEqual(len(self.mail), 2, "the escalation is ONE mail, ever")
+            # the terminal event still ends the watch normally
+            km._pr_watch_read = lambda pr, repo: ("merged", "")
+            km._pr_watch_tick(100.0 + km.PR_WATCH_ESCALATE_S + 300)
+            self.assertEqual(len(self.mail), 3)
+            self.assertIn("has MERGED", self.mail[2][1])
+            self.assertEqual(km._pr_watches, [])
+        finally:
+            km._sid_of = km._sid_of_saved
+
+    def test_resolution_events_clear_the_held_failure_without_a_clock(self):
+        km.add_pr_watch(9, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._pr_watch_read = lambda pr, repo: ("failed", "x")
         km._pr_watch_tick(100.0)
-        self.assertEqual(len(self.mail), 1)
-        self.assertIn("FAILED check (Shell (bats))", self.mail[0][1])
-        self.assertEqual(km._pr_watches, [])
+        self.assertTrue(km._pr_watches[0].get("failedAt"))
+        km._pr_watch_read = lambda pr, repo: (None, "busy")   # checks re-running — the EVENT
+        km._pr_watch_tick(200.0)
+        self.assertFalse(km._pr_watches[0].get("failedAt"),
+                         "the held state clears on the resolution event, no bound involved")
+        self.assertEqual(len(self.mail), 1, "clearing is silent — the watch just continues")
+
+    def test_no_target_means_no_ping_ever(self):
+        km.add_pr_watch(11, "TESTORG/testrepo", SID, now=0)   # no escalate; no box default in this temp state
+        km._pr_watch_read = lambda pr, repo: ("failed", "x")
+        km._pr_watch_tick(100.0)
+        km._pr_watch_tick(100.0 + km.PR_WATCH_ESCALATE_S + 61)
+        self.assertEqual(len(self.mail), 1, "the kernel never guesses a manager — unset = no ping")
+
+    def test_failed_state_survives_the_save_load_cycle(self):
+        # the specimen window held ~21 restarts — a clock that reset each boot would never fire
+        km.add_pr_watch(13, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._pr_watch_read = lambda pr, repo: ("failed", "x")
+        km._pr_watch_tick(100.0)
+        km._pr_watches_save()
+        km._pr_watches[:] = []
+        km._pr_watches_load()
+        r = km._pr_watches[0]
+        self.assertEqual((r.get("failedAt"), r.get("escalate")), (100, "mgr"),
+                         "failedAt and the target persist across the restart")
 
     def test_gh_failure_retires_loudly_after_three_never_silently(self):
         km.add_pr_watch(9, "TESTORG/testrepo", SID, now=0)

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -66,11 +66,29 @@ class CutRow(unittest.TestCase):
         audit.unlink()
         self.assertEqual(km._recent_restart_reason(now=1050), "", "no audit → anonymous, honestly")
 
+    def test_a_cutting_drain_counts_mid_shutdown_and_threadless_sessions(self):
+        # T143's two undercounts, executed: a session already flagged `ended` with a live in-flight
+        # turn IS a cut (its CLI is reaped all the same — the old `not s.ended` clause filtered it
+        # out of cutTurns: 10 transcript-verified cuts vs 7 rows), and a constructed-but-never-
+        # started session (thread=None) must not crash the whole drain recordless.
+        import types as _t
+        sbmod = km.sb if hasattr(km, "sb") else None
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        self.assertIn("cut = [{\"sid\": s.sid, \"name\": s.name} for s in sessions if s.inflight]", src,
+                      "every in-flight session is a cut — ended included (the join, not a filter)")
+        self.assertIn("if s.thread is not None:", src,
+                      "a threadless session can no longer crash the drain")
+
     def test_sigterm_handler_writes_the_ledger(self):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
         block = src[src.index("def _graceful_term"):src.index("def main():")]
-        self.assertIn("_append_restart_cut(_restart_cut_row(res, watches_armed=len(_pr_watches),",
-                      block, "the SIGTERM drain writes one ledger row before exit")
+        self.assertIn("row = _restart_cut_row(res, watches_armed=len(_pr_watches) + len(_watches),",
+                      block, "the row counts BOTH persisted watch stores (T143) — and is built in the")
+        self.assertIn("finally:", block)
+        self.assertIn("_append_restart_cut(row)", block,
+                      "…FINALLY block, so a raising drain still writes what it knew (T143: 2 of 18 "
+                      "restarts died recordless)")
+        self.assertIn('row["drainError"]', block, "an errored drain's row names the error")
         self.assertIn("audit_reason=_recent_restart_reason()", block)
 
 

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -408,6 +408,28 @@ class Drain(unittest.TestCase):
                          "drain writes no idle/waiting — the trailing 'working' IS the boot "
                          "reconcile's resume marker")
 
+    def test_drain_counts_mid_shutdown_cuts_and_survives_threadless_sessions(self):
+        # T143's two ledger undercounts, executed: an `ended` session with a live in-flight turn IS
+        # a cut (10 transcript-verified cuts vs 7 rows — the old filter dropped mid-shutdown ones),
+        # and a constructed-but-never-started session (thread None) crashed the WHOLE drain
+        # recordless on 2 of 18 restarts.
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        s1 = sb.SdkSession(be, _reg(d, "11111111-aaaa-0000-0000-0000000000c1"))
+        s1.inflight = 1
+        s1.ended = True                                   # mid-shutdown, turn still live
+        s1.thread = threading.Thread(target=lambda: None, daemon=True)
+        s1.thread.start()
+        s2 = sb.SdkSession(be, _reg(d, "11111111-aaaa-0000-0000-0000000000c2"))
+        s2.inflight = 1                                   # constructed, never started: thread is None
+        s2.thread = None
+        be.sessions[s1.sid] = s1
+        be.sessions[s2.sid] = s2
+        r = be.drain(0.2)
+        cut_sids = sorted(c["sid"] for c in r["cutTurns"])
+        self.assertEqual(cut_sids, [s1.sid, s2.sid],
+                         "both cuts recorded — ended included, threadless included, no crash")
+
     def test_drain_with_nothing_running_is_a_quiet_noop(self):
         be = _backend()
         self.assertEqual(be.drain(0.1), {"stopped": 0, "inflight": 0, "unjoined": 0, "reaped": 0,


### PR DESCRIPTION
**Ledger accuracy — three verified undercounts fixed.** (1) `cutTurns`' `and not s.ended` clause was a filter where a join was meant: a mid-shutdown session with a live in-flight turn was cut (its CLI reaped all the same) but never recorded — 10 transcript-verified cuts vs 7 ledger rows. Every in-flight session is a cut now. (2) A constructed-but-never-started session (thread `None`) crashed the whole drain at `thread.join`, and the exception path wrote no row — 2 of 18 restarts died recordless. The join is guarded and the row write moved into the `finally` block: an errored drain records what it knew plus a `drainError` field. (3) `watchesArmed` counts both persisted watch stores now; the docstring claimed all while counting only PR watches.

**Stalled-failure escalation** (the ~6h invisible-ask specimen: the worker's failure notice landed in a session a restart had killed, and the user discovered the stalled PR). A failed check no longer retires the watch — the owner is mailed once and the watch holds, polling on. Resolution is event-keyed: checks re-running clears the held state silently; merged/closed ends the watch with its normal mail. Only the gap with no event — nobody acted — takes the bounded check-back: held past 2h with the failure still standing, one mail to the named escalation target. The target is never inferred (the kernel cannot trace a PR to a user ask): `romp watch-pr --escalate <session>` per watch, or `STATE/watch-escalate.json` as the box default; unset means no ping. `failedAt`/`escalated` persist with the row — the specimen window held ~21 restarts, and a clock that reset each boot would never fire.

**Tests.** The hold/one-mail/escalate/terminal cycle; event-keyed clearing (no clock involved); no-target-no-ping; failed state surviving save/load; both ledger undercounts executed (an ended in-flight session and a threadless one both land in `cutTurns`, no crash); the finally-block row write pinned.

Suites: pytest 5893 passed / 34 skipped; vscode-extension 2514/2514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)