### PR TITLE
The latched 'Sent' button explains itself — what went, when, and what re-arms it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20222,6 +20222,7 @@ def build_feed(now, tmux=None):
                 **({"satellite": True} if isinstance(o, dict) and o.get("tracked")
                    and origin and origin.get("live") and column != "needs_input" else {}),
                 "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
+                "followupAt": nodes[nid].get("followupAt") or None,   # WHEN the follow-up/continue went — the latched button's honest age (T150)
                 # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
                 # pending. The card STAYS in Working (the settle gate exists precisely so the column never
                 # flickers working↔done) and wears a steady "done, confirming" cue instead. From the

--- a/ui/webview/feed-continue.test.ts
+++ b/ui/webview/feed-continue.test.ts
@@ -33,6 +33,20 @@ test("Continue shows only on a LIVE needs-you card with no live ask (and never o
   assert.match(FEED, /contBtn\.style\.display = \(askColumn\(it\) === "needsInput" && it\.live && !it\.provisional && !it\.blocked\)/);
 });
 
+test("the latched 'Sent' explains itself — what went, when, and the exact re-arm event (T150)", () => {
+  // the buttons rule's honest-disabled half (the user 2026-08-28: a card read 'Sent' and clicking did
+  // nothing — the latch was correct, the silence was the violation). ONE title writer for both states
+  // of both buttons; the age rides the payload's followupAt, shipped beside followupPending.
+  assert.match(FEED, /function contTitle\(latched: boolean, verb: string, at\?: number \| null\): string \{/);
+  assert.match(FEED, /" — waiting for the session's reply to be judged; this re-arms then, and the card moves on its own"/);
+  assert.match(FEED, /contBtn\.title = contTitle\(contBtn\.disabled, "a continue", it\.followupAt\);/,
+    "the card button re-titles on every push — the age stays honest");
+  assert.match(FEED, /cont\.title = contTitle\(true, "a continue", null\);/, "…and the instant it latches");
+  assert.match(FEED, /csEl\.title = contTitle\(csEl\.disabled, "a status ask", it\.followupAt\);/, "the modal pair too");
+  assert.match(FEED, /contEl\.title = contTitle\(contEl\.disabled, "a continue", it\.followupAt\);/);
+  assert.match(KERNEL, /"followupAt": nodes\[nid\]\.get\("followupAt"\) or None,/, "the payload carries the when");
+});
+
 test("Continue acknowledges INSTANTLY (disable + relabel) and re-arms only after the judge has ruled", () => {
   // the click-safety rule: the ack precedes any kernel round-trip; same contract as the modal's
   // Check status ("Sent" survives re-renders while followupPending/recheck holds)

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -73,6 +73,7 @@ interface AskItem {
   trgb: [number, number, number];
   column: "working" | "needs_input" | "completed";   // RAW kernel value (build_feed): working/needs_input/completed. askColumn() maps it to the local Column. NOT "asks" — that was a stale lie that silently broke `it.column === "asks"` checks.
   followupPending?: boolean;                       // you followed up on a settled card → optimistically reopened, awaiting the judge's re-file (kernel)
+  followupAt?: number | null;                      // when that follow-up/continue went — the latched button's honest age (T150)
   doneConfirming?: boolean;                        // the done verdict is in, only the settle event is pending → steady "done, confirming" chip on the Working card; placement deliberately does NOT move early (no working↔done flicker) (kernel build_feed ← judge rollup confirming export; the user 2026-07-24)
   recheck?: boolean;                               // soft-block you answered with a TARGETED follow-up → de-urgented (dotted), moved to Working, dropped from the "need input" count, until the judge resolves or re-blocks it (kernel build_feed; the user 2026-06-27)
   rejudging?: boolean;                             // soft-block + a PLAIN thread reply after it → moves to WORKING while the reply is in flight (echo/open turn), with a "Re-judging…" swirl; returns to Needs-You on its own if the judge leaves it blocked (kernel build_feed; the user 2026-07-02, immediate)
@@ -772,6 +773,20 @@ function clockHM(t: number): string {
   return new Date(t * 1000).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
 }
 
+// The latched Continue/Check-status button explains itself (T150, the user 2026-08-28: a card read
+// 'Sent' and clicking did nothing — the latch was honest, the silence was not). One title writer for
+// both states of both buttons: while held, it names WHAT was sent, WHEN, and the exact event that
+// re-arms it; enabled, it says what a click does. The hover title is the minimum honest surface for
+// a disabled control (the buttons rule) — the label itself stays one word.
+function contTitle(latched: boolean, verb: string, at?: number | null): string {
+  return latched
+    ? verb + " sent" + (at ? " " + relAge(hostNow - at) : "") +
+      " — waiting for the session's reply to be judged; this re-arms then, and the card moves on its own"
+    : verb === "a continue"
+      ? "nothing needed from you — asks the session to keep going"
+      : "asks the session where each open item stands";
+}
+
 function relAge(sec: number): string {
   const s = Math.max(0, sec);
   // Sub-minute ages all read "<1m ago" (the user 2026-07-20): a card the user just acted on stamps t=now,
@@ -1195,6 +1210,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     // same optimistic move a typed reply gets; updateAskCard re-arms the label once the judge has ruled.
     vscodeApi?.postMessage({ type: "askFollowUp", itemId: it.itemId, sid: it.sid, cont: true });
     cont.disabled = true; cont.textContent = "Sent";
+    cont.title = contTitle(true, "a continue", null);
     optimisticFollowMove(it.itemId);
     render();
   };
@@ -2027,6 +2043,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   if (contBtn.disabled && !it.followupPending && !it.recheck && !it.rejudging) {
     contBtn.disabled = false; contBtn.textContent = "Continue";
   }
+  contBtn.title = contTitle(contBtn.disabled, "a continue", it.followupAt);
   if (showApiErr && it.blocked) {
     // on-you errors name themselves: a spend cap (raise it), "prompt too long" (compact), or a spent model
     // allowance (switch model); other API errors are transient and auto-retrying (2026-06-29 / 07-14 / 08-01).
@@ -3152,11 +3169,13 @@ function renderModal() {
     if (csEl && it.live && statusSweepText(it).n > 0) {
       csEl.style.display = "";
       if (csEl.disabled && !it.followupPending && !it.recheck && !it.rejudging) { csEl.disabled = false; csEl.textContent = "Check status"; }
+      csEl.title = contTitle(csEl.disabled, "a status ask", it.followupAt);
       csEl.onclick = () => {
         const sweep = statusSweepText(it);
         if (!sweep.n) return;
         vscodeApi?.postMessage({ type: "askFollowUp", itemId: it.itemId, text: sweep.text, sid: it.sid });
         csEl.disabled = true; csEl.textContent = "Asked";
+        csEl.title = contTitle(true, "a status ask", null);
         optimisticFollowMove(it.itemId);
         render();
       };
@@ -3165,9 +3184,11 @@ function renderModal() {
     if (contEl && askColumn(it) === "needsInput" && it.live && !it.provisional && !it.blocked) {
       contEl.style.display = "";
       if (contEl.disabled && !it.followupPending && !it.recheck && !it.rejudging) { contEl.disabled = false; contEl.textContent = "Continue"; }
+      contEl.title = contTitle(contEl.disabled, "a continue", it.followupAt);
       contEl.onclick = () => {
         vscodeApi?.postMessage({ type: "askFollowUp", itemId: it.itemId, sid: it.sid, cont: true });
         contEl.disabled = true; contEl.textContent = "Sent";
+        contEl.title = contTitle(true, "a continue", null);
         optimisticFollowMove(it.itemId);
         render();
       };


### PR DESCRIPTION
The user (2026-08-28, screenshot): a stalled card's button read **'Sent'**, clicking did nothing, and nothing said why. **Diagnosis**: 'Sent' is the Continue button's post-click acknowledged label, correctly latched until the judge rules on the continue's own reply — `followupPending` holds it, verified live on the specimen card (flag true, the reply not yet judged, a blocked sub keeping the card in needs-you). The latch is the cards-move rule working as designed; the **silence** was the violation of the buttons rule's honest-disabled half.

So the latch now speaks: one title writer (`contTitle`) serves both states of both buttons — enabled, Continue says what a click does; latched, it names **what** was sent, **when** (a new `followupAt` rides the payload beside `followupPending`, refreshed every push so the age stays honest), and the **exact event that re-arms it** ('waiting for the session's reply to be judged; this re-arms then, and the card moves on its own'). The modal's Continue and Check status wear the same contract, and the title lands the instant the click latches, before any payload echo. No restore change: the re-arm event exists and is correct — any judge verdict landing on the top ends the hold.

Pins: the shared title writer, the re-title on every push and at latch time, the modal pair, the payload's followupAt. Python 5903 passed / extension 2516 passed on the pushed head; both-states screenshot in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)