### PR TITLE
A comment thread's spend bills its owning session (T144)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1364,6 +1364,11 @@ class SdkSession:
         # the conversation into a NEW file pinned to THIS sid instead of continuing the parent's. One-shot:
         # cleared the moment the init's lastSid flip says the fork landed (see _on_message).
         self._fork_of = reg.get("forkOf") or ""
+        # the OWNING session for a highlight-reply comment thread (reg threadOf, durable): the
+        # thread's spend bills the OWNER's sid (T144 — fork sids minted phantom cheap sessions in
+        # spend.json and undercounted the owner: one session split $360.31 own + $3.11 + $5.36
+        # fork sids). A deliberate user fork has no threadOf and bills itself — it IS a session.
+        self.thread_of = reg.get("threadOf") or ""
         self._fork_at = reg.get("forkAt") or ""
         # Heal STRANDED pending-switch flags (the user 2026-07-11, who reported the three dots sitting there
         # forever): a /model or /effort switch that was mid-flight when the previous kernel/process
@@ -2553,7 +2558,10 @@ class SdkSession:
                     last = self._last_usage_totals.get(k, 0)
                     turn_u[k] = v - last if v >= last else v
                     self._last_usage_totals[k] = v
-                self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth, sid=self.sid)   # the rail's spend
+                self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
+                                           sid=self.thread_of or self.sid)   # the rail's spend —
+                #   a comment THREAD bills its owning session (T144: whole-session truth for the
+                #   rail and the optimizer; a deliberate fork has no threadOf and bills itself)
                 #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
                 #   honest on a mixed host (see _record_spend)
             self.retrying = False
@@ -4267,6 +4275,7 @@ class SdkBackend:
         s = self.sessions.get(sid)
         if s:
             s.name = name
+            s.thread_of = ""   # a promoted session bills ITSELF from this moment (T144's owner billing)
         self._poke()
         return True
 

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1908,6 +1908,46 @@ class SpendRecord(unittest.TestCase):
         h = json.loads(self.p.read_text())["hours"][time.strftime("%Y-%m-%dT%H")]
         self.assertAlmostEqual(h["bySid"]["aaaa1111-spend-attr-1"]["usd"], 0.07, msg="the hour buckets attribute too")
 
+    def test_a_thread_turn_bills_the_owning_session(self):
+        # T144: highlight-reply comment threads minted phantom cheap sessions in spend.json and
+        # undercounted the owner (one session split $360.31 own + $3.11 + $5.36 fork sids). The
+        # settle passes threadOf when present — assert at the recorder level with the owner's sid.
+        OWNER = "aaaa1111-spend-own-1"
+        self.be._record_spend(0.02, keyed=True, sid=OWNER)                  # the owner's own turn
+        self.be._record_spend(0.03, keyed=True, sid=OWNER)                  # a thread turn, billed via threadOf
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertAlmostEqual(d["bySid"][OWNER]["usd"], 0.05,
+                               msg="whole-session truth: the thread's spend lands under the owner")
+        self.assertEqual(len(d["bySid"]), 1, "no phantom fork sid appears")
+
+    def test_the_settle_seam_prefers_thread_of(self):
+        # the session-object seam, executed: thread_of set → the owner's sid reaches the recorder;
+        # promotion clears it → the session bills itself from that moment
+        sid = "aaaa1111-spend-own-2"
+        own = "aaaa1111-spend-own-3"
+        sb.write_reg(Path(self.d), sid, {"sid": sid, "name": "c1", "cwd": "/tmp", "threadOf": own})
+        s = sb.SdkSession(self.be, sb.read_reg(Path(self.d), sid))
+        self.assertEqual(s.thread_of, own, "the durable reg field seeds the object")
+        self.assertEqual(s.thread_of or s.sid, own, "the settle's sid expression bills the owner")
+        self.be.sessions[sid] = s
+        sb.write_name(Path(self.d), sid, "promoted", "/tmp", "#123456", "white")  # promote needs no name write order here
+        self.assertTrue(self.be.promote_thread(sid, "promoted"))
+        self.assertEqual(s.thread_of, "", "a promoted session bills ITSELF from this moment")
+        self.assertEqual(s.thread_of or s.sid, sid)
+
+    def test_fork_spend_spanning_days_stays_under_the_owner(self):
+        # the day-spanning fixture: a thread that worked before and after midnight accumulates
+        # under the OWNER in each day's bucket independently (buckets key on local date at fold
+        # time; the owner sid is constant, so both days read whole-session truth)
+        OWNER = "aaaa1111-spend-own-4"
+        yesterday = {"usd": 1.0, "turns": 2, "bySid": {OWNER: {"usd": 1.0, "turns": 2, "tok": 5}}}
+        self.p.write_text(json.dumps({"days": {"2020-01-01": yesterday}}))
+        self.be._record_spend(0.04, keyed=True, sid=OWNER)                  # after midnight, same owner
+        days = json.loads(self.p.read_text())["days"]
+        self.assertAlmostEqual(days["2020-01-01"]["bySid"][OWNER]["usd"], 1.0, msg="yesterday untouched")
+        self.assertAlmostEqual(days[self._today()]["bySid"][OWNER]["usd"], 0.04,
+                               msg="today's bucket bills the same owner — no phantom split at midnight")
+
     def test_legacy_rows_and_sidless_folds_stay_lossless(self):
         # a pre-T100 bucket (no bySid) folds cleanly, and a sid-less fold never drops attribution
         # already there (lossless legacy, the T18 discipline)
@@ -1945,9 +1985,11 @@ class SpendRecord(unittest.TestCase):
     def test_result_message_records_and_the_kernel_serves_it(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth, sid=self.sid)", src,
-                      "the settle folds THIS turn's DELTAS — cost AND tokens are cumulative per process — "
-                      "tagged with the session's own auth AND its sid (T100: per-session attribution)")
+        self.assertIn("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,", src,
+                      "the settle folds THIS turn's DELTAS — cost AND tokens are cumulative per process")
+        self.assertIn("sid=self.thread_of or self.sid)   # the rail's spend", src,
+                      "a comment THREAD bills its OWNING session (T144); a plain session bills itself "
+                      "(T100's per-session attribution, completed)")
         self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero",
                       src, "each connect resets the watermark with its new process")
         self.assertIn("self._last_usage_totals = {}  # …and its cumulative token counters", src,

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -47,8 +47,8 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   // the accumulator: cumulative-per-process DELTAS, and each bucket splits out the key's own turns
   assert.ok(BACKEND.includes("delta = total - self._last_cost_total if total >= self._last_cost_total else total"));
   assert.ok(BACKEND.includes("turn_u[k] = v - last if v >= last else v"));
-  assert.ok(BACKEND.includes("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth, sid=self.sid)"),
-    "the settle threads the session sid — per-session attribution (T100)");
+  assert.ok(BACKEND.includes("sid=self.thread_of or self.sid)   # the rail's spend"),
+    "the settle threads the OWNING sid — a comment thread bills its owner (T144), a plain session itself (T100)");
   assert.ok(BACKEND.includes("if keyed or ke:   # carry an existing key split forward even on a login turn"));
   assert.ok(BACKEND.includes("_fold(days, day, 90)"));
   assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");


### PR DESCRIPTION
Highlight-reply fork turns billed under the fork transcript's sid in spend.json, minting phantom cheap sessions and undercounting the owner — the specimen session split $360.31 own + $3.11 + $5.36 across fork sids.

**Fix.** The settle passes the owning sid: `reg.threadOf` is the durable owner link a comment thread carries for life — picked over a view-side rollup because billing at the recorder keeps every consumer (the rail and the optimizer alike) reading whole-session truth with no join. A deliberate user fork has no `threadOf` and bills itself — it is a first-class session. A promoted thread bills itself from the moment of promotion (the live object drops its owner link with the reg field). Lossless legacy: old rows under fork sids remain readable history; nothing rewrites.

**Completes T100's attribution.** Fixtures: owner+thread same-day fold (no phantom sid appears); the settle seam executed (threadOf preferred; promotion flips it); the day-spanning fork (yesterday's bucket untouched, today's bills the same owner — no split at midnight). Call-site pins retargeted in both mirrors.

Suites: pytest 5906 passed / 34 skipped (pre-rebase full; post-rebase the combined touched surfaces green); vscode-extension 2515/2515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)