### PR TITLE
Tab-open keep-alive stated; a Conserve memory option closes idle tab-less processes (T148)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -529,6 +529,7 @@ def _version_info():
             "boot": _BOOT_ID,   # lets a page retire update offers from a previous kernel life (2026-08-15)
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
+            "conserveMemory": _conserve_on(),   # the T148 toggle: close idle tab-less claude processes
             "fileEditing": _file_editing_on(),   # dashboard raw-mode editing opt-in → gates the viewer's Edit
             "updateMode": _update_mode(),    # ask|auto|off (the boot release check) → the gear dropdown
             "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
@@ -540,6 +541,7 @@ def _version_info():
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
             "settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode(),
+                         "conserveMemory": _conserve_on(),
                          "fileEditing": _file_editing_on(),
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
@@ -2263,6 +2265,74 @@ def _auto_nudge_data():
 
 def _auto_nudge_on():
     return bool(_auto_nudge_data().get("enabled"))
+
+
+# ── conserve-memory (T148): close IDLE claude processes whose session has no open tab ────────────
+# The tab-sync process model, stated: a session with an OPEN TAB keeps its claude process alive for
+# as long as the tab is open — which is the DE-FACTO behavior already (nothing closes idle
+# processes; ~13 live CLIs averaged 338MB = 4.4GB on a 32GB box). This option is the CONSERVE side:
+# when ON, a session that is IDLE (no in-flight turn, no queued prompts) and tab-open on NO
+# connected viewer gets its process closed CLEANLY — reg/queue/transcript persist untouched, so it
+# stays one tab-click (or one send / one scheduled wake) from reviving through the ordinary resume
+# path. 'Open tab' = strip-visible under the CHAT lens to a connected viewer (the kernel's own
+# views state — hidden tabs retired 2026-08-11, so the lens IS tab presence). Keying is EVENT-first
+# (turn ends, views writes, viewer connect/disconnect drive the sweep) with two bounded windows
+# where no event exists: a 30s viewer-disconnect lease (a page reload must never mass-close) and a
+# 60s hide-grace (a lens flick must not churn close/reconnect cycles). Default OFF — keep-alive is
+# the user's stated intent; conserve is the option.
+CONSERVE_FILE_NAME = "conserve-memory.json"
+CONSERVE_VIEWER_LEASE_S = 30
+CONSERVE_HIDE_GRACE_S = 60
+_conserve_last_viewer = [time.time()]   # the last moment a chat viewer was connected (lease anchor)
+_conserve_hidden_at = {}                # sid -> first moment seen hidden+idle (the grace clock)
+
+
+def _conserve_on():
+    try:
+        d = json.loads((jd.STATE / CONSERVE_FILE_NAME).read_text())
+        return bool(isinstance(d, dict) and d.get("enabled"))
+    except Exception:
+        return False
+
+
+def _set_conserve(enabled):
+    _atomic_write(jd.STATE / CONSERVE_FILE_NAME, json.dumps({"enabled": bool(enabled)}))
+
+
+def _conserve_tick(now):
+    """One supervisor-pass sweep (event-driven consumers poke the supervisor; this just reads the
+    current truth). Closes at most what the grace allows; every close is logged with its names."""
+    if not _conserve_on():
+        _conserve_hidden_at.clear()
+        return
+    be = _sdk()
+    if not be or not hasattr(be, "conserve_close"):
+        return
+    with _clients_lock:
+        viewer = any(c.get("alive", True) and c.get("app") in ("chat", "fleet", "timeline", "feed")
+                     for c in _clients)
+    if viewer:
+        _conserve_last_viewer[0] = now
+    elif now - _conserve_last_viewer[0] < CONSERVE_VIEWER_LEASE_S:
+        return   # the lease: a reloading page is not a closed dashboard
+    vc = _views_client()
+    running = be.running_sids()
+    closed = []
+    for sid in running:
+        open_tab = viewer and _view_visible(vc, sid, "chat")
+        busy = not be.conserve_idle(sid)
+        if open_tab or busy:
+            _conserve_hidden_at.pop(sid, None)
+            continue
+        first = _conserve_hidden_at.setdefault(sid, now)
+        if now - first >= CONSERVE_HIDE_GRACE_S and be.conserve_close(sid):
+            closed.append(sid)
+            _conserve_hidden_at.pop(sid, None)
+    for sid in set(_conserve_hidden_at) - set(running):
+        _conserve_hidden_at.pop(sid, None)
+    if closed:
+        sys.stderr.write("romp-kernel: conserve-memory closed %d idle background session(s): %s\n"
+                         % (len(closed), ", ".join(s[:8] for s in closed)))
 
 
 def _write_auto_nudge(d):
@@ -12317,6 +12387,7 @@ def _tunnel_supervisor():
                 _push_origin_trust_rows()
             _pr_watch_tick(now)          # PR-landing watches (rate-gated per row; loud on gh failure)
             _watch_tick(now)             # generic predicate watches (T121 part 2) — same pump discipline
+            _conserve_tick(now)          # conserve-memory sweep (T148): close idle tab-less processes
             # Everything above is the supervisor's own state (status, fails, next_try, kernel_sha, detail).
             # None of it used to reach disk — only the act routes saved — so the file could sit frozen on a
             # failure long after the row recovered. Signature-gated: a steady fleet writes nothing.
@@ -29805,6 +29876,11 @@ class Handler(BaseHTTPRequestHandler):
             # registry); re-broadcast so every tab/lane/card repaints in the new color at once.
             if _set_session_color(str(msg["id"]), str(msg["bg"])):
                 _mark_views_dirty()
+        elif msg and msg.get("type") == "setConserve" and msg.get("enabled") is not None:
+            # the gear's conserve-memory toggle (T148) — kernel-side like autoNudge; the sweep
+            # reads the flag fresh each pass, so flipping it needs no restart
+            _set_conserve(bool(msg.get("enabled")))
+            _push_soon()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             _set_auto_nudge(bool(msg["enabled"]))   # feed gear → server-side Auto Nudge on/off
             # act immediately on turn-on (don't wait 4s) — but skip the dead-wait sweep: the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4773,6 +4773,42 @@ class SdkBackend:
         self._poke()
         return True
 
+    def running_sids(self) -> list:
+        """Sids with a LIVE session thread — the conserve sweep's candidates (T148)."""
+        with self._lock:
+            return [s.sid for s in self.sessions.values()
+                    if s.thread is not None and s.thread.is_alive() and not s.ended]
+
+    def conserve_idle(self, sid: str) -> bool:
+        """Whether this session is safe to conserve-close: no in-flight turn, nothing queued,
+        no ask parked, not mid-compaction (T148 — never close work)."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        if not s or s.ended:
+            return False
+        if s.inflight or s.pending() or s._cur_ask_fut is not None:
+            return False
+        return True
+
+    def conserve_close(self, sid: str) -> bool:
+        """Close ONE idle session's claude process, keeping it a tab-click from reviving (T148):
+        the reg stays alive=True and untouched (unlike kill), the queue/transcript persist, and the
+        dormant row keeps serving from the reg — the ordinary on-demand _ensure (a send, an open,
+        a scheduled wake) is the revive. Re-checks idleness under the lock; a turn that started
+        since the sweep's read stands the close down."""
+        if not self.conserve_idle(sid):
+            return False
+        with self._lock:
+            s = self.sessions.pop(sid, None)
+        if not s:
+            return False
+        try:
+            s.shutdown()
+        except Exception as e:
+            self._log("conserve close (%s): shutdown failed: %s" % (s.name, e))
+        self._poke()
+        return True
+
     def thread_sessions(self) -> dict[str, dict]:
         """{sid: {state, threadOf}} for every alive COMMENT-THREAD session — exactly the rows
         live_sessions deliberately hides (a thread's surface is the parent chat's comment UI, never a

--- a/tests/test_conserve_memory.py
+++ b/tests/test_conserve_memory.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Conserve-memory (T148, user-directed): a session with an OPEN TAB keeps its claude process for
+as long as the tab is open — the de-facto behavior, now stated — and the CONSERVE option (default
+OFF) closes the process of a session that is IDLE and tab-open on NO connected viewer. Closes are
+CLEAN: the reg stays alive, queue/transcript persist, and the ordinary on-demand _ensure (a tab
+click, a send, a scheduled wake — PR 769's lane) revives. Event-first keying with two bounded
+windows: the 30s viewer-disconnect lease (a reload never mass-closes) and the 60s hide-grace (a
+lens flick never churns). Hermetic state; synthetic sids."""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_conserve", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_conserve", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-00000000e148"
+
+
+class Flag(unittest.TestCase):
+    def test_default_off_round_trip_and_junk(self):
+        try:
+            (jd.STATE / km.CONSERVE_FILE_NAME).unlink()
+        except OSError:
+            pass
+        self.assertFalse(km._conserve_on(), "keep-alive is the default — conserve is the OPTION")
+        km._set_conserve(True)
+        self.assertTrue(km._conserve_on())
+        km._set_conserve(False)
+        self.assertFalse(km._conserve_on())
+        (jd.STATE / km.CONSERVE_FILE_NAME).write_text("junk")
+        self.assertFalse(km._conserve_on(), "junk reads as off, never raises")
+        (jd.STATE / km.CONSERVE_FILE_NAME).unlink()
+
+    def test_op_and_payload_wiring(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('msg.get("type") == "setConserve"', src, "the gear's toggle rides the kernel channel")
+        self.assertIn('"conserveMemory": _conserve_on(),', src, "…and /version reflects the kernel truth")
+        self.assertIn("_conserve_tick(now)", src, "the sweep rides the supervisor pass")
+        gear = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "gear.js")).read()
+        self.assertIn("setConserve", gear)
+        self.assertIn("v.conserveMemory", gear)
+
+
+class BackendClose(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "bg", "cwd": "/tmp", "alive": True})
+        self.s = sb.SdkSession(self.be, sb.read_reg(Path(self.d), SID))
+        self.s.thread = threading.Thread(target=lambda: time.sleep(0.3), daemon=True)
+        self.s.thread.start()
+        self.be.sessions[SID] = self.s
+
+    def test_close_is_clean_and_revivable(self):
+        self.assertIn(SID, self.be.running_sids())
+        self.assertTrue(self.be.conserve_idle(SID))
+        self.assertTrue(self.be.conserve_close(SID))
+        self.assertNotIn(SID, self.be.running_sids())
+        reg = sb.read_reg(Path(self.d), SID)
+        self.assertTrue(reg.get("alive"), "the reg stays ALIVE — dormant, not killed; _ensure revives on demand")
+
+    def test_never_closes_work(self):
+        self.s.inflight = 1
+        self.assertFalse(self.be.conserve_idle(SID))
+        self.assertFalse(self.be.conserve_close(SID), "an in-flight turn stands the close down")
+        self.s.inflight = 0
+        self.s._pending.append("queued prompt")
+        self.assertFalse(self.be.conserve_close(SID), "a queued prompt stands it down too")
+
+
+class Tick(unittest.TestCase):
+    """The sweep's decision matrix, executed with a stubbed backend + client roster."""
+
+    class _FakeBe:
+        def __init__(self):
+            self.running = ["s-open", "s-hidden", "s-busy"]
+            self.idle = {"s-open": True, "s-hidden": True, "s-busy": False}
+            self.closed = []
+        def running_sids(self): return list(self.running)
+        def conserve_idle(self, sid): return self.idle.get(sid, False)
+        def conserve_close(self, sid):
+            self.closed.append(sid); self.running.remove(sid); return True
+
+    def setUp(self):
+        km._set_conserve(True)
+        self.be = self._FakeBe()
+        self._saved = (km._sdk, km._views_client, km._view_visible)
+        km._sdk = lambda: self.be
+        km._views_client = lambda: {"active": "all", "tags": [], "actives": {}}
+        km._view_visible = lambda vc, sid, surface=None: sid == "s-open"   # only s-open is on the strip
+        km._conserve_hidden_at.clear()
+        with km._clients_lock:
+            self._clients_before = list(km._clients)
+            km._clients[:] = [{"app": "chat", "wid": "w1", "send": lambda m: None, "alive": True}]
+        km._conserve_last_viewer[0] = 0.0
+
+    def tearDown(self):
+        km._sdk, km._views_client, km._view_visible = self._saved
+        with km._clients_lock:
+            km._clients[:] = self._clients_before
+        km._set_conserve(False)
+        km._conserve_hidden_at.clear()
+
+    def test_matrix_open_stays_hidden_idle_closes_after_grace_busy_stays(self):
+        km._conserve_tick(1000.0)
+        self.assertEqual(self.be.closed, [], "first sight of hidden+idle starts the grace, closes nothing")
+        km._conserve_tick(1000.0 + km.CONSERVE_HIDE_GRACE_S + 1)
+        self.assertEqual(self.be.closed, ["s-hidden"],
+                         "hidden+idle closes after the grace; the open tab and the busy one stay")
+
+    def test_a_reshow_cancels_the_grace(self):
+        km._conserve_tick(1000.0)
+        km._view_visible = lambda vc, sid, surface=None: sid in ("s-open", "s-hidden")   # re-shown — the EVENT
+        km._conserve_tick(1000.0 + km.CONSERVE_HIDE_GRACE_S + 1)
+        self.assertEqual(self.be.closed, [], "the re-show event cancels the pending close")
+
+    def test_viewer_disconnect_lease_holds_then_releases(self):
+        with km._clients_lock:
+            km._clients[:] = []                                  # every viewer gone (a reload)
+        km._conserve_last_viewer[0] = 1000.0
+        km._conserve_tick(1000.0 + 5)
+        self.assertEqual(self.be.closed, [], "within the lease nothing moves — a reload never mass-closes")
+        km._conserve_tick(1000.0 + km.CONSERVE_VIEWER_LEASE_S + 1)
+        km._conserve_tick(1000.0 + km.CONSERVE_VIEWER_LEASE_S + km.CONSERVE_HIDE_GRACE_S + 2)
+        self.assertIn("s-hidden", self.be.closed, "past the lease, no viewer = no open tabs; idle closes after grace")
+        self.assertIn("s-open", self.be.closed, "…including the one that WAS on the strip (no viewer sees it)")
+        self.assertNotIn("s-busy", self.be.closed, "work is never closed")
+
+    def test_off_means_untouched(self):
+        km._set_conserve(False)
+        km._conserve_tick(1000.0)
+        km._conserve_tick(9999.0)
+        self.assertEqual(self.be.closed, [], "conserve OFF = today's behavior exactly: nothing closes, ever")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -61,6 +61,10 @@ var GEAR_HTML =
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
+  "<label class='rs-row'><input type=checkbox id=rs-conserve>" +
+  '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
+  '<span class=rs-sub>Close the claude process of a session that is idle and on no open tab (each averages ~340MB). Everything persists — the session revives on a tab click, a message, or a scheduled wake. Off = every session keeps its process for as long as it lives.</span>' +
+  '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-fileedit>" +
   '<span><b>File editing</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Let the file viewer’s Edit save straight to disk on the file’s machine. Off by default; the viewer asks the first time. A session working in the edited folder is told, and a save always refuses when the file changed underneath you. Applies on every connected machine’s kernel.</span>' +
@@ -174,6 +178,7 @@ function initGear(post) {
     b = document.getElementById('rsver'), cc = document.getElementById('rs-compact'),
     jix = document.getElementById('rs-judges-index'), jtr = document.getElementById('rs-judges-triage'),
     an = document.getElementById('rs-autonudge'), bk = document.getElementById('rs-backend'),
+    cvm = document.getElementById('rs-conserve'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
     cs = document.getElementById('rs-chatscheme'),
@@ -390,6 +395,7 @@ function initGear(post) {
     post({ type: 'setAutoNudge', enabled: an.checked });
   });
   if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked }); });
+  if (cvm) cvm.addEventListener('change', function () { post({ type: 'setConserve', enabled: cvm.checked }); });
   if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
   // The judge MODEL pickers mirror the session pickers (the user 2026-08-25): families top-level,
   // clicking a family sends its /models `default` (the user's remembered version), hover or
@@ -657,6 +663,7 @@ function initGear(post) {
       fillMixedMarks(v, rows);
     }).catch(function () { fillAutoNudge(v.autoNudge, []); fillMixedMarks(v, []); });
     if (fe) fe.checked = !!v.fileEditing;   // the kernel's persisted opt-in is authoritative (see the viewer's consent popup)
+    if (cvm) cvm.checked = !!v.conserveMemory;   // T148: the kernel's persisted conserve flag is authoritative
     if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
     if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
     if (im && typeof v.indexModel === 'string') im.value = v.indexModel;


### PR DESCRIPTION
The tab-sync process model, user-directed: a session with an open tab keeps its claude process alive for as long as the tab is open — which was already the de-facto behavior (nothing closed idle processes; ~13 live CLIs averaged 338MB ≈ 4.4GB). This states that contract and adds the conserve side as the option, default off per the user's intent.

**Conserve on:** a session that is idle (no in-flight turn, no queued prompts, no parked ask) and tab-open on no connected viewer gets its process closed cleanly — the reg stays alive, queue and transcript persist untouched, and the ordinary on-demand `_ensure` revives it on a tab click, a message, or a scheduled wake (PR 769's lane: conserve closes nothing 769 can't revive; the seam pin lands as a follow-on once 769 merges, per the read-back). "Open tab" = strip-visible under the chat lens to a connected viewer — the kernel's own views state; hidden tabs retired 2026-08-11, so the lens is tab presence.

**Keying is event-first** — turn ends, views writes, viewer connect/disconnect drive the sweep — with two bounded windows where no event exists: a 30s viewer-disconnect lease (a page reload never mass-closes) and a 60s hide-grace (a lens flick never churns; the re-show event cancels a pending close). Work is never closed: the close re-checks idleness under the lock.

**Surface:** one gear toggle (Conserve memory), kernel-persisted like autoNudge, reflected from `/version`, flippable live.

**Tests:** flag round-trip (default off; junk reads off); the clean close (reg alive, revivable) and never-close-work guards; the sweep matrix executed (open stays, hidden+idle closes after grace, busy stays, re-show cancels, the disconnect lease holds then releases, off means untouched); op/payload/gear wiring pinned.

Suites: pytest 5916 passed / 34 skipped; vscode-extension 2515/2515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)