### PR TITLE
A contentless open thread never renders blank — the boot loader holds past its backstop

### DIFF
--- a/tools/romp-lab/highlight-loop.mjs
+++ b/tools/romp-lab/highlight-loop.mjs
@@ -11,7 +11,14 @@ const { chromium } = require2("playwright");
 
 const PORT = process.env.PORT, TOKEN = process.env.TOKEN, LAB = process.env.LAB_DIR, PROJ = process.env.PROJECT_DIR;
 const MODEL = process.env.LAB_MODEL || "Haiku";
-const PASSAGE = "the moon has no weather to speak of";
+// The anchor turn is RICH on purpose (T152, the user 2026-08-28: a comment on a long turn with
+// bold sections, links and an inline image rendered a floating quote over a blank thread): the
+// model echoes markdown — bold + inline code + a path + an image — so the passage's rendered text
+// SPANS ELEMENT BOUNDARIES and the exact-match re-find, the selection, and the quote all exercise
+// the hard case. PASSAGE is the RENDERED (plain) text the user would drag over.
+const PASSAGE_MD = "the **moon** has `no weather` to speak of (notes: /tmp/moon-notes.txt)";
+const PASSAGE = "the moon has no weather to speak of (notes: /tmp/moon-notes.txt)";
+const TURN_MD = PASSAGE_MD + "\n\n![plot](/tmp/moon-plot.png)";
 const shots = path.join(LAB, "shots");
 let phaseN = 0;
 const fails = [];
@@ -81,7 +88,7 @@ const moded = await page.evaluate(async () => {
 console.log("mode bypass:", moded);
 
 // ── a REAL turn: ask for a stable, selectable sentence ──
-await page.fill("#composer-input", `Reply with exactly this sentence and nothing else: ${PASSAGE}`);
+await page.fill("#composer-input", `Reply with exactly this markdown and nothing else (verbatim, keep all formatting characters): ${TURN_MD}`);
 await page.keyboard.press("Enter");
 await page.waitForFunction((p) => Array.from(document.querySelectorAll(".turn-assistant .md"))
   .some((e) => e.textContent.includes(p)), PASSAGE, { timeout: 180000 });
@@ -89,12 +96,27 @@ await shot("reply-landed");
 
 // ── the COMMENT flow: select the passage → context menu → Comment → send ──
 await page.evaluate((p) => {
+  // cross-node selection (T152): the rich turn splits the passage across <strong>/<code>/link text
+  // nodes — walk the text nodes accumulating rendered text, and set the range ends INSIDE the
+  // nodes where the passage starts and ends, exactly as a user's drag would land
   const el = Array.from(document.querySelectorAll(".turn-assistant .md")).find((e) => e.textContent.includes(p));
   const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
-  let tn; while ((tn = walker.nextNode())) if (tn.data.includes(p)) break;
+  const nodes = []; let all = "";
+  let tn; while ((tn = walker.nextNode())) { nodes.push({ n: tn, at: all.length }); all += tn.data; }
+  const start = all.indexOf(p);
+  const end = start + p.length;
+  const locate = (pos, isEnd) => {
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const { n, at } = nodes[i];
+      if (pos > at || (pos === at && (!isEnd || i === 0))) return [n, pos - at];
+      if (pos === at && isEnd) return [nodes[i - 1].n, nodes[i - 1] ? pos - nodes[i - 1].at : 0];
+    }
+    return [nodes[0].n, 0];
+  };
+  const [sn, so] = locate(start, false);
+  const [en, eo] = locate(end, true);
   const r = document.createRange();
-  const off = tn.data.indexOf(p);
-  r.setStart(tn, off); r.setEnd(tn, off + p.length);
+  r.setStart(sn, so); r.setEnd(en, eo);
   const sel = getSelection(); sel.removeAllRanges(); sel.addRange(r);
   document.dispatchEvent(new Event("selectionchange"));
   el.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 420, clientY: 300 }));
@@ -113,6 +135,27 @@ check("1-latch-at-send", (await busy()) === true, `pre-send busy was ${preSend}`
 await shot("send-latched");
 sampleFlicker();
 
+// T152, permanent: the open popover NEVER renders a blank conversation area — at every sample it
+// shows the loader, pending sends, or content (the live specimen blanked for 200+s while a 40MB
+// fork booted across restarts). Sampled through the whole thread-open window below.
+const blankSamples = { blank: 0, total: 0 };
+const blankTimer = setInterval(async () => {
+  try {
+    blankSamples.total++;
+    const st = await page.evaluate(() => {
+      const msgs = document.querySelector(".cmt-pop .cmt-msgs");
+      return msgs ? msgs.children.length : -1;   // -1: popover closed (not a blank verdict)
+    });
+    if (st === 0) blankSamples.blank++;
+  } catch { /* page busy */ }
+}, 150);
+// …and the QUOTE must carry the WHOLE selected passage, rich rendering notwithstanding
+const quoteWhole = await page.evaluate((p) => {
+  const q = document.querySelector(".cmt-pop .cmt-quote");
+  return !!q && q.textContent.includes(p);
+}, PASSAGE);
+check("1b-whole-quote-on-rich-anchor", quoteWhole, "the quote block lost part of the cross-node passage");
+
 // PHASE 2+3: hold through thread-open, clear exactly when the reply text renders in the popover
 await page.waitForFunction(() => {
   const msgs = document.querySelector(".cmt-pop .cmt-msgs");
@@ -120,7 +163,10 @@ await page.waitForFunction(() => {
     .some((e) => e.textContent.trim().length > 0);
 }, undefined, { timeout: 240000 });
 const flick = flickerStop();
+clearInterval(blankTimer);
 check("2-no-flicker-through-thread-open", flick.falses === 0, `${flick.falses}/${flick.samples} false samples before the reply`);
+check("2b-thread-open-never-blanks", blankSamples.blank === 0,
+  `${blankSamples.blank}/${blankSamples.total} samples showed an EMPTY conversation area (T152's floating-quote blank)`);
 await shot("reply-in-thread");
 // the clear rides the same frame that rendered the reply — allow one push
 await page.waitForFunction(() => !document.querySelector("mark.cmt-hl.busy"), undefined, { timeout: 12000 })

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -60,9 +60,11 @@ test("the action buttons wear the chat's under-bubble family; Fork stays out by 
 
 test("a fresh thread boots on the romp loader, then renders its final format ONCE", () => {
   // the loader holds the list until the thread's REAL render (its events) is ready — the plain
-  // msgs projection no longer flashes as an intermediate format
-  assert.match(RENDER, /if \(!evs\.length && th\.status === "open" && !th\.error && cmtBootHolds\(th\.tid\)\) \{/);
-  assert.match(RENDER, /boot\.appendChild\(rompLoaderInner\("opening the thread…", \{ wordmark: false \}\)\);/);
+  // msgs projection no longer flashes as an intermediate format. Since T152 the guard requires
+  // BOTH projections empty and holds PAST the backstop with a slower label (never blank; a msgs-
+  // only old-kernel thread still falls through to the plain projection).
+  assert.match(RENDER, /if \(!evs\.length && !th\.msgs\.length && th\.status === "open" && !th\.error\) \{/);
+  assert.match(RENDER, /rompLoaderInner\(\s*\n?\s*slow \? "still opening — the thread's session is taking longer than usual…" : "opening the thread…",/);
   // logo-only in the POPOVER (the user 2026-08-25): the spinning swirl + dots stay, the R-o-m-p
   // letters drop — parameterized on the ONE shared builder, so the boot splash and the pane/revive
   // loaders keep the full treatment (their call sites pass no opts)
@@ -75,7 +77,7 @@ test("a fresh thread boots on the romp loader, then renders its final format ONC
   assert.match(RENDER, /window\.setTimeout\(\(\) => \{ if \(openCommentKey\?\.tid === tid\) refillOpenCommentPop\(\); \}, CMT_BOOT_BACKSTOP_MS \+ 50\);/);
   // the user's own pending sends still acknowledge under the loader — through the CHAT'S queued
   // idiom (T104: the one-off gray pill is gone; cmtPendingQueued IS renderQueued's bare group)
-  const gate = RENDER.split("cmtBootHolds(th.tid)) {")[1].split("return;")[0];
+  const gate = RENDER.split('!th.msgs.length && th.status === "open" && !th.error) {')[1].split("return;")[0];
   assert.ok(gate.includes("cmtPendingQueued(pend)"), "pending bubbles ride the boot view, chat-idiom");
 });
 

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -649,3 +649,16 @@ test("the popover interrupt posts the THREAD sid, clears the send-latch on the g
   assert.match(UI, /cmtInterrupted\.delete\(cur\.th\.tid\);/);
   assert.match(body, /chip chip-interrupting/, "instant acknowledgment: the chip flips before any kernel round-trip");
 });
+
+test("a contentless open thread NEVER renders blank — the loader stays past the backstop (T152)", () => {
+  // the live specimen: a fork of a 40MB parent took 200+s to spend across kernel restarts; the 8s
+  // boot backstop expired and the popover showed the quote floating over an empty list. The
+  // backstop now swaps the loader's LABEL (an honest 'taking longer'), never to blank; error and
+  // stuck branches still take over on the frame that says so.
+  const at = UI.indexOf('if (!evs.length && !th.msgs.length && th.status === "open" && !th.error) {');
+  assert.ok(at > 0, "the never-blank guard exists, gated on BOTH projections being empty");
+  const body = UI.slice(at, UI.indexOf("return;", at));
+  assert.match(body, /const slow = !cmtBootHolds\(th\.tid\);/);
+  assert.match(body, /still opening — the thread's session is taking longer than usual…/);
+  assert.match(body, /opening the thread…/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6697,9 +6697,19 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
   // render appears once. Event-based fade (the comments frame carrying events refills this list);
   // the backstop falls through to the msgs projection so a thread whose events never come (an old
   // kernel) can't trap the loader.
-  if (!evs.length && th.status === "open" && !th.error && cmtBootHolds(th.tid)) {
+  // A CONTENTLESS open thread NEVER renders blank (T152, the user 2026-08-28, live specimen: a
+  // fork of a 40MB parent took 200+ seconds to spend across kernel restarts, the 8s boot backstop
+  // expired, and the popover showed the quote floating over nothing — 'nothing shows up when I
+  // click on it'). While BOTH projections are empty on an open, error-free thread, the loader
+  // stays; past the backstop it swaps to an honest slower message (the backstop changes the LABEL,
+  // never to blank — the error and stuck branches below still take over the moment the frame says
+  // so, and any content arriving replaces this whole render, all event-keyed).
+  if (!evs.length && !th.msgs.length && th.status === "open" && !th.error) {
+    const slow = !cmtBootHolds(th.tid);
     const boot = el("div", "cmt-boot");
-    boot.appendChild(rompLoaderInner("opening the thread…", { wordmark: false }));
+    boot.appendChild(rompLoaderInner(
+      slow ? "still opening — the thread's session is taking longer than usual…" : "opening the thread…",
+      { wordmark: false }));
     list.appendChild(boot);
     if (pend.length) list.appendChild(cmtPendingQueued(pend));
     list.scrollTop = list.scrollHeight;


### PR DESCRIPTION
The user (live specimen): clicking a comment highlight opened the popover to the quote floating over an **empty** conversation area.

## The trace (read-only, live store)
Thread row, reg, transcript: all healthy — and both projections extract the full exchange **now**. At click time the fork was unspent: the parent transcript is 40MB, the copy raced several kernel restarts, and the CLI spent it **200+ seconds after the click**. Both projections were legitimately empty throughout; the popover's 8s boot backstop expired and fell through to a blank list. (The mid-word quote is the stored selection being drag-faithful — verified; the events slice is sound — the cut record is a plain text event.)

## The fix
The boot guard gates on **both projections empty** (open, error-free) and holds the loader **past the backstop** — the backstop swaps the label to 'still opening — the thread's session is taking longer than usual…', never to blank. All exits stay event-keyed (content replaces on its frame; error/stuck branches take over). Old-kernel msgs-only threads fall through exactly as before.

## Lab (permanent)
The anchor turn is **rich** now (bold + code + path + image — the passage spans element boundaries; a cross-node range builder replaces the single-node finder); **1b** asserts the whole quote survives; **2b** samples the popover through the entire thread-open window and fails on any empty conversation area. **ALL PHASES GREEN (24 checks).** Suite 2516/2516, tsc clean.

**Flagged follow-up, not folded in**: fork boot cost scales with parent transcript size (the 40MB copy is the 200s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)