### PR TITLE
Conserve closes only FADED tab-less sessions — the look and the process are one fact (T155)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2283,6 +2283,16 @@ def _auto_nudge_on():
 CONSERVE_FILE_NAME = "conserve-memory.json"
 CONSERVE_VIEWER_LEASE_S = 30
 CONSERVE_HIDE_GRACE_S = 60
+FADED_S = 3600   # ready + idle this long = the FADED look (timeline lanes + chat tabs)
+
+
+def _idle_faded(state, since, now):
+    """THE faded fact, stated once (T155): ready/idle for over an hour. Both payload renderers
+    (the chat chip, the timeline lane) and the conserve sweep read THIS — the user's design
+    instinct is that the faded look and the parked process should be one fact, and one function is
+    how the two can never drift. `state` accepts both spellings ('ready' is the chip vocabulary,
+    'waiting' the backend snapshot's)."""
+    return state in ("ready", "waiting", "idle") and bool(since) and now - float(since) > FADED_S
 _conserve_last_viewer = [time.time()]   # the last moment a chat viewer was connected (lease anchor)
 _conserve_hidden_at = {}                # sid -> first moment seen hidden+idle (the grace clock)
 
@@ -2317,11 +2327,19 @@ def _conserve_tick(now):
         return   # the lease: a reloading page is not a closed dashboard
     vc = _views_client()
     running = be.running_sids()
+    rows = be.live_sessions()
     closed = []
     for sid in running:
         open_tab = viewer and _view_visible(vc, sid, "chat")
         busy = not be.conserve_idle(sid)
-        if open_tab or busy:
+        # THE COMPOSITION (T155, weighed b->c): close only sessions BOTH faded (ready + idle > 1h —
+        # the same _idle_faded fact the UI renders, so the faded look on an unviewed session
+        # honestly means 'process parked') AND tab-open on no connected viewer (an open tab always
+        # protects — the tab-sync direction that started this). The hour is the churn hysteresis
+        # the user asked for: a worker idling minutes between dispatches never pays a respawn.
+        st = rows.get(sid) or {}
+        fresh = not _idle_faded(str(st.get("state") or ""), st.get("since") or 0, now)
+        if open_tab or busy or fresh:
             _conserve_hidden_at.pop(sid, None)
             continue
         first = _conserve_hidden_at.setdefault(sid, now)
@@ -18369,7 +18387,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \
                 and spawn_inflight:
             chip = "opening"
-        faded = chip == "ready" and bool(tm["since"]) and now - tm["since"] > 3600
+        faded = chip == "ready" and _idle_faded(chip, tm["since"], now)
         # apiTooLong distinguishes a "prompt is too long" block (on YOU → red dashed tab) from a TRANSIENT API
         # error (auto-retrying → the tab renders amber/retrying, not alarm-red). chip stays "blocked" either way
         # so the client auto-retry still fires + recovers the transient ones (the user 2026-06-29).
@@ -22303,7 +22321,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         # tmux's vocabulary and counted "waiting" as active — but "waiting" IS the post-turn idle state, so
         # every live lane stayed active forever and only DEAD lanes ever dimmed (the user 2026-07-22: idle
         # threads dim in the chat but never on the timeline). Dead lanes still fade via `not live`.
-        faded = (not live) or (state == "ready" and bool(tm and tm["since"]) and now - tm["since"] > 3600)
+        faded = (not live) or (state == "ready" and _idle_faded(state, tm and tm["since"], now))
         # AWAITING dispatched/background work — the SAME _session_awaiting the chat chip folds into its
         # yellow working dot, emitted per lane so the timeline shows the in-flight-elsewhere state instead
         # of a bare READY (the user 2026-07-01: the surfaces must share one working model; this was the

--- a/tests/test_conserve_memory.py
+++ b/tests/test_conserve_memory.py
@@ -87,10 +87,15 @@ class Tick(unittest.TestCase):
 
     class _FakeBe:
         def __init__(self):
-            self.running = ["s-open", "s-hidden", "s-busy"]
-            self.idle = {"s-open": True, "s-hidden": True, "s-busy": False}
+            self.running = ["s-open", "s-hidden", "s-busy", "s-fresh"]
+            self.idle = {"s-open": True, "s-hidden": True, "s-busy": False, "s-fresh": True}
+            # the FADED fact rides the snapshot rows (T155): everyone idled since t=0 except
+            # s-fresh, which settled moments ago — inside the hour, never closed
+            self.since = {"s-open": "1", "s-hidden": "1", "s-busy": "1", "s-fresh": "999"}
             self.closed = []
         def running_sids(self): return list(self.running)
+        def live_sessions(self):
+            return {sid: {"state": "waiting", "since": self.since.get(sid, "1")} for sid in self.running}
         def conserve_idle(self, sid): return self.idle.get(sid, False)
         def conserve_close(self, sid):
             self.closed.append(sid); self.running.remove(sid); return True
@@ -115,12 +120,27 @@ class Tick(unittest.TestCase):
         km._set_conserve(False)
         km._conserve_hidden_at.clear()
 
-    def test_matrix_open_stays_hidden_idle_closes_after_grace_busy_stays(self):
-        km._conserve_tick(1000.0)
-        self.assertEqual(self.be.closed, [], "first sight of hidden+idle starts the grace, closes nothing")
-        km._conserve_tick(1000.0 + km.CONSERVE_HIDE_GRACE_S + 1)
+    def test_matrix_open_stays_hidden_faded_closes_after_grace_busy_and_fresh_stay(self):
+        # ticks run past the FADED hour (sessions idled since t~0) — s-fresh alone is inside it
+        t0 = 5000.0
+        self.be.since["s-fresh"] = str(t0 - 60)   # settled a minute before the tick — inside the hour
+        km._conserve_tick(t0)
+        self.assertEqual(self.be.closed, [], "first sight of hidden+faded starts the grace, closes nothing")
+        km._conserve_tick(t0 + km.CONSERVE_HIDE_GRACE_S + 1)
         self.assertEqual(self.be.closed, ["s-hidden"],
-                         "hidden+idle closes after the grace; the open tab and the busy one stay")
+                         "hidden+faded closes after the grace; the open tab, the busy one, and the "
+                         "fresh-idle one all stay (T155: the hour IS the churn hysteresis)")
+
+    def test_a_fresh_idle_session_never_closes_inside_the_hour(self):
+        self.be.since["s-hidden"] = "999999"                   # settled moments before the tick
+        self.be.since["s-fresh"] = "999999"
+        km._conserve_tick(1000000.0)
+        km._conserve_tick(1000000.0 + km.CONSERVE_HIDE_GRACE_S + 1)
+        self.assertEqual(self.be.closed, [], "inside the faded hour nothing closes — no churn, ever")
+        self.be.since["s-hidden"] = "1"                        # …and once faded, it goes
+        km._conserve_tick(1000000.0 + 2 * km.CONSERVE_HIDE_GRACE_S + 2)
+        km._conserve_tick(1000000.0 + 3 * km.CONSERVE_HIDE_GRACE_S + 3)
+        self.assertEqual(self.be.closed, ["s-hidden"])
 
     def test_a_reshow_cancels_the_grace(self):
         km._conserve_tick(1000.0)
@@ -129,16 +149,20 @@ class Tick(unittest.TestCase):
         self.assertEqual(self.be.closed, [], "the re-show event cancels the pending close")
 
     def test_viewer_disconnect_lease_holds_then_releases(self):
+        # tick times sit past the faded hour for the since="1" rows; s-fresh settled a minute before
+        t0 = 10000.0
+        self.be.since["s-fresh"] = str(t0 - 60)
         with km._clients_lock:
             km._clients[:] = []                                  # every viewer gone (a reload)
-        km._conserve_last_viewer[0] = 1000.0
-        km._conserve_tick(1000.0 + 5)
+        km._conserve_last_viewer[0] = t0
+        km._conserve_tick(t0 + 5)
         self.assertEqual(self.be.closed, [], "within the lease nothing moves — a reload never mass-closes")
-        km._conserve_tick(1000.0 + km.CONSERVE_VIEWER_LEASE_S + 1)
-        km._conserve_tick(1000.0 + km.CONSERVE_VIEWER_LEASE_S + km.CONSERVE_HIDE_GRACE_S + 2)
-        self.assertIn("s-hidden", self.be.closed, "past the lease, no viewer = no open tabs; idle closes after grace")
+        km._conserve_tick(t0 + km.CONSERVE_VIEWER_LEASE_S + 1)
+        km._conserve_tick(t0 + km.CONSERVE_VIEWER_LEASE_S + km.CONSERVE_HIDE_GRACE_S + 2)
+        self.assertIn("s-hidden", self.be.closed, "past the lease, no viewer = no open tabs; faded closes after grace")
         self.assertIn("s-open", self.be.closed, "…including the one that WAS on the strip (no viewer sees it)")
         self.assertNotIn("s-busy", self.be.closed, "work is never closed")
+        self.assertNotIn("s-fresh", self.be.closed, "…and fresh-idle stays even with no viewer (the hour holds)")
 
     def test_off_means_untouched(self):
         km._set_conserve(False)

--- a/tests/test_timeline_idle_fade.py
+++ b/tests/test_timeline_idle_fade.py
@@ -26,15 +26,18 @@ class TimelineIdleFade(unittest.TestCase):
         # the fade rides the derived chip `state` (from _session_chip), mirroring the chat tab's rule,
         # and `not live` keeps dead lanes dimmed as before
         self.assertIn(
-            'faded = (not live) or (state == "ready" and bool(tm and tm["since"]) and now - tm["since"] > 3600)',
+            'faded = (not live) or (state == "ready" and _idle_faded(state, tm and tm["since"], now))',
             src)
         # the old raw-tmux set — which listed "waiting", the IDLE state, as ACTIVE — is gone
         self.assertNotIn('tm["state"] in ("working", "permission", "picker", "compacting", "waiting")', src)
 
     def test_both_surfaces_share_one_idle_rule(self):
         # the chat tab's rule is the reference: ready chip + idle longer than an hour
-        self.assertIn('faded = chip == "ready" and bool(tm["since"]) and now - tm["since"] > 3600',
+        self.assertIn('faded = chip == "ready" and _idle_faded(chip, tm["since"], now)',
                       inspect.getsource(km))
+        # ONE shared rule since T155: both payload sites AND the conserve sweep read _idle_faded,
+        # so the faded look and the parked process can never drift apart
+        self.assertIn("def _idle_faded(state, since, now):", inspect.getsource(km))
 
     def test_the_derived_state_is_computed_before_the_fade_uses_it(self):
         # build_timeline already derives the chip into `state`; the fade must read THAT, not re-derive

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -63,7 +63,7 @@ var GEAR_HTML =
   '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-conserve>" +
   '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
-  '<span class=rs-sub>Close the claude process of a session that is idle and on no open tab (each averages ~340MB). Everything persists — the session revives on a tab click, a message, or a scheduled wake. Off = every session keeps its process for as long as it lives.</span>' +
+  '<span class=rs-sub>Close the claude process of a session that has FADED (idle over an hour) and is on no open tab (each averages ~340MB). Everything persists — it revives on a tab click, a message, or a scheduled wake. An open tab always keeps its process; off = every session keeps its process for as long as it lives.</span>' +
   '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-fileedit>" +
   '<span><b>File editing</b><span class=rs-mixed hidden></span>' +


### PR DESCRIPTION
The weigh, from the shipped machinery (T148 shipped pure tab-keyed):

- **(a) pure faded-keyed** makes the UI and resource state one fact, but closes sessions the user has visibly open on a tab — contradicting the tab-sync direction that started this. Rejected.
- **(b) pure tab-keyed** (as shipped) respects tabs but closes a five-minute-idle session the moment no viewer shows it — thin hysteresis, real churn risk for workers idling between dispatches. 
- **(c) the composition — recommended and landed:** close only sessions both faded (ready + idle > 1h) and tab-open on no connected viewer. The hour is the churn hysteresis the user asked for (rapid cycles never pay a respawn; spawns already ride `_spawn_sem`), open tabs always protect, and on any unviewed session the faded look now honestly means "process parked". The stated caveat: a faded session still on an open tab keeps its process — `faded == no-process` holds for unviewed sessions only; the visual equivalence is real but scoped.

**One fact, one function.** `_idle_faded(state, since, now)` — both payload renderers (chat chip, timeline lane) and the conserve sweep read it, so the look and the sweep can never drift; `FADED_S = 3600` replaces the two inlined literals. Bonus as predicted: timeline process-liveness becomes predictable from visible state.

**Tests.** The conserve matrix gains the fresh-idle row (never closes inside the hour; closes once faded); the no-viewer lease keeps the hour floor; the idle-fade pins retarget to the shared helper (the stronger pin — the old ones anchored the inlined expressions).

Suites: pytest full run green with the two retargeted pins (5918 passed + the retargets verified); vscode-extension 2516/2516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)