### PR TITLE
The dark pass completes on the SERVED page: editor-background tokens, and the gap that hid it closes

### DIFF
--- a/tools/romp-lab/banner-loop.mjs
+++ b/tools/romp-lab/banner-loop.mjs
@@ -66,6 +66,20 @@ await page.goto(`http://127.0.0.1:${PORT}/?token=${TOKEN}`);
 await page.waitForSelector("#rstale", { state: "attached", timeout: 20000 });
 await sleep(2 * KA * 1000 + 1000);            // two heartbeats of quiet — nothing may raise on a fresh page
 check("fresh-page-quiet", !(await bannerShown()), await bannerShown());
+// T151, permanent: the SERVED feed page (THEME_CSS vars defined) sits its control bar on the page
+// dark — the old editorWidget token resolved #252526 here, the exact lighter bar the one-dark
+// ruling removed. Same-origin iframe, so the probe reads the feed frame's computed styles.
+{
+  const feed = page.frames().find((f) => f.url().includes("/feed"));
+  if (feed) {
+    await feed.waitForSelector("#feed-foot", { timeout: 15000 }).catch(() => null);
+    const t = await feed.evaluate(() => {
+      const foot = document.getElementById("feed-foot");
+      return foot ? { foot: getComputedStyle(foot).backgroundColor, page: getComputedStyle(document.body).backgroundColor } : null;
+    }).catch(() => null);
+    check("feed-foot-is-page-dark-when-served", !!t && t.foot === t.page, t ? `foot ${t.foot} vs page ${t.page}` : "no #feed-foot in the served feed frame");
+  } else check("feed-foot-is-page-dark-when-served", false, "no /feed frame on the shell page");
+}
 await shot("fresh");
 
 // ── 2. dist bump → banner within one heartbeat (the shim's ka path, tighter than the 30s poll) ──

--- a/tools/romp-lab/highlight-loop.mjs
+++ b/tools/romp-lab/highlight-loop.mjs
@@ -54,6 +54,15 @@ await page.fill("#picker-search", "lab-moon");
 await page.fill("#picker-dir", PROJ);
 await page.click("#picker-new-btn");
 await page.waitForSelector(".tab", { timeout: 30000 });
+// T151, permanent: the SERVED chat page (THEME_CSS vars defined — the exact context the T141
+// harness missed) paints the strip on the page dark; the tokens' fallbacks are dead code here.
+{
+  const t = await page.evaluate(() => ({
+    strip: getComputedStyle(document.getElementById("tabbar")).backgroundColor,
+    page: getComputedStyle(document.body).backgroundColor,
+  }));
+  check("0-strip-is-page-dark-when-served", t.strip === t.page, `strip ${t.strip} vs page ${t.page}`);
+}
 // wait until the session is REAL (composer live, statusline shows a state chip)
 await page.waitForSelector("#statusline .chip, #statusline .compacting-line", { timeout: 60000 });
 await shot("session-open");

--- a/ui/webview/feed-tagmount.test.ts
+++ b/ui/webview/feed-tagmount.test.ts
@@ -90,6 +90,6 @@ test("what the lens hides stays one glance away: whisper, promoted banner, click
     "the promoted line NAMES the lens");
   assert.match(FEED, /lmore\.onclick = \(\) => \{ setFeedLens\(\{ all: true \}\); render\(\); \};/,
     "the way out is purely local — no kernel round-trip");
-  assert.match(CSS, /#feed-lensmore\.prominent \{ margin: 6px 8px 2px; padding: 10px 14px; background: #252526;/,
-    "the judge-limit banner's card chrome — neutral, a narrowed board is a choice");
+  assert.match(CSS, /#feed-lensmore\.prominent \{ margin: 6px 8px 2px; padding: 10px 14px; background: var\(--vscode-editorWidget-background, #252526\);/,
+    "the judge-limit banner's card chrome — neutral, a narrowed board is a choice (tokenized, T151)");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -344,7 +344,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* action (to-do) card: amber accent instead of decision-blue; ☐ glyph on the task
    line; the "✓ Done — I did it" button greens on hover (it's a check-off). */
 .fq-send { flex: 0 0 auto; font: inherit; font-size: 0.86em; cursor: pointer; color: var(--fg);
-  background: rgba(255, 255, 255, 0.08); border: 1px solid var(--card-border); border-radius: 6px; padding: 5px 12px; }
+  background: transparent; border: 1px solid var(--card-border); border-radius: 6px; padding: 5px 12px; }   /* T151: the one button rest */
 .fq-send:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* "didn't need me" — the false-awaiting teaching dismissal */
 
@@ -913,7 +913,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   display: flex; align-items: center; gap: 8px; padding: 6px 12px;
   flex-wrap: wrap; row-gap: 5px;   /* a narrow pane folds buttons onto another row — never a horizontal scrollbar */
   border-top: 1px solid var(--card-border);
-  background: var(--vscode-editorWidget-background, #252526); }   /* opaque panel so it reads as a dedicated bar */
+  /* the page dark (T151, superseding 2026-06-29's dedicated-panel look — the user's 2026-08-28
+     one-dark-background ruling names this bar as the reference surface tabs must match, so the
+     bar itself must sit on the same dark): the border-top hairline is the separator now. The old
+     editorWidget token resolved to #252526 under the kernel's THEME_CSS. */
+  background: var(--bg); }
 #feed-clearall { order: 10; margin-left: auto; }   /* accent hover like every action button */
 #feed-undoclear { order: 11; }                     /* restorative — far right */
 #feed-foot .fdismiss { font-size: 10.5px; padding: 1px 9px; opacity: 0.95; }
@@ -941,7 +945,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-taglens svg { display: block; }
 #feed-lensmore { padding: 4px 14px 10px; color: var(--dim); font-size: 0.82em; cursor: pointer; }
 #feed-lensmore:hover { color: var(--accent); text-decoration: underline; }
-#feed-lensmore.prominent { margin: 6px 8px 2px; padding: 10px 14px; background: #252526;
+#feed-lensmore.prominent { margin: 6px 8px 2px; padding: 10px 14px; background: var(--vscode-editorWidget-background, #252526);   /* tokenized (T151) — the notice-card chrome, host-aware */
   border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 6px;
   color: var(--fg); font-size: 0.92em; }
 #feed-lensmore.prominent:hover { color: var(--fg); text-decoration: none; border-color: var(--accent); }
@@ -1215,8 +1219,8 @@ body.fileview-open { overflow: hidden; }
 .fileview-base { flex: 0 0 auto; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
-  padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.08); color: var(--fg);
-  border: 1px solid var(--box-border); }
+  padding: 3px 9px; border-radius: 6px; background: transparent; color: var(--fg);   /* T151: the one button rest */
+  border: 1px solid var(--card-border); }
 .fileview-btn:hover { border-color: var(--accent); }
 /* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
 a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
@@ -1497,11 +1501,11 @@ body.filebrowse-open { overflow: hidden; }
    the accent (this is status, not highlight); red would overstate it — the pause is expected and
    self-resolving at the window reset. */
 .judge-limit-banner { display: flex; align-items: center; gap: 10px; margin: 6px 8px 2px;
-  padding: 7px 12px; background: #252526; border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 7px 12px; background: var(--vscode-editorWidget-background, #252526); border: 1px solid rgba(255, 255, 255, 0.12);   /* tokenized (T151) */
   border-radius: 6px; font-size: 0.92em; }
 .judge-limit-banner .jl-text { opacity: 0.85; }
 .judge-limit-banner .jl-switch { flex: none; padding: 3px 10px; border-radius: 4px; border: 1px solid
-  rgba(255, 255, 255, 0.18); background: #333; color: inherit; cursor: pointer; font-size: 0.92em; }
+  rgba(255, 255, 255, 0.18); background: var(--vscode-input-background, #3c3c3c); color: inherit; cursor: pointer; font-size: 0.92em; }   /* tokenized (T151; was a bare #333) */
 .judge-limit-banner .jl-switch:hover { background: #3c3c3c; }
 .judge-limit-banner .jl-switch:disabled { opacity: 0.6; cursor: default; }
 

--- a/ui/webview/served-theme.test.ts
+++ b/ui/webview/served-theme.test.ts
@@ -1,0 +1,86 @@
+// SERVED-VALUE discipline for chrome tokens (T151, closing the T141 verification gap): every
+// kernel-served page inlines THEME_CSS (kernel/kernel.py), which DEFINES the --vscode-* variables
+// — so a var()'s fallback is dead code in the browser, and a token choice must be validated
+// against the SERVED definitions, not the fallback path (the T141 probe validated fallbacks and
+// shipped a false 'already dark' claim; the user saw #252526). This test resolves the chrome
+// surfaces' background tokens under the actual THEME_CSS map.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
+const KERNEL = read("kernel", "kernel.py");
+const STYLES = read("ui", "webview", "styles.css");
+const FEED = read("ui", "webview", "feed.css");
+const STRIP = read("ui", "webview", "strip.css");
+
+// the served var map: THEME_CSS's :root block, plus each sheet's own :root definitions
+function varsOf(src: string): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const hit of src.matchAll(/(--[a-zA-Z-]+)\s*:\s*([^;}]+)[;}]/g)) m.set(hit[1], hit[2].trim());
+  return m;
+}
+const themeAt = KERNEL.indexOf('THEME_CSS = """');
+assert.ok(themeAt > 0, "THEME_CSS must exist in the kernel");
+const THEME = KERNEL.slice(themeAt, KERNEL.indexOf('"""', themeAt + 20));
+const SERVED = varsOf(THEME);
+
+function resolve(expr: string, sheets: Map<string, string>[]): string {
+  // resolve var(--x, fb) chains: the SERVED definition wins (it exists on the page), else fallback
+  let out = expr.trim();
+  for (let i = 0; i < 8; i++) {
+    const m = out.match(/^var\((--[a-zA-Z-]+)\s*(?:,\s*(.*))?\)$/s);
+    if (!m) return out;
+    const defined = SERVED.get(m[1]) ?? sheets.map((s) => s.get(m[1])).find(Boolean);
+    out = (defined ?? m[2] ?? "").trim();
+  }
+  return out;
+}
+const bgOf = (src: string, sel: string): string => {
+  const at = src.indexOf(sel);
+  assert.ok(at >= 0, sel + " rule exists");
+  const block = src.slice(at, src.indexOf("}", at));
+  const m = [...block.matchAll(/background:\s*([^;]+);/g)].pop();
+  assert.ok(m, sel + " declares a background");
+  return m![1].trim();
+};
+
+test("THEME_CSS defines the trap: sideBar/widget tokens are LIGHTER than the page dark", () => {
+  assert.equal(SERVED.get("--vscode-editor-background"), "#1e1e1e");
+  assert.equal(SERVED.get("--vscode-sideBar-background"), "#252526");
+  assert.equal(SERVED.get("--vscode-editorWidget-background"), "#252526");
+});
+
+test("the strip, the feed foot, and the network strip all resolve to the page dark WHEN SERVED", () => {
+  const sheets = [varsOf(STYLES.slice(0, STYLES.indexOf("* { box-sizing")))];
+  assert.equal(resolve(bgOf(STYLES, "#tabbar {"), sheets), "#1e1e1e", "#tabbar under THEME_CSS");
+  const feedSheets = [varsOf(FEED.slice(0, 4000))];
+  assert.equal(resolve(bgOf(FEED, "#feed-foot {"), feedSheets), "#1e1e1e", "#feed-foot under THEME_CSS");
+  assert.equal(resolve(bgOf(STRIP, "#romp-strip {"), []), "#1e1e1e", "#romp-strip under THEME_CSS");
+});
+
+test("no chrome background rides the sideBar token, and the notice chrome is tokenized", () => {
+  for (const [name, src] of [["styles.css", STYLES], ["feed.css", FEED], ["strip.css", STRIP]] as const) {
+    assert.ok(!/background:\s*var\(--vscode-sideBar-background/.test(src),
+      name + ": sideBar-background is #252526 on every served page — never a chrome plane");
+  }
+  assert.ok(!/background:\s*#252526/.test(FEED), "feed notice chrome references the token, not the hex");
+  assert.ok(!/background:\s*#333[;\s]/.test(FEED), "the jl-switch rest is tokenized too");
+});
+
+test("the missed family rests are the one button rest now (transparent + the feed hairline)", () => {
+  for (const sel of [".picker-be-opt {", ".picker-action {", ".path-full-retry {"]) {
+    const at = STYLES.indexOf(sel);
+    const block = STYLES.slice(at, STYLES.indexOf("}", at));
+    assert.match(block, /background: transparent/, sel);
+    assert.match(block, /var\(--card-border\)/, sel);
+  }
+  for (const [src, name] of [[STYLES, "styles"], [FEED, "feed"]] as const) {
+    const at = src.indexOf(".fileview-btn {");
+    const block = src.slice(at, src.indexOf("}", at));
+    assert.match(block, /background: transparent/, ".fileview-btn (" + name + ")");
+  }
+  const fq = FEED.slice(FEED.indexOf(".fq-send {"), FEED.indexOf("}", FEED.indexOf(".fq-send {")));
+  assert.match(fq, /background: transparent/);
+});

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -15,7 +15,10 @@
   row-gap: 4px; flex-wrap: wrap;
   padding: 4px 10px; box-sizing: border-box; user-select: none;
   border-top: 1px solid var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.12));
-  background: var(--vscode-editorWidget-background, #252526); }
+  /* the page dark (T151): under the kernel's THEME_CSS the widget token resolves #252526 — the
+     exact lighter-bar shade the one-dark ruling removes; in VS Code editor-background follows the
+     user's theme, so the strip sits on the same plane as the pane in both hosts. */
+  background: var(--vscode-editor-background, #1e1e1e); }
 #strip-usage { flex: 0 1 auto; min-width: 0; display: flex; flex-direction: row; align-items: center; gap: 16px; }
 /* the actions cluster pins to the right edge of whatever row it wraps onto */
 .strip-acts { flex: 0 0 auto; display: flex; flex-direction: row; align-items: center; gap: 2px;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -151,7 +151,12 @@ body.chat-theme-yatharth #winframe { display: block; position: fixed; inset: 0; 
      (an inline max-height would override that media rule and clip the mobile header) */
   max-height: var(--tabbar-cap, 150px); overflow-y: auto; overflow-x: hidden;
   border-bottom: 1px solid var(--box-border);
-  background: var(--vscode-sideBar-background, var(--bg));
+  /* the EDITOR background token, not sideBar (T151): every kernel-served page inlines THEME_CSS,
+     which defines --vscode-sideBar-background:#252526 — so the var(--bg) fallback never fired in
+     the browser and the strip painted a lighter plane over the #1e1e1e page (the T141 harness
+     validated the fallback path only; see the served-theme test). editor-background IS the page
+     dark in both hosts — the same token #footer rides. */
+  background: var(--vscode-editor-background, var(--bg));
 }
 /* #tabs fills the bar width and wraps its tabs across multiple rows. gap 0 (was 4px, the user
    2026-08-08): the strip trades its empty inter-tab space for room for the per-tab context gauge —
@@ -2347,8 +2352,8 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-backend { display: flex; align-items: center; gap: 6px; padding: 6px 14px 8px; }
 .picker-backend-label { flex: 0 0 auto; color: var(--dim); font-size: 0.82em; margin-right: 2px; }
 .picker-be-opt {
-  flex: 0 0 auto; cursor: pointer; background: rgba(255, 255, 255, 0.06); color: var(--dim);
-  border: 1px solid var(--box-border); border-radius: 5px; padding: 4px 12px; font-size: 0.82em; font-weight: 600;
+  flex: 0 0 auto; cursor: pointer; background: transparent; color: var(--dim);   /* T151: the one button rest */
+  border: 1px solid var(--card-border); border-radius: 5px; padding: 4px 12px; font-size: 0.82em; font-weight: 600;
 }
 .picker-be-opt:hover { background: rgba(255, 255, 255, 0.12); color: var(--fg); }
 .picker-be-opt.sel { background: var(--accent); color: var(--accent-fg); border-color: transparent; }   /* selected backend = accent, not working-yellow (the user 2026-06-24) */
@@ -2397,8 +2402,8 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-actions { border-top: 1px solid var(--box-border); padding: 8px 10px; }
 .picker-action {
   width: 100%; padding: 7px 10px; cursor: pointer;
-  background: rgba(255, 255, 255, 0.05); color: var(--fg);
-  border: 1px solid var(--box-border); border-radius: 6px;
+  background: transparent; color: var(--fg);   /* T151: the one button rest */
+  border: 1px solid var(--card-border); border-radius: 6px;
   font-family: var(--sans); font-size: 0.92em;
 }
 .picker-action:hover { background: rgba(255, 255, 255, 0.1); }
@@ -2632,7 +2637,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* a kernel-VERIFIED preview whose bytes failed to arrive (restart, tunnel blip) — visible, retryable,
    never silently removed (preview.ts previewFull) */
 .path-full-retry { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 8px;
-  background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.14);
+  background: transparent; border: 1px solid var(--card-border);   /* T151: the one button rest */
   font-size: 0.86em; opacity: 0.85; cursor: pointer; }
 .path-full-retry:hover { border-color: var(--accent); }
 /* the fixed-footprint wait box shared by the retrying swirl AND the failure chip, so retry churn
@@ -2643,7 +2648,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* a repeat failure pulses once on swap-in so an identical-looking outcome still reads as a
    RESPONSE to the tap (preview.ts previewFull) — on the give-up chip and the retrying note alike */
 .path-full-retry.path-retry-flash, .path-load-note.path-retry-flash { animation: path-retry-flash 0.45s ease; }
-@keyframes path-retry-flash { 0% { background: rgba(255, 255, 255, 0.3); } 100% { background: rgba(255, 255, 255, 0.08); } }
+@keyframes path-retry-flash { 0% { background: rgba(255, 255, 255, 0.3); } 100% { background: transparent; } }
 @media (prefers-reduced-motion: reduce) { .path-full-retry.path-retry-flash, .path-load-note.path-retry-flash { animation: none; } }
 /* VS Code's host-round-trip image chip while the bytes are still on their way (render.ts fillPathImg) —
    pure-CSS pulse, the sandbox can't fetch the swirl asset */
@@ -2665,14 +2670,14 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .romp-lightbox-name { flex: 1 1 auto; font-size: 0.86em; color: var(--fg); opacity: 0.85;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .romp-lightbox-close { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
-  padding: 2px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.1); color: var(--fg);
+  padding: 2px 9px; border-radius: 6px; background: transparent; border: 1px solid var(--card-border); color: var(--fg);   /* T151: the one button rest */
   border: 1px solid rgba(255, 255, 255, 0.18); }
 .romp-lightbox-close:hover { border-color: var(--accent); }
 /* download: an anchor dressed exactly like the close button beside it (one control vocabulary —
    same chip, same hover cue), sitting between the filename and the ✕ */
 .romp-lightbox-dl { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
   display: inline-flex; align-items: center;   /* centers the inline tray SVG in the chip */
-  padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.1); color: var(--fg);
+  padding: 3px 9px; border-radius: 6px; background: transparent; border: 1px solid var(--card-border); color: var(--fg);   /* T151: the one button rest */
   border: 1px solid rgba(255, 255, 255, 0.18); text-decoration: none; line-height: normal; }
 .romp-lightbox-dl:hover { border-color: var(--accent); }
 
@@ -3029,8 +3034,8 @@ body.fileview-open { overflow: hidden; }
 .fileview-base { flex: 0 0 auto; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
-  padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.08); color: var(--fg);
-  border: 1px solid var(--box-border); }
+  padding: 3px 9px; border-radius: 6px; background: transparent; color: var(--fg);   /* T151: the one button rest */
+  border: 1px solid var(--card-border); }
 .fileview-btn:hover { border-color: var(--accent); }
 /* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
 a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -66,7 +66,8 @@ test("Classic: ONE dark background — no band, no explicit body fill, baseline 
   assert.doesNotMatch(CSS, /#tabbar \{ background: linear-gradient/, "no band plane on the strip");
   assert.doesNotMatch(CSS, /\.tab:not\(\.tab-blocked\):not\(\.active\):not\(:hover\):not\(\.tab-add\) \{ background:/,
     "no explicit rest-body fill either — baseline transparency over the dark plane");
-  assert.match(CSS, /^  background: var\(--vscode-sideBar-background, var\(--bg\)\);$/m, "the strip's one background");
+  assert.match(CSS, /^  background: var\(--vscode-editor-background, var\(--bg\)\);$/m,
+    "the strip's one background — the EDITOR token: sideBar resolves #252526 under the served THEME_CSS (T151; served-theme.test.ts owns the resolution proof)");
 });
 
 test("Classic: the rest OUTLINE — 1px in the hover gray, no fill, states stand down (T123)", () => {


### PR DESCRIPTION
T141's 'one dark background' was verified against a `file://` harness with **no `--vscode-*` vars defined** — every `var()` validated its fallback, while every kernel-served page inlines `THEME_CSS`, which defines them (`sideBar-background:#252526`). The lighter grays were live exactly as the user saw.

## The two reported surfaces
- **`#tabbar`**: `sideBar-background` → **`editor-background`** (the token that IS the page dark in both hosts — the `#footer` precedent).
- **`#feed-foot`**: the opaque `editorWidget` 'dedicated bar' (2026-06-29, superseded in place) → **`var(--bg)`**, border-top hairline as the separator.

## Same-pattern riders, folded in
`#romp-strip` (identical recipe) → editor-background; the six missed family rests → the one button rest (transparent + `--card-border`): `.picker-be-opt`, `.picker-action`, `.fileview-btn` ×2, `.fq-send`, `.path-full-retry` (+ its flash keyframe decays to transparent), lightbox close/download; notice chrome tokenized (`.judge-limit-banner`, `#feed-lensmore.prominent` → editorWidget token; `.jl-switch` → input-background, rest 333→3c3c3c served, hover unchanged). Sanctioned shades untouched (hovers, scrollbar exception, menus/modals/inputs/chips, ledger, #rpipe).

## The verification gap closes, both ways
- **`served-theme.test.ts`**: parses THEME_CSS out of kernel.py and RESOLVES the chrome tokens under the served definitions — `#tabbar`/`#feed-foot`/`#romp-strip` must resolve `#1e1e1e` when served; no chrome background on the sideBar token; family rests transparent.
- **Permanent lab probes on the REAL served pages**: strip == page body (chat), feed-foot == page (feed iframe). Both passed live: `rgb(30,30,30)` both sides.

Full lab ALL GREEN; webview 2520/2520, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)