### PR TITLE
T154: rose joins the romp identity palette, and slots learned to survive length differences

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -2011,11 +2011,11 @@ else
         if (( ${#_palette[@]} == 0 )); then
         _palette=(
             "#1EA1EB"  "#54B204"  "#4EA8A9"  "#DD42FF"  "#E87221"
-            "#98998A"  "#F85B5A"  "#F9D849"  "#9088F0"
+            "#98998A"  "#F85B5A"  "#F9D849"  "#9088F0"  "#E0629C"
         )
         _fg=(
             "white"    "black"    "white"    "white"    "black"
-            "black"    "white"    "black"    "black"
+            "black"    "white"    "black"    "black"    "white"
         )
         fi
         # Collect colors already in use by other romp sessions.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -842,10 +842,15 @@ def _set_palette(name):
         except Exception:
             continue
         loc = pal.find(parts[2]) if len(parts) > 2 else None
-        if not loc or (parts[2], parts[3] if len(parts) > 3 else "") == (new_bg[loc[1]], new_fg[loc[1]]):
+        if loc:
+            # palettes may differ in LENGTH now (the romp set grows append-only, 2026-08-28): a
+            # session on a slot the new set lacks wraps modulo — a total, deterministic mapping
+            # beats an IndexError or a stale off-palette color surviving the switch
+            _slot = loc[1] % len(new_bg)
+        if not loc or (parts[2], parts[3] if len(parts) > 3 else "") == (new_bg[_slot], new_fg[_slot]):
             continue
         parts += [""] * (4 - len(parts))
-        parts[2], parts[3] = new_bg[loc[1]], new_fg[loc[1]]
+        parts[2], parts[3] = new_bg[_slot], new_fg[_slot]
         _atomic_write(NAMES / sid, "\t".join(parts[:4]) + "\n")
     _write_palette_mirror()
     _send_to_app("chat", {"type": "palette", "colors": new_bg})   # fresh swatches for open right-click menus

--- a/kernel/palette.py
+++ b/kernel/palette.py
@@ -17,7 +17,7 @@ Alongside romp's own set: the best categorical schemes from Fabio Crameri's
 Scientific colour maps and from cmocean (the user 2026-07-12). Crameri's "S"
 palettes order their samples for maximum adjacent distinction but include
 near-black / near-white entries (built for white paper figures), so each set
-here is CURATED to 9 mid-tone, mutually distinct colors that hold up as
+here is CURATED to at least 9 mid-tone, mutually distinct colors that hold up as
 identity chrome on the dark UI. batlowS — Crameri's flagship categorical — was
 auditioned and dropped: a sequential map's gamut collapses into look-alike
 olives and salmons at 9 swatches. cmocean has no categorical maps; "phase" is
@@ -35,10 +35,15 @@ DEFAULT = "romp"
 PALETTES = {
     "romp": {
         "label": "romp",
+        # slot 9 ROSE #E0629C (the user's explicit pick, 2026-08-28): lightness-matched to the
+        # band, zero new close pairs under normal/protan/deutan/tritan (validated before the ask);
+        # APPENDED so existing slot assignments never shift. White fg per the set's own convention
+        # for saturated warm mids (its neighbors #F85B5A and #DD42FF wear white at comparable
+        # contrast). Three more additions are expected here — append-only, same rule.
         "bg": ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221",
-               "#98998A", "#F85B5A", "#F9D849", "#9088F0"],
+               "#98998A", "#F85B5A", "#F9D849", "#9088F0", "#E0629C"],
         "fg": ["white", "black", "white", "white", "black",
-               "black", "white", "black", "black"],
+               "black", "white", "black", "black", "white"],
     },
     "phase": {
         "label": "phase — cmocean",

--- a/tests/test_kernel_session_color.py
+++ b/tests/test_kernel_session_color.py
@@ -41,11 +41,22 @@ class SessionColor(unittest.TestCase):
         km.jd.STATE = self._state
         km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})
 
-    def test_active_palette_has_nine_colors_and_a_fg_word_each(self):
-        # the SAME set the tmux launcher / SDK backend assign from — romp_palette is the single source
-        self.assertEqual(len(km.pal.colors(km._palette_name())), 9)
-        self.assertEqual(len(km.pal.fgs(km._palette_name())), 9)
-        self.assertIn("#1EA1EB", km.pal.colors(km._palette_name()))
+    def test_active_palette_shape_and_the_rose_slot(self):
+        # the SAME set the tmux launcher / SDK backend assign from — romp_palette is the single
+        # source. The romp set grows APPEND-ONLY (slot 9 = rose #E0629C, the user 2026-08-28), so
+        # the pin is shape + the stable prefix, never a fixed nine.
+        bgs, fgs = km.pal.colors(km._palette_name()), km.pal.fgs(km._palette_name())
+        self.assertEqual(len(bgs), len(fgs))
+        self.assertGreaterEqual(len(bgs), 9)
+        self.assertTrue(all(f in ("black", "white") for f in fgs))
+        self.assertEqual(bgs[:2], ["#1EA1EB", "#54B204"], "existing assignments never shift")
+        self.assertEqual((bgs[9], fgs[9]), ("#E0629C", "white"))
+        # the fg contrast floor the set's whites all clear: WCAG relative-luminance contrast >= 3.0
+        r, g, b = (int("E0629C"[i:i + 2], 16) / 255.0 for i in (0, 2, 4))
+        lin = lambda c: c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+        L = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+        self.assertGreaterEqual((1.0 + 0.05) / (L + 0.05), 3.0, "white text clears the set's floor")
+        self.assertIn("#1EA1EB", bgs)
 
     def test_set_color_rewrites_bg_and_fg_preserving_name_and_cwd(self):
         (self.names / SID).write_text("mysess\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -22,7 +22,7 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 pal = SourceFileLoader("romp_palette", os.path.join(BIN, "romp_palette.py")).load_module()
 
 ROMP_BG = ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221",
-           "#98998A", "#F85B5A", "#F9D849", "#9088F0"]
+           "#98998A", "#F85B5A", "#F9D849", "#9088F0", "#E0629C"]
 
 
 def _lum(h):
@@ -34,11 +34,13 @@ def _lum(h):
 
 
 class PaletteShapes(unittest.TestCase):
-    def test_every_palette_is_nine_unique_hex_colors_with_fg_words(self):
+    def test_every_palette_is_at_least_nine_unique_hex_colors_with_fg_words(self):
+        # the romp set grows APPEND-ONLY past nine (rose #E0629C, the user 2026-08-28; more
+        # additions expected) — the invariant is shape + uniqueness + the nine-slot floor
         for name, p in pal.PALETTES.items():
-            self.assertEqual(len(p["bg"]), 9, name)
-            self.assertEqual(len(p["fg"]), 9, name)
-            self.assertEqual(len(set(p["bg"])), 9, "%s: duplicate swatch" % name)
+            self.assertGreaterEqual(len(p["bg"]), 9, name)
+            self.assertEqual(len(p["fg"]), len(p["bg"]), name)
+            self.assertEqual(len(set(p["bg"])), len(p["bg"]), "%s: duplicate swatch" % name)
             self.assertTrue(p["label"], name)
             for bg in p["bg"]:
                 self.assertRegex(bg, r"^#[0-9A-F]{6}$", name)
@@ -85,7 +87,7 @@ class PaletteLookups(unittest.TestCase):
 
     def test_colors_and_fgs_fall_back_to_the_default_set(self):
         self.assertEqual(pal.colors("no-such-palette"), ROMP_BG)
-        self.assertEqual(len(pal.fgs("no-such-palette")), 9)
+        self.assertEqual(len(pal.fgs("no-such-palette")), len(ROMP_BG))
 
 
 class ActiveName(unittest.TestCase):


### PR DESCRIPTION
Rose #E0629C (the user's explicit pick) appended at slot 9 of the romp set — append-only so existing assignments never shift, white fg per the set's own convention for saturated warm mids (neighbors #F85B5A/#DD42FF wear white; 3.0 contrast floor pinned). The shell launcher's hardcoded fallback gains the same tenth entry (the sync test caught it). Room left for the three coming additions; the pins now state the append-only rule.

**Length-safety fix the tenth slot exposed**: the palette-switch remap indexed `new_bg[slot]` unguarded — a session on slot 9 switching to a nine-color set would have crashed. Slots wrap modulo: total and deterministic.

Pins: shape + uniqueness + nine-slot floor + stable prefix, the rose pair, launcher-fallback byte sync.

Suites: Python 5919/0 (+313 subtests), UI 2516/2516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)