### PR TITLE
Conserve never closes a timer-armed session — the promised 769 seam, which was a loop

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4944,12 +4944,19 @@ class SdkBackend:
 
     def conserve_idle(self, sid: str) -> bool:
         """Whether this session is safe to conserve-close: no in-flight turn, nothing queued,
-        no ask parked, not mid-compaction (T148 — never close work)."""
+        no ask parked (T148 — never close work) — and NO ARMED SESSION TIMERS (the T148/769 seam:
+        a timer-armed session's CLI process IS its scheduler, and ensure_scheduled revives any
+        timer-armed session with no thread every producer pass — closing one here would be a
+        close/revive loop, one respawn per sweep, forever. The timer set living in the reg is the
+        same record ensure_scheduled reads, so the two sides can never disagree)."""
         with self._lock:
             s = self.sessions.get(sid)
         if not s or s.ended:
             return False
         if s.inflight or s.pending() or s._cur_ask_fut is not None:
+            return False
+        reg = read_reg(self.state_dir, sid) or {}
+        if reg.get("sessionCrons"):
             return False
         return True
 

--- a/tests/test_conserve_memory.py
+++ b/tests/test_conserve_memory.py
@@ -73,6 +73,20 @@ class BackendClose(unittest.TestCase):
         reg = sb.read_reg(Path(self.d), SID)
         self.assertTrue(reg.get("alive"), "the reg stays ALIVE — dormant, not killed; _ensure revives on demand")
 
+    def test_never_closes_a_timer_armed_session(self):
+        # the T148/769 seam, executed: ensure_scheduled revives any timer-armed threadless session
+        # every producer pass — if conserve closed one, the pair would loop close/revive forever
+        # (one respawn per sweep, the exact churn the user feared). The reg's sessionCrons is the
+        # SAME record ensure_scheduled reads, so conserve refusing on it can never drift from 769.
+        reg = sb.read_reg(Path(self.d), SID)
+        reg["sessionCrons"] = {"gen": 1, "crons": [{"id": "c1", "schedule": "0 * * * *"}]}
+        sb.write_reg(Path(self.d), SID, reg)
+        self.assertFalse(self.be.conserve_idle(SID), "armed timers pin the process — its CLI is the scheduler")
+        self.assertFalse(self.be.conserve_close(SID))
+        reg.pop("sessionCrons")
+        sb.write_reg(Path(self.d), SID, reg)
+        self.assertTrue(self.be.conserve_idle(SID), "…and disarming the timers frees it")
+
     def test_never_closes_work(self):
         self.s.inflight = 1
         self.assertFalse(self.be.conserve_idle(SID))


### PR DESCRIPTION
The deferred T148/PR-769 seam pin, landed now that 769 merged — and the seam analysis surfaced a real conflict, not just a missing test.

**The loop.** 769's `ensure_scheduled` revives any alive, timer-armed session with no running thread on every producer pass (the CLI process is the scheduler; a dormant session's timers silently never fire). A conserve sweep that closed a faded timer-armed session would pair with it into a close/revive loop — one respawn per sweep, forever, the exact churn the faded-hysteresis design exists to prevent.

**The fix.** `conserve_idle` refuses any session whose reg carries `sessionCrons` — the same record `ensure_scheduled` reads, so the two sides can never drift. Disarming the timers frees the session for conserve as before. The other half of the seam needed no change: a conserve-closed timerless session revives through the ordinary on-demand `_ensure` (tab click, message, delivered wake), exactly as T148 shipped — the executed test covers both directions.

Suites: pytest 5944 passed / 34 skipped; vscode-extension 2517/2517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)