### PR TITLE
Fork-boot observability lands where the optimization died — one log line per fork spend

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2430,6 +2430,11 @@ class SdkSession:
                 # plainly — re-applying fork_session would copy it into yet another session.
                 self._fork_of = self._fork_at = ""
                 self.backend._update_reg(self.sid, forkOf="", forkAt="")
+                reg_now = read_reg(self.backend.state_dir, self.sid) or {}
+                _ff = reg_now.get("forkedFrom") or {}
+                self.backend._log("fork spent (%s): src %.1fMB, create->spend %ds"
+                          % (self.sid[:8], (reg_now.get("forkSrcBytes") or 0) / 1048576.0,
+                             max(0, int(time.time()) - int(_ff.get("t") or time.time()))))
             cli_cwd = d.get("cwd")
             if isinstance(cli_cwd, str) and cli_cwd and cli_cwd != self.cwd:
                 # The CLI's own cwd is the AUTHORITATIVE string: its projects-dir/transcript encoding
@@ -4374,6 +4379,23 @@ class SdkBackend:
             transcript_path(cwd, parent.get("lastSid") or parent_sid))
         reg["forkedFrom"] = {"sid": parent_sid, "name": parent.get("name", ""),
                              "cut": lineage_cut, "t": int(time.time())}
+        # Fork-boot OBSERVABILITY (T156, measured no-build): the tail-copy optimization died on
+        # evidence — a 46MB resume+fork cost ~5s more than a 4.4MB one; the wall is fixed costs —
+        # so instead every fork spend logs its source size + create-to-spend duration (the spend
+        # site in _on_message), and a recurrence of 200s-class boots reopens the case with data.
+        try:
+            reg["forkSrcBytes"] = os.path.getsize(
+                transcript_path(cwd, parent.get("lastSid") or parent_sid))
+        except OSError:
+            reg["forkSrcBytes"] = 0
+        # Two probe findings recorded where the fork lives (T156 step-0, 2026-08-28):
+        # - PRINT-MODE --resume-session-at refused every record uuid tried (user + assistant,
+        #   pre- and post-compaction) with "No message found with message.uuid of:" on CLI
+        #   2.1-era — the SDK connect path works (threads fork daily), so the print-mode flag
+        #   matches a DIFFERENT id; the first person to fork through `-p` will hit this.
+        # - The CLI refuses resume-at targets from before its last compaction boundary by design
+        #   (the rewind doc above) — a comment anchored to a pre-compaction turn is a WATCH ITEM
+        #   for the SDK path too: live forks work today, but nothing pins that.
         if thread_of:
             reg["threadOf"] = thread_of
         if parent.get("model") and parent["model"] != "default":

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -194,6 +194,25 @@ class ThreadForkInvisibility(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.td, ignore_errors=True)
 
+    def test_fork_observability_stamps_the_source_size_for_the_spend_log(self):
+        # T156, measured no-build: the tail-copy optimization died on evidence (~5s of a ~70s wall
+        # was file size), so every fork records its resume-source size at mint; the spend site logs
+        # size + create-to-spend duration, and a recurrence of 200s-class boots reopens the case
+        # with data instead of speculation.
+        import os as _os
+        tp = sb.transcript_path(self.td, PARENT)
+        _os.makedirs(_os.path.dirname(tp), exist_ok=True)
+        with open(tp, "w") as f:
+            f.write('{"type":"user","uuid":"a1"}\n' * 100)
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertEqual(reg.get("forkSrcBytes"), _os.path.getsize(tp))
+        self.assertGreater(reg.get("forkedFrom", {}).get("t", 0), 0, "the duration base is the mint stamp")
+        # the spend site reads both back into one log line (source pin — the spend needs a live CLI)
+        import inspect
+        spend = inspect.getsource(sb.SdkSession._on_message)
+        self.assertIn('self.backend._log("fork spent (%s): src %.1fMB, create->spend %ds"', spend)
+
     def test_a_thread_fork_writes_no_names_entry_and_carries_threadOf(self):
         self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
         self.assertFalse((Path(self.td) / "names" / THREAD).exists(),


### PR DESCRIPTION
T156's measured outcome (quantify-first): the planned tail-copy-at-fork optimization is a **no-build**. Step-0 probes on a real 46MB transcript: full-file CLI resume+fork = **69.5s**; a 4.4MB compact-boundary-headed slice = **64.7s**. The CLI accepts a truncated head — but file size is ~5s of a ~70s wall dominated by fixed costs. The 200-second specimen's cost lives elsewhere (heavy kernel-restart churn at the time); T152's honest loader stands as the UX answer.

## What ships instead
Every fork records its resume-source size at mint (`forkSrcBytes`), and the fork-flag spend site logs one line — sid, source MB, create-to-spend seconds — so a recurrence of 200s-class boots reopens the case on live evidence.

## Side findings, recorded at the fork seam
- Print-mode `--resume-session-at` refused **every** record uuid tried ('No message found with message.uuid of:') on the current CLI — the SDK path works, so the print-mode flag matches a different id; the first fork through `-p` hits this.
- The CLI's designed pre-compaction refusal makes pre-compaction comment anchors a watch item for the SDK path too.

Tests: mint stamps `forkSrcBytes` == real source size; the spend log line source-pinned. Comment suites 53/53 + fork/merge suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)