### PR TITLE
T159: dusty mauve and dark gold join the romp identity palette at slots 10 and 11

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -2012,10 +2012,12 @@ else
         _palette=(
             "#1EA1EB"  "#54B204"  "#4EA8A9"  "#DD42FF"  "#E87221"
             "#98998A"  "#F85B5A"  "#F9D849"  "#9088F0"  "#E0629C"
+            "#B585B6"  "#B69513"
         )
         _fg=(
             "white"    "black"    "white"    "white"    "black"
             "black"    "white"    "black"    "black"    "white"
+            "black"    "black"
         )
         fi
         # Collect colors already in use by other romp sessions.

--- a/kernel/palette.py
+++ b/kernel/palette.py
@@ -35,15 +35,18 @@ DEFAULT = "romp"
 PALETTES = {
     "romp": {
         "label": "romp",
-        # slot 9 ROSE #E0629C (the user's explicit pick, 2026-08-28): lightness-matched to the
-        # band, zero new close pairs under normal/protan/deutan/tritan (validated before the ask);
-        # APPENDED so existing slot assignments never shift. White fg per the set's own convention
-        # for saturated warm mids (its neighbors #F85B5A and #DD42FF wear white at comparable
-        # contrast). Three more additions are expected here — append-only, same rule.
+        # slots 9-11, the user's 2026-08-28 picks, APPENDED so existing assignments never shift:
+        # ROSE #E0629C (white fg — the set's convention for saturated warm mids, like #F85B5A and
+        # #DD42FF), DUSTY MAUVE #B585B6 and DARK GOLD #B69513 (black fg — computed: white sits at
+        # 3.0 and 2.9 contrast respectively, at/below the pinned floor, while black clears 7.0 on
+        # both, matching the gray/yellow convention). All validated for lightness band + no new
+        # close pairs under normal/protan/deutan/tritan before the ask. Append-only, same rule.
         "bg": ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221",
-               "#98998A", "#F85B5A", "#F9D849", "#9088F0", "#E0629C"],
+               "#98998A", "#F85B5A", "#F9D849", "#9088F0", "#E0629C",
+               "#B585B6", "#B69513"],
         "fg": ["white", "black", "white", "white", "black",
-               "black", "white", "black", "black", "white"],
+               "black", "white", "black", "black", "white",
+               "black", "black"],
     },
     "phase": {
         "label": "phase — cmocean",

--- a/tests/test_kernel_session_color.py
+++ b/tests/test_kernel_session_color.py
@@ -51,6 +51,10 @@ class SessionColor(unittest.TestCase):
         self.assertTrue(all(f in ("black", "white") for f in fgs))
         self.assertEqual(bgs[:2], ["#1EA1EB", "#54B204"], "existing assignments never shift")
         self.assertEqual((bgs[9], fgs[9]), ("#E0629C", "white"))
+        self.assertEqual((bgs[10], fgs[10]), ("#B585B6", "black"),
+                         "dusty mauve: white sits AT the 3.0 floor; black clears 7.0")
+        self.assertEqual((bgs[11], fgs[11]), ("#B69513", "black"),
+                         "dark gold: white FAILS the 3.0 floor (2.9); black clears 7.3")
         # the fg contrast floor the set's whites all clear: WCAG relative-luminance contrast >= 3.0
         r, g, b = (int("E0629C"[i:i + 2], 16) / 255.0 for i in (0, 2, 4))
         lin = lambda c: c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -22,7 +22,8 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 pal = SourceFileLoader("romp_palette", os.path.join(BIN, "romp_palette.py")).load_module()
 
 ROMP_BG = ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221",
-           "#98998A", "#F85B5A", "#F9D849", "#9088F0", "#E0629C"]
+           "#98998A", "#F85B5A", "#F9D849", "#9088F0", "#E0629C",
+           "#B585B6", "#B69513"]
 
 
 def _lum(h):


### PR DESCRIPTION
The user's two remaining picks (hot pink dropped), appended by the T154 recipe: `PALETTES['romp']` slots 10 and 11, the same pairs in bin/romp's launcher fallback, ROMP_BG test line extended. Order stable, append-only.

Both wear black text, computed against the pinned 3.0 contrast floor: dusty mauve #B585B6 puts white exactly at the floor (3.0) while black clears 7.0; dark gold #B69513 puts white below it (2.9) while black clears 7.3 — matching the gray/yellow convention. Slot pins added for both pairs.

Suites: Python 5944/0 (+313 subtests), UI 2521/2521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)