### PR TITLE
Claude login runs inside the dashboard — paste-code flow, workable from a phone

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -530,6 +530,8 @@ def _version_info():
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
             "conserveMemory": _conserve_on(),   # the T148 toggle: close idle tab-less claude processes
+            "login": _login_state(),         # the in-dashboard login flow's state/url/err (T157) — never a secret
+            "acctLabel": _claude_account_label(),   # which login this box holds ("" = none) — the gear's Billing row
             "fileEditing": _file_editing_on(),   # dashboard raw-mode editing opt-in → gates the viewer's Edit
             "updateMode": _update_mode(),    # ask|auto|off (the boot release check) → the gear dropdown
             "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
@@ -7200,7 +7202,9 @@ _sdk_lock = threading.Lock()   # single-flight construction: the eager boot thre
 
 
 def _claude_bin():
-    return shutil.which("claude") or os.path.expanduser("~/.local/bin/claude")
+    # ROMP_CLAUDE_BIN is the resolution seam (main() exports it for judges/subprocesses; the lab
+    # and the login-flow tests point it at a mock) — reading it FIRST makes every spawn honor it
+    return os.environ.get("ROMP_CLAUDE_BIN") or shutil.which("claude") or os.path.expanduser("~/.local/bin/claude")
 
 
 def _ensure_sdk_on_path():
@@ -20679,6 +20683,191 @@ def _state_intervals(sid, want, now):
 _ACCT_CACHE = {"mtime": -1.0, "val": "", "label": ""}
 
 
+# ── in-dashboard LOGIN (T157, the user 2026-08-28: today an expired login means dropping to a
+# terminal for /login — unreachable from the phone over Tailscale, so everything stalls until they
+# are physically back. The dashboard IS on the phone, so it becomes the login surface.) ──────────
+# The CLI's login is PTY-driven: a spawned REPL + /login + the subscription option prints an OAuth
+# URL with code=true and platform.claude.com's OWN code-display callback (probed on 2.1.221 — no
+# localhost anywhere, so ANY device's browser completes it and shows a code), then waits at "Paste
+# code here". The kernel drives exactly that: spawn → gates (trust dialog, method picker) → parse
+# the URL out of its OSC-8 wrapping → stream it to the dashboard as a link → pass the user's code
+# STRAIGHT THROUGH to the PTY. The code and the resulting tokens exist nowhere but the PTY write
+# and the CLI's own credential store: never logged, never echoed into a transcript, never in a
+# payload. One flow at a time per kernel (each box logs in its own store); a stuck flow self-reaps.
+LOGIN_FLOW_TIMEOUT_S = 600
+_login_lock = threading.Lock()
+_login_flow = {"state": "", "url": "", "err": "", "t": 0.0, "pid": 0, "fd": -1}
+
+
+def _login_state():
+    """The payload-safe view: state/url/err only — nothing secret ever sits in the dict."""
+    with _login_lock:
+        if _login_flow["state"] and time.time() - _login_flow["t"] > LOGIN_FLOW_TIMEOUT_S:
+            _login_abort_locked("the login flow timed out — start it again when ready")
+        return {"state": _login_flow["state"], "url": _login_flow["url"], "err": _login_flow["err"]}
+
+
+def _login_abort_locked(err=""):
+    pid, fd = _login_flow["pid"], _login_flow["fd"]
+    _login_flow.update(state=("error" if err else ""), url="", err=err, pid=0, fd=-1)
+    if pid:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except Exception:
+            pass
+    if fd >= 0:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+
+
+def _login_cancel():
+    with _login_lock:
+        _login_abort_locked()
+    _push_soon()
+
+
+def _login_code(code):
+    """Pass the user's code STRAIGHT to the PTY — a pure pass-through (T157 house rule: the code is
+    never logged, stored, or echoed anywhere; this function's only trace is the write itself)."""
+    code = str(code or "").strip()
+    if not code:
+        return "empty code"
+    with _login_lock:
+        if _login_flow["state"] != "url" or _login_flow["fd"] < 0:
+            return "no login flow is waiting for a code"
+        try:
+            os.write(_login_flow["fd"], code.encode() + b"\r")
+            _login_flow["state"] = "verifying"
+            _login_flow["t"] = time.time()
+        except Exception as e:
+            _login_abort_locked("the code never reached the login flow (%s) — start again" % type(e).__name__)
+            return "the login flow died taking the code — start again"
+    _push_soon()
+    return ""
+
+
+def _login_start():
+    """Spawn the PTY login flow; the reader thread drives the gates and parses the URL."""
+    import pty as _pty
+    with _login_lock:
+        if _login_flow["state"] in ("starting", "url", "verifying"):
+            return "a login flow is already running — finish or cancel it first"
+        scratch = jd.STATE / "login-scratch"
+        try:
+            scratch.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            pass
+        env = dict(os.environ)
+        env.pop("ANTHROPIC_API_KEY", None)          # the login flow, never key auth
+        env.pop("CLAUDE_CODE_CHILD_SESSION", None)  # a plain top-level CLI
+        try:
+            m, s = _pty.openpty()
+            proc = subprocess.Popen([_claude_bin()], stdin=s, stdout=s, stderr=s,
+                                    env=env, cwd=str(scratch), close_fds=True)
+            os.close(s)
+        except Exception as e:
+            _login_flow.update(state="error", url="",
+                               err="could not start the login flow: %s" % e, pid=0, fd=-1)
+            return _login_flow["err"]
+        _login_flow.update(state="starting", url="", err="", t=time.time(), pid=proc.pid, fd=m)
+    threading.Thread(target=_login_reader, args=(m, proc), daemon=True).start()
+    _push_soon()
+    return ""
+
+
+_LOGIN_URL_RE = re.compile(r"https://claude\.com/[^\s\x1b\x07]*oauth[^\s\x1b\x07]*")
+
+
+def trust_gate_passed(low0):
+    """The REPL is up and past its gates (the composer hints render) — space-free matching, since
+    PTY cursor codes concatenate words (probed: 'Tipsforgetting')."""
+    return "tipsforgetting" in low0 or "try\"" in low0 or "welcomeback" in low0
+
+
+def _login_reader(fd, proc):
+    """Drive the spawned CLI to the URL and through the result. Output is parsed for STATES only —
+    nothing from this stream is ever logged verbatim (the paste prompt window can contain the code
+    echo), and the buffer dies with the thread."""
+    import select as _select
+    buf = ""
+    sent_login = sent_pick = trust_answered = False
+    t0 = time.time()
+    while time.time() - t0 < LOGIN_FLOW_TIMEOUT_S:
+        with _login_lock:
+            if _login_flow["pid"] != proc.pid:      # cancelled/superseded
+                break
+        r, _, _ = _select.select([fd], [], [], 0.5)
+        if r:
+            try:
+                chunk = os.read(fd, 8192).decode("utf-8", "replace")
+            except OSError:
+                break
+            buf = (buf + chunk)[-20000:]
+        plain = re.sub(r"\x1b\][^\x07\x1b]*(\x07|\x1b\\\\)", "", buf)
+        plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", plain)
+        low0 = plain.lower().replace(" ", "")
+        if not trust_answered and "trustthisfolder" in low0:
+            os.write(fd, b"\r")                     # the kernel's own scratch dir — trusted
+            trust_answered = True
+            buf = ""
+            continue
+        if not sent_login and trust_gate_passed(low0):
+            time.sleep(0.8)                          # the REPL settles, then the command
+            os.write(fd, b"/login\r")
+            sent_login = True
+            buf = ""
+            continue
+        if sent_login and not sent_pick and "selectloginmethod" in plain.lower().replace(" ", ""):
+            # PTY cursor-move codes mangle spacing (probed: 'Selectloginmethod:') — match space-free
+            os.write(fd, b"\r")                     # option 1: Claude account with subscription
+            sent_pick = True
+            buf = ""
+            continue
+        murl = _LOGIN_URL_RE.search(plain)
+        if murl:
+            with _login_lock:
+                if _login_flow["pid"] == proc.pid and _login_flow["state"] in ("starting",):
+                    _login_flow.update(state="url", url=murl.group(0), t=time.time())
+            _push_soon()
+        low = plain.lower()
+        # the VERDICT WINDOW is anchored on the paste prompt itself, not a buffer clear (a clear
+        # raced an instant verdict and wiped it): verdict phrases count only AFTER the last
+        # "Paste code here", which by construction precedes any verdict and follows every REPL
+        # hint ('how do I log an error?' false-fired the old loose match)
+        low0all = low.replace(" ", "")
+        pidx = low0all.rfind("pastecodehere")
+        low0v = low0all[pidx:] if pidx >= 0 else ""
+        if "loggedinas" in low0v or "loginsuccessful" in low0v:
+            with _login_lock:
+                if _login_flow["pid"] == proc.pid:
+                    _login_abort_locked()            # done: reap the CLI; state clears to ""
+                    _login_flow["state"] = "done"
+            _ACCT_CACHE["mtime"] = -2.0   # bust the account cache: the Billing rows flip on the next read
+            _push_soon()
+            return
+        if "invalidcode" in low0v or "loginerror" in low0v or "loginfailed" in low0v:
+            # tight FAILURE phrases, and only in the post-code window — a loose error/login word
+            # match false-fired on the REPL's own hints (found by the mocked-PTY test)
+            # loud honest failure — the copy names the retry, never the code
+            with _login_lock:
+                if _login_flow["pid"] == proc.pid and _login_flow["state"] == "verifying":
+                    _login_abort_locked("the login code was not accepted — start the flow again")
+            _push_soon()
+            return
+        if proc.poll() is not None:
+            with _login_lock:
+                if _login_flow["pid"] == proc.pid and _login_flow["state"] not in ("done", "error"):
+                    _login_abort_locked("the login flow ended before completing — start it again")
+            _push_soon()
+            return
+    with _login_lock:
+        if _login_flow["pid"] == proc.pid and _login_flow["state"] not in ("done", ""):
+            _login_abort_locked("the login flow timed out — start it again when ready")
+    _push_soon()
+
+
 def _claude_account():
     """WHICH Claude login this machine's sessions run under, as an opaque 12-hex digest — or "" when
     there is no signed-in account to read (the user 2026-07-30, who switches between accounts and wanted
@@ -29924,6 +30113,19 @@ class Handler(BaseHTTPRequestHandler):
             # registry); re-broadcast so every tab/lane/card repaints in the new color at once.
             if _set_session_color(str(msg["id"]), str(msg["bg"])):
                 _mark_views_dirty()
+        elif msg and msg.get("type") == "loginStart":
+            # the in-dashboard login (T157): spawn the PTY flow; the gear polls /version for state
+            err = _login_start()
+            if err:
+                client["send"](json.dumps({"type": "warn", "text": err}))
+        elif msg and msg.get("type") == "loginCode":
+            # PASS-THROUGH ONLY (T157 house rule): the code goes straight to the PTY — this handler
+            # must never log, store, or echo it anywhere
+            err = _login_code(msg.get("code"))
+            if err:
+                client["send"](json.dumps({"type": "warn", "text": err}))
+        elif msg and msg.get("type") == "loginCancel":
+            _login_cancel()
         elif msg and msg.get("type") == "setConserve" and msg.get("enabled") is not None:
             # the gear's conserve-memory toggle (T148) — kernel-side like autoNudge; the sweep
             # reads the flag fresh each pass, so flipping it needs no restart

--- a/tests/test_login_flow.py
+++ b/tests/test_login_flow.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""The in-dashboard LOGIN flow (T157, the user 2026-08-28: an expired login stalls everything when
+they're on the phone over Tailscale — the dashboard becomes the login surface). The kernel drives
+the CLI's PTY login: spawn → gates (trust dialog, method picker) → parse the code=true OAuth URL
+out of its OSC-8 wrapping → stream to the dashboard → PASS the user's code straight to the PTY.
+HOUSE RULE UNDER TEST: the code and tokens exist nowhere but the PTY write and the CLI's own
+store — never logged, never in state files (the secrecy pin scans for the fake code after a full
+flow). All against a MOCKED login PTY (never a real account); hermetic state; synthetic values."""
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+
+# the MOCK login CLI: reproduces the probed 2.1.221 transcript shape (trust gate → REPL hints →
+# /login → method picker → OSC-8-wrapped code=true URL → paste prompt → verdict). It records a
+# SHA-256 of the code it received (proof of arrival without the code existing anywhere readable).
+_MOCK_DIR = tempfile.mkdtemp()
+_MOCK = os.path.join(_MOCK_DIR, "claude")
+_MARKER = os.path.join(_MOCK_DIR, "code-sha.txt")
+with open(_MOCK, "w") as f:
+    f.write('''#!/usr/bin/env python3
+import sys, os, hashlib
+def say(s):
+    sys.stdout.write(s); sys.stdout.flush()
+say("Do you trust this folder?\\n1. Yes, I trust this folder\\n")
+line = sys.stdin.readline()
+say("Welcome back! Tips for getting started\\n> Try \\"how do I log an error?\\"\\n")
+line = sys.stdin.readline()          # /login
+if "/login" not in line:
+    say("Not logged in\\n"); sys.exit(1)
+say("Select login method:\\n1. Claude account with subscription\\n2. Anthropic Console account\\n")
+line = sys.stdin.readline()          # option 1
+url = "https://claude.com/cai/oauth/authorize?code=true&client_id=x&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&state=SYNTH"
+say("Browser didn't open? Use the url below to sign in\\n")
+say("\\x1b]8;id=1;" + url + "\\x1b\\\\\\\\" + url + "\\x1b]8;;\\x1b\\\\\\\\\\n")
+say("Paste code here if prompted >\\n")
+code = sys.stdin.readline().strip()
+open(@@MARKER@@, "w").write(hashlib.sha256(code.encode()).hexdigest())
+if code == "SYNTH-GOOD-CODE":
+    say("Logged in as Test User (test@example.invalid)\\n")
+else:
+    say("Invalid code. Login error.\\n")
+'''.replace("@@MARKER@@", repr(_MARKER)))
+os.chmod(_MOCK, os.stat(_MOCK).st_mode | stat.S_IEXEC)
+os.environ["ROMP_CLAUDE_BIN"] = _MOCK
+
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_login", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+
+def _wait_state(want, seconds=15):
+    t0 = time.time()
+    while time.time() - t0 < seconds:
+        st = km._login_state()
+        if st["state"] == want:
+            return st
+        time.sleep(0.1)
+    return km._login_state()
+
+
+class LoginFlow(unittest.TestCase):
+    def setUp(self):
+        km._login_cancel()
+        try:
+            os.unlink(_MARKER)
+        except OSError:
+            pass
+
+    def tearDown(self):
+        km._login_cancel()
+
+    def test_full_flow_url_code_done_and_the_secrecy_pin(self):
+        self.assertEqual(km._login_start(), "")
+        st = _wait_state("url")
+        self.assertEqual(st["state"], "url", "the driver walked the gates to the URL: %r" % st)
+        self.assertTrue(st["url"].startswith("https://claude.com/cai/oauth/authorize?code=true"),
+                        "the code=true URL, parsed clean out of the OSC-8 wrapping: %r" % st["url"])
+        self.assertNotIn("\x1b", st["url"], "no terminal escapes survive into the link")
+        self.assertEqual(km._login_code("SYNTH-GOOD-CODE"), "")
+        st = _wait_state("done")
+        self.assertEqual(st["state"], "done", "success surfaces truthfully: %r" % st)
+        self.assertEqual(open(_MARKER).read(),
+                         hashlib.sha256(b"SYNTH-GOOD-CODE").hexdigest(),
+                         "the code reached the PTY intact (proved by hash, never by value)")
+        # THE SECRECY PIN: the code exists NOWHERE in romp's state or this kernel module's world
+        for root, _, files in os.walk(str(jd.STATE)):
+            for fn in files:
+                p = os.path.join(root, fn)
+                try:
+                    body = open(p, "rb").read()
+                except OSError:
+                    continue
+                self.assertNotIn(b"SYNTH-GOOD-CODE", body,
+                                 "the code leaked into state file %s — the pass-through rule broke" % p)
+
+    def test_a_bad_code_fails_loudly_and_honestly(self):
+        self.assertEqual(km._login_start(), "")
+        _wait_state("url")
+        self.assertEqual(km._login_code("SYNTH-BAD-CODE"), "")
+        st = _wait_state("error")
+        self.assertEqual(st["state"], "error")
+        self.assertIn("start", st["err"].lower(), "the copy names the retry, never the code: %r" % st["err"])
+        self.assertNotIn("SYNTH-BAD-CODE", st["err"])
+
+    def test_one_flow_at_a_time_and_cancel(self):
+        self.assertEqual(km._login_start(), "")
+        _wait_state("url")
+        self.assertNotEqual(km._login_start(), "", "a second start refuses while one runs")
+        km._login_cancel()
+        self.assertEqual(km._login_state()["state"], "", "cancel clears the flow")
+        self.assertEqual(km._login_start(), "", "…and a fresh start is allowed after")
+        km._login_cancel()
+
+    def test_code_without_a_flow_refuses(self):
+        self.assertNotEqual(km._login_code("SYNTH-ORPHAN"), "")
+
+    def test_stale_flow_self_reaps_via_state_read(self):
+        self.assertEqual(km._login_start(), "")
+        _wait_state("url")
+        with km._login_lock:
+            km._login_flow["t"] = time.time() - km.LOGIN_FLOW_TIMEOUT_S - 1
+        st = km._login_state()
+        self.assertEqual(st["state"], "error")
+        self.assertIn("timed out", st["err"])
+
+    def test_ops_payload_and_gear_wiring(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        for pin in ('msg.get("type") == "loginStart"', 'msg.get("type") == "loginCode"',
+                    'msg.get("type") == "loginCancel"', '"login": _login_state(),',
+                    '"acctLabel": _claude_account_label(),'):
+            self.assertIn(pin, src)
+        gear = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "gear.js")).read()
+        for pin in ("loginStart", "loginCode", "rs-login-input", "rs-login-url", "v.acctLabel"):
+            self.assertIn(pin, gear)
+        feed = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "feed.ts")).read()
+        self.assertIn('loginBtn.style.display = (showApiErr && authErr) ? "" : "none";', feed,
+                      "the auth-expired card offers the fix, not just the problem")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/romp-lab/lab.sh
+++ b/tools/romp-lab/lab.sh
@@ -13,6 +13,7 @@ for a in "$@"; do case "$a" in
   --banner-only) MODE=banner ;;       # the T119 reload-banner phase alone (no model spend)
   --highlight-only) MODE=highlight ;; # the T102/T106 highlight loop alone
   --modes-only) MODE=modes ;;         # the T139 permission-mode sweep alone
+  --login-only) MODE=login ;;         # the T157 in-dashboard login flow (mocked CLI, no model spend)
 esac; done
 
 LAB="$(mktemp -d /tmp/romp-lab-XXXXXX)"
@@ -58,6 +59,12 @@ export ROMP_DIST_DIR="$LAB/dist"
 # a fast heartbeat so the banner phase's one-heartbeat assertions run in seconds, not tens of them
 export ROMP_WS_KEEPALIVE=2
 
+if [ "$MODE" = "login" ]; then
+  # the T157 phase drives the LOGIN flow only (no sessions run): the kernel resolves claude through
+  # ROMP_CLAUDE_BIN, so pointing it at the mock makes the whole flow synthetic — never a real account
+  export ROMP_CLAUDE_BIN="$ROOT/tools/romp-lab/login-mock-claude.py"
+  export LOGIN_MOCK_MARKER="$LAB/login-code-sha.txt"
+fi
 "$ROOT/bin/romp-kernel" > "$LAB/kernel.log" 2>&1 &
 KPID=$!
 cleanup() {
@@ -78,14 +85,14 @@ curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null || { echo "kernel never be
 echo "lab kernel up on :$PORT (state: $LAB/state)"
 
 RC=0
-if [ "$MODE" != "highlight" ] && [ "$MODE" != "modes" ]; then
+if [ "$MODE" != "highlight" ] && [ "$MODE" != "modes" ] && [ "$MODE" != "login" ]; then
   # the reload-banner contract (T119) — first, because it spends no model turns
   LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" KPID="$KPID" KERNEL_BIN="$ROOT/bin/romp-kernel" \
     node "$ROOT/tools/romp-lab/banner-loop.mjs" || RC=$?
   echo "banner loop exit: $RC (shots: $LAB/shots)"
   [ -f "$LAB/kernel.pid" ] && KPID="$(cat "$LAB/kernel.pid")"
 fi
-if [ "$MODE" != "banner" ] && [ "$MODE" != "modes" ] && [ "$RC" = 0 ]; then
+if [ "$MODE" != "banner" ] && [ "$MODE" != "modes" ] && [ "$MODE" != "login" ] && [ "$RC" = 0 ]; then
   # the kernel may have been bounced by the banner phase — wait for health before driving it
   for i in $(seq 1 60); do
     curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && break; sleep 0.5
@@ -94,7 +101,12 @@ if [ "$MODE" != "banner" ] && [ "$MODE" != "modes" ] && [ "$RC" = 0 ]; then
     node "$ROOT/tools/romp-lab/highlight-loop.mjs" || RC=$?
   echo "highlight loop exit: $RC (shots: $LAB/shots)"
 fi
-if [ "$MODE" != "banner" ] && [ "$MODE" != "highlight" ] && [ "$RC" = 0 ]; then
+if [ "$MODE" = "login" ] && [ "$RC" = 0 ]; then
+  LAB_DIR="$LAB" PORT="$PORT" TOKEN="$ROMP_SERVE_TOKEN" LOGIN_MOCK_MARKER="$LOGIN_MOCK_MARKER" \
+    node "$ROOT/tools/romp-lab/login-loop.mjs" || RC=$?
+  echo "login loop exit: $RC (shots: $LAB/shots)"
+fi
+if [ "$MODE" != "banner" ] && [ "$MODE" != "highlight" ] && [ "$MODE" != "login" ] && [ "$RC" = 0 ]; then
   # the T139 permission-mode sweep: every mode's ask contract on the real stack
   for i in $(seq 1 60); do
     curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1 && break; sleep 0.5

--- a/tools/romp-lab/login-loop.mjs
+++ b/tools/romp-lab/login-loop.mjs
@@ -1,0 +1,83 @@
+// The scripted LOGIN loop (T157): the gear's Billing login element end to end on the real stack,
+// against the MOCKED login CLI (ROMP_CLAUDE_BIN — never a real account; the lab kernel spends no
+// model turns in this phase). Asserts: click → the code=true URL renders as a link; the code input
+// passes through (the mock proves arrival by hash); success surfaces; and the SECRECY pin — the
+// fixture code appears nowhere in the kernel log.
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const require2 = createRequire(path.join(ROOT, "vscode-extension", "package.json"));
+const { chromium } = require2("playwright");
+
+const PORT = process.env.PORT, TOKEN = process.env.TOKEN, LAB = process.env.LAB_DIR;
+const shots = path.join(LAB, "shots");
+const fails = [];
+let n = 0;
+const check = (name, ok, detail = "") => {
+  console.log(`${ok ? "PASS" : "FAIL"} login:${name}${detail ? " — " + detail : ""}`);
+  if (!ok) fails.push(name);
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const b = await chromium.launch();
+const page = await b.newPage({ viewport: { width: 900, height: 800 } });
+page.on("pageerror", (e) => console.log("PAGEERR", String(e)));
+const shot = async (name) => page.screenshot({ path: path.join(shots, `lg${String(++n).padStart(2, "0")}-${name}.png`) });
+
+// the FEED page hosts the gear (the openSettings listener lives in gear.js, required by feed.ts;
+// the palette routes openSettings to the feed pane) — the login block rides it
+await page.goto(`http://127.0.0.1:${PORT}/feed?token=${TOKEN}`);
+await page.waitForSelector("#feed-foot", { timeout: 20000, state: "attached" });   // an empty lab feed keeps it hidden
+await page.evaluate(() => window.postMessage({ romp: "openSettings" }, "*"));
+await page.waitForSelector("#rs-login-btn", { timeout: 15000, state: "attached" });
+await page.waitForFunction(() => { const b = document.getElementById("rs-login-btn"); return b && b.offsetParent; }, { timeout: 15000 });
+await shot("gear-open");
+check("element-present", true);
+await page.click("#rs-login-btn");
+// the flow: starting → url (the mock walks the gates in under a second; the gear polls /version)
+const url = await (async () => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < 30000) {
+    const u = await page.evaluate(() => {
+      const d = document.getElementById("rs-login-url");
+      const a = d && d.querySelector("a");
+      return a ? a.href : "";
+    });
+    if (u) return u;
+    await sleep(400);
+  }
+  return "";
+})();
+check("url-streams-as-link", url.startsWith("https://claude.com/cai/oauth/authorize?code=true"),
+  url || "no link rendered");
+await shot("url-shown");
+await page.fill("#rs-login-input", "LAB-SYNTH-CODE");
+await page.click("#rs-login-send");
+const done = await (async () => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < 20000) {
+    const s = await page.evaluate(() => {
+      const acct = document.getElementById("rs-login-acct");
+      const st = document.getElementById("rs-login-state");
+      return { acct: acct ? acct.textContent : "", state: st ? st.textContent : "" };
+    });
+    if (!s.state && !(await page.evaluate(() => { const c = document.getElementById("rs-login-code"); return c && !c.hidden; }))) return s;
+    if (/failed|error/i.test(s.state)) return s;
+    await sleep(400);
+  }
+  return { acct: "", state: "timeout" };
+})();
+check("flow-completes", !/failed|error|timeout/i.test(done.state), JSON.stringify(done));
+await shot("done");
+// the mock proves the code ARRIVED (by hash), and the kernel log must never carry it
+const marker = process.env.LOGIN_MOCK_MARKER || "";
+check("code-passed-through", marker && fs.existsSync(marker), marker);
+const klog = fs.readFileSync(path.join(LAB, "kernel.log"), "utf8");
+check("secrecy-kernel-log", !klog.includes("LAB-SYNTH-CODE"),
+  "the code must exist nowhere but the PTY write");
+await b.close();
+if (fails.length) { console.log("LOGIN LOOP FAILURES:", fails.join(", ")); process.exit(1); }
+console.log("login loop: all green");

--- a/tools/romp-lab/login-mock-claude.py
+++ b/tools/romp-lab/login-mock-claude.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# The MOCKED login CLI for the T157 lab phase — reproduces the probed 2.1.221 login transcript
+# shape (trust gate, REPL hints, /login, method picker, OSC-8-wrapped code=true URL, paste prompt,
+# verdict). SYNTHETIC ONLY: the URL is inert, the accepted code is a fixture string, and nothing
+# touches any credential store. Never a real account in tests (the T157 house rule).
+import sys, hashlib, os
+
+def say(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+say("Do you trust this folder?\n1. Yes, I trust this folder\n")
+sys.stdin.readline()
+say("Welcome back! Tips for getting started\n> Try \"how do I log an error?\"\n")
+line = sys.stdin.readline()
+if "/login" not in line:
+    say("Not logged in\n")
+    sys.exit(1)
+say("Select login method:\n1. Claude account with subscription\n2. Anthropic Console account\n")
+sys.stdin.readline()
+url = ("https://claude.com/cai/oauth/authorize?code=true&client_id=SYNTHETIC"
+       "&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&state=LABFIXTURE")
+say("Browser didn't open? Use the url below to sign in\n")
+say("\x1b]8;id=1;" + url + "\x1b\\" + url + "\x1b]8;;\x1b\\\n")
+say("Paste code here if prompted >\n")
+code = sys.stdin.readline().strip()
+marker = os.environ.get("LOGIN_MOCK_MARKER")
+if marker:
+    open(marker, "w").write(hashlib.sha256(code.encode()).hexdigest())
+if code == "LAB-SYNTH-CODE":
+    say("Logged in as Lab Fixture (lab@example.invalid)\n")
+else:
+    say("Invalid code. Login error.\n")

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-apierror-working.test.ts
+++ b/ui/webview/feed-apierror-working.test.ts
@@ -32,7 +32,7 @@ test("Retry renders WITH its explaining badge as one visual unit — never alone
   // badge immediately before its button, as DIRECT row2 children: grouped mode hides idwrap (the
   // card drops its name there), which is exactly how the screenshot got a lone Retry with no badge —
   // the badge sat in the hidden wrap while the action-row button stayed visible
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin,/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin,/);
   assert.match(FEED, /actions\.append\(revive, qApprove, qDeny\);/);
   assert.doesNotMatch(FEED, /actions\.append\(apiRetry/, "no lone Retry detached from its badge");
   assert.doesNotMatch(FEED, /idwrap\.append\([^)]*apiBadge/, "…and never inside the grouped-mode-hidden idwrap");

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -21,7 +21,7 @@ test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails t
   // name row keeps only identity + chips
   assert.match(FEED, /btns\.append\(cont, clr\);/, "ask card: Continue left of Clear in the action corner");
   assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
@@ -60,7 +60,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -77,7 +77,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);
@@ -136,7 +136,7 @@ test("a long no-space token (file/func/type name) WRAPS instead of overflowing t
 // blanked every badge inside it — ⚠ retrying-since, judge-auth, and the ⏸ approval chip never
 // showed on grouped-mode cards. Every state badge is a DIRECT row2 child now; placement only.
 test("every session-state badge is a direct row2 child — visible in grouped AND flat mode", () => {
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin,/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin,/);
   assert.match(FEED, /idwrap\.append\(name\);/, "idwrap = the name alone; hiding it hides nothing else");
   assert.doesNotMatch(FEED, /idwrap\.append\([^)]*(retryBadge|apiBadge|jauthBadge|blkBadge)/,
     "no state badge ever returns to the grouped-mode-hidden wrap");

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-judge-auth.test.ts
+++ b/ui/webview/feed-judge-auth.test.ts
@@ -18,7 +18,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the judge-auth chip is built once, rides the session-state row, and keys on blocked.state", () => {
   assert.match(FEED, /const jauthBadge = el\("span", "fask-jauth"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge,/,
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge,/,
     "the chip rides the name row with its api-trouble siblings");
   assert.match(FEED, /a\._jauthBadge = jauthBadge;/);
   assert.match(FEED, /const isJudgeAuth = it\.blocked\?\.state === "judgeAuth"/);

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-retrying.test.ts
+++ b/ui/webview/feed-retrying.test.ts
@@ -15,7 +15,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the retrying badge is built once and rides the session-state row beside the API-error badge", () => {
   assert.match(FEED, /const retryBadge = el\("span", "fask-retrying"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge,/,
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge,/,
     "session-STATE badges ride the name row, off the action row");
   assert.match(FEED, /a\._retryBadge = retryBadge;/);
 });

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1011,6 +1011,11 @@ function makeAskCard(it: AskItem): HTMLElement {
   // auto-retry is already doing that.
   const retryBadge = el("span", "fask-retrying"); retryBadge.style.display = "none";
   const apiRetry = el("button", "fdismiss fretry"); apiRetry.textContent = "Retry"; apiRetry.title = "send “retry” into this session to resume"; apiRetry.style.display = "none";
+  // the auth-expired card offers THE FIX, not just the problem (T157, the user: watch it, log in,
+  // it works again): opens the gear's Billing login — the paste-code flow that works from the phone
+  const apiLogin = el("button", "fdismiss ffollow"); apiLogin.textContent = "Log in…";
+  apiLogin.title = "open Billing login — sign in from any browser (your phone works) and this session recovers on its next turn";
+  apiLogin.style.display = "none";
   const revive = el("button", "fdismiss frevive"); revive.textContent = "Revive"; revive.title = "bring this offline session back so the parked hand-off is delivered"; revive.style.display = "none";
   // RESUME-GATE buttons (the user 2026-07-21): a boot-deferred high-context session — Proceed reloads it now,
   // Compact on resume /compacts first so future turns shrink (still one reload now), Skip leaves it dormant.
@@ -1071,7 +1076,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // direct children they render in BOTH modes, count toward row2's grouped-mode liveness, and the
   // API badge stays immediately before its Retry button — one visual unit. idwrap keeps only the
   // name. Placement only; every badge's mint/retire semantics are untouched.
-  row2.append(idwrap, retryBadge, apiBadge, apiRetry, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
+  row2.append(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
   // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
   // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
   // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or
@@ -1282,7 +1287,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   a._warnChip = warnChip;
   a._waitOn = waitOnBadge;
   a._blocked = blkBadge;
-  a._apiBadge = apiBadge; a._apiRetry = apiRetry; a._retryBadge = retryBadge; a._revive = revive; a._clr = clr;
+  a._apiBadge = apiBadge; a._apiRetry = apiRetry; a._apiLogin = apiLogin; a._retryBadge = retryBadge; a._revive = revive; a._clr = clr;
   a._jauthBadge = jauthBadge;
   a._cont = cont;
   a._qApprove = qApprove; a._qDeny = qDeny; a._qBody = qbody;
@@ -2032,6 +2037,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   const spendLimit = !!(it.blocked && it.blocked.spendLimit);
   const modelLimit = !!(it.blocked && it.blocked.modelLimit);
   const refusal = !!(it.blocked && it.blocked.refusal);
+  const authErr = !!(it.blocked && (it.blocked as { authErr?: boolean }).authErr);
   // …and the whole unit RETIRES the moment the session recovers (the user 2026-08-24, screenshot: a
   // GREEN awaiting dot beside a lone red Retry — the control read as arbitrary): visibility keys on
   // the session's LIVE state from this very payload — a session working again, or awaiting the
@@ -2048,6 +2054,13 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // A safeguards REFUSAL is the same shape again (the user 2026-08-15): deterministic on the same input,
   // so Retry re-collects the same refusal — the badge names the real fix (rewrite it or drop the thread).
   a._apiRetry.style.display = (showApiErr && !spendLimit && !modelLimit && !refusal) ? "" : "none";
+  // a dead credential's card carries THE FIX (T157): the gear's Billing login — phone-workable
+  const loginBtn = a._apiLogin as HTMLButtonElement;
+  loginBtn.style.display = (showApiErr && authErr) ? "" : "none";
+  if (showApiErr && authErr) loginBtn.onclick = (ev: Event) => {
+    ev.stopPropagation();
+    window.postMessage({ romp: "openSettings" }, "*");   // the login flow lives in the gear's Billing block
+  };
   // "Continue" shows on a LIVE needs-you card with no live ask attached: the gesture claims "you're not
   // waiting on me", which means nothing in Working/Completed, can't answer a real permission prompt or
   // picker (it.blocked — text sent there would just queue behind the ask), and has no one to tell on a

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -61,6 +61,18 @@ var GEAR_HTML =
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
+  "<div class='rs-row rs-sep' id=rs-billing>" +
+  '<span><b>Billing login</b>' +
+  '<span class=rs-sub id=rs-login-acct>…</span>' +
+  "<div id=rs-login-flow style='margin-top:6px'>" +
+  "<button id=rs-login-btn type=button style='cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Log in…</button>" +
+  "<span id=rs-login-state class=rs-sub style='margin-left:8px'></span>" +
+  "<div id=rs-login-url hidden style='margin-top:6px'></div>" +
+  "<div id=rs-login-code hidden style='margin-top:6px;display:flex;gap:6px;align-items:center'>" +
+  "<input id=rs-login-input type=text autocomplete=off spellcheck=false placeholder='paste the code from the browser…' style='flex:1;background:#1e1e1e;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:4px 8px'>" +
+  "<button id=rs-login-send type=button style='cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Submit</button>" +
+  "<button id=rs-login-cancel type=button style='cursor:pointer;background:transparent;color:#888;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Cancel</button>" +
+  '</div></div></span></div>' +
   "<label class='rs-row'><input type=checkbox id=rs-conserve>" +
   '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Close the claude process of a session that has FADED (idle over an hour) and is on no open tab (each averages ~340MB). Everything persists — it revives on a tab click, a message, or a scheduled wake. An open tab always keeps its process; off = every session keeps its process for as long as it lives.</span>' +
@@ -396,6 +408,63 @@ function initGear(post) {
   });
   if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked }); });
   if (cvm) cvm.addEventListener('change', function () { post({ type: 'setConserve', enabled: cvm.checked }); });
+  // ── the in-dashboard LOGIN flow (T157): the dashboard is already on the phone over Tailscale,
+  // so streaming the CLI's paste-code OAuth URL here IS the phone login. The code input is a pure
+  // pass-through to the kernel's PTY — nothing is stored or logged on any side.
+  var lgB = document.getElementById('rs-login-btn'), lgS = document.getElementById('rs-login-state'),
+      lgU = document.getElementById('rs-login-url'), lgC = document.getElementById('rs-login-code'),
+      lgI = document.getElementById('rs-login-input'), lgSend = document.getElementById('rs-login-send'),
+      lgX = document.getElementById('rs-login-cancel'), lgA = document.getElementById('rs-login-acct');
+  var lgTimer = null;
+  function lgRender(v) {
+    if (!lgB) return;
+    var f = (v && v.login) || { state: '' };
+    if (lgA) lgA.textContent = v && v.acctLabel ? 'Logged in as ' + v.acctLabel + '. Each machine logs in its own credential store.'
+                                                : 'No Claude login on this machine — sessions can only bill an API key. Log in from any browser (your phone works: the code flow needs no localhost).';
+    lgB.hidden = f.state === 'url' || f.state === 'starting' || f.state === 'verifying';
+    lgS.textContent = f.state === 'starting' ? 'starting the login flow…'
+      : f.state === 'verifying' ? 'checking the code…'
+      : f.state === 'error' ? (f.err || 'the login flow failed — try again') : '';
+    lgS.style.color = f.state === 'error' ? '#F85B5A' : '';
+    lgU.hidden = f.state !== 'url';
+    lgC.hidden = f.state !== 'url';
+    if (f.state === 'url' && f.url && lgU.getAttribute('data-url') !== f.url) {
+      lgU.setAttribute('data-url', f.url);
+      lgU.textContent = '';
+      var a = document.createElement('a');
+      a.href = f.url; a.target = '_blank'; a.rel = 'noreferrer';
+      a.textContent = '1. Open the sign-in page (any device) →';
+      a.style.color = '#9cd2ff';
+      lgU.appendChild(a);
+      var hint = document.createElement('div');
+      hint.className = 'rs-sub';
+      hint.textContent = '2. Finish signing in there; it shows a code. 3. Paste the code below.';
+      lgU.appendChild(hint);
+    }
+  }
+  function lgPoll() {
+    fetch(ku('/version'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (v) {
+      lgRender(v);
+      var st = (v.login || {}).state;
+      if (st === 'starting' || st === 'url' || st === 'verifying') lgTimer = setTimeout(lgPoll, 1500);
+      else lgTimer = null;
+    }).catch(function () { lgTimer = setTimeout(lgPoll, 3000); });
+  }
+  if (lgB) lgB.addEventListener('click', function () {
+    post({ type: 'loginStart' });
+    lgS.textContent = 'starting the login flow…';
+    if (!lgTimer) lgTimer = setTimeout(lgPoll, 800);
+  });
+  if (lgSend) lgSend.addEventListener('click', function () {
+    var code = lgI && lgI.value ? lgI.value.trim() : '';
+    if (!code) return;
+    post({ type: 'loginCode', code: code });   // pass-through; the kernel writes it to the PTY and nothing else
+    if (lgI) lgI.value = '';
+    lgS.textContent = 'checking the code…';
+    if (!lgTimer) lgTimer = setTimeout(lgPoll, 800);
+  });
+  if (lgI) lgI.addEventListener('keydown', function (e) { if (e.key === 'Enter' && lgSend) lgSend.click(); });
+  if (lgX) lgX.addEventListener('click', function () { post({ type: 'loginCancel' }); if (lgTimer) { clearTimeout(lgTimer); lgTimer = null; } lgRender({ login: { state: '' } }); });
   if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
   // The judge MODEL pickers mirror the session pickers (the user 2026-08-25): families top-level,
   // clicking a family sends its /models `default` (the user's remembered version), hover or
@@ -664,6 +733,8 @@ function initGear(post) {
     }).catch(function () { fillAutoNudge(v.autoNudge, []); fillMixedMarks(v, []); });
     if (fe) fe.checked = !!v.fileEditing;   // the kernel's persisted opt-in is authoritative (see the viewer's consent popup)
     if (cvm) cvm.checked = !!v.conserveMemory;   // T148: the kernel's persisted conserve flag is authoritative
+    lgRender(v);   // the Billing login block (T157) rides the same /version read
+    if ((v.login || {}).state && !lgTimer) lgTimer = setTimeout(lgPoll, 1500);   // a flow mid-run resumes polling
     if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
     if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
     if (im && typeof v.indexModel === 'string') im.value = v.indexModel;


### PR DESCRIPTION
## What

The Billing panel (gear) grows a **Log in** element that runs the Claude CLI's OAuth login end to end without a terminal — designed so the whole thing works from a phone over Tailscale:

1. The kernel spawns a real `claude` REPL on a pty and drives it through the trust gate, `/login`, and the method picker.
2. The `code=true` sign-in URL streams into the gear as a tappable link — open it on **any** device; the platform site displays a code after sign-in.
3. Paste the code into the gear; the kernel writes it straight to the pty. The CLI's own credential store is the only place credentials land, exactly as a terminal login would.

Auth-expired needs-you cards grow a "Log in…" button that opens the gear, shown only when the API error is an auth failure.

## Flow verdict (probed, CLI 2.1.221)

`/login` prints an OAuth URL carrying `code=true` whose callback displays a code on the platform site, then waits at "Paste code here" — no localhost redirect, no shared browser required. That is the fact that makes this phone-workable, and it was verified on a live pty before any UI was built.

## Driver honesty + secrecy

- **The pasted code is a pass-through**: written to the pty, existing nowhere else — no transcript, no log, no state file. A test walks the entire state dir asserting the synthetic code is absent; the lab greps the kernel log for the same.
- One flow at a time; states `"" → starting → url → verifying → done/error` surfaced in `/version`; stale flows self-reap after 10 minutes.
- Bad code → a plain error naming the retry; success busts the account cache so `login_ok`/the account label flip immediately.
- Verdict window anchors after the last "Paste code here" prompt (never a buffer clear, which raced instant verdicts); gates match space-free lowercase to survive TUI reflow; OSC-8/CSI stripped before URL capture.
- `_claude_bin()` honors `ROMP_CLAUDE_BIN` first — the seam the mock rides (without it the tests drove the REAL binary's login flow; only synthetic codes were ever submitted).

## Lab + tests

- `tools/romp-lab/lab.sh --login-only`: full-stack phase against a mocked login PTY (`login-mock-claude.py`, never a real account) — element present, URL streams as a link, flow completes, code passed through (sha-256-proved), code absent from the kernel log. All green.
- `tests/test_login_flow.py`: 6 tests — full flow + secrecy pin, bad-code error, one-flow-at-a-time + cancel, orphan-code refusal, stale self-reap, ops/payload/UI wiring pins.
- Feed row2 pins updated for the new `apiLogin` sibling.

## Suites

- pytest: 5950 passed + 313 subtests, 34 skipped
- extension: 2521 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)