### PR TITLE
The image lightbox pinch-zooms on touch — pointer-pair math, no gesture library

### DIFF
--- a/ui/webview/pinch.test.ts
+++ b/ui/webview/pinch.test.ts
@@ -1,0 +1,76 @@
+// Executable geometry for the lightbox pinch-zoom (T162). The DOM/gesture wiring is pinned below;
+// real pinch FEEL needs the phone — the user judges that; these pin the math that must never lie.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { identity, zoomAt, pan, clampPan, settle, doubleTapToggle, dist, midpoint,
+         PINCH_MIN, PINCH_MAX, PINCH_SNAP, DOUBLE_TAP_SCALE, type PinchView } from "./pinch";
+
+const contentAt = (v: PinchView, qx: number, qy: number) => ({ x: (qx - v.tx) / v.s, y: (qy - v.ty) / v.s });
+
+test("the content point under the gesture midpoint stays under it through any zoom", () => {
+  let v = identity();
+  for (const [mx, my, f] of [[120, 80, 1.6], [40, 200, 2.0], [90, 90, 0.7], [10, 10, 3.0]] as const) {
+    const before = contentAt(v, mx, my);
+    v = zoomAt(v, mx, my, f);
+    const after = contentAt(v, mx, my);
+    assert.ok(Math.abs(before.x - after.x) < 1e-9 && Math.abs(before.y - after.y) < 1e-9,
+      `midpoint invariance at s=${v.s.toFixed(2)}`);
+  }
+});
+
+test("scale clamps to [1, 8] and the clamp keeps the midpoint invariant too", () => {
+  const vMax = zoomAt(identity(), 50, 50, 100);
+  assert.equal(vMax.s, PINCH_MAX);
+  const vMin = zoomAt(vMax, 50, 50, 0.0001);
+  assert.equal(vMin.s, PINCH_MIN);
+  const before = contentAt(vMax, 50, 50);
+  const after = contentAt(zoomAt(vMax, 50, 50, 100), 50, 50);
+  assert.ok(Math.abs(before.x - after.x) < 1e-9, "a clamped zoom still pivots on the midpoint");
+});
+
+test("pan clamps: an over-scrolled edge never pulls inside the box; a fitting axis centers", () => {
+  // content 100×100 at 4× = 400×400 in a 300×200 box
+  const v: PinchView = { s: 4, tx: 50, ty: -500 };
+  const c = clampPan(v, 100, 100, 300, 200);
+  assert.equal(c.tx, 0, "left edge stops at the box edge");
+  assert.equal(c.ty, 200 - 400, "bottom edge stops at the box edge");
+  // content that FITS (1×) centers on both axes
+  const f = clampPan({ s: 1, tx: -40, ty: 999 }, 100, 100, 300, 200);
+  assert.deepEqual([f.tx, f.ty], [100, 50]);
+});
+
+test("a gesture ending near 1× settles exactly home; a real zoom survives", () => {
+  assert.deepEqual(settle({ s: PINCH_SNAP - 0.01, tx: 3, ty: -2 }), identity());
+  const kept = { s: 2, tx: -10, ty: -20 };
+  assert.deepEqual(settle(kept), kept);
+});
+
+test("double-tap toggles: home → 2.5× around the tap; any zoom → home", () => {
+  const z = doubleTapToggle(identity(), 60, 40);
+  assert.equal(z.s, DOUBLE_TAP_SCALE);
+  const under = contentAt(z, 60, 40);
+  assert.ok(Math.abs(under.x - 60) < 1e-9 && Math.abs(under.y - 40) < 1e-9, "zooms around the tap point");
+  assert.deepEqual(doubleTapToggle(z, 0, 0), identity());
+});
+
+test("pointer-pair helpers", () => {
+  assert.equal(dist({ x: 0, y: 0 }, { x: 3, y: 4 }), 5);
+  assert.deepEqual(midpoint({ x: 0, y: 0 }, { x: 10, y: 6 }), { x: 5, y: 3 });
+});
+
+test("the wiring: captured pointers, stage-owned gestures, and the close gesture untouched", () => {
+  const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(PREVIEW, /function wirePinchZoom\(stage: HTMLElement, img: HTMLImageElement\): void/);
+  assert.match(PREVIEW, /stage\.setPointerCapture\(e\.pointerId\);/,
+    "every gesture pointer is captured — a drag ending anywhere can never read as a backdrop tap");
+  assert.match(PREVIEW, /wirePinchZoom\(inner, img\);/, "images only — the PDF branch is untouched");
+  assert.match(PREVIEW, /wrap\.onclick = \(ev\) => \{ if \(ev\.target === wrap\) dismiss\(\); \};/,
+    "dismissal stays tap-on-backdrop + the ✕, byte-identical");
+  assert.match(PREVIEW, /closest\(".romp-lightbox-bar"\)/, "the bar's buttons own their taps");
+  assert.match(CSS, /\.romp-lightbox-inner \{ touch-action: none; \}/,
+    "the stage owns every touch gesture — the browser's page-zoom never fires here");
+  assert.match(CSS, /transform-origin: 0 0; will-change: transform;/);
+});

--- a/ui/webview/pinch.ts
+++ b/ui/webview/pinch.ts
@@ -1,0 +1,56 @@
+// Pure pinch-zoom math for the image lightbox (T162, the user 2026-08-28 on Android: a picture
+// popped up from the chat should support pinch and zoom). No gesture library — pointer-pair
+// arithmetic only, kept pure so the geometry is executable-testable headless; the DOM wiring
+// (pointer capture, touch-action, the close-gesture guard) lives with openLightbox in preview.ts.
+//
+// Coordinate frame: q-space — pointer positions relative to the image's UNTRANSFORMED layout
+// top-left (the caller subtracts the rest rect). The view renders as
+// `translate(tx,ty) scale(s)` with transform-origin 0 0, so a content point c appears at
+// q = c*s + t, and the invariant a pinch must keep is THE CONTENT POINT UNDER THE GESTURE
+// MIDPOINT STAYS UNDER IT while s changes.
+
+export interface PinchView { s: number; tx: number; ty: number; }
+export const PINCH_MIN = 1;
+export const PINCH_MAX = 8;
+export const PINCH_SNAP = 1.05;        // a pinch ending this close to 1× settles home
+export const DOUBLE_TAP_SCALE = 2.5;   // the platform-convention double-tap zoom step
+
+export const identity = (): PinchView => ({ s: 1, tx: 0, ty: 0 });
+
+export function dist(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+export function midpoint(a: { x: number; y: number }, b: { x: number; y: number }): { x: number; y: number } {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+/** Scale by `factor` around viewport point q=(mx,my): solve t' so (m - t')/s' == (m - t)/s. */
+export function zoomAt(v: PinchView, mx: number, my: number, factor: number): PinchView {
+  const s = Math.min(PINCH_MAX, Math.max(PINCH_MIN, v.s * factor));
+  const k = s / v.s;
+  return { s, tx: mx - (mx - v.tx) * k, ty: my - (my - v.ty) * k };
+}
+
+export function pan(v: PinchView, dx: number, dy: number): PinchView {
+  return { s: v.s, tx: v.tx + dx, ty: v.ty + dy };
+}
+
+/** Keep the scaled content covering the viewport: when the scaled size exceeds the box, the edges
+ *  may never pull inside it (no void beyond the image); when it fits, center that axis. (w,h) is
+ *  the content's rest size, (vw,vh) the box it rests in, both in q-space. */
+export function clampPan(v: PinchView, w: number, h: number, vw: number, vh: number): PinchView {
+  const sw = w * v.s, sh = h * v.s;
+  const clampAxis = (t: number, scaled: number, box: number): number =>
+    scaled <= box ? (box - scaled) / 2 : Math.min(0, Math.max(box - scaled, t));
+  return { s: v.s, tx: clampAxis(v.tx, sw, vw), ty: clampAxis(v.ty, sh, vh) };
+}
+
+/** A gesture ending near 1× settles exactly home — event-keyed (the gesture's own end), no timer. */
+export function settle(v: PinchView): PinchView {
+  return v.s < PINCH_SNAP ? identity() : v;
+}
+
+/** Double-tap toggles: zoomed (any s>1) → home; home → DOUBLE_TAP_SCALE around the tap point. */
+export function doubleTapToggle(v: PinchView, mx: number, my: number): PinchView {
+  return v.s > 1 ? identity() : zoomAt(identity(), mx, my, DOUBLE_TAP_SCALE);
+}

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -8,6 +8,7 @@
 
 import { hostOf, bareId } from "./host-prefix";
 import { mediaSrc } from "./media";
+import * as pz from "./pinch";
 
 // Extensions the kernel's _PREVIEW_MIME serves — keep the two lists in step (tests pin both).
 const IMG_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
@@ -113,6 +114,80 @@ export function fileUrl(path: string, sid?: string | null): string {
 // Full-view lightbox: dark backdrop, the image at natural-but-capped size or the PDF in the browser's
 // native viewer, filename caption. One singleton element; backdrop click / Esc / ✕ closes. Styles live
 // in BOTH styles.css and feed.css (each page loads only its own sheet — the .romp-acted precedent).
+// Pinch-zoom on the lightbox image (T162, the user 2026-08-28 on Android). Pointer events only —
+// no gesture library: two pointers pinch around the gesture midpoint (the content point under it
+// held fixed — pinch.ts owns the math, executable-tested), one pointer PANS while zoomed,
+// double-tap toggles home/2.5× around the tap. touch-action:none on the stage (CSS) keeps the
+// browser's own page-zoom out of it. The CLOSE gesture is untouched by construction: dismissal
+// stays tap-on-BACKDROP (target === wrap) and the ✕ — every pinch/pan pointer is CAPTURED by the
+// stage, so a drag that ends anywhere can never read as a backdrop tap.
+function wirePinchZoom(stage: HTMLElement, img: HTMLImageElement): void {
+  let view = pz.identity();
+  const ptrs = new Map<number, { x: number; y: number }>();
+  let start: { view: pz.PinchView; d: number } | null = null;   // two-pointer gesture snapshot
+  let rest: { left: number; top: number; w: number; h: number; vw: number; vh: number } | null = null;
+  let lastTap = 0, lastTapAt = { x: 0, y: 0 };
+  const apply = () => {
+    img.style.transform = view.s === 1 && !view.tx && !view.ty
+      ? "" : `translate(${view.tx}px, ${view.ty}px) scale(${view.s})`;
+  };
+  // the image's REST frame (its untransformed layout box, q-space origin) — measured at gesture
+  // start by removing the current transform's offset from the live rect; origin 0 0 keeps the
+  // top-left corner exactly translate() away from layout, so the inversion is exact
+  const measure = () => {
+    const r = img.getBoundingClientRect();
+    const box = stage.getBoundingClientRect();
+    rest = { left: r.left - view.tx, top: r.top - view.ty,
+             w: r.width / view.s, h: r.height / view.s,
+             vw: box.width, vh: box.height };
+  };
+  const q = (e: PointerEvent) => ({ x: e.clientX - rest!.left, y: e.clientY - rest!.top });
+  stage.addEventListener("pointerdown", (e) => {
+    if ((e.target as HTMLElement).closest(".romp-lightbox-bar")) return;   // the bar's buttons own their taps
+    ptrs.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    try { stage.setPointerCapture(e.pointerId); } catch { /* a pointer gone between event and capture — the move/up handlers still see bubbled events */ }
+    measure();
+    if (ptrs.size === 2) {
+      const [a, b] = [...ptrs.values()];
+      start = { view, d: pz.dist(a, b) };
+    } else if (ptrs.size === 1) {
+      // double-tap: a second down within the platform window and radius toggles the zoom. The
+      // 350ms is the GESTURE'S definition (like a double-click), not state logic.
+      const now = e.timeStamp;
+      const p = q(e);
+      if (now - lastTap < 350 && Math.hypot(p.x - lastTapAt.x, p.y - lastTapAt.y) < 30) {
+        view = pz.clampPan(pz.doubleTapToggle(view, p.x, p.y), rest!.w, rest!.h, rest!.vw, rest!.vh);
+        apply();
+        lastTap = 0;
+      } else { lastTap = now; lastTapAt = p; }
+    }
+    if (view.s > 1 || ptrs.size === 2) e.preventDefault();
+  });
+  stage.addEventListener("pointermove", (e) => {
+    const prev = ptrs.get(e.pointerId);
+    if (!prev || !rest) return;
+    ptrs.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (ptrs.size === 2 && start) {
+      const [a, b] = [...ptrs.values()];
+      const m = pz.midpoint(a, b);
+      view = pz.clampPan(
+        pz.zoomAt(start.view, m.x - rest.left, m.y - rest.top, pz.dist(a, b) / start.d),
+        rest.w, rest.h, rest.vw, rest.vh);
+      apply();
+    } else if (ptrs.size === 1 && view.s > 1) {
+      view = pz.clampPan(pz.pan(view, e.clientX - prev.x, e.clientY - prev.y), rest.w, rest.h, rest.vw, rest.vh);
+      apply();
+    }
+  });
+  const lift = (e: PointerEvent) => {
+    ptrs.delete(e.pointerId);
+    if (ptrs.size < 2) start = null;
+    if (ptrs.size === 0) { view = pz.settle(view); apply(); }
+  };
+  stage.addEventListener("pointerup", lift);
+  stage.addEventListener("pointercancel", lift);
+}
+
 export function openLightbox(path: string, sid?: string | null, pin?: string): void {
   document.getElementById("romp-lightbox")?.remove();
   const kind = previewKind(path);
@@ -133,6 +208,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
     img.src = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
     img.alt = path;
     inner.appendChild(img);
+    wirePinchZoom(inner, img);
   }
   const bar = document.createElement("div");
   bar.className = "romp-lightbox-bar";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2663,7 +2663,11 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   display: flex; align-items: center; justify-content: center; }
 .romp-lightbox-inner { display: flex; flex-direction: column; gap: 8px; max-width: 92vw; max-height: 90vh; }
 .romp-lightbox-img { max-width: 92vw; max-height: 82vh; object-fit: contain; border-radius: 8px;
-  box-shadow: var(--shadow-modal); }
+  box-shadow: var(--shadow-modal);
+  transform-origin: 0 0; will-change: transform; }   /* pinch-zoom renders translate+scale from this corner (T162; pinch.ts) */
+/* the stage owns every touch gesture (T162): pinch must zoom the IMAGE, never the page — the bar's
+   buttons still tap fine (touch-action only disables the browser's own gestures) */
+.romp-lightbox-inner { touch-action: none; }
 .romp-lightbox-inner.pdf { width: 88vw; height: 88vh; }
 .romp-lightbox-frame { flex: 1 1 auto; width: 100%; border: 0; border-radius: 8px; background: #fff; }
 .romp-lightbox-bar { display: flex; align-items: center; gap: 10px; min-width: 0; }


### PR DESCRIPTION
The user (Android): popping up a picture from the chat should support pinch and zoom.

## Pure geometry (`pinch.ts`, executable-tested)
- Pinch scales around the gesture midpoint with **the content point under it held fixed** (pinned to 1e-9), clamped 1×–8× — the clamp preserves the invariant.
- One-finger **pan while zoomed**, clamped (an edge never pulls inside the box; a fitting axis centers).
- A gesture ending within 5% of 1× **settles home** (event-keyed, the gesture's own end). **Double-tap** toggles home ↔ 2.5× around the tap.

## Wiring (`wirePinchZoom`, images only)
Pointer events with per-pointer capture — a drag ending anywhere can never read as a backdrop tap by construction (capture try/catch-guarded; the headless probe hit the gone-pointer case for real). Rest frame re-measured at gesture start by inverting the current transform (origin 0 0 makes it exact). The bar's buttons own their taps. `touch-action: none` on the stage keeps the browser's page-zoom out. **Dismissal byte-identical**: backdrop tap, ✕, Esc.

## Verification
Headless over the real exported `openLightbox`: two-pointer spread → `scale(5)` midpoint-anchored; pan moves the clamped view; the drag's release leaves it open; backdrop tap closes; computed `touch-action: none`. **Honest note: real pinch feel needs the phone** — shipped for the user's judgment. Suite 2528/2528, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)