### PR TITLE
The phone gets the chat tag control — the shared button rides the mobile header

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25133,6 +25133,7 @@ _CHAT_MOBILE_CSS = (
     "#mcur .wd{flex:0 0 auto;width:7px;height:7px;border-radius:50%;background:var(--st-working-bg,#e0b020)}"
     "#mcur .wd.await{background:var(--st-awaitbg-bg,#54B204)}"   # green when idle-waiting-on-bg-work
     "#mcur .cv{flex:0 0 auto;opacity:.6;font-size:11px}"
+    "#mtag-slot{flex:0 0 auto;display:flex;align-items:center;gap:5px}"   # T161: the tag control's slot, sized by the shared button's own inline metrics
     "#madd{flex:0 0 auto;width:36px;display:flex;align-items:center;justify-content:center;cursor:pointer;"
     "background:#2a2a2a;color:#bbbbbb;border:1px solid #3a3a3a;border-radius:6px;font-size:16px;line-height:1}"
     "#mlist{display:none;position:absolute;left:8px;right:8px;top:100%;margin-top:4px;z-index:200;"
@@ -25179,7 +25180,10 @@ var cur=document.createElement('button');cur.id='mcur';cur.type='button';
 cur.innerHTML='<span class="wd" style="display:none"></span><span class="nm"></span><span class="cv">▾</span>';
 var add=document.createElement('button');add.id='madd';add.type='button';add.textContent='+';add.title='Open / new session';
 var list=document.createElement('div');list.id='mlist';
-hdr.appendChild(cur);hdr.appendChild(add);
+// T161: an empty slot for the chat surface's TAG control — render.js mounts the shared button into
+// it (the real component, not a copy), so the phone gets the same lens/menu the desktop strip has
+var tslot=document.createElement('span');tslot.id='mtag-slot';
+hdr.appendChild(cur);hdr.appendChild(tslot);hdr.appendChild(add);
 tabbar.appendChild(hdr);tabbar.appendChild(list);
 function realTab(id){return tabs.querySelector('.tab[data-id="'+id+'"]');}
 function hide(){list.classList.remove('open');}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4634,6 +4634,42 @@ function renderTabs() {
       postViews(nv);
     });
   }
+  // T161 (the user 2026-08-28, Android: no tag control on mobile): the phone chat page hides the whole
+  // #tabs strip — and the mount above with it. The kernel's mobile header carries an empty #mtag-slot
+  // (left of +); mount the SAME shared button + chips into it ONCE — the slot is kernel-built and never
+  // rebuilt, so the ensure-once mount is click-safe by construction — and re-sync it every render like
+  // the desktop pair. Same chat lens, same house menu, same echo dismissal: one vocabulary, no copy.
+  // Absent slot (VS Code webview, desktop-only pages) → no-op; on the desktop kernel page the slot
+  // hides with #mhdr. The touch padding is set inline because the shared button styles inline by design.
+  const mslot = document.getElementById("mtag-slot");
+  if (mslot) {
+    if (!mslot.firstChild) {
+      const mBtn = tagMenuButton("filter sessions by tag", (btn) => {
+        openTagMenu(btn, {
+          lens: () => surfaceLens(effViews(), "chat"),
+          unions: () => viewTagUnion(effViews()),
+          onApply: (l) => {
+            const mv = JSON.parse(JSON.stringify(effViews() || { active: "all", tags: [] }));
+            mv.actives = Object.assign({}, mv.actives, { chat: l });
+            postViews(mv);
+          },
+          onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
+        });
+      });
+      mBtn.classList.add("tab-tagfilter");
+      mBtn.style.padding = "8px 9px";   // the coarse-pointer target: ~32px tall, the header row's own scale
+      const mChips = el("span", "tab-tagchips");
+      mChips.setAttribute("style", "display:inline-flex;gap:5px;align-items:center;margin-left:2px;");
+      mslot.append(mBtn, mChips);
+    }
+    const mv2 = effViews();
+    syncTagFilter(mslot.children[0] as HTMLElement, mslot.children[1] as HTMLElement,
+      surfaceLens(mv2, "chat"), viewTagUnion(mv2), (l) => {
+        const nv = JSON.parse(JSON.stringify(mv2 || { active: "all", tags: [] }));
+        nv.actives = Object.assign({}, nv.actives, { chat: l });
+        postViews(nv);
+      });
+  }
   paintTabRowLines(bar);
   ensureTabRowObserver(bar);
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).

--- a/ui/webview/tag-mounts.test.ts
+++ b/ui/webview/tag-mounts.test.ts
@@ -43,6 +43,23 @@ test("executed: revealIn is ADDITIVE on the chat lens — never a switch that hi
     "already visible → no move at all");
 });
 
+test("the phone gets the chat tag control too — the SHARED button mounted into the kernel header's slot (T161)", () => {
+  // the mobile chat page hides the whole #tabs strip (kernel _CHAT_MOBILE_CSS) — and the desktop
+  // mount with it (the user 2026-08-28, Android: 'there's no tag view control on mobile'). The
+  // kernel's mobile header builds an EMPTY #mtag-slot; render.ts mounts the real tagMenuButton into
+  // it once (kernel-built and never rebuilt → ensure-once is click-safe) and re-syncs per render.
+  assert.match(KERNEL, /tslot\.id='mtag-slot';/, "the slot rides the kernel's mobile header, left of +");
+  assert.match(KERNEL, /hdr\.appendChild\(cur\);hdr\.appendChild\(tslot\);hdr\.appendChild\(add\);/);
+  assert.match(RENDER, /const mslot = document\.getElementById\("mtag-slot"\);/);
+  assert.match(RENDER, /if \(!mslot\.firstChild\) \{/, "ensure-once — the slot never rebuilds");
+  const mnt = RENDER.slice(RENDER.indexOf('const mslot = document.getElementById("mtag-slot")'),
+                           RENDER.indexOf("paintTabRowLines(bar);"));
+  assert.match(mnt, /tagMenuButton\("filter sessions by tag"/, "the SHARED component, never a copy");
+  assert.match(mnt, /Object\.assign\(\{\}, mv\.actives, \{ chat: l \}\)/, "writes land on the chat lens — per-surface semantics");
+  assert.match(mnt, /syncTagFilter\(mslot\.children\[0\] as HTMLElement, mslot\.children\[1\] as HTMLElement,/,
+    "the mobile pair re-syncs every render like the desktop one");
+});
+
 test("the chat strip and the outline both mount the shared component (source pins)", () => {
   assert.match(RENDER, /function chatVisible\(id: string\): boolean/);
   assert.match(RENDER, /lensVisible\(surfaceLens\(v, "chat"\), viewTagUnion\(v\), id\)/,


### PR DESCRIPTION
The user (2026-08-28, Android): no tag view control on mobile. **The trace**: the phone chat page hides the whole `#tabs` strip (the mobile header replaces it), and the chat surface's tag button lives inside that strip — hidden with it. The feed and outline panes keep their own mounts; the chat surface was the dropped one.

The kernel's mobile header now carries an empty `#mtag-slot` between the session button and `+`, and render.ts mounts the **real shared `tagMenuButton`** into it — same component, same chat lens (writes land on `actives.chat`), same house menu and echo dismissal, never a copy. The mount is ensure-once (the slot is kernel-built and never rebuilt — click-safe by construction) and re-syncs every render exactly like the desktop pair. Touch padding set inline (~32px target, the header row's scale); the slot hides with `#mhdr` on desktop, and the absent slot makes the mount a no-op on VS Code pages.

**Placement call, per the dispatch**: the chat surface's lens belongs in the chat pane's own header, not the shell's `#mtabs` bar — the lens is per-surface, the menu module lives in the pane bundle, and T158 just tightened the bar; the header row had the room and the semantics.

**Verified live** on a hermetic kernel under Pixel-5 emulation: button visible in the header, tap opens the house menu anchored beneath it — closed + open shots in the report. Pins hold the slot, the ensure-once mount, the shared component, the chat-lens write, and the per-render sync. Python 5945 passed / extension 2522 passed on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)