### PR TITLE
The tab menu's Tags flyout opens on hover-intent and gains Configure tags…

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4972,10 +4972,22 @@ function showTabMenu(e: MouseEvent, id: string) {
       }
       if (dirty) postViews(nv);
     };
-    tagsItem.addEventListener("click", (ev) => {
-      ev.stopPropagation();
+    // HOVER-INTENT open (T163, the user 2026-08-28: hovering down to Tags should open the submenu
+    // without another click): the feed's 120ms intent debounce — enough to skip a graze, never a
+    // wait. Click still opens instantly (and focuses the input; a hover-open must NOT steal the
+    // keyboard). Leaving is tolerant the way native menus are: the same 120ms lets the pointer
+    // cross the gap into the submenu; entering either surface cancels the close, leaving BOTH
+    // closes. Timers here are gesture DEFINITIONS (hover intent), not state proxies.
+    const HOVER_INTENT_MS = 120;
+    let hoverOpenT: number | null = null;
+    let hoverCloseT: number | null = null;
+    const cancelHoverTimers = () => {
+      if (hoverOpenT != null) { clearTimeout(hoverOpenT); hoverOpenT = null; }
+      if (hoverCloseT != null) { clearTimeout(hoverCloseT); hoverCloseT = null; }
+    };
+    const openTagsFly = (focusInput: boolean) => {
       const openFly = menu.querySelector(".ctx-sub-tags");
-      if (openFly) { openFly.remove(); return; }                 // second click folds the flyout
+      if (openFly) return openFly as HTMLElement;
       menu.querySelector(".ctx-sub")?.remove();                  // one flyout at a time (Billing's rule)
       const sub = el("div", "ctx-menu ctx-sub ctx-sub-tags");
       const build = () => {
@@ -5027,12 +5039,51 @@ function showTabMenu(e: MouseEvent, id: string) {
         sub.appendChild(nrow);
       };
       build();
+      // Configure tags… at the foot, behind the divider (T163): the ONE route the tag-lens menus
+      // use — openTagsDialog — never a copy of the dialog wiring.
+      sub.appendChild(el("div", "ctx-sep"));
+      const cfg = el("div", "ctx-item ctx-item-configtags");
+      const cfgBody = el("span", "ctx-item-body");
+      const cfgL = el("span", "ctx-item-label"); cfgL.textContent = "Configure tags…"; cfgBody.appendChild(cfgL);
+      cfg.appendChild(cfgBody);
+      cfg.addEventListener("click", (e2) => {
+        e2.stopPropagation(); dismissTabMenu();
+        vscodeApi?.postMessage({ type: "openTagsDialog" });
+      });
+      sub.appendChild(cfg);
       menu.appendChild(sub);
       const ir = tagsItem.getBoundingClientRect();
       const sr = sub.getBoundingClientRect();
-      sub.style.left = Math.max(0, Math.min(ir.right + 2, window.innerWidth - sr.width - 4)) + "px";
+      // the side rule (the model-version submenus): PREFER right; fall LEFT only when the right
+      // edge would clip — never slide over the row
+      if (ir.right + 2 + sr.width <= window.innerWidth - 8) sub.style.left = Math.round(ir.right + 2) + "px";
+      else sub.style.left = Math.max(8, Math.round(ir.left) - sr.width - 2) + "px";
       sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
-      (sub.querySelector(".ctx-tag-input") as HTMLInputElement | null)?.focus();
+      if (focusInput) (sub.querySelector(".ctx-tag-input") as HTMLInputElement | null)?.focus();
+      // leave-tolerance: entering either surface cancels the pending close; leaving both arms it
+      sub.addEventListener("pointerenter", cancelHoverTimers);
+      sub.addEventListener("pointerleave", armHoverClose);
+      return sub;
+    };
+    const armHoverClose = () => {
+      cancelHoverTimers();
+      hoverCloseT = window.setTimeout(() => {
+        hoverCloseT = null;
+        menu.querySelector(".ctx-sub-tags")?.remove();
+      }, HOVER_INTENT_MS);
+    };
+    tagsItem.addEventListener("pointerenter", () => {
+      cancelHoverTimers();
+      if (menu.querySelector(".ctx-sub-tags")) return;           // already open — nothing to intend
+      hoverOpenT = window.setTimeout(() => { hoverOpenT = null; openTagsFly(false); }, HOVER_INTENT_MS);
+    });
+    tagsItem.addEventListener("pointerleave", armHoverClose);
+    tagsItem.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      cancelHoverTimers();
+      const openFly = menu.querySelector(".ctx-sub-tags");
+      if (openFly) { openFly.remove(); return; }                 // second click folds the flyout
+      openTagsFly(true);
     });
     menu.appendChild(tagsItem);
   }

--- a/ui/webview/tab-tags-flyout.test.ts
+++ b/ui/webview/tab-tags-flyout.test.ts
@@ -1,0 +1,45 @@
+// The chat-tab context menu's Tags flyout opens on HOVER-INTENT and carries Configure tags…
+// (T163, the user 2026-08-28: hovering down to Tags should open the submenu without another
+// click, and it should have a thing that goes into the configure-tags dialog). Source pins; the
+// hover/tolerance behavior is also driven headless over the built bundle (task harness).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const at = RENDER.indexOf('const tagsItem = el("div", "ctx-item ctx-item-toggle ctx-item-tags");');
+const block = RENDER.slice(at, RENDER.indexOf('menu.appendChild(tagsItem);', at));
+
+test("hover-intent opens the flyout: the feed's 120ms, click still instant, hover never steals focus", () => {
+  assert.match(block, /const HOVER_INTENT_MS = 120;/);
+  assert.match(block, /tagsItem\.addEventListener\("pointerenter", \(\) => \{/);
+  assert.match(block, /hoverOpenT = window\.setTimeout\(\(\) => \{ hoverOpenT = null; openTagsFly\(false\); \}, HOVER_INTENT_MS\);/,
+    "hover opens WITHOUT focusing the input — a graze must not grab the keyboard");
+  assert.match(block, /openTagsFly\(true\);/, "click opens instantly and focuses");
+  assert.match(block, /cancelHoverTimers\(\);\s*\n\s*const openFly = menu\.querySelector\(".ctx-sub-tags"\);/,
+    "a click cancels any pending hover intent before acting");
+});
+
+test("diagonal tolerance: entering either surface cancels the close; leaving both closes", () => {
+  assert.match(block, /sub\.addEventListener\("pointerenter", cancelHoverTimers\);/);
+  assert.match(block, /sub\.addEventListener\("pointerleave", armHoverClose\);/);
+  assert.match(block, /tagsItem\.addEventListener\("pointerleave", armHoverClose\);/);
+  assert.match(block, /hoverCloseT = window\.setTimeout\(/, "the close is armed on leave with the same tolerance window");
+});
+
+test("expansion follows the standing side rule and the caret faces right", () => {
+  assert.match(block, /if \(ir\.right \+ 2 \+ sr\.width <= window\.innerWidth - 8\) sub\.style\.left = Math\.round\(ir\.right \+ 2\) \+ "px";/);
+  assert.match(block, /else sub\.style\.left = Math\.max\(8, Math\.round\(ir\.left\) - sr\.width - 2\) \+ "px";/,
+    "prefer right, FALL LEFT on clip — never slide over the row");
+  assert.match(block, /caret\.textContent = "▸";/);
+});
+
+test("Configure tags… sits at the foot behind the divider and rides the ONE dialog route", () => {
+  const cfgAt = block.indexOf('cfgL.textContent = "Configure tags…";');
+  assert.ok(cfgAt > 0);
+  assert.match(block, /sub\.appendChild\(el\("div", "ctx-sep"\)\);\s*\n\s*const cfg = el\("div", "ctx-item ctx-item-configtags"\);/);
+  assert.match(block, /vscodeApi\?\.postMessage\(\{ type: "openTagsDialog" \}\);/,
+    "the same route the tag-lens menus use — one dialog, no copy");
+  assert.match(block, /e2\.stopPropagation\(\); dismissTabMenu\(\);/, "opening the dialog closes the menu");
+});


### PR DESCRIPTION
The user: right-clicking a chat tab and hovering down to Tags should open the submenu without another click, and it should have an entry into the configure-tags dialog.

## Hover-intent + tolerance
- The feed's **120ms intent debounce** — skips a graze, never a wait. Click still opens instantly (and focuses the input); a **hover-open never steals focus**. Keyboard untouched.
- Native-menu leave tolerance: the same window lets the pointer **cross the gap** into the flyout; entering either surface cancels the close, **leaving both** closes.

## Expansion + the entry
- The flyout now follows the standing side rule (model-version precedent): prefer right, **fall left on clip** — the old clamp slid it back over the row.
- **Configure tags…** at the foot behind a divider, riding the one existing `openTagsDialog` route (the tag-lens menus' message — no dialog wiring copied), closing the menu as it opens.

## Verification
Headless over the built bundle: closed at hover-instant → open after the intent window, focus unstolen, gap-crossing keeps it, Configure posts exactly one `openTagsDialog` + closes, leaving both closes. Suite 2533/2533, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)