### PR TITLE
Deploy restarts cut immediately — the quiet-window drain becomes an explicit opt-in

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1490,9 +1490,10 @@ print(json.dumps({"t": int(time.time()), "ppid": int(os.environ.get("RA_PPID") o
 PYEOF
                } 2>/dev/null || true
                "${ROMP_POSTAL_BIN:-romp-postal-service}" restart >/dev/null 2>&1 || true
-               # Deploys defer to the next quiet window (no SDK turn in flight) so a peer's
-               # refresh never cuts another session's turn; `romp refresh --now` forces the
-               # old immediate bounce (the manager coalesces everything queued meanwhile).
+               # Deploys bounce IMMEDIATELY, cutting in-flight turns (T160 — the parked
+               # quiet window cost minutes per push; boot reconcile resumes cut turns with
+               # their history). `romp refresh --quiet` defers to the next quiet window
+               # explicitly (no SDK turn in flight, drain lease held, backstop-capped).
                exec "${ROMP_MANAGER_BIN:-romp-manager}" restart-all "${2:-}" ;;
     status)    exec "${ROMP_MANAGER_BIN:-romp-manager}" status ;;
 esac

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -479,7 +479,7 @@ function startManager() {
         return json(202, { ok: true, deferred: true, coalesced: queueQuietRestart('all') });
       }
       clearPendingQuiet();                                       // this bounce delivers any pending deploy too
-      const r = restartAllOrSelf();                              // `romp refresh --now` — every kernel
+      const r = restartAllOrSelf();                              // `romp refresh` — every kernel
       return json(200, { ok: true, restarted: r.ids, managerRestart: r.self });
     }
     if (req.method === 'POST' && url.pathname === '/restart') {
@@ -549,14 +549,17 @@ function ensureUp() {
 module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileStamp };
 if (require.main === module) {
   const cmd = process.argv[2];
-  // `restart-all` (the `romp refresh` deploy path) defers to the next quiet window by default —
-  // `--now` keeps the old immediate bounce for emergencies/humans in a hurry.
+  // `restart-all` (the `romp refresh` deploy path) bounces IMMEDIATELY by default (T160, the user
+  // 2026-08-28, reversing the T121 quiet default: parked windows cost minutes per push and still cut
+  // turns at the backstop). `--quiet` defers to the next quiet window explicitly — the drain lease
+  // and the coalescing gate are invoked, not gone. `--now` stays accepted as the explicit spelling
+  // of the default, so scripts written against either era keep working.
   if (cmd === 'restart') control('POST', '/restart', process.argv[3]);
   else if (cmd === 'restart-all') control('POST', '/restart-all', null,
-    process.argv[3] === '--now' ? {} : { when: 'quiet' });
+    process.argv[3] === '--quiet' ? { when: 'quiet' } : {});
   else if (cmd === 'status') control('GET', '/status');
   else if (cmd === 'down') control('POST', '/stop');
   else if (cmd === 'ensure') ensureUp();
   else if (!cmd || cmd === 'up') runManager();
-  else { console.error('usage: romp-manager [up | ensure | restart-all [--now] | restart [kernel] | status | down]'); process.exit(2); }
+  else { console.error('usage: romp-manager [up | ensure | restart-all [--quiet] | restart [kernel] | status | down]'); process.exit(2); }
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,7 +20,7 @@ update` starts a session called "update".
 | `romp new -t <name>` | Start it as a terminal (tmux) session and attach; add `--detach` to leave it running |
 | `romp resume` | Resume a past conversation, chosen from a full-screen picker |
 | `romp status` | Manager and kernel status |
-| `romp refresh` | Restart the postal bus and every kernel, picking up new code |
+| `romp refresh` | Restart the postal bus and every kernel immediately, picking up new code (cut turns resume with their history) |
 | `romp update [host…]` | Push this machine's committed Romp to attached remotes and restart them |
 | `romp up` | Run the kernel manager in the foreground; rare, since the login service runs it |
 | `romp version` | Version report across the moving parts |
@@ -40,7 +40,7 @@ These are for scripting and for agents rather than daily use:
 | `romp default-dir [PATH]` | The default working directory for new sessions; no argument prints it, `""` clears it |
 | `romp debug [on\|off\|status]` | Judge debug mode, where rejection rows carry the full input and reply |
 | `romp resume <id> [--name <n>] [--detach]` | Resume one exact conversation by UUID |
-| `romp refresh --now` | Refresh without waiting for sessions to finish their turns |
+| `romp refresh --quiet` | Refresh at the next quiet window instead — waits for sessions to finish their turns (15-min backstop) |
 
 Two things to know before building on `romp sessions --json`. **`waiting` means
 at rest**, the ordinary state of a session that has finished its turn, so

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2463,11 +2463,18 @@ def _run_update(tag):
     q = shlex.quote
     log, rep = q(str(jd.STATE / "update.log")), q(str(jd.STATE / "update-report.json"))
     mport = os.environ.get("ROMP_MANAGER_PORT") or ""
-    # ?when=quiet (T121): the self-update is a DEPLOY — it rides the manager's quiet-window gate
-    # (drain first, backstop-capped) exactly like `romp refresh`, instead of cutting every in-flight
-    # turn immediately. The human Restart buttons (_restart_this_kernel) stay immediate on purpose:
-    # a person pressing Restart wants it now.
-    restart = ("  curl -s -X POST 'http://127.0.0.1:%d/restart-all?when=quiet' >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
+    # IMMEDIATE (T160, the user 2026-08-28, reversing T121's quiet default from live experience):
+    # a deploy cuts in-flight turns NOW. The parked quiet window held every push for minutes
+    # (measured 0–570s waits, 15-min backstop) and still cut turns when the window never quieted,
+    # while boot reconcile resumes a cut turn with its history and a continuation nudge either way.
+    # The quiet gate is not gone — `romp refresh --quiet` invokes it explicitly. The audit line the
+    # script writes right before the curl is what names this restart in restart-cuts.jsonl: the
+    # detached script outlives this kernel, so the dying kernel's cut row can only join to a reason
+    # written at curl time (auto deploys used to leave the row anonymous).
+    aud = q(str(jd.STATE / "restart-audit.jsonl"))
+    restart = (("  printf '{\"t\": %%s, \"action\": \"self-update\", \"tag\": \"%s\"}\\n' \"$(date +%%s)\" >> %s\n"
+                % (tag, aud))
+               + "  curl -s -X POST 'http://127.0.0.1:%d/restart-all' >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
         else "  : # no manager — the new code arms on the next romp start (the report says so)\n"
     ok_rep = {"ok": True, "tag": tag, "restarted": bool(mport.isdigit())}
     script = (
@@ -2761,11 +2768,13 @@ def _main_drift_check():
 _PORT_FROM_ENV = object()
 
 
-def _run_main_update(kind, immediate=False, manager_port=_PORT_FROM_ENV):
+def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
     """Converge on newest main: advance the checkout (fast-forward only; a DIRTY shared tree refuses
     LOUDLY — peer sessions' uncommitted work is never discarded) and bounce every kernel through the
-    manager. `kind` "restart" skips the pull (the checkout is already ahead). Unattended (auto mode)
-    the bounce rides the quiet window; a banner CLICK is the user's own deliberate cut → immediate.
+    manager. `kind` "restart" skips the pull (the checkout is already ahead). The bounce is IMMEDIATE
+    for every caller (T160, the user 2026-08-28: deploys cut in-flight turns now; the parked quiet
+    window cost minutes per push and boot reconcile resumes cut turns either way) — pass
+    immediate=False to ride the manager's quiet-window gate explicitly.
     `manager_port` is the value the /update handler resolved before its ack (see _PORT_FROM_ENV)."""
     if kind == "pull":
         try:
@@ -2803,6 +2812,9 @@ def _run_main_update(kind, immediate=False, manager_port=_PORT_FROM_ENV):
         manager_port = os.environ.get("ROMP_MANAGER_PORT")
     try:
         import urllib.request
+        # the reason joins the dying kernel's restart-cuts.jsonl row to WHO restarted it (see
+        # _recent_restart_reason) — the auto converge used to leave the row anonymous
+        _audit_restart_request("main-converge", tag=kind, when=("now" if immediate else "quiet"))
         req = urllib.request.Request("http://127.0.0.1:%d/restart-all%s"
                                      % (int(manager_port or 7432),
                                         "" if immediate else "?when=quiet"), method="POST")

--- a/tests/manager-restart.test.js
+++ b/tests/manager-restart.test.js
@@ -130,3 +130,15 @@ test('the parked quiet poll refreshes the kernel drain lease in the same probe',
   assert.ok(src.includes('path: path || \'/busy\''),
     'a plain /busy stays side-effect free — only the parked poll holds');
 });
+
+// ── T160 (the user 2026-08-28): deploys bounce IMMEDIATELY by default ─────────────────────────────
+// The quiet window is an explicit opt-in now (`restart-all --quiet`), never the implicit deploy
+// default: parked windows cost minutes per push (0–570s measured) and still cut turns at the
+// backstop. Source pins on the CLI dispatch, the one place the default lives.
+test('restart-all dispatches IMMEDIATE by default — --quiet is the explicit drain spelling', () => {
+  const src = require('node:fs').readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
+  assert.match(src, /process\.argv\[3\] === '--quiet' \? \{ when: 'quiet' \} : \{\}/,
+    'the dispatch default sends NO when param (immediate); --quiet opts into the drain');
+  assert.doesNotMatch(src, /'--now' \? \{\} : \{ when: 'quiet' \}/,
+    'the old quiet-by-default dispatch is gone');
+});

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -72,8 +72,12 @@ class DrainLease(unittest.TestCase):
                       "/busy?drain=1 refreshes the lease in the same round-trip that reads the count")
         self.assertIn('json.dumps({"busy": n, "draining": draining})', ksrc,
                       "the payload says when the box is draining — glanceable, never mysterious")
-        self.assertIn("'http://127.0.0.1:%d/restart-all?when=quiet'", ksrc,
-                      "the self-update deploy rides the quiet gate instead of cutting immediately")
+        self.assertIn("'http://127.0.0.1:%d/restart-all'", ksrc,
+                      "the self-update deploy cuts IMMEDIATELY (T160, reversing the T121 quiet "
+                      "default: parked windows cost minutes per push) — the quiet gate stays for "
+                      "explicit `romp refresh --quiet`")
+        self.assertNotIn("/restart-all?when=quiet'", ksrc,
+                         "no kernel-side deploy path defaults to the quiet window any more")
         msrc = open(os.path.join(BIN, "romp-manager")).read()
         self.assertIn("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')", msrc,
                       "the manager's PARKED poll is the lease's refresher")

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -287,9 +287,14 @@ class RunUpdate(Fresh):
         # the restart rides the SUCCESS branch only: everything after `if` up to `else` has it,
         # the failure branch does not
         ok_branch, fail_branch = script.split("else\n", 1)
-        self.assertIn("/restart-all?when=quiet", ok_branch,
-                      "the self-update is a DEPLOY: it rides the quiet-window gate (drain first, "
-                      "backstop-capped) instead of cutting every in-flight turn (T121)")
+        self.assertIn("/restart-all'", ok_branch,
+                      "the self-update deploy bounces IMMEDIATELY (T160, the user's call from live "
+                      "experience — the quiet window cost minutes per push; explicit "
+                      "`romp refresh --quiet` still drains)")
+        self.assertNotIn("when=quiet", ok_branch, "no drain default on the deploy path")
+        self.assertIn('"action": "self-update"', ok_branch,
+                      "the script stamps restart-audit.jsonl at curl time, so the dying kernel's "
+                      "restart-cuts row joins to a named reason instead of reading anonymous")
         self.assertNotIn("/restart-all", fail_branch)
         self.assertEqual(km._UPDATE_STATE[0], "running")
 

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -61,12 +61,21 @@ class DriftWiring(unittest.TestCase):
         self.assertIn('_MAIN_DRIFT[0] = ""', src, "the notice re-fires once the tree is clean")
         self.assertIn('"checkout", "--detach", "origin/main"', src, "advance is the repo's own convention")
 
-    def test_the_click_converges_immediately_and_auto_rides_the_quiet_window(self):
+    def test_every_converge_is_immediate_by_default_and_quiet_stays_expressible(self):
+        # T160 (the user 2026-08-28): deploys cut in-flight turns NOW — auto converge included.
+        # The quiet spelling survives as an explicit opt-in, so the drain machinery stays testable
+        # and reachable, it just stopped being the default.
+        sig = inspect.signature(km._run_main_update)
+        self.assertIs(sig.parameters["immediate"].default, True,
+                      "auto converge is a deploy: immediate by default")
         src = inspect.getsource(km._run_main_update)
-        self.assertIn('"" if immediate else "?when=quiet"', src)
+        self.assertIn('"" if immediate else "?when=quiet"', src,
+                      "immediate=False still rides the quiet window explicitly")
+        self.assertIn('_audit_restart_request("main-converge"', src,
+                      "the converge names itself in restart-audit.jsonl so the cut row joins to it")
         route = inspect.getsource(km)
         self.assertIn('threading.Thread(target=_run_main_update, args=(kind, True),', route,
-                      "the banner click is the user's own deliberate cut")
+                      "the banner click stays explicitly immediate")
 
     def test_auto_converges_batch_behind_the_cool_down(self):
         # the user 2026-08-15, after flipping auto: main took a merge every few minutes and auto mode


### PR DESCRIPTION
## What

Reverses the deploy-restart default: pushes now bounce every kernel **immediately**, cutting in-flight turns, which boot reconcile resumes with their history and a continuation nudge. The quiet-window drain survives as an explicit opt-in — `romp refresh --quiet` / `romp-manager restart-all --quiet` — with the whole lease + gate + coalescing machinery untouched and still tested.

## Why (evidence, gathered before flipping)

- The manager journal since the drain landed records **14 deferred deploys: half applied at 0–2s, the other half parked 1–9.5 minutes (57–570s)**, two resolving as "kernel unreachable" rather than quiet. Back-to-back pushes serialize — three bounces in 26 minutes one afternoon, each parked minutes first.
- The parked window doesn't buy clean cuts: **24 of 36 restart-cuts.jsonl rows since the drain landed still cut 1–5 turns.**
- Multi-kernel connection thrash: **no redial defect** (teardown needs 3 consecutive silent polls; the backoff ladder advances on teardown and clears only after 8 stable polls; demand-redial is self-limiting). The thrash is the drain's *asynchrony* — independent per-host quiet windows roll one push's bounces across the mesh over many minutes, each bounce costing peers a teardown + redial + handshake. Immediate restarts collapse the spread into one episode.

## Changes

- `kernel/kernel.py`: self-update script curls bare `/restart-all`; `_run_main_update` defaults `immediate=True` (explicit `immediate=False` still rides the quiet window); both auto deploy paths now stamp `restart-audit.jsonl` — the self-update script at curl time (the detached script outlives the dying kernel), the converge before its POST — so the cut ledger's `reason` field finally attributes cuts to deploys (every live row was anonymous).
- `bin/romp-manager`: dispatch default is immediate; `--quiet` is the explicit drain spelling; `--now` stays accepted.
- `bin/romp`, `docs/reference.md`: comments + rows updated.
- The cut ledger itself is unchanged — the cost of immediate cuts stays measured, now with named causes.

## Tests

- Flipped pins: `test_deploy_drain.py` (self-update curls bare restart-all, no deploy path defaults quiet), `test_kernel_update.py` (immediate + audit stamp in the success branch only), `test_main_drift_notice.py` (immediate default by signature, quiet stays expressible, converge audits itself).
- New: `manager-restart.test.js` pins the dispatch default + `--quiet` spelling.
- All drain-machinery tests stand unchanged (explicit `?when=quiet` exercises the full path).

## Suites

- pytest: 5945 passed + 313 subtests, 34 skipped
- extension: 2521 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)