### PR TITLE
Conserve and the timer sweep go recurring-only, through one shared predicate

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1046,6 +1046,21 @@ def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> i
     return None
 
 
+def recurring_crons(reg):
+    """The RECURRING entries of a reg's armed-timer set (sessionCrons) — THE shared predicate for
+    "this session needs a live CLI process", read by BOTH conserve_idle (refuses to close on it) and
+    ensure_scheduled (revives on it), so the two sides can never drift (the T148/769 seam, refined
+    2026-08-28 with the 769 author: recurring-only). One-shots are deliberately excluded on both
+    sides: a THREADLESS session's one-shot belongs to a dead process generation — a fresh CLI cannot
+    re-hydrate a lost wakeup (verified live 2026-08-28), so pinning or reviving a process buys the
+    wakeup nothing; deliver_lost_wakeups owns dead-generation one-shots outright and delivers the
+    prompt itself at due, which revives a dormant session through the normal send path. Recurring
+    entries have no such catch-up: their live CLI is the only scheduler, so they pin the process.
+    Reads the entry's `recurring` field, never the cron string's shape — toolhook-minted one-shots
+    carry an empty cron string."""
+    return [c for c in (reg.get("sessionCrons") or []) if isinstance(c, dict) and c.get("recurring")]
+
+
 def wakeup_due_epoch(cron: str, armed_t: float) -> "float | None":
     """The due moment of a ONE-SHOT wakeup cron ("<min> <hour> * * *", the shape ScheduleWakeup mints
     from delaySeconds, local time) — the first occurrence of H:M at/after the arm record. Any other
@@ -4966,11 +4981,15 @@ class SdkBackend:
 
     def conserve_idle(self, sid: str) -> bool:
         """Whether this session is safe to conserve-close: no in-flight turn, nothing queued,
-        no ask parked (T148 — never close work) — and NO ARMED SESSION TIMERS (the T148/769 seam:
-        a timer-armed session's CLI process IS its scheduler, and ensure_scheduled revives any
-        timer-armed session with no thread every producer pass — closing one here would be a
-        close/revive loop, one respawn per sweep, forever. The timer set living in the reg is the
-        same record ensure_scheduled reads, so the two sides can never disagree)."""
+        no ask parked (T148 — never close work) — and no armed RECURRING timers (the T148/769
+        seam: a recurring cron's CLI process is its only scheduler, no catch-up exists, and
+        ensure_scheduled revives any recurring-armed session with no thread every producer pass —
+        closing one here would be a close/revive loop, one respawn per sweep, forever). One-shot
+        wakeups do NOT hold the close (refined 2026-08-28 with the 769 author): the entry's
+        absolute dueEpoch + arming-generation stamp make the close safe — the dead generation
+        hands the wakeup to deliver_lost_wakeups, which delivers the prompt at due and revives
+        the session then. Both this guard and ensure_scheduled read recurring_crons(reg), the
+        same predicate over the same record, so the two sides can never disagree."""
         with self._lock:
             s = self.sessions.get(sid)
         if not s or s.ended:
@@ -4978,7 +4997,7 @@ class SdkBackend:
         if s.inflight or s.pending() or s._cur_ask_fut is not None:
             return False
         reg = read_reg(self.state_dir, sid) or {}
-        if reg.get("sessionCrons"):
+        if recurring_crons(reg):
             return False
         return True
 
@@ -5378,7 +5397,12 @@ class SdkBackend:
         for reg in list_regs(self.state_dir):
             if not reg.get("alive") or reg.get("threadOf"):
                 continue
-            if not reg.get("sessionCrons"):
+            rec = recurring_crons(reg)
+            if not rec:
+                # one-shot-only armed sets do NOT pin a process (refined 2026-08-28): a threadless
+                # session's one-shots are dead-generation — a fresh CLI cannot re-hydrate them, so a
+                # revival here buys nothing and would loop against conserve_close forever (close,
+                # revive, close…). deliver_lost_wakeups owns them and revives at due instead.
                 continue
             sid = reg["sid"]
             with self._lock:
@@ -5399,8 +5423,8 @@ class SdkBackend:
             try:
                 if self._ensure(sid, on_boot_settled=self._spawn_sem.release) is not None:
                     n += 1
-                    self._log("scheduled-session sweep: reviving %s — %d armed timer(s) need a live process"
-                              % (reg.get("name") or sid[:13], len(reg.get("sessionCrons") or [])))
+                    self._log("scheduled-session sweep: reviving %s — %d recurring timer(s) need a live process"
+                              % (reg.get("name") or sid[:13], len(rec)))
                 else:
                     self._spawn_sem.release()       # nothing spawned — the parked release never attaches
             except Exception:

--- a/tests/test_conserve_memory.py
+++ b/tests/test_conserve_memory.py
@@ -73,19 +73,47 @@ class BackendClose(unittest.TestCase):
         reg = sb.read_reg(Path(self.d), SID)
         self.assertTrue(reg.get("alive"), "the reg stays ALIVE — dormant, not killed; _ensure revives on demand")
 
-    def test_never_closes_a_timer_armed_session(self):
-        # the T148/769 seam, executed: ensure_scheduled revives any timer-armed threadless session
-        # every producer pass — if conserve closed one, the pair would loop close/revive forever
-        # (one respawn per sweep, the exact churn the user feared). The reg's sessionCrons is the
-        # SAME record ensure_scheduled reads, so conserve refusing on it can never drift from 769.
+    def test_never_closes_a_recurring_armed_session(self):
+        # the T148/769 seam, refined 2026-08-28 with the 769 author: only RECURRING entries pin the
+        # process — their live CLI is the only scheduler and ensure_scheduled revives any
+        # recurring-armed threadless session every producer pass, so conserve closing one would
+        # loop close/revive forever. Both sides read recurring_crons(reg) over the same record
+        # (the as-merged 769 shape: a LIST of entries carrying the `recurring` boolean), so they
+        # can never drift.
         reg = sb.read_reg(Path(self.d), SID)
-        reg["sessionCrons"] = {"gen": 1, "crons": [{"id": "c1", "schedule": "0 * * * *"}]}
+        reg["sessionCrons"] = [{"id": "c1", "cron": "0 * * * *", "prompt": "tick", "kind": "cron",
+                                "recurring": True, "armedAt": time.time(), "dueEpoch": None,
+                                "procGen": "gen-dead"}]
         sb.write_reg(Path(self.d), SID, reg)
-        self.assertFalse(self.be.conserve_idle(SID), "armed timers pin the process — its CLI is the scheduler")
+        self.assertFalse(self.be.conserve_idle(SID), "a recurring cron pins the process — its CLI is the scheduler")
         self.assertFalse(self.be.conserve_close(SID))
         reg.pop("sessionCrons")
         sb.write_reg(Path(self.d), SID, reg)
         self.assertTrue(self.be.conserve_idle(SID), "…and disarming the timers frees it")
+
+    def test_a_one_shot_only_session_conserves_and_its_wake_delivers_at_due(self):
+        # The other half of the refinement, both directions in one flow: a ONE-SHOT wakeup does not
+        # hold the close — its absolute dueEpoch + dead arming generation hand it to
+        # deliver_lost_wakeups, which delivers the prompt at due through the normal send path (the
+        # revive). Toolhook-minted shape on purpose: empty cron string, so any predicate inferring
+        # from the cron's shape (instead of the `recurring` field) would misread it as recurring.
+        reg = sb.read_reg(Path(self.d), SID)
+        reg["sessionCrons"] = [{"id": "toolhook-1", "cron": "", "prompt": "the wake prompt",
+                                "kind": "loop", "recurring": False, "armedAt": time.time() - 120,
+                                "dueEpoch": time.time() - 30, "procGen": "gen-dead", "src": "toolhook"}]
+        sb.write_reg(Path(self.d), SID, reg)
+        self.assertTrue(self.be.conserve_idle(SID), "a one-shot never pins the process (769 catch-up owns it)")
+        self.assertTrue(self.be.conserve_close(SID))
+        self.assertEqual(self.be.ensure_scheduled(), 0,
+                         "the sweep must not revive a one-shot-only session — that would be the "
+                         "close/revive loop conserve's refusal exists to prevent, moved one door over")
+        sent = []
+        self.be.send = lambda sid, prompt: sent.append((sid, prompt)) or True
+        self.assertEqual(self.be.deliver_lost_wakeups(), 1)
+        self.assertEqual(sent, [(SID, "the wake prompt")],
+                         "the due wake is delivered through the normal send path — the revive")
+        self.assertEqual((sb.read_reg(Path(self.d), SID) or {}).get("sessionCrons"), [],
+                         "the record strips with delivery, so the next pass can never double-fire")
 
     def test_never_closes_work(self):
         self.s.inflight = 1

--- a/tests/test_scheduled_sessions.py
+++ b/tests/test_scheduled_sessions.py
@@ -119,7 +119,9 @@ class StopHookRecordsTheArmedSet(_Backend):
 
 
 class SweepKeepsTimerArmedSessionsAlive(_Backend):
-    CRONS = [{"id": "bbbb2222", "cron": "5 * * * *", "prompt": "p", "kind": "loop", "recurring": False}]
+    CRONS = [{"id": "bbbb2222", "cron": "5 * * * *", "prompt": "p", "kind": "cron", "recurring": True}]
+    SHOT = [{"id": "toolhook-9", "cron": "", "prompt": "wake", "kind": "loop", "recurring": False,
+             "armedAt": 0.0, "dueEpoch": None, "procGen": "gen-dead", "src": "toolhook"}]
 
     def test_a_dormant_timer_armed_session_is_revived(self):
         self._reg(sessionCrons=self.CRONS)
@@ -127,7 +129,19 @@ class SweepKeepsTimerArmedSessionsAlive(_Backend):
         self.be._ensure = lambda sid, on_boot_settled=None: ensured.append(sid) or True
         self.assertEqual(self.be.ensure_scheduled(), 1)
         self.assertEqual(ensured, [SID])
-        self.assertTrue(any("armed timer" in m for m in self.logs), "revivals are logged, never silent")
+        self.assertTrue(any("recurring timer" in m for m in self.logs), "revivals are logged, never silent")
+
+    def test_a_one_shot_only_session_stays_dormant(self):
+        # Refined 2026-08-28 with the 769 author: the sweep reads recurring_crons(reg), the same
+        # predicate conserve_idle refuses on — recurring-only BOTH sides, or conserve closes a
+        # one-shot session and this sweep revives it every 120s until due (the close/revive loop
+        # moved one door over). A threadless session's one-shot is dead-generation by construction:
+        # a fresh CLI cannot re-hydrate it, so a revival buys the wakeup nothing —
+        # deliver_lost_wakeups owns it and revives the session at due through the normal send path.
+        self._reg(sessionCrons=self.SHOT)
+        self.be._ensure = lambda sid, on_boot_settled=None: self.fail(
+            "a one-shot-only armed set must not pin a process")
+        self.assertEqual(self.be.ensure_scheduled(), 0)
 
     def test_sessions_without_timers_stay_lazy(self):
         self._reg()                                     # alive, no sessionCrons


### PR DESCRIPTION
## What

Refines the T148/769 seam per the 769 author's design input: only **recurring** timers pin a live CLI process.

- `conserve_idle` refuses to close only on recurring entries — a recurring cron's live CLI is its only scheduler, and no catch-up exists.
- One-shot wakeups no longer hold the close: the merged 769 records carry an absolute `dueEpoch` and the arming process's generation stamp, so closing the process just dead-ends the generation and `deliver_lost_wakeups` delivers the prompt itself at due, reviving the session through the normal send path (769's catch-up half, late by at most a producer pass).

## Why both readers, not just conserve

`ensure_scheduled`'s scan goes recurring-only too. With conserve alone refined, the sweep would revive every conserve-closed one-shot session on each 120s floor until due — the exact close/revive loop the original seam guard prevented, moved one door over. A revival also buys the wakeup nothing: a threadless session's one-shot is dead-generation by construction, and a fresh CLI cannot re-hydrate a lost wakeup.

Both sides now read one shared predicate, `recurring_crons(reg)`, keyed on the entry's `recurring` field — never inferred from the cron string's shape, since toolhook-minted one-shots carry an empty cron string.

## Tests (pins both ways, on as-merged shapes)

- Recurring-armed session refuses conserve (`test_conserve_memory.py`, now using the merged flat-list record shape — the old test pinned a pre-merge dict shape).
- One-shot (toolhook-shaped) session conserves, the sweep leaves it dormant, and its wake still delivers at due with the record stripped — the deferred revive-direction seam test, landed against the real merged code.
- The sweep fixture that armed a one-shot and expected revival flips to recurring; a new pin holds one-shot-only sessions dormant (`test_scheduled_sessions.py`).

## Suites

- pytest: 5953 passed + 313 subtests, 34 skipped
- extension: 2533 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)