### PR TITLE
T164: every palette grows to 12 in its own idiom, swatch grids balance their rows, and high slots survive any switch

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -657,7 +657,7 @@ EOF
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
-    _romp_cmd "romp color <session> [<#hex|1-9>]" -     "Recolor a session's identity swatch (palette hex or slot 1-9; no color arg reads bg/fg)"
+    _romp_cmd "romp color <session> [<#hex|slot>]" -    "Recolor a session's identity swatch (palette hex or slot number; no color arg reads bg/fg)"
     _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the no-tags view); --host <kernel> edits an attached kernel's tag; --rename renames"
     _romp_cmd "romp watch-pr <n> [--repo o/r]" -        "One mail here when the PR lands or fails — the kernel owns the watch, so it survives restarts (replaces the mortal shell loop)"
     _romp_cmd "romp watch --cmd '<pred>' [...]" -       "One mail when the command exits 0 (or the timeout passes) — kernel-owned like watch-pr, for ANY background wait (--every Ns --timeout Ns --note '...' | --list | --cancel <id>)"
@@ -871,7 +871,7 @@ fi
 # a manager keeps its worker roster as a session group, all one identity color): the kernel's
 # POST /color, the exact sibling of `romp rename` — a names-registry write, so a dormant session
 # recolors by sid. With no color argument it READS: the session's current bg and fg off
-# GET /sessions, tab-separated, for scripts. A slot digit 1-9 resolves HERE against the
+# GET /sessions, tab-separated, for scripts. A slot number resolves HERE against the
 # STATE/palette-colors mirror the kernel rewrites at boot — the same file the launcher assigns
 # from, so "slot 3" is the same hex at recolor time as at launch time; a missing mirror is a loud
 # error, never a silent fall-back to the hardcoded default set the gear may have switched away
@@ -880,7 +880,7 @@ fi
 # stored half-styled.
 if [[ "${1:-}" == "color" ]]; then
     shift
-    _cl_usage="usage: romp color <session> [<#hex|1-9>]"
+    _cl_usage="usage: romp color <session> [<#hex|slot>]"
     if [[ $# -lt 1 || $# -gt 2 || "$1" == -* || ( $# -eq 2 && -z "$2" ) ]]; then echo "$_cl_usage" >&2; exit 2; fi
     _tok="$(_romp_token)"
     _kport="${ROMP_KERNEL_PORT:-29855}"
@@ -908,7 +908,9 @@ for r in rows:
         exit 0
     fi
     _cl_bg="$2"
-    if [[ "$_cl_bg" =~ ^[1-9]$ ]]; then
+    if [[ "$_cl_bg" =~ ^[1-9][0-9]?$ ]]; then    # slots past 9 exist since the palette grew to 12
+        #                                            (T164); the awk read below stays the loud floor
+        #                                            for a slot the active set lacks
         _palfile="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/palette-colors"
         if [[ ! -r "$_palfile" ]]; then
             echo "romp color: no palette mirror at $_palfile — the kernel writes it at boot (is romp running?)" >&2

--- a/kernel/palette.py
+++ b/kernel/palette.py
@@ -50,34 +50,57 @@ PALETTES = {
     },
     "phase": {
         "label": "phase — cmocean",
+        # slots 9-11 (2026-08-28, equalizing every set to 12): three more samples of the cyclic
+        # hue wheel at its own luminance band (0.14-0.30) — a green, a red, and an azure filling
+        # the wheel's widest hue gaps, each keeping the set's all-white text (contrast 3.8-5.0)
+        # and its dichromacy floor (worst simulated pair 44 vs the set's own 46).
         "bg": ["#5883DF", "#0F9A6B", "#DE357B", "#A8780D", "#A05DF4",
-               "#1E93A8", "#CB5A3C", "#689119", "#D02FD0"],
+               "#1E93A8", "#CB5A3C", "#689119", "#D02FD0", "#149614",
+               "#DE1212", "#0D83F2"],
         "fg": ["white", "white", "white", "white", "white",
-               "white", "white", "white", "white"],
+               "white", "white", "white", "white", "white",
+               "white", "white"],
     },
     "hawaiiS": {
         "label": "hawaiiS — crameri",
+        # slots 9-11 (2026-08-28): maximin midpoint interpolations of the published samples (the
+        # source map is smooth, interpolation stays in-gamut) — a slate violet, a gray-olive, and
+        # a muted teal, each clearing the set's own separation bar (adds min 100 vs bar 60) and
+        # improving its dichromacy floor (17 vs the set's pre-existing 11). fg per the 3.0 floor.
         "bg": ["#8C0273", "#9C951C", "#6CD48C", "#974E3E", "#66E8D3",
-               "#8ABC48", "#9B6F28", "#922E55", "#60DEB0"],
+               "#8ABC48", "#9B6F28", "#922E55", "#60DEB0", "#7975A3",
+               "#848066", "#75A7A7"],
         "fg": ["white", "black", "black", "white", "black",
-               "black", "white", "white", "black"],
+               "black", "white", "white", "black", "white",
+               "white", "black"],
     },
     "romaO": {
         "label": "romaO — crameri",
+        # slots 9-11 (2026-08-28): maximin midpoint interpolations, same recipe as hawaiiS — a
+        # warm gray, a pale sage, and an olive-tan in the map's muted-earth register (adds min 82
+        # vs bar 61; dichromacy floor held at 47). fg per the 3.0 floor.
         "bg": ["#4F86B8", "#C3A34B", "#94D0CE", "#874037", "#5C538B",
-               "#A2662C", "#74BBCD", "#733957", "#D1C26E"],
+               "#A2662C", "#74BBCD", "#733957", "#D1C26E", "#8E8882",
+               "#B2C99E", "#A7AB78"],
         "fg": ["white", "black", "black", "white", "white",
-               "white", "black", "white", "black"],
+               "white", "black", "white", "black", "white",
+               "black", "black"],
     },
     # pastel — a soft high-lightness set (all-black text) for anyone who finds the saturated sets
     # loud across many tabs (2026-08-26). Hand-tuned like the romp set, same colorblind-tuned
     # order (blue, green, teal first); every swatch stays under the mid-tone luminance cap.
     "pastel": {
         "label": "pastel — romp soft",
+        # slots 9-11 (2026-08-28): the pastel-register equivalents of the romp set's rose, dusty
+        # mauve, and dark gold — lightened and desaturated into this set's band, tuned so the
+        # gold clears the standing butter yellow and the pair separation survives dichromacy at
+        # or above the set's own floor (28 vs 23). All-black text, the set's rule.
         "bg": ["#8FC7F2", "#9AD48A", "#7ED4C8", "#D9A7EC", "#F2B27C",
-               "#C9CBB0", "#F2A09E", "#EBD584", "#B4AFF2"],
+               "#C9CBB0", "#F2A09E", "#EBD584", "#B4AFF2", "#D897B4",
+               "#BBA3BD", "#C2BE70"],
         "fg": ["black", "black", "black", "black", "black",
-               "black", "black", "black", "black"],
+               "black", "black", "black", "black", "black",
+               "black", "black"],
     },
 }
 

--- a/tests/test_kernel_session_color.py
+++ b/tests/test_kernel_session_color.py
@@ -154,6 +154,83 @@ class SessionColor(unittest.TestCase):
                       "gear open re-reads the server-authoritative choice from /palette")
 
 
+class HighSlotSwitches(SessionColor):
+    """The T164 length-mismatch sweep, executed: sessions ON slots 9/10/11 survive palette switches
+    in both directions. All built-in sets are 12 now (equalized), so the equal-length path maps
+    slot-for-slot; the modulo wrap is exercised against a SYNTHETIC short set so the guard stays
+    proven for future drift (a 13th romp color reopens the gap silently otherwise)."""
+
+    def _seed(self, slot, sid):
+        bg = km.pal.PALETTES["romp"]["bg"][slot]
+        fg = km.pal.PALETTES["romp"]["fg"][slot]
+        (self.names / sid).write_text("s%d\t/proj/TESTHOST/app\t%s\t%s\n" % (slot, bg, fg))
+
+    def test_equal_length_switch_maps_high_slots_straight_across(self):
+        sids = ["%08d-2222-3333-4444-555555555555" % i for i in range(4)]
+        for slot, sid in zip((0, 9, 10, 11), sids):
+            self._seed(slot, sid)
+        self.assertTrue(km._set_palette("phase"))
+        for slot, sid in zip((0, 9, 10, 11), sids):
+            parts = (self.names / sid).read_text().rstrip("\n").split("\t")
+            self.assertEqual(parts[2], km.pal.PALETTES["phase"]["bg"][slot], "slot %d" % slot)
+            self.assertEqual(parts[3], km.pal.PALETTES["phase"]["fg"][slot])
+        self.assertTrue(km._set_palette("romp"))
+        for slot, sid in zip((0, 9, 10, 11), sids):
+            parts = (self.names / sid).read_text().rstrip("\n").split("\t")
+            self.assertEqual(parts[2], km.pal.PALETTES["romp"]["bg"][slot],
+                             "equal-length round trip restores every high slot")
+
+    def test_a_shorter_set_wraps_high_slots_modulo_without_crashing(self):
+        km.pal.PALETTES["tiny"] = {"label": "tiny", "bg": ["#101010", "#202020", "#303030"],
+                                   "fg": ["white", "white", "white"]}
+        try:
+            sids = ["%08d-2222-3333-4444-555555555555" % i for i in range(4)]
+            for slot, sid in zip((0, 9, 10, 11), sids):
+                self._seed(slot, sid)
+            self.assertTrue(km._set_palette("tiny"))
+            got = {}
+            for slot, sid in zip((0, 9, 10, 11), sids):
+                parts = (self.names / sid).read_text().rstrip("\n").split("\t")
+                got[slot] = parts[2]
+            self.assertEqual(got[9], "#101010", "slot 9 wraps to 0 — and COLLIDES with slot 0")
+            self.assertEqual(got[0], "#101010")
+            self.assertEqual(got[10], "#202020")
+            self.assertEqual(got[11], "#303030")
+            # the documented-lossy round trip: wrapped slots come back as their wrap targets
+            self.assertTrue(km._set_palette("romp"))
+            parts9 = (self.names / sids[1]).read_text().rstrip("\n").split("\t")
+            self.assertEqual(parts9[2], km.pal.PALETTES["romp"]["bg"][0],
+                             "a round trip through a shorter set is lossy for high slots, by design")
+        finally:
+            km.pal.PALETTES.pop("tiny", None)
+            km._set_palette("romp")
+
+    def test_the_mirror_writes_every_slot_with_both_fields(self):
+        km._set_palette("romp")
+        lines = (km.jd.STATE / "palette-colors").read_text().splitlines()
+        self.assertEqual(len(lines), len(km.pal.PALETTES["romp"]["bg"]),
+                         "the launcher mirror carries EVERY slot — zip truncation would drop tails")
+        for ln in lines:
+            self.assertEqual(len(ln.split("\t")), 2)
+
+    def test_identity_picks_pair_bg_and_fg_past_slot_nine(self):
+        # the SDK picker: find a sid hashing into 9..11 and assert the paired read holds
+        import zlib
+        bgs, fgs = km.pal.colors("romp"), km.pal.fgs("romp")
+        sid = next("%08x-2222-3333-4444-555555555555" % i
+                   for i in range(4096)
+                   if zlib.crc32(("%08x-2222-3333-4444-555555555555" % i).encode()) % len(bgs) >= 9)
+        import importlib
+        sdk = km.sdk_backend if hasattr(km, "sdk_backend") else None
+        if sdk is None:
+            from importlib.machinery import SourceFileLoader as _L
+            sdk = _L("romp_sdk_pal", os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+        bg, fg = sdk.pick_identity_color(sid)
+        i = zlib.crc32(sid.encode()) % len(bgs)
+        self.assertGreaterEqual(i, 9)
+        self.assertEqual((bg, fg), (bgs[i], fgs[i]), "the paired index holds past the old nine")
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -57,7 +57,8 @@ class PaletteShapes(unittest.TestCase):
         # the 2026-08-26 addition: a high-lightness identity set for anyone who finds the saturated
         # palettes loud across many tabs — soft by construction, so every fg must be black
         self.assertIn("pastel", pal.PALETTES)
-        self.assertEqual(pal.PALETTES["pastel"]["fg"], ["black"] * 9)
+        self.assertEqual(pal.PALETTES["pastel"]["fg"],
+                         ["black"] * len(pal.PALETTES["pastel"]["bg"]))
 
     def test_crameri_and_cmocean_sets_are_curated_mid_tone(self):
         # The raw Crameri "S" orderings include near-black (#011959) and near-white entries — built for

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3186,7 +3186,12 @@ class TimelinePanel {
           }
           // the color — the identity-palette swatches inline in the row's last column
           const colCell = tgrid.createDiv();
-          colCell.setAttribute('style', 'display:flex;gap:6px;align-items:center;flex-wrap:wrap;');
+          // balanced swatch rows: ceil-split (T164) — width-driven flex wrap gave arbitrary 5/5/2
+          // runs; inline styles are this file's convention (it also runs inside Obsidian)
+          const swN = (this._palette && this._palette.length) || 1;
+          const swCols = Math.ceil(swN / Math.ceil(swN / 6));
+          colCell.setAttribute('style', 'display:grid;grid-template-columns:repeat(' + swCols
+            + ',14px);gap:6px;align-items:center;');
           if (editable) {
             for (const c of (this._palette && this._palette.length ? this._palette : [tc])) {
               const sw = colCell.createSpan();

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4822,6 +4822,11 @@ function showTabMenu(e: MouseEvent, id: string) {
     const sNow = sessions.get(id);
     const cur = (sNow && sNow.color ? sNow.color.bg : "").toLowerCase();
     const row = el("div", "ctx-colors");
+    // balanced swatch rows (the user 2026-08-28, T164): for n swatches, the fewest rows that keep
+    // each row within the menu-friendly cap, split ceil-evenly — 12 reads 6+6, 9 reads 5+4, a
+    // future 13 reads 7+6; the CSS keeps repeat(5) as the no-JS fallback
+    const swRows = Math.ceil(paletteColors.length / 6);
+    row.style.gridTemplateColumns = "repeat(" + Math.ceil(paletteColors.length / swRows) + ", 18px)";
     for (const bg of paletteColors) {
       const sw = el("button", "ctx-swatch" + (bg.toLowerCase() === cur ? " sel" : ""));
       sw.style.background = bg;

--- a/ui/webview/tab-color-picker.test.ts
+++ b/ui/webview/tab-color-picker.test.ts
@@ -41,3 +41,14 @@ test("setSessionColor optimistically repaints and posts setSessionColor to the k
   // then tell the kernel (it persists + re-broadcasts)
   assert.match(RENDER, /postMessage\(\{ type: "setSessionColor", id, bg \}\)/);
 });
+
+test("swatch grids balance their rows: ceil-split over a six-per-row cap (T164)", () => {
+  // 12 -> 6+6, 9 -> 5+4, 13 -> 7+6 — computed per render, CSS repeat(5) stays the no-JS fallback
+  assert.match(RENDER, /const swRows = Math\.ceil\(paletteColors\.length \/ 6\)/);
+  assert.match(RENDER, /repeat\(" \+ Math\.ceil\(paletteColors\.length \/ swRows\) \+ ", 18px\)"/);
+  const TIMELINE = fs.readFileSync(
+    path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+  assert.match(TIMELINE, /Math\.ceil\(swN \/ Math\.ceil\(swN \/ 6\)\)/);
+  assert.match(TIMELINE, /grid-template-columns:repeat\(' \+ swCols/);
+});
+


### PR DESCRIPTION
**The four trios** (the user's better-yet amendment): every choosable set now matches the romp set's 12, extended in its own idiom — phase samples its cyclic hue wheel's three widest gaps at its own luminance band (all-white text held, dichromacy floor 44 vs its pre-existing 46); hawaiiS/romaO get maximin midpoint interpolations of their published samples (in-gamut by smoothness), each trio clearing its set's separation bar and holding/improving its dichromacy floor; pastel gets the pastel-register equivalents of the romp rose/mauve/gold, tuned to clear the standing butter yellow. fg per entry computed against the pinned 3.0 floor.

**Balanced swatch rows**: the tab menu's hardcoded five-per-row grid (12 wrapped 5/5/2) now computes its column count per render — ceil-split over a six cap: 12→6+6, 9→5+4, 13→7+6; CSS keeps repeat(5) as no-JS fallback. The timeline's Sessions & tags color column gets the same formula (inline, its Obsidian convention). The gear picker's non-clickable preview strips fit one line — left alone deliberately.

**The mismatch sweep, executed** and kept as drift guards: high-slot sessions switch straight across between equal-length sets; a synthetic short set engages the modulo wrap (collision + lossy round trip pinned); the launcher mirror writes every slot both-fielded; the SDK picker's paired index holds past nine (executed via a high-hashing sid); `romp color` slots 10-12 became addressable (^[1-9]$ predated double digits). Consumer verdicts: remap already guarded, pickers length-safe, UI find()-based — the per-set len(fg)==len(bg) invariant stays the load-bearing pin.

Suites: Python 5968/0 (+313 subtests), UI 2534/2534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)