### PR TITLE
The drag slot stops flapping: hit-testing moves to a virtual layout the insert cannot shift

### DIFF
--- a/ui/webview/dragslot.test.ts
+++ b/ui/webview/dragslot.test.ts
@@ -1,0 +1,45 @@
+// Executable geometry for the drag-flap fix (2026-08-28): the slot the provisional tab lands in
+// is computed against a VIRTUAL wrap layout of the non-dragged tabs — boundaries that cannot move
+// in response to the insert they cause, so monotone pointer motion gives monotone slots and the
+// oscillation in the user's recording is impossible by construction.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { dragSlotIndex, type SlotBox } from "./dragslot";
+
+const boxes = (...w: number[]): SlotBox[] => w.map((x, i) => ({ id: "t" + i, w: x }));
+
+test("a smooth leftward sweep crosses each boundary once — slots are monotone, never oscillating", () => {
+  // variable widths on a wrapping strip: 3 rows at 300px
+  const b = boxes(120, 90, 140, 60, 110, 100, 80);
+  let prev = Infinity;
+  for (let x = 299; x >= 0; x -= 3) {
+    const idx = dragSlotIndex(b, 300, 0, 30, x, 45);   // sweeping row 2 (y=45, rowH=30)
+    assert.ok(idx <= prev, `monotone under monotone motion (x=${x}: ${idx} > ${prev})`);
+    prev = idx;
+  }
+});
+
+test("rows resolve by y band; within a row the midpoints decide", () => {
+  const b = boxes(100, 100, 100, 100);   // 2 per 250px row
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 40, 10), 0, "row 1, left of t0's midpoint");
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 60, 10), 1, "row 1, past t0's midpoint");
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 40, 40), 2, "row 2 by y band");
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 160, 40), 4, "past row 2's last midpoint → the end");
+});
+
+test("past a row's tabs lands at the next row's head; beyond every row lands at the end", () => {
+  const b = boxes(200, 200, 200);        // one per 250px row
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 240, 5), 1, "right of row 1's tab → row 2's head");
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 99, 900), 2, "y clamps to the last row");
+  assert.equal(dragSlotIndex(b, 250, 0, 30, 240, 900), 3, "…and past its midline is the very end");
+});
+
+test("the gap participates in the layout (the Yatharth strip's 3px seam)", () => {
+  const b = boxes(120, 120);             // 120+3+120 = 243 > 240 → wraps
+  assert.equal(dragSlotIndex(b, 240, 3, 30, 10, 40), 1, "the second tab wrapped to row 2");
+});
+
+test("degenerate inputs stay sane", () => {
+  assert.equal(dragSlotIndex([], 300, 0, 30, 50, 50), 0);
+  assert.equal(dragSlotIndex(boxes(400), 300, 0, 30, 10, -20), 0, "negative y clamps to row 0");
+});

--- a/ui/webview/dragslot.ts
+++ b/ui/webview/dragslot.ts
@@ -1,0 +1,33 @@
+// Pure slot geometry for the tab strip's live drag reorder (the drag-flap fix, 2026-08-28; the
+// T127 surface). The first implementation hit-tested the LIVE layout — but inserting the
+// variable-width provisional tab re-wraps the row, the tab under the cursor changes identity, the
+// next hit-test lands on the other side, and the slot oscillates between distant positions while
+// the cursor moves smoothly (the user's recording, frames f024–f035). The fix: the pointer is
+// hit-tested against a VIRTUAL layout of the NON-dragged tabs only — widths captured once at
+// dragstart, the strip's flex-wrap simulated deterministically — so the boundaries cannot move in
+// response to the insert they cause. Monotone pointer motion crosses each boundary once by
+// construction; no debounce, no heuristics.
+
+export interface SlotBox { id: string; w: number; }
+
+/** Simulate the strip's wrap layout (row fill left-to-right up to `containerW`, `gapX` between
+ *  tabs, uniform `rowH`) over the non-dragged boxes, and return the insertion index for pointer
+ *  (x, y) in the container's content space: 0..boxes.length, where boxes.length = the end. */
+export function dragSlotIndex(boxes: readonly SlotBox[], containerW: number, gapX: number,
+                              rowH: number, x: number, y: number): number {
+  if (!boxes.length) return 0;
+  // lay the boxes into rows exactly as flex-wrap would
+  const rows: { start: number; mids: number[] }[] = [];
+  let cx = 0, row: { start: number; mids: number[] } | null = null;
+  boxes.forEach((b, i) => {
+    const needsWrap = row !== null && cx + b.w > containerW && cx > 0;
+    if (row === null || needsWrap) { row = { start: i, mids: [] }; rows.push(row); cx = 0; }
+    row.mids.push(cx + b.w / 2);
+    cx += b.w + gapX;
+  });
+  const ri = Math.max(0, Math.min(rows.length - 1, Math.floor(y / Math.max(1, rowH))));
+  const r = rows[ri];
+  const within = r.mids.findIndex((m) => x < m);
+  if (within >= 0) return r.start + within;
+  return ri + 1 < rows.length ? rows[ri + 1].start : boxes.length;   // past the row's last tab → the next row's head, or the very end
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -48,6 +48,7 @@ import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
 import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { dragSlotIndex } from "./dragslot";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -4119,6 +4120,22 @@ function auditTabOrder(ids: string[]) {
 }
 let draggedId: string | null = null;
 let tabDragCommitted = false;   // set by the strip's drop handler; dragend without it = a cancel (Escape / dropped outside)
+// The drag hit-test's stable inputs (the drag-flap fix, 2026-08-28): every tab's outer width and
+// the strip's geometry, measured ONCE at dragstart. The pointer is then hit-tested against a
+// VIRTUAL wrap layout of the non-dragged tabs (dragslot.ts) — the live rects shift when the
+// provisional tab inserts (wrap cascade included), which is exactly the feedback loop that made
+// the slot oscillate between distant positions in the user's recording.
+let dragGeom: { widths: Map<string, number>; containerW: number; gapX: number; rowH: number } | null = null;
+function snapshotDragGeometry(sample: HTMLElement): void {
+  const bar = document.getElementById("tabs");
+  if (!bar) { dragGeom = null; return; }
+  const widths = new Map<string, number>();
+  bar.querySelectorAll<HTMLElement>(".tab[data-id]").forEach((t) => { if (t.dataset.id) widths.set(t.dataset.id, t.getBoundingClientRect().width); });
+  const cs = getComputedStyle(bar);
+  dragGeom = { widths, containerW: bar.clientWidth,
+               gapX: parseFloat(cs.columnGap || "0") || 0,
+               rowH: sample.getBoundingClientRect().height || 1 };
+}
 let dragBlankEl: HTMLElement | null = null;
 function dragImageBlank(): HTMLElement {
   if (!dragBlankEl || !dragBlankEl.isConnected) {
@@ -4178,6 +4195,7 @@ function reorderTo(dragId: string, targetId: string, after: boolean) {
 let tabTipEl: HTMLElement | null = null;
 function hideTabTip(): void { if (tabTipEl) tabTipEl.style.display = "none"; }
 function showTabTip(tab: HTMLElement, s: Session): void {
+  if (draggedId) return;   // a drag owns the strip — the info popover pinned open through the whole gesture, occluding the row below (the user's recording, 2026-08-28)
   if (!tabTipEl) { tabTipEl = el("div", "tab-tip"); document.body.appendChild(tabTipEl); }
   const tip = tabTipEl;
   tip.replaceChildren();
@@ -4478,6 +4496,8 @@ function renderTabs() {
       draggedId = id; tabDragCommitted = false;
       if (e.dataTransfer) { e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setDragImage(dragImageBlank(), 0, 0); }
       tab.classList.add("dragging");
+      hideTabTip();                        // defect 2 (2026-08-28): the hover popover pinned open through the gesture
+      snapshotDragGeometry(tab);           // widths once at dragstart — the virtual hit-test's stable input (dragslot.ts)
     });
     // dragend closes EVERY drag (drop, Escape, released outside). The pointerdown that started the
     // drag latched tabPointerHeld, and the drag swallowed the matching pointerup — so the hold is
@@ -12999,15 +13019,26 @@ setupSettings();
   // (flipTabs). The no-op guard (already sitting immediately before the reference node) is what
   // keeps a pointer resting inside one slot from churning the DOM on every dragover tick.
   tabs.addEventListener("dragover", (e) => {
-    if (!draggedId) return;
+    if (!draggedId || !dragGeom) return;
     e.preventDefault();   // the whole strip is a valid drop target
     if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
-    const over = (e.target as HTMLElement).closest?.(".tab[data-id]") as HTMLElement | null;
     const dragged = tabs.querySelector<HTMLElement>(`.tab[data-id="${CSS.escape(draggedId)}"]`);
-    if (!over || !dragged || over === dragged) return;
-    const r = over.getBoundingClientRect();
-    const ref = e.clientX > r.left + r.width / 2 ? over.nextElementSibling : over;
-    if (ref !== dragged && dragged.nextElementSibling !== ref) flipTabs(() => tabs.insertBefore(dragged, ref));
+    if (!dragged) return;
+    // native feel: a pointer still inside the dragged tab's own box moves nothing (without this,
+    // the virtual mapping — which removes the dragged tab — can read the untouched start position
+    // as one slot over and hop the tab before the user has left it)
+    const dr = dragged.getBoundingClientRect();
+    if (e.clientX >= dr.left && e.clientX <= dr.right && e.clientY >= dr.top && e.clientY <= dr.bottom) return;
+    // the virtual layout: the OTHER tabs in current DOM order, widths from the dragstart snapshot —
+    // boundaries that cannot move in response to the insert they cause (dragslot.ts owns the math)
+    const others = Array.from(tabs.querySelectorAll<HTMLElement>(".tab[data-id]")).filter((t) => t !== dragged);
+    const boxes = others.map((t) => ({ id: t.dataset.id!, w: dragGeom!.widths.get(t.dataset.id!) ?? t.getBoundingClientRect().width }));
+    const br = tabs.getBoundingClientRect();
+    const idx = dragSlotIndex(boxes, dragGeom.containerW, dragGeom.gapX, dragGeom.rowH,
+                              e.clientX - br.left, e.clientY - br.top);
+    const ref = idx < others.length ? others[idx] : dragged.parentElement === tabs ? tabs.querySelector(".tab-add") : null;
+    if (ref !== dragged && dragged.nextElementSibling !== ref)
+      flipTabs(() => tabs.insertBefore(dragged, ref));
   });
   // Drop commits the LIVE DOM position through the same reorderTo the strip has always used —
   // neighbor id + side — so persistence and the kernel write are byte-identical, and ids that a

--- a/ui/webview/tab-drag-live.test.ts
+++ b/ui/webview/tab-drag-live.test.ts
@@ -33,21 +33,35 @@ test("exactly ONE thing on screen looks like the dragged tab (T133)", () => {
     "a rendered but invisible node — Chromium snapshots the drag image at dragstart, so it must be in the DOM");
 });
 
-test("slot boundary is the event: midpoint compare moves the dragged element in DOM order", () => {
+test("the slot comes from the VIRTUAL layout — boundaries that cannot move under the insert", () => {
+  // the drag-flap fix (2026-08-28, the user's recording): hit-testing the LIVE rects fed back —
+  // the insert re-wrapped the row and the next hit-test landed on the other side. The pointer is
+  // now tested against dragslot.ts's simulated wrap of the NON-dragged tabs, widths snapshotted
+  // once at dragstart.
   const body = between('tabs.addEventListener("dragover"', "});");
-  assert.match(body, /const ref = e\.clientX > r\.left \+ r\.width \/ 2 \? over\.nextElementSibling : over;/,
-    "crossing the midpoint of the tab under the pointer decides the slot — an event, not a timer");
-  assert.match(body, /if \(ref !== dragged && dragged\.nextElementSibling !== ref\) flipTabs\(\(\) => tabs\.insertBefore\(dragged, ref\)\);/,
+  assert.match(body, /const others = Array\.from\(tabs\.querySelectorAll<HTMLElement>\("\.tab\[data-id\]"\)\)\.filter\(\(t\) => t !== dragged\);/,
+    "the dragged tab never participates in its own hit geometry");
+  assert.match(body, /dragSlotIndex\(boxes, dragGeom\.containerW, dragGeom\.gapX, dragGeom\.rowH,/);
+  assert.match(body, /if \(ref !== dragged && dragged\.nextElementSibling !== ref\)/,
     "already-in-place is a no-op, so a pointer resting in one slot never churns the DOM");
   assert.doesNotMatch(body, /setTimeout|debounce|Date\.now/, "no time-based logic in the reorder decision");
+  // the stable inputs are captured once, at the gesture's own start — an event, not a poll
+  assert.match(RENDER, /snapshotDragGeometry\(tab\);/);
+  assert.match(RENDER, /widths\.set\(t\.dataset\.id, t\.getBoundingClientRect\(\)\.width\)/);
 });
 
-test("cross-row reflow is the wrap layout's own: DOM insertion, no per-row special case", () => {
-  // the strip wraps (flex-wrap) — moving the element IS the cross-row mechanism, so there must be
-  // no row math in the drag path
+test("the DOM insertion still does the cross-row move; the simulation only decides WHERE", () => {
   assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; \}/);
   const body = between('tabs.addEventListener("dragover"', "});");
-  assert.doesNotMatch(body, /row|clientY/i, "no row bookkeeping — insertion order + wrap does it");
+  assert.match(body, /flipTabs\(\(\) => tabs\.insertBefore\(dragged, ref\)\);/,
+    "one insert per boundary crossing — the wrap layout itself performs the visual reflow");
+});
+
+test("the hover popover never survives a drag (defect 2, the user's recording)", () => {
+  const ds = between('tab.addEventListener("dragstart"', "});");
+  assert.match(ds, /hideTabTip\(\);/, "dismissed at dragstart");
+  const stt = between("function showTabTip(", "\n}");
+  assert.match(stt, /if \(draggedId\) return;/, "…and suppressed for the whole gesture");
 });
 
 test("drop commits through the SAME reorderTo — neighbor + side, hidden-view ids keep their places", () => {


### PR DESCRIPTION
The user (recording): the provisional tab lagged the cursor and teleported between two distant positions; the session-info hover popover pinned open through the whole gesture.

## Defect 1 — the flap (feedback loop, wrap-cascade form)
The T127 hit-test compared the pointer against **live rects** — but inserting the variable-width provisional tab re-wraps the row, the tab under the cursor changes identity, the next dragover decides against the shifted layout and re-inserts: an oscillator. Fix: the pointer is hit-tested against a **virtual wrap layout of the non-dragged tabs** (`dragslot.ts`, pure — widths captured once at dragstart, flex-wrap simulated deterministically), so **the boundaries cannot move in response to the insert they cause**. The dragged tab stays the in-flow single visual (T133) but never participates in its own hit geometry; the DOM insert + FLIP still do the visual reflow. Native-feel guard: a pointer inside the dragged tab's own box moves nothing. Event-based, no debounce.

## Defect 2 — the pinned popover
`hideTabTip()` at dragstart; `showTabTip` refuses while `draggedId` is set.

## Evidence (headless, both bundles, element-under-point targets)
| probe | before | after |
|---|---|---|
| pointer PARKED at a boundary (12 dragovers) | slot **bounces 3→4→3** | **holds one slot** |
| smooth leftward sweep | monotone | monotone |
| tooltip during drag | **pinned open** | dismissed |

## Tests
`dragslot.test.ts` (executable): monotone slots under monotone motion, row bands, wrap boundaries incl. the Yatharth seam, landings, degenerates. `tab-drag-live.test.ts` retargeted to the virtual hit-test + tooltip pins. Suite 2540/2540, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)