### PR TITLE
Dead sessions settle their cards, and relayed delegations finally link

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -11537,7 +11537,7 @@ _postal_from_memo = {"key": None, "map": {}}   # messages.jsonl (mtime,size) -> 
 
 
 def _postal_row(mid):
-    """(from_name, from_host, tracked, body, userAsk) for a delivered postal message id, from the
+    """(from_name, from_host, tracked, body, userAsk, originMid) for a delivered postal message id, from the
     "sent" row — the AUTHORITATIVE record of who sent it and how (the row schema is the postal
     consumer contract). The sender may be a session of ANOTHER kernel (federated mail), so the local
     names registry cannot resolve it; the log row carries the name the sender wore, the origin host
@@ -11547,14 +11547,16 @@ def _postal_row(mid):
     2026-08-27 (T126) the origin kernel's WALKED root-ask record ({text, sid, host} or None): the
     sending kernel ran its local chain walk at relay time and the bus carried the proof, so a
     cross-host delegate reads user-anchored though the local walk rightly refuses foreign hops.
-    ("", "", False, "", None) for None/unknown mids. Memoized on the log file's (mtime, size)."""
+    originMid (2026-08-28, the dead-session round) is the SENDER-side id deliver() stamps on a
+    relayed row — the durable join key when the two sides mint different mids for one message.
+    ("", "", False, "", None, "") for None/unknown mids. Memoized on the log file's (mtime, size)."""
     if not mid:
-        return ("", "", False, "", None)
+        return ("", "", False, "", None, "")
     try:
         st = os.stat(MESSAGES)
         key = (st.st_mtime, st.st_size)
     except OSError:
-        return ("", "", False, "", None)
+        return ("", "", False, "", None, "")
     if _postal_from_memo["key"] != key:
         mp = {}
         try:
@@ -11567,11 +11569,12 @@ def _postal_row(mid):
                     ua = r.get("userAsk")
                     mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "", bool(r.get("tracked")),
                                    str(r.get("body") or ""),
-                                   ua if isinstance(ua, dict) and str(ua.get("text") or "").strip() else None)
+                                   ua if isinstance(ua, dict) and str(ua.get("text") or "").strip() else None,
+                                   str(r.get("originMid") or ""))
         except OSError:
-            return ("", "", False, "", None)
+            return ("", "", False, "", None, "")
         _postal_from_memo["key"], _postal_from_memo["map"] = key, mp
-    return _postal_from_memo["map"].get(mid, ("", "", False, "", None))
+    return _postal_from_memo["map"].get(mid, ("", "", False, "", None, ""))
 
 
 def _frame_head(s):
@@ -11743,6 +11746,14 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
     nid = "%s:g%d" % (store["rompUuid"], store["seq"])
     label = "↪ delegated to %s: %s" % (peer_name or peer_sid[:8], _strip_title_ticket(text) or "(work)")
     handoff = {"peer": peer_sid, "msgId": mid}
+    for _xnid, _xnd in nodes.items():
+        _xh = _xnd.get("handoff") if isinstance(_xnd, dict) else None
+        if (isinstance(_xh, dict) and _xh.get("peer") == peer_sid and not _xnd.get("nodeComplete")
+                and not _xnd.get("cleared") and _xnd.get("text") == label[:120]
+                and _xnd.get("parentId") == parent_id):
+            return _xnid                               # byte-identical OPEN twin (2026-08-28: an ext
+            #                                            mailer double-minted the same delegation in one
+            #                                            minute under two mids) — reuse, never duplicate
     if tracked:
         handoff["tracked"] = True
     nodes[nid] = GuardedNode({"id": nid, "text": label[:120], "parentId": parent_id,
@@ -11896,6 +11907,40 @@ def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
     return None
 
 
+def _presumed_closed(sid, now):
+    """Deadness for a session no live parse can answer for (the user 2026-08-28, the dead-session
+    round: complete tops on dead sids read working forever because the settle gate derived
+    closed=False from mere registry absence). The ladder, most-evidence-first:
+      1. discovered in the recency window → the parse decides (_session_closed), exactly as before;
+      2. absent from the window but the transcript exists → windowless lookup + parse — a dead
+         LOCAL session's own record says it closed;
+      3. an ext: pseudo-sid → closed by construction (a one-shot mailer, no session behind it);
+      4. a sid the postal bus reports LIVE ON ANOTHER HOST (STATE/remote-sids, the federated
+         presence mirror) → NOT closed — a live remote session's local mirror store must never be
+         presumed settled (the premature-settle flicker the gate exists to prevent);
+      5. nothing anywhere knows it AND the bus has spoken (the mirror file exists) → a dead
+         determination, True; no mirror file at all → conservative False (cannot determine)."""
+    for f, p, _a, _n in discover(now):
+        if f == sid:
+            try:
+                return _session_closed(parsed_session(sid, [str(p)], now))
+            except Exception:
+                return False
+    for f, p, _a, _n in discover(now, window=now):
+        if f == sid:
+            try:
+                return _session_closed(parsed_session(sid, [str(p)], now))
+            except Exception:
+                return False
+    if str(sid).startswith("ext:"):
+        return True
+    try:
+        remote = set((STATE / "remote-sids").read_text().split())
+    except OSError:
+        return False                                   # the bus has not spoken → cannot determine
+    return sid not in remote
+
+
 def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
     """DETERMINISTIC delegation completion link-back (the user 2026-06-22). When a courier-planted goal G
     (origin.peer + origin.goalId) is COMPLETE on the recipient B's tree, mark the SENDER's tracking node
@@ -11941,7 +11986,11 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                     why += ": " + sub[:220]
                 record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now, why=why)
                 _mark_node_done(a_store, a_gid, why, now, src="courier")
-                rollup_status(a_store, False)           # sender just had work close → recompute its columns
+                rollup_status(a_store, _presumed_closed(a_sid, now))   # sender just had work close →
+                #                                        recompute its columns, SETTLING them when the
+                #                                        sender is determined dead (2026-08-28: a live
+                #                                        sender's own pass settles as before; a dead one
+                #                                        has no pass, so this write is its only settler)
                 save_goals(a_sid, a_store)
                 n += 1
     # REMOTE recipients (the user 2026-08-24): their goal stores live on another kernel, so the
@@ -11970,11 +12019,32 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
             o = rd.get("origin")
             refs = ([o] if isinstance(o, dict) else []) + [l for l in (rd.get("links") or [])
                                                            if isinstance(l, dict)]
-            if any(r.get("msgId") == mid for r in refs):
+            if any(mid in (r.get("msgId"), r.get("originMid")) for r in refs):
                 return rd
         return None
 
-    for fsid, path, anchor, name in discover(now)[:sessions_cap]:
+    # SENDER COVERAGE (the user 2026-08-28, the dead-session round): this arm used to walk only
+    # DISCOVERED sessions as senders, so a dead session's — or an ext: mailer's, or a remote
+    # kernel's local mirror store's — quiet trackers were never swept again and sat Working
+    # forever (the audited board: 18 of 23 stale cards, all on exactly these sids). The recipient's
+    # reply is the event and this sweep is its only writer for such stores, so absent stores that
+    # still hold open trackers join the walk (the T110 straggler-drain shape; self-retiring — a
+    # closed tracker leaves the predicate).
+    _sw_fleet = discover(now)[:sessions_cap]
+    _sw_seen = {f for f, _p, _a, _n in _sw_fleet}
+    _sw_senders = [f for f, _p, _a, _n in _sw_fleet]
+    for _f in sorted(GOALDIR.glob("*.json")):
+        if _f.stem in _sw_seen:
+            continue
+        try:
+            _st0 = load_goals(_f.stem)
+        except Exception:
+            continue
+        if any(isinstance(v, dict) and isinstance(v.get("handoff"), dict)
+               and not v.get("nodeComplete") and not v.get("cleared")
+               for v in (_st0.get("nodes") or {}).values()):
+            _sw_senders.append(_f.stem)
+    for fsid in _sw_senders:
         store = load_goals(fsid)
         changed = False
         for nid, nd in list(store.get("nodes", {}).items()):
@@ -12018,7 +12088,7 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                     changed = True
                     n += 1
         if changed:
-            rollup_status(store, False)
+            rollup_status(store, fsid not in _sw_seen and _presumed_closed(fsid, now))
             save_goals(fsid, store)
     if verbose:
         sys.stderr.write("romp-judge: propagated %d delegation completions\n" % n)
@@ -12287,6 +12357,12 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # time: a cross-host sender's sid resolves to nothing in this kernel's names registry, and
             # without the snapshot the "from" chip degrades to a bare sid prefix (the user 2026-07-26).
             origin = {"peer": sender, "goalId": track_id, "msgId": mid}
+            _om = _postal_row(mid)[5]
+            if _om and _om != mid:
+                origin["originMid"] = _om              # the SENDER-side id for relayed mail (2026-08-28):
+                #                                        local delivery mints its own mid, so without this
+                #                                        the sender's tracker and the recipient's origin
+                #                                        held different ids and the link never formed
             if trk:
                 origin["tracked"] = True               # the satellite mark — the feed collapses on it
             frm_name, frm_host = _postal_from(mid)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18852,10 +18852,10 @@ def _delegation_linked_ids(item_ids):
             seen.add(x)
             stack.extend(kids.get(x, []))
             h = nodes[x].get("handoff")
-            if isinstance(h, dict) and h.get("peer") and h.get("msgId"):     # sender → recipient (match msgId)
-                for pnid, pnd in _nodes(h["peer"]).items():
-                    o = pnd.get("origin")
-                    if isinstance(o, dict) and o.get("msgId") == h["msgId"]:
+            if isinstance(h, dict) and h.get("peer") and h.get("msgId"):     # sender → recipient (match msgId,
+                for pnid, pnd in _nodes(h["peer"]).items():                  # or the relayed row's originMid —
+                    o = pnd.get("origin")                                    # the two sides mint different ids
+                    if isinstance(o, dict) and h["msgId"] in (o.get("msgId"), o.get("originMid")):
                         out.add(pnid)
             o = nodes[x].get("origin")
             if isinstance(o, dict) and o.get("peer") and o.get("goalId") in _nodes(o.get("peer")):
@@ -19082,7 +19082,13 @@ def _resolve_node(sid, node_id):
     nd["mt"] = now                                    # deep-link / recency land on the resolution moment
     try:                                              # session_closed gate for the rollup, same as run_plan
         path = next((s["path"] for s in _sessions(now) if s["sid"] == sid), None)
-        closed = jd._session_closed(_parse(path, sid, now)) if path else False
+        closed = (jd._session_closed(_parse(path, sid, now)) if path
+                  else jd._presumed_closed(sid, now))   # absent from the live registry is not an open
+        #                                                 turn: a dead local session's transcript, an
+        #                                                 ext: mailer, or a bus-confirmed-gone sid reads
+        #                                                 CLOSED so post-mortem completions settle; a
+        #                                                 live REMOTE session's mirror store never does
+        #                                                 (2026-08-28, the dead-session round)
     except Exception:
         closed = False
     jd.rollup_status(store, closed)

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -341,6 +341,13 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         #                                              no header, no prose (the recipient reads nothing)
     if from_host:
         ev["from_host"] = from_host                  # additive (consumer contract above)
+    if relay_mid:
+        ev["originMid"] = relay_mid                  # the SENDER-side id for relayed mail (2026-08-28,
+        #                                              the dead-session round): local delivery mints its
+        #                                              own maildir mid, so sender and recipient held
+        #                                              DIFFERENT ids for one message and the delegation
+        #                                              mirror join never formed — this is the durable
+        #                                              join key the courier stamps into origin
     if isinstance(user_ask, dict) and str(user_ask.get("text") or "").strip():
         # the origin kernel's walked root-ask record (T126) — whitelisted copy, additive: the
         # receiving courier reads it off this row (_postal_row) as walk-proved provenance
@@ -679,6 +686,7 @@ def _record_heartbeat(sid, name):
     reaching us over an -R tunnel, is NOT in the local kernel — heartbeats are its only presence signal."""
     if sid and _safe_id(sid) and sid not in {a["id"] for a in local_agents()}:
         HEARTBEATS[sid] = (name or "?", time.time())
+    _write_remote_sids()                           # presence changed → refresh the deadness mirror
 
 def present_count():
     return len(all_agents())
@@ -1767,6 +1775,27 @@ def my_tier_of(host):
     return row.get("trust") or "directed"
 
 
+def _write_remote_sids():
+    """STATE/remote-sids — every session id this box knows to be LIVE on another host (federated
+    presence gossip + legacy heartbeats), one per line, atomically. A best-effort mirror for the
+    kernel/judge DEADNESS rule (2026-08-28, the dead-session round): a sid absent from the local
+    registry but present here is a live REMOTE session whose local mirror store must never be
+    presumed closed. The FILE's existence means the bus has spoken; readers treat a missing file
+    as "cannot determine" and stay conservative."""
+    try:
+        now = time.time()
+        ids = {sid for sid, (_nm, ts) in HEARTBEATS.items() if now - ts < HEARTBEAT_TTL}
+        for st in PEER_STATE.values():
+            for pa in st.get("presence") or []:
+                if pa.get("id"):
+                    ids.add(str(pa["id"]))
+        tmp = STATE / "remote-sids.tmp"
+        tmp.write_text("\n".join(sorted(ids)) + ("\n" if ids else ""))
+        os.replace(tmp, STATE / "remote-sids")
+    except Exception:
+        pass
+
+
 def peers_snapshot():
     peers = {}
     for h, p in PEERS.items():
@@ -2317,6 +2346,7 @@ def peer_exchange_handle(data):
                          "hostname (or set ROMP_POSTAL_HOST) and redial" % host}, 400
     PEER_STATE[host] = {"presence": data.get("presence") or [], "epoch": data.get("epoch"),
                         "holds": data.get("holds") or [], "seenAt": int(time.time())}
+    _write_remote_sids()                           # presence changed → refresh the deadness mirror
     if bus_id:
         PEER_STATE[host]["busId"] = bus_id
         _drop_peer_name_dupes(host, bus_id)
@@ -2387,6 +2417,7 @@ def peer_exchange_apply(host, req_sent, resp):
         readbox_del(host, r)
     PEER_STATE[host] = {"presence": resp.get("presence") or [], "epoch": resp.get("epoch"),
                         "holds": resp.get("holds") or [], "seenAt": int(time.time())}
+    _write_remote_sids()                           # presence changed → refresh the deadness mirror
     bus_id = str(resp.get("busId") or "")
     if bus_id:                                       # the dialed alias is canonical for this bus: fold any
         PEER_STATE[host]["busId"] = bus_id           # row it left under its self-declared hostname

--- a/tests/test_dead_session_staleness.py
+++ b/tests/test_dead_session_staleness.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Cards on dead sessions must still move (the user 2026-08-28: a board audit found 18 of 23
+working/blocked cards stale, every one on a dead / ext: / remote-mirror sid). Three roots, each
+pinned: (1) the quiet reply sweep walked only DISCOVERED sessions as senders, so a dead sender's
+trackers were never swept again — absent stores holding open trackers now join the walk, and the
+recipient's reply (the event) closes them with the sweep as its only writer; (2) settle derived
+closed=False from mere registry absence — _presumed_closed now determines deadness from everything
+the kernel knows (windowed parse, windowless transcript, ext:-by-construction, the bus's federated
+remote-sids mirror), with a LIVE REMOTE session's mirror store never presumed settled; (3) relayed
+mail minted DIFFERENT ids on the two sides, so the delegation link never formed — deliver() stamps
+the sender-side originMid on the receiving row and every join seam accepts either id. Plus the
+plant-time dedupe of byte-identical same-peer mirrors (the ext mailer's same-minute twins).
+SYNTHETIC fixtures only; private synthetic sids; hostname TESTHOST."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_deadstale", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1_788_300_000
+T0 = NOW - 3600
+DEAD = "a11f0001-1111-4222-8333-000000000001"   # private synthetic sids — never the shared placeholder
+RCP = "a11f0001-1111-4222-8333-000000000002"
+EXT = "ext:vault-warning-mailer"
+MID = "1788299000.000001_1.TESTHOST"
+
+
+def _node(nid, text, parent, t=T0, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return base
+
+
+class World(unittest.TestCase):
+    def setUp(self):
+        self._disc = jd.discover
+        self.td = tempfile.TemporaryDirectory()
+        self._msgs = jd.MESSAGES
+        jd.MESSAGES = Path(self.td.name) / "messages.jsonl"
+        jd.MESSAGES.write_text("")
+        # only the RECIPIENT is discovered; the sender is dead by construction
+        jd.discover = lambda now, window=None, forks=True: [(RCP, "/dev/null", None, "api")]
+
+    def tearDown(self):
+        jd.discover = self._disc
+        jd.MESSAGES = self._msgs
+        for sid in (DEAD, RCP, EXT):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+            try:
+                (jd._overrides_dir() / (sid + ".jsonl")).unlink()
+            except OSError:
+                pass
+        try:
+            (jd.STATE / "remote-sids").unlink()
+        except OSError:
+            pass
+        self.td.cleanup()
+
+    def _dead_sender(self, sid=DEAD):
+        # lastNode = the tracker: the settle gate holds only the ACTIVE FOCUS top, so the
+        # dead-vs-remote distinction is visible exactly there (a focusless store settles anyway)
+        st = {"rompUuid": sid, "seq": 2, "lastNode": sid + ":g1", "nodes":
+              {sid + ":g1": _node(sid + ":g1", "↪ delegated to api: verify refs", None,
+                                  handoff={"peer": RCP, "msgId": MID, "quiet": True})},
+              "placements": {}, "status": {}}
+        jd.save_goals(sid, st)
+
+    def _reply(self, at):
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": at, "ev": "sent", "id": "r1", "from_id": RCP, "to_id": DEAD,
+             "kind": "coordinate", "body": "verified; drift zero"}) + "\n")
+
+
+class DeadSenderSweep(World):
+    def test_a_dead_senders_quiet_tracker_closes_on_the_reply_and_settles(self):
+        (jd.STATE / "remote-sids").write_text("")     # the bus has spoken: no remote sessions
+        self._dead_sender()
+        self._reply(T0 + 500)
+        jd.run_propagate(now=NOW)
+        st = jd.load_goals(DEAD)
+        nd = st["nodes"][DEAD + ":g1"]
+        self.assertTrue(nd.get("nodeComplete"), "the reply is the event; the sweep is its only writer")
+        self.assertEqual(st["status"].get(DEAD + ":g1"), "completed",
+                         "a dead determination settles the top — the card leaves Working")
+
+    def test_a_live_remote_mirror_closes_but_never_presumes_settled(self):
+        (jd.STATE / "remote-sids").write_text(DEAD + "\n")   # the bus says: alive on another host
+        self._dead_sender()
+        self._reply(T0 + 500)
+        jd.run_propagate(now=NOW)
+        st = jd.load_goals(DEAD)
+        self.assertTrue(st["nodes"][DEAD + ":g1"].get("nodeComplete"))
+        self.assertNotEqual(st["status"].get(DEAD + ":g1"), "completed",
+                            "a live remote session's mirror store is never premature-settled")
+
+    def test_no_reply_leaves_the_tracker_open(self):
+        (jd.STATE / "remote-sids").write_text("")
+        self._dead_sender()
+        jd.run_propagate(now=NOW)
+        self.assertFalse(jd.load_goals(DEAD)["nodes"][DEAD + ":g1"].get("nodeComplete"),
+                         "no report-back event → nothing moves")
+
+
+class PresumedClosed(World):
+    def test_the_deadness_ladder(self):
+        self.assertTrue(jd._presumed_closed(EXT, NOW), "ext: is closed by construction")
+        # absent everywhere + the bus has spoken (empty mirror) → dead
+        (jd.STATE / "remote-sids").write_text("")
+        self.assertTrue(jd._presumed_closed(DEAD, NOW))
+        # the bus lists it as remote-live → not closed
+        (jd.STATE / "remote-sids").write_text(DEAD + "\n")
+        self.assertFalse(jd._presumed_closed(DEAD, NOW))
+        # no mirror file at all → cannot determine → conservative
+        (jd.STATE / "remote-sids").unlink()
+        self.assertFalse(jd._presumed_closed(DEAD, NOW))
+
+
+class OriginMidJoin(World):
+    def test_postal_row_carries_the_origin_mid(self):
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0, "ev": "sent", "id": "local-9", "from": "web", "from_id": DEAD,
+             "to_id": RCP, "kind": "delegate", "body": "do the thing",
+             "originMid": MID}) + "\n")
+        self.assertEqual(jd._postal_row("local-9")[5], MID)
+
+    def test_the_dismissal_join_accepts_the_origin_mid(self):
+        # a LINKED (non-quiet) tracker whose recipient carries only the RELAYED local mid: the
+        # recipient's origin.originMid is the sender-side id, and the dismissed-recipient ending
+        # must join on it (pre-fix, the differing ids meant no join and the mirror sat forever)
+        st = {"rompUuid": DEAD, "seq": 2, "nodes":
+              {DEAD + ":g1": _node(DEAD + ":g1", "↪ delegated to api: verify refs", None,
+                                   handoff={"peer": RCP, "msgId": MID})},
+              "placements": {}, "status": {}}
+        jd.save_goals(DEAD, st)
+        rn = _node(RCP + ":g5", "Verify the refs", None, cleared=True,
+                   origin={"peer": DEAD, "goalId": DEAD + ":g1", "msgId": "local-9",
+                           "originMid": MID})
+        jd.save_goals(RCP, {"rompUuid": RCP, "nodes": {RCP + ":g5": rn},
+                            "placements": {}, "status": {}})
+        self._reply(T0 + 500)
+        (jd.STATE / "remote-sids").write_text("")
+        jd.run_propagate(now=NOW)
+        nd = jd.load_goals(DEAD)["nodes"][DEAD + ":g1"]
+        self.assertTrue(nd.get("nodeComplete"), "the join formed across the relay's re-stamped id")
+        self.assertIn("dismissed", nd.get("doneWhy") or "")
+
+
+class PlantDedupe(unittest.TestCase):
+    def test_byte_identical_open_twins_reuse_the_node(self):
+        st = {"rompUuid": DEAD, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        a = jd._plant_handoff_track(st, None, "check the vault warning", RCP, "api", T0, MID)
+        b = jd._plant_handoff_track(st, None, "check the vault warning", RCP, "api", T0 + 30,
+                                    "1788299030.000002_2.TESTHOST")
+        self.assertEqual(a, b, "same peer + same text while OPEN → one mirror, not twins")
+        c = jd._plant_handoff_track(st, None, "a different errand", RCP, "api", T0 + 60,
+                                    "1788299060.000003_3.TESTHOST")
+        self.assertNotEqual(a, c, "different work still plants its own mirror")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -2766,7 +2766,7 @@ class DelegationPropagation(unittest.TestCase):
             saved = (jd.GOALDIR, jd.discover)
             jd.GOALDIR = Path(td) / "goals"
             jd.GOALDIR.mkdir(parents=True)
-            jd.discover = lambda now: [(self.B, "p", "a", "bee")]
+            jd.discover = lambda now, window=None, forks=True: [(self.B, "p", "a", "bee")]
             try:
                 jd.save_goals(self.A, a_store)
                 jd.save_goals(self.B, b_store)


### PR DESCRIPTION
## Summary
Cards on dead sessions sat stuck forever, for two independent reasons, plus a twin-mint leak:

- **Delegation mirrors never linked.** Relayed/parked mail re-stamps message ids, so the sender's tracker and the recipient's origin held *different* ids for one message — every msgId join missed (0 of 11 audited recipients matched). `deliver()` now stamps the sender-side id as `originMid` on the receiving ledger row, the courier copies it into the recipient's `origin`, and every join (`_ref_goal` reply sweep, `_delegation_linked_ids`) accepts either id. `_postal_row` widens to a 6-tuple.
- **Dead tops never settled.** The settle gate derived `closed=False` from mere registry absence. New `jd._presumed_closed` ladder, most-evidence-first: windowed discover → parse decides; windowless discover → the dead local session's own transcript says it closed; `ext:` pseudo-sids closed by construction; a sid the bus reports live on another host (`STATE/remote-sids`) is **never** presumed closed (a live remote session's local mirror store must not premature-settle); otherwise closed only once the bus has spoken (mirror file exists), conservative `False` when it hasn't. The postal bus writes `remote-sids` atomically at both federated-presence writers and the legacy heartbeat path. `run_propagate`'s reply sweep widens its sender walk beyond discovered sessions to any store holding open trackers (the T110 straggler-drain shape) — the recipient's verdict is the event, and this sweep is its only writer once the sender is gone. `_resolve_node` uses the same ladder.
- **Byte-identical twin mints.** An ext mailer double-minted one delegation under two mids in one minute; `_plant_handoff_track` now reuses an open tracker with the same peer, parent ask, and label (keyed on the parent too, so several asks to one worker stay several cards).

## Test plan
- New `tests/test_dead_session_staleness.py`: dead-sender sweep closes + settles; live-remote fixture proves the mirror-store holdback (closes but never settles); no-reply stays open; `_presumed_closed` ladder matrix; `originMid` join through `_postal_row` and the dismissal sweep; twin-mint dedupe.
- Full Python suite: 5975 passed, 34 skipped. Extension suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)