### PR TITLE
The judge-limit banner names who the window touches, and dismisses per episode

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7377,6 +7377,31 @@ def _auth_avail():
             "acct": _claude_account_label(), "default": default}
 
 
+def _judge_limit_view():
+    """The judge-limit latch, enriched for the banner (the user 2026-08-28, who asked WHICH sessions a
+    full usage window actually touches): the judges bill ONE credential, so a full window pauses CARD
+    ANALYSIS board-wide — but the only SESSIONS the same window also rate-limits are the ones billing
+    the login account themselves. loginSessions = live sessions whose billing is the login, read from
+    the authoritative per-session source (the CLI's own authLive report, falling back to the session's
+    picked intent — the exact fields the Billing tooltip trusts); billingUnknown = live sessions whose
+    billing romp cannot know (a tmux CLI: its env is not romp's), listed honestly rather than silently
+    omitted (the fail-loud rule). Names resolve at read time, so a rename never shows stale."""
+    row = jd._limit_down()
+    if not row:
+        return None
+    billed, unknown = [], []
+    for sid, tm in (_tmux_sessions() or {}).items():
+        if not isinstance(tm, dict):
+            continue
+        b = str(tm.get("authLive") or tm.get("auth") or "")
+        nm = _name_of(sid) or str(sid)[:8]
+        if b == "login":
+            billed.append(nm)
+        elif not b:
+            unknown.append(nm)
+    return dict(row, loginSessions=sorted(billed), billingUnknown=sorted(unknown))
+
+
 def _sdk_problem_count():
     """Total problems recorded so far (boot + backend). The view-cache key: it changes only when
     something actually failed, so a failure lands in the payload on its own event."""
@@ -20616,7 +20641,7 @@ def build_feed(now, tmux=None):
             # usage-limit-down latch (judge-limit.json): analysis is paused because the account
             # cannot bill judge calls — the dashboard must SAY so, never fail quietly into retries
             # (the user 2026-08-18); self-expires at the window reset, cleared by the next success
-            "judgeLimit": jd._limit_down(),
+            "judgeLimit": _judge_limit_view(),   # the latch + WHO it actually touches (the user 2026-08-28)
             "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → await-green dot (the user 2026-07-13)
             # listed-but-unreadable names → an explicit gray ring, so a BLANK pip means "alive and
             # quiet" and nothing else (see _state_unknown_names)

--- a/tests/test_judge_limit_view.py
+++ b/tests/test_judge_limit_view.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""The judge-limit banner names WHO the window actually touches (the user 2026-08-28): the payload's
+_judge_limit_view enriches the latch with the sessions billing the login account — read from the
+authoritative per-session billing (the CLI's own authLive report, then the picked intent), with a
+live session whose billing is unknowable (a tmux CLI) listed honestly, never silently omitted. All
+fixtures SYNTHETIC."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_jlview", os.path.join(BIN, "romp-kernel")).load_module()
+
+S_LOGIN = "aaaa2828-0000-0000-0000-000000000001"   # authLive says login
+S_KEY = "aaaa2828-0000-0000-0000-000000000002"     # authLive says key → untouched by the window
+S_INTENT = "aaaa2828-0000-0000-0000-000000000003"  # no init yet; the picked intent says login
+S_TMUX = "aaaa2828-0000-0000-0000-000000000004"    # reports nothing → billing unknown
+
+
+class JudgeLimitView(unittest.TestCase):
+    def setUp(self):
+        self._saved = (km._tmux_sessions, km._name_of, km.jd._limit_down)
+        km._name_of = lambda sid: {S_LOGIN: "web", S_KEY: "api", S_INTENT: "tests",
+                                   S_TMUX: "notes"}.get(str(sid))
+        km._tmux_sessions = lambda: {
+            S_LOGIN: {"authLive": "login", "auth": "key"},   # the CLI's own report OUTRANKS the intent
+            S_KEY: {"authLive": "key", "auth": "login"},
+            S_INTENT: {"authLive": "", "auth": "login"},
+            S_TMUX: {},
+        }
+        km.jd._limit_down = lambda: {"bucket": "five_hour", "resets_at": 1_780_000_000, "pct": 100}
+
+    def tearDown(self):
+        (km._tmux_sessions, km._name_of, km.jd._limit_down) = self._saved
+
+    def test_no_latch_no_view(self):
+        km.jd._limit_down = lambda: None
+        self.assertIsNone(km._judge_limit_view())
+
+    def test_login_billed_sessions_ride_the_latch_key_billed_do_not(self):
+        v = km._judge_limit_view()
+        self.assertEqual(v["loginSessions"], ["tests", "web"],
+                         "authLive wins where it exists; the intent covers a pre-init session; sorted")
+        self.assertNotIn("api", v["loginSessions"], "a key-billed session is untouched by this window")
+
+    def test_unreadable_billing_is_said_not_omitted(self):
+        self.assertEqual(km._judge_limit_view()["billingUnknown"], ["notes"],
+                         "a tmux CLI reports nothing — the fail-loud rule lists it as unknown")
+
+    def test_the_latch_fields_pass_through_intact(self):
+        v = km._judge_limit_view()
+        self.assertEqual((v["bucket"], v["resets_at"], v["pct"]), ("five_hour", 1_780_000_000, 100))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -17,7 +17,9 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "judge.py"), "utf8");
 
 test("the kernel ships the latch and the judge gate writes it model-aware", () => {
-  assert.match(KERNEL, /"judgeLimit": jd\._limit_down\(\),/);
+  assert.match(KERNEL, /"judgeLimit": _judge_limit_view\(\),/,
+    "the latch rides enriched — WHO the window touches joins it (2026-08-28)");
+  assert.match(KERNEL, /def _judge_limit_view\(\):/);
   assert.match(JUDGE, /_buckets = \["five_hour", "seven_day"\] \+ \(\["fable"\] if "fable" in str\(model\)\.lower\(\) else \[\]\)/,
     "the gated buckets follow the CALL'S model — a fable pin gates on the fable window");
   assert.match(JUDGE, /_limit_mark\(_b, _lim\.get\("pct"\), _lim\.get\("resets_at"\), model\)/);
@@ -39,4 +41,36 @@ test("the banner is build-once, acknowledges, and offers Opus only for the Fable
   assert.match(FEED, /paintJudgeLimit\(\);   \/\/ the usage-limit banner above the columns/,
     "painted on every feed render");
   assert.match(CSS, /\.judge-limit-banner \{/);
+});
+
+test("the banner names who the window actually touches — authoritative billing, fail-loud unknowns", () => {
+  // the judges bill ONE credential: card movement pauses board-wide, and ONLY the sessions billing
+  // this account rate-limit on their own turns (the user 2026-08-28). The kernel reads the CLI's own
+  // authLive report first, the picked intent second — the Billing tooltip's exact sources — and a
+  // session whose billing it cannot know is listed as unknown, never silently omitted.
+  assert.match(KERNEL, /b = str\(tm\.get\("authLive"\) or tm\.get\("auth"\) or ""\)/);
+  assert.match(KERNEL, /loginSessions=sorted\(billed\), billingUnknown=sorted\(unknown\)/);
+  assert.match(FEED, /Card analysis is paused board-wide/, "the scope is stated in the reader's terms");
+  assert.match(FEED, /These sessions bill this account, so their own turns are rate-limited too: "/);
+  assert.match(FEED, /const many = names\.length > 3;/, "inline when few…");
+  assert.match(FEED, /names\.slice\(0, 2\) : names;/, "…two named + a count when many");
+  assert.match(FEED, /billing unknown for " \+ unk\.join\(", "\)/, "the fail-loud row");
+});
+
+test("the '+N more' expand is keyed and delegated — click-safe across the per-push repaints", () => {
+  assert.match(FEED, /let jlSessOpen = false;/, "module state, survives re-renders");
+  assert.match(FEED, /if \(t && t\.dataset && t\.dataset\.act === "jl-more"\) \{ jlSessOpen = !jlSessOpen; paintJudgeLimit\(\); \}/,
+    "the toggle is rebuilt per paint, so its action rides the build-once banner root");
+});
+
+test("dismiss latches to THIS episode and re-arms only on a NEW one — no timers", () => {
+  assert.match(FEED, /const jlEpisodeKey = \(j: \{ bucket\?: string; resets_at\?: number \} \| null\) =>\s*\n\s*\(j\?\.bucket \|\| ""\) \+ ":" \+ \(j\?\.resets_at \|\| 0\);/,
+    "the episode's identity IS bucket + resets_at");
+  assert.match(FEED, /localStorage\.setItem\("romp:jlDismiss", jlEpisodeKey\(judgeLimit\)\)/,
+    "stored, so the dismissal survives re-renders and reloads for the episode's lifetime");
+  assert.match(FEED, /if \(dismissed === jlEpisodeKey\(judgeLimit\)\) \{ b\.style\.display = "none"; return; \}/,
+    "a NEW episode has a new key and shows again — the deciding event, never a timer");
+  assert.match(FEED, /paintJudgeLimit\(\);\s*\n\s*\};\s*\n\s*b\.appendChild\(x\);/,
+    "the hide is the immediate acknowledgment, on the build-once button");
+  assert.match(CSS, /\.judge-limit-banner \.jl-dismiss \{/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1508,6 +1508,13 @@ body.filebrowse-open { overflow: hidden; }
   rgba(255, 255, 255, 0.18); background: var(--vscode-input-background, #3c3c3c); color: inherit; cursor: pointer; font-size: 0.92em; }   /* tokenized (T151; was a bare #333) */
 .judge-limit-banner .jl-switch:hover { background: #3c3c3c; }
 .judge-limit-banner .jl-switch:disabled { opacity: 0.6; cursor: default; }
+/* who the window touches (2026-08-28): same text size as the line it extends (fonts: reuse), dimmer */
+.judge-limit-banner .jl-sess { opacity: 0.65; min-width: 0; }
+.judge-limit-banner .jl-more { color: var(--accent); cursor: pointer; white-space: nowrap; }
+.judge-limit-banner .jl-unknown { opacity: 0.8; font-style: italic; }
+.judge-limit-banner .jl-dismiss { flex: none; margin-left: auto; background: none; border: none;
+  color: var(--dim); cursor: pointer; font-size: 1em; padding: 2px 6px; border-radius: 4px; }
+.judge-limit-banner .jl-dismiss:hover { color: var(--fg); background: rgba(255, 255, 255, 0.07); }
 
 /* The footer SEARCH box (the user 2026-08-23; restyled 2026-08-24): a "Search" word-button expanding
    to an inline input that live-filters the board by session name, host prefix included. The expanded

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4191,7 +4191,14 @@ function feedToast(text: string) {
 // payload (self-expiring at the window reset, cleared by the next successful call). Built ONCE and
 // updated in place — the button must survive re-renders (the click-safety rule), and it
 // acknowledges immediately, then the latch clearing hides the banner on a later payload.
-let judgeLimit: { bucket?: string; resets_at?: number; model?: string } | null = null;
+let judgeLimit: { bucket?: string; resets_at?: number; model?: string;
+                  loginSessions?: string[]; billingUnknown?: string[] } | null = null;
+// The dismiss latches to THIS episode's identity — a NEW episode (different bucket or reset time)
+// is new information and re-shows the banner; nothing else does (event-based, no timers). Stored
+// in localStorage so the dismissal survives re-renders and reloads for the episode's lifetime.
+const jlEpisodeKey = (j: { bucket?: string; resets_at?: number } | null) =>
+  (j?.bucket || "") + ":" + (j?.resets_at || 0);
+let jlSessOpen = false;   // the session list's keyed expand — module state, survives re-renders
 function ensureJudgeLimit(): HTMLElement {
   let b = document.getElementById("judge-limit-banner");
   if (b) return b;
@@ -4208,6 +4215,24 @@ function ensureJudgeLimit(): HTMLElement {
     vscodeApi?.postMessage({ type: "setJudgeModel", model: "opus" });
   };
   b.appendChild(btn);
+  const sess = el("span", "jl-sess"); b.appendChild(sess);   // who the window actually touches (2026-08-28)
+  const x = el("button", "jl-dismiss") as HTMLButtonElement;
+  x.type = "button";
+  x.textContent = "✕";
+  x.title = "dismiss this notice — it returns only if a new limit episode starts";
+  x.onclick = () => {
+    // the hide IS the acknowledgment, immediate and local; the latch key makes it stick (build-once
+    // button — the listener survives every re-render, per the click-safety rule)
+    try { localStorage.setItem("romp:jlDismiss", jlEpisodeKey(judgeLimit)); } catch { /* storage blocked */ }
+    paintJudgeLimit();
+  };
+  b.appendChild(x);
+  // the "+N more" toggle is REBUILT per paint, so its action rides the build-once banner root
+  // (delegation to the stable ancestor — the same rule the tab strip follows)
+  b.addEventListener("click", (ev) => {
+    const t = ev.target as HTMLElement;
+    if (t && t.dataset && t.dataset.act === "jl-more") { jlSessOpen = !jlSessOpen; paintJudgeLimit(); }
+  });
   const list = document.getElementById("feed-list")!;
   list.parentElement!.insertBefore(b, list);
   return b;
@@ -4215,14 +4240,45 @@ function ensureJudgeLimit(): HTMLElement {
 function paintJudgeLimit(): void {
   const b = ensureJudgeLimit();
   if (!judgeLimit) { b.style.display = "none"; return; }
+  let dismissed = "";
+  try { dismissed = localStorage.getItem("romp:jlDismiss") || ""; } catch { /* storage blocked */ }
+  if (dismissed === jlEpisodeKey(judgeLimit)) { b.style.display = "none"; return; }
   const ra = judgeLimit.resets_at;
   const when = typeof ra === "number" && ra > 0
     ? new Date(ra * 1000).toTimeString().slice(0, 5) : "";
   const fable = judgeLimit.bucket === "fable";
   const txt = b.querySelector(".jl-text")!;
+  // board-wide is the honest scope: the judges bill one credential, so card movement pauses for
+  // every session's cards — running sessions keep going on their own billing (the user 2026-08-28)
   txt.textContent = fable
-    ? "Analysis is paused — the Fable usage window is full" + (when ? " (resets " + when + ")." : ".")
-    : "Analysis is paused — the account's usage window is full" + (when ? "; it resumes at " + when + "." : ".");
+    ? "Card analysis is paused board-wide — the Fable usage window is full" + (when ? " (resets " + when + ")." : ".")
+    : "Card analysis is paused board-wide — the account's usage window is full" + (when ? "; it resumes at " + when + "." : ".");
+  // …and WHO ELSE the window touches: only the sessions billing this account rate-limit on their
+  // own turns. Inline names when few; a keyed "+N more" expand when many (progressive disclosure);
+  // a session whose billing romp cannot read is listed as unknown, never silently omitted.
+  const sessEl = b.querySelector(".jl-sess") as HTMLElement;
+  sessEl.replaceChildren();
+  const names = judgeLimit.loginSessions || [];
+  const unk = judgeLimit.billingUnknown || [];
+  if (names.length) {
+    const many = names.length > 3;
+    const shown = many && !jlSessOpen ? names.slice(0, 2) : names;
+    sessEl.append("These sessions bill this account, so their own turns are rate-limited too: "
+      + shown.join(", "));
+    if (many) {
+      const more = el("span", "jl-more");
+      more.dataset.act = "jl-more";
+      more.textContent = jlSessOpen ? " · fewer" : " +" + (names.length - shown.length) + " more";
+      more.title = jlSessOpen ? "collapse the list" : "show every affected session";
+      sessEl.appendChild(more);
+    }
+  }
+  if (unk.length) {
+    const u = el("span", "jl-unknown");
+    u.textContent = (names.length ? " · " : "") + "billing unknown for " + unk.join(", ")
+      + " (their CLI doesn't report it)";
+    sessEl.appendChild(u);
+  }
   const btn = b.querySelector(".jl-switch") as HTMLButtonElement;
   btn.style.display = fable ? "" : "none";
   if (!judgeLimit || !fable) { btn.disabled = false; btn.textContent = "Run analysis on Opus until then"; }


### PR DESCRIPTION
The user (2026-08-28), reading 'Analysis is paused — the account's usage window is full': *this only applies to sessions on the login account, right? List them — and let me dismiss the notice.*

Their read was half right, and the banner now says the whole truth in the reader's terms: the judges bill **one credential**, so card analysis pauses **board-wide** until the reset (the line says so now), and only the sessions billing this account also rate-limit on their own turns — those are **named**. The kernel enriches the latch on the payload (`_judge_limit_view`): `loginSessions` from the authoritative per-session billing (the CLI's own `authLive` report first, the picked intent second — the Billing tooltip's exact sources), and `billingUnknown` for a live session whose billing romp cannot know (a tmux CLI), listed honestly rather than silently omitted (fail-loud). Names inline when ≤3; two named + a keyed **'+N more'** expand when many (module state survives re-renders; the toggle is rebuilt per paint so its action rides the build-once banner root — the delegation rule).

The **dismiss ✕** latches to this episode's identity (bucket + resets_at) in localStorage: the hide is the immediate acknowledgment, it survives re-renders and reloads for the episode's lifetime, and the banner returns only when a **new episode** latches — the deciding event, never a timer. The fable bucket's 'Run analysis on Opus until then' button is untouched (pinned).

Tests: the payload view's matrix (authLive outranks intent, key-billed untouched, unknown listed, latch passthrough, none→none) + extended banner pins (list + fail-loud row, keyed delegated expand, per-episode dismiss + re-arm, retargeted payload pin). Python 5972 passed / extension 2543 passed on the pushed head; few- and many-sessions screenshots in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)