### PR TITLE
Image-pin associations survive restarts — the first-ever resolve wins forever

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23778,10 +23778,12 @@ def _space_paths(md, sid, uuid):
                 out.append(tok)
         pins = {}
         for tok in out:                      # the verify moment doubles as the mention-time snapshot
-            pin = _pin_for(tok, sid)         # (see _pin_mention) — latched with the span's verdict
+            pin = _pin_assoc(sid, uuid).get(tok) or _pin_for(tok, sid)   # first-ever latch wins (durable sidecar)
             if pin:
                 pins[tok] = pin
-        if len(_SPACE_PATH_CACHE) > 50000:   # runaway backstop; one entry per rendered message
+                if _pin_assoc(sid, uuid).get(tok) != pin:
+                    _pin_assoc_append(sid, uuid, tok, pin)
+        if len(_SPACE_PATH_CACHE) > 50000:   # runaway backstop; harmless to pins now (assoc sidecar)
             _SPACE_PATH_CACHE.clear()
         _SPACE_PATH_CACHE[key] = hit = (tuple(out), pins)
     spans = hit[0] if isinstance(hit, tuple) and len(hit) == 2 and isinstance(hit[0], tuple) else hit
@@ -23937,6 +23939,60 @@ def _pin_dir():
     return _MENTION_PINS
 
 
+# ── durable pin associations (2026-08-28, the user catching history rewrite again after kernel
+# restarts): the 2026-08-16 pin fix latched (message → pin id) only in the in-memory caches below,
+# so every restart (routine here) re-resolved old messages and re-pinned the file's CURRENT bytes —
+# history rewrote exactly as before, just restart-shaped. The FIRST-EVER resolve now wins forever:
+# each latch appends (uuid, target → pin id) to a per-sid jsonl sidecar under mention-pins/assoc,
+# and every latch CONSULTS it before pinning. Rows are ~100 bytes, one per image mention, loaded
+# lazily once per sid; the blob store's bound/eviction and the evicted-pin → live-file fallback are
+# unchanged (an association whose blob aged out just falls back like today). The 50k cache clears
+# below become harmless by construction — re-resolves reload from here.
+_PIN_ASSOC_MEMO = {}                    # sid -> {uuid: {target: pin id}}, the sidecar's lazy load
+
+
+def _pin_assoc_dir():
+    d = _pin_dir() / "assoc"
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    return d
+
+
+def _pin_assoc(sid, uuid):
+    """The durable pins already latched for this message — {target: pin id}, {} when none."""
+    memo = _PIN_ASSOC_MEMO.get(sid)
+    if memo is None:
+        memo = {}
+        try:
+            with open(_pin_assoc_dir() / (str(sid) + ".jsonl"), encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        row = json.loads(line)
+                        memo.setdefault(str(row["u"]), {})[str(row["t"])] = str(row["p"])
+                    except (ValueError, KeyError, TypeError):
+                        continue                     # a torn tail line loses one row, never the file
+        except OSError:
+            pass
+        if len(_PIN_ASSOC_MEMO) > 2048:              # sid-count bound; reloads are one small file read
+            _PIN_ASSOC_MEMO.clear()
+        _PIN_ASSOC_MEMO[sid] = memo
+    return memo.get(uuid) or {}
+
+
+def _pin_assoc_append(sid, uuid, target, pid):
+    """Record a first-ever latch durably (append + memo). Best-effort: a failed write degrades to
+    the old in-memory behavior for this message, never blocks the build."""
+    memo = _PIN_ASSOC_MEMO.setdefault(sid, {})
+    memo.setdefault(uuid, {})[target] = pid
+    try:
+        with open(_pin_assoc_dir() / (str(sid) + ".jsonl"), "a", encoding="utf-8") as f:
+            f.write(json.dumps({"u": uuid, "t": target, "p": pid}) + "\n")
+    except OSError:
+        pass
+
+
 def _pin_mention(fp):
     """Snapshot a mentioned IMAGE's bytes as they are RIGHT NOW, content-addressed — the pin an old
     chat message's embed keeps forever (the user 2026-08-16: an agent re-generating a plot under the
@@ -24019,12 +24075,17 @@ def _path_links(md, sid, uuid, memo):
                 still.append(tok)
             else:
                 links[tok] = r
-                pin = _pin_for(r, sid)                    # the resolve moment IS the mention-time snapshot
+                # the FIRST-EVER latch wins forever (durable sidecar): a restart or cache clear
+                # re-resolves this message, and without the lookup it would re-pin the file's
+                # CURRENT bytes — the history rewrite the pin store exists to prevent
+                pin = _pin_assoc(sid, uuid).get(r) or _pin_for(r, sid)
                 if pin:                                   # (see _pin_mention) — latched with the link, so an
                     pins[r] = pin                         # overwrite can never rewrite this message's embed
+                    if _pin_assoc(sid, uuid).get(r) != pin:
+                        _pin_assoc_append(sid, uuid, r, pin)
         misses = tuple(still)
-    if len(_PATH_LINK_CACHE) > 50000:                     # runaway backstop; one entry per rendered message
-        _PATH_LINK_CACHE.clear()
+    if len(_PATH_LINK_CACHE) > 50000:                     # runaway backstop; harmless to pins now —
+        _PATH_LINK_CACHE.clear()                          # re-resolves reload from the assoc sidecar
     _PATH_LINK_CACHE[key] = (links, misses, pins)
     return dict(links) if (links or misses) else None
 

--- a/tests/test_pin_durability.py
+++ b/tests/test_pin_durability.py
@@ -1,0 +1,118 @@
+"""Image-pin associations survive kernel restarts (the user 2026-08-28, catching history rewrite
+AGAIN: the 2026-08-16 pin fix latched message→pin only in in-memory caches, so every routine
+restart re-resolved old messages and re-pinned the file's CURRENT bytes). The first-ever resolve
+now wins forever: each latch appends (uuid, target → pin id) to a per-sid jsonl sidecar under
+mention-pins/assoc, consulted before any re-pin. The blob store's bound/eviction and the
+evicted-pin → live-file fallback are untouched. Synthetic data only; hermetic state."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_pindur", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+# a real 1×1 PNG and a DIFFERENT 1×1 PNG (changed pixel) — content-addressing must tell them apart
+PNG_A = bytes.fromhex("89504e470d0a1a0a0000000d494844520000000100000001080600000"
+                      "01f15c4890000000d49444154789c62f8cfc0000000ffff0300000600"
+                      "0557bfabd40000000049454e44ae426082")
+PNG_B = bytes.fromhex("89504e470d0a1a0a0000000d494844520000000100000001080600000"
+                      "01f15c4890000000d49444154789c62f80f040000ffff0300000600"
+                      "0557bfabd40000000049454e44ae426082")
+
+
+def _cold_restart_resolve_state():
+    """What a kernel restart does to the resolve layer: every in-memory cache empties."""
+    km._PATH_LINK_CACHE.clear()
+    km._SPACE_PATH_CACHE.clear()
+    km._PIN_ASSOC_MEMO.clear()          # the memo is a cache OF the sidecar — the FILE is the survivor
+
+
+class PinDurability(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.cwd = Path(self.td.name)
+        self._saved_cwd_of = km._cwd_of
+        km._cwd_of = lambda sid: str(self.cwd) if sid == SID else ""
+        self.img = self.cwd / "plot.png"
+        self.img.write_bytes(PNG_A)
+        self._n = 0
+        _cold_restart_resolve_state()
+        for e in os.listdir(km._pin_dir()):          # a hermetic BLOB store per test — the module
+            fp = km._pin_dir() / e                   # shares one XDG root across the whole file
+            if fp.is_file():
+                fp.unlink()
+        af = km._pin_assoc_dir() / (SID + ".jsonl")   # and a hermetic sidecar per test
+        af.unlink(missing_ok=True)
+
+    def tearDown(self):
+        km._cwd_of = self._saved_cwd_of
+        _cold_restart_resolve_state()
+        self.td.cleanup()
+
+    def _uuid(self):
+        self._n += 1
+        return "aaaaaaa%d-1111-2222-3333-444444444444" % self._n
+
+    def _resolve(self, uuid):
+        md = "the plot is at %s" % self.img
+        self.assertIsNotNone(km._path_links(md, SID, uuid, {}))
+        return dict(km._path_pins(SID, uuid))
+
+    def test_a_restart_must_not_rewrite_history(self):
+        u = self._uuid()
+        pins1 = self._resolve(u)
+        self.assertEqual(len(pins1), 1, "the mention latched a pin")
+        original = next(iter(pins1.values()))
+        # the agent regenerates the plot under the same name…
+        self.img.write_bytes(PNG_B)
+        # …and the kernel restarts (routine here): every in-memory resolve cache is gone
+        _cold_restart_resolve_state()
+        pins2 = self._resolve(u)
+        self.assertEqual(next(iter(pins2.values())), original,
+                         "the old message ships the ORIGINAL pin id — the first-ever resolve wins forever")
+
+    def test_the_runaway_clear_no_longer_orphans_associations(self):
+        u = self._uuid()
+        original = next(iter(self._resolve(u).values()))
+        self.img.write_bytes(PNG_B)
+        km._PATH_LINK_CACHE.clear()          # the 50k backstop's exact effect
+        pins = self._resolve(u)
+        self.assertEqual(next(iter(pins.values())), original)
+
+    def test_unchanged_file_dedupes_to_one_blob_and_one_id(self):
+        u1, u2 = self._uuid(), self._uuid()
+        p1 = next(iter(self._resolve(u1).values()))
+        _cold_restart_resolve_state()
+        p2 = next(iter(self._resolve(u2).values()))
+        self.assertEqual(p1, p2, "unchanged bytes = the same content-addressed id (covers 'use the file directly')")
+        blobs = [e for e in os.listdir(km._pin_dir()) if e.endswith(".png")]
+        self.assertEqual(len(blobs), 1, "…and exactly one stored blob")
+
+    def test_a_new_message_after_the_change_pins_the_new_bytes(self):
+        u1 = self._uuid()
+        old = next(iter(self._resolve(u1).values()))
+        self.img.write_bytes(PNG_B)
+        u2 = self._uuid()
+        new = next(iter(self._resolve(u2).values()))
+        self.assertNotEqual(old, new, "history is pinned; the PRESENT is always the live file's bytes")
+
+    def test_the_sidecar_is_the_survivor_and_a_torn_line_loses_one_row_only(self):
+        u = self._uuid()
+        original = next(iter(self._resolve(u).values()))
+        f = km._pin_assoc_dir() / (SID + ".jsonl")
+        self.assertTrue(f.exists(), "the association is on disk, not only in memory")
+        with open(f, "a", encoding="utf-8") as fh:
+            fh.write('{"u": "torn')        # a crash mid-append
+        _cold_restart_resolve_state()
+        pins = self._resolve(u)
+        self.assertEqual(next(iter(pins.values())), original, "the intact rows still load")

--- a/ui/webview/chat-pin-history.test.ts
+++ b/ui/webview/chat-pin-history.test.ts
@@ -32,7 +32,10 @@ test("the embed and its lightbox request the pinned bytes; unpinned surfaces sta
 
 test("the kernel pins at the resolve latch and serves pins shape-gated with live fallback", () => {
   assert.match(KERNEL, /def _pin_mention\(fp\):/);
-  assert.match(KERNEL, /pin = _pin_for\(r, sid\)\s+# the resolve moment IS the mention-time snapshot/);
+  // durable-first since 2026-08-28 (the restart-rewrite hole): the latch CONSULTS the per-sid
+  // assoc sidecar before ever re-pinning — the first-ever resolve wins forever
+  assert.match(KERNEL, /pin = _pin_assoc\(sid, uuid\)\.get\(r\) or _pin_for\(r, sid\)/);
+  assert.match(KERNEL, /def _pin_assoc_append\(sid, uuid, target, pid\):/);
   assert.match(KERNEL, /ev\["pathPins"\] = pp/, "attached on both user and assistant events");
   assert.match(KERNEL, /_PIN_ID_RE = re\.compile\(r"\^\[0-9a-f\]\{64\}\\\.\[a-z0-9\]\{1,8\}\$"\)/);
   assert.match(KERNEL, /if pin and _PIN_ID_RE\.match\(pin\):/);


### PR DESCRIPTION
The user, catching history rewrite **again**: a regenerated file still replaced the previously rendered version inside old chat messages after kernel restarts.

## The hole (as scouted)
The content-addressed blob store was always durable — but the **message→pin association** lived only in the in-memory `_PATH_LINK_CACHE` / `_SPACE_PATH_CACHE`. A restart empties them; the rebuild re-resolves old messages and `_pin_for` re-pins the file's **current** bytes: history rewrites, restart-shaped. The 50k backstops wholesale-cleared with the same effect.

## The fix
Each latch appends `(uuid, target → pin id)` to a compact per-sid jsonl sidecar under `mention-pins/assoc` (~100 B/row), loaded lazily per sid; **both latch sites consult it before pinning** — the first-ever resolve wins forever. The 50k clears stay and become harmless by construction. Untouched: content-addressed dedupe, the bounded blob store + eviction, the evicted-pin → live-file fallback. Torn tail line = one lost row, never the file.

## Before/after (hermetic kernels, same synthetic transcript)
| | at mention | after overwrite + restart | verdict |
|---|---|---|---|
| pre-fix | `8c3479…` | `4100e9…` | **history REWRITTEN** |
| fixed | `8c3479…` | `8c3479…` | intact |

## Tests
`test_pin_durability.py`: restart repro, runaway-clear equivalent, unchanged-file dedupe (one blob), new-message-pins-new-bytes, torn-line tolerance. Path-links + mention-pins + settings suites green (38 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)