### PR TITLE
The judge-limit layer scopes to the billing that owns the window

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1064,15 +1064,19 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             return ""                                 # from a real call failure — event-based, no time window
     except Exception:
         pass
+    fsid = getattr(_judge_ctx, "fsid", None)
+    auth = _judge_auth(fsid)                          # this call bills what the judged session bills
     try:
-        # RATE-LIMIT GATE (the user 2026-07-07): while the ACCOUNT is limit-exhausted, every judge call
-        # fleet-wide just burns a doomed API retry (the archiver postmortem: ~1160 wasted calls in one
-        # 90-min window). usage.json (the SDK backend's /usage poll) says so exactly; `resets_at` makes
-        # the gate self-expiring — a stale "limited" stops gating the moment the window resets, no age
-        # heuristics. Skips ride the SAME paused flag, so no give-up counter ever counts one as a
-        # failure. The `fable` bucket is deliberately ignored (judges run Sonnet). Unreadable/absent
-        # usage.json → never gate: the gate is an optimization, judging is the job.
-        u = json.loads((STATE / "usage.json").read_text())
+        # RATE-LIMIT GATE (the user 2026-07-07), scoped to the calls it can actually starve (the user
+        # 2026-08-28, who watched key-billed cards keep landing under a "paused" banner): usage.json is
+        # the LOGIN account's windows (the SDK backend's /usage poll), and every bucket in it —
+        # five_hour/seven_day/fable alike — is a login-account window. A judge call bills the JUDGED
+        # session's account (_judge_auth, the 2026-08-12 rule), so only LOGIN-billed calls are doomed
+        # while a window sits full; a key-billed call is pay-per-token (no windows, the 2026-08-13
+        # ruling) and always proceeds. The old fleet-wide gate predated the per-session billing rule
+        # and starved key-billed judging for nothing. `resets_at` keeps the gate self-expiring, skips
+        # ride the paused flag, unreadable usage.json never gates — all unchanged.
+        u = json.loads((STATE / "usage.json").read_text()) if auth == "login" else {}
         # The gated buckets FOLLOW THE CALL'S MODEL (2026-08-18, user-approved via the optimizer's
         # audit): the account-wide windows gate every model, and a model-scoped window gates exactly
         # the calls that would bill it. The old tuple hardcoded the account buckets and deliberately
@@ -1094,7 +1098,6 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 return ""
     except Exception:
         pass
-    fsid = getattr(_judge_ctx, "fsid", None)
     sys_prompt = _with_user_notes(sys_prompt, judge)  # the user's standing style notes ride every prose call
     if mark:
         # AFTER the notes, deliberately: the notes block ends "where a note conflicts with the rules
@@ -1103,8 +1106,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
         # win against. Nothing else about it changes — it still rides the SYSTEM prompt, never the
         # payload, and a call with no marked sections still gets no suffix at all.
         sys_prompt += UNTRUSTED_SYS % (mark, mark)
-    auth = _judge_auth(fsid)                          # this call bills what the judged session bills
-    env = _judge_env(tier, auth)
+    env = _judge_env(tier, auth)                      # auth resolved above, before the gate (2026-08-28)
     # Per-tier effort from the gear (STATE/judge-effort | index-effort | distill-effort) when the caller
     # didn't pass one — "" or None means NO --effort flag, the long-standing default. An explicit caller
     # effort (the plan A/B) still wins.
@@ -1172,8 +1174,14 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 if _LIMIT_ENVELOPE_RE.search(msg):
                     # a limit-shaped envelope is the EVENT that says usage.json is stale (get_usage
                     # rides turn ends; an idle fleet refreshes nothing): latch the loud banner NOW
-                    # and poke one exact poll so the gate blocks the follow-on calls
-                    _limit_mark("account", None, None, model)
+                    # and poke one exact poll so the gate blocks the follow-on calls. LOGIN-billed
+                    # only (the manager's ruling 2026-08-28): this latch means "the login account's
+                    # window is full" and carries no resets_at, so it never self-expires — and a
+                    # KEY-billed limit envelope (a per-call 429 on pay-per-token, no window behind
+                    # it) would mint a false banner that only a later login success could clear.
+                    # The key call keeps the call-failed mark and error row; the poke is harmless.
+                    if auth == "login":
+                        _limit_mark("account", None, None, model)
                     if _USAGE_REFRESH_FN:
                         try:
                             _USAGE_REFRESH_FN()
@@ -1188,7 +1196,11 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
-                _limit_clear()                        # ...and the usage-limit latch (a reset, or a model switch)
+                if auth == "login":
+                    # only a LOGIN-billed success is evidence the login window reset early — a
+                    # key-billed success says nothing about it (the user 2026-08-28; before this,
+                    # any key success wrongly cleared the latch and the banner flapped)
+                    _limit_clear()
                 _mark_call_served(model)              # THIS model serves again → the give-up re-arm edge
                 _judge_ctx.last_call_fail = None      # a served reply retires the stashed error evidence
                 return wrap["result"]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7380,8 +7380,8 @@ def _auth_avail():
 def _judge_limit_view():
     """The judge-limit latch, enriched for the banner (the user 2026-08-28, who asked WHICH sessions a
     full usage window actually touches): the judges bill ONE credential, so a full window pauses CARD
-    ANALYSIS board-wide — but the only SESSIONS the same window also rate-limits are the ones billing
-    the login account themselves. loginSessions = live sessions whose billing is the login, read from
+    ANALYSIS for the sessions billing that credential (their turns rate-limit too); every other
+    session's analysis rides its own billing (the judge bills the judged session, the 2026-08-12 rule). loginSessions = live sessions whose billing is the login, read from
     the authoritative per-session source (the CLI's own authLive report, falling back to the session's
     picked intent — the exact fields the Billing tooltip trusts); billingUnknown = live sessions whose
     billing romp cannot know (a tmux CLI: its env is not romp's), listed honestly rather than silently
@@ -7394,12 +7394,12 @@ def _judge_limit_view():
         if not isinstance(tm, dict):
             continue
         b = str(tm.get("authLive") or tm.get("auth") or "")
-        nm = _name_of(sid) or str(sid)[:8]
         if b == "login":
-            billed.append(nm)
-        elif not b:
-            unknown.append(nm)
-    return dict(row, loginSessions=sorted(billed), billingUnknown=sorted(unknown))
+            billed.append(_peer_identity(sid))    # {name, host, sid, color} — the one identity ladder,
+        elif not b:                               # so the banner wears the standard session chip
+            unknown.append(_peer_identity(sid))   # (the user 2026-08-28: bold name in its own colour)
+    key = lambda d: d["name"]
+    return dict(row, loginSessions=sorted(billed, key=key), billingUnknown=sorted(unknown, key=key))
 
 
 def _sdk_problem_count():

--- a/tests/test_judge_limit_view.py
+++ b/tests/test_judge_limit_view.py
@@ -44,12 +44,16 @@ class JudgeLimitView(unittest.TestCase):
 
     def test_login_billed_sessions_ride_the_latch_key_billed_do_not(self):
         v = km._judge_limit_view()
-        self.assertEqual(v["loginSessions"], ["tests", "web"],
+        self.assertEqual([d["name"] for d in v["loginSessions"]], ["tests", "web"],
                          "authLive wins where it exists; the intent covers a pre-init session; sorted")
-        self.assertNotIn("api", v["loginSessions"], "a key-billed session is untouched by this window")
+        self.assertEqual(v["loginSessions"][1],
+                         {"name": "web", "host": "", "sid": S_LOGIN, "color": None},
+                         "the ONE identity ladder (_peer_identity) — the banner wears the standard chip")
+        self.assertNotIn("api", [d["name"] for d in v["loginSessions"]],
+                         "a key-billed session is untouched by this window")
 
     def test_unreadable_billing_is_said_not_omitted(self):
-        self.assertEqual(km._judge_limit_view()["billingUnknown"], ["notes"],
+        self.assertEqual([d["name"] for d in km._judge_limit_view()["billingUnknown"]], ["notes"],
                          "a tmux CLI reports nothing — the fail-loud rule lists it as unknown")
 
     def test_the_latch_fields_pass_through_intact(self):

--- a/tests/test_judge_rate_limit_gate.py
+++ b/tests/test_judge_rate_limit_gate.py
@@ -30,6 +30,10 @@ class RateLimitGate(unittest.TestCase):
         jd._RATE_GATE_LOGGED.clear()
         self.calls = []
         self._saved_run = jd.subprocess.run
+        # the gate scopes to LOGIN-billed calls (2026-08-28) — pin the billing deterministically:
+        # these tests always assumed login, which silently flipped to key on an env-keyed machine
+        self._saved_key = jd._work_key
+        jd._work_key = lambda: ""
 
         class _FakeDone:
             stdout = '{"result": "the-model-reply"}'
@@ -41,6 +45,7 @@ class RateLimitGate(unittest.TestCase):
 
     def tearDown(self):
         jd.subprocess.run = self._saved_run
+        jd._work_key = self._saved_key
         shutil.rmtree(self.td, ignore_errors=True)
 
     def _usage(self, pct, resets_in, bucket="five_hour"):
@@ -116,6 +121,43 @@ class RateLimitGate(unittest.TestCase):
         finally:
             jd._USAGE_REFRESH_FN = saved
 
+
+
+class GateScopedToLoginBilling(RateLimitGate):
+    """The correction round (the user 2026-08-28, who watched key-billed cards keep landing under a
+    'paused' banner): usage.json's windows are the LOGIN account's, a judge call bills the JUDGED
+    session's account, so the gate — and the latch's clear, and the envelope's mark — scope to
+    login-billed calls. A key-billed call is pay-per-token: no windows, never gated, and its
+    outcomes say nothing about the login window in either direction."""
+
+    def _key_billed(self):
+        jd._work_key = lambda: "sk-test-000"          # no per-session pick on file → the key default
+
+    def test_key_billed_calls_pass_a_full_window(self):
+        self._usage(100, 3600)
+        self._key_billed()
+        self.assertEqual(jd._judge_run("m", "sys", "user"), "the-model-reply")
+        self.assertEqual(len(self.calls), 1, "the call went out — pay-per-token has no window to burn")
+
+    def test_key_success_never_clears_the_login_latch_login_success_does(self):
+        jd._limit_mark("five_hour", 100, int(time.time()) + 3600, "m")
+        self._key_billed()
+        self.assertEqual(jd._judge_run("m", "sys", "user"), "the-model-reply")
+        self.assertEqual((jd._limit_down() or {}).get("bucket"), "five_hour",
+                         "a key-billed success says nothing about the login window")
+        jd._work_key = lambda: ""                     # back to login billing
+        self.assertEqual(jd._judge_run("m", "sys", "user"), "the-model-reply")
+        self.assertIsNone(jd._limit_down(), "a login-billed success IS the early-reset evidence")
+
+    def test_key_billed_limit_envelope_mints_no_latch(self):
+        # the manager's ruling: the account latch carries no resets_at (never self-expires), and with
+        # key successes no longer clearing it, a key 429 minting it would stick a false banner
+        class _FakeErr:
+            stdout = '{"is_error": true, "result": "rate limit reached, try again shortly"}'
+        jd.subprocess.run = lambda *a, **k: _FakeErr()
+        self._key_billed()
+        self.assertEqual(jd._judge_run("m", "sys", "user"), "")
+        self.assertIsNone(jd._limit_down(), "no account-window latch off a pay-per-token 429")
 
 class SegKeyUnified(unittest.TestCase):
     def test_kernel_delegates_to_the_judge_seg_key(self):

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -37,7 +37,7 @@ test("the banner is build-once, acknowledges, and offers Opus only for the Fable
     "acknowledges before the kernel round-trip");
   assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setJudgeModel", model: "opus" \}\)/);
   assert.match(FEED, /btn\.style\.display = fable \? "" : "none";/, "the switch offer is Fable-specific");
-  assert.match(FEED, /the account's usage window is full/, "general exhaustion states it plainly");
+  assert.match(FEED, /The account's usage window is full/, "general exhaustion states it plainly");
   assert.match(FEED, /paintJudgeLimit\(\);   \/\/ the usage-limit banner above the columns/,
     "painted on every feed render");
   assert.match(CSS, /\.judge-limit-banner \{/);
@@ -49,12 +49,29 @@ test("the banner names who the window actually touches — authoritative billing
   // authLive report first, the picked intent second — the Billing tooltip's exact sources — and a
   // session whose billing it cannot know is listed as unknown, never silently omitted.
   assert.match(KERNEL, /b = str\(tm\.get\("authLive"\) or tm\.get\("auth"\) or ""\)/);
-  assert.match(KERNEL, /loginSessions=sorted\(billed\), billingUnknown=sorted\(unknown\)/);
-  assert.match(FEED, /Card analysis is paused board-wide/, "the scope is stated in the reader's terms");
-  assert.match(FEED, /These sessions bill this account, so their own turns are rate-limited too: "/);
+  assert.match(KERNEL, /loginSessions=sorted\(billed, key=key\), billingUnknown=sorted\(unknown, key=key\)/);
+  assert.ok(!/board-wide/.test(FEED), "the corrected scope (2026-08-28): a judge bills the judged session — key-billed analysis never pauses");
+  assert.match(FEED, /"Analysis and turns pause for the sessions billing it: "/);
+  assert.match(FEED, /"\. Other sessions' analysis continues on their own billing\."/);
+  assert.match(FEED, /No live session bills this account/, "the empty list is stated, not blank");
   assert.match(FEED, /const many = names\.length > 3;/, "inline when few…");
   assert.match(FEED, /names\.slice\(0, 2\) : names;/, "…two named + a count when many");
-  assert.match(FEED, /billing unknown for " \+ unk\.join\(", "\)/, "the fail-loud row");
+  assert.match(FEED, /" · billing unknown for "/, "the fail-loud row");
+  // the standard session chip: bold, identity colour, the shared host-prefix treatment
+  assert.match(FEED, /const c = el\("b", "jl-chip"\);\s*\n\s*c\.replaceChildren\(\.\.\.hostPartsNodes\(p\.host, p\.name\)\);\s*\n\s*if \(p\.color && p\.color\.bg\) c\.style\.color = p\.color\.bg;/);
+  assert.match(KERNEL, /billed\.append\(_peer_identity\(sid\)\)/, "identities via the ONE ladder");
+});
+
+test("the gate, the clear, and the envelope mark all scope to LOGIN-billed calls (2026-08-28)", () => {
+  // usage.json's windows are the login account's; a judge call bills the JUDGED session's account
+  // (the 2026-08-12 rule) — so a key-billed call (pay-per-token, no windows) is never gated, its
+  // success never clears the login latch, and its limit-shaped 429 never mints one.
+  assert.match(JUDGE, /auth = _judge_auth\(fsid\) {10,}# this call bills what the judged session bills\n    try:/,
+    "billing resolves BEFORE the gate");
+  assert.match(JUDGE, /json\.loads\(\(STATE \/ "usage\.json"\)\.read_text\(\)\) if auth == "login" else \{\}/);
+  assert.match(JUDGE, /if auth == "login":\s*\n\s*# only a LOGIN-billed success is evidence/);
+  assert.match(JUDGE, /if auth == "login":\s*\n\s{24}_limit_mark\("account", None, None, model\)/,
+    "the envelope mark too (the manager's ruling: it carries no resets_at, so a false one sticks)");
 });
 
 test("the '+N more' expand is keyed and delegated — click-safe across the per-push repaints", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1511,6 +1511,9 @@ body.filebrowse-open { overflow: hidden; }
 /* who the window touches (2026-08-28): same text size as the line it extends (fonts: reuse), dimmer */
 .judge-limit-banner .jl-sess { opacity: 0.65; min-width: 0; }
 .judge-limit-banner .jl-more { color: var(--accent); cursor: pointer; white-space: nowrap; }
+/* the standard session reference (the user 2026-08-28): bold name in its identity colour; the
+   host: prefix keeps the shared .host-prefix treatment */
+.judge-limit-banner .jl-chip { font-weight: 700; font-style: normal; }
 .judge-limit-banner .jl-unknown { opacity: 0.8; font-style: italic; }
 .judge-limit-banner .jl-dismiss { flex: none; margin-left: auto; background: none; border: none;
   color: var(--dim); cursor: pointer; font-size: 1em; padding: 2px 6px; border-radius: 4px; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4191,8 +4191,9 @@ function feedToast(text: string) {
 // payload (self-expiring at the window reset, cleared by the next successful call). Built ONCE and
 // updated in place — the button must survive re-renders (the click-safety rule), and it
 // acknowledges immediately, then the latch clearing hides the banner on a later payload.
+type JlIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };
 let judgeLimit: { bucket?: string; resets_at?: number; model?: string;
-                  loginSessions?: string[]; billingUnknown?: string[] } | null = null;
+                  loginSessions?: JlIdent[]; billingUnknown?: JlIdent[] } | null = null;
 // The dismiss latches to THIS episode's identity — a NEW episode (different bucket or reset time)
 // is new information and re-shows the banner; nothing else does (event-based, no timers). Stored
 // in localStorage so the dismissal survives re-renders and reloads for the episode's lifetime.
@@ -4248,23 +4249,32 @@ function paintJudgeLimit(): void {
     ? new Date(ra * 1000).toTimeString().slice(0, 5) : "";
   const fable = judgeLimit.bucket === "fable";
   const txt = b.querySelector(".jl-text")!;
-  // board-wide is the honest scope: the judges bill one credential, so card movement pauses for
-  // every session's cards — running sessions keep going on their own billing (the user 2026-08-28)
+  // the HONEST scope (the user 2026-08-28, correction round — the everything-is-paused framing was
+  // wrong: a judge call bills the JUDGED session's account, so key-billed analysis keeps flowing):
+  // the window is the login account's; only the sessions billing it pause.
   txt.textContent = fable
-    ? "Card analysis is paused board-wide — the Fable usage window is full" + (when ? " (resets " + when + ")." : ".")
-    : "Card analysis is paused board-wide — the account's usage window is full" + (when ? "; it resumes at " + when + "." : ".");
-  // …and WHO ELSE the window touches: only the sessions billing this account rate-limit on their
-  // own turns. Inline names when few; a keyed "+N more" expand when many (progressive disclosure);
-  // a session whose billing romp cannot read is listed as unknown, never silently omitted.
+    ? "The account's Fable usage window is full" + (when ? " (resets " + when + ")." : ".")
+    : "The account's usage window is full" + (when ? "; it resumes at " + when + "." : ".");
+  // WHO it touches: the sessions billing this account lose BOTH their turns (rate-limited) and
+  // their card analysis until the reset; everyone else's analysis continues on their own billing.
+  // Names wear the standard session chip — bold, identity colour, quiet host: prefix (the user's
+  // ask). Inline when few; a keyed "+N more" expand when many; unknown billing said, never omitted.
   const sessEl = b.querySelector(".jl-sess") as HTMLElement;
   sessEl.replaceChildren();
   const names = judgeLimit.loginSessions || [];
   const unk = judgeLimit.billingUnknown || [];
+  const chip = (p: JlIdent) => {
+    const c = el("b", "jl-chip");
+    c.replaceChildren(...hostPartsNodes(p.host, p.name));
+    if (p.color && p.color.bg) c.style.color = p.color.bg;
+    return c;
+  };
+  const appendChips = (list: JlIdent[]) => list.forEach((p, i) => { if (i) sessEl.append(", "); sessEl.appendChild(chip(p)); });
   if (names.length) {
     const many = names.length > 3;
     const shown = many && !jlSessOpen ? names.slice(0, 2) : names;
-    sessEl.append("These sessions bill this account, so their own turns are rate-limited too: "
-      + shown.join(", "));
+    sessEl.append("Analysis and turns pause for the sessions billing it: ");
+    appendChips(shown);
     if (many) {
       const more = el("span", "jl-more");
       more.dataset.act = "jl-more";
@@ -4272,12 +4282,18 @@ function paintJudgeLimit(): void {
       more.title = jlSessOpen ? "collapse the list" : "show every affected session";
       sessEl.appendChild(more);
     }
+    sessEl.append(". Other sessions' analysis continues on their own billing.");
+  } else {
+    sessEl.append("No live session bills this account — every session's analysis continues on its own billing.");
   }
   if (unk.length) {
     const u = el("span", "jl-unknown");
-    u.textContent = (names.length ? " · " : "") + "billing unknown for " + unk.join(", ")
-      + " (their CLI doesn't report it)";
+    u.textContent = " · billing unknown for ";
     sessEl.appendChild(u);
+    appendChips(unk);
+    const u2 = el("span", "jl-unknown");
+    u2.textContent = " (their CLI doesn't report it)";
+    sessEl.appendChild(u2);
   }
   const btn = b.querySelector(".jl-switch") as HTMLButtonElement;
   btn.style.display = fable ? "" : "none";


### PR DESCRIPTION
Correction round (the user 2026-08-28, who watched cards keep landing under a 'paused' banner): a judge call bills the **judged session's** account (the 2026-08-12 rule), but the rate-limit gate predated that rule — it read the login account's usage windows and gated **every** call, starving key-billed judging that has no windows at all (pay-per-token, the 2026-08-13 ruling). Three legs, all scoped to login-billed calls:

- **Gate**: the call's billing resolves first (fsid from the judge context); usage.json is read only for login-billed calls — every bucket (five_hour/seven_day/fable alike) is a login-account window; key-billed calls always proceed.
- **Latch**: `_limit_clear` fires only on a login-billed success — a key success says nothing about the login window. The limit-shaped **envelope mark** follows (the manager's ruling): that latch carries no `resets_at`, so a key-billed 429 minting it would stick a false banner only a later login success could clear; the key call keeps its call-failed mark, error row, and the harmless usage poke.
- **Banner**: the honest scope — the account's window is full; analysis **and** turns pause for the sessions billing it, named as the **standard session chip** (bold, identity colour, shared host-prefix treatment; identities ride the payload through the one `_peer_identity` ladder) — and every other session's analysis continues on its own billing. Empty-list and unknown-billing rows stated, never blank. Keyed expand, per-episode dismiss, and the Opus button keep last round's contracts.

Tests: the gate matrix (login gated at 100%, key passes, clear only by login success, key 429 mints no latch) with billing pinned deterministically in the existing gate tests — they implicitly assumed login and would have flipped on an env-keyed machine; payload-view matrix updated to identity dicts; banner copy/chip pins retargeted plus a no-everything-paused sweep. Python 5990 passed / extension 2544 passed on the pushed head; corrected-banner screenshot with colored chips in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)