### PR TITLE
The redundancy memo can no longer deadlock a quiet session's Working cards

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3565,12 +3565,15 @@ def _walk_root_record(sid):
         return None
 
 
-def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None):
+def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None, parked_s=None):
     """Append one auto-nudge event to STATE/nudge-events.jsonl — {sid, gid, t, count, verdict, evT} —
     for the timeline's DEBUG judging band (per-nudge ⚡ marker) AND the redundancy accounting (the
     user 2026-08-25): every decision the gate takes is a row — fired / skipped-redundant /
     held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap / skipped-redundant-memo (the
-    T142 memo served a ruling already made on this exact evidence, no judge call) /
+    T142 memo served a ruling already made on this exact evidence, no judge call; the row carries
+    parkedS — seconds the session has sat parked since the skip's answeredAt — so the quiet-session
+    deadlock fingerprint is countable from this log alone, 2026-08-29) / fired-parked-backstop (the
+    memo held but the session sat parked past the dead-man stand — the fire re-engages it) /
     resolved-at-send / blocked-on-user-at-send — carrying the evidence snapshot's timestamp, so redundant fires are
     countable from the log alone. That accounting is what extended the freshness guard to the cap
     path (the user 2026-08-27, T120: the pre-T120 force-fired-at-cap rows measured the blind fire
@@ -3582,7 +3585,8 @@ def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None):
         with p.open("a") as f:
             f.write(json.dumps({"sid": sid, "gid": gid, "t": int(t), "count": count,
                                 "verdict": verdict,
-                                **({"evT": int(ev_t)} if ev_t else {})}) + "\n")
+                                **({"evT": int(ev_t)} if ev_t else {}),
+                                **({"parkedS": int(parked_s)} if parked_s else {})}) + "\n")
     except Exception:
         pass
 
@@ -3714,6 +3718,24 @@ def _last_state(sid):
 def _last_state_value(sid):
     """Just the value of _last_state — the most-recent STATE transition; '' when none."""
     return _last_state(sid)[0]
+
+
+def _settle_event_key(sid):
+    """The session's newest recorded SETTLE (turn-end) event, as an opaque key — the redundancy
+    memo's second key half (the user 2026-08-29, the quiet-session deadlock; seam agreed with the
+    hook-ledger round). Primary: the SDK backend's hook ledger — the CLI's own Stop hook stamps
+    `lastStopAt` (int epoch seconds) on the session's registry entry (STATE/sdk/<sid>.json) on
+    EVERY turn end; that is the authoritative settle signal. Fallback when the field is absent
+    (tmux CLIs have no SDK hooks; a pre-ledger SDK session carries no field until its first
+    post-ledger turn): the newest states/ transition (_last_state), which the tmux Stop hook
+    writes. Absence reads as "no settle evidence" (key 0), never as "never settled". Both sources
+    stamp on every turn end including romp-fed ones — fine here: a settle re-arms at most ONE
+    re-judge, and the memo re-mints against the new key."""
+    try:
+        t = int((_thread_reg(sid) or {}).get("lastStopAt") or 0)
+    except Exception:
+        t = 0
+    return t or (_last_state(sid)[1] or 0)
 
 
 # Session states the authoritative log reports while a session is ACTIVELY PROGRESSING (not genuinely stopped).
@@ -5354,7 +5376,18 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                     fired = True                           # push so the chip/floor reaches the feed now
                 elif _fate == "moot":
                     nudged[gid] = dict(rec, moot=True)     # the judges superseded the ask — no chip, no block
-            continue
+            _anch = max(rec.get("answeredAt") or 0, rec.get("at") or 0) if rec else 0
+            if not (arm_id is not None and rec.get("moot") and not rec.get("failed")
+                    and _anch and now - _anch > AWAITING_DEADMAN_SECS):
+                continue
+            # MOOT IS NOT TERMINAL ON A PARKED SESSION (the user 2026-08-29, the quiet-session
+            # deadlock): the moot retire's own justification is "a genuinely still-stalled goal
+            # re-arms on the next GENUINE ended turn" — a turn a parked session never produces
+            # (the audited node: moot, still Working, silent for 8 hours). Past the same dead-man
+            # stand the wake ladder uses for unobservable waits, the goal re-enters the due path
+            # below; the redundancy gate then owns it (fresh judge, memo, or the parked-backstop
+            # fire). A `failed` record stays terminal — its needs-you block already reached the
+            # user, whose reply is the pending event.
         count = rec.get("count", 0) + 1
         # (the nudge-fire forensics side-log was retired with the P3.4 sweep, 2026-07-07 — the goal's
         # verdict diary is the audit trail now)
@@ -5400,6 +5433,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                 _nodes = jd.load_goals(sid).get("nodes", {})
             except Exception:
                 _nodes = {}
+            settle_t = _settle_event_key(sid)      # the memo's second key half — one read per tick
 
             def _judge_batch(cands, report, report_ts, held_pass):
                 keep = []
@@ -5434,13 +5468,42 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                         # dies the moment the transcript's newest report moves or a fire replaces
                         # the record. Consulted before ANY call, so the flip class dies by
                         # construction. Event-true: no time backoff, no counter.
-                        if report_ts and rec0.get("redundantEvT") == report_ts:
+                        # THE MEMO IS TWO-KEYED NOW (the user 2026-08-29, the quiet-session
+                        # deadlock): same evidence AND same settle event = the world has provably
+                        # not moved, serve the ruling. Either key moving re-arms exactly ONE
+                        # re-judge, which re-memos against the new pair — no storm returns. The
+                        # settle key is the session's own turn-end event (_settle_event_key:
+                        # hook-ledger lastStopAt primary, idle-atom fallback). Keyed on evT alone,
+                        # a quiet session's one-time ruling was a PERMANENT veto — the audited
+                        # board: four Working cards skip-looped for 8 hours on one frozen evT.
+                        if report_ts and rec0.get("redundantEvT") == report_ts \
+                                and rec0.get("redundantSettleT") == settle_t:
+                            _anch = max(rec0.get("answeredAt") or 0, rec0.get("at") or 0)
+                            if _anch and now - _anch > AWAITING_DEADMAN_SECS:
+                                # PARKED DEAD-MAN: a fully-quiet session produces NO future event
+                                # — no report, no settle — so no key change can ever re-arm it;
+                                # the absence of events IS the condition. That is the wake
+                                # ladder's "unobservable wait", and it takes the SAME documented
+                                # stand (answeredAt + AWAITING_DEADMAN_SECS — never a new
+                                # window): the candidate stays in the fire list and the fire
+                                # re-engages the session, honoring the 2026-08-22 promise that
+                                # every Working card is nudged/woken until it lands. One fire per
+                                # memo epoch by construction — the fire writes a fresh record,
+                                # and its response either moves the evidence (a new judgment
+                                # world) or converts through the normal failed/needs-you leg.
+                                _verdicts[f[0]] = ("fired-parked-backstop", report_ts)
+                                if skips:
+                                    nudged[f[0]] = dict(rec0, redundantSkips=0)
+                                    _put_nudged(f[0], nudged[f[0]])
+                                keep.append(f)
+                                continue
                             _log_nudge_event(sid, f[0], now, f[1],
-                                             verdict="skipped-redundant-memo", ev_t=report_ts)
+                                             verdict="skipped-redundant-memo", ev_t=report_ts,
+                                             parked_s=(now - _anch) if _anch else None)
                             continue
                         if gtxt and jd.nudge_redundant(gtxt, report):
                             nudged[f[0]] = dict(rec0, answeredAt=int(now), redundantSkips=skips + 1,
-                                                redundantEvT=report_ts)
+                                                redundantEvT=report_ts, redundantSettleT=settle_t)
                             _put_nudged(f[0], nudged[f[0]])
                             _v = ("skipped-redundant-at-cap" if skips >= 2
                                   else "held-fresh-re-judged" if held_pass else "skipped-redundant")

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -211,7 +211,11 @@ class FreshGuard(unittest.TestCase):
         # consumes no arm, so a capped goal came due every tick and re-judged constant evidence
         # (147 re-judgments on one goal in 68 minutes; ~$1.92/day)
         self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
-                        "redundantSkips": 1, "redundantEvT": ARM_T + 50})
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50,
+                        "redundantSettleT": 0})       # both memo keys current (2026-08-29: the memo
+        #                                               is two-keyed; a record missing the settle key
+        #                                               re-judges ONCE by design — the upgrade path,
+        #                                               pinned in test_nudge_memo_deadlock.py)
         self.judge_replies = [True]                   # would be consulted only by a bug
         self._tick()
         self.assertEqual(self.sent, [])
@@ -224,7 +228,8 @@ class FreshGuard(unittest.TestCase):
         # ruled redundant — nondeterminism delivering the stale nudge T120 exists to stop. The
         # memo is consulted before the at-cap consult too, so the flip cannot happen.
         self._seed_rec({"count": 1, "lastTurnId": "t0", "armAtoms": 1, "at": ARM_T - 500,
-                        "redundantSkips": 2, "redundantEvT": ARM_T + 50})
+                        "redundantSkips": 2, "redundantEvT": ARM_T + 50,
+                        "redundantSettleT": 0})       # both memo keys current (see the memo test above)
         self.judge_replies = [False]                  # the flip verdict, never reachable
         self._tick()
         self.assertEqual(self.sent, [], "a pair ruled redundant can never fire on the same evidence")

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""The redundancy memo must never be a PERMANENT veto (the user 2026-08-29, the quiet-session
+deadlock): the T142 memo keyed only on newest-evidence-time, and a quiet session's evidence time
+never moves — so one redundant ruling froze four Working cards in an 8-hour skipped-redundant-memo
+loop, breaking the 2026-08-22 promise that every Working card is nudged/woken until it lands. The
+fix, all event-keyed: (1) the memo is TWO-keyed — evidence time AND the session's settle event
+(_settle_event_key: the hook ledger's lastStopAt primary, the states/ idle atom fallback); either
+key moving re-arms exactly ONE re-judge, which re-memos against the new pair — no storm returns;
+(2) a session parked past the wake ladder's dead-man stand (answeredAt + AWAITING_DEADMAN_SECS,
+the documented stand for unobservable waits — a fully-quiet session produces NO future event, so
+no key change can ever re-arm it) takes a real fire that re-engages it, once per memo epoch;
+(3) a moot retire is not terminal on a parked session — its own justification ("re-arms on the
+next GENUINE ended turn") never holds when no turn will come; (4) skipped-redundant-memo rows
+carry parkedS, so the deadlock fingerprint is countable from nudge-events.jsonl alone.
+SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_memodl", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-dddddddddddd"
+G1 = SID + ":g1"
+ARM_T, NOW = 1_787_000_000, 1_787_000_600
+PARKED = NOW - km.AWAITING_DEADMAN_SECS - 60      # answeredAt long past the dead-man stand
+
+
+def _store():
+    return {"rompUuid": SID, "seq": 1, "placements": {}, "status": {},
+            "nodes": {G1: {"id": G1, "text": "Ship the exporter", "parentId": None,
+                           "nodeComplete": False, "blocked": False, "cleared": False,
+                           "trail": [], "t": ARM_T - 100, "mt": ARM_T - 100, "log": []}},
+            "confirming": []}
+
+
+class MemoDeadlock(unittest.TestCase):
+    """Drives the real _auto_nudge_session with the fresh-guard harness idiom."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._autonudge_cache.clear()
+        self._orig_km = {n: getattr(km, n) for n in (
+            "_session_flag", "_compacting_now", "_api_error", "_session_working",
+            "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
+            "_last_state", "_session_awaiting", "_closer_settled", "_revivers_pending",
+            "_pending_ops", "_last_assistant_report", "_all_outstanding_delegated")}
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs",
+                                                     "plan_units", "nudge_redundant")}
+        self._orig_backend = km.Sessions.backend_for
+        km._session_flag = lambda sid, flag: False
+        km._compacting_now = lambda sid: False
+        km._api_error = lambda path: None
+        km._session_working = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._backend_queued = lambda sid: False
+        km._backend_rewind_pending = lambda sid: False
+        km._last_state = lambda sid: ("", 0)
+        km._session_awaiting = lambda *a, **k: False
+        km._closer_settled = lambda *a: True
+        km._revivers_pending = lambda *a: ""
+        km._all_outstanding_delegated = lambda nodes, gid: False
+        km._pending_ops = {}
+        jd._segs = lambda tn, store: []
+        jd.plan_units = lambda session, store: []
+        uid = "u-t1"
+        self.turns = [{"id": "t1", "t": ARM_T, "end": ARM_T + 60, "ended": True,
+                       "trigger": {"uuid": uid},
+                       "atoms": [{"uuid": uid, "type": "user", "author": "human", "t": ARM_T}]}]
+        jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+        self.store = _store()
+        jd.load_goals = lambda sid: self.store
+        self.sent = []
+        self.reports = [("working through the queue", ARM_T + 50),
+                        ("working through the queue", ARM_T + 50)]
+        self.report_reads = []
+        self.judge_calls = []
+        self.judge_replies = []
+        test = self
+        km._last_assistant_report = lambda path, cap=4000: (
+            test.report_reads.append(1) or test.reports[min(len(test.report_reads) - 1,
+                                                            len(test.reports) - 1)])
+        jd.nudge_redundant = lambda gtxt, recent: (
+            test.judge_calls.append(recent) or
+            test.judge_replies[min(len(test.judge_calls) - 1, len(test.judge_replies) - 1)])
+
+        class FakeBackend:
+            def send(self, sid, body):
+                test.sent.append(body)
+        km.Sessions.backend_for = staticmethod(lambda sid: FakeBackend())
+
+    def tearDown(self):
+        for n, v in self._orig_km.items():
+            setattr(km, n, v)
+        for n, v in self._orig_jd.items():
+            setattr(jd, n, v)
+        km.Sessions.backend_for = self._orig_backend
+        jd.STATE = self.saved_state
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _tick(self):
+        nudged = dict(km._auto_nudge_data().get("nudged", {}))
+        return km._auto_nudge_session({"sid": SID, "path": "/nonexistent.jsonl"}, NOW, {}, nudged, {})
+
+    def _rows(self):
+        p = jd.STATE / "nudge-events.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+    def _seed_rec(self, rec):
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps({"enabled": True, "nudged": {G1: rec}}))
+        km._autonudge_cache.clear()
+
+    def _rec(self):
+        return km._auto_nudge_data()["nudged"][G1]
+
+    # ── the memo veto: two keys, active-session behavior preserved ──
+    def test_same_evidence_same_settle_serves_the_memo_with_parked_s(self):
+        self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50, "redundantSettleT": 0})
+        self._tick()
+        self.assertEqual(self.sent, [], "the memo veto stands — no fire")
+        self.assertEqual(self.judge_calls, [], "served from the memo, no judge call")
+        rows = self._rows()
+        self.assertEqual([r["verdict"] for r in rows], ["skipped-redundant-memo"])
+        self.assertEqual(rows[0]["parkedS"], 300,
+                         "the row carries the parked duration — the deadlock fingerprint is "
+                         "countable from the log alone")
+
+    def test_a_new_settle_event_rearms_exactly_one_rejudge_then_rememos(self):
+        self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50, "redundantSettleT": 0})
+        km._last_state = lambda sid: ("idle", NOW - 30)   # the session settled ANEW since the memo
+        self.judge_replies = [True]
+        self._tick()
+        self.assertEqual(self.sent, [], "still redundant — no fire")
+        self.assertEqual(len(self.judge_calls), 1, "the new settle bought exactly ONE re-judge")
+        self.assertEqual(self._rec().get("redundantSettleT"), NOW - 30,
+                         "…which re-memos against the new settle key")
+        self._tick()
+        self.assertEqual(len(self.judge_calls), 1, "same pair again → served from the memo, no loop")
+        self.assertEqual([r["verdict"] for r in self._rows()],
+                         ["skipped-redundant", "skipped-redundant-memo"])
+
+    # ── the parked dead-man: the quiet-session deadlock's exit ──
+    def test_parked_past_the_deadman_fires_once_and_writes_a_fresh_record(self):
+        self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": PARKED,
+                        "redundantSkips": 2, "redundantEvT": ARM_T + 50, "redundantSettleT": 0})
+        self.assertTrue(self._tick())
+        self.assertEqual(len(self.sent), 1, "the parked backstop re-engages the session")
+        self.assertEqual(self.judge_calls, [], "an escalation, not a judgment — no judge call")
+        rows = [r for r in self._rows() if r["verdict"] not in ("skipped-redundant-memo",)]
+        self.assertEqual([r["verdict"] for r in rows], ["fired-parked-backstop"])
+        self.assertEqual(rows[0]["evT"], ARM_T + 50, "the row names the evidence it out-waited")
+        rec = self._rec()
+        self.assertEqual(rec.get("lastTurnId"), "t1", "a fresh fire record replaces the memo's")
+        self.assertNotIn("redundantEvT", rec, "…so the memo epoch is over")
+        self._tick()
+        self.assertEqual(len(self.sent), 1, "one fire per epoch: the fresh record owns the aftermath")
+
+    # ── moot is not terminal on a parked session ──
+    def test_moot_on_a_parked_session_reenters_the_ladder(self):
+        self._seed_rec({"lastTurnId": "t1", "count": 1, "moot": True, "answeredAt": PARKED})
+        self.judge_replies = [False]
+        self.assertTrue(self._tick())
+        self.assertEqual(len(self.sent), 1,
+                         "moot + still Working + parked past the dead-man → the ladder proceeds")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["fired"])
+
+    def test_moot_within_patience_stays_silent(self):
+        self._seed_rec({"lastTurnId": "t1", "count": 1, "moot": True, "answeredAt": NOW - 300})
+        self._tick()
+        self.assertEqual(self.sent, [], "the moot retire holds while the stand is still patient")
+        self.assertEqual(self._rows(), [])
+
+    def test_failed_stays_terminal_however_long_parked(self):
+        self._seed_rec({"lastTurnId": "t1", "count": 1, "failed": True, "failedAt": PARKED,
+                        "answeredAt": PARKED, "at": PARKED})
+        self._tick()
+        self.assertEqual(self.sent, [], "failed already produced the needs-you block — the user's "
+                                        "reply is the pending event, not another fire")
+        self.assertEqual(self._rows(), [])
+
+
+class SettleEventKey(unittest.TestCase):
+    """_settle_event_key: hook-ledger lastStopAt primary, idle-atom fallback, absence reads 0."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        self._orig_last_state = km._last_state
+        km._last_state = lambda sid: ("idle", 99)
+
+    def tearDown(self):
+        km._last_state = self._orig_last_state
+        jd.STATE = self.saved_state
+        self.td.cleanup()
+
+    def test_hook_ledger_wins_when_present(self):
+        (jd.STATE / "sdk").mkdir(parents=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"lastStopAt": 12345}))
+        self.assertEqual(km._settle_event_key(SID), 12345)
+
+    def test_absent_field_falls_to_the_idle_atom(self):
+        (jd.STATE / "sdk").mkdir(parents=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"lastSid": SID}))
+        self.assertEqual(km._settle_event_key(SID), 99, "a pre-ledger SDK session reads the atom")
+
+    def test_no_registry_no_atom_reads_zero(self):
+        km._last_state = lambda sid: ("", 0)
+        self.assertEqual(km._settle_event_key(SID), 0, "absence is 'no settle evidence', never a crash")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -155,6 +155,26 @@ class MemoDeadlock(unittest.TestCase):
         self.assertEqual([r["verdict"] for r in self._rows()],
                          ["skipped-redundant", "skipped-redundant-memo"])
 
+    def test_a_pre_upgrade_record_missing_the_settle_key_rejudges_exactly_once(self):
+        # THE UPGRADE PATH: every record minted before this change carries redundantEvT but no
+        # redundantSettleT — the veto must FAIL for it (None never equals the always-int settle
+        # key, 0 included) so each deployed deadlock gets exactly one fresh judgment, whose
+        # re-memo then carries both keys. Pins the .get() default: rec0.get("redundantSettleT")
+        # must not grow a 0 fallback, or every pre-upgrade record on a settle-key-0 session
+        # regains the frozen veto this round exists to kill.
+        self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50})
+        self.judge_replies = [True]
+        self._tick()
+        self.assertEqual(self.sent, [], "still redundant — no fire")
+        self.assertEqual(len(self.judge_calls), 1, "the missing key bought exactly ONE re-judge")
+        self.assertEqual(self._rec().get("redundantSettleT"), 0,
+                         "…and the re-memo now carries the settle key")
+        self._tick()
+        self.assertEqual(len(self.judge_calls), 1, "second tick serves from the upgraded memo")
+        self.assertEqual([r["verdict"] for r in self._rows()],
+                         ["skipped-redundant", "skipped-redundant-memo"])
+
     # ── the parked dead-man: the quiet-session deadlock's exit ──
     def test_parked_past_the_deadman_fires_once_and_writes_a_fresh_record(self):
         self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": PARKED,


### PR DESCRIPTION
## Summary
The T142 redundancy memo keyed only on newest-evidence-time; a quiet session's evidence time never moves, so one redundant ruling became a **permanent veto** — nothing re-judged, nothing fired, nothing escalated. Live measure: 82% of all nudge-events rows (7,143 of 8,698) were `skipped-redundant-memo` loops; four Working cards on one parked session alone logged 1,960 + 3×1,477 rows over 8–10 hours on a single frozen evT, breaking the promise that every Working card is nudged/woken until it lands.

Three coupled fixes, all event-keyed:

- **The memo is two-keyed**: evidence time AND the session's settle event. New `_settle_event_key` seam: the SDK hook ledger's `lastStopAt` (stamped by the CLI's own Stop hook on every turn end; seam shape agreed with the hook-ledger round — field name + absence rule, absence reads "no evidence") primary, the `states/` idle atom fallback for tmux CLIs and pre-ledger sessions. Either key moving re-arms exactly ONE re-judge, which re-memos against the new pair — no storm returns, and the redundant-kill on active sessions stands. A pre-upgrade record (no settle key) re-judges once by design, pinned.
- **Parked sessions escalate through the existing dead-man stand.** A fully quiet session produces no future event, so no key change can ever re-arm it — the wake ladder's documented "unobservable wait". The memo veto takes the same stand (`answeredAt` + `AWAITING_DEADMAN_SECS`, never a new window): past it the candidate stays in the fire list and the fire re-engages the session, once per memo epoch by construction.
- **Moot is not terminal on a parked session.** The moot retire's own justification ("re-arms on the next GENUINE ended turn") never holds when no turn will come. Past the same stand, a moot record on a still-Working goal re-enters the due path. `failed` records stay terminal — their needs-you block already reached the user.

Plus the fingerprint: `skipped-redundant-memo` rows carry `parkedS`, so the deadlock signature is countable from nudge-events.jsonl alone — and transient by construction.

## Test plan
- New `tests/test_nudge_memo_deadlock.py` (10 tests) against the real `_auto_nudge_session`: memo serves with parkedS; a new settle event re-arms exactly one re-judge then re-memos (no loop); the pre-upgrade record path (adversarial-review finding — pins the `.get()` default); parked past the dead-man fires once with a fresh record; moot re-enters when parked, holds when patient; failed stays terminal; the settle-key ladder (hook ledger wins, absent field falls to the atom, absence reads zero).
- Full Python suite: 6,004 passed. Extension suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)