### PR TITLE
The launch ledger: background work recorded at the call moment, and the turn-end event as a fact

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -221,6 +221,9 @@ def _parse_task_notification(txt):
 # which an idle transcript never busts. The grace absorbs kill/notify latency.
 def _bg_expired(task, now, grace=120.0):
     dl = (task or {}).get("deadline")
+    if (task or {}).get("deadlineSrc") == "hook":
+        grace = 5.0   # a hook-recorded deadline is the harness's own kill moment (Monitor's
+        #               required timeout_ms, journaled at launch) — exact, so only clock skew
     return bool(dl) and now > dl + grace
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13997,22 +13997,29 @@ def _bg_live_norm(sid, path):
     if live is None:
         return []
     if "bgTasks" in live:
-        return [{"tid": t.get("toolUseId"), "desc": str(t.get("desc") or "").strip(),
-                 "t": int(t.get("since") or 0), "type": str(t.get("type") or "")}
-                for t in live.get("bgTasks") or [] if isinstance(t, dict)]
-    # source 0.6 — the LAUNCH LEDGER (2026-08-29): hook-recorded launch facts in the reg, durable
-    # across backend restarts, with EXACT deadlines (Monitor's own timeout_ms) — so expiry here is
-    # the recorded moment plus clock skew, never the scrape's +120s guess. Present-but-empty is
-    # authoritative like the lifecycle set above; only its ABSENCE (tmux, a pre-ledger session)
-    # falls through to the transcript pairing below.
-    reg = _thread_reg(str(sid))   # the SDK registry entry, {} when unreadable — same read the threads use
-    led = reg.get("bgLedger")
-    if led is not None:
-        now = time.time()
-        return [{"tid": e.get("toolUseId") or e.get("tid"), "desc": str(e.get("desc") or "").strip(),
-                 "t": int(e.get("armedAt") or 0), "type": str(e.get("tool") or "")}
-                for e in led if isinstance(e, dict)
-                and not (e.get("deadlineEpoch") and now > float(e["deadlineEpoch"]) + 5)]
+        # The launch LEDGER (2026-08-29) ENRICHES the stream's rows, never replaces them: the
+        # lifecycle set stays the liveness authority (SDK CLIs are kernel children, so a task
+        # cannot outlive the stream that watches it — the first cut's ladder rung here was
+        # unreachable dead code, caught in review). The join adds what only the launch hook
+        # knows: Monitor's EXACT deadline (expiry at the recorded moment + skew, not the
+        # scrape's +120s guess — em._bg_expired reads deadlineSrc) and the acting agent.
+        led = {str(e.get("toolUseId")): e
+               for e in (_thread_reg(str(sid)).get("bgLedger") or [])
+               if isinstance(e, dict) and e.get("toolUseId")}
+        out = []
+        for t in live.get("bgTasks") or []:
+            if not isinstance(t, dict):
+                continue
+            row = {"tid": t.get("toolUseId"), "desc": str(t.get("desc") or "").strip(),
+                   "t": int(t.get("since") or 0), "type": str(t.get("type") or "")}
+            e = led.get(str(t.get("toolUseId")))
+            if e and e.get("deadlineEpoch"):
+                row["deadline"] = float(e["deadlineEpoch"])
+                row["deadlineSrc"] = "hook"
+            if e and e.get("agentId"):
+                row["agentId"] = e["agentId"]
+            out.append(row)
+        return [r for r in out if not em._bg_expired(r, time.time())]
     if not path:
         return []
     sp = _sdk_spawned_at(sid)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14000,6 +14000,19 @@ def _bg_live_norm(sid, path):
         return [{"tid": t.get("toolUseId"), "desc": str(t.get("desc") or "").strip(),
                  "t": int(t.get("since") or 0), "type": str(t.get("type") or "")}
                 for t in live.get("bgTasks") or [] if isinstance(t, dict)]
+    # source 0.6 — the LAUNCH LEDGER (2026-08-29): hook-recorded launch facts in the reg, durable
+    # across backend restarts, with EXACT deadlines (Monitor's own timeout_ms) — so expiry here is
+    # the recorded moment plus clock skew, never the scrape's +120s guess. Present-but-empty is
+    # authoritative like the lifecycle set above; only its ABSENCE (tmux, a pre-ledger session)
+    # falls through to the transcript pairing below.
+    reg = _thread_reg(str(sid))   # the SDK registry entry, {} when unreadable — same read the threads use
+    led = reg.get("bgLedger")
+    if led is not None:
+        now = time.time()
+        return [{"tid": e.get("toolUseId") or e.get("tid"), "desc": str(e.get("desc") or "").strip(),
+                 "t": int(e.get("armedAt") or 0), "type": str(e.get("tool") or "")}
+                for e in led if isinstance(e, dict)
+                and not (e.get("deadlineEpoch") and now > float(e["deadlineEpoch"]) + 5)]
     if not path:
         return []
     sp = _sdk_spawned_at(sid)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2920,10 +2920,13 @@ class SdkSession:
                         kept.append(e)
                     elif str(e.get("procGen") or "") != self.proc_gen:
                         ended.append({"tid": e.get("tid"), "why": "processDied", "at": nw})
-                    elif tid:
+                    elif tid and e.get("tool") == "bash":
+                        # only SHELLS are proven to ride the payload (probe 2026-08-28) — a monitor
+                        # absent from it may simply be uncovered, and a false "gone" would silently
+                        # un-wait the session; monitors end by deadline, fail, stop, or processDied
                         ended.append({"tid": e.get("tid"), "why": "gone", "at": nw})
                     else:
-                        kept.append(e)   # no id to match on — the reconciler cannot rule on it
+                        kept.append(e)   # no id / unproven coverage — the reconciler cannot rule on it
                 have = {str(e.get("tid")) for e in kept}
                 for tid, t in running.items():
                     if tid not in have:
@@ -3015,8 +3018,13 @@ class SdkSession:
     # invisible to the transcript fold). Live set in the reg (bounded: running entries only) plus a
     # small tombstone tail (bgLedgerEnded) so "called off its own wait" and "died with its process"
     # are events the kernel can say, not guesses.
-    _LEDGER_TOOLS = ("Bash", "Monitor", "Task", "Workflow")
+    # Bash-bg + Monitor ONLY (2026-08-29 review): their ack/input shapes are probe-verified
+    # (backgroundTaskId; required timeout_ms/persistent). Task/Workflow launches ride the
+    # lifecycle stream + the Subagent hooks — journaling them here recorded every FOREGROUND
+    # subagent call as a phantom launch and flooded the tombstone tail.
+    _LEDGER_TOOLS = ("Bash", "Monitor")
     _LEDGER_TOMBSTONES = 20
+    _LEDGER_CAP = 40
 
     def _ledger_read(self):
         reg = read_reg(self.backend.state_dir, self.sid) or {}
@@ -3042,7 +3050,8 @@ class SdkSession:
             nw = time.time()
             live, ended = self._ledger_read()
             if tname == "TaskStop":
-                tid = str(targs.get("task_id") or targs.get("taskId") or targs.get("id") or "")
+                tid = str(targs.get("task_id") or targs.get("taskId") or targs.get("id")
+                          or targs.get("shell_id") or "")   # shell_id: the deprecated param the CLI still accepts
                 if tid:
                     kept = [e for e in live if str(e.get("tid")) != tid]
                     if len(kept) != len(live):
@@ -3064,12 +3073,20 @@ class SdkSession:
                     deadline = nw + float(tmo) / 1000.0   # the harness kills the watcher then — exact,
                     #                                       not the job's ETA (research map item 2)
             desc = str(targs.get("description") or targs.get("prompt") or targs.get("command") or "")[:300]
-            entry = {"tid": tid or None, "toolUseId": str(tool_use_id or (inp or {}).get("tool_use_id") or "") or None,
+            tuid = str(tool_use_id or (inp or {}).get("tool_use_id") or "") or None
+            if not tid and not tuid:
+                return {}   # nothing to key on — an entry no event could ever clear must not be born
+            entry = {"tid": tid or None, "toolUseId": tuid,
                      "tool": tname.lower(), "desc": desc, "armedAt": int(nw),
                      "deadlineEpoch": deadline, "persistent": persistent,
                      "procGen": self.proc_gen,
                      "agentId": str((inp or {}).get("agent_id") or "") or None, "src": "hook"}
-            live = [e for e in live if not (tid and str(e.get("tid")) == tid)] + [entry]
+            live = [e for e in live
+                    if not (tid and str(e.get("tid")) == tid)
+                    and not (tuid and str(e.get("toolUseId")) == tuid)] + [entry]
+            if len(live) > self._LEDGER_CAP:   # bounded like every reg field — oldest launches evict, loudly
+                self.backend._log("bg-ledger (%s): cap %d hit, evicting oldest" % (self.name, self._LEDGER_CAP))
+                live = live[-self._LEDGER_CAP:]
             self._ledger_write(live, ended)
         except Exception as e:
             self.backend._log("bg-ledger hook (%s): %s" % (self.name, e))
@@ -4368,10 +4385,10 @@ class SdkBackend:
                    "PostToolUse": [HookMatcher(matcher="ScheduleWakeup|CronCreate|CronDelete",
                                                hooks=[sess._sched_tool_hook]),
                                    # launch ledger: exact launch facts at the call moment (2026-08-29)
-                                   HookMatcher(matcher="Bash|Monitor|Task|Workflow|TaskStop",
+                                   HookMatcher(matcher="Bash|Monitor|TaskStop",
                                                hooks=[sess._ledger_tool_hook])],
                    # a launch whose ack errored never started — drop it before it phantom-waits
-                   "PostToolUseFailure": [HookMatcher(matcher="Bash|Monitor|Task|Workflow",
+                   "PostToolUseFailure": [HookMatcher(matcher="Bash|Monitor",
                                                       hooks=[sess._ledger_fail_hook])]},
             permission_mode=sess.mode,
             # File-checkpoint rewind (the user 2026-08-04): the CLI backs files up before modifying them,

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2900,6 +2900,42 @@ class SdkSession:
                     self.backend._update_reg(self.sid, sessionCrons=slim, sessionCronsAt=int(nw))
         except Exception as e:
             self.backend._log("stop hook (%s): session_crons record failed: %s" % (self.name, e))
+        # Reconcile the LAUNCH LEDGER against the payload's background_tasks — the per-turn snapshot
+        # this hook used to discard (2026-08-29). The ledger is launch-authoritative; the payload is
+        # the CLI's own answer to "what is still running", so: a live-generation ledger entry absent
+        # from the payload ENDED (tombstone, why:"gone"); a DEAD-generation entry died with its
+        # process (background tasks are children of the CLI); a payload task the ledger never saw is
+        # adopted (src:"stopReconcile" — the hook missed a shape, or the entry predates the ledger).
+        try:
+            bg = inp.get("background_tasks") if isinstance(inp, dict) else None
+            if isinstance(bg, list):
+                nw = int(time.time())
+                live, ended = self._ledger_read()
+                running = {str(t.get("id")): t for t in bg
+                           if isinstance(t, dict) and t.get("status") == "running" and t.get("id")}
+                kept = []
+                for e in live:
+                    tid = str(e.get("tid") or "")
+                    if tid and tid in running:
+                        kept.append(e)
+                    elif str(e.get("procGen") or "") != self.proc_gen:
+                        ended.append({"tid": e.get("tid"), "why": "processDied", "at": nw})
+                    elif tid:
+                        ended.append({"tid": e.get("tid"), "why": "gone", "at": nw})
+                    else:
+                        kept.append(e)   # no id to match on — the reconciler cannot rule on it
+                have = {str(e.get("tid")) for e in kept}
+                for tid, t in running.items():
+                    if tid not in have:
+                        kept.append({"tid": tid, "toolUseId": None, "tool": str(t.get("type") or "shell"),
+                                     "desc": str(t.get("description") or "")[:300], "armedAt": nw,
+                                     "deadlineEpoch": None, "persistent": False,
+                                     "procGen": self.proc_gen, "agentId": None, "src": "stopReconcile"})
+                l0, e0 = self._ledger_read()
+                if kept != l0 or ended != e0:
+                    self._ledger_write(kept, ended)
+        except Exception as e:
+            self.backend._log("stop hook (%s): bg-ledger reconcile failed: %s" % (self.name, e))
         self.backend._poke()
         return {}
 
@@ -2960,6 +2996,98 @@ class SdkSession:
         return {}
 
     # ---- subagent tracking (the transparency tmux never had) ----
+
+    # ── the background-launch LEDGER (2026-08-29, the hookable-tools round) ────────────────────
+    # Launch facts recorded at the CALL moment from the tools' own inputs/acks, replacing the
+    # transcript scrape as the durable source for SDK sessions (the scrape stays for tmux and
+    # pre-ledger sessions — see kernel._bg_live_norm's source ladder). What the hook knows exactly
+    # that every other channel guesses: the launch's tool_use_id and task id pairing (the ack's
+    # backgroundTaskId, probe-verified 2026-08-28), Monitor's REQUIRED timeout_ms/persistent (an
+    # exact watcher deadline — retires the +120s grace for ledger entries), the arming process
+    # generation (launches die with their process), and the acting agent_id (subagent launches are
+    # invisible to the transcript fold). Live set in the reg (bounded: running entries only) plus a
+    # small tombstone tail (bgLedgerEnded) so "called off its own wait" and "died with its process"
+    # are events the kernel can say, not guesses.
+    _LEDGER_TOOLS = ("Bash", "Monitor", "Task", "Workflow")
+    _LEDGER_TOMBSTONES = 20
+
+    def _ledger_read(self):
+        reg = read_reg(self.backend.state_dir, self.sid) or {}
+        live = [e for e in (reg.get("bgLedger") or []) if isinstance(e, dict)]
+        ended = [e for e in (reg.get("bgLedgerEnded") or []) if isinstance(e, dict)]
+        return live, ended
+
+    def _ledger_write(self, live, ended):
+        self.backend._update_reg(self.sid, bgLedger=live,
+                                 bgLedgerEnded=ended[-self._LEDGER_TOMBSTONES:])
+
+    async def _ledger_tool_hook(self, inp, tool_use_id, context):
+        """PostToolUse on the launch/stop tools. Defensive throughout: an unrecognized shape records
+        nothing and logs — the Stop-hook reconciler and the lifecycle stream remain the safety nets."""
+        try:
+            tname = str((inp or {}).get("tool_name") or "")
+            targs = (inp or {}).get("tool_input") or {}
+            tresp = (inp or {}).get("tool_response") or {}
+            if not isinstance(targs, dict):
+                return {}
+            if not isinstance(tresp, dict):
+                tresp = {}
+            nw = time.time()
+            live, ended = self._ledger_read()
+            if tname == "TaskStop":
+                tid = str(targs.get("task_id") or targs.get("taskId") or targs.get("id") or "")
+                if tid:
+                    kept = [e for e in live if str(e.get("tid")) != tid]
+                    if len(kept) != len(live):
+                        ended.append({"tid": tid, "why": "stopped", "at": int(nw)})
+                        self._ledger_write(kept, ended)   # the session called off its own wait — an
+                        self.backend._poke()              # event, not a crash (review map item 4)
+                return {}
+            if tname == "Bash" and not targs.get("run_in_background"):
+                return {}                                 # foreground Bash is a turn, not a launch
+            if tname not in self._LEDGER_TOOLS:
+                return {}
+            tid = str(tresp.get("backgroundTaskId") or tresp.get("task_id") or tresp.get("taskId")
+                      or tresp.get("id") or "")
+            deadline, persistent = None, False
+            if tname == "Monitor":
+                persistent = bool(targs.get("persistent"))
+                tmo = targs.get("timeout_ms")
+                if not persistent and isinstance(tmo, (int, float)) and tmo > 0:
+                    deadline = nw + float(tmo) / 1000.0   # the harness kills the watcher then — exact,
+                    #                                       not the job's ETA (research map item 2)
+            desc = str(targs.get("description") or targs.get("prompt") or targs.get("command") or "")[:300]
+            entry = {"tid": tid or None, "toolUseId": str(tool_use_id or (inp or {}).get("tool_use_id") or "") or None,
+                     "tool": tname.lower(), "desc": desc, "armedAt": int(nw),
+                     "deadlineEpoch": deadline, "persistent": persistent,
+                     "procGen": self.proc_gen,
+                     "agentId": str((inp or {}).get("agent_id") or "") or None, "src": "hook"}
+            live = [e for e in live if not (tid and str(e.get("tid")) == tid)] + [entry]
+            self._ledger_write(live, ended)
+        except Exception as e:
+            self.backend._log("bg-ledger hook (%s): %s" % (self.name, e))
+        return {}
+
+    async def _ledger_fail_hook(self, inp, tool_use_id, context):
+        """PostToolUseFailure on the launch tools: a launch whose ack ERRORED never started — drop any
+        entry recorded for it so it cannot hold an awaiting gate open as a phantom wait (probe-verified
+        2026-08-28: the event emits with error + is_interrupt; a DENIED tool does not reach here)."""
+        try:
+            tuid = str((inp or {}).get("tool_use_id") or tool_use_id or "")
+            if not tuid:
+                return {}
+            live, ended = self._ledger_read()
+            kept = [e for e in live if str(e.get("toolUseId")) != tuid]
+            if len(kept) != len(live):
+                why = "interrupted" if (inp or {}).get("is_interrupt") else "launch-failed"
+                ended.append({"tid": next((e.get("tid") for e in live
+                                           if str(e.get("toolUseId")) == tuid), None),
+                              "why": why, "at": int(time.time())})
+                self._ledger_write(kept, ended)
+                self.backend._poke()
+        except Exception as e:
+            self.backend._log("bg-ledger fail hook (%s): %s" % (self.name, e))
+        return {}
 
     async def _subagent_start_hook(self, inp, tool_use_id, context):
         """A Task-spawned subagent just STARTED. Record it live (agent_id -> type + start time) so the session
@@ -4231,7 +4359,13 @@ class SdkBackend:
                    # scheduling tools record their arm at the CALL moment, with the exact due time the
                    # tool input carries — the Stop hook's set-record reconciles (see _sched_tool_hook)
                    "PostToolUse": [HookMatcher(matcher="ScheduleWakeup|CronCreate|CronDelete",
-                                               hooks=[sess._sched_tool_hook])]},
+                                               hooks=[sess._sched_tool_hook]),
+                                   # launch ledger: exact launch facts at the call moment (2026-08-29)
+                                   HookMatcher(matcher="Bash|Monitor|Task|Workflow|TaskStop",
+                                               hooks=[sess._ledger_tool_hook])],
+                   # a launch whose ack errored never started — drop it before it phantom-waits
+                   "PostToolUseFailure": [HookMatcher(matcher="Bash|Monitor|Task|Workflow",
+                                                      hooks=[sess._ledger_fail_hook])]},
             permission_mode=sess.mode,
             # File-checkpoint rewind (the user 2026-08-04): the CLI backs files up before modifying them,
             # so rewind_files() can put the workspace back to its state at any user message. The uuid a

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2936,6 +2936,13 @@ class SdkSession:
                     self._ledger_write(kept, ended)
         except Exception as e:
             self.backend._log("stop hook (%s): bg-ledger reconcile failed: %s" % (self.name, e))
+        # The turn-end EVENT itself, durable and kernel-readable (2026-08-29, for the nudge layer's
+        # memo re-arm and any consumer that needs "this session settled a turn at T" as a fact
+        # rather than an inference from transcript mtimes — romp_cards' round keys on it).
+        try:
+            self.backend._update_reg(self.sid, lastStopAt=int(time.time()))
+        except Exception:
+            pass
         self.backend._poke()
         return {}
 

--- a/tests/test_bg_ledger.py
+++ b/tests/test_bg_ledger.py
@@ -55,6 +55,31 @@ class LaunchRecording(_Backend):
         self.assertEqual(e["procGen"], self.sess.proc_gen, "launches die with their process")
         self.assertEqual(ended, [])
 
+    def test_task_and_workflow_calls_are_not_journaled(self):
+        # subagents/workflows ride the lifecycle stream + Subagent hooks; journaling them here
+        # recorded every FOREGROUND subagent call as a phantom launch (review 2026-08-29)
+        for tname in ("Task", "Workflow"):
+            asyncio.run(self.sess._ledger_tool_hook(
+                {"tool_name": tname, "tool_input": {"prompt": "go"},
+                 "tool_response": {"id": "x-1"}}, "toolu_01XXX", None))
+        self.assertEqual(self._ledger(), ([], []))
+
+    def test_an_ack_with_no_key_at_all_is_not_recorded(self):
+        # an entry no event could ever clear must not be born (the immortal tid-None leak)
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "Bash",
+             "tool_input": {"command": "sleep 9", "run_in_background": True},
+             "tool_response": "opaque string ack"}, None, None))
+        self.assertEqual(self._ledger(), ([], []))
+
+    def test_the_ledger_is_capped_and_evicts_oldest_loudly(self):
+        for i in range(45):
+            self._launch_bash(tid="task-%03d" % i, tuid="toolu_%03d" % i)
+        live, _ = self._ledger()
+        self.assertEqual(len(live), self.sess._LEDGER_CAP)
+        self.assertEqual(live[0]["tid"], "task-005", "oldest evicted")
+        self.assertTrue(any("cap" in m for m in self.logs))
+
     def test_foreground_bash_is_a_turn_not_a_launch(self):
         asyncio.run(self.sess._ledger_tool_hook(
             {"tool_name": "Bash", "tool_input": {"command": "ls"},
@@ -149,6 +174,18 @@ class StopReconciler(_Backend):
         reg = sb.read_reg(self.d, SID) or {}
         self.assertAlmostEqual(reg.get("lastStopAt"), time.time(), delta=30)
 
+    def test_a_monitor_absent_from_the_payload_is_NOT_tombstoned_gone(self):
+        # only shells are proven to ride background_tasks; a false "gone" would silently un-wait
+        # the session — monitors end by deadline, fail, stop, or processDied
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "Monitor", "tool_use_id": "toolu_01MMM",
+             "tool_input": {"description": "watching CI", "timeout_ms": 600000, "persistent": False},
+             "tool_response": {"task_id": "mon-9"}}, "toolu_01MMM", None))
+        self._stop(self.sess, [])
+        live, ended = self._ledger()
+        self.assertEqual([e["tid"] for e in live], ["mon-9"])
+        self.assertEqual(ended, [])
+
     def test_absence_of_the_field_reconciles_nothing(self):
         self._launch_bash()
         asyncio.run(self.sess._stop_hook({"transcript_path": "/tmp/x.jsonl"}, None, None))
@@ -156,10 +193,11 @@ class StopReconciler(_Backend):
         self.assertEqual(len(live), 1, "no payload field, no verdict — never treat absence as empty")
 
 
-class KernelSeamPrefersTheLedger(unittest.TestCase):
-    """_bg_live_norm's source ladder: live lifecycle set (0.5) > launch ledger (0.6) > transcript
-    pairing (0.75). The ledger branch applies EXACT deadlines (recorded moment + 5s skew), never the
-    scrape's +120s grace."""
+class KernelSeamEnrichesTheStream(unittest.TestCase):
+    """_bg_live_norm: the lifecycle set stays the liveness authority; the ledger ENRICHES its rows by
+    toolUseId join (exact Monitor deadline -> em._bg_expired at +5s skew, not +120s; agent attribution).
+    The first cut placed the ledger as a ladder SOURCE below bgTasks — unreachable, because every SDK
+    row carries bgTasks unconditionally (review 2026-08-29); these tests use the production row shape."""
 
     @classmethod
     def setUpClass(cls):
@@ -176,38 +214,53 @@ class KernelSeamPrefersTheLedger(unittest.TestCase):
         except OSError:
             pass
 
-    def _write_reg(self, **kw):
+    def _wire(self, bg_tasks, ledger):
         (self.km.jd.STATE / "sdk" / (SID + ".json")).write_text(
-            json.dumps({"sid": SID, "name": "web", "alive": True, **kw}))
+            json.dumps({"sid": SID, "name": "web", "alive": True, "bgLedger": ledger}))
+        self.km._tmux_sessions = lambda: {SID: {"bgTasks": bg_tasks}}   # the PRODUCTION shape:
+        #                                    Sessions.live() sets bgTasks unconditionally on SDK rows
 
-    def test_ledger_present_beats_the_scrape_and_expires_exactly(self):
+    def test_a_streamed_monitor_expires_at_its_recorded_deadline_exactly(self):
         now = time.time()
-        self._write_reg(bgLedger=[
-            {"tid": "t-1", "toolUseId": "toolu_1", "tool": "bash", "desc": "campaign timer",
-             "armedAt": int(now) - 30, "deadlineEpoch": None, "persistent": False, "src": "hook"},
-            {"tid": "t-2", "toolUseId": "toolu_2", "tool": "monitor", "desc": "expired watcher",
-             "armedAt": int(now) - 400, "deadlineEpoch": now - 60, "persistent": False, "src": "hook"}])
-        self.km._tmux_sessions = lambda: {SID: {}}   # live session, NO lifecycle set (mid-reattach)
-        got = self.km._bg_live_norm(SID, path="/nonexistent-transcript")
-        self.assertEqual([g["tid"] for g in got], ["toolu_1"],
-                         "the timed-out watcher is gone AT its recorded deadline — no +120s grace; "
-                         "and the scrape was never consulted (the path does not exist)")
-        self.assertEqual(got[0]["desc"], "campaign timer")
-
-    def test_present_but_empty_ledger_is_authoritative(self):
-        self._write_reg(bgLedger=[])
-        self.km._tmux_sessions = lambda: {SID: {}}
-        self.assertEqual(self.km._bg_live_norm(SID, path="/nonexistent-transcript"), [],
-                         "an empty ledger says NO tasks — never fall through to the scrape")
-
-    def test_a_live_lifecycle_set_still_outranks_the_ledger(self):
-        self._write_reg(bgLedger=[{"tid": "stale", "toolUseId": "toolu_9", "tool": "bash",
-                                   "desc": "stale", "armedAt": 1, "deadlineEpoch": None,
-                                   "persistent": False, "src": "hook"}])
-        self.km._tmux_sessions = lambda: {SID: {"bgTasks": [
-            {"toolUseId": "toolu_live", "desc": "the stream's truth", "since": 100, "type": "shell"}]}}
+        self._wire(
+            bg_tasks=[{"toolUseId": "toolu_1", "desc": "watching CI", "since": int(now) - 400,
+                       "type": "monitor"},
+                      {"toolUseId": "toolu_2", "desc": "campaign timer", "since": int(now) - 30,
+                       "type": "shell"}],
+            ledger=[{"tid": "mon-1", "toolUseId": "toolu_1", "tool": "monitor", "desc": "watching CI",
+                     "armedAt": int(now) - 400, "deadlineEpoch": now - 60, "persistent": False,
+                     "src": "hook"}])
         got = self.km._bg_live_norm(SID, path=None)
-        self.assertEqual([g["tid"] for g in got], ["toolu_live"])
+        self.assertEqual([g["tid"] for g in got], ["toolu_2"],
+                         "the watcher died AT its recorded kill moment — 60s past deadline is out, "
+                         "where the scrape's +120s grace would still call it a live wait")
+
+    def test_within_the_skew_window_the_watcher_still_counts(self):
+        now = time.time()
+        self._wire(
+            bg_tasks=[{"toolUseId": "toolu_1", "desc": "watching CI", "since": int(now) - 100,
+                       "type": "monitor"}],
+            ledger=[{"tid": "mon-1", "toolUseId": "toolu_1", "tool": "monitor", "desc": "watching CI",
+                     "armedAt": int(now) - 100, "deadlineEpoch": now - 2, "persistent": False,
+                     "src": "hook"}])
+        self.assertEqual(len(self.km._bg_live_norm(SID, path=None)), 1)
+
+    def test_unledgered_rows_pass_through_untouched(self):
+        now = time.time()
+        self._wire(bg_tasks=[{"toolUseId": "toolu_9", "desc": "pre-ledger task", "since": int(now),
+                              "type": "shell"}], ledger=[])
+        got = self.km._bg_live_norm(SID, path=None)
+        self.assertEqual([g["tid"] for g in got], ["toolu_9"])
+        self.assertNotIn("deadline", got[0])
+
+    def test_agent_attribution_rides_the_join(self):
+        now = time.time()
+        self._wire(
+            bg_tasks=[{"toolUseId": "toolu_3", "desc": "sub launch", "since": int(now), "type": "shell"}],
+            ledger=[{"tid": "t-3", "toolUseId": "toolu_3", "tool": "bash", "desc": "sub launch",
+                     "armedAt": int(now), "deadlineEpoch": None, "persistent": False,
+                     "agentId": "agent-77", "src": "hook"}])
+        self.assertEqual(self.km._bg_live_norm(SID, path=None)[0].get("agentId"), "agent-77")
 
 
 if __name__ == "__main__":

--- a/tests/test_bg_ledger.py
+++ b/tests/test_bg_ledger.py
@@ -142,6 +142,13 @@ class StopReconciler(_Backend):
         self.assertEqual(adopted["src"], "stopReconcile", "the reconciler is the safety net, labeled")
         self.assertEqual([w["why"] for w in ended], [])
 
+    def test_every_stop_stamps_the_turn_end_event(self):
+        # lastStopAt is the settle event itself, durable in the reg — consumers (the nudge memo
+        # re-arm) read a fact, not a transcript-mtime inference (2026-08-29, romp_cards' seam)
+        asyncio.run(self.sess._stop_hook({}, None, None))
+        reg = sb.read_reg(self.d, SID) or {}
+        self.assertAlmostEqual(reg.get("lastStopAt"), time.time(), delta=30)
+
     def test_absence_of_the_field_reconciles_nothing(self):
         self._launch_bash()
         asyncio.run(self.sess._stop_hook({"transcript_path": "/tmp/x.jsonl"}, None, None))

--- a/tests/test_bg_ledger.py
+++ b/tests/test_bg_ledger.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""The background-launch LEDGER (2026-08-29): launch facts recorded at the CALL moment by PostToolUse
+hooks, replacing the transcript scrape as the durable source for SDK sessions. Payload shapes below are
+the ones probe-verified against CLI 2.1.221 / sdk 0.2.144 on 2026-08-28 (backgroundTaskId in the Bash
+ack; error+is_interrupt on PostToolUseFailure; background_tasks [{id,type,status,description,command}]
+on the Stop payload). Synthetic fixtures only."""
+import asyncio
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_ledger", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-000000000031"
+
+
+class _Backend(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.logs = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        sb.write_reg(self.d, SID, {"sid": SID, "name": "web", "cwd": "/tmp", "alive": True})
+        self.sess = sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+
+    def _ledger(self):
+        reg = sb.read_reg(self.d, SID) or {}
+        return reg.get("bgLedger") or [], reg.get("bgLedgerEnded") or []
+
+    def _launch_bash(self, tid="task-aa11", tuid="toolu_01AAA"):
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "Bash", "tool_use_id": tuid,
+             "tool_input": {"command": "sleep 40", "description": "campaign timer",
+                            "run_in_background": True},
+             "tool_response": {"backgroundTaskId": tid, "stdout": "", "stderr": ""}}, tuid, None))
+
+
+class LaunchRecording(_Backend):
+    def test_a_background_bash_launch_lands_with_its_pairing_keys(self):
+        self._launch_bash()
+        live, ended = self._ledger()
+        self.assertEqual(len(live), 1)
+        e = live[0]
+        self.assertEqual((e["tid"], e["toolUseId"], e["tool"]), ("task-aa11", "toolu_01AAA", "bash"))
+        self.assertEqual(e["desc"], "campaign timer")
+        self.assertIsNone(e["deadlineEpoch"], "a background shell runs until done — no deadline")
+        self.assertEqual(e["procGen"], self.sess.proc_gen, "launches die with their process")
+        self.assertEqual(ended, [])
+
+    def test_foreground_bash_is_a_turn_not_a_launch(self):
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "ls"},
+             "tool_response": {"stdout": "x"}}, "toolu_01BBB", None))
+        self.assertEqual(self._ledger(), ([], []))
+
+    def test_monitor_records_its_EXACT_deadline_and_persistent_records_none(self):
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "Monitor", "tool_use_id": "toolu_01CCC",
+             "tool_input": {"description": "watching CI", "timeout_ms": 300000, "persistent": False},
+             "tool_response": {"task_id": "mon-1"}}, "toolu_01CCC", None))
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "Monitor", "tool_use_id": "toolu_01DDD",
+             "tool_input": {"description": "log tail", "timeout_ms": 300000, "persistent": True},
+             "tool_response": {"task_id": "mon-2"}}, "toolu_01DDD", None))
+        live, _ = self._ledger()
+        timed = next(e for e in live if e["tid"] == "mon-1")
+        furn = next(e for e in live if e["tid"] == "mon-2")
+        self.assertAlmostEqual(timed["deadlineEpoch"], time.time() + 300, delta=30,
+                               msg="the harness kills the watcher THEN — exact, no +120s grace")
+        self.assertFalse(timed["persistent"])
+        self.assertIsNone(furn["deadlineEpoch"], "a persistent watcher is furniture, not a wait")
+        self.assertTrue(furn["persistent"])
+
+
+class CalledOffAndFailed(_Backend):
+    def test_taskstop_is_a_deliberate_call_off_not_a_crash(self):
+        self._launch_bash()
+        asyncio.run(self.sess._ledger_tool_hook(
+            {"tool_name": "TaskStop", "tool_input": {"task_id": "task-aa11"},
+             "tool_response": {}}, "toolu_01EEE", None))
+        live, ended = self._ledger()
+        self.assertEqual(live, [])
+        self.assertEqual((ended[-1]["tid"], ended[-1]["why"]), ("task-aa11", "stopped"))
+
+    def test_a_failed_launch_never_phantom_waits(self):
+        self._launch_bash(tid="task-bb22", tuid="toolu_01FFF")
+        asyncio.run(self.sess._ledger_fail_hook(
+            {"tool_name": "Bash", "tool_use_id": "toolu_01FFF", "is_interrupt": False,
+             "error": "command not found",
+             "tool_input": {"command": "definitely-not-real", "run_in_background": True}},
+            "toolu_01FFF", None))
+        live, ended = self._ledger()
+        self.assertEqual(live, [])
+        self.assertEqual(ended[-1]["why"], "launch-failed")
+
+    def test_a_user_interrupt_is_typed_as_one(self):
+        self._launch_bash(tid="task-cc33", tuid="toolu_01GGG")
+        asyncio.run(self.sess._ledger_fail_hook(
+            {"tool_name": "Bash", "tool_use_id": "toolu_01GGG", "is_interrupt": True},
+            "toolu_01GGG", None))
+        _, ended = self._ledger()
+        self.assertEqual(ended[-1]["why"], "interrupted")
+
+
+class StopReconciler(_Backend):
+    def _stop(self, sess, bg):
+        asyncio.run(sess._stop_hook({"background_tasks": bg}, None, None))
+
+    def test_a_live_generation_entry_absent_from_the_payload_ended(self):
+        self._launch_bash()
+        self._stop(self.sess, [])
+        live, ended = self._ledger()
+        self.assertEqual(live, [])
+        self.assertEqual((ended[-1]["tid"], ended[-1]["why"]), ("task-aa11", "gone"))
+
+    def test_a_dead_generation_entry_died_with_its_process(self):
+        self._launch_bash()
+        fresh = sb.SdkSession(self.be, sb.read_reg(self.d, SID))   # the recycle
+        self._stop(fresh, [])
+        _, ended = self._ledger()
+        self.assertEqual(ended[-1]["why"], "processDied",
+                         "background tasks are children of the CLI — its death is theirs")
+
+    def test_a_still_running_entry_survives_and_an_unseen_one_is_adopted(self):
+        self._launch_bash()
+        self._stop(self.sess, [
+            {"id": "task-aa11", "type": "shell", "status": "running",
+             "description": "campaign timer", "command": "sleep 40"},
+            {"id": "task-zz99", "type": "shell", "status": "running",
+             "description": "a launch the hook missed", "command": "tail -f x"}])
+        live, ended = self._ledger()
+        self.assertEqual({e["tid"] for e in live}, {"task-aa11", "task-zz99"})
+        adopted = next(e for e in live if e["tid"] == "task-zz99")
+        self.assertEqual(adopted["src"], "stopReconcile", "the reconciler is the safety net, labeled")
+        self.assertEqual([w["why"] for w in ended], [])
+
+    def test_absence_of_the_field_reconciles_nothing(self):
+        self._launch_bash()
+        asyncio.run(self.sess._stop_hook({"transcript_path": "/tmp/x.jsonl"}, None, None))
+        live, _ = self._ledger()
+        self.assertEqual(len(live), 1, "no payload field, no verdict — never treat absence as empty")
+
+
+class KernelSeamPrefersTheLedger(unittest.TestCase):
+    """_bg_live_norm's source ladder: live lifecycle set (0.5) > launch ledger (0.6) > transcript
+    pairing (0.75). The ledger branch applies EXACT deadlines (recorded moment + 5s skew), never the
+    scrape's +120s grace."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.km = SourceFileLoader("romp_kernel_ledger", os.path.join(BIN, "romp-kernel")).load_module()
+
+    def setUp(self):
+        self.km._tmux_sessions_saved = self.km._tmux_sessions
+        (self.km.jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self.km._tmux_sessions = self.km._tmux_sessions_saved
+        try:
+            (self.km.jd.STATE / "sdk" / (SID + ".json")).unlink()
+        except OSError:
+            pass
+
+    def _write_reg(self, **kw):
+        (self.km.jd.STATE / "sdk" / (SID + ".json")).write_text(
+            json.dumps({"sid": SID, "name": "web", "alive": True, **kw}))
+
+    def test_ledger_present_beats_the_scrape_and_expires_exactly(self):
+        now = time.time()
+        self._write_reg(bgLedger=[
+            {"tid": "t-1", "toolUseId": "toolu_1", "tool": "bash", "desc": "campaign timer",
+             "armedAt": int(now) - 30, "deadlineEpoch": None, "persistent": False, "src": "hook"},
+            {"tid": "t-2", "toolUseId": "toolu_2", "tool": "monitor", "desc": "expired watcher",
+             "armedAt": int(now) - 400, "deadlineEpoch": now - 60, "persistent": False, "src": "hook"}])
+        self.km._tmux_sessions = lambda: {SID: {}}   # live session, NO lifecycle set (mid-reattach)
+        got = self.km._bg_live_norm(SID, path="/nonexistent-transcript")
+        self.assertEqual([g["tid"] for g in got], ["toolu_1"],
+                         "the timed-out watcher is gone AT its recorded deadline — no +120s grace; "
+                         "and the scrape was never consulted (the path does not exist)")
+        self.assertEqual(got[0]["desc"], "campaign timer")
+
+    def test_present_but_empty_ledger_is_authoritative(self):
+        self._write_reg(bgLedger=[])
+        self.km._tmux_sessions = lambda: {SID: {}}
+        self.assertEqual(self.km._bg_live_norm(SID, path="/nonexistent-transcript"), [],
+                         "an empty ledger says NO tasks — never fall through to the scrape")
+
+    def test_a_live_lifecycle_set_still_outranks_the_ledger(self):
+        self._write_reg(bgLedger=[{"tid": "stale", "toolUseId": "toolu_9", "tool": "bash",
+                                   "desc": "stale", "armedAt": 1, "deadlineEpoch": None,
+                                   "persistent": False, "src": "hook"}])
+        self.km._tmux_sessions = lambda: {SID: {"bgTasks": [
+            {"toolUseId": "toolu_live", "desc": "the stream's truth", "since": 100, "type": "shell"}]}}
+        got = self.km._bg_live_norm(SID, path=None)
+        self.assertEqual([g["tid"] for g in got], ["toolu_live"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Background launches (Bash run_in_background, Monitor) are journaled by a PostToolUse hook at the call moment, with the pairing keys the ack carries, the acting agent, and — for Monitor — the EXACT deadline its required timeout_ms declares. The lifecycle stream keeps liveness authority; the ledger ENRICHES its rows by toolUseId join, so a watcher expires at its recorded kill moment plus clock skew instead of the scrape's +120s guess, and subagent-launched work is finally attributable. TaskStop records a deliberate call-off (previously indistinguishable from a crash); PostToolUseFailure drops a launch whose ack errored before it can phantom-wait; the Stop payload's background_tasks — delivered every turn end and previously discarded — reconciles the set. The Stop hook also stamps lastStopAt, the turn-end event as a durable reg fact (the nudge-memo re-arm's seam, coordinated with the cards round).

Payload shapes are probe-verified against CLI 2.1.221 / sdk 0.2.144: PostToolUseFailure emits with error and is_interrupt (a DENIED tool does not reach it); the Bash ack carries backgroundTaskId; background_tasks rows carry id/type/status/description/command. Journaling deliberately covers only those verified shapes: Task/Workflow ride the lifecycle stream and the Subagent hooks.

An adversarial pass on the first cut confirmed one blocker (the kernel rung was unreachable — every SDK row carries bgTasks unconditionally; the enrichment-join design replaces it) and three materials (foreground subagent journaling, immortal keyless entries, tool-name/task-type vocabulary mix), all fixed here; the review's cleanup sweep filed eight follow-up items separately.

Verified at e8ddd6aa merged with main: full pytest 6014 passed (34 skipped, the usual), webview suite 2544/2544 with typecheck and build clean. Touches kernel/sdk_backend.py, kernel/kernel.py, kernel/event_model.py, tests/test_bg_ledger.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)