### PR TITLE
A late moot ruling gets its own full patience window

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3322,7 +3322,11 @@ def _mark_nudge_failed(gid, ev_t=None, wake=False):
         try:
             _nd0 = jd.load_goals(gid.rsplit(":", 1)[0]).get("nodes", {}).get(gid)
             if _nd0 is not None and any(_supersedes(e) for e in _nd0.get("log") or []):
-                nudged[gid] = dict(rec, moot=True)
+                nudged[gid] = dict(rec, moot=True, mootAt=now)   # the ruling's own time — the parked
+                #                                        escape measures its patience from it, never
+                #                                        from the fire's `at` (a moot landing hours
+                #                                        after the fire otherwise inherits a spent
+                #                                        window and re-enters at once, 2026-08-29)
                 d["nudged"] = nudged
                 _write_auto_nudge(d)
                 return "moot"
@@ -4597,7 +4601,8 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
         _ev = max(rec.get("at") or 0, lt.get("end") or lt.get("t") or 0) or None
         _fate = _mark_nudge_failed(gid, ev_t=_ev, wake=True)
         if _fate:
-            nudged[gid] = dict(rec, **({"failed": True} if _fate == "failed" else {"moot": True}))
+            nudged[gid] = dict(rec, **({"failed": True} if _fate == "failed"
+                                       else {"moot": True, "mootAt": int(now)}))
         return _fate == "failed"
     if rec.get("failed") or rec.get("moot"):
         if (rec.get("anchor") or 0) >= at:
@@ -5375,8 +5380,13 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                     nudged[gid] = dict(rec, failed=True)   # mirror in-memory for the rest of this tick
                     fired = True                           # push so the chip/floor reaches the feed now
                 elif _fate == "moot":
-                    nudged[gid] = dict(rec, moot=True)     # the judges superseded the ask — no chip, no block
-            _anch = max(rec.get("answeredAt") or 0, rec.get("at") or 0) if rec else 0
+                    nudged[gid] = dict(rec, moot=True, mootAt=int(now))   # the judges superseded the
+                    #                                        ask — no chip, no block; mootAt mirrors
+                    #                                        _mark_nudge_failed's durable stamp
+            _anch = (max(rec.get("answeredAt") or 0, rec.get("at") or 0,
+                         rec.get("mootAt") or 0) if rec else 0)   # the moot ruling is new information —
+            #                                            patience runs from IT (a legacy record without
+            #                                            the stamp keeps the old anchors)
             if not (arm_id is not None and rec.get("moot") and not rec.get("failed")
                     and _anch and now - _anch > AWAITING_DEADMAN_SECS):
                 continue

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -200,6 +200,17 @@ class MemoDeadlock(unittest.TestCase):
                          "moot + still Working + parked past the dead-man → the ladder proceeds")
         self.assertEqual([r["verdict"] for r in self._rows()], ["fired"])
 
+    def test_a_late_moot_ruling_gets_its_own_full_patience_window(self):
+        # the adversarial pass's last finding (its verifier died mid-run; verified by hand): the
+        # escape's anchor once read only answeredAt/at, so a moot ruling landing HOURS after the
+        # fire inherited a spent window and re-entered the very next tick. The moot ruling is new
+        # information — patience runs from ITS stamp (mootAt), not the fire's.
+        self._seed_rec({"lastTurnId": "t1", "count": 1, "moot": True,
+                        "at": PARKED, "answeredAt": PARKED, "mootAt": NOW - 300})
+        self._tick()
+        self.assertEqual(self.sent, [], "the fresh moot ruling restarts the stand — no instant re-entry")
+        self.assertEqual(self._rows(), [])
+
     def test_moot_within_patience_stays_silent(self):
         self._seed_rec({"lastTurnId": "t1", "count": 1, "moot": True, "answeredAt": NOW - 300})
         self._tick()


### PR DESCRIPTION
## Summary
Follow-up to the memo-deadlock round: its adversarial pass filed one finding whose verifier died mid-run; verified by hand, it holds. The parked-moot escape anchored its dead-man on `answeredAt`/`at` only, and a fired record's `at` is the fire time — so a moot ruling landing hours after the fire inherited an already-spent window and re-entered the due path on the very next tick. The re-entry was judge-gated (a fresh look at the newest report, never a blind fire), but the moot ruling IS new information and the cards-move rule says patience runs from the deciding event: every moot writer now stamps `mootAt`, and the escape's anchor includes it. A legacy record without the stamp keeps the old anchors.

## Test plan
- New pin in `tests/test_nudge_memo_deadlock.py`: a record with fire time and answer long past the stand but a fresh `mootAt` stays silent — the fresh ruling restarts the stand.
- Full Python suite: 6,006 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)