### PR TITLE
Arrow keys step the lightbox through the chat's pictures — pin-aware, no wrap

### DIFF
--- a/ui/webview/chat-pin-history.test.ts
+++ b/ui/webview/chat-pin-history.test.ts
@@ -27,7 +27,7 @@ test("the embed and its lightbox request the pinned bytes; unpinned surfaces sta
   assert.match(PREVIEW, /previewFull\(path: string, sid\?: string \| null, verified = false, pin\?: string\)/);
   assert.match(PREVIEW, /const url = fileUrl\(path, sid\) \+ \(pin \? "&pin=" \+ encodeURIComponent\(pin\) : ""\);/);
   assert.match(PREVIEW, /openLightbox\(path, sid, pin\); \};/, "the big view shows the same pixels the embed did");
-  assert.match(PREVIEW, /img\.src = fileUrl\(path, sid\) \+ \(pin \? "&pin=" \+ encodeURIComponent\(pin\) : ""\);/);
+  assert.match(PREVIEW, /im\.src = fileUrl\(e\.path, e\.sid\) \+ \(e\.pin \? "&pin=" \+ encodeURIComponent\(e\.pin\) : ""\);/);
 });
 
 test("the kernel pins at the resolve latch and serves pins shape-gated with live fallback", () => {

--- a/ui/webview/lightbox-nav.test.ts
+++ b/ui/webview/lightbox-nav.test.ts
@@ -1,0 +1,51 @@
+// Lightbox arrow navigation (the user 2026-08-29: arrows step to the previous/next picture in the
+// chat, like a messaging app). The index is provider-built from the session's EVENTS — the DOM
+// misses virtualization-windowed turns — and every entry threads the (path, sid, pin) triple so a
+// step renders THAT message's pinned bytes: the history-rewrite guard extends to navigation.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+
+test("the index walks EVENTS oldest→newest and threads pins per target", () => {
+  const at = RENDER.indexOf("function chatImagesFor(");
+  assert.ok(at > 0);
+  const body = RENDER.slice(at, RENDER.indexOf("\n}", at));
+  assert.match(body, /for \(const ev of s\.events/, "events, not the DOM — virtualization windows images out");
+  assert.match(body, /out\.push\(\{ path: target, sid, pin: pins\[target\] \}\);/,
+    "the SAME triple the embed's click passes — a step shows that message's pinned bytes");
+  assert.match(body, /previewKind\(target\) !== "img"/, "the lightbox's own image gate decides image-ness");
+  assert.match(body, /seen\.has\(target\)/, "one entry per (event, target)");
+  assert.match(RENDER, /setLightboxNav\(chatImagesFor\);/, "registered once; providerless surfaces keep inert arrows");
+});
+
+test("arrows clamp at the ends, ride the capture listener, and never scroll the chat", () => {
+  const at = PREVIEW.indexOf("const onKey = (ev: KeyboardEvent) => {");
+  const body = PREVIEW.slice(at, PREVIEW.indexOf("};", at));
+  assert.match(body, /ev\.key === "ArrowLeft" \|\| ev\.key === "ArrowRight"/);
+  assert.match(body, /ev\.stopPropagation\(\); ev\.preventDefault\(\);/);
+  assert.match(body, /ev\.key === "ArrowLeft" \? -1 : 1/, "← older, → newer — the transcript's own order");
+  const stepAt = PREVIEW.indexOf("step = (delta: number) => {");
+  const step = PREVIEW.slice(stepAt, PREVIEW.indexOf("};", stepAt));
+  assert.match(step, /if \(at < 0 \|\| nav\.length < 2\) return;/, "a single image means arrows do nothing");
+  assert.match(step, /if \(n < 0 \|\| n >= nav\.length\) return;/, "the ends END — no wrap, the messaging-app feel");
+});
+
+test("a step swaps the whole embed identity and resets the zoom (T162 contracts intact)", () => {
+  const stepAt = PREVIEW.indexOf("step = (delta: number) => {");
+  const step = PREVIEW.slice(stepAt, PREVIEW.indexOf("};", stepAt));
+  assert.match(step, /e\.pin \? "&pin=" \+ encodeURIComponent\(e\.pin\) : ""/, "the new entry's PIN rides the src");
+  assert.match(step, /pzc\.retarget\(next\);/, "zoom resets to the fit view for the new image");
+  assert.match(step, /dl\.href = fileUrl\(e\.path, e\.sid\)/, "…and the download anchor follows");
+  // the retarget re-identities the view for a FRESH element; the stage's listeners are wired once
+  assert.match(PREVIEW, /return \{ retarget: \(next: HTMLImageElement\) => \{ img = next; view = pz\.identity\(\); ptrs\.clear\(\); start = null; apply\(\); \} \};/);
+});
+
+test("the position cue wears the house sub scale and only shows for a real sequence", () => {
+  assert.match(PREVIEW, /if \(nav\.length > 1 && at >= 0\) \{/);
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.romp-lightbox-cue \{ flex: 0 0 auto; font-size: 0\.82em; color: var\(--dim\); font-variant-numeric: tabular-nums; \}/);
+});

--- a/ui/webview/pinch.test.ts
+++ b/ui/webview/pinch.test.ts
@@ -63,7 +63,7 @@ test("pointer-pair helpers", () => {
 test("the wiring: captured pointers, stage-owned gestures, and the close gesture untouched", () => {
   const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
-  assert.match(PREVIEW, /function wirePinchZoom\(stage: HTMLElement, img: HTMLImageElement\): void/);
+  assert.match(PREVIEW, /function wirePinchZoom\(stage: HTMLElement, img: HTMLImageElement\): \{ retarget: \(next: HTMLImageElement\) => void \}/);
   assert.match(PREVIEW, /stage\.setPointerCapture\(e\.pointerId\);/,
     "every gesture pointer is captured — a drag ending anywhere can never read as a backdrop tap");
   assert.match(PREVIEW, /wirePinchZoom\(inner, img\);/, "images only — the PDF branch is untouched");

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -47,7 +47,7 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   // (the user 2026-07-20: full renders replaced the 2026-07-08 thumbnails in the chat; the user
   // 2026-08-15: figures moved from a tail strip to the mentioning block —
   // chat-inline-preview.test.ts pins the placement shape)
-  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal \} from "\.\/preview";/);
+  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry \} from "\.\/preview";/);
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /previewable\.slice\(0, 4\)/, "capped so a directory listing doesn't wallpaper the chat");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -121,7 +121,7 @@ export function fileUrl(path: string, sid?: string | null): string {
 // browser's own page-zoom out of it. The CLOSE gesture is untouched by construction: dismissal
 // stays tap-on-BACKDROP (target === wrap) and the ✕ — every pinch/pan pointer is CAPTURED by the
 // stage, so a drag that ends anywhere can never read as a backdrop tap.
-function wirePinchZoom(stage: HTMLElement, img: HTMLImageElement): void {
+function wirePinchZoom(stage: HTMLElement, img: HTMLImageElement): { retarget: (next: HTMLImageElement) => void } {
   let view = pz.identity();
   const ptrs = new Map<number, { x: number; y: number }>();
   let start: { view: pz.PinchView; d: number } | null = null;   // two-pointer gesture snapshot
@@ -186,6 +186,22 @@ function wirePinchZoom(stage: HTMLElement, img: HTMLImageElement): void {
   };
   stage.addEventListener("pointerup", lift);
   stage.addEventListener("pointercancel", lift);
+  // stepping the lightbox swaps the img element: re-identity the view for the fresh element —
+  // the stage's listeners are wired ONCE (steps must never stack handlers), only the target moves
+  return { retarget: (next: HTMLImageElement) => { img = next; view = pz.identity(); ptrs.clear(); start = null; apply(); } };
+}
+
+// ── lightbox arrow navigation (the user 2026-08-29: arrow keys step to the previous/next picture
+// in the chat, like a messaging app) ────────────────────────────────────────────────────────────
+// The image sequence comes from a PROVIDER the chat registers (render.ts walks the session's
+// EVENTS oldest→newest — the DOM misses virtualization-windowed images), each entry the same
+// (path, sid, pin) triple the click path passes, so a step shows THAT message's pinned bytes and
+// can never resurrect the history-rewrite the pin store prevents. Surfaces that register no
+// provider (the feed) keep inert arrows.
+export interface LightboxNavEntry { path: string; sid?: string | null; pin?: string; }
+let lightboxNav: ((sid: string | null | undefined) => LightboxNavEntry[]) | null = null;
+export function setLightboxNav(fn: (sid: string | null | undefined) => LightboxNavEntry[]): void {
+  lightboxNav = fn;
 }
 
 export function openLightbox(path: string, sid?: string | null, pin?: string): void {
@@ -196,6 +212,10 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   wrap.id = "romp-lightbox";
   const inner = document.createElement("div");
   inner.className = "romp-lightbox-inner" + (kind === "pdf" ? " pdf" : "");
+  let nav: LightboxNavEntry[] = [];
+  let at = -1;
+  let step: ((delta: number) => void) | null = null;     // arrows step the chat's image sequence (img kind only)
+  let cue: HTMLElement | null = null;                    // the compact position mark ("3/17") in the bar
   if (kind === "pdf") {
     const frame = document.createElement("iframe");
     frame.className = "romp-lightbox-frame";
@@ -203,12 +223,37 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
     frame.title = path;
     inner.appendChild(frame);
   } else {
-    const img = document.createElement("img");
-    img.className = "romp-lightbox-img";
-    img.src = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
-    img.alt = path;
+    const mkImg = (e: LightboxNavEntry) => {
+      const im = document.createElement("img");
+      im.className = "romp-lightbox-img";
+      im.src = fileUrl(e.path, e.sid) + (e.pin ? "&pin=" + encodeURIComponent(e.pin) : "");
+      im.alt = e.path;
+      return im;
+    };
+    let img = mkImg({ path, sid, pin });
     inner.appendChild(img);
-    wirePinchZoom(inner, img);
+    const pzc = wirePinchZoom(inner, img);
+    // the chat's image sequence, oldest→newest (empty on surfaces with no provider): the current
+    // position matches by (path, pin) — two messages embedding different VERSIONS of one path are
+    // different entries — falling back to the path alone for pre-pin history
+    nav = (lightboxNav ? lightboxNav(sid) : []).filter((e) => previewKind(e.path) === "img");
+    at = nav.findIndex((e) => e.path === path && (e.pin || "") === (pin || ""));
+    if (at < 0) at = nav.findIndex((e) => e.path === path);
+    step = (delta: number) => {
+      if (at < 0 || nav.length < 2) return;
+      const n = at + delta;
+      if (n < 0 || n >= nav.length) return;              // the ends END (messaging-app feel) — no wrap
+      at = n;
+      const e = nav[at];
+      const next = mkImg(e);
+      img.replaceWith(next);
+      img = next;
+      pzc.retarget(next);                                // a step lands on the fit view, zoom reset
+      name.textContent = e.path; name.title = e.path;
+      dl.href = fileUrl(e.path, e.sid) + (e.pin ? "&pin=" + encodeURIComponent(e.pin) : "");
+      dl.download = e.path.slice(e.path.lastIndexOf("/") + 1) || "image";
+      if (cue) cue.textContent = (at + 1) + "/" + nav.length;
+    };
   }
   const bar = document.createElement("div");
   bar.className = "romp-lightbox-bar";
@@ -219,6 +264,12 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   // download rides an ANCHOR with the download attribute (the user 2026-08-19): the browser saves
   // the same bytes the lightbox is showing — the pinned URL when a pin rode in, so a re-generated
   // file can't swap the image between viewing and saving. The filename is the path's basename.
+  if (nav.length > 1 && at >= 0) {
+    cue = document.createElement("span");
+    cue.className = "romp-lightbox-cue";
+    cue.textContent = (at + 1) + "/" + nav.length;
+    cue.title = "picture " + (at + 1) + " of " + nav.length + " in this chat — ←/→ to step";
+  }
   const dl = document.createElement("a");
   dl.className = "romp-lightbox-dl";
   dl.href = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
@@ -237,11 +288,17 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   close.className = "romp-lightbox-close";
   close.textContent = "✕";
   close.title = "close (Esc)";
-  bar.append(name, dl, close);
+  if (cue) bar.append(name, cue, dl, close); else bar.append(name, dl, close);
   inner.appendChild(bar);
   wrap.appendChild(inner);
   const dismiss = () => { wrap.remove(); document.removeEventListener("keydown", onKey, true); };
-  const onKey = (ev: KeyboardEvent) => { if (ev.key === "Escape") { ev.stopPropagation(); dismiss(); } };
+  const onKey = (ev: KeyboardEvent) => {
+    if (ev.key === "Escape") { ev.stopPropagation(); dismiss(); return; }
+    if ((ev.key === "ArrowLeft" || ev.key === "ArrowRight") && step) {
+      ev.stopPropagation(); ev.preventDefault();         // the chat must not scroll under the lightbox
+      step(ev.key === "ArrowLeft" ? -1 : 1);             // ← older, → newer — the transcript's own order
+    }
+  };
   close.onclick = (ev) => { ev.stopPropagation(); dismiss(); };
   wrap.onclick = (ev) => { if (ev.target === wrap) dismiss(); };   // backdrop closes; content clicks don't
   document.addEventListener("keydown", onKey, true);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -35,7 +35,7 @@ import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional 
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
-import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal } from "./preview";
+import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView } from "./file-view";
@@ -1156,6 +1156,31 @@ installMdImgHeal();   // markdown-inline <img> failures register for the per-mes
 // pathInText: the path is ALREADY visible (linkified) in the message text — a
 // dropped/pasted screenshot inserts it there — so a caption would just repeat it
 // (the user 2026-07-15). Skip the caption then; the in-text link already opens it.
+// The lightbox's arrow-navigation sequence (2026-08-29): every image embed in this chat, oldest
+// to newest, from the session's EVENTS — the DOM misses virtualization-windowed turns. Each entry
+// carries the same (path, sid, pin) triple the embed's own click passes, so a step renders that
+// message's pinned bytes (never the live file — the history-rewrite guard extends to navigation).
+// One entry per (event, target): a message mentioning one image twice is one stop.
+function chatImagesFor(sid: string | null | undefined): LightboxNavEntry[] {
+  const s = sid ? sessions.get(sid) : null;
+  if (!s) return [];
+  const out: LightboxNavEntry[] = [];
+  for (const ev of s.events as (ChatEvent & { images?: { src: string; path?: string }[]; pathLinks?: Record<string, string>; spacePaths?: string[]; pathPins?: Record<string, string> })[]) {
+    const pins = ev.pathPins || {};
+    const seen = new Set<string>();
+    const add = (target: string) => {
+      if (!target || seen.has(target) || previewKind(target) !== "img") return;
+      seen.add(target);
+      out.push({ path: target, sid, pin: pins[target] });
+    };
+    for (const im of ev.images || []) if (im.path) add(im.path);
+    for (const tok of Object.keys(ev.pathLinks || {})) add((ev.pathLinks as Record<string, string>)[tok]);
+    for (const sp of ev.spacePaths || []) add(sp);
+  }
+  return out;
+}
+setLightboxNav(chatImagesFor);
+
 function userImage(im: { src: string; path?: string }, pathInText = false): HTMLElement {
   const fig = el("span", "user-img-wrap");
   if (im.src.startsWith("path:")) {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2679,6 +2679,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .romp-lightbox-close:hover { border-color: var(--accent); }
 /* download: an anchor dressed exactly like the close button beside it (one control vocabulary —
    same chip, same hover cue), sitting between the filename and the ✕ */
+.romp-lightbox-cue { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); font-variant-numeric: tabular-nums; }   /* the ←/→ position mark (house sub scale) */
 .romp-lightbox-dl { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
   display: inline-flex; align-items: center;   /* centers the inline tray SVG in the chip */
   padding: 3px 9px; border-radius: 6px; background: transparent; border: 1px solid var(--card-border); color: var(--fg);   /* T151: the one button rest */


### PR DESCRIPTION
The user: full-screen on a picture, arrows should go to the previous/next picture in the chat, like a messaging app.

## The sequence
Provider-built: `chatImagesFor` walks the session's **events** oldest→newest (the DOM misses virtualization-windowed turns), collecting every image embed as the same **(path, sid, pin)** triple its click passes — a step renders **that message's pinned bytes** (the history-rewrite guard extends to navigation), and two pinned versions of one path are two distinct stops. Providerless surfaces (feed) keep inert arrows.

## Stepping
Swaps image + name + download anchor (pin riding each) and **resets the pinch view** via a new `retarget` on `wirePinchZoom` — stage listeners wired once, every T162 contract intact. Arrows ride the same capture listener as Escape (stopPropagation + preventDefault — the chat never scrolls beneath). **Ends clamp, no wrap**; single image = inert arrows, no cue. A dim tabular `n/m` cue (house 0.82em) shows only for a real sequence.

## Demo (headless, real exported openLightbox)
Opened mid-sequence at 2/3 with the right pin → ArrowLeft = 1/3, older pin, zoom cleared → clamped at both ends → the same-path later-pin entry steps as its own stop (3/3) → Escape closes → single image: cue-less, inert.

Suite 2548/2548 (new nav pins + three neighboring pins retargeted), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)