### PR TITLE
Tag deletes reach hosts that were offline at the ruling — tag federation v2

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1684,10 +1684,16 @@ def _norm_timeline_views(d):
             continue
         members = [m for m in (_member_pair(x) for x in _lst(g.get("members"))) if m]
         dedup = {(m["host"], m["sid"]): m for m in members}
-        tags.append({"id": g["id"][:64],
-                     "name": str(g.get("name") or "tag")[:_VIEWS_MAX_NAME],
-                     "color": str(g.get("color") or "")[:16],
-                     "members": [dedup[k] for k in sorted(dedup)]})
+        rec = {"id": g["id"][:64],
+               "name": str(g.get("name") or "tag")[:_VIEWS_MAX_NAME],
+               "color": str(g.get("color") or "")[:16],
+               "members": [dedup[k] for k in sorted(dedup)]}
+        if g.get("mtime"):                       # v2's edit stamp survives the rebuild (absent = 0 = legacy)
+            try:
+                rec["mtime"] = int(g["mtime"])
+            except (TypeError, ValueError):
+                pass
+        tags.append(rec)
     active = d.get("active") if isinstance(d.get("active"), str) else "all"
     if active not in ("all", "untagged") and ":" not in active \
             and not any(t["id"] == active for t in tags):
@@ -1755,7 +1761,27 @@ def _timeline_views():
 
 
 def _set_timeline_views(blob):
-    _atomic_write(_views_path(), json.dumps(_norm_timeline_views(blob), sort_keys=True))
+    # Per-tag mtime, stamped at the store's ONE write door by diffing against the previous blob
+    # (tag federation v2, the user 2026-08-29): a pending edit queued for an unreachable host must
+    # be able to tell, at late-apply time, whether the host's copy changed AFTER the user's ruling —
+    # a writer whose evidence predates newer information stands down (the cards-move corollary).
+    # The stamp rides /views to every peer for free. Only set when a tag actually changes, so
+    # untouched legacy stores round-trip byte-identical; a client echoing a blob without mtimes
+    # merely resets the field, which reads as "no newer information" — the safe direction.
+    v = _norm_timeline_views(blob)
+    try:
+        prev = {t["id"]: t for t in (_timeline_views().get("tags") or [])}
+    except Exception:
+        prev = {}
+    now = int(time.time())
+    for t in v["tags"]:
+        pt = prev.get(t["id"])
+        if pt is None or (pt.get("name"), pt.get("color"), pt.get("members")) != \
+                (t.get("name"), t.get("color"), t.get("members")):
+            t["mtime"] = now
+        elif pt.get("mtime"):
+            t["mtime"] = pt["mtime"]
+    _atomic_write(_views_path(), json.dumps(v, sort_keys=True))
 
 
 def _remote_tag_member_str(owner_host, m):
@@ -1804,6 +1830,176 @@ def _forward_tag_edit(host, body):
     return ans, None
 
 
+# ── tag federation v2: deletes reach hosts that were offline at the ruling (the user 2026-08-29:
+# "if I delete a tag, it should delete across all federated machines") ────────────────────────────
+# A tag DELETE / RENAME / member-REMOVE that could not land on an attached-but-unreachable host is
+# journaled here — durable, kernel-side, restart-proof — and applied ONCE when that host answers
+# again (the tunnel supervisor's pass calls _apply_pending_tag_edits for an "up" row with rows
+# pending). The immediate loud refusal STAYS (tagEditFailed, now saying "queued"); this journal is
+# the intent surviving it. ADD never queues: an add prefers a live home. The late apply moves state
+# only on evidence (the cards-move rule): the remote copy is fetched fresh at apply time, and a
+# same-named tag CREATED there after the ruling (tag ids encode their creation ms) — or the same
+# tag EDITED there after the ruling (the v2 mtime stamp) — is new information and survives, loudly.
+_PENDING_TAG_LOCK = threading.Lock()
+_PENDING_TAG_CACHE = {"rows": None}          # None = not loaded; kept in sync under the lock
+
+
+def _pending_tag_path():
+    return jd.STATE / "pending-tag-edits.json"
+
+
+def _pending_tag_rows():
+    """The journal, cached after one disk read (writes keep the cache in sync under the lock)."""
+    with _PENDING_TAG_LOCK:
+        if _PENDING_TAG_CACHE["rows"] is None:
+            try:
+                d = json.loads(_pending_tag_path().read_text())
+                _PENDING_TAG_CACHE["rows"] = [r for r in d if isinstance(r, dict)] if isinstance(d, list) else []
+            except Exception:
+                _PENDING_TAG_CACHE["rows"] = []
+        return list(_PENDING_TAG_CACHE["rows"])
+
+
+def _save_pending_tag_rows(rows):
+    with _PENDING_TAG_LOCK:
+        _PENDING_TAG_CACHE["rows"] = list(rows)
+        try:
+            _atomic_write(_pending_tag_path(), json.dumps(rows))
+        except OSError:
+            sys.stderr.write("pending-tag-edits: journal write failed (%s)\n" % traceback.format_exc())
+
+
+def _queue_pending_tag_edit(host, body):
+    """Journal one qualifying failed edit for `host` (delete / rename / member-remove; add and
+    color changes never queue). Returns True when a row was journaled. Captures the remote tag's
+    id from the host's CACHED views at the ruling moment, so the late apply can tell the tag the
+    user ruled on from a same-named successor. Coalescing: a delete supersedes every earlier row
+    for its (host, name) and refuses later ones (the delete already rules); removes merge; a
+    rename replaces a prior rename. Only ATTACHED hosts queue — a detached host has no reattach
+    event coming, and detach was its own intent."""
+    name = str(body.get("name") or "")
+    qual = bool(body.get("delete")) or isinstance(body.get("rename"), str) \
+        or (isinstance(body.get("remove"), list) and body.get("remove"))
+    if not (host and name and qual):
+        return False
+    with _remotes_lock:
+        r = next((x for x in _remotes.values() if x.get("host") == host), None)
+        cached = (r or {}).get("views") if isinstance((r or {}).get("views"), dict) else {}
+    if r is None:
+        return False
+    tid = next((str(t.get("id") or "") for t in (cached.get("tags") or [])
+                if isinstance(t, dict) and t.get("name") == name), "")
+    rows = _pending_tag_rows()
+    mine = [x for x in rows if x.get("host") == host and x.get("name") == name]
+    if any(x.get("delete") for x in mine):
+        return True                              # the delete already rules this name; nothing to add
+    row = {"host": host, "name": name, "tagId": tid, "ruledAt": int(time.time()), "at": int(time.time())}
+    if body.get("delete"):
+        rows = [x for x in rows if not (x.get("host") == host and x.get("name") == name)]
+        row["delete"] = True
+    else:
+        if isinstance(body.get("rename"), str) and body["rename"].strip():
+            row["rename"] = body["rename"]
+            rows = [x for x in rows if not (x.get("host") == host and x.get("name") == name
+                                            and x.get("rename"))]
+        if isinstance(body.get("remove"), list) and body.get("remove"):
+            merged = []
+            for x in mine:
+                if x.get("remove") and not x.get("rename"):
+                    merged += [m for m in x["remove"] if m not in merged]
+                    rows = [y for y in rows if y is not x]
+            row["remove"] = merged + [m for m in body["remove"] if m not in merged]
+            row["tagId"] = row["tagId"] or next((x.get("tagId") or "" for x in mine), "")
+    rows.append(row)
+    _save_pending_tag_rows(rows)
+    return True
+
+
+def _tag_id_ms(tid):
+    """The creation moment a store-minted tag id encodes ("g" + base36 of epoch-ms; _edit_tag and
+    the dialog both mint this shape), or None for a foreign/legacy id. A None reads as "created
+    before ids carried dates" — which predates any v2 ruling by construction."""
+    try:
+        return int(str(tid)[1:], 36) if str(tid)[:1] == "g" and len(str(tid)) > 1 else None
+    except ValueError:
+        return None
+
+
+def _apply_pending_tag_edits(r):
+    """The reattach half: apply `r["host"]`'s journaled rows now that it answers again. Fetches the
+    host's views FRESH first (ask the host, never the cache) and moves state only where the
+    evidence says the ruling still applies; every outcome logs to tunnel-dials.jsonl (the reattach
+    is a tunnel event). Terminal outcomes retire the row; a transport failure keeps it for the
+    next pass, so a link that drops mid-apply loses nothing."""
+    host = r.get("host") or ""
+    rows = [x for x in _pending_tag_rows() if x.get("host") == host]
+    if not rows:
+        return 0
+    r.pop("_views_at", None)                     # the poll gate must not serve the stale cache here
+    try:
+        rv = _poll_remote_views(r)
+    except Exception:
+        rv = None
+    if not isinstance(rv, dict):
+        _tunnel_log(host, "pending-tag-edits", note="views unreadable — retrying next pass",
+                    pending=len(rows))
+        return 0
+    r["views"] = rv
+    by_name = {}
+    for t in (rv.get("tags") or []):
+        if isinstance(t, dict):
+            by_name.setdefault(str(t.get("name") or ""), []).append(t)
+    retired, applied = [], 0
+    for row in rows:
+        cand = by_name.get(row.get("name") or "") or []
+        t = next((x for x in cand if row.get("tagId") and x.get("id") == row["tagId"]), None)
+        if t is None and cand:
+            # same name, different identity: NEW if its id says it was created after the ruling;
+            # an undecodable id predates dated ids, hence the ruling — the edit still applies.
+            ms = _tag_id_ms(cand[0].get("id") or "")
+            if ms is not None and ms / 1000.0 > float(row.get("ruledAt") or 0):
+                _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
+                            outcome="survives — a same-named tag was created there after the ruling")
+                retired.append(row)
+                continue
+            t = cand[0]
+        if t is None:
+            _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
+                        outcome="already gone there — nothing to apply")
+            retired.append(row)
+            continue
+        mt = t.get("mtime")
+        if mt and float(mt) > float(row.get("ruledAt") or 0):
+            _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
+                        outcome="yields — the tag changed on %s after the ruling" % host)
+            retired.append(row)
+            continue
+        body = {"name": str(t.get("name") or row.get("name") or "")}
+        for k in ("delete", "rename", "remove"):
+            if row.get(k):
+                body[k] = row[k]
+        ans = _remote_forward(r, "/tag", body)
+        if ans is None:
+            _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
+                        outcome="transport failed — retrying next pass")
+            continue
+        ok = bool(ans.get("ok"))
+        _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
+                    outcome=("applied" if ok else "refused by the host: %s" % (ans.get("error") or "?")))
+        retired.append(row)                      # a refusal is the host's own answer — terminal
+        applied += 1 if ok else 0
+    if retired:
+        keep = [x for x in _pending_tag_rows() if x not in retired]
+        _save_pending_tag_rows(keep)
+        r.pop("_views_at", None)                 # re-read the post-apply truth next pass
+        _mark_views_dirty()
+    return applied
+
+
+def _row_op(row):
+    return "delete" if row.get("delete") else ("rename" if row.get("rename") else "remove")
+
+
 def _views_client():
     """The views blob every client renders and matches against — the RENDERING of the canonical
     store (federation v0, the user 2026-08-24): local tags with members as viewer-relative strings
@@ -1835,6 +2031,19 @@ def _views_client():
                            "members": [_remote_tag_member_str(host, m) for m in members]})
     if remote:
         v["remoteTags"] = remote
+    # tag federation v2: a queued edit is VISIBLE, never gone-but-not-gone — the matching cached
+    # remote entry wears `pending` ("delete"/"rename"/"remove") for the dialog's compact idiom,
+    # and the raw rows ride as pendingTagEdits so an intent for a host with no cached tag entry
+    # still surfaces.
+    pend = _pending_tag_rows()
+    if pend:
+        v["pendingTagEdits"] = [{"host": x.get("host") or "", "name": x.get("name") or "",
+                                 "op": _row_op(x)} for x in pend]
+        by_hn = {(x.get("host"), x.get("name")): _row_op(x) for x in pend}
+        for t in (v.get("remoteTags") or []):
+            op = by_hn.get((t.get("host"), t.get("name")))
+            if op:
+                t["pending"] = op
     return v
 
 
@@ -12495,6 +12704,15 @@ def _tunnel_supervisor():
                     # row and may spawn a worker. Runs here, in the one supervisor, so an advance is pushed
                     # exactly once no matter how many dashboards are open.
                     _maybe_auto_push(r)
+                    # tag federation v2, the reattach half (also outside the lock — it round-trips the
+                    # tunnel): a host that answers this pass applies any journaled tag edits that
+                    # failed while it was unreachable. Steady state costs one cached-list scan.
+                    try:
+                        if any(x.get("host") == r.get("host") for x in _pending_tag_rows()):
+                            _apply_pending_tag_edits(r)
+                    except Exception:
+                        _tunnel_log(r.get("host") or "?", "pending-tag-edits",
+                                    note="apply pass raised: %s" % traceback.format_exc(limit=3))
                 if _postal_peers_on() and want != notified:
                     # Peer-bus mode: a change to (effective-up, trust) is the event the local bus keys its
                     # peer table on (reachable at 127.0.0.1:bus_port through the second -L). Keyed on trust
@@ -29761,9 +29979,14 @@ class Handler(BaseHTTPRequestHandler):
                 # refuses loudly: an unreachable kernel must never silently no-op an edit.
                 th = str((b or {}).get("host") or "").strip()
                 if th:
-                    ans, err = _forward_tag_edit(th, {k: v for k, v in b.items() if k != "host"})
+                    fbody = {k: v for k, v in b.items() if k != "host"}
+                    ans, err = _forward_tag_edit(th, fbody)
                     if err:
-                        return self._send(200, json.dumps({"ok": False, "error": err}),
+                        # v2: the loud refusal stands, and a delete/rename/remove now also persists —
+                        # applied once when the host reattaches (see _queue_pending_tag_edit)
+                        if _queue_pending_tag_edit(th, fbody):
+                            err += " — queued: it applies when %s reattaches" % th
+                        return self._send(200, json.dumps({"ok": False, "error": err, "queued": "queued" in err}),
                                           "application/json")
                     _mark_views_dirty()
                     return self._send(200, json.dumps(ans), "application/json")
@@ -30305,8 +30528,15 @@ class Handler(BaseHTTPRequestHandler):
                     body["delete"] = True
                 ans, err = _forward_tag_edit(host, body)
                 if err or not (ans or {}).get("ok", False):
+                    # v2: a TRANSPORT failure (err — down/unreachable/hiccup) journals the intent so
+                    # it applies at reattach; a host that ANSWERED and refused (ok=False) is the
+                    # host's own ruling and never queues. The refusal stays loud either way.
+                    msg_err = err or (ans or {}).get("error") or "refused"
+                    queued = bool(err) and _queue_pending_tag_edit(host, body)
+                    if queued:
+                        msg_err += " — queued: it applies when %s reattaches" % host
                     _send_to_view("timeline", {"type": "tagEditFailed", "host": host, "name": nm,
-                                               "error": err or (ans or {}).get("error") or "refused"},
+                                               "error": msg_err, "queued": queued},
                                   (client or {}).get("wid") or "")
                 _mark_views_dirty()
         elif msg and msg.get("type") == "cardNotify" and msg.get("itemId"):

--- a/tests/test_tag_federation_v2.py
+++ b/tests/test_tag_federation_v2.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Tag federation v2 (the user 2026-08-29): a tag DELETE / RENAME / member-REMOVE that failed on an
+attached-but-unreachable host PERSISTS — a kernel-side journal (pending-tag-edits.json) applies it
+once when that host answers again — so a delete propagates to every federated kernel instead of the
+down host's surviving copy resurrecting the name in the union. The 2026-08-24 loud-refusal design
+stands (tagEditFailed still fires, now saying "queued"); what changed is that the intent outlives it.
+
+The late apply moves state only on evidence (the cards-move rule): the host's views are fetched
+FRESH at apply time, a same-named tag CREATED there after the ruling survives (tag ids encode their
+creation ms), and the same tag EDITED there after the ruling makes the queued edit yield (the v2
+per-tag mtime, stamped at the store's one write door). ADD never queues. Synthetic hosts/sids only.
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_tf2", os.path.join(BIN, "romp-kernel")).load_module()
+
+HOST = "TESTHOST"
+
+
+def _fresh_journal():
+    """Reset the journal (file + cache) between tests — the cache is module state."""
+    try:
+        km._pending_tag_path().unlink()
+    except OSError:
+        pass
+    with km._PENDING_TAG_LOCK:
+        km._PENDING_TAG_CACHE["rows"] = None
+
+
+def _attach(views=None, status="up"):
+    """A synthetic attached-host row in the live registry; returns the row."""
+    r = {"host": HOST, "status": status, "local_port": 1, "token": ""}
+    if views is not None:
+        r["views"] = views
+    km._remotes.clear()
+    km._remotes[HOST] = r
+    return r
+
+
+def _remote_tag(tid, name, members=(), mtime=0):
+    t = {"id": tid, "name": name, "color": "", "members": list(members)}
+    if mtime:
+        t["mtime"] = mtime
+    return t
+
+
+class Queueing(unittest.TestCase):
+    def setUp(self):
+        _fresh_journal()
+        _attach(views={"tags": [_remote_tag("g" + km._b36(int(time.time() * 1000) - 10_000_000), "web")]})
+
+    def tearDown(self):
+        _fresh_journal()
+        km._remotes.clear()
+
+    def test_delete_journals_with_the_cached_identity(self):
+        self.assertTrue(km._queue_pending_tag_edit(HOST, {"name": "web", "delete": True}))
+        rows = km._pending_tag_rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual((rows[0]["host"], rows[0]["name"], rows[0]["delete"]), (HOST, "web", True))
+        self.assertTrue(rows[0]["tagId"].startswith("g"),
+                        "the ruling captures WHICH tag it ruled on, from the host's cached views")
+        self.assertAlmostEqual(rows[0]["ruledAt"], time.time(), delta=30)
+
+    def test_add_and_color_never_queue(self):
+        self.assertFalse(km._queue_pending_tag_edit(HOST, {"name": "web", "add": ["s1"]}))
+        self.assertFalse(km._queue_pending_tag_edit(HOST, {"name": "web", "color": "#123456"}))
+        self.assertEqual(km._pending_tag_rows(), [])
+
+    def test_an_unattached_host_never_queues(self):
+        km._remotes.clear()
+        self.assertFalse(km._queue_pending_tag_edit("gone-host", {"name": "web", "delete": True}),
+                         "no reattach event is coming for a detached host — detach was its own intent")
+
+    def test_a_delete_supersedes_and_then_rules(self):
+        km._queue_pending_tag_edit(HOST, {"name": "web", "remove": ["s1"]})
+        km._queue_pending_tag_edit(HOST, {"name": "web", "rename": "site"})
+        km._queue_pending_tag_edit(HOST, {"name": "web", "delete": True})
+        rows = km._pending_tag_rows()
+        self.assertEqual([r.get("delete") for r in rows], [True],
+                         "the delete supersedes every earlier row for its (host, name)")
+        km._queue_pending_tag_edit(HOST, {"name": "web", "remove": ["s2"]})
+        self.assertEqual(len(km._pending_tag_rows()), 1, "…and refuses later rows: the delete already rules")
+
+    def test_removes_merge(self):
+        km._queue_pending_tag_edit(HOST, {"name": "web", "remove": ["s1"]})
+        km._queue_pending_tag_edit(HOST, {"name": "web", "remove": ["s2", "s1"]})
+        rows = [r for r in km._pending_tag_rows() if r.get("remove")]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["remove"], ["s1", "s2"])
+
+    def test_the_journal_survives_a_kernel_restart(self):
+        km._queue_pending_tag_edit(HOST, {"name": "web", "delete": True})
+        with km._PENDING_TAG_LOCK:
+            km._PENDING_TAG_CACHE["rows"] = None      # a fresh process knows nothing — the file is the truth
+        rows = km._pending_tag_rows()
+        self.assertEqual([(r["host"], r["name"]) for r in rows], [(HOST, "web")])
+
+
+class LateApply(unittest.TestCase):
+    """_apply_pending_tag_edits against a scripted host: _poll_remote_views and _remote_forward are
+    seams (monkeypatched per test), so every leg drives the REAL decision code."""
+
+    def setUp(self):
+        _fresh_journal()
+        self.r = _attach(views={"tags": [_remote_tag("g100", "web")]})
+        self.forwarded = []
+        self._orig_poll, self._orig_fwd = km._poll_remote_views, km._remote_forward
+        km._remote_forward = lambda r, path, body: (self.forwarded.append((path, body))
+                                                    or {"ok": True, "deleted": True})
+
+    def tearDown(self):
+        km._poll_remote_views, km._remote_forward = self._orig_poll, self._orig_fwd
+        _fresh_journal()
+        km._remotes.clear()
+
+    def _host_answers(self, tags):
+        km._poll_remote_views = lambda r: {"tags": tags}
+
+    def _rule(self, body, name="web"):
+        self.assertTrue(km._queue_pending_tag_edit(HOST, dict(body, name=name)))
+        return km._pending_tag_rows()[-1]
+
+    def test_reattach_applies_the_delete_once_and_the_union_is_clean(self):
+        self._rule({"delete": True})
+        self._host_answers([_remote_tag("g100", "web")])       # same identity, untouched since
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 1)
+        self.assertEqual(self.forwarded, [("/tag", {"name": "web", "delete": True})])
+        self.assertEqual(km._pending_tag_rows(), [], "a terminal outcome retires the row — once, ever")
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 0, "nothing pending → nothing re-applies")
+
+    def test_a_same_named_tag_created_after_the_ruling_survives(self):
+        self._rule({"delete": True})
+        newer = "g" + km._b36(int((time.time() + 60) * 1000))  # created AFTER ruledAt
+        self._host_answers([_remote_tag(newer, "web")])
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 0)
+        self.assertEqual(self.forwarded, [], "new information lives — nothing is forwarded")
+        self.assertEqual(km._pending_tag_rows(), [], "…and the stale ruling retires")
+
+    def test_a_post_ruling_edit_on_the_host_makes_the_ruling_yield(self):
+        self._rule({"delete": True})
+        self._host_answers([_remote_tag("g100", "web", mtime=int(time.time()) + 60)])
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 0)
+        self.assertEqual(self.forwarded, [],
+                         "a writer whose evidence predates newer information stands down")
+        self.assertEqual(km._pending_tag_rows(), [])
+
+    def test_already_gone_retires_without_a_forward(self):
+        self._rule({"delete": True})
+        self._host_answers([])
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 0)
+        self.assertEqual(self.forwarded, [])
+        self.assertEqual(km._pending_tag_rows(), [])
+
+    def test_rename_and_member_remove_legs(self):
+        self._rule({"rename": "site"})
+        self._rule({"remove": ["s1"]}, name="api")
+        self.r["views"] = {"tags": [_remote_tag("g100", "web"), _remote_tag("g200", "api")]}
+        self._host_answers([_remote_tag("g100", "web"), _remote_tag("g200", "api", members=["s1"])])
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 2)
+        self.assertIn(("/tag", {"name": "web", "rename": "site"}), self.forwarded)
+        self.assertIn(("/tag", {"name": "api", "remove": ["s1"]}), self.forwarded)
+        self.assertEqual(km._pending_tag_rows(), [])
+
+    def test_transport_failure_keeps_the_row_for_the_next_pass(self):
+        self._rule({"delete": True})
+        self._host_answers([_remote_tag("g100", "web")])
+        km._remote_forward = lambda r, path, body: None
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 0)
+        self.assertEqual(len(km._pending_tag_rows()), 1, "a link that drops mid-apply loses nothing")
+
+    def test_unreadable_views_waits_ask_the_host_never_guess(self):
+        self._rule({"delete": True})
+        km._poll_remote_views = lambda r: None
+        self.assertEqual(km._apply_pending_tag_edits(self.r), 0)
+        self.assertEqual(self.forwarded, [])
+        self.assertEqual(len(km._pending_tag_rows()), 1)
+
+
+class MtimeStamp(unittest.TestCase):
+    """The v2 per-tag mtime: stamped at the store's ONE write door, only when the tag changed."""
+
+    def test_an_edit_stamps_and_an_untouched_tag_keeps_its_stamp(self):
+        km._edit_tag("alpha", add=[])
+        v = km._timeline_views()
+        t0 = next(t for t in v["tags"] if t["name"] == "alpha")
+        self.assertTrue(t0.get("mtime"), "creation is an edit")
+        old = t0["mtime"] - 1000
+        # pin an OLD stamp by writing the FILE directly — the write door itself refuses to move a
+        # stamp on an unchanged tag (a client blob cannot forge mtimes), which is the point
+        vv = json.loads(json.dumps(v))
+        next(t for t in vv["tags"] if t["name"] == "alpha")["mtime"] = old
+        km._atomic_write(km._views_path(), json.dumps(vv, sort_keys=True))
+        km._edit_tag("beta", add=[])
+        v2 = km._timeline_views()
+        self.assertEqual(next(t for t in v2["tags"] if t["name"] == "alpha").get("mtime"), old)
+        km._edit_tag("alpha", color="#9cd2ff")
+        v3 = km._timeline_views()
+        self.assertGreater(next(t for t in v3["tags"] if t["name"] == "alpha")["mtime"], old,
+                           "an actual change moves the stamp")
+
+
+class Visibility(unittest.TestCase):
+    """The queued intent is loud: pending stamps on the rendered blob, never gone-but-not-gone."""
+
+    def setUp(self):
+        _fresh_journal()
+        _attach(views={"tags": [_remote_tag("g100", "web")]})
+
+    def tearDown(self):
+        _fresh_journal()
+        km._remotes.clear()
+
+    def test_views_client_stamps_the_pending_intent(self):
+        km._queue_pending_tag_edit(HOST, {"name": "web", "delete": True})
+        v = km._views_client()
+        rt = next(t for t in v["remoteTags"] if t["host"] == HOST and t["name"] == "web")
+        self.assertEqual(rt.get("pending"), "delete")
+        self.assertEqual(v["pendingTagEdits"], [{"host": HOST, "name": "web", "op": "delete"}])
+
+    def test_the_dialog_renders_the_compact_idiom(self):
+        src = open(os.path.join(os.path.dirname(HERE), "ui", "romp-timeline-view.js")).read()
+        self.assertIn("'pending ' + rt.pending + ' on ' + (rt.host || '?')", src,
+                      "the tag dialog says pending-<op>-on-<host> beside the pill (compact idiom)")
+
+    def test_the_loud_refusal_says_queued(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn("queued: it applies when %s reattaches", src,
+                      "the immediate refusal stays AND says the intent persists (both WS and /tag)")
+        self.assertEqual(src.count("queued: it applies when %s reattaches"), 2,
+                         "both failure doors carry the wording (WS editTag + POST /tag --host)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -200,12 +200,15 @@ class TagRoute(unittest.TestCase):
         km._set_timeline_views({"active": "gb", "tags": [
             {"id": "ga", "name": "alpha", "color": "", "members": ["s1"]}, GB]})
         km._flags_cache.clear()
+        seeded = next(g for g in km._timeline_views()["tags"] if g["id"] == "gb")
         st, r = self._post({"name": "alpha", "add": ["api"]})
         self.assertTrue(r.get("ok"), r)
         st, v = self._views()
         self.assertEqual(v["active"], "gb", "the active view survives the merge")
         self.assertNotIn("hidden", v, "the hidden key is retired (2026-08-24) — never re-minted by an edit")
-        want = dict(GB, members=[{"host": "", "sid": "s2"}])
+        # the seed write stamps mtime (creation IS an edit — tag federation v2); the pin is that
+        # the edit to alpha touched NOTHING on beta, stamp included
+        want = dict(GB, members=[{"host": "", "sid": "s2"}], mtime=seeded["mtime"])
         self.assertEqual([g for g in v["tags"] if g["id"] == "gb"], [want],
                          "the tag the edit never looked at is untouched (stored as pairs)")
         alpha = next(g for g in v["tags"] if g["id"] == "ga")

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3163,6 +3163,16 @@ class TimelinePanel {
             pill.setAttribute('style', 'display:inline-flex;align-items:center;padding:2px 9px;'
               + 'border-radius:10px;border:1px solid ' + tc + ';color:' + tc + ';background:transparent;font-weight:650;'
               + (gid && tg.ids.indexOf(gid) >= 0 ? 'outline:1px solid rgba(255,255,255,0.25);outline-offset:2px;' : ''));
+            // tag federation v2: a queued edit for an unreachable home is VISIBLE, never
+            // gone-but-not-gone — the kernel stamps the cached remote entry with `pending`
+            // ("delete"/"rename"/"remove"; it applies when that host reattaches). Compact idiom:
+            // the dialog's sub-line size, muted, beside the pill.
+            const pend = (tg.remotes || []).filter((rt) => rt.pending);
+            if (pend.length) {
+              const note = pillCell.createSpan({
+                text: pend.map((rt) => 'pending ' + rt.pending + ' on ' + (rt.host || '?')).join(', ') });
+              note.setAttribute('style', 'margin-left:6px;font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
+            }
           }
           // delete — the destructive convention: dim at rest, red on hover
           const del = tgrid.createDiv();


### PR DESCRIPTION
## What

The user's ruling: deleting a tag deletes it across **all** federated machines — including ones offline at the delete moment. Previously a delete/rename/member-remove fanned out to attached hosts only; an unreachable host refused loudly (by design) and nothing ever re-applied, so its surviving copy resurrected the name in the view-time union on reattach. The loud refusal stays; what changes is that the intent now also persists.

## Mechanism (event-based end to end)

- **Durable journal** (`STATE/pending-tag-edits.json`, cached, restart-proof): a qualifying edit that fails on an attached-but-unreachable host is journaled with the ruling moment and the identity of the tag ruled on (the remote tag's id from that host's cached views). Only **transport** failures queue — a host that answered and refused has ruled. **ADD never queues.** Coalescing: a delete supersedes every earlier row for its (host, name); removes merge.
- **Late apply at reattach**: the tunnel supervisor applies a host's rows when it answers, fetching its views **fresh** first (ask the host, never the cache). Cards-move semantics at federation scale:
  - same-named tag **created** there after the ruling → survives (tag ids encode creation ms — no store migration, works against old-code hosts);
  - same tag **edited** there after the ruling → the queued edit yields (a writer whose evidence predates newer information stands down);
  - undecodable legacy id → predates dated ids, hence the ruling → applies;
  - transport failure → retry next pass; the host's own refusal → terminal. Every outcome logs to tunnel-dials.jsonl.
- **Per-tag mtime** (the yield leg's evidence): stamped at the store's one write door by diffing against the previous blob — an incoming client blob cannot forge or rewind a stamp on an unchanged tag — and rides `/views` to peers for free.
- **Loud both ways**: `tagEditFailed` stays and now says "queued: it applies when <host> reattaches" (both the WS door and `POST /tag --host`); the rendered blob stamps matching remote entries `pending:"delete"/"rename"/"remove"` plus a raw `pendingTagEdits` list; the tag dialog shows "pending delete on <host>" beside the pill in its compact idiom — never gone-but-not-gone.

## Tests

`tests/test_tag_federation_v2.py` (17): down-host delete → journal row with captured identity + loud refusal; reattach applies once and never re-applies; late same-named create survives; post-ruling remote edit yields; already-gone retires; rename + member-remove legs; transport failure keeps the row; unreadable views waits; add/color/unattached never queue; delete-supersedes + remove-merge coalescing; journal survives a kernel restart; mtime stamps on change only and cannot be forged through the write door; pending visibility on the blob + the dialog idiom + the queued wording pins. The tag-route untouched-tag pin now also asserts an unrelated edit doesn't move the stamp.

## Suites

- pytest: 6042 passed + 313 subtests, 34 skipped
- extension: 2548 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)