### PR TITLE
Default comment model/effort/fast setting — new threads launch on a gear pick

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -539,6 +539,11 @@ def _version_info():
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),  # current per-tier judge efforts ("" = default/none)
             "distillModel": jd._state_str("distill-model", "triage"),   # RAW ("triage" = follow the triage pick) — the gear shows the choice, not the resolution
             "distillEffort": jd._state_str("distill-effort", "triage"),
+            # the default-comment trio, RAW too ("session" = same as the session) — the gear shows
+            # the user's choice; _comment_launch_prefs resolves it at each create
+            "commentModel": jd._state_str("comment-model", "session"),
+            "commentEffort": jd._state_str("comment-effort", "session"),
+            "commentFast": jd._state_str("comment-fast", "session"),
             # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
@@ -548,7 +553,10 @@ def _version_info():
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
                          "distillModel": jd._state_str("distill-model", "triage"),
-                         "distillEffort": jd._state_str("distill-effort", "triage")},
+                         "distillEffort": jd._state_str("distill-effort", "triage"),
+                         "commentModel": jd._state_str("comment-model", "session"),
+                         "commentEffort": jd._state_str("comment-effort", "session"),
+                         "commentFast": jd._state_str("comment-fast", "session")},
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
             "nativeDialogs": _native_dialogs()}   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
 
@@ -7137,7 +7145,7 @@ def _comment_markers(sid):
 # alone starves; the client's frame-keyed re-post stays as the belt for a kernel restart that loses
 # this in-memory park). The typed transient nack keeps the client's optimistic mark alive meanwhile.
 ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"
-_parked_creates = []                       # [{sid,uuid,exact,text,name,model,effort,color,tries}]
+_parked_creates = []                       # [{sid,uuid,exact,text,name,model,effort,fast,color,tries}]
 _PARK_MAX_TRIES = 30                       # pusher cycles (~15-90s) — past this the record isn't coming
 
 
@@ -7152,7 +7160,8 @@ def _retry_parked_creates():
     for pk in list(_parked_creates):
         pk["tries"] += 1
         err, tid = _comment_create(pk["sid"], pk["uuid"], pk["exact"], pk["text"], name=pk["name"],
-                                   model=pk["model"], effort=pk["effort"], color=pk["color"])
+                                   model=pk["model"], effort=pk["effort"], fast=pk.get("fast", ""),
+                                   color=pk["color"])
         if err == ANCHOR_LAG_ERR and pk["tries"] < _PARK_MAX_TRIES:
             continue
         _parked_creates.remove(pk)
@@ -7170,7 +7179,25 @@ def _retry_parked_creates():
                     pass
 
 
-def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", color="", now=None):
+def _comment_launch_prefs(model="", effort="", fast=""):
+    """Resolve what a new comment thread launches on: the dialog's explicit pick wins; else the
+    kernel's default-comment setting (the user 2026-08-29, who wanted every new thread on one
+    model/effort/fast pick regardless of the session it branches from); else empty = inherit the
+    parent session. The shipped "session" sentinel resolves to the empty override — byte-identical
+    to the no-setting fork() always did. Values ride RAW into fork(): an unsupported fast ask is
+    the CLI's call to refuse, surfaced by _adopt_fast_state's toast — never silently pre-dropped
+    here (fail loudly; the thread keeps its model either way)."""
+    out = []
+    for arg, fname in ((model, "comment-model"), (effort, "comment-effort"), (fast, "comment-fast")):
+        v = str(arg or "")
+        if not v:
+            stored = jd._state_str(fname, "session")
+            v = "" if stored == "session" else stored
+        out.append(v)
+    return tuple(out)
+
+
+def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", fast="", color="", now=None):
     """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
     threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
     opening message. Returns (error, tid): error is the warn-toast string (tid None), success is
@@ -7181,7 +7208,9 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
     had. It rides the reg (so a break-out inherits it) and the frame (the popover's title).
 
     `model`/`effort` (the user 2026-08-17): per-thread overrides picked in the same dialog — the
-    thread runs on them, the parent is untouched (fork() writes them into the thread's reg only)."""
+    thread runs on them, the parent is untouched (fork() writes them into the thread's reg only).
+    `fast` ("on"/"off"/"" — the user 2026-08-29) rides the same way; empty falls through
+    _comment_launch_prefs to the kernel's default-comment settings, then to inheriting the parent."""
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "fork") and _sdk_ready()):
         return "threads need the SDK backend; this session runs on tmux, so there is nothing to fork.", None
@@ -7214,9 +7243,10 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
             row["color"] = col                     # the comment's identity color (the dialog's name tint)
         data.setdefault("threads", []).append(row)
         _save_comments(parent_sid, data)
+    model, effort, fast = _comment_launch_prefs(model, effort, fast)
     try:
         be.fork(nm, parent_sid, cut, bg=col, fg=(pal.fg_for(col) if col else ""), sid=tsid, thread_of=parent_sid,
-                model=str(model or ""), effort=str(effort or ""))
+                model=model, effort=effort, fast=fast)
         be.connect(tsid)
         be.send(tsid, _comment_first_message(exact, text))
     except Exception as e:
@@ -8461,6 +8491,7 @@ def _drive(msg, client):
         err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]),
                                    name=str(msg.get("name") or ""),
                                    model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""),
+                                   fast=str(msg.get("fast") or ""),
                                    color=str(msg.get("color") or ""))
         if err:
             # a TRANSIENT refusal (the live-streamed reply's file flush lagging) PARKS the create —
@@ -8472,6 +8503,7 @@ def _drive(msg, client):
                                         "text": str(msg["text"]), "name": str(msg.get("name") or ""),
                                         "model": str(msg.get("model") or ""),
                                         "effort": str(msg.get("effort") or ""),
+                                        "fast": str(msg.get("fast") or ""),
                                         "color": str(msg.get("color") or ""), "tries": 0})
             else:
                 client["send"](json.dumps({"type": "warn", "text": err}))
@@ -23599,6 +23631,16 @@ def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, al
 # read back as "follow" (caught by test_distill_tier before it shipped).
 def _set_distill_model(v):  _set_judge_state("distill-model", v, _JUDGE_MODEL_VALUES | {"triage"})
 def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES | {"triage", "none"})
+# The default-COMMENT-THREAD trio (the user 2026-08-29, who wanted every new comment thread on one
+# model/effort/fast pick regardless of the session it branches from). Sentinel "session" — the shipped
+# default — means SAME AS THE SESSION: resolved to the empty override at create time
+# (_comment_launch_prefs), the byte-identical no-op fork() always did. The model also takes "default"
+# (clear to the account default) so the setting speaks the create dialog's exact value space; fast is
+# "on" or the sentinel — a checkbox has no third state, and forcing a thread SLOW from a fast parent
+# stays a per-thread dialog pick, never a standing default.
+def _set_comment_model(v):  _set_judge_state("comment-model", v, _JUDGE_MODEL_VALUES | {"session", "default"})
+def _set_comment_effort(v): _set_judge_state("comment-effort", v, _EFFORT_VALUES | {"session"})
+def _set_comment_fast(v):   _set_judge_state("comment-fast", v, {"session", "on"})
 
 
 # The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
@@ -23613,7 +23655,12 @@ def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES
 
 _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_index_model),
                          ("judgeEffort", _set_judge_effort), ("indexEffort", _set_index_effort),
-                         ("distillModel", _set_distill_model), ("distillEffort", _set_distill_effort))
+                         ("distillModel", _set_distill_model), ("distillEffort", _set_distill_effort),
+                         # the comment-thread defaults ride the same cross-kernel door: kernel-side
+                         # settings follow to every machine (the 2026-08-14 gear rule), and
+                         # /judge-settings is the tunnel-side propagation that already does it
+                         ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
+                         ("commentFast", _set_comment_fast))
 
 
 def _apply_judge_settings(body):
@@ -23646,7 +23693,10 @@ def _apply_judge_settings(body):
     return {"ok": True, "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),
             "distillModel": jd._state_str("distill-model", "triage"),
-            "distillEffort": jd._state_str("distill-effort", "triage")}
+            "distillEffort": jd._state_str("distill-effort", "triage"),
+            "commentModel": jd._state_str("comment-model", "session"),
+            "commentEffort": jd._state_str("comment-effort", "session"),
+            "commentFast": jd._state_str("comment-fast", "session")}
 
 
 def _propagate_judge_settings(body):
@@ -29296,7 +29346,13 @@ class Handler(BaseHTTPRequestHandler):
                                          or ((MODEL_VERSIONS.get(c["value"]) or [{}])[0].get("value")
                                              or c["value"]))
                                 for c in MODEL_CHOICES],
-                     "efforts": [dict(c, color=_effort_color(c["value"], _stops)) for c in EFFORT_CHOICES]}),
+                     "efforts": [dict(c, color=_effort_color(c["value"], _stops)) for c in EFFORT_CHOICES],
+                     # the create dialog's pre-read (the user 2026-08-29): what a new comment thread
+                     # gets when the dialog is left untouched — RAW ("session" = same as the session),
+                     # so the dialog shows the effective default and a pick stays a deviation
+                     "commentDefaults": {"model": jd._state_str("comment-model", "session"),
+                                         "effort": jd._state_str("comment-effort", "session"),
+                                         "fast": jd._state_str("comment-fast", "session")}}),
                     "application/json", cache="no-cache")
             if p == "/usage":                                 # the /usage rate-limit bars, re-read on demand: the rail's
                 # usage widget is click-to-refresh (the user 2026-06-30). Returns the freshest on-disk snapshot
@@ -31049,6 +31105,18 @@ class Handler(BaseHTTPRequestHandler):
             _set_distill_effort(str(msg["effort"]))   # gear "Distilling effort" ("triage" = follow; "none" = pinned no-flag)
             threading.Thread(target=_propagate_judge_settings,
                              args=({"distillEffort": str(msg["effort"])},), daemon=True).start()
+        elif msg and msg.get("type") == "setCommentModel" and msg.get("model"):
+            _set_comment_model(str(msg["model"]))   # gear "Comment model" ("session" = same as the session)
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"commentModel": str(msg["model"])},), daemon=True).start()
+        elif msg and msg.get("type") == "setCommentEffort" and msg.get("effort"):
+            _set_comment_effort(str(msg["effort"]))   # gear "Comment effort"
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"commentEffort": str(msg["effort"])},), daemon=True).start()
+        elif msg and msg.get("type") == "setCommentFast" and msg.get("fast"):
+            _set_comment_fast(str(msg["fast"]))     # gear "Fast comment threads" ("on" / "session")
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"commentFast": str(msg["fast"])},), daemon=True).start()
 
     def _ws(self):
         key = self.headers.get("Sec-WebSocket-Key")

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4512,7 +4512,8 @@ class SdkBackend:
         return sid
 
     def fork(self, name: str, parent_sid: str, cut_uuid: str = "", bg: str = "", fg: str = "",
-             sid: str | None = None, thread_of: str = "", model: str = "", effort: str = "") -> str:
+             sid: str | None = None, thread_of: str = "", model: str = "", effort: str = "",
+             fast: str = "") -> str:
         """Mint a NEW session that is a FORK of `parent_sid`'s conversation — up to `cut_uuid` when given
         (a transcript record uuid; empty = the whole conversation), the parent untouched either way (the
         user 2026-08-13). The new session gets its OWN sid, registry, name and identity colour — a fork
@@ -4573,10 +4574,14 @@ class SdkBackend:
             reg["threadOf"] = thread_of
         if parent.get("model") and parent["model"] != "default":
             reg["model"] = parent["model"]
-        if parent.get("fast"):
-            # fast rides the fork like model/effort do (the user 2026-08-25: a comment made from an
-            # Opus-high-FAST session came up slow) — the reg's `fast` is the persisted ask fast_opt
-            # reads at connect, so the thread's first frame already reports it
+        # fast rides the fork like model/effort do (the user 2026-08-25: a comment made from an
+        # Opus-high-FAST session came up slow) — the reg's `fast` is the persisted ask fast_opt
+        # reads at connect, so the thread's first frame already reports it. `fast` (the user
+        # 2026-08-29) is the per-fork override: "" inherits the parent's ask, "on" arms it
+        # regardless of the parent, "off" launches plain from a fast one. An arm the CLI refuses
+        # (a model /fast won't run) surfaces through _adopt_fast_state's refusal toast and clears
+        # the ask — same model, normal speed, never a silent substitute.
+        if fast == "on" or (not fast and parent.get("fast")):
             reg["fast"] = True
         # Per-fork model/effort OVERRIDES (the user 2026-08-17: a comment thread on a different model
         # or effort, without touching the parent). Applied HERE, in the reg the first connect reads —

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -239,6 +239,34 @@ class ThreadForkInvisibility(unittest.TestCase):
         reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
         self.assertNotIn("fast", reg, "no inherited fast key when the parent never asked for it")
 
+    def test_a_fork_fast_on_arms_the_ask_on_a_slow_parent(self):
+        # the user 2026-08-29: the default-comment setting (or a dialog pick) can arm fast for the
+        # thread regardless of the parent; the reg's `fast` is what fast_opt reads at connect
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT, fast="on")
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertTrue(reg.get("fast"), "an explicit on arms the ask on a slow parent")
+
+    def test_a_fork_fast_off_launches_plain_from_a_fast_parent(self):
+        preg_path = Path(self.td) / "sdk" / (PARENT + ".json")
+        preg = json.loads(preg_path.read_text())
+        preg["fast"] = True
+        preg_path.write_text(json.dumps(preg))
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT, fast="off")
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertNotIn("fast", reg, "off launches plain; the parent keeps its own ask untouched")
+
+    def test_the_fast_ask_reaches_the_clis_flag_settings(self):
+        # the chain the reg key rides (source pins — the flag file needs a live CLI connect):
+        # reg["fast"] → fast_opt at construct → _options hands it to flag_settings_path → the
+        # CLI's documented fastMode opt-in key. A refusal clears the ask + toasts, same model.
+        import inspect
+        self.assertIn('self.fast_opt = bool(reg.get("fast"))', inspect.getsource(sb.SdkSession.__init__))
+        self.assertIn("fast=sess.fast_opt", inspect.getsource(sb.SdkBackend._options))
+        self.assertIn('keys["fastMode"] = True', inspect.getsource(sb.flag_settings_path))
+        refusal = inspect.getsource(sb.SdkSession._adopt_fast_state)
+        self.assertIn('refused_ask = bool(reason) and self.fast_opt and fast != "on"', refusal)
+        self.assertIn('kw["fast"] = False', refusal, "a refused ask is cleared, never left armed")
+
     def test_a_plain_fork_still_writes_its_names_entry(self):
         self.be.fork("fork-x", PARENT, "a1", sid=THREAD)
         self.assertTrue((Path(self.td) / "names" / THREAD).exists())
@@ -436,9 +464,10 @@ class FakeBackend:
         self.sent = []
 
     def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None, thread_of="",
-             model="", effort=""):
+             model="", effort="", fast=""):
         self.calls.append(("fork", name, parent_sid, cut_uuid, sid, thread_of))
         self.forked_meta = (model, effort)
+        self.forked_fast = fast
         self.forked_bg = bg
         return sid
 
@@ -492,7 +521,21 @@ class CommentOps(CommentBase):
         km._sessions = self._saved_sessions
         km._reveal_chat_for = self._saved_reveal
         km._push_session_now = self._saved_push_now
+        self._clear_defaults()   # the module shares one hermetic STATE — never leak across tests
         super().tearDown()
+
+    def _clear_defaults(self):
+        for f in ("comment-model", "comment-effort", "comment-fast"):
+            try:
+                (km.jd.STATE / f).unlink()
+            except OSError:
+                pass
+        km.jd._state_cache.clear()
+
+    def _put_default(self, name, value):
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        (km.jd.STATE / name).write_text(value)
+        km.jd._state_cache.clear()   # same-second writes share an mtime; the cache is not under test
 
     def test_create_forks_a_thread_and_sends_the_framed_opener(self):
         err, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why jitter at all?")
@@ -537,6 +580,49 @@ class CommentOps(CommentBase):
         _, tid2 = km._comment_create(PARENT, "a1", "the cap", "Junk color.", color="not-a-hex")
         self.assertEqual(self.be.forked_bg, "", "a non-hex color falls to the backend's own pick")
         self.assertNotIn("color", km._comment_thread(PARENT, tid2))
+
+    def test_settings_defaults_ride_every_new_thread(self):
+        # the user 2026-08-29, who wanted every new comment thread on one model/effort/fast pick
+        # regardless of the session it branches from: the kernel-side default applies when the
+        # dialog is left untouched
+        self._put_default("comment-model", "claude-opus-5")
+        self._put_default("comment-effort", "high")
+        self._put_default("comment-fast", "on")
+        err, _ = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        self.assertIsNone(err)
+        self.assertEqual(self.be.forked_meta, ("claude-opus-5", "high"))
+        self.assertEqual(self.be.forked_fast, "on")
+
+    def test_the_dialog_pick_beats_the_setting(self):
+        self._put_default("comment-model", "haiku")
+        self._put_default("comment-fast", "on")
+        km._comment_create(PARENT, "a1", "exponential backoff", "Why?", model="fable", fast="off")
+        self.assertEqual(self.be.forked_meta[0], "fable")
+        self.assertEqual(self.be.forked_fast, "off", "a per-thread pick deviates BOTH ways")
+
+    def test_the_session_sentinel_is_a_byte_identical_noop(self):
+        # "session" (the shipped default) resolves to the empty override — exactly the fork()
+        # arguments a create sent before the setting existed
+        for f in ("comment-model", "comment-effort", "comment-fast"):
+            self._put_default(f, "session")
+        km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        self.assertEqual(self.be.forked_meta, ("", ""))
+        self.assertEqual(self.be.forked_fast, "")
+
+    def test_absent_files_resolve_the_same_as_the_sentinel(self):
+        self.assertEqual(km._comment_launch_prefs(), ("", "", ""))
+
+    def test_the_setters_validate_like_every_kernel_setting(self):
+        km._set_comment_model("gpt-99")
+        self.assertFalse((km.jd.STATE / "comment-model").exists(), "garbage never reaches the file")
+        km._set_comment_model("claude-opus-5")
+        self.assertEqual((km.jd.STATE / "comment-model").read_text(), "claude-opus-5")
+        km._set_comment_effort("bogus")
+        self.assertFalse((km.jd.STATE / "comment-effort").exists())
+        km._set_comment_fast("true")
+        self.assertFalse((km.jd.STATE / "comment-fast").exists(), '"on"/"session" only — never a bool word')
+        km._set_comment_fast("on")
+        self.assertEqual((km.jd.STATE / "comment-fast").read_text(), "on")
 
     def test_a_harness_task_notification_never_renders_as_the_users_words(self):
         recs = self._parent_records()

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -33,7 +33,8 @@ km = SourceFileLoader("romp_kernel_judgesync", os.path.join(BIN, "romp-kernel"))
 class ApplySettings(unittest.TestCase):
     def setUp(self):
         for f in ("judge-model", "index-model", "judge-effort", "index-effort",
-                  "distill-model", "distill-effort"):
+                  "distill-model", "distill-effort",
+                  "comment-model", "comment-effort", "comment-fast"):
             try:
                 (km.jd.STATE / f).unlink()
             except OSError:
@@ -51,6 +52,24 @@ class ApplySettings(unittest.TestCase):
         self.assertEqual((res["distillModel"], res["distillEffort"]), ("haiku", "none"))
         res = km._apply_judge_settings({"distillEffort": ""})
         self.assertEqual(res["distillEffort"], "none", "an empty distill effort is invalid, not a clear")
+
+    def test_comment_defaults_apply_and_report_raw(self):
+        # the default-comment trio (the user 2026-08-29) rides the same cross-kernel door as the
+        # judge tiers: applied through the validated setters, answered RAW ("session" = same as
+        # the session), garbage ignored and visible in the ack
+        res = km._apply_judge_settings({})
+        self.assertEqual((res["commentModel"], res["commentEffort"], res["commentFast"]),
+                         ("session", "session", "session"))
+        res = km._apply_judge_settings({"commentModel": "claude-opus-5", "commentEffort": "high",
+                                        "commentFast": "on"})
+        self.assertEqual((km.jd.STATE / "comment-model").read_text(), "claude-opus-5")
+        self.assertEqual((km.jd.STATE / "comment-effort").read_text(), "high")
+        self.assertEqual((km.jd.STATE / "comment-fast").read_text(), "on")
+        self.assertEqual((res["commentModel"], res["commentEffort"], res["commentFast"]),
+                         ("claude-opus-5", "high", "on"))
+        res = km._apply_judge_settings({"commentModel": "gpt-99", "commentFast": "true"})
+        self.assertEqual((res["commentModel"], res["commentFast"]), ("claude-opus-5", "on"),
+                         "garbage never reaches the files or `claude --model`")
 
     def test_distill_sentinel_returns_the_pair_to_follow_mode(self):
         km._apply_judge_settings({"distillModel": "haiku", "distillEffort": "high"})
@@ -148,7 +167,10 @@ class OneHopNeverALoop(unittest.TestCase):
         for frag in ('args=({"judgeModel": str(msg["model"])},)',
                      'args=({"indexModel": str(msg["model"])},)',
                      'args=({"judgeEffort": str(msg.get("effort") or "")},)',
-                     'args=({"indexEffort": str(msg.get("effort") or "")},)'):
+                     'args=({"indexEffort": str(msg.get("effort") or "")},)',
+                     'args=({"commentModel": str(msg["model"])},)',
+                     'args=({"commentEffort": str(msg["effort"])},)',
+                     'args=({"commentFast": str(msg["fast"])},)'):
             self.assertIn(frag, self.src, frag)
 
     def test_the_gear_copy_says_the_pick_follows(self):

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -71,12 +71,13 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertNotIn("headless", h)
 
     def test_judge_rows_are_one_line_label_plus_picker(self):
-        # label + picker share the line (the user 2026-07-12): six .rs-jrow rows since the distilling
-        # tier split out of triage (the user 2026-08-14), the select right after the hover sub, no
-        # full-width select stacked under the label; the flex CSS carries the layout. Each label now
-        # carries the hidden mixed-state marker (the settings-sync work, same day).
+        # label + picker share the line (the user 2026-07-12): eight .rs-jrow rows — six judge rows
+        # since the distilling tier split out of triage (the user 2026-08-14), plus the default-comment
+        # model/effort pair (the user 2026-08-29), which reuses the same one-line layout — the select
+        # right after the hover sub, no full-width select stacked under the label; the flex CSS
+        # carries the layout. Each label carries the hidden mixed-state marker (the settings-sync work).
         h = _gear_src()
-        self.assertEqual(h.count("rs-jrow"), 6)
+        self.assertEqual(h.count("rs-jrow"), 8)
         for sel in ("rs-judgemodel", "rs-judgeeffort", "rs-distillmodel", "rs-distilleffort",
                     "rs-indexmodel", "rs-indexeffort"):
             self.assertRegex(h, r"rs-jrow'><b>[^<]+<span class=rs-mixed hidden></span></b>"

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -258,6 +258,34 @@ test("break out posts commentPromote and acks with a provisional tab", () => {
   assert.match(UI, /type: "commentPromote", id: sid, tid, name \}\);\s*\n\s*close\(\);\s*\n\s*closeCommentPop\(\);\s*\n\s*openProvisional\(\{ name, backend: "sdk", dir: "", host: hostOf\(sid\) \}\);/);
 });
 
+test("the create dialog pre-reads the kernel's default-comment trio and shows it", () => {
+  // The user 2026-08-29: the gear can pin a default model/effort/fast for every NEW thread. The
+  // dialog must SHOW the effective default (pick > setting > inherit) so a pick stays a visible
+  // deviation; the kernel re-resolves the same order at create, so a stale pre-read can mislabel
+  // a chip but never mislaunch a thread.
+  assert.match(UI, /let commentDefaults = \{ model: "session", effort: "session", fast: "session" \};/);
+  assert.match(UI, /if \(d\.commentDefaults\) adoptCommentDefaults\(d\.commentDefaults\);/);
+  assert.match(UI, /function refreshCommentDefaults/);
+  // re-read at dialog open, repainting the row IN PLACE (the composer holds focus and a draft)
+  assert.match(UI, /refreshCommentDefaults\(\(\) => \{\s*\n\s*if \(pendingCommentAnchor !== create\) return;/);
+  assert.match(UI, /const effVal = chosen \|\| setDef\(kind\);/);
+  // a version id stored in the setting still labels correctly (families hold their versions)
+  assert.match(UI, /function modelChoiceLabel\(value: string\)/);
+  assert.match(KERNEL, /"commentDefaults": \{"model": jd\._state_str\("comment-model", "session"\),/);
+});
+
+test("fast rides the create end to end, resolved dialog > setting > inherit at the kernel", () => {
+  // the chip is offered only where the effective model could run fast (no control that only toasts)
+  assert.match(UI, /if \(canFast\(create\.model \|\| setDef\("model"\) \|\| st\?\.model \|\| ""\)\) metaRight\.append\(mkSel\("fast"\)\);/);
+  assert.match(UI, /fast: create\.fast \|\| "", color: create\.color \|\| "" \}\);/);
+  assert.match(UI, /fast: c\.fast, color: c\.color \}\);/);   // the in-flight retry keeps the pick
+  assert.match(KERNEL, /def _comment_launch_prefs\(model="", effort="", fast=""\):/);
+  assert.match(KERNEL, /model, effort, fast = _comment_launch_prefs\(model, effort, fast\)/);
+  assert.match(KERNEL, /fast=str\(msg\.get\("fast"\) or ""\)/);       // the ws op hands it through…
+  assert.match(KERNEL, /"fast": str\(msg\.get\("fast"\) or ""\),/);   // …and a lag-parked create keeps it
+  assert.match(KERNEL, /fast=pk\.get\("fast", ""\)/);
+});
+
 test("kernel registers every comment drive op", () => {
   for (const op of ["commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote"]) {
     assert.ok(KERNEL.includes(`"${op}"`), `${op} missing from ID_OPS/handlers`);
@@ -324,7 +352,7 @@ test("the create dialog names the thread right there: prefilled <session>-commen
   assert.match(UI, /"New comment:"/);
   assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, closeBtn\);/);
   assert.match(UI, /send\.setAttribute\("aria-label", create \? "Comment" : "Send"\);/);   // the ➤ carries the word
-  assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| "",\s*\n\s*color: create\.color \|\| ""/);
+  assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| "",\s*\n\s*fast: create\.fast \|\| "", color: create\.color \|\| ""/);
   // the comment's own model/effort selectors reuse the statusline's /models-fed choices + menu skin
   assert.match(UI, /const metaRow = el\("div", "statusline cmt-meta-row"\);/);   // the chat statusline dress (2026-08-25 parity)
   assert.match(UI, /META_CHOICES\[kind\]/);

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -59,7 +59,8 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 // the old way. setUpdateMode belongs here too: each kernel runs its own boot release check, so a machine
 // that misses the change keeps handling new releases under the old policy (ask/auto/off). The distilling
 // pair rides like the other judge tiers (the user 2026-08-14: everything kernel-side stays in sync; the
-// gear's mixed marks surface any machine that disagrees rather than overwriting it silently). Broadcast in
+// gear's mixed marks surface any machine that disagrees rather than overwriting it silently), and the
+// default-comment trio (setCommentModel/Effort/Fast, the user 2026-08-29) rides the same way. Broadcast in
 // routeOutbound rather than routed. setFileEditing is the viewer's edit opt-in (the user 2026-08-22:
 // one consent popup answers for the mesh — every kernel's save route gates on its own copy, so the
 // broadcast is what makes the one yes reach them all). Deliberately NOT here: setDefaultDir (a path on
@@ -67,7 +68,8 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 // local kernel persists for this browser).
 const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
                                 "setJudgeEffort", "setIndexEffort", "setUpdateMode",
-                                "setDistillModel", "setDistillEffort", "setFileEditing"]);
+                                "setDistillModel", "setDistillEffort", "setFileEditing",
+                                "setCommentModel", "setCommentEffort", "setCommentFast"]);
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -98,6 +98,13 @@ var GEAR_HTML =
   "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it). Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
+  '<div class=rs-sec>Comments</div>' +
+  "<div class='rs-row rs-jrow'><b>Comment model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model NEW comment threads start on. Same as the session (the default) keeps each thread on the model of the conversation it branches from; pinning one here starts every new thread on it. The comment dialog shows this default and its own pick still wins. Follows to every connected machine's kernel.</span><select id=rs-cmtmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Comment effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for new comment threads. Same as the session (the default) inherits the effort of the conversation the thread branches from. Follows to every connected machine's kernel.</span><select id=rs-cmteffort></select></div>" +
+  "<label class='rs-row'><input type=checkbox id=rs-cmtfast>" +
+  '<span><b>Fast comment threads</b><span class=rs-mixed hidden></span>' +
+  "<span class=rs-sub>Start new comment threads in fast mode (Opus-only research preview). If the thread's model can't run it, the thread still opens on that model at normal speed, with a notice. Off = same as the session. Follows to every connected machine's kernel.</span>" +
+  '</span></label>' +
   '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
   '<div class=rs-sec>Chat</div>' +
   '<label class=rs-row><input type=checkbox id=rs-compact>' +
@@ -201,6 +208,8 @@ function initGear(post) {
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates'),
     dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
+    cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
+    cmf = document.getElementById('rs-cmtfast'),
     fe = document.getElementById('rs-fileedit'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
   function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
@@ -392,6 +401,7 @@ function initGear(post) {
   selectPick(je, 'flex:0 0 auto;width:45%');
   selectPick(ie, 'flex:0 0 auto;width:45%');
   selectPick(de, 'flex:0 0 auto;width:45%');
+  selectPick(cme, 'flex:0 0 auto;width:45%');
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -584,6 +594,8 @@ function initGear(post) {
     versionMenu(jm);
     versionMenu(im);
     versionMenu(dm, [{ value: 'triage', label: 'Follow triage', versions: [] }]);
+    versionMenu(cmm, [{ value: 'session', label: 'Same as the session', versions: [] },
+                      { value: 'default', label: 'Default', versions: [] }]);
   });
   if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value }); });
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
@@ -591,6 +603,24 @@ function initGear(post) {
   if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value }); });
   if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value }); });
   if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value }); });
+  // Fast is an Opus-only research preview (render.ts fastAvailable, the same rule): a pinned
+  // non-Opus comment model makes the box a dead control, so it disables — and a model pick that
+  // strands a checked box also unchecks it, visibly, as part of the user's own gesture (never a
+  // silent per-fill flap; the kernel would otherwise ask fast on every create and toast every
+  // refusal). 'session'/'default' stay enabled: the session/account default may be Opus.
+  function cmtFastGate(fromModelPick) {
+    if (!cmf || !cmm) return;
+    var val = (cmm.value || '').toLowerCase();
+    var can = val === 'session' || val === 'default' || val.indexOf('opus') !== -1;
+    cmf.disabled = !can;
+    if (!can && cmf.checked && fromModelPick) {
+      cmf.checked = false;
+      post({ type: 'setCommentFast', fast: 'session' });
+    }
+  }
+  if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value }); cmtFastGate(true); });
+  if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value }); });
+  if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session' }); });
   // feed-colormap preview bar: a horizontal gradient of the SELECTED map's stops (mirrors render.ts COLORMAPS).
   var CMAPS = { aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],
     hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
@@ -661,6 +691,10 @@ function initGear(post) {
       // stored sentinel "none", never "" — an empty state file reads back as the default ("follow").
       if (dm) dm.innerHTML = '<option value="triage">Follow triage</option>' + mo;
       if (de) de.innerHTML = '<option value="triage">Follow triage</option><option value="none">Default</option>' + eff;
+      // the comment pair leads with the same-as-the-session sentinel — its default, so a fresh
+      // kernel shows the inherit behavior, not a model nobody picked; "default" = the account default
+      if (cmm) cmm.innerHTML = '<option value="session">Same as the session</option><option value="default">Default</option>' + mo;
+      if (cme) cme.innerHTML = '<option value="session">Same as the session</option>' + eff;
       return choices;
     }).catch(function () { return null; });
   }
@@ -706,7 +740,8 @@ function initGear(post) {
   function fillMixedMarks(v, rows) {
     var mine = (v && v.settings) || null;
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
-     ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe]].forEach(function (pair) {
+     ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
+     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
       var row = el.closest ? el.closest('.rs-row') : null;
@@ -742,6 +777,10 @@ function initGear(post) {
     if (ie && typeof v.indexEffort === 'string') ie.value = v.indexEffort;
     if (dm && typeof v.distillModel === 'string') dm.value = v.distillModel;   // RAW: "triage" selects the Follow-triage option
     if (de && typeof v.distillEffort === 'string') de.value = v.distillEffort;
+    if (cmm && typeof v.commentModel === 'string') cmm.value = v.commentModel;   // RAW: "session" selects Same as the session
+    if (cme && typeof v.commentEffort === 'string') cme.value = v.commentEffort;
+    if (cmf && typeof v.commentFast === 'string') cmf.checked = v.commentFast === 'on';
+    cmtFastGate(false);
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
     // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to
     // vanish into a macOS-only dialog. Drop the button rather than offer one that cannot work; the

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -45,7 +45,8 @@ test("every gear fetch routes through the kernel base + token (VS Code's webview
 test("the gear posts kernel ops through ONE shared channel (never re-acquires the VS Code API)", () => {
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort",
-    "setDistillModel", "setDistillEffort", "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
+    "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast",
+    "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 
@@ -62,6 +63,23 @@ test("the distilling tier is its own gear pair, defaulting to follow-triage", ()
   assert.ok(GEAR.includes("v.distillEffort"), "fill() reads the RAW distill effort value");
 });
 
+test("the default-comment trio is its own gear group, defaulting to same-as-the-session", () => {
+  // The user 2026-08-29: every new comment thread on one model/effort/fast pick regardless of the
+  // session it branches from. The stored sentinel "session" means inherit the parent — today's
+  // behavior until the user pins — so the selects lead with it and fill from the RAW /version value.
+  for (const id of ["rs-cmtmodel", "rs-cmteffort", "rs-cmtfast"])
+    assert.ok(GEAR.includes(id), `the gear must render ${id}`);
+  assert.ok(GEAR.includes('"session">Same as the session'), "the sentinel option leads both selects");
+  assert.ok(GEAR.includes("v.commentModel"), "fill() reads the RAW comment model value");
+  assert.ok(GEAR.includes("v.commentEffort"), "fill() reads the RAW comment effort value");
+  assert.ok(GEAR.includes("v.commentFast === 'on'"), "the fast box reflects the stored ask");
+  // fast is an Opus-only research preview: a pinned non-Opus comment model disables the box, and a
+  // model pick that strands a checked box unchecks it as part of that gesture — never a silent flap
+  assert.ok(GEAR.includes("function cmtFastGate"), "the availability gate must exist");
+  assert.ok(GEAR.includes("cmtFastGate(true)"), "the model pick runs the gate as a user gesture");
+  assert.ok(GEAR.includes("cmtFastGate(false)"), "fill() re-checks availability without posting");
+});
+
 test("every kernel-side select says so when connected machines disagree (the autoNudge rule generalized)", () => {
   // The user 2026-08-14: everything stays in sync; on disagreement the gear ASKS by showing the local
   // value with a mixed mark beside it — hover names the hosts, one pick sets every machine — and a
@@ -71,7 +89,7 @@ test("every kernel-side select says so when connected machines disagree (the aut
     "non-reporting rows are excluded, not read as disagreeing");
   assert.ok(GEAR.includes("differs on: "), "the hover names the disagreeing hosts");
   const mixedSpans = GEAR.match(/class=rs-mixed hidden/g) || [];
-  assert.ok(mixedSpans.length >= 7, `every kernel-side select carries a marker span (got ${mixedSpans.length})`);
+  assert.ok(mixedSpans.length >= 10, `every kernel-side select carries a marker span (got ${mixedSpans.length})`);
 });
 
 test("the Auto Nudge box speaks for every attached machine, and says so when they disagree", () => {

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -480,6 +480,9 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setUpdateMode", mode: "auto" },
                      { type: "setDistillModel", model: "haiku" },
                      { type: "setDistillEffort", effort: "triage" },
+                     { type: "setCommentModel", model: "claude-opus-5" },
+                     { type: "setCommentEffort", effort: "high" },
+                     { type: "setCommentFast", fast: "on" },
                      { type: "setFileEditing", enabled: true }]) {
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));
     assert.deepEqual(routes.map((r) => r.host).sort(), ["", "TESTHOST", "gpu1"].sort(), msg.type);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6372,7 +6372,7 @@ const cmtAwaitBase = new Map<string, number>();
 // next session frame for the sid arrives (frames are built from the kernel's parse — a new frame IS
 // the parse catching up). Bounded by attempts, not time; a real refusal or the ack drops the hold.
 const cmtCreateInFlight = new Map<string, { sid: string; uuid: string; exact: string; text: string;
-  name: string; model: string; effort: string; color: string; tries: number }>();
+  name: string; model: string; effort: string; fast: string; color: string; tries: number }>();
 const CMT_CREATE_MAX_TRIES = 12;
 
 function retryCmtCreates(sid: string): void {
@@ -6386,7 +6386,7 @@ function retryCmtCreates(sid: string): void {
     }
     c.tries++;
     vscodeApi?.postMessage({ type: "commentCreate", id: c.sid, uuid: c.uuid, exact: c.exact,
-      text: c.text, name: c.name, model: c.model, effort: c.effort, color: c.color });
+      text: c.text, name: c.name, model: c.model, effort: c.effort, fast: c.fast, color: c.color });
   }
 }
 
@@ -6431,7 +6431,7 @@ function cmtBootHolds(tid: string): boolean {
 }
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
 let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
-  model?: string; effort?: string; color?: string } | null = null; // create mode (+ the thread's own picks)
+  model?: string; effort?: string; fast?: string; color?: string } | null = null; // create mode (+ the thread's own picks)
 let pendingAdoptTid: string | null = null;                          // commentCreated ack that beat its frame
 let commentPopPos: { x: number; y: number } | null = null;
 
@@ -7124,10 +7124,10 @@ function commentSendFromPop(pop: HTMLElement): void {
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
-      color: create.color || "" });
+      fast: create.fast || "", color: create.color || "" });
     cmtCreateInFlight.set(create.uuid, { sid: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
-      color: create.color || "", tries: 0 });
+      fast: create.fast || "", color: create.color || "", tries: 0 });
     return;
   }
   const cur = openCommentThread();
@@ -7264,55 +7264,93 @@ function renderCommentPopover(): void {
   }
   let metaRowPending: HTMLElement | null = null;   // appended under the composer row — the statusline position
   if (create) {
-    // the thread's OWN model + effort (the user 2026-08-17): the same /models-fed choices the
-    // chat's statusline selectors use, defaulting to what this session runs now — picking one
-    // affects only the thread; the conversation it branches from is never touched
+    // the thread's OWN model + effort + fast (the user 2026-08-17; fast and the kernel-side
+    // defaults the user 2026-08-29): the same /models-fed choices the chat's statusline selectors
+    // use. Each chip shows the EFFECTIVE default — the dialog's own pick, else the kernel's
+    // default-comment setting (commentDefaults), else what this session runs now — so a pick is
+    // always a visible deviation; picking affects only the thread, never the conversation it
+    // branches from. The kernel re-resolves the same order at create (_comment_launch_prefs).
     const st = sessions.get(sid)?.status;
-    const metaRow = el("div", "statusline cmt-meta-row");
-    const mkSel = (kind: "model" | "effort") => {
-      // the statusline's own badge chrome (.meta-btn/.meta-label/.meta-caret) so the two stay in
-      // sync by construction (the user 2026-08-17), tinted from the /models list's shared colors
-      const btn = el("span", "meta-btn") as HTMLElement;
-      const chosen = kind === "model" ? create.model : create.effort;
-      const choice = chosen ? META_CHOICES[kind].find((c) => c.value === chosen) : null;
-      const label = el("span", "meta-label");
-      label.textContent = choice ? choice.label : (kind === "model" ? (st?.model || "Default") : (st?.effort || "default"));
-      const tint = choice?.color || (kind === "model" ? st?.modelColor : st?.effortColor);
-      if (tint && tint.length === 3) label.style.color = `rgb(${tint[0]},${tint[1]},${tint[2]})`;
-      const caret = el("span", "meta-caret");
-      caret.textContent = "▾";
-      btn.append(label, caret);
-      btn.title = chosen ? "the comment runs on its own " + kind + "; this session keeps its"
-        : "inherits this session's " + kind + " — click to pick another for the comment only";
-      btn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        closeMetaMenu();
-        const menu = el("div", "meta-menu");
-        for (const c of META_CHOICES[kind]) {
-          const cur = chosen ? c.value === chosen : (st ? isCurrentMeta(kind, st, c.value) : false);
-          const item = el("div", "meta-item" + (cur ? " current" : ""));
-          item.textContent = c.label;
-          item.addEventListener("click", (ev) => {
-            ev.stopPropagation();
-            if (pendingCommentAnchor) pendingCommentAnchor[kind] = c.value;
-            closeMetaMenu();
-            document.getElementById("cmt-pop")?.remove();   // full rebuild shows the pick
-            renderCommentPopover();
-          });
-          menu.appendChild(item);
-        }
-        document.body.appendChild(menu);
-        const r2 = btn.getBoundingClientRect();
-        menu.style.left = r2.left + "px";
-        menu.style.top = (r2.bottom + 4) + "px";
-        metaMenuEl = menu;
-      });
-      return btn;
+    // the kernel default for one chip, resolved ("session" → none → inherit this session)
+    const setDef = (kind: "model" | "effort" | "fast") => {
+      const v = kind === "model" ? commentDefaults.model : kind === "effort" ? commentDefaults.effort
+        : commentDefaults.fast;
+      return v === "session" ? "" : v;
     };
-    const metaRight = el("span", "sl-right");
-    metaRight.append(mkSel("model"), mkSel("effort"));
-    metaRow.appendChild(metaRight);
-    metaRowPending = metaRow;
+    // fast is offered only where the effective model could run it (fastAvailable's rule: unknown
+    // and opus stay offered; an explicit non-Opus pick drops the chip — no control that only toasts)
+    const canFast = (m: string) => {
+      const v = (m || "").toLowerCase();
+      return !v || v === "default" || v.includes("opus");
+    };
+    const buildMetaRow = (): HTMLElement => {
+      const metaRow = el("div", "statusline cmt-meta-row");
+      const mkSel = (kind: "model" | "effort" | "fast") => {
+        // the statusline's own badge chrome (.meta-btn/.meta-label/.meta-caret) so the two stay in
+        // sync by construction (the user 2026-08-17), tinted from the /models list's shared colors
+        const btn = el("span", "meta-btn") as HTMLElement;
+        const chosen = (kind === "model" ? create.model : kind === "effort" ? create.effort : create.fast) || "";
+        const effVal = chosen || setDef(kind);
+        const label = el("span", "meta-label");
+        if (kind === "fast") {
+          const on = (effVal || st?.fast || "off").toLowerCase() === "on";
+          label.textContent = prettyFast(on ? "on" : "off");
+          if (on) label.style.color = "var(--fast)";
+        } else {
+          const choice = kind === "model" ? (effVal ? modelChoiceLabel(effVal) : null)
+            : (effVal ? EFFORT_CHOICES.find((c) => c.value === effVal) : null);
+          label.textContent = choice ? choice.label : (kind === "model" ? (st?.model || "Default") : (st?.effort || "default"));
+          const tint = choice?.color || (kind === "model" ? st?.modelColor : st?.effortColor);
+          if (tint && tint.length === 3) label.style.color = `rgb(${tint[0]},${tint[1]},${tint[2]})`;
+        }
+        const caret = el("span", "meta-caret");
+        caret.textContent = "▾";
+        btn.append(label, caret);
+        btn.title = chosen ? "the comment runs on its own " + kind + "; this session keeps its"
+          : setDef(kind) ? "the default for new comments (set in Settings) — click to pick another for this one"
+          : "inherits this session's " + kind + " — click to pick another for the comment only";
+        btn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          closeMetaMenu();
+          const menu = el("div", "meta-menu");
+          for (const c of META_CHOICES[kind]) {
+            const cur = kind === "fast"
+              ? c.value === ((effVal || st?.fast || "off").toLowerCase() === "on" ? "on" : "off")
+              : effVal ? (c.value === effVal || !!c.versions?.some((v) => v.value === effVal))
+              : (st ? isCurrentMeta(kind, st, c.value) : false);
+            const item = el("div", "meta-item" + (cur ? " current" : ""));
+            item.textContent = c.label;
+            item.addEventListener("click", (ev) => {
+              ev.stopPropagation();
+              if (pendingCommentAnchor) pendingCommentAnchor[kind] = c.value;
+              closeMetaMenu();
+              document.getElementById("cmt-pop")?.remove();   // full rebuild shows the pick
+              renderCommentPopover();
+            });
+            menu.appendChild(item);
+          }
+          document.body.appendChild(menu);
+          const r2 = btn.getBoundingClientRect();
+          menu.style.left = r2.left + "px";
+          menu.style.top = (r2.bottom + 4) + "px";
+          metaMenuEl = menu;
+        });
+        return btn;
+      };
+      const metaRight = el("span", "sl-right");
+      metaRight.append(mkSel("model"), mkSel("effort"));
+      if (canFast(create.model || setDef("model") || st?.model || "")) metaRight.append(mkSel("fast"));
+      metaRow.appendChild(metaRight);
+      return metaRow;
+    };
+    metaRowPending = buildMetaRow();
+    // the gear may have moved the defaults since page load — re-read at open and repaint the row
+    // IN PLACE (never the whole popover: the composer holds focus and an unsent draft)
+    refreshCommentDefaults(() => {
+      if (pendingCommentAnchor !== create) return;   // the dialog already sent or closed
+      const live = pop.querySelector(".cmt-meta-row");
+      if (live) live.replaceWith(buildMetaRow());
+    });
   }
   if (create || th!.status !== "promoted") {
     const dk = create ? "new:" + create.uuid : th!.tid;
@@ -9850,7 +9888,34 @@ const EFFORT_CHOICES: { label: string; value: string; color?: number[] | null }[
 fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
   if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models, { label: "Default", value: "default" }); }
   if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; EFFORT_CHOICES.push(...d.efforts); }
+  if (d.commentDefaults) adoptCommentDefaults(d.commentDefaults);
 }).catch(() => { /* picker stays empty until it lands */ });
+// The kernel's default-comment settings, RAW ("session" = same as the session — the user 2026-08-29):
+// what a new comment thread launches on when the dialog is left untouched. Pre-read so the create
+// dialog SHOWS the effective default and a pick stays a deviation; the kernel re-resolves at create,
+// so a stale pre-read can mislabel a chip but never mislaunch a thread. Re-fetched at each dialog
+// open (the gear may have changed it since page load).
+let commentDefaults = { model: "session", effort: "session", fast: "session" };
+function adoptCommentDefaults(d: any): void {
+  commentDefaults = { model: String(d.model || "session"), effort: String(d.effort || "session"),
+                      fast: String(d.fast || "session") };
+}
+function refreshCommentDefaults(then: () => void): void {
+  fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
+    if (d && d.commentDefaults) { adoptCommentDefaults(d.commentDefaults); then(); }
+  }).catch(() => { /* keep the page-load pre-read — the kernel still resolves at create */ });
+}
+// A model VALUE's display label + family tint, version ids included ("claude-opus-5" → its version
+// label under the opus family) — the create dialog's default chip must name whatever the setting
+// holds, not just top-level families.
+function modelChoiceLabel(value: string): { label: string; color?: number[] | null } {
+  for (const c of MODEL_CHOICES as MetaChoice[]) {
+    if (c.value === value) return c;
+    const v = c.versions?.find((x) => x.value === value);
+    if (v) return { label: v.label, color: c.color };
+  }
+  return { label: value };
+}
 // Permission mode. A tmux session has no slash command for it — the host cycles shift+tab the right
 // number of times (the user 2026-06-16) — so the four CYCLE modes are all that backend can reach.
 // An SDK session sets it outright over the control channel (set_permission_mode), which is what makes


### PR DESCRIPTION
The user (2026-08-29) wanted every new comment thread to launch on one model/effort/fast pick — e.g. Opus 5, fast, high effort — regardless of the model the session it branches from runs, with the shipped default keeping today's behavior byte-identically.

**Kernel (the distill-model gear idiom).** Three validated STATE files (`comment-model`/`comment-effort`/`comment-fast`) with the sentinel `session` = same as the session; WS setters `setCommentModel`/`setCommentEffort`/`setCommentFast`; the trio joins `_JUDGE_SETTING_FIELDS` (cross-kernel propagation via `/judge-settings`, one hop) and `KERNEL_SETTING` in federation.ts (broadcast to every attached kernel); `/version` carries the raw values (top-level + the settings dict for mixed marks); `/models` gains `commentDefaults` for the dialog pre-read.

**Resolution: dialog pick > setting > inherit** (`_comment_launch_prefs`). The kernel never pre-drops an unsupported fast ask — the CLI rules, and the existing `_adopt_fast_state` refusal path toasts and clears it: the thread opens on the same model at normal speed, never silently a different one. `fork()` gains a fast tri-state (`""` inherit / `"on"` arm / `"off"` plain), writing the reg key `fast_opt` already reads at connect. The `commentCreate` op, lag-parked retries, and client in-flight resends all carry the fast field.

**Gear.** A Comments section: Comment model (versionMenu, sentinel leading), Comment effort, and a Fast comment threads checkbox gated on the model (fastAvailable's rule; a model pick that strands a checked box unchecks it as part of that gesture, never a silent per-fill flap).

**Create dialog.** Each chip shows the EFFECTIVE default (pick > setting > this session) so a pick stays a visible deviation; a stored version id labels through its family; defaults re-read at dialog open, repainting the row in place; a fast chip appears when the effective model could run it.

**Tests.** Resolution precedence, sentinel no-op, setter validation, fork fast tri-state, the reg→fast_opt→flag-settings chain pins, `/judge-settings` apply/propagate, gear rows + gate + mixed marks, broadcast membership, dialog pre-read + fast end-to-end pins. Retargeted two stale pins (create-payload shape; rs-jrow count 6→8). Verified against the real served gear headlessly: picks round-trip to the kernel's files, the gate unchecks on Haiku, `/models` follows the picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)