### PR TITLE
Deleting a message works mid-turn — interrupt, then arm the rewind at the turn's end

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16023,8 +16023,9 @@ def _rewind_rollback(sid, user_uuid, now=None):
     be = Sessions.backend_for(sid)
     if not hasattr(be, "rollback"):
         return "deleting past messages needs the SDK backend — this session runs in tmux (use Esc Esc in its terminal)"
-    if _ops_gate(sid):
-        return "the session is busy — wait for the current turn to finish, then delete"
+    # NO busy gate here (delete-while-busy, the user 2026-08-29): the backend decides — a bare
+    # delete on an in-flight turn interrupts it and arms the rewind at the turn's actual end;
+    # compacting and queued-strangers keep their honest refusals inside _arm_rewind.
     now = now or time.time()
     sess = next((s for s in _sessions(now) if s["sid"] == sid), None)
     if not sess:
@@ -16036,7 +16037,11 @@ def _rewind_rollback(sid, user_uuid, now=None):
     # abandoned. Read its time NOW, before be.rollback arms the pending_cut that would hide it from _parse.
     # The gesture HIDES the affected cards; the archive waits for the branch-take (_on_rewind_resolved).
     cut_t = _atom_epoch(sess["path"], sid, str(user_uuid), now)
-    ok, berr = be.rollback(sid, target)
+    # the arm-time re-check for a mid-window delete: a compaction landing between the interrupt
+    # and the turn's end can move the boundary past the target — only this parse can see that
+    path = sess["path"]
+    ok, berr = be.rollback(sid, target,
+                           revalidate=lambda: _rewind_target(path, sid, str(user_uuid))[1])
     if ok:
         _arm_rewind_hold(be, sid, cut_t)
     return None if ok else (berr or "the rollback could not be applied")

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1559,6 +1559,15 @@ class SdkSession:
         self._rewind_leaf = reg.get("rewindLeaf") or ""
         self._rewind_bare = bool(reg.get("rewindBare"))   # a DELETE rollback: no replacement turn enqueued
         self._rewind_armed = False
+        # delete-while-busy (the user 2026-08-29): the gesture landed mid-turn — the interrupt is in
+        # flight and the arm completes at the turn's actual END (_complete_rewind_wait, keyed on the
+        # Stop hook / inflight settle, never a sleep). Reg-seeded so a kernel death mid-window is
+        # VISIBLE at the next connect (the leaf verification there reads the flag as spent and
+        # restores loudly — never a wrong-branch cut). The revalidate closure is the kernel's
+        # arm-time re-check (the compaction boundary lives in the kernel's parse); in-memory on
+        # purpose — it cannot survive a restart, and the spent path covers that honestly.
+        self._rewind_wait = bool(reg.get("rewindWait"))
+        self._rewind_revalidate = None
         # reconnect machinery: effort changes (a connect-time flag) reconnect the client; _wake breaks the
         # receive loop cleanly for shutdown OR reconnect even when idle (a bare async-for would block forever).
         self._wake: asyncio.Event | None = None
@@ -2294,8 +2303,10 @@ class SdkSession:
             with self._lock:
                 dropped = self._pending.pop(0) if self._pending else None
             self._persist_queue()
+        self._rewind_wait = False
         try:
-            self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False)
+            self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False,
+                                     rewindWait=False)
         except Exception as e:
             self.backend._log("rewind (%s): registry clear failed: %s" % (self.name, e))
         self.backend._log("rewind (%s): the CLI refused --resume-session-at (%s: %s) — flag dropped, "
@@ -2635,15 +2646,32 @@ class SdkSession:
             # the authoritative flag so parked ops proceed immediately, instead of waiting out a 180s cap.
             self._compacting = False
             self._clearing = False   # /clear backstop: the turn settled, whatever the init did or didn't flip
-            if self._rewind_to:
+            if self._rewind_to and getattr(self, "_rewind_wait", False):
+                # delete-while-busy: THIS settle is the interrupted turn ending — the flag is being
+                # ARMED here, not consumed. Second observer of the turn-end fact (the Stop hook is
+                # the first; _complete_rewind_wait is idempotent, first one wins) — it exists for
+                # the turn shapes where Stop never fires (an interrupt that dies straight to the
+                # ResultMessage).
+                try:
+                    self.backend._complete_rewind_wait(self)
+                except Exception as e:
+                    self.backend._log("rewind (%s): delete-while-busy completion failed at the "
+                                      "settle: %s" % (self.name, e))
+            elif self._rewind_to and self._rewind_armed:
                 # the rewind turn settled — the flag is CONSUMED (the leaf moved past the recorded one, so
                 # rewind_disposition would drop it on the next connect anyway; this just tidies the reg now).
                 # A bare rollback consumes here too: the settled turn IS the branch's first (leaf moved).
+                # ARMED is part of the guard (delete-while-busy): the interrupted turn's own settle
+                # lands moments after the Stop hook armed the flag, and an unguarded consume read
+                # that fresh arm as the branch-take — flags could never accompany an UNARMED
+                # running turn before, so armed-only is byte-identical for the idle paths.
                 self._rewind_to = self._rewind_leaf = ""
                 self._rewind_bare = False
                 self._rewind_armed = False
+                self._rewind_wait = False
                 try:
-                    self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False)
+                    self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False,
+                                             rewindWait=False)
                 except Exception as e:
                     self.backend._log("rewind (%s): registry clear failed after the turn landed: %s" % (self.name, e))
                 # the BRANCH-TAKE event: the settled turn is the new branch's first landed record —
@@ -2946,6 +2974,13 @@ class SdkSession:
             self.backend._update_reg(self.sid, lastStopAt=int(time.time()))
         except Exception:
             pass
+        # delete-while-busy: the turn this delete interrupted has ENDED — complete the arm here,
+        # on the same turn-end fact that stamps lastStopAt (never a sleep)
+        if getattr(self, "_rewind_wait", False):
+            try:
+                self.backend._complete_rewind_wait(self)
+            except Exception as e:
+                self.backend._log("rewind (%s): delete-while-busy completion failed: %s" % (self.name, e))
         self.backend._poke()
         return {}
 
@@ -4445,8 +4480,11 @@ class SdkBackend:
         elif disp == "spent":
             sess._rewind_to = sess._rewind_leaf = ""
             sess._rewind_bare = False
+            sess._rewind_wait = False       # a kernel death mid-delete-window lands here: loud spent
+            #                                 restore, never a wrong-branch cut — the wait dies with the flags
             try:
-                self._update_reg(sess.sid, rewindTo="", rewindLeaf="", rewindBare=False)
+                self._update_reg(sess.sid, rewindTo="", rewindLeaf="", rewindBare=False,
+                                 rewindWait=False)
             except Exception as e:
                 self._log("rewind (%s): registry clear failed: %s" % (sess.name, e))
             self._log("rewind (%s): conversation moved since the request — flag spent, resuming plainly"
@@ -4958,30 +4996,51 @@ class SdkBackend:
         turn is a data-loss hazard, and queued strangers would ride the new branch unasked."""
         return self._arm_rewind(sid, target_uuid, text)
 
-    def rollback(self, sid: str, target_uuid: str) -> "tuple[bool, str]":
+    def rollback(self, sid: str, target_uuid: str, revalidate=None) -> "tuple[bool, str]":
         """The chat's delete-message rollback: the edit rewind with NO replacement turn. The one-shot
         flag arms the same --resume-session-at reconnect, but nothing is enqueued — the conversation
         just stands at `target_uuid`, and the user's NEXT message (whenever it comes) takes the branch.
         Until then no record lands past the recorded leaf, so the flag stays pending (rewindBare) and
-        the kernel parse renders the cut (pending_cut) instead of the abandoned tail."""
-        return self._arm_rewind(sid, target_uuid, None)
+        the kernel parse renders the cut (pending_cut) instead of the abandoned tail. `revalidate`
+        (delete-while-busy) is the kernel's arm-time re-check, run at the interrupted turn's end —
+        None keeps the idle path exactly as before."""
+        return self._arm_rewind(sid, target_uuid, None, revalidate=revalidate)
 
-    def _arm_rewind(self, sid, target_uuid, text):
+    def _arm_rewind(self, sid, target_uuid, text, revalidate=None):
         reg = read_reg(self.state_dir, sid)
         if not reg or not reg.get("alive"):
             return False, "the session is not running — revive it first"
-        if self.busy(sid) or self.compacting(sid):
-            return False, "the session is busy — wait for the current turn to finish"
         if any(t for t in (reg.get("queue") or []) if isinstance(t, str) and t):
             return False, "messages are queued for this session — send or cancel them first"
+        if self.busy(sid) or self.compacting(sid):
+            # Delete-while-busy (the user 2026-08-29): at an explicit DELETE the old data-loss
+            # hazard inverts — the user is knowingly discarding the turn their deleted message
+            # started, and its partial output becomes the abandoned branch tail, the rewind
+            # family's normal shape. So a BARE rollback on a live in-flight session takes the
+            # interrupt-then-arm pipeline instead of refusing. Everything else keeps an honest
+            # refusal: a compaction is not the user's turn to discard (interrupting it is its own
+            # hazard); queued strangers would ride the new branch unasked (s._pending checked in
+            # the pipeline); an edit rewind (text) still needs the idle path — its replacement
+            # turn should not race a dying one.
+            if self.compacting(sid):
+                return False, ("the session is compacting its context — interrupting that is its "
+                               "own hazard; wait for it to finish, then delete")
+            s = self.sessions.get(sid)
+            if text is None and s is not None and not s.ended:
+                with s._lock:
+                    strangers = bool(s._pending)
+                if strangers:
+                    return False, "messages are queued for this session — send or cancel them first"
+                return self._arm_rollback_busy(s, sid, target_uuid, revalidate)
+            return False, "the session is busy — wait for the current turn to finish"
         leaf = last_record_uuid(transcript_path(reg.get("cwd") or "~", reg.get("lastSid") or sid))
         if not leaf:
             return False, "no conversation on disk to rewind"
         bare = text is None
-        self._update_reg(sid, rewindTo=target_uuid, rewindLeaf=leaf, rewindBare=bare)
+        self._update_reg(sid, rewindTo=target_uuid, rewindLeaf=leaf, rewindBare=bare, rewindWait=False)
         s = self._ensure(sid)
         if not s:
-            self._update_reg(sid, rewindTo="", rewindLeaf="", rewindBare=False)
+            self._update_reg(sid, rewindTo="", rewindLeaf="", rewindBare=False, rewindWait=False)
             return False, "the session could not start"
         s._rewind_leaf, s._rewind_to = leaf, target_uuid   # already-running thread: the reg seed didn't apply
         s._rewind_bare = bare
@@ -4990,6 +5049,66 @@ class SdkBackend:
         s.request_reconnect()   # idle → reconnects now; a fresh thread's FIRST connect applies the flag
         self._poke()
         return True, ""
+
+    def _arm_rollback_busy(self, s, sid, target_uuid, revalidate):
+        """Delete-while-busy, the GESTURE half: set the pending-rewind fields NOW — the existing
+        inputs() gate holds message intake on exactly these fields (rewind set, not armed), and
+        pending_cut renders the cut immediately via _rewind_wait, so the UI acknowledges at the
+        click like an idle delete — then interrupt the running turn through the owner-scoped
+        interrupt and let the turn's actual END complete the arm (_complete_rewind_wait). The leaf
+        is recorded THERE, after the dust settles: the interrupted turn's partial records are the
+        abandoned branch tail. rewindLeaf stays "" across the window on purpose — a kernel death
+        mid-window makes the next connect's leaf verification read the flag as SPENT, which
+        restores the cards loudly (never a wrong-branch cut)."""
+        self._update_reg(sid, rewindTo=target_uuid, rewindLeaf="", rewindBare=True, rewindWait=True)
+        s._rewind_to, s._rewind_leaf, s._rewind_bare = target_uuid, "", True
+        s._rewind_wait, s._rewind_revalidate = True, revalidate
+        self.interrupt(sid)
+        # the turn may have settled BETWEEN the busy() read and the fields landing — with intake
+        # held, no later turn-end event would ever complete the arm. Third observer, idempotent.
+        with s._lock:
+            settled = s.inflight == 0 and not s._pending
+        if settled:
+            self._complete_rewind_wait(s)
+        self._poke()
+        return True, ""
+
+    def _complete_rewind_wait(self, s):
+        """Delete-while-busy, the ARM half — run on the turn-end fact (the Stop hook, with the
+        inflight settle as a second observer; idempotent, first one wins under the lock). Re-check
+        through the kernel's closure — a mid-window auto-compaction lands a boundary record that
+        can put the target out of reach, and only the kernel's parse can see that — then record
+        the ACTUAL post-turn leaf and reconnect: from here it is the idle rollback path exactly.
+        Any failure restores loudly through _rewind_resolved("failed"), the same event the
+        two-phase card cleanup already keys its restore on."""
+        with s._lock:
+            if not s._rewind_wait:
+                return
+            s._rewind_wait = False
+        sid = s.sid
+        revalidate, s._rewind_revalidate = s._rewind_revalidate, None
+
+        def _restore(why):
+            self._update_reg(sid, rewindTo="", rewindLeaf="", rewindBare=False, rewindWait=False)
+            s._rewind_to, s._rewind_leaf, s._rewind_bare = "", "", False
+            self._log("rewind (%s): delete-while-busy restored — %s" % (s.name, why))
+            self._rewind_resolved(sid, "failed")
+            self._poke()
+
+        err = None
+        try:
+            err = revalidate() if revalidate else None
+        except Exception as e:
+            err = "the arm-time re-check raised: %s" % e
+        if err:
+            return _restore(err)
+        leaf = last_record_uuid(transcript_path(s.cwd, s.resume_sid or s.sid))
+        if not leaf:
+            return _restore("no conversation on disk at the turn's end")
+        self._update_reg(sid, rewindTo=s._rewind_to, rewindLeaf=leaf, rewindBare=True, rewindWait=False)
+        s._rewind_leaf = leaf
+        s.request_reconnect()
+        self._poke()
 
     def rewind_flags(self, sid: str) -> "tuple[str, str, bool]":
         """The session's armed rewind flags (rewindTo, rewindLeaf, rewindBare) — live session first,
@@ -5050,15 +5169,23 @@ class SdkBackend:
         s = self.sessions.get(sid)
         if s is not None and not s.ended:
             to, leaf, bare = s._rewind_to, s._rewind_leaf, getattr(s, "_rewind_bare", False)
+            wait = bool(getattr(s, "_rewind_wait", False))
             cwd, fsid = s.cwd, s.resume_sid or s.sid
         else:
             reg = read_reg(self.state_dir, sid)
             if not reg:
                 return ""
             to, leaf, bare = reg.get("rewindTo") or "", reg.get("rewindLeaf") or "", bool(reg.get("rewindBare"))
+            wait = bool(reg.get("rewindWait"))
             cwd, fsid = reg.get("cwd") or "~", reg.get("lastSid") or sid
         if not to or not bare:
             return ""
+        if wait:
+            # delete-while-busy window: the interrupted turn's records are STILL landing — on the
+            # abandoned tail, by design — so the leaf check below would expire the cut the user
+            # just made. The UI acknowledges at the click; verification resumes the moment the
+            # turn ends and the arm records the real leaf.
+            return to
         now_leaf = last_record_uuid(transcript_path(cwd, fsid))
         return to if rewind_disposition(to, leaf, now_leaf) == "apply" else ""
 

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -153,12 +153,19 @@ class DeleteRollback(unittest.TestCase):
         self.assertIn('client["send"](json.dumps({"type": "warn", "text": err}))', arm)
         self.assertNotIn("_send_or_park", arm)
 
-    def test_rollback_gates_match_the_edit_rewind(self):
+    def test_rollback_validates_like_the_edit_but_never_gates_on_busy(self):
+        # Delete-while-busy (the user 2026-08-29): the kernel-side busy gate is GONE from the
+        # delete path — the backend decides (a bare delete on an in-flight turn interrupts it and
+        # arms the rewind at the turn's end; compacting/queued keep honest refusals there). The
+        # edit rewind keeps its gate (test above): its replacement turn must not race a dying one.
         src = inspect.getsource(km._rewind_rollback)
         self.assertIn('if not hasattr(be, "rollback"):', src)    # SDK-only (tmux has Esc Esc natively)
-        self.assertIn("if _ops_gate(sid):", src)                 # busy/compacting/parked-queue → refuse
+        self.assertNotIn("if _ops_gate(sid):", src)              # busy is the BACKEND's decision now
         self.assertIn("target, err = _rewind_target(", src)      # the SAME cut point as an edit
-        self.assertIn("be.rollback(sid, target)", src)
+        # the arm-time re-check rides along: a mid-window compaction can move the boundary past
+        # the target, and only the kernel's parse can see that — so the closure re-runs it
+        self.assertIn("be.rollback(sid, target,", src)
+        self.assertIn('revalidate=lambda: _rewind_target(path, sid, str(user_uuid))[1]', src)
 
 
 class ParseCut(unittest.TestCase):
@@ -287,9 +294,9 @@ class RevertOnDelete(unittest.TestCase):
         # never happened).
         src = inspect.getsource(km._rewind_rollback)
         self.assertIn("cut_t = _atom_epoch(", src)                   # resolved before be.rollback
-        self.assertIn("ok, berr = be.rollback(sid, target)", src)
+        self.assertIn("ok, berr = be.rollback(sid, target,", src)   # + the arm-time revalidate closure
         self.assertIn("_arm_rewind_hold(be, sid, cut_t)", src)       # hide on success; archive at the take
-        self.assertLess(src.index("cut_t = _atom_epoch("), src.index("be.rollback(sid, target)"),
+        self.assertLess(src.index("cut_t = _atom_epoch("), src.index("be.rollback(sid, target,"),
                         "the deleted message's time is read BEFORE the cut is armed")
 
     def test_edit_hides_born_in_range_goals_too(self):

--- a/tests/test_sdk_rewind.py
+++ b/tests/test_sdk_rewind.py
@@ -107,7 +107,10 @@ class WiringPins(unittest.TestCase):
 
     def test_spent_flag_is_cleared_from_session_and_reg(self):
         self.assertIn('elif disp == "spent":', BACKEND_SRC)
-        self.assertIn('self._update_reg(sess.sid, rewindTo="", rewindLeaf="", rewindBare=False)', BACKEND_SRC)
+        self.assertIn('self._update_reg(sess.sid, rewindTo="", rewindLeaf="", rewindBare=False,', BACKEND_SRC)
+        # …and the delete-while-busy wait dies with the flags (a kernel death mid-window lands
+        # here: the "" leaf reads as spent, the cards restore loudly, never a wrong-branch cut)
+        self.assertIn('sess._rewind_wait = False', BACKEND_SRC)
 
     def test_input_gate_holds_the_edit_until_a_rewound_client_is_up(self):
         # feeding the edit turn to the un-rewound client is the wrong-branch delivery this kills
@@ -120,6 +123,9 @@ class WiringPins(unittest.TestCase):
 
     def test_result_message_consumes_the_flag(self):
         self.assertIn("# the rewind turn settled — the flag is CONSUMED", BACKEND_SRC)
+        # ARMED-only (delete-while-busy): the interrupted turn's own settle lands moments after
+        # the Stop hook armed the flag — an unguarded consume read that arm as the branch-take
+        self.assertIn("elif self._rewind_to and self._rewind_armed:", BACKEND_SRC)
 
     def test_refused_connect_fails_loudly_and_drops_the_held_edit(self):
         # a CLI exit-1 on the rewind connect: drop flag + queue head, toast, reconnect plainly —
@@ -136,7 +142,7 @@ class WiringPins(unittest.TestCase):
     def test_rewind_persists_the_flag_before_ensuring_the_thread(self):
         # a fresh session thread seeds _rewind_to from the reg — writing after _ensure could race
         # the first connect and strand the held queue
-        i_reg = BACKEND_SRC.index("self._update_reg(sid, rewindTo=target_uuid, rewindLeaf=leaf, rewindBare=bare)")
+        i_reg = BACKEND_SRC.index("self._update_reg(sid, rewindTo=target_uuid, rewindLeaf=leaf, rewindBare=bare, rewindWait=False)")
         i_ensure = BACKEND_SRC.index("s = self._ensure(sid)", i_reg - 2000)
         self.assertLess(i_reg, i_ensure)
 
@@ -171,8 +177,8 @@ class RollbackAndPendingCut(unittest.TestCase):
     pending, because no record lands to move the leaf until the user's next message."""
 
     def test_rollback_is_the_bare_arm_and_rewind_the_texted_one(self):
-        self.assertIn("def rollback(self, sid: str, target_uuid: str)", BACKEND_SRC)
-        self.assertIn("return self._arm_rewind(sid, target_uuid, None)", BACKEND_SRC)
+        self.assertIn("def rollback(self, sid: str, target_uuid: str, revalidate=None)", BACKEND_SRC)
+        self.assertIn("return self._arm_rewind(sid, target_uuid, None, revalidate=revalidate)", BACKEND_SRC)
         self.assertIn("return self._arm_rewind(sid, target_uuid, text)", BACKEND_SRC)
         self.assertIn("bare = text is None", BACKEND_SRC)
         # nothing is enqueued for a bare rollback — the next real message takes the branch
@@ -190,7 +196,7 @@ class RollbackAndPendingCut(unittest.TestCase):
 
     def test_settle_consume_clears_the_bare_flag_too(self):
         i = BACKEND_SRC.index("the flag is CONSUMED")
-        seg = BACKEND_SRC[i:i + 600]
+        seg = BACKEND_SRC[i:i + 1200]
         self.assertIn('rewindTo="", rewindLeaf="", rewindBare=False', seg)
 
     def _fixture(self, tmp, bare=True, leaf_moved=False):
@@ -306,3 +312,159 @@ class RollbackAndPendingCut(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class _BusySession:
+    """The attrs the delete-while-busy pipeline reads/writes off a live SdkSession, with the
+    interrupt and reconnect as call recorders. inflight=1 = a running turn."""
+    def __init__(self, sid, cwd):
+        import threading
+        self.sid, self.cwd, self.name = sid, cwd, "busy"
+        self.resume_sid = ""
+        self.ended = False
+        self.inflight = 1
+        self._pending = []
+        self._compacting = False
+        self._lock = threading.Lock()
+        self._rewind_to = self._rewind_leaf = ""
+        self._rewind_bare = self._rewind_armed = self._rewind_wait = False
+        self._rewind_revalidate = None
+        self.interrupts, self.reconnects = 0, 0
+
+    def interrupt(self):
+        self.interrupts += 1
+
+    def request_reconnect(self):
+        self.reconnects += 1
+
+
+class DeleteWhileBusy(unittest.TestCase):
+    """Delete-while-busy (the user 2026-08-29), EXECUTED on the real backend methods: a bare
+    rollback on an in-flight turn interrupts it, holds intake (the existing rewind gate), renders
+    the cut immediately, and arms the rewind at the turn's actual END — where the interrupted
+    turn's partial records become the abandoned branch tail. Failures restore loudly through
+    _rewind_resolved("failed"); the idle path is byte-identical to before (the tests above)."""
+
+    def setUp(self):
+        import pathlib
+        self._env = os.environ.get("HOME")
+        self.tmp = tempfile.mkdtemp()
+        os.environ["HOME"] = self.tmp
+        self.cwd = os.path.join(self.tmp, "proj")
+        os.makedirs(self.cwd)
+        self.sid = "11111111-2222-3333-4444-000000000077"
+        self.be = sb.SdkBackend(os.path.join(self.tmp, "sdk"), "/bin/true", lambda *a, **k: None,
+                                log=lambda *a, **k: None)
+        sb.write_reg(pathlib.Path(self.be.state_dir), self.sid,
+                     {"sid": self.sid, "name": "busy", "cwd": self.cwd, "alive": True})
+        tp = sb.transcript_path(self.cwd, self.sid)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        with open(tp, "w") as f:
+            f.write(json.dumps({"type": "user", "uuid": "t1"}) + "\n")
+            f.write(json.dumps({"type": "user", "uuid": "u2"}) + "\n")
+        self.s = _BusySession(self.sid, self.cwd)
+        self.be.sessions[self.sid] = self.s
+        self.resolved = []
+        self.be.rewind_resolved_cb = lambda sid, outcome: self.resolved.append((sid, outcome))
+
+    def tearDown(self):
+        if self._env is not None:
+            os.environ["HOME"] = self._env
+
+    def _partial_lands(self):
+        """The interrupted turn's partial output — records landing AFTER the gesture."""
+        with open(sb.transcript_path(self.cwd, self.sid), "a") as f:
+            f.write(json.dumps({"type": "assistant", "uuid": "a-partial"}) + "\n")
+
+    def test_gesture_interrupts_holds_and_renders_then_the_turn_end_arms(self):
+        ok, err = self.be.rollback(self.sid, "t1", revalidate=lambda: None)
+        self.assertTrue(ok, err)
+        self.assertEqual(self.s.interrupts, 1, "the running turn is interrupted at the gesture")
+        self.assertTrue(self.s._rewind_wait)
+        self.assertEqual((self.s._rewind_to, self.s._rewind_bare), ("t1", True))
+        # intake held: the inputs() gate's exact expression (rewind set, not armed)
+        self.assertTrue(bool(self.s._rewind_to and not self.s._rewind_armed),
+                        "the existing rewind gate holds message intake across the window")
+        # the UI acknowledged at the click: pending_cut renders even as records keep landing
+        self._partial_lands()
+        self.assertEqual(self.be.pending_cut(self.sid), "t1")
+        reg = sb.read_reg(self.be.state_dir, self.sid)
+        self.assertTrue(reg.get("rewindWait"), "the window survives a kernel death VISIBLY (reg)")
+        # the turn's actual end (the Stop hook / settle call this): the arm completes
+        self.s.inflight = 0
+        self.be._complete_rewind_wait(self.s)
+        self.assertFalse(self.s._rewind_wait)
+        self.assertEqual(self.s._rewind_leaf, "a-partial",
+                         "the leaf records AFTER the dust settles — the partial output is the "
+                         "abandoned branch tail, the rewind family's normal shape")
+        self.assertEqual(self.s.reconnects, 1, "from here it is the idle rollback path exactly")
+        reg = sb.read_reg(self.be.state_dir, self.sid)
+        self.assertEqual((reg.get("rewindTo"), reg.get("rewindLeaf"), bool(reg.get("rewindWait"))),
+                         ("t1", "a-partial", False))
+        # idempotent: the settle observer firing after the Stop observer is a no-op
+        self.be._complete_rewind_wait(self.s)
+        self.assertEqual(self.s.reconnects, 1)
+        self.assertEqual(self.resolved, [], "no failure — nothing resolved until the branch takes")
+
+    def test_arm_time_revalidation_failure_restores_loudly(self):
+        # a mid-window auto-compaction moved the boundary past the target: the closure refuses
+        ok, _ = self.be.rollback(self.sid, "t1",
+                                 revalidate=lambda: "the target fell behind a compaction")
+        self.assertTrue(ok)
+        self.s.inflight = 0
+        self.be._complete_rewind_wait(self.s)
+        self.assertEqual((self.s._rewind_to, self.s._rewind_wait), ("", False))
+        self.assertEqual(self.resolved, [(self.sid, "failed")],
+                         "the held cards restore through the existing failure event")
+        self.assertEqual(self.s.reconnects, 0, "nothing to reconnect for — the delete is off")
+        self.assertEqual(self.be.pending_cut(self.sid), "", "the cut render dies with the restore")
+
+    def test_queued_strangers_still_refuse(self):
+        self.s._pending.append("a queued message")
+        ok, err = self.be.rollback(self.sid, "t1")
+        self.assertFalse(ok)
+        self.assertIn("queued", err)
+        self.assertEqual(self.s.interrupts, 0, "refused at the gesture — nothing was interrupted")
+
+    def test_compacting_refuses_with_its_own_honest_message(self):
+        self.s._compacting = True
+        ok, err = self.be.rollback(self.sid, "t1")
+        self.assertFalse(ok)
+        self.assertIn("compacting", err)
+        self.assertEqual(self.s.interrupts, 0)
+
+    def test_the_edit_rewind_keeps_the_busy_refusal(self):
+        # only the DELETE inverts the hazard — an edit's replacement turn must not race a dying one
+        ok, err = self.be.rewind(self.sid, "t1", "the edited text")
+        self.assertFalse(ok)
+        self.assertIn("busy", err)
+        self.assertEqual(self.s.interrupts, 0)
+
+    def test_a_turn_that_settled_under_the_gesture_completes_inline(self):
+        # the third observer: busy() read true, but the turn settled before the fields landed —
+        # with intake held, no later turn-end event would ever fire
+        real_interrupt = self.s.interrupt
+        def settle_and_interrupt():
+            real_interrupt()
+            self.s.inflight = 0
+        self.s.interrupt = settle_and_interrupt
+        ok, _ = self.be.rollback(self.sid, "t1", revalidate=lambda: None)
+        self.assertTrue(ok)
+        self.assertFalse(self.s._rewind_wait, "completed inline — nothing left to wait on")
+        self.assertEqual(self.s.reconnects, 1)
+
+    def test_wait_render_survives_a_kernel_restart_until_the_connect_rules(self):
+        # restart mid-window: the reg carries the wait; pending_cut still renders the cut from the
+        # reg (no live session), and the connect path's "" leaf reads as spent → loud restore
+        ok, _ = self.be.rollback(self.sid, "t1", revalidate=lambda: None)
+        self.assertTrue(ok)
+        del self.be.sessions[self.sid]
+        self.assertEqual(self.be.pending_cut(self.sid), "t1")
+        self.assertEqual(sb.rewind_disposition("t1", "", "u2"), "spent",
+                         "the mid-window '' leaf can never read as apply — a kernel death "
+                         "degrades to the loud spent restore, never a wrong-branch cut")
+
+    def test_stop_hook_and_settle_both_observe_the_turn_end(self):
+        self.assertIn('if getattr(self, "_rewind_wait", False):\n            try:\n'
+                      '                self.backend._complete_rewind_wait(self)', BACKEND_SRC)
+        self.assertIn('if self._rewind_to and getattr(self, "_rewind_wait", False):', BACKEND_SRC)

--- a/ui/webview/rewind-delete.test.ts
+++ b/ui/webview/rewind-delete.test.ts
@@ -96,7 +96,7 @@ test("kernel: rewindDelete sends nothing and the parse renders the pending cut",
   assert.match(KERNEL, /elif t == "rewindDelete" and msg\.get\("uuid"\):/);
   assert.match(KERNEL, /def _rewind_rollback\(sid, user_uuid, now=None\):/);
   assert.match(KERNEL, /leaf_override=cut or None/);
-  assert.match(BACKEND, /def rollback\(self, sid: str, target_uuid: str\)/);
+  assert.match(BACKEND, /def rollback\(self, sid: str, target_uuid: str, revalidate=None\)/);
   assert.match(BACKEND, /def pending_cut\(self, sid: str\) -> str:/);
   assert.match(EM, /if leaf_override and leaf_override in self\.by_uuid:/);
 });


### PR DESCRIPTION
## What

The user's ask: realizing you sent the wrong message usually happens right after sending it — while the turn it started is still running — and delete should handle that: interrupt, roll back, all immediate from the click.

The old busy refusal guarded a real hazard for the **edit** rewind, and still does. At an explicit **delete** the hazard inverts: the user is knowingly discarding the turn their deleted message started, and its partial output becomes the abandoned branch tail — the rewind family's normal shape. Built in-place per the dispatch's recommendation (the fork-first alternative churns session identity; mailboxes/goals/tabs are uuid-keyed).

## The pipeline (event-keyed end to end)

1. **Gesture**: the kernel validates the cut via `_rewind_target` exactly as today and hands the backend a revalidate closure. The backend's busy branch (bare rollback + in-flight turn + nothing queued) sets the pending-rewind fields plus a reg-persisted `rewindWait`, and fires the owner-scoped interrupt. The **existing** `inputs()` gate holds intake on exactly those fields (no new gate), and `pending_cut` is wait-aware — every surface renders the cut from the click, exactly like an idle delete. No UI change needed: the chat already posts unconditionally with an optimistic overlay.
2. **Turn end**: the arm completes on the turn-end fact, never a sleep — three idempotent observers (the Stop hook; the ResultMessage settle for turn shapes where Stop never fires; a gesture-time backstop for a turn that settled under the click). It re-validates through the kernel closure first (a mid-window compaction can move the boundary past the target — only the kernel's parse sees that), then records the **actual** post-turn leaf and reconnects: from there it is the idle rollback path exactly.
3. **Failure anywhere** restores loudly through `_rewind_resolved("failed")` — the same event the two-phase card cleanup already keys on.

One latent-hazard fix rode along: the settle's flag consume is now **armed-only** — the interrupted turn's own settle lands moments after the Stop hook arms the flag, and an unguarded consume read that fresh arm as the branch-take. Flags could never accompany an unarmed running turn before, so armed-only is byte-identical for the idle paths.

## Kept refusals (honest, per the dispatch's edge list)

- **Compacting**: interrupting a compaction is its own hazard — refused with its own message.
- **Queued strangers**: they would ride the new branch unasked — refused as today.
- **Edit rewind while busy**: its replacement turn must not race a dying one — unchanged.
- **tmux**: no rewind machinery — unchanged.
- **Kernel death mid-window**: degrades loudly — the reg-persisted wait renders the cut until the next connect, whose leaf verification reads the "" mid-window leaf as spent and restores the cards. Never a wrong-branch cut.

## Tests

Executed end-to-end on the real backend methods (`test_sdk_rewind.py::DeleteWhileBusy`): gesture → interrupt → hold → immediate render → turn-end arm with the partial record as the abandoned tail → reconnect; arm-time revalidation failure restores loudly; all four kept refusals; the settled-under-the-gesture inline completion; restart-mid-window degradation (spent, provably never apply); idempotent observers. Kernel-side pins updated (`test_kernel_rewind.py`): the delete path's busy gate pinned **absent**, the revalidate closure pinned present, the edit path's gate pinned as the contrast. The idle-path tests stand unchanged — the byte-identical pin.

## Suites

- pytest: 6050 passed + 313 subtests, 34 skipped
- extension: 2548 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)