### PR TITLE
Interaction facts ride their own hooks: task-write pokes, the push mirror, skill telemetry

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3148,6 +3148,68 @@ class SdkSession:
             self.backend._log("bg-ledger fail hook (%s): %s" % (self.name, e))
         return {}
 
+    # ── session FACTS from the interaction tools (2026-08-29, hook round 2) ────────────────────
+    # Three fact families, all probe-verified shapes (CLI 2.1.221): the task STORE stays the
+    # authoritative snapshot per the repo rule — the TaskCreate/TaskUpdate hook is the POKE to
+    # re-read it now plus the attribution the store can never provide (which agent wrote, incl.
+    # subagent writes the transcript fold structurally misses); PushNotification's ack carries
+    # pushSent/localSent, so an agent's own "come look" judgment stops being invisible when the
+    # OS push was suppressed; Skill's ack names the role/command the session just took on.
+    _PUSH_NOTES_CAP = 10
+    _TASK_WRITES_CAP = 15
+
+    async def _facts_tool_hook(self, inp, tool_use_id, context):
+        try:
+            tname = str((inp or {}).get("tool_name") or "")
+            targs = (inp or {}).get("tool_input") or {}
+            tresp = (inp or {}).get("tool_response") or {}
+            if not isinstance(targs, dict):
+                targs = {}
+            if not isinstance(tresp, dict):
+                tresp = {}
+            nw = int(time.time())
+            aid = str((inp or {}).get("agent_id") or "") or None
+            if tname in ("TaskCreate", "TaskUpdate"):
+                # a capped TAIL, not a slot (review 2026-08-29): parallel subagents cluster task
+                # writes faster than any consumer's read cadence, and a last-write-wins slot loses
+                # every agentId but the newest — the attribution this field exists for
+                tid = str(tresp.get("taskId") or targs.get("taskId") or "") or None
+                reg = read_reg(self.backend.state_dir, self.sid) or {}   # sole writer; no await
+                #                                                          before the write below —
+                #                                                          the event loop IS the lock
+                writes = [w for w in (reg.get("taskWrites") or []) if isinstance(w, dict)]
+                writes.append({"at": nw, "tool": tname, "taskId": tid, "agentId": aid})
+                self.backend._update_reg(self.sid, taskWrites=writes[-self._TASK_WRITES_CAP:])
+                self.backend._poke()          # the store is authoritative — this says "re-read it NOW"
+            elif tname == "PushNotification":
+                reg = read_reg(self.backend.state_dir, self.sid) or {}   # sole writer of pushNotes;
+                #                              NO await between this read and the write below — the
+                #                              session's single event loop is what serializes this
+                #                              RMW, not _reg_lock. Inserting an await here reopens
+                #                              the lost-note race (review 2026-08-29).
+                notes = [n for n in (reg.get("pushNotes") or []) if isinstance(n, dict)]
+                notes.append({"at": nw, "message": str(targs.get("message") or "")[:200],
+                              "pushSent": bool(tresp.get("pushSent")),
+                              "localSent": bool(tresp.get("localSent")), "agentId": aid})
+                self.backend._update_reg(self.sid, pushNotes=notes[-self._PUSH_NOTES_CAP:])
+                self.backend._poke()          # a suppressed push is still the agent saying "come look"
+            elif tname == "Skill":
+                if aid:
+                    return {}                 # a SUBAGENT's skill is not the session's role — the
+                    #                           stamp answers "what is this session acting as", and a
+                    #                           drafting subagent invoking jld must not clobber it
+                nm = str(tresp.get("commandName") or "") or None
+                # commandName is the ONE authority (probe-verified on 2.1.221; failures route to
+                # PostToolUseFailure, unregistered here). No tool_input fallback: recording the
+                # REQUESTED alias when the resolved name vanished would be a silent degrade.
+                if nm:
+                    self.backend._update_reg(self.sid, lastSkill={"at": nw, "name": nm})
+                elif tresp:
+                    self.backend._log("facts hook (%s): Skill ack carried no commandName — not recording" % self.name)
+        except Exception as e:
+            self.backend._log("facts hook (%s): %s" % (self.name, e))
+        return {}
+
     async def _subagent_start_hook(self, inp, tool_use_id, context):
         """A Task-spawned subagent just STARTED. Record it live (agent_id -> type + start time) so the session
         reads 'working' while it runs and the lane can show how many are in flight. The SDK's SubagentStart
@@ -4421,7 +4483,10 @@ class SdkBackend:
                                                hooks=[sess._sched_tool_hook]),
                                    # launch ledger: exact launch facts at the call moment (2026-08-29)
                                    HookMatcher(matcher="Bash|Monitor|TaskStop",
-                                               hooks=[sess._ledger_tool_hook])],
+                                               hooks=[sess._ledger_tool_hook]),
+                                   # interaction facts: store-poke + attribution, push mirror, role
+                                   HookMatcher(matcher="TaskCreate|TaskUpdate|PushNotification|Skill",
+                                               hooks=[sess._facts_tool_hook])],
                    # a launch whose ack errored never started — drop it before it phantom-waits
                    "PostToolUseFailure": [HookMatcher(matcher="Bash|Monitor",
                                                       hooks=[sess._ledger_fail_hook])]},

--- a/tests/test_hook_facts.py
+++ b/tests/test_hook_facts.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Interaction-tool FACTS (2026-08-29, hook round 2): the TaskCreate/TaskUpdate poke + writer
+attribution (the store stays authoritative), the PushNotification mirror (pushSent/localSent are the
+ack's own delivered-or-suppressed booleans), and Skill role telemetry. Payload shapes probe-verified
+against CLI 2.1.221 on 2026-08-29. Synthetic fixtures only."""
+import asyncio
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_facts", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-000000000041"
+
+
+class _Backend(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.pokes = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None,
+                                poke=lambda: self.pokes.append(1), log=lambda m: None)
+        sb.write_reg(self.d, SID, {"sid": SID, "name": "web", "cwd": "/tmp", "alive": True})
+        self.sess = sb.SdkSession(self.be, sb.read_reg(self.d, SID))
+
+    def _hook(self, payload):
+        asyncio.run(self.sess._facts_tool_hook(payload, payload.get("tool_use_id"), None))
+
+    def _reg(self):
+        return sb.read_reg(self.d, SID) or {}
+
+
+class TaskWritePoke(_Backend):
+    def test_task_writes_are_a_tail_so_parallel_attribution_survives(self):
+        # a last-write-wins slot lost every agentId but the newest (review 2026-08-29)
+        self._hook({"tool_name": "TaskUpdate", "agent_id": "agent-42",
+                    "tool_input": {"taskId": "7", "status": "in_progress"},
+                    "tool_response": {"success": True, "taskId": "7", "updatedFields": ["status"]}})
+        self._hook({"tool_name": "TaskUpdate", "agent_id": "agent-43",
+                    "tool_input": {"taskId": "8", "status": "completed"},
+                    "tool_response": {"success": True, "taskId": "8", "updatedFields": ["status"]}})
+        tw = self._reg().get("taskWrites")
+        self.assertEqual([(w["taskId"], w["agentId"]) for w in tw],
+                         [("7", "agent-42"), ("8", "agent-43")])
+        self.assertTrue(self.pokes, "the store is authoritative — the hook says re-read it NOW")
+
+    def test_the_write_tail_is_capped(self):
+        for i in range(20):
+            self._hook({"tool_name": "TaskCreate", "tool_input": {},
+                        "tool_response": {"taskId": str(i)}})
+        self.assertEqual(len(self._reg().get("taskWrites")), self.sess._TASK_WRITES_CAP)
+
+
+class PushMirror(_Backend):
+    def test_a_suppressed_push_is_still_recorded(self):
+        self._hook({"tool_name": "PushNotification",
+                    "tool_input": {"message": "come look at the failing build", "status": "proactive"},
+                    "tool_response": {"message": "come look at the failing build",
+                                      "pushSent": False, "localSent": False}})
+        notes = self._reg().get("pushNotes")
+        self.assertEqual(len(notes), 1)
+        self.assertFalse(notes[0]["pushSent"], "suppressed — exactly the case that was silently lost")
+        self.assertTrue(self.pokes)
+
+    def test_the_note_tail_is_capped(self):
+        for i in range(15):
+            self._hook({"tool_name": "PushNotification",
+                        "tool_input": {"message": "note %d" % i},
+                        "tool_response": {"pushSent": True, "localSent": False}})
+        notes = self._reg().get("pushNotes")
+        self.assertEqual(len(notes), self.sess._PUSH_NOTES_CAP)
+        self.assertEqual(notes[-1]["message"], "note 14")
+
+
+class SkillTelemetry(_Backend):
+    def test_the_invoked_skill_lands_on_the_reg(self):
+        self._hook({"tool_name": "Skill", "tool_input": {"skill": "worker"},
+                    "tool_response": {"success": True, "commandName": "worker"}})
+        self.assertEqual(self._reg().get("lastSkill", {}).get("name"), "worker")
+
+    def test_a_subagents_skill_never_clobbers_the_sessions_role(self):
+        # the drafting pipeline: a session acting as manager spawns a jld subagent (review 2026-08-29)
+        self._hook({"tool_name": "Skill", "tool_input": {"skill": "manager"},
+                    "tool_response": {"success": True, "commandName": "manager"}})
+        self._hook({"tool_name": "Skill", "agent_id": "agent-7", "tool_input": {"skill": "jld"},
+                    "tool_response": {"success": True, "commandName": "jld"}})
+        self.assertEqual(self._reg().get("lastSkill", {}).get("name"), "manager")
+
+    def test_a_missing_commandName_records_nothing_and_says_so(self):
+        # ONE authority: the resolved commandName — the requested alias would be a silent degrade
+        self._hook({"tool_name": "Skill", "tool_input": {"skill": "deploy"},
+                    "tool_response": {"success": True}})
+        self.assertIsNone(self._reg().get("lastSkill"))
+
+    def test_a_failed_or_shapeless_ack_records_nothing(self):
+        self._hook({"tool_name": "Skill", "tool_input": {}, "tool_response": "opaque"})
+        self.assertIsNone(self._reg().get("lastSkill"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The second, smaller half of the hookable-tools map (items 5-7), all probe-verified shapes (CLI 2.1.221, 2026-08-29):

- **Task writes become a poke plus an attribution tail.** The task store stays the authoritative snapshot per the repo rule; the TaskCreate/TaskUpdate hook pokes the kernel to re-read it at the write moment and records a capped tail of {at, tool, taskId, agentId} — the writer attribution the store cannot provide, including subagent writes the transcript fold structurally misses. A tail, not a slot: parallel subagents cluster writes faster than any consumer reads.
- **PushNotification mirror.** The ack's own pushSent/localSent booleans land in a capped reg tail, so an agent's 'come look' judgment stops being invisible exactly when the OS push was suppressed. Allow-and-mirror only; nothing speaks back to the agent.
- **Skill telemetry.** The resolved commandName (single authority; a missing field logs loudly rather than falling back to the requested alias) stamps lastSkill — and only for the session itself: a subagent's skill invocation never clobbers the session's role.

An adversarial pass on the first cut confirmed two materials (the attribution slot losing parallel writers; subagent skill clobbering) and two minors (an undeclared no-await RMW invariant, now pinned in comments at both read sites; a dual-authority fallback, dropped) — all fixed here, none refuted.

Kernel-side facts only; the reg fields are the seam feed/card surfaces read at their own pace.

Verified at 104523e0 merged with main: full pytest 6067 passed (34 skipped, the usual), webview 2551/2551 with typecheck and build clean. Touches kernel/sdk_backend.py and tests/test_hook_facts.py only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)