### PR TITLE
A just-sent message is labeled and cancellable from the press — no unlabeled stage

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8402,6 +8402,22 @@ def _drive(msg, client):
         client["send"](json.dumps({"type": "cancelResult", "ok": not err, "id": sid,
                                    "md": str(msg.get("md") or ""), "text": err or ""}))
         _push_soon()
+    elif t == "cancelQueued" and msg.get("md"):
+        # ✕ at the OPTIMISTIC stage (the user 2026-08-30, who pressed send mid-compaction and sat in
+        # an unlabeled, uncancellable beat): the client knows only the body — no park/idx has round-
+        # tripped yet — so locate the send wherever it landed. The ws is ordered, so the send op was
+        # processed before this cancel: the FIFO's md-relocate finds a parked one, a backend-queued
+        # one is found by body, and neither means it already forwarded into the CLI — the one honest
+        # refusal, loud (the same cancelResult contract as the park/idx arms).
+        md = str(msg["md"])
+        err = _cancel_parked(sid, -1, md)
+        if err and hasattr(be, "unqueue"):
+            err2 = _cancel_backend_queued(be, sid, -1, md)
+            if err2 is None:
+                err = None
+        client["send"](json.dumps({"type": "cancelResult", "ok": not err, "id": sid,
+                                   "md": md, "text": err or ""}))
+        _push_soon()
     elif t == "dismissEcho" and hasattr(be, "dismiss_echo"):
         # ✕ on a never-delivered bubble (a send whose CLI died holding it — the backend's dropped-echo
         # marking): the user has seen the loss, so retire the echo. Idempotent: a miss means it is

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1097,6 +1097,48 @@ class ViewBuilder(unittest.TestCase):
         sent = [e for e in events if e["kind"] == "user" and e.get("md") == "and also fix the header"]
         self.assertEqual(sent, [], "it must NOT also show as a sent (solid) user bubble — that was the flip")
 
+    def test_a_mid_compaction_parked_send_renders_queued_and_cancelable_immediately(self):
+        # The user (2026-08-30) pressed send during compaction and sat in an unlabeled, uncancellable
+        # stage. The kernel half of the always-labeled rule, pinned behaviorally: the parked op is in
+        # the VERY NEXT build — the queued append has no compaction gate — carrying its park index and
+        # cancelable:true, so the ✕ exists the moment any push paints (and _park_op marks views dirty,
+        # so that push is immediate, never the backstop poll).
+        km._tmux_sessions = lambda: {SID: {"state": "compacting", "since": NOW - 5, "model": "",
+                                           "effort": "", "context": None, "compactPct": None, "color": None}}
+        km._parse_cache.clear()
+        km._park_op(SID, ("send", "wrap up the strip work", "human"))
+        try:
+            events = km.build_session(SID, NOW)["events"]
+        finally:
+            km._pending_ops.pop(SID, None)
+            km._save_pending_ops()
+        q = [e for e in events if e["kind"] == "queued"]
+        self.assertEqual(len(q), 1, "the parked send renders as a queued bubble DURING compaction")
+        m = q[0]["texts"][0]
+        self.assertEqual(m["md"], "wrap up the strip work")
+        self.assertEqual(m["park"], 0)
+        self.assertTrue(m["cancelable"], "a parked send is cancellable from its first paint")
+
+    def test_cancel_by_body_alone_removes_the_parked_op(self):
+        # The optimistic ✕'s kernel contract (the user 2026-08-30): the client knows only the BODY —
+        # no park index has round-tripped yet — so the md-relocate finds and drops the op; a repeat
+        # is the honest loud miss, never a silent fake-delete. The ws arm speaking this (md-only
+        # cancelQueued: FIFO first, then the backend queue, then the loud refusal) is source-pinned.
+        km._park_op(SID, ("send", "wrap up the strip work", "human"))
+        try:
+            self.assertIsNone(km._cancel_parked(SID, -1, "wrap up the strip work"))
+            self.assertNotIn(SID, km._pending_ops, "the FIFO op is gone")
+            miss = km._cancel_parked(SID, -1, "wrap up the strip work")
+            self.assertIn("too late", miss)
+        finally:
+            km._pending_ops.pop(SID, None)
+            km._save_pending_ops()
+        import inspect
+        src = inspect.getsource(km)
+        self.assertIn('elif t == "cancelQueued" and msg.get("md"):', src)
+        self.assertIn("err = _cancel_parked(sid, -1, md)", src)
+        self.assertIn("err2 = _cancel_backend_queued(be, sid, -1, md)", src)
+
     def test_tmux_echo_the_transcript_OVERTOOK_is_not_counted_as_queued(self):
         # The reported bug (the user 2026-08-26): a busy session's queued header counted sends from DAYS
         # earlier — echoes whose text never landed verbatim (one lost at the pane, two delivered under text

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -397,13 +397,14 @@ class QueuedBubble(unittest.TestCase):
 
     def test_drive_answers_every_cancel_with_an_authoritative_result_frame(self):
         # the user 2026-07-20: a ✕ whose target had already been handed to the CLI silently no-opped
-        # while the client showed the message as deleted — and the CLI answered it anyway. BOTH cancel
-        # arms now reply with a cancelResult frame (ok + the 'too late' text on a miss) so the client
-        # can toast and undo its optimistic composer restore.
+        # while the client showed the message as deleted — and the CLI answered it anyway. EVERY cancel
+        # arm replies with a cancelResult frame (ok + the 'too late' text on a miss) so the client
+        # can toast and undo its optimistic composer restore. Three arms since 2026-08-30: park, idx,
+        # and the optimistic md-only arm (a ✕ before any park/idx has round-tripped).
         import inspect
         src = inspect.getsource(km._drive)
-        self.assertEqual(src.count('"type": "cancelResult"'), 2,
-                         "one authoritative reply per cancel arm (park + idx)")
+        self.assertEqual(src.count('"type": "cancelResult"'), 3,
+                         "one authoritative reply per cancel arm (park + idx + md-only)")
         self.assertIn('"ok": not err', src)
         self.assertIn('"text": err or ""', src)
 

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -640,7 +640,8 @@ test("the parity bundle (2026-08-26): dividers, owner-scoped in-turn controls, t
   // from the DOM at click time — queued ✕ and the api-error card act on the thread, never the tab
   assert.match(UI, /list\.dataset\.session = th\.tid;/);
   assert.match(UI, /function owningSidOf\(el0: HTMLElement \| null\): string \| null \{/);
-  assert.match(UI, /\{ type: "cancelQueued", id: owningSidOf\(el\), md: qmd \}/);
+  assert.match(UI, /const sidQ = owningSidOf\(el\) \|\| activeId;/);   // resolved once — the optimistic arm reuses it
+  assert.match(UI, /\{ type: "cancelQueued", id: sidQ, md: qmd \}/);
   assert.match(UI, /\{ type: "dismissDialog", id: owningSidOf\(dismiss\) \}/);
 });
 

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -81,7 +81,7 @@ test("retire needs a NEW landed atom (base count); kernel provisionals only supp
 test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — never a solid user bubble", () => {
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   assert.match(RENDER, /const OPT_PREFIX = "optimistic:";/);
-  assert.match(RENDER, /const mk = \(p: \{ text: string; imgPaths\?: string\[\] \}\) => \(\{ md: p\.text, optimistic: true, cancelable: false, imgPaths: p\.imgPaths \}\);/);   // the echo carries its dragged-image paths (2026-08-25)
+  assert.match(RENDER, /const mk = \(p: \{ text: string; imgPaths\?: string\[\] \}\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths \}\);/);   // the echo carries its dragged-image paths (2026-08-25); cancelable from the press (2026-08-30)
   // stale ones pop cheaply off the end (always tail-appended)
   assert.match(RENDER, /while \(s\.events\.length && isOptimistic\(s\.events\[s\.events\.length - 1\]\)\) s\.events\.pop\(\);/);
   // the abandoned dim/pending idiom is FULLY gone: render, guard fields, and stylesheet — the last
@@ -95,9 +95,15 @@ test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — n
   assert.match(CSS, /\.queued-bubble \{[\s\S]*?border: 1px dashed/);
 });
 
-test("nothing known-queued → a BARE dashed bubble (no 'N queued' header we can't back)", () => {
+test("nothing known-queued → a bare group wearing the honest 'sending…' header", () => {
   assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: inject\.map\(mk\), uuid: OPT_PREFIX \+ inject\[0\]\.ts \}\);/);
-  assert.match(RENDER, /if \(!ev\.bare\) \{/, "renderQueued skips the header for a bare group");
+  // "N queued messages" stays unclaimable pre-confirmation — but NO label was the user's 2026-08-30
+  // bug (a mid-compaction send sat unlabeled and uncuttable): the bare group now states exactly what
+  // is known, and the reflow recounts it in the same vocabulary after a ✕
+  assert.match(RENDER, /label\.dataset\.bare = "1";/);
+  assert.match(RENDER, /ev\.texts\.length === 1 \? "sending…" : `sending \$\{ev\.texts\.length\}…`/);
+  assert.match(RENDER, /if \(label\.dataset\.bare === "1"\) \{/, "reflow keeps the bare vocabulary");
+  assert.match(RENDER, /if \(!ev\.bare\) \{/, "the standard 'N queued' header still needs confirmation");
 });
 
 test("something IS queued → ours merges into that group, counted under its header", () => {
@@ -106,10 +112,28 @@ test("something IS queued → ours merges into that group, counted under its hea
   assert.match(RENDER, /if \(q\.texts\.some\(\(t\) => t\.optimistic\)\) s\.events\[qi\] = \{ \.\.\.q, texts: q\.texts\.filter\(\(t\) => !t\.optimistic\) \};/);
 });
 
-test("an unconfirmed echo gets its own tooltip and never an ✕ (nothing confirmed to cancel)", () => {
+test("an unconfirmed echo keeps its tooltip AND carries a ✕ from the press (the 2026-08-30 rule)", () => {
+  // The retargeted contract: from the instant send is pressed the message is labeled and cancellable —
+  // the old cancelable:false stage was exactly where the user sat during a mid-compaction send. The
+  // optimistic ✕ rides the same qx delegate with data-qopt (no idx/park exists yet).
   assert.match(RENDER, /if \(t\.optimistic\) bubble\.title = "sent just now — romp hasn't confirmed the session has it yet";/);
-  // cancelable:false → the ✕ branch (which needs cancelable AND an idx/park handle) can't fire for ours
-  assert.match(RENDER, /if \(t\.cancelable && \(t\.idx !== undefined \|\| t\.park !== undefined\)\) \{/);
+  assert.match(RENDER, /optimistic: true, cancelable: true/);
+  assert.match(RENDER, /if \(t\.cancelable && \(t\.idx !== undefined \|\| t\.park !== undefined \|\| t\.optimistic\)\) \{/);
+  assert.match(RENDER, /if \(t\.optimistic\) x\.dataset\.qopt = "1";/);
+});
+
+test("EVERY ✕ stops our re-injection first; the optimistic one cancels by body at the kernel", () => {
+  // Order matters: the pendingSent entry goes FIRST — at the optimistic stage the kernel may not
+  // have pushed its park yet (the reconcile would repaint the bubble the user just cut), and on a
+  // parked/backend ✕ the kernel bubble had been SUPPRESSING our still-live entry, so a kernel-only
+  // cancel resurrected the cancelled message as a dashed bubble until the TTL (served-probe find,
+  // 2026-08-30). Then the same cancelQueued the ✕ always posted — the optimistic one with only the
+  // body (ws ordering puts it after the send it names); a miss comes back through the same loud
+  // cancelResult, and the composer restore reverts (pendingCancelRestores).
+  assert.match(RENDER, /if \(qmd\) \{/);
+  assert.match(RENDER, /const i = list\.findIndex\(\(p\) => p\.text === qmd\);/);
+  assert.match(RENDER, /echoShownSig\.delete\(sidQ\);/);
+  assert.match(RENDER, /const msg: Record<string, unknown> = \{ type: "cancelQueued", id: sidQ, md: qmd \};/);
 });
 
 test("chatTail speaks the KERNEL's coordinates — the injected tail is not part of its space", () => {

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -43,8 +43,11 @@ test("a queued slash command renders as a command chip, not a plain 'message' (t
 });
 
 test("a cancelable queued bubble carries an explicit ✕ — messages AND parked commands (the user 2026-07-08)", () => {
-  // both queues cancel: the backend's own (idx) and ops parked during compaction/model switches (park)
-  assert.match(RENDER, /if \(t\.cancelable && \(t\.idx !== undefined \|\| t\.park !== undefined\)\)/);
+  // every stage cancels: the backend's own queue (idx), ops parked during compaction/model switches
+  // (park), and the pre-confirmation optimistic echo (qopt — the 2026-08-30 rule: labeled and
+  // cancellable from the instant send is pressed)
+  assert.match(RENDER, /if \(t\.cancelable && \(t\.idx !== undefined \|\| t\.park !== undefined \|\| t\.optimistic\)\)/);
+  assert.match(RENDER, /if \(t\.optimistic\) x\.dataset\.qopt = "1";/);
   assert.match(RENDER, /el\("button", "queued-x"\)/);
   assert.match(RENDER, /x\.dataset\.act = "qx";/, "the ✕ routes through the stable document.body delegate");
   assert.match(RENDER, /if \(t\.idx !== undefined\) x\.dataset\.qidx = String\(t\.idx\);/);
@@ -60,7 +63,7 @@ test("a cancelable queued bubble carries an explicit ✕ — messages AND parked
 test("the delegated qx handler cancels click-safely: kernel op + composer restore for messages only", () => {
   // one handler on document.body (stable across every per-push rebuild) — never a per-render listener
   assert.match(RENDER, /qx: \(el\) => \{/);
-  assert.match(RENDER, /\{ type: "cancelQueued", id: owningSidOf\(el\), md: qmd \}/, "the body rides along as the kernel's drift guard; owner-scoped for the popover (2026-08-26)");
+  assert.match(RENDER, /\{ type: "cancelQueued", id: sidQ, md: qmd \}/, "the body rides along as the kernel's drift guard; owner-scoped for the popover (2026-08-26, sidQ = owningSidOf ?? activeId)");
   assert.match(RENDER, /if \(el\.dataset\.qidx !== undefined\) msg\.idx = Number\(el\.dataset\.qidx\);/);
   assert.match(RENDER, /if \(el\.dataset\.qpark !== undefined\) msg\.park = Number\(el\.dataset\.qpark\);/);
   // a MESSAGE returns to the composer to re-edit; a slash COMMAND (qcmd) just cancels
@@ -83,7 +86,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 const SDKBE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
 
 test("the kernel answers every cancelQueued with an authoritative cancelResult frame", () => {
-  assert.equal(KERNEL.split('"type": "cancelResult"').length - 1, 2, "one reply per cancel arm (park + idx)");
+  assert.equal(KERNEL.split('"type": "cancelResult"').length - 1, 3, "one reply per cancel arm (park + idx + the 2026-08-30 md-only optimistic arm)");
   assert.match(KERNEL, /"ok": not err/);
   assert.match(KERNEL, /def _cancel_miss_text\(md\):/, "the 'too late' wording is built kernel-side");
   assert.match(KERNEL, /too late to cancel — the message already reached the session/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -352,7 +352,10 @@ function reconcileOptimistic(s: Session): void {
   if (keep.length) pendingSent.set(s.id, keep); else pendingSent.delete(s.id);
   const inject = keep.filter((p) => !shownProvisional(p.text));
   if (!inject.length) { settle([]); return; }
-  const mk = (p: { text: string; imgPaths?: string[] }) => ({ md: p.text, optimistic: true, cancelable: false, imgPaths: p.imgPaths });
+  // cancelable from the PRESS (the user 2026-08-30, who sent mid-compaction and sat in an unlabeled,
+  // uncancellable beat until the kernel's park round-tripped): the ✕ on an optimistic bubble drops our
+  // re-injection and asks the kernel to cancel by body wherever the send landed (see the qx handler).
+  const mk = (p: { text: string; imgPaths?: string[] }) => ({ md: p.text, optimistic: true, cancelable: true, imgPaths: p.imgPaths });
   const qj = tailQueuedIdx(s.events);
   if (qj >= 0) {
     // something IS queued here → ours queues behind it: show it in that group, under its header, counted
@@ -3397,17 +3400,33 @@ function reflowQueuedGroup(turn: HTMLElement): void {
   const bubbles = Array.from(turn.querySelectorAll(".queued-bubble"));
   if (!bubbles.length) { turn.remove(); return; }
   const label = turn.querySelector(".queued-count") as HTMLElement | null;
-  if (!label) return;                                     // a bare (optimistic) group has no header to fix
+  if (!label) return;
+  if (label.dataset.bare === "1") {                       // the pre-confirmation group recounts in its own words
+    label.textContent = bubbles.length === 1 ? "sending…" : `sending ${bubbles.length}…`;
+    return;
+  }
   const nCmd = bubbles.filter((b) => b.querySelector(".slash-cmd-chip")).length;
   label.textContent = queuedCountText(bubbles.length, nCmd) + (label.dataset.why || "");
 }
 
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   const turn = el("div", "turn turn-queued");
-  // A BARE group is romp's own optimistic echo with nothing else known-queued: it gets the dashed bubble but
-  // NO header, because "N queued messages" is a claim we can't back for a send the session hasn't confirmed
-  // (the user 2026-07-16). Merged into a real queued group, the header returns and counts ours in — there the
+  // A BARE group is romp's own optimistic echo with nothing else known-queued: "N queued messages" is a
+  // claim we can't back for a send the session hasn't confirmed (the user 2026-07-16) — so it wears its
+  // OWN honest label instead: "sending…" states exactly what is known, the press happened and nothing is
+  // confirmed yet (the user 2026-08-30, who sat in that stage with no state label and no way to cut the
+  // message). Merged into a real queued group, the standard header returns and counts ours in — there the
   // queueing IS established, so assuming this one joins it is honest.
+  if (ev.bare) {
+    const head = el("div", "queued-head");
+    head.appendChild(hourglassIcon());
+    const label = el("span", "queued-count");
+    label.dataset.bare = "1";     // reflow rewrites this label in its own vocabulary, never "N queued"
+    label.textContent = ev.texts.length === 1 ? "sending…" : `sending ${ev.texts.length}…`;
+    label.title = "on its way to the session — cancellable until the session takes it";
+    head.appendChild(label);
+    turn.appendChild(head);
+  }
   if (!ev.bare) {
     const n = ev.texts.length;
     const nCmd = ev.texts.filter((t) => SLASH_CMD_RE.test(t.md)).length;
@@ -3463,13 +3482,14 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     // a MESSAGE returns to the composer to re-edit, a slash COMMAND just cancels. Covers both queues:
     // the backend's own (idx; SDK only — tmux's queue lives inside Claude Code, no recall) and ops
     // PARKED during compaction/model switches (park; romp-owned on every backend).
-    if (t.cancelable && (t.idx !== undefined || t.park !== undefined)) {
+    if (t.cancelable && (t.idx !== undefined || t.park !== undefined || t.optimistic)) {
       const x = el("button", "queued-x");
       x.textContent = "✕";
       x.title = isCmd ? "cancel this queued command" : "cancel this queued message and move it back to the composer";
       x.dataset.act = "qx";
       if (t.idx !== undefined) x.dataset.qidx = String(t.idx);
       if (t.park !== undefined) x.dataset.qpark = String(t.park);
+      if (t.optimistic) x.dataset.qopt = "1";   // ✕ before confirmation → cancel-by-body (no park/idx yet)
       if (isCmd) x.dataset.qcmd = "1";
       (x as any)._qmd = t.md;   // the bubble's body — the kernel's drift guard + the composer restore read it
       bubble.appendChild(x);
@@ -12943,7 +12963,20 @@ setupSettings();
     qx: (el) => {
       if (!activeId || !vscodeApi) return;
       const qmd = (el as any)._qmd as string | undefined;
-      const msg: Record<string, unknown> = { type: "cancelQueued", id: owningSidOf(el), md: qmd };
+      const sidQ = owningSidOf(el) || activeId;
+      if (qmd) {
+        // EVERY ✕ drops our own optimistic entry for the text first (the user 2026-08-30). At the
+        // optimistic stage (qopt) that is the whole client half — the kernel may not have pushed its
+        // park yet, and the reconcile would otherwise repaint the bubble the user just cut. And on a
+        // PARKED/backend ✕ it is just as load-bearing: the kernel bubble had been SUPPRESSING our
+        // still-live entry (shownProvisional), so cancelling only the kernel op resurrected the
+        // cancelled message as a dashed bubble until the TTL (caught by this fix's served-page probe).
+        const list = pendingSent.get(sidQ) || [];
+        const i = list.findIndex((p) => p.text === qmd);
+        if (i >= 0) { list.splice(i, 1); if (list.length) pendingSent.set(sidQ, list); else pendingSent.delete(sidQ); }
+        echoShownSig.delete(sidQ);
+      }
+      const msg: Record<string, unknown> = { type: "cancelQueued", id: sidQ, md: qmd };
       if (el.dataset.qidx !== undefined) msg.idx = Number(el.dataset.qidx);
       if (el.dataset.qpark !== undefined) msg.park = Number(el.dataset.qpark);
       vscodeApi.postMessage(msg);


### PR DESCRIPTION
The user (2026-08-30) pressed send during a compaction: the message sat as a dashed bubble with no state label and no way to cut it, until the kernel's park round-tripped and the queued ✕ appeared.

**Root cause.** The kernel half was already right — a mid-compaction send parks immediately, renders cancelable with its park index, and `_park_op` wakes the push. The unlabeled, uncancellable stage was the client's own optimistic echo: minted `cancelable: false`, rendered in a bare group whose header was deliberately dropped.

**The rule this lands:** from the instant send is pressed, the message is always visibly labeled with its state AND cancellable; the one honest refusal is a loud "too late" when it already reached the session.

- Client: the bare group wears an honest "sending…" header, the optimistic bubble carries the same queued-✕ (`data-qopt`), and EVERY ✕ drops the matching `pendingSent` entry before posting its cancel — at the optimistic stage that stops the reconcile repainting the cancelled bubble, and on a parked/backend ✕ it fixes a second bug the served-page probe caught: a kernel-only cancel resurrected the cancelled message as a dashed bubble until the 20s TTL (the kernel bubble had been suppressing the still-live optimistic entry).
- Kernel: a third `cancelQueued` arm for the optimistic ✕ (body only — no park/idx has round-tripped): FIFO md-relocate first, then the backend queue by body, then the loud `cancelResult ok:false`. The ws is ordered, so the cancel always arrives after the send it names.

**Tests.** Parked bubble renders queued+cancelable in a build made DURING compaction (no push-gate dependence); md-only cancel removes the FIFO op, a repeat misses loudly, the ws arm source-pinned; client pins for the "sending…" header, bare reflow vocabulary, the optimistic ✕, and the unconditional pendingSent drop; six stale pins retargeted. Verified headlessly on the real served chat (hermetic kernel, held queue): the optimistic stage is labeled and cancellable in the same tick as the keystroke, the md-only cancel empties the kernel FIFO, the parked ✕ restores the composer with no resurrect, and the parked bubble's ✕ arrived 32ms after Enter. Suites: extension 2554, python 6069, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)