### PR TITLE
The quiet card stops implying a wait you could go find

### DIFF
--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -230,9 +230,13 @@ test("THE FLOOR IS TOTAL — a working-column card can never be mute (the user 2
   assert.equal(open.caption, "Working…");
   assert.ok(!open.still, "an open turn spins — it IS in flight");
   const quiet = spinFor({ column: "working", sessState: "quiet" }, false, false, 100);
-  assert.match(quiet.caption || "", /^Paused — resumes when its wait ends$/);   // plain truth (the user
-  // 2026-08-24): never promise the session's NEXT turn — waits lift on their own ending events, and
-  // the next turn may work another thread entirely
+  assert.match(quiet.caption || "", /^Paused — nothing running right now; the session picks this back up$/);
+  // plain truth, both rounds pinned: no NEXT-turn promise (2026-08-24 — the next turn may work
+  // another thread) and no implied inspectable "wait" either (2026-08-29 — the user went looking
+  // in the chat for one). The tooltip may promise the chase: the memo re-arm + dead-man backstop
+  // landed 2026-08-27, so "romp nudges the session if this stays parked" is now simply true.
+  assert.ok(!/wait/.test(quiet.caption || ""), "no invented wait to go looking for");
+  assert.match(quiet.tip || "", /romp nudges the session about it/, "the chase promise — true since the dead-session round");
   assert.equal(quiet.still, true, "nothing in motion → the glyph stills (a spin would lie)");
   const unk = spinFor({ column: "working", sessState: "unknown" }, false, false, 100);
   assert.match(unk.caption || "", /unknown — this machine isn't reporting/);

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -219,12 +219,15 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     }
     if (it.sessState === "quiet") {
       return {
-        // plain truth (the user 2026-08-24): the old line promised the session's NEXT turn, but the
-        // next turn may work another thread entirely — this goal resumes when its own wait ends
-        caption: "Paused — resumes when its wait ends",
-        tip: "Nothing is in motion right now: the session is between turns and this goal stays open. "
-           + "It picks back up when the session returns to this thread — not necessarily on its very "
-           + "next turn.",
+        // plain truth, round two (the user 2026-08-29, who went looking in the chat for the "wait"
+        // this line implied): there is no inspectable wait — the session is simply between turns
+        // with the goal open. The 2026-08-24 constraint stands too: never promise the session's
+        // NEXT turn (it may work another thread). Say only what is so.
+        caption: "Paused — nothing running right now; the session picks this back up",
+        tip: "Nothing is in motion: the session is between turns and this goal stays open. It picks "
+           + "back up when the session returns to this thread — not necessarily on its very next "
+           + "turn — and if it stays parked, romp nudges the session about it, so this card can't "
+           + "silently rot.",
         awaitingBg: false,
         still: true,
       };


### PR DESCRIPTION
The user (2026-08-29), reading 'Paused — resumes when its wait ends' on an idle session's Working card, went looking in the chat for the wait and asked if the UI was broken. There is no inspectable wait — the session is simply between turns with the goal open — so the caption now says only what is so: **'Paused — nothing running right now; the session picks this back up.'** Both standing constraints hold: the 2026-08-24 rule (never promise the session's NEXT turn — it may work another thread) and this round's (never imply a findable wait either).

The tooltip aligns and gains a promise that became true this week: with the memo re-arm and the dead-man backstop landed, romp genuinely nudges the session if the thread stays parked — so the tip says the card can't silently rot. One caption for every surface sharing the ladder; pins hold the exact new line, a no-'wait' sweep on the caption, and the chase promise. 2554/2554 extension tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)