### PR TITLE
Judge calls stop paying the cache-write premium they can never read back

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1006,6 +1006,16 @@ def _judge_env(tier, auth="login"):
     for k in ("TMUX", "TMUX_PANE"):
         env.pop(k, None)
     env["ROMP_SUMMARIZING"] = "1"                     # trips the Stop-hook recursion guard
+    # NO PROMPT CACHING for judge calls (user-approved via the nightly optimizer, 2026-08-30): a
+    # one-shot `claude -p` judge call pays the 1.25x cache-WRITE premium on nearly its whole prompt
+    # and never reads back — cache_r was 0 across every call in two 24h windows, because the per-call
+    # security mark (_mark: a fresh CSPRNG token in the SYSTEM prompt, re-rolled so a learned mark
+    # can't be replayed) makes every prefix unique BY DESIGN. Measured live: with this var the CLI
+    # sends no cache_control breakpoints, the same tokens bill as plain input, and an identical call
+    # costs 19.6% less ($0.0161 vs $0.0200 on a 5.1k-token sonnet probe); ~$12/day on this box's
+    # judge volume alone. If the marks are ever made prefix-stable (a security-semantics change,
+    # the user's call), flip this off so clustered calls READ instead — reads beat no-cache 10:1.
+    env["DISABLE_PROMPT_CACHING"] = "1"
     if tier == "index":
         env["MAX_THINKING_TOKENS"] = "0"              # no thinking for mechanical summarization (the cost lever)
     if auth == "key" and wk:

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -5919,6 +5919,16 @@ class JudgeEnv(unittest.TestCase):
         self.assertEqual(jd._judge_env("index").get("MAX_THINKING_TOKENS"), "0",
                          "captioner/archiver run with thinking off")
 
+    def test_every_tier_disables_prompt_caching(self):
+        # One-shot judge calls never read the cache back — the per-call security mark re-rolls the
+        # system prompt every call, so every prefix is unique and cache_r stayed 0 across full 24h
+        # windows while every call paid the 1.25x cache-write premium (user-approved fix via the
+        # nightly optimizer, 2026-08-30; measured 19.6% per-call saving live). Every tier: the mark
+        # rides triage, distill, and index calls alike.
+        for tier in ("triage", "distill", "index"):
+            self.assertEqual(jd._judge_env(tier).get("DISABLE_PROMPT_CACHING"), "1",
+                             "%s judge calls must not pay the cache-write premium" % tier)
+
     def test_triage_tier_does_not_force_thinking_off(self):
         had = os.environ.pop("MAX_THINKING_TOKENS", None)   # isolate from an inherited cap
         try:


### PR DESCRIPTION
The nightly optimizer's finding, user-approved for investigation: one-shot `claude -p` judge calls paid the 1.25x prompt-cache WRITE premium on nearly their whole prompt and never read a byte back — cache_read was zero across every call in two 24-hour windows (~9.1M cache-write tokens/day, ~15% of judge spend as pure premium).

**Root cause, measured.** The per-call security mark (`_mark` — a fresh CSPRNG token appended to the SYSTEM prompt, deliberately re-rolled per call so a mark learned from one prompt can't be replayed into the next) makes every call's prefix unique, so a cache read is structurally impossible while the CLI still writes a breakpoint every call. Live probes confirmed each link: an identical repeat call DOES read (89% cheaper), a call with a re-rolled mark reads nothing despite 99% shared bytes, and `DISABLE_PROMPT_CACHING=1` drops the breakpoints entirely — same tokens bill as plain input, 19.6% cheaper per call, byte-identical prompt to the model.

**Fix.** One env var in `_judge_env`, scoped to judge subprocesses only: no behavioral change, no security change, ~19.6% off every judge call's written-prefix cost (~$12/day on one box's volume). The alternative — stable prefixes so the 96% of calls landing within the cache TTL READ instead (~3x the saving) — requires weakening the mark's per-call re-roll, a security-semantics decision that goes to the user separately; the code comment marks this env var as the thing to flip back if that's approved.

**Test:** every tier's judge env pins `DISABLE_PROMPT_CACHING=1`. Suites: python 6070, extension 2554, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)