### PR TITLE
A cap-dead login session gets an explicit offer to bill the key — never a silent switch

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7689,6 +7689,36 @@ def _auth_avail():
             "acct": _claude_account_label(), "default": default}
 
 
+def _cap_switch_offer(sid, aerr):
+    """The explicit billing-switch OFFER for a login-billed session dead on the account's usage cap —
+    or None. The user's BINDING ruling (2026-08-30, via the nightly optimizer): a session must NEVER
+    silently switch billing in either direction — so romp only OFFERS, and only the user's explicit
+    pick (the card button → the same setAuth route a gear billing pick takes) switches; the reverse
+    is equally manual. Minted only when every leg is true and readable: the error is the plain
+    retryable class (spend/model/auth/tooLong/refusal each carry their own remedy), a login-account
+    window actually sits at its cap with a readable reset ahead (usage.json — the authority the retry
+    pause reads; fable excluded, model-scoped), THIS session bills the login (the CLI's authLive
+    first, the picked intent second — the Billing tooltip's sources), and the machine holds a key to
+    offer. Self-expiring: resets_at passing ends the mint on the next build — the deciding event —
+    and the post-reset auto-retry is untouched either way (this offer sits beside it, never instead)."""
+    if not aerr or aerr.get("tooLong") or aerr.get("spendLimit") or aerr.get("modelLimit") \
+            or aerr.get("authErr") or aerr.get("refusal"):
+        return None
+    tm = (_tmux_sessions() or {}).get(str(sid)) or {}
+    if str(tm.get("authLive") or tm.get("auth") or "") != "login" or not _auth_key_present():
+        return None
+    try:
+        u = json.loads((jd.STATE / "usage.json").read_text())
+    except Exception:
+        return None
+    now = time.time()
+    for k in ("five_hour", "seven_day"):
+        w = u.get(k) or {}
+        if isinstance(w, dict) and (w.get("pct") or 0) >= 100 and (w.get("resets_at") or 0) > now:
+            return {"resetsAt": int(w["resets_at"]), "window": k}
+    return None
+
+
 def _judge_limit_view():
     """The judge-limit latch, enriched for the banner (the user 2026-08-28, who asked WHICH sessions a
     full usage window actually touches): the judges bill ONE credential, so a full window pauses CARD
@@ -20356,6 +20386,7 @@ def build_feed(now, tmux=None):
         # the truth. One formula, one truth: awaiting wins; the floor applies only to a session truly dead
         # in the water.
         aerr = _api_error(s["path"]) if (ps and not who_working and not sess_awaiting_why) else None   # cache-only: fills in after the warm
+        _cap_off = _cap_switch_offer(fsid, aerr) if aerr else None   # the billing-switch OFFER (never a silent switch, 2026-08-30)
         api_top = None
         if aerr:
             f = store.get("lastNode")
@@ -20841,6 +20872,10 @@ def build_feed(now, tmux=None):
                 "nudged": ({"count": int(nrec.get("count", 0)), "times": _nudge_times().get(nid, [])[-8:]}
                            if nrec.get("count") else None),   # auto-nudge HISTORY (fires + when) → the stalled chip's evidence, on the chip tooltip + modal (the user 2026-07-02)
                 "blocked": ({"state": "apiError",
+                             # the OFFER (2026-08-30): login-billed + capped window + a key on hand →
+                             # the card proposes switching THIS session's billing; the pick is the
+                             # user's alone, both directions (see _cap_switch_offer)
+                             **({"capOffer": _cap_off} if _cap_off else {}),
                              "status": aerr.get("status"),
                              "text": aerr.get("text"), "tooLong": bool(aerr.get("tooLong")),
                              "spendLimit": bool(aerr.get("spendLimit")),

--- a/tests/test_cap_switch_offer.py
+++ b/tests/test_cap_switch_offer.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""The cap-death billing-switch OFFER (the user's binding ruling, 2026-08-30: a session must NEVER
+silently switch billing in either direction — romp offers, only the explicit pick switches).
+_cap_switch_offer mints only when every leg holds: a plain retryable API error (the on-you classes
+carry their own remedies), a login-account window at its cap with a readable reset ahead, THIS
+session billing the login, and a key on hand to offer. Self-expires with the window. The pick's one
+path is the setAuth route a gear billing pick takes — pinned by census below. Synthetic fixtures."""
+import json
+import os
+import re
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_capoffer", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "aaaa3008-0000-0000-0000-000000000001"
+ERR = {"text": "API Error 529 overloaded", "status": 529}
+
+
+class CapSwitchOffer(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.jd.STATE, km._tmux_sessions, km._auth_key_present)
+        km.jd.STATE = Path(self.td.name)
+        km._tmux_sessions = lambda: {SID: {"authLive": "login", "auth": "key"}}
+        km._auth_key_present = lambda: True
+        self._cap(100, 3600)
+
+    def tearDown(self):
+        (km.jd.STATE, km._tmux_sessions, km._auth_key_present) = self._saved
+        self.td.cleanup()
+
+    def _cap(self, pct, resets_in, bucket="five_hour"):
+        (km.jd.STATE / "usage.json").write_text(json.dumps(
+            {bucket: {"pct": pct, "resets_at": int(time.time()) + resets_in}}))
+
+    def test_minted_for_a_login_billed_cap_death(self):
+        v = km._cap_switch_offer(SID, ERR)
+        self.assertEqual(v["window"], "five_hour")
+        self.assertGreater(v["resetsAt"], time.time())
+
+    def test_never_for_a_key_billed_session(self):
+        km._tmux_sessions = lambda: {SID: {"authLive": "key", "auth": "login"}}
+        self.assertIsNone(km._cap_switch_offer(SID, ERR),
+                          "a key-billed error is not a cap death — nothing to offer")
+
+    def test_never_for_the_on_you_error_classes(self):
+        for k in ("tooLong", "spendLimit", "modelLimit", "authErr", "refusal"):
+            self.assertIsNone(km._cap_switch_offer(SID, dict(ERR, **{k: True})),
+                              k + " carries its own remedy — no billing offer rides it")
+
+    def test_never_without_a_key_to_offer(self):
+        km._auth_key_present = lambda: False
+        self.assertIsNone(km._cap_switch_offer(SID, ERR))
+
+    def test_never_when_no_window_is_capped(self):
+        self._cap(90, 3600)
+        self.assertIsNone(km._cap_switch_offer(SID, ERR))
+
+    def test_retires_with_the_window(self):
+        self._cap(100, -5)                            # resets_at already passed — the deciding event
+        self.assertIsNone(km._cap_switch_offer(SID, ERR))
+
+    def test_no_path_flips_billing_without_the_explicit_pick_both_directions(self):
+        # CENSUS PIN: the ONLY set_auth call sites in the kernel are the setAuth route's helper and
+        # the parked-op replay of that same user pick — no auto path, either direction. A new caller
+        # lands here first.
+        src = Path(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read_text()
+        sites = [l.strip() for l in src.splitlines() if re.search(r"\bbe\.set_auth\(", l)]
+        self.assertEqual(len(sites), 2, "exactly the helper + the parked replay: %r" % sites)
+        self.assertTrue(any("return be.set_auth(sid, value)" in l for l in sites))
+        self.assertTrue(any("be.set_auth(sid, op[1])" in l for l in sites))
+        self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src,
+                      "the route is a user gesture, and the ONLY door")
+        self.assertNotIn("set_auth", src[src.index("def _cap_switch_offer"):
+                                         src.index("def _judge_limit_view")],
+                         "the offer itself never switches anything")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-apierror-working.test.ts
+++ b/ui/webview/feed-apierror-working.test.ts
@@ -32,7 +32,7 @@ test("Retry renders WITH its explaining badge as one visual unit — never alone
   // badge immediately before its button, as DIRECT row2 children: grouped mode hides idwrap (the
   // card drops its name there), which is exactly how the screenshot got a lone Retry with no badge —
   // the badge sat in the hidden wrap while the action-row button stayed visible
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin,/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin,/);
   assert.match(FEED, /actions\.append\(revive, qApprove, qDeny\);/);
   assert.doesNotMatch(FEED, /actions\.append\(apiRetry/, "no lone Retry detached from its badge");
   assert.doesNotMatch(FEED, /idwrap\.append\([^)]*apiBadge/, "…and never inside the grouped-mode-hidden idwrap");

--- a/ui/webview/feed-cap-offer.test.ts
+++ b/ui/webview/feed-cap-offer.test.ts
@@ -1,0 +1,45 @@
+// The cap-death billing-switch OFFER (the user's binding ruling, 2026-08-30: a session must NEVER
+// silently switch billing in either direction). The kernel mints capOffer only for a login-billed
+// session dead on the account's cap with a key on hand (tests/test_cap_switch_offer.py holds that
+// matrix + the set_auth caller census); these pins hold the render half: the tradeoff stated
+// plainly and visibly, the button's click-safety + latched ack, declining = the existing Clear,
+// and the gesture census — the ONE setAuth postMessage in the feed is this button.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const FEED = fs.readFileSync(path.join(UI, "feed.ts"), "utf8");
+const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the offer states the tradeoff plainly and visibly — never tooltip-only", () => {
+  assert.match(FEED, /This session bills the subscription, whose usage window is full — it can "\s*\n\s*\+ "bill your API key instead until the window resets at " \+ clockHM\(cap\.resetsAt\)/);
+  assert.match(FEED, /"\. It switches back only if you switch it\."/, "the reverse direction named, per the ruling");
+});
+
+test("the button acknowledges, latches across pushes, and self-resolves — the T150 idiom", () => {
+  assert.match(FEED, /a\._capBtn\.disabled = true; a\._capBtn\.textContent = "Switching…";   \/\/ ack before the round-trip/);
+  assert.match(FEED, /if \(!\(a\._capBtn as HTMLButtonElement\)\.disabled\) \{/,
+    "a push while the switch applies must not re-arm the button under the user");
+  assert.match(FEED, /\} else \{ \(a\._capBtn as HTMLButtonElement\)\.disabled = false; a\._capBtn\.textContent = "Switch to the key"; \}/,
+    "the offer vanishing (switch landed, or window reset) is what re-arms");
+  assert.match(FEED, /const capBtn = el\("button", "fdismiss fcapswitch"\)/, "build-once on the card skeleton — click-safe");
+});
+
+test("only the explicit pick switches — the gesture census, both surfaces", () => {
+  // the feed's ONE setAuth send is this button; the chat gear's ONE is the billing selector.
+  // Any new sender shows up as a count change here before it ships.
+  assert.equal((FEED.match(/type: "setAuth"/g) || []).length, 1, "feed: the offer button only");
+  assert.equal((RENDER.match(/type: "setAuth"/g) || []).length, 1, "chat: the gear billing pick only");
+  assert.match(KERNEL, /a session must NEVER\s*\n\s*silently switch billing in either direction/, "the ruling, verbatim at the mint");
+});
+
+test("the offer retires with the window and rides beside the auto-retry, never instead", () => {
+  assert.match(KERNEL, /\(w\.get\("resets_at"\) or 0\) > now/, "resets_at passing ends the mint — the deciding event");
+  assert.match(KERNEL, /_cap_off = _cap_switch_offer\(fsid, aerr\) if aerr else None/);
+  assert.match(KERNEL, /\*\*\(\{"capOffer": _cap_off\} if _cap_off else \{\}\),/, "sparse — absent payloads are byte-identical");
+  // the auto-retry contract is untouched: the retry button + auto ladder read exactly as before
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "apiRetry", id: it\.sid \}\);/);
+});

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -21,7 +21,7 @@ test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails t
   // name row keeps only identity + chips
   assert.match(FEED, /btns\.append\(cont, clr\);/, "ask card: Continue left of Clear in the action corner");
   assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
@@ -60,7 +60,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -77,7 +77,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);
@@ -136,7 +136,7 @@ test("a long no-space token (file/func/type name) WRAPS instead of overflowing t
 // blanked every badge inside it — ⚠ retrying-since, judge-auth, and the ⏸ approval chip never
 // showed on grouped-mode cards. Every state badge is a DIRECT row2 child now; placement only.
 test("every session-state badge is a direct row2 child — visible in grouped AND flat mode", () => {
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin,/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin,/);
   assert.match(FEED, /idwrap\.append\(name\);/, "idwrap = the name alone; hiding it hides nothing else");
   assert.doesNotMatch(FEED, /idwrap\.append\([^)]*(retryBadge|apiBadge|jauthBadge|blkBadge)/,
     "no state badge ever returns to the grouped-mode-hidden wrap");

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-judge-auth.test.ts
+++ b/ui/webview/feed-judge-auth.test.ts
@@ -18,7 +18,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the judge-auth chip is built once, rides the session-state row, and keys on blocked.state", () => {
   assert.match(FEED, /const jauthBadge = el\("span", "fask-jauth"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge,/,
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge,/,
     "the chip rides the name row with its api-trouble siblings");
   assert.match(FEED, /a\._jauthBadge = jauthBadge;/);
   assert.match(FEED, /const isJudgeAuth = it\.blocked\?\.state === "judgeAuth"/);

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-retrying.test.ts
+++ b/ui/webview/feed-retrying.test.ts
@@ -15,7 +15,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the retrying badge is built once and rides the session-state row beside the API-error badge", () => {
   assert.match(FEED, /const retryBadge = el\("span", "fask-retrying"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge,/,
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge,/,
     "session-STATE badges ride the name row, off the action row");
   assert.match(FEED, /a\._retryBadge = retryBadge;/);
 });

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
+  assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1514,6 +1514,9 @@ body.filebrowse-open { overflow: hidden; }
 /* the standard session reference (the user 2026-08-28): bold name in its identity colour; the
    host: prefix keeps the shared .host-prefix treatment */
 .judge-limit-banner .jl-chip { font-weight: 700; font-style: normal; }
+/* the cap-switch offer (2026-08-30): the tradeoff line rides the api-trouble row, dim like the
+   badge family; the button keeps the fdismiss vocabulary */
+.fask-capoffer { color: var(--dim); min-width: 0; overflow-wrap: anywhere; }
 .judge-limit-banner .jl-unknown { opacity: 0.8; font-style: italic; }
 .judge-limit-banner .jl-dismiss { flex: none; margin-left: auto; background: none; border: none;
   color: var(--dim); cursor: pointer; font-size: 1em; padding: 2px 6px; border-radius: 4px; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -93,6 +93,7 @@ interface AskItem {
               modelLimit?: boolean;   // apiError: this session's MODEL is out of allowance (on you → switch model or add credits; the user 2026-08-01)
               refusal?: boolean;   // apiError: the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — deterministic on the same input, the user 2026-08-15)
               mode?: string; since?: number;   // judgeAuth adds these: which billing its judges ride ('key'|'login') + the first refusal time — romp can't analyze the session until the credential is fixed (the user 2026-08-12)
+              capOffer?: { resetsAt: number; window?: string };   // apiError: login-billed session dead on the account's cap + a key on hand → the explicit switch OFFER; the pick is yours alone, both directions (2026-08-30)
               toName?: string; toSid?: string;    // parkedHandoff adds to*
               mid?: string; frm?: string; to?: string; origin?: string; body?: string; gist?: string };   // quarantine (held peer mail) adds these; gist = the bus's 90-char collapse for the compact card line
   summary?: string | null;                         // distiller's key takeaway for a COMPLETED goal → the done card's one auto-written line (kernel asks.append); null until produced
@@ -1016,6 +1017,14 @@ function makeAskCard(it: AskItem): HTMLElement {
   const apiLogin = el("button", "fdismiss ffollow"); apiLogin.textContent = "Log in…";
   apiLogin.title = "open Billing login — sign in from any browser (your phone works) and this session recovers on its next turn";
   apiLogin.style.display = "none";
+  // CAP-SWITCH OFFER (the user's binding ruling, 2026-08-30: a session must NEVER silently switch
+  // billing in either direction): a login-billed session dead on the account's usage cap gets an
+  // explicit offer to bill the key for the rest of the window — the pick is the user's alone, and
+  // switching back is equally manual. Declining is just Clear; the kernel stops minting the offer
+  // the moment the window resets (the deciding event), and the post-reset auto-retry runs either way.
+  const capLine = el("span", "fask-capoffer"); capLine.style.display = "none";
+  const capBtn = el("button", "fdismiss fcapswitch") as HTMLButtonElement;
+  capBtn.textContent = "Switch to the key"; capBtn.style.display = "none";
   const revive = el("button", "fdismiss frevive"); revive.textContent = "Revive"; revive.title = "bring this offline session back so the parked hand-off is delivered"; revive.style.display = "none";
   // RESUME-GATE buttons (the user 2026-07-21): a boot-deferred high-context session — Proceed reloads it now,
   // Compact on resume /compacts first so future turns shrink (still one reload now), Skip leaves it dormant.
@@ -1076,7 +1085,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // direct children they render in BOTH modes, count toward row2's grouped-mode liveness, and the
   // API badge stays immediately before its Retry button — one visual unit. idwrap keeps only the
   // name. Placement only; every badge's mint/retire semantics are untouched.
-  row2.append(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
+  row2.append(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
   // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
   // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
   // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or
@@ -1288,6 +1297,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   a._waitOn = waitOnBadge;
   a._blocked = blkBadge;
   a._apiBadge = apiBadge; a._apiRetry = apiRetry; a._apiLogin = apiLogin; a._retryBadge = retryBadge; a._revive = revive; a._clr = clr;
+  a._capLine = capLine; a._capBtn = capBtn;
   a._jauthBadge = jauthBadge;
   a._cont = cont;
   a._qApprove = qApprove; a._qDeny = qDeny; a._qBody = qbody;
@@ -2090,6 +2100,28 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       a._apiRetry.disabled = true; a._apiRetry.textContent = "Retrying…";
     };
   }
+  // CAP-SWITCH OFFER (2026-08-30): the tradeoff stated plainly, the pick the user's alone. The
+  // latched "Switching…" survives pushes (the T150 idiom — the payload still says login until the
+  // reconnect applies the pick) and self-resolves: once authLive flips to key, the kernel stops
+  // minting the offer and both elements hide.
+  const cap = (showApiErr && it.blocked && it.blocked.capOffer) || null;
+  (a._capLine as HTMLElement).style.display = cap ? "" : "none";
+  (a._capBtn as HTMLButtonElement).style.display = cap ? "" : "none";
+  if (cap) {
+    a._capLine.textContent = "This session bills the subscription, whose usage window is full — it can "
+      + "bill your API key instead until the window resets at " + clockHM(cap.resetsAt)
+      + ". It switches back only if you switch it.";
+    if (!(a._capBtn as HTMLButtonElement).disabled) {
+      a._capBtn.title = "bills THIS session to the API key — only your pick switches billing, in either "
+        + "direction, and the auto-retry at the reset runs whether or not you switch";
+      a._capBtn.onclick = (ev: Event) => {
+        ev.stopPropagation();
+        vscodeApi?.postMessage({ type: "setAuth", id: it.sid, value: "key" });
+        a._capBtn.disabled = true; a._capBtn.textContent = "Switching…";   // ack before the round-trip
+        a._capBtn.title = "the switch is applying — it lands the way a gear billing pick does, and this offer clears itself";
+      };
+    }
+  } else { (a._capBtn as HTMLButtonElement).disabled = false; a._capBtn.textContent = "Switch to the key"; }
   // JUDGE-AUTH (the user 2026-08-12): romp's own analysis of this session is refused on its credential —
   // the judges bill what the session bills (kernel _judge_auth), that credential is failing, and no card
   // here can move until the user fixes it. The chip names which credential; no Retry (nothing in-session


### PR DESCRIPTION
The user's **binding ruling** (2026-08-30, via the nightly optimizer): *a session must NEVER silently switch billing in either direction.* When a login-billed session dies on the account's usage cap, the existing API-error card now carries an explicit **offer**: the tradeoff stated plainly and visibly ('This session bills the subscription, whose usage window is full — it can bill your API key instead until the window resets at HH:MM. **It switches back only if you switch it.**') and a 'Switch to the key' button flowing into the **same setAuth route** a gear billing pick takes — launch-flag reconnect semantics unchanged. Declining is just the card's existing Clear.

The kernel mints `capOffer` only when every leg holds and is readable: the plain retryable error class (spend/model/auth/tooLong/refusal each carry their own remedy), a login-account window actually at its cap with a readable reset ahead (usage.json — the retry pause's own authority; fable excluded, model-scoped), THIS session billing the login (authLive first, picked intent second), and a key on hand. The offer **self-expires with the window** (resets_at passing ends the mint — the deciding event), and the **post-reset auto-retry is untouched** either way: this sits beside it, never instead.

Click-safety: build-once on the card skeleton, ack before the round-trip; the latched 'Switching…' survives pushes and self-resolves once authLive flips (the mint stops, the offer hides).

Tests: the mint matrix (login+cap+key mints; key-billed never; each on-you class never; no key never; uncapped never; reset passing retires) plus the **no-silent-flip census pinned both directions** — the kernel's only `set_auth` call sites are the setAuth route's helper and the parked replay of that same pick; the feed's only setAuth send is this button; the chat's only one is the gear selector; the offer code contains no set_auth. Python 6076 passed / extension 2558 passed on the pushed head; card screenshot in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)