### PR TITLE
Watch hardening: short bounds check in instead of dying, predicates can't self-match, no watch retires unheard

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1021,6 +1021,8 @@ print(json.dumps(b))' "$_w_cmd" "$_w_key" "$_w_who" "$_w_every" "$_w_timeout" "$
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
         _wid="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["watch"]["id"])' "$_resp" 2>/dev/null || true)"
         echo "romp watch: registered${_wid:+ ($_wid)} — one mail here when the condition holds or the timeout passes"
+        _whint="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("hint") or "")' "$_resp" 2>/dev/null || true)"
+        [[ -n "$_whint" ]] && echo "romp watch: heads-up — $_whint" >&2
         exit 0
     fi
     _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11472,7 +11472,7 @@ WATCH_RUN_TIMEOUT = 45        # one predicate run's own bound
 WATCH_MAX = 200               # registration cap — a runaway loop's backstop, far above real use
 _watches = []                 # [{id, cmd, every, timeoutS, sid, note, at} + runtime {_next, _ran}]
 _watch_lock = threading.Lock()
-_WATCH_KEYS = ("id", "cmd", "every", "timeoutS", "sid", "note", "at")
+_WATCH_KEYS = ("id", "cmd", "every", "timeoutS", "sid", "note", "at", "soft")
 
 
 def _watches_load():
@@ -11523,7 +11523,7 @@ def add_watch(cmd, sid, every=None, timeout_s=None, note="", now=None):
         row = {"id": wid, "cmd": cmd, "every": every, "timeoutS": timeout_s,
                "sid": str(sid), "note": str(note or "")[:200],
                "at": int(now if now is not None else time.time()),
-               "_next": 0, "_ran": False}
+               "soft": False, "_next": 0, "_ran": False}
         _watches.append(row)
     _watches_save()
     return {k: row[k] for k in _WATCH_KEYS}, None
@@ -11558,7 +11558,13 @@ def _watch_notice(kind, row, detail=""):
     elif kind == "timeout":
         body = ("[romp] romp gave up watching after %s: %s never held (the check kept saying not-yet). "
                 "This watch is done — re-register with `romp watch` if you still need it."
-                % (_fmt_span_s(int(row.get("timeoutS") or 0)), what))
+                % (_fmt_span_s(int(row.get("hardS") or row.get("timeoutS") or 0)), what))
+    elif kind == "soft":
+        body = ("[romp] Still watching: %s has not held after %s (your requested bound). A short bound "
+                "no longer ends a watch silently — romp keeps checking through %s total, and will mail "
+                "the moment it holds. If it's moot, cancel with `romp watch --cancel %s`."
+                % (what, _fmt_span_s(int(row.get("timeoutS") or 0)),
+                   _fmt_span_s(WATCH_DEFAULT_TIMEOUT), row.get("id") or "?"))
     else:   # execfail — the first run could not even execute
         body = ("[romp] The watch command could not run at all (%s): %s. This watch was dropped — "
                 "fix the command and re-register with `romp watch`."
@@ -11575,11 +11581,35 @@ def _fmt_span_s(s):
     return "%ds" % s
 
 
+def _watch_reg_hint(cmd):
+    """The one self-match the script-file runner cannot fix, answered at registration: the kernel's
+    own wrapper no longer carries the predicate text (see _watch_run), but a wrapper the predicate
+    ITSELF spawns — an ssh far-side shell, a parent bash — still echoes the pattern in its own argv,
+    and that construction is the caller's. pgrep/pkill -f registrations get told loudly, up front."""
+    if re.search(r"\bp(?:grep|kill)\b[^|;&]*\s-\w*f", str(cmd or "")):
+        return ("pgrep/pkill -f match whole command lines: a wrapper your check spawns (an ssh "
+                "remote shell, a parent bash) carries the pattern in its own argv and self-matches. "
+                "Prefer pgrep -x, a pidfile, or an output-file check.")
+    return None
+
+
 def _watch_run(cmd):
     """One predicate run → (exitcode, output tail). Bounded; a timeout reads as not-yet (the
-    predicate gets another try — its own bound is the watch timeout)."""
+    predicate gets another try — its own bound is the watch timeout). The predicate text lives in a
+    SCRIPT FILE and the runner's argv carries only its path (the user 2026-08-29, structural
+    self-match-proofing): under `sh -c <text>` the wrapper's own command line CONTAINED the
+    predicate, so a `pgrep -f <pattern>` watch matched its own wrapper — the pattern rode the argv,
+    e.g. the watched job's ssh line — and reported still-running until the timeout flushed it, 35
+    minutes after the job actually finished. With the text on disk, no process the runner owns ever
+    carries the pattern; what the predicate itself spawns (a remote ssh shell echoing it) is the
+    caller's construction, hinted loudly at registration."""
+    sp = None
     try:
-        r = subprocess.run(["/bin/sh", "-c", cmd], capture_output=True, text=True,
+        sd = jd.STATE / "watch-scratch"
+        sd.mkdir(parents=True, exist_ok=True)
+        sp = sd / ("w-%s.sh" % os.urandom(4).hex())
+        sp.write_text(cmd + "\n")
+        r = subprocess.run(["/bin/sh", str(sp)], capture_output=True, text=True,
                            timeout=WATCH_RUN_TIMEOUT)
         out = ((r.stdout or "") + (("\n" + r.stderr) if r.stderr else "")).strip()
         return r.returncode, out[-1000:]
@@ -11587,34 +11617,72 @@ def _watch_run(cmd):
         return None, "the check ran past %ds" % WATCH_RUN_TIMEOUT
     except Exception as e:
         return 127, str(e)[:200]
+    finally:
+        try:
+            if sp is not None:
+                sp.unlink()
+        except OSError:
+            pass
 
 
 def _watch_tick(now):
-    """One supervisor-pass sweep (rate-gated per row) — the pr-watch pump's twin."""
+    """One supervisor-pass sweep (rate-gated per row) — the pr-watch pump's twin.
+
+    TIMEOUTS split soft/hard (the user 2026-08-29, after two overnight cluster watches died at
+    1h caller-habit bounds while their conditions held later): a caller bound SHORTER than the
+    kernel default no longer ends the watch — it sends one still-watching check-in (naming the
+    cancel id) and the watch re-arms through the DEFAULT cap, where the giving-up mail ends it as
+    ever (the standing never-a-silent-dead-loop rule). A caller bound at or past the default is an
+    explicit choice and ends there, as before. And every retiring NOTICE must actually DELIVER
+    before its row retires: delivery is best-effort transport, and retiring on a failed send lost
+    a met condition silently — the row now stays for the next cadence and retries, bounded an hour
+    past the hard cap (stderr, never a zombie)."""
     with _watch_lock:
         rows = list(_watches)
     done = []
+    changed = False
     for r in rows:
         if now < r.get("_next", 0):
             continue
-        if now - int(r.get("at") or 0) >= int(r.get("timeoutS") or WATCH_DEFAULT_TIMEOUT):
-            _pr_watch_deliver(r["sid"], _watch_notice("timeout", r))
+        every = int(r.get("every") or WATCH_DEFAULT_EVERY)
+        born = int(r.get("at") or 0)
+        t_o = int(r.get("timeoutS") or WATCH_DEFAULT_TIMEOUT)
+        hard = max(t_o, WATCH_DEFAULT_TIMEOUT)
+        r["hardS"] = hard                                # the timeout notice names the REAL span
+        if now - born >= hard + 3600:
+            sys.stderr.write("romp-kernel: watch %s dropped — its notices would not deliver\n"
+                             % r.get("id"))
             done.append(r)
+            continue
+        if now - born >= hard:
+            if _pr_watch_deliver(r["sid"], _watch_notice("timeout", r)):
+                done.append(r)
+            else:
+                r["_next"] = now + every                 # the notice failed — retry, never lose it
             continue
         code, out = _watch_run(r["cmd"])
         first = not r.get("_ran")
         r["_ran"] = True
         if code == 0:
-            _pr_watch_deliver(r["sid"], _watch_notice("met", r, out))
-            done.append(r)
+            if _pr_watch_deliver(r["sid"], _watch_notice("met", r, out)):
+                done.append(r)
+            else:
+                r["_next"] = now + every                 # met but unheard — the row retries the mail
             continue
         if first and code in (126, 127):
             # a command that cannot exec at all must not wait silently for its timeout
-            _pr_watch_deliver(r["sid"], _watch_notice("execfail", r, out or ("exit %s" % code)))
-            done.append(r)
+            if _pr_watch_deliver(r["sid"], _watch_notice("execfail", r, out or ("exit %s" % code))):
+                done.append(r)
+            else:
+                r["_next"] = now + every
             continue
-        r["_next"] = now + int(r.get("every") or WATCH_DEFAULT_EVERY)
-    if done:
+        if t_o < hard and now - born >= t_o and not r.get("soft"):
+            # the caller's short bound: one still-watching check-in, then the watch keeps going
+            if _pr_watch_deliver(r["sid"], _watch_notice("soft", r)):
+                r["soft"] = True                         # once, persisted — a restart must not repeat it
+                changed = True
+        r["_next"] = now + every
+    if done or changed:
         with _watch_lock:
             for r in done:
                 if r in _watches:
@@ -30027,7 +30095,11 @@ class Handler(BaseHTTPRequestHandler):
                                      timeout_s=b.get("timeoutS"), note=b.get("note"))
                 if err:
                     return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
-                return self._send(200, json.dumps({"ok": True, "watch": row}), "application/json")
+                resp = {"ok": True, "watch": row}
+                hint = _watch_reg_hint(b.get("cmd"))
+                if hint:
+                    resp["hint"] = hint
+                return self._send(200, json.dumps(resp), "application/json")
             if u.path in ("/tag", "/group"):
                 # Headless tag edit (`romp tag`, the user 2026-08-23, the manager/worker workflow:
                 # the worker roster IS a session tag, so an agent needs to keep one current — and can

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11477,6 +11477,11 @@ _WATCH_KEYS = ("id", "cmd", "every", "timeoutS", "sid", "note", "at", "soft")
 
 def _watches_load():
     try:
+        for f in (jd.STATE / "watch-scratch").glob("*.sh"):
+            f.unlink()          # a crash mid-run strands its predicate script; boot sweeps the scratch
+    except Exception:
+        pass
+    try:
         rows = json.loads(WATCH_FILE.read_text())
     except Exception:
         return

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -577,25 +577,36 @@ def _kernel_sessions(threads=False):
 
     ROMP_SESSIONS_FILE is a test seam (like ROMP_*_BIN): a JSON file of the same rows, read instead of the
     live kernel so the bus is testable without one."""
+    return _kernel_sessions_checked(threads=threads)[0]
+
+
+def _kernel_sessions_checked(threads=False):
+    """(rows, answered) — answered False means the liveness source DID NOT ANSWER (the kernel is
+    unreachable, typically mid-restart), which is different information from an empty listing.
+    Callers that are about to make a CLAIM about liveness (resolve_recipient's refusal) must
+    check `answered` — an unanswered fetch collapsed to [] read exactly like universal deadness,
+    and the refusal it produced blamed a demonstrably live peer (sighting 2026-08-29: a send was
+    refused as not-live mid-restart; the retry 101 seconds later delivered)."""
     seam = os.environ.get("ROMP_SESSIONS_FILE")
     if seam:
         try:
             data = json.loads(Path(seam).read_text())
             if not isinstance(data, list):
-                return []
+                return [], True
             # the seam mirrors the route: thread rows ride only when asked (the user 2026-08-22)
-            return data if threads else [r for r in data if not (isinstance(r, dict) and r.get("thread"))]
+            return (data if threads else
+                    [r for r in data if not (isinstance(r, dict) and r.get("thread"))]), True
         except Exception:
-            return []
+            return [], True
     import urllib.request
     try:
         req = urllib.request.Request(KERNEL_BASE + "/sessions" + ("?threads=1" if threads else ""),
                                      headers={"X-Romp-Token": SERVE_TOKEN})
         with urllib.request.urlopen(req, timeout=2) as r:
             data = json.loads(r.read().decode("utf-8"))
-        return data if isinstance(data, list) else []
+        return (data if isinstance(data, list) else []), True
     except Exception:
-        return []
+        return [], False
 
 
 def local_agents(threads=False):
@@ -767,9 +778,10 @@ def resolve_recipient(to, frm_id=""):
     # unique by construction, so the ambiguity arm below never fires for it; the self-send check
     # still does — mailing your own sid is the same loopback as mailing your own name.
     by_id = bool(re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", bare))
+    pool = all_agents(threads=True)                                   # threads addressable for replies
     direct_all = ([] if (want_host and want_host != here)
-                  else [a for a in all_agents(threads=True)
-                        if (a.get("id") == bare if by_id else a["name"] == bare)])   # threads addressable for replies
+                  else [a for a in pool
+                        if (a.get("id") == bare if by_id else a["name"] == bare)])
     if not direct_all and not by_id and not want_host             and re.fullmatch(r"[0-9a-fA-F][0-9a-fA-F-]{7,35}", bare):
         # a SHORT id — the ` · <8-char>` form every list_agents row now carries (the user
         # 2026-08-24) — addresses by unambiguous id PREFIX, so the row is enough to act on. An
@@ -777,7 +789,7 @@ def resolve_recipient(to, frm_id=""):
         # a stray word can never catch a session by luck; a remote row's id ("host:uuid") matches
         # on its uuid part, the part the row shows. TWO prefix hits fall through to the standing
         # ambiguity refusal below, exactly like a duplicated name.
-        direct_all = [a for a in all_agents(threads=True)
+        direct_all = [a for a in pool
                       if str(a.get("id") or "").rsplit(":", 1)[-1].startswith(bare)]
 
     if frm_id and any(a["id"] == frm_id for a in direct_all):
@@ -818,7 +830,18 @@ def resolve_recipient(to, frm_id=""):
                          "postal isolation — its mailbox icon is toggled off), so it can't receive "
                          "mail right now. YOUR mailbox is fine; nothing was sent. It'll "
                          "be reachable once the user toggles ITS mailbox back on." % to}
-    # Addressing is LIVE-only: no dead-session resurrection, so anything left is a typo.
+    # Addressing is LIVE-only: no dead-session resurrection — but "not live" is a claim about the
+    # world, and the kernel is its authoritative source (fail loudly, never degrade silently, the
+    # user 2026-07-03). Before making the claim, ask whether the source ANSWERED: a mid-restart
+    # kernel yields an empty listing that reads exactly like universal deadness. One loopback GET,
+    # paid only on this refusal path.
+    if not any(not a.get("remote") for a in pool) and not _kernel_sessions_checked()[1]:
+        # only an EMPTY local world raises the question — a listing with live locals in it proves
+        # the source answered (and heartbeating remotes can't vouch for LOCAL liveness)
+        return {"kind": "error", "status": 503,
+                "error": "can't tell whether '%s' is live right now: the liveness source (the romp "
+                         "kernel) didn't answer — likely mid-restart. Nothing was sent, and this is "
+                         "NOT a claim that '%s' is dead. Retry shortly." % (bare, bare)}
     return {"kind": "error", "status": 404, "error": "no live romp session named '%s'" % to}
 
 
@@ -832,6 +855,15 @@ def _recall(from_id, to, mid):
         return []
     if to:
         rid = _recip_id_for(to)
+        if not rid and MAILROOT.is_dir():
+            # Addressing is live-only, but RECALL is not addressing: the sender is unsending their
+            # own bytes, not raising the dead. Mail parked for a session that has since died sits
+            # right here in its new/ — a name that no longer resolves live falls back to the
+            # durable name map so parked mail stays recallable (sighting 2026-08-29: a handoff
+            # parked for a dead session could not be unsent by name; only the raw id worked).
+            hits = [b.name for b in MAILROOT.iterdir()
+                    if b.is_dir() and _name_for_id(b.name) == to]
+            rid = hits[0] if len(hits) == 1 else None    # two dead boxes, one name: refuse, stay scoped
         boxes = [rid] if rid else []
     elif MAILROOT.is_dir():
         boxes = [b.name for b in MAILROOT.iterdir() if b.is_dir()]

--- a/tests/test_generic_watch.py
+++ b/tests/test_generic_watch.py
@@ -8,6 +8,7 @@ at once. Persisted (watches.json), boot re-armed, the pr-watch pump's discipline
 Synthetic only; hermetic state; predicates are stubbed at _watch_run."""
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -97,16 +98,71 @@ class Tick(_Watches):
         self.assertIn("<!-- romp-injected --><!-- romp-system -->", text)
         self.assertEqual(km.list_watches(), [], "one mail, then the watch retires")
 
-    def test_timeout_mails_the_giving_up_notice(self):
-        km.add_watch("never", SID, every=15, timeout_s=60, now=0)
+    def test_a_short_caller_bound_softens_and_the_default_cap_gives_up(self):
+        """The 2026-08-29 hardening: two overnight cluster watches died at 1h caller-habit bounds
+        while their conditions held later. A bound SHORTER than the kernel default is now a
+        CHECK-IN, not an end: one still-watching mail (naming the cancel id), then the watch keeps
+        going through the default cap, where the giving-up notice ends it as ever."""
+        row, _ = km.add_watch("never", SID, every=15, timeout_s=60, now=0)
         km._watch_run = lambda cmd: (1, "")
         km._watch_tick(30.0)
         self.assertEqual(self.mails, [])
         km._watch_tick(61.0)
         self.assertEqual(len(self.mails), 1)
-        self.assertIn("gave up watching", self.mails[0][1])
-        self.assertIn("never held", self.mails[0][1])
+        self.assertIn("Still watching", self.mails[0][1])
+        self.assertIn("--cancel %s" % row["id"], self.mails[0][1], "the check-in hands over the off switch")
+        self.assertEqual(len(km.list_watches()), 1, "the caller's short bound no longer ends the watch")
+        km._watch_tick(200.0)
+        self.assertEqual(len(self.mails), 1, "the check-in mails ONCE, not per cadence")
+        km._watch_tick(km.WATCH_DEFAULT_TIMEOUT + 1.0)
+        self.assertEqual(len(self.mails), 2)
+        self.assertIn("gave up watching", self.mails[1][1])
+        self.assertIn("never held", self.mails[1][1])
+        self.assertIn(km._fmt_span_s(km.WATCH_DEFAULT_TIMEOUT), self.mails[1][1],
+                      "the giving-up notice names the REAL span watched, not the softened bound")
         self.assertEqual(km.list_watches(), [], "the standing watcher rule: never a silent dead loop")
+
+    def test_the_soft_checkin_mark_survives_a_restart(self):
+        km.add_watch("never", SID, every=15, timeout_s=60, now=0)
+        km._watch_run = lambda cmd: (1, "")
+        km._watch_tick(61.0)
+        self.assertEqual(len(self.mails), 1)
+        with km._watch_lock:
+            km._watches[:] = []
+        km._watches_load()
+        km._watch_run = lambda cmd: (1, "")
+        km._watch_tick(200.0)
+        self.assertEqual(len(self.mails), 1, "a reboot must not repeat the check-in — soft is persisted")
+
+    def test_an_explicit_long_bound_ends_where_the_caller_said(self):
+        km.add_watch("never", SID, every=15, timeout_s=2 * km.WATCH_DEFAULT_TIMEOUT, now=0)
+        km._watch_run = lambda cmd: (1, "")
+        km._watch_tick(km.WATCH_DEFAULT_TIMEOUT + 10.0)
+        self.assertEqual(self.mails, [], "a bound past the default is an explicit choice — no check-in")
+        km._watch_tick(2 * km.WATCH_DEFAULT_TIMEOUT + 1.0)
+        self.assertEqual(len(self.mails), 1)
+        self.assertIn("gave up watching", self.mails[0][1])
+
+    def test_a_met_condition_survives_a_failed_delivery(self):
+        """Delivery is best-effort transport; retiring on a failed send silently LOST the met mail
+        (2026-08-29 audit find). The row now stays and retries next cadence."""
+        km.add_watch("check", SID, every=15, note="the job finished", now=0)
+        km._watch_run = lambda cmd: (0, "held")
+        km._pr_watch_deliver = lambda sid, text: False
+        km._watch_tick(1.0)
+        self.assertEqual(len(km.list_watches()), 1, "met but unheard — the watch must not vanish")
+        km._pr_watch_deliver = lambda sid, text: self.mails.append((sid, text)) or True
+        km._watch_tick(20.0)
+        self.assertEqual(len(self.mails), 1)
+        self.assertIn("now HOLDS", self.mails[0][1])
+        self.assertEqual(km.list_watches(), [])
+
+    def test_an_undeliverable_watch_is_bounded_not_a_zombie(self):
+        km.add_watch("never", SID, every=15, timeout_s=60, now=0)
+        km._watch_run = lambda cmd: (1, "")
+        km._pr_watch_deliver = lambda sid, text: False
+        km._watch_tick(km.WATCH_DEFAULT_TIMEOUT + 3601.0)
+        self.assertEqual(km.list_watches(), [], "an hour past the cap with no ear to mail, the row drops")
 
     def test_first_run_exec_failure_retires_loudly_at_once(self):
         km.add_watch("nosuchbinary --flag", SID, now=0)
@@ -150,6 +206,26 @@ class Wiring(_Watches):
         self.assertEqual(code, 3)
         code, out = km._watch_run("echo held; exit 0")
         self.assertEqual((code, out), (0, "held"))
+        scratch = km.jd.STATE / "watch-scratch"
+        self.assertEqual(list(scratch.glob("*.sh")), [], "each run cleans its script file")
+
+    @unittest.skipUnless(shutil.which("pgrep"), "pgrep not installed")
+    def test_the_runner_never_matches_its_own_argv(self):
+        """The self-match bug: under `sh -c <text>` the wrapper's argv CONTAINED the predicate, so a
+        `pgrep -f <pattern>` watch matched its own wrapper and said still-running forever (35 min
+        past actual completion, 2026-08-28 overnight). Script-file execution: no process the runner
+        owns carries the pattern, so a token nothing else runs must come back not-found."""
+        code, _ = km._watch_run("pgrep -f romptest_selfmatch_e5c1a9")
+        self.assertNotEqual(code, 0, "the runner's own argv must never satisfy the predicate")
+
+    def test_pgrep_f_registration_answers_with_the_remote_wrapper_hint(self):
+        self.assertIn("pgrep -x", km._watch_reg_hint("pgrep -f 'train.py'") or "")
+        self.assertIn("self-match", km._watch_reg_hint("ssh box pkill -0 -f job") or "")
+        self.assertIsNone(km._watch_reg_hint("test -f /tmp/done"))
+        self.assertIsNone(km._watch_reg_hint("pgrep -x trainer"), "-x is the fix, not the footgun")
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('hint = _watch_reg_hint(b.get("cmd"))', src,
+                      "the /watch route surfaces the hint to the registering CLI")
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_live_only.py
+++ b/tests/test_postal_live_only.py
@@ -62,6 +62,79 @@ class LiveOnlyAddressing(unittest.TestCase):
         self.assertEqual(pm._recip_id_for("beta"), GHOST)
 
 
+class RecallReachesParkedMailForTheDead(unittest.TestCase):
+    """The ONE deliberate carve-out from live-only addressing (2026-08-29): RECALL is not
+    addressing. The sender is unsending their OWN bytes, which sit locally in the recipient's
+    new/ — no delivery, no resurrection. A handoff parked for a session that then died could not
+    be unsent by NAME (only the raw box id worked, which nobody has at hand); _recall now falls
+    back to the durable name map when the name no longer resolves live. Ambiguity still refuses:
+    two dead boxes wearing one name is not a guess the sender authorized."""
+
+    def setUp(self):
+        _set_live([{"id": ALPHA, "name": "alpha"}])
+
+    def tearDown(self):
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        for rid in (GHOST, "99999999-8888-7777-6666-555555555556"):
+            box = pm.MAILROOT / rid / "new"
+            if box.is_dir():
+                for f in box.iterdir():
+                    f.unlink()
+
+    def _park(self, rid, name, mid="m1"):
+        box = pm.MAILROOT / rid / "new"
+        box.mkdir(parents=True, exist_ok=True)
+        (box / mid).write_text("From: alpha\nFrom-Id: %s\nX-Park: 1\n\nthe handoff body" % ALPHA)
+        pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
+        (pm.NAMES_DIR / rid).write_text("%s\thost" % name)
+
+    def test_recall_by_dead_name_finds_the_parked_box(self):
+        self._park(GHOST, "ghost")
+        removed = pm._recall(ALPHA, "ghost", None)
+        self.assertEqual([r["id"] for r in removed], ["m1"])
+        self.assertEqual(list((pm.MAILROOT / GHOST / "new").iterdir()), [])
+
+    def test_two_dead_boxes_one_name_refuses(self):
+        twin = "99999999-8888-7777-6666-555555555556"
+        self._park(GHOST, "ghost", mid="m1")
+        self._park(twin, "ghost", mid="m2")
+        self.assertEqual(pm._recall(ALPHA, "ghost", None), [])
+
+    def test_only_the_senders_own_mail_comes_back(self):
+        self._park(GHOST, "ghost")
+        self.assertEqual(pm._recall("00000000-0000-0000-0000-000000000001", "ghost", None), [])
+
+
+class KernelSilenceIsNotDeadness(unittest.TestCase):
+    """The liveness source not ANSWERING is different information from "nobody by that name is
+    live" (the authoritative-sources rule: fail loudly, never degrade silently). _kernel_sessions
+    collapsed both to [], so a send during a kernel restart was refused with a false deadness
+    claim about a demonstrably live peer (sighting 2026-08-29; the retry 101s later delivered).
+    resolve_recipient now probes the source once on the refusal path and answers 503-honestly."""
+
+    def setUp(self):
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        self._base = pm.KERNEL_BASE
+        pm.KERNEL_BASE = "http://127.0.0.1:9"      # nothing listens: every fetch fails fast
+
+    def tearDown(self):
+        pm.KERNEL_BASE = self._base
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        pm.HEARTBEATS.clear()
+
+    def test_unanswered_source_refuses_without_claiming_death(self):
+        res = pm.resolve_recipient("ghost")
+        self.assertEqual((res["kind"], res["status"]), ("error", 503))
+        self.assertIn("didn't answer", res["error"])
+        self.assertNotIn("no live romp session", res["error"], "the false deadness claim is the bug")
+
+    def test_an_answered_empty_listing_still_refuses_as_not_live(self):
+        _set_live([])
+        res = pm.resolve_recipient("ghost")
+        self.assertEqual((res["kind"], res["status"]), ("error", 404))
+        self.assertIn("no live romp session named 'ghost'", res["error"])
+
+
 class RemovedSurfacesAreGone(unittest.TestCase):
     def test_removed_mcp_tools_absent(self):
         names = _tool_names()


### PR DESCRIPTION
## Why

Overnight (2026-08-28/29), three kernel-watch failures cost real recovery turns:
- Two cluster-job watches expired at 1h caller-habit timeouts while their conditions held later — the watch gave up exactly when it was still needed.
- A `pgrep -f` predicate matched its own `sh -c` wrapper (whose argv carried the watched job's command line) and reported still-running until the timeout flushed it, 35 minutes after actual completion.

Auditing the same surface turned up two more holes: the tick retired a watch even when its notice FAILED to deliver (a met condition silently lost), and two postal liveness edges (below).

## What changed

**Soft/hard timeout split** (`_watch_tick`, `kernel/kernel.py`): a caller bound shorter than the kernel's 24h default no longer ends a watch — at the caller bound the registrant gets one still-watching check-in (naming the cancel id) and the watch re-arms through the default cap, where the giving-up notice ends it as ever (the standing never-a-silent-dead-loop rule). A bound at or past the default is an explicit choice and ends there. The `soft` mark is persisted so a restart never repeats the check-in.

**Script-file predicates** (`_watch_run`): the predicate text lives in a script file and the runner's argv carries only its path, so a `pgrep -f` pattern can never match the watch's own wrapper — structural, not a caller convention. Registration answers with a loud hint when the predicate uses `pgrep/pkill -f` (wrappers the predicate itself spawns, like an ssh far-side shell, are the caller's construction and still self-match). Boot sweeps the scratch dir for scripts stranded by a crash mid-run.

**Delivery-checked retirement**: a watch notice that fails to deliver keeps its row for the next cadence and retries, bounded an hour past the hard cap (stderr, never a zombie).

**Postal fold-ins** (`postal/postal_service.py`):
- *Recall reaches parked mail for the dead*: recall is not addressing — the sender is unsending their own bytes, not raising the dead. A name that no longer resolves live falls back to the durable name map; two dead boxes wearing one name still refuse.
- *Kernel silence is not deadness*: `_kernel_sessions` collapsed kernel-didn't-answer into an empty listing, so a send during a kernel restart was refused with a false deadness claim about a demonstrably live peer (the retry 101s later delivered). `resolve_recipient` now probes the source once on the refusal path when the local world came back empty, and answers 503-honestly (retry shortly) instead.

**Named, not taken**: cross-host tracked delegation (the primary/satellite pair can't span kernels; the relay already degrades loudly, and un-degrading it is a pending design decision).

## Tests

`tests/test_generic_watch.py`: soft-then-hard sequence, once-only check-in, soft-mark restart persistence, explicit-long-bound semantics, met-survives-failed-delivery, undeliverable-bounded drop, real-runner self-match regression (`pgrep -f` on a token nothing runs), scratch cleanup, registration-hint seam. `tests/test_postal_live_only.py`: recall-by-dead-name, dead-twin refusal, sender-only scope; unanswered-source 503 vs answered-empty 404.

Full local suites: pytest 6080 passed / 34 skipped; vscode-extension 2554 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)