### PR TITLE
A parked goal sleeps: event-indexed parking, rows only on state changes

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5527,6 +5527,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     # follow-ups (the user 2026-06-28). Due goals COLLECT into to_fire and go out ONCE after the loop —
     # several in the same tick bundle into one message (the user 2026-07-24) instead of N separate ones.
     to_fire = []                                     # [(gid, count, stalled)] due THIS tick
+    _pworld = {}                                     # the park gate's lazy world read (report + settle
+    #                                                  key), shared with the judge batch below so the
+    #                                                  tick's read count and sequencing don't change
     for gid in list(nodes):
         nd = nodes[gid]
         if nd.get("parentId") is not None or nd.get("cleared") or gid in cleared:
@@ -5550,6 +5553,39 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             # same records, same response gates, same escalation, its own copy (see _wake_goal).
             fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, tmux) or fired
             continue
+        # PARK GATE (the user 2026-08-30, the parked-tick round): a goal whose record holds the full
+        # memo pair is PARKED — the ruling already said this exact world doesn't warrant a fire — so
+        # it must not be re-evaluated (or logged) at every pass: 98.5% of a day's nudge-events rows
+        # (8877 of 9010) were per-visit memo re-serves on parked goals, ~9k rows/day, the worst goal
+        # 2628 rows in 15h. Event-indexed instead: while BOTH keys still match the current world and
+        # the dead-man stand is unexpired, continue with no row and no machinery; the goal re-enters
+        # exactly on its own events — a key move lifts the park (one re-armed row, then the batch
+        # re-judges), dead-man expiry falls through to the batch's parked-backstop fire. One lazy
+        # world read per session-tick, SHARED with the judge batch below (reads and freshness-guard
+        # sequencing unchanged). An unreadable report read keeps the park — the memo's own semantics
+        # ("dies when the report MOVES"), never a blind re-arm. Sits BELOW the awaiting-stamp branch
+        # on purpose: a judge stamping a wait on a parked goal still takes the wake ladder (that
+        # verdict moves neither memo key), and ABOVE the reviver/deferral machinery, which exists to
+        # protect fires this goal isn't taking.
+        _prec = nudged.get(gid) or {}
+        if _prec.get("redundantEvT") and "redundantSettleT" in _prec and not _prec.get("failed"):
+            if "r" not in _pworld:
+                _pworld["r"] = _last_assistant_report(s["path"])
+                _pworld["s"] = _settle_event_key(sid)
+            _cur_ts, _cur_st = _pworld["r"][1], _pworld["s"]
+            _panch = max(_prec.get("answeredAt") or 0, _prec.get("at") or 0)
+            if not _cur_ts or (_prec["redundantEvT"] == _cur_ts
+                               and _prec["redundantSettleT"] == _cur_st):
+                if _panch and now - _panch <= AWAITING_DEADMAN_SECS:
+                    continue                         # PARKED: asleep until its own next event
+                #                                      (dead-man expired → fall through: the batch's
+                #                                       parked-backstop leg owns the fire)
+            else:
+                _log_nudge_event(sid, gid, now, _prec.get("count") or 0, verdict="re-armed",
+                                 ev_t=_cur_ts, parked_s=(now - _panch) if _panch else None)
+                #                                    ^ the park LIFTED — one row per state change,
+                #                                      visible even if a downstream hold then defers
+                #                                      the fire; the batch re-judges right after
         # LAST-RESORT GATE (the user 2026-07-22): every OTHER mechanism that could still move this card
         # off 'working' must be exhausted first. This is what the 2026-07-22 false interrupt needed: the
         # card's 'working' came from a STALE agent-to-do mirror, and the nudge fired before the sync that
@@ -5654,13 +5690,15 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         # report as the ANSWER (answeredAt: the ladder measures its next patience window from it,
         # exactly as it would from a real reply) and skips the fire. Any failure fires as before —
         # the gate is an optimization, the ladder is the job.
-        recent, recent_ts = _last_assistant_report(s["path"])
+        recent, recent_ts = _pworld["r"] if "r" in _pworld else _last_assistant_report(s["path"])
         if recent:
             try:
                 _nodes = jd.load_goals(sid).get("nodes", {})
             except Exception:
                 _nodes = {}
-            settle_t = _settle_event_key(sid)      # the memo's second key half — one read per tick
+            settle_t = _pworld["s"] if "s" in _pworld else _settle_event_key(sid)
+            #                                      ^ the memo's second key half — the park gate's
+            #                                        read when it ran, one read per tick either way
 
             def _judge_batch(cands, report, report_ts, held_pass):
                 keep = []

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3791,10 +3791,12 @@ def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None, parked_s=No
     for the timeline's DEBUG judging band (per-nudge ⚡ marker) AND the redundancy accounting (the
     user 2026-08-25): every decision the gate takes is a row — fired / skipped-redundant /
     held-fresh-re-judged / fired-at-cap / skipped-redundant-at-cap / skipped-redundant-memo (the
-    T142 memo served a ruling already made on this exact evidence, no judge call; the row carries
-    parkedS — seconds the session has sat parked since the skip's answeredAt — so the quiet-session
-    deadlock fingerprint is countable from this log alone, 2026-08-29) / fired-parked-backstop (the
-    memo held but the session sat parked past the dead-man stand — the fire re-engages it) /
+    T142 memo served a ruling already made on this exact evidence, no judge call — since the
+    parked-tick round, 2026-08-30, a parked goal SLEEPS at the gate instead, so this row marks a
+    rare race, never a per-visit re-serve) / re-armed (the park lifted: a memo key moved — written
+    once per key-move, carrying parkedS, seconds since the skip's answeredAt) /
+    fired-parked-backstop (the memo held but the session sat parked past the dead-man stand — the
+    fire re-engages it; carries the final parkedS via its evidence row) /
     resolved-at-send / blocked-on-user-at-send — carrying the evidence snapshot's timestamp, so redundant fires are
     countable from the log alone. That accounting is what extended the freshness guard to the cap
     path (the user 2026-08-27, T120: the pre-T120 force-fired-at-cap rows measured the blind fire
@@ -5580,12 +5582,16 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                     continue                         # PARKED: asleep until its own next event
                 #                                      (dead-man expired → fall through: the batch's
                 #                                       parked-backstop leg owns the fire)
-            else:
+            elif (_cur_ts, _cur_st) != (_prec.get("rearmEvT"), _prec.get("rearmSettleT")):
+                # the park LIFTED — one row per state change. The stamp below is what makes it
+                # once: a downstream hold can defer the fire for many ticks with the memo keys
+                # still the old pair, and without the stamp this leg re-logged per visit (the
+                # adversarial pass's catch) — the very shape this round kills. A fire replaces
+                # the record (stamp drops); a re-memo re-parks it (this leg unreachable).
                 _log_nudge_event(sid, gid, now, _prec.get("count") or 0, verdict="re-armed",
                                  ev_t=_cur_ts, parked_s=(now - _panch) if _panch else None)
-                #                                    ^ the park LIFTED — one row per state change,
-                #                                      visible even if a downstream hold then defers
-                #                                      the fire; the batch re-judges right after
+                nudged[gid] = dict(_prec, rearmEvT=_cur_ts, rearmSettleT=_cur_st)
+                _put_nudged(gid, nudged[gid])
         # LAST-RESORT GATE (the user 2026-07-22): every OTHER mechanism that could still move this card
         # off 'working' must be exhausted first. This is what the 2026-07-22 false interrupt needed: the
         # card's 'working' came from a STALE agent-to-do mirror, and the nudge fired before the sync that

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -220,8 +220,8 @@ class FreshGuard(unittest.TestCase):
         self._tick()
         self.assertEqual(self.sent, [])
         self.assertEqual(self.judge_calls, [], "the memo serves the ruling — no call")
-        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant-memo"])
-        self.assertEqual(self._rows()[0]["evT"], ARM_T + 50)
+        self.assertEqual(self._rows(), [], "a parked visit logs nothing (the parked-tick round: "
+                                           "rows mark state changes, never visits)")
 
     def test_the_at_cap_flip_class_dies_by_construction(self):
         # 3 of 10 measured fired-at-cap rows were the judge FLIPPING on a (gid, evT) it had just
@@ -233,8 +233,8 @@ class FreshGuard(unittest.TestCase):
         self.judge_replies = [False]                  # the flip verdict, never reachable
         self._tick()
         self.assertEqual(self.sent, [], "a pair ruled redundant can never fire on the same evidence")
+        self.assertEqual(self._rows(), [], "…and the parked visit logs nothing")
         self.assertEqual(self.judge_calls, [])
-        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant-memo"])
 
     def test_a_judged_redundancy_stamps_the_memo(self):
         self.judge_replies = [True]

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -127,18 +127,19 @@ class MemoDeadlock(unittest.TestCase):
     def _rec(self):
         return km._auto_nudge_data()["nudged"][G1]
 
-    # ── the memo veto: two keys, active-session behavior preserved ──
-    def test_same_evidence_same_settle_serves_the_memo_with_parked_s(self):
+    # ── the park gate: a parked goal sleeps — no rows, no work, per visit ──
+    def test_a_parked_goal_sleeps_silently(self):
+        # the parked-tick round (the user 2026-08-30): per-visit memo re-serves were 98.5% of a
+        # day's nudge-events rows (~9k/day). A goal whose memo pair still matches the world is
+        # PARKED: the gate continues before the fire list, the judge batch, and the log — the
+        # log gains rows only on state CHANGES (park mint / re-armed / fired), never per visit.
         self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
                         "redundantSkips": 1, "redundantEvT": ARM_T + 50, "redundantSettleT": 0})
         self._tick()
-        self.assertEqual(self.sent, [], "the memo veto stands — no fire")
-        self.assertEqual(self.judge_calls, [], "served from the memo, no judge call")
-        rows = self._rows()
-        self.assertEqual([r["verdict"] for r in rows], ["skipped-redundant-memo"])
-        self.assertEqual(rows[0]["parkedS"], 300,
-                         "the row carries the parked duration — the deadlock fingerprint is "
-                         "countable from the log alone")
+        self._tick()
+        self.assertEqual(self.sent, [], "the park stands — no fire")
+        self.assertEqual(self.judge_calls, [], "…no judge call")
+        self.assertEqual(self._rows(), [], "…and NO rows: two parked visits, zero log growth")
 
     def test_a_new_settle_event_rearms_exactly_one_rejudge_then_rememos(self):
         self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
@@ -150,10 +151,13 @@ class MemoDeadlock(unittest.TestCase):
         self.assertEqual(len(self.judge_calls), 1, "the new settle bought exactly ONE re-judge")
         self.assertEqual(self._rec().get("redundantSettleT"), NOW - 30,
                          "…which re-memos against the new settle key")
+        rows = self._rows()
+        self.assertEqual([r["verdict"] for r in rows], ["re-armed", "skipped-redundant"],
+                         "one row per state change: the park lifted, then the re-park")
+        self.assertEqual(rows[0]["parkedS"], 300, "the re-armed row says how long it sat")
         self._tick()
-        self.assertEqual(len(self.judge_calls), 1, "same pair again → served from the memo, no loop")
-        self.assertEqual([r["verdict"] for r in self._rows()],
-                         ["skipped-redundant", "skipped-redundant-memo"])
+        self.assertEqual(len(self.judge_calls), 1, "same pair again → parked, no loop")
+        self.assertEqual(len(self._rows()), 2, "…and the parked visit logs nothing")
 
     def test_a_pre_upgrade_record_missing_the_settle_key_rejudges_exactly_once(self):
         # THE UPGRADE PATH: every record minted before this change carries redundantEvT but no
@@ -171,9 +175,9 @@ class MemoDeadlock(unittest.TestCase):
         self.assertEqual(self._rec().get("redundantSettleT"), 0,
                          "…and the re-memo now carries the settle key")
         self._tick()
-        self.assertEqual(len(self.judge_calls), 1, "second tick serves from the upgraded memo")
-        self.assertEqual([r["verdict"] for r in self._rows()],
-                         ["skipped-redundant", "skipped-redundant-memo"])
+        self.assertEqual(len(self.judge_calls), 1, "second tick: parked on the upgraded memo")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant"],
+                         "…silently — the park is the state, the mint row was its record")
 
     # ── the parked dead-man: the quiet-session deadlock's exit ──
     def test_parked_past_the_deadman_fires_once_and_writes_a_fresh_record(self):

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -179,6 +179,32 @@ class MemoDeadlock(unittest.TestCase):
         self.assertEqual([r["verdict"] for r in self._rows()], ["skipped-redundant"],
                          "…silently — the park is the state, the mint row was its record")
 
+    def test_a_held_rearm_logs_once_not_per_visit(self):
+        # the adversarial pass's catch: a downstream hold can defer the fire for many ticks with
+        # the memo keys still the old pair — without the rearm stamp, re-armed logged per visit,
+        # the very shape this round kills. Simulate the hold with a not-redundant verdict whose
+        # fire is deferred by a reviver: judge says fire, reviver defers, keys unchanged.
+        self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50, "redundantSettleT": 0})
+        km._last_state = lambda sid: ("idle", NOW - 30)   # a key moved → the park lifts
+        km._revivers_pending = lambda *a: "judge-pass"     # …but a reviver holds every fire
+        self._tick()
+        self._tick()
+        self.assertEqual(self.sent, [], "the hold defers the fire")
+        self.assertEqual([r["verdict"] for r in self._rows()], ["re-armed"],
+                         "…and the lift logged ONCE across both held visits")
+
+    def test_an_unreadable_report_keeps_the_park(self):
+        # the conservative leg: the memo dies when the report MOVES — a transient read failure is
+        # not a move, so the park stands (no re-arm row, no judge call, no fire).
+        self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": NOW - 300,
+                        "redundantSkips": 1, "redundantEvT": ARM_T + 50, "redundantSettleT": 0})
+        self.reports = [("", 0)]
+        self._tick()
+        self.assertEqual(self.sent, [], "no blind re-arm off a failed read")
+        self.assertEqual(self.judge_calls, [])
+        self.assertEqual(self._rows(), [])
+
     # ── the parked dead-man: the quiet-session deadlock's exit ──
     def test_parked_past_the_deadman_fires_once_and_writes_a_fresh_record(self):
         self._seed_rec({"lastTurnId": "t0", "count": 1, "answeredAt": PARKED,

--- a/tests/test_nudge_redundancy.py
+++ b/tests/test_nudge_redundancy.py
@@ -75,7 +75,8 @@ class NudgeRedundancy(unittest.TestCase):
         # the snapshot read carries its timestamp so a report landing mid-deliberation holds the
         # fire and re-judges once — the anchors below moved with it
         self.assertIn("jd.nudge_redundant(gtxt, report)", src)
-        self.assertIn('recent, recent_ts = _last_assistant_report(s["path"])', src)
+        self.assertIn('recent, recent_ts = _pworld["r"] if "r" in _pworld '
+                      'else _last_assistant_report(s["path"])', src)
         self.assertIn("redundantSkips=skips + 1", src)
         self.assertIn("if gtxt and jd.nudge_redundant", src,
                       "the judge is consulted on EVERY due fire — past two consecutive skips the "


### PR DESCRIPTION
## Summary
The memo-deadlock fix parked goals correctly but the tick kept re-visiting them: every ~19s pass re-entered the due path, re-served the memo, and logged a row — 8,877 of 9,010 nudge-events rows in 24h (98.5%) were per-visit memo re-serves, the worst goal 2,628 rows in 15h, ~9k rows/day of log growth against 47 real fires.

- **Park gate, event-indexed.** A goal whose record holds the full memo pair gets a gate early in the due loop — below the awaiting-stamp branch (a judge stamping a wait still takes the wake ladder), above the reviver/deferral machinery. While both keys match the current world and the dead-man is unexpired: no row, no work. The goal re-enters exactly on its own events — a key move lifts the park, dead-man expiry falls through to the parked-backstop fire. One lazy world read per session-tick, cached and shared with the judge batch (read count and freshness-guard sequencing unchanged). An unreadable report read keeps the park, never a blind re-arm.
- **Rows mark state changes, never visits.** parked = the existing skipped-redundant mint row; re-armed = a new row written once per key-move (stamped on the record, so a downstream hold deferring the fire can't re-log it — an adversarial-review catch), carrying parkedS; fired / fired-parked-backstop unchanged. Per-visit skipped-redundant-memo rows cease entirely.

Projected from the live 24h window: ~9k rows/day → a handful per park episode (mint + at most one re-arm + at most one fire), with the judged-decision rate untouched.

## Test plan
- `tests/test_nudge_memo_deadlock.py` grown to 12 tests: two parked visits log zero rows with zero judge calls; the re-arm cycle logs exactly [re-armed, skipped-redundant]; a held re-arm logs once across visits; an unreadable read keeps the park; upgrade path parks silently after its one re-judge; dead-man, moot, and settle-key ladders unchanged.
- T142/T120 pins updated to the same no-judge-call intent with empty logs; the redundancy source-pin follows the cache-aware read.
- Full Python suite: 6,071 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)