### PR TITLE
A multi-item brief covers every owed item: counted retry, then the verbatim list

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10933,25 +10933,40 @@ def _distill_session(fsid, path, now):
             # built verbatim from the owed pairs — complete by construction, the stamps align, and
             # honest-plain beats polished-lossy. Countable only for a LIST; a single why that
             # names several decisions inside its own prose has no deterministic item count.
+            _fallback_brief = False
             if not proc_only and isinstance(owed, list) and len(owed) > 1:
-                _paras = [p for p in out.split("\n\n") if p.strip()]
+                # count with the FEED's own split (\n\s*\n, feed.ts paras) — a stricter literal
+                # \n\n read a blank-ish separator as one paragraph and manufactured a shortfall
+                # the render would never show (the adversarial pass's catch)
+                _paras = [p for p in re.split(r"\n\s*\n", out) if p.strip()]
                 if len(_paras) < len(owed):
                     _r2 = brief_llm(nodes[top].get("text", ""), work, owed,
                                     frame=_deleg_frame(store, top),
                                     user_ask=_user_ask_text(store, top, fsid, path, now),
                                     shortfall=(len(_paras), len(owed)))
+                    if not _r2 and getattr(_judge_ctx, "paused", False):
+                        # the retry was SKIPPED, not tried — the standing pause discipline: leave
+                        # the brief null and re-enter next pass once the pause clears; a pause-skip
+                        # never counts as a verdict (the 2026-07-03 rule, met again here)
+                        changed = True
+                        continue
                     _o2, _s2 = _split_source(_r2 or "")
                     _b2, _o2 = _split_sections(_o2)
-                    if len([p for p in _o2.split("\n\n") if p.strip()]) >= len(owed):
+                    if _r2 and len([p for p in re.split(r"\n\s*\n", _o2) if p.strip()]) >= len(owed):
                         raw, out, src = _r2, _o2, _s2
                         bg = _b2 or bg                 # keep the draft's orientation if the retry lost it
                     else:
                         out = "\n\n".join("%s: %s" % ((t or "this sub-goal").strip().rstrip("."),
                                                        (w or "").strip()) for t, w in owed)
                         src = None                     # verbatim recorded whys — no model citation
+                        _fallback_brief = True         # …so the cite-miss check below stands down:
+                        #                                romp authored this text; "no SOURCE line"
+                        #                                would report the stale first draft's tail
                         _log_judge_error("briefer", fsid, "owed-shortfall", goal=top,
-                                         note="draft covered %d of %d owed items; retry still short; "
-                                              "stored the verbatim owed list" % (len(_paras), len(owed)))
+                                         note="draft covered %d of %d owed items; %s; "
+                                              "stored the verbatim owed list"
+                                              % (len(_paras), len(owed),
+                                                 "retry still short" if _r2 else "retry call failed"))
             nodes[top]["blockSummary"] = out            # full text — NEVER truncate a brief mid-word (the user 2026-07-06)
             nodes[top]["background"] = bg if bg else None   # re-orientation for a reader who forgot the thread (2026-07-02)
             # PER-PARAGRAPH stamps (the user 2026-07-24): a MULTI-item brief writes one paragraph per
@@ -10965,8 +10980,11 @@ def _distill_session(fsid, path, now):
             # the brief's cited source, else the WRITE-TIME deterministic stamp: the newest labeled atom
             # the gather fed this very call (the user 2026-07-21) — every brief ships a stored anchor
             nodes[top]["summaryAnchor"] = marks.map.get(src) or marks.newest()
-            if marks.map and marks.map.get(src) is None:   # labels offered, no usable citation → log only:
-                # the stamp already grounded the anchor, so a card warn would be noise (the user 2026-07-21)
+            if marks.map and marks.map.get(src) is None and not _fallback_brief:
+                # labels offered, no usable citation → log only (the stamp already grounded the
+                # anchor, so a card warn would be noise, the user 2026-07-21). The verbatim
+                # fallback stands down: romp authored that text, and the row would report the
+                # STALE first draft's tail as the offender (the adversarial pass's catch).
                 _log_judge_error("staller" if proc_only else "briefer", fsid, "cite-miss", goal=top, note="%s; %d labels offered; reply tail: %r" % (
                     ("cited unoffered label %s" % src) if src else "no SOURCE line", len(marks.map), (raw or "")[-160:]))
             _node_warn_clear(nodes[top], "cite-miss")      # anchored either way → any older warn is over

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10308,7 +10308,7 @@ BLOCK_BRIEF_SYS = (
     "must be exactly SOURCE: mN. Do not stop at the takeaway; the SOURCE line always comes last.")
 
 
-def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None):
+def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None, shortfall=None):
     """The briefer's decision brief for one blocked goal from the TRIAGE-tier model (Sonnet). '' on
     failure. Logged as judge='briefer' — its own name, its own prompt (the user 2026-07-08). Its timeline
     mark still rides the distiller row: the kernel folds fine labels to role-family rows (_JUDGE_FAMILY),
@@ -10345,6 +10345,18 @@ def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None):
         user += ("\n<note>The <delegating-request> is how this work was framed when it was handed "
                  "to this session — usually the requester's own words. State what is owed in those "
                  "terms; keep implementation nouns to the supporting detail.</note>")
+    if shortfall:
+        # THE OWED-COVERAGE RETRY (the user 2026-08-30, the dropped-4th-decision specimen): the
+        # standing TAKEAWAY spec is measured wording (see the note above BLOCK_BRIEF_SYS) and
+        # allows same-decision items to merge — which makes an OMITTED item indistinguishable
+        # from a merge in the reply. This per-call note fires only on a counted shortfall, so
+        # the green path's measured behavior is untouched; it overrides the merge allowance for
+        # this one reply because complete coverage outranks brevity once an item has provably
+        # gone missing (the user had to ask what the missing decision was).
+        user += ("\n<note>Your previous draft covered %d of the %d owed items in <owed>. Even "
+                 "when items come down to the same decision, write one short paragraph per owed "
+                 "item, in <owed>'s order — exactly %d paragraphs, each leading with its item's "
+                 "own decision.</note>" % (shortfall[0], shortfall[1], shortfall[1]))
     return _judge_run(_distill_model(), BLOCK_BRIEF_SYS, user, judge="briefer", tier="distill",
                       mark=mk).strip()   # caller splits SOURCE, then caps
 
@@ -10912,6 +10924,34 @@ def _distill_session(fsid, path, now):
             raw = out
             out, src = _split_source(out)
             bg, out = _split_sections(out)
+            # OWED COVERAGE IS COUNTABLE (the user 2026-08-30): a multi-item <owed> demands one
+            # paragraph per item, but the merge allowance made a dropped item look like a merge —
+            # the live specimen rendered decisions 1-3 whole and omitted the 4th entirely, and the
+            # user had to ask what was missing. Fewer paragraphs than owed items is the omission
+            # signal (more is fine — the trailing leftover paragraph): retry ONCE with the
+            # corrective note, and if the count still falls short, store the deterministic brief
+            # built verbatim from the owed pairs — complete by construction, the stamps align, and
+            # honest-plain beats polished-lossy. Countable only for a LIST; a single why that
+            # names several decisions inside its own prose has no deterministic item count.
+            if not proc_only and isinstance(owed, list) and len(owed) > 1:
+                _paras = [p for p in out.split("\n\n") if p.strip()]
+                if len(_paras) < len(owed):
+                    _r2 = brief_llm(nodes[top].get("text", ""), work, owed,
+                                    frame=_deleg_frame(store, top),
+                                    user_ask=_user_ask_text(store, top, fsid, path, now),
+                                    shortfall=(len(_paras), len(owed)))
+                    _o2, _s2 = _split_source(_r2 or "")
+                    _b2, _o2 = _split_sections(_o2)
+                    if len([p for p in _o2.split("\n\n") if p.strip()]) >= len(owed):
+                        raw, out, src = _r2, _o2, _s2
+                        bg = _b2 or bg                 # keep the draft's orientation if the retry lost it
+                    else:
+                        out = "\n\n".join("%s: %s" % ((t or "this sub-goal").strip().rstrip("."),
+                                                       (w or "").strip()) for t, w in owed)
+                        src = None                     # verbatim recorded whys — no model citation
+                        _log_judge_error("briefer", fsid, "owed-shortfall", goal=top,
+                                         note="draft covered %d of %d owed items; retry still short; "
+                                              "stored the verbatim owed list" % (len(_paras), len(owed)))
             nodes[top]["blockSummary"] = out            # full text — NEVER truncate a brief mid-word (the user 2026-07-06)
             nodes[top]["background"] = bg if bg else None   # re-orientation for a reader who forgot the thread (2026-07-02)
             # PER-PARAGRAPH stamps (the user 2026-07-24): a MULTI-item brief writes one paragraph per

--- a/tests/test_brief_owed_coverage.py
+++ b/tests/test_brief_owed_coverage.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""OWED COVERAGE IS COUNTABLE (the user 2026-08-30). The briefer's contract writes one paragraph
+per owed item, but the merge allowance ("several that come down to the SAME decision, write ONE
+paragraph") made an OMITTED item indistinguishable from a merge: the live specimen rendered owed
+decisions 1-3 whole and dropped the 4th entirely, and the user had to ask what was missing. The
+standing TAKEAWAY spec is measured wording (see the note above BLOCK_BRIEF_SYS) and stays
+untouched; the enforcement is kernel-side: fewer takeaway paragraphs than owed items is the
+omission signal (more is fine — the trailing leftover paragraph), and it earns ONE corrective
+retry whose per-call note overrides the merge allowance, then a deterministic fallback built
+verbatim from the owed pairs — complete by construction, honest-plain over polished-lossy.
+Countable only for a multi-item owed LIST; a single why naming several decisions inside its own
+prose has no deterministic item count. SYNTHETIC fixtures only."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_owedcov", os.path.join(BIN, "romp-judge")).load_module()
+em = jd.em
+
+NOW = 1_787_800_000
+T0 = NOW - 3600
+SID = "f44e0002-1111-4222-8333-000000000001"    # private synthetic sid — never the shared placeholder
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _node(nid, text, parent, t=T0, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return base
+
+
+WHYS = ["confirm the six-step rollout order or reorder it",
+        "pick the scored labels for the size ladder",
+        "set the download timing for the hardened instruments",
+        "extend the read-view check now, or after the crossings"]
+
+P3 = "BACKGROUND: b.\n\nTAKEAWAY: Decide the rollout order.\n\nPick the labels.\n\nSet the timing."
+P4 = P3 + "\n\nDecide the read-view timing."
+
+
+class OwedCoverage(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.path = Path(self.td.name) / (SID + ".jsonl")
+        self.path.write_text(json.dumps(
+            {"type": "user", "timestamp": iso(T0), "uuid": "u1", "parentUuid": None,
+             "promptSource": "typed",
+             "message": {"role": "user", "content": "please plan the capture rollout"}}) + "\n")
+        self._brief = jd.brief_llm
+        self.calls = []                                # [(owed, shortfall)]
+        self.replies = []
+        test = self
+
+        def fake_brief(goal_text, work, owed, frame=None, user_ask=None, shortfall=None):
+            test.calls.append((owed, shortfall))
+            return test.replies[min(len(test.calls) - 1, len(test.replies) - 1)]
+        jd.brief_llm = fake_brief
+
+    def tearDown(self):
+        jd.brief_llm = self._brief
+        for d in (jd.GOALDIR, jd.GOALARCHDIR):
+            try:
+                (d / (SID + ".json")).unlink()
+            except OSError:
+                pass
+        try:
+            (jd._overrides_dir() / (SID + ".jsonl")).unlink()
+        except OSError:
+            pass
+        self.td.cleanup()
+
+    def _world(self, k=4):
+        st = {"rompUuid": SID, "seq": 6, "nodes": {}, "placements": {}, "status": {}}
+        st["nodes"]["g"] = jd.GuardedNode(_node("g", "plan the capture rollout", None))
+        for i in range(k):
+            nid = "c%d" % i
+            st["nodes"][nid] = jd.GuardedNode(_node(nid, "decision %d" % (i + 1), "g",
+                                                    t=T0 + i, mt=T0 + i))
+            # blocks land as VERDICTS — a bare flag never rolls the top to blocked
+            jd.record_verdict(st, st["nodes"][nid], "closer", "block", T0 + 100 + i, why=WHYS[i])
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        return st
+
+    def _run(self):
+        return jd._distill_session(SID, str(self.path), NOW)
+
+    def _stored(self):
+        return jd.load_goals(SID)["nodes"]["g"]
+
+    def test_a_complete_brief_stores_in_one_call(self):
+        self._world()
+        self.replies = [P4]
+        self._run()
+        self.assertEqual(len(self.calls), 1, "four paragraphs for four items → no retry")
+        self.assertIsNone(self.calls[0][1], "…and no shortfall note on the first call")
+        nd = self._stored()
+        self.assertIn("read-view timing", nd["blockSummary"])
+        self.assertEqual(len(nd.get("briefParts") or []), 4)
+
+    def test_a_dropped_item_earns_one_corrective_retry(self):
+        # the specimen's shape: decisions 1-3 whole, the 4th omitted entirely
+        self._world()
+        self.replies = [P3, P4]
+        self._run()
+        self.assertEqual(len(self.calls), 2, "counted shortfall → exactly one retry")
+        self.assertEqual(self.calls[1][1], (3, 4), "the retry names the counted shortfall")
+        self.assertIn("read-view timing", self._stored()["blockSummary"],
+                      "the retry's complete brief is the one stored")
+
+    def test_a_still_short_retry_falls_back_to_the_verbatim_owed_list(self):
+        self._world()
+        self.replies = [P3, P3]
+        self._run()
+        self.assertEqual(len(self.calls), 2, "one retry, never a loop")
+        bs = self._stored()["blockSummary"]
+        for why in WHYS:
+            self.assertIn(why, bs, "the fallback carries every owed why verbatim — complete "
+                                   "by construction, an item can never silently vanish")
+        self.assertEqual(len([p for p in bs.split("\n\n") if p.strip()]), 4)
+
+    def test_a_single_item_owed_is_out_of_the_contract(self):
+        self._world(k=1)
+        self.replies = [P3]
+        self._run()
+        self.assertEqual(len(self.calls), 1, "a lone why has no deterministic item count — "
+                                             "no retry however many paragraphs come back")
+        self.assertIsNone(self.calls[0][1])
+
+
+class ShortfallNote(unittest.TestCase):
+    """The real brief_llm renders the corrective note — per-call, never a standing reword of the
+    measured TAKEAWAY spec (the regression warning above BLOCK_BRIEF_SYS)."""
+
+    def setUp(self):
+        self.calls = {}
+        self._saved = jd._judge_run
+
+        def fake(model, sys_p, user, judge=None, tier=None, mark=None, **kw):
+            self.calls.update(user=user)
+            return "BACKGROUND: b\n\nTAKEAWAY: t"
+        jd._judge_run = fake
+
+    def tearDown(self):
+        jd._judge_run = self._saved
+
+    def test_the_note_names_the_count_and_overrides_the_merge_allowance(self):
+        jd.brief_llm("g", "w", [("a", "why a"), ("b", "why b")], shortfall=(1, 2))
+        self.assertIn("covered 1 of the 2 owed items", self.calls["user"])
+        self.assertIn("exactly 2 paragraphs", self.calls["user"])
+        self.assertIn("Even when items come down to the same decision", self.calls["user"],
+                      "the override is per-call: the standing spec keeps its measured merge clause")
+
+    def test_no_shortfall_no_note(self):
+        jd.brief_llm("g", "w", [("a", "why a"), ("b", "why b")])
+        self.assertNotIn("owed items in <owed>", self.calls["user"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_brief_owed_coverage.py
+++ b/tests/test_brief_owed_coverage.py
@@ -59,10 +59,15 @@ class OwedCoverage(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.path = Path(self.td.name) / (SID + ".jsonl")
-        self.path.write_text(json.dumps(
+        self.path.write_text("\n".join(json.dumps(r) for r in [
             {"type": "user", "timestamp": iso(T0), "uuid": "u1", "parentUuid": None,
              "promptSource": "typed",
-             "message": {"role": "user", "content": "please plan the capture rollout"}}) + "\n")
+             "message": {"role": "user", "content": "please plan the capture rollout"}},
+            {"type": "assistant", "timestamp": iso(T0 + 60), "uuid": "a1", "parentUuid": "u1",
+             "message": {"role": "assistant", "stop_reason": "end_turn",
+                         "content": [{"type": "text",
+                                      "text": "Four decisions are open on the rollout plan; "
+                                              "each is written up with its options."}]}}]) + "\n")
         self._brief = jd.brief_llm
         self.calls = []                                # [(owed, shortfall)]
         self.replies = []
@@ -105,6 +110,10 @@ class OwedCoverage(unittest.TestCase):
     def _stored(self):
         return jd.load_goals(SID)["nodes"]["g"]
 
+    def _errors(self):
+        p = jd.STATE / "judge-errors.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
     def test_a_complete_brief_stores_in_one_call(self):
         self._world()
         self.replies = [P4]
@@ -135,6 +144,12 @@ class OwedCoverage(unittest.TestCase):
             self.assertIn(why, bs, "the fallback carries every owed why verbatim — complete "
                                    "by construction, an item can never silently vanish")
         self.assertEqual(len([p for p in bs.split("\n\n") if p.strip()]), 4)
+        rows = self._errors()
+        self.assertIn("owed-shortfall", [r.get("err") for r in rows])
+        self.assertNotIn("cite-miss", [r.get("err") for r in rows],
+                         "romp authored the fallback text — a 'no SOURCE line' row would report "
+                         "the stale first draft's tail (the adversarial pass's catch; the fixture "
+                         "carries a labeled assistant reply so this guard is genuinely exercised)")
 
     def test_a_pause_skipped_retry_leaves_the_brief_null_for_the_next_pass(self):
         # the adversarial pass's catch: a retry the pause SKIPPED is not a short reply — counting

--- a/tests/test_brief_owed_coverage.py
+++ b/tests/test_brief_owed_coverage.py
@@ -136,6 +136,36 @@ class OwedCoverage(unittest.TestCase):
                                    "by construction, an item can never silently vanish")
         self.assertEqual(len([p for p in bs.split("\n\n") if p.strip()]), 4)
 
+    def test_a_pause_skipped_retry_leaves_the_brief_null_for_the_next_pass(self):
+        # the adversarial pass's catch: a retry the pause SKIPPED is not a short reply — counting
+        # it as one stored the fallback and logged a retry that never ran. The standing pause
+        # discipline holds: leave null, re-enter once the pause clears.
+        self._world()
+        test = self
+
+        def fake_paused(goal_text, work, owed, frame=None, user_ask=None, shortfall=None):
+            test.calls.append((owed, shortfall))
+            if shortfall:
+                jd._judge_ctx.paused = True
+                return ""
+            return P3
+        jd.brief_llm = fake_paused
+        try:
+            self._run()
+        finally:
+            jd._judge_ctx.paused = False
+        self.assertEqual(len(self.calls), 2)
+        self.assertIsNone(self._stored().get("blockSummary"),
+                          "nothing stored off a skipped call — next pass re-runs the whole brief")
+
+    def test_blankish_separators_count_as_the_feed_renders(self):
+        # the kernel counts with the feed's own split (\n\s*\n): a reply whose paragraphs are
+        # separated by a whitespace-bearing blank line is complete, not a shortfall
+        self._world()
+        self.replies = [P4.replace("\n\n", "\n \n")]
+        self._run()
+        self.assertEqual(len(self.calls), 1, "no spurious retry off a stricter split than the render")
+
     def test_a_single_item_owed_is_out_of_the_contract(self):
         self._world(k=1)
         self.replies = [P3]


### PR DESCRIPTION
## Summary
The optimizer's specimen pinned the class the dead-session round could only name: the briefer rendered owed decisions 1–3 whole and dropped the 4th entirely — no clamp anywhere (owed list, prompt sections, store, and render are all uncapped, verified), but the model omitting a paragraph, indistinguishable from the TAKEAWAY spec's legitimate merge allowance. The user had to ask what the missing decision was.

The standing prompt stays untouched — its wording is measured (the regression note above `BLOCK_BRIEF_SYS`) and the merge clause is pinned by the paragraph-contract tests. Enforcement is kernel-side, on the one countable signal:

- For a multi-item owed **list**, fewer takeaway paragraphs than owed items (counted with the feed's own `\n\s*\n` split) is the omission signal — more is fine, that's the trailing leftover paragraph.
- It earns **one corrective retry** whose per-call note names the counted shortfall and overrides the merge allowance for that reply alone.
- A still-short retry stores the **deterministic brief built verbatim from the owed pairs** — complete by construction, stamps align — and logs an owed-shortfall row. The cite-miss check stands down for it (romp authored the text).
- A **pause-skipped retry is not a short reply**: the standing pause discipline holds — leave the brief null, re-enter next pass (adversarial-review finding, as were the cite-miss stand-down and the split mismatch).
- A single why naming several decisions inside its own prose has no deterministic item count and stays out of the contract (named limit).

## Test plan
- New `tests/test_brief_owed_coverage.py` (8 tests) drives the real distill pass: complete brief = one call; the specimen's 3-of-4 shape = exactly one retry carrying (3, 4); still-short retry = verbatim fallback with every why present, owed-shortfall logged, **no** cite-miss row (fixture carries labeled work so the guard is genuinely exercised); pause-skipped retry leaves the brief null; whitespace-bearing separators count as the feed renders; single-item out of scope; the note's rendering pinned per-call against the standing spec.
- Full Python suite: 6,098 passed. Extension suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)