### PR TITLE
The reconnect strip leads the feed — above the first column chip

### DIFF
--- a/ui/webview/feed-hostload.test.ts
+++ b/ui/webview/feed-hostload.test.ts
@@ -57,6 +57,10 @@ test("the hint covers the WHOLE pending window: escalate at 45s, remove only on 
   assert.match(FEED, /if \(!pendingHosts\.length\) \{ strip\?\.remove\(\); return; \}   \/\/ the real events emptied the list — the only way off/);
   assert.match(FEED, /if \(!pendingHosts\.includes\(h\)\) \{   \/\/ the payload landed \(or the host detached\) — the ONLY removals/);
   assert.doesNotMatch(FEED, /hostloadGaveUp/, "no hide-set survives — nothing ever hides a true wait");
+  // placement (the user 2026-08-30): the strip LEADS the feed — first child, above the column chips,
+  // in both board states; re-inserted only when displaced, and non-interactive so the move is safe
+  assert.match(FEED, /if \(list\.firstChild !== strip\) list\.insertBefore\(strip, list\.firstChild\);/);
+  assert.doesNotMatch(FEED, /list\.appendChild\(strip\)/, "the bottom placement retired");
   // the three honest copies: loading → still waiting (45s) → a dead link names itself (fail-loudly)
   assert.match(FEED, /"loading cards from " \+ h \+ "\\u2026"/);
   assert.match(FEED, /"still waiting on " \+ h \+ "\\u2026"/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4392,7 +4392,11 @@ function ensureHostLoad(list: HTMLElement): void {
     strip = el("div", "");
     strip.id = "feed-hostload";
   }
-  list.appendChild(strip);   // last child in either board state (cards or the empty wordmark)
+  // FIRST child in either board state (the user 2026-08-30: the reconnect strip sits at the TOP of
+  // the feed, above the first column chip — it announces what is COMING, so it leads). Re-inserted
+  // only when displaced (a fresh empty-state paint replaces children); non-interactive, so the move
+  // is click-safe by construction.
+  if (list.firstChild !== strip) list.insertBefore(strip, list.firstChild);
   strip.replaceChildren(...pendingHosts.map((h) => {
     const line = el("div", "hostload-line");
     const swirl = el("span", "fask-awaiting-swirl");   // the shared reverse-spin glyph, LEFT of the text


### PR DESCRIPTION
The user (2026-08-30): put the loading-cards-from-server strip at the top of the feed, above the top chip, rather than at the bottom. The strip announces what is **coming**, so it leads: `ensureHostLoad` now inserts it as `#feed-list`'s first child in both board states — re-inserted only when displaced (a fresh empty-state paint replaces children), and non-interactive, so the move is click-safe by construction. On the empty wordmark state the strip sits quietly at the top with the wordmark centered below (verified headless — no crowding). Everything else stands: per-host lines, the retire-on-first-contribution event, the escalating backstop, the shared swirl. Placement pinned (first-child insert present, bottom append gone). 2558/2558 extension tests green; typecheck clean; both-states screenshot in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)