### PR TITLE
Awaited things show even while working, and kernel watches feed the green box

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11623,6 +11623,33 @@ def list_watches():
         return [{k: r.get(k) for k in _WATCH_KEYS} for r in _watches]
 
 
+def _watch_awaiting(sid):
+    """Armed kernel-owned watches REGISTERED BY this session — generic `romp watch --cmd` rows plus
+    `romp watch-pr` rows — as awaited CONTENT: {"kind","why","since","tasks"} or None. The user's rule
+    (2026-08-30, relayed from a session whose cluster-job watch showed only a chip tooltip): ANY awaited
+    thing — jobs, watches, pending externals — shows in the chat's green box, even mid-turn. A watch row
+    is event-true at both ends (armed at registration, removed when the predicate fires, times out, or
+    is cancelled), and it's kernel-owned, so this source survives restarts like the watches themselves.
+    `tasks` lists each watch in the registrant's own words (the --note, else an elided predicate), so a
+    plural wait can enumerate them in the box's fold."""
+    sid = str(sid)
+    with _watch_lock:
+        rows = [dict(r) for r in _watches if str(r.get("sid")) == sid]
+    prs = [dict(r) for r in _pr_watches if str(r.get("sid")) == sid]   # tick-thread idiom: copy, no lock
+    descs = []
+    for r in rows:
+        note = (r.get("note") or "").strip()
+        cmd = str(r.get("cmd") or "")
+        descs.append(note or "a kernel watch: %s" % (cmd if len(cmd) <= 80 else cmd[:77] + "…"))
+    for r in prs:
+        descs.append("PR #%s (%s) to land" % (r.get("pr"), r.get("repo")))
+    if not descs:
+        return None
+    since = min([r.get("at") for r in rows + prs if r.get("at")] or [None])
+    why = ("waiting on " + descs[0]) if len(descs) == 1 else         ("waiting on %d armed watches — %s, …" % (len(descs), descs[0]))
+    return {"kind": "job", "why": why, "since": since, "tasks": descs}
+
+
 def _watch_notice(kind, row, detail=""):
     """The one mail a generic watch sends — the [romp] mechanics-notice family (ABOUT romp's own
     watch service, like the pr-watch and restart notices). PURE for the voice test. The session's
@@ -14423,6 +14450,14 @@ def _session_awaiting(sid, path, idle, stamp=False):
             return {"kind": kind, "since": since,
                     "why": "waiting on %d background tasks%s"
                            % (len(pending), (" — " + d0 + ", …") if d0 else "")}
+    # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
+    # kernel-owned and restart-proof like the rows themselves, event-true at both ends (armed at
+    # registration, cleared when the predicate fires or the watch cancels/times out). The user's rule
+    # (2026-08-30): ANY awaited thing shows — an idle session holding only a watch used to read plain
+    # ready, its wait visible nowhere but `romp watch --list`.
+    w = _watch_awaiting(sid)
+    if w:
+        return w
     ov = _states_awaiting_overlay(sid)
     if ov is not None and ov.get("awaiting"):         # a producer wrote a LIVE awaiting:true → trust its why
         ovk = ov.get("kind")
@@ -18723,6 +18758,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # (_session_awaiting returns None while open_now). Session-scoped chat-view chip → the durable stamp too,
     # so the composer's awaiting chip survives a kernel restart like the feed card.
     _aw = _session_awaiting(sid, sess["path"], not open_now, stamp=True)
+    # Armed kernel watches stay visible even MID-TURN (the user 2026-08-30, whose cluster-job watch
+    # showed only a chip tooltip while the box at the chat bottom stayed dark): _session_awaiting
+    # answers None while the turn is open BY DESIGN — the chip must keep reading "working" (the shared
+    # state formula is untouched) — but the awaited CONTENT still rides the payload, and the box keys
+    # on the fields' presence, never on the state. Idle sessions get watches through
+    # _session_awaiting's own source 0.9, which also stamps the awaitingBg chip.
+    if not _aw and open_now:
+        _aw = _watch_awaiting(sid)
     awaiting_why = _aw["why"] if _aw else None
     awaiting_kind = _aw["kind"] if _aw else None
     # API error → the session is BLOCKED until retried: a bottom card (renderApiError, a RED dot) AND the chip
@@ -18959,7 +19002,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # WHO a peer-kind wait is on — [{name, host, sid, color}], the same identities the feed
                   # box wears, so the chat chip + awaiting box name the actual session (2026-08-26)
                   "awaitingPeers": ((_aw or {}).get("peers") or None),
-                  "awaitingTasks": (_awaiting_task_descs(sid, sess["path"]) if awaiting_why else []),
+                  "awaitingTasks": (((_awaiting_task_descs(sid, sess["path"]) or
+                                      (_aw or {}).get("tasks") or [])) if awaiting_why else []),
                   # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
                   # rows in the chip's await-green (the user 2026-08-19)
                   "awaitingTaskIds": (_awaiting_task_ids(sid, sess["path"]) if awaiting_why else []),

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1097,6 +1097,73 @@ class ViewBuilder(unittest.TestCase):
         sent = [e for e in events if e["kind"] == "user" and e.get("md") == "and also fix the header"]
         self.assertEqual(sent, [], "it must NOT also show as a sent (solid) user bubble — that was the flip")
 
+    def _clear_watches(self):
+        with km._watch_lock:
+            km._watches.clear()
+        km._pr_watches.clear()
+        km._watches_save()
+        km._pr_watches_save()
+
+    def test_a_working_session_still_lists_its_armed_kernel_watches(self):
+        # The user (2026-08-30, paraphrased): even while working, anything the session awaits shows
+        # at the chat bottom in the green box. Kernel half: the status payload carries the awaited
+        # content mid-turn while the chip formula stays untouched — state reads working, the box
+        # renders from the fields.
+        with self.tpath.open("a") as f:                  # an OPEN turn → the session reads working
+            f.write(json.dumps(uline(NOW, "keep working on the strip", "uOpen", parent="a2")) + "\n")
+        km._parse_cache.clear()
+        km.add_watch("test -f /tmp/synthetic-sentinel", SID, note="the cluster job's sentinel file")
+        try:
+            st = km.build_session(SID, NOW)["status"]
+            self.assertEqual(st["state"], "working", "the shared chip formula is untouched")
+            self.assertIn("the cluster job's sentinel file", st["awaitingWhy"] or "")
+            self.assertEqual(st["awaitingKind"], "job")
+            self.assertEqual(st["awaitingTasks"], ["the cluster job's sentinel file"],
+                             "the box's fold lists each watch in the registrant's own words")
+        finally:
+            self._clear_watches()
+
+    def test_an_idle_session_with_only_an_armed_watch_reads_awaitingBg(self):
+        # the second leg of the same report: an idle session holding only a kernel watch used to
+        # read plain ready — its wait visible nowhere but `romp watch --list`
+        km._parse_cache.clear()
+        km.add_watch("test -f /tmp/synthetic-sentinel", SID, note="the nightly export")
+        try:
+            st = km.build_session(SID, NOW)["status"]
+            self.assertEqual(st["state"], "awaitingBg", "an armed watch is a wait like any other")
+            self.assertIn("the nightly export", st["awaitingWhy"])
+        finally:
+            self._clear_watches()
+
+    def test_pr_watches_feed_the_awaited_content_too(self):
+        km._parse_cache.clear()
+        km.add_pr_watch(842, "example-org/notes-api", SID)
+        try:
+            st = km.build_session(SID, NOW)["status"]
+            self.assertIn("PR #842 (example-org/notes-api)", st["awaitingWhy"])
+        finally:
+            self._clear_watches()
+
+    def test_no_watch_no_wait_means_no_awaited_content(self):
+        km._parse_cache.clear()
+        st = km.build_session(SID, NOW)["status"]
+        self.assertIsNone(st["awaitingWhy"], "nothing awaited -> the box stays absent")
+        self.assertEqual(st["state"], "ready")
+
+    def test_watch_awaiting_shapes(self):
+        # note wins; a note-less watch elides its predicate; plural counts; foreign sids excluded
+        try:
+            km.add_watch("x" * 200, SID)
+            w = km._watch_awaiting(SID)
+            self.assertEqual(w["kind"], "job")
+            self.assertIn("a kernel watch:", w["why"])
+            self.assertLess(len(w["tasks"][0]), 120, "the predicate is elided, never dumped whole")
+            km.add_watch("true", SID, note="second wait")
+            self.assertIn("2 armed watches", km._watch_awaiting(SID)["why"])
+            self.assertIsNone(km._watch_awaiting("99999999-0000-0000-0000-000000000000"))
+        finally:
+            self._clear_watches()
+
     def test_a_mid_compaction_parked_send_renders_queued_and_cancelable_immediately(self):
         # The user (2026-08-30) pressed send during compaction and sat in an unlabeled, uncancellable
         # stage. The kernel half of the always-labeled rule, pinned behaviorally: the parked op is in

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -65,7 +65,7 @@ test("the kernel split happens in the ONE shared derivation (_session_chip), not
 test("the awaiting WHY lives in the background box, not the statusline (the user 2026-08-13, twice)", () => {
   // the kernel ships the why + the live awaited task descriptions in the chat status payload…
   assert.match(KERNEL, /"awaitingWhy": awaiting_why or None,/);
-  assert.match(KERNEL, /"awaitingTasks": \(_awaiting_task_descs\(sid, sess\["path"\]\) if awaiting_why else \[\]\),/);
+  assert.match(KERNEL, /"awaitingTasks": \(\(\(_awaiting_task_descs\(sid, sess\["path"\]\) or[\s\S]{0,80}?\.get\("tasks"\) or \[\]\)\) if awaiting_why else \[\]\),/);   // watch descs ride when no bg-task descs exist (2026-08-30)
   // …plus WHAT the wait is on, as data (jd.AWAIT_KINDS; the user 2026-08-15) — on the chat status,
   // the timeline lane, and the feed card's awaiting object alike, so every surface words one fact
   assert.match(KERNEL, /"awaitingKind": awaiting_kind,/);
@@ -98,7 +98,7 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
   assert.match(KERNEL, /return \[t\["tid"\] for t in awaited if t\.get\("tid"\)\]/);
   // client: rows are marked from awaitingTaskIds only while the chip is awaitingBg…
   assert.match(RENDER, /awaitingTaskIds\?: string\[\];/);
-  assert.match(RENDER, /const awaited = new Set<string>\(\(s!\.status\.state === "awaitingBg" && s!\.status\.awaitingTaskIds\) \|\| \[\]\);/);
+  assert.match(RENDER, /const awaited = new Set<string>\(s!\.status\.awaitingTaskIds \|\| \[\]\);/);   // ids' presence, never the chip state (2026-08-30: awaited things show even while working)
   assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
   assert.match(RENDER, /\(awaited\.has\(t\.id\) \? " bg-awaited" : ""\)/);
   // …the untracked-wait box (renderAwaitWhy) IS the awaited thing, so it wears the border whole
@@ -107,6 +107,27 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
   assert.match(STYLES, /#bg-tasks\.bg-awaited \{ border-color: var\(--st-awaitbg-bg\); \}/);
   assert.match(STYLES, /\.bg-task\.bg-awaited \{ box-shadow: inset 0 0 0 1px var\(--st-awaitbg-bg\); border-radius: 5px; \}/);
   assert.match(STYLES, /\.bg-task \{ --bgt: var\(--st-working-bg\); \}/);
+});
+
+test("awaited things show even while WORKING, and kernel watches feed the box (the user 2026-08-30)", () => {
+  // Their requirement, paraphrased: even mid-turn, anything the session awaits — jobs, watches,
+  // pending externals — shows at the chat bottom in the green box. Three legs, pinned where they live:
+  // 1. the box keys on awaited CONTENT, never the chip state (the old state gate was the defect)
+  assert.match(RENDER, /const why = \(s && \(s\.status\.awaitingWhy \|\| ""\)\.trim\(\)\) \|\| "";/);
+  assert.doesNotMatch(RENDER.split("function renderAwaitWhy")[1].split("\n}")[0],
+    /state === "awaitingBg" &&/);
+  // …with the fold's plain-words note adapting to the chip: idle keeps the historic sentence,
+  // working says the session keeps going and is told when the wait lands
+  assert.match(RENDER, /s!\.status\.state === "awaitingBg"\s*\n\s*\? "The session is idle until this finishes/);
+  assert.match(RENDER, /: "The session keeps working meanwhile; it's told when this lands\."/);
+  // 2. kernel watches are an awaiting SOURCE (idle: flips the chip like any wait; the rows are
+  // kernel-owned and event-true at both ends — armed at registration, cleared on fire/cancel)
+  assert.match(KERNEL, /def _watch_awaiting\(sid\):/);
+  assert.match(KERNEL, /w = _watch_awaiting\(sid\)\s*\n\s*if w:\s*\n\s*return w/);
+  // 3. mid-turn, the CONTENT rides the payload while the shared state formula stays untouched —
+  // the chip keeps reading working, the box renders from the fields
+  assert.match(KERNEL, /if not _aw and open_now:\s*\n\s*_aw = _watch_awaiting\(sid\)/);
+  assert.match(KERNEL, /"working" if open_now else\n/);   // the state formula's ordering is intact
 });
 
 test("the timeline lane's awaitingBg why reads the SAME working signal as its badge (same input, 2026-07-03 rule)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9317,10 +9317,12 @@ function renderBgTasks() {
   host.classList.remove("bg-awaited");   // re-derived below from THIS payload (renderAwaitWhy adds its own)
   if (!count || !tasks.length) { renderAwaitWhy(host, s || null); return; }
   host.style.display = "";
-  // the AWAITED rows (the user 2026-08-19): when the await-green chip waits on specific tasks, those
-  // rows — and the box holding them — wear a thin outline in the chip's green (awaitingTaskIds, the
-  // kernel's exact launch-id match); the status DOT keeps its meaning (yellow = the task is running)
-  const awaited = new Set<string>((s!.status.state === "awaitingBg" && s!.status.awaitingTaskIds) || []);
+  // the AWAITED rows (the user 2026-08-19): when the chip waits on specific tasks, those rows — and
+  // the box holding them — wear a thin outline in the chip's green (awaitingTaskIds, the kernel's
+  // exact launch-id match); the status DOT keeps its meaning (yellow = the task is running). Keyed on
+  // the ids' PRESENCE, never the chip state (the user 2026-08-30: awaited things show even while the
+  // session is working — the kernel only ships ids when something genuinely awaits them).
+  const awaited = new Set<string>(s!.status.awaitingTaskIds || []);
   host.classList.toggle("bg-awaited", tasks.some((t) => awaited.has(t.id)));
   const sid = activeId as string;
   const open = bgFoldOpen.has(sid);
@@ -9376,7 +9378,11 @@ function renderBgTasks() {
 // (a peer's PR, a build) has no process to kill; tracked run_in_background tasks take the list path
 // above, which carries one Stop per running row.
 function renderAwaitWhy(host: HTMLElement, s: Session | null) {
-  const why = (s && s.status.state === "awaitingBg" && (s.status.awaitingWhy || "").trim()) || "";
+  // Keyed on awaited CONTENT, never the chip state (the user 2026-08-30, their words paraphrased:
+  // even while working, anything the session awaits shows at the chat bottom in the green box). The
+  // kernel ships awaitingWhy whenever something is genuinely awaited — armed kernel watches included,
+  // mid-turn included — so the fields' presence IS the render condition; the chip keeps its meaning.
+  const why = (s && (s.status.awaitingWhy || "").trim()) || "";
   if (!why || !activeId) { host.style.display = "none"; return; }
   host.style.display = "";
   host.classList.add("bg-awaited");   // this whole box IS the awaited thing — the chip's green border
@@ -9417,7 +9423,9 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
     for (const t of items) { const r = el("div", "bg-await-task"); r.textContent = "· " + t; det.appendChild(r); }
   }
   const note = el("div", "bg-await-note");
-  note.textContent = "The session is idle until this finishes; it picks back up on its own when the result lands.";
+  note.textContent = s!.status.state === "awaitingBg"
+    ? "The session is idle until this finishes; it picks back up on its own when the result lands."
+    : "The session keeps working meanwhile; it's told when this lands.";
   det.appendChild(note);
   host.appendChild(det);
 }


### PR DESCRIPTION
The user's rule (2026-08-30, paraphrased): even while the session is working, anything it awaits — jobs, watches, pending externals — shows at the bottom of the chat in the green box. Live repro: an armed kernel watch showed only the chip; the box stayed dark.

**Two defects, both fixed at the source.**

1. **The state gate.** `_session_awaiting` answers None while the turn is open by design (the chip must read working — that stays), and the client re-gated the box on `state === "awaitingBg"` in both `renderAwaitWhy` and the tracked-tasks awaited outline. Now the box keys on awaited CONTENT: `build_session` merges watch content into the status fields even mid-turn (chip formula untouched — tab dots, feed, timeline keep their meaning), and the client renders whenever the fields exist. The fold's note adapts: idle keeps the historic sentence; working says the session keeps going and is told when the wait lands.

2. **Kernel watches fed nothing.** `romp watch --cmd` and `romp watch-pr` rows carry the registering sid but had no awaiting consumer — an idle session holding only a watch read plain ready. New `_session_awaiting` source (`_watch_awaiting`): kernel-owned, restart-proof, event-true at both ends. Kind "job"; the why speaks the registrant's own `--note`, else an elided predicate; PR watches read "PR #N (repo) to land".

Tracked-tasks precedence and the box's look unchanged.

**Tests:** working+watch keeps state "working" while the payload carries the watch; idle+watch flips to awaitingBg; PR watches feed content; nothing awaited → no fields; `_watch_awaiting` shapes; client pins for the ungated render, adaptive note, ids'-presence outline; two stale pins retargeted. Verified on the real served chat (hermetic kernel, open-turn transcript + pre-armed watch): Working chip + green box naming the watch. Suites: python 6103, extension 2559, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)