### PR TITLE
Gear round: distill-pick stomp fixed twice over, login modal at the top, full regrouping

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23879,6 +23879,26 @@ _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_i
                          ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
                          ("commentFast", _set_comment_fast))
 
+# field -> its STATE file, for the per-field PICK STAMPS below (the user 2026-08-30, whose distill
+# pick kept "resetting": authority between kernels must be per field and per pick time, never
+# whichever machine spoke last).
+_JUDGE_SETTING_FILES = {"judgeModel": "judge-model", "indexModel": "index-model",
+                        "judgeEffort": "judge-effort", "indexEffort": "index-effort",
+                        "distillModel": "distill-model", "distillEffort": "distill-effort",
+                        "commentModel": "comment-model", "commentEffort": "comment-effort",
+                        "commentFast": "comment-fast"}
+
+
+def _setting_stamp(field):
+    """WHEN a kernel-side setting was last picked = its STATE file's mtime. The write IS the pick
+    event (every setter writes the file at pick time), and a propagated apply preserves the ORIGIN's
+    stamp via utime below — so the stamp is the pick's own event time on every machine, and recency
+    comparisons stay honest across hops. None = never picked here."""
+    try:
+        return (jd.STATE / _JUDGE_SETTING_FILES[field]).stat().st_mtime
+    except (OSError, KeyError):
+        return None
+
 
 def _apply_judge_settings(body):
     """Apply any of the judge-tier fields in `body` through the validated setters (garbage
@@ -23887,9 +23907,34 @@ def _apply_judge_settings(body):
     distill pair answers RAW ("triage" = following the triage pick), matching /version: the
     gear shows the user's choice, not its resolution."""
     _dm_before = jd._distill_model()
+    # Per-field PICK AUTHORITY (the user 2026-08-30, whose Distilling pick "continually gets reset"):
+    # a propagated body stamps each field with its pick time, and an OLDER (or same-moment) value
+    # never overwrites a newer local pick — the stomp was any later-arriving propagation replacing a
+    # fresher pick wholesale. A stampless body (an older kernel, a manual curl) keeps the legacy
+    # apply-unconditionally behavior; the protection needs both ends on this code. An applied
+    # stamped field keeps the ORIGIN's pick time (utime) so recency survives re-fans, and the stamp
+    # is copied only when the value actually LANDED (a rejected/garbage value must not steal the
+    # newer time onto the old content).
+    stamps = body.get("stamps") if isinstance(body, dict) and isinstance(body.get("stamps"), dict) else {}
     for key, setter in _JUDGE_SETTING_FIELDS:
         if isinstance(body, dict) and key in body:
+            st = stamps.get(key)
+            try:
+                st = float(st) if st is not None else None
+            except (TypeError, ValueError):
+                st = None
+            if st is not None:
+                local = _setting_stamp(key)
+                if local is not None and local >= st:
+                    continue                          # older never overwrites newer (the fix's whole point)
             setter(str(body.get(key) or ""))
+            if st is not None:
+                try:
+                    p = jd.STATE / _JUDGE_SETTING_FILES[key]
+                    if p.exists() and p.read_text().strip() == str(body.get(key) or "").strip():
+                        os.utime(p, (st, st))
+                except OSError:
+                    pass
     if jd._distill_model() != _dm_before:
         # Switching the distill tier's EFFECTIVE model is a discrete recovery event (the user
         # 2026-08-18, who pointed the tier away from an outage-scoped model and expected the failed
@@ -23922,6 +23967,12 @@ def _propagate_judge_settings(body):
     itself never blocks on the machines. A miss is LOUD (a machine that missed the pick would
     silently run its judges on another model forever) but not retried — the next change re-fans,
     and /judge-settings with {"propagate": true} re-syncs on demand."""
+    # Every fanned field carries its PICK STAMP (the local STATE file's mtime — the pick event
+    # itself, or the origin's preserved time on a re-fan), so the receiving side can refuse an
+    # older value over a newer pick (the user 2026-08-30). Computed once, at fan time.
+    body = dict(body)
+    _st = {f: _setting_stamp(f) for f in body if f in _JUDGE_SETTING_FILES}
+    body["stamps"] = {f: t for f, t in _st.items() if t is not None}
     with _remotes_lock:
         rows = [dict(r) for r in _remotes.values()
                 if r.get("status") == "up" and r.get("local_port") and r.get("token")]

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -18,6 +18,7 @@ import contextlib
 import io
 import os
 import tempfile
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -70,6 +71,38 @@ class ApplySettings(unittest.TestCase):
         res = km._apply_judge_settings({"commentModel": "gpt-99", "commentFast": "true"})
         self.assertEqual((res["commentModel"], res["commentFast"]), ("claude-opus-5", "on"),
                          "garbage never reaches the files or `claude --model`")
+
+    def test_an_older_propagated_value_never_overwrites_a_newer_pick(self):
+        # THE REPORTED STOMP (the user 2026-08-30): their Distilling pick kept resetting — any
+        # later-arriving propagation replaced a fresher local pick wholesale, because the apply had
+        # no notion of WHEN each value was picked. Now every propagated field carries its pick
+        # stamp, and older-or-equal never lands.
+        km._apply_judge_settings({"distillModel": "claude-opus-4-8"})   # the user's pick, mtime = now
+        res = km._apply_judge_settings({"distillModel": "triage",
+                                        "stamps": {"distillModel": time.time() - 3600}})
+        self.assertEqual(res["distillModel"], "claude-opus-4-8",
+                         "an hour-old peer value must not stomp the fresh pick")
+        newer = time.time() + 60
+        res = km._apply_judge_settings({"distillModel": "triage", "stamps": {"distillModel": newer}})
+        self.assertEqual(res["distillModel"], "triage", "a genuinely newer pick still lands")
+        self.assertAlmostEqual((km.jd.STATE / "distill-model").stat().st_mtime, newer, delta=1,
+                               msg="the ORIGIN's pick time rides the file, so recency survives re-fans")
+
+    def test_a_stampless_body_keeps_the_legacy_apply(self):
+        # an older kernel (or a manual curl) sends no stamps — it applies unconditionally, exactly
+        # as before; the stomp protection needs both ends on this code
+        km._apply_judge_settings({"distillModel": "claude-opus-4-8"})
+        res = km._apply_judge_settings({"distillModel": "haiku"})
+        self.assertEqual(res["distillModel"], "haiku")
+
+    def test_a_rejected_value_never_steals_the_stamp(self):
+        # garbage with a newer stamp: the setter refuses it, and the utime must NOT re-stamp the
+        # surviving old content with the new time (that would shadow-block the next honest pick)
+        km._apply_judge_settings({"judgeModel": "fable"})
+        t0 = (km.jd.STATE / "judge-model").stat().st_mtime
+        km._apply_judge_settings({"judgeModel": "gpt-99", "stamps": {"judgeModel": time.time() + 999}})
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+        self.assertEqual((km.jd.STATE / "judge-model").stat().st_mtime, t0)
 
     def test_distill_sentinel_returns_the_pair_to_follow_mode(self):
         km._apply_judge_settings({"distillModel": "haiku", "distillEffort": "high"})
@@ -136,9 +169,24 @@ class PropagateFansOut(unittest.TestCase):
     def test_every_up_kernel_with_an_admin_path_gets_the_pick(self):
         km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
             self.calls.append((r["host"], m, p, payload)) or (200, {"ok": True}, None))
+        try:
+            (km.jd.STATE / "judge-model").unlink()   # never picked here -> no stamp to carry
+        except OSError:
+            pass
         km._propagate_judge_settings({"judgeModel": "fable"})
-        self.assertEqual(self.calls, [("boxup", "POST", "/judge-settings", {"judgeModel": "fable"})],
+        self.assertEqual(self.calls,
+                         [("boxup", "POST", "/judge-settings", {"judgeModel": "fable", "stamps": {}})],
                          "up + token only; a down row or one with no token is not an admin path")
+
+    def test_the_fanned_body_stamps_each_field_with_its_pick_time(self):
+        # the user 2026-08-30 ("my Distilling pick continually gets reset"): authority is per field
+        # and per PICK TIME — the stamp is the STATE file's own mtime, the pick event itself
+        km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
+            self.calls.append(payload) or (200, {"ok": True}, None))
+        km._set_distill_model("claude-opus-4-8")
+        want = (km.jd.STATE / "distill-model").stat().st_mtime
+        km._propagate_judge_settings({"distillModel": "claude-opus-4-8"})
+        self.assertEqual(self.calls[0]["stamps"], {"distillModel": want})
 
     def test_a_miss_is_loud_and_names_the_machine(self):
         km._remote_kernel_call = lambda *a, **k: (None, None, "could not reach boxup's kernel: boom")

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -23,38 +23,43 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 class SettingsSectionsTest(unittest.TestCase):
     def test_the_subsection_headers_are_present_in_order(self):
+        # The 2026-08-30 regrouping, the user's anchors fixed: login at the very top (Account),
+        # Comments folded into Chat, session lifecycle apart from the panes, colors together,
+        # judges low, updates + debug + version at the very bottom.
         h = _gear_src()
-        self.assertIn("<div class='rs-sec rs-sec-first'>Sessions</div>", h)
-        for sec in ("Judges", "Keyboard shortcuts", "Chat", "Feed", "Sessions pane", "Colors", "Debug"):
+        self.assertIn("<div class='rs-sec rs-sec-first'>Account</div>", h)
+        for sec in ("Sessions", "Chat", "Sessions pane", "Feed", "Colors",
+                    "Keyboard shortcuts", "Judges", "Updates & debug"):
             self.assertIn("<div class=rs-sec>%s</div>" % sec, h)
-        # (The 2026-07-12 "Feed dissolved into Colors" rule ended 2026-08-18: the Feed section is back,
-        # carrying the collapse-by-default checkbox moved off the feed footer.)
-        order = [">Sessions<", ">Judges<", ">Keyboard shortcuts<", ">Chat<",
-                 ">Feed<", ">Sessions pane<", ">Colors<", ">Debug<", ">romp · version<"]
+        order = [">Account<", ">Sessions<", ">Chat<", ">Sessions pane<", ">Feed<",
+                 ">Colors<", ">Keyboard shortcuts<", ">Judges<", ">Updates & debug<",
+                 ">romp · version<"]
         idx = [h.index(t) for t in order]
-        self.assertEqual(idx, sorted(idx), "sections in the 2026-07-12 order, version last")
+        self.assertEqual(idx, sorted(idx), "sections in the 2026-08-30 order, version last")
 
     def test_each_setting_sits_under_the_right_section(self):
         h = _gear_src()
-        # Sessions (top): default dir + auto nudge + backend before the Judges header
-        self.assertTrue(h.index(">Sessions<") < h.index("id=rs-defaultdir") < h.index(">Judges<"))
-        self.assertTrue(h.index(">Sessions<") < h.index("id=rs-autonudge") < h.index(">Judges<"))
-        self.assertTrue(h.index(">Sessions<") < h.index("id=rs-backend") < h.index(">Judges<"))
-        # Judges (top): the four model/effort dropdowns — the SHOW toggles are NOT here anymore
-        self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgemodel") < h.index(">Keyboard shortcuts<"))
-        self.assertTrue(h.index(">Judges<") < h.index("id=rs-indexeffort") < h.index(">Keyboard shortcuts<"))
-        # Chat (middle): compact + branch between Chat and the Sessions-pane section
-        self.assertTrue(h.index(">Chat<") < h.index("id=rs-compact") < h.index(">Sessions pane<"))
-        self.assertTrue(h.index(">Chat<") < h.index("id=rs-branch") < h.index(">Sessions pane<"))
-        # Sessions pane (middle towards the bottom): collapse idle gaps before the Colors header
-        self.assertTrue(h.index(">Sessions pane<") < h.index("id=rs-collapsegaps") < h.index(">Colors<"))
-        # Colors (bottom): the global colormap + the session palette between Colors and Debug
-        self.assertTrue(h.index(">Colors<") < h.index("id=rs-cmap") < h.index(">Debug<"))
-        self.assertTrue(h.index(">Colors<") < h.index("id=rs-pal") < h.index(">Debug<"))
+        # Account (the very top, the user 2026-08-30): the login row leads the gear
+        self.assertTrue(h.index(">Account<") < h.index("id=rs-login-btn") < h.index(">Sessions<"))
+        # Sessions (lifecycle): dir, backend, nudge, conserve, file editing — before Chat
+        for rid in ("id=rs-defaultdir", "id=rs-backend", "id=rs-autonudge", "id=rs-conserve", "id=rs-fileedit"):
+            self.assertTrue(h.index(">Sessions<") < h.index(rid) < h.index(">Chat<"), rid)
+        # Chat: transcript prefs AND the comment defaults (comments are part of the chat)
+        for rid in ("id=rs-compact", "id=rs-branch", "id=rs-cmtmodel", "id=rs-cmtfast"):
+            self.assertTrue(h.index(">Chat<") < h.index(rid) < h.index(">Sessions pane<"), rid)
+        # Sessions pane, then Feed, then Colors
+        self.assertTrue(h.index(">Sessions pane<") < h.index("id=rs-collapsegaps") < h.index(">Feed<"))
+        self.assertTrue(h.index(">Feed<") < h.index("id=rs-feedcollapsed") < h.index(">Colors<"))
+        self.assertTrue(h.index(">Colors<") < h.index("id=rs-cmap") < h.index(">Keyboard shortcuts<"))
+        self.assertTrue(h.index(">Colors<") < h.index("id=rs-pal") < h.index(">Keyboard shortcuts<"))
+        # Judges sit low: the six dropdowns between Judges and the bottom group
+        self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgemodel") < h.index(">Updates & debug<"))
+        self.assertTrue(h.index(">Judges<") < h.index("id=rs-indexeffort") < h.index(">Updates & debug<"))
         self.assertNotIn("rs-oldest", h)
-        # Debug (bottom): the judge-set SHOW toggles after Debug; analytics + version after them
-        self.assertLess(h.index(">Debug<"), h.index("id=rs-judges-index"))
-        self.assertLess(h.index(">Debug<"), h.index("id=rs-judges-triage"))
+        # Updates & debug (the very bottom): auto-updates, the judge-SHOW toggles, analytics, version
+        self.assertLess(h.index(">Updates & debug<"), h.index("id=rs-updates"))
+        self.assertLess(h.index(">Updates & debug<"), h.index("id=rs-judges-index"))
+        self.assertLess(h.index(">Updates & debug<"), h.index("id=rs-judges-triage"))
         self.assertLess(h.index("id=rs-judges-triage"), h.index("id=ra-open"))
         self.assertLess(h.index("id=ra-open"), h.index("id=rsver"), "version is the very bottom")
         self.assertNotIn("id=rs-debug", h)   # the single Debug toggle is gone

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -132,3 +132,12 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 .ra-li b { color: #e8eaed; font-weight: 600; }
 .ra-sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; flex: 0 0 auto; }
 .ra-note { color: #9aa0a6; font-size: 11.5px; border-top: 1px solid #3a3a3a; padding-top: 7px; }
+
+/* the login paste-code MODAL (the user 2026-08-30): the panel treatment — centered card over a
+   translucent backdrop, everything behind dimmed but visible; menus vocabulary card chrome. */
+#rs-login-modal { position: fixed; inset: 0; z-index: 1400; background: rgba(0,0,0,0.55);
+  display: flex; align-items: center; justify-content: center; }
+#rs-login-modal[hidden] { display: none; }   /* the author display:flex would otherwise defeat [hidden] (the #rsettings[hidden] precedent) */
+#rs-login-modal .rs-login-card { background: #252526; border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.35); padding: 14px 16px;
+  width: min(480px, calc(100vw - 48px)); }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -49,7 +49,15 @@ var GEAR_HTML =
   '<button id=rgear hidden aria-hidden=true></button>' +
   '<div id=rsettings hidden><div class=rs-card>' +
   '<div class=rs-h>Settings</div>' +
-  "<div class='rs-sec rs-sec-first'>Sessions</div>" +
+  "<div class='rs-sec rs-sec-first'>Account</div>" +
+  "<div class='rs-row' id=rs-billing style='cursor:default'>" +
+  '<span style="flex:1 1 auto"><b>Claude login</b>' +
+  '<span class=rs-sub id=rs-login-acct>…</span>' +
+  "<div id=rs-login-flow style='margin-top:6px'>" +
+  "<button id=rs-login-btn type=button style='cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Log in to Claude Code</button>" +
+  "<span id=rs-login-state class=rs-sub style='margin-left:8px'></span>" +
+  '</div></span></div>' +
+  '<div class=rs-sec>Sessions</div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Default directory</b>" +
   '<span class=rs-sub>The default directory for NEW sessions (still editable per session). Persisted kernel-side — also settable with <code>romp default-dir</code>. Falls back to the romp install dir until you set one; blank reverts to it. ~ and $VARs expand.</span>' +
   "<div style='display:flex;gap:6px;margin-top:5px'>" +
@@ -57,22 +65,15 @@ var GEAR_HTML =
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 6px'>" +
   "<button id=rs-defaultdir-browse type=button style='flex:0 0 auto;cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 8px'>Browse…</button>" +
   '</div></span></div>' +
+  "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
+  '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK. Both kinds run side by side; this only sets the default.</span>' +
+  "<select id=rs-backend style='display:none'>" +
+  '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option>' +
+  '</select></span></div>' +
   "<label class='rs-row rs-sep'><input type=checkbox id=rs-autonudge>" +
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
-  "<div class='rs-row rs-sep' id=rs-billing>" +
-  '<span><b>Billing login</b>' +
-  '<span class=rs-sub id=rs-login-acct>…</span>' +
-  "<div id=rs-login-flow style='margin-top:6px'>" +
-  "<button id=rs-login-btn type=button style='cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Log in…</button>" +
-  "<span id=rs-login-state class=rs-sub style='margin-left:8px'></span>" +
-  "<div id=rs-login-url hidden style='margin-top:6px'></div>" +
-  "<div id=rs-login-code hidden style='margin-top:6px;display:flex;gap:6px;align-items:center'>" +
-  "<input id=rs-login-input type=text autocomplete=off spellcheck=false placeholder='paste the code from the browser…' style='flex:1;background:#1e1e1e;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:4px 8px'>" +
-  "<button id=rs-login-send type=button style='cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Submit</button>" +
-  "<button id=rs-login-cancel type=button style='cursor:pointer;background:transparent;color:#888;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Cancel</button>" +
-  '</div></div></span></div>' +
   "<label class='rs-row'><input type=checkbox id=rs-conserve>" +
   '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Close the claude process of a session that has FADED (idle over an hour) and is on no open tab (each averages ~340MB). Everything persists — it revives on a tab click, a message, or a scheduled wake. An open tab always keeps its process; off = every session keeps its process for as long as it lives.</span>' +
@@ -81,31 +82,6 @@ var GEAR_HTML =
   '<span><b>File editing</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Let the file viewer’s Edit save straight to disk on the file’s machine. Off by default; the viewer asks the first time. A session working in the edited folder is told, and a save always refuses when the file changed underneath you. Applies on every connected machine’s kernel.</span>' +
   '</span></label>' +
-  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
-  '<span class=rs-sub>romp watches for new tagged releases (every 6 hours) AND new commits on main (origin polled every few minutes, plus a restart offer when updated code sits on disk unbooted) — one banner covers both, and acting on it converges every attached machine. Check and ask (the default) offers the banner with an Update button; Install automatically converges by itself, restarting at the next quiet moment; Off never checks. Kernel-side setting.</span>' +
-  "<select id=rs-updates style='display:none'>" +
-  '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +
-  '</select></span></div>' +
-  "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
-  '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK. Both kinds run side by side; this only sets the default.</span>' +
-  "<select id=rs-backend style='display:none'>" +
-  '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option>' +
-  '</select></span></div>' +
-  '<div class=rs-sec>Judges</div>' +
-  "<div class='rs-row rs-jrow'><b>Triage model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Triage effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it). Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
-  '<div class=rs-sec>Comments</div>' +
-  "<div class='rs-row rs-jrow'><b>Comment model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model NEW comment threads start on. Same as the session (the default) keeps each thread on the model of the conversation it branches from; pinning one here starts every new thread on it. The comment dialog shows this default and its own pick still wins. Follows to every connected machine's kernel.</span><select id=rs-cmtmodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Comment effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for new comment threads. Same as the session (the default) inherits the effort of the conversation the thread branches from. Follows to every connected machine's kernel.</span><select id=rs-cmteffort></select></div>" +
-  "<label class='rs-row'><input type=checkbox id=rs-cmtfast>" +
-  '<span><b>Fast comment threads</b><span class=rs-mixed hidden></span>' +
-  "<span class=rs-sub>Start new comment threads in fast mode (Opus-only research preview). If the thread's model can't run it, the thread still opens on that model at normal speed, with a notice. Off = same as the session. Follows to every connected machine's kernel.</span>" +
-  '</span></label>' +
-  '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
   '<div class=rs-sec>Chat</div>' +
   '<label class=rs-row><input type=checkbox id=rs-compact>' +
   '<span><b>Compact transcript</b>' +
@@ -130,19 +106,25 @@ var GEAR_HTML =
   "<span class=rs-sub>Chat text colors only. Each option previews its own tiers — prose, the dimmer tool text, code. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
   "<div id=rs-chatscheme style='position:relative;margin-top:5px'></div>" +
   '</span></div>' +
-  '<div class=rs-sec>Feed</div>' +
-  '<label class=rs-row><input type=checkbox id=rs-feedcollapsed>' +
-  '<span><b>Collapse cards by default</b>' +
-  '<span class=rs-sub>Every card arrives collapsed to its one-line gist; expanding one is a per-card override. Moved here from the feed footer — a set-and-forget default, not a per-glance action.</span>' +
+  
+  "<div class='rs-row rs-jrow'><b>Comment model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model NEW comment threads start on. Same as the session (the default) keeps each thread on the model of the conversation it branches from; pinning one here starts every new thread on it. The comment dialog shows this default and its own pick still wins. Follows to every connected machine's kernel.</span><select id=rs-cmtmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Comment effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for new comment threads. Same as the session (the default) inherits the effort of the conversation the thread branches from. Follows to every connected machine's kernel.</span><select id=rs-cmteffort></select></div>" +
+  "<label class='rs-row'><input type=checkbox id=rs-cmtfast>" +
+  '<span><b>Fast comment threads</b><span class=rs-mixed hidden></span>' +
+  "<span class=rs-sub>Start new comment threads in fast mode (Opus-only research preview). If the thread's model can't run it, the thread still opens on that model at normal speed, with a notice. Off = same as the session. Follows to every connected machine's kernel.</span>" +
   '</span></label>' +
-  '<div class=rs-sec>Sessions pane</div>' +   // the pane's label (renamed from Timeline, the user 2026-08-24); "pane" disambiguates from the session-defaults section above
-  '<label class=rs-row><input type=checkbox id=rs-activeonly checked>' +
+  '<div class=rs-sec>Sessions pane</div>' +  '<label class=rs-row><input type=checkbox id=rs-activeonly checked>' +
   '<span><b>Show active sessions only</b>' +
   '<span class=rs-sub>Only draw lanes for sessions with work in the visible time range, so idle sessions do not take up room. They stay in the chat, and a lane reappears the moment you zoom or pan to a stretch where it did something.</span>' +
   '</span></label>' +
   '<label class=rs-row><input type=checkbox id=rs-collapsegaps checked>' +
   '<span><b>Collapse idle gaps</b>' +
   '<span class=rs-sub>Squish long idle stretches (no work on any lane — e.g. overnight) into a thin break on the timeline, so the active periods get the width.</span>' +
+  '</span></label>' +
+  '<div class=rs-sec>Feed</div>' +
+  '<label class=rs-row><input type=checkbox id=rs-feedcollapsed>' +
+  '<span><b>Collapse cards by default</b>' +
+  '<span class=rs-sub>Every card arrives collapsed to its one-line gist; expanding one is a per-card override. Moved here from the feed footer — a set-and-forget default, not a per-glance action.</span>' +
   '</span></label>' +
   '<div class=rs-sec>Colors</div>' +
   "<div class=rs-row style='cursor:default'><span style='flex:1 1 auto'><b>Colormap</b>" +
@@ -153,7 +135,21 @@ var GEAR_HTML =
   '<span class=rs-sub>The palette sessions draw their identity color from — tabs, cards, lanes. Switching recolors every session to the same slot in the new set.</span>' +
   "<div id=rs-pal><button id=rs-pal-btn type=button title='Pick the session palette'></button>" +
   '<div id=rs-pal-list hidden></div></div></span></div>' +
-  '<div class=rs-sec>Debug</div>' +
+  '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
+  '<div class=rs-sec>Judges</div>' +
+  "<div class='rs-row rs-jrow'><b>Triage model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Triage effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it). Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
+  '<div class=rs-sec>Updates & debug</div>' +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
+  '<span class=rs-sub>romp watches for new tagged releases (every 6 hours) AND new commits on main (origin polled every few minutes, plus a restart offer when updated code sits on disk unbooted) — one banner covers both, and acting on it converges every attached machine. Check and ask (the default) offers the banner with an Update button; Install automatically converges by itself, restarting at the next quiet moment; Off never checks. Kernel-side setting.</span>' +
+  "<select id=rs-updates style='display:none'>" +
+  '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +
+  '</select></span></div>' +
+  
   '<div class=rs-judges>' +
   '<label class=rs-row rs-half><input type=checkbox id=rs-judges-index>' +
   '<span><b>Show indexing judges</b>' +
@@ -168,6 +164,17 @@ var GEAR_HTML =
   '<button id=ra-open class=ra-openbtn>Token usage analytics</button></div>' +
   "<div class='rs-h rs-sep'>romp · version</div>" +
   '<div id=rsver>…</div></div></div>' +
+  '<div id=rs-login-modal hidden>' +
+  '<div class=rs-login-card>' +
+  "<div class=rs-h style='margin-bottom:4px'>Log in to Claude Code</div>" +
+  "<div id=rs-login-url hidden style='margin-top:6px'></div>" +
+  "<div id=rs-login-code hidden style='margin-top:8px;display:flex;gap:6px;align-items:center'>" +
+  "<input id=rs-login-input type=text autocomplete=off spellcheck=false placeholder='paste the code from the browser…' style='flex:1;background:#1e1e1e;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:4px 8px'>" +
+  "<button id=rs-login-send type=button style='cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Submit</button>" +
+  '</div>' +
+  "<div style='margin-top:10px;text-align:right'>" +
+  "<button id=rs-login-cancel type=button style='cursor:pointer;background:transparent;color:#888;border:1px solid #3a3a3a;border-radius:5px;padding:3px 10px'>Cancel</button>" +
+  '</div></div></div>' +
   '<div id=ranalytics-back hidden><div id=ranalytics>' +
   '<div class=ra-top><div class=ra-title>Token usage</div>' +
   '<button id=ra-close aria-label=Close>✕</button></div>' +
@@ -425,13 +432,26 @@ function initGear(post) {
       lgU = document.getElementById('rs-login-url'), lgC = document.getElementById('rs-login-code'),
       lgI = document.getElementById('rs-login-input'), lgSend = document.getElementById('rs-login-send'),
       lgX = document.getElementById('rs-login-cancel'), lgA = document.getElementById('rs-login-acct');
-  var lgTimer = null;
+  var lgTimer = null, lgLive = '';   // lgLive = the flow state lgRender last saw (drives the button's two jobs)
+  // The paste-code UI lives in a MODAL (the user 2026-08-30: "it would just be a login button…
+  // then it would pop up another modal that says paste the code so it doesn't always sit there
+  // taking up space") — centered card over a translucent backdrop, the panel rule's treatment.
+  // Closing the modal never cancels the flow (Cancel does); the row's state span keeps narrating,
+  // and the button reopens the modal mid-flow instead of restarting the login.
+  var lgM = document.getElementById('rs-login-modal');
+  function lgModal(on) { if (lgM) lgM.hidden = !on; }
+  if (lgM) lgM.addEventListener('click', function (e) { if (e.target === lgM) lgModal(false); });
+  document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && lgM && !lgM.hidden) lgModal(false); });
   function lgRender(v) {
     if (!lgB) return;
     var f = (v && v.login) || { state: '' };
     if (lgA) lgA.textContent = v && v.acctLabel ? 'Logged in as ' + v.acctLabel + '. Each machine logs in its own credential store.'
                                                 : 'No Claude login on this machine — sessions can only bill an API key. Log in from any browser (your phone works: the code flow needs no localhost).';
-    lgB.hidden = f.state === 'url' || f.state === 'starting' || f.state === 'verifying';
+    lgLive = f.state || '';
+    var mid = f.state === 'url' || f.state === 'starting' || f.state === 'verifying';
+    lgB.hidden = false;
+    lgB.textContent = mid ? 'Show login code…' : 'Log in to Claude Code';
+    if (!f.state) lgModal(false);   // the flow ended (logged in / cancelled) — the modal's job is done
     lgS.textContent = f.state === 'starting' ? 'starting the login flow…'
       : f.state === 'verifying' ? 'checking the code…'
       : f.state === 'error' ? (f.err || 'the login flow failed — try again') : '';
@@ -461,6 +481,8 @@ function initGear(post) {
     }).catch(function () { lgTimer = setTimeout(lgPoll, 3000); });
   }
   if (lgB) lgB.addEventListener('click', function () {
+    lgModal(true);
+    if (lgLive === 'url' || lgLive === 'starting' || lgLive === 'verifying') return;   // reopen only — never restart a live flow
     post({ type: 'loginStart' });
     lgS.textContent = 'starting the login flow…';
     if (!lgTimer) lgTimer = setTimeout(lgPoll, 800);
@@ -474,7 +496,7 @@ function initGear(post) {
     if (!lgTimer) lgTimer = setTimeout(lgPoll, 800);
   });
   if (lgI) lgI.addEventListener('keydown', function (e) { if (e.key === 'Enter' && lgSend) lgSend.click(); });
-  if (lgX) lgX.addEventListener('click', function () { post({ type: 'loginCancel' }); if (lgTimer) { clearTimeout(lgTimer); lgTimer = null; } lgRender({ login: { state: '' } }); });
+  if (lgX) lgX.addEventListener('click', function () { lgModal(false); post({ type: 'loginCancel' }); if (lgTimer) { clearTimeout(lgTimer); lgTimer = null; } lgRender({ login: { state: '' } }); });
   if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
   // The judge MODEL pickers mirror the session pickers (the user 2026-08-25): families top-level,
   // clicking a family sends its /models `default` (the user's remembered version), hover or
@@ -674,9 +696,10 @@ function initGear(post) {
   // The model/effort <option>s come from /models — the same single source the
   // chat + timeline pickers use. Cached after the first successful fetch.
   var choices = null;
+  var choicesP = null;   // the single-flight promise — options are written exactly once per page
   function fillChoices() {
-    if (choices) return Promise.resolve(choices);
-    return fetch(ku('/models'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
+    if (choicesP) return choicesP;
+    choicesP = fetch(ku('/models'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
       choices = d || { models: [], efforts: [] };
       var mo = (choices.models || []).map(function (m) {
         var vs = (m.versions || []).map(function (v) { return '<option value="' + v.value + '">' + v.label + '</option>'; }).join('');
@@ -696,7 +719,8 @@ function initGear(post) {
       if (cmm) cmm.innerHTML = '<option value="session">Same as the session</option><option value="default">Default</option>' + mo;
       if (cme) cme.innerHTML = '<option value="session">Same as the session</option>' + eff;
       return choices;
-    }).catch(function () { return null; });
+    }).catch(function () { choicesP = null; return null; });   // retry on the next open, never a second live fetch
+    return choicesP;
   }
   function lv() { var t = document.querySelector('script[src*="feed.js"]');
     var m = t && t.getAttribute('src').match(/[?&]v=(\d+)/); return m ? +m[1] : 0; }

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -50,6 +50,36 @@ test("the gear posts kernel ops through ONE shared channel (never re-acquires th
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 
+test("model/effort options are written exactly once — the single-flight /models fetch (2026-08-30)", () => {
+  // The user's "my Distilling pick keeps resetting": fillChoices memoized its RESULT, so a settings
+  // open racing the page-load fetch fired a second /models fetch, and whichever resolved last
+  // REWROTE every select's options AFTER fill() had set their values — a rewritten select falls
+  // back to its first option ("Follow triage" for distill; invisible on Triage model, whose first
+  // option coincides with the stored value). The promise is the memo now; a failed fetch clears it.
+  assert.ok(GEAR.includes("var choicesP = null;"), "the promise is the memo");
+  assert.ok(GEAR.includes("if (choicesP) return choicesP;"), "second callers reuse the in-flight fetch");
+  assert.ok(GEAR.includes("choicesP = null; return null;"), "a failed fetch clears the memo for retry");
+  assert.ok(!GEAR.includes("if (choices) return Promise.resolve(choices);"), "the result-memo race is gone");
+});
+
+test("the login flow lives in a modal behind one button (the user 2026-08-30)", () => {
+  // "it would just be a login button… then it would pop up another modal that says paste the code
+  // so it doesn't always sit there taking up space" — the paste-code UI collapses behind the
+  // Account button; the modal wears the panel treatment (centered card over a dimmed backdrop).
+  assert.ok(GEAR.includes("id=rs-login-modal"), "the modal exists");
+  assert.ok(GEAR.includes("Log in to Claude Code"), "the button says what it does");
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.css"), "utf8");
+  assert.match(CSS, /#rs-login-modal \{ position: fixed; inset: 0; z-index: \d+; background: rgba\(0,0,0,0\.55\);/);
+  assert.match(CSS, /\.rs-login-card \{ background: #252526; border: 1px solid rgba\(255,255,255,0\.12\);/);
+  // mid-flow the button REOPENS the modal, never restarts the flow; terminal state closes it;
+  // Cancel + Escape + backdrop close; the code input stays a pure pass-through (T157)
+  assert.ok(GEAR.includes("if (lgLive === 'url' || lgLive === 'starting' || lgLive === 'verifying') return;"));
+  assert.ok(GEAR.includes("if (!f.state) lgModal(false);"));
+  assert.ok(GEAR.includes("if (e.key === 'Escape' && lgM && !lgM.hidden) lgModal(false);"));
+  assert.ok(GEAR.includes("if (e.target === lgM) lgModal(false);"));
+  assert.ok(GEAR.includes("post({ type: 'loginCode', code: code });"), "pass-through untouched");
+});
+
 test("the distilling tier is its own gear pair, defaulting to follow-triage", () => {
   // The user 2026-08-14: the card-prose judges (distiller, briefer, staller) split out of triage so
   // what you READ can run a richer model than the placement judges. The stored sentinel "triage"


### PR DESCRIPTION
**Part 1 — "my Distilling pick continually gets reset."** Two mechanisms, both fixed. (a) The display reset the user actually watched: `fillChoices` memoized its result, so a settings open racing the page-load fetch fired a second `/models` fetch — whichever resolved last rewrote every select's options AFTER `fill()` set values, and a rewritten select falls back to its first option ("Follow triage" for distill — visible; the stored value itself for triage — invisible, which is why only distill ever "reset"). Single-flight now: the promise is the memo, options are written exactly once, failed fetches retry. (b) The file-level stomp window: propagation was already per-field and nothing pushes on attach, but the merge had no recency — every fanned field now carries its pick stamp (the STATE file's mtime, preserved via utime on apply), and `_apply_judge_settings` refuses any field whose stamp isn't newer than the local pick. Stampless legacy bodies keep today's behavior; rejected values never steal the stamp.

**Part 2 — login at the top, code box behind a modal.** The Account group leads the gear with one "Log in to Claude Code" button; the url + paste-code UI moved into a centered card over a dimmed backdrop (panel treatment). Same element ids — the T157 flow is untouched and the lab login loop passes end to end (code pass-through + kernel-log secrecy). Mid-flow the button relabels to "Show login code…" and only reopens the modal; Cancel/Escape/backdrop close it.

**Part 3 — regrouping** (user anchors fixed, judgment on the rest): Account / Sessions / Chat (+ Comment defaults folded in) / Sessions pane / Feed / Colors / Keyboard shortcuts / Judges / Updates & debug (bottom, with version).

**Tests:** stomp repro (older peer value bounces, newer lands with origin time, garbage can't steal the stamp, stampless = legacy), fanned-body stamps, single-flight pins, login-modal pins, section-order pins retargeted. Suites: python 6107, extension 2561; lab login loop all green. Screenshots in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)