### PR TITLE
Every figure renders — the eager cap and its chip retire on the user's ruling

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -105,9 +105,8 @@ test("figures render AT their mention: after the block naming them; same-block f
   assert.match(RENDER, /const BLOCK_SEL = "p, li, h1, h2, h3, h4, h5, h6, blockquote, td, th";/);
   assert.match(RENDER, /anchor\.insertAdjacentElement\("afterend", strip\);/, "a paragraph's figure lands right after it");
   assert.match(RENDER, /\/\^\(LI\|TD\|TH\)\$\/\.test\(anchor\.tagName\)/, "a list item keeps its figure inside, under its bullet");
-  // the wallpaper guard survives as the EAGER cap — the remainder folds behind the chip
-  // (the overflow test below) instead of dropping silently (the 2026-08-30 report)
-  assert.match(RENDER, /previewable\.slice\(0, expanded \? previewable\.length : FIG_EAGER\)/, "the eager cap stays");
+  // no eager cap since the user's 2026-08-30 ruling: every mention renders, lazily loaded
+  assert.match(RENDER, /for \(const p of previewable\) renderFig\(p\);/);
 });
 
 test("VS Code's pending image chip pulses while the host round-trip is in flight; a failed one doesn't", () => {
@@ -129,28 +128,17 @@ test("full-size images wear the user-image scale — one size per information ty
   assert.match(CSS, /\.path-full-pdfcard \{/);
 });
 
-test("figure overflow folds behind '+N more figures' — nothing silently dropped", () => {
-  // The 2026-08-30 report: a message led with four absolute mentions and then listed six VERIFIED
-  // repo-relative ones; the old silent previewable.slice(0, 4) kept exactly the absolutes, which
-  // read as "relative paths don't preview" when the break was the cap all along (the live payload
-  // carried verdicts + pins for all ten). The first FIG_EAGER render eagerly — byte-identical to
-  // the old first-four behavior — the REST render on the chip click at their own mentions through
-  // the same renderFig path, and the expansion latches per event uuid (the openFolds pattern) so
-  // re-renders keep the message open.
-  assert.match(RENDER, /const FIG_EAGER = 4;/);
-  assert.ok(!/previewable\.slice\(0, 4\)/.test(RENDER), "the bare silent cap is gone");
-  assert.match(RENDER, /previewable\.slice\(0, expanded \? previewable\.length : FIG_EAGER\)/);
-  assert.match(RENDER, /const rest = expanded \? \[\] : previewable\.slice\(FIG_EAGER\);/);
-  assert.match(RENDER, /"\+" \+ rest\.length \+ " more figure"/);
-  assert.match(RENDER, /const figsExpanded = new Set<string>\(\);/);
-  assert.match(RENDER, /if \(foldKey\) figsExpanded\.add\(foldKey\);/);
-  // the click acknowledges by BECOMING the figures — chip out, remainder in, same code path
-  assert.match(RENDER, /chip\.remove\(\);\s*\n\s*for \(const p of rest\) renderFig\(p\);/);
-  const calls = RENDER.match(/linkifyFileUris\([^\n]*ev\.uuid\)/g) || [];
-  assert.equal(calls.length, 3, "every call site keys the latch on the event uuid");
-  assert.ok(CSS.includes(".path-more"), "the chip is styled");
-  assert.match(CSS, /\.path-more \{[^}]*background: transparent; border: 1px solid var\(--card-border\)/,
-    "the chip wears the one shared button rest (T151), never its own shade");
+test("EVERY figure mention renders eagerly — no cap, no chip (the user's 2026-08-30 ruling)", () => {
+  // Their ruling, paraphrased: they should be able to preview as many images as they want in the
+  // thread — overruling the 4-eager+chip fold shipped a day earlier. All verified mentions render
+  // at their anchors through the one renderFig path; off-screen cost is bounded by the browser's
+  // own lazy loading, never by a count.
+  assert.match(RENDER, /for \(const p of previewable\) renderFig\(p\);/);
+  assert.ok(!/FIG_EAGER|figsExpanded|path-more/.test(RENDER), "the cap/latch/chip machinery is gone, not dormant");
+  assert.ok(!/linkifyFileUris\([^)]*foldKey/.test(RENDER), "the latch's foldKey param retired with it");
+  assert.ok(!CSS.includes(".path-more"), "the chip's CSS retired with it");
+  assert.match(PREVIEW, /img\.loading = "lazy";/);
+  assert.match(PREVIEW, /img\.decoding = "async";/);
 });
 
 test("a verified relative path is previewable exactly like an absolute one — the cap was the only gate", () => {

--- a/ui/webview/chat-pin-history.test.ts
+++ b/ui/webview/chat-pin-history.test.ts
@@ -17,8 +17,8 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 
 test("pathPins ride the chat events as a sibling map and thread into every linkify pass", () => {
   assert.match(RENDER, /pathLinks\?: Record<string, string>; pathPins\?: Record<string, string> \}\n  \| \{ kind: "assistant";/);
-  assert.match(RENDER, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, foldKey\?: string\): void/);
-  const uses = RENDER.match(/linkifyFileUris\((?:body|bubble|full), [^)]*ev\.pathPins, ev\.uuid\)/g) || [];
+  assert.match(RENDER, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
+  const uses = RENDER.match(/linkifyFileUris\((?:body|bubble|full), [^)]*ev\.pathPins\)/g) || [];
   assert.equal(uses.length, 3, "all three chat bodies thread the pins");
 });
 

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -35,7 +35,7 @@ test("the kernel verifies with the filesystem, resolved exactly like a click", (
 });
 
 test("linkifyFileUris whole-links a verified span's entire inline-code content", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, foldKey\?: string\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
   // the pass targets inline <code> only, skips anything already linked or fenced
   assert.match(RENDER, /for \(const code of Array\.from\(root\.querySelectorAll\("code"\)\)\) \{\s*\n\s*if \(code\.closest\("a, \.file-uri-link, pre"\)\) continue;/);
   // exact-match against the kernel's verified set, then the whole content becomes one open link
@@ -54,7 +54,7 @@ test("the whole-span pass runs BEFORE the token walk, so the new link is skipped
 });
 
 test("every message render threads its event's spacePaths through", () => {
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\);/);   // user bubble
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\);/);     // expanded nudge body
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\);/);    // assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);   // user bubble
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);     // expanded nudge body
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);    // assistant reply
 });

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -278,7 +278,7 @@ test("fast rides the create end to end, resolved dialog > setting > inherit at t
   // the chip is offered only where the effective model could run fast (no control that only toasts)
   assert.match(UI, /if \(canFast\(create\.model \|\| setDef\("model"\) \|\| st\?\.model \|\| ""\)\) metaRight\.append\(mkSel\("fast"\)\);/);
   assert.match(UI, /fast: create\.fast \|\| "", color: create\.color \|\| "" \}\);/);
-  assert.match(UI, /fast: c\.fast, color: c\.color \}\);/);   // the in-flight retry keeps the pick
+  assert.match(UI, /fast: c\.fast, color: c\.color \}\);/);   // the in-flight retry keeps the pick (unchanged by the 2026-08-30 eager-all round)
   assert.match(KERNEL, /def _comment_launch_prefs\(model="", effort="", fast=""\):/);
   assert.match(KERNEL, /model, effort, fast = _comment_launch_prefs\(model, effort, fast\)/);
   assert.match(KERNEL, /fast=str\(msg\.get\("fast"\) or ""\)/);       // the ws op hands it through…

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -12,7 +12,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, foldKey\?: string\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
   assert.match(RENDER, /el\("span", "file-uri-link"\)/);
   // clicking is ROUTED by openPath, never a blocked window.open(file://) — a file:// URI is absolute,
   // so it takes the shared openPathLink's no-session-id branch
@@ -24,9 +24,9 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
 });
 
 test("linkify runs on chat message bodies (assistant reply + user bubble + nudge full text) and nowhere else — never tool summaries", () => {
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\)/);   // the assistant reply
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\)/); // your own bubble (in-bubble images don't re-thumb)
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\)/);   // a compact nudge's expanded full text (2026-07-17)
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\)/);   // the assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\)/); // your own bubble (in-bubble images don't re-thumb)
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\)/);   // a compact nudge's expanded full text (2026-07-17)
   // exactly the definition + those three applications — so tool-use reports/summaries stay untouched
   const uses = RENDER.match(/linkifyFileUris\(/g) || [];
   assert.equal(uses.length, 4, "linkifyFileUris is defined once and applied to exactly the three chat bodies");

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -50,8 +50,8 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry \} from "\.\/preview";/);
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
-  assert.match(RENDER, /previewable\.slice\(0, expanded \? previewable\.length : FIG_EAGER\)/,
-    "the eager cap guards against wallpapering; the remainder folds behind the '+N more figures' chip (2026-08-30), never dropped silently");
+  assert.match(RENDER, /for \(const p of previewable\) renderFig\(p\);/,
+    "every mention renders eagerly (the user's 2026-08-30 ruling); the browser's lazy loading bounds the cost, not a count");
   assert.match(RENDER, /previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/, "URLs bake the OWNING session's id — a background build must never capture activeId; verified paths fail loudly");
 });
 

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -466,7 +466,8 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       img.className = "path-full-img";
       img.src = src;
       img.alt = path;
-      img.loading = "lazy";
+      img.loading = "lazy";       // off-screen figures don't fetch until scrolled near (eager-all, 2026-08-30)
+      img.decoding = "async";     // and never decode on the main thread mid-scroll
       img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid, pin); };
       return img;
     };

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1320,14 +1320,8 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // gate below still applies; the map only ever narrows. An event with NO pathLinks key at all (an old
 // kernel, a cached payload) keeps today's shape-only linking rather than unlinking history.
 // file:// URIs are explicit absolute paths — never gated on the map.
-// Messages whose "+N more figures" chip was clicked (keyed by event uuid) — the expansion LATCHES
-// so the constant re-renders keep it open (the openFolds pattern). Page-life only, like openFolds.
-const figsExpanded = new Set<string>();
-// How many figures render EAGERLY per message before the rest fold behind the chip: enough for the
-// common report shape, few enough that a directory enumeration never wallpapers the chat.
-const FIG_EAGER = 4;
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
-    pathLinks?: Record<string, string>, pathPins?: Record<string, string>, foldKey?: string): void {
+    pathLinks?: Record<string, string>, pathPins?: Record<string, string>): void {
   // A whole-backtick http(s) URL becomes a TAPPABLE link that still looks like code (the user
   // 2026-08-16, on mobile, wanting to tap through to a dashboard link a session sent). Bare URLs
   // and [text](url) already link via marked's gfm autolink + the global anchor click delegate;
@@ -1415,13 +1409,12 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
   //               the same host data-URL flow the user-message pictures use (buildPathImg, imgRequest
   //               now carrying the session id for relative resolution); a PDF keeps its click-to-open
   //               link (no inline viewer in the sandbox).
-  // The first FIG_EAGER figures render eagerly; the REST fold behind a "+N more figures" chip on the
-  // last strip — never silently dropped (the 2026-08-30 report: a message led with four absolute
-  // mentions and then listed six repo-relative ones; the old silent slice(0, 4) kept exactly the
-  // absolutes, which read as "relative paths don't preview" when the break was the cap all along).
-  // Clicking the chip renders the remainder at their mentions — the figures ARE the acknowledgment —
-  // and latches via figsExpanded so re-renders keep the message expanded. Every path stays clickable
-  // regardless.
+  // EVERY verified figure mention renders eagerly at its mention anchor (the user 2026-08-30,
+  // overruling the 4-eager+chip fold shipped a day earlier, paraphrased: they should be able to
+  // preview as many images as they want in the thread). No cap and no chip: previewFull's <img>s
+  // are browser-lazy (loading="lazy"), so an off-screen figure costs one DOM node until scrolled
+  // near — a many-figure message can't hurt scroll or startup — and the kernel's mention-pin store
+  // is already size-bounded with eviction. Every path stays clickable regardless.
   if (previewable.length) {
     const BLOCK_SEL = "p, li, h1, h2, h3, h4, h5, h6, blockquote, td, th";
     const strips = new Map<HTMLElement, HTMLElement>();   // figure anchor → its strip (same block shares one)
@@ -1442,24 +1435,7 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
       strip.appendChild(full);
       return strip;
     };
-    const expanded = !!foldKey && figsExpanded.has(foldKey);
-    let lastStrip: HTMLElement | null = null;
-    for (const p of previewable.slice(0, expanded ? previewable.length : FIG_EAGER))
-      lastStrip = renderFig(p) || lastStrip;
-    const rest = expanded ? [] : previewable.slice(FIG_EAGER);
-    if (rest.length) {
-      const chip = el("button", "path-more") as HTMLButtonElement;
-      chip.type = "button";
-      chip.textContent = "+" + rest.length + " more figure" + (rest.length === 1 ? "" : "s");
-      chip.title = "show the remaining figures at their mentions";
-      chip.addEventListener("click", (ev) => {
-        ev.stopPropagation();
-        if (foldKey) figsExpanded.add(foldKey);
-        chip.remove();
-        for (const p of rest) renderFig(p);
-      });
-      (lastStrip ?? root).appendChild(chip);
-    }
+    for (const p of previewable) renderFig(p);
   }
 }
 
@@ -2416,7 +2392,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         if (more) {
           const full = el("div", "nudge-full md");
           full.innerHTML = md(raw);
-          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.uuid);
+          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins);
           bubble.appendChild(full);
           bubble.classList.add("nudge-collapsible");
           // toggle rides the stable document.body delegate (data-act), NOT a per-render listener —
@@ -2429,7 +2405,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         }
       } else if (ev.md) {
         bubble.innerHTML = md(ev.md);
-        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.uuid);   // bare file:// URLs in a message → clickable (open in the host's default app)
+        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins);   // bare file:// URLs in a message → clickable (open in the host's default app)
       }
       // images, IN the bubble (part of his message): thumbnail + open/copy caption;
       // a literal path in the typed text becomes the same open-link inline.
@@ -2576,7 +2552,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     const body = el("div", "assistant md");
     body.innerHTML = md(ev.md);
     highlight(body);
-    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.uuid);   // bare file:// URLs + verified spaced filenames → clickable
+    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins);   // bare file:// URLs + verified spaced filenames → clickable
     turn.appendChild(body);
     return turn;
   }

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -16,7 +16,7 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   assert.match(RENDER, /const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = m\[1\];/);
   assert.match(RENDER, /const args = el\("span", "slash-cmd-args"\); args\.textContent = rest;/);
   // the non-command path still renders markdown as before (now also linkifies bare file:// URLs)
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\);[^\n]*\n\s*\}/);
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2640,12 +2640,6 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   background: transparent; border: 1px solid var(--card-border);   /* T151: the one button rest */
   font-size: 0.86em; opacity: 0.85; cursor: pointer; }
 .path-full-retry:hover { border-color: var(--accent); }
-/* the figure-overflow chip ("+N more figures") — the retry chip's exact rest (T151: one button rest),
-   one click to expand the folded figures */
-.path-more { display: inline-flex; align-items: center; align-self: center; padding: 5px 10px;
-  border-radius: 8px; background: transparent; border: 1px solid var(--card-border);
-  color: inherit; font: inherit; font-size: 0.86em; opacity: 0.85; cursor: pointer; }
-.path-more:hover { border-color: var(--accent); }
 /* the fixed-footprint wait box shared by the retrying swirl AND the failure chip, so retry churn
    never shifts the chat's scroll (preview.ts mkWait; the user 2026-08-16 watched it thrash ~a line) */
 .path-full-wait { display: inline-flex; flex-direction: column; align-items: center; justify-content: center;

--- a/ui/webview/user-img-dedup.test.ts
+++ b/ui/webview/user-img-dedup.test.ts
@@ -15,7 +15,7 @@ const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbnail strip", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, foldKey\?: string\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
   // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't render a figure
   assert.match(RENDER,
     /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{\s*\n\s*previewable\.push\(open\);\s*\n\s*mentionAt\.set\(open, link\);/);
@@ -24,9 +24,9 @@ test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbna
 test("the user bubble passes its ev.images paths (caption path AND path:-src) as skipThumbs", () => {
   // both ways an in-bubble image names its file: im.path (caption) and a "path:<abs>" src
   assert.match(RENDER, /\.flatMap\(\(im\) => \[im\.path, im\.src\.startsWith\("path:"\) \? im\.src\.slice\(5\) : ""\]\)/);
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);
   // the assistant reply has no ev.images — its call stays bare (mentioned plots still thumb there)
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.uuid\);/);
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);
 });
 
 // executed: replicate the strip-collection decision — a path already rendered as an in-bubble


### PR DESCRIPTION
The user's ruling (2026-08-30, paraphrased): they should be able to preview as many images as they want in the thread — a 9-figure set got 4 inline. This overrules the 4-eager + "+N more figures" fold shipped a day earlier: the cap itself dies, not just its silence.

Every verified figure mention now renders eagerly at its mention anchor through the one `renderFig` path — pins and strip placement byte-identical. The chip, its `figsExpanded` latch, `FIG_EAGER`, the `foldKey` param threaded through `linkifyFileUris`'s three call sites, and the chip's CSS all retire outright. Off-screen cost is bounded by the browser, not a count: the figure imgs were already `loading="lazy"`, and `decoding="async"` joins.

**On a residual bound:** none kept. A 30-figure synthetic message on the real served chat put the first figure up 452ms after navigation with a 10MB JS heap; the kernel's mention-pin store is already size-bounded with eviction. Nothing left for a cap to protect.

**Tests:** the overflow/latch pins become the eager-all contract (all mentions render, machinery gone not dormant, lazy+async pinned); call-site and signature pins across six suites revert to the 5-arg shape. Headless: 30/30 render, every img lazy+async, no chip. Suites: python 6107, extension 2561, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)