### PR TITLE
Owed decisions render as a numbered yes/no list; stall stories open with the split

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10362,7 +10362,7 @@ def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None, shortfall=N
         # gone missing (the user had to ask what the missing decision was).
         user += ("\n<note>Your previous draft covered %d of the %d owed items in <owed>. Even "
                  "when items come down to the same decision, write one numbered single-line "
-                 "question per owed item, in <owed>'s order — exactly %d numbered paragraphs, "
+                 "question per owed item, in <owed>'s order: exactly %d numbered paragraphs, "
                  "each answerable with a yes/no or a one-word pick.</note>"
                  % (shortfall[0], shortfall[1], shortfall[1]))
     return _judge_run(_distill_model(), BLOCK_BRIEF_SYS, user, judge="briefer", tier="distill",
@@ -10968,8 +10968,11 @@ def _distill_session(fsid, path, now):
                         raw, out, src = _r2, _o2, _s2
                         bg = _b2 or bg                 # keep the draft's orientation if the retry lost it
                     else:
-                        out = "\n\n".join("%s: %s" % ((t or "this sub-goal").strip().rstrip("."),
-                                                       (w or "").strip()) for t, w in owed)
+                        out = "\n\n".join(
+                            "%d. %s: %s" % (i + 1, (t or "this sub-goal").strip().rstrip("."),
+                                            (w or "").strip()) for i, (t, w) in enumerate(owed))
+                        #      ^ numbered like the rule's own list shape (the review's catch: an
+                        #        unnumbered fallback re-shipped the dense recap the rule kills)
                         src = None                     # verbatim recorded whys — no model citation
                         _fallback_brief = True         # …so the cite-miss check below stands down:
                         #                                romp authored this text; "no SOURCE line"

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10276,6 +10276,13 @@ BLOCK_BRIEF_SYS = (
     "next by a blank line, so you can weigh and answer each on its own. When <owed> lists a single item, "
     "or several that come down to the SAME decision, write ONE paragraph, and never remark that the items "
     "repeat.\n\n"
+    "Those per-item paragraphs are a NUMBERED DECISION LIST (the user 2026-08-30: dense recaps stalled "
+    "their decisions for hours; a numbered yes/no list cleared them in one turn). Each owed item's "
+    "paragraph is one numbered single line - '1. <the question>' - phrased as a question the reader can "
+    "answer with a yes/no, or with a one-word pick when the choice is between named options. Numbers run "
+    "in <owed>'s order, one numbered line per paragraph, so the reader answers straight down the list. "
+    "Supporting context that a question truly needs stays inside that item's own line, in a clause, "
+    "never as a separate recap paragraph.\n\n"
     "If something apart from the decision is still open and worth knowing, it gets the last paragraph, "
     "alone, in one short sentence with no label. Never attach it to a paragraph about the decision.\n\n"
     "The reader is the person who asked, not the team that built it. When a <user-ask> section is "
@@ -10354,9 +10361,10 @@ def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None, shortfall=N
         # this one reply because complete coverage outranks brevity once an item has provably
         # gone missing (the user had to ask what the missing decision was).
         user += ("\n<note>Your previous draft covered %d of the %d owed items in <owed>. Even "
-                 "when items come down to the same decision, write one short paragraph per owed "
-                 "item, in <owed>'s order — exactly %d paragraphs, each leading with its item's "
-                 "own decision.</note>" % (shortfall[0], shortfall[1], shortfall[1]))
+                 "when items come down to the same decision, write one numbered single-line "
+                 "question per owed item, in <owed>'s order — exactly %d numbered paragraphs, "
+                 "each answerable with a yes/no or a one-word pick.</note>"
+                 % (shortfall[0], shortfall[1], shortfall[1]))
     return _judge_run(_distill_model(), BLOCK_BRIEF_SYS, user, judge="briefer", tier="distill",
                       mark=mk).strip()   # caller splits SOURCE, then caps
 
@@ -10390,6 +10398,10 @@ STALL_BRIEF_SYS = (
     "to the takeaway.\n\n"
     "TAKEAWAY: lead with where the work actually stopped, in your terms: the last thing that was finished "
     "or in progress, not a play-by-play. One or two sentences.\n\n"
+    "When <work> holds several separate strands, open the takeaway with the split the reader scans "
+    "fastest instead (the user 2026-08-30): what is done, what was in motion, and what is left - one "
+    "short clause each, in that order, before anything else. A single-strand stall keeps the plain "
+    "where-it-stopped lead above.\n\n"
     "What is holding it then gets the last paragraph, alone, in one short sentence with no label, "
     "translating <holding> out of romp's vocabulary into plain language. Restate <holding> faithfully. "
     "Never substitute a cause you inferred from <work>, and never say the goal is waiting on you unless "

--- a/tests/test_brief_owed_coverage.py
+++ b/tests/test_brief_owed_coverage.py
@@ -173,6 +173,17 @@ class OwedCoverage(unittest.TestCase):
         self.assertIsNone(self._stored().get("blockSummary"),
                           "nothing stored off a skipped call — next pass re-runs the whole brief")
 
+    def test_a_numbered_question_list_passes_the_count(self):
+        # the decision-list rule and the shortfall guard reinforce each other: one numbered
+        # single-line question per paragraph IS the countable shape — no spurious retry
+        self._world()
+        self.replies = ["BACKGROUND: b.\n\nTAKEAWAY: 1. Confirm the order?\n\n"
+                        "2. Judge-score the labels?\n\n3. Download both now?\n\n"
+                        "4. Extend the check now?"]
+        self._run()
+        self.assertEqual(len(self.calls), 1, "four numbered lines, four paragraphs — complete")
+        self.assertEqual(len(self._stored().get("briefParts") or []), 4)
+
     def test_blankish_separators_count_as_the_feed_renders(self):
         # the kernel counts with the feed's own split (\n\s*\n): a reply whose paragraphs are
         # separated by a whitespace-bearing blank line is complete, not a shortfall
@@ -209,7 +220,9 @@ class ShortfallNote(unittest.TestCase):
     def test_the_note_names_the_count_and_overrides_the_merge_allowance(self):
         jd.brief_llm("g", "w", [("a", "why a"), ("b", "why b")], shortfall=(1, 2))
         self.assertIn("covered 1 of the 2 owed items", self.calls["user"])
-        self.assertIn("exactly 2 paragraphs", self.calls["user"])
+        self.assertIn("exactly 2 numbered paragraphs", self.calls["user"])
+        self.assertIn("yes/no", self.calls["user"],
+                      "the retry converges on the numbered-question shape the standing rule asks for")
         self.assertIn("Even when items come down to the same decision", self.calls["user"],
                       "the override is per-call: the standing spec keeps its measured merge clause")
 

--- a/tests/test_brief_owed_coverage.py
+++ b/tests/test_brief_owed_coverage.py
@@ -140,9 +140,10 @@ class OwedCoverage(unittest.TestCase):
         self._run()
         self.assertEqual(len(self.calls), 2, "one retry, never a loop")
         bs = self._stored()["blockSummary"]
-        for why in WHYS:
+        for i, why in enumerate(WHYS):
             self.assertIn(why, bs, "the fallback carries every owed why verbatim — complete "
                                    "by construction, an item can never silently vanish")
+            self.assertIn("%d. " % (i + 1), bs, "…in the numbered shape the standing rule renders")
         self.assertEqual(len([p for p in bs.split("\n\n") if p.strip()]), 4)
         rows = self._errors()
         self.assertIn("owed-shortfall", [r.get("err") for r in rows])

--- a/tests/test_distill_paragraph_contract.py
+++ b/tests/test_distill_paragraph_contract.py
@@ -116,6 +116,47 @@ class ParagraphContract(unittest.TestCase):
             self.assertEqual(p.count("—"), 0, "%s: the prompt must not model what it forbids" % name)
 
 
+class DecisionListContract(unittest.TestCase):
+    """The user-approved communication rule (2026-08-30, via the optimizer): pending user decisions
+    render as a short numbered list of one-line yes/no questions, never buried inside status
+    recaps; and a status-shaped report opens with a done / in-motion / left-to-do split. Additive
+    paragraphs only — the takeaway specs' measured wording (the regression note above
+    BLOCK_BRIEF_SYS) is untouched, and the numbered list is exactly the countable per-paragraph
+    shape the owed-coverage guard verifies (tests/test_brief_owed_coverage.py)."""
+
+    def test_the_briefer_renders_owed_items_as_a_numbered_question_list(self):
+        p = jd.BLOCK_BRIEF_SYS
+        self.assertIn("NUMBERED DECISION LIST", p)
+        self.assertIn("one numbered single line", p)
+        self.assertIn("answer with a yes/no", p)
+        self.assertIn("one-word pick when the choice is between named options", p)
+        self.assertIn("one numbered line per paragraph", p,
+                      "each numbered item is its own paragraph — the render's per-paragraph "
+                      "stamps and the owed-coverage count both key on it")
+
+    def test_decisions_are_never_buried_in_recaps(self):
+        self.assertIn("never as a separate recap paragraph", jd.BLOCK_BRIEF_SYS,
+                      "context rides inside the question's own line — the buried-recap shape "
+                      "stalled the user's decisions for hours")
+
+    def test_the_merge_clause_and_the_single_item_lead_survive_untouched(self):
+        p = jd.BLOCK_BRIEF_SYS
+        self.assertIn("come down to the SAME decision, write ONE paragraph", p,
+                      "the measured merge clause is not reworded by the addition")
+        self.assertIn("Lead with exactly what you must decide or provide", p)
+
+    def test_the_staller_opens_status_with_the_three_way_split(self):
+        p = jd.STALL_BRIEF_SYS
+        self.assertIn("what is done, what was in motion, and what is left", p)
+        self.assertIn("before anything else", p)
+        self.assertIn("single-strand stall keeps the plain", p,
+                      "conditional: a one-strand stall keeps its terse where-it-stopped lead")
+
+    def test_the_split_stays_off_the_outcome_writer(self):
+        self.assertNotIn("what is done, what was in motion", jd.DISTILL_SYS,
+                         "a finished goal's takeaway is an outcome, not a status story")
+
+
 class ParserKeepsTheParagraphs(unittest.TestCase):
     """The reply parser is what has to survive the new shape: a takeaway is now MULTI-paragraph, the
     trailing SOURCE line still peels off around it, and a decorated label still parses."""


### PR DESCRIPTION
## Summary
The user-approved communication rule (via the nightly optimizer): dense recaps stalled pending decisions for 8 hours; a numbered list of one-line yes/no questions cleared them in one turn. Folded into the two judge prompts that write those surfaces, additively — the takeaway specs' measured wording and the pinned merge clause are untouched:

- **BLOCK_BRIEF_SYS multi-item branch**: the per-item paragraphs are a numbered decision list — each owed item one numbered single-line question answerable with a yes/no or a one-word pick between named options, in `<owed>`'s order, one numbered line per paragraph, supporting context inside the question's own line and never a separate recap paragraph. One numbered line per paragraph keeps the render's per-paragraph stamps AND is exactly the countable shape the owed-coverage shortfall guard verifies — the rule and the guard reinforce each other. The single-item branch keeps its lead-with-the-decision paragraph. The shortfall retry note and the deterministic fallback both converge on the same numbered shape (the fallback numbering and the note's em-dash removal are adversarial-review catches).
- **STALL_BRIEF_SYS** (the one status-story surface — the distiller writes finished outcomes, the gist writes topic phrases): when the work holds several strands, the takeaway opens with what is done, what was in motion, and what is left, one short clause each, before anything else; a single-strand stall keeps its terse where-it-stopped lead.

## Test plan
- Adherence pins in the prompt-contract idiom (`DecisionListContract` in `tests/test_distill_paragraph_contract.py`), including that the split stays OFF the outcome writer and the measured merge clause survives untouched.
- `tests/test_brief_owed_coverage.py`: a numbered question list passes the owed-coverage count without a spurious retry; the fallback pins its numbered shape; ShortfallNote pins follow the new wording.
- Full Python suite: 6,113 passed. Extension suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)