### PR TITLE
Send while scrolled up stays put; the reveal snap now belongs to the tail only

### DIFF
--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -28,14 +28,21 @@ test("the plain send registers an optimistic bubble; follow-up/quote sends keep 
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
   // registerOptimistic shows it NOW (before any push) via reconcile + appendActive
   assert.match(RENDER, /function registerOptimistic\(id: string, text: string, imgPaths\?: string\[\]\): void/);   // + the dragged-image paths → echo thumbnails (2026-08-25)
-  assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) \{\s*\n\s*appendActive\(\);/);
+  // the active-tab arm still paints via appendActive (the snap gate moved ahead of it, 2026-08-30)
+  assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) \{/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);/);
 });
 
-test("your OWN send always reveals itself — the >80px stick rule never hides it below the fold", () => {
-  // appendActive keeps the viewport still when the reader is scrolled up; a send made from there
-  // painted below the fold and looked like it never appeared (the user 2026-08-09). Enter = intent
-  // to see the message, so registerOptimistic scrolls to the bottom, once, at send time.
-  assert.match(RENDER, /appendActive\(\);[\s\S]{0,500}if \(content\) content\.scrollTop = content\.scrollHeight;\s*\n\s*\}\s*\n\}/);
+test("your OWN send reveals itself from the TAIL only — scrolled up, the viewport stays put", () => {
+  // The 2026-08-09 always-reveal snap (Enter = intent to see the message) survives where it belongs:
+  // at — or within the stick rule's 80px of — the bottom. Scrolled UP reading history, the user's
+  // 2026-08-30 ruling overrules it: the send must not move the scroll position at all, so the snap
+  // is gated on a nearBottom read taken BEFORE appendActive lands the bubble (the append grows
+  // scrollHeight, which would misread a tail-sitter as scrolled-up). Behavioral scenarios live in
+  // send-scroll-preserve.test.ts.
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) content\.scrollTop = content\.scrollHeight;/);
+  // the unconditional form is retired everywhere — nothing snaps a scrolled-up reader on send
+  assert.doesNotMatch(RENDER, /if \(content\) content\.scrollTop = content\.scrollHeight;/);
 });
 
 // The reconcile's two IN-PLACE tail mutations — merging into an existing queued group (a busy session

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -385,13 +385,16 @@ function registerOptimistic(id: string, text: string, imgPaths?: string[]): void
   const v = views.get(id);
   if (v) v.stale = true;
   if (id === activeId) {
-    appendActive();
-    // Your OWN send always reveals itself: appendActive's stick rule keeps the viewport still when
-    // you're read up >80px from the bottom, so a send made while scrolled up painted below the fold
-    // and looked like it never appeared (the user 2026-08-09). Hitting Enter is the intent to see
-    // the message — scroll to it, exactly once, at send time.
+    // Your own send reveals itself only from the TAIL, measured BEFORE the bubble lands (the append
+    // grows scrollHeight, which would misread a tail-sitter as scrolled-up). At — or within the
+    // stick rule's 80px of — the bottom, hitting Enter scrolls to the new bubble, exactly once, at
+    // send time (the user 2026-08-09, whose send painted below the fold and looked lost). Scrolled
+    // UP reading history, the viewport stays exactly where it is and the bubble waits below (the
+    // user 2026-08-30, yanked mid-read by the unconditional snap that used to live here).
     const content = document.getElementById("content");
-    if (content) content.scrollTop = content.scrollHeight;
+    const wasAtBottom = !!content && nearBottom(content);
+    appendActive();
+    if (content && wasAtBottom) content.scrollTop = content.scrollHeight;
   }
 }
 

--- a/ui/webview/send-scroll-preserve.test.ts
+++ b/ui/webview/send-scroll-preserve.test.ts
@@ -1,0 +1,84 @@
+// Sending from the composer while scrolled UP must not move the scroll position at all: the message
+// sends, the optimistic bubble lands below the fold, and the reader stays exactly where they were
+// (the user 2026-08-30, yanked to the bottom mid-read by the old unconditional snap). Sending while
+// at — or within the stick rule's 80px of — the bottom keeps the old behavior: the view follows the
+// new bubble (the 2026-08-09 always-reveal rule, now scoped to the tail). The gate is a nearBottom
+// read taken BEFORE appendActive lands the bubble, because the append grows scrollHeight and a
+// post-append read would misclassify a tail-sitter as scrolled-up.
+//
+// render.ts has import-time DOM side effects → source pins + an executed replica of the decision
+// (optimistic-send.test.ts / user-img-dedup.test.ts precedent).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+// ── executed replica ──────────────────────────────────────────────────────────────────────────────
+// Mirrors registerOptimistic's active-tab arm + appendActive's stick rule, both pinned to source
+// below so the replica can't drift silently.
+type Box = { scrollHeight: number; clientHeight: number; scrollTop: number };
+const nearBottom = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight < 80;   // render.ts nearBottom
+const maxScroll = (c: Box) => Math.max(0, c.scrollHeight - c.clientHeight);          // DOM clamps scrollTop
+function sendOwnMessage(c: Box, bubbleGrowth: number): void {
+  const wasAtBottom = nearBottom(c);                                   // measured BEFORE the append
+  // appendActive: stick only when overflowing AND near the bottom; otherwise restore the viewport
+  const stick = c.scrollHeight > c.clientHeight + 2 && nearBottom(c);
+  const before = c.scrollTop;
+  c.scrollHeight += bubbleGrowth;                                      // the bubble lands
+  c.scrollTop = stick ? maxScroll(c) : before;                         // stick or anchor/before restore
+  if (wasAtBottom) c.scrollTop = maxScroll(c);                         // the gated snap
+}
+
+test("scrolled-up send preserves scrollTop exactly — mid-history", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 1000 };
+  sendOwnMessage(c, 200);
+  assert.equal(c.scrollTop, 1000);
+});
+
+test("scrolled-up send preserves scrollTop exactly — just above the 80px stick threshold", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 5000 - 600 - 100 };   // 100px up
+  sendOwnMessage(c, 200);
+  assert.equal(c.scrollTop, 5000 - 600 - 100);
+});
+
+test("at-bottom send still follows the new bubble", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 5000 - 600 };
+  sendOwnMessage(c, 200);
+  assert.equal(c.scrollTop, 5200 - 600);
+});
+
+test("within-80px send still follows — the stick rule's near-bottom band is 'at the bottom'", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 5000 - 600 - 40 };    // 40px up
+  sendOwnMessage(c, 200);
+  assert.equal(c.scrollTop, 5200 - 600);
+});
+
+test("a send that first overflows the pane still reveals itself — nearBottom is trivially true", () => {
+  const c: Box = { scrollHeight: 500, clientHeight: 600, scrollTop: 0 };
+  sendOwnMessage(c, 400);   // 500 → 900: crosses the overflow boundary
+  assert.equal(c.scrollTop, 900 - 600);
+});
+
+// ── source pins: the replica models the real code ─────────────────────────────────────────────────
+
+test("registerOptimistic gates the snap on a pre-append nearBottom read", () => {
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) content\.scrollTop = content\.scrollHeight;/);
+  // nearBottom's 80px threshold — the replica's constant
+  assert.match(RENDER, /function nearBottom\(c: HTMLElement\): boolean \{\s*\n\s*return c\.scrollHeight - c\.scrollTop - c\.clientHeight < 80;/);
+  // appendActive's stick rule — overflow gate + nearBottom, restore otherwise
+  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);/);
+});
+
+test("every composer-shaped send rides the same gate — staged flush and provisional adoption included", () => {
+  // the staged flush releases each message through routeUserMessage…
+  assert.match(RENDER, /function flushStaged\(sid: string\): number \{\s*\n\s*const batch = stagedMsgs\.takeAll\(sid\);\s*\n\s*for \(const s of batch\) routeUserMessage\(sid, s\.text, s\.cites as Citation\[\]\);/);
+  // …whose every branch registers the optimistic bubble (2026-08-23), so the gate covers them all
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ [^\n]*registerOptimistic\(sid, text, imgPaths\); \}/);
+  assert.match(RENDER, /else if \(quoteCites\.length\) \{ [^\n]*registerOptimistic\(sid, body, imgPaths\); \}/);
+  assert.match(RENDER, /else \{ [^\n]*registerOptimistic\(sid, text, imgPaths\); \}/);
+  // provisional adoption re-sends through registerOptimistic too
+  assert.match(RENDER, /registerOptimistic\(realId, text\);/);
+});


### PR DESCRIPTION
Sending from the composer while scrolled up reading history yanked the view to the bottom: `registerOptimistic` followed its `appendActive` with an unconditional `content.scrollTop = content.scrollHeight` (the 2026-08-09 always-reveal rule). The user's 2026-08-30 ruling overrules that for the scrolled-up case: a send must not move the scroll position at all.

**Fix**: the snap is gated on a `nearBottom` read taken BEFORE `appendActive` lands the bubble (the append grows `scrollHeight`, so a post-append read would misclassify a tail-sitter as scrolled-up). At — or within the stick rule's 80px of — the bottom, today's follow behavior holds, including the send that first overflows the pane; scrolled up, `appendActive`'s anchor/before restore keeps `scrollTop` byte-exact.

One gate covers every composer-shaped send: plain Enter, quote replies, goal follow-ups, the staged flush, and provisional adoption all funnel through `routeUserMessage`/`registerOptimistic` (audited; the edit path never snapped, and the comment popover scrolls only its own thread list).

**Tests**: `ui/webview/send-scroll-preserve.test.ts` — executed replica of the decision (mid-history + 150px-up preserved exactly; at-bottom, the 40px band, and first-overflow follow) plus source pins on the pre-append read, the 80px threshold, the stick rule, and the one-funnel audit; `optimistic-send.test.ts`'s always-reveal pin retargeted, the unconditional form pinned absent. Verified end to end on the served page: scrolled-up `scrollTop` held byte-exact through the send tick and the kernel round-trip; at-bottom followed.

Suites: npm 2568/2568, pytest 6113 passed + 313 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)