### PR TITLE
Request threads poke the pusher — never build the fleet inline

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4069,7 +4069,10 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     except Exception:
         sys.stderr.write("awaiting-wake outcomes: %s\n" % traceback.format_exc())
     if fired:
-        _push_all()
+        # ack-fast, not inline: this tick usually runs on the pusher thread, but the WS setAutoNudge
+        # op calls it directly (act-now on turn-on) — a fleet build there is the 2026-08-30 POST-wedge
+        # class, so the fired nudges ride the woken pusher's next cycle instead
+        _push_soon()
 
 
 # The awaiting WAKE (the user 2026-07-22, reworked 2026-08-11): a durable ⏳ stamp can, in the worst case,
@@ -8834,7 +8837,7 @@ def _open_or_revive(sid, live=False, client=None):
                               # model / permission-mode publish from the init message right away AND the model
                               # is changeable BEFORE the first message — not only after one (the user 2026-06-24:
                               # opening an SDK session showed no model/effort until a message was sent).
-        _push_all()
+        _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
     focus = {"type": "focus", "id": sid}
     if live:
         focus["live"] = True
@@ -8880,7 +8883,7 @@ def _revive_session(sid, client=None):
                                "text": detail or "unknown error"}, (client or {}).get("wid") or "")
         return
     _kept_open.discard(sid)       # it's live again → no longer a read-only kept tab
-    _push_all()                   # surface it promptly (the 4s pusher would catch it anyway)
+    _push_soon()                  # surface it promptly — the woken pusher builds it off this thread
     if client is not None:        # the asker's revive loader clears on this focus; other windows stay put
         _reveal_chat_for(client, {"type": "focus", "id": sid})
 
@@ -13615,7 +13618,7 @@ def _cycle_mode(name, sid, target):
         # a stale `cur`. We caused the change, so we know the new mode is `target` — write it. (A switch made
         # directly in the terminal TUI still can't be observed; that's a CC-exposure gap, not ours.) (2026-06-18.)
         _TMUX.record_permission_mode(name, target)
-        _push_all()                                                 # re-render so the chat mode label flips now
+        _push_soon()                                                # re-render so the chat mode label flips now
     threading.Thread(target=go, daemon=True).start()
 
 
@@ -16697,7 +16700,7 @@ def _warm_fleet_bg(now):
                     break
                 _parse(s["path"], s["sid"], now)          # warm the kernel parse cache
             _built_feed[1] = None                         # force the next build to use the now-warm parses
-            _push_all()
+            _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
         except Exception:
             sys.stderr.write("warm: %s\n" % traceback.format_exc())
         finally:
@@ -23951,7 +23954,7 @@ def _apply_judge_settings(body):
         except Exception:
             sys.stderr.write("rearm-on-model-change: %s\n" % traceback.format_exc())
         _producer_wake.set()
-        _push_all()
+        _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
     return {"ok": True, "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),
             "distillModel": jd._state_str("distill-model", "triage"),
@@ -30061,7 +30064,7 @@ class Handler(BaseHTTPRequestHandler):
                     _record_death(sid, int(time.time()), "kill")
                     _comment_kill_all(sid, be)   # its comment threads must not outlive it (the WS endSession twin)
                     _send_to_app("chat", {"type": "closed", "id": sid})
-                _push_all()
+                _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
                 return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path == "/new":
                 # Headless session creation (`romp new`, 2026-07-25): the WS createSession op as a
@@ -31147,7 +31150,7 @@ class Handler(BaseHTTPRequestHandler):
             # (and covers the endSession companion post, so an ended session never lingers as a tab).
             _kept_open.discard(msg["id"])
             _send_to_app("chat", {"type": "closed", "id": msg["id"]})
-            _push_all()
+            _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
         elif msg and msg.get("type") == "openSession" and msg.get("id"):
             # live → focus its (always-shown) tab; dead → the chat's confirmRevive modal. `live` lands on
             # the chat's LIVE TAIL (a blocked card's picker chip → right on the prompt, the user 2026-07-08).
@@ -31169,7 +31172,7 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "viewReadOnly" and msg.get("id"):
             _kept_open.add(msg["id"])            # confirmRevive → "View read-only": this dead session
             #                                      gets a (struck) read-only tab now, without resuming it
-            _push_all()
+            _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
             _reveal_chat_for(client, {"type": "focus", "id": msg["id"]})
         elif msg and msg.get("type") == "deepLink" and msg.get("session"):
             _reveal_or_confirm(msg["session"], {"type": "focus", "id": msg["session"], "anchor": msg.get("anchor"),

--- a/tests/test_distill_rearm.py
+++ b/tests/test_distill_rearm.py
@@ -456,7 +456,9 @@ class KernelRearmWiring(unittest.TestCase):
                       "the EFFECTIVE model is compared — a triage change while following counts too")
         self.assertIn("rearm_failed_summaries", src, "the switch is a discrete recovery event")
         self.assertIn("_producer_wake.set()", src, "the retry pass starts now, not at the next tick")
-        self.assertIn("_push_all()", src, "the swirl replaces the chip immediately")
+        self.assertIn("_push_soon()", src,
+                      "the swirl replaces the chip via the woken pusher — never an inline fleet build "
+                      "on the request thread (the 2026-08-30 POST wedge)")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5350,7 +5350,7 @@ class ViewBuilder(unittest.TestCase):
         # mode has no event source to self-heal from — _cycle_mode must record the mode it just cycled to,
         # or the var stays frozen (and the next press count is computed from a stale `cur`).
         calls, saved_run, saved_sleep = [], km.subprocess.run, km.time.sleep
-        saved_tmux, saved_thread, saved_push = km._tmux_sessions, km.threading.Thread, km._push_all
+        saved_tmux, saved_thread, saved_push = km._tmux_sessions, km.threading.Thread, km._push_soon
         class _SyncThread:                                  # run go() inline so the test sees the result
             def __init__(self, target=None, daemon=None): self._t = target
             def start(self): self._t()
@@ -5358,17 +5358,17 @@ class ViewBuilder(unittest.TestCase):
         km.time.sleep = lambda *_a, **_k: None
         km._tmux_sessions = lambda: {SID: {"mode": "auto"}}   # current mode is auto
         km.threading.Thread = _SyncThread
-        km._push_all = lambda: calls.append(["__push_all__"])
+        km._push_soon = lambda: calls.append(["__push_soon__"])   # ack-fast poke, never an inline build (2026-08-30)
         try:
             km._cycle_mode("mysess", SID, "plan")
         finally:
             km.subprocess.run, km.time.sleep = saved_run, saved_sleep
-            km._tmux_sessions, km.threading.Thread, km._push_all = saved_tmux, saved_thread, saved_push
+            km._tmux_sessions, km.threading.Thread, km._push_soon = saved_tmux, saved_thread, saved_push
         btab = [c for c in calls if c[:2] == ["tmux", "send-keys"] and "BTab" in c]
         self.assertEqual(len(btab), 3, "auto → plan is 3 shift+tab presses")
         self.assertIn(["tmux", "set", "-t", "mysess", "@claude-permission-mode", "plan"], calls,
                       "after cycling, the kernel records the new mode so the chat label updates")
-        self.assertIn(["__push_all__"], calls, "and re-renders so the label flips immediately")
+        self.assertIn(["__push_soon__"], calls, "and pokes the pusher so the label flips on its next cycle")
 
     def test_tmux_set_mode_refuses_a_mode_the_cycle_cannot_reach(self):
         # The picker gained Bypass for SDK sessions (the user 2026-08-15). shift+tab is the only handle

--- a/tests/test_post_push_coalescing.py
+++ b/tests/test_post_push_coalescing.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""The 2026-08-30 POST wedge: every well-formed POST hung (curl 000 at 60s) while ~114 handler
+threads piled inside do_POST → _push_all → build_session — each control POST ran a synchronous
+FULL-FLEET build on its request thread, arrivals outran service, and the pile starved the GIL.
+The designed fix predates the wedge: _push_soon() (2026-07-05) wakes the dedicated pusher — the ONE
+builder — which coalesces bursts; these tests pin that every request-side site now uses it, that
+pokes coalesce, and that a control route answers while a build runs. Synthetic only."""
+import http.client
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+import unittest
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_postpush", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The ONLY functions allowed to build inline: the pusher's own cycle and the tick jobs that run ON
+# the pusher thread (see _pusher_cycle_jobs). Everything request-side pokes instead.
+PUSHER_THREAD_FNS = {"_push_all", "_pusher_cycle_jobs", "_auto_pause_on_limit",
+                     "_auto_pause_on_spend_limit", "_auto_resume_retry", "_interrupt_block_tick"}
+
+
+class PushCallerCensus(unittest.TestCase):
+    def test_no_request_side_inline_build_survives(self):
+        src = Path(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read_text()
+        enclosing, offenders = None, []
+        for ln in src.splitlines():
+            m = re.match(r"(?:    )?def (\w+)", ln)
+            if m:
+                enclosing = m.group(1)
+            if re.match(r"\s*_push_all\(", ln) and "def _push_all" not in ln:
+                if enclosing not in PUSHER_THREAD_FNS:
+                    offenders.append((enclosing, ln.strip()))
+        self.assertEqual(offenders, [],
+                         "a request-side inline fleet build is the 2026-08-30 wedge — use _push_soon()")
+
+
+class PokeCoalescing(unittest.TestCase):
+    def test_n_pokes_latch_one_wakeup(self):
+        km._pusher_wake.clear()
+        for _ in range(50):
+            km._push_soon()
+        self.assertTrue(km._pusher_wake.is_set(), "the poke wakes the pusher immediately")
+        km._pusher_wake.clear()                       # ONE cycle consumes the whole burst
+        self.assertFalse(km._pusher_wake.is_set(), "50 pokes = 1 wakeup = 1 build — coalesced")
+
+
+class ControlRouteLatency(unittest.TestCase):
+    """A control POST answers while builds run: the handler thread never builds, so a flooded push
+    queue cannot pile handlers (the wedge's exact shape, inverted)."""
+
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self._saved_push = km._push_all
+        self.builds = []
+        def slow_build(tmux=None):
+            self.builds.append(time.time())
+            time.sleep(2.0)
+        km._push_all = slow_build
+
+    def tearDown(self):
+        km._push_all = self._saved_push
+        self.srv.shutdown()
+
+    def _post(self, path, body):
+        c = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        c.request("POST", path, json.dumps(body),
+                  {"Content-Type": "application/json", "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        r = c.getresponse()
+        out = (r.status, r.read())
+        c.close()
+        return out
+
+    def test_end_answers_fast_while_builds_run(self):
+        # simulate the pile: three threads stuck in the (patched, slow) fleet build
+        for _ in range(3):
+            threading.Thread(target=km._push_all, daemon=True).start()
+        km._pusher_wake.clear()
+        t0 = time.time()
+        status, _ = self._post("/end", {"name": "nonexistent-session-probe"})
+        took = time.time() - t0
+        self.assertLess(took, 1.5, "the control route sat behind push work — the wedge shape")
+        self.assertEqual(status, 200)
+        self.assertTrue(km._pusher_wake.is_set(),
+                        "…and the echo freshness rides the poke: the pusher wakes to build off-thread")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**The 2026-08-30 wedge**: every well-formed POST hung (curl 000 at 60s) while ~114 handler threads piled inside `do_POST → _push_all → build_session`. Each control POST ran a synchronous full-fleet build on its request thread; arrivals outran service and the pile starved the GIL — `/end` (the dashboard team's user-approved worker recycling) and every other control route sat behind push work.

**The designed fix predates the wedge**: `_push_soon()` (2026-07-05) wakes the dedicated pusher — the one builder — whose Event latches, so any burst of pokes coalesces into one build within the 0.5s cycle. **Nine request-side call sites had never converted**; they all poke now: the `/end`/`/kill` route (the py-spy's exact pile site), both `_dispatch_ws` inline builds, `_open_or_revive`, `_revive_session`, the permission-mode flip thread, the boot warm thread, `_apply_judge_settings`, and `_auto_nudge_tick`'s push (it runs on the WS thread via setAutoNudge's act-now call). **Echo freshness holds by construction**: the poke returns the pusher's wait immediately, so the rebuild lands within one cycle, off the request thread — the freshness the WS drive ops have had since 2026-07-05. The pusher-thread tick jobs keep their inline push: they ARE the builder thread.

**Tests**: a caller census (every statement-shaped `_push_all` call must live in a pusher-thread function — a new request-side builder trips the pin before it ships); executed coalescing (fifty pokes latch one wakeup); and a live-harness proof — real `Handler`, `_push_all` patched to a 2s build, three builds running, and **POST /end answers in <1.5s** with the wake set (the wedge shape, inverted). Two stale pins on converted sites retargeted. Python 6116 passed / extension 2561 passed on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)