### PR TITLE
A live session blinked out of one listing is never ruled dead

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5882,7 +5882,7 @@ class SdkBackend:
 
     def _live_row(self, reg, sid):
         """One session's live_sessions row (running snapshot, else the dormant reg row) — factored
-        so live_sessions can guard it PER SESSION (one bad row must not hide the fleet-mates)."""
+        so live_sessions can guard it PER SESSION (one bad row must not hide the other sessions)."""
         s = self.sessions.get(sid)
         if s and s.thread.is_alive():
             return s.snapshot()
@@ -5919,7 +5919,6 @@ class SdkBackend:
                     "fast": reg.get("liveFast", ""),
                     "fastReason": reg.get("liveFastReason", ""),
                     "ctx": lc if isinstance(lc, (int, float)) else "", "summary": ""}
-        return out
 
     # ---- picker/permission UI bridge (kernel-thread API) ----
     def on_ask(self, sid: str, kind: str, payload=None) -> bool:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5859,44 +5859,66 @@ class SdkBackend:
                 continue
             if reg.get("threadOf"):
                 continue   # a comment thread: its surface is the parent chat's comment UI, never a tab
-            sid = reg["sid"]
-            s = self.sessions.get(sid)
-            if s and s.thread.is_alive():
-                out[sid] = s.snapshot()
-            else:
-                ls = last_state(self.state_dir, sid)
-                st = ls.get("state") or "waiting"
-                # A NOT-running (dormant, resumable) SDK session can't actually be mid-turn: after a kernel
-                # restart its thread is gone, but the state log still reads its last in-flight state
-                # ("working"/"permission"/"picker"/…). Reporting that verbatim makes a dormant session look
-                # FALSELY blocked/working with NO live ask to resolve it — the prompt died with the thread (the
-                # user 2026-06-24: reorder_bug showed "blocked, needs approval" with no prompt after a refresh).
-                # Map any in-flight state → "waiting", the true state of a dormant session (it resumes on the
-                # next drive). A GENUINELY-blocked session is RUNNING → snapshot() above (with a real
-                # current_ask), so it's unaffected. Keyed on thread-not-running, not a time heuristic.
-                if st in ("working", "permission", "picker", "compacting", "retrying"):
-                    st = "waiting"
-                lc = reg.get("liveCtx")   # last persisted context fill → bar survives idle/restart
-                out[sid] = {"state": st,
-                            "since": str(ls.get("t") or ""),
-                            # not running (e.g. post-restart): prefer the last LIVE model we persisted
-                            # (liveModel), else the chosen alias — so the badge isn't blank while dormant.
-                            "model": model_label(reg.get("liveModel") or "", reg.get("model") or ""),
-                            "modelPending": bool(reg.get("modelPending")),
-                            "effortPending": bool(reg.get("effortPending")),
-                            "effort": reg.get("effort", ""),
-                            "auth": self.default_auth(reg),
-                            # the persisted CLI truth (apiKeyAuth, the liveModel pattern) so a dormant
-                            # session's Billing row keeps telling it; absent = no init ever landed
-                            "authLive": ("key" if reg.get("apiKeyAuth") else "login")
-                                        if isinstance(reg.get("apiKeyAuth"), bool) else "",
-                            "authPending": bool(reg.get("authPending")),
-                            "mode": reg.get("mode", ""),
-                            # last persisted fast state (liveFast, like liveCtx above) → the badge
-                            # survives idle/restart instead of vanishing until the next turn
-                            "fast": reg.get("liveFast", ""),
-                            "fastReason": reg.get("liveFastReason", ""),
-                            "ctx": lc if isinstance(lc, (int, float)) else "", "summary": ""}
+            sid = reg.get("sid")
+            if not sid:
+                continue
+            try:
+                out[sid] = self._live_row(reg, sid)
+            except Exception:
+                # One session's bad row must not hide the OTHERS — this loop used to run unguarded
+                # under the kernel merge's single try, so one snapshot() exception silently dropped
+                # EVERY SDK session from an otherwise-successful listing, and absence from a listing
+                # reads as death downstream (the postal bus refused sends to live peers, 2026-08-31).
+                # The failing session itself stays VISIBLE as a minimal waiting row: present beats
+                # perfect, and the loud line makes the real bug findable.
+                sys.stderr.write("live_sessions: row for %s failed (kept as minimal row): %s\n"
+                                 % (sid, traceback.format_exc()))
+                out[sid] = {"state": "waiting", "since": "", "model": "", "modelPending": False,
+                            "effortPending": False, "effort": "", "auth": "", "authLive": "",
+                            "authPending": False, "mode": "", "fast": "", "fastReason": "",
+                            "color": None, "connected": False, "spawning": False, "retryCount": 0,
+                            "retryInfo": None, "ctx": None, "subagents": [], "bgTasks": []}
+        return out
+
+    def _live_row(self, reg, sid):
+        """One session's live_sessions row (running snapshot, else the dormant reg row) — factored
+        so live_sessions can guard it PER SESSION (one bad row must not hide the fleet-mates)."""
+        s = self.sessions.get(sid)
+        if s and s.thread.is_alive():
+            return s.snapshot()
+        ls = last_state(self.state_dir, sid)
+        st = ls.get("state") or "waiting"
+        # A NOT-running (dormant, resumable) SDK session can't actually be mid-turn: after a kernel
+        # restart its thread is gone, but the state log still reads its last in-flight state
+        # ("working"/"permission"/"picker"/…). Reporting that verbatim makes a dormant session look
+        # FALSELY blocked/working with NO live ask to resolve it — the prompt died with the thread (the
+        # user 2026-06-24: reorder_bug showed "blocked, needs approval" with no prompt after a refresh).
+        # Map any in-flight state → "waiting", the true state of a dormant session (it resumes on the
+        # next drive). A GENUINELY-blocked session is RUNNING → snapshot() above (with a real
+        # current_ask), so it's unaffected. Keyed on thread-not-running, not a time heuristic.
+        if st in ("working", "permission", "picker", "compacting", "retrying"):
+            st = "waiting"
+        lc = reg.get("liveCtx")   # last persisted context fill → bar survives idle/restart
+        return {"state": st,
+                    "since": str(ls.get("t") or ""),
+                    # not running (e.g. post-restart): prefer the last LIVE model we persisted
+                    # (liveModel), else the chosen alias — so the badge isn't blank while dormant.
+                    "model": model_label(reg.get("liveModel") or "", reg.get("model") or ""),
+                    "modelPending": bool(reg.get("modelPending")),
+                    "effortPending": bool(reg.get("effortPending")),
+                    "effort": reg.get("effort", ""),
+                    "auth": self.default_auth(reg),
+                    # the persisted CLI truth (apiKeyAuth, the liveModel pattern) so a dormant
+                    # session's Billing row keeps telling it; absent = no init ever landed
+                    "authLive": ("key" if reg.get("apiKeyAuth") else "login")
+                                if isinstance(reg.get("apiKeyAuth"), bool) else "",
+                    "authPending": bool(reg.get("authPending")),
+                    "mode": reg.get("mode", ""),
+                    # last persisted fast state (liveFast, like liveCtx above) → the badge
+                    # survives idle/restart instead of vanishing until the next turn
+                    "fast": reg.get("liveFast", ""),
+                    "fastReason": reg.get("liveFastReason", ""),
+                    "ctx": lc if isinstance(lc, (int, float)) else "", "summary": ""}
         return out
 
     # ---- picker/permission UI bridge (kernel-thread API) ----

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -602,7 +602,12 @@ def _kernel_sessions_checked(threads=False):
     try:
         req = urllib.request.Request(KERNEL_BASE + "/sessions" + ("?threads=1" if threads else ""),
                                      headers={"X-Romp-Token": SERVE_TOKEN})
-        with urllib.request.urlopen(req, timeout=2) as r:
+        # 5s, not 2: on a loaded box a cold-cache /sessions can outrun a tight timeout, and a
+        # failed fetch here starts the exact refusal chain the 2026-08-31 specimens rode (the
+        # listing "fails" → the pool loses every local → the probe hits a now-warm kernel and
+        # answers → a live peer gets ruled dead). The corroboration arms make even a timeout
+        # honest now, but not paying the false-negative at all is better.
+        with urllib.request.urlopen(req, timeout=5) as r:
             data = json.loads(r.read().decode("utf-8"))
         return (data if isinstance(data, list) else []), True
     except Exception:
@@ -749,6 +754,38 @@ def _recip_id_for(to):
         return to
     return None
 
+def _durable_session(bare, by_id):
+    """Does `bare` name a session the DURABLE per-session registry knows as live-or-resumable?
+    The corroboration read behind the answered-but-absent refusal arm (2026-08-31): the kernel's
+    listing transiently omitted live sessions (a restart-settle blink), and the bus converted an
+    incomplete-but-200 listing into a hard "not live" for both address forms — one specimen
+    mis-routed a warning mail. A reg with alive=true is a session romp WILL list (running or
+    dormant-resumable), so its absence from one listing is a listing gap, never evidence of death.
+    tmux sessions have no reg — their liveness is tmux's own, and this read stays honestly silent
+    for them. Reads the registry file directly (same box, kernel-owned): the designed API is the
+    listing itself, which is exactly the thing being second-guessed here."""
+    root = STATE.parent
+    sids = [bare] if by_id else []
+    if not by_id:
+        try:
+            for f in NAMES_DIR.iterdir():
+                try:
+                    if f.read_text().split("\t")[0].strip() == bare:
+                        sids.append(f.name)
+                except OSError:
+                    continue
+        except OSError:
+            pass
+    for sid in sids:
+        try:
+            reg = json.loads((root / "sdk" / (sid + ".json")).read_text())
+        except (OSError, ValueError):
+            continue
+        if isinstance(reg, dict) and reg.get("alive"):
+            return True
+    return False
+
+
 def resolve_recipient(to, frm_id=""):
     """Resolve a recipient reference to exactly ONE destination, or explain why it can't.
 
@@ -834,14 +871,31 @@ def resolve_recipient(to, frm_id=""):
     # world, and the kernel is its authoritative source (fail loudly, never degrade silently, the
     # user 2026-07-03). Before making the claim, ask whether the source ANSWERED: a mid-restart
     # kernel yields an empty listing that reads exactly like universal deadness. One loopback GET,
-    # paid only on this refusal path.
-    if not any(not a.get("remote") for a in pool) and not _kernel_sessions_checked()[1]:
-        # only an EMPTY local world raises the question — a listing with live locals in it proves
-        # the source answered (and heartbeating remotes can't vouch for LOCAL liveness)
+    # paid only on this refusal path — and even an ANSWERED listing is interrogated before the
+    # death ruling (2026-08-31: two verified specimens of a 200 listing omitting a LIVE session,
+    # by id and by name — a restart-settle blink; the refusal mis-routed a warning mail). The
+    # fresh fetch's own rows and the answered bit travel together from ONE call, so a kernel
+    # coming back between two fetches can't convert unreachable into a false death ruling; the
+    # durable per-session registry (_durable_session) corroborates what one listing missed.
+    rows, answered = _kernel_sessions_checked(threads=True)
+    if not answered and not any(not a.get("remote") for a in pool):
+        # only an EMPTY local world raises the unreachable question — a pool with live locals in
+        # it proves the source was answering (and heartbeating remotes can't vouch for LOCALS)
         return {"kind": "error", "status": 503,
                 "error": "can't tell whether '%s' is live right now: the liveness source (the romp "
                          "kernel) didn't answer — likely mid-restart. Nothing was sent, and this is "
                          "NOT a claim that '%s' is dead. Retry shortly." % (bare, bare)}
+    fresh = set()
+    for r in rows:
+        if isinstance(r, dict):
+            fresh.add(str(r.get("id") or ""))
+            fresh.add(str(r.get("name") or ""))
+    if bare in fresh or _durable_session(bare, by_id):
+        return {"kind": "error", "status": 503,
+                "error": "'%s' looks live (its durable registry entry stands) but the session "
+                         "listing came back without it — likely a restart-settle blink. Nothing "
+                         "was sent, and this is NOT a claim that '%s' is dead. Retry shortly."
+                         % (bare, bare)}
     return {"kind": "error", "status": 404, "error": "no live romp session named '%s'" % to}
 
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -570,7 +570,10 @@ _lock = threading.Lock()
 def _kernel_sessions(threads=False):
     """LIVE romp sessions (tmux + SDK) from the kernel's unified GET /sessions — the kernel owns the backend
     query (TmuxBackend for tmux liveness + the SDK registry), so the bus enumerates sessions WITHOUT shelling
-    tmux and WITHOUT reading the SDK registry directly: ONE source. Loopback, authorized with X-Romp-Token
+    tmux and, for ADDRESSING, without reading the SDK registry directly: ONE source. (One deliberate
+    exception since 2026-08-31: _durable_session reads a per-session reg file on the REFUSAL path only,
+    to corroborate a suspected listing blink before ruling a session dead — never to resolve delivery.)
+    Loopback, authorized with X-Romp-Token
     (the shared 0600 serve-token file — the kernel gates every request, loopback included). [] if the kernel
     is unreachable (rare — the manager supervises it); the bus then shows no local
     agents until it's back, rather than reaching past the abstraction to tmux.
@@ -602,12 +605,13 @@ def _kernel_sessions_checked(threads=False):
     try:
         req = urllib.request.Request(KERNEL_BASE + "/sessions" + ("?threads=1" if threads else ""),
                                      headers={"X-Romp-Token": SERVE_TOKEN})
-        # 5s, not 2: on a loaded box a cold-cache /sessions can outrun a tight timeout, and a
-        # failed fetch here starts the exact refusal chain the 2026-08-31 specimens rode (the
-        # listing "fails" → the pool loses every local → the probe hits a now-warm kernel and
-        # answers → a live peer gets ruled dead). The corroboration arms make even a timeout
-        # honest now, but not paying the false-negative at all is better.
-        with urllib.request.urlopen(req, timeout=5) as r:
+        # 2s is a BUDGET, not a guess: a refusal-bound send makes two sequential fetches (the
+        # pool + the corroboration probe), and every same-box bus CLIENT talks to the bus with a
+        # 5s cap (_http) — 2+2 stays inside it, so the honest refusal always reaches the sender.
+        # Raising this to 5s (tried 2026-08-31) made the worst case 10s: the client aborted with
+        # a bare "bus timed out" and the carefully-worded refusal died on a closed socket. A slow
+        # /sessions is instead healed by the corroboration arms, which read files, not the kernel.
+        with urllib.request.urlopen(req, timeout=2) as r:
             data = json.loads(r.read().decode("utf-8"))
         return (data if isinstance(data, list) else []), True
     except Exception:
@@ -765,8 +769,20 @@ def _durable_session(bare, by_id):
     for them. Reads the registry file directly (same box, kernel-owned): the designed API is the
     listing itself, which is exactly the thing being second-guessed here."""
     root = STATE.parent
-    sids = [bare] if by_id else []
-    if not by_id:
+    if by_id:
+        sids = [bare]
+    elif re.fullmatch(r"[0-9a-fA-F][0-9a-fA-F-]{7,35}", bare):
+        # the short-id form (the ` · <8-char>` every list_agents row shows) — the third address
+        # form, blink-protected like the other two: prefix-match the registry files themselves
+        try:
+            sids = [f.stem for f in (root / "sdk").glob("*.json") if f.stem.startswith(bare)]
+        except OSError:
+            sids = []
+        if len(sids) != 1:
+            sids = []          # ambiguity is the standing refusal's call, never a guess here
+    else:
+        sids = []
+    if not by_id and not sids:
         try:
             for f in NAMES_DIR.iterdir():
                 try:
@@ -877,6 +893,12 @@ def resolve_recipient(to, frm_id=""):
     # fresh fetch's own rows and the answered bit travel together from ONE call, so a kernel
     # coming back between two fetches can't convert unreachable into a false death ruling; the
     # durable per-session registry (_durable_session) corroborates what one listing missed.
+    if want_host and want_host != here:
+        # a host qualifier naming somebody ELSE took every local out of the running by DESIGN —
+        # the local listing and registry can say nothing about that host's sessions, and blink
+        # arms firing on a same-named LOCAL row turned a typo'd host into an endless retry-shortly
+        # (review find, 2026-08-31)
+        return {"kind": "error", "status": 404, "error": "no live romp session named '%s'" % to}
     rows, answered = _kernel_sessions_checked(threads=True)
     if not answered and not any(not a.get("remote") for a in pool):
         # only an EMPTY local world raises the unreachable question — a pool with live locals in
@@ -890,7 +912,12 @@ def resolve_recipient(to, frm_id=""):
         if isinstance(r, dict):
             fresh.add(str(r.get("id") or ""))
             fresh.add(str(r.get("name") or ""))
-    if bare in fresh or _durable_session(bare, by_id):
+    blinked = bare in fresh or _durable_session(bare, by_id)
+    if not blinked and not by_id and re.fullmatch(r"[0-9a-fA-F][0-9a-fA-F-]{7,35}", bare):
+        # the short-id form prefix-matches the fresh rows too, like the pool arm it mirrors
+        hits = {i for i in fresh if i.startswith(bare)}
+        blinked = len(hits) == 1
+    if blinked:
         return {"kind": "error", "status": 503,
                 "error": "'%s' looks live (its durable registry entry stands) but the session "
                          "listing came back without it — likely a restart-settle blink. Nothing "

--- a/tests/test_postal_live_only.py
+++ b/tests/test_postal_live_only.py
@@ -135,6 +135,77 @@ class KernelSilenceIsNotDeadness(unittest.TestCase):
         self.assertIn("no live romp session named 'ghost'", res["error"])
 
 
+class AnsweredButAbsentIsNotDeadness(unittest.TestCase):
+    """The OTHER false-refusal arm (2026-08-31): the kernel ANSWERED but its listing transiently
+    omitted a live session (a restart-settle blink), and the bus converted that into a hard "not
+    live" — two verified specimens, one by id and one by name, one of which mis-routed a warning
+    mail. A pool miss now corroborates against the DURABLE per-session registry (and the probe
+    fetch's own rows) before ruling death: reg alive=true → soft retry-shortly, never a death
+    claim. A name with no reg anywhere keeps the hard 404 — a typo stays a typo."""
+
+    GHOST_SID = "99999999-8888-7777-6666-000000000001"
+
+    def setUp(self):
+        _set_live([{"id": ALPHA, "name": "alpha"}])     # answered listing, target absent
+        self._sdk = pm.STATE.parent / "sdk"
+        self._sdk.mkdir(parents=True, exist_ok=True)
+        pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        pm.HEARTBEATS.clear()
+        for f in list(self._sdk.iterdir()) + list(pm.NAMES_DIR.iterdir()):
+            f.unlink()
+
+    def _reg(self, sid, name, alive=True):
+        (self._sdk / (sid + ".json")).write_text(json.dumps({"sid": sid, "name": name, "alive": alive}))
+        (pm.NAMES_DIR / sid).write_text("%s\t/tmp" % name)
+
+    def test_id_addressed_with_a_live_reg_refuses_soft(self):
+        self._reg(self.GHOST_SID, "blinky")
+        res = pm.resolve_recipient(self.GHOST_SID)
+        self.assertEqual((res["kind"], res["status"]), ("error", 503))
+        self.assertIn("restart-settle blink", res["error"])
+        self.assertIn("NOT a claim", res["error"])
+
+    def test_name_addressed_with_a_live_reg_refuses_soft(self):
+        self._reg(self.GHOST_SID, "blinky")
+        res = pm.resolve_recipient("blinky")
+        self.assertEqual((res["kind"], res["status"]), ("error", 503))
+        self.assertIn("restart-settle blink", res["error"])
+
+    def test_a_dead_reg_keeps_the_hard_404_both_forms(self):
+        self._reg(self.GHOST_SID, "gone4good", alive=False)
+        for who in (self.GHOST_SID, "gone4good"):
+            res = pm.resolve_recipient(who)
+            self.assertEqual((res["kind"], res["status"]), ("error", 404), who)
+            self.assertIn("no live romp session", res["error"])
+
+    def test_no_reg_anywhere_keeps_the_hard_404(self):
+        res = pm.resolve_recipient("typo-name")
+        self.assertEqual((res["kind"], res["status"]), ("error", 404))
+
+    def test_the_probe_fetchs_own_rows_count_as_presence(self):
+        # the pool (all_agents) missed the target but the probe's fresh listing has it — the
+        # kernel came back between the two reads; that is a blink, never a death ruling
+        saved = pm.all_agents
+        pm.all_agents = lambda threads=False: [{"id": ALPHA, "name": "alpha", "remote": False}]
+        try:
+            _set_live([{"id": ALPHA, "name": "alpha"}, {"id": self.GHOST_SID, "name": "blinky"}])
+            res = pm.resolve_recipient("blinky")
+        finally:
+            pm.all_agents = saved
+        self.assertEqual((res["kind"], res["status"]), ("error", 503))
+        self.assertIn("restart-settle blink", res["error"])
+
+    def test_durable_session_reads(self):
+        self._reg(self.GHOST_SID, "blinky")
+        self.assertTrue(pm._durable_session(self.GHOST_SID, by_id=True))
+        self.assertTrue(pm._durable_session("blinky", by_id=False))
+        self.assertFalse(pm._durable_session("nobody", by_id=False))
+        self.assertFalse(pm._durable_session("99999999-8888-7777-6666-000000000002", by_id=True))
+
+
 class RemovedSurfacesAreGone(unittest.TestCase):
     def test_removed_mcp_tools_absent(self):
         names = _tool_names()

--- a/tests/test_postal_live_only.py
+++ b/tests/test_postal_live_only.py
@@ -198,6 +198,31 @@ class AnsweredButAbsentIsNotDeadness(unittest.TestCase):
         self.assertEqual((res["kind"], res["status"]), ("error", 503))
         self.assertIn("restart-settle blink", res["error"])
 
+    def test_a_host_qualified_miss_keeps_the_hard_404(self):
+        # a host qualifier naming somebody ELSE takes every local out of the running by design —
+        # the local listing/registry can say nothing about that host, so the blink arms must not
+        # fire on a same-named LOCAL row (review find: a typo'd host became an endless retry-shortly)
+        self._reg(self.GHOST_SID, "blinky")
+        _set_live([{"id": self.GHOST_SID, "name": "blinky"}])
+        res = pm.resolve_recipient("otherhost:blinky")
+        self.assertEqual((res["kind"], res["status"]), ("error", 404))
+
+    def test_short_id_blink_refuses_soft(self):
+        # the third address form (the 8-char id prefix every list_agents row shows) is
+        # blink-protected like the other two
+        self._reg(self.GHOST_SID, "blinky")
+        res = pm.resolve_recipient(self.GHOST_SID[:8])
+        self.assertEqual((res["kind"], res["status"]), ("error", 503))
+        self.assertIn("restart-settle blink", res["error"])
+
+    def test_short_id_with_two_matching_regs_keeps_the_404(self):
+        twin = self.GHOST_SID[:-1] + "f"
+        self._reg(self.GHOST_SID, "blinky")
+        self._reg(twin, "blinky2")
+        res = pm.resolve_recipient(self.GHOST_SID[:8])
+        self.assertEqual((res["kind"], res["status"]), ("error", 404),
+                         "two registry hits on one prefix is the ambiguity family: refuse, never guess")
+
     def test_durable_session_reads(self):
         self._reg(self.GHOST_SID, "blinky")
         self.assertTrue(pm._durable_session(self.GHOST_SID, by_id=True))

--- a/tests/test_sdk_live_rows.py
+++ b/tests/test_sdk_live_rows.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""live_sessions is guarded PER SESSION (2026-08-31): the row loop used to run unguarded under the
+kernel merge's single try, so ONE session's snapshot() exception silently dropped EVERY SDK session
+from an otherwise-successful listing — and absence from a listing reads as death downstream (the
+postal bus refused sends to live peers over exactly this class of gap). One bad row now keeps its
+fleet-mates listed, and the failing session itself stays visible as a minimal waiting row.
+Synthetic; hermetic state."""
+import os
+import tempfile
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_liverows", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID_A = "11111111-2222-3333-4444-aaaaaaaaaaaa"
+SID_B = "11111111-2222-3333-4444-bbbbbbbbbbbb"
+
+
+class LiveRowsGuard(unittest.TestCase):
+    def setUp(self):
+        self.be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        for sid, name in ((SID_A, "web"), (SID_B, "api")):
+            sb.write_reg(self.be.state_dir, sid,
+                         {"sid": sid, "name": name, "alive": True, "model": "opus"})
+
+    def test_one_bad_snapshot_never_hides_the_others(self):
+        broken = mock.Mock()
+        broken.thread.is_alive.return_value = True
+        broken.snapshot.side_effect = RuntimeError("mid-reconnect blink")
+        self.be.sessions[SID_A] = broken
+        out = self.be.live_sessions()
+        self.assertEqual(set(out), {SID_A, SID_B},
+                         "the whole point: a bad row keeps its fleet-mates LISTED")
+        self.assertEqual(out[SID_A]["state"], "waiting",
+                         "the failing session stays visible as a minimal row — absent reads as dead")
+        self.assertEqual(out[SID_B]["state"], "waiting", "the dormant fleet-mate's real row")
+        self.assertEqual(out[SID_B]["model"], "Opus")
+
+    def test_a_sidless_reg_dict_is_not_fatal(self):
+        # list_regs injects the filename as sid for a reg missing the field; either way the
+        # loop must survive it and keep the real sessions listed
+        sb.write_reg(self.be.state_dir, "nosid", {"alive": True})
+        out = self.be.live_sessions()
+        self.assertIn(SID_A, out)
+        self.assertIn(SID_B, out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_live_rows.py
+++ b/tests/test_sdk_live_rows.py
@@ -3,7 +3,7 @@
 kernel merge's single try, so ONE session's snapshot() exception silently dropped EVERY SDK session
 from an otherwise-successful listing — and absence from a listing reads as death downstream (the
 postal bus refused sends to live peers over exactly this class of gap). One bad row now keeps its
-fleet-mates listed, and the failing session itself stays visible as a minimal waiting row.
+other sessions listed, and the failing session itself stays visible as a minimal waiting row.
 Synthetic; hermetic state."""
 import os
 import tempfile
@@ -35,10 +35,10 @@ class LiveRowsGuard(unittest.TestCase):
         self.be.sessions[SID_A] = broken
         out = self.be.live_sessions()
         self.assertEqual(set(out), {SID_A, SID_B},
-                         "the whole point: a bad row keeps its fleet-mates LISTED")
+                         "the whole point: a bad row keeps the OTHER sessions listed")
         self.assertEqual(out[SID_A]["state"], "waiting",
                          "the failing session stays visible as a minimal row — absent reads as dead")
-        self.assertEqual(out[SID_B]["state"], "waiting", "the dormant fleet-mate's real row")
+        self.assertEqual(out[SID_B]["state"], "waiting", "the dormant sibling's real row")
         self.assertEqual(out[SID_B]["model"], "Opus")
 
     def test_a_sidless_reg_dict_is_not_fatal(self):


### PR DESCRIPTION
## Why

Two verified specimens (2026-08-31, one by id and one by name, one mis-routing a warning mail): the kernel ANSWERED but its session listing transiently omitted a live session, and the postal bus converted that into a hard "not live" refusal. The earlier watch-hardening fix covered only the kernel-UNREACHABLE arm.

The evidence (journal shows no kernel restarts at either specimen) points at a fetch-pair race needing no restart at all: the bus's listing fetch fails — a 2s timeout a loaded kernel can outrun — the pool loses every local, and the is-the-kernel-answering probe then hits a now-warm kernel, converting a transient miss into a death ruling.

## What

- **`resolve_recipient`'s refusal arm corroborates before ruling death.** ONE fetch whose rows and answered-bit travel together; presence in the fresh rows, or a live entry in the durable per-session registry (`_durable_session` — reg `alive=true` means romp WILL list it, running or dormant-resumable), refuses SOFT ("restart-settle blink, retry shortly, NOT a claim it is dead", 503) instead of 404. All THREE address forms are protected: name, full uuid, and the 8-char short-id prefix (registry prefix-match; two hits keep the ambiguity-family hard 404). A name with no reg anywhere keeps the hard 404 — a typo stays a typo, and a names-file record alone still proves nothing (the dead-`gamma` bats case holds; live-only addressing unchanged). A HOST-QUALIFIED miss short-circuits to 404 before any local corroboration — local evidence says nothing about another host's sessions.
- **`sdk_backend.live_sessions` is guarded per session** (row build factored into `_live_row`): one session's `snapshot()` exception used to silently drop EVERY SDK session from an otherwise-successful listing under the kernel merge's single try. The failing session stays visible as a minimal waiting row, loudly, and the other sessions stay listed.
- The bus's `/sessions` fetch stays at 2s deliberately — it's a BUDGET (two sequential fetches on the refusal path must fit the bus clients' 5s cap; a tried 5s bump made the honest refusal die on a closed socket, blaming the bus). Slow listings are healed by the file-reading corroboration arms instead.

An adversarial review pass confirmed and reproduced four defects in the first cut (host-qualifier bypass with endless retry-shortly, the uncovered short-id form, the timeout budget collision, a dead `return` from the factoring) — all fixed here with regression tests.

## Tests

`tests/test_postal_live_only.py` +10 (soft-503 for id/name/short-id with a live reg; dead-reg and no-reg keep 404 both forms; host-qualified 404; short-id ambiguity 404; probe-rows-count-as-presence; `_durable_session` unit). New `tests/test_sdk_live_rows.py` (one bad snapshot keeps the others listed + the failing sid visible; sid-less reg non-fatal). Full suites: pytest 6140 passed / 34 skipped; vscode-extension 2568 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)