### PR TITLE
Mobile tabs wear the desktop's pane order — one ordering, never two

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28384,6 +28384,28 @@ _REFRESH_SVG = (
     "<path d='M9.5 5.4 L11.7 1.6 L13.5 5.2 Z' fill='currentColor'/></svg>")
 
 
+# THE pane presentation order (the user 2026-08-30: mobile must list the panes in the desktop
+# order — "mobile is a re-layout of the desktop, never a re-ordering"). This list is the desktop
+# rail strip's left-to-right order, which is the user's own choice (2026-07-05) and the desktop's
+# actual visible LIST of the named panes (the column layout cannot express it: Sessions/timeline
+# is a band, not a column). BOTH the desktop rail buttons and the mobile #mtabs buttons render
+# from this one constant — reorder here and both surfaces move together; a second hardcoded list
+# is the bug this replaces. Keys stay internal (timeline/fleet); labels are the user-facing names.
+_PANE_ORDER = (("chat", "Chat"), ("timeline", "Sessions"), ("fleet", "Outline"), ("feed", "Feed"))
+
+
+def _rail_buttons_html():
+    """The desktop rail's pane toggles, in _PANE_ORDER."""
+    return "".join("<div class=rail-btn data-pane=%s>%s</div>" % kv for kv in _PANE_ORDER)
+
+
+def _mtab_buttons_html():
+    """The mobile bottom bar's pane tabs — the SAME order as the desktop rail, by construction.
+    class=on keys on the chat KEY (the initially shown pane), never on position."""
+    return "".join("<button data-pane=%s%s>%s</button>"
+                   % (k, " class=on" if k == "chat" else "", lbl) for k, lbl in _PANE_ORDER)
+
+
 def _landing():
     # one flex row of up to FOUR independently-toggled panes (chat | fleet | feed | timeline) behind a far-left
     # rail; draggable gutters between visible panes; the rail also pins the ⛭ settings + ↻ refresh actions at
@@ -28990,10 +29012,8 @@ def _landing():
             # (.rail-acts, pinned RIGHT via margin-left:auto) with the ↻ refresh + network + ⛭ gear, always visible.
             "<div class=pane-rail>"
             "<div class=rail-scroll>"
-            "<div class=rail-btn data-pane=chat>Chat</div>"
-            "<div class=rail-btn data-pane=timeline>Sessions</div>"   # data-pane key stays 'timeline' (internal); the pane outgrew the label (the user 2026-08-24)
-            "<div class=rail-btn data-pane=fleet>Outline</div>"   # data-pane key stays 'fleet' (internal); the user-facing label is Outline
-            "<div class=rail-btn data-pane=feed>Feed</div>"
+            # the pane toggles, from _PANE_ORDER — the ONE ordering the mobile tabs share
+            + _rail_buttons_html() +
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
             # elapsed % slate), %-label, full detail on hover — side-by-side in the bottom bar.
             "<div id=rail-usage data-keycmd=usage.open></div>"
@@ -29041,10 +29061,9 @@ def _landing():
             "</div>"   # /.pane-rail (bottom bar)
             "</div>"
             "<nav id=mtabs>"
-            "<button data-pane=chat class=on>Chat</button>"
-            "<button data-pane=fleet>Outline</button>"   # data-pane key stays 'fleet' (internal), label Outline
-            "<button data-pane=feed>Feed</button>"
-            "<button data-pane=timeline>Sessions</button>"   # same rename on the phone tabs
+            # the pane tabs, from _PANE_ORDER — the desktop rail's exact order (the user 2026-08-30:
+            # mobile is a re-layout, never a re-ordering)
+            + _mtab_buttons_html() +
             # the rail's ACTIONS, reachable on mobile too (the user 2026-07-11): settings + the network
             # panel + a usage panel showing the desktop tooltip's window bars. data-act (not data-pane) —
             # they fire, they don't switch the shown pane.

--- a/tests/test_pane_order_parity.py
+++ b/tests/test_pane_order_parity.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Mobile/desktop pane-order parity (the user 2026-08-30): the mobile bottom tabs must list the
+panes in the SAME order the desktop presents them — "mobile is a re-layout of the desktop, never a
+re-ordering". The desktop's presentation order is the rail strip's left-to-right list (the user's
+own choice, 2026-07-05); both the rail buttons and the mobile #mtabs now render from the one
+_PANE_ORDER constant, so the pin below survives any future reorder of that constant: it asserts
+the two BUILT surfaces agree, not any particular sequence."""
+import os
+import re
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_pop", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _pane_seq(fragment):
+    return re.findall(r"data-pane=(\w+)", fragment)
+
+
+class PaneOrderParity(unittest.TestCase):
+    def _built(self):
+        html = km._landing()
+        # anchor on the body's TAGS — the bare class names also appear in the <style> block
+        rail = html[html.index("<div class=rail-scroll>"):html.index("<div id=rail-usage")]
+        mtabs = html[html.index("<nav id=mtabs>"):html.index("<span class=mtabs-div>")]
+        return rail, mtabs
+
+    def test_mobile_tabs_wear_the_desktop_rail_order(self):
+        rail, mtabs = self._built()
+        self.assertEqual(_pane_seq(mtabs), _pane_seq(rail),
+                         "one ordering, not two: #mtabs must list the panes exactly as the "
+                         "desktop rail strip does (change one, both move)")
+        self.assertEqual(len(_pane_seq(rail)), 4, "all four panes present on both surfaces")
+
+    def test_both_surfaces_render_from_the_one_constant(self):
+        # the mechanism, not just the outcome: a future hand-edit of either HTML block back to a
+        # literal list would pass the parity test above right up until someone reorders — this pin
+        # fails at the re-hardcoding itself
+        order = [k for k, _ in km._PANE_ORDER]
+        rail, mtabs = self._built()
+        self.assertEqual(_pane_seq(rail), order)
+        self.assertEqual(_pane_seq(mtabs), order)
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("+ _rail_buttons_html() +", src)
+        self.assertIn("+ _mtab_buttons_html() +", src)
+
+    def test_the_initial_mobile_pane_keys_on_chat_not_position(self):
+        _, mtabs = self._built()
+        m = re.search(r"<button data-pane=chat class=on>", mtabs)
+        self.assertIsNotNone(m, "chat is the initially shown pane by KEY — wherever it sits")
+        self.assertEqual(mtabs.count("class=on"), 1)
+
+    def test_labels_match_the_pn_map(self):
+        # the JS-side PN map (key → user-facing label) and the constant must agree, or a pane
+        # wears one name in the shell chrome and another in the tabs
+        html = km._landing()
+        pn = re.search(r"var PN=\{([^}]*)\}", html).group(1)
+        js = dict(re.findall(r"(\w+):'([^']*)'", pn))
+        self.assertEqual(dict(km._PANE_ORDER), js)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The user's ruling: the mobile tabs must list the panes in the desktop's order, always. Mobile is a re-layout of the desktop, never a re-ordering.

**"The" order = the desktop rail strip** (Chat / Sessions / Outline / Feed), on three grounds: it is what the desktop actually shows the user as a *list* of the named panes; the code marks that exact sequence as the user's own choice (2026-07-05, independent of the panes' layout order); and the column layout cannot express a four-pane list at all — Sessions/timeline is a band, not a column. The mobile `#mtabs` bar had its own hardcoded list (Chat / Outline / Feed / Sessions) — the bug.

## Fix

Both surfaces render from **one constant** (`_PANE_ORDER`): reorder it and the rail and the tabs move together. The mobile bar's initial lit tab keys on the chat *key*, never on position. The rail order is static (chosen in code, not runtime-arrangeable), so the shared constant is the whole of "follows it live".

**Secondary reading verified clean**: the mobile shell shows the same pane iframes the desktop does, one at a time, and re-sorts nothing — session-list parity holds by construction, so no pin was added for it.

## Tests (executed, on the built page)

- `#mtabs`'s data-pane sequence equals the rail strip's — change one, both move; the pin survives future reorders of the constant.
- Both surfaces render through the shared helpers — a re-hardcoding fails at the edit, not at the next reorder.
- The initial mobile pane keys on chat wherever it sits; the constant's labels agree with the JS `PN` map so a pane never wears two names.

Screenshots (hermetic lab kernel, synthetic): mobile footer and desktop strip both read Chat / Sessions / Outline / Feed.

## Suites

- pytest: 6144 passed + 313 subtests, 34 skipped
- extension: 2568 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)