### PR TITLE
Kernel endpoints for forked comment dispatch: /fork-comment and /fork-promote

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7244,7 +7244,8 @@ def _comment_launch_prefs(model="", effort="", fast=""):
     return tuple(out)
 
 
-def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", fast="", color="", now=None):
+def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", fast="", color="",
+                    now=None, raw_opener=False, meta=None):
     """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
     threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
     opening message. Returns (error, tid): error is the warn-toast string (tid None), success is
@@ -7257,7 +7258,17 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
     `model`/`effort` (the user 2026-08-17): per-thread overrides picked in the same dialog — the
     thread runs on them, the parent is untouched (fork() writes them into the thread's reg only).
     `fast` ("on"/"off"/"" — the user 2026-08-29) rides the same way; empty falls through
-    _comment_launch_prefs to the kernel's default-comment settings, then to inheriting the parent."""
+    _comment_launch_prefs to the kernel's default-comment settings, then to inheriting the parent.
+
+    `anchor_uuid ""` = a TIP fork, no highlighted record: the restart-seam fallback
+    _comment_cut_target already produces (cut "" → the thread takes the whole conversation) made a
+    designed input for callers with no transcript anchor — the /fork-comment door (the user
+    2026-08-31, whose track-changes review comments dispatch onto parallel forks). cut_t is the
+    create moment, so the timeline square sits where the thread began. `raw_opener` sends `text`
+    VERBATIM as the opening message — the caller authored the whole prompt (the plugin's thread
+    instructions); the quote frame would bury it under a passage that doesn't exist. `meta`
+    ({thread, note} strings) rides the registry row for provenance — the popover shows the row's
+    exact/name as usual; nothing kernel-side consumes meta beyond storing it."""
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "fork") and _sdk_ready()):
         return "threads need the SDK backend; this session runs on tmux, so there is nothing to fork.", None
@@ -7267,9 +7278,12 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
     sess = next((s for s in _sessions(now) if s["sid"] == parent_sid), None)
     if not sess:
         return "no transcript for this session yet, so nothing to comment on.", None
-    cut, cut_t, err = _comment_cut_target(sess["path"], parent_sid, str(anchor_uuid))
-    if err:
-        return err, None
+    if str(anchor_uuid or ""):
+        cut, cut_t, err = _comment_cut_target(sess["path"], parent_sid, str(anchor_uuid))
+        if err:
+            return err, None
+    else:
+        cut, cut_t = "", int(now)   # tip fork by request (see docstring) — no record to cut at
     nm = str(name or "").strip()
     if nm and not NAME_RE.match(nm):
         return "thread names use letters, digits, . _ - only.", None
@@ -7277,10 +7291,12 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
     if col and not re.fullmatch(r"#[0-9a-fA-F]{6}", col):
         col = ""                                   # not a palette hex → let the backend hash one
     tsid = str(uuid.uuid4())
-    row = {"tid": tsid, "sid": tsid, "anchorUuid": str(anchor_uuid), "cutUuid": cut,
+    row = {"tid": tsid, "sid": tsid, "anchorUuid": str(anchor_uuid or ""), "cutUuid": cut,
            "anchorT": cut_t,   # the commented message's own time — the timeline square's x
            "exact": str(exact)[:2000], "status": "open",
            "createdT": int(now), "lastSeenT": int(now)}
+    if isinstance(meta, dict) and (meta.get("thread") or meta.get("note")):
+        row["meta"] = {k: str(meta.get(k) or "")[:500] for k in ("thread", "note") if meta.get(k)}
     with _comments_lock:
         data = _load_comments(parent_sid)
         if not nm:
@@ -7295,7 +7311,7 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
         be.fork(nm, parent_sid, cut, bg=col, fg=(pal.fg_for(col) if col else ""), sid=tsid, thread_of=parent_sid,
                 model=model, effort=effort, fast=fast)
         be.connect(tsid)
-        be.send(tsid, _comment_first_message(exact, text))
+        be.send(tsid, text if raw_opener else _comment_first_message(exact, text))
     except Exception as e:
         with _comments_lock:                       # loud + lossless: no half-born thread row
             data = _load_comments(parent_sid)
@@ -7552,6 +7568,96 @@ def _comment_promote(parent_sid, tid, new_name, now=None, client=None):
         # presenting a dead tab as a healthy one (fail loudly)
         return "the thread is now the session '%s', but its process didn't start — revive it from its tab." % nm
     return None
+
+
+def _comment_fork_owner(tid):
+    """(parent_sid, row) for the comment thread with this tid, scanning every parent's registry —
+    /fork-promote arrives with only the forkId, no parent (the caller got it from /fork-comment and
+    kept nothing else). The store is one small json per commented-on session; None when no parent
+    holds it (including an empty/absent comments dir)."""
+    try:
+        files = sorted((jd.STATE / "comments").glob("*.json"))
+    except OSError:
+        return None
+    for f in files:
+        for th in _load_comments(f.stem).get("threads") or []:
+            if th.get("tid") == tid:
+                return f.stem, th
+    return None
+
+
+def _fork_comment_request(body):
+    """POST /fork-comment's brain, factored for tests (the _compact_request precedent): create a
+    transcript-comment-STYLE fork of the target session — the threadOf idiom, anchored at the TIP
+    (no highlighted record exists on this door) — and send `text` VERBATIM as the opening message
+    (the caller authored the whole prompt; the user 2026-08-31, whose track-changes review comments
+    dispatch onto parallel forks instead of interleaving through the target's main lane). Response
+    {"ok", "forkId"} or {"ok": False, "error"} (+_status when not 200). model/effort/fast ride
+    empty, so _comment_launch_prefs applies the kernel's default-comment picks exactly as a
+    dialog-created thread. Remote targets forward like /send; the far kernel runs this same brain
+    and its forkId passes through."""
+    if not isinstance(body, dict):
+        return {"ok": False, "error": "bad json", "_status": 400}
+    who = str(body.get("id") or body.get("name") or "")
+    text = body.get("text")
+    if not who or not isinstance(text, str) or not text.strip():
+        return {"ok": False, "error": "id (or name) and text required", "_status": 400}
+    meta = body.get("meta") if isinstance(body.get("meta"), dict) else {}
+    sid = _sid_of(who)
+    # the /send postal-isolation gate, same wrong-door reasoning: a fork of the target carries the
+    # target's context, so postal-shaped content routed here is agent mail dodging the mailbox
+    if _postal_shaped(text) and _postal_isolated(sid):
+        return {"ok": False, "error":
+                "isolation: the target session's mailbox is OFF — agent mail is refused on every "
+                "route; the refusal is final (the user can toggle its mailbox back on)"}
+    r = _host_for_sid(sid)
+    if r is not None:                                   # remote session → forward over its -L tunnel
+        res = _remote_forward(r, "/fork-comment", {"id": sid, "text": text, "meta": meta})
+        if isinstance(res, dict) and res.get("forkId"):
+            return {"ok": True, "forkId": str(res["forkId"])}
+        err = res.get("error") if isinstance(res, dict) else None
+        return {"ok": False, "error": str(err) if err else
+                "the remote kernel for this session (%s) isn't answering — thread not created"
+                % r.get("host", "?")}
+    if not _name_of(sid) and sid not in Sessions.live():
+        return {"ok": False, "error": "no session named '%s' here" % who, "_status": 404}
+    # the popover title: the note under review beats the generic default (glanceable), and the
+    # exact slot carries the same string — the header's "about" line for a thread with no passage
+    gist = str(meta.get("note") or meta.get("thread") or "").strip()
+    err, tid = _comment_create(sid, "", gist or "a review thread", text,
+                               raw_opener=True, meta=meta)
+    if err:
+        return {"ok": False, "error": err}
+    return {"ok": True, "forkId": tid}
+
+
+def _fork_promote_request(body):
+    """POST /fork-promote's brain: materialize a /fork-comment thread as a first-class session —
+    the existing break-out path (_comment_promote), exposed over HTTP. The promoted name is the
+    thread's own registry name (the <parent>-comment-N default or whatever it was renamed to).
+    REFUSALS RIDE NON-2xx (_status 400/404/409): the shipped caller treats any 2xx JSON as
+    success (the plugin's promote call), so an ok:false 200 would read as promoted. An
+    already-promoted thread is idempotent success — the ask is already true."""
+    if not isinstance(body, dict) or not str(body.get("forkId") or "").strip():
+        return {"ok": False, "error": "forkId required", "_status": 400}
+    fid = str(body["forkId"]).strip()
+    hit = _comment_fork_owner(fid)
+    if hit is None:
+        with _remotes_lock:
+            rows = list(_remotes.values())
+        for r in rows:                                  # the fork may live on an attached remote —
+            res = _remote_forward(r, "/fork-promote", {"forkId": fid})   # its kernel owns the registry
+            if isinstance(res, dict) and res.get("ok"):
+                return {"ok": True, "name": str(res.get("name") or "")}
+        return {"ok": False, "error": "no comment thread with that forkId", "_status": 404}
+    parent_sid, row = hit
+    if (row.get("status") or "") == "promoted":
+        return {"ok": True, "name": str(row.get("promotedName") or "")}
+    nm = str(row.get("name") or "").strip() or ("thread-" + fid[:8])
+    err = _comment_promote(parent_sid, fid, nm)
+    if err:
+        return {"ok": False, "error": err, "_status": 409}
+    return {"ok": True, "name": nm}
 
 
 # --- optional SDK (non-tmux) session backend (docs/sdk-backend.md) --------------------
@@ -30097,6 +30203,19 @@ class Handler(BaseHTTPRequestHandler):
                 # isn't a human composer bubble.
                 _send_or_park(Sessions.backend_for(sid), sid, body["text"])
                 return self._send(200, json.dumps({"ok": True}), "application/json")
+            if u.path in ("/fork-comment", "/fork-promote"):
+                # Parallel review dispatch (the user 2026-08-31, via the Obsidian track-changes
+                # plugin): /fork-comment forks the target as a transcript-comment-style thread and
+                # opens it with the caller's text verbatim → {"forkId"}; /fork-promote breaks a
+                # thread out into a first-class session. Brains factored for tests; refusal
+                # statuses are part of the contract (see _fork_promote_request).
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = None
+                res = (_fork_comment_request(b) if u.path == "/fork-comment"
+                       else _fork_promote_request(b))
+                return self._send(res.pop("_status", 200), json.dumps(res), "application/json")
             if u.path == "/compact":
                 # `romp compact <session>` — see _compact_request. Body: {"id"|"name": <session>};
                 # response {"ok", "queued"} so the CLI can say "compacting now" vs "queued".

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -831,5 +831,179 @@ class ExchangeLatchReplacedThePushCount(unittest.TestCase):
         self.assertIn('"msgs": msgs, "events": events', src)
 
 
+# ── the /fork-comment + /fork-promote route brains ───────────────────────────────────────────────
+# Parallel review dispatch (the user 2026-08-31): an external local tool (the Obsidian track-changes
+# plugin) POSTs /fork-comment to open a transcript-comment-STYLE thread on a session — TIP-anchored
+# (no highlighted record exists on that door) with the caller's own text as the opening message,
+# VERBATIM — and /fork-promote to break a thread out by forkId alone. The brains are factored from
+# the routes (_compact_request precedent), so these run without HTTP.
+
+class ForkCommentRoutes(CommentBase):
+    def setUp(self):
+        super().setUp()
+        self.be = FakeBackend()
+        self._saved_backend_for = km.Sessions.backend_for
+        self._saved_live = km.Sessions.live
+        self._saved_ready = km._sdk_ready
+        self._saved_sessions = km._sessions
+        self._saved_push_now = km._push_session_now
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km.Sessions.live = staticmethod(lambda: {})   # hermetic: never consult the box's real tmux
+        km._sdk_ready = lambda: True
+        # km.NAMES is bound at import (module-scope constant) — _rebind_state moves only jd's copy,
+        # so _name_of would read the import-time root and miss the per-test registry entry
+        self._saved_names = km.NAMES
+        km.NAMES = jd.NAMES
+        p = self._write(PARENT, self._parent_records())
+        (jd.NAMES / PARENT).write_text("parent\t%s" % self.cdir)
+        km._sessions = lambda now, window=None, forks=True: [
+            {"sid": PARENT, "name": "parent", "path": str(p), "mtime": self.now}]
+        km._push_session_now = lambda sid: None
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved_backend_for
+        km.Sessions.live = self._saved_live
+        km.NAMES = self._saved_names
+        km._sdk_ready = self._saved_ready
+        km._sessions = self._saved_sessions
+        km._push_session_now = self._saved_push_now
+        for f in ("comment-model", "comment-effort", "comment-fast"):
+            try:
+                (km.jd.STATE / f).unlink()
+            except OSError:
+                pass
+        km.jd._state_cache.clear()
+        super().tearDown()
+
+    OPENER = ("Please review the tracked edits in this note and reply in the review thread.\n\n"
+              "Use the thread id t-123 with every reply.")
+
+    def test_fork_comment_creates_a_tip_thread_with_the_text_verbatim(self):
+        res = km._fork_comment_request({"id": PARENT, "text": self.OPENER,
+                                        "meta": {"thread": "t-123", "note": "notes/demo.md"}})
+        self.assertTrue(res.get("ok"), res)
+        tid = res["forkId"]
+        self.assertEqual([c[0] for c in self.be.calls], ["fork", "connect", "send"])
+        self.assertEqual(self.be.calls[0][3], "", "TIP fork — no highlighted record on this door")
+        self.assertEqual(self.be.calls[0][5], PARENT, "born as a threadOf fork, never a board session")
+        self.assertEqual(self.be.sent[0][1], self.OPENER,
+                         "the caller authored the whole prompt — sent verbatim, never re-framed")
+        self.assertFalse(self.be.sent[0][1].startswith(km._COMMENT_FRAME_HEAD))
+        row = km._comment_thread(PARENT, tid)
+        self.assertEqual(row["status"], "open")
+        self.assertEqual(row["cutUuid"], "")
+        self.assertEqual(row["anchorUuid"], "")
+        self.assertEqual(row["meta"], {"thread": "t-123", "note": "notes/demo.md"})
+        self.assertEqual(row["exact"], "notes/demo.md",
+                         "the popover's about-line names the note under review")
+        self.assertEqual(row["name"], "parent-comment-1", "the standard autoname idiom")
+
+    def test_fork_comment_thread_reaches_the_popover_frame(self):
+        res = km._fork_comment_request({"id": PARENT, "text": self.OPENER, "meta": {"thread": "t-1"}})
+        fr = km._comments_frame(PARENT)
+        self.assertEqual([t["tid"] for t in fr["threads"]], [res["forkId"]],
+                         "a dispatched review thread is a normal popover thread")
+
+    def test_fork_comment_resolves_a_live_session_name(self):
+        km.Sessions.live = staticmethod(lambda: {PARENT: {}})
+        res = km._fork_comment_request({"name": "parent", "text": self.OPENER})
+        self.assertTrue(res.get("ok"), res)
+
+    def test_fork_comment_applies_the_default_comment_settings(self):
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        (km.jd.STATE / "comment-model").write_text("haiku")
+        km.jd._state_cache.clear()
+        km._fork_comment_request({"id": PARENT, "text": self.OPENER})
+        self.assertEqual(self.be.forked_meta[0], "haiku",
+                         "the gear trio governs these forks exactly like dialog-created threads")
+
+    def test_fork_comment_refusals_are_honest(self):
+        self.assertEqual(km._fork_comment_request(None)["_status"], 400)
+        self.assertEqual(km._fork_comment_request({"id": PARENT})["_status"], 400)
+        self.assertEqual(km._fork_comment_request({"id": PARENT, "text": "  "})["_status"], 400)
+        res = km._fork_comment_request({"name": "no-such-session", "text": self.OPENER})
+        self.assertEqual(res["_status"], 404)
+        self.assertIn("no session named", res["error"])
+        km.Sessions.backend_for = staticmethod(lambda sid: object())   # tmux: no fork machinery
+        res = km._fork_comment_request({"id": PARENT, "text": self.OPENER})
+        self.assertNotIn("_status", res)
+        self.assertIn("tmux", res["error"])
+
+    def test_fork_comment_holds_the_postal_isolation_gate(self):
+        saved_shaped, saved_iso = km._postal_shaped, km._postal_isolated
+        km._postal_shaped, km._postal_isolated = (lambda t: True), (lambda s: True)
+        try:
+            res = km._fork_comment_request({"id": PARENT, "text": self.OPENER})
+        finally:
+            km._postal_shaped, km._postal_isolated = saved_shaped, saved_iso
+        self.assertFalse(res.get("ok"))
+        self.assertIn("isolation", res["error"])
+        self.assertEqual(self.be.calls, [], "refused before any fork")
+
+    def test_fork_comment_forwards_a_remote_target_and_passes_the_forkId_through(self):
+        saved_host, saved_fwd = km._host_for_sid, km._remote_forward
+        sent = []
+        km._host_for_sid = lambda sid: {"host": "TESTHOST", "local_port": 1, "token": ""}
+        km._remote_forward = lambda r, path, body: sent.append((path, body)) or {"ok": True, "forkId": "far-tid"}
+        try:
+            res = km._fork_comment_request({"id": PARENT, "text": self.OPENER, "meta": {"note": "n.md"}})
+            self.assertEqual(res, {"ok": True, "forkId": "far-tid"})
+            self.assertEqual(sent, [("/fork-comment", {"id": PARENT, "text": self.OPENER,
+                                                       "meta": {"note": "n.md"}})])
+            km._remote_forward = lambda r, path, body: None   # the tunnel didn't answer — say so
+            res = km._fork_comment_request({"id": PARENT, "text": self.OPENER})
+            self.assertFalse(res.get("ok"))
+            self.assertIn("TESTHOST", res["error"])
+        finally:
+            km._host_for_sid, km._remote_forward = saved_host, saved_fwd
+        self.assertEqual(self.be.calls, [], "a remote target never forks locally")
+
+    def _promotable(self, tid):
+        t = self.now - 200
+        self._write(tid, [uline(t, "opener", "cu1"), aline(t + 10, "reply", "ca1", parent="cu1")])
+        (jd.SDKDIR / (tid + ".json")).write_text(json.dumps(
+            {"sid": tid, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": tid, "alive": True, "threadOf": PARENT}))
+
+    def test_fork_promote_materializes_under_the_threads_own_name(self):
+        tid = km._fork_comment_request({"id": PARENT, "text": self.OPENER})["forkId"]
+        self._promotable(tid)
+        res = km._fork_promote_request({"forkId": tid})
+        self.assertEqual(res, {"ok": True, "name": "parent-comment-1"})
+        self.assertIn(("promote", tid, "parent-comment-1"), self.be.calls)
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "promoted")
+        again = km._fork_promote_request({"forkId": tid})
+        self.assertEqual(again, {"ok": True, "name": "parent-comment-1"},
+                         "already promoted = idempotent success, never a refusal")
+
+    def test_fork_promote_refusals_ride_non_2xx(self):
+        # the shipped caller reads ANY 2xx JSON as success, so every refusal must carry a status
+        self.assertEqual(km._fork_promote_request(None)["_status"], 400)
+        self.assertEqual(km._fork_promote_request({})["_status"], 400)
+        self.assertEqual(km._fork_promote_request({"forkId": "not-a-thread"})["_status"], 404)
+        tid = km._fork_comment_request({"id": PARENT, "text": self.OPENER})["forkId"]
+        res = km._fork_promote_request({"forkId": tid})   # no transcript yet → promote refuses
+        self.assertEqual(res["_status"], 409)
+        self.assertFalse(res.get("ok"))
+
+    def test_fork_promote_scans_attached_remotes_for_an_unknown_forkId(self):
+        saved_remotes, saved_fwd = km._remotes, km._remote_forward
+        asked = []
+        km._remotes = {"TESTHOST": {"host": "TESTHOST", "local_port": 1, "token": ""}}
+        km._remote_forward = lambda r, path, body: asked.append((r["host"], path, body)) or {"ok": True, "name": "far-name"}
+        try:
+            res = km._fork_promote_request({"forkId": "far-tid"})
+        finally:
+            km._remotes, km._remote_forward = saved_remotes, saved_fwd
+        self.assertEqual(res, {"ok": True, "name": "far-name"})
+        self.assertEqual(asked, [("TESTHOST", "/fork-promote", {"forkId": "far-tid"})])
+
+    def test_routes_are_wired_and_pop_the_status(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('if u.path in ("/fork-comment", "/fork-promote"):', src)
+        self.assertIn('res = (_fork_comment_request(b) if u.path == "/fork-comment"', src)
+        self.assertIn('return self._send(res.pop("_status", 200), json.dumps(res), "application/json")', src)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Review comments from the user's editor-integration plugin all interleaved through the target session's main lane; each should dispatch onto its own parallel fork. The semantics are exactly romp's transcript-comment branches (threadOf fork, no `names/` entry, parent's comment-thread registry, popover-reachable, existing comment-fork lifecycle), so two endpoints expose that machinery over the same localhost door `/send` uses (X-Romp-Token auth; the caller side is already shipped and speaks this shape).

**POST `/fork-comment` {id?|name?, text, meta:{thread, note}} → {forkId}** — a comment-style thread on the target, opening message sent VERBATIM (the caller authored the whole prompt; the quote frame would bury it under a passage that doesn't exist). No highlight exists on this door, so the fork anchors at the session TIP: `_comment_create`'s restart-seam fallback (cut `""`) made a designed input (`anchor_uuid ""` → cut `""`, cut_t = create moment). `meta` rides the registry row sanitized; `exact` carries the note path as the popover's about-line. model/effort/fast ride empty → `_comment_launch_prefs` applies the default-comment picks exactly as dialog-created threads. The `/send` postal-isolation gate holds here too. Remote targets forward like `/send`, forkId passed through.

**POST `/fork-promote` {forkId} → 2xx** — the existing break-out (`_comment_promote`) by forkId alone; `_comment_fork_owner` scans the per-parent registries; promoted name is the thread's own. **Refusals ride non-2xx** (400/404/409): the shipped caller treats any 2xx JSON as success, so an ok:false 200 would read as promoted. Already-promoted is idempotent success; an unknown forkId is tried against each attached remote before the honest 404.

Both brains factored from the routes (`_compact_request` precedent). **Tests**: `ForkCommentRoutes` (12) on `tests/test_comment_threads.py`'s hermetic harness — tip fork + verbatim opener + registry/meta/frame reachability, live-name resolution, default-comment settings, honest refusals (bad body/missing text/unknown name/tmux/isolation), remote forward both routes, promote materialize + idempotent repeat + refusal statuses, route-wiring pins. **Live**: 8/8 HTTP checks against a hermetic kernel (header-token auth, statuses, honest bodies).

Suites: pytest 6155 passed + 313 subtests, npm 2568/2568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)