### PR TITLE
Lightbox Copy button: the shown image onto the clipboard, beside download

### DIFF
--- a/ui/webview/lightbox-copy.test.ts
+++ b/ui/webview/lightbox-copy.test.ts
@@ -1,0 +1,73 @@
+// The lightbox Copy button (the user 2026-08-31): beside download, it puts the IMAGE ITSELF on the
+// clipboard — and it must copy the DISPLAYED bytes, so the source is the current img element's src
+// (pin param already baked in) read at CLICK time, which also keeps arrow-stepping retarget-free.
+// preview.ts has import-time DOM side effects → source pins + an executed replica of the decisions
+// (optimistic-send.test.ts precedent).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const PREVIEW = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+const CSS = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the button exists only where the clipboard API does — honest absence, never a dead control", () => {
+  assert.match(PREVIEW, /if \(curImg && typeof ClipboardItem !== "undefined" && navigator\.clipboard && navigator\.clipboard\.write\) \{/);
+  // img kind only: curImg is set in the img branch; the pdf branch never sets it
+  assert.match(PREVIEW, /let curImg: \(\(\) => HTMLImageElement\) \| null = null;/);
+  assert.match(PREVIEW, /curImg = \(\) => img;/);
+});
+
+test("copy reads the CURRENT img's src at click time — pin rides, arrow-stepping needs no retarget", () => {
+  assert.match(PREVIEW, /const src = curImg!\(\)\.src;/);
+  // the pin param is baked into src by mkImg…
+  assert.match(PREVIEW, /im\.src = fileUrl\(e\.path, e\.sid\) \+ \(e\.pin \? "&pin=" \+ encodeURIComponent\(e\.pin\) : ""\);/);
+  // …and step() rebinds the closure variable the accessor reads
+  assert.match(PREVIEW, /img\.replaceWith\(next\);\s*\n\s*img = next;/);
+});
+
+test("write() runs synchronously in the gesture — the ClipboardItem takes the png PROMISE", () => {
+  assert.match(PREVIEW, /const png = \(async \(\) => \{/);
+  assert.match(PREVIEW, /navigator\.clipboard\.write\(\[new ClipboardItem\(\{ "image\/png": png \}\)\]\)/);
+});
+
+test("a png source writes directly; anything else re-encodes to png through a canvas", () => {
+  assert.match(PREVIEW, /if \(blob\.type === "image\/png"\) return blob;/);
+  assert.match(PREVIEW, /await createImageBitmap\(blob\)/);
+  assert.match(PREVIEW, /cv\.toBlob\(\(b\) => \(b \? res\(b\) : rej\(new Error\("png encode failed"\)\)\), "image\/png"\)/);
+});
+
+test("the click acknowledges immediately and failures state why — both self-restore", () => {
+  assert.match(PREVIEW, /btn\.textContent = "✓"; btn\.classList\.add\("ok"\); btn\.title = "copied";/);
+  assert.match(PREVIEW, /btn\.textContent = "✕"; btn\.classList\.add\("err"\);/);
+  assert.match(PREVIEW, /btn\.title = "copy failed: " \+ \(\(e && \(e as Error\)\.message\) \|\| String\(e\)\);/);
+  assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss/);
+});
+
+test("the copy chip wears the download chip's exact dress — one control vocabulary", () => {
+  assert.match(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{/);
+  assert.match(CSS, /\.romp-lightbox-dl:hover, \.romp-lightbox-copy:hover \{ border-color: var\(--accent\); \}/);
+});
+
+// ── executed replica: the two decisions ───────────────────────────────────────────────────────────
+
+test("replica: click-time read copies what a step put on screen, pin included", () => {
+  // mirrors mkImg + step + the copy handler's read
+  const fileUrl = (p: string) => "/file?path=" + encodeURIComponent(p) + "&sid=s1";
+  const mkSrc = (p: string, pin?: string) => fileUrl(p) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
+  let img = { src: mkSrc("plots/run1.png", "v1") };      // opened on a pinned historical version
+  const curImg = () => img;
+  assert.ok(curImg().src.includes("pin=v1"), "the pinned version is the copy source, not the live file");
+  img = { src: mkSrc("plots/run2.jpg") };                // arrow-step rebinds the closure variable
+  assert.equal(curImg().src, mkSrc("plots/run2.jpg"), "after a step the copy source IS the new image");
+});
+
+test("replica: only a png blob skips the re-encode", () => {
+  const route = (blobType: string) => (blobType === "image/png" ? "direct" : "reencode");
+  assert.equal(route("image/png"), "direct");
+  assert.equal(route("image/jpeg"), "reencode");
+  assert.equal(route("image/webp"), "reencode");
+  assert.equal(route(""), "reencode", "an untyped blob still lands on the one type clipboards accept");
+});

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -74,12 +74,13 @@ test("the lightbox offers a download beside the close, saving the same bytes it 
     "saved under the file's own basename");
   assert.ok(body.indexOf("dl.onclick = (ev) => ev.stopPropagation()") > 0,
     "saving must not also dismiss the lightbox");
-  assert.ok(body.indexOf('bar.append(name, dl, close)') > 0, "between the filename and the ✕");
+  assert.ok(body.indexOf('const controls = [dl, ...(cp ? [cp] : []), close]') > 0,
+    "between the filename and the ✕ — with copy slotted beside it where the clipboard API exists (2026-08-31)");
   // an inline TRAY SVG, not a codepoint: "⭳" (U+2B73) has no coverage in the mac system fonts and
   // rendered as a tofu box (the user 2026-08-19). Same stroke family as the composer's buttons.
   assert.ok(body.indexOf('<polyline points="7 10 12 15 17 10"/>') > 0, "the arrow-into-tray glyph");
   assert.ok(body.indexOf("\u2b73") < 0 && body.indexOf("⭳") < 0, "the uncovered codepoint is gone");
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
-  assert.match(CSS, /\.romp-lightbox-dl \{ font: inherit; font-size: 0\.86em;/,
-    "one control vocabulary — the same chip dress as the close beside it");
+  assert.match(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{ font: inherit; font-size: 0\.86em;/,
+    "one control vocabulary — download and copy share the chip dress of the close beside them (2026-08-31)");
 });

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -216,6 +216,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   let at = -1;
   let step: ((delta: number) => void) | null = null;     // arrows step the chat's image sequence (img kind only)
   let cue: HTMLElement | null = null;                    // the compact position mark ("3/17") in the bar
+  let curImg: (() => HTMLImageElement) | null = null;    // the img on screen NOW (step rebinds it) — the copy source
   if (kind === "pdf") {
     const frame = document.createElement("iframe");
     frame.className = "romp-lightbox-frame";
@@ -231,6 +232,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
       return im;
     };
     let img = mkImg({ path, sid, pin });
+    curImg = () => img;
     inner.appendChild(img);
     const pzc = wirePinchZoom(inner, img);
     // the chat's image sequence, oldest→newest (empty on surfaces with no provider): the current
@@ -284,11 +286,58 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   dl.title = "download";
   dl.setAttribute("aria-label", "download");
   dl.onclick = (ev) => ev.stopPropagation();               // saving must not also dismiss
+  // copy beside download (the user 2026-08-31): the image ITSELF onto the clipboard. It reads the
+  // CURRENT img's src at CLICK time — mkImg bakes the pin param into src and an arrow step rebinds
+  // `img`, so a pinned historical version copies as exactly what is on screen, and stepping needs no
+  // retarget bookkeeping. Rendered only where the clipboard API exists (an insecure-context http
+  // origin drops navigator.clipboard entirely — canPreview's honest-absence precedent: no dead
+  // control). Clipboards take image/png; any other source re-encodes through a canvas. The
+  // ClipboardItem takes the PROMISE form so write() runs synchronously inside the click gesture
+  // (Safari refuses a write that awaits first — the tailnet phone case). Success and failure both
+  // speak in place: the icon flips to a check, or to an × whose title names the reason, and the
+  // button restores itself either way.
+  const COPY_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"'
+    + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>'
+    + '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+  let cp: HTMLButtonElement | null = null;
+  if (curImg && typeof ClipboardItem !== "undefined" && navigator.clipboard && navigator.clipboard.write) {
+    const btn = document.createElement("button");
+    cp = btn;
+    btn.className = "romp-lightbox-copy";
+    btn.innerHTML = COPY_SVG;
+    btn.title = "copy image";
+    btn.setAttribute("aria-label", "copy image");
+    const restore = () => { btn.innerHTML = COPY_SVG; btn.title = "copy image"; btn.classList.remove("ok", "err"); };
+    btn.onclick = (ev) => {
+      ev.stopPropagation();                                // copying must not also dismiss
+      const src = curImg!().src;
+      const png = (async () => {
+        const blob = await (await fetch(src)).blob();
+        if (blob.type === "image/png") return blob;
+        const bmp = await createImageBitmap(blob);         // jpeg/webp → decode → png, the one type
+        const cv = document.createElement("canvas");       // every clipboard accepts
+        cv.width = bmp.width; cv.height = bmp.height;
+        cv.getContext("2d")!.drawImage(bmp, 0, 0);
+        return await new Promise<Blob>((res, rej) =>
+          cv.toBlob((b) => (b ? res(b) : rej(new Error("png encode failed"))), "image/png"));
+      })();
+      navigator.clipboard.write([new ClipboardItem({ "image/png": png })]).then(() => {
+        btn.textContent = "✓"; btn.classList.add("ok"); btn.title = "copied";
+        window.setTimeout(restore, 1400);                  // the ack pulse, then back to a button
+      }, (e) => {
+        btn.textContent = "✕"; btn.classList.add("err");   // loud: the reason, never a silent no-op
+        btn.title = "copy failed: " + ((e && (e as Error).message) || String(e));
+        window.setTimeout(restore, 3000);
+      });
+    };
+  }
   const close = document.createElement("button");
   close.className = "romp-lightbox-close";
   close.textContent = "✕";
   close.title = "close (Esc)";
-  if (cue) bar.append(name, cue, dl, close); else bar.append(name, dl, close);
+  const controls = [dl, ...(cp ? [cp] : []), close];
+  if (cue) bar.append(name, cue, ...controls); else bar.append(name, ...controls);
   inner.appendChild(bar);
   wrap.appendChild(inner);
   const dismiss = () => { wrap.remove(); document.removeEventListener("keydown", onKey, true); };

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2680,11 +2680,14 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* download: an anchor dressed exactly like the close button beside it (one control vocabulary —
    same chip, same hover cue), sitting between the filename and the ✕ */
 .romp-lightbox-cue { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); font-variant-numeric: tabular-nums; }   /* the ←/→ position mark (house sub scale) */
-.romp-lightbox-dl { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
-  display: inline-flex; align-items: center;   /* centers the inline tray SVG in the chip */
+.romp-lightbox-dl, .romp-lightbox-copy { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
+  display: inline-flex; align-items: center;   /* centers the inline SVG in the chip */
   padding: 3px 9px; border-radius: 6px; background: transparent; border: 1px solid var(--card-border); color: var(--fg);   /* T151: the one button rest */
   border: 1px solid rgba(255, 255, 255, 0.18); text-decoration: none; line-height: normal; }
-.romp-lightbox-dl:hover { border-color: var(--accent); }
+.romp-lightbox-dl:hover, .romp-lightbox-copy:hover { border-color: var(--accent); }
+/* copy's spoken states: the ✓/✕ glyphs sit where the icon was — same chip, no reflow */
+.romp-lightbox-copy.ok { color: var(--accent); border-color: var(--accent); }
+.romp-lightbox-copy.err { color: #f48771; border-color: #f48771; }
 
 /* The "host:" prefix on a FEDERATED session's name (host-prefix.ts): metadata, not part of the name
    (the user 2026-07-11) — quiet gray, never bold, italic, a step smaller than the name it precedes.


### PR DESCRIPTION
The lightbox bar had download but no copy. The new button copies the IMAGE ITSELF — specifically the DISPLAYED bytes: the handler reads the CURRENT `img` element's `src` at CLICK time, where `mkImg` has already baked the pin param, so a pinned historical version copies as exactly what's on screen, and an arrow step (which rebinds the `img` closure variable) retargets the copy with zero bookkeeping.

Clipboards take `image/png`: a png source writes directly, anything else re-encodes via `createImageBitmap` → canvas → `toBlob("image/png")`. The `ClipboardItem` takes the PROMISE form so `clipboard.write()` runs synchronously inside the click gesture (Safari refuses a write that awaits first; it's also the shape lib.dom types). The button renders only where the clipboard API exists (insecure-context http drops `navigator.clipboard` entirely) — `canPreview`'s honest-absence precedent, no dead control. A runtime denial lands the loud failure path: icon flips to ✕, title names the reason, self-restoring; success acks immediately with ✓, same restore. The lightbox lives on `document.body` outside `#content`, so kernel-push re-renders never rebuild it — click-safety is structural. Image kind only; the chip wears the download chip's exact dress (shared CSS rule).

**Tests**: `ui/webview/lightbox-copy.test.ts` — source pins (API-presence gate, click-time src read + step rebinding, promise-form ClipboardItem, png-direct vs re-encode, ack/failure states, shared chip CSS) plus executed replicas of the click-time-read-after-step and png-routing decisions; `preview-core.test.ts`'s bar-order and chip-CSS pins retargeted. **Live** (clipboard permissions granted): copy of a 1×1 png landed 1×1 bytes on the real clipboard; ArrowRight then copied the 2×2 neighbor — click-time retarget proven end to end; ack showed and self-restored.

Suites: npm 2576/2576, pytest 6155 passed + 313 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)