### PR TITLE
Jump-to-newest chip: the deliberate way back into follow mode

### DIFF
--- a/ui/webview/jump-bottom.test.ts
+++ b/ui/webview/jump-bottom.test.ts
@@ -1,0 +1,90 @@
+// The jump-to-newest chip (the user 2026-08-31): scrolled-up reading leaves follow mode — and the
+// send gate keeps it that way — so a floating ↓ at the transcript's bottom-center is the deliberate
+// way back: click = snap to the bottom + re-engage follow (today's at-bottom behavior). Visibility
+// reads the SAME nearBottom threshold the stick rule and the send gate use — one definition.
+// render.ts has import-time DOM side effects → source pins + an executed replica of the decisions
+// (send-scroll-preserve.test.ts precedent).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the chip lives on BODY, never inside the re-rendered #content — click-safety is structural", () => {
+  assert.match(RENDER, /document\.body\.appendChild\(jumpBtn\);/);
+  assert.match(RENDER, /jumpBtn\.id = "jump-bottom";/);
+});
+
+test("visibility reads the one nearBottom definition, off a passive scroll listener — no polling", () => {
+  assert.match(RENDER, /const off = c\.scrollHeight > c\.clientHeight \+ 2 && !nearBottom\(c\);/);
+  assert.match(RENDER, /c\.addEventListener\("scroll", updateJumpBtn, \{ passive: true \}\);/);
+  // a hidden pane measures 0 — the chip must not float over nothing
+  assert.match(RENDER, /if \(!c \|\| c\.clientHeight <= 0\) \{ jumpBtn\.hidden = true; return; \}/);
+  // appends and tab switches re-read the truth (per-tab correctness rides the restored position)
+  assert.match(RENDER, /scheduleRailSticky\(\);\s*\n\s*updateJumpBtn\(\);\s*\/\/ appends can cross the overflow boundary/);
+  assert.match(RENDER, /v\.shown = true;\s*\n\s*scheduleRailSticky\(\);\s*\n\s*updateJumpBtn\(\);\s*\/\/ per-tab truth/);
+});
+
+test("click snaps to the bottom AND sets the view's stick — the explicit re-entry into follow mode", () => {
+  assert.match(RENDER, /c\.scrollTop = c\.scrollHeight;\s*\/\/ the snap IS the acknowledgment/);
+  assert.match(RENDER, /if \(v\) \{ v\.stick = true; v\.scrollTop = c\.scrollTop; \}/);
+});
+
+test("the send gate stays byte-intact — the chip is the sanctioned mover, sends are not", () => {
+  // T187's contract, cross-pinned from this feature so a regression here names both
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) content\.scrollTop = content\.scrollHeight;/);
+});
+
+test("the chip wears the menu-card vocabulary and survives [hidden] against its own display:flex", () => {
+  assert.match(CSS, /#jump-bottom \{\s*\n\s*position: fixed; left: 50%; transform: translateX\(-50%\);/);
+  assert.match(CSS, /#jump-bottom\[hidden\] \{ display: none; \}/);
+  assert.match(CSS, /#jump-bottom:hover \{ border-color: var\(--accent\); color: var\(--accent\); \}/);
+  assert.match(CSS, /@media \(pointer: coarse\) \{ #jump-bottom \{ width: 44px; height: 44px; \} \}/);
+});
+
+// ── executed replica: visibility + click + follow ─────────────────────────────────────────────────
+type Box = { scrollHeight: number; clientHeight: number; scrollTop: number };
+const nearBottom = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight < 80;   // render.ts nearBottom
+const maxScroll = (c: Box) => Math.max(0, c.scrollHeight - c.clientHeight);
+const visible = (c: Box) => c.clientHeight > 0 && c.scrollHeight > c.clientHeight + 2 && !nearBottom(c);
+const clickJump = (c: Box, v: { stick: boolean }) => { c.scrollTop = maxScroll(c); v.stick = true; };
+const append = (c: Box, growth: number) => {          // appendActive's stick rule
+  const stick = c.scrollHeight > c.clientHeight + 2 && nearBottom(c);
+  const before = c.scrollTop;
+  c.scrollHeight += growth;
+  c.scrollTop = stick ? maxScroll(c) : before;
+};
+
+test("replica: shown only when overflowing AND off the bottom", () => {
+  assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 4400 }), false, "at bottom");
+  assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 4360 }), false, "inside the 80px band");
+  assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 1000 }), true, "mid-history");
+  assert.equal(visible({ scrollHeight: 500, clientHeight: 600, scrollTop: 0 }), false, "no overflow, no chip");
+  assert.equal(visible({ scrollHeight: 5000, clientHeight: 0, scrollTop: 0 }), false, "hidden pane");
+});
+
+test("replica: click lands the bottom, hides the chip, and the next appends keep descending", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 1000 };
+  const v = { stick: false };
+  assert.equal(visible(c), true);
+  clickJump(c, v);
+  assert.equal(c.scrollTop, 4400);
+  assert.equal(v.stick, true);
+  assert.equal(visible(c), false, "at the bottom the chip is gone");
+  append(c, 300);
+  assert.equal(c.scrollTop, 4700, "follow mode engaged — the append descended");
+  assert.equal(visible(c), false, "still at the bottom, still no chip");
+});
+
+test("replica: scrolling back up disengages follow and re-shows the chip; appends then stay put", () => {
+  const c: Box = { scrollHeight: 5300, clientHeight: 600, scrollTop: 4700 };
+  c.scrollTop = 3000;                                  // the user scrolls up to read
+  assert.equal(visible(c), true, "off the bottom — the chip is back");
+  append(c, 300);
+  assert.equal(c.scrollTop, 3000, "reading position preserved exactly — the never-yank rule holds");
+  assert.equal(visible(c), true);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8830,6 +8830,7 @@ function landActive(content: HTMLElement | null, v: View): void {
   }
   v.shown = true;
   scheduleRailSticky();
+  updateJumpBtn();   // per-tab truth: the entering tab's restored position decides the chip, not the left one's
 }
 
 // Scroll ANCHORING for scrolled-up re-renders (the user 2026-07-05). "Appended content is below the
@@ -8909,6 +8910,7 @@ function appendActive() {
   if (stick) content.scrollTop = content.scrollHeight;
   else if (!(v && restoreScrollAnchor(content, v, anchor))) content.scrollTop = before;
   scheduleRailSticky();
+  updateJumpBtn();   // appends can cross the overflow boundary either way — re-read the chip's truth
 }
 
 // Row heights change when the pane is resized (text re-wraps), so the spacing-based
@@ -8929,6 +8931,49 @@ if (typeof ResizeObserver === "function") {
   const c = document.getElementById("content");
   if (c) c.addEventListener("scroll", scheduleRailSticky, { passive: true });
 }
+// ── jump to newest (the user 2026-08-31) ─────────────────────────────────────────────────────────
+// Scrolled-up reading leaves follow mode, and the send gate keeps it that way — this chip is the
+// deliberate way BACK. Visible only while the transcript overflows AND the view is off the bottom,
+// read through the SAME nearBottom threshold appendActive's stick and the send gate use (one
+// definition, never a second). Click = snap to the bottom + set the view's stick: follow mode
+// re-engaged exactly as today's at-bottom behavior — every subsequent append recomputes stick from
+// the at-bottom position and keeps descending until the user scrolls up, which re-shows the chip
+// from the same listener. It lives on BODY, never inside #content, so window re-renders cannot
+// rebuild it mid-click (the click-safety rule satisfied structurally); the snap itself is the
+// acknowledgment. Anchored to #content's bottom edge by measurement, re-run by the content
+// ResizeObserver below (the composer growing moves that edge) — event-based, no polling.
+const jumpBtn = document.createElement("button");
+jumpBtn.id = "jump-bottom";
+jumpBtn.title = "jump to newest — then follow new content";
+jumpBtn.setAttribute("aria-label", "jump to newest");
+jumpBtn.hidden = true;
+jumpBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"'
+  + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+  + '<line x1="12" y1="5" x2="12" y2="19"/><polyline points="5 12 12 19 19 12"/></svg>';
+function updateJumpBtn(): void {
+  const c = document.getElementById("content");
+  if (!c || c.clientHeight <= 0) { jumpBtn.hidden = true; return; }   // hidden pane measures 0 — no chip
+  const off = c.scrollHeight > c.clientHeight + 2 && !nearBottom(c);
+  jumpBtn.hidden = !off;
+  if (off) jumpBtn.style.bottom = (Math.max(0, window.innerHeight - c.getBoundingClientRect().bottom) + 12) + "px";
+}
+jumpBtn.onclick = () => {
+  const c = document.getElementById("content");
+  if (!c) return;
+  c.scrollTop = c.scrollHeight;                       // the snap IS the acknowledgment
+  const v = activeId ? views.get(activeId) : undefined;
+  if (v) { v.stick = true; v.scrollTop = c.scrollTop; }   // the explicit re-entry into follow mode
+  updateJumpBtn();                                    // at the bottom now — the chip hides itself
+};
+{
+  const c = document.getElementById("content");
+  if (c) {
+    document.body.appendChild(jumpBtn);
+    c.addEventListener("scroll", updateJumpBtn, { passive: true });   // it only measures
+    if (typeof ResizeObserver === "function") new ResizeObserver(updateJumpBtn).observe(c);
+  }
+}
+window.addEventListener("resize", updateJumpBtn);
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for
 // #tabbar; extended to #ledger 2026-07-05). Both are `flex: 0 0 auto` directly above the `flex: 1 1 auto`
 // #content scroll area, so when one grows — a working dot wraps the tab strip to a second row, a ledger

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2448,6 +2448,22 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   box-shadow: var(--shadow-toast); font-size: 12px; color: var(--fg);
 }
 #seek-note .seek-note-label { color: var(--dim); }
+
+/* jump to newest (the user 2026-08-31): the deliberate way back into follow mode once scrolled-up
+   reading (and the send gate that respects it) has left it. The seek-note's menu-card vocabulary in
+   a circular chip: dim at rest, accent on hover; body-level and fixed, so re-renders never rebuild
+   it; render.ts measures its bottom against #content's edge (the composer growing moves it). Below
+   toasts/seek (60), above the transcript. */
+#jump-bottom {
+  position: fixed; left: 50%; transform: translateX(-50%); z-index: 40;
+  width: 34px; height: 34px; border-radius: 50%; cursor: pointer; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--vscode-menu-background, var(--surface-raised)); color: var(--dim);
+  border: 1px solid rgba(255, 255, 255, 0.12); box-shadow: var(--shadow-toast);
+}
+#jump-bottom:hover { border-color: var(--accent); color: var(--accent); }
+#jump-bottom[hidden] { display: none; }   /* author display:flex defeats [hidden] — the login-modal lesson */
+@media (pointer: coarse) { #jump-bottom { width: 44px; height: 44px; } }   /* the shared pane's phone half */
 #seek-note .seek-note-x {
   flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var(--dim);
   font-size: 11px; line-height: 1.4; padding: 2px 4px; border-radius: 8px;


### PR DESCRIPTION
Scrolled-up reading leaves follow mode, and the send gate now keeps it that way — but there was no cheap way BACK: a floating ↓ chip at the transcript's bottom-center, visible whenever the view is off the bottom, snaps to the newest content on click and re-engages follow mode (exactly today's at-bottom behavior).

Visibility reads the SAME `nearBottom` threshold the stick rule and the send gate use — one definition — through one `updateJumpBtn()` driven by a passive `#content` scroll listener, the end of `appendActive`, the tab-show path (per-tab truth via the restored position), a ResizeObserver on `#content` (composer growth moves the edge the chip is measured against), and window resize. Event-based throughout, no polling; a hidden pane shows no chip.

Click = snap (the acknowledgment) + set the view's stick — the explicit re-entry into follow: subsequent appends recompute stick from the at-bottom position and keep descending until the user scrolls up, which re-shows the chip. **The send gate stays byte-intact** (cross-pinned): sends while scrolled up still never move the view; this chip is the user's own gesture, the sanctioned mover.

The chip lives on BODY, never inside the re-rendered `#content` — click-safety structural. Look: the seek-note's menu-card vocabulary in a circular chip, dim at rest, accent on hover, `[hidden]{display:none}` guard, 34px (44px under `pointer: coarse`).

**Tests**: `ui/webview/jump-bottom.test.ts` — source pins + executed replicas (visibility at/off bottom/in-band/non-overflow/hidden-pane; click→bottom→appends descend; scroll-up disengages, re-shows, appends hold position exactly). **Live**: chip visible/centered mid-history, click landed bottom and hid it, a LIVE transcript append auto-descended, scroll-up re-showed it, a further live append held the reading position byte-exact.

Suites: npm 2584/2584, pytest 6155 passed + 313 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)