### PR TITLE
Jump chip reshaped: a short pill with a stemless chevron, hugging the bottom

### DIFF
--- a/ui/webview/jump-bottom.test.ts
+++ b/ui/webview/jump-bottom.test.ts
@@ -43,7 +43,15 @@ test("the chip wears the menu-card vocabulary and survives [hidden] against its 
   assert.match(CSS, /#jump-bottom \{\s*\n\s*position: fixed; left: 50%; transform: translateX\(-50%\);/);
   assert.match(CSS, /#jump-bottom\[hidden\] \{ display: none; \}/);
   assert.match(CSS, /#jump-bottom:hover \{ border-color: var\(--accent\); color: var\(--accent\); \}/);
-  assert.match(CSS, /@media \(pointer: coarse\) \{ #jump-bottom \{ width: 44px; height: 44px; \} \}/);
+  // the phone target WIDENS, never heightens — the compact pill is the ask (the user 2026-08-31)
+  assert.match(CSS, /@media \(pointer: coarse\) \{ #jump-bottom \{ width: 64px; height: 32px; \} \}/);
+});
+
+test("a short PILL with a stemless chevron — the circle + full arrow were the user's revision (2026-08-31)", () => {
+  assert.match(CSS, /width: 40px; height: 22px; border-radius: var\(--radius-pill\);/);
+  // the glyph is the chevron alone: one polyline, no <line> stem
+  assert.match(RENDER, /jumpBtn\.innerHTML = [^;]*<polyline points="6 9\.5 12 15\.5 18 9\.5"\/><\/svg>/);
+  assert.doesNotMatch(RENDER, /jumpBtn\.innerHTML = [^;]*<line /);
 });
 
 // ── executed replica: visibility + click + follow ─────────────────────────────────────────────────

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8949,13 +8949,13 @@ jumpBtn.setAttribute("aria-label", "jump to newest");
 jumpBtn.hidden = true;
 jumpBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"'
   + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
-  + '<line x1="12" y1="5" x2="12" y2="19"/><polyline points="5 12 12 19 19 12"/></svg>';
+  + '<polyline points="6 9.5 12 15.5 18 9.5"/></svg>';   // stemless chevron — the full arrow fought the short pill (the user 2026-08-31)
 function updateJumpBtn(): void {
   const c = document.getElementById("content");
   if (!c || c.clientHeight <= 0) { jumpBtn.hidden = true; return; }   // hidden pane measures 0 — no chip
   const off = c.scrollHeight > c.clientHeight + 2 && !nearBottom(c);
   jumpBtn.hidden = !off;
-  if (off) jumpBtn.style.bottom = (Math.max(0, window.innerHeight - c.getBoundingClientRect().bottom) + 12) + "px";
+  if (off) jumpBtn.style.bottom = (Math.max(0, window.innerHeight - c.getBoundingClientRect().bottom) + 8) + "px";
 }
 jumpBtn.onclick = () => {
   const c = document.getElementById("content");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2456,14 +2456,14 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    toasts/seek (60), above the transcript. */
 #jump-bottom {
   position: fixed; left: 50%; transform: translateX(-50%); z-index: 40;
-  width: 34px; height: 34px; border-radius: 50%; cursor: pointer; padding: 0;
+  width: 40px; height: 22px; border-radius: var(--radius-pill); cursor: pointer; padding: 0;   /* a short PILL, wider than tall, hugging the bottom (the user 2026-08-31, revising the circle) */
   display: flex; align-items: center; justify-content: center;
   background: var(--vscode-menu-background, var(--surface-raised)); color: var(--dim);
   border: 1px solid rgba(255, 255, 255, 0.12); box-shadow: var(--shadow-toast);
 }
 #jump-bottom:hover { border-color: var(--accent); color: var(--accent); }
 #jump-bottom[hidden] { display: none; }   /* author display:flex defeats [hidden] — the login-modal lesson */
-@media (pointer: coarse) { #jump-bottom { width: 44px; height: 44px; } }   /* the shared pane's phone half */
+@media (pointer: coarse) { #jump-bottom { width: 64px; height: 32px; } }   /* the phone half: WIDEN for the hit area, never heighten — the compact look is the ask */
 #seek-note .seek-note-x {
   flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var(--dim);
   font-size: 11px; line-height: 1.4; padding: 2px 4px; border-radius: 8px;


### PR DESCRIPTION
The user's design revision on the just-merged jump-to-newest chip: not a circle but a compact rounded rectangle wider than it is tall, closer to the transcript's bottom edge, with the arrow's stem dropped so the glyph fits the shorter height.

CSS-only plus the glyph: 40×22 pill through the `--radius-pill` token (the css-vocab rule caught the literal), measured bottom offset 12px → 8px, svg reduced to the chevron polyline alone. The coarse-pointer target WIDENS instead of heightening (64×32) — the compact look is the ask, a wider rect keeps the phone hit area. Everything behavioral untouched; behavior tests run unmodified.

**Tests**: coarse-pointer pin retargeted + a new shape/glyph pin (pill token, one polyline, no `<line>` stem). **Live**: visible mid-history at 40×22, 8px off the content edge, chevron stemless, click still lands the bottom and hides it (4/4).

Suites: npm 2585/2585, pytest 6162 passed + 313 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)