### PR TITLE
Dev commits never notify plain installs — the drift watcher learns its audience

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2696,11 +2696,32 @@ def _run_update(tag):
                + "  curl -s -X POST 'http://127.0.0.1:%d/restart-all' >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
         else "  : # no manager — the new code arms on the next romp start (the report says so)\n"
     ok_rep = {"ok": True, "tag": tag, "restarted": bool(mport.isdigit())}
+    # advance() — the tree lands EXACTLY on the release commit. The fast-forward is the normal
+    # release-to-release move, EXCEPT for an install sitting DETACHED off every tag: the
+    # pre-2026-08-31 drift banner's Update ran `git checkout --detach origin/main` on plain
+    # installs, and from a main sha AHEAD of the next tag `git merge --ff-only <tag>` does not
+    # fail — it silently no-ops ("Already up to date"), stranding the install off the release
+    # channel forever with an ok report. So: detached AND not exactly on a tag → check the tag out
+    # directly, LOUDLY in the update log (never a silent history jump). A BRANCH checkout (the
+    # maintainer's main-tracking clones) never takes the fallback — for it the no-op ff stays the
+    # harmless behavior it always was; and a diverged install exactly ON a tag still fails
+    # visibly through the ff.
+    advance = (
+        "advance(){\n"
+        + "  if ! git symbolic-ref -q HEAD >/dev/null 2>&1 "
+          "&& ! git describe --exact-match --tags >/dev/null 2>&1; then\n"
+        + "    echo 'HEAD is detached off every release tag (an older update walked this install "
+          "onto a main-branch commit) - checking out %s directly to return to the release "
+          "channel' >> %s;\n" % (tag, log)
+        + "    git checkout --detach refs/tags/%s >> %s 2>&1; return $?;\n" % (tag, log)
+        + "  fi\n"
+        + "  git merge --ff-only %s >> %s 2>&1; }\n" % (tag, log))
     script = (
         "cd %s || exit 1\n" % q(str(ROOT))
         + "{ echo; echo \"== romp self-update to %s ==\"; date; } >> %s 2>&1\n" % (tag, log)
-        + "if git fetch origin refs/tags/%s:refs/tags/%s >> %s 2>&1 && git merge --ff-only %s >> %s 2>&1 "
-          "&& ./install.sh >> %s 2>&1; then\n" % (tag, tag, log, tag, log, log)
+        + advance
+        + "if git fetch origin refs/tags/%s:refs/tags/%s >> %s 2>&1 && advance "
+          "&& ./install.sh >> %s 2>&1; then\n" % (tag, tag, log, log)
         + "  printf '%%s' %s > %s\n" % (q(json.dumps(ok_rep)), rep)
         + restart
         + "else\n"
@@ -2775,12 +2796,15 @@ def _update_check():
             _sync_notice("a newer romp (%s) is available, but the automatic update to it already ran "
                          "once without landing — update.log under ~/.local/state/romp has the story; "
                          "the banner still offers it" % latest, ok=False)
-            _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest,
-                                   "boot": _BOOT_ID})
+            if latest not in _dismissed_updates():
+                _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest,
+                                       "boot": _BOOT_ID})
             return
         _atomic_write(jd.STATE / "update-attempted.json", json.dumps({"tag": latest, "t": int(time.time())}))
         _run_update(latest)
     else:
+        if latest in _dismissed_updates():
+            return                    # Not-now'd THIS release, durably — a newer one offers again
         _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest,
                                "boot": _BOOT_ID})
 
@@ -2829,6 +2853,72 @@ def _checkout_sha():
         return out.stdout.strip()[:8]
     except Exception:
         return ""
+
+
+def _checkout_branch():
+    """The shared checkout's current branch name, '' when detached (a bootstrap install sits
+    detached at a release tag — and the maintainer's auto-converged boxes sit detached at main
+    shas, which is why the branch alone is not the whole channel verdict) or unreadable."""
+    try:
+        out = subprocess.run(["git", "symbolic-ref", "-q", "--short", "HEAD"],
+                             cwd=str(ROOT), capture_output=True, text=True, timeout=10)
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _main_channel_verdict(branch, mode, attached):
+    """The pure audience decision for the main-drift watcher (the user 2026-08-31, after two
+    independent "constant update notices" reports from plain installs): dev commits must never
+    notify a plain install — their channel is release TAGS, one notice each, owned by
+    _update_check. The watcher's audience was always the maintainer's own mesh (its 2026-08-14
+    design comment says so), and that mesh is recognizable by its own signals:
+      * the checkout is ON branch main — a deliberate main-tracking clone;
+      * update mode "auto" — the unattended-converge machines;
+      * attached remotes — the federated dashboard's mesh (live rows or remembered hosts).
+    Everything else — a bootstrap install detached at a release tag, and the installs an old
+    banner already walked onto a DETACHED main sha (at-or-behind origin/main with no mesh
+    signals = the release channel, not drift) — stays silent here."""
+    return branch == "main" or mode == "auto" or bool(attached)
+
+
+def _main_tracking():
+    """_main_channel_verdict over the live inputs."""
+    with _remotes_lock:
+        attached = bool(_remotes)
+    if not attached:
+        try:
+            attached = bool(json.loads(KNOWN_FILE.read_text()))
+        except Exception:
+            attached = False
+    return _main_channel_verdict(_checkout_branch(), _update_mode(), attached)
+
+
+# ── Not-now, PERSISTED (the user 2026-08-31): a dismissal used to live in one page's JS var, so
+# every page load re-derived the offer and every kernel restart re-offered the same sha — the
+# re-nag half of the notice-spam reports. The store is a small capped list of dismissed
+# identifiers (release tags and drift shas, one mechanism); event-keyed: a NEW sha/tag is not in
+# the list and offers normally. Auto mode never consults it — dismissal is a banner concept.
+_DISMISSED_UPDATES_FILE_NAME = "update-dismissed.json"
+
+
+def _dismissed_updates():
+    try:
+        d = json.loads((jd.STATE / _DISMISSED_UPDATES_FILE_NAME).read_text())
+        return [str(x) for x in d if isinstance(x, str)][-20:] if isinstance(d, list) else []
+    except Exception:
+        return []
+
+
+def _dismiss_update(ident):
+    ident = str(ident or "").strip()[:80]
+    if not ident:
+        return
+    cur = [x for x in _dismissed_updates() if x != ident] + [ident]
+    try:
+        _atomic_write(jd.STATE / _DISMISSED_UPDATES_FILE_NAME, json.dumps(cur[-20:]))
+    except OSError:
+        sys.stderr.write("update-dismiss: store write failed\n")
 
 
 def _main_drift_verdict(origin, checkout, running):
@@ -2937,6 +3027,11 @@ def _main_drift_check():
     CHANGES — new information, never a re-nag of the sha already offered or dismissed."""
     if _update_mode() == "off":
         return
+    if not _main_tracking():
+        # the audience gate (the user 2026-08-31): plain installs live on the release channel —
+        # one notice per new TAG, from _update_check — and must never hear about dev commits.
+        # The maintainer's mesh keeps this watcher through its own signals (_main_channel_verdict).
+        return
     kind, target = _main_drift_verdict(_origin_main_sha(), _checkout_sha(), _kernel_sha())
     if kind == "restart" and target == _REBUILT_FOR[0]:
         return                                        # already converged in place (UI-only rebuild)
@@ -2973,6 +3068,8 @@ def _main_drift_check():
         _LAST_AUTO_CONVERGE[0] = time.time()
         _run_main_update(kind)
     else:
+        if target in _dismissed_updates():
+            return                    # Not-now'd THIS sha, durably — a NEW sha offers again
         _send_to_app("shell", {"type": "updateAvail", "kind": "main", "drift": kind,
                                "cur": _kernel_sha() or "", "tag": target, "boot": _BOOT_ID})
 
@@ -28338,8 +28435,8 @@ _UPD_JS = (
     "show('romp is updating \\u2014 the dashboard reloads when it restarts\\u2026');poll();return;}"
     "if(boot&&bootNow&&boot!==bootNow)return;"
     "if(waiting||!tag||tag===dismissedTag)return;curTag=tag;go.hidden=false;go.disabled=false;dm.hidden=false;"
-    "if(drift==='pull')show('new romp commits are on main ('+tag+') \\u2014 Update pulls them and restarts every kernel.');"
-    "else if(drift==='restart')show('romp '+tag+' is ready on disk \\u2014 Update restarts every kernel onto it.');"
+    "if(drift==='pull')show('new romp commits are on main ('+tag+') \\u2014 Update pulls them and restarts romp.');"
+    "else if(drift==='restart')show('romp '+tag+' is ready on disk \\u2014 Update restarts romp onto it.');"
     "else show('romp '+tag+' is available'+(cur?' \\u2014 you are on '+cur:'')+'.');}"
     "window.__rompUpdateOffer=offer;"   # the shell WS relays the kernel's boot-check push here
     # the kernel restarted under a SHOWING offer → the offer's evidence predates the new life: retire
@@ -28366,7 +28463,10 @@ _UPD_JS = (
     "if(window.__rompNotify)window.__rompNotify('sync','the update this prompt offered already ran \\u2014 nothing left to do');return;}"
     "go.disabled=false;dm.hidden=false;"
     "show('Could not start the update: '+em);});};"
-    "dm.onclick=function(){dismissedTag=curTag;box.classList.remove('show');};"
+    "dm.onclick=function(){dismissedTag=curTag;box.classList.remove('show');"
+    # persist the Not-now (the user 2026-08-31): page loads and kernel restarts stop re-offering
+    "try{fetch('/update-dismiss',{method:'POST',headers:{'Content-Type':'application/json'},"
+    "body:JSON.stringify({tag:curTag})}).catch(function(){});}catch(e){}};"
     "fetch('/update-check',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
     "bootNow=(d&&d.boot)||'';"
     "if(d&&d.state==='running'){waiting=true;go.hidden=true;dm.hidden=true;"
@@ -29934,13 +30034,21 @@ class Handler(BaseHTTPRequestHandler):
                             failed = str(rep.get("why") or "the pull or install failed")
                         elif rep is not None:
                             updated = str(rep.get("tag") or "")
+                # a DISMISSED identifier never re-derives an offer on a page load (the user
+                # 2026-08-31: the per-page-load re-offer was a notice-spam compounder)
+                dis = _dismissed_updates()
+                dsha = _MAIN_DRIFT[0] or _MAIN_DRIFT[1]
+                if dsha in dis:
+                    dsha = ""
                 return self._send(200, json.dumps({
-                    "cur": _kernel_ver() or "", "tag": _UPDATE_AVAIL[0], "mode": _update_mode(),
+                    "cur": _kernel_ver() or "",
+                    "tag": ("" if _UPDATE_AVAIL[0] in dis else _UPDATE_AVAIL[0]),
+                    "mode": _update_mode(),
                     "state": _UPDATE_STATE[0], "failed": failed, "updated": updated,
                     # the pending MAIN-DRIFT offer (2026-08-15): a page loaded after the push can
                     # re-derive it, and a stale page can revalidate before acting
-                    "drift": ("pull" if _MAIN_DRIFT[0] else ("restart" if _MAIN_DRIFT[1] else "")),
-                    "driftSha": _MAIN_DRIFT[0] or _MAIN_DRIFT[1],
+                    "drift": (("pull" if _MAIN_DRIFT[0] else "restart") if dsha else ""),
+                    "driftSha": dsha,
                     "boot": _BOOT_ID}), "application/json", cache="no-cache")
             if p == "/notify-all":
                 # the master bell's state (the user 2026-08-09): on = every task notifies when it
@@ -30042,6 +30150,15 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, FLEET_REPORT.read_text(), "application/json")
                 except OSError:
                     return self._send(200, json.dumps({"rows": []}), "application/json")
+            if u.path == "/update-dismiss":
+                # the banner's Not-now, PERSISTED (the user 2026-08-31): the dismissal outlives the
+                # page and the kernel — event-keyed, a NEW sha/tag offers again. Body: {"tag": id}.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                _dismiss_update((b or {}).get("tag"))
+                return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path == "/update":
                 # the banner's Update button (the user 2026-08-09). Only what the kernel's own checks
                 # found is ever acted on — the route takes no version from the client. A pending

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -7,6 +7,7 @@ discovered version; off = never checks. The update runs DETACHED (fetch + ff-onl
 report to update-report.json, restart through the manager door only on success), and the outcome is
 always filed as a sync notice — by the next boot, or by /update-check's poll on the still-running
 kernel (fail loudly, never silent). Synthetic tags/paths only."""
+import inspect
 import io
 import json
 import os
@@ -477,6 +478,111 @@ class Wiring(unittest.TestCase):
         self.assertIn("post({ type: 'setUpdateMode', mode: upm.value })", self.gear)
         self.assertIn("upm.value = v.updateMode", self.gear)
         self.assertIn('msg.get("type") == "setUpdateMode"', self.src)
+
+
+class ReleaseChannelMigration(unittest.TestCase):
+    """The REQUIRED migration (the user 2026-08-31): installs the old drift banner walked onto a
+    detached main sha must return to the release channel on the next tag. From a sha AHEAD of the
+    tag, `git merge --ff-only <tag>` fails — the script now falls back to checking the tag out
+    directly when HEAD is not itself on any tag, loudly in the update log. EXECUTED on a real
+    throwaway repo pair (bare origin + detached install), not a source pin: the fallback's git
+    behavior is the thing under test."""
+
+    def _repos(self, tmp):
+        """origin (bare) with c1 —tag v9.9.8→ c2 —tag v9.9.9→ c3 (main tip); the install cloned
+        and DETACHED at c3 — ahead of v9.9.9, on no tag: the walked-onto-main shape."""
+        env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid"}
+        def g(cwd, *args):
+            r = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, "git %s: %s%s" % (" ".join(args), r.stdout, r.stderr))
+            return r.stdout.strip()
+        src = os.path.join(tmp, "src")
+        os.makedirs(src)
+        g(src, "init", "-q", "-b", "main")
+        with open(os.path.join(src, "install.sh"), "w") as f:
+            f.write("#!/bin/sh\nexit 0\n")
+        os.chmod(os.path.join(src, "install.sh"), 0o755)
+        g(src, "add", "install.sh")
+        g(src, "commit", "-qm", "c1")
+        g(src, "tag", "v9.9.8")
+        g(src, "commit", "-qm", "c2", "--allow-empty")
+        g(src, "tag", "v9.9.9")
+        g(src, "commit", "-qm", "c3", "--allow-empty")
+        bare = os.path.join(tmp, "origin.git")
+        g(tmp, "clone", "-q", "--bare", src, bare)
+        inst = os.path.join(tmp, "install")
+        g(tmp, "clone", "-q", bare, inst)
+        g(inst, "checkout", "-q", "--detach", "origin/main")     # the old banner's walk
+        return g, inst
+
+    def _run(self, tag, inst):
+        """Capture _run_update's script via the Popen seam, run it SYNCHRONOUSLY. The log and
+        report are shared hermetic state — start each run clean or one test reads another's."""
+        for f in ("update.log", "update-report.json"):
+            try:
+                (km.jd.STATE / f).unlink()
+            except OSError:
+                pass
+        calls = []
+        env = {**os.environ, "ROMP_MANAGER_PORT": ""}            # no manager → no restart leg
+        with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append(a)), \
+             mock.patch.object(km, "ROOT", Path(inst)), \
+             mock.patch.dict(km.os.environ, env, clear=True):
+            km._UPDATE_STATE[0] = ""
+            self.assertTrue(km._run_update(tag))
+        km._UPDATE_STATE[0] = ""
+        script = calls[0][0][2]
+        subprocess.run(["bash", "-c", script], cwd=inst, capture_output=True, text=True)
+        return script
+
+    def test_a_walked_onto_main_install_returns_to_the_release_channel_loudly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            g, inst = self._repos(tmp)
+            self._run("v9.9.9", inst)
+            self.assertEqual(g(inst, "rev-parse", "HEAD"), g(inst, "rev-parse", "v9.9.9^{}"),
+                             "HEAD landed exactly on the tag — back on the release channel")
+            rep = json.loads((km.jd.STATE / "update-report.json").read_text())
+            self.assertTrue(rep.get("ok"), rep)
+            log = (km.jd.STATE / "update.log").read_text()
+            self.assertIn("return to the release channel", log,
+                          "the move is LOUD in the update log, never a silent history jump")
+
+    def test_forward_only_no_path_ever_moves_an_install_backward(self):
+        # the user's freeze ruling (2026-08-31): walked-along installs freeze WHERE THEY SIT —
+        # never rolled back — and move only when a NEW release offers forward. The guarantee is
+        # the offer gate itself: _run_update is reachable only through _update_check, which
+        # refuses any tag whose version is not strictly newer than the running one — so the
+        # migration's explicit checkout can only ever land on a release AHEAD of the install.
+        src = inspect.getsource(km._update_check)
+        self.assertIn("if not lv or lv <= cur:", src)
+        i_gate = src.index("if not lv or lv <= cur:")
+        i_run = src.index("_run_update(latest)")
+        self.assertLess(i_gate, i_run, "the strictly-newer gate precedes the only auto _run_update call")
+
+    def test_a_branch_checkout_never_takes_the_fallback(self):
+        # the maintainer guard: a main-tracking BRANCH clone ahead of the tag keeps the harmless
+        # no-op fast-forward it always had — the fallback yanking it onto a tag would strand the
+        # very mesh the channel gate exists to keep noticed
+        with tempfile.TemporaryDirectory() as tmp:
+            g, inst = self._repos(tmp)
+            g(inst, "checkout", "-q", "main")                     # a dev clone, ahead of v9.9.9
+            head = g(inst, "rev-parse", "HEAD")
+            self._run("v9.9.9", inst)
+            self.assertEqual(g(inst, "rev-parse", "HEAD"), head,
+                             "branch checkouts are never moved by the migration")
+            log = (km.jd.STATE / "update.log").read_text()
+            self.assertNotIn("return to the release channel", log)
+
+    def test_the_normal_release_to_release_move_never_takes_the_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            g, inst = self._repos(tmp)
+            g(inst, "checkout", "-q", "--detach", "v9.9.8")       # a healthy bootstrap install
+            self._run("v9.9.9", inst)
+            self.assertEqual(g(inst, "rev-parse", "HEAD"), g(inst, "rev-parse", "v9.9.9^{}"))
+            log = (km.jd.STATE / "update.log").read_text()
+            self.assertNotIn("return to the release channel", log,
+                             "the fast-forward is the whole move — no fallback, no log line")
 
 
 if __name__ == "__main__":

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -131,7 +131,8 @@ class UiOnlyConverge(unittest.TestCase):
     def setUp(self):
         self._saved = {n: getattr(km, n) for n in
                        ("_main_drift_verdict", "_kernel_code_changed", "_rebuild_dist",
-                        "_sync_notice", "_update_mode", "_send_to_app", "_kernel_sha")}
+                        "_sync_notice", "_update_mode", "_send_to_app", "_kernel_sha",
+                        "_main_tracking")}
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
         self.notices, self.banners, self.rebuilds = [], [], []
@@ -139,6 +140,7 @@ class UiOnlyConverge(unittest.TestCase):
         km._send_to_app = lambda app, payload: self.banners.append(payload)
         km._update_mode = lambda: "ask"
         km._kernel_sha = lambda: "cur-sha"
+        km._main_tracking = lambda: True   # these tests exercise POST-gate behavior; the gate has its own
 
     def tearDown(self):
         for n, f in self._saved.items():
@@ -195,3 +197,108 @@ class UiOnlyConverge(unittest.TestCase):
         self.assertIn('if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):', src)
         self.assertIn("_rebuild_dist()", src)
         self.assertIn("_REBUILT_FOR[0] = _checkout_sha()", src)
+
+
+class ChannelGate(unittest.TestCase):
+    """The audience gate (the user 2026-08-31, two independent "constant update notices" reports):
+    dev commits must never notify a plain install — one notice per release TAG is their whole
+    channel, owned by _update_check. The maintainer's mesh keeps the drift watcher through its own
+    signals; everything else (bootstrap installs detached at a tag, and the installs an old banner
+    walked onto a detached main sha) is the release channel and stays silent here."""
+
+    def test_the_pure_verdict_truth_table(self):
+        V = km._main_channel_verdict
+        self.assertTrue(V("main", "ask", False), "a deliberate branch-main clone tracks main")
+        self.assertTrue(V("", "auto", False), "auto mode = the unattended-converge machines")
+        self.assertTrue(V("", "ask", True), "attached remotes = the federated mesh")
+        self.assertFalse(V("", "ask", False),
+                         "detached + ask + no remotes = a plain install: the bootstrap tag "
+                         "checkout AND the old banner's walked-onto-main victims both land here")
+        self.assertFalse(V("some-branch", "ask", False), "a feature-branch checkout is not main-tracking")
+
+    def test_the_check_bails_for_a_plain_install_before_any_git_io(self):
+        saved = (km._main_tracking, km._main_drift_verdict, km._send_to_app, km._update_mode)
+        calls, banners = [], []
+        try:
+            km._update_mode = lambda: "ask"
+            km._main_tracking = lambda: False
+            km._main_drift_verdict = lambda *a: calls.append(a) or ("pull", "deadbeef")
+            km._send_to_app = lambda app, payload: banners.append(payload)
+            km._main_drift_check()
+        finally:
+            (km._main_tracking, km._main_drift_verdict, km._send_to_app, km._update_mode) = saved
+        self.assertEqual(calls, [], "gated out BEFORE the verdict — no ls-remote, no banner")
+        self.assertEqual(banners, [])
+
+    def test_the_live_reader_consults_branch_mode_and_both_remote_stores(self):
+        src = inspect.getsource(km._main_tracking)
+        self.assertIn("bool(_remotes)", src, "live attached rows count (the Mac's dial-in included)")
+        self.assertIn("KNOWN_FILE", src, "remembered hosts count — the mesh signal survives a detach")
+        self.assertIn("_main_channel_verdict(_checkout_branch(), _update_mode(), attached)", src)
+
+
+class PersistentDismissal(unittest.TestCase):
+    """Not-now outlives the page and the kernel (the user 2026-08-31): a dismissed sha/tag stays
+    dismissed until a NEW one — the per-page-load re-derive and the per-restart re-offer were the
+    notice-spam compounders on the dev mesh too."""
+
+    def setUp(self):
+        try:
+            (km.jd.STATE / km._DISMISSED_UPDATES_FILE_NAME).unlink()
+        except OSError:
+            pass
+
+    tearDown = setUp
+
+    def test_round_trip_and_restart_survival(self):
+        km._dismiss_update("aaaa1111")
+        km._dismiss_update("v0.14.0")
+        self.assertEqual(km._dismissed_updates(), ["aaaa1111", "v0.14.0"],
+                         "the store is a FILE — module state resets (a restart) cannot re-offer")
+        km._dismiss_update("aaaa1111")
+        self.assertEqual(km._dismissed_updates(), ["v0.14.0", "aaaa1111"], "re-dismissal dedupes")
+
+    def test_a_dismissed_drift_sha_never_banners_but_a_new_one_does(self):
+        saved = {n: getattr(km, n) for n in
+                 ("_main_tracking", "_main_drift_verdict", "_send_to_app", "_update_mode",
+                  "_kernel_sha", "_kernel_code_changed")}
+        banners = []
+        try:
+            km._update_mode = lambda: "ask"
+            km._main_tracking = lambda: True
+            km._kernel_sha = lambda: "cur"
+            km._kernel_code_changed = lambda a, b: True
+            km._send_to_app = lambda app, payload: banners.append(payload)
+            km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+            km._dismiss_update("deadbee1")
+            km._main_drift_verdict = lambda *a: ("pull", "deadbee1")
+            km._main_drift_check()
+            self.assertEqual(banners, [], "the dismissed sha stays quiet across restarts")
+            km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+            km._main_drift_verdict = lambda *a: ("pull", "feedf00d")
+            km._main_drift_check()
+            self.assertEqual([b.get("tag") for b in banners], ["feedf00d"],
+                             "a NEW sha is new information and offers")
+        finally:
+            for n, f in saved.items():
+                setattr(km, n, f)
+            km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+
+    def test_the_banner_posts_the_dismissal_and_the_route_stores_it(self):
+        src = inspect.getsource(km)
+        self.assertIn("fetch('/update-dismiss'", src, "Not-now persists server-side, not just page-local")
+        self.assertIn('u.path == "/update-dismiss"', src)
+        self.assertIn("_dismiss_update((b or {}).get(\"tag\"))", src)
+
+    def test_update_check_route_blanks_dismissed_offers(self):
+        src = inspect.getsource(km)
+        self.assertIn('"tag": ("" if _UPDATE_AVAIL[0] in dis else _UPDATE_AVAIL[0])', src,
+                      "a page load can no longer re-derive a dismissed offer")
+
+
+class PlainInstallCopy(unittest.TestCase):
+    def test_the_drift_copy_drops_mesh_operator_language(self):
+        src = inspect.getsource(km)
+        self.assertNotIn("restarts every kernel", src)
+        self.assertIn("Update pulls them and restarts romp.", src)
+        self.assertIn("Update restarts romp onto it.", src)


### PR DESCRIPTION
## What

Fixes the "constant update notices" reports (two independent, one day): the main-drift watcher bannered every default-mode install on every merge to main — bootstrap installs sit permanently detached at a release tag, so sha-inequality read them as forever "behind". Per the user's ruling: **plain installs get exactly one notice per new release tag; walked-along installs freeze where they sit, forward-only.**

## Changes

- **Channel gate**: `_main_drift_check` bails unless the install is genuinely main-tracking — checkout ON branch main, or the maintainer-mesh signals (update mode `auto`, or attached remotes: live rows or remembered hosts). Plain installs (detached at a tag, and the old banner's walked-onto-main victims) stay silent here; `_update_check`'s one-per-tag notice is their channel. The maintainer's mesh keeps the watcher untouched.
- **Persisted dismissal**: Not-now writes `update-dismissed.json` through a new `POST /update-dismiss`; the drift check, the release check, and `/update-check`'s page-load re-derive all skip dismissed identifiers. Event-keyed: a new sha/tag offers again. (The old dismissal was one page's JS variable — every page load and kernel restart re-offered.)
- **Migration, forward-only** — with a finding that inverts the diagnosis's premise: from a main sha *ahead* of the next tag, `git merge --ff-only <tag>` does not fail — it **silently no-ops** ("Already up to date"), stranding the install off the channel with an ok report. The update script's `advance()` now keys on the *state*, not the merge: HEAD detached AND on no tag → check the tag out directly, loudly in the update log. A branch checkout never takes the fallback (maintainer clones keep the harmless no-op ff); a diverged install exactly on a tag still fails visibly; and no path ever moves an install backward — the offer gate refuses tags not strictly newer than the running version (pinned as the freeze ruling's guarantee).
- **Copy**: the drift banner drops "restarts every kernel" for "restarts romp".

## Tests

Channel-verdict truth table + gated-before-any-git-IO + the both-store remotes reader; dismissal round-trip, restart survival, dismissed-sha-silent/new-sha-offers, route pins; **three executed git-repo migration cases** (walked-onto-main returns loudly, release-to-release never falls back, branch checkouts never move) plus the forward-only pin. The UI-only converge harness pins the gate open explicitly.

## Suites

- pytest: 6173 passed + 313 subtests, 34 skipped
- extension: 2585 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)