### PR TITLE
GET /sessions pays one transcript sweep, not one per row

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13189,6 +13189,21 @@ def _session_rows():
     responds. NB: 0-arg, distinct from the picker's _session_list(now, tmux) — they once collided (the user
     2026-06-22); keep the names distinct."""
     notes = _working_notes()                                # {sid: working-note} (tmux @romp-working; P3 adds SDK)
+    # ONE transcript-path sweep for the WHOLE listing: _path_of per row re-ran discover()'s
+    # fingerprint validity check (3 stats × every names entry + a stat per discovered transcript)
+    # for every live session — ~30 rows × ~280 syscalls a request, measured at ~71% of this route's
+    # handler time on a loaded kernel (py-spy 2026-08-31, the /sessions p90-3.3s complaint). Same
+    # hoist idiom as the pusher cycle's _tmux_sessions() snapshot (2026-08-10) and the tm= param.
+    try:
+        paths = {s["sid"]: s["path"] for s in _sessions(time.time())}
+    except Exception:
+        # the hoist runs OUTSIDE the per-row guard below, so it needs its own containment (review
+        # find, 2026-08-31): a discover raise (a names-dir permission fault or remove race) must
+        # degrade to PATHLESS rows — an empty map is exactly _path_of's miss, so every row still
+        # serves complete with compacting=False — never a 500 for the whole route.
+        sys.stderr.write("session-list path sweep failed (rows serve pathless): %s\n"
+                         % traceback.format_exc())
+        paths = {}
     out = []
     for sid, meta in Sessions.live().items():
         try:
@@ -13203,7 +13218,7 @@ def _session_rows():
                         # compacting: the corroborated signal the chat chip uses (_compacting_now, cached
                         # parse), exposed so `romp compact --wait` and scripted recycling can watch a
                         # compaction start and clear through the kernel's own read, never a scrape.
-                        "compacting": bool(_compacting_now(sid, tm=meta)),
+                        "compacting": bool(_compacting_now(sid, tm=meta, path=paths.get(sid))),
                         "working": notes.get(sid, ""), "backend": meta.get("backend", "")})
         except Exception:
             # one row's helper blowing up must not hide the session — or the WHOLE listing (this
@@ -17294,17 +17309,27 @@ def _save_pending_ops():
 _pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("compact",), …] in park order
 
 
-def _compacting_now(sid, tm=None):
+_PATH_UNRESOLVED = object()   # _compacting_now's "no path was passed" sentinel — None is a real value (no transcript)
+
+
+def _compacting_now(sid, tm=None, path=_PATH_UNRESOLVED):
     """Is this session compacting RIGHT NOW — the same corroborated signal the chip uses (_compacting:
     live/optimistic state, disproved by resumed work or a compact_boundary, 180s optimistic cap), read
     from the CACHED parse only so it's cheap enough for the WS handler and the producer tick. `tm` lets
     a caller already holding the session's live() meta pass it in — _session_rows exposes this per row,
     and refetching would pay one full Sessions.live() merge PER ROW on a polled route (review find,
-    2026-08-30)."""
+    2026-08-30). `path` is the same hoist for the transcript path: the default _path_of resolves
+    through a full _sessions() sweep — discover()'s fingerprint re-stats every names entry ×3 plus a
+    stat per discovered transcript, ON EVERY CALL, cache hit included — and paying that per row was
+    ~71% of GET /sessions' handler time on a loaded kernel (py-spy 2026-08-31; p90 3.3s, bimodal:
+    the syscalls are ~50ms quiet but each GIL re-acquire can lose a 5ms slice to the pusher/judge
+    threads). A caller holding a listing-wide sid→path map passes the row's path; None means "no
+    transcript", exactly _path_of's miss."""
     sid = str(sid)
     if tm is None:
         tm = _tmux_sessions().get(sid)
-    path = _path_of(sid)
+    if path is _PATH_UNRESOLVED:
+        path = _path_of(sid)
     session = (_parse_cached(path) if path else None) or {"turns": []}
     return _compacting(sid, (tm or {}).get("state", ""), session, int(time.time()), (tm or {}).get("since"))
 

--- a/tests/test_kernel_compact_route.py
+++ b/tests/test_kernel_compact_route.py
@@ -134,16 +134,16 @@ class CompactRequest(_Stubbed):
 
 class SessionsRowCompacting(_Stubbed):
     def test_rows_expose_the_corroborated_compacting_signal(self):
-        km._compacting_now = lambda sid, tm=None: sid == SID
+        km._compacting_now = lambda sid, tm=None, path=None: sid == SID
         rows = km._session_rows()
         self.assertEqual([r["id"] for r in rows], [SID])
         self.assertTrue(rows[0]["compacting"], "--wait and scripted recycling poll this field")
-        km._compacting_now = lambda sid, tm=None: False
+        km._compacting_now = lambda sid, tm=None, path=None: False
         self.assertFalse(km._session_rows()[0]["compacting"])
 
     def test_rows_pass_their_own_live_meta_so_the_route_never_pays_per_row_merges(self):
         seen = []
-        km._compacting_now = lambda sid, tm=None: seen.append(tm) or False
+        km._compacting_now = lambda sid, tm=None, path=None: seen.append(tm) or False
         km._session_rows()
         self.assertEqual(seen, [{"state": "waiting", "backend": "sdk"}],
                          "the row's live() meta rides in — refetching cost one full merge PER ROW")

--- a/tests/test_kernel_send.py
+++ b/tests/test_kernel_send.py
@@ -111,6 +111,42 @@ class SessionList(unittest.TestCase):
                          "the minimal row keeps what the live() meta already knew")
         self.assertEqual(rows["sid-s"]["name"], "beta", "the healthy sibling is untouched")
 
+    def test_listing_pays_one_transcript_sweep_not_one_per_row(self):
+        # the /sessions latency root (py-spy 2026-08-31): _path_of per row re-ran discover()'s
+        # fingerprint validity stats for EVERY live session — ~71% of the route's handler time on a
+        # loaded kernel (the p90-3.3s complaint). The listing resolves transcript paths through ONE
+        # _sessions() sweep and hands each row its path; a regression to per-row resolution makes
+        # the sweep count scale with the row count, which this pins at exactly 1.
+        live = {"sid-%d" % i: {"state": "waiting", "backend": "sdk"} for i in range(12)}
+        names = {sid: (sid, "/w", "blue", "white") for sid in live}
+        self._stub(live=live, notes={}, names=names)
+        calls = []
+        saved = km._sessions
+        km._sessions = lambda now, window=None, forks=True: (calls.append(1), [])[1]
+        try:
+            rows = km._session_rows()
+        finally:
+            km._sessions = saved
+        self.assertEqual(len(rows), 12)
+        self.assertEqual(len(calls), 1, "one transcript-path sweep for the whole listing, not one per row")
+
+    def test_sweep_failure_never_takes_the_listing_down(self):
+        # the hoisted path sweep runs OUTSIDE the per-row guard, so its failure needs its own
+        # containment (review find, 2026-08-31): a discover raise (names-dir permission fault,
+        # remove race) degrades to pathless FULL rows — compacting reads False that build — and
+        # never turns GET /sessions into a 500 (absence reads as death downstream).
+        self._stub(live={"sid-t": {"state": "working", "backend": "tmux"}},
+                   notes={}, names={"sid-t": ("alpha", "/w", "#112233", "#ffffff")})
+        saved = km._sessions
+        km._sessions = lambda now, window=None, forks=True: (_ for _ in ()).throw(OSError("names dir EACCES"))
+        try:
+            rows = km._session_rows()
+        finally:
+            km._sessions = saved
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "alpha", "a FULL row, not the minimal fallback")
+        self.assertFalse(rows[0]["compacting"])
+
     def test_empty_when_no_live_sessions(self):
         self._stub(live={}, notes={}, names={})
         self.assertEqual(km._session_rows(), [])


### PR DESCRIPTION
## What

`_session_rows` resolved each row's transcript path through `_path_of`, which runs a full `_sessions()` sweep — and `discover()`'s fingerprint validity check re-stats every names entry three times plus every discovered transcript on every call, cache hit included. ~30 rows × ~280 syscalls ≈ 8k+ syscalls per GET /sessions request, each GIL re-acquire a chance to lose a 5ms slice to the pusher/judge threads.

Measured on a loaded live kernel (py-spy 2026-08-31, non-blocking 50Hz): `_discover_fingerprint` 59% + `_sessions` stat-sweep 12% of request-handler time; endpoint bimodal 0.4s quiet / 3-5s contended (25-sample baseline: /sessions p50 0.44 / p90 3.23 / max 4.86s).

The listing now hoists ONE sid→path map per request and hands each row its path through `_compacting_now`'s new sentinel-defaulted `path=` param (every other caller keeps the `_path_of` fallback). Same hoist idiom as the pusher cycle's `_tmux_sessions()` snapshot (2026-08-10) and the `tm=` param (2026-08-30). Quiet-box micro-timing: ~51ms → ~1.9ms per request.

The hoist runs outside the per-row guard, so it carries its own containment (adversarial-review find): a discover raise degrades to pathless full rows (compacting=False that build), never a 500 for the whole route.

## Tests

- `test_listing_pays_one_transcript_sweep_not_one_per_row` — pins exactly one `_sessions()` sweep for a 12-row listing (fails 12≠1 against the base kernel).
- `test_sweep_failure_never_takes_the_listing_down` — a discover raise serves full pathless rows, never a 500.
- Compact-route `_compacting_now` doubles learn the new signature.
- Both suites green: Python 6186 passed + 313 subtests; npm 2628/2628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)