### PR TITLE
The pusher cycle takes one names snapshot; the postal index memoizes

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -696,14 +696,46 @@ def iso(t):
         return ""
 
 
-def _name_color(sid):
-    """Session display color {bg,fg} from the names registry (3rd tab field), or null."""
+def _names_snapshot():
+    """{sid: tab-fields list} for every names-registry entry, read once. The pusher cycle publishes
+    this as its names scope (_live_scope.names): build_session re-resolves every path token through
+    _cwd_of and every outgoing postal card through _name_color_by_name, so the ACTIVE tab's rebuild
+    re-read the same ~64 one-line files hundreds of times per 0.5s cycle — ~38% of the pusher's wall
+    time (py-spy 2026-08-31: _cwd_of 22%, _name_color_by_name 16%). Same one-snapshot-per-cycle idiom
+    as the tmux liveness hoist (2026-08-10); a mid-cycle rename/create lands next cycle, the exact
+    staleness the liveness snapshot already tolerates by construction."""
+    snap = {}
     try:
-        parts = (NAMES / sid).read_text().rstrip("\n").split("\t")
-        if len(parts) > 2 and parts[2].startswith("#"):
-            return {"bg": parts[2], "fg": "#ffffff"}
+        for f in NAMES.iterdir():
+            try:
+                snap[f.name] = f.read_text().rstrip("\n").split("\t")
+            except Exception:   # OSError, but ALSO UnicodeDecodeError on a torn/raw-bytes entry — the
+                continue        # per-call readers this replaces caught bare Exception, and this function
+        #                         runs on the pusher thread's bare loop, so it must NEVER raise (review
+        #                         find 2026-08-31: one non-UTF-8 entry would have killed the pusher for
+        #                         good, and again on every restart while the file persisted)
     except Exception:
         pass
+    return snap
+
+
+def _names_parts(sid):
+    """The names-registry tab fields for sid — from the cycle's names scope when one is set (one
+    registry read per PUSHER CYCLE instead of per token/card), else a direct read. None = no entry."""
+    snap = getattr(_live_scope, "names", None)
+    if snap is not None:
+        return snap.get(str(sid))
+    try:
+        return (NAMES / str(sid)).read_text().rstrip("\n").split("\t")
+    except Exception:
+        return None
+
+
+def _name_color(sid):
+    """Session display color {bg,fg} from the names registry (3rd tab field), or null."""
+    parts = _names_parts(sid)
+    if parts and len(parts) > 2 and parts[2].startswith("#"):
+        return {"bg": parts[2], "fg": "#ffffff"}
     return None
 
 
@@ -871,32 +903,26 @@ def _set_palette(name):
 def _name_of(sid):
     """Session display name from the names registry (1st tab field), or None. The event model gives a
     postal atom's peer as the sender's rompUuid (sid), so a postal card resolves it to a name + color."""
-    try:
-        return (NAMES / sid).read_text().rstrip("\n").split("\t")[0] or None
-    except Exception:
-        return None
+    parts = _names_parts(sid)
+    return (parts[0] or None) if parts else None
 
 
 def _cwd_of(sid):
     """The session's working directory from the names registry (2nd tab field: name\\tcwd\\tbg\\tfg), or "".
     Written at launch for BOTH backends (tmux romp launcher + SDK write_name), so it's available before any
     transcript exists. The directory is fixed at creation — there's no SDK call to relocate a session."""
-    try:
-        parts = (NAMES / sid).read_text().rstrip("\n").split("\t")
-        return parts[1] if len(parts) > 1 else ""
-    except Exception:
-        return ""
+    parts = _names_parts(sid)
+    return parts[1] if parts and len(parts) > 1 else ""
 
 
 def _identity_of(sid):
     """The session's identity colors (bg, fg) from the names registry (3rd/4th tab fields), or ("", ""). Written
     at launch for BOTH backends (tmux launcher + SDK write_name), so it's available without shelling tmux —
     the unified GET /sessions reads identity from here for either backend."""
-    try:
-        parts = (NAMES / sid).read_text().rstrip("\n").split("\t")
-        return (parts[2] if len(parts) > 2 else "", parts[3] if len(parts) > 3 else "")
-    except Exception:
+    parts = _names_parts(sid)
+    if not parts:
         return ("", "")
+    return (parts[2] if len(parts) > 2 else "", parts[3] if len(parts) > 3 else "")
 
 
 def _session_backend(sid, tm):
@@ -15771,12 +15797,28 @@ def _postal_intent(kind, body=""):
     return m.group(1) if m else ""
 
 
+_postal_index_memo = [None]   # ((mtime_ns, size), idx) — exact-change key of messages.jsonl
+
+
 def _postal_index():
     """messages.jsonl 'sent' rows keyed by msg id → {id, from, fromId, toId, body, kind, t, park}. The
-    clean body lives here, not in the delivered text. Mirrors postal-spec.ts loadPostalIndex."""
+    clean body lives here, not in the delivered text. Mirrors postal-spec.ts loadPostalIndex.
+    Memoized on the log's (mtime_ns, size): the log is append-only and every send appends, so the key
+    moves on exactly the events that change the answer — build_session hydrates every postal card
+    through this and re-parsed the whole log per push otherwise (~7% of the pusher's wall time,
+    py-spy 2026-08-31). Consumers only read the index (_hydrate_postal), so sharing one dict is safe."""
+    p = jd.STATE / "timeline" / "messages.jsonl"
+    try:
+        st = os.stat(p)
+        key = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return {}                                       # no log yet → nothing to memoize
+    hit = _postal_index_memo[0]
+    if hit is not None and hit[0] == key:
+        return hit[1]
     idx = {}
     try:
-        lines = (jd.STATE / "timeline" / "messages.jsonl").read_text(errors="replace").splitlines()
+        lines = p.read_text(errors="replace").splitlines()
     except OSError:
         return idx
     for ln in lines:
@@ -15789,12 +15831,21 @@ def _postal_index():
                             "fromHost": o.get("from_host", ""),
                             "toId": o.get("to_id", ""), "body": o.get("body", ""), "kind": o.get("kind", ""),
                             "t": o["t"] if isinstance(o.get("t"), (int, float)) else 0, "park": bool(o.get("park"))}
+    _postal_index_memo[0] = (key, idx)
     return idx
 
 
 def _name_color_by_name(name):
     """Identity color {bg,fg} for a session by NAME (outgoing postal carries the recipient name, not a
-    sid). Scans the names registry. None if not found."""
+    sid). Reads the cycle's names scope when one is set — build_session hydrates every outgoing postal
+    card through here, and the full-registry rescans were ~16% of the pusher's wall time (py-spy
+    2026-08-31) — else scans the registry. None if not found."""
+    snap = getattr(_live_scope, "names", None)
+    if snap is not None:
+        for parts in snap.values():
+            if parts and parts[0] == name and len(parts) > 2 and parts[2].startswith("#"):
+                return {"bg": parts[2], "fg": "#ffffff"}
+        return None
     try:
         for f in NAMES.iterdir():
             parts = f.read_text().rstrip("\n").split("\t")
@@ -26132,9 +26183,15 @@ def _pusher_cycle():
     #                                       however deep it hides (_bg_live_norm, _compacting_now,
     #                                       build_feed's per-session gates) — see _live_scope
     try:
+        _live_scope.names = _names_snapshot()   # …and the cycle's NAMES snapshot, same idiom: the name/
+        #                                       cwd/color helpers otherwise re-read the registry per path
+        #                                       token and per postal card (~38% of pusher wall, py-spy
+        #                                       2026-08-31). INSIDE the try: a raise here must still hit
+        #                                       the finally, or the liveness scope above leaks set
         _pusher_cycle_jobs(now, tmux, any_client)
     finally:
         _live_scope.snapshot = None
+        _live_scope.names = None
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):

--- a/tests/test_kernel_names_scope.py
+++ b/tests/test_kernel_names_scope.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""The pusher cycle takes ONE names-registry snapshot (round 2 of the latency workstream).
+
+build_session re-resolves every path token through _cwd_of and every outgoing postal card through
+_name_color_by_name, so the ACTIVE tab's rebuild re-read the same ~64 one-line registry files
+hundreds of times per 0.5s cycle — py-spy (2026-08-31) attributed ~38% of the pusher's wall time
+to those two helpers alone, standing GIL pressure every request thread paid for. The cycle now
+publishes ONE snapshot as _live_scope.names (the tmux-liveness hoist idiom, 2026-08-10); the
+helpers read it when set and keep their direct disk reads otherwise (request threads, WS builds).
+_postal_index gets the sibling fix: an exact-change (mtime_ns, size) memo over the append-only
+messages log it re-parsed per push.
+
+SYNTHETIC fixtures only: placeholder UUIDs, invented names.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_names_scope", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class NamesScopeReads(unittest.TestCase):
+    """The name/cwd/identity/color helpers read the cycle's snapshot when set, disk otherwise."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        names = Path(self.td.name) / "names"
+        names.mkdir()
+        (names / SID).write_text("web\t/work/web\t#112233\t#ffffff\n")
+        self.saved_names = km.NAMES
+        km.NAMES = names
+        self.addCleanup(lambda: setattr(km, "NAMES", self.saved_names))
+        self.addCleanup(self.td.cleanup)
+        self.addCleanup(lambda: setattr(km._live_scope, "names", None))
+
+    def test_scope_serves_all_helpers_without_disk(self):
+        # scope content deliberately DIFFERS from disk, so a disk read is caught as a wrong answer
+        km._live_scope.names = {SID: ["api", "/work/api", "#445566", "#000000"]}
+        self.assertEqual(km._name_of(SID), "api")
+        self.assertEqual(km._cwd_of(SID), "/work/api")
+        self.assertEqual(km._identity_of(SID), ("#445566", "#000000"))
+        self.assertEqual(km._name_color(SID), {"bg": "#445566", "fg": "#ffffff"})
+        self.assertEqual(km._name_color_by_name("api"), {"bg": "#445566", "fg": "#ffffff"})
+        self.assertIsNone(km._name_color_by_name("web"), "the scope is authoritative while set")
+
+    def test_scope_miss_is_a_miss_not_a_disk_fallback(self):
+        # half-and-half reads would smear two moments in time across one build
+        km._live_scope.names = {}
+        self.assertIsNone(km._name_of(SID))
+        self.assertEqual(km._cwd_of(SID), "")
+        self.assertEqual(km._identity_of(SID), ("", ""))
+
+    def test_no_scope_reads_disk(self):
+        self.assertEqual(km._name_of(SID), "web")
+        self.assertEqual(km._cwd_of(SID), "/work/web")
+        self.assertEqual(km._identity_of(SID), ("#112233", "#ffffff"))
+        self.assertEqual(km._name_color_by_name("web"), {"bg": "#112233", "fg": "#ffffff"})
+
+    def test_snapshot_reads_every_entry_once(self):
+        snap = km._names_snapshot()
+        self.assertEqual(snap, {SID: ["web", "/work/web", "#112233", "#ffffff"]})
+
+    def test_an_undecodable_entry_is_skipped_never_raised(self):
+        # review find (2026-08-31): the snapshot runs on the pusher thread's bare loop, so ONE
+        # non-UTF-8 names entry (a torn temp flush, a raw-bytes path from the shell launcher) raising
+        # UnicodeDecodeError would kill the pusher permanently — and again every restart while the
+        # file persisted. The poisoned entry degrades to a miss (the old per-call readers' semantics);
+        # the healthy sibling still snapshots.
+        bad = "99999999-8888-7777-6666-555555555555"
+        (km.NAMES / bad).write_bytes(b"caf\xe9\t/work/caf\xe9\t#112233\t#ffffff\n")
+        snap = km._names_snapshot()
+        self.assertEqual(snap, {SID: ["web", "/work/web", "#112233", "#ffffff"]})
+        km._live_scope.names = snap
+        self.assertIsNone(km._name_of(bad), "the poisoned sid reads as a miss, not a crash")
+
+
+class CyclePublishesNamesScope(unittest.TestCase):
+    """_pusher_cycle sets the names scope for its jobs and ALWAYS clears it — a leaked snapshot
+    would freeze names/colors on the pusher thread forever."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        names = Path(self.td.name) / "names"
+        names.mkdir()
+        (names / SID).write_text("web\t/work/web\t#112233\t#ffffff\n")
+        self.saved = (km.NAMES, km._tmux_sessions, km._pusher_cycle_jobs)
+        km.NAMES = names
+        km._tmux_sessions = lambda: {}
+        self.addCleanup(lambda: (setattr(km, "NAMES", self.saved[0]),
+                                 setattr(km, "_tmux_sessions", self.saved[1]),
+                                 setattr(km, "_pusher_cycle_jobs", self.saved[2])))
+        self.addCleanup(self.td.cleanup)
+
+    def test_jobs_see_the_snapshot_and_it_clears_after(self):
+        seen = []
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: seen.append(getattr(km._live_scope, "names", None))
+        km._pusher_cycle()
+        self.assertEqual(seen, [{SID: ["web", "/work/web", "#112233", "#ffffff"]}])
+        self.assertIsNone(getattr(km._live_scope, "names", None), "cleared at cycle end")
+
+    def test_a_jobs_raise_still_clears_the_scope(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: (_ for _ in ()).throw(RuntimeError("job died"))
+        with self.assertRaises(RuntimeError):
+            km._pusher_cycle()
+        self.assertIsNone(getattr(km._live_scope, "names", None), "the finally clears it on the raise too")
+
+
+class PostalIndexMemo(unittest.TestCase):
+    """_postal_index re-parsed the whole messages log per push; the memo keys on (mtime_ns, size),
+    which the append-only log moves on exactly the sends that change the answer."""
+
+    def setUp(self):
+        self.log = km.jd.STATE / "timeline" / "messages.jsonl"
+        self.log.parent.mkdir(parents=True, exist_ok=True)
+        km._postal_index_memo[0] = None
+        self.addCleanup(lambda: km._postal_index_memo.__setitem__(0, None))
+        self.addCleanup(lambda: self.log.unlink(missing_ok=True))
+
+    def _row(self, mid, body):
+        return json.dumps({"ev": "sent", "id": mid, "from": "web", "to_id": SID, "body": body, "t": 1781100000}) + "\n"
+
+    def test_unchanged_log_returns_the_cached_object(self):
+        self.log.write_text(self._row("m1", "hello"))
+        first = km._postal_index()
+        self.assertEqual(set(first), {"m1"})
+        self.assertIs(km._postal_index(), first, "same (mtime_ns, size) → the memoized dict, no reparse")
+
+    def test_an_append_invalidates_exactly(self):
+        self.log.write_text(self._row("m1", "hello"))
+        first = km._postal_index()
+        with open(self.log, "a") as f:
+            f.write(self._row("m2", "and back"))
+        second = km._postal_index()
+        self.assertIsNot(second, first)
+        self.assertEqual(set(second), {"m1", "m2"})
+
+    def test_missing_log_is_empty_and_unmemoized(self):
+        self.log.unlink(missing_ok=True)
+        self.assertEqual(km._postal_index(), {})
+        self.log.write_text(self._row("m3", "late start"))
+        self.assertEqual(set(km._postal_index()), {"m3"}, "the miss was not cached")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Round 2 of the /sessions latency workstream (contained wins for ambient GIL pressure). The ambient py-spy profile put ~52% of the pusher thread's wall time in per-call re-reads of small state files: `build_session` re-resolves every path token through `_cwd_of` (22%) and every outgoing postal card through `_name_color_by_name`'s full-registry rescan (16%); `_postal_index` re-parsed the whole messages log per push (~7%). All of it standing GIL pressure every request thread pays for (GIL held ~73% of ambient wall time; the pusher alone 37%).

Two event-exact fixes, no timers:
- `_pusher_cycle` publishes ONE names-registry snapshot as `_live_scope.names` (the tmux-liveness hoist idiom, 2026-08-10). The name/cwd/identity/color helpers read it when set and keep their direct disk reads otherwise (request threads, WS builds unchanged). A mid-cycle rename lands next cycle — the staleness the liveness snapshot already tolerates by construction.
- `_postal_index` memoizes on the log's `(mtime_ns, size)`: append-only, every send appends, so the key moves on exactly the events that change the answer. Its one consumer (`_hydrate_postal`) only reads.

Adversarial review caught a major gap pre-merge, fixed at both layers: `_names_snapshot`'s per-entry catch was `except OSError`, but a non-UTF-8 names entry (torn temp flush, raw-bytes path) raises `UnicodeDecodeError` — and the snapshot runs on the pusher daemon's bare loop, so one poisoned file would have killed pushes and every tick job permanently, re-killing on each restart. The snapshot now never raises (bare-Exception per entry, the old readers' semantics) and its assignment moved inside the cycle's try so the finally always clears both scopes.

## Tests

New `tests/test_kernel_names_scope.py` (10): scope serves all five helpers without disk; a scope miss stays a miss (no half-and-half reads); no-scope reads disk; the cycle publishes and ALWAYS clears the scope (including when a job raises); an undecodable entry is skipped, never raised; postal-index memo identity on unchanged log, exact-change invalidation on append, miss-not-cached.

Both suites green: Python 6196 passed + 313 subtests; npm 2628/2628.

Before/after in the pusher's own wall-time shares + the ambient GIL number lands in the workstream report once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)