### PR TITLE
A stale dashboard can no longer wipe tag members — the write door refuses old evidence

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1755,6 +1755,14 @@ def _norm_timeline_views(d):
             order.append(n[:_VIEWS_MAX_NAME])
     if order:
         out["tagOrder"] = order
+    # `at` — the store's write stamp, served to every client and echoed back with its blob: the
+    # WRITER'S EVIDENCE TIME the stale-writer guard in _set_timeline_views compares tag mtimes
+    # against. Preserved through the rebuild like mtime; absent stays absent (a legacy blob).
+    try:
+        if d.get("at"):
+            out["at"] = int(d["at"])
+    except (TypeError, ValueError):
+        pass
     return out
 
 
@@ -1808,6 +1816,50 @@ def _set_timeline_views(blob):
     except Exception:
         prev = {}
     now = int(time.time())
+    # ── the stale-writer guard (the user 2026-08-31: a tag silently lost all 7 of its members) ──
+    # The full-blob path (setTimelineViews) is last-writer-wins by design, so a dashboard whose
+    # in-memory copy predates newer edits — a page that slept through a kernel restart, a second
+    # dashboard, a long-lived Obsidian panel — posts the whole STALE world back, and every member
+    # or tag added since vanishes silently. The v2 mtimes are forge-proof at this very door, so
+    # the door enforces the cards-move rule on itself: a writer whose evidence predates a tag's
+    # newer store state stands down FOR THAT TAG — the rest of its write lands — and the refusal
+    # is LOUD (a dashboard notice + stderr), never a silent divergence.
+    #   ev — the writer's evidence time: the `at` stamp the store put on the blob it served
+    #   (every client echoes the whole blob back; RMW writers like _edit_tag deep-copy the store,
+    #   so they always carry the newest), else the newest tag mtime the blob carries, else 0 —
+    #   an mtime-less legacy blob can never de-member or delete a stamped tag.
+    ev = 0
+    if isinstance(blob, dict):
+        try:
+            ev = int(blob.get("at") or 0)
+        except (TypeError, ValueError):
+            ev = 0
+    ev = max([ev] + [int(t.get("mtime") or 0) for t in v["tags"]])
+    incoming = {t["id"] for t in v["tags"]}
+    refused, kept = [], []
+    for t in v["tags"]:
+        pt = prev.get(t["id"])
+        if pt and pt.get("mtime") and int(pt["mtime"]) > ev and \
+                (pt.get("name"), pt.get("color"), pt.get("members")) != \
+                (t.get("name"), t.get("color"), t.get("members")):
+            refused.append('"%s"' % pt.get("name"))
+            kept.append(json.loads(json.dumps(pt)))       # the store's newer truth stands
+        else:
+            kept.append(t)
+    for tid, pt in prev.items():
+        if tid not in incoming and pt.get("mtime") and int(pt["mtime"]) > ev:
+            refused.append('"%s" (deletion)' % pt.get("name"))
+            kept.append(json.loads(json.dumps(pt)))       # a stale writer cannot delete newer state
+    v["tags"] = kept[:_VIEWS_MAX_TAGS]
+    if refused:
+        why = ("a stale dashboard write was partially refused: its copy of %s predates newer "
+               "edits (the newer state was kept — reload that dashboard to resync)"
+               % ", ".join(sorted(set(refused))))
+        sys.stderr.write("romp-kernel: %s\n" % why)
+        try:
+            _sync_notice(why, ok=False)
+        except Exception:
+            pass
     for t in v["tags"]:
         pt = prev.get(t["id"])
         if pt is None or (pt.get("name"), pt.get("color"), pt.get("members")) != \
@@ -1815,6 +1867,7 @@ def _set_timeline_views(blob):
             t["mtime"] = now
         elif pt.get("mtime"):
             t["mtime"] = pt["mtime"]
+    v["at"] = now
     _atomic_write(_views_path(), json.dumps(v, sort_keys=True))
 
 

--- a/tests/test_views_stale_writer.py
+++ b/tests/test_views_stale_writer.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""The stale-writer guard on the views store's write door (the user 2026-08-31, from the nightly
+optimizer: a tag silently lost all 7 of its members, and re-adding recreated it with only 1).
+
+The full-blob path (setTimelineViews) is last-writer-wins by design — its own comment says so —
+so a dashboard whose in-memory copy predates newer edits (a page that slept through a kernel
+restart, a second dashboard, a long-lived Obsidian panel) posts the whole stale world back and
+every member or tag added since vanishes silently. The v2 per-tag mtimes are forge-proof at the
+write door, so the door now enforces the cards-move rule on itself: a writer whose evidence time
+(the echoed `at` stamp, else its newest tag mtime) predates a tag's newer store state stands down
+for that tag, loudly. Fresh writers — every RMW path, and any dashboard that echoes the blob the
+kernel just served — are byte-identical to before. Synthetic sids only."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_stale", os.path.join(BIN, "romp-kernel")).load_module()
+
+MEMBERS7 = [{"host": "", "sid": "s%d" % i} for i in range(7)]
+
+
+class StaleWriterGuard(unittest.TestCase):
+    def setUp(self):
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+        km._flags_cache.clear()
+        self.notices = []
+        self._sync = km._sync_notice
+        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+
+    def tearDown(self):
+        km._sync_notice = self._sync
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+        km._flags_cache.clear()
+
+    def _seed(self):
+        """Tag T with 7 members through the RMW door (mtime + at land), then a STALE full blob:
+        the client's copy from before those members existed."""
+        km._set_timeline_views({"active": "all", "tags": [
+            {"id": "gT", "name": "web", "color": "", "members": []}]})
+        km._flags_cache.clear()
+        stale = json.loads(json.dumps(km._timeline_views()))       # the dashboard's old copy
+        time.sleep(1.1)                                            # int-second mtimes need a tick
+        cur = json.loads(json.dumps(km._timeline_views()))
+        cur["tags"][0]["members"] = list(MEMBERS7)                 # the 7 members land (RMW shape)
+        km._set_timeline_views(cur)
+        km._flags_cache.clear()
+        return stale
+
+    def test_the_reproduction_a_stale_full_blob_cannot_wipe_members(self):
+        stale = self._seed()
+        km._set_timeline_views(stale)                              # the clobber that ate 7 members
+        km._flags_cache.clear()
+        t = next(x for x in km._timeline_views()["tags"] if x["id"] == "gT")
+        self.assertEqual(len(t["members"]), 7,
+                         "the store's newer members SURVIVE a stale writer — the exact bug shape")
+        self.assertTrue(self.notices and not self.notices[0][1],
+                        "the refusal is LOUD (a dashboard notice), never a silent divergence")
+        self.assertIn("stale dashboard write", self.notices[0][0])
+
+    def test_a_stale_blob_omitting_the_tag_cannot_delete_it(self):
+        stale = self._seed()
+        stale["tags"] = []                                         # the wipe-by-absence shape
+        km._set_timeline_views(stale)
+        km._flags_cache.clear()
+        tags = km._timeline_views()["tags"]
+        self.assertEqual([t["id"] for t in tags], ["gT"], "a stale writer cannot delete newer state")
+        self.assertEqual(len(tags[0]["members"]), 7)
+
+    def test_a_fresh_writer_still_removes_members_and_deletes_tags(self):
+        self._seed()
+        fresh = json.loads(json.dumps(km._timeline_views()))       # echoes the served `at`
+        fresh["tags"][0]["members"] = fresh["tags"][0]["members"][:3]
+        km._set_timeline_views(fresh)
+        km._flags_cache.clear()
+        self.assertEqual(len(km._timeline_views()["tags"][0]["members"]), 3,
+                         "an informed removal lands — the guard refuses staleness, not removals")
+        fresh2 = json.loads(json.dumps(km._timeline_views()))
+        fresh2["tags"] = []
+        km._set_timeline_views(fresh2)
+        km._flags_cache.clear()
+        self.assertEqual(km._timeline_views()["tags"], [], "an informed deletion lands too")
+        self.assertEqual(len(self.notices), 0, "fresh writers are never noisy")
+
+    def test_the_rmw_paths_always_carry_the_newest_evidence(self):
+        self._seed()
+        t, err = km._edit_tag("web", remove=["s0", "s1"])
+        self.assertIsNone(err)
+        km._flags_cache.clear()
+        self.assertEqual(len(km._timeline_views()["tags"][0]["members"]), 5,
+                         "_edit_tag deep-copies the store, so its writes are informed by construction")
+        self.assertIsNone(km._edit_tag("web", delete=True)[1])
+        km._flags_cache.clear()
+        self.assertEqual(km._timeline_views()["tags"], [])
+        self.assertEqual(len(self.notices), 0)
+
+    def test_an_mtime_less_legacy_tag_keeps_last_writer_wins(self):
+        # a tag never touched since before the mtime feature has no stamp — the guard cannot
+        # prove staleness, so the legacy behavior stands for it (any future edit stamps it)
+        km._atomic_write(km._views_path(), json.dumps(
+            {"active": "all", "tags": [{"id": "gL", "name": "legacy", "color": "",
+                                        "members": [{"host": "", "sid": "s1"}]}]}))
+        km._flags_cache.clear()
+        km._set_timeline_views({"active": "all", "tags": [
+            {"id": "gL", "name": "legacy", "color": "", "members": []}]})
+        km._flags_cache.clear()
+        self.assertEqual(km._timeline_views()["tags"][0]["members"], [])
+
+    def test_the_at_stamp_is_served_and_survives_the_normalizer(self):
+        self._seed()
+        v = km._timeline_views()
+        self.assertTrue(v.get("at"), "the store carries its write stamp")
+        self.assertEqual(km._norm_timeline_views(json.loads(json.dumps(v))).get("at"), v["at"],
+                         "clients echo the blob wholesale — the stamp survives the round trip")
+        self.assertTrue(km._views_client().get("at"),
+                        "…and the rendered client blob serves it, so every dashboard echoes it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

A tag silently lost all 7 of its members; re-adding recreated it with only 1 (user-approved from the nightly optimizer, suspected near a kernel restart).

## Diagnosis

Live-store forensics couldn't date the loss (the victim's mtime was overwritten by the user's own re-add writes; the final writes had no restart beside them), but the class is unambiguous — the handler's own comment names it: `setTimelineViews` **replaces the whole views blob, "last-write-wins across dashboards"**. Any dashboard holding a stale in-memory copy — a page that slept through a kernel restart, a second dashboard, a long-lived Obsidian panel — posts the whole old world back, silently wiping every member and tag added since. Exactly the loss shape, exactly the suspected restart-window timing.

## The fix, at the store's one write door

The v2 per-tag mtimes are forge-proof at this exact spot, so the door enforces the cards-move rule on itself: **a writer whose evidence predates a tag's newer store state stands down for that tag** — its stale copy can't overwrite members, its omission can't delete — while the rest of its write lands. The refusal is **loud** (dashboard notice + stderr), never a silent divergence.

The writer's evidence time is a new `at` stamp written on every blob and served to every client; clients echo blobs wholesale, so a fresh dashboard always carries the newest stamp and behaves byte-identically — informed member removals and tag deletions land exactly as before. RMW paths (`_edit_tag`, `romp tag`) deep-copy the store and are informed by construction. An mtime-less legacy tag keeps last-writer-wins until its first edit stamps it (the guard refuses provable staleness, never guesses).

## Tests

`tests/test_views_stale_writer.py`: the exact reproduction (a stale full blob cannot wipe 7 members), the wipe-by-absence shape, informed removals/deletions land silently, RMW always informed, the legacy carve-out, the at-stamp serve/echo round trip. All adjacent tag/views files green.

## Suites

- pytest: 6202 passed + 313 subtests, 34 skipped
- extension: 2628 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)