### PR TITLE
Idle sessions past 400k/800k context get a compaction suggestion, their call

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4139,6 +4139,94 @@ def _closer_pending(sid, path, now, store):
     return not _closer_settled(store, lt.get("id"), len(lt.get("atoms") or []))
 
 
+# ── the compaction SUGGESTION (the user 2026-08-30, via the nightly optimizer) ──────────────────
+# The ~300k RECYCLE rule stays workers-only; every OTHER session gets a suggestion it decides on
+# itself: once its context crosses each threshold below AND it has been idle at least an hour, it
+# is told — in the person's voice, marker-free (the rename-ping precedent) — that a /compact at a
+# natural boundary would keep it snappy. Event-keyed end to end: the CROSSING arms it, a per-
+# threshold latch on the auto-nudge blob makes each fire once per episode, the idle gate reads the
+# settle event's age at fire time (_settle_event_key — the hook-ledger seam), and the latch re-arms
+# only on the session's own CONTEXT RESET (compact//clear/rewind), observed as the authoritative
+# token counter falling back below the latched threshold — a session that ignores the suggestion
+# is never re-asked (its counter never falls, the latch stands), one that acts hears nothing until
+# it has genuinely filled up again (the manager's amendment, 2026-08-30). Workers are excluded by
+# their roster tags (*_workers in the session-tag store), comment-thread forks by their registry
+# marker, and anything mid-turn by the progressing-state gate. Rides the auto-nudge tick's
+# alive-session walk — no new poll, no timer.
+COMPACT_SUGGEST_TOKENS = (400_000, 800_000)
+COMPACT_SUGGEST_IDLE_S = 3600
+COMPACT_SUGGEST_TEXT = (
+    "It's been quiet here for a while and this conversation has built up a lot of context. "
+    "When you next reach a natural stopping point, run /compact to keep things snappy; "
+    "your call, nothing is waiting on it.")
+
+
+def _worker_tag_member(sid):
+    """True when any *_workers tag in the session-tag store holds this sid — the worker rosters ARE
+    session tags (the `romp tag` headless-edit workflow), and the recycle rule owns those sessions."""
+    try:
+        d = json.loads(_views_path().read_text())
+    except (OSError, ValueError):
+        return False
+    for t in (d.get("tags") or []):
+        if not str(t.get("name") or "").lower().endswith("workers"):
+            continue
+        for m in (t.get("members") or []):
+            ms = m.get("sid") if isinstance(m, dict) else str(m or "")
+            if ms == sid or (isinstance(ms, str) and ms.split(":", 1)[-1] == sid):
+                return True
+    return False
+
+
+def _compact_suggest_tick(sid, tm, now):
+    """One session's slice of the compaction-suggestion watcher (contract in the block comment
+    above). Returns True when the suggestion went out (the caller pushes once at tick end)."""
+    tokens = (tm or {}).get("ctxTokens")
+    if not isinstance(tokens, (int, float)) or tokens <= 0:
+        return False                                   # tmux CLIs / pre-plumbing sessions carry no
+    #                                                    count → never suggested (conservative)
+    tokens = int(tokens)
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        latched = [int(x) for x in (d.get("compactSuggested") or {}).get(sid, [])]
+        live = [t for t in latched if tokens >= t]     # the RE-ARM: a latch whose threshold the
+        #                                                counter has fallen back below was reset by
+        #                                                the session's own compact//clear — that
+        #                                                episode is over (the amendment's middle path)
+        due = [t for t in COMPACT_SUGGEST_TOKENS if tokens >= t and t not in live]
+        if not due and live == latched:
+            return False
+        if not due:                                    # nothing to fire, but persist the pruning so
+            cs = dict(d.get("compactSuggested") or {})  # a restart can't resurrect a spent latch
+            cs[sid] = live
+            d["compactSuggested"] = cs
+            _write_auto_nudge(d)
+            return False
+        # exclusions + the idle gate, all AT FIRE TIME (never latch a fire that never went out):
+        if _worker_tag_member(sid):
+            return False                               # the recycle rule owns workers
+        if _thread_reg(sid).get("threadOf"):
+            return False                               # a comment-thread fork is not first-class
+        if (tm or {}).get("state", "") in _PROGRESSING_STATES:
+            return False                               # mid-turn — not idle, and never interrupt
+        _st = _settle_event_key(sid)
+        if not _st or now - _st < COMPACT_SUGGEST_IDLE_S:
+            return False                               # not settled long enough — the crossing stays
+        #                                                armed; a later tick re-checks the same gate
+        try:
+            Sessions.backend_for(sid).send(sid, COMPACT_SUGGEST_TEXT)
+        except Exception:
+            sys.stderr.write("compact-suggest send (%s): %s\n" % (sid, traceback.format_exc()))
+            return False
+        cs = dict(d.get("compactSuggested") or {})
+        cs[sid] = live + due                           # BOTH thresholds latch when found past both —
+        #                                                one message, never two in a tick
+        d["compactSuggested"] = cs
+        _write_auto_nudge(d)
+    _log_nudge_event(sid, sid, now, 0, verdict="compact-suggested", ev_t=tokens)
+    return True
+
+
 def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     """One Auto-Nudge pass (from the periodic pusher). For each ALIVE, IDLE session (its turn ended) that
     isn't awaiting/compacting/api-error, isn't WAITING ON A LIVE PEER (a wait isn't a stall — the human's
@@ -4170,6 +4258,10 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
                 _put_walk_gate(s["sid"], r, now)
             else:
                 _pop_walk_gate(s["sid"])
+            # the compaction suggestion rides the same walk (contract at _compact_suggest_tick).
+            # Deliberately INSIDE the auto-nudge toggle: a user who turned injected follow-ups
+            # off has said no unprompted messages, and this is exactly that class.
+            fired = _compact_suggest_tick(s["sid"], tmux.get(s["sid"]), now) or fired
         except Exception:
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
@@ -9681,6 +9773,8 @@ class Sessions:
                                 "connected": bool(st.get("connected")),   # SDK handshake up → the opening-chip override stands down (fresh sessions have no transcript yet)
                                 "spawning": bool(st.get("spawning")),   # spawn/handshake in flight NOW — the ONLY window the opening chip covers (a dormant created session must read ready, the user 2026-08-13)
                                 "context": ctx if isinstance(ctx, (int, float)) else None, "compactPct": None,
+                                "ctxTokens": st.get("ctxTokens"),   # raw totalTokens (SDK only) — the
+                                #   compaction-suggestion thresholds key on true tokens (2026-08-30)
                                 "fast": st.get("fast", ""),   # fast-mode state from the CLI's init ("on"/"off"/"cooldown"; "" = unknown → no badge)
                                 "fastReason": st.get("fastReason", ""),   # init's disabled_reason — non-empty hides the chat toggle
                                 "auth": st.get("auth", ""),   # which account this session bills ('login'|'key') → gear badge

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3920,6 +3920,8 @@ def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None, parked_s=No
     once per key-move, carrying parkedS, seconds since the skip's answeredAt) /
     fired-parked-backstop (the memo held but the session sat parked past the dead-man stand — the
     fire re-engages it; carries the final parkedS via its evidence row) /
+    compact-suggested (the idle+context watcher's suggestion went out; evT carries the token count
+    it fired on, 2026-08-30) /
     resolved-at-send / blocked-on-user-at-send — carrying the evidence snapshot's timestamp, so redundant fires are
     countable from the log alone. That accounting is what extended the freshness guard to the cap
     path (the user 2026-08-27, T120: the pre-T120 force-fired-at-cap rows measured the blind fire
@@ -4186,40 +4188,42 @@ def _compact_suggest_tick(sid, tm, now):
         return False                                   # tmux CLIs / pre-plumbing sessions carry no
     #                                                    count → never suggested (conservative)
     tokens = int(tokens)
-    with _NUDGE_LOCK:
-        d = dict(_auto_nudge_data())
+    with _NUDGE_LOCK:                                  # blob read-modify-write only — the send happens
+        d = dict(_auto_nudge_data())                   # OUTSIDE the lock (never hold it across IO)
         latched = [int(x) for x in (d.get("compactSuggested") or {}).get(sid, [])]
         live = [t for t in latched if tokens >= t]     # the RE-ARM: a latch whose threshold the
         #                                                counter has fallen back below was reset by
         #                                                the session's own compact//clear — that
         #                                                episode is over (the amendment's middle path)
         due = [t for t in COMPACT_SUGGEST_TOKENS if tokens >= t and t not in live]
-        if not due and live == latched:
+        if not due:
+            if live != latched:                        # nothing to fire, but persist the pruning so
+                cs = dict(d.get("compactSuggested") or {})   # a restart can't resurrect a spent latch
+                cs[sid] = live
+                d["compactSuggested"] = cs
+                _write_auto_nudge(d)
             return False
-        if not due:                                    # nothing to fire, but persist the pruning so
-            cs = dict(d.get("compactSuggested") or {})  # a restart can't resurrect a spent latch
-            cs[sid] = live
-            d["compactSuggested"] = cs
-            _write_auto_nudge(d)
-            return False
-        # exclusions + the idle gate, all AT FIRE TIME (never latch a fire that never went out):
-        if _worker_tag_member(sid):
-            return False                               # the recycle rule owns workers
-        if _thread_reg(sid).get("threadOf"):
-            return False                               # a comment-thread fork is not first-class
-        if (tm or {}).get("state", "") in _PROGRESSING_STATES:
-            return False                               # mid-turn — not idle, and never interrupt
-        _st = _settle_event_key(sid)
-        if not _st or now - _st < COMPACT_SUGGEST_IDLE_S:
-            return False                               # not settled long enough — the crossing stays
-        #                                                armed; a later tick re-checks the same gate
-        try:
-            Sessions.backend_for(sid).send(sid, COMPACT_SUGGEST_TEXT)
-        except Exception:
-            sys.stderr.write("compact-suggest send (%s): %s\n" % (sid, traceback.format_exc()))
-            return False
+    # exclusions + the idle gate, all AT FIRE TIME (never latch a fire that never went out):
+    if _worker_tag_member(sid):
+        return False                                   # the recycle rule owns workers
+    if _thread_reg(sid).get("threadOf"):
+        return False                                   # a comment-thread fork is not first-class
+    if (tm or {}).get("state", "") in _PROGRESSING_STATES:
+        return False                                   # mid-turn — not idle, and never interrupt
+    _st = _settle_event_key(sid)
+    if not _st or now - _st < COMPACT_SUGGEST_IDLE_S:
+        return False                                   # not settled long enough — the crossing stays
+    #                                                    armed; a later tick re-checks the same gate
+    try:
+        Sessions.backend_for(sid).send(sid, COMPACT_SUGGEST_TEXT)
+    except Exception:
+        sys.stderr.write("compact-suggest send (%s): %s\n" % (sid, traceback.format_exc()))
+        return False
+    with _NUDGE_LOCK:                                  # latch AFTER the send went out, fresh read —
+        d = dict(_auto_nudge_data())                   # a concurrent writer's blob is not clobbered
         cs = dict(d.get("compactSuggested") or {})
-        cs[sid] = live + due                           # BOTH thresholds latch when found past both —
+        cs[sid] = [t for t in [int(x) for x in cs.get(sid, [])] if tokens >= t] + due
+        #                                                BOTH thresholds latch when found past both —
         #                                                one message, never two in a tick
         d["compactSuggested"] = cs
         _write_auto_nudge(d)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1495,6 +1495,9 @@ class SdkSession:
         _lc0 = reg.get("liveCtx")                 # context-window fill %, as the SDK reports it (see _ctx_pct).
         self._ctx: int | None = _lc0 if isinstance(_lc0, (int, float)) else None  # seeded from the last persisted
         #   value so the bar survives idle/restart; refreshed live from get_context_usage() on connect + each turn.
+        _lt0 = reg.get("liveCtxTokens")           # raw totalTokens from the same get_context_usage payload —
+        self._ctx_tokens: int | None = (int(_lt0) if isinstance(_lt0, (int, float)) else None)   # the kernel's
+        #   compaction-suggestion thresholds key on true tokens, window-independent (2026-08-30)
         self._ctx_refreshing = False             # one get_context_usage control request in flight at a time
         self._usage_refreshing = False           # one get_usage control request in flight at a time
         self.retrying = False                        # an api_retry storm (API rate-limit/overload) is stalling the turn → 'retrying', not 'working'
@@ -1940,6 +1943,9 @@ class SdkSession:
             v = max(0, min(100, round(pct)))
             if v != self._ctx:
                 self._ctx, changed = v, True
+        tt = cu.get("totalTokens")
+        if isinstance(tt, (int, float)) and int(tt) != self._ctx_tokens:
+            self._ctx_tokens, changed = int(tt), True
         pm = pretty_model(cu.get("model"))
         if pm and self._resolve_model_pending(pm):
             changed = True
@@ -1951,6 +1957,8 @@ class SdkSession:
         upd["modelPending"] = bool(self._model_pending)
         if self._ctx is not None:
             upd["liveCtx"] = self._ctx
+        if self._ctx_tokens is not None:
+            upd["liveCtxTokens"] = self._ctx_tokens
         if upd:
             try:
                 self.backend._update_reg(self.sid, **upd)
@@ -3423,7 +3431,8 @@ class SdkSession:
                 #   lands) — the Billing row says so when it disagrees with the launch intent above
                 #   (a key found via apiKeyHelper bills the key while `auth` still reads login)
                 "authPending": bool(self._auth_pending),   # an /auth switch reconnecting → badge dots
-                "mode": self.perm_mode, "ctx": self._ctx_pct(), "summary": "",
+                "mode": self.perm_mode, "ctx": self._ctx_pct(), "ctxTokens": self._ctx_tokens,
+                "summary": "",
                 "connected": bool(self.client),   # the SDK handshake is up (set at connect, cleared at
                 #   teardown) — the "this session is OPEN" event for a transcript-less fresh session:
                 #   the kernel's opening-chip override stands down on it, so a new SDK session reads
@@ -5949,7 +5958,10 @@ class SdkBackend:
                     # survives idle/restart instead of vanishing until the next turn
                     "fast": reg.get("liveFast", ""),
                     "fastReason": reg.get("liveFastReason", ""),
-                    "ctx": lc if isinstance(lc, (int, float)) else "", "summary": ""}
+                    "ctx": lc if isinstance(lc, (int, float)) else "",
+                    "ctxTokens": (int(reg["liveCtxTokens"])
+                                  if isinstance(reg.get("liveCtxTokens"), (int, float)) else None),
+                    "summary": ""}
 
     # ---- picker/permission UI bridge (kernel-thread API) ----
     def on_ask(self, sid: str, kind: str, payload=None) -> bool:

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""The kernel-level compaction SUGGESTION (the user 2026-08-30, via the nightly optimizer). The
+~300k recycle rule stays workers-only; every OTHER session is told — once idle at least an hour,
+first past 400k context tokens, again past 800k — that a /compact at a natural boundary would keep
+it snappy, its call. Event-keyed end to end: the CROSSING arms it; a per-threshold latch on the
+auto-nudge blob makes each fire once per episode; the idle gate reads the settle event's age AT
+FIRE TIME; and the latch re-arms only on the session's own context RESET (compact//clear/rewind),
+observed as the authoritative token counter falling back below the latched threshold — ignored =
+silent forever, acted+regrown+idle = one fresh suggestion per threshold (the manager's amendment).
+Workers (their roster tags), comment-thread forks, and mid-turn sessions are excluded at fire
+time. The voice render is pinned in test_injected_voice.py. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_compsug", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-eeeeeeeeeeee"
+NOW = 1_788_200_000
+IDLE = NOW - 7200          # settled two hours ago — past the hour gate
+FRESH = NOW - 120          # settled two minutes ago — inside it
+
+
+class CompactSuggest(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._autonudge_cache.clear()
+        self._orig = {n: getattr(km, n) for n in ("_settle_event_key", "_thread_reg")}
+        km._settle_event_key = lambda sid: IDLE
+        km._thread_reg = lambda sid: {}
+        self._orig_backend = km.Sessions.backend_for
+        self.sent = []
+        test = self
+
+        class FakeBackend:
+            def send(self, sid, body):
+                test.sent.append(body)
+        km.Sessions.backend_for = staticmethod(lambda sid: FakeBackend())
+
+    def tearDown(self):
+        for n, v in self._orig.items():
+            setattr(km, n, v)
+        km.Sessions.backend_for = self._orig_backend
+        jd.STATE = self.saved_state
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _tick(self, tokens, state="idle"):
+        return km._compact_suggest_tick(SID, {"state": state, "ctxTokens": tokens}, NOW)
+
+    def _latched(self):
+        km._autonudge_cache.clear()
+        return (km._auto_nudge_data().get("compactSuggested") or {}).get(SID, [])
+
+    # ── the crossing latch ──
+    def test_a_crossing_fires_once_and_latches(self):
+        self.assertTrue(self._tick(450_000))
+        self.assertEqual(len(self.sent), 1)
+        self.assertIn("/compact", self.sent[0])
+        self.assertEqual(self._latched(), [400_000], "latched on the durable record")
+        self.assertFalse(self._tick(460_000), "same episode → never a second fire")
+        self.assertEqual(len(self.sent), 1)
+
+    def test_the_second_threshold_is_its_own_episode(self):
+        self.assertTrue(self._tick(450_000))
+        self.assertTrue(self._tick(820_000), "the 800k crossing is new information")
+        self.assertEqual(len(self.sent), 2)
+        self.assertEqual(sorted(self._latched()), [400_000, 800_000])
+        self.assertFalse(self._tick(950_000), "…and both latches now stand: ignored = silent")
+
+    def test_found_past_both_thresholds_fires_one_message(self):
+        self.assertTrue(self._tick(900_000))
+        self.assertEqual(len(self.sent), 1, "two suggestions in one tick would read as nagging")
+        self.assertEqual(sorted(self._latched()), [400_000, 800_000])
+
+    # ── the re-arm: the session's own context reset, never a nag ──
+    def test_a_compact_rearms_exactly_the_thresholds_it_fell_below(self):
+        self.assertTrue(self._tick(900_000))
+        self.assertFalse(self._tick(500_000), "compacted to 500k: below 800k, still above 400k — "
+                                              "nothing due (400k stands latched)")
+        self.assertEqual(self._latched(), [400_000], "the 800k latch was pruned by the reset")
+        self.assertTrue(self._tick(820_000), "regrown past 800k after the reset → one fresh fire")
+        self.assertEqual(len(self.sent), 2)
+
+    def test_a_full_reset_rearms_both(self):
+        self.assertTrue(self._tick(900_000))
+        self.assertFalse(self._tick(50_000), "fresh context — nothing due, latches prune")
+        self.assertEqual(self._latched(), [])
+        self.assertTrue(self._tick(450_000), "the next 400k crossing is a genuinely new episode")
+        self.assertEqual(len(self.sent), 2)
+
+    # ── the idle gate, at fire time ──
+    def test_a_fresh_settle_holds_the_fire_without_spending_the_crossing(self):
+        km._settle_event_key = lambda sid: FRESH
+        self.assertFalse(self._tick(450_000), "settled minutes ago — not idle enough")
+        self.assertEqual(self.sent, [])
+        self.assertEqual(self._latched(), [], "the crossing stays ARMED — never latch a fire "
+                                              "that never went out")
+        km._settle_event_key = lambda sid: IDLE
+        self.assertTrue(self._tick(450_000), "an hour idle later, the same crossing fires")
+
+    def test_no_settle_evidence_no_fire(self):
+        km._settle_event_key = lambda sid: 0
+        self.assertFalse(self._tick(450_000))
+        self.assertEqual(self.sent, [])
+
+    # ── the exclusions ──
+    def test_a_worker_tagged_session_is_never_suggested(self):
+        (jd.STATE / "timeline-views.json").write_text(json.dumps(
+            {"active": "all", "tags": [{"id": "t1", "name": "notes_workers",
+                                        "members": [{"host": "", "sid": SID}]}]}))
+        self.assertFalse(self._tick(450_000), "the recycle rule owns workers")
+        self.assertEqual(self.sent, [])
+
+    def test_a_comment_thread_fork_is_never_suggested(self):
+        km._thread_reg = lambda sid: {"threadOf": "11111111-2222-3333-4444-ffffffffffff"}
+        self.assertFalse(self._tick(450_000))
+        self.assertEqual(self.sent, [])
+
+    def test_a_mid_turn_session_is_never_suggested(self):
+        self.assertFalse(self._tick(450_000, state="working"))
+        self.assertEqual(self.sent, [])
+        self.assertEqual(self._latched(), [], "…and the crossing stays armed for its settle")
+
+    def test_no_token_count_no_fire(self):
+        self.assertFalse(self._tick(None))
+        self.assertFalse(self._tick(0))
+        self.assertEqual(self.sent, [])
+
+    # ── the fingerprint row ──
+    def test_a_fire_logs_a_countable_row(self):
+        self._tick(450_000)
+        p = jd.STATE / "nudge-events.jsonl"
+        rows = [json.loads(l) for l in p.read_text().splitlines()]
+        self.assertEqual([r["verdict"] for r in rows], ["compact-suggested"])
+        self.assertEqual(rows[0]["evT"], 450_000, "the row carries the token count it fired on")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -142,6 +142,10 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # the dashboard-edit trace (the user 2026-08-22): the file viewer saved over a file in this
             # session's tree, and the session is told in the person's voice — never edited under silently
             "edit trace": km._edit_trace_body("/TESTDIR/notes-api/README.md"),
+            # the compaction suggestion (the user 2026-08-30): idle + a lot of context → the person
+            # suggests a /compact at a natural boundary; /compact is a CLI feature the session
+            # already knows, and the thresholds behind the timing are never mentioned
+            "compaction suggestion": km.COMPACT_SUGGEST_TEXT,
         }
         # every repeat-nudge variant wears the same voice as the first fire (the user 2026-08-11): the
         # rotation exists so a re-ask doesn't read canned, so a variant that broke the voice rule would
@@ -214,7 +218,8 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             if name in ("typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
                         "debt reminder (several)", "comment thread opener", "edit trace",
-                        "comment-thread merge"):
+                        "comment-thread merge", "compaction suggestion"):
+                #        ^ a housekeeping suggestion, not a progress ask — it elicits nothing
                 continue
             text = prose(body).lower()
             with self.subTest(message=name):


### PR DESCRIPTION
## Summary
The user's ruling (via the nightly optimizer): the ~300k recycle rule stays workers-only; every other session gets a suggestion it decides on itself — once idle at least an hour, first past 400k context tokens, again past 800k. Built once in the kernel so every group of sessions inherits it.

- **Measure: true tokens.** The same `get_context_usage` payload the backend already consumes carries `totalTokens`; it is now stored beside the percent (`liveCtxTokens`, persisted, boot-seeded) and exported through both live-row shapes and the kernel's merged live map. tmux CLIs carry no count and are never suggested.
- **Watcher rides the auto-nudge tick** (no new poll; deliberately inside the auto-nudge toggle). Event-keyed: the crossing arms it; a per-threshold latch on the auto-nudge blob fires each episode once and survives restarts; the idle gate reads the settle event's age at fire time (the hook-ledger seam) — a held crossing stays armed, never spent; the latch re-arms only on the session's own context reset (compact//clear/rewind), observed as the counter falling back below the latched threshold: ignored = silent forever, acted+regrown+idle = one fresh suggestion per threshold, a partial compact re-arms only the threshold it fell below. Found past both = one message. Workers excluded by their roster tags, comment-thread forks by their registry marker, mid-turn by the progressing-state gate. Each fire logs a countable nudge-events row. The send happens outside the nudge lock (decide under lock, send, latch on a fresh re-read).
- **Message**: marker-free, in the person's voice, registered in the injected-voice index — it names `/compact` (a CLI feature the session knows), an idle stretch, and that it's the session's call; no thresholds, no internal vocabulary.

## Test plan
- `tests/test_compact_suggest.py` (12): crossing latch + store round-trip, second threshold as its own episode, both-at-once folds to one message, partial and full reset re-arms, ignored stays silent, idle gate holds without spending the crossing, no-evidence/no-count fire nothing, all three exclusions, the countable row.
- Voice render pinned in `tests/test_injected_voice.py`.
- Full Python suite: 6,208 passed. Extension suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)