### PR TITLE
The compaction suggestion honors the per-session mute

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4257,6 +4257,12 @@ def _compact_suggest_tick(sid, tm, now):
                 _write_auto_nudge(d)
             return False
     # exclusions + the idle gate, all AT FIRE TIME (never latch a fire that never went out):
+    if _session_flag(sid, "hideFromFeed"):
+        return False                                   # muted — the user's explicit per-session
+    #                                                    opt-out that every sibling injector honors
+    #                                                    (the nudge gate, the interrupt-block tick;
+    #                                                    a routed review caught this one missing,
+    #                                                    2026-09-01)
     if _worker_tag_member(sid):
         return False                                   # the recycle rule owns workers
     if _thread_reg(sid).get("threadOf"):

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -126,6 +126,15 @@ class CompactSuggest(unittest.TestCase):
         self.assertFalse(self._tick(450_000), "the recycle rule owns workers")
         self.assertEqual(self.sent, [])
 
+    def test_a_muted_session_is_never_suggested(self):
+        # the user's explicit per-session opt-out (hideFromFeed) — every sibling injector honors
+        # it; a routed review pass caught this tick missing the check (2026-09-01)
+        (jd.STATE / "session-flags.json").write_text(json.dumps({SID: {"hideFromFeed": True}}))
+        km._flags_cache.clear()
+        self.assertFalse(self._tick(450_000))
+        self.assertEqual(self.sent, [])
+        self.assertEqual(self._latched(), [], "…and the crossing stays armed, never spent")
+
     def test_a_comment_thread_fork_is_never_suggested(self):
         km._thread_reg = lambda sid: {"threadOf": "11111111-2222-3333-4444-ffffffffffff"}
         self.assertFalse(self._tick(450_000))


### PR DESCRIPTION
## Summary
A routed review pass caught the gap (both verifiers upheld it): the compaction-suggestion tick checked worker tags, thread forks, and progressing state but never the mute flag — a muted, alive session past a threshold and idle over an hour still got the suggestion injected and spent a turn, against the user's explicit opt-out that every sibling injector honors (the nudge gate and the interrupt-block tick both stand down on `hideFromFeed`). The flag joins the fire-time exclusions through the same reader, before anything else.

## Test plan
- Regression test in `tests/test_compact_suggest.py`: muted = no fire, no spent latch (the crossing stays armed for an unmute).
- Full Python suite: 6,215 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)