### PR TITLE
Gear model rows now repaint on fill(): the facade showed defaults over real picks

### DIFF
--- a/tests/test_gear_select_matrix.py
+++ b/tests/test_gear_select_matrix.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Every gear select DISPLAYS the stored value, for every value the kernel accepts.
+
+The user (2026-09-01): STATE/distill-model held claude-opus-4-8 — their own pick, the mtimes
+proving only pick-writes — while the gear's Distilling row said Follow triage. The store, the
+/version payload, and the option list were all correct; the lie was the FACADE: the four model
+rows are painted by versionMenu buttons that synced only on a user gesture or an options rewrite,
+and fill()'s per-open value writes are deliberately silent (a change event here would POST the
+setting back). The effort rows' selectPick facades joined the repaintSelectPicks registry; the
+versionMenu buttons never did — so any page reload reset every model row's label to its first
+option until the next hand pick, and the row lied about a value the kernel was honoring.
+
+Two guards, pinning the CLASS (a select/option vocabulary or repaint drift must never again show
+a silent default):
+  * SourcePins — runs everywhere, CI included: versionMenu's label sync joins the ONE repaint
+    registry fill() flushes; every kernel-backed select assignment rides setShow, which INJECTS a
+    marked option when the stored value is off this kernel's list (an honest row, never a default
+    lie).
+  * ServedMatrix — the executed guard: boots the hermetic kernel, and for EACH gear select writes
+    EACH kernel-acceptable value into its STATE file (the vocabulary is drawn from the kernel's
+    own tables, so drift auto-tracks), loads the gear, and asserts the VISIBLE facade label is the
+    stored value's own option label. Skips LOUDLY when the extension deps or a playwright browser
+    are absent (CI installs no browsers); it executes on any dev box with the extension installed,
+    which is where ships are gated.
+
+All fixtures synthetic.
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+# Hermetic state BEFORE the load — bin/romp-kernel resolves its state root at import time, and only
+# pytest runs conftest's floor (a bare unittest run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_gsm", os.path.join(BIN, "romp-kernel")).load_module()
+
+GEAR = open(os.path.join(ROOT, "ui", "webview", "gear.js")).read()
+
+
+class SourcePins(unittest.TestCase):
+    def test_every_facade_joins_the_one_repaint_registry(self):
+        # the versionMenu label sync must repaint on fill()'s silent writes exactly like the
+        # selectPick facades do — one registry, flushed at the end of fill()
+        self.assertIn("selectPickPaints.push(syncBtn);", GEAR)
+        self.assertIn("selectPickPaints.push(paint);", GEAR)
+        self.assertIn("repaintSelectPicks();", GEAR)
+
+    def test_every_kernel_backed_assignment_rides_setShow(self):
+        self.assertIn("function setShow(sel, val)", GEAR)
+        # a stored value with no option INJECTS a marked one — honest, never the default lie
+        self.assertIn("not in this kernel's list", GEAR)
+        for sel in ("jm", "im", "dm", "cmm", "je", "ie", "de", "cme", "upm"):
+            self.assertIn("setShow(%s, v." % sel, GEAR, sel + " must render through setShow")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+MODELS_ALL = [c["value"] for c in km.MODEL_CHOICES] + \
+             [v["value"] for vs in km.MODEL_VERSIONS.values() for v in vs]
+EFFORTS = [c["value"] for c in km.EFFORT_CHOICES]
+# select id → (STATE file, every storable value the kernel accepts for it)
+MATRIX = {
+    "rs-judgemodel":    ("judge-model", MODELS_ALL),
+    "rs-indexmodel":    ("index-model", MODELS_ALL),
+    "rs-distillmodel":  ("distill-model", ["triage"] + MODELS_ALL),
+    "rs-cmtmodel":      ("comment-model", ["session", "default"] + MODELS_ALL),
+    "rs-judgeeffort":   ("judge-effort", EFFORTS),
+    "rs-indexeffort":   ("index-effort", EFFORTS),
+    "rs-distilleffort": ("distill-effort", ["triage", "none"] + EFFORTS),
+    "rs-cmteffort":     ("comment-effort", ["session"] + EFFORTS),
+}
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 900 } });
+const out = [];
+for (const round of cfg.rounds) {
+  for (const [name, val] of Object.entries(round.files)) fs.writeFileSync(cfg.stateDir + "/" + name, val);
+  await page.goto(cfg.url + "&r=" + Math.random());
+  // gear.js must be INITIALIZED before the open message: the vermenu buttons exist only after
+  // fillChoices resolves, which also proves the openSettings listener is installed — posting
+  // earlier is silently lost and fill() never runs (first driver draft raced exactly this)
+  await page.waitForSelector(".rs-vermenu-btn", { state: "attached", timeout: 15000 });   // panel still hidden here
+  await page.evaluate(() => window.postMessage({ romp: "openSettings" }, "*"));
+  await page.waitForSelector("#rsettings:not([hidden])", { timeout: 15000 });
+  // fill()'s /version assigns land in one tick; once every select HOLDS its value the facades
+  // have had their repaint chance in that same tick
+  await page.waitForFunction((exp) => Object.entries(exp).every(([id, v]) => {
+    const s = document.getElementById(id);
+    return s && s.value === v;
+  }), round.expect, { timeout: 15000 }).catch(() => {});
+  out.push(await page.evaluate((exp) => {
+    const r = {};
+    for (const id of Object.keys(exp)) {
+      const s = document.getElementById(id);
+      const o = s && s.selectedIndex >= 0 ? s.options[s.selectedIndex] : null;
+      r[id] = { value: s ? s.value : null,
+                optLabel: o ? o.textContent : null,
+                facade: s && s.nextElementSibling ? s.nextElementSibling.textContent.trim() : null };
+    }
+    return r;
+  }, round.expect));
+}
+await browser.close();
+console.log("MATRIX:" + JSON.stringify(out));
+"""
+
+
+class ServedMatrix(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served matrix needs them")
+        cls.lab = tempfile.mkdtemp(prefix="gear-matrix-")
+        # a fresh bundle of THIS tree's gear.js — the kernel serves the copy, never the live dist
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        os.makedirs(cls.state, exist_ok=True)
+        cls.port = _free_port()
+        cls.token = "testtok-matrix"
+        env = dict(os.environ,
+                   XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
+                   CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
+                   ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
+                   ROMP_DIST_DIR=dist)
+        env.pop("ROMP_STATE_DIR", None)
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(os.path.join(cls.lab, "kernel.log"), "w"),
+                                      stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_every_select_displays_every_acceptable_stored_value(self):
+        rounds = []
+        depth = max(len(vals) for _, vals in MATRIX.values())
+        for r in range(depth):
+            files, expect = {}, {}
+            for sel_id, (fname, vals) in MATRIX.items():
+                v = vals[min(r, len(vals) - 1)]
+                files[fname] = v
+                expect[sel_id] = v
+            rounds.append({"files": files, "expect": expect})
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"stateDir": self.state, "rounds": rounds,
+                       "url": "http://127.0.0.1:%d/feed?token=%s" % (self.port, self.token)}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=600,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the matrix needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-2000:] + p.stderr[-2000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("MATRIX:")), None)
+        self.assertIsNotNone(line, "driver printed no matrix:\n" + p.stdout[-2000:])
+        results = json.loads(line[len("MATRIX:"):])
+        bad = []
+        for r, (round_cfg, got) in enumerate(zip(rounds, results)):
+            for sel_id, want in round_cfg["expect"].items():
+                g = got.get(sel_id) or {}
+                if g.get("value") != want:
+                    bad.append("%s round %d: select holds %r, stored %r — the option vocabulary lost a kernel-acceptable value"
+                               % (sel_id, r, g.get("value"), want))
+                elif not g.get("facade") or not g.get("optLabel") or g["optLabel"] not in g["facade"]:
+                    bad.append("%s round %d: stored %r, option label %r, but the row SHOWS %r — the facade lies"
+                               % (sel_id, r, want, g.get("optLabel"), g.get("facade")))
+        self.assertEqual(bad, [], "\n" + "\n".join(bad))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -476,7 +476,9 @@ class Wiring(unittest.TestCase):
         for opt in ("value=ask", "value=auto", "value=off"):
             self.assertIn(opt, self.gear)
         self.assertIn("post({ type: 'setUpdateMode', mode: upm.value })", self.gear)
-        self.assertIn("upm.value = v.updateMode", self.gear)
+        # fill() renders through setShow now (2026-09-01): the same silent write, plus the
+        # honest marked-option injection when a stored value is off this page's list
+        self.assertIn("setShow(upm, v.updateMode)", self.gear)
         self.assertIn('msg.get("type") == "setUpdateMode"', self.src)
 
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -530,6 +530,11 @@ function initGear(post) {
     var mo = new MutationObserver(syncBtn);
     mo.observe(sel, { childList: true });
     sel.addEventListener('change', syncBtn);
+    // fill() writes sel.value SILENTLY on every open (a change event here would POST the setting
+    // back), so the button must join the ONE repaint registry fill() flushes — without this it
+    // showed its install-tick label (the first option) while the select and the STATE file held
+    // the user's pick (the user 2026-09-01, whose Opus distill pick displayed as Follow triage).
+    selectPickPaints.push(syncBtn);
     setTimeout(syncBtn, 0);
     var menu = null, sub = null;
     var closeAll = function () { if (sub) { sub.remove(); sub = null; } if (menu) { menu.remove(); menu = null; } };
@@ -791,6 +796,21 @@ function initGear(post) {
       mark.hidden = false;
     });
   }
+  // fill()'s ONE write path for kernel-backed selects (the user 2026-09-01, whose stored distill
+  // pick displayed as the default): a stored value the option list doesn't carry is INJECTED as a
+  // marked option and selected — the row shows the truth (an off-list value, named) rather than
+  // silently falling to its first option. Values are validated at write time by the kernel, so an
+  // injection here means THIS page's list is behind the store — worth seeing, never worth hiding.
+  function setShow(sel, val) {
+    if (!sel) return;
+    if (val && !Array.prototype.some.call(sel.options, function (o) { return o.value === val; })) {
+      var o = document.createElement('option');
+      o.value = val;
+      o.textContent = val + " — not in this kernel's list";
+      sel.appendChild(o);
+    }
+    sel.value = val;
+  }
   function fill() { fillChoices().then(function () { return fetch(ku('/version'), { cache: 'no-store' }); }).then(function (r) { return r.json(); }).then(function (v) {
     // ONE /tunnels fetch feeds every cross-machine comparison: the autoNudge box and the select marks.
     // A failed /tunnels leaves the local answers standing, unmarked — same fallback as before.
@@ -803,15 +823,15 @@ function initGear(post) {
     if (cvm) cvm.checked = !!v.conserveMemory;   // T148: the kernel's persisted conserve flag is authoritative
     lgRender(v);   // the Billing login block (T157) rides the same /version read
     if ((v.login || {}).state && !lgTimer) lgTimer = setTimeout(lgPoll, 1500);   // a flow mid-run resumes polling
-    if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
-    if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
-    if (im && typeof v.indexModel === 'string') im.value = v.indexModel;
-    if (je && typeof v.judgeEffort === 'string') je.value = v.judgeEffort;
-    if (ie && typeof v.indexEffort === 'string') ie.value = v.indexEffort;
-    if (dm && typeof v.distillModel === 'string') dm.value = v.distillModel;   // RAW: "triage" selects the Follow-triage option
-    if (de && typeof v.distillEffort === 'string') de.value = v.distillEffort;
-    if (cmm && typeof v.commentModel === 'string') cmm.value = v.commentModel;   // RAW: "session" selects Same as the session
-    if (cme && typeof v.commentEffort === 'string') cme.value = v.commentEffort;
+    if (typeof v.updateMode === 'string') setShow(upm, v.updateMode);   // the kernel's persisted mode is authoritative
+    if (typeof v.judgeModel === 'string') setShow(jm, v.judgeModel);   // the judge's ACTUAL current model/effort per tier is authoritative
+    if (typeof v.indexModel === 'string') setShow(im, v.indexModel);
+    if (typeof v.judgeEffort === 'string') setShow(je, v.judgeEffort);
+    if (typeof v.indexEffort === 'string') setShow(ie, v.indexEffort);
+    if (typeof v.distillModel === 'string') setShow(dm, v.distillModel);   // RAW: "triage" selects the Follow-triage option
+    if (typeof v.distillEffort === 'string') setShow(de, v.distillEffort);
+    if (typeof v.commentModel === 'string') setShow(cmm, v.commentModel);   // RAW: "session" selects Same as the session
+    if (typeof v.commentEffort === 'string') setShow(cme, v.commentEffort);
     if (cmf && typeof v.commentFast === 'string') cmf.checked = v.commentFast === 'on';
     cmtFastGate(false);
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative


### PR DESCRIPTION
The user's report: STATE/distill-model held `claude-opus-4-8` (their own pick, mtimes proving only pick-writes) while the gear's Distilling row said Follow triage. Store, payload, and option list were all correct — the lie was the FACADE: the four model rows' versionMenu buttons synced only on the install tick, a user change event, or an options rewrite, and `fill()`'s per-open value writes are deliberately silent (a change event would POST the setting back). The effort rows' selectPick facades joined the `repaintSelectPicks` registry; the versionMenu buttons never did — so any page reload reset every model row's label to its first option while the hidden select and the file held the pick. Whichever row the user hand-picked last looked right, which is the report's exact discriminator.

**Root fixes** (gear.js): versionMenu's `syncBtn` joins the ONE repaint registry `fill()` flushes; and every kernel-backed select write rides `setShow`, which INJECTS a marked option (`<value> — not in this kernel's list`) when the stored value is off the page's list — the row shows the truth, never the default lie.

**Class guard** (`tests/test_gear_select_matrix.py`): a served-page MATRIX — hermetic kernel; for EACH gear select, EACH kernel-acceptable value (drawn from the kernel's own tables, so vocabulary drift auto-tracks) written to its STATE file; the VISIBLE facade label must be that value's own option label. Red pre-fix (every model row lying), green post-fix — 16 rounds × 8 selects in ~5s. Skips loudly where playwright browsers are absent (CI installs none); SourcePins covers the registry + setShow contract in CI. One stale pin retargeted (`test_kernel_update`).

Verified on the served page with the user's exact scenario: file `claude-opus-4-8`, untouched, Distilling row shows **Opus 4.8**.

Suites: pytest 6217 passed + 321 subtests, npm 2628/2628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)