### PR TITLE
The false-refusal honesty arms reach the cross-host legs; id sends route

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10271,7 +10271,11 @@ def _bus_quarantine_act(body):
     delivery and the held-message store. On approve the bus re-runs the peer's deliver(), so an approved
     message lands as normal postal mail. Returns (ok, error)."""
     try:
-        conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=6)
+        # 20s: the client half of the approve path's budget pair (2026-09-01). The bus-side approve
+        # pays one checked kernel fetch (≤6s) plus the recipient's deliver push (≤12s), so a 6s cap
+        # here gave up mid-approve — the delivery landed while the kernel reported the bus
+        # unreachable. The halves move together (the 830 budget-pair discipline).
+        conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=20)
         conn.request("POST", "/quarantine/act", json.dumps(body),
                      {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
         resp = conn.getresponse()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1127,7 +1127,18 @@ def list_regs(state_dir: Path) -> list[dict]:
     try:
         entries = list(os.scandir(d))
     except OSError:
+        # the WHOLE-LISTING twin of the per-entry contract (review find 2026-09-01): a transient
+        # enumeration failure blanked every row at once — the loudest possible false-death signal
+        # under this very docstring. Serve every reg's last good row instead; a genuinely empty or
+        # missing dir enumerates FINE (scandir yields []/raises only on real faults), so truth is
+        # untouched. A fresh process with an empty cache still returns [] — it has nothing to claim.
+        if _REG_CACHE:
+            if "\x00scan" not in _REG_SERVE_WARNED:   # sentinel key: incidents log once, not per scan
+                _REG_SERVE_WARNED.add("\x00scan")
+                sys.stderr.write("list_regs: scan of %s failed — serving every last good row\n" % d)
+            return [dict(v[1]) for v in _REG_CACHE.values()]
         return out
+    _REG_SERVE_WARNED.discard("\x00scan")             # healed → the next scan incident logs afresh
     seen = set()
     for de in entries:
         if not de.name.endswith(".json"):
@@ -1149,8 +1160,10 @@ def list_regs(state_dir: Path) -> list[dict]:
             continue
         key = (st.st_mtime_ns, st.st_size, st.st_ino)
         if hit is not None and hit[0] == key:
-            out.append(dict(hit[1]))
-            continue
+            _REG_SERVE_WARNED.discard(de.path)         # a healed STAT blip lands here (cache hit, no
+            out.append(dict(hit[1]))                   # re-read) — without this the once-per-incident
+            continue                                   # latch never cleared and later blips logged
+        #                                                nothing (review find 2026-09-01)
         try:
             r = json.loads(Path(de.path).read_text())
         except (OSError, ValueError) as e:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -630,8 +630,12 @@ def local_agents(threads=False):
     every other reader stay exactly as they were: self-identity, recipient resolution, and the agents
     listing pass True (a thread mails its parent under its OWN name and is addressable for replies);
     everything else never sees them."""
+    return _agent_rows(_kernel_sessions(threads=threads))
+
+
+def _agent_rows(sessions):
     res = []
-    for s in _kernel_sessions(threads=threads):
+    for s in sessions:
         sid = s.get("id")
         if not sid:
             continue
@@ -644,6 +648,15 @@ def local_agents(threads=False):
             row["parent"] = s.get("parent") or ""
         res.append(row)
     return res
+
+
+def local_agents_checked(threads=False):
+    """(local_agents rows, answered) — the honesty-arm variant for consumers whose REFUSALS ride the
+    listing (the inbound relay's bounces, the presence producer): 'answered' distinguishes a kernel
+    that said "no sessions" from one that couldn't answer at all (mid-restart), the same bit the
+    sending resolver has carried since the answered-but-absent round (2026-08-31)."""
+    rows, answered = _kernel_sessions_checked(threads=threads)
+    return _agent_rows(rows), answered
 
 
 def _kernel_post(path, body, timeout=2):
@@ -1463,7 +1476,14 @@ class Handler(BaseHTTPRequestHandler):
                 tnote = (" — report-back tracking does not cross hosts yet; sent as a plain handoff"
                          if tracked else "")
                 mid = "px-" + _unique()
-                relay_msg = {"mid": mid, "to": hit.get("name") or to, "frm": frm,
+                # `to` carries the display name (an old-code far side matches names only), and
+                # `toId` carries the resolved row's SID (review find 2026-09-01): parking the name
+                # ALONE discarded exactly what an id-addressed send chose the sid for — a rename
+                # during the park window bounced a rename-proof address as no-live, and two
+                # same-named far sessions could silently swap deliveries. A new far side matches
+                # toId exactly first; an old one ignores the extra key. Compatible both ways.
+                relay_msg = {"mid": mid, "to": hit.get("name") or to,
+                             "toId": str(hit.get("id") or ""), "frm": frm,
                              "frm_id": frm_id, "body": body, "kind": kind,
                              "t": int(time.time())}
                 if kind == "delegate":
@@ -2188,6 +2208,57 @@ def _bounce_apply(host, b):
                                   "to": msg.get("to") or "?", "host": host,
                                   "why": (b or {}).get("why") or "refused"})
 
+_LOCAL_PRESENCE_GOOD = [[], False]   # [rows, ever_answered] — the last ANSWERED local listing
+_PRESENCE_SERVE_WARNED = [False]     # transition-only logging, the _REG_SERVE_WARNED idiom
+_PRESENCE_GOOD_FILE = STATE / "local-presence-good.json"   # …and its DISK twin: a bus restart
+#   overlapping a kernel restart (the normal self-update path — both restart on code staleness)
+#   would otherwise boot with an empty cache and gossip the blink as authoritative emptiness
+#   (review find 2026-09-01); persisting rides the cache across bus restarts, like remote-sids.
+
+
+def _presence_good_load():
+    """Prime the in-memory last-answered cache from its disk twin, once, at first need."""
+    if _LOCAL_PRESENCE_GOOD[1]:
+        return
+    try:
+        rows = json.loads(_PRESENCE_GOOD_FILE.read_text())
+        if isinstance(rows, list):
+            _LOCAL_PRESENCE_GOOD[0], _LOCAL_PRESENCE_GOOD[1] = rows, True
+    except Exception:
+        pass                                         # no twin yet (fresh box) → nothing to prime
+
+
+def _local_presence():
+    """Local agent rows for an exchange payload, blink-honest: an UNANSWERED kernel listing (a
+    mid-restart blink) must never gossip as "nobody lives here" — the far boxes' PEER_STATE flaps
+    empty and their resolvers mint hard no-live refusals for sessions that never died (specimen
+    2026-08-31: three sends refused across a far restart while the target stayed live throughout).
+    Serve the last ANSWERED rows instead (the registry's serve-last-good idiom, 2026-08-31); an
+    ANSWERED-empty listing is the truth — it serves and caches as such. This protects every peer,
+    including ones running older code, because the honesty lands in the payload itself."""
+    rows, answered = local_agents_checked()
+    if answered:
+        _LOCAL_PRESENCE_GOOD[0], _LOCAL_PRESENCE_GOOD[1] = rows, True
+        try:
+            tmp = _PRESENCE_GOOD_FILE.with_suffix(".tmp")
+            tmp.write_text(json.dumps(rows))
+            os.replace(tmp, _PRESENCE_GOOD_FILE)     # the disk twin follows every answered read
+        except Exception:
+            pass
+        if _PRESENCE_SERVE_WARNED[0]:
+            _PRESENCE_SERVE_WARNED[0] = False
+            sys.stderr.write("postal: the local listing answers again — presence serves live rows\n")
+        return rows
+    _presence_good_load()                            # a fresh bus process primes from the disk twin
+    if _LOCAL_PRESENCE_GOOD[1]:
+        if not _PRESENCE_SERVE_WARNED[0]:
+            _PRESENCE_SERVE_WARNED[0] = True
+            sys.stderr.write("postal: the local listing didn't answer — presence serves the last "
+                             "answered rows until it does\n")
+        return list(_LOCAL_PRESENCE_GOOD[0])
+    return rows                                     # never answered ANYWHERE yet → claim nothing either way
+
+
 def fleet_presence(exclude_host):
     """Presence for an exchange payload: local agents + ONE hop of gossip from our other peers, each
     labeled `via` (plans/postal-peer-buses.md 3b) — so a spoke can address the far spoke through the
@@ -2196,7 +2267,7 @@ def fleet_presence(exclude_host):
     (`viaBus`): the receiver folds gossip about a box it ALREADY peers with directly, and the id is
     the identity that survives nickname drift — the same machine wears different ssh aliases on
     different hosts, so a name can't say "same box" (the user 2026-08-12; see _via_duplicate)."""
-    out = list(local_agents())
+    out = list(_local_presence())
     for h, st in PEER_STATE.items():
         if h == exclude_host:
             continue
@@ -2296,9 +2367,18 @@ def quarantine_decide(mid, action, text=None, feedback=None):
     if action == "approve":
         body = str(text) if (text is not None and str(text).strip()) else (rec.get("body") or "")
         to_id = rec.get("toId") or ""
-        live = {a["id"] for a in local_agents()}
+        # ONE checked snapshot (2026-09-01): this arm paid TWO kernel fetches — its own fetch-pair
+        # TOCTOU, and the pair alone (2×6s) could outlast the kernel's client cap on /quarantine/act
+        # (the 830 budget-pair discipline: the halves move together — see _bus_quarantine_act). And
+        # an approve clicked during a kernel restart read the blink as "no longer live": unanswered
+        # is not absence, so it refuses retryably instead (the held message stays put).
+        agents, answered = local_agents_checked()
+        if not answered:
+            return False, ("the liveness source (the romp kernel) didn't answer — likely "
+                           "mid-restart. The held message is untouched; retry the approve shortly.")
+        live = {a["id"] for a in agents}
         if to_id not in live:                         # session renamed/revived since it was held → re-match by name
-            match = [a for a in local_agents() if a["name"] == rec.get("to") and not _postal_off(a["id"])]
+            match = [a for a in agents if a["name"] == rec.get("to") and not _postal_off(a["id"])]
             if not match:
                 return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
             to_id = match[0]["id"]
@@ -2334,7 +2414,24 @@ def _relay_in(host, m, token_proven=False):
     if peer_seen_check(mid):
         return "ack", None                           # duplicate → re-ack, deliver nothing
     to = m.get("to") or ""
-    match = [a for a in local_agents() if a["name"] == to and not _postal_off(a["id"])]
+    # ONE listing snapshot for every ruling below. The isolation bounce used to re-fetch the
+    # listing after the match filtered it — and a blink between the two fetches (agent absent,
+    # then healed) minted a FALSE isolation, final by norm, with no flag involved (specimen
+    # 2026-08-30: a delegate bounced "isolation" with no flag set on either kernel and the
+    # maildir delivering minutes either side). Same fetch-pair race the sending resolver's
+    # one-fetch fix killed (2026-08-31); `answered` feeds the death-ruling gate at the tail.
+    agents, listing_answered = local_agents_checked()
+    to_id = str(m.get("toId") or "")
+    if to_id and _ID_FORM_RE.fullmatch(to_id) is None:
+        to_id = ""            # a malformed wire toId degrades to name matching — it must NEVER reach
+        #                       the durable-registry read below (a crafted "../" would turn that stat
+        #                       into a path-traversal alive-oracle; skeptic find 2026-09-01)
+    # toId (a sender-resolved SID) matches EXACTLY when present — never a name fallback, which
+    # could hand the mail to a same-named sibling, the ambiguity the sid exists to bypass. Mail
+    # from an older sender has no toId and matches by name/id-shape as before.
+    named = ([a for a in agents if str(a.get("id") or "") == to_id] if to_id
+             else [a for a in agents if _addr_matches(a, to)])
+    match = [a for a in named if not _postal_off(a["id"])]
     if match:
         # Trust key = the true ORIGIN (the forwarding host stamps m["origin"]; else the direct peer).
         # Unknown host (a race before the kernel's notify lands) defaults to directed — never auto-inject.
@@ -2367,14 +2464,37 @@ def _relay_in(host, m, token_proven=False):
         # defensive backstop for the checkin-peer path where the mobile dials our /peer-exchange.
         peer_seen_add(mid)
         return "ack", None
-    if any(a["name"] == to for a in local_agents()):
+    if named:
+        # every live candidate's mailbox flag read TRUE in THIS snapshot — a genuine flag ruling,
+        # the only thing allowed to mint an isolation bounce (finality makes this arm zero-tolerance)
         return "bounce", {"mid": mid, "why": "recipient '%s' has its mailbox off (postal isolation)" % to}
     if not m.get("origin"):                          # one hop MAX: a message that already hopped never re-forwards
-        fh, hit = peer_route(to)
+        # route by the SID when the mail carries one, by name otherwise (skeptic finds
+        # 2026-09-01, both rounds): the hub's name-only forward final-bounced a sid-addressed
+        # message whose session renamed during the park window — gossip rows carry ids, and
+        # _addr_matches routes them. Pinned mail routes by sid OR NOT AT ALL: a name fallback
+        # here forwarded the same mid to a NAMESAKE's host when gossip blinked the sid out
+        # (per-host hold dedupe let both parks stand), and the wrong host's final bounce could
+        # beat the right host's delivery ack back to the sender.
+        fh, hit = (peer_route(to_id) if to_id else peer_route(to))
         if fh and fh != host and not (hit or {}).get("via"):
             if outbox_get(fh, mid) is None:          # a resend while we hold it forwards nothing twice
                 outbox_put(fh, dict(m, origin=host))
             return "hold", None
+    # death-ruling gate — the relay leg's honesty arms (2026-08-31; the sending resolver got these
+    # in the answered-but-absent round, this inbound leg never did): an UNANSWERED listing proves
+    # nothing (a mid-restart kernel yields exactly this), and an answered listing that omits a name
+    # whose durable registry entry stands is a blink, never a death. Both read as 'retry' — a
+    # verdict neither ack'd nor bounced crosses the wire as SILENCE, so the sender's outbox keeps
+    # the mail parked and re-relays it next exchange: the honest retry-shortly, where a bounce is
+    # final. The mid stays out of peer_seen, so the re-relay is processed in full.
+    # …and when the mail PINS a sid, the corroboration is by that id ALONE: the name arm read a
+    # same-named REPLACEMENT session's standing reg as evidence and held a genuinely-gone sid in
+    # never-healing silent retry — the sender parked forever, never told (skeptic repro
+    # 2026-09-01). A pinned sid whose reg is gone everywhere bounces FINAL and honestly: the
+    # session it named no longer exists, however many namesakes live on.
+    if not listing_answered or (_durable_session(to_id, True) if to_id else _durable_session(to, False)):
+        return "retry", None
     return "bounce", {"mid": mid, "why": "no live session named '%s' on %s" % (to, self_host())}
 
 def _ack_arrived(host, mid):
@@ -2481,7 +2601,8 @@ def peer_exchange_handle(data):
         if verdict == "ack":
             acks.append(m.get("mid"))
         elif verdict == "bounce" and bounce:
-            bounces.append(bounce)                   # 'hold': forwarded — its ack comes back later
+            bounces.append(bounce)                   # 'hold': forwarded — its ack comes back later;
+        #                                              'retry': silence on purpose — the sender re-relays
 
     def _drain_backflow():                           # acks/bounces relayed BACK through us for this host
         p = _pending(host)
@@ -2553,7 +2674,28 @@ def peer_exchange_apply(host, req_sent, resp):
             if verdict == "ack":
                 p["acks"].append(m.get("mid"))
             elif verdict == "bounce" and bounce:
-                p["bounces"].append(bounce)          # 'hold': forwarded — its ack comes back later
+                p["bounces"].append(bounce)          # 'hold': forwarded — its ack comes back later;
+            #                                          'retry': silence on purpose — the sender re-relays
+
+_ID_FORM_RE = re.compile(r"[0-9a-fA-F][0-9a-fA-F-]{7,35}")   # uuid / short-id address shapes
+
+
+def _addr_matches(a, to):
+    """Does agent row `a` answer to address `to` — by name, by full session id, or by the short-id
+    prefix form every list_agents row prints (`· <8-char>`)? Review find 2026-09-01: presence rows
+    have always CARRIED ids, but the route matched names only, so a uuid send to a live far-host
+    session had no route at all — it fell through to the refusal tail and read as deadness (and a
+    first-cut mirror arm here turned that into a never-healing retry; routing is the honest cure).
+    Prefix collisions surface as multiple candidates: peer_route's standing ambiguity machinery
+    refuses multi-hits; _relay_in prefers the exact toId a new-code sender parks (see the relay
+    message), so its name matching is the old-sender compatibility path only."""
+    if a.get("name") == to:
+        return True
+    sid = str(a.get("id") or "")
+    if not sid:
+        return False
+    return sid == to or (_ID_FORM_RE.fullmatch(to) is not None and sid.startswith(to))
+
 
 def peer_route(to):
     """Where a non-local name lives: (host, agent) for exactly ONE peer match; (None, candidates) on
@@ -2572,7 +2714,7 @@ def peer_route(to):
         if want_host and host != want_host:
             continue
         for a in st.get("presence") or []:
-            if a.get("name") != to or _via_duplicate(a, direct_bus):
+            if not _addr_matches(a, to) or _via_duplicate(a, direct_bus):
                 continue
             sid = a.get("id") or ""
             if sid and sid in seen_ids:                # one session, two gossip paths → one candidate;
@@ -2892,6 +3034,11 @@ def _mcp_call(name, args):
     if name == "set_working":
         if not mid:
             return "Not inside a romp session.", True
+        if "text" not in args or args.get("text") is None:
+            # a MISSING param is never a clear command (fold-in 2026-08-31: a malformed call
+            # silently wiped the published note); the documented clear stays text=''
+            return ("set_working needs its `text` argument — nothing was changed. "
+                    "Pass text='' if you mean to clear your published note."), True
         text = args.get("text", "")
         _publish_working(mid, text)        # backend-agnostic kernel store (POST /working), not the @romp-working var
         return ("Cleared your 'working on' note." if not text.strip()

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -129,11 +129,16 @@ class TwoBusExchange(unittest.TestCase):
 
     def setUp(self):
         os.environ["ROMP_POSTAL_PEERS"] = "1"
-        self._saved = (pm.self_host, pmb.self_host, pm.local_agents, pmb.local_agents)
+        self._saved = (pm.self_host, pmb.self_host, pm.local_agents, pmb.local_agents,
+                       pm.local_agents_checked, pmb.local_agents_checked)
         pm.self_host = lambda: "hosta"
         pmb.self_host = lambda: "hostb"
         pm.local_agents = lambda: [{"name": "alpha", "id": "sid-a", "dir": ""}]
         pmb.local_agents = lambda: [{"name": "beta", "id": "sid-b", "dir": ""}]
+        # _relay_in and fleet_presence rule from the CHECKED seam now (2026-08-31): same stub
+        # rows, answered=True — the harness's world is authoritative
+        pm.local_agents_checked = lambda threads=False: (pm.local_agents(), True)
+        pmb.local_agents_checked = lambda threads=False: (pmb.local_agents(), True)
         for m in (pm, pmb):
             m.PEER_STATE.clear()
             m.PEERS.clear()
@@ -158,7 +163,8 @@ class TwoBusExchange(unittest.TestCase):
 
     def tearDown(self):
         os.environ.pop("ROMP_POSTAL_PEERS", None)
-        pm.self_host, pmb.self_host, pm.local_agents, pmb.local_agents = self._saved
+        (pm.self_host, pmb.self_host, pm.local_agents, pmb.local_agents,
+         pm.local_agents_checked, pmb.local_agents_checked) = self._saved
 
     def _exchange(self):
         req = pm.build_exchange_request("srv", wait=False)
@@ -267,13 +273,18 @@ class ThreeBusRelay(unittest.TestCase):
     def setUp(self):
         os.environ["ROMP_POSTAL_PEERS"] = "1"
         self._saved = (pm.self_host, pmb.self_host, pmc.self_host,
-                       pm.local_agents, pmb.local_agents, pmc.local_agents)
+                       pm.local_agents, pmb.local_agents, pmc.local_agents,
+                       pm.local_agents_checked, pmb.local_agents_checked, pmc.local_agents_checked)
         pm.self_host = lambda: "hosta"
         pmb.self_host = lambda: "hostb"
         pmc.self_host = lambda: "hostc"
         pm.local_agents = lambda: [{"name": "alpha", "id": "sid-a", "dir": ""}]
         pmb.local_agents = lambda: [{"name": "beta", "id": "sid-b", "dir": ""}]
         pmc.local_agents = lambda: [{"name": "carol", "id": "sid-c", "dir": ""}]
+        # _relay_in and fleet_presence rule from the CHECKED seam now (2026-08-31)
+        pm.local_agents_checked = lambda threads=False: (pm.local_agents(), True)
+        pmb.local_agents_checked = lambda threads=False: (pmb.local_agents(), True)
+        pmc.local_agents_checked = lambda threads=False: (pmc.local_agents(), True)
         import shutil
         for m in (pm, pmb, pmc):
             m.PEER_STATE.clear()
@@ -303,7 +314,8 @@ class ThreeBusRelay(unittest.TestCase):
     def tearDown(self):
         os.environ.pop("ROMP_POSTAL_PEERS", None)
         (pm.self_host, pmb.self_host, pmc.self_host,
-         pm.local_agents, pmb.local_agents, pmc.local_agents) = self._saved
+         pm.local_agents, pmb.local_agents, pmc.local_agents,
+         pm.local_agents_checked, pmb.local_agents_checked, pmc.local_agents_checked) = self._saved
 
     def _xchg(self, dialer, dialed, alias):
         req = dialer.build_exchange_request(alias, wait=False)

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""The false-refusal honesty arms on the CROSS-HOST legs (2026-08-31). The sending resolver got
+its arms in the answered-but-absent round; two verified specimens showed the class surviving on
+the relay path: (i) an inbound relay bounced "postal isolation" — final by norm — with no flag
+set on either kernel (the isolation ruling was INFERRED from two disagreeing listing fetches);
+(ii) sends to a live far-host session were refused no-live-session while the sid stood in the
+sending box's own remote-sids mirror (far-kernel restart flapped presence empty). Three fixes:
+_relay_in takes ONE checked snapshot and corroborates both bounces (unanswered/blinked → 'retry',
+which crosses the wire as silence so the sender's outbox re-relays); resolve_recipient consults
+the remote-sids mirror for id-shaped forms before its 404; and the presence PRODUCER serves the
+last ANSWERED rows when the local listing doesn't answer, so a local blink never gossips as
+"nobody lives here". Fold-in: set_working without its text param refused loudly, never a clear.
+
+SYNTHETIC fixtures only: placeholder UUIDs, invented names.
+"""
+import json
+import os
+import tempfile
+import unittest
+import uuid
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+pm = SourceFileLoader("romp_postal_relay", os.path.join(BIN, "romp-postal-service")).load_module()
+
+ALPHA = "11111111-2222-3333-4444-555555555555"
+GHOST = "99999999-8888-7777-6666-555555555555"
+
+
+def _set_live(rows):
+    f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump(rows, f)
+    f.close()
+    os.environ["ROMP_SESSIONS_FILE"] = f.name
+
+
+def _fresh_mid():
+    return "relayt-" + uuid.uuid4().hex
+
+
+class _RelayBase(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        self._base = pm.KERNEL_BASE
+        self.addCleanup(lambda: (setattr(pm, "KERNEL_BASE", self._base),
+                                 os.environ.pop("ROMP_SESSIONS_FILE", None),
+                                 pm.HEARTBEATS.clear()))
+
+    def _msg(self, to):
+        return {"mid": _fresh_mid(), "to": to, "frm": "web", "frm_id": ALPHA, "body": "hi"}
+
+
+class RelayInboundHonesty(_RelayBase):
+    """_relay_in's bounces are FINAL on the sender side, so both must be corroborated rulings."""
+
+    def test_one_listing_snapshot_for_the_whole_ruling(self):
+        # specimen (i)'s mechanism: two fetches, a blink between them → a false FINAL isolation.
+        # Pinned structurally: the whole ruling pays exactly one listing fetch.
+        _set_live([])
+        calls = []
+        saved = pm.local_agents_checked
+        pm.local_agents_checked = lambda threads=False: (calls.append(1), saved(threads=threads))[1]
+        try:
+            pm._relay_in("TESTHOST", self._msg("web"))
+        finally:
+            pm.local_agents_checked = saved
+        self.assertEqual(len(calls), 1, "one snapshot rules match, isolation, and death together")
+
+    def test_true_isolation_still_bounces(self):
+        _set_live([{"id": ALPHA, "name": "web"}])
+        pm.SESSION_FLAGS.parent.mkdir(parents=True, exist_ok=True)
+        pm.SESSION_FLAGS.write_text(json.dumps({ALPHA: {"postalServiceOff": True}}))
+        self.addCleanup(lambda: pm.SESSION_FLAGS.unlink(missing_ok=True))
+        verdict, bounce = pm._relay_in("TESTHOST", self._msg("web"))
+        self.assertEqual(verdict, "bounce")
+        self.assertIn("postal isolation", bounce["why"], "a TRUE flag read still rules isolation")
+
+    def test_unanswered_listing_retries_never_bounces(self):
+        # a mid-restart kernel proves nothing — neither isolation nor death may be minted from it
+        pm.KERNEL_BASE = "http://127.0.0.1:9"      # nothing listens: every fetch fails fast
+        m = self._msg("web")
+        verdict, bounce = pm._relay_in("TESTHOST", m)
+        self.assertEqual((verdict, bounce), ("retry", None))
+        self.assertFalse(pm.peer_seen_check(m["mid"]), "the re-relay must be processed in full")
+
+    def test_blink_with_durable_reg_retries(self):
+        # answered listing omits the name, but its durable reg stands alive → a blink, not a death
+        _set_live([])
+        root = pm.STATE.parent
+        (root / "sdk").mkdir(parents=True, exist_ok=True)
+        (root / "sdk" / (GHOST + ".json")).write_text(json.dumps({"sid": GHOST, "alive": True}))
+        pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
+        (pm.NAMES_DIR / GHOST).write_text("web\t/work/web\t#112233\t#ffffff\n")
+        self.addCleanup(lambda: ((root / "sdk" / (GHOST + ".json")).unlink(missing_ok=True),
+                                 (pm.NAMES_DIR / GHOST).unlink(missing_ok=True)))
+        verdict, bounce = pm._relay_in("TESTHOST", self._msg("web"))
+        self.assertEqual((verdict, bounce), ("retry", None))
+
+    def test_genuinely_absent_still_bounces_honestly(self):
+        _set_live([])
+        verdict, bounce = pm._relay_in("TESTHOST", self._msg("nobody-here"))
+        self.assertEqual(verdict, "bounce")
+        self.assertIn("no live session named 'nobody-here'", bounce["why"])
+
+
+class IdShapedAddressingRoutes(_RelayBase):
+    """specimen (ii)'s uuid leg, cured by ROUTING (review find 2026-09-01): presence rows have
+    always carried ids, but peer_route matched names only — a uuid or short-id send to a live
+    far-host session had NO route at all and fell through to the refusal tail as false deadness
+    (a first-cut mirror-503 here prescribed a retry that could never succeed; removed)."""
+
+    def _far(self, rows):
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        pm.PEER_STATE["farhost"] = {"presence": rows, "epoch": 1, "seenAt": 0}
+        self.addCleanup(lambda: (pm.PEER_STATE.clear(), os.environ.pop("ROMP_POSTAL_PEERS", None)))
+
+    def test_uuid_send_relays_to_the_presence_row(self):
+        _set_live([])
+        self._far([{"id": GHOST, "name": "web"}])
+        res = pm.resolve_recipient(GHOST)
+        self.assertEqual((res["kind"], res["host"]), ("relay", "farhost"))
+
+    def test_short_id_prefix_relays_too(self):
+        _set_live([])
+        self._far([{"id": GHOST, "name": "web"}])
+        res = pm.resolve_recipient(GHOST[:8])
+        self.assertEqual((res["kind"], res["host"]), ("relay", "farhost"))
+
+    def test_host_qualified_uuid_relays(self):
+        _set_live([])
+        self._far([{"id": GHOST, "name": "web"}])
+        res = pm.resolve_recipient("farhost:" + GHOST)
+        self.assertEqual((res["kind"], res["host"]), ("relay", "farhost"))
+
+    def test_ambiguous_prefix_refuses_never_guesses(self):
+        _set_live([])
+        self._far([{"id": GHOST, "name": "web"},
+                   {"id": GHOST[:8] + "aaaa-bbbb-cccc-dddddddddddd", "name": "api"}])
+        res = pm.resolve_recipient(GHOST[:8])
+        self.assertEqual((res["kind"], res["status"]), ("error", 409))
+
+    def test_unknown_uuid_keeps_the_honest_404(self):
+        _set_live([])
+        self._far([{"id": ALPHA, "name": "web"}])
+        res = pm.resolve_recipient(GHOST)
+        self.assertEqual((res["kind"], res["status"]), ("error", 404))
+
+    def test_park_carries_the_resolved_sid_alongside_the_name(self):
+        # review find 2026-09-01: the park rewrote an id-addressed send to the far session's NAME,
+        # discarding what the sid was chosen for (rename-proof, ambiguity-proof). The relay message
+        # carries toId now; this pins the dict literal so the key can't quietly drop.
+        src = open(os.path.join(os.path.dirname(HERE), "postal", "postal_service.py")).read()
+        self.assertIn('"toId": str(hit.get("id") or "")', src)
+
+    def test_toid_matches_exactly_never_falls_back_to_a_same_named_sibling(self):
+        # two live sessions share a name; the mail carries the sid of the SECOND — a name match
+        # would hand it to the first (silent misdelivery, the ambiguity the sid bypasses)
+        _set_live([{"id": ALPHA, "name": "web"}, {"id": GHOST, "name": "web"}])
+        pm.PEERS["TESTHOST"] = {"port": 1, "up": True, "trust": "trusted"}
+        delivered = []
+        saved = pm.deliver
+        pm.deliver = lambda *a, **k: delivered.append(a) or "m-x"
+        self.addCleanup(lambda: (setattr(pm, "deliver", saved), pm.PEERS.clear()))
+        m = dict(self._msg("web"), toId=GHOST)
+        verdict, _ = pm._relay_in("TESTHOST", m)
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(delivered[0][0], GHOST, "the sid picks the session, not the name order")
+
+    def test_toid_miss_with_standing_reg_retries_never_misdelivers(self):
+        # the toId's session blinked out of the listing (rename mid-park is the specimen shape) —
+        # a name fallback could misdeliver; the durable reg by ID corroborates a retry instead
+        _set_live([{"id": ALPHA, "name": "web"}])
+        root = pm.STATE.parent
+        (root / "sdk").mkdir(parents=True, exist_ok=True)
+        (root / "sdk" / (GHOST + ".json")).write_text(json.dumps({"sid": GHOST, "alive": True}))
+        self.addCleanup(lambda: (root / "sdk" / (GHOST + ".json")).unlink(missing_ok=True))
+        verdict, bounce = pm._relay_in("TESTHOST", dict(self._msg("web"), toId=GHOST))
+        self.assertEqual((verdict, bounce), ("retry", None))
+
+    def test_toid_gone_everywhere_bounces_honestly(self):
+        _set_live([{"id": ALPHA, "name": "web"}])
+        verdict, bounce = pm._relay_in("TESTHOST", dict(self._msg("web"), toId=GHOST))
+        self.assertEqual(verdict, "bounce")
+
+    def test_a_same_named_replacement_never_holds_a_gone_sid_in_limbo(self):
+        # skeptic repro (2026-09-01): the pinned sid is gone for good, but a NEW session took the
+        # name — with reg and names entry, as every live SDK session has. The gate's name arm read
+        # that replacement's reg as evidence and returned retry FOREVER (parked mail, sender never
+        # told). A pinned sid corroborates by ID alone: gone everywhere → final honest bounce.
+        _set_live([{"id": ALPHA, "name": "web"}])
+        root = pm.STATE.parent
+        (root / "sdk").mkdir(parents=True, exist_ok=True)
+        (root / "sdk" / (ALPHA + ".json")).write_text(json.dumps({"sid": ALPHA, "alive": True}))
+        pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
+        (pm.NAMES_DIR / ALPHA).write_text("web\t/work/web\t#112233\t#ffffff\n")
+        self.addCleanup(lambda: ((root / "sdk" / (ALPHA + ".json")).unlink(missing_ok=True),
+                                 (pm.NAMES_DIR / ALPHA).unlink(missing_ok=True)))
+        verdict, bounce = pm._relay_in("TESTHOST", dict(self._msg("web"), toId=GHOST))
+        self.assertEqual(verdict, "bounce", "the replacement's standing reg is not the pinned sid's")
+
+    def test_a_malformed_wire_toid_never_reaches_the_registry_read(self):
+        # skeptic find (2026-09-01): the wire toId flowed into a registry-path read — a crafted
+        # "../" made that stat a path-traversal alive-oracle. Malformed shapes degrade to name
+        # matching (old-mail behavior) and never touch the filesystem as a path.
+        _set_live([{"id": ALPHA, "name": "web"}])
+        pm.PEERS["TESTHOST"] = {"port": 1, "up": True, "trust": "trusted"}
+        delivered = []
+        saved_del, saved_dur = pm.deliver, pm._durable_session
+        pm.deliver = lambda *a, **k: delivered.append(a) or "m-x"
+        pm._durable_session = lambda bare, by_id: (_ for _ in ()).throw(
+            AssertionError("the malformed toId must not reach the durable read"))
+        self.addCleanup(lambda: (setattr(pm, "deliver", saved_del),
+                                 setattr(pm, "_durable_session", saved_dur), pm.PEERS.clear()))
+        verdict, _ = pm._relay_in("TESTHOST", dict(self._msg("web"), toId="../../etc/hostname"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(delivered[0][0], ALPHA, "degrades to name matching, delivers normally")
+
+    def test_the_forward_hop_routes_by_the_pinned_sid_through_a_rename(self):
+        # skeptic repro (2026-09-01): the hub's forward matched names only, so a session renamed
+        # during the park window final-bounced at the hub while living one hop away — the gossip
+        # row carries the sid, and the forward routes by it now (name stays the old-mail fallback)
+        _set_live([])
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        pm.PEER_STATE["spokec"] = {"presence": [{"id": GHOST, "name": "web2"}], "epoch": 1, "seenAt": 0}
+        parked = []
+        saved_put, saved_get = pm.outbox_put, pm.outbox_get
+        pm.outbox_put = lambda h, m: parked.append((h, m))
+        pm.outbox_get = lambda h, mid: None
+        self.addCleanup(lambda: (setattr(pm, "outbox_put", saved_put), setattr(pm, "outbox_get", saved_get),
+                                 pm.PEER_STATE.clear(), os.environ.pop("ROMP_POSTAL_PEERS", None)))
+        verdict, _ = pm._relay_in("TESTHOST", dict(self._msg("web"), toId=GHOST))
+        self.assertEqual(verdict, "hold", "forwarded by sid, not bounced on the stale name")
+        self.assertEqual(parked[0][0], "spokec")
+        self.assertEqual(parked[0][1].get("toId"), GHOST, "the sid rides the hop intact")
+
+    def test_pinned_mail_never_forwards_to_a_namesake_host(self):
+        # skeptic repro (2026-09-01, round 2): with the pinned sid blinked out of gossip and a
+        # same-named session on ANOTHER host, the name fallback forwarded the pinned mid there —
+        # double-parked across hosts, and the namesake host's final bounce could beat the real
+        # delivery ack. Pinned mail routes by sid or not at all.
+        _set_live([])
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        pm.PEER_STATE["spokec"] = {"presence": [{"id": ALPHA, "name": "web"}], "epoch": 1, "seenAt": 0}
+        parked = []
+        saved_put, saved_get = pm.outbox_put, pm.outbox_get
+        pm.outbox_put = lambda h, m: parked.append((h, m))
+        pm.outbox_get = lambda h, mid: None
+        self.addCleanup(lambda: (setattr(pm, "outbox_put", saved_put), setattr(pm, "outbox_get", saved_get),
+                                 pm.PEER_STATE.clear(), os.environ.pop("ROMP_POSTAL_PEERS", None)))
+        verdict, _ = pm._relay_in("TESTHOST", dict(self._msg("web"), toId=GHOST))
+        self.assertNotEqual(verdict, "hold", "the namesake host is not this mail's destination")
+        self.assertEqual(parked, [], "nothing forwarded on a name the mail did not trust")
+
+    def test_relay_in_matches_an_id_addressed_arrival(self):
+        # the far side of the same cure: a relayed message whose `to` is the uuid (a resolved row
+        # with no name) must find its local session by id, not bounce no-live
+        _set_live([{"id": ALPHA, "name": "web"}])
+        pm.PEERS["TESTHOST"] = {"port": 1, "up": True, "trust": "trusted"}
+        delivered = []
+        saved = pm.deliver
+        pm.deliver = lambda *a, **k: delivered.append(a) or "m-x"
+        self.addCleanup(lambda: (setattr(pm, "deliver", saved), pm.PEERS.clear()))
+        verdict, _ = pm._relay_in("TESTHOST", self._msg(ALPHA))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(delivered[0][0], ALPHA)
+
+
+class PresenceBlinkHonesty(_RelayBase):
+    """The producer half of specimen (ii): an unanswered local listing must never gossip as empty."""
+
+    def setUp(self):
+        super().setUp()
+        pm._LOCAL_PRESENCE_GOOD[0], pm._LOCAL_PRESENCE_GOOD[1] = [], False
+        pm._PRESENCE_SERVE_WARNED[0] = False
+        pm._PRESENCE_GOOD_FILE.unlink(missing_ok=True)
+
+    def test_unanswered_serves_the_last_answered_rows(self):
+        _set_live([{"id": ALPHA, "name": "web"}])
+        self.assertEqual([a["id"] for a in pm._local_presence()], [ALPHA])   # answered → cached
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        pm.KERNEL_BASE = "http://127.0.0.1:9"
+        self.assertEqual([a["id"] for a in pm._local_presence()], [ALPHA],
+                         "a blink serves the last answered rows, never an empty claim")
+
+    def test_answered_empty_is_the_truth(self):
+        _set_live([{"id": ALPHA, "name": "web"}])
+        pm._local_presence()
+        _set_live([])
+        self.assertEqual(pm._local_presence(), [], "an ANSWERED empty listing serves and caches as truth")
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        pm.KERNEL_BASE = "http://127.0.0.1:9"
+        self.assertEqual(pm._local_presence(), [], "the cached truth is the empty listing")
+
+    def test_never_answered_claims_nothing(self):
+        pm.KERNEL_BASE = "http://127.0.0.1:9"
+        self.assertEqual(pm._local_presence(), [])
+
+    def test_disk_twin_carries_the_cache_across_a_bus_restart(self):
+        # review find 2026-09-01: a bus restart overlapping a kernel restart (the normal
+        # self-update path) boots with an empty in-memory cache and would gossip the blink as
+        # authoritative emptiness — the disk twin primes it
+        _set_live([{"id": ALPHA, "name": "web"}])
+        pm._local_presence()                                     # answered → disk twin written
+        pm._LOCAL_PRESENCE_GOOD[0], pm._LOCAL_PRESENCE_GOOD[1] = [], False   # a fresh bus process
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        pm.KERNEL_BASE = "http://127.0.0.1:9"
+        self.assertEqual([a["id"] for a in pm._local_presence()], [ALPHA],
+                         "the disk twin serves through the double-restart window")
+
+    def test_no_twin_still_claims_nothing(self):
+        pm._PRESENCE_GOOD_FILE.unlink(missing_ok=True)
+        pm.KERNEL_BASE = "http://127.0.0.1:9"
+        self.assertEqual(pm._local_presence(), [])
+
+
+class QuarantineApproveHonesty(_RelayBase):
+    """The approve arm shares this round's diseases (2026-09-01): it paid TWO kernel fetches (its
+    own fetch-pair TOCTOU, and 2x6s could outlast the kernel's client cap on /quarantine/act —
+    the budget pair now reconciled at 20s client-side), and it read a mid-restart blink as
+    "no longer a live local session" — a false terminal on a held message."""
+
+    def setUp(self):
+        super().setUp()
+        self.rec = {"mid": "q-1", "to": "web", "toId": ALPHA, "frm": "api", "frmId": GHOST,
+                    "body": "held hello", "origin": "TESTHOST", "kind": "coordinate"}
+        self.delivered, self.deleted = [], []
+        self._saved = (pm.quarantine_get, pm.quarantine_del, pm.deliver)
+        pm.quarantine_get = lambda mid: dict(self.rec) if mid == "q-1" else None
+        pm.quarantine_del = lambda mid: self.deleted.append(mid)
+        pm.deliver = lambda *a, **k: self.delivered.append((a, k)) or "m-q"
+        self.addCleanup(lambda: (setattr(pm, "quarantine_get", self._saved[0]),
+                                 setattr(pm, "quarantine_del", self._saved[1]),
+                                 setattr(pm, "deliver", self._saved[2])))
+
+    def test_unanswered_listing_refuses_retryably_and_keeps_the_hold(self):
+        pm.KERNEL_BASE = "http://127.0.0.1:9"
+        ok, err = pm.quarantine_decide("q-1", "approve")
+        self.assertFalse(ok)
+        self.assertIn("retry the approve shortly", err)
+        self.assertEqual((self.delivered, self.deleted), ([], []),
+                         "nothing delivered, nothing dropped — the held message stays put")
+
+    def test_answered_approve_pays_one_fetch_and_delivers(self):
+        _set_live([{"id": ALPHA, "name": "web"}])
+        calls = []
+        saved = pm.local_agents_checked
+        pm.local_agents_checked = lambda threads=False: (calls.append(1), saved(threads=threads))[1]
+        try:
+            ok, err = pm.quarantine_decide("q-1", "approve")
+        finally:
+            pm.local_agents_checked = saved
+        self.assertTrue(ok, err)
+        self.assertEqual(len(calls), 1, "one snapshot rules the whole approve")
+        self.assertEqual(self.delivered[0][0][0], ALPHA)
+
+    def test_kernel_client_cap_matches_the_pair(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('HTTPConnection("127.0.0.1", BUS_PORT, timeout=20)', src,
+                      "the client half of the approve budget pair — the halves move together")
+
+
+class SetWorkingMissingParamRefuses(unittest.TestCase):
+    """Fold-in: a missing param is never a clear command."""
+
+    def setUp(self):
+        self.saved = (pm.my_name, pm.my_id, pm._publish_working)
+        self.calls = []
+        pm.my_name, pm.my_id = (lambda: "web"), (lambda: ALPHA)
+        pm._publish_working = lambda mid, text: self.calls.append((mid, text))
+        self.addCleanup(lambda: (setattr(pm, "my_name", self.saved[0]),
+                                 setattr(pm, "my_id", self.saved[1]),
+                                 setattr(pm, "_publish_working", self.saved[2])))
+
+    def test_missing_text_refuses_and_changes_nothing(self):
+        msg, is_err = pm._mcp_call("set_working", {})
+        self.assertTrue(is_err)
+        self.assertIn("nothing was changed", msg)
+        self.assertEqual(self.calls, [], "the note is untouched")
+
+    def test_null_text_refuses_too(self):
+        msg, is_err = pm._mcp_call("set_working", {"text": None})
+        self.assertTrue(is_err)
+        self.assertEqual(self.calls, [])
+
+    def test_explicit_empty_string_still_clears(self):
+        msg, is_err = pm._mcp_call("set_working", {"text": ""})
+        self.assertFalse(is_err)
+        self.assertIn("Cleared", msg)
+        self.assertEqual(self.calls, [(ALPHA, "")], "text='' stays the documented clear command")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_walked_ask.py
+++ b/tests/test_postal_walked_ask.py
@@ -92,10 +92,13 @@ class RelayInPassesItThrough(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self._saved = (pm.deliver, pm.local_agents, pm._postal_off, pm.peer_seen_check,
-                       pm.peer_seen_add, dict(pm.PEERS), pm.QUARANTINE)
+                       pm.peer_seen_add, dict(pm.PEERS), pm.QUARANTINE, pm.local_agents_checked)
         self.delivered = []
         pm.deliver = lambda *a, **k: self.delivered.append((a, k)) or "m-local"
         pm.local_agents = lambda threads=False: [{"id": RCP, "name": "api", "remote": False}]
+        # _relay_in rules from the CHECKED seam now (the one-snapshot honesty arms, 2026-08-31);
+        # wrap the same stub rows with answered=True so the harness's world stays authoritative
+        pm.local_agents_checked = lambda threads=False: (pm.local_agents(threads=threads), True)
         pm._postal_off = lambda sid: False
         pm.peer_seen_check = lambda mid: False
         pm.peer_seen_add = lambda mid: None
@@ -103,7 +106,7 @@ class RelayInPassesItThrough(unittest.TestCase):
 
     def tearDown(self):
         (pm.deliver, pm.local_agents, pm._postal_off, pm.peer_seen_check,
-         pm.peer_seen_add, peers, pm.QUARANTINE) = self._saved
+         pm.peer_seen_add, peers, pm.QUARANTINE, pm.local_agents_checked) = self._saved
         pm.PEERS.clear()
         pm.PEERS.update(peers)
         self.td.cleanup()

--- a/tests/test_sdk_live_rows.py
+++ b/tests/test_sdk_live_rows.py
@@ -93,6 +93,31 @@ class ListingCompleteness(unittest.TestCase):
         self.assertTrue(reg.get("alive"), "a gutted reg (no alive) vanishes from every listing")
         self.assertNotIn("queue", reg, "the mirror update was skipped, not applied to a bare reg")
 
+    def test_a_failed_enumeration_serves_every_last_good_row(self):
+        # the WHOLE-LISTING twin (review find 2026-09-01): the scandir arm returned [] on a
+        # transient OSError — every session ruled dead at once, under the very contract above
+        warm = {r["sid"] for r in sb.list_regs(self.be.state_dir)}
+        self.assertIn(self.SID, warm, "cache warmed")
+        saved = sb.os.scandir
+        sb.os.scandir = lambda d: (_ for _ in ()).throw(OSError("transient scan fault"))
+        try:
+            rows = {r["sid"] for r in sb.list_regs(self.be.state_dir)}
+        finally:
+            sb.os.scandir = saved
+            sb._REG_SERVE_WARNED.discard("\x00scan")
+        self.assertIn(self.SID, rows, "a transient enumeration failure must not blank the listing")
+        self.assertIn(self.SID, {r["sid"] for r in sb.list_regs(self.be.state_dir)}, "healed scan is live")
+
+    def test_a_healed_stat_blip_unlatches_the_incident_log(self):
+        # review find 2026-09-01: the once-per-incident latch only cleared on the re-READ path, but
+        # a healed stat blip takes the cache-hit path (unchanged file) — the latch stuck and every
+        # later incident for that reg logged nothing
+        sb.list_regs(self.be.state_dir)                    # warm + healthy
+        sb._REG_SERVE_WARNED.add(str(self.path))           # as if a stat blip just logged
+        sb.list_regs(self.be.state_dir)                    # healthy CACHE-HIT scan (file untouched)
+        self.assertNotIn(str(self.path), sb._REG_SERVE_WARNED,
+                         "the cache-hit path must clear the latch too")
+
     def test_a_missing_reg_still_mints_the_bare_mirror(self):
         sid2 = "eeeeeeee-2222-3333-4444-cccccccccccc"
         self.be._update_reg(sid2, queue=["x"])


### PR DESCRIPTION
## What

Two verified specimens showed the false-refusal class surviving on the relay path after the sending resolver's honesty arms landed: (i) an inbound relay bounced "postal isolation" — final by norm — with no flag set on either kernel (`_relay_in` fetched the listing twice and a blink between the fetches minted the ruling by inference); (ii) sends to a live far-host session were refused no-live-session while the far kernel's restart blink was gossiped as empty presence.

Fixes, each event-exact:
- **`_relay_in` takes ONE checked snapshot**: isolation bounces only on actual flag reads within it; the terminal no-live bounce corroborates first (unanswered listing or standing durable reg → a new non-terminal `retry` verdict that crosses the wire as silence, so the sender's outbox re-relays — honest retry-shortly where a bounce is final).
- **Id-shaped addresses route cross-host** (`_addr_matches` in `peer_route` and `_relay_in`): presence rows always carried ids but the route matched names only, so a uuid/short-id send to a live far session had no route at all. A first-cut remote-sids 503 arm was review-refuted (mirror hits coincide with presence health — a never-healing retry) and replaced by routing. The relay park carries `toId` so the sid survives end-to-end: the far side matches it exactly (never a name fallback that could hand mail to a same-named sibling), the retry gate corroborates by the pinned id alone, the forward hop routes pinned mail by sid or not at all, and the wire `toId` is shape-gated (a crafted path would otherwise reach a registry read as a traversal oracle). Old code on either end keeps working.
- **The presence producer serves the last ANSWERED rows** when the local kernel doesn't answer, with a disk twin surviving bus restarts — a local blink never gossips as "nobody lives here" to any peer, old code included.
- **quarantine approve**: one checked snapshot (was its own fetch-pair TOCTOU), a retryable refusal when the listing doesn't answer (was a false "no longer live" terminal), and the kernel client cap reconciled to the measured budget pair (6s → 20s).
- **`list_regs`**: a transient enumeration failure serves every last-good row instead of blanking the whole listing (the per-entry completeness contract's whole-listing twin); a healed stat blip unlatches the once-per-incident log.
- **`set_working` without its `text` argument refuses loudly** — a missing param is never a clear command; `text=''` stays the documented clear.

## Tests

`tests/test_postal_relay_honesty.py` (30): specimen-shaped repros for both legs (one-snapshot pin, true-isolation preserved, unanswered→retry with the mid kept out of peer_seen, blink-with-durable-reg→retry, honest 404/bounce terminals preserved), id-routing across all three address forms + ambiguity refusal, toId exact-match/misdelivery/limbo/traversal/namesake-forward repros (adversarial-review and skeptic findings, each landed as its regression test), presence last-answered + disk-twin-across-restart, set_working refusals. Harness updates keep the stubbed seams authoritative; `test_sdk_live_rows.py` pins the whole-listing serve and the warned-latch heal.

Both suites green: Python 6228 passed + 313 subtests; npm 2628/2628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)