### PR TITLE
T208: the compaction suggestion ships default-OFF, a per-install opt-in

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -549,6 +549,7 @@ def _version_info():
             # The top-level fields above stay: this tab's own gear and older kernels read those.
             "settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode(),
                          "conserveMemory": _conserve_on(),
+                         "compactSuggest": _compact_suggest_on(),   # T208: per-install, default OFF
                          "fileEditing": _file_editing_on(),
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
@@ -2666,6 +2667,20 @@ def _set_auto_nudge(enabled):
     _write_auto_nudge(d)
 
 
+def _compact_suggest_on():
+    """The compaction-suggestion regime's own per-install toggle (T208, the user 2026-09-01: the
+    regime must NOT ship default-on to every install — it stays behind this install's config).
+    OFF by default: the key is absent from a fresh install's blob and absent reads False — no
+    setdefault, deliberately, so shipping the feature never turns it on anywhere."""
+    return bool(_auto_nudge_data().get("compactSuggestEnabled"))
+
+
+def _set_compact_suggest(enabled):
+    d = dict(_auto_nudge_data())
+    d["compactSuggestEnabled"] = bool(enabled)
+    _write_auto_nudge(d)
+
+
 def _file_editing_on():
     """Dashboard raw-mode file editing is OFF until the user says yes once (the user 2026-08-22: the
     viewer's Edit asks with a popup the first time). The flag is a SERVER-side boundary, not
@@ -4236,6 +4251,9 @@ def _worker_tag_member(sid):
 def _compact_suggest_tick(sid, tm, now):
     """One session's slice of the compaction-suggestion watcher (contract in the block comment
     above). Returns True when the suggestion went out (the caller pushes once at tick end)."""
+    if not _compact_suggest_on():
+        return False                                   # T208: default-OFF per install — the regime
+    #                                                    runs only where this install's config says so
     tokens = (tm or {}).get("ctxTokens")
     if not isinstance(tokens, (int, float)) or tokens <= 0:
         return False                                   # tmux CLIs / pre-plumbing sessions carry no
@@ -31611,6 +31629,8 @@ class Handler(BaseHTTPRequestHandler):
             _push_soon()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             _set_auto_nudge(bool(msg["enabled"]))   # feed gear → server-side Auto Nudge on/off
+        elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
+            _set_compact_suggest(bool(msg["enabled"]))   # T208 opt-in — kernel-side like autoNudge
             # act immediately on turn-on (don't wait 4s) — but skip the dead-wait sweep: the
             # death transition has ONE observer (the pusher's tick; see _auto_nudge_tick), and
             # this WS thread racing its prev-swap could spend a transition uncorroborated

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -39,6 +39,8 @@ class CompactSuggest(unittest.TestCase):
         self.saved_state = jd.STATE
         jd.STATE = Path(self.td.name)
         km._autonudge_cache.clear()
+        km._set_compact_suggest(True)          # T208: default-OFF per install — these tests opt in
+        km._autonudge_cache.clear()
         self._orig = {n: getattr(km, n) for n in ("_settle_event_key", "_thread_reg")}
         km._settle_event_key = lambda sid: IDLE
         km._thread_reg = lambda sid: {}
@@ -162,6 +164,25 @@ class CompactSuggest(unittest.TestCase):
         self.assertFalse(self._tick(None))
         self.assertFalse(self._tick(0))
         self.assertEqual(self.sent, [])
+
+    # ── the T208 default: OFF for a fresh install, ON only by this install's own config ──
+    def test_a_fresh_install_is_off_and_never_fires(self):
+        (jd.STATE / "auto-nudge.json").unlink()        # a virgin install: no blob at all
+        km._autonudge_cache.clear()
+        self.assertFalse(km._compact_suggest_on(), "absent key reads OFF — shipping the feature "
+                                                   "turns it on nowhere (the user's ruling)")
+        self.assertFalse(self._tick(900_000), "idle, far past both thresholds — still nothing")
+        self.assertEqual(self.sent, [])
+        km._autonudge_cache.clear()
+        self.assertEqual(self._latched(), [], "…and no latch spent while off")
+
+    def test_the_designed_toggle_flips_it_on_and_off(self):
+        km._set_compact_suggest(False)
+        km._autonudge_cache.clear()
+        self.assertFalse(self._tick(450_000))
+        km._set_compact_suggest(True)
+        km._autonudge_cache.clear()
+        self.assertTrue(self._tick(450_000), "the same crossing fires once opted in")
 
     # ── the fingerprint row ──
     def test_a_fire_logs_a_countable_row(self):


### PR DESCRIPTION
## Summary
The compaction-suggestion regime must not ship default-on to every romp install — it stays behind each install's own config. The minimal shape: the watcher keeps riding the auto-nudge walk but now leads with its own toggle, `compactSuggestEnabled` in the auto-nudge blob — read fresh each pass like `autoNudge`/`conserve`, flipped by the same designed surface (`setCompactSuggest` beside `setAutoNudge`, exported in the settings payload). OFF by default, deliberately without a setdefault: absent reads False, so shipping the feature turns it on nowhere. While off, no latch is spent or pruned — a later opt-in starts with the crossing semantics unchanged. The injected rendering and the exclusions stand untouched for opted-in installs.

## Test plan
- New pins in `tests/test_compact_suggest.py`: a virgin install (no blob at all) reads OFF and never fires however far past both thresholds, with no latch spent; the designed toggle flips it live; every existing behavior test opts in explicitly.
- Full Python suite: 6,262 passed. Extension suite: green. Local bats (`npx bats@1.11.0`): 363 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)