### PR TITLE
After T209: the eclipse keeps one property-selected chain, so machine-spur siblings never ride the salvage

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -520,6 +520,13 @@ def _read_jsonl_incremental(path):
     return records
 
 
+def _is_tool_result(r):
+    """True when a user-typed record is a machine-made tool_result (its first content block),
+    not a person's prompt — the discriminator the eclipse stand-down needs."""
+    c = _content((r or {}).get("message"))
+    return bool(c) and isinstance(c[0], dict) and c[0].get("type") == "tool_result"
+
+
 def _content(message):
     """The content[] of a message, normalized: a bare string becomes one text block,
     so every atom carries a list of blocks (the 'one atom, many blocks' shape)."""
@@ -1189,24 +1196,38 @@ class FileAdapter:
         deleted: a rollback typed DURING a storm produces exactly this geometry, because the
         CLI flushes its buffered api_error records at the next enqueue, so the user's
         replacement prompt lands past the error spur and their abandoned branch rejoins at an
-        api_error fork. So the eclipse keeps ONE chain, selected by what it carries, never by
-        the CLI's byte order of writes (nothing contracts flush order; an order-keyed pick let
-        a late-written stub pair steal the keep, and a late-written burst veto it): among the
-        component's leaf->fork chains, the max-seq chain whose HEAD is an assistant record AND
-        which carries reply text (landed_text_uuids, the one existing definition) — the two
-        properties every corpus incident's salvaged chain has (49/49 across 4,678 transcripts;
-        the 2,809 non-eclipse rewind forks: 2,035 stub pairs, 700 superseded retries, 42
-        user-gesture rollbacks, 32 other; zero overlap). A (max-seq, leaf-seq) key keeps the
-        pick deterministic; the latest write is the CLI's final word on the turn, and it
-        matches the single-chain walk whenever only one chain exists. Everything else in the
-        component demotes to "rewind", exactly as its on-spine twins classify.
+        api_error fork. So the eclipse keeps ONE BRANCH — the sub-tree under one fork-side
+        head — selected by what it carries, never by the CLI's byte order of writes (nothing
+        contracts flush order; an order-keyed pick let a late-written stub pair steal the keep,
+        and a late-written burst veto it). A branch qualifies when its fork-side HEAD is an
+        assistant record (a user gesture's head is always the user's own record) and it
+        carries reply text anywhere in the sub-tree; the winner is the branch with the
+        latest-written reply text, tiebroken by head seq. The text witness is landed_text_uuids
+        MINUS isApiErrorMessage records (error-as-text failure echoes, which atoms() likewise
+        refuses to treat as replies) — so junk carries no weight in the key, and no textless
+        tail can move the pick whatever its file position. The unit is deliberately the WHOLE
+        branch, never a leaf-chain within it: leaf-chains of one branch share records, and
+        every per-chain read of shared state proved breakable (a full-chain gate laundered a
+        junk tail's steal; a unique-suffix gate let a branch's own twin sub-branches strip
+        their turn's text and hand the keep to an older sibling — reply loss, this repo's one
+        fatal error). The accepted cost is cosmetic: a stub twin inside the winning branch
+        renders one output-less duplicate tool row, and a grafted burst inside it costs
+        nothing (system records never become atoms). The qualifying properties are the ones
+        every incident's salvaged branch has in the author's corpus scan (49/49 across 4,678
+        transcripts; the 2,809 non-eclipse rewind forks: 2,035 stub pairs, 700 superseded
+        retries, 42 user-gesture rollbacks, 32 other; zero overlap). Sibling branches demote
+        to "rewind", exactly as their on-spine twins classify.
 
         When NO chain qualifies, the two eclipse terminals part ways, each on its own event:
           "user"      — the flush COMPLETED (the next prompt sits past the spur), so a machine-
-                        orphaned reply would qualify if one existed; a component of user-headed
-                        chains here is indistinguishable from a rollback the storm raced, and
-                        re-showing deleted content is the hazard this verdict was designed
-                        around. The fork stands down whole: the component demotes to "rewind".
+                        orphaned reply would qualify if one existed; a USER-HEADED branch here
+                        is indistinguishable from a rollback the storm raced, and re-showing
+                        deleted content is the hazard this verdict was designed around. The
+                        user-headed branches demote to "rewind" — and ONLY those, where
+                        user-headed means a user PROMPT at the fork-side head: an assistant-
+                        headed textless branch (a turn of pure tool activity) and a stranded
+                        tool_result head (user-TYPED but machine-MADE) are both provably not
+                        rollback residue, and they stay "eclipsed"/kept.
           "exhausted" — the spur is the transcript's TAIL (a parse racing the multi-line
                         flush, a session dead mid-storm) or a corrupt machine cycle: no next
                         prompt exists, so no user gesture can have abandoned anything, and
@@ -1240,30 +1261,59 @@ class FileAdapter:
                 stack.extend(children.get(x, ()))
             if landed is None:
                 landed = self.landed_text_uuids()
-            best = None                   # (max-seq key, chain): the qualifying chain that stays kept
-            for leaf in comp:             # one candidate chain per component leaf
-                if any(c in comp for c in children.get(leaf, ())):
-                    continue              # interior record — its leaf's walk covers it
-                chain, cu = [], leaf      # this sibling chain's own leaf->fork walk
-                while cu is not None and cu != F and cu in comp:
-                    chain.append(cu)
-                    cu = self.parent_of.get(cu)
-                if cu != F or not chain:
-                    continue              # unwalkable shape — never a candidate
-                if (self.by_uuid.get(chain[-1]) or {}).get("type") != "assistant":
-                    continue              # head isn't a streamed reply record (a user gesture, a burst)
-                if not any(u in landed for u in chain):
-                    continue              # no reply text anywhere on the chain → a stub pair, not a reply
-                key = (max(self.seq_of.get(x, 0) for x in chain), self.seq_of.get(leaf, 0))
-                if best is None or key > best[0]:
-                    best = (key, chain)
-            if best is not None:
-                for u in comp - set(best[1]):
-                    verdict[u] = "rewind"     # siblings drop exactly as their on-spine twins do
+            # SELECTION IS PER BRANCH — the sub-tree under each fork-side head — never per
+            # leaf-chain. Leaf-chains of one branch SHARE records, and any per-chain read of
+            # shared state proved breakable by construction: a full-chain gate let a junk tail
+            # inherit the prefix's text and steal the pick on write order, and a unique-suffix
+            # gate let a branch's own twin sub-branches strip their turn's text record from
+            # both suffixes and disenfranchise the REAL reply (an older sibling then stole the
+            # keep — reply loss, this repo's one fatal error). The branch is the unit the CLI
+            # persisted; it is kept or dropped WHOLE. The known cost is cosmetic and deliberate:
+            # a parallel stub twin inside the winning branch renders one output-less duplicate
+            # tool row, and a grafted error burst inside it costs nothing at all (system
+            # records never become atoms, kept or not). Never trade a possible reply for a
+            # duplicate row.
+            def _subtree(h):
+                seen, st = set(), [h]
+                while st:
+                    x = st.pop()
+                    if x in seen or x not in comp:
+                        continue
+                    seen.add(x)
+                    st.extend(children.get(x, ()))
+                return seen
+            qual, user_heads = [], []
+            for h in heads:
+                hr = self.by_uuid.get(h) or {}
+                head_t = hr.get("type")
+                if head_t == "user" and not _is_tool_result(hr):
+                    user_heads.append(h)  # rollback-shaped: the "user" stand-down's one target.
+                #                           A tool_result head is user-TYPED but machine-MADE (a
+                #                           result the storm stranded beside its on-spine tool_use)
+                #                           — provably not rollback residue, so it stays kept; its
+                #                           output even reunites with the spine's tool call.
+                if head_t != "assistant":
+                    continue              # fork-side head isn't a streamed reply record (a user gesture, a burst)
+                sub = _subtree(h)
+                txt = [self.seq_of.get(x, 0) for x in sub
+                       if x in landed and not (self.by_uuid.get(x) or {}).get("isApiErrorMessage")]
+                #                           failure echoes (isApiErrorMessage: error-as-text) are not
+                #                           replies — mirrors atoms()' own refusal to anchor on them
+                if not txt:
+                    continue              # no reply text anywhere in the branch → a stub pair, a burst
+                qual.append(((max(txt), self.seq_of.get(h, 0)), h, sub))
+                #             ^ ranked by the branch's LATEST REPLY TEXT — the CLI's final word on the
+                #               turn. Junk records carry no text, so nothing textless can move the key.
+            if qual:
+                keep = max(qual)[2]
+                for u in comp - keep:
+                    verdict[u] = "rewind"     # sibling branches drop exactly as their on-spine twins do
             elif fork_terminal.get(F) == "user":
-                for u in comp:
-                    verdict[u] = "rewind"     # completed flush, no reply chain → stand down whole
-            # "exhausted" with no qualifying chain: everything stays eclipsed (keep-on-unprovable)
+                for h in user_heads:          # completed flush, no reply branch → drop ONLY rollback-shaped
+                    for u in _subtree(h):     # branches (fork-side head = the user's own deleted record);
+                        verdict[u] = "rewind" # an assistant-headed textless branch (a tool-only turn) is
+                #                               provably not rollback residue and stays kept
+            # "exhausted" with no qualifying branch: everything stays eclipsed (keep-on-unprovable)
 
     def kept_uuids(self, active):
         """The active leaf-ancestors PLUS any line on a BROKEN chain (its parentUuid points
@@ -1281,8 +1331,10 @@ class FileAdapter:
         predicate (chain_membership) can never diverge from what the parse keeps.
         set(active) is unioned as-is: the walk can record a dangling FINAL ancestor that is
         in no file's index, and it has always been kept. Within an eclipsed fork's component,
-        _select_eclipsed_chains has already narrowed the verdict to the one machine-orphaned
-        reply chain, so this union keeps exactly what the eclipse salvages."""
+        _select_eclipsed_chains has already narrowed the verdict — to the one machine-orphaned
+        reply chain when one qualifies, and otherwise per that walk's terminal rules (user-
+        headed chains demote behind a completed flush; a tail spur keeps everything) — so this
+        union keeps exactly what the eclipse salvages."""
         return set(active) | {u for u, v in self.chain_verdicts(active).items()
                               if v in ("broken", "eclipsed")}
 
@@ -2081,8 +2133,9 @@ def chain_membership(leaf_path, candidate_files=None, states=None, leaf_override
     "rewind" is the ONLY set that ever justifies sweeping a goal: "clear" branches are /clear
     jurisdiction (the episode machinery settles those cards), "broken" chains are kept by design,
     "eclipsed" chains are KEPT content a machine spur abandoned (never a user gesture — T209;
-    narrowed to the fork's one machine-orphaned reply chain by _select_eclipsed_chains, so
-    nothing sweeps a reply nobody abandoned and nothing keeps a sibling the walk drops on-spine),
+    narrowed by _select_eclipsed_chains to the fork's one machine-orphaned reply chain when one
+    qualifies, else per its terminal rules, so nothing sweeps a reply nobody abandoned and
+    nothing keeps a sibling the walk drops on-spine),
     and a uuid in NO set is unprovable (a synthetic orphan:<t> salvage id, a cross-file uuid whose
     file is outside the lineage, a legacy None) — callers must treat unknown as NOT abandoned.
     Caveat (resume-fork stitch shape): a recorded fork's fresh head is re-pointed at the from-file's

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1083,6 +1083,10 @@ class FileAdapter:
                      user 2026-09-01 — a five-minute turn's answer vanished behind a
                      "Recovered after retries" note when the next send flushed the spur;
                      no orphanReply marker exists because the disk DID keep the text).
+                     Within the fork's component the verdict is NARROWED to the one
+                     machine-orphaned reply chain — sibling stub pairs, error bursts and
+                     user-headed branches drop exactly as they do at any other fork
+                     (see _select_eclipsed_chains).
           "clear"  — the chain reaches a clean null root the leaf does not share: `/clear`
                      jurisdiction (the episode machinery settles those) — never swept as
                      a rewind.
@@ -1099,7 +1103,7 @@ class FileAdapter:
                 break                              # root, or a cycle already crossed
             spine_child[_p] = _u
             _u = _p; _guard += 1
-        _fork_memo = {}
+        _fork_memo, _fork_terminal = {}, {}
         def fork_kind(f):
             """rewind vs eclipsed for a chain rejoining the spine at f. A genuine rollback
             re-parents the user's NEXT PROMPT directly at the cut (the spine leaves f with a
@@ -1107,7 +1111,11 @@ class FileAdapter:
             api_error record STRICTLY BETWEEN f and the next conversational record — an
             exact machine event, so this can never re-show content a person deleted. An
             assistant record ending the probe means the spine re-replied: the fork is a
-            superseded attempt (the orphan salvage's jurisdiction), not an eclipse."""
+            superseded attempt (the orphan salvage's jurisdiction), not an eclipse.
+            An eclipse also records WHICH terminal decided it in _fork_terminal — "user"
+            (the flush completed: the next prompt sits past the spur) or "exhausted" (the
+            spur is the transcript's tail, or a corrupt cycle) — because the two terminals
+            keep differently (see _select_eclipsed_chains)."""
             if f in _fork_memo:
                 return _fork_memo[f]
             res, u, saw_err, _seen = "rewind", spine_child.get(f), False, set()
@@ -1120,6 +1128,7 @@ class FileAdapter:
                 if t == "user":
                     if saw_err:
                         res = "eclipsed"
+                        _fork_terminal[f] = "user"
                     break
                 if t == "system" and r.get("subtype") == "api_error":
                     saw_err = True
@@ -1137,6 +1146,7 @@ class FileAdapter:
                 # spine child, so the loop never runs and saw_err stays False.
                 if saw_err:
                     res = "eclipsed"
+                    _fork_terminal[f] = "exhausted"
             _fork_memo[f] = res
             return res
         verdict = {}
@@ -1163,7 +1173,97 @@ class FileAdapter:
         out = {}
         for u in self.by_uuid:
             out[u] = "active" if u in active else classify(u)
+        self._select_eclipsed_chains(out, active, _fork_terminal)
         return out
+
+    def _select_eclipsed_chains(self, verdict, active, fork_terminal):
+        """WHICH uuids an eclipsed fork keeps (2026-09-01). fork_kind above decides WHETHER a
+        fork was machine-abandoned — >=1 system api_error record strictly between the fork and
+        the spine's next conversational record (T209) — and classify hands every chain
+        rejoining there the "eclipsed" verdict. But an eclipsed fork can hold SIBLING chains
+        that are not the bypassed reply: a parallel tool-call stub pair (textless twins the
+        walk drops everywhere else), a second flushed api_error burst, an older persisted
+        attempt, or a branch headed by a USER record. Keeping the whole component re-renders
+        the stub twins beside their kept originals, doubles a two-attempt turn, and — the one
+        direction the eclipsed verdict promised never to take — can re-show a prompt the user
+        deleted: a rollback typed DURING a storm produces exactly this geometry, because the
+        CLI flushes its buffered api_error records at the next enqueue, so the user's
+        replacement prompt lands past the error spur and their abandoned branch rejoins at an
+        api_error fork. So the eclipse keeps ONE chain, selected by what it carries, never by
+        the CLI's byte order of writes (nothing contracts flush order; an order-keyed pick let
+        a late-written stub pair steal the keep, and a late-written burst veto it): among the
+        component's leaf->fork chains, the max-seq chain whose HEAD is an assistant record AND
+        which carries reply text (landed_text_uuids, the one existing definition) — the two
+        properties every corpus incident's salvaged chain has (49/49 across 4,678 transcripts;
+        the 2,809 non-eclipse rewind forks: 2,035 stub pairs, 700 superseded retries, 42
+        user-gesture rollbacks, 32 other; zero overlap). A (max-seq, leaf-seq) key keeps the
+        pick deterministic; the latest write is the CLI's final word on the turn, and it
+        matches the single-chain walk whenever only one chain exists. Everything else in the
+        component demotes to "rewind", exactly as its on-spine twins classify.
+
+        When NO chain qualifies, the two eclipse terminals part ways, each on its own event:
+          "user"      — the flush COMPLETED (the next prompt sits past the spur), so a machine-
+                        orphaned reply would qualify if one existed; a component of user-headed
+                        chains here is indistinguishable from a rollback the storm raced, and
+                        re-showing deleted content is the hazard this verdict was designed
+                        around. The fork stands down whole: the component demotes to "rewind".
+          "exhausted" — the spur is the transcript's TAIL (a parse racing the multi-line
+                        flush, a session dead mid-storm) or a corrupt machine cycle: no next
+                        prompt exists, so no user gesture can have abandoned anything, and
+                        keep-on-unprovable — this module's bias — holds. Everything stays
+                        "eclipsed".
+        The CLI's buffered flush is the root cause (filed as anthropics/claude-code#91113);
+        this parse-side keep defends regardless."""
+        ecl = {u for u, v in verdict.items() if v == "eclipsed"}
+        if not ecl:
+            return
+        children = {}
+        for u in self.by_uuid:
+            p = self.parent_of.get(u)
+            if p is not None:
+                children.setdefault(p, []).append(u)
+        forks = {}                        # fork uuid -> its eclipsed branch heads
+        for u in ecl:
+            p = self.parent_of.get(u)
+            if p in active:
+                forks.setdefault(p, []).append(u)
+        landed = None                     # text-bearing assistant uuids (the reply witness) — computed
+        #                                   lazily: chain_verdicts runs on every build of a held
+        #                                   session, and most transcripts carry no eclipse at all
+        for F, heads in forks.items():
+            comp, stack = set(), list(heads)
+            while stack:                  # the branch component: child-closure of the eclipsed heads
+                x = stack.pop()
+                if x in comp or x not in ecl:
+                    continue
+                comp.add(x)
+                stack.extend(children.get(x, ()))
+            if landed is None:
+                landed = self.landed_text_uuids()
+            best = None                   # (max-seq key, chain): the qualifying chain that stays kept
+            for leaf in comp:             # one candidate chain per component leaf
+                if any(c in comp for c in children.get(leaf, ())):
+                    continue              # interior record — its leaf's walk covers it
+                chain, cu = [], leaf      # this sibling chain's own leaf->fork walk
+                while cu is not None and cu != F and cu in comp:
+                    chain.append(cu)
+                    cu = self.parent_of.get(cu)
+                if cu != F or not chain:
+                    continue              # unwalkable shape — never a candidate
+                if (self.by_uuid.get(chain[-1]) or {}).get("type") != "assistant":
+                    continue              # head isn't a streamed reply record (a user gesture, a burst)
+                if not any(u in landed for u in chain):
+                    continue              # no reply text anywhere on the chain → a stub pair, not a reply
+                key = (max(self.seq_of.get(x, 0) for x in chain), self.seq_of.get(leaf, 0))
+                if best is None or key > best[0]:
+                    best = (key, chain)
+            if best is not None:
+                for u in comp - set(best[1]):
+                    verdict[u] = "rewind"     # siblings drop exactly as their on-spine twins do
+            elif fork_terminal.get(F) == "user":
+                for u in comp:
+                    verdict[u] = "rewind"     # completed flush, no reply chain → stand down whole
+            # "exhausted" with no qualifying chain: everything stays eclipsed (keep-on-unprovable)
 
     def kept_uuids(self, active):
         """The active leaf-ancestors PLUS any line on a BROKEN chain (its parentUuid points
@@ -1180,7 +1280,9 @@ class FileAdapter:
         Derived from chain_verdicts — one implementation, so the exported membership
         predicate (chain_membership) can never diverge from what the parse keeps.
         set(active) is unioned as-is: the walk can record a dangling FINAL ancestor that is
-        in no file's index, and it has always been kept."""
+        in no file's index, and it has always been kept. Within an eclipsed fork's component,
+        _select_eclipsed_chains has already narrowed the verdict to the one machine-orphaned
+        reply chain, so this union keeps exactly what the eclipse salvages."""
         return set(active) | {u for u, v in self.chain_verdicts(active).items()
                               if v in ("broken", "eclipsed")}
 
@@ -1251,8 +1353,9 @@ class FileAdapter:
         return atoms
 
     def atoms(self, rompuuid, postal_index):
-        """Every emitted atom on the active path (plus broken-chain survivors), plus
-        synthesized absorbed atoms. (Idle atoms are added separately from the state log.)
+        """Every emitted atom on the active path (plus broken-chain survivors and eclipsed
+        machine-orphaned reply chains — see _select_eclipsed_chains), plus synthesized
+        absorbed atoms. (Idle atoms are added separately from the state log.)
         One fold from an EMPTY carry over every kept record in chronological order — the
         assembly cache (_assemble) folds later appends through the same _prepass/_emit_fold
         code with the carried state, so full parse and fold are one implementation."""
@@ -1967,16 +2070,19 @@ def _lineage_closure(leaf_path, candidate_files, links):
 
 
 def chain_membership(leaf_path, candidate_files=None, states=None, leaf_override=None):
-    """THE exported chain-membership fact — {"kept", "rewind", "clear", "broken"} uuid sets, built
-    from the DISPLAY parse's exact inputs (resume links + lineage closure + leaf_override = the
-    kernel's pending bare-rollback cut) so it can never disagree with what the user sees. This is
-    the one predicate every rewind-cleanup consumer must use (goal sweeps, mint-time stand-downs,
-    the dead-branch reconciliation): before it was exported, four partial hand-rolled twins of this
-    walk disagreed on resume forks, pending cuts and broken chains (2026-08-17).
+    """THE exported chain-membership fact — {"kept", "rewind", "clear", "broken", "eclipsed"}
+    uuid sets, built from the DISPLAY parse's exact inputs (resume links + lineage closure +
+    leaf_override = the kernel's pending bare-rollback cut) so it can never disagree with what the
+    user sees. This is the one predicate every rewind-cleanup consumer must use (goal sweeps,
+    mint-time stand-downs, the dead-branch reconciliation): before it was exported, four partial
+    hand-rolled twins of this walk disagreed on resume forks, pending cuts and broken chains
+    (2026-08-17).
 
     "rewind" is the ONLY set that ever justifies sweeping a goal: "clear" branches are /clear
     jurisdiction (the episode machinery settles those cards), "broken" chains are kept by design,
-    "eclipsed" chains are KEPT content a machine spur abandoned (never a user gesture — T209),
+    "eclipsed" chains are KEPT content a machine spur abandoned (never a user gesture — T209;
+    narrowed to the fork's one machine-orphaned reply chain by _select_eclipsed_chains, so
+    nothing sweeps a reply nobody abandoned and nothing keeps a sibling the walk drops on-spine),
     and a uuid in NO set is unprovable (a synthetic orphan:<t> salvage id, a cross-file uuid whose
     file is outside the lineage, a legacy None) — callers must treat unknown as NOT abandoned.
     Caveat (resume-fork stitch shape): a recorded fork's fresh head is re-pointed at the from-file's

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -215,7 +215,7 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          model actually wrote. Closer / grouper / consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 10                        # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 11                        # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v2 (2026-07-09): a 07-07/07-08 change to segment-text derivation
 #                                          stepped the text hash without this bump — dormant segments' old-hash
 #                                          placements stopped matching, and every restart/touch replayed them as
@@ -273,6 +273,14 @@ PLACEMENTS_V = 10                        # placements-identity schema version (p
 #                                          the CLI's buffered api_error flush knocked off the spine parses out
 #                                          again. Existing transcripts with that geometry GROW their atom set
 #                                          (v3/v7's shape), so the same seal applies.
+#                                          v11 (2026-09-01): the eclipse keeps ONE chain, not the whole fork
+#                                          component (em._select_eclipsed_chains) — parallel tool-stub twins,
+#                                          sibling error bursts, older attempts and user-headed branches at an
+#                                          eclipsed fork drop again exactly as their on-spine twins do (v10
+#                                          rendered them beside the kept originals; a user-headed branch could
+#                                          even re-show a prompt deleted mid-storm). v8's shape: a SMALLER
+#                                          atom set for transcripts whose eclipsed fork carried siblings,
+#                                          same seal.
 PLAN_SESSIONS = None                     # per-pass session cap — REMOVED (the user 2026-06-30): the fairness
                                          # caps were a recurring source of confusing starvation bugs (a goal/
                                          # nudge stuck behind a full per-pass window), never clearly needed.

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -79,6 +79,28 @@ def attline(t, prompt, uuid, parent=None):
             "isSidechain": False, "attachment": {"type": "queued_command", "prompt": prompt}}
 
 
+def reminder_line(t, uuid, parent):
+    # the total_tokens_reminder attachment the CLI writes at request start — the record the
+    # api_error-flush forks at in both verified incidents (uuid-chained, never an atom)
+    return {"type": "attachment", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "isSidechain": False, "attachment": {"type": "total_tokens_reminder"}}
+
+
+def api_error_line(t, uuid, parent, attempt=1):
+    # shape mirrors the live corpus (2026-09-01): level "error", source request_retry, a
+    # retryAttempt counter that resets between bursts — all content synthetic
+    return {"type": "system", "subtype": "api_error", "timestamp": iso(t), "uuid": uuid,
+            "parentUuid": parent, "isSidechain": False, "level": "error",
+            "retryAttempt": attempt, "maxRetries": 10, "retryInMs": 1000,
+            "source": "request_retry", "error": {"status": 429, "message": "synthetic rate limit"}}
+
+
+def stop_hook_line(t, uuid, parent):
+    return {"type": "system", "subtype": "stop_hook_summary", "timestamp": iso(t), "uuid": uuid,
+            "parentUuid": parent, "isSidechain": False, "level": "suggestion",
+            "hookCount": 1, "hookErrors": [], "preventedContinuation": False}
+
+
 def compact_line(t, uuid, logical_parent, trigger="manual", pre=263239, post=6514):
     return {"type": "system", "subtype": "compact_boundary", "timestamp": iso(t), "uuid": uuid,
             "parentUuid": None, "logicalParentUuid": logical_parent, "isMeta": False,
@@ -1185,6 +1207,314 @@ class EclipsedBranch(unittest.TestCase):
         self.assertTrue(mem["eclipsed"] <= mem["kept"], "eclipsed chains are kept")
         self.assertEqual(mem["rewind"], set(),
                          "an eclipse is not a rewind — nothing here may be swept")
+
+class EclipsedChainSelection(unittest.TestCase):
+    """WHICH uuids an eclipsed fork keeps (2026-09-01, two incidents verified at transcript
+    level): the CLI recovers from an API-error storm internally, streams AND persists the
+    reply — then flushes its buffered api_error records at the NEXT turn's start,
+    parent-chained from the leaf as it stood at ERROR time. The flushed chain (api_error+
+    then a stop_hook_summary, then the next user record) hijacks the leaf, so the persisted
+    reply branch is bypassed on disk: pre-eclipse the parse called it a rewind and dropped it,
+    while the ghost-reply gates rightly refused the orphanReply salvage (the text landed on
+    SOME branch). The reply vanished from the chat, the judges, and the model's own next
+    reload. The eclipsed fork probe (EclipsedBranch above) detects the machine bypass; this
+    class pins the SELECTION layered on it (em._select_eclipsed_chains): the eclipse keeps
+    exactly one chain — max-seq, assistant-headed, carrying reply text — so sibling stub
+    pairs, error bursts and older attempts drop as their on-spine twins do, and a user-headed
+    branch behind a COMPLETED flush stands the fork down (a rollback typed mid-storm forks
+    exactly there, and re-showing deleted content is the one direction the eclipse must never
+    take). All fixtures here are synthetic; the shapes mirror the two incident transcripts."""
+
+    def _run(self, records, states=None):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            out = em.parse_session(str(path), rompuuid=SID, dir="/TESTDIR",
+                                   candidate_files=[str(path)], states=states,
+                                   postal_log=[], now=NOW)
+            mem = em.chain_membership(str(path))
+        return out, mem
+
+    def _atoms(self, out):
+        return [a for t in out["turns"] for a in t["atoms"]]
+
+    def _episode(self, t, tag, fork_parent, reply_text, n_errors=2):
+        """One flush-orphaned episode, the exact single-episode incident shape: the reminder
+        attachment fork, the persisted thinking+reply branch (dead end), then the flushed
+        api_error run, the stop hook, and the next turn's opener. Returns (records, uuids)."""
+        rem, th, rp = "rem" + tag, "th" + tag, "rp" + tag
+        recs = [reminder_line(t, rem, fork_parent),
+                aline(t + 60, "", th, rem, stop=None, thinking="working through it"),
+                aline(t + 61, reply_text, rp, th, stop="end_turn")]
+        prev = rem
+        for i in range(n_errors):
+            recs.append(api_error_line(t + i, "e%d%s" % (i, tag), prev, attempt=i + 1))
+            prev = "e%d%s" % (i, tag)
+        recs.append(stop_hook_line(t + 70, "sh" + tag, prev))
+        recs.append(uline(t + 100, "next ask %s" % tag, "u" + tag, "sh" + tag))
+        return recs, (rem, th, rp)
+
+    def base(self):
+        return [uline(T0, "storm-turn ask", "u1", parent=None, ps="typed")]
+
+    def test_flush_orphaned_reply_is_kept(self):
+        ep, (rem, th, rp) = self._episode(T0 + 10, "A", "u1", "the reply the user watched stream")
+        out, mem = self._run(self.base() + ep + [aline(T0 + 140, "reply on the next turn", "a2", "uA")])
+        texts = [_text(a) for a in self._atoms(out) if a["type"] == "assistant"]
+        self.assertIn("the reply the user watched stream", texts,
+                      "the persisted reply the flush bypassed must render")
+        self.assertIn(rp, mem["eclipsed"])
+        self.assertIn(rp, mem["kept"])
+        self.assertNotIn(rp, mem["rewind"], "a machine-orphaned reply is never a rewind")
+        # the reply closes ITS OWN turn: same turn as the ask, ended, before the next opener
+        turn0 = out["turns"][0]
+        self.assertEqual([a.get("uuid") for a in turn0["atoms"]], ["u1", th, rp])
+        self.assertTrue(turn0["ended"], "the eclipsed end_turn reply ends the stormed turn")
+        self.assertEqual(out["turns"][1]["trigger"], {"uuid": "uA"})
+        # the flushed bookkeeping never becomes atoms
+        self.assertFalse({"e0A", "e1A", "shA", rem} & {a.get("uuid") for a in self._atoms(out)})
+
+    def test_consecutive_storm_episodes_each_keep_their_reply(self):
+        # case 1's shape: five back-to-back stormed turns; two suffice to pin the chaining —
+        # each episode forks where the PREVIOUS episode's flushed spine left the leaf
+        epA, (_, _, rpA) = self._episode(T0 + 10, "A", "u1", "first stormed reply")
+        epB, (_, _, rpB) = self._episode(T0 + 200, "B", "uA", "second stormed reply", n_errors=1)
+        out, mem = self._run(self.base() + epA + epB
+                             + [aline(T0 + 400, "clean reply at last", "a9", "uB")])
+        texts = [_text(a) for a in self._atoms(out) if a["type"] == "assistant"]
+        self.assertIn("first stormed reply", texts)
+        self.assertIn("second stormed reply", texts)
+        self.assertTrue({rpA, rpB} <= mem["eclipsed"])
+        self.assertEqual(mem["rewind"], set())
+
+    def test_mid_turn_storm_with_tool_cycles_keeps_the_whole_turn(self):
+        # the mid-turn variant (case 1 episodes C/D): the storm hits INSIDE the turn, the CLI
+        # recovers and the turn runs on — tool cycles, a second reminder attachment — before the
+        # final text; the flush then buffers SEVERAL bursts (retryAttempt resets between them)
+        recs = self.base() + [
+            reminder_line(T0 + 10, "remC", "u1"),
+            aline(T0 + 20, "", "tuC1", "remC", tools=("Bash",), stop=None),
+            trline(T0 + 25, "tu_tuC1_0", "trC1", "tuC1"),
+            reminder_line(T0 + 26, "remC2", "trC1"),
+            aline(T0 + 30, "", "tuC2", "remC2", tools=("Read",), stop=None),
+            trline(T0 + 35, "tu_tuC2_0", "trC2", "tuC2"),
+            aline(T0 + 40, "finished after the mid-turn storm", "rpC", "trC2", stop="end_turn"),
+            # the flush: two bursts' records in one chain, counters restarting
+            api_error_line(T0 + 11, "eC1", "remC", attempt=1),
+            api_error_line(T0 + 12, "eC2", "eC1", attempt=2),
+            api_error_line(T0 + 28, "eC3", "eC2", attempt=1),
+            stop_hook_line(T0 + 41, "shC", "eC3"),
+            uline(T0 + 100, "and the next thing", "u2", "shC"),
+            aline(T0 + 130, "next thing handled", "a2", "u2"),
+        ]
+        out, mem = self._run(recs)
+        uuids = [a.get("uuid") for a in self._atoms(out)]
+        for u in ("tuC1", "trC1", "tuC2", "trC2", "rpC"):
+            self.assertIn(u, uuids, "the whole bypassed turn stays kept, tools included (%s)" % u)
+        self.assertTrue({"tuC1", "trC1", "remC2", "tuC2", "trC2", "rpC"} <= mem["eclipsed"])
+        self.assertEqual(len(out["turns"]), 2, "one stormed turn, one clean turn")
+        self.assertTrue(out["turns"][0]["ended"])
+
+    def test_user_gesture_fork_stays_dropped_and_the_ghost_gate_holds(self):
+        # the genuine-rollback contrast: the abandoned branch carries a REAL landed reply, but
+        # the bypass at the fork is the user's replacement prompt — a gesture, no api_error
+        # witness — so it stays dropped, and a stale orphanReply marker for that reply must not
+        # resurrect it through the salvage door (the 2026-08-03 ghost-reply gate, fully intact)
+        recs = [uline(T0, "first attempt", "u1", parent=None, ps="typed"),
+                aline(T0 + 30, "did it one way", "a1", "u1"),
+                uline(T0 + 100, "deleted follow-up", "u2", "a1", ps="typed"),
+                aline(T0 + 130, "reply the rollback abandoned", "a2", "u2"),
+                uline(T0 + 200, "second attempt instead", "u3", "a1", ps="typed"),
+                aline(T0 + 230, "better approach done", "a3", "u3")]
+        marker = [{"t": T0 + 130, "orphanReply": {"uuid": "a2", "text": "reply the rollback abandoned"}}]
+        out, mem = self._run(recs, states=marker)
+        atoms = self._atoms(out)
+        self.assertNotIn("reply the rollback abandoned",
+                         [_text(a) for a in atoms if a["type"] == "assistant"],
+                         "a user-gesture rollback's branch stays dropped")
+        self.assertFalse(any(a.get("orphaned") for a in atoms), "and its marker stays suppressed")
+        self.assertEqual(mem["rewind"], {"u2", "a2"})
+        self.assertEqual(mem["eclipsed"], set())
+
+    def test_marker_stands_down_when_the_branch_is_kept(self):
+        # a settle-time salvage marker may predate the fix for the same bypassed reply — the
+        # eclipse renders the REAL atom, and the marker must not double it
+        ep, (_, th, rp) = self._episode(T0 + 10, "A", "u1", "the reply the user watched stream")
+        marker = [{"t": T0 + 71, "orphanReply": {"uuid": rp, "text": "the reply the user watched stream"}}]
+        out, _ = self._run(self.base() + ep + [aline(T0 + 140, "onward", "a2", "uA")],
+                           states=marker)
+        atoms = self._atoms(out)
+        hits = [a for a in atoms if _text(a) == "the reply the user watched stream"]
+        self.assertEqual(len(hits), 1, "exactly one rendering of the reply — the real atom")
+        self.assertEqual(hits[0].get("uuid"), rp)
+        self.assertFalse(any(a.get("orphaned") for a in atoms))
+
+    def test_parallel_tool_stub_inside_the_branch_stays_dropped(self):
+        # parallel tool-call stubs fork off the spine and are dropped by the walk; the same stub
+        # INSIDE an eclipsed branch must drop identically — the selection keeps the branch's
+        # own reply chain, not every descendant of the fork
+        recs = self.base() + [
+            reminder_line(T0 + 10, "remA", "u1"),
+            aline(T0 + 20, "", "tuA1", "remA", tools=("Bash",), stop=None),
+            # the stub pair: a second tool_use chained BESIDE the result, with its own result
+            aline(T0 + 21, "", "stub1", "tuA1", tools=("Read",), stop=None),
+            trline(T0 + 24, "tu_stub1_0", "stub2", "stub1"),
+            # the real chain: result of tuA1 -> final text
+            trline(T0 + 25, "tu_tuA1_0", "trA1", "tuA1"),
+            aline(T0 + 30, "reply after the parallel calls", "rpA", "trA1", stop="end_turn"),
+            api_error_line(T0 + 11, "eA1", "remA", attempt=1),
+            stop_hook_line(T0 + 31, "shA", "eA1"),
+            uline(T0 + 100, "next ask", "u2", "shA"),
+            aline(T0 + 130, "done", "a2", "u2"),
+        ]
+        out, mem = self._run(recs)
+        uuids = {a.get("uuid") for a in self._atoms(out)}
+        self.assertIn("rpA", uuids)
+        self.assertIn("trA1", uuids)
+        self.assertFalse({"stub1", "stub2"} & uuids, "the stub drops exactly as its on-spine twin does")
+        self.assertTrue({"tuA1", "trA1", "rpA"} <= mem["eclipsed"])
+        self.assertTrue({"stub1", "stub2"} <= mem["rewind"])
+
+    def test_stop_hook_only_bypass_stays_dropped(self):
+        # the conservative scope: a bypass of stop_hook_summary records with NO api_error carries
+        # no studied machine witness (15 such forks in the live corpus, forensics pending) — the
+        # fork probe requires an api_error between the fork and the next conversational
+        # record, so this shape keeps today's behavior
+        recs = self.base() + [
+            reminder_line(T0 + 10, "remA", "u1"),
+            aline(T0 + 20, "reply behind a hook-only bypass", "rpA", "remA"),
+            stop_hook_line(T0 + 30, "shA", "remA"),
+            stop_hook_line(T0 + 31, "shB", "shA"),
+            uline(T0 + 100, "next ask", "u2", "shB"),
+            aline(T0 + 130, "done", "a2", "u2"),
+        ]
+        out, mem = self._run(recs)
+        self.assertNotIn("reply behind a hook-only bypass",
+                         [_text(a) for a in self._atoms(out) if a["type"] == "assistant"])
+        self.assertIn("rpA", mem["rewind"])
+        self.assertEqual(mem["eclipsed"], set())
+
+    def test_a_user_headed_branch_never_survives_a_completed_flush(self):
+        # the belt on the buckle: even AT an api_error bypass with the next prompt landed (a
+        # COMPLETED flush — the "user" terminal), a branch whose head is a user record is not
+        # a streamed reply (all 49 corpus matches are assistant-headed) and is exactly what a
+        # rollback typed mid-storm leaves behind — the fork stands down whole rather than
+        # re-show a prompt its user may have deleted
+        recs = self.base() + [
+            uline(T0 + 20, "prompt on a dead side branch", "ux", "u1", ps="typed"),
+            aline(T0 + 30, "reply on that side branch", "ax", "ux"),
+            api_error_line(T0 + 11, "eA1", "u1", attempt=1),
+            stop_hook_line(T0 + 31, "shA", "eA1"),
+            uline(T0 + 100, "next ask", "u2", "shA"),
+            aline(T0 + 130, "done", "a2", "u2"),
+        ]
+        out, mem = self._run(recs)
+        self.assertTrue({"ux", "ax"} <= mem["rewind"])
+        self.assertEqual(mem["eclipsed"], set())
+
+    def test_a_user_headed_branch_at_a_tail_spur_stays_kept(self):
+        # the other eclipse terminal: the spur is the transcript's TAIL (a mid-flush race, a
+        # session dead mid-storm — the "exhausted" terminal), so NO next prompt exists and no
+        # user gesture can have abandoned anything — keep-on-unprovable holds and the component
+        # stays eclipsed whole (the completed-flush belt above needs the landed next prompt to
+        # bite)
+        recs = self.base() + [
+            uline(T0 + 20, "prompt on a dying branch", "ux", "u1", ps="typed"),
+            aline(T0 + 30, "reply on that branch", "ax", "ux"),
+            api_error_line(T0 + 40, "eA1", "u1", attempt=1),
+        ]
+        out, mem = self._run(recs)
+        self.assertTrue({"ux", "ax"} <= mem["eclipsed"])
+        self.assertEqual(mem["rewind"], set())
+        self.assertIn("reply on that branch",
+                      [_text(a) for a in self._atoms(out) if a["type"] == "assistant"])
+
+    def test_a_pending_cut_outranks_the_eclipse(self):
+        # a bare-rollback cut armed at the fork: the walk's leaf IS the fork, there is no bypass
+        # segment to read, and nothing eclipses — the user's pending gesture wins
+        ep, (_, _, rp) = self._episode(T0 + 10, "A", "u1", "the reply the user watched stream")
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            recs = self.base() + ep + [aline(T0 + 140, "onward", "a2", "uA")]
+            path.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+            mem = em.chain_membership(str(path), leaf_override="u1")
+        self.assertEqual(mem["eclipsed"], set())
+        self.assertIn(rp, mem["rewind"])
+
+    # ── sibling chains at ONE fork: selection reads properties, never the CLI's byte order of
+    # writes (no on-disk transcript carries these shapes today — this is the defense against
+    # write-order drift, since nothing contracts the order the CLI flushes its buffers in) ──
+
+    def _fork_pieces(self):
+        """The shared single-episode skeleton, split so tests can permute WRITE order without
+        changing the graph: (head, reply, flush_spine, closer). The graph is always the same —
+        fork at remA, reply chain rpA, flushed spine eA1->shA->u2 — only file order varies."""
+        head = self.base() + [reminder_line(T0 + 10, "remA", "u1")]
+        reply = [aline(T0 + 30, "the reply the user watched stream", "rpA", "remA")]
+        flush_spine = [api_error_line(T0 + 11, "eA1", "remA", attempt=1),
+                       stop_hook_line(T0 + 31, "shA", "eA1"),
+                       uline(T0 + 100, "next ask", "u2", "shA")]
+        closer = [aline(T0 + 130, "done", "a2", "u2")]  # the true leaf — always written last
+        return head, reply, flush_spine, closer
+
+    def test_late_written_stub_pair_never_steals_the_keep(self):
+        # a parallel tool-stub pair parented directly AT the fork but written AFTER the reply
+        # records: the stub chain is assistant-headed, so a max-seq-record selection would keep
+        # the STUBS and leave the real reply dropped — inverting the fix's own contract purely
+        # on write order. The stub chain carries no reply text; the reply chain does.
+        head, reply, flush_spine, closer = self._fork_pieces()
+        stubs = [aline(T0 + 20, "", "stubA", "remA", tools=("Bash",), stop=None),
+                 trline(T0 + 25, "tu_stubA_0", "stubB", "stubA")]
+        out, mem = self._run(head + reply + flush_spine + stubs + closer)
+        self.assertIn("the reply the user watched stream",
+                      [_text(a) for a in self._atoms(out) if a["type"] == "assistant"],
+                      "the persisted reply stays kept whatever the stub pair's file position")
+        self.assertIn("rpA", mem["eclipsed"])
+        self.assertTrue({"stubA", "stubB"} <= mem["rewind"],
+                        "the textless stub chain drops exactly as an early-written one does")
+
+    def test_sibling_error_burst_chain_never_stands_the_fork_down(self):
+        # a second api_error burst flushed as its OWN sibling chain from the same fork, written
+        # last: its tail was the component's max-seq record, the head check saw a system record,
+        # and the WHOLE fork stood down — the reply silently kept the pre-fix data-loss behavior.
+        # An ineligible sibling chain must never veto the eligible one.
+        head, reply, flush_spine, closer = self._fork_pieces()
+        burst2 = [api_error_line(T0 + 40, "eB1", "remA", attempt=1),
+                  api_error_line(T0 + 41, "eB2", "eB1", attempt=2)]
+        out, mem = self._run(head + reply + flush_spine + burst2 + closer)
+        self.assertIn("the reply the user watched stream",
+                      [_text(a) for a in self._atoms(out) if a["type"] == "assistant"])
+        self.assertIn("rpA", mem["eclipsed"])
+        self.assertTrue({"eB1", "eB2"} <= mem["rewind"], "the burst chain itself is never kept")
+        self.assertFalse({"eB1", "eB2"} & {a.get("uuid") for a in self._atoms(out)})
+
+    def test_stub_pair_write_order_never_changes_the_verdict(self):
+        # both chains present, both write orders — stubs before the reply records and after —
+        # must yield the SAME membership: order-independence pinned at the membership level
+        head, reply, flush_spine, closer = self._fork_pieces()
+        stubs = [aline(T0 + 20, "", "stubA", "remA", tools=("Bash",), stop=None),
+                 trline(T0 + 25, "tu_stubA_0", "stubB", "stubA")]
+        _, early = self._run(head + stubs + reply + flush_spine + closer)
+        _, late = self._run(head + reply + flush_spine + stubs + closer)
+        for key in ("kept", "rewind", "eclipsed"):
+            self.assertEqual(early[key], late[key], "write order changed the %r set" % key)
+        self.assertIn("rpA", early["eclipsed"])
+        self.assertTrue({"stubA", "stubB"} <= early["rewind"])
+
+    def test_two_reply_chains_prefer_the_latest_written(self):
+        # two assistant-headed, text-carrying sibling chains at one fork — NOT observed in the
+        # corpus (every incident fork holds exactly one) — pinned deliberately: the latest-written
+        # chain wins, as the CLI's final word on that turn, and it is the same chain the pre-fix
+        # walk picked when only one existed. Only the selected chain stays eclipsed.
+        head, _, flush_spine, closer = self._fork_pieces()
+        replies = [aline(T0 + 20, "first persisted attempt", "rpA", "remA"),
+                   aline(T0 + 30, "second persisted attempt", "rpB", "remA")]
+        out, mem = self._run(head + replies + flush_spine + closer)
+        self.assertIn("rpB", mem["eclipsed"])
+        self.assertIn("rpA", mem["rewind"], "only the selected chain survives")
+        texts = [_text(a) for a in self._atoms(out) if a["type"] == "assistant"]
+        self.assertIn("second persisted attempt", texts)
+        self.assertNotIn("first persisted attempt", texts)
 
 
 class SlashCommandTurn(unittest.TestCase):

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -1349,10 +1349,11 @@ class EclipsedChainSelection(unittest.TestCase):
         self.assertEqual(hits[0].get("uuid"), rp)
         self.assertFalse(any(a.get("orphaned") for a in atoms))
 
-    def test_parallel_tool_stub_inside_the_branch_stays_dropped(self):
-        # parallel tool-call stubs fork off the spine and are dropped by the walk; the same stub
-        # INSIDE an eclipsed branch must drop identically — the selection keeps the branch's
-        # own reply chain, not every descendant of the fork
+    def test_parallel_tool_stub_inside_the_winning_branch_rides_the_keep(self):
+        # the selection unit is the BRANCH, kept whole: a stub twin inside it stays (one
+        # output-less duplicate tool row — deliberate; per-leaf-chain narrowing proved
+        # reply-lossy), while stub CHAINS at the fork itself still drop (they are branches
+        # of their own and never qualify)
         recs = self.base() + [
             reminder_line(T0 + 10, "remA", "u1"),
             aline(T0 + 20, "", "tuA1", "remA", tools=("Bash",), stop=None),
@@ -1371,9 +1372,13 @@ class EclipsedChainSelection(unittest.TestCase):
         uuids = {a.get("uuid") for a in self._atoms(out)}
         self.assertIn("rpA", uuids)
         self.assertIn("trA1", uuids)
-        self.assertFalse({"stub1", "stub2"} & uuids, "the stub drops exactly as its on-spine twin does")
+        # the stub twin rides the kept branch: the selection unit is the WHOLE branch (a
+        # per-leaf-chain read of shared records proved reply-lossy by construction), and the
+        # cost is one output-less duplicate tool row — never a lost reply
         self.assertTrue({"tuA1", "trA1", "rpA"} <= mem["eclipsed"])
-        self.assertTrue({"stub1", "stub2"} <= mem["rewind"])
+        self.assertTrue({"stub1", "stub2"} <= mem["eclipsed"],
+                        "over-keep is the deliberate trade: a dup tool row beats a possible reply loss")
+        self.assertEqual(mem["rewind"], set())
 
     def test_stop_hook_only_bypass_stays_dropped(self):
         # the conservative scope: a bypass of stop_hook_summary records with NO api_error carries
@@ -1500,6 +1505,139 @@ class EclipsedChainSelection(unittest.TestCase):
             self.assertEqual(early[key], late[key], "write order changed the %r set" % key)
         self.assertIn("rpA", early["eclipsed"])
         self.assertTrue({"stubA", "stubB"} <= early["rewind"])
+
+    def test_a_grafted_burst_below_the_reply_text_never_steals_the_keep(self):
+        # shared-prefix laundering: gates and a ranking key that read leaf->fork CHAINS let a
+        # junk tail grafted BELOW a text-carrying record inherit the prefix's qualifications —
+        # a second flushed burst at the mid-turn graft point, written last, out-seq'd the real
+        # reply chain and the actual reply demoted to rewind. The selection unit is the BRANCH
+        # (ranked by its latest reply text), so a textless tail can never move the pick.
+        head = self.base() + [reminder_line(T0 + 10, "remA", "u1")]
+        reply = [aline(T0 + 20, "mid-turn text before the tool", "tuA1", "remA", tools=("Bash",), stop=None),
+                 trline(T0 + 25, "tu_tuA1_0", "trA1", "tuA1"),
+                 aline(T0 + 30, "the reply the user watched stream", "rpA", "trA1")]
+        flush_spine = [api_error_line(T0 + 11, "eA1", "remA", attempt=1),
+                       stop_hook_line(T0 + 31, "shA", "eA1"),
+                       uline(T0 + 100, "next ask", "u2", "shA")]
+        burst = [api_error_line(T0 + 40, "eB1", "tuA1", attempt=1),
+                 api_error_line(T0 + 41, "eB2", "eB1", attempt=2)]
+        closer = [aline(T0 + 130, "done", "a2", "u2")]
+        for recs in (head + reply + flush_spine + burst + closer,
+                     head + reply + burst + flush_spine + closer):
+            out, mem = self._run(recs)
+            texts = [_text(a) for a in self._atoms(out) if a["type"] == "assistant"]
+            self.assertIn("the reply the user watched stream", texts,
+                          "a grafted burst tail must never steal the keep from the reply")
+            self.assertTrue({"tuA1", "trA1", "rpA"} <= mem["eclipsed"])
+            # the grafted burst rides the kept branch (kept whole, see above) at zero display
+            # cost: system records never become atoms, kept or not
+            self.assertFalse({"eB1", "eB2"} & {a.get("uuid") for a in self._atoms(out)},
+                             "burst records never surface as atoms")
+
+    def test_a_late_stub_pair_below_the_reply_text_never_steals_the_keep(self):
+        # the same laundering, stub flavor: a parallel stub pair parented one level BELOW a
+        # text-carrying record must never steal the pick from the reply records beside it
+        # (the at-the-fork variant is a branch of its own and still drops — covered above)
+        head = self.base() + [reminder_line(T0 + 10, "remA", "u1")]
+        reply = [aline(T0 + 20, "mid-turn text before the tool", "tuA1", "remA", tools=("Bash",), stop=None),
+                 trline(T0 + 25, "tu_tuA1_0", "trA1", "tuA1"),
+                 aline(T0 + 30, "the reply the user watched stream", "rpA", "trA1")]
+        flush_spine = [api_error_line(T0 + 11, "eA1", "remA", attempt=1),
+                       stop_hook_line(T0 + 31, "shA", "eA1"),
+                       uline(T0 + 100, "next ask", "u2", "shA")]
+        stubs = [aline(T0 + 21, "", "stubA", "tuA1", tools=("Read",), stop=None),
+                 trline(T0 + 26, "tu_stubA_0", "stubB", "stubA")]
+        closer = [aline(T0 + 130, "done", "a2", "u2")]
+        out, mem = self._run(head + reply + flush_spine + stubs + closer)
+        self.assertIn("the reply the user watched stream",
+                      [_text(a) for a in self._atoms(out) if a["type"] == "assistant"],
+                      "the reply survives whatever the stub pair's file position")
+        self.assertTrue({"rpA", "trA1", "tuA1"} <= mem["eclipsed"])
+        self.assertTrue({"stubA", "stubB"} <= mem["eclipsed"],
+                        "the in-branch twin rides the keep — the deliberate over-keep trade")
+
+    def test_a_textless_tool_only_turn_survives_a_completed_flush(self):
+        # a machine-orphaned turn of PURE tool activity (no reply text) has no qualifying
+        # chain, and the whole-component stand-down swept it — reverting the eclipse's keep
+        # for work that really ran. A rollback branch's fork-side head is always the user's
+        # own record (the head-gate's reasoning, and 42/42 user-gesture rollbacks in the
+        # author's corpus), so the stand-down demotes user-headed chains ONLY; an
+        # assistant-headed textless chain is provably not rollback residue and stays kept.
+        recs = self.base() + [
+            reminder_line(T0 + 10, "remA", "u1"),
+            aline(T0 + 20, "", "tuA1", "remA", tools=("Bash",), stop=None),
+            trline(T0 + 25, "tu_tuA1_0", "trA1", "tuA1"),
+            api_error_line(T0 + 11, "eA1", "remA", attempt=1),
+            stop_hook_line(T0 + 31, "shA", "eA1"),
+            uline(T0 + 100, "next ask", "u2", "shA"),
+            aline(T0 + 130, "done", "a2", "u2"),
+        ]
+        out, mem = self._run(recs)
+        self.assertTrue({"tuA1", "trA1"} <= mem["eclipsed"],
+                        "tool work that really ran survives the completed flush")
+        self.assertTrue({"tuA1", "trA1"} <= mem["kept"])
+        self.assertEqual(mem["rewind"], set())
+
+    def test_a_failure_record_chain_never_outranks_the_reply(self):
+        # Claude Code writes a FAILED attempt as an assistant record carrying the error as a
+        # text block (isApiErrorMessage:true) — atoms() refuses to treat it as a reply, and the
+        # eclipse's reply witness must too, or a late-written failed-attempt chain qualifies
+        # and steals the keep from the turn's only real text.
+        head, reply, flush_spine, closer = self._fork_pieces()
+        failed = aline(T0 + 40, "API Error: 529 overloaded", "rpF", "remA", stop="stop_sequence")
+        failed["isApiErrorMessage"] = True
+        out, mem = self._run(head + reply + flush_spine + [failed] + closer)
+        texts = [_text(a) for a in self._atoms(out) if a["type"] == "assistant"]
+        self.assertIn("the reply the user watched stream", texts)
+        self.assertNotIn("API Error: 529 overloaded", texts)
+        self.assertIn("rpA", mem["eclipsed"])
+        self.assertIn("rpF", mem["rewind"], "a failure echo is never the eclipse's reply")
+
+    def test_twin_sub_branches_never_disenfranchise_their_own_turn(self):
+        # the shape that broke per-leaf-chain selection (adversarial construction, 2026-09-01):
+        # the REAL turn's text record has two textless sub-branches below it (the storm-cut
+        # tool result + a parallel stub twin), and an OLDER superseded attempt sits beside the
+        # branch at the fork. A unique-suffix read stripped the shared text record from both
+        # of its own chains' suffixes, both failed the text gate, and the older sibling stole
+        # the keep — reply loss. Branch-level selection keys on the branch's latest reply
+        # text: the real turn (newer text) must win, whole.
+        head = self.base() + [reminder_line(T0 + 10, "remA", "u1")]
+        older = [aline(T0 + 15, "first persisted attempt", "rpQ", "remA")]
+        turn = [aline(T0 + 20, "the reply the user watched stream", "tuT", "remA",
+                      tools=("Bash", "Read"), stop=None),
+                trline(T0 + 25, "tu_tuT_0", "trT", "tuT"),
+                aline(T0 + 21, "", "stubX", "tuT", tools=("Read",), stop=None),
+                trline(T0 + 26, "tu_stubX_0", "trX", "stubX")]
+        flush_spine = [api_error_line(T0 + 11, "eA1", "remA", attempt=1),
+                       stop_hook_line(T0 + 31, "shA", "eA1"),
+                       uline(T0 + 100, "next ask", "u2", "shA")]
+        closer = [aline(T0 + 130, "done", "a2", "u2")]
+        out, mem = self._run(head + older + turn + flush_spine + closer)
+        texts = [_text(a) for a in self._atoms(out) if a["type"] == "assistant"]
+        self.assertIn("the reply the user watched stream", texts,
+                      "the turn with the LATEST reply text wins, its twin sub-branches notwithstanding")
+        self.assertNotIn("first persisted attempt", texts)
+        self.assertTrue({"tuT", "trT"} <= mem["eclipsed"])
+        self.assertIn("rpQ", mem["rewind"], "the superseded older attempt drops")
+
+    def test_a_stranded_tool_result_at_the_fork_survives_the_stand_down(self):
+        # the storm strands a tool_result beside its ON-SPINE tool_use (the CLI buffered the
+        # errors while the tool ran, then flushed from the tool_use as the leaf): the branch
+        # head is user-TYPED but machine-MADE. The stand-down demotes only user PROMPT heads —
+        # a tool_result head is provably not rollback residue and stays kept, where its output
+        # reunites with the spine's own tool call.
+        recs = self.base() + [
+            aline(T0 + 10, "", "tuF", "u1", tools=("Bash",), stop=None),
+            trline(T0 + 20, "tu_tuF_0", "trF", "tuF"),
+            api_error_line(T0 + 15, "eA1", "tuF", attempt=1),
+            stop_hook_line(T0 + 25, "shA", "eA1"),
+            uline(T0 + 100, "next ask", "u2", "shA"),
+            aline(T0 + 130, "done", "a2", "u2"),
+        ]
+        out, mem = self._run(recs)
+        self.assertIn("trF", mem["eclipsed"], "a machine-made tool_result head survives the stand-down")
+        self.assertIn("trF", mem["kept"])
+        self.assertEqual(mem["rewind"], set())
 
     def test_two_reply_chains_prefer_the_latest_written(self):
         # two assistant-headed, text-carrying sibling chains at one fork — NOT observed in the

--- a/tests/test_event_model_incremental.py
+++ b/tests/test_event_model_incremental.py
@@ -236,5 +236,112 @@ class ManualCompactAdoptionEquivalence(unittest.TestCase):
         self.assertEqual(len(self._cards(cold)), 1, "exactly one adopted card either way")
 
 
+def _flush_orphan_recs():
+    """A transcript that grows THROUGH an api_error-flush orphaning (synthetic content; shape
+    mirrors the 2026-09-01 incident transcripts): the prefix ends with the streamed reply as the
+    leaf — a perfectly linear chain — and the growth is the CLI's next-turn flush (buffered
+    api_error records parent-chained from the PRE-reply leaf, a stop_hook_summary, the next user
+    record), which bypasses the reply branch on disk. Returns (prefix, growth)."""
+    b = lambda i: "11111111-2222-3333-4444-%012d" % i
+    ts = lambda s: "2026-07-05T10:%02d:%02dZ" % (s // 60, s % 60)
+    prefix = [
+        {"type": "user", "uuid": b(0), "parentUuid": None, "timestamp": ts(0),
+         "promptSource": "typed", "message": {"role": "user", "content": "storm-turn ask"}},
+        {"type": "attachment", "uuid": b(1), "parentUuid": b(0), "timestamp": ts(5),
+         "attachment": {"type": "total_tokens_reminder"}},
+        {"type": "assistant", "uuid": b(2), "parentUuid": b(1), "timestamp": ts(60),
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "the reply the storm nearly ate"}],
+                     "stop_reason": "end_turn"}},
+    ]
+    growth = [
+        {"type": "system", "subtype": "api_error", "uuid": b(3), "parentUuid": b(1),
+         "timestamp": ts(6), "level": "error", "retryAttempt": 1, "maxRetries": 10,
+         "retryInMs": 1000, "source": "request_retry"},
+        {"type": "system", "subtype": "api_error", "uuid": b(4), "parentUuid": b(3),
+         "timestamp": ts(7), "level": "error", "retryAttempt": 2, "maxRetries": 10,
+         "retryInMs": 1049, "source": "request_retry"},
+        {"type": "system", "subtype": "stop_hook_summary", "uuid": b(5), "parentUuid": b(4),
+         "timestamp": ts(61), "level": "suggestion", "hookCount": 1},
+        {"type": "user", "uuid": b(6), "parentUuid": b(5), "timestamp": ts(120),
+         "promptSource": "typed", "message": {"role": "user", "content": "next ask after the storm"}},
+        {"type": "assistant", "uuid": b(7), "parentUuid": b(6), "timestamp": ts(130),
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "clean reply on the next turn"}],
+                     "stop_reason": "end_turn"}},
+    ]
+    return prefix, growth
+
+
+class FlushOrphanEclipseEquivalence(unittest.TestCase):
+    """Growth THROUGH an api_error-flush orphaning parses identically warm and cold: before the
+    flush lands the reply is simply the leaf (active); the flush append bypasses it, and the
+    eclipse (fork probe + em._select_eclipsed_chains) must reach the same verdict from the incremental
+    cache's grew-branch reuse as from a byte-zero read — the compactcard precedent
+    (ManualCompactAdoptionEquivalence) extended to the eclipse."""
+
+    def setUp(self):
+        em._JSONL_CACHE.clear()
+        fd, self.p = tempfile.mkstemp(suffix=".jsonl")
+        os.close(fd)
+
+    def tearDown(self):
+        em._JSONL_CACHE.clear()
+        os.unlink(self.p)
+
+    def _reply_uuids(self, out):
+        return [a.get("uuid") for t in out["turns"] for a in t["atoms"]
+                if a.get("type") == "assistant"]
+
+    def test_growth_through_the_flush_eclipses_identically_warm_and_cold(self):
+        reply = "11111111-2222-3333-4444-%012d" % 2
+        prefix, growth = _flush_orphan_recs()
+        _write(self.p, prefix)
+        first = em.parse_session(self.p)                  # cold; primes the cache
+        self.assertIn(reply, self._reply_uuids(first), "pre-flush, the reply is simply the leaf")
+        _append(self.p, growth)
+        warm = em.parse_session(self.p)                   # rides the grew-branch reuse
+        self.assertEqual(em.parse_session(self.p), warm,
+                         "a re-parse from the warm cache is stable — the eclipse mutated no cached record")
+        em._JSONL_CACHE.clear()
+        cold = em.parse_session(self.p)
+        self.assertEqual(warm, cold, "grown through the flush: warm == cold, eclipse included")
+        self.assertIn(reply, self._reply_uuids(cold),
+                      "the bypassed reply survives the flush append")
+
+    def test_late_stub_pair_append_eclipses_identically_warm_and_cold(self):
+        # the write-order-drift append: a parallel tool-stub pair parented at the PRE-reply fork
+        # arrives AFTER the flush growth, so the stub records outrank every reply record in file
+        # order. Selection is by property, not byte order — warm and cold must both splice back
+        # the reply and leave the stubs dropped, in this order too.
+        b = lambda i: "11111111-2222-3333-4444-%012d" % i
+        reply = b(2)
+        prefix, growth = _flush_orphan_recs()
+        stub_pair = [
+            {"type": "assistant", "uuid": b(8), "parentUuid": b(1),
+             "timestamp": "2026-07-05T10:00:10Z",
+             "message": {"role": "assistant", "stop_reason": None,
+                         "content": [{"type": "tool_use", "id": "tu_8_0",
+                                      "name": "Bash", "input": {}}]}},
+            {"type": "user", "uuid": b(9), "parentUuid": b(8),
+             "timestamp": "2026-07-05T10:00:15Z",
+             "message": {"role": "user", "content": [{"type": "tool_result",
+                         "tool_use_id": "tu_8_0", "content": "ok"}]}},
+        ]
+        _write(self.p, prefix)
+        em.parse_session(self.p)                          # cold; primes the cache
+        _append(self.p, growth[:-1])                      # the flush spine, up to the next ask
+        em.parse_session(self.p)                          # warm mid-step: grew-branch reuse
+        _append(self.p, stub_pair + growth[-1:])          # stubs land LAST but before the true leaf
+        warm = em.parse_session(self.p)
+        em._JSONL_CACHE.clear()
+        cold = em.parse_session(self.p)
+        self.assertEqual(warm, cold, "grown through the late-stub append: warm == cold")
+        self.assertIn(reply, self._reply_uuids(cold),
+                      "the reply stays kept even when the stub chain is the newest write")
+        atom_uuids = {a.get("uuid") for t in cold["turns"] for a in t["atoms"]}
+        self.assertFalse({b(8), b(9)} & atom_uuids, "the stub chain stays dropped")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_judge_rewind_cleanup.py
+++ b/tests/test_judge_rewind_cleanup.py
@@ -106,6 +106,24 @@ class Base(unittest.TestCase):
                 aline(T0 + 70, "Third synthetic reply.", "a3", "u3")]
 
 
+def flush_orphan_recs():
+    """The api_error-flush orphaning shape (2026-09-01, synthetic): the CLI recovered from a
+    storm and persisted the reply (a2x), then flushed its buffered api_error records from the
+    PRE-reply leaf (u2), hijacking the chain — the reply branch is bypassed on disk with no user
+    gesture anywhere near the fork."""
+    return [uline(T0, "first synthetic ask", "u1"),
+            aline(T0 + 10, "First synthetic reply, fully settled here.", "a1", "u1"),
+            uline(T0 + 20, "the stormed ask", "u2", "a1"),
+            aline(T0 + 40, "Reply the flush bypassed on disk.", "a2x", "u2"),
+            {"type": "system", "subtype": "api_error", "timestamp": iso(T0 + 21), "uuid": "e1",
+             "parentUuid": "u2", "level": "error", "retryAttempt": 1, "maxRetries": 10,
+             "retryInMs": 1000, "source": "request_retry"},
+            {"type": "system", "subtype": "stop_hook_summary", "timestamp": iso(T0 + 41),
+             "uuid": "sh1", "parentUuid": "e1", "level": "suggestion"},
+            uline(T0 + 60, "the ask after the storm", "u3", "sh1"),
+            aline(T0 + 70, "Reply on the flushed spine.", "a3", "u3")]
+
+
 class ChainMembershipPredicate(Base):
     """em.chain_membership — the ONE exported membership fact (identity-key hazards, per verdict)."""
 
@@ -224,6 +242,33 @@ class ChainMembershipPredicate(Base):
         cut = em.chain_membership(self.path, leaf_override="a1")
         self.assertEqual(cut["rewind"], {"u2", "a2"})
 
+    def test_a_flush_bypassed_reply_is_eclipsed_never_rewind(self):
+        # the api_error-flush orphaning (2026-09-01): the bypass at the fork is the CLI's own
+        # buffered-error chain — probed THROUGH the stop_hook_summary to the landed next
+        # prompt — so the persisted reply rejoins "kept" via "eclipsed" and no sweep
+        # predicate can ever read it as abandoned
+        self.write(flush_orphan_recs())
+        mem = em.chain_membership(self.path)
+        self.assertEqual(mem["eclipsed"], {"a2x"})
+        self.assertIn("a2x", mem["kept"], "eclipsed is a subset of kept")
+        self.assertEqual(mem["rewind"], set())
+
+    def test_the_sweep_predicates_spare_an_eclipsed_branch(self):
+        # the fix's downstream face: _rewound_away is the write-moment mint stand-down AND the
+        # drop-sweep discriminator; _per_file_rewound feeds the dead-branch reconciliation
+        # (reconcile_rewound_goals unions it with mem["rewind"]) — before the eclipse, both
+        # read the machine-orphaned branch as a rewind and goals anchored there were archived
+        # by a sweep no user gesture ever justified
+        self.write(flush_orphan_recs())
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "a2x"),
+                         "an eclipsed uuid never stands a mint down")
+        pf, fails = jd._per_file_rewound(SID, [str(self.path)])
+        self.assertEqual(fails, 0)
+        self.assertNotIn("a2x", pf, "the per-file discriminator agrees: nothing to sweep")
+        # contrast, same predicates: a genuine user-gesture fork still answers durably rewound
+        self.write(self.base_recs() + self.fork_recs())
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+
 
 class PredicateParityGolden(Base):
     """Item 10: the exported helper vs the display parse's own adapter — byte-identical kept sets
@@ -253,6 +298,12 @@ class PredicateParityGolden(Base):
         self.assert_parity(self.path)
         mem = em.chain_membership(self.path)
         self.assertIn("a2", mem["kept"])
+
+    def test_parity_on_a_flush_orphaned_branch(self):
+        # the eclipse (probe + chain selection) lives inside chain_verdicts, so BOTH faces
+        # (kept_uuids and chain_membership) inherit it from the one implementation — pinned anyway
+        self.write(flush_orphan_recs())
+        self.assert_parity(self.path)
 
     def test_parity_under_a_pending_cut(self):
         self.write(self.base_recs())

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -204,7 +204,11 @@ class PlacementIdentityCanary(unittest.TestCase):
         # so every pinned id is UNCHANGED — the bump seals transcripts whose retry-storm flush
         # knocked a turn's output off the spine; those atoms rejoin the set
         # (tests/test_romp_events_golden.py's eclipsed fixture covers the keep itself).
-        self.assertEqual(jd.PLACEMENTS_V, 10, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=10 — "
+        # v11 (2026-09-01, the eclipsed-chain selection): this fixture still carries no api_error
+        # spur, so every pinned id is UNCHANGED — the bump seals transcripts whose eclipsed fork
+        # held SIBLING chains (stub twins, error bursts, older attempts), whose atoms leave the
+        # set again (tests/test_event_model_golden.py EclipsedChainSelection covers the pick).
+        self.assertEqual(jd.PLACEMENTS_V, 11, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=11 — "
                          "re-pin the ids and this version together, in the same commit")
 
 


### PR DESCRIPTION
Rebased onto main after T209 (1fa891a8) and reworked to build on the eclipsed verdict rather than duplicate it.

T209 now covers the healing this PR originally shipped: its fork probe (at least one `system/api_error` record strictly between the fork and the spine's next conversational record) detects the machine bypass, and the kept branch renders again. The probe is also stronger than the first-record signature this PR proposed: it reads through leading non-error system records, refuses to double a spine that re-replied, and eclipses the tail-spur and corrupt-cycle windows. This rework keeps all of that unchanged.

What this PR adds on top is the selection half: which uuids the eclipse keeps. T209 keeps the whole fork component, and three sibling shapes ride along with the reply:

- A parallel tool-stub pair inside the branch renders beside its kept originals. The same stub pair drops as a rewind at every other fork.
- Two persisted attempts at one fork both render: a doubled reply.
- A branch headed by a user record behind a completed flush is kept. A rollback typed mid-storm forks in that same place (the buffered flush lands the user's replacement prompt past the error spur), so keeping the branch can re-show a prompt its user deleted, the one direction the eclipsed verdict is designed never to take.

`em._select_eclipsed_chains` narrows the keep to one chain per fork, and all three shapes are pinned red-first: of the 14 golden scenarios, six fail on the unnarrowed T209 keep and eight already pass on it (the healing and contrast cases).

## Selection is by property, not CLI write order

Nothing contracts the byte order in which the CLI flushes its buffers, so the kept chain is chosen by what it carries. Among the eclipsed fork's component chains (one per leaf, walked leaf to fork), the winner is the max-seq chain whose head is an assistant record and which carries reply text (witnessed by `landed_text_uuids`, the one existing definition); everything else in the component demotes to `rewind`, exactly as its on-spine twins classify. A late-written stub pair therefore cannot steal the keep, and a late-written second error burst cannot veto it. The (max-seq, leaf-seq) tiebreak for the two-qualifying-chains case (unobserved in the corpus) is deliberate and pinned by a test: the latest write is the CLI's final word on the turn, and it matches the single-chain pick whenever exactly one chain qualifies.

## When no chain qualifies, the two eclipse terminals part ways

At a completed flush (the probe ended on the user's landed next prompt) the fork stands down whole: a machine-orphaned reply would qualify if one existed, and what remains is indistinguishable from a rollback the storm raced. At an exhausted spur (the transcript's tail mid-flush or mid-storm, or a corrupt cycle) everything stays eclipsed: no next prompt exists, so no user gesture can have abandoned anything, and keep-on-unprovable holds. T209's tests pass unchanged under the composition, including the cycle case's kept real ask.

## Corpus evidence (counts)

Scanning 4,678 transcripts: 49 machine-orphaned bypasses, every one an assistant-headed branch carrying reply text, against 2,809 rewind forks that are not (2,035 parallel tool stubs, 700 superseded retries, 42 genuine user-gesture rollbacks, 32 other), zero overlap. 5 of the 49 storms wrote no stop-hook record, so the stop hook is characterization, not predicate; stop-hook-only bypasses (15 observed, unstudied) deliberately keep today's behavior. Two incidents were verified at the transcript level (8 episodes); the shape reaches back to at least mid-Aug 2026.

## PLACEMENTS_V

Bumps 10 to 11 (T209 took 9 to 10). The narrowed keep shrinks the parsed atom set of transcripts whose eclipsed fork carried sibling chains: v8's shape, same seal. The canary is re-pinned in the same commit; the canary fixture carries no api_error spur, so every pinned id is unchanged.

## Companion CLI report

The buffered flush hijacking the leaf instead of chaining from the current one is a CLI bug, filed as anthropics/claude-code#91113. That report is the real fix; this parse-side selection defends regardless.

## Tests (all written red-first)

- `tests/test_event_model_golden.py`, `EclipsedChainSelection` (14 tests): single, consecutive, and mid-turn-storm episodes; user-gesture contrast with the ghost gate intact; marker stand-down; stub isolation; stop-hook-only bypass stays dropped; the completed-flush user-headed belt and its tail-spur counterpart; pending-cut precedence; and the write-order defense (late-written stub pair, sibling error burst, order-independent membership, two-chain tiebreak). T209's `EclipsedBranch` scenarios pass unchanged beside it.
- `tests/test_event_model_incremental.py`: warm/cold equivalence through the flush append, including the late-stub append order.
- `tests/test_judge_rewind_cleanup.py`: membership sets, sweep predicates spare the kept chain, kept-parity, beside T209's eclipsed classification, tail-spur, and cycle cases, all unchanged.
- `tests/test_placements_canary.py`: v11 seal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)