### PR TITLE
T209: keep turns a machine api_error spur knocked off the spine (eclipsed verdict)

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -953,6 +953,15 @@ class FileAdapter:
           "active" — on the leaf->root spine (what the chat shows).
           "rewind" — the chain rejoins the active spine: this line was REWOUND AWAY. The
                      only verdict that ever justifies dropping/sweeping content.
+          "eclipsed" — the chain rejoins the active spine, but the spine leaves the fork
+                     through MACHINE bookkeeping (an api_error spur): nobody rewound
+                     anything — the CLI flushed its buffered retry-storm records chained
+                     off the turn's opener and hung the next prompt on that spur, so the
+                     turn's real output fell off the spine with no user gesture. KEPT:
+                     it is the ONLY copy of a reply the user watched render (T209, the
+                     user 2026-09-01 — a five-minute turn's answer vanished behind a
+                     "Recovered after retries" note when the next send flushed the spur;
+                     no orphanReply marker exists because the disk DID keep the text).
           "clear"  — the chain reaches a clean null root the leaf does not share: `/clear`
                      jurisdiction (the episode machinery settles those) — never swept as
                      a rewind.
@@ -961,12 +970,61 @@ class FileAdapter:
         `active` defaults to active_path(); pass it when already computed."""
         if active is None:
             active = self.active_path()
+        # spine child map (parent -> its child ON the spine), for the fork-kind probe below
+        spine_child, _u, _guard = {}, self.leaf_uuid, 0
+        while _u is not None and _guard < 500000:
+            _p = self.parent_of.get(_u)
+            if _p is None or _p in spine_child:
+                break                              # root, or a cycle already crossed
+            spine_child[_p] = _u
+            _u = _p; _guard += 1
+        _fork_memo = {}
+        def fork_kind(f):
+            """rewind vs eclipsed for a chain rejoining the spine at f. A genuine rollback
+            re-parents the user's NEXT PROMPT directly at the cut (the spine leaves f with a
+            conversational record); the SDK's buffered-flush geometry puts >=1 system
+            api_error record STRICTLY BETWEEN f and the next conversational record — an
+            exact machine event, so this can never re-show content a person deleted. An
+            assistant record ending the probe means the spine re-replied: the fork is a
+            superseded attempt (the orphan salvage's jurisdiction), not an eclipse."""
+            if f in _fork_memo:
+                return _fork_memo[f]
+            res, u, saw_err, _seen = "rewind", spine_child.get(f), False, set()
+            while u is not None and u not in _seen:
+                _seen.add(u)
+                r = self.by_uuid.get(u) or {}
+                t = r.get("type")
+                if t == "assistant":
+                    break
+                if t == "user":
+                    if saw_err:
+                        res = "eclipsed"
+                    break
+                if t == "system" and r.get("subtype") == "api_error":
+                    saw_err = True
+                u = spine_child.get(u)
+            else:
+                # The spine RAN OUT (or cycled — _seen is the guard classify's own cycle branch
+                # has and this probe first shipped without: a multi-node cycle of system records
+                # hung every parse, found by adversarial review) before any conversational
+                # record: the spur is the transcript's current TAIL — a parse racing the CLI's
+                # multi-line flush, or a session that died in the storm. An api_error on the
+                # spine out of the fork is a machine artifact whatever follows, and defaulting
+                # this terminal to the one SWEEPABLE verdict re-opened the T209 loss for
+                # exactly those windows (one-way goal archives in the race; a permanent eat on
+                # the mid-storm death). A pending-cut fork is untouched: the cut leaf has no
+                # spine child, so the loop never runs and saw_err stays False.
+                if saw_err:
+                    res = "eclipsed"
+            _fork_memo[f] = res
+            return res
         verdict = {}
         def classify(start):
             path, u = [], start
             while True:
                 if u in active:
-                    res = "rewind"; break          # chain rejoins the active spine -> rewound fork
+                    res = fork_kind(u); break      # chain rejoins the active spine -> rewound fork,
+                    #                                unless a machine spur abandoned it (eclipsed)
                 if u in verdict:
                     res = verdict[u]; break
                 if u not in self.by_uuid:
@@ -995,11 +1053,15 @@ class FileAdapter:
         dangling chain is the one thing we cannot prove dead, and silently dropping a real
         ask is this repo's one fatal error, so we keep it. (Verified 0 dangling cases
         across the live corpus: this is a safety net, not a behavior change.)
+        An ECLIPSED chain is also kept: a machine-written api_error spur stole the leaf's
+        ancestry from a turn's real output (see chain_verdicts) — dropping it ate the only
+        visible copy of a rendered reply (T209).
         Derived from chain_verdicts — one implementation, so the exported membership
         predicate (chain_membership) can never diverge from what the parse keeps.
         set(active) is unioned as-is: the walk can record a dangling FINAL ancestor that is
         in no file's index, and it has always been kept."""
-        return set(active) | {u for u, v in self.chain_verdicts(active).items() if v == "broken"}
+        return set(active) | {u for u, v in self.chain_verdicts(active).items()
+                              if v in ("broken", "eclipsed")}
 
     def _absorbed_atom(self, full, t, seq, auid, rompuuid, postal_index):
         """One synthesized user atom for a mid-turn splice. The atom carries the FULL text — any
@@ -1747,6 +1809,7 @@ def chain_membership(leaf_path, candidate_files=None, states=None, leaf_override
 
     "rewind" is the ONLY set that ever justifies sweeping a goal: "clear" branches are /clear
     jurisdiction (the episode machinery settles those cards), "broken" chains are kept by design,
+    "eclipsed" chains are KEPT content a machine spur abandoned (never a user gesture — T209),
     and a uuid in NO set is unprovable (a synthetic orphan:<t> salvage id, a cross-file uuid whose
     file is outside the lineage, a legacy None) — callers must treat unknown as NOT abandoned.
     Caveat (resume-fork stitch shape): a recorded fork's fresh head is re-pointed at the from-file's
@@ -1761,11 +1824,11 @@ def chain_membership(leaf_path, candidate_files=None, states=None, leaf_override
     active = adapter.active_path()
     verdicts = adapter.chain_verdicts(active)
     # kept, derived from the verdicts already in hand — BY DEFINITION the same set kept_uuids
-    # computes (active ∪ broken; see its docstring: "derived from chain_verdicts — one
+    # computes (active ∪ broken ∪ eclipsed; see its docstring: "derived from chain_verdicts — one
     # implementation"), without paying the graph walk a second time inside it. The hold view
     # re-asks this on every build of a held session, so the walk count matters there.
-    out = {"kept": set(active) | {u for u, v in verdicts.items() if v == "broken"},
-           "rewind": set(), "clear": set(), "broken": set()}
+    out = {"kept": set(active) | {u for u, v in verdicts.items() if v in ("broken", "eclipsed")},
+           "rewind": set(), "clear": set(), "broken": set(), "eclipsed": set()}
     for u, v in verdicts.items():
         if v != "active":
             out[v].add(u)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -215,7 +215,7 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          model actually wrote. Closer / grouper / consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 9                         # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 10                        # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v2 (2026-07-09): a 07-07/07-08 change to segment-text derivation
 #                                          stepped the text hash without this bump — dormant segments' old-hash
 #                                          placements stopped matching, and every restart/touch replayed them as
@@ -269,6 +269,10 @@ PLACEMENTS_V = 9                         # placements-identity schema version (p
 #                                          finding). v3's shape: a GROWN atom set for every forked session
 #                                          (865 such files in one live corpus), so the seal is what keeps
 #                                          months of restored history from replaying as fresh cards.
+#                                          v10 (2026-09-01): eclipsed-branch keep (T209) — a turn whose output
+#                                          the CLI's buffered api_error flush knocked off the spine parses out
+#                                          again. Existing transcripts with that geometry GROW their atom set
+#                                          (v3/v7's shape), so the same seal applies.
 PLAN_SESSIONS = None                     # per-pass session cap — REMOVED (the user 2026-06-30): the fairness
                                          # caps were a recurring source of confusing starvation bugs (a goal/
                                          # nudge stuck behind a full per-pass window), never clearly needed.
@@ -1657,7 +1661,8 @@ def _rewound_away(fsid, path, uuid):
     Only "rewind" answers non-False. None/unknown uuids (umbrellas, legacy nodes, synthetic
     orphan:<t> salvage ids, cross-file uuids outside the lineage) answer False — abandonment can't
     be proven, and a false stand-down silently drops a real ask. "clear" is /clear jurisdiction;
-    "broken" is kept by design. A check that itself fails logs loudly and answers False (the
+    "broken" is kept by design; "eclipsed" is LIVE content a machine api_error spur abandoned
+    (T209) — its mints proceed. A check that itself fails logs loudly and answers False (the
     pre-fix behavior), never silently blocks a mint.
 
     The verdict is TWO-VALUED because the evidence comes in two strengths (2026-08-17):
@@ -3227,8 +3232,8 @@ def reconcile_rewound_goals(fsid, path, now):
     changes AND the transcript's abandoned-branch set actually CHANGED, archive live goals whose
     anchor lies on a dead branch. The predicate is em.chain_membership's "rewind" UNIONED with the
     per-file discriminator (_per_file_rewound, minus the current graph's kept set — a resume-stitched
-    survivor is never swept): "rewind" is the only sweepable verdict, "clear" is /clear jurisdiction
-    and "broken"/unknown prove nothing — and a dead branch INSIDE a pre-/clear episode file, which
+    survivor is never swept): "rewind" is the only sweepable verdict, "clear" is /clear jurisdiction,
+    "eclipsed" is kept content (a machine spur's abandonment, T209) and "broken"/unknown prove nothing — and a dead branch INSIDE a pre-/clear episode file, which
     the whole-graph walk can only ever call "clear", is caught by its own file's walk, exactly the
     incident scan's dead-episode-vs-dead-branch discriminator. This is the only cover for the
     rewinds romp never sees: CLI-native Esc-Esc in a tmux terminal, the SDK forkAt resume, a cut the

--- a/tests/fixtures/event-model-golden/eclipsed_branch_kept.json
+++ b/tests/fixtures/event-model-golden/eclipsed_branch_kept.json
@@ -1,0 +1,151 @@
+{
+ "color": "#888888",
+ "dir": "/TESTDIR",
+ "landedTextUuids": [
+  "a1",
+  "a2",
+  "a3"
+ ],
+ "leafFsid": "11111111-2222-3333-4444-555555555555",
+ "name": "impl",
+ "rompUuid": "11111111-2222-3333-4444-555555555555",
+ "turns": [
+  {
+   "atoms": [
+    {
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "please chart the throughput numbers",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": null,
+     "promptSource": "typed",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096400,
+     "type": "user",
+     "uuid": "u1"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "Charting the throughput numbers now.",
+        "type": "text"
+       },
+       {
+        "id": "tu_a1_0",
+        "input": {},
+        "name": "Bash",
+        "type": "tool_use"
+       }
+      ],
+      "role": "assistant"
+     },
+     "parentUuid": "u1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096430,
+     "type": "assistant",
+     "uuid": "a1"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "content": "ok",
+        "tool_use_id": "tu_a1_0",
+        "type": "tool_result"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "a1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096440,
+     "type": "user",
+     "uuid": "tr1"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "Throughput rises linearly until the cache saturates.",
+        "type": "text"
+       }
+      ],
+      "role": "assistant",
+      "stop_reason": "end_turn"
+     },
+     "parentUuid": "tr1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096460,
+     "type": "assistant",
+     "uuid": "a2"
+    }
+   ],
+   "end": 1781096460,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096400:7c744a9a",
+   "t": 1781096400,
+   "trigger": {
+    "uuid": "u1"
+   }
+  },
+  {
+   "atoms": [
+    {
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "thanks - now label the axes",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "sh1",
+     "promptSource": "typed",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096520,
+     "type": "user",
+     "uuid": "u2"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "Labeled both axes.",
+        "type": "text"
+       }
+      ],
+      "role": "assistant",
+      "stop_reason": "end_turn"
+     },
+     "parentUuid": "u2",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096550,
+     "type": "assistant",
+     "uuid": "a3"
+    }
+   ],
+   "end": 1781096550,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096520:a0c6234d",
+   "t": 1781096520,
+   "trigger": {
+    "uuid": "u2"
+   }
+  }
+ ]
+}

--- a/tests/fixtures/event-model-golden/retry_superseded.json
+++ b/tests/fixtures/event-model-golden/retry_superseded.json
@@ -1,0 +1,61 @@
+{
+ "color": "#888888",
+ "dir": "/TESTDIR",
+ "landedTextUuids": [
+  "a_new",
+  "a_old"
+ ],
+ "leafFsid": "11111111-2222-3333-4444-555555555555",
+ "name": "impl",
+ "rompUuid": "11111111-2222-3333-4444-555555555555",
+ "turns": [
+  {
+   "atoms": [
+    {
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "summarize the log file",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": null,
+     "promptSource": "typed",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096400,
+     "type": "user",
+     "uuid": "u1"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "The full answer after the retry.",
+        "type": "text"
+       }
+      ],
+      "role": "assistant",
+      "stop_reason": "end_turn"
+     },
+     "parentUuid": "e1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096490,
+     "type": "assistant",
+     "uuid": "a_new"
+    }
+   ],
+   "end": 1781096490,
+   "ended": true,
+   "id": "11111111-2222-3333-4444-555555555555:1781096400:a2b85cfa",
+   "t": 1781096400,
+   "trigger": {
+    "uuid": "u1"
+   }
+  }
+ ]
+}

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -342,6 +342,55 @@ def scenario_resume_lineage_fileB():
     ]
 
 
+def sysline(t, subtype, uuid, parent, **extra):
+    r = {"type": "system", "subtype": subtype, "timestamp": iso(t), "uuid": uuid,
+         "parentUuid": parent}
+    r.update(extra)
+    return r
+
+
+def scenario_eclipsed_branch_kept():
+    """T209 (the user 2026-09-01): during a rate-limit storm the CLI buffers its api_error
+    records and flushes them at the NEXT enqueue — chained off the turn's OPENING prompt —
+    then hangs the stop hook and the next prompt on that spur. The turn's real output
+    (thinking, tool work, the final reply the user watched render) falls off the
+    leaf->root spine with no user gesture, and no orphanReply marker exists because the
+    disk DID keep the text. The eclipsed verdict keeps the branch: >=1 api_error record
+    sits STRICTLY BETWEEN the fork and the next conversational record, an exact machine
+    event no genuine rollback produces (a rollback re-parents the user's next prompt
+    directly at the cut)."""
+    return [
+        uline(T0, "please chart the throughput numbers", "u1", parent=None, ps="typed"),
+        aline(T0 + 30, "Charting the throughput numbers now.", "a1", "u1",
+              tools=("Bash",), stop=None),
+        trline(T0 + 40, "tu_a1_0", "tr1", "a1"),
+        aline(T0 + 60, "Throughput rises linearly until the cache saturates.", "a2", "tr1",
+              stop="end_turn"),
+        # the buffered spur, flushed later in FILE order but parent-chained off u1
+        sysline(T0 + 31, "api_error", "e1", "u1", level="error",
+                error={"message": "429 rate_limit_error (synthetic)"}),
+        sysline(T0 + 45, "api_error", "e2", "e1", level="error",
+                error={"message": "429 rate_limit_error (synthetic)"}),
+        sysline(T0 + 61, "stop_hook_summary", "sh1", "e2", hookCount=1),
+        uline(T0 + 120, "thanks - now label the axes", "u2", parent="sh1", ps="typed"),
+        aline(T0 + 150, "Labeled both axes.", "a3", "u2", stop="end_turn"),
+    ]
+
+
+def scenario_retry_superseded():
+    """The other side of the eclipse discriminator: when the spine RE-REPLIED after the
+    api_error records (an assistant record ends the fork probe before any user prompt),
+    the off-path partial is a superseded attempt — kept OFF, exactly as before, so a
+    retry that re-replied never doubles (the orphan salvage's own dedup rule)."""
+    return [
+        uline(T0, "summarize the log file", "u1", parent=None, ps="typed"),
+        aline(T0 + 30, "Half an answer that a retry replaced.", "a_old", "u1", stop=None),
+        sysline(T0 + 31, "api_error", "e1", "u1", level="error",
+                error={"message": "429 rate_limit_error (synthetic)"}),
+        aline(T0 + 90, "The full answer after the retry.", "a_new", "e1", stop="end_turn"),
+    ]
+
+
 SINGLE_FILE = {
     "multi_input_absorbed": (scenario_multi_input_absorbed, None),
     "author_kinds": (scenario_author_kinds, SENT_LOG),
@@ -355,6 +404,8 @@ SINGLE_FILE = {
     "rewind_off_path": (scenario_rewind_off_path, None),
     "broken_chain_kept": (scenario_broken_chain_kept, None),
     "slash_command_turn": (scenario_slash_command_turn, None),
+    "eclipsed_branch_kept": (scenario_eclipsed_branch_kept, None),
+    "retry_superseded": (scenario_retry_superseded, None),
 }
 
 # fsid stems for the resume scenario (placeholder UUIDs)
@@ -1097,6 +1148,43 @@ class BrokenChainFloor(unittest.TestCase):
         self.assertIn("orphaned but real ask", texts, "a real ask must never be silently dropped")
         self.assertIn("main line ask", texts)
         self.assertIn("second main ask", texts)
+
+
+class EclipsedBranch(unittest.TestCase):
+    """T209 (the user 2026-09-01): a rendered five-minute turn vanished behind the
+    "Recovered after retries" note the moment the user sent their next message — the CLI's
+    buffered api_error flush had re-rooted the conversation spine through its error spur,
+    abandoning the turn's kept output with no user gesture and no orphanReply marker to
+    salvage it (the disk kept the text; only the spine left it). Both directions pinned:
+    the machine-abandoned branch is KEPT, while a superseded retry and a genuine rollback
+    (test_rewind_branch_is_dropped above) stay dropped."""
+
+    def test_eclipsed_turn_output_is_kept(self):
+        out = run_scenario("eclipsed_branch_kept")
+        uuids = [a.get("uuid") for t in out["turns"] for a in t["atoms"]]
+        for u in ("u1", "a1", "tr1", "a2", "u2", "a3"):
+            self.assertIn(u, uuids, "eclipsed turn output must stay visible")
+        texts = [_text(a) for t in out["turns"] for a in t["atoms"]]
+        self.assertIn("Throughput rises linearly until the cache saturates.", texts,
+                      "the only visible copy of the reply must never be eaten")
+
+    def test_superseded_retry_stays_dropped(self):
+        out = run_scenario("retry_superseded")
+        texts = [_text(a) for t in out["turns"] for a in t["atoms"]]
+        self.assertIn("The full answer after the retry.", texts)
+        self.assertNotIn("Half an answer that a retry replaced.", texts,
+                         "a retry that re-replied must not double")
+
+    def test_chain_membership_reports_eclipsed_kept(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("\n".join(json.dumps(r) for r in scenario_eclipsed_branch_kept()) + "\n")
+            mem = em.chain_membership(str(path))
+        self.assertIn("eclipsed", mem)
+        self.assertEqual(mem["eclipsed"], {"a1", "tr1", "a2"})
+        self.assertTrue(mem["eclipsed"] <= mem["kept"], "eclipsed chains are kept")
+        self.assertEqual(mem["rewind"], set(),
+                         "an eclipse is not a rewind — nothing here may be swept")
 
 
 class SlashCommandTurn(unittest.TestCase):

--- a/tests/test_judge_rewind_cleanup.py
+++ b/tests/test_judge_rewind_cleanup.py
@@ -8,7 +8,8 @@ and a producer pass framed before the rewind published its mints after the sweep
 shape, proven live). The fix, pinned here:
   - em.chain_membership: THE exported membership predicate, built from the display parse's exact
     inputs (resume links + lineage closure + pending cut). "rewind" is the only sweepable verdict;
-    "clear" is /clear jurisdiction, "broken" chains are kept, unknown uuids prove nothing.
+    "clear" is /clear jurisdiction, "broken" chains are kept, "eclipsed" chains are kept (a machine
+    api_error spur's abandonment, T209 — never a user gesture), unknown uuids prove nothing.
   - jd.parsed_session honors the backend's pending cut (leaf_override), so an armed bare rollback
     stops yielding abandoned units at the source.
   - jd.apply_plan_guarded: the write-moment stand-down at every planner mint site — fresh,
@@ -95,6 +96,15 @@ class Base(unittest.TestCase):
         return [uline(T0 + 60, "second ask, rewritten", "u3", "a1"),
                 aline(T0 + 70, "Reply on the new branch, settled.", "a3", "u3")]
 
+    def eclipse_recs(self):
+        """T209's machine geometry: the CLI's buffered api_error spur roots at u2 (the turn's
+        opener) and the next prompt chains onto it, abandoning a2 with no user gesture."""
+        return [{"type": "system", "subtype": "api_error", "timestamp": iso(T0 + 25),
+                 "uuid": "e1", "parentUuid": "u2",
+                 "error": {"message": "429 rate_limit_error (synthetic)"}},
+                uline(T0 + 60, "third synthetic ask", "u3", "e1"),
+                aline(T0 + 70, "Third synthetic reply.", "a3", "u3")]
+
 
 class ChainMembershipPredicate(Base):
     """em.chain_membership — the ONE exported membership fact (identity-key hazards, per verdict)."""
@@ -154,8 +164,57 @@ class ChainMembershipPredicate(Base):
     def test_an_unknown_uuid_is_in_no_set(self):
         self.write(self.base_recs())
         mem = em.chain_membership(self.path)
-        for k in ("kept", "rewind", "clear", "broken"):
+        for k in ("kept", "rewind", "clear", "broken", "eclipsed"):
             self.assertNotIn("orphan:12345", mem[k], "a synthetic salvage id proves nothing")
+
+    def test_an_eclipsed_branch_is_kept_never_rewind(self):
+        # T209: the abandoned reply is the ONLY visible copy — it must classify eclipsed (kept),
+        # and never enter the one sweepable set.
+        self.write(self.base_recs() + self.eclipse_recs())
+        mem = em.chain_membership(self.path)
+        self.assertEqual(mem["eclipsed"], {"a2"}, "the machine-abandoned reply is eclipsed")
+        self.assertIn("a2", mem["kept"], "eclipsed content is kept")
+        self.assertEqual(mem["rewind"], set(), "an eclipse is never sweepable")
+
+    def test_a_tail_spur_is_already_eclipsed_mid_flush(self):
+        # adversarial-review finding on the first cut: with the spur as the transcript's TAIL
+        # (a parse racing the CLI's multi-line flush, or a session dead mid-storm) the probe
+        # exhausted into "rewind" — one-way goal archives in the race window, and the T209 eat
+        # made permanent on the mid-storm death. An api_error on the spine out of the fork is
+        # a machine artifact whatever follows.
+        self.write(self.base_recs() + [
+            {"type": "system", "subtype": "api_error", "timestamp": iso(T0 + 25),
+             "uuid": "e1", "parentUuid": "u2",
+             "error": {"message": "429 rate_limit_error (synthetic)"}}])
+        mem = em.chain_membership(self.path)
+        self.assertEqual(mem["eclipsed"], {"a2"}, "the tail spur already eclipses, never sweeps")
+        self.assertEqual(mem["rewind"], set())
+        self.assert_parity_shape(mem)
+
+    def test_a_cyclic_machine_spine_terminates_and_keeps(self):
+        # adversarial-review finding on the first cut: a multi-node parent CYCLE of system
+        # records (corruption this module's classify already anticipates with its own cycle
+        # branch) closed the spine-child map and the probe looped forever — one corrupt
+        # transcript hung every chat build and judge pass. The guard exits the cycle and the
+        # machine-spine terminal keeps the branch (keep-on-unprovable, the module's bias).
+        # the LEAF sits inside the cycle (cyC is the file's last uuid-bearing record), which
+        # is what closes the spine-child map — a leaf outside it leaves an open chain and only
+        # the exhaustion terminal fires
+        recs = [{"type": "system", "subtype": "api_error", "timestamp": iso(T0 + i),
+                 "uuid": u, "parentUuid": pu,
+                 "error": {"message": "429 rate_limit_error (synthetic)"}}
+                for i, (u, pu) in enumerate([("cyA", "cyC"), ("cyB", "cyA")])]
+        recs.append(uline(T0 + 10, "ask rejoining the cycle", "ux", "cyA"))
+        recs.append({"type": "system", "subtype": "api_error", "timestamp": iso(T0 + 11),
+                     "uuid": "cyC", "parentUuid": "cyB",
+                     "error": {"message": "429 rate_limit_error (synthetic)"}})
+        self.write(recs)
+        mem = em.chain_membership(self.path)          # pre-guard: this call never returned
+        self.assertIn("ux", mem["kept"], "a real ask off a corrupt machine spine is kept")
+
+    def assert_parity_shape(self, mem):
+        """kept == active ∪ broken ∪ eclipsed, from the same verdict sets we were handed."""
+        self.assertTrue(mem["eclipsed"] <= mem["kept"])
 
     def test_a_pending_cut_moves_the_tail_into_rewind(self):
         # the armed bare-rollback window: nothing on disk yet, but the cut is the ground truth
@@ -186,6 +245,14 @@ class PredicateParityGolden(Base):
     def test_parity_on_a_plain_rewind_fork(self):
         self.write(self.base_recs() + self.fork_recs())
         self.assert_parity(self.path)
+
+    def test_parity_on_an_eclipsed_machine_spur(self):
+        # the parity guard bites on the eclipsed geometry too: kept_uuids and
+        # chain_membership["kept"] must include the eclipsed branch IDENTICALLY (T209)
+        self.write(self.base_recs() + self.eclipse_recs())
+        self.assert_parity(self.path)
+        mem = em.chain_membership(self.path)
+        self.assertIn("a2", mem["kept"])
 
     def test_parity_under_a_pending_cut(self):
         self.write(self.base_recs())

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -637,6 +637,36 @@ class TwoPhaseRewindTiming(unittest.TestCase):
         self.assertIsNone(km._rewind_hold_get(SID))
 
 
+class HoldLeafEclipsedFlip(unittest.TestCase):
+    """T209 companion: _hold_leaf_still_active on a leaf a MACHINE api_error spur abandoned.
+    Before the eclipsed verdict, that leaf read "rewind" -> False -> the resolver ARCHIVED the
+    held cards on a machine artifact; now it reads kept -> True -> restore, the direction that
+    never destroys on an event no user made."""
+
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        self._saved_sessions = km._sessions
+
+    def tearDown(self):
+        km._sessions = self._saved_sessions
+
+    def test_an_eclipsed_leaf_reads_still_active(self):
+        p = self.td / (SID + ".jsonl")
+        with open(p, "w") as f:
+            for r in [_rec("user", "u1", None, "first ask"),
+                      _rec("assistant", "a1", "u1", "first reply"),
+                      _rec("user", "u2", "a1", "second ask"),
+                      _rec("assistant", "a2", "u2", "the reply the spur eclipsed"),
+                      _rec("system", "e1", "u2", subtype="api_error",
+                           error={"message": "429 rate_limit_error (synthetic)"}),
+                      _rec("user", "u3", "e1", "third ask"),
+                      _rec("assistant", "a3", "u3", "third reply")]:
+                f.write(json.dumps(r) + "\n")
+        km._sessions = lambda now: [{"sid": SID, "path": str(p)}]
+        self.assertIs(km._hold_leaf_still_active(SID, "a2"), True,
+                      "a machine-eclipsed leaf is live content, not a taken rewind")
+
+
 class RewindKeptLookupEconomy(unittest.TestCase):
     """_rewind_kept_uuids runs on EVERY feed/chat build of a held session, for the whole armed
     window — unbounded on a bare delete. Three properties pinned here: the kept walk memoizes on

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -200,7 +200,11 @@ class PlacementIdentityCanary(unittest.TestCase):
         # every pinned id is UNCHANGED — the bump seals sessions whose machine-cut resumes forked
         # fresh-headed transcripts, whose previously-dropped pre-cut atoms rejoin the set
         # (tests/test_kernel_resume_fork_lineage.py covers the stitch itself).
-        self.assertEqual(jd.PLACEMENTS_V, 9, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=9 — "
+        # v10 (2026-09-01, the eclipsed-branch keep, T209): this fixture carries no api_error spur,
+        # so every pinned id is UNCHANGED — the bump seals transcripts whose retry-storm flush
+        # knocked a turn's output off the spine; those atoms rejoin the set
+        # (tests/test_romp_events_golden.py's eclipsed fixture covers the keep itself).
+        self.assertEqual(jd.PLACEMENTS_V, 10, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=10 — "
                          "re-pin the ids and this version together, in the same commit")
 
 


### PR DESCRIPTION
## What happened (user report, 2026-09-01)

A rendered assistant reply vanished from the chat — replaced by the collapsed "Recovered after retries ×N" line — the moment the user sent their next message. The fold layer and renderers were already exonerated; the parsed events list itself lost the text.

## Root cause (convicted on the live specimen, reproduced synthetically)

During a rate-limit storm the CLI buffers its `api_error` system records and flushes them at the NEXT enqueue, parent-chained off the turn's **opening** user prompt, with the stop hook and the next user prompt chained onto that spur. The turn's real output stays on disk but falls off the leaf→root spine: `chain_verdicts` filed the branch **"rewind"** (user-rollback semantics) and `kept_uuids` dropped every atom of the turn. No `orphanReply` marker exists to salvage it — those are written only for streamed-but-never-kept text, and the disk DID keep this reply — so the only visible copy was eaten. The same misclassification let `_per_file_rewound` count these branches sweepable and made `_hold_leaf_still_active` archive held cards on a machine artifact.

## Fix — fails toward showing

New chain verdict **"eclipsed"**, decided by an exact machine event: ≥1 `api_error` record strictly between the fork and the next conversational record on the spine. A genuine rollback re-parents the user's next prompt directly at the cut (no `api_error` between), so this can never re-show deleted content — the 2026-08-03 ghost-bubble direction stays covered — and a spine that re-replied stays "rewind" so a retry never doubles. Eclipsed chains join `kept_uuids` and `chain_membership["kept"]` (plus the new dict key), so the chat build, judges, mint stand-down, sweeps, and hold resolver all inherit the keep from the one shared predicate. `PLACEMENTS_V` 9→10 per the deploy rule (the keep grows the atom set of existing transcripts with this geometry).

Two first-cut defects found by adversarial review are fixed here with red-first repros: a visited-set guard on the fork probe (a multi-node parent cycle of system records hung every parse — reproduced at exit 124), and the probe's exhaustion terminal now eclipses instead of defaulting to the sweepable verdict when the spur is the transcript's tail (mid-flush race / mid-storm death).

## Tests (red-first, all synthetic)

- Golden scenarios `eclipsed_branch_kept` + `retry_superseded` with unit pins both directions (`tests/test_event_model_golden.py`); existing goldens byte-identical.
- `chain_membership` eclipsed classification, never-sweepable, kept-parity, tail-spur, and cycle-termination cases (`tests/test_judge_rewind_cleanup.py`).
- The `_hold_leaf_still_active` flip (`tests/test_kernel_rewind.py`); placements canary re-pinned at v10 (fixture ids unchanged).
- Served-page proof: before — the turn renders as just the retry note; after — the full turn is back with the note interleaved at its true time.

Suites: pytest 6272 passed + 321 subtests, 34 skipped; npm 2628 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)