### PR TITLE
A garbled timestamp borrows its neighbor's, and the parse counters ride /version

### DIFF
--- a/cli/version.py
+++ b/cli/version.py
@@ -77,15 +77,18 @@ def report():
                      % (k.get("kernel_sha") or "?", k.get("pid"), up // 60, up % 60,
                         k.get("dist_ver"), k.get("url")))
         pa = k.get("parse") or {}
-        if pa.get("fold", 0) + pa.get("full", 0) > 0:
-            # the assembly cache's live hit rate — the deploy-verification number (T210)
-            rate = 100.0 * pa["fold"] / (pa["fold"] + pa["full"])
+        if pa.get("fold", 0) + pa.get("full", 0) + pa.get("fallback", 0) > 0:
+            # the assembly cache's live hit rate — the deploy-verification number (T210). The
+            # fallback term keeps an all-fallback kernel VISIBLE: _asm_full counts "full" as its
+            # last act, so a kernel whose every parse errors into fallback has fold+full == 0.
+            rate = 100.0 * pa.get("fold", 0) / max(1, pa.get("fold", 0) + pa.get("full", 0))
             gates = ", ".join("%s %d" % (g[2:], n) for g, n in sorted(pa.items())
                               if g.startswith("g:") and n)
-            lines.append("parse    fold %.0f%% (%d fold / %d full / %d served)%s%s"
-                         % (rate, pa["fold"], pa["full"], pa.get("serve", 0),
+            lines.append("parse    fold %.0f%% (%d fold / %d full / %d served)%s%s%s"
+                         % (rate, pa.get("fold", 0), pa.get("full", 0), pa.get("serve", 0),
                             "  fallbacks=%d" % pa["fallback"] if pa.get("fallback") else "",
-                            ("  demotes: " + gates) if gates else ""))
+                            ("  demotes: " + gates) if gates else "",
+                            "  ts-repair=%d" % pa["ts-repair"] if pa.get("ts-repair") else ""))
     elif kind == "stale":
         lines.append("kernel   running at %s but predates /version — `romp refresh` to populate" % k)
     else:

--- a/cli/version.py
+++ b/cli/version.py
@@ -76,6 +76,16 @@ def report():
         lines.append("kernel   sha=%s pid=%s up=%dm%02ds dist_ver=%s  (%s)"
                      % (k.get("kernel_sha") or "?", k.get("pid"), up // 60, up % 60,
                         k.get("dist_ver"), k.get("url")))
+        pa = k.get("parse") or {}
+        if pa.get("fold", 0) + pa.get("full", 0) > 0:
+            # the assembly cache's live hit rate — the deploy-verification number (T210)
+            rate = 100.0 * pa["fold"] / (pa["fold"] + pa["full"])
+            gates = ", ".join("%s %d" % (g[2:], n) for g, n in sorted(pa.items())
+                              if g.startswith("g:") and n)
+            lines.append("parse    fold %.0f%% (%d fold / %d full / %d served)%s%s"
+                         % (rate, pa["fold"], pa["full"], pa.get("serve", 0),
+                            "  fallbacks=%d" % pa["fallback"] if pa.get("fallback") else "",
+                            ("  demotes: " + gates) if gates else ""))
     elif kind == "stale":
         lines.append("kernel   running at %s but predates /version — `romp refresh` to populate" % k)
     else:

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -685,8 +685,7 @@ def _emit_state():
 def _chrono(ad, uuids):
     """`uuids` in the emit layer's canonical order — ascending (timestamp, read order), exactly
     the key the replay pre-pass has always walked in."""
-    return sorted(uuids, key=lambda x: (parse_z((ad.by_uuid.get(x) or {}).get("timestamp")) or 0,
-                                        ad.seq_of.get(x, 0)))
+    return sorted(uuids, key=lambda x: (ad.ts_of.get(x) or 0, ad.seq_of.get(x, 0)))
 
 
 class FileAdapter:
@@ -709,6 +708,15 @@ class FileAdapter:
                                  #   text (full prompt, markers intact), seq}
         self.leaf_uuid = None
         self._seq = 0            # global read-order counter — continued by assembly folds
+        self.ts_of = {}          # uuid -> repaired epoch seconds — THE timestamp every consumer
+        #                          reads (_chrono, the emit, the boundary splice). A record whose
+        #                          stamp does not parse borrows the last good stamp seen in file
+        #                          order (its real neighbor): the atom stays VISIBLE at a truthful
+        #                          adjacent time instead of t=None TypeError-ing segment_turns'
+        #                          sort and taking the whole session view down (T210). Fold-safe
+        #                          with no carry: _ingest is the one shared path and re-ingestion
+        #                          replays the same order, so fold and full repair identically.
+        self._last_ts = 0        # the borrow source — last parseable stamp ingested
         # Graph-level facts the assembly fast-path gates read, collected at INGEST so they cover
         # the whole graph (kept or not): every user record's promptId (a delta record repeating
         # one forces a full parse — command twins/episodes key on it), every assistant Skill
@@ -757,6 +765,18 @@ class FileAdapter:
                 self.by_uuid[u] = r
                 self.fsid_of[u] = fsid
                 self.seq_of[u] = seq
+                ts = parse_z(r.get("timestamp"))
+                if ts is None:
+                    ts = self._last_ts
+                    _ASM_STATS["ts-repair"] = _ASM_STATS.get("ts-repair", 0) + 1
+                    if fsid not in _TS_REPAIR_NOTED and len(_TS_REPAIR_NOTED) < 64:
+                        _TS_REPAIR_NOTED.add(fsid)
+                        print("romp event-model: unparseable timestamp on record %s in %s.jsonl — "
+                              "shown at the previous record's time (ts-repair in parse stats)"
+                              % (u, fsid), file=sys.stderr)
+                else:
+                    self._last_ts = ts
+                self.ts_of[u] = ts
                 # parentUuid normally; compact_boundary carries parentUuid:null +
                 # logicalParentUuid:<pre-compaction leaf> — follow that so the active
                 # path survives compaction instead of orphaning every pre-compaction turn.
@@ -1360,7 +1380,7 @@ class FileAdapter:
             if not r:
                 continue
             t = r.get("type")
-            ts = parse_z(r.get("timestamp"))
+            ts = self.ts_of.get(u, 0)   # repaired at ingest — never None (T210)
             fsid = self.fsid_of.get(u)
             seq = self.seq_of.get(u, 0)
             if t == "assistant":
@@ -1493,7 +1513,7 @@ class FileAdapter:
                     # and the stdout atom would then fold into the boundary's fresh turn as
                     # "assistant work", minting a phantom WORK unit (2026-08-19). Sort it right
                     # after the stdout instead: the moment the compaction visibly completed.
-                    spt = parse_z((self.by_uuid.get(sp) or {}).get("timestamp"))
+                    spt = self.ts_of.get(sp)
                     if spt is not None and (ts is None or spt > ts):
                         ts = spt
                     seq = self.seq_of.get(sp, seq) + 0.5
@@ -2003,6 +2023,7 @@ _ASM_KEYLOCKS = {}                 # key -> Lock; never pruned (a Lock is tiny, 
 #                                    key's lock mid-flight would let two folds interleave)
 _ASM_STATS = {"full": 0, "fold": 0, "serve": 0, "bypass": 0, "fallback": 0}   # observability + tests
 _ASM_WARNED = [False]
+_TS_REPAIR_NOTED = set()   # file stems already warned about a garbled stamp — once per file, capped
 
 
 def _asm_demote(reason):

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -768,8 +768,17 @@ class FileAdapter:
                 ts = parse_z(r.get("timestamp"))
                 if ts is None:
                     ts = self._last_ts
-                    _ASM_STATS["ts-repair"] = _ASM_STATS.get("ts-repair", 0) + 1
-                    if fsid not in _TS_REPAIR_NOTED and len(_TS_REPAIR_NOTED) < 64:
+                    if u not in _TS_REPAIRED_SEEN:   # count DISTINCT corrupt records — a full
+                        #                              parse re-ingests every line, and a stable
+                        #                              corrupt one must not inflate per parse
+                        if len(_TS_REPAIRED_SEEN) >= 4096:
+                            _TS_REPAIRED_SEEN.clear()
+                        _TS_REPAIRED_SEEN.add(u)
+                        _ASM_STATS["ts-repair"] = _ASM_STATS.get("ts-repair", 0) + 1
+                    if fsid not in _TS_REPAIR_NOTED:
+                        if len(_TS_REPAIR_NOTED) >= 64:
+                            _TS_REPAIR_NOTED.clear()   # re-arm — capped silence must not become
+                            #                            permanent silence for every NEW file
                         _TS_REPAIR_NOTED.add(fsid)
                         print("romp event-model: unparseable timestamp on record %s in %s.jsonl — "
                               "shown at the previous record's time (ts-repair in parse stats)"
@@ -809,7 +818,9 @@ class FileAdapter:
                     # path) — extract the TEXT either way; str() of a list keyed the Python repr,
                     # which no enqueue content ever matches (the user 2026-07-06)
                     ptext = a["prompt"] if isinstance(a["prompt"], str) else _text_of(a["prompt"])
-                    self.qatts.append({"uuid": u, "ts": parse_z(r.get("timestamp")),
+                    # the repaired stamp when the record is uuid-bearing (real CLI splices are):
+                    # raw-None dropped the user's typed prompt from the chat (T210 review)
+                    self.qatts.append({"uuid": u, "ts": self.ts_of.get(u, parse_z(r.get("timestamp"))),
                                        "text": ptext, "seq": seq})
         self._seq = seq
         self.dangling -= self.by_uuid.keys()   # a target that landed later in the read is not dangling
@@ -1312,7 +1323,7 @@ class FileAdapter:
                     # timestamp, so this chronological walk meets it right beside the original — before
                     # the boundary that produced it — and gating on _compacted would never fire. It is
                     # the same record either way. Only the restore-burst case is compaction-scoped.
-                    key = (int(parse_z(r.get("timestamp")) or 0), txt)
+                    key = (int(self.ts_of.get(u) or 0), txt)
                     if key in _seen_exact or (_compacted and _restoring and txt in _seen_text):
                         replay_uuids.add(u)
                     else:
@@ -1322,13 +1333,16 @@ class FileAdapter:
         # The chronological watermark the assembly fold's monotonic gate compares appended records
         # against: a delta that sorts at-or-after everything already folded is the invariant that
         # makes carrying the sets above across folds valid at all. `order` is ascending by
-        # (parse_z or 0, seq), so the LAST pre-pass-relevant record carries the max — one lookup,
-        # not a second parse_z sweep of the whole session (that re-walk measured 33ms at 30k).
+        # (ts_of, seq), so the LAST pre-pass-relevant record carries the max — one lookup, not a
+        # second sweep of the whole session (that re-walk measured 33ms at 30k). MUST read the
+        # repaired ts_of, the exact key the sort used: reading the raw stamp here let a garbled
+        # TAIL record (which borrows the max stamp and sorts last) zero the watermark and disarm
+        # the g:ts gate — a reproduced fold!=full divergence (T210 review).
         for u in reversed(order):
             r = self.by_uuid.get(u) or {}
             if r.get("type") in ("user", "assistant") or (
                     r.get("type") == "system" and r.get("subtype") == "compact_boundary"):
-                ts = parse_z(r.get("timestamp"))
+                ts = self.ts_of.get(u)
                 if ts and ts > st["max_ppt"]:
                     st["max_ppt"] = ts
                 break
@@ -2023,7 +2037,10 @@ _ASM_KEYLOCKS = {}                 # key -> Lock; never pruned (a Lock is tiny, 
 #                                    key's lock mid-flight would let two folds interleave)
 _ASM_STATS = {"full": 0, "fold": 0, "serve": 0, "bypass": 0, "fallback": 0}   # observability + tests
 _ASM_WARNED = [False]
-_TS_REPAIR_NOTED = set()   # file stems already warned about a garbled stamp — once per file, capped
+_TS_REPAIR_NOTED = set()     # file stems already warned about a garbled stamp — once per file;
+#                              the cap CLEARS and re-arms (an occasional repeat note beats silence)
+_TS_REPAIRED_SEEN = set()    # record uuids already counted in ts-repair — distinct corruption,
+#                              not parse volume; races only overcount by one, acceptable
 
 
 def _asm_demote(reason):
@@ -2251,7 +2268,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
         ad.sdk_human = sdk_human
         cut_t = None
         if leaf_override in ad.by_uuid:
-            cut_t = parse_z(ad.by_uuid[leaf_override].get("timestamp"))
+            cut_t = ad.ts_of.get(leaf_override)
         return ad.atoms(rompuuid, postal_index), ad.landed_text_uuids(), cut_t
     key = (os.path.realpath(str(leaf_path)), str(rompuuid), bool(sdk_human))
     try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -528,6 +528,13 @@ def _version_info():
     return {"kernel_sha": _kernel_sha(), "kernel_ver": _kernel_ver(), "pid": os.getpid(), "started": int(_STARTED),
             "boot": _BOOT_ID,   # lets a page retire update offers from a previous kernel life (2026-08-15)
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
+            # THIS kernel process's transcript-assembly counters (event_model._ASM_STATS: full/fold/
+            # serve/bypass/fallback + per-gate g:<reason> demotes + ts-repair) — the designed home for
+            # runtime observability: /healthz's body is a frozen liveness contract ("ok"), while this
+            # route already reports process runtime (pid/uptime) and `romp version` reads it. Bare
+            # counters, no paths — safe for the auth-exempt route. Deploy verification reads the live
+            # fold rate here instead of trusting an offline replay number (T210).
+            "parse": dict(em._ASM_STATS),
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
             "conserveMemory": _conserve_on(),   # the T148 toggle: close idle tab-less claude processes
             "login": _login_state(),         # the in-dashboard login flow's state/url/err (T157) — never a secret

--- a/tests/test_event_model_assembly.py
+++ b/tests/test_event_model_assembly.py
@@ -110,6 +110,123 @@ class Replay(unittest.TestCase):
                                "multi-file sessions silently demote to permanent full parses")
 
 
+class GarbledTimestamps(unittest.TestCase):
+    """A malformed record must never eclipse the rest of the session (T210): a kept record whose
+    timestamp does not parse used to reach segment_turns' (t, _seq) sort as t=None and TypeError
+    the WHOLE parse — one corrupt line took down the session view for chat and judges alike. The
+    fix fails toward SHOWING: ingest borrows the last good stamp seen in file order (the record's
+    real neighbor), so the atom stays visible at a truthful adjacent time, counted and noted
+    loudly. Skipping it instead would silently drop a possibly-real ask — the one fatal error."""
+    maxDiff = None
+
+    def _parse_both(self, path, kw):
+        inc = emi.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+        emr._ASM_CACHE.clear()
+        ref = emr.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+        self.assertEqual(_tree(ref), _tree(inc))
+        return inc
+
+    def _write(self, path, records):
+        with open(path, "a") as fh:
+            for r in records:
+                fh.write(json.dumps(r) + "\n")
+
+    def test_garbled_timestamp_never_takes_the_session_down(self):
+        # the dispatch's two-record repro: second record's stamp is garbage — parse_session used
+        # to TypeError in segment_turns' sort and the whole session view went down with it
+        bad = G.aline(T0 + 10, "the reply the user must still see", "a1", "u1")
+        bad["timestamp"] = "not-a-timestamp"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            self._write(path, [G.uline(T0, "hello", "u1"), bad])
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            ses = self._parse_both(path, kw)
+            atoms = [a for t in ses["turns"] for a in t["atoms"]]
+            self.assertIn("a1", [a.get("uuid") for a in atoms],
+                          "the garbled-stamp record was dropped — it must stay visible")
+            a1 = next(a for a in atoms if a.get("uuid") == "a1")
+            self.assertEqual(a1["t"], T0, "the borrow is the last good stamp in file order")
+
+    def test_garbled_first_record_still_shows(self):
+        bad = G.uline(T0, "opening ask", "u1")
+        bad["timestamp"] = "garbage"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            self._write(path, [bad, G.aline(T0 + 10, "answer", "a1", "u1")])
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            ses = self._parse_both(path, kw)
+            atoms = [a for t in ses["turns"] for a in t["atoms"]]
+            self.assertIn("u1", [a.get("uuid") for a in atoms])
+            u1 = next(a for a in atoms if a.get("uuid") == "u1")
+            self.assertEqual(u1["t"], 0, "no good stamp yet -> epoch zero, deterministically")
+
+    def test_garbled_assistant_append_demotes_and_survives(self):
+        # a garbled user/assistant stamp in the DELTA trips the existing ts gate (fold refuses,
+        # full parse serves) — and the full parse must now survive it
+        bad = G.aline(T0 + 20, "late reply", "a2", "a1")
+        bad["timestamp"] = "###"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            self._write(path, [G.uline(T0, "hi", "u1"), G.aline(T0 + 10, "ok", "a1", "u1")])
+            self._parse_both(path, kw)
+            g0 = emi._ASM_STATS.get("g:ts", 0)
+            self._write(path, [bad])
+            ses = self._parse_both(path, kw)
+            self.assertEqual(emi._ASM_STATS.get("g:ts", 0), g0 + 1,
+                             "a garbled delta stamp folds only the full emit can place — demote")
+            atoms = [a for t in ses["turns"] for a in t["atoms"]]
+            self.assertIn("a2", [a.get("uuid") for a in atoms])
+
+    def test_garbled_system_record_folds_equivalently(self):
+        # a system record (no ts gate) with a garbled stamp FOLDS — the ingest repair must give
+        # fold and full parse the same borrowed time, or they diverge
+        refusal = {"type": "system", "subtype": "model_refusal_fallback", "uuid": "s1",
+                   "parentUuid": "a1", "timestamp": "junk", "content": "swapped models",
+                   "originalModel": "m-one", "fallbackModel": "m-two"}
+        tail = G.aline(T0 + 30, "from the fallback model", "a2", "s1")
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            self._write(path, [G.uline(T0, "hi", "u1"), G.aline(T0 + 10, "ok", "a1", "u1")])
+            self._parse_both(path, kw)
+            f0 = emi._ASM_STATS["fold"]
+            self._write(path, [refusal, tail])
+            ses = self._parse_both(path, kw)
+            self.assertEqual(emi._ASM_STATS["fold"], f0 + 1,
+                             "the garbled system record must fold, not silently demote")
+            atoms = [a for t in ses["turns"] for a in t["atoms"]]
+            s1 = next(a for a in atoms if a.get("uuid") == "s1")
+            self.assertEqual(s1["t"], T0 + 10, "borrowed from its file neighbor, both paths")
+
+    def test_ts_repair_is_counted_and_noted_loudly(self):
+        import io, contextlib
+        bad = G.aline(T0 + 10, "reply", "a1", "u1")
+        bad["timestamp"] = "zzz"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            self._write(path, [G.uline(T0, "hello", "u1"), bad, G.uline(T0 + 20, "more", "u2", "a1")])
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            c0 = emr._ASM_STATS.get("ts-repair", 0)
+            emr._TS_REPAIR_NOTED.clear()
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                emr._ASM_CACHE.clear()
+                emr.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+            self.assertGreater(emr._ASM_STATS.get("ts-repair", 0), c0, "repairs ride the stats")
+            self.assertIn("timestamp", err.getvalue(), "the repair is loud, never silent")
+            err2 = io.StringIO()
+            with contextlib.redirect_stderr(err2):
+                emr._ASM_CACHE.clear()
+                emr.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+            self.assertEqual(err2.getvalue(), "", "the note fires once per file, not per parse")
+
+
 class GateDemotions(unittest.TestCase):
     """Each fast-path gate, tripped on purpose: equivalence must hold BY DEMOTION."""
     maxDiff = None

--- a/tests/test_event_model_assembly.py
+++ b/tests/test_event_model_assembly.py
@@ -41,6 +41,10 @@ SID, NOW, T0 = G.SID, G.NOW, G.T0
 iso = G.iso
 
 
+def _text_of(blocks):
+    return " ".join(b.get("text", "") for b in blocks if isinstance(b, dict))
+
+
 def _tree(x):
     return json.loads(json.dumps(x, sort_keys=True))
 
@@ -203,6 +207,110 @@ class GarbledTimestamps(unittest.TestCase):
             s1 = next(a for a in atoms if a.get("uuid") == "s1")
             self.assertEqual(s1["t"], T0 + 10, "borrowed from its file neighbor, both paths")
 
+    def test_garbled_tail_never_zeroes_the_watermark(self):
+        # review-reproduced divergence (T210): the prepass watermark read the RAW stamp of the
+        # chronologically-last record — a garbled tail (which borrows the max stamp and sorts
+        # last) zeroed max_ppt, disarmed the g:ts gate, and a timestamp-regressed append FOLDED
+        # into carried state a fresh full parse disagrees with. The watermark must read ts_of.
+        bad = G.aline(T0 + 20, "tail with a rotten stamp", "aX", "a1")
+        bad["timestamp"] = "rotten"
+        regressed = G.uline(T0 + 5, "arrives stamped BEFORE the fold watermark", "u2", "aX")
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            self._write(path, [G.uline(T0, "hi", "u1"), G.aline(T0 + 10, "ok", "a1", "u1"), bad])
+            self._parse_both(path, kw)
+            g0 = emi._ASM_STATS.get("g:ts", 0)
+            self._write(path, [regressed])
+            self._parse_both(path, kw)
+            self.assertEqual(emi._ASM_STATS.get("g:ts", 0), g0 + 1,
+                             "a regressed append after a garbled tail must DEMOTE — folding it "
+                             "diverges (the watermark was zeroed by the raw-stamp read)")
+
+    def test_garbled_spliced_prompt_still_shows(self):
+        # a queued_command attachment is the WITNESS for a prompt the user actually typed
+        # mid-turn: dropping it on a garbled stamp is the exact silent loss this repo calls
+        # fatal — it must ride the repaired stamp like every other record (T210 review)
+        att = G.attline(T0 + 15, "the mid-turn ask that must not vanish", "q1", "a1")
+        att["timestamp"] = "mangled"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            self._write(path, [G.uline(T0, "start", "u1"),
+                               G.aline(T0 + 10, "working", "a1", "u1", tools=("Bash",), stop="tool_use"),
+                               att,
+                               G.trline(T0 + 20, "tu_a1_0", "u2", "q1"),
+                               G.aline(T0 + 30, "done", "a2", "u2")])
+            ses = self._parse_both(path, kw)
+            texts = [(_text_of(a["message"]["content"]) if a.get("message") else "")
+                     for t in ses["turns"] for a in t["atoms"]]
+            self.assertTrue(any("must not vanish" in x for x in texts),
+                            "the spliced prompt was dropped on its garbled stamp")
+            atoms = [a for t in ses["turns"] for a in t["atoms"]]
+            spliced = next(a for a in atoms if a.get("absorbed"))
+            self.assertEqual(spliced["t"], T0 + 10, "borrowed from its file neighbor")
+
+    def test_garbled_cut_record_still_trims_orphans(self):
+        # the pending-cut orphan filter read the cut record's RAW stamp: garbled -> None ->
+        # filter skipped -> the deleted prompt's salvaged reply stood alone in the chat (the
+        # half-worked-delete shape). The filter must read the repaired stamp (T210 review).
+        cut = G.aline(T0 + 10, "the reply being rolled back", "a1", "u1")
+        cut["timestamp"] = "shredded"
+        rows = [{"t": T0 + 30, "orphanReply": {"uuid": "zz9", "text": "landed after the cut",
+                                               "ts": iso(T0 + 30)}}]
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            self._write(path, [G.uline(T0, "hello", "u1"), cut,
+                               G.uline(T0 + 20, "next", "u2", "a1")])
+            kw = {"candidate_files": [str(path)], "states": rows, "postal_log": [], "now": NOW,
+                  "leaf_override": "a1"}
+            ses = self._parse_both(path, kw)
+            atoms = [a for t in ses["turns"] for a in t["atoms"]]
+            self.assertNotIn("zz9", [a.get("uuid") for a in atoms],
+                             "an orphan landing AFTER the cut must be trimmed — the garbled cut "
+                             "stamp disarmed the filter")
+
+    def test_ts_repair_counts_distinct_records_not_parses(self):
+        # a stable corrupt line must not inflate the counter on every full parse — it counts
+        # CORRUPTION, not parse volume (T210 review)
+        bad = G.aline(T0 + 10, "reply", "a1", "u1")
+        bad["timestamp"] = "xxx"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            self._write(path, [G.uline(T0, "hello", "u1"), bad])
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            emr._ASM_CACHE.clear()
+            emr.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+            c1 = emr._ASM_STATS.get("ts-repair", 0)
+            emr._ASM_CACHE.clear()
+            emr.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+            self.assertEqual(emr._ASM_STATS.get("ts-repair", 0), c1,
+                             "the second full parse re-ingested the same corrupt line and "
+                             "counted it again")
+
+    def test_note_cap_rearms_instead_of_going_silent(self):
+        import io, contextlib
+        bad = G.uline(T0, "ask", "u1")
+        bad["timestamp"] = "bad"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("")
+            self._write(path, [bad, G.aline(T0 + 10, "answer", "a1", "u1")])
+            kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
+            emr._TS_REPAIR_NOTED.clear()
+            emr._TS_REPAIR_NOTED.update("stem%d" % i for i in range(64))   # cap reached
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                emr._ASM_CACHE.clear()
+                emr.parse_session(str(path), rompuuid=SID, name="impl", dir="/TESTDIR", **kw)
+            self.assertIn("timestamp", err.getvalue(),
+                          "a full cap silenced every NEW file forever — it must re-arm")
+            emr._TS_REPAIR_NOTED.clear()
+
     def test_ts_repair_is_counted_and_noted_loudly(self):
         import io, contextlib
         bad = G.aline(T0 + 10, "reply", "a1", "u1")
@@ -214,6 +322,7 @@ class GarbledTimestamps(unittest.TestCase):
             kw = {"candidate_files": [str(path)], "states": None, "postal_log": [], "now": NOW}
             c0 = emr._ASM_STATS.get("ts-repair", 0)
             emr._TS_REPAIR_NOTED.clear()
+            emr._TS_REPAIRED_SEEN.clear()   # distinct-record counting — this file's uuids again
             err = io.StringIO()
             with contextlib.redirect_stderr(err):
                 emr._ASM_CACHE.clear()

--- a/tests/test_fleet_sync_log.py
+++ b/tests/test_fleet_sync_log.py
@@ -109,6 +109,22 @@ class VersionTag(unittest.TestCase):
     def test_the_version_route_publishes_it(self):
         self.assertIn("kernel_ver", km._version_info())
 
+    def test_the_version_route_publishes_parse_stats(self):
+        # the assembly cache's counters ride /version (T210): /healthz's body is a frozen
+        # liveness contract, so this is the designed runtime-observability home — deploy
+        # verification reads the live fold rate here
+        v = km._version_info()
+        self.assertIn("parse", v)
+        for key in ("full", "fold", "serve", "bypass", "fallback"):
+            self.assertIsInstance(v["parse"].get(key), int)
+        before = km.em._ASM_STATS["fold"]
+        km.em._ASM_STATS["fold"] = before + 7
+        try:
+            self.assertEqual(km._version_info()["parse"]["fold"], before + 7,
+                             "the payload reads the LIVE counters, not a boot-time copy")
+        finally:
+            km.em._ASM_STATS["fold"] = before
+
     def test_a_remote_poll_carries_the_tag_alongside_the_sha(self):
         src = inspect.getsource(km._poll_remote_version)
         self.assertIn('"ver": str(j.get("kernel_ver") or "")', src)

--- a/tests/test_romp_version.py
+++ b/tests/test_romp_version.py
@@ -27,6 +27,34 @@ def test_report_flags_stale_served_bundle(monkeypatch=None):
     assert "feed.js" in out and "romp refresh" in out    # stale flag present on the newer-on-disk bundle
 
 
+def test_report_shows_the_live_fold_rate():
+    ver._git_sha = lambda: "abc1234"
+    ver._disk_bundles = lambda: {}
+    ver._probe_kernel = lambda: ("version", {"kernel_sha": "abc1234", "pid": 9, "uptime_s": 65,
+                                             "dist_ver": 100, "url": "http://127.0.0.1:29855",
+                                             "bundles": {},
+                                             "parse": {"full": 129, "fold": 2078, "serve": 446,
+                                                       "bypass": 0, "fallback": 0,
+                                                       "g:boundary": 5, "g:ts": 1}})
+    out = ver.report()
+    assert "fold 94%" in out                      # 2078 / (2078+129)
+    assert "2078 fold / 129 full / 446 served" in out
+    assert "boundary 5" in out and "ts 1" in out  # per-gate demotes, named
+    assert "fallbacks" not in out                 # zero fallbacks stay quiet
+
+
+def test_report_stays_quiet_before_any_parse():
+    ver._git_sha = lambda: "abc1234"
+    ver._disk_bundles = lambda: {}
+    ver._probe_kernel = lambda: ("version", {"kernel_sha": "abc1234", "pid": 9, "uptime_s": 5,
+                                             "dist_ver": 100, "url": "http://127.0.0.1:29855",
+                                             "bundles": {},
+                                             "parse": {"full": 0, "fold": 0, "serve": 0,
+                                                       "bypass": 0, "fallback": 0}})
+    out = ver.report()
+    assert "parse" not in out                     # a 0/0 rate is noise, not a report
+
+
 def test_report_handles_down_kernel():
     ver._git_sha = lambda: "abc1234"
     ver._disk_bundles = lambda: {"feed.js": 200}

--- a/tests/test_romp_version.py
+++ b/tests/test_romp_version.py
@@ -43,6 +43,34 @@ def test_report_shows_the_live_fold_rate():
     assert "fallbacks" not in out                 # zero fallbacks stay quiet
 
 
+def test_report_shows_an_all_fallback_kernel():
+    # _asm_full counts "full" as its LAST act — a kernel whose every parse errors into the
+    # fallback has fold+full == 0 but the loudest possible story; it must render (T210 review)
+    ver._git_sha = lambda: "abc1234"
+    ver._disk_bundles = lambda: {}
+    ver._probe_kernel = lambda: ("version", {"kernel_sha": "abc1234", "pid": 9, "uptime_s": 65,
+                                             "dist_ver": 100, "url": "http://127.0.0.1:29855",
+                                             "bundles": {},
+                                             "parse": {"full": 0, "fold": 0, "serve": 0,
+                                                       "bypass": 0, "fallback": 3}})
+    out = ver.report()
+    assert "fallbacks=3" in out
+
+
+def test_report_shows_ts_repair_when_present():
+    # the stderr repair note points at "parse stats" — the stats line must actually show it
+    ver._git_sha = lambda: "abc1234"
+    ver._disk_bundles = lambda: {}
+    ver._probe_kernel = lambda: ("version", {"kernel_sha": "abc1234", "pid": 9, "uptime_s": 65,
+                                             "dist_ver": 100, "url": "http://127.0.0.1:29855",
+                                             "bundles": {},
+                                             "parse": {"full": 4, "fold": 96, "serve": 10,
+                                                       "bypass": 0, "fallback": 0,
+                                                       "ts-repair": 2}})
+    out = ver.report()
+    assert "ts-repair=2" in out
+
+
 def test_report_stays_quiet_before_any_parse():
     ver._git_sha = lambda: "abc1234"
     ver._disk_bundles = lambda: {}


### PR DESCRIPTION
## What

Two byproducts of the incremental-parse work (T210), one small round.

**The crash**: a kept record whose timestamp doesn't parse reached `segment_turns`' `(t, _seq)` sort as `t=None` and TypeError'd the whole parse — one corrupt line took the session view down for the chat build and every judge. The fix fails toward showing: `_ingest` (the one path full parse and assembly fold share) repairs the stamp at its single derivation point, borrowing the last good timestamp in file order (the record's real neighbor). The atom stays visible at a truthful adjacent time; skipping it would silently drop a possibly-real ask. Every timestamp consumer reads the repaired map (`ts_of`): the chrono sort, the emit, the boundary splice, the prepass watermark, the replay-dedup key, the queued_command splice witness, and the pending-cut orphan filter. Counted (`ts-repair`, distinct corrupt records, not parse volume) and noted on stderr once per file (cap re-arms, never permanent silence).

**The surface**: `_ASM_STATS` (fold/full/serve/bypass/fallback + per-gate demotes + ts-repair) now rides `/version` — the designed runtime-observability home after a route read: `/healthz`'s body is a frozen liveness contract, `/busy` is single-purpose, and `/version` already reports process runtime and is what `romp version` reads. Bare counters, no paths, so the auth-exempt leverage rule holds. `romp version` prints one line: fold rate, volume counters, fallbacks only when nonzero (including the all-fallback kernel whose fold+full is 0 — previously the loudest story was the hidden one), per-gate demotes by name, ts-repair when present. Deploy verification now reads the live prod fold rate instead of trusting the offline replay number.

## Evidence

- Red-first throughout: the dispatch's two-record repro TypeError'd on main; 10 pins in `tests/test_event_model_assembly.py` (crash, first-record, demote-and-survive, system-record fold equivalence, spliced-prompt, cut-filter, watermark, counter/note semantics), 4 rendering pins in `tests/test_romp_version.py`, live-counter pin in `tests/test_fleet_sync_log.py`.
- An adversarial review round (4 lenses, 15 findings, 12 verified real after refutation attempts) caught five raw-`parse_z` stragglers behind the repair — one a **reproduced fold≠full divergence** (garbled tail zeroes the prepass watermark and disarms the g:ts gate) — all fixed and pinned in the third commit.
- Deliberate non-fix, pinned as intended: a garbled *first* record borrows epoch zero (whole-file-corrupt degenerate; a forward borrow would need fold-unsafe back-fill).

Suites: 6313 passed + 34 skipped (pytest), vscode-extension npm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)