### PR TITLE
The /compact suggestion is a real settings checkbox beside Auto Nudge

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -536,6 +536,7 @@ def _version_info():
             # fold rate here instead of trusting an offline replay number (T210).
             "parse": dict(em._ASM_STATS),
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
+            "compactSuggest": _compact_suggest_on(),   # T208+: its gear checkbox rides the same read
             "conserveMemory": _conserve_on(),   # the T148 toggle: close idle tab-less claude processes
             "login": _login_state(),         # the in-dashboard login flow's state/url/err (T157) — never a secret
             "acctLabel": _claude_account_label(),   # which login this box holds ("" = none) — the gear's Billing row
@@ -4273,7 +4274,18 @@ def _compact_suggest_tick(sid, tm, now):
         #                                                counter has fallen back below was reset by
         #                                                the session's own compact//clear — that
         #                                                episode is over (the amendment's middle path)
-        due = [t for t in COMPACT_SUGGEST_TOKENS if tokens >= t and t not in live]
+        _cfg = d.get("compactSuggestTokens")
+        thresholds = (tuple(sorted(int(x) for x in _cfg))
+                      if isinstance(_cfg, list) and _cfg
+                      and all(isinstance(x, (int, float)) and x > 0 for x in _cfg)
+                      else COMPACT_SUGGEST_TOKENS)    # "how to do it exactly" is config too (the
+        #                                               user 2026-09-01): optional per-install keys
+        #                                               beside the toggle, the shipped constants as
+        #                                               the defaults; junk shapes fall to defaults
+        _ci = d.get("compactSuggestIdleS")
+        idle_s = (int(_ci) if isinstance(_ci, (int, float)) and _ci > 0
+                  else COMPACT_SUGGEST_IDLE_S)
+        due = [t for t in thresholds if tokens >= t and t not in live]
         if not due:
             if live != latched:                        # nothing to fire, but persist the pruning so
                 cs = dict(d.get("compactSuggested") or {})   # a restart can't resurrect a spent latch
@@ -4295,7 +4307,7 @@ def _compact_suggest_tick(sid, tm, now):
     if (tm or {}).get("state", "") in _PROGRESSING_STATES:
         return False                                   # mid-turn — not idle, and never interrupt
     _st = _settle_event_key(sid)
-    if not _st or now - _st < COMPACT_SUGGEST_IDLE_S:
+    if not _st or now - _st < idle_s:
         return False                                   # not settled long enough — the crossing stays
     #                                                    armed; a later tick re-checks the same gate
     try:

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -184,6 +184,32 @@ class CompactSuggest(unittest.TestCase):
         km._autonudge_cache.clear()
         self.assertTrue(self._tick(450_000), "the same crossing fires once opted in")
 
+    # ── the per-install config keys: "how to do it exactly" is config too ──
+    def test_custom_thresholds_replace_the_defaults(self):
+        d = dict(km._auto_nudge_data())
+        d["compactSuggestTokens"] = [100_000, 200_000]
+        km._write_auto_nudge(d)
+        km._autonudge_cache.clear()
+        self.assertTrue(self._tick(150_000), "past the CUSTOM first threshold, under the default")
+        self.assertEqual(self._latched(), [100_000])
+        self.assertTrue(self._tick(250_000), "…and the custom second is its own episode")
+
+    def test_a_junk_thresholds_shape_falls_to_the_defaults(self):
+        d = dict(km._auto_nudge_data())
+        d["compactSuggestTokens"] = ["soon", -3]
+        km._write_auto_nudge(d)
+        km._autonudge_cache.clear()
+        self.assertFalse(self._tick(150_000), "junk config never lowers the bar")
+        self.assertTrue(self._tick(450_000), "the shipped defaults stand")
+
+    def test_a_custom_idle_window_replaces_the_default(self):
+        d = dict(km._auto_nudge_data())
+        d["compactSuggestIdleS"] = 30
+        km._write_auto_nudge(d)
+        km._autonudge_cache.clear()
+        km._settle_event_key = lambda sid: FRESH       # two minutes idle — under the default hour
+        self.assertTrue(self._tick(450_000), "…but past the custom 30s window")
+
     # ── the fingerprint row ──
     def test_a_fire_logs_a_countable_row(self):
         self._tick(450_000)

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -42,7 +42,8 @@ class SettingsSectionsTest(unittest.TestCase):
         # Account (the very top, the user 2026-08-30): the login row leads the gear
         self.assertTrue(h.index(">Account<") < h.index("id=rs-login-btn") < h.index(">Sessions<"))
         # Sessions (lifecycle): dir, backend, nudge, conserve, file editing — before Chat
-        for rid in ("id=rs-defaultdir", "id=rs-backend", "id=rs-autonudge", "id=rs-conserve", "id=rs-fileedit"):
+        for rid in ("id=rs-defaultdir", "id=rs-backend", "id=rs-autonudge", "id=rs-suggestcompact",
+                    "id=rs-conserve", "id=rs-fileedit"):
             self.assertTrue(h.index(">Sessions<") < h.index(rid) < h.index(">Chat<"), rid)
         # Chat: transcript prefs AND the comment defaults (comments are part of the chat)
         for rid in ("id=rs-compact", "id=rs-branch", "id=rs-cmtmodel", "id=rs-cmtfast"):

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -74,6 +74,10 @@ var GEAR_HTML =
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
+  "<label class='rs-row'><input type=checkbox id=rs-suggestcompact>" +
+  '<span><b>Suggest /compact</b><span class=rs-mixed hidden></span>' +
+  '<span class=rs-sub>When a session has been idle over an hour with a lot of context built up (first past 400k tokens, again past 800k), send it ONE suggestion to /compact at a natural boundary — its call, once per fill-up. Never sent to workers, muted sessions, or anything mid-turn. Off by default for a fresh install; this kernel keeps its own copy.</span>' +
+  '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-conserve>" +
   '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Close the claude process of a session that has FADED (idle over an hour) and is on no open tab (each averages ~340MB). Everything persists — it revives on a tab click, a message, or a scheduled wake. An open tab always keeps its process; off = every session keeps its process for as long as it lives.</span>' +
@@ -205,6 +209,7 @@ function initGear(post) {
     jix = document.getElementById('rs-judges-index'), jtr = document.getElementById('rs-judges-triage'),
     an = document.getElementById('rs-autonudge'), bk = document.getElementById('rs-backend'),
     cvm = document.getElementById('rs-conserve'),
+    csg = document.getElementById('rs-suggestcompact'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
     cs = document.getElementById('rs-chatscheme'),
@@ -434,6 +439,7 @@ function initGear(post) {
   });
   if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked }); });
   if (cvm) cvm.addEventListener('change', function () { post({ type: 'setConserve', enabled: cvm.checked }); });
+  if (csg) csg.addEventListener('change', function () { post({ type: 'setCompactSuggest', enabled: csg.checked }); });
   // ── the in-dashboard LOGIN flow (T157): the dashboard is already on the phone over Tailscale,
   // so streaming the CLI's paste-code OAuth URL here IS the phone login. The code input is a pure
   // pass-through to the kernel's PTY — nothing is stored or logged on any side.
@@ -779,6 +785,7 @@ function initGear(post) {
     var mine = (v && v.settings) || null;
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
      ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
+     ['compactSuggest', csg],
      ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
@@ -821,6 +828,7 @@ function initGear(post) {
     }).catch(function () { fillAutoNudge(v.autoNudge, []); fillMixedMarks(v, []); });
     if (fe) fe.checked = !!v.fileEditing;   // the kernel's persisted opt-in is authoritative (see the viewer's consent popup)
     if (cvm) cvm.checked = !!v.conserveMemory;   // T148: the kernel's persisted conserve flag is authoritative
+    if (csg) csg.checked = !!v.compactSuggest;   // T208+: the kernel's persisted opt-in is authoritative
     lgRender(v);   // the Billing login block (T157) rides the same /version read
     if ((v.login || {}).state && !lgTimer) lgTimer = setTimeout(lgPoll, 1500);   // a flow mid-run resumes polling
     if (typeof v.updateMode === 'string') setShow(upm, v.updateMode);   // the kernel's persisted mode is authoritative

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -137,6 +137,24 @@ test("the Auto Nudge box speaks for every attached machine, and says so when the
     "the hover line must name who differs");
 });
 
+test("the /compact suggestion is a real settings checkbox beside Auto Nudge (the user 2026-09-01)", () => {
+  // T208 shipped the kernel toggle with no UI; the user ruled it must be an ordinary settings
+  // checkbox next to Auto Nudge — off by default for new installs, one click to turn on.
+  assert.ok(GEAR.includes("id=rs-suggestcompact"), "the checkbox exists in the gear markup");
+  const sessions = GEAR.indexOf(">Sessions<"), chat = GEAR.indexOf(">Chat<");
+  const at = GEAR.indexOf("id=rs-suggestcompact");
+  assert.ok(sessions < at && at < chat, "…in the Sessions section, with its siblings");
+  assert.ok(GEAR.indexOf("id=rs-autonudge") < at && at < GEAR.indexOf("id=rs-conserve"),
+    "…directly after Auto Nudge, where the user asked for it");
+  assert.ok(/csg\.addEventListener\('change'/.test(GEAR)
+    && GEAR.includes("post({ type: 'setCompactSuggest', enabled: csg.checked })"),
+    "the click posts the kernel's designed setCompactSuggest message");
+  assert.ok(GEAR.includes("csg.checked = !!v.compactSuggest"),
+    "…and the box always shows the kernel's persisted answer, never a page default");
+  assert.ok(GEAR.includes("['compactSuggest', csg]"),
+    "attached machines that disagree get the same mixed mark as every kernel-side setting");
+});
+
 test("the gear owns its browseResult (the reply lands in the FEED document, not the chat's)", () => {
   assert.ok(GEAR.includes("'browseResult'") && GEAR.includes("'gear'"));
 });


### PR DESCRIPTION
## Summary
The user's ruling: the compaction-suggestion opt-in must be an ordinary checkbox in settings, right next to Auto Nudge — not a hidden key. The kernel toggle and `setCompactSuggest` existed (T208); this gives them the surface:

- **gear.js**: a "Suggest /compact" row directly after Auto Nudge in the Sessions section — the click posts the designed `setCompactSuggest` message, the box always shows the kernel's persisted answer off `/version`, and attached machines that disagree wear the same mixed mark as every kernel-side setting. (Id is `rs-suggestcompact`; `rs-compactsuggest` collided as a substring with the Chat section's `rs-compact` pin.)
- **/version** exports `compactSuggest` at top level beside `autoNudge`.
- **Config keys**: the thresholds and idle window read optional per-install keys (`compactSuggestTokens`, `compactSuggestIdleS`) with the shipped constants as defaults; junk shapes fall to the defaults.

Default stays OFF for fresh installs (the T208 pin stands untouched); this install stays opted in.

## Test plan
- gear.test.ts pins the checkbox's placement (after Auto Nudge, before Conserve), the post wiring, the kernel-authoritative fill, and the mixed-mark membership.
- Settings-section order pin updated; three config-key tests (custom thresholds, junk falls to defaults, custom idle window).
- Full Python suite: 6,316 passed. Extension suite: green. Local bats: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)