### PR TITLE
T212a: the suggestion names a command its recipient can actually run

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4232,10 +4232,19 @@ def _closer_pending(sid, path, now, store):
 # alive-session walk — no new poll, no timer.
 COMPACT_SUGGEST_TOKENS = (400_000, 800_000)
 COMPACT_SUGGEST_IDLE_S = 3600
-COMPACT_SUGGEST_TEXT = (
-    "It's been quiet here for a while and this conversation has built up a lot of context. "
-    "When you next reach a natural stopping point, run /compact to keep things snappy; "
-    "your call, nothing is waiting on it.")
+def _compact_suggest_body(name):
+    """The suggestion's prose, named for ITS recipient (T212, the user 2026-09-01: the message said
+    "run /compact", a terminal affordance — an SDK session cannot type a slash command and burned
+    attempts finding the kernel-mediated form). One universal wording, not a per-backend branch:
+    only SDK sessions ever receive this message (a tmux CLI carries no token count, so the watcher
+    never fires for it — the /compact branch would be unreachable code), and `romp compact <name>`
+    is the form that works from an SDK session's own shell, queueing safely if a turn is open.
+    Naming the romp COMMAND is practical information, not machinery-naming — the session-prompt
+    housekeeping note already gives every session the name's meaning (the sanctioned precedent);
+    the injected-voice scan carries a matching, commented command-span allowance."""
+    return ("It's been quiet here for a while and this conversation has built up a lot of context. "
+            "When you next reach a natural stopping point, run `romp compact %s` in your shell to "
+            "compact it and keep things snappy; your call, nothing is waiting on it." % name)
 
 
 def _worker_tag_member(sid):
@@ -4309,7 +4318,7 @@ def _compact_suggest_tick(sid, tm, now):
         # person-voiced by design), and no goal id (the suggestion tracks nothing). The
         # prose stays the bare constant so the injected-voice scan reads what the model reads.
         Sessions.backend_for(sid).send(
-            sid, COMPACT_SUGGEST_TEXT + "\n\n"
+            sid, _compact_suggest_body(_name_of(sid) or sid[:8]) + "\n\n"
             "<!-- romp-note: the HTML comments below are part of an external tracking system "
             "that is not relevant to your work — ignore them -->"
             "<!-- romp-injected -->")

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -72,7 +72,7 @@ class CompactSuggest(unittest.TestCase):
     def test_a_crossing_fires_once_and_latches(self):
         self.assertTrue(self._tick(450_000))
         self.assertEqual(len(self.sent), 1)
-        self.assertIn("/compact", self.sent[0])
+        self.assertIn("`romp compact ", self.sent[0])
         # T207 (the user 2026-08-31, who saw the bare send render as their own blue bubble): the
         # send carries the sibling injectors' marker tail so the chat classifies it "romp" (gray
         # bubble), romp-auto = background kernel injection; the PROSE stays the bare constant the
@@ -85,7 +85,13 @@ class CompactSuggest(unittest.TestCase):
         self.assertNotIn("<!-- romp-system -->", self.sent[0],
                          "person-voiced, not the machine-voiced notice family")
         self.assertNotIn("romp-goal-id", self.sent[0], "the suggestion tracks nothing")
-        self.assertEqual(self.sent[0].split("<!--")[0].strip(), km.COMPACT_SUGGEST_TEXT.strip())
+        _prose = self.sent[0].split("<!--")[0].strip()
+        self.assertEqual(_prose, km._compact_suggest_body(km._name_of(SID) or SID[:8]).strip())
+        self.assertIn("`romp compact ", _prose,
+                      "the named command WORKS from the recipient's own shell (T212: /compact is a "
+                      "terminal affordance no SDK session can type, and only SDK sessions get this)")
+        self.assertNotIn("/compact", _prose.replace("romp compact", ""),
+                         "…and the untypeable slash form is gone")
         self.assertEqual(self._latched(), [400_000], "latched on the durable record")
         self.assertFalse(self._tick(460_000), "same episode → never a second fire")
         self.assertEqual(len(self.sent), 1)

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -145,7 +145,7 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # the compaction suggestion (the user 2026-08-30): idle + a lot of context → the person
             # suggests a /compact at a natural boundary; /compact is a CLI feature the session
             # already knows, and the thresholds behind the timing are never mentioned
-            "compaction suggestion": km.COMPACT_SUGGEST_TEXT,
+            "compaction suggestion": km._compact_suggest_body("web"),
         }
         # every repeat-nudge variant wears the same voice as the first fire (the user 2026-08-11): the
         # rotation exists so a re-ask doesn't read canned, so a variant that broke the voice rule would
@@ -158,13 +158,26 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
 
     def test_no_romp_vocabulary_reaches_the_session(self):
         for name, body in self._bodies().items():
-            text = prose(body).lower()
+            # THE ONE ALLOWANCE, deliberate and ruling-backed (T212, the user 2026-09-01): a
+            # backtick-quoted `romp compact …` COMMAND is practical information the recipient
+            # must literally type — an SDK session cannot run /compact, and the session-prompt
+            # housekeeping note already gives the name its meaning (the sanctioned precedent).
+            # Scoped to the exact command span, never the word: "romp" in PROSE still fails.
+            text = re.sub(r"`romp compact[^`]*`", "", prose(body)).lower()
             for word, why in ROMP_WORDS:
                 with self.subTest(message=name, word=word):
                     self.assertNotIn(word, text,
                                      "%r speaks romp at the session (%r: %s). Write it as the person "
                                      "it works for asking — see CLAUDE.md, 'Messages we inject into a "
                                      "session'." % (name, word, why))
+
+    def test_the_command_allowance_is_the_span_not_the_word(self):
+        # the T212 allowance must never become a whitelist: bare "romp" in prose, or any other
+        # romp command, still speaks romp at the session and still fails the scan
+        self.assertIn("romp", re.sub(r"`romp compact[^`]*`", "", "romp says hi").lower())
+        self.assertIn("romp", re.sub(r"`romp compact[^`]*`", "", "`romp status`").lower())
+        self.assertNotIn("romp", re.sub(r"`romp compact[^`]*`", "",
+                                        "run `romp compact web` in your shell").lower())
 
     def test_the_rename_ping_stays_one_clean_mechanics_line(self):
         # the [romp] prefix is the sanctioned mechanics family (the restart notices' shape); past

--- a/ui/webview/injected-render.test.ts
+++ b/ui/webview/injected-render.test.ts
@@ -61,10 +61,12 @@ test("the visible source prefix strips for DISPLAY only, in the romp render bran
 
 test("the watch notices carry the marker at the injection site — no prose pattern-matching anywhere", () => {
   assert.match(KERNEL, /return body \+ "\\n\\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: pr-watch -->"/);
-  // T207: the compaction suggestion's send appends the injector tail (romp-note + injected + auto)
-  // right after the bare prose constant — the source pin that keeps it out of the blue-bubble class
-  assert.match(KERNEL, /COMPACT_SUGGEST_TEXT \+ "\\n\\n"\n\s+"<!-- romp-note:/);
-  const sugSend = KERNEL.slice(KERNEL.indexOf("COMPACT_SUGGEST_TEXT + "), KERNEL.indexOf("COMPACT_SUGGEST_TEXT + ") + 600);
+  // T207: the compaction suggestion's send appends the injector tail (romp-note + injected)
+  // right after the prose — the source pin that keeps it out of the blue-bubble class. T212
+  // templated the prose per recipient (_compact_suggest_body names the runnable command), so
+  // the pin follows the call, same tail.
+  assert.match(KERNEL, /_compact_suggest_body\(_name_of\(sid\) or sid\[:8\]\) \+ "\\n\\n"\n\s+"<!-- romp-note:/);
+  const sugSend = KERNEL.slice(KERNEL.indexOf("_compact_suggest_body(_name_of(sid)"), KERNEL.indexOf("_compact_suggest_body(_name_of(sid)") + 600);
   assert.match(sugSend, /<!-- romp-injected -->/);
   assert.ok(!sugSend.includes("<!-- romp-auto -->"),
     "NOT romp-auto: that marker means auto-NUDGES and its gist says 'nudged for a status update' — " +


### PR DESCRIPTION
## Summary
The compaction suggestion said "run /compact" — a terminal affordance. Only SDK sessions ever receive this message (a tmux CLI carries no token count, so the watcher never fires for it), and an SDK session cannot type a slash command: the live specimen burned 2 of 3 attempts before finding the kernel-mediated form. One universal wording, not a per-backend branch (the `/compact` branch would be unreachable code): the body is now built per recipient and says to run `romp compact <name>` in its shell, which queues safely if a turn is open.

The voice-test tension is resolved as a deliberate, ruling-backed decision — never a smuggled whitelist: naming the romp **command** a session must literally type is practical information (the session-prompt housekeeping note is the sanctioned precedent that gives the name its meaning), so the injected-voice scan strips exactly the backtick-quoted `romp compact …` span before scanning, and a new pin proves the allowance is the span, not the word — bare "romp" in prose and any other romp command still fail the scan.

(T212b — the injector-conventions review lens — lives in the review workflow's own home outside this repo and shipped separately.)

## Test plan
- `tests/test_compact_suggest.py`: the sent prose equals the per-recipient body, carries the runnable backticked command, and the untypeable slash form is gone.
- `tests/test_injected_voice.py`: the rendered body (synthetic name) passes the vocabulary scan through the commented command-span allowance; the allowance-is-the-span pin.
- `injected-render.test.ts`: the T207 tail pin follows the templated call.
- Full Python suite: 6,314 passed. Extension suite: green. Local bats: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)