### PR TITLE
A swallowed answer can never look like progress — and the killed question re-asks

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8628,6 +8628,23 @@ def _ack_card_move(ids, ok):
                               "buildId": _feed_build_id[0]})
 
 
+def _ask_lost(sid, client):
+    """A user's ANSWER found no waiting question (T214, verified live 2026-09-01): the ask died with
+    a kernel restart before the click arrived — the page queues clicks across the reconnect and
+    flushes them at the new kernel. The delivery outcome is honored: the caller flips NOTHING (a
+    swallowed answer must never look like progress — the cards-move rule), and the asker HEARS it
+    (fail loudly, never silence). The boot reconcile separately asks the resumed session to raise
+    its killed question again (ASK_DIED_NOTICE + the pendingAsk reg flag), so a fresh ask is already
+    on its way; the toast says so."""
+    sys.stderr.write("askLost: %s — an answer arrived with no live ask to receive it\n" % sid)
+    try:
+        client["send"](json.dumps({"type": "askLost", "id": str(sid),
+            "text": "That answer didn't reach the session — its question was lost with a restart. "
+                    "The session has been asked to raise it again; answer when it reappears."}))
+    except Exception:
+        pass
+
+
 def _picker_mid_series(sid):
     """A multi-question AskUserQuestion answered mid-series (the user 2026-07-21): one tool call carries N
     questions, and the SDK loop holds the session in the `picker` state across ALL of them (sdk_backend
@@ -8870,8 +8887,10 @@ def _drive(msg, client):
         # in `picker` across the whole set, so predicting Working would only bounce the card out and back —
         # check BEFORE answering (current_ask still holds this sub-question), suppress the flip if more remain.
         _mid = _picker_mid_series(sid)
-        be.on_ask(sid, "answer", msg["target"])
-        if not _mid: _predict_working("answer", sid=sid)
+        if be.on_ask(sid, "answer", msg["target"]):   # the DELIVERY outcome gates the flip (T214)
+            if not _mid: _predict_working("answer", sid=sid)
+        else:
+            _ask_lost(sid, client)
         _mark_views_dirty()
     elif t == "navAsk" and msg.get("target") is not None:
         be.on_ask(sid, "focus", msg["target"])            # cursor only, no select → ↑/↓ steps the preview
@@ -8879,20 +8898,26 @@ def _drive(msg, client):
         be.on_ask(sid, "toggle", msg["target"])
     elif t == "submitAsk":
         _mid = _picker_mid_series(sid)                     # mid-series multi-question submit → hold the card (see answerAsk)
-        be.on_ask(sid, "submit")
-        if not _mid: _predict_working("answer", sid=sid)
+        if be.on_ask(sid, "submit"):
+            if not _mid: _predict_working("answer", sid=sid)
+        else:
+            _ask_lost(sid, client)
         _mark_views_dirty()
     elif t == "addCustomAsk" and msg.get("text"):
         _mid = _picker_mid_series(sid)
-        be.on_ask(sid, "custom", str(msg["text"]))
-        if not _mid: _predict_working("answer", sid=sid)
+        if be.on_ask(sid, "custom", str(msg["text"])):
+            if not _mid: _predict_working("answer", sid=sid)
+        else:
+            _ask_lost(sid, client)
         _mark_views_dirty()
     elif t == "cancelAsk":
         be.on_ask(sid, "cancel"); _mark_views_dirty()     # a cancel answers nothing — no Working prediction
     elif t == "askText" and msg.get("text"):
         _mid = _picker_mid_series(sid)
-        be.on_ask(sid, "text", str(msg["text"]))
-        if not _mid: _predict_working("answer", sid=sid)
+        if be.on_ask(sid, "text", str(msg["text"])):
+            if not _mid: _predict_working("answer", sid=sid)
+        else:
+            _ask_lost(sid, client)
         _mark_views_dirty()
     elif t == "cancelQueued" and msg.get("park") is not None:
         # ✕ on a PARKED op (compaction/model queue — romp-owned, any backend). The result frame is

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -864,6 +864,15 @@ BOOT_RESUME_NUDGE = (
     "stopped, without asking whether to continue. Any messages queued before the restart follow "
     "this one.")
 
+# T214: the restart also killed a QUESTION the session had up — the ask future lived only in the
+# old process, so the user's answer (often flushed by the reconnecting page) had nowhere to land,
+# and the resume nudge alone told the session to continue WITHOUT asking. Same sanctioned [romp]
+# mechanics family as the restart notice above; queued right after it, before the restored backlog.
+ASK_DIED_NOTICE = (
+    "<!-- romp-injected --><!-- romp-system -->[romp] The restart also killed a question this "
+    "session had up awaiting the user's answer — it was never delivered, and any answer they sent "
+    "could not land. Ask the question again so they can answer it.")
+
 # Staggered boot-resume (the user 2026-07-20): spawning every reconciled session's CLI at once
 # detonated a fleet-wide CPU storm — each resumed claude burns ~a full core catching up on its
 # transcript, so a 13-session restart pegged the machine (load ~20) and starved the kernel's own
@@ -1789,16 +1798,27 @@ class SdkSession:
             self.loop.call_soon_threadsafe(
                 lambda: asyncio.ensure_future(self._do_set_mode(mode, prev)))
 
-    def resolve_ask(self, kind: str, payload=None):
+    def resolve_ask(self, kind: str, payload=None) -> bool:
         """Deliver a picker/permission UI action (answer/toggle/submit/custom/
-        cancel/text) into the waiting can_use_tool coroutine."""
+        cancel/text) into the waiting can_use_tool coroutine. Returns whether a live
+        ask was actually WAITING (T214, verified live 2026-09-01: an answer flushed
+        across a kernel restart found _cur_ask_fut None — the ask died with the old
+        process — and this silently no-opped while the caller reported success and
+        the board flipped to Working; the delivery outcome must be the truth). The
+        synchronous check races a concurrently-presenting ask by microseconds
+        against human-scale answers — the guarded _set below keeps the delivery
+        itself safe either way."""
         if not self.loop:
-            return
+            return False
+        fut = self._cur_ask_fut
+        if fut is None or fut.done():
+            return False                       # nothing is waiting — the ask died (a restart) or is already resolved
         def _set():
-            fut = self._cur_ask_fut
-            if fut and not fut.done():
-                fut.set_result((kind, payload))
+            f = self._cur_ask_fut
+            if f and not f.done():
+                f.set_result((kind, payload))
         self.loop.call_soon_threadsafe(_set)
+        return True
 
     def shutdown(self):
         self.ended = True
@@ -3739,12 +3759,14 @@ class SdkBackend:
                     # bg tasks the dead kernel's CLI took with it (the reg mirror, _on_task_event):
                     # the session must HEAR about them or it waits forever on a dead timer/watcher.
                     dead_tasks = [t for t in (r.get("bgTasks") or []) if isinstance(t, dict)]
-                    if not (cut or queued or dead_tasks):
+                    ask_died = bool(r.get("pendingAsk"))   # a question was up when the old kernel died (T214)
+                    if not (cut or queued or dead_tasks or ask_died):
                         continue                   # idle, empty-queued, nothing died → stays lazy
                     # Prepend to the PERSISTED queue (not enqueue()) so it is fed FIRST, before the
                     # restored backlog, and survives even a death mid-reconcile. Order: the resume
                     # nudge (continuation context), then the task-death notice.
                     prepend = ([BOOT_RESUME_NUDGE] if cut else []) \
+                            + ([ASK_DIED_NOTICE] if ask_died else []) \
                             + ([task_death_notice(dead_tasks)] if dead_tasks else [])
                     if prepend or dead_tasks:
                         with self._reg_lock:
@@ -3753,6 +3775,8 @@ class SdkBackend:
                                                       if isinstance(t, str) and t and t not in prepend]
                             if dead_tasks:
                                 reg["bgTasks"] = []   # reported — never re-notify for the same deaths
+                            if ask_died:
+                                reg["pendingAsk"] = False   # asked once per death — the re-raise mints a fresh flag
                             write_reg(self.state_dir, sid, reg)
                     if cut:
                         # Durable "romp cut this, romp is continuing it" stamp, written with the resume
@@ -6031,8 +6055,7 @@ class SdkBackend:
         if kind == "focus":
             return True   # ↑/↓ preview-step: SDK options carry their OWN preview, so the webview swaps it
                           # locally — there's no TUI cursor to drive, and it must NOT resolve the ask.
-        s.resolve_ask(kind, payload)
-        return True
+        return s.resolve_ask(kind, payload)    # the DELIVERY outcome, not mere routing (T214)
 
     # ---- callbacks used by sessions ----
     def _emit_ask(self, sess: SdkSession, ask: dict):
@@ -6041,11 +6064,17 @@ class SdkBackend:
         # was raised — the durable replay tmux gets from pane-scraping. The immediate push below is just for
         # snappiness (no 1.2s wait); the poll is the source of truth. (the user 2026-06-24: blocked-no-prompt.)
         self._pending_ask[sess.sid] = ask
+        # …and a DURABLE marker (T214): the in-memory ask dies with the kernel, and a restart-cut
+        # question was never re-presented — the boot reconcile reads this flag off the reg and asks
+        # the resumed session to raise its question again (ASK_DIED_NOTICE), so the user's answer
+        # has somewhere real to land. Cleared on resolve below and by the reconcile after it notices.
+        self._update_reg(sess.sid, pendingAsk=True)
         self._notify("chat", {"type": "askLive", "id": sess.sid, "ask": ask})
         self._poke()
 
     def _clear_ask(self, sess: SdkSession):
         self._pending_ask.pop(sess.sid, None)
+        self._update_reg(sess.sid, pendingAsk=False)   # resolved in THIS life — nothing owed at the next boot (T214)
         self._notify("chat", {"type": "askLiveClear", "id": sess.sid})
 
     def current_ask(self, sid: str):

--- a/tests/test_ask_lost.py
+++ b/tests/test_ask_lost.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""T214 (verified live 2026-09-01): an answer flushed across a kernel restart found no waiting ask
+and was silently swallowed while the board flipped to Working. The truth now flows from where it
+lives: resolve_ask returns whether a live future was actually waiting, on_ask forwards it, the
+kernel's answer sites honor it (tests/test_kernel_card_predict.py holds that half), and the ask's
+existence is DURABLE — a pendingAsk reg flag written at present, cleared at resolve, read by the
+boot reconcile to ask the resumed session to raise its killed question again. Synthetic only."""
+import os
+import re
+import tempfile
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+sb = SourceFileLoader("romp_sdk_backend_t214", os.path.join(BIN, "..", "kernel", "sdk_backend.py")).load_module()
+
+SID = "aaaa2141-0000-0000-0000-000000000001"
+
+
+class _Fut:
+    def __init__(self, done):
+        self._done = done
+        self.result = None
+    def done(self):
+        return self._done
+    def set_result(self, v):
+        self.result = v
+
+
+class ResolveTruth(unittest.TestCase):
+    """resolve_ask answers 'was anything actually waiting?' — the swallow's root."""
+
+    def _sess(self, fut):
+        s = object.__new__(sb.SdkSession)
+        s.loop = types.SimpleNamespace(call_soon_threadsafe=lambda f: f())   # run inline for the test
+        s._cur_ask_fut = fut
+        return s
+
+    def test_no_loop_is_false(self):
+        s = object.__new__(sb.SdkSession); s.loop = None
+        self.assertFalse(s.resolve_ask("answer", 0))
+
+    def test_no_waiting_future_is_false(self):
+        self.assertFalse(self._sess(None).resolve_ask("answer", 0),
+                         "the ask died with the old process — nothing was waiting")
+
+    def test_already_resolved_future_is_false(self):
+        self.assertFalse(self._sess(_Fut(done=True)).resolve_ask("answer", 0))
+
+    def test_live_future_is_true_and_delivered(self):
+        f = _Fut(done=False)
+        self.assertTrue(self._sess(f).resolve_ask("answer", 2))
+        self.assertEqual(f.result, ("answer", 2))
+
+    def test_on_ask_forwards_the_delivery_outcome(self):
+        be = object.__new__(sb.SdkBackend)
+        s = self._sess(None)
+        be.sessions = {SID: s}
+        self.assertFalse(be.on_ask(SID, "answer", 0), "routing is not delivery — the outcome forwards")
+        s2 = self._sess(_Fut(done=False))
+        be.sessions = {SID: s2}
+        self.assertTrue(be.on_ask(SID, "answer", 0))
+        self.assertTrue(be.on_ask(SID, "focus", 1), "focus never resolves and never fails")
+
+
+class DurableAskMarker(unittest.TestCase):
+    """The ask's existence survives the process: pendingAsk rides the reg."""
+
+    def _backend(self):
+        be = object.__new__(sb.SdkBackend)
+        be._pending_ask = {}
+        be.regged = []
+        be._update_reg = lambda sid, **f: be.regged.append((sid, f))
+        be._notify = lambda *a, **k: None
+        be._poke = lambda: None
+        return be
+
+    def test_present_writes_and_resolve_clears(self):
+        be = self._backend()
+        sess = types.SimpleNamespace(sid=SID)
+        be._emit_ask(sess, {"q": "which port?"})
+        self.assertIn((SID, {"pendingAsk": True}), be.regged, "the marker outlives the process")
+        be._clear_ask(sess)
+        self.assertIn((SID, {"pendingAsk": False}), be.regged, "resolved in this life → nothing owed at boot")
+
+    def test_boot_reconcile_re_presents_and_clears_once(self):
+        src = Path(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read_text()
+        self.assertIn('ask_died = bool(r.get("pendingAsk"))', src)
+        self.assertIn("([ASK_DIED_NOTICE] if ask_died else [])", src, "the rider queues after the resume nudge")
+        self.assertIn('reg["pendingAsk"] = False   # asked once per death', src, "one re-raise per death, never a nag loop")
+        self.assertIn("if not (cut or queued or dead_tasks or ask_died):", src,
+                      "a killed ask alone is reason enough to wake the resume path")
+
+    def test_the_notice_wears_the_sanctioned_mechanics_voice(self):
+        body = sb.ASK_DIED_NOTICE
+        line = re.sub(r"<!--.*?-->", "", body).strip()
+        self.assertTrue(line.startswith("[romp] "), "the sanctioned mechanics prefix — the restart-notice family")
+        for word in ("card", "board", "goal", "column", "nudge"):
+            self.assertNotIn(word, line.lower(), "no romp nouns beyond the sanctioned name")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_card_predict.py
+++ b/tests/test_kernel_card_predict.py
@@ -9,6 +9,7 @@ resolves sid → the live-blocked card(s) from the LAST BUILT feed payload (pre-
 the cards about to unblock); apiError floors are excluded — an answer doesn't lift those. SYNTHETIC
 fixtures only."""
 import os
+import json
 import unittest
 from importlib.machinery import SourceFileLoader
 import tempfile
@@ -168,6 +169,37 @@ class PredictWorkingFanOut(unittest.TestCase):
         # longer a drive op, routes nowhere, and fans no prediction.
         self.assertFalse(km._drive({"type": "cardMove", "itemId": SID + ":g2", "to": "working"}, client))
         self.assertEqual(self._feed_frames(), [])
+
+
+
+class SwallowedAnswerNeverLooksLikeProgress(PredictWorkingFanOut):
+    """T214 (verified live 2026-09-01): an answer flushed across a kernel restart found no waiting
+    ask — on_ask returned False (sid not respawned) or resolve_ask silently no-opped — yet the
+    handler predicted Working unconditionally and told no one. The delivery outcome is honored now:
+    a False flips nothing and surfaces loudly; a True keeps the exact old behavior."""
+
+    def test_red_repro_a_swallowed_answer_flips_nothing_and_surfaces(self):
+        self.be.on_ask = lambda sid, action, target=None: False   # the ask died with the old kernel
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s))}
+        for op in ({"type": "answerAsk", "id": SID, "target": 0},
+                   {"type": "submitAsk", "id": SID},
+                   {"type": "addCustomAsk", "id": SID, "text": "mine"},
+                   {"type": "askText", "id": SID, "text": "typed"}):
+            self.frames.clear(); sent.clear()
+            km._drive(op, client)
+            self.assertEqual(self._feed_frames(), [],
+                             "%s: a swallowed answer must never look like progress" % op["type"])
+            lost = [m for m in sent if m.get("type") == "askLost" and m.get("id") == SID]
+            self.assertEqual(len(lost), 1, "%s: the swallow must surface loudly to the asker" % op["type"])
+            self.assertIn("didn't reach", lost[0].get("text", ""))
+
+    def test_regression_a_delivered_answer_still_flips_and_stays_quiet(self):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s))}
+        km._drive({"type": "answerAsk", "id": SID, "target": 0}, client)
+        self.assertEqual(len(self._feed_frames()), 1, "the delivered answer flips exactly as before")
+        self.assertEqual([m for m in sent if m.get("type") == "askLost"], [], "…with no false alarm")
 
 
 if __name__ == "__main__":

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11893,6 +11893,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   // had already left romp's queue (handed to the CLI — no recall exists): toast the kernel's 'too late'
   // and UNDO the optimistic composer restore if the draft is untouched — leaving the copy there invited
   // re-sending a message that is already being answered. ok:true just drops the stash (restore stands).
+  // T214: an answer that found no waiting question (the ask died with a kernel restart) — the
+  // kernel flipped nothing and says so; the toast carries the whole story, including that the
+  // session was already asked to raise its question again.
+  else if (m.type === "askLost" && typeof m.text === "string") warnToast(m.text);
   else if (m.type === "cancelResult" && typeof m.id === "string") {
     const key = m.id + " " + (typeof m.md === "string" ? m.md : "");
     const stash = pendingCancelRestores.get(key);


### PR DESCRIPTION
**T214, red repro first**: an answer landing across a kernel restart found no waiting ask — the page queues the click and flushes it at the new kernel; `on_ask` returned False for an unrespawned sid, and deeper, `resolve_ask` silently no-opped on a dead future **while on_ask still reported success** — yet every answer-family site predicted Working unconditionally. The user answered, nothing was delivered, no error surfaced, and the board claimed progress.

**The delivery outcome is the truth now, from where the truth lives**: `resolve_ask` returns whether a live future was actually waiting (the synchronous check races a concurrently-presenting ask by microseconds against human-scale answers; the guarded set keeps delivery itself safe), `on_ask` forwards it, and all four answer sites honor it — a True keeps the exact old behavior (regression-pinned), a False flips nothing and surfaces loudly: a stderr line plus an `askLost` frame the chat renders as a warn toast telling the whole story.

**The durable half**: the ask's existence outlives the process — a `pendingAsk` flag rides the per-session reg (written at present, cleared at resolve) — and the boot reconcile reads it to queue `ASK_DIED_NOTICE` (the sanctioned [romp] mechanics family, right after the resume nudge) asking the resumed session to raise its killed question again, cleared once per death so it never nags. The re-ask is what makes the toast's promise true: *answer when it reappears*.

**Tests**: the red repro (all four answer ops: no cardPredict frame + one askLost frame each) now green; both-directions regression (a delivered answer flips exactly as before, no false alarm); the resolve-truth matrix (no loop / no future / done future → False, live future → True + delivered; on_ask forwards; focus never resolves); the durable marker (present writes, resolve clears); the reconcile rider pins (gate, queue position, clear-once); and the notice's voice (sanctioned prefix, no romp nouns). Python 6333 passed / extension 2629 passed on the pushed head; honest-surface screenshot in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)