### PR TITLE
A delivered schedule slot survives the restart that killed its process (T211)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1069,7 +1069,10 @@ def recurring_crons(reg):
     re-hydrate a lost wakeup (verified live 2026-08-28), so pinning or reviving a process buys the
     wakeup nothing; deliver_lost_wakeups owns dead-generation one-shots outright and delivers the
     prompt itself at due, which revives a dormant session through the normal send path. Recurring
-    entries have no such catch-up: their live CLI is the only scheduler, so they pin the process.
+    entries pin the process for TIMELINESS: their live CLI is the only ON-TIME scheduler. (A resumed
+    CLI does catch-up-fire a recurring slot that passed while its previous process was dead —
+    verified live 2026-09-01, T211 — but that is a replay hazard as much as a recovery: every kernel
+    restart re-fired already-delivered slots until _prompt_submit_hook's delivered-slot gate.)
     Reads the entry's `recurring` field, never the cron string's shape — toolhook-minted one-shots
     carry an empty cron string."""
     return [c for c in (reg.get("sessionCrons") or []) if isinstance(c, dict) and c.get("recurring")]
@@ -1096,6 +1099,83 @@ def wakeup_due_epoch(cron: str, armed_t: float) -> "float | None":
     if due.timestamp() < armed_t - 60:            # H:M already passed at arm time → the wrap is tomorrow
         due += timedelta(days=1)
     return due.timestamp()
+
+
+def _cron_field(spec: str, lo: int, hi: int) -> "set[int] | None":
+    """One 5-field cron field as the set of ints it names (vixie shapes: *, steps, ranges, lists),
+    or None for anything outside that grammar — the caller stands down rather than guessing."""
+    out: set[int] = set()
+    for part in str(spec).split(","):
+        part, step = part.strip(), 1
+        if "/" in part:
+            part, s = part.split("/", 1)
+            if not s.isdigit() or int(s) < 1:
+                return None
+            step = int(s)
+        if part == "*":
+            a, b = lo, hi
+        elif "-" in part:
+            aa, _, bb = part.partition("-")
+            if not (aa.isdigit() and bb.isdigit()):
+                return None
+            a, b = int(aa), int(bb)
+        elif part.isdigit():
+            a = b = int(part)
+        else:
+            return None
+        if a < lo or b > hi or a > b:
+            return None
+        out.update(range(a, b + 1, step))
+    return out or None
+
+
+def cron_prev_due(cron: str, now: float) -> "float | None":
+    """The most recent moment at/before `now` a 5-field RECURRING cron names — the SLOT identity the
+    replay gate keys on (_prompt_submit_hook): a delivered fire is recorded against this epoch, and a
+    later fire computing the SAME slot is a replay by definition, however long its process was down
+    in between — exact event identity, never an age window. Vixie semantics: lists/ranges/steps,
+    day-of-month OR day-of-week when both are restricted, dow 0/7 = Sunday. Local time, matching the
+    CLI's own scheduler. Anything unparseable returns None and the gate stands down — romp only
+    reasons about schedules it understands exactly (wakeup_due_epoch's rule). Lookback bounded at
+    ~400 days so a never-matching string (a Feb 30) terminates. Pure for tests."""
+    try:
+        m, h, dom, mon, dow = str(cron).split()
+    except (ValueError, AttributeError):
+        return None
+    mins, hrs = _cron_field(m, 0, 59), _cron_field(h, 0, 23)
+    doms, mons, dows = _cron_field(dom, 1, 31), _cron_field(mon, 1, 12), _cron_field(dow, 0, 7)
+    if None in (mins, hrs, doms, mons, dows):
+        return None
+    dows = {d % 7 for d in dows}                       # 7 is Sunday too
+    from datetime import date, timedelta               # local, like wakeup_due_epoch
+    lt = time.localtime(now)
+    day0 = date(lt.tm_year, lt.tm_mon, lt.tm_mday)
+    for back in range(400):
+        day = day0 - timedelta(days=back)
+        if day.month not in mons:
+            continue
+        dom_ok, dow_ok = day.day in doms, ((day.weekday() + 1) % 7) in dows
+        if not ((dom_ok or dow_ok) if (dom != "*" and dow != "*")
+                else (dow_ok if dom == "*" and dow != "*" else dom_ok)):
+            continue
+        if back == 0:
+            cand = [(H, M) for H in hrs for M in mins if (H, M) <= (lt.tm_hour, lt.tm_min)]
+            if not cand:
+                continue                                # today matches but only later than now
+            H, M = max(cand)
+        else:
+            H, M = max(hrs), max(mins)
+        return time.mktime((day.year, day.month, day.day, H, M, 0, -1, -1, -1))
+    return None
+
+
+def cron_slot_key(cron: str, prompt: str) -> str:
+    """The SCHEDULE IDENTITY half of the replay gate's key. Deliberately NOT the CLI's cron id: a
+    resume re-hydration or a delete/re-create mints fresh ids for the same nightly job (observed
+    live — the same schedule wore two ids across two process generations), and an id-keyed record
+    would greet every re-mint as a brand-new schedule and wave its replay through. The (cron string,
+    prompt) pair is what makes two fires "the same scheduled work", so it IS the identity."""
+    return hashlib.sha1(("%s\n%s" % (cron, prompt)).encode("utf-8", "replace")).hexdigest()[:16]
 
 
 def interrupt_action(level: int, channel_up: bool) -> tuple[str, int]:
@@ -3113,6 +3193,68 @@ class SdkSession:
             self.backend._log("sched tool hook (%s): %s" % (self.name, e))
         return {}
 
+    async def _prompt_submit_hook(self, inp, tool_use_id, context):
+        """UserPromptSubmit: the RECURRING-CRON REPLAY GATE (T211, 2026-09-01). A resumed CLI
+        catch-up-fires a recurring cron whose slot passed while its previous process was dead, so
+        under immediate deploy restarts every kernel restart bought one spurious fire per recurring
+        cron: revive (ensure_scheduled) → --resume → sub-second re-fire of an already-delivered
+        slot. Field damage: one nightly fired ~21x on 2026-08-31, each extra fire within ~1s of a
+        "reviving …" log line and preceded by the fresh process's own startup records — the CLI's
+        last-fired memory dies with its process, and nothing durable said the slot already ran. This
+        hook is that durable memory, at the only moment that counts — DELIVERY, never arm time: a
+        prompt matching an armed recurring cron computes its slot (cron_prev_due) and consults the
+        reg's cronDelivered map, keyed (cron_slot_key, slot epoch). Recorded → the fire is a replay:
+        blocked before the model runs, loudly. Not recorded → record, then let it through — so a
+        slot the dead process genuinely never delivered still fires exactly once after a restart
+        (the CLI's own catch-up becomes the recovery instead of the bug). Every uncertain path fails
+        OPEN (unreadable reg, unparseable schedule, hook error → the prompt runs): a duplicate fire
+        costs a turn, a swallowed slot costs the schedule itself."""
+        try:
+            prompt = str((inp or {}).get("prompt") or "")
+            if not prompt:
+                return {}
+            reg = read_reg_for_rmw(self.backend.state_dir, self.sid)
+            if reg is None:
+                self.backend._log("cron dedupe (%s): reg unreadable — prompt allowed rather than "
+                                  "risking a swallowed schedule slot" % self.name, problem=True)
+                return {}
+            hits = [c for c in recurring_crons(reg)
+                    if str(c.get("prompt") or "") == prompt[:500] and str(c.get("cron") or "").strip()]
+            if not hits:
+                return {}
+            delivered = reg.get("cronDelivered")
+            delivered = dict(delivered) if isinstance(delivered, dict) else {}
+            now = time.time()
+            record, replay_of = {}, None
+            for c in hits:
+                slot = cron_prev_due(str(c.get("cron")), now)
+                if slot is None:
+                    return {}                  # a shape we can't reason about exactly → stand down
+                k = cron_slot_key(str(c.get("cron")), prompt[:500])
+                if float(delivered.get(k) or 0) >= slot:
+                    replay_of = slot           # this schedule's current slot already delivered
+                else:
+                    record[k] = slot
+            if record:
+                # Record AT the delivery moment; keys whose schedule left the armed set drop here
+                # (natural GC — the map can never outgrow the armed set + this delivery).
+                live = {cron_slot_key(str(c.get("cron")), str(c.get("prompt") or ""))
+                        for c in recurring_crons(reg)}
+                delivered = {k: v for k, v in delivered.items() if k in live}
+                delivered.update(record)
+                self.backend._update_reg(self.sid, cronDelivered=delivered)
+                return {}
+            when = time.strftime("%Y-%m-%d %H:%M", time.localtime(replay_of))
+            self.backend._log("cron dedupe (%s): blocked a replayed schedule fire — its %s slot was "
+                              "already delivered (a fresh process re-fires passed slots on resume)"
+                              % (self.name, when), problem=False)
+            return {"decision": "block",
+                    "reason": "This scheduled prompt already ran for its %s slot — skipping the "
+                              "duplicate." % when}
+        except Exception as e:
+            self.backend._log("cron dedupe (%s): %s — prompt allowed" % (self.name, e))
+            return {}
+
     # ---- subagent tracking (the transparency tmux never had) ----
 
     # ── the background-launch LEDGER (2026-08-29, the hookable-tools round) ────────────────────
@@ -4570,6 +4712,8 @@ class SdkBackend:
             stderr=sess._on_cli_stderr,
             can_use_tool=sess._can_use_tool,
             hooks={"Stop": [HookMatcher(matcher=None, hooks=[sess._stop_hook])],          # awaiting overlay producer
+                   # recurring-cron replay gate: a resumed CLI re-fires passed slots (T211)
+                   "UserPromptSubmit": [HookMatcher(matcher=None, hooks=[sess._prompt_submit_hook])],
                    "SubagentStart": [HookMatcher(matcher=None, hooks=[sess._subagent_start_hook])],  # live subagent
                    "SubagentStop": [HookMatcher(matcher=None, hooks=[sess._subagent_stop_hook])],    #   count/types
                    # scheduling tools record their arm at the CALL moment, with the exact due time the
@@ -5835,9 +5979,12 @@ class SdkBackend:
         producer calls this every pass: any alive, timer-armed session with no running thread is
         reconnected — resume re-hydrates its timer set (verified live 2026-08-28: CronList shows the
         same cron in a fresh process after a kill), and the CLI does ALL the firing natively; romp
-        never fires a timer itself. Residual, accepted: a timer due inside the ~minute a kernel
-        restart takes can still miss (the down window has no process to fire it and no catch-up
-        exists for session-scoped timers CLI-side).
+        never fires a timer itself. A recurring slot due inside a down window is CAUGHT UP by the
+        resumed CLI itself (it re-fires passed slots on --resume, verified live 2026-09-01) — and
+        the same behavior re-fires slots that already ran, once per restart, so the catch-up is
+        only safe because _prompt_submit_hook's delivered-slot gate blocks the replays (T211).
+        Residual, accepted: a ONE-SHOT due inside the down window still misses CLI-side
+        (deliver_lost_wakeups owns those).
 
         A 120s per-sid retry floor bounds the failure mode where a timer-armed session's CLI dies
         instantly on every spawn — without it this sweep would respawn it every producer pass

--- a/tests/test_cron_replay_dedupe.py
+++ b/tests/test_cron_replay_dedupe.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""T211 (2026-09-01): kernel restarts REPLAYED recurring-cron prompts. A resumed CLI catch-up-fires
+the slot that passed while its previous process was dead — its last-fired memory dies with the
+process — so under immediate deploy restarts every restart bought one spurious fire per recurring
+cron (a real nightly fired ~21x in one merge-heavy day; each extra fire landed within ~1s of a
+"reviving …" revive and was preceded by the fresh process's own startup records). The fix is the
+UserPromptSubmit replay gate (_prompt_submit_hook): the DELIVERY moment durably records
+(schedule identity, slot epoch) in the reg's cronDelivered map, and a fire recomputing an
+already-recorded slot is blocked before the model runs. These tests drive the dispatch's repro
+shape exactly: arm → deliver → simulate the restart (a fresh SdkSession over the same reg — the
+boot re-arm) → the replay is refused; and the converse — armed but never delivered → still fires
+after the restart. Synthetic fixtures; PRIVATE sid (the goal-store fixture rule)."""
+import asyncio
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the load — the module resolves its state root at import time, and only
+# pytest runs conftest's floor (a bare unittest run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_t211", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "7a7a7a7a-1111-4222-8333-000000000211"          # private synthetic sid — never the shared one
+PROMPT = "nightly sweep of the notes-api test corpus"
+CRON = "0 0 1 1 *"          # Jan 1 00:00 — its most recent slot is FIXED for the whole test run,
+#                             so a delivery and its replay compute the same slot deterministically
+CORRUPT = b'{"sid": "trunca'
+
+
+def _epoch(y, mo, d, h=0, mi=0):
+    return time.mktime((y, mo, d, h, mi, 0, -1, -1, -1))
+
+
+class CronPrevDue(unittest.TestCase):
+    """The slot function is the gate's event identity — pin its truth table."""
+
+    def test_nightly_before_and_after_the_slot(self):
+        # 2026-03-10 is an arbitrary fixed date; cron 02:37 nightly
+        self.assertEqual(sb.cron_prev_due("37 2 * * *", _epoch(2026, 3, 10, 12, 0)),
+                         _epoch(2026, 3, 10, 2, 37))
+        self.assertEqual(sb.cron_prev_due("37 2 * * *", _epoch(2026, 3, 10, 2, 36)),
+                         _epoch(2026, 3, 9, 2, 37), "before today's slot → yesterday's")
+        self.assertEqual(sb.cron_prev_due("37 2 * * *", _epoch(2026, 3, 10, 2, 37)),
+                         _epoch(2026, 3, 10, 2, 37), "the due minute itself counts")
+
+    def test_every_minute_floors_to_the_minute(self):
+        now = _epoch(2026, 3, 10, 12, 5) + 42
+        self.assertEqual(sb.cron_prev_due("* * * * *", now), _epoch(2026, 3, 10, 12, 5))
+
+    def test_steps_ranges_lists(self):
+        self.assertEqual(sb.cron_prev_due("*/15 * * * *", _epoch(2026, 3, 10, 12, 40)),
+                         _epoch(2026, 3, 10, 12, 30))
+        self.assertEqual(sb.cron_prev_due("5,35 9-17 * * *", _epoch(2026, 3, 10, 8, 0)),
+                         _epoch(2026, 3, 9, 17, 35), "before the range opens → yesterday's last")
+
+    def test_weekly_dow(self):
+        # 2026-03-10 is a Tuesday; cron Monday 09:00 → Monday 2026-03-09
+        self.assertEqual(sb.cron_prev_due("0 9 * * 1", _epoch(2026, 3, 10, 12, 0)),
+                         _epoch(2026, 3, 9, 9, 0))
+        self.assertEqual(sb.cron_prev_due("0 9 * * 7", _epoch(2026, 3, 10, 12, 0)),
+                         _epoch(2026, 3, 8, 9, 0), "dow 7 is Sunday")
+
+    def test_dom_dow_both_restricted_is_vixie_or(self):
+        # Friday 2026-03-13: matches BOTH "the 13th" and "Friday"; from the 14th, the most
+        # recent "13th OR Friday" hit is the 13th itself
+        self.assertEqual(sb.cron_prev_due("0 0 13 * 5", _epoch(2026, 3, 14, 12, 0)),
+                         _epoch(2026, 3, 13, 0, 0))
+        # from Thursday the 12th, the previous FRIDAY (the 6th) beats the previous 13th (Feb 13)
+        self.assertEqual(sb.cron_prev_due("0 0 13 * 5", _epoch(2026, 3, 12, 12, 0)),
+                         _epoch(2026, 3, 6, 0, 0))
+
+    def test_month_restriction_reaches_back(self):
+        self.assertEqual(sb.cron_prev_due("0 0 1 1 *", _epoch(2026, 6, 1, 0, 0)),
+                         _epoch(2026, 1, 1, 0, 0))
+
+    def test_unparseable_and_impossible_shapes_return_none(self):
+        for bad in ("", "x", "61 2 * * *", "1 2 3", "1 2 3 4 5 6", "5/ * * * *", "9-3 * * * *"):
+            self.assertIsNone(sb.cron_prev_due(bad, time.time()), bad)
+        self.assertIsNone(sb.cron_prev_due("0 0 30 2 *", time.time()),
+                          "a never-matching date terminates via the lookback bound")
+
+
+class _Gate(unittest.TestCase):
+    """A real backend + session over a private reg; 'restart' = a FRESH SdkSession over the same
+    reg (fresh procGen — exactly what boot re-arm/ensure_scheduled builds after a kernel death)."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.logs = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        sb.write_reg(Path(self.d), SID, {
+            "sid": SID, "name": "sched", "cwd": "/tmp", "alive": True,
+            "sessionCrons": [{"id": "c1", "cron": CRON, "prompt": PROMPT, "kind": "cron",
+                              "recurring": True, "armedAt": time.time() - 3600,
+                              "dueEpoch": None, "procGen": "gen-A"}]})
+        self._path = sb._reg_path(Path(self.d), SID)
+
+    def _session(self):
+        return sb.SdkSession(self.be, sb.read_reg(Path(self.d), SID))
+
+    def _fire(self, sess, prompt=PROMPT):
+        return asyncio.run(sess._prompt_submit_hook({"prompt": prompt}, None, None))
+
+    def _reg(self):
+        return sb.read_reg(Path(self.d), SID) or {}
+
+
+class ReplayAcrossRestarts(_Gate):
+    """The dispatch's required repro, red before the gate existed."""
+
+    def test_delivered_slot_blocks_the_restart_replay(self):
+        s1 = self._session()
+        self.assertEqual(self._fire(s1), {}, "the first delivery of a slot goes through")
+        slot = sb.cron_prev_due(CRON, time.time())
+        key = sb.cron_slot_key(CRON, PROMPT)
+        self.assertEqual(self._reg().get("cronDelivered"), {key: slot},
+                         "delivery — not arming — writes the durable slot record")
+        s2 = self._session()                       # the kernel restarted; boot re-arm resumed it
+        out = self._fire(s2)                       # the fresh CLI catch-up re-fires the slot
+        self.assertEqual(out.get("decision"), "block", "the replay is refused")
+        self.assertIn("already ran", out.get("reason", ""))
+        self.assertEqual(self._reg().get("cronDelivered"), {key: slot},
+                         "a refused replay changes nothing")
+        self.assertTrue(any("blocked a replayed schedule fire" in m for m in self.logs),
+                        "the refusal is loud, never silent")
+
+    def test_armed_but_undelivered_still_fires_after_the_restart(self):
+        s2 = self._session()                       # died before ever delivering; resumed post-restart
+        self.assertEqual(self._fire(s2), {},
+                         "no delivery record → the catch-up fire is the recovery, not a replay")
+        self.assertTrue(self._reg().get("cronDelivered"), "…and it records at that moment")
+
+    def test_same_process_double_fire_is_also_blocked(self):
+        s1 = self._session()
+        self._fire(s1)
+        self.assertEqual(self._fire(s1).get("decision"), "block",
+                         "the key is the slot, not the process generation")
+
+    def test_the_next_slot_is_not_a_replay(self):
+        key = sb.cron_slot_key(CRON, PROMPT)
+        prev_year_slot = _epoch(time.localtime().tm_year - 1, 1, 1)
+        reg = self._reg()
+        reg["cronDelivered"] = {key: prev_year_slot}
+        sb.write_reg(Path(self.d), SID, reg)
+        s2 = self._session()
+        self.assertEqual(self._fire(s2), {}, "a NEWER slot due → delivery, not replay")
+        self.assertEqual(self._reg()["cronDelivered"][key], sb.cron_prev_due(CRON, time.time()),
+                         "the record advances to the delivered slot")
+
+
+class GateScope(_Gate):
+    """What the gate must NOT touch."""
+
+    def test_non_matching_prompts_pass_untouched(self):
+        s = self._session()
+        self.assertEqual(self._fire(s, "an ordinary user message"), {})
+        self.assertNotIn("cronDelivered", self._reg(), "no matching schedule → no write at all")
+
+    def test_one_shots_never_engage_the_gate(self):
+        reg = self._reg()
+        reg["sessionCrons"] = [{"id": "w1", "cron": "", "prompt": PROMPT, "recurring": False,
+                                "armedAt": time.time(), "dueEpoch": time.time() + 60,
+                                "procGen": "gen-A", "src": "toolhook"}]
+        sb.write_reg(Path(self.d), SID, reg)
+        s = self._session()
+        self.assertEqual(self._fire(s), {})
+        self.assertNotIn("cronDelivered", self._reg(),
+                         "one-shots are deliver_lost_wakeups' domain (strip-first, already safe)")
+
+    def test_unparseable_schedule_stands_down_open(self):
+        reg = self._reg()
+        reg["sessionCrons"][0]["cron"] = "@daily"
+        sb.write_reg(Path(self.d), SID, reg)
+        s = self._session()
+        self.assertEqual(self._fire(s), {}, "a shape romp can't reason about exactly → allow")
+        self.assertNotIn("cronDelivered", self._reg())
+
+    def test_long_prompts_match_on_the_recorded_500(self):
+        long_prompt = "x" * 480 + PROMPT           # the reg stores prompt[:500]
+        reg = self._reg()
+        reg["sessionCrons"][0]["prompt"] = long_prompt[:500]
+        sb.write_reg(Path(self.d), SID, reg)
+        s1 = self._session()
+        self.assertEqual(self._fire(s1, long_prompt), {})
+        s2 = self._session()
+        self.assertEqual(self._fire(s2, long_prompt).get("decision"), "block")
+
+    def test_stale_keys_gc_with_the_armed_set(self):
+        reg = self._reg()
+        reg["cronDelivered"] = {"deadbeefdeadbeef": 12345.0}   # a schedule no longer armed
+        sb.write_reg(Path(self.d), SID, reg)
+        s = self._session()
+        self._fire(s)
+        self.assertNotIn("deadbeefdeadbeef", self._reg()["cronDelivered"],
+                         "the map never outgrows the armed set + this delivery")
+
+
+class FailsOpen(_Gate):
+    """Uncertainty must cost a possible duplicate, never a swallowed slot."""
+
+    def test_unreadable_reg_allows_and_says_so(self):
+        s = self._session()
+        self._path.write_bytes(CORRUPT)
+        self.assertEqual(self._fire(s), {}, "fail OPEN")
+        self.assertEqual(self._path.read_bytes(), CORRUPT, "…and never writes through the corruption")
+        self.assertTrue(any("unreadable" in m for m in self.logs), "loudly")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

Kernel restarts re-delivered scheduled cron prompts. A resumed CLI catch-up-fires a recurring cron whose slot passed while its previous process was dead — its last-fired memory dies with the process — so under immediate deploy restarts every restart bought one spurious fire per recurring cron. Field damage: one nightly cron fired ~21 times on 2026-08-31 (a ~15-restart day), and the replays continued daily until this change.

## Conviction (live forensics)

- Every extra fire lands within ~1s of a `scheduled-session sweep: reviving …` log line, each from a different kernel pid (post-restart revive).
- 21/23 replay enqueues are immediately preceded in the transcript by the fresh CLI's own startup records; the two exceptions are the exact-slot legitimate fires.
- `deliver_lost_wakeups` is clean (recurring-filtered, strip-first); the reg entries are correctly `recurring:true` — the replayer is the CLI itself, triggered by every revive.
- Verified live with a throwaway probe session (3 phases): UserPromptSubmit fires for the CLI's own cron deliveries with the raw prompt text; the resume catch-up reproduces synthetically (fires 2-6s after resume, off the minute boundary); a hook `decision:block` stops the turn at `duration_api_ms=0, num_turns=0, total_cost_usd=0`.

## The fix

The durable memory lives at the only moment that counts — DELIVERY, never arm time: a `UserPromptSubmit` hook (`_prompt_submit_hook`) matches the prompt against the reg's armed recurring crons, computes the slot (`cron_prev_due`, exact vixie semantics with the dom/dow OR rule), and consults the reg's new `cronDelivered` map keyed on (schedule identity, slot epoch):

- recorded → the fire is a replay: blocked before the model runs, loudly (kernel log + the hook reason in the transcript);
- not recorded → record, then allow — so a slot the dead process genuinely never delivered still fires exactly once after a restart (the CLI's own catch-up becomes the recovery instead of the bug).

Schedule identity is `cron_slot_key(cron string, prompt)`, deliberately NOT the CLI's cron id: re-hydration mints fresh ids for the same schedule, and an id-keyed record would wave every re-minted replay through. Every uncertain path fails OPEN (unreadable reg via `read_reg_for_rmw`, unparseable schedule, hook error): a duplicate fire costs a turn, a swallowed slot costs the schedule itself.

## Tests

`tests/test_cron_replay_dedupe.py` (17, red against the unpatched backend — verified: 17 failures pre-fix): the dispatch's repro shape exactly (arm → deliver → fresh SdkSession over the same reg = the boot re-arm → replay refused; converse: armed-but-undelivered still fires post-restart), the slot function's truth table (nightly/steps/ranges/dow-7/vixie dom-or-dow/month reach-back/impossible dates), scope guards (non-matching prompts untouched, one-shots never engage, unparseable schedules stand down open, 500-char prompt truncation matches, stale-key GC), and fail-open on an unreadable reg with the loud log pinned.

Suites on this head: pytest 6333 passed + 335 subtests (35 skipped), vscode-extension npm 2629/2629. No shell surfaces touched (bats not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)