### PR TITLE
T217: the restart gap is measured, announced, bridged translucently, and unflagged

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13063,6 +13063,9 @@ def _append_restart_cut(row):
 
 
 _BOOT_MARKS = {}                                   # {"firstServe": t, "reconcileDone": t} — see _mark_boot
+_BOOT_MARKS_LOCK = threading.Lock()                # the two marks land on DIFFERENT threads (main vs the
+#                                                    lazy backend builder) — without this, both could see
+#                                                    "both present" and double-append the boot row
 
 
 def _append_boot_settled(first_serve, reconcile_done):
@@ -13100,10 +13103,15 @@ def _mark_boot(kind):
     builds LAZILY, so the two marks land in either order; whichever lands second appends the
     boot-settled row. Idempotent per kind, never raises."""
     try:
-        if kind in _BOOT_MARKS:
-            return
-        _BOOT_MARKS[kind] = time.time()
-        if "firstServe" in _BOOT_MARKS and "reconcileDone" in _BOOT_MARKS:
+        with _BOOT_MARKS_LOCK:
+            if kind in _BOOT_MARKS:
+                return
+            _BOOT_MARKS[kind] = time.time()
+            write = "firstServe" in _BOOT_MARKS and "reconcileDone" in _BOOT_MARKS \
+                and not _BOOT_MARKS.get("_row")
+            if write:
+                _BOOT_MARKS["_row"] = True         # exactly one row per boot, whichever thread wins
+        if write:
             _append_boot_settled(_BOOT_MARKS["firstServe"], _BOOT_MARKS["reconcileDone"])
     except Exception:
         pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8116,10 +8116,13 @@ def _sdk_locked():
             # The backend's flag-consumption events resolve held rewinds (two-phase goal cleanup:
             # archive at the branch-take, restore on failure — _on_rewind_resolved).
             _sdk_backend.rewind_resolved_cb = _on_rewind_resolved
+            _mark_boot("reconcileDone")            # T217: the boot reconcile ran inside the
+            #                                        construct above — the settle's other bookend
         except Exception:
             sys.stderr.write("sdk-backend unavailable: %s\n" % traceback.format_exc())
             _sdk_problem("the SDK backend could not be built: %s" % traceback.format_exc())
             _sdk_backend = False
+            _mark_boot("reconcileDone")            # unavailable = the reconcile phase is over too
     return _sdk_backend or None
 
 
@@ -13055,6 +13058,53 @@ def _append_restart_cut(row):
         with open(RESTART_CUTS_FILE, "a", encoding="utf-8") as f:
             f.write(json.dumps(row) + "\n")
             f.flush()
+    except Exception:
+        pass
+
+
+_BOOT_MARKS = {}                                   # {"firstServe": t, "reconcileDone": t} — see _mark_boot
+
+
+def _append_boot_settled(first_serve, reconcile_done):
+    """The outage's other bookend (T217: nothing recorded how long a restart GAP lasted, so no seam
+    work is verifiable): one boot row in the same ledger, carrying when this kernel first accepted
+    requests and when its boot reconcile finished, plus outageS — firstServe minus the PREVIOUS cut
+    row's t, the felt window. Same-host deltas only by construction: the ledger lives under this
+    host's own STATE, so rows never mix clocks. Best-effort like every writer here."""
+    try:
+        prev_cut = None
+        try:
+            for line in RESTART_CUTS_FILE.read_text(encoding="utf-8").splitlines():
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(r, dict) and "cutTurns" in r:
+                    prev_cut = r
+        except OSError:
+            pass
+        row = {"t": int(time.time()), "pid": os.getpid(), "bootSettled": True,
+               "firstServe": round(first_serve, 2), "reconcileDone": round(reconcile_done, 2),
+               "settleS": round(reconcile_done - first_serve, 2)}
+        if prev_cut and isinstance(prev_cut.get("t"), int) and first_serve >= prev_cut["t"]:
+            row["prevCutT"] = prev_cut["t"]
+            row["outageS"] = round(first_serve - prev_cut["t"], 2)
+        _append_restart_cut(row)
+    except Exception:
+        pass
+
+
+def _mark_boot(kind):
+    """One boot milestone (firstServe = the accept loop starts; reconcileDone = the SDK backend's
+    boot reconcile returned, or was found unavailable — the phase is over either way). The backend
+    builds LAZILY, so the two marks land in either order; whichever lands second appends the
+    boot-settled row. Idempotent per kind, never raises."""
+    try:
+        if kind in _BOOT_MARKS:
+            return
+        _BOOT_MARKS[kind] = time.time()
+        if "firstServe" in _BOOT_MARKS and "reconcileDone" in _BOOT_MARKS:
+            _append_boot_settled(_BOOT_MARKS["firstServe"], _BOOT_MARKS["reconcileDone"])
     except Exception:
         pass
 
@@ -25678,6 +25728,30 @@ def _push(targets, connect=False, tmux=None):
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 
 
+def _broadcast_restarting(budget_s=0.8):
+    """One final frame to every connected ws client as the kernel dies (T217: the shims otherwise
+    learn of the restart only when their socket closes and redial on a blind cadence): {type:
+    restarting, boot} — the announced-death event the shim keys its eager reconnect and its
+    banner-suppression latch on. Best-effort with a HARD sub-second budget: a client whose pipe
+    stalls is skipped, a raising send is swallowed, and the whole walk stops at the deadline — the
+    frame must never widen the shutdown (the dispatch's bound). Same-thread, no queue: the process
+    is about to _exit and nothing else will flush."""
+    try:
+        deadline = time.time() + budget_s
+        with _clients_lock:
+            clients = list(_clients)
+        payload = json.dumps({"type": "restarting", "boot": _BOOT_ID})
+        for c in clients:
+            if time.time() >= deadline:
+                break
+            try:
+                c["send"](payload)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
 def _push_all(tmux=None):
     with _clients_lock:
         clients = list(_clients)
@@ -26590,7 +26664,7 @@ function armStale(why){if(staleTimer)return;staleTimer=setTimeout(function(){sta
 // baked LOADEDV is older is running outdated code against newer kernel state — prompt a reload (never auto).
 // In the dashboard the raise routes to the shell's #rstale banner (build:1 → its BUILDMSG); standalone pages
 // self-inject the same bar. Latched: one prompt per page life, cleared only by the reload it asks for.
-var buildRaised=false,freshPending=false;   // freshPending: a reconnect is awaiting its resync frame
+var buildRaised=false,freshPending=false,restartAnnounced=0;   // freshPending: a reconnect is awaiting its resync frame; restartAnnounced: the kernel's dying frame (T217)
 function raiseBuild(){if(buildRaised)return;buildRaised=true;
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale",build:1},"*");}catch(e){}}
 else selfBar("A newer romp build is available.","build");}
@@ -26605,16 +26679,27 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s"+(wid?"&wid="+encodeURIComponen
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
-ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){armStale("reconnect");freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
+ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];
+if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;   // one-shot: spent here
+if(!ann)armStale("reconnect");   // T217: an ANNOUNCED restart's reconnect skips the arm — the resync lands in a beat and the flash was pure noise; the resync-never-arrives case re-raises through the keepalive watchdog's forced second reconnect, which arms as always
+freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
+// T217: the kernel announces its own death (one final frame from the dying process). Latch it: the
+// imminent close is EXPECTED — onclose redials eagerly instead of on the blind cadence, and the
+// reconnect skips the stale-banner arm once (the resync is seconds away; a restart that never
+// comes back stays loud through the disconnected state itself, and a SECOND reconnect arms as
+// always — the latch is one-shot). 30s staleness bound so a spent announcement can never drive
+// tight retries forever.
+if(msg&&msg.type==="restarting"){restartAnnounced=Date.now();staleDiag("restart-announced","");return;}
 // the first REAL frame after a reconnect is the kernel's connect-time push — the resync itself, so the
 // "what you see may be stale" prompt is answered and retires (see clearStale). Keepalives return above.
 if(freshPending){freshPending=false;clearStale();}
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
-ws.onclose=function(){netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}setTimeout(connect,1500);};
+ws.onclose=function(){netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}
+setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);};   // announced death → tight redial (the frame is the event; the blind 1.5s stays for unannounced drops)
 ws.onerror=function(){try{ws.close();}catch(e){}};}
 function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);else queue.push(s);}
 window.__rompLocalSend=send;window.__rompApp=APP;   // federation.ts (the multi-kernel manager) routes local sends + knows the app through these
@@ -26885,8 +26970,20 @@ def _pane_spin(cid, ignore_id=""):
             "background:var(--vscode-editor-background,#1e1e1e);transition:opacity .3s ease}"
             "#pane-spin.gone{opacity:0;pointer-events:none}"
             # light theme: the loader backdrop goes warm-light with the page
-            "body.theme-light #pane-spin{background:#F1EAE2}" + _LOADER_CSS + "</style>"
+            "body.theme-light #pane-spin{background:#F1EAE2}" + _LOADER_CSS +
+            # T217: the RECONNECTING affordance for a pane that already HAS content — a small corner
+            # badge (swirl + label) over the frozen, still-legible pane, never the opaque loader (the
+            # user kept losing seconds-stale but perfectly readable content behind a full-pane sheet).
+            # pointer-events:none: clicks land on the content and queue in the shim, by design.
+            "#pane-reconn{position:fixed;top:8px;right:8px;z-index:61;display:none;align-items:center;"
+            "gap:7px;padding:4px 11px;border-radius:6px;background:rgba(37,37,38,0.88);"
+            "border:1px solid rgba(255,255,255,0.12);box-shadow:0 4px 12px rgba(0,0,0,0.35);"
+            "font:12px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#ccc;pointer-events:none}"
+            "#pane-reconn.on{display:flex}"
+            "#pane-reconn img{width:14px;height:14px;animation:rl-spin 7s linear infinite}"
+            "body.theme-light #pane-reconn{background:rgba(241,234,226,0.92);color:#333}</style>"
             "<div id=pane-spin>" + _loader_inner() + "</div>"
+            "<div id=pane-reconn><img src=/media/romp-swirl-glyph.svg alt=''>reconnecting…</div>"
             "<script>(function(){var o=document.getElementById('pane-spin'),c=document.getElementById('" + cid + "'),IGN='" + ignore_id + "';"
             "if(!o)return;var fail=0;"
             "function arm(){clearTimeout(fail);fail=setTimeout(hide,30000);}"   # per SHOW, not per page load
@@ -26896,8 +26993,13 @@ def _pane_spin(cid, ignore_id=""):
             "arm();"
             "if(c){try{new MutationObserver(function(){if(ready())hide();}).observe(c,{childList:true});}catch(e){}"
             "if(ready())hide();}"
-            "window.addEventListener('romp:wsdown',show);"
-            "window.addEventListener('romp:wsup',hide);})();</script>")
+            "var rb=document.getElementById('pane-reconn');"
+            "function badge(on){if(rb)rb.classList.toggle('on',!!on);}"
+            # T217: a drop over EXISTING content keeps the content — translucent corner badge, not
+            # the opaque sheet; the sheet stays for a genuinely empty pane (cold load / never
+            # painted), per the loading-states rule. wsup ends both, exactly as before.
+            "window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});"
+            "window.addEventListener('romp:wsup',function(){badge(false);hide();});})();</script>")
 
 
 def _chat_page():
@@ -32562,6 +32664,9 @@ def _graceful_term(signum, frame):
     mutation, and a cut turn keeps its 'working' state tail — the NEXT kernel's boot reconcile
     resumes exactly those. Bounded (~2s) so `romp refresh` stays snappy. Never construct the
     backend here — no SDK sessions were running if it doesn't exist."""
+    _broadcast_restarting()                        # T217: announce the death FIRST — the frame is
+    #                                                the shims' eager-reconnect event, and its
+    #                                                sub-second budget cannot widen the shutdown
     res = {}
     err = ""
     try:
@@ -32653,6 +32758,8 @@ def main():
             webbrowser.open(url + "/?token=" + TOKEN)   # seeds the year-long cookie on first open (Jupyter's URL flow)
         except Exception:
             pass
+    _mark_boot("firstServe")                       # T217: the socket is bound and the accept loop
+    #                                                starts now — the outage's closing bookend
     try:
         srv.serve_forever()
     except KeyboardInterrupt:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6670,7 +6670,7 @@ class ServeSecurity(unittest.TestCase):
         self.assertIn('app=fleet', body)
         # the romp loader RE-SHOWS on a kernel restart / WS drop (the user 2026-06-29): the shim fires
         # 'romp:wsdown' on ws.onclose and the pane loader un-fades over the stale pane until reconnect.
-        self.assertIn("window.addEventListener('romp:wsdown',show)", body)        # loader re-shows
+        self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});", body)   # T217: content → badge; empty pane → the sheet
         self.assertIn('dispatchEvent(new Event("romp:wsdown"))', body)            # shim fires it on close
         self.assertIn("function show(){o.classList.remove('gone')", body)         # kept in the DOM, not removed
 

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -31,7 +31,8 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('postMessage({romp:"wsState",app:APP,state:s}', js)
         self.assertIn('ws.onopen=function(){lastRecv=Date.now();netState("up");', js)   # lastRecv stamp → heartbeat watchdog
         self.assertIn('ws.onclose=function(){netState("down");', js)   # reconnects on close (wsdown loader + retry follow)
-        self.assertIn("setTimeout(connect,1500);", js)
+        self.assertIn("setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);",
+                      js, "T217: an ANNOUNCED death redials tight; the blind 1.5s stays for real drops")
         self.assertIn("ws.onerror=function(){try{ws.close();}catch(e){}};", js)
         # a RECONNECT no longer silently reloads (the user 2026-07-05): it PROMPTS via raiseStale, and the fresh
         # socket resyncs live. The old auto-reload-on-reopen is gone.
@@ -39,8 +40,10 @@ class DisconnectBanner(unittest.TestCase):
         # (test_pane_loader_reconnect.py owns that half)
         # …and ARMS the retire (freshPending) so the prompt clears itself when the resync frame lands
         # (the user 2026-08-01) — see test_the_connection_prompt_retires_when_the_resync_lands
-        self.assertIn('if(wasReconn){armStale("reconnect");freshPending=true;'
-                      'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
+        self.assertIn('if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;'
+                      'restartAnnounced=0;', js)   # T217: the announced-restart latch spends inside the gate
+        self.assertIn('if(!ann)armStale("reconnect");', js)
+        self.assertIn('try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
         self.assertNotIn("if(everConnected){location.reload();return;}", js,
                          "the silent auto-reload-on-reconnect is replaced by a reload PROMPT")
         self.assertNotIn("ws.onclose=function(){setTimeout(function(){location.reload();},1500);};", js,
@@ -140,7 +143,8 @@ class DisconnectBanner(unittest.TestCase):
         # and straight back down on nearly every dashboard open, since the resync lands within a beat.
         self.assertIn("staleTimer=setTimeout(function(){staleTimer=0;raiseStale(why);},1000)", js,
                       "a one-second arming window, not an immediate raise")
-        self.assertIn('if(wasReconn){armStale("reconnect");', js, "the reconnect ARMS it")
+        self.assertIn('if(!ann)armStale("reconnect");', js,
+                      "the reconnect ARMS it — except the one an ANNOUNCED restart already explained (T217)")
         self.assertNotIn("if(wasReconn){raiseStale();", js, "…and never raises it outright")
         self.assertIn("if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}", js,
                       "a resync inside the window disarms it, so it never appears at all")

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -114,7 +114,7 @@ class BuildDriftBanner(unittest.TestCase):
                       "embedded pane routes build drift to the shell banner, tagged so it words it as a BUILD")
         self.assertIn('selfBar("A newer romp build is available.","build")', js,
                       "standalone page self-injects the same reload bar")
-        self.assertIn("var buildRaised=false,freshPending=false;", js)   # latched: one prompt per page life
+        self.assertIn("var buildRaised=false,freshPending=false,restartAnnounced=0;", js)   # latched: one prompt per page life (T217 added the announced-restart latch to the line)
         #                                    (freshPending rides along: the CONN prompt's self-retire, 2026-08-01)
 
     def test_every_pane_page_passes_its_version_to_the_shim(self):

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -61,18 +61,20 @@ class PaneLoaderReconnect(unittest.TestCase):
     def test_the_loader_comes_down_when_the_socket_comes_back(self):
         """The event-based exit for the re-show path. Without it the only way down is the failsafe, i.e.
         30 seconds of romp logo over a pane whose socket reconnected in under two."""
-        self.assertIn("window.addEventListener('romp:wsup',hide);", self.js)
-        self.assertIn("window.addEventListener('romp:wsdown',show);", self.js,
-                      "the drop still raises it — this is a matched pair")
+        self.assertIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", self.js)
+        self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});", self.js,
+                      "the drop still raises SOMETHING — a matched pair; since T217 a pane with "
+                      "content gets the translucent badge and only an empty pane the opaque sheet")
 
     def test_the_shim_fires_wsup_on_a_reconnect_only(self):
         """A first connect must NOT fire it: the loader is legitimately up during a cold load and has to
         stay there until real content lands (an 8s timer that hid it early was the 2026-07-03 bug)."""
         shim = km._shim("chat")
-        self.assertIn('if(wasReconn){armStale("reconnect");freshPending=true;'
-                      'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}',
-                      shim, "wsup rides the same wasReconn gate as the reload prompt (which now also arms "
-                            "its own retire — the user 2026-08-01)")
+        self.assertIn('if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;'
+                      'restartAnnounced=0;', shim,
+                      "the wasReconn gate stands; T217 spends the announced-restart latch inside it")
+        self.assertIn('try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', shim,
+                      "wsup still rides the same wasReconn gate as the reload prompt")
         self.assertIn("var wasReconn=everConnected;everConnected=true;", shim,
                       "and wasReconn still means 'this socket had connected before'")
 
@@ -82,10 +84,10 @@ class PaneLoaderReconnect(unittest.TestCase):
         bars-area loader instead, the user 2026-06-26) — it still carries the shim, so it gets the event
         whether or not anything listens today."""
         for page in (km._chat_page(), km._feed_page(), km._fleet_page()):
-            self.assertIn("window.addEventListener('romp:wsup',hide);", page)
+            self.assertIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", page)
             self.assertIn('new Event("romp:wsup")', page)
         self.assertIn('new Event("romp:wsup")', km._timeline_page())
-        self.assertNotIn("window.addEventListener('romp:wsup',hide);", km._timeline_page(),
+        self.assertNotIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", km._timeline_page(),
                          "the timeline still owns no _pane_spin overlay")
 
 

--- a/tests/test_restart_seam.py
+++ b/tests/test_restart_seam.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Restart layer 2 (T217, the user 2026-09-01): the felt restart gap shrinks to a blip, and is
+finally MEASURED. Four pieces, tested per piece:
+(1) boot-settled — the outage's other bookend in restart-cuts.jsonl: firstServe (the accept loop
+    starts) + reconcileDone (the SDK boot reconcile returned, or was found unavailable), plus
+    outageS = firstServe minus the previous cut row's t. Same-host deltas only by construction
+    (the ledger lives under one host's STATE).
+(2) the dying kernel ANNOUNCES itself: one {type: restarting, boot} frame to every ws client,
+    enqueue-only (the per-client writer thread owns the socket) under a hard sub-second walk
+    budget — the frame can never widen the shutdown.
+(3) the shims reconnect ON that event (tight redial after an announced death; the blind 1.5s
+    cadence stays for unannounced drops), and a drop over EXISTING content shows a translucent
+    corner badge instead of the opaque loader — content stays legible; the opaque sheet remains
+    for a genuinely empty pane (the loading-states rule).
+(4) an announced restart's reconnect skips the stale-banner arm ONCE (the resync lands in a
+    beat; the flash was noise) — a restart that never comes back stays loud through the
+    disconnected state, and any SECOND reconnect arms exactly as before.
+SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_rseam", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+KSRC = open(os.path.join(BIN, "romp-kernel")).read()
+
+
+class BootSettled(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = km.RESTART_CUTS_FILE
+        km.RESTART_CUTS_FILE = Path(self.td.name) / "restart-cuts.jsonl"
+        km._BOOT_MARKS.clear()
+
+    def tearDown(self):
+        km.RESTART_CUTS_FILE = self.saved
+        km._BOOT_MARKS.clear()
+        self.td.cleanup()
+
+    def _rows(self):
+        p = km.RESTART_CUTS_FILE
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+    def test_the_second_mark_appends_one_row_with_the_outage_delta(self):
+        cut_t = int(time.time()) - 7
+        km._append_restart_cut({"t": cut_t, "pid": 1, "cutTurns": [], "stopped": 0,
+                                "unjoined": 0, "reaped": 0, "watchesArmed": 0, "reason": "x"})
+        km._mark_boot("firstServe")
+        self.assertEqual(len(self._rows()), 1, "one mark alone appends nothing")
+        km._mark_boot("reconcileDone")
+        rows = self._rows()
+        self.assertEqual(len(rows), 2)
+        b = rows[-1]
+        self.assertTrue(b.get("bootSettled"))
+        self.assertEqual(b.get("prevCutT"), cut_t)
+        self.assertAlmostEqual(b["outageS"], b["firstServe"] - cut_t, places=1,
+                               msg="outageS IS the felt window: previous cut to first serve")
+        self.assertIn("settleS", b, "reconcile-done minus first-serve rides along")
+
+    def test_marks_land_in_either_order(self):
+        km._mark_boot("reconcileDone")               # the backend builds lazily — order is not fixed
+        self.assertEqual(self._rows(), [])
+        km._mark_boot("firstServe")
+        self.assertEqual(len(self._rows()), 1)
+
+    def test_a_fresh_install_row_carries_no_outage(self):
+        km._mark_boot("firstServe")
+        km._mark_boot("reconcileDone")
+        b = self._rows()[-1]
+        self.assertNotIn("outageS", b, "no previous cut row → no delta to claim")
+
+    def test_marks_are_idempotent(self):
+        km._mark_boot("firstServe")
+        km._mark_boot("firstServe")
+        km._mark_boot("reconcileDone")
+        km._mark_boot("reconcileDone")
+        self.assertEqual(len(self._rows()), 1, "one row per boot, however often the marks re-fire")
+
+    def test_the_boot_hooks_are_wired_at_both_bookends(self):
+        self.assertIn('_mark_boot("firstServe")', KSRC.split("srv.serve_forever()")[0][-600:],
+                      "firstServe stamps right before the accept loop starts")
+        self.assertEqual(KSRC.count('_mark_boot("reconcileDone")'), 2,
+                         "the reconcile phase ends on BOTH backend arms (built and unavailable)")
+
+
+class RestartingBroadcast(unittest.TestCase):
+    def setUp(self):
+        self._saved = list(km._clients)
+        with km._clients_lock:
+            km._clients[:] = []
+
+    def tearDown(self):
+        with km._clients_lock:
+            km._clients[:] = self._saved
+
+    def _client(self, sends, fail=False):
+        def send(s):
+            if fail:
+                raise OSError("dead pipe")
+            sends.append(s)
+        return {"app": "chat", "wid": "w", "send": send, "alive": True}
+
+    def test_every_client_gets_the_one_dying_frame(self):
+        sends = []
+        with km._clients_lock:
+            km._clients[:] = [self._client(sends), self._client(sends)]
+        km._broadcast_restarting()
+        self.assertEqual(len(sends), 2)
+        for s in sends:
+            m = json.loads(s)
+            self.assertEqual(m["type"], "restarting")
+            self.assertIn("boot", m, "the boot id rides along — the shim can tell lives apart")
+
+    def test_a_dead_client_never_breaks_the_walk(self):
+        sends = []
+        with km._clients_lock:
+            km._clients[:] = [self._client(sends, fail=True), self._client(sends)]
+        km._broadcast_restarting()
+        self.assertEqual(len(sends), 1, "the raising client is skipped, the next still gets its frame")
+
+    def test_the_walk_respects_its_budget(self):
+        # sends are enqueue-only in production (the per-client writer thread owns the socket), so
+        # the budget is a backstop — pinned here with a deliberately slow fake
+        sends = []
+
+        def slow(s):
+            time.sleep(0.4)
+            sends.append(s)
+        with km._clients_lock:
+            km._clients[:] = [{"app": "chat", "wid": str(i), "send": slow, "alive": True}
+                              for i in range(10)]
+        t0 = time.time()
+        km._broadcast_restarting(budget_s=0.5)
+        took = time.time() - t0
+        self.assertLess(took, 1.5, "the deadline stops the walk — a slow pipe cannot widen the shutdown")
+        self.assertLess(len(sends), 10, "…so distant clients are shed, not waited on")
+
+    def test_the_dying_kernel_announces_before_it_drains(self):
+        g = KSRC[KSRC.index("def _graceful_term"):KSRC.index("def main()")]
+        self.assertLess(g.index("_broadcast_restarting()"), g.index('be.drain'),
+                        "the frame goes out FIRST — the drain must not eat the announce window")
+
+
+class ShimSeam(unittest.TestCase):
+    """The shim + pane-loader halves are inline JS in kernel.py — source pins, the suite's idiom."""
+
+    def setUp(self):
+        self.js = km._shim("chat")
+        self.spin = km._pane_spin("content", "live-ask")
+
+    def test_the_restarting_frame_latches(self):
+        self.assertIn('if(msg&&msg.type==="restarting"){restartAnnounced=Date.now();', self.js)
+
+    def test_an_announced_death_redials_tight_and_a_blind_drop_keeps_the_cadence(self):
+        self.assertIn('setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);',
+                      self.js)
+
+    def test_the_announced_reconnect_skips_the_stale_arm_once(self):
+        self.assertIn("var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;",
+                      self.js, "the latch is one-shot: spent at the reconnect that consumes it")
+        self.assertIn('if(!ann)armStale("reconnect");', self.js)
+        self.assertIn("freshPending=true;", self.js,
+                      "…and the resync bookkeeping still runs, so the retire path is intact")
+
+    def test_the_reraise_path_survives(self):
+        # a restart that comes back SILENT re-raises through the keepalive watchdog's forced close →
+        # second reconnect → latch already spent → armStale as always; and one that never comes back
+        # stays loud through the disconnected state itself
+        self.assertIn('armStale("foreground")', self.js, "the foreground fast-path still arms")
+        self.assertIn("staleDiag(\"watchdog-close\",\"quiet\")", self.js, "the quiet watchdog still closes")
+
+    def test_a_drop_over_content_shows_the_badge_not_the_sheet(self):
+        self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});",
+                      self.spin, "content stays legible under a translucent corner affordance; the "
+                                 "opaque loader is only for a genuinely empty pane")
+        self.assertIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", self.spin)
+        self.assertIn("id=pane-reconn", self.spin)
+        self.assertIn("pointer-events:none", self.spin,
+                      "clicks pass through to the content and queue in the shim, by design")
+        self.assertIn("reconnecting…", self.spin)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Restart layer 2 (user-approved): the felt restart gap shrinks to a subtle blip, and is finally measured. Four pieces that compound:

1. **Measured.** `restart-cuts.jsonl` gains a boot-settled row: `firstServe` (the accept loop starts) + `reconcileDone` (the SDK boot reconcile returned, or was found unavailable — the backend builds lazily, so the marks land in either order; a lock guarantees exactly one row per boot), plus `outageS` = firstServe minus the previous cut row's t. Same-host deltas by construction; best-effort append like every ledger writer.
2. **Announced.** The dying kernel broadcasts one final `{type: restarting, boot}` frame to every ws client at the head of `_graceful_term`, before the drain — enqueue-only under a hard sub-second walk budget: a stalled pipe is shed, a raising send swallowed; the frame can never widen the shutdown.
3. **Bridged.** The shims latch the frame: an announced death redials at 250ms instead of the blind 1.5s (the frame is the event; a 30s staleness bound keeps a spent announcement from driving tight retries). A drop over existing content shows a **translucent corner badge** (small swirl + "reconnecting…", pointer-events none — clicks pass through and queue in the shim) over the frozen, legible pane; the opaque full-pane loader remains for genuinely empty panes, per the loading-states rule.
4. **Unflagged.** The reconnect that consumes the latch skips the stale-banner arm once. Event-keyed re-raise, no new timers: a silent comeback re-raises via the keepalive watchdog's forced second reconnect (latch spent, arms as always); a restart that never comes back stays loud through the disconnected state.

Deliberately out of scope (the dispatch's own list): listener-fd handover, bind-before-boot-work, service-worker caching.

## Test plan
- `tests/test_restart_seam.py` (14): boot-row delta + either-order marks + idempotence + bookend hooks; broadcast payload, dead-client skip, walk budget, announce-before-drain order; shim latch, tight-vs-blind redial, one-shot arm skip, surviving re-raise paths; badge-vs-sheet branch + pass-through clicks.
- Seven sibling pins across four files follow the new literals (each was red before the update — non-vacuous).
- Full Python suite: 6,331 passed. Extension suite: green. Local bats: green.
- Rendered verification of the translucent badge and the cold-load sheet (screenshots in the ship report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)