### PR TITLE
The sessions pane's tag filter works again: in-menu presses no longer echo their own menu shut (T213)

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1116,8 +1116,13 @@ class TimelinePanel {
     // in the OTHER same-origin panes, exactly the gap the local closers can't cover.
     this._onMenuEcho = (e) => { if (e.key === 'romp:menu-echo' && e.newValue) this._onDocClick(); };
     try { window.addEventListener('storage', this._onMenuEcho); } catch (e) { /* storage blocked */ }
-    document.addEventListener('pointerdown', () => {
-      try { localStorage.setItem('romp:menu-echo', JSON.stringify({ t: Date.now() })); } catch (e) { /* storage blocked */ }
+    document.addEventListener('pointerdown', (e) => {
+      // in-menu presses broadcast NO echo (T213): with this pane's menus LIFTED into the shell
+      // document (_menuHost), the echo bounced back here and detached the pressed row before its
+      // click could fire — tag-menu.ts's writer carries the same guard and the whole story
+      const t = e.target;
+      if (t && typeof t.closest === 'function' && t.closest('[data-tag-menu],[data-romp-menu]')) return;
+      try { localStorage.setItem('romp:menu-echo', JSON.stringify({ t: Date.now() })); } catch (e2) { /* storage blocked */ }
     }, true);
     // The menus render in the tip's host document (see _menuHost), so a click or Escape landing on the
     // HOST page — which now shows the menu — must close them too. Same teardown discipline as the tip:
@@ -2560,6 +2565,7 @@ class TimelinePanel {
     // (Obsidian) that loads neither styles.css nor romp's font stack.
     const menu = document.body.createDiv();
     menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:96px;' + MENU_STYLE);
+    menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu._kind = kind; menu._sid = s.id;
     const h = this._menuHost(anchorEl.getBoundingClientRect());
     const pick = (value) => {
@@ -2586,6 +2592,7 @@ class TimelinePanel {
         closeSub();
         const sub = document.body.createDiv();
         sub.setAttribute('style', 'position:fixed;z-index:1002;min-width:96px;' + MENU_STYLE);
+    sub.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
         for (const v of versions) {
           const cv = ((s.model || '').toLowerCase() === v.label.toLowerCase());
           const row = sub.createDiv({ text: v.label });
@@ -3010,6 +3017,7 @@ class TimelinePanel {
     if (reopen) return;
     const menu = document.body.createDiv();
     menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:200px;' + MENU_STYLE);
+    menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu.addEventListener('click', (e) => e.stopPropagation());
     const item = (label, opts) => {
       const row = menu.createDiv();
@@ -3083,6 +3091,7 @@ class TimelinePanel {
     if (reopen) return;
     const menu = document.body.createDiv();
     menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:180px;' + MENU_STYLE);
+    menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu.addEventListener('click', (e) => e.stopPropagation());
     const item = (label, opts) => {
       const row = menu.createDiv();
@@ -3569,6 +3578,7 @@ class TimelinePanel {
     // shared menu vocabulary again (MENU_STYLE).
     const menu = document.body.createDiv();
     menu.setAttribute('style', 'position:fixed;z-index:1001;width:280px;' + MENU_STYLE);
+    menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu._sid = s.id;
     menu.addEventListener('click', (e) => e.stopPropagation());   // inside clicks must not reach the doc closer
     const build = () => {

--- a/ui/timeline-tagbtn-click.test.ts
+++ b/ui/timeline-tagbtn-click.test.ts
@@ -147,3 +147,33 @@ test("the view speaks plain DOM: no Obsidian-only helper calls (the hosts instal
   for (const bad of [/\.empty\(\)/, /\.setText\(/, /\.addClass\(/, /\.removeClass\(/, /\.toggleClass\(/, /\.detach\(\)/])
     assert.doesNotMatch(SRC, bad, "Obsidian-only helper in the shared view: " + bad);
 });
+
+test("executed: clicking a tag row in the views menu APPLIES the lens — the filter filters (T213)", () => {
+  // The dashboard regression: with the menu LIFTED into the shell document, the shell's menu-echo
+  // writer broadcast the row's own pointerdown, the storage event bounced back into this pane, and
+  // _onMenuEcho detached the row before its click fired — a human-length press always lost the
+  // race, so "clicking a tag does nothing". The fix keeps in-menu presses out of the echo (both
+  // writers skip [data-tag-menu]/[data-romp-menu] subtrees — menu-echo.test.ts pins that); THIS
+  // test executes the click's productive half end-to-end: row click → lens toggled → views posted
+  // → redraw narrows the lanes to the tag's members, menu still open (a settings panel, not a command).
+  const panel = drawnPanel();
+  const posts: any[] = [];
+  (g as any).__rompTimelineSetViews = (v: any) => posts.push(v);
+  try {
+    const btn = cornerBtn(panel, "filter these lanes by tag");
+    btn._listeners.pointerdown({ preventDefault() {}, stopPropagation() {} });
+    const menu = g.document.body.children[g.document.body.children.length - 1];
+    assert.equal(menu.dataset.rompMenu, "1", "the menu marks itself for the echo writers' skip");
+    const textOf = (n: any): string => (n.textContent || "") + (n.children || []).map(textOf).join("");
+    const row = (menu.children || []).find((r: any) => textOf(r) === "infra");
+    assert.ok(row, "the tag's row renders in the menu");
+    row._listeners.click();
+    assert.equal(posts.length, 1, "the click posts the views blob (setTimelineViews)");
+    assert.deepEqual(posts[0].actives.timeline, { tags: ["infra"] }, "the lens carries the picked NAME");
+    assert.deepEqual(panel._vis.map((s: any) => s.id), ["s2"],
+      "the redraw narrows the lanes to the tag's members — the filter FILTERS");
+    assert.ok(menu.parentNode, "multi-select: the menu stays open across toggles");
+  } finally {
+    delete (g as any).__rompTimelineSetViews;
+  }
+});

--- a/ui/webview/menu-echo.test.ts
+++ b/ui/webview/menu-echo.test.ts
@@ -44,6 +44,15 @@ test("executed: loading tag-menu in a real-DOM context installs the writer — n
     assert.equal(writes[0][0], "romp:menu-echo", "the shared key every listener watches");
     const body = JSON.parse(writes[0][1]);
     assert.equal(typeof body.t, "number", "the { t } shape — a fresh value so same-tick echoes still fire");
+    // T213: a press INSIDE a marked menu broadcasts NOTHING — with the timeline's menus lifted
+    // into the shell document, this very writer's echo detached the pressed row between its
+    // pointerdown and its click, so every human-length press on the tag filter died silently
+    pd[0].fn({ target: { closest: (sel: string) => (sel.includes("data-tag-menu") ? {} : null) } });
+    assert.equal(writes.length, 1, "in-menu press: no echo — it would close the menu being used");
+    pd[0].fn({ target: { closest: () => null } });
+    assert.equal(writes.length, 2, "presses on pane content keep broadcasting");
+    pd[0].fn({ target: {} });   // a target with no closest (foreign node) — broadcast, the safe default
+    assert.equal(writes.length, 3, "a closest-less target still broadcasts (echo fails open)");
   } finally {
     delete g.document; delete g.window; delete g.localStorage;
   }
@@ -65,7 +74,20 @@ test("every pane document the dashboard composes carries the writer at load", ()
   assert.match(PALETTE, /^installMenuEcho\(\);$/m, "module-level — before boot()'s in-iframe early return");
   assert.match(KERNEL, /dist\/palette-main\.js/, "the shell page loads the bundle that broadcasts");
   // the timeline pane loads romp-timeline-view.js, not tag-menu — its constructor is its page boot
-  const ctorWriter = /document\.addEventListener\('pointerdown', \(\) => \{\s*\n\s*try \{ localStorage\.setItem\('romp:menu-echo', JSON\.stringify\(\{ t: Date\.now\(\) \}\)\); \} catch \(e\) \{ \/\* storage blocked \*\/ \}\s*\n\s*\}, true\);/;
+  const ctorWriter = /document\.addEventListener\('pointerdown', \(e\) => \{[\s\S]{0,600}?closest\('\[data-tag-menu\],\[data-romp-menu\]'\)\) return;\s*\n\s*try \{ localStorage\.setItem\('romp:menu-echo', JSON\.stringify\(\{ t: Date\.now\(\) \}\)\); \} catch \(e2\) \{ \/\* storage blocked \*\/ \}\s*\n\s*\}, true\);/;
   assert.match(TIMELINE, ctorWriter,
     "same key, same shape, capture phase, try/catch kept (Obsidian's localStorage may be foreign)");
+});
+
+test("every timeline menu marks itself for the writers' in-menu skip (T213)", () => {
+  // an unmarked menu dies to its own echo the moment _menuHost lifts it into the shell document:
+  // the count pin makes a NEW menu that forgets the mark fail here, not in the field
+  const creations = (TIMELINE.match(/\+ MENU_STYLE\);/g) || []).length;
+  const marks = (TIMELINE.match(/\.dataset\.rompMenu = '1'/g) || []).length;
+  assert.ok(creations >= 5, "the timeline's menus render through MENU_STYLE");
+  assert.equal(marks, creations, "every MENU_STYLE menu carries data-romp-menu");
+  assert.match(MENU, /menu\.dataset\.tagMenu = "1"/, "the shared menu marks itself too (its own key)");
+  // both writers skip the marked subtrees with the SAME selector — one vocabulary, two mirrors
+  for (const src2 of [MENU, TIMELINE])
+    assert.match(src2, /closest\((?:"|')\[data-tag-menu\],\[data-romp-menu\](?:"|')\)/);
 });

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -34,7 +34,18 @@ let echoInstalled = false;
 export function installMenuEcho(): void {
   if (echoInstalled) return;
   echoInstalled = true;
-  document.addEventListener("pointerdown", () => {
+  document.addEventListener("pointerdown", (e) => {
+    // A press INSIDE a romp menu is interaction WITH that menu, never a click-away — broadcasting
+    // it closes the very menu being used. The case that found this (T213, 2026-09-01): the
+    // timeline lifts its menus into the SHELL document (same-origin top), so a tag-row press
+    // landed there, the shell's copy of this writer echoed it, and the storage event bounced into
+    // the timeline iframe, whose listener detached the row between its pointerdown and its click.
+    // A human-length press (~100ms) always lost that race — the sessions pane's tag filter read
+    // as dead — while an instant synthetic click still won it. The echo exists for presses on
+    // pane CONTENT; menus mark themselves (data-tag-menu here, data-romp-menu in the timeline's
+    // inlined mirror) and are skipped.
+    const t = e.target as Element | null;
+    if (t && typeof t.closest === "function" && t.closest("[data-tag-menu],[data-romp-menu]")) return;
     try { localStorage.setItem("romp:menu-echo", JSON.stringify({ t: Date.now() })); } catch { /* storage blocked */ }
   }, true);
 }


### PR DESCRIPTION
## The bug (user-reported)

In the sessions tab, clicking a tag to view a subset of sessions did nothing: the menu closed, the lanes never narrowed.

## Conviction (served-page repro, real clicks)

The dispatch's prime suspect — the tag-views write door's stale-writer guard — is **exonerated**: the write never happened, because the click died in the UI before anything was posted.

Mechanism: `_menuHost` lifts every timeline menu into the SHELL document whenever the pane runs in a same-origin iframe — in the dashboard, always. A press on a menu row therefore lands in the shell document, whose menu-echo writer (`palette-main` → `installMenuEcho`, capture phase) broadcasts it; the storage event fires back into the timeline iframe (storage events skip only the WRITING context, and the writer here is the shell), and `_onMenuEcho` detaches the pressed row between its pointerdown and its click. A human-length press (~100ms) always loses that race.

Proof by differential repro (hermetic kernel + playwright, seeded `web`/`api`/`tests` sessions + a `webwork` tag): an *instant* synthetic click wins the race and works; a **150ms-held click** — human timing — leaves the store lens-less with the menu killed. That timing signature also explains why Obsidian and pane-local menus (writer in the same document → no self-echo) never showed it, and why it read as flaky-to-never in the dashboard.

## The fix (event-exact, no grace windows)

A press INSIDE a romp menu is interaction WITH that menu, never a click-away — so both echo writers (`tag-menu.ts` and the timeline's inlined mirror) skip `[data-tag-menu]`/`[data-romp-menu]` subtrees, and every timeline `MENU_STYLE` menu now marks itself `data-romp-menu`. Cross-pane dismissal is untouched for presses on pane content — the only reachable case the echo existed for (opening another pane's menu already closes the first via its own button press, which is not inside a menu). The timeline's other lifted menus (model/effort picker, lane gear, display) were exposed to the same class and are marked too.

## Tests

- `menu-echo.test.ts`: executes the suppression (in-menu press writes NO echo; content presses and closest-less targets still broadcast), re-pins the timeline writer's new shape, and pins mark-count == menu-count so a future menu that forgets the mark fails in CI.
- `timeline-tagbtn-click.test.ts`: executes the productive half end-to-end — row click → lens posted (`actives.timeline` carries the picked name) → redraw narrows `_vis` to the tag's members → menu stays open (multi-select).
- Served-page red/green captured with real 150ms clicks (red: store lens-less, menu killed, all lanes; green: lens landed, menu open with ✓, lanes narrowed with the "+N more" cue).

Suites on this head: pytest 6376 passed + 335 subtests (34 skipped), vscode-extension npm 2631/2631 (includes the 2 new tests). No shell surfaces touched (bats not run). No kernel-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)