### PR TITLE
Summary deep links land on the substance — citable results, and a highlighted span

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1469,6 +1469,10 @@ def _tool_arg(name, inp):
 # announcement stub instead of the wrap-up).
 CITE_MIN_CHARS = 80
 
+# a PR/commit/compare link in a tool result — the result class the anchor study convicted (T218):
+# the substance of "shipped it" IS the link, so the atom holding it must be citable
+_PR_LINK_RE = re.compile(r"https://github\.com/\S+/(?:pull|commit|compare)/\S+")
+
 
 def _unit_text(atoms, marker=None):
     """The caption model's input for one unit (segment or turn): what the user asked, what the
@@ -1477,17 +1481,23 @@ def _unit_text(atoms, marker=None):
     ([m3]) so the model can CITE the one message its takeaway is grounded in (see _split_source).
     Sub-floor stubs (< CITE_MIN_CHARS) still ride along as context, just unlabeled — uncitable by
     construction."""
-    user_said, asst_said, tools = [], [], []
+    user_said, asst_said, tools, results = [], [], [], []
     for a in atoms:
         if a["type"] == "user" and a.get("author") is not None:
             t = _FOLLOWUP_MARKER_RE.sub("", _atom_text(a)).strip()   # the follow-up marker is plumbing, not user text
             if t:
+                # a PEER's postal report is SUBSTANCE, not just context (T218, the study's postal class:
+                # the summary's evidence was the peer's ready-report, but only assistant prose could be
+                # cited, so the click landed on the announcement) — same substantive-prose floor
+                if marker is not None and a.get("uuid") and isinstance(a.get("author"), dict) \
+                        and len(t) >= CITE_MIN_CHARS:
+                    t = "%s %s" % (marker.label(a["uuid"], t), t)
                 user_said.append(t)
         elif a["type"] == "assistant" and not a.get("isApiError"):   # skip API-error records — a retry / usage-limit storm's noise, never captionable work (the user 2026-07-06)
             t = _atom_text(a)
             if t:
                 if marker is not None and a.get("uuid") and len(t) >= CITE_MIN_CHARS:
-                    t = "%s %s" % (marker.label(a["uuid"]), t)
+                    t = "%s %s" % (marker.label(a["uuid"], t), t)
                 asst_said.append(t)
             for b in (a.get("message") or {}).get("content", []):
                 if isinstance(b, dict) and b.get("type") == "tool_use":
@@ -1498,6 +1508,19 @@ def _unit_text(atoms, marker=None):
                     label = "%s(%s)" % (n, arg) if arg else n
                     if label not in tools:
                         tools.append(label)
+        if a["type"] == "user" and marker is not None and a.get("uuid"):
+            # a tool RESULT carrying a PR/commit link is substance by construction (T218: 'Committing
+            # and shipping…' was citable while the PR it shipped was not) — offer the label on a compact
+            # RESULT line; plain tool output stays out (noise floors the prompt, not the citation)
+            for b in (a.get("message") or {}).get("content", []):
+                if isinstance(b, dict) and b.get("type") == "tool_result":
+                    rt = " ".join(c.get("text", "") for c in (b.get("content") or [])
+                                  if isinstance(c, dict) and c.get("type") == "text").strip()
+                    mlink = _PR_LINK_RE.search(rt)
+                    if mlink:
+                        head = rt.splitlines()[0][:160] if rt else mlink.group(0)
+                        results.append("%s %s" % (marker.label(a["uuid"], rt), head))
+                        break
     out = []
     if user_said:
         out.append("USER ASKED: " + _shape(" | ".join(user_said), 1200, 1800))
@@ -1511,6 +1534,8 @@ def _unit_text(atoms, marker=None):
             picked.append(t)
             total += len(t) + 2
         out.append("TOOLS USED: " + ", ".join(picked))
+    if results:
+        out.append("RESULTS: " + " | ".join(results[:4]))   # the PR/commit links the work actually produced
     return "\n".join(out).strip()
 
 
@@ -2602,7 +2627,8 @@ def _rebase_onto_disk(fsid, store):
         # or older disk stamp keeps ours, which also preserves the deliberate blockSummary re-open
         # (the ""→None null keeps its old briefedMt on purpose).
         for _stamp, _fields in (("distilledMt", ("summary", "summaryParts", "background",
-                                                 "summaryAnchor", "distillFails")),
+                                                 "summaryAnchor", "summaryQuote", "summaryQuoteOff",
+                                                 "distillFails")),
                                 ("briefedMt", ("blockSummary", "briefParts", "briefFails")),
                                 ("stalledMt", ("stallSummary", "stallFails"))):
             if int(dnd.get(_stamp) or 0) > int(mnd.get(_stamp) or 0):
@@ -3440,12 +3466,16 @@ class _CiteMarks:
     2026-07-01). One instance per call; labels are meaningless across calls."""
     def __init__(self):
         self.map = {}                                       # "m3" → atom uuid
+        self.texts = {}                                     # "m3" → the atom's raw text (T218: the span
+        #                                                     locate validates the QUOTE against the very
+        #                                                     text the label was offered on)
         self._n = 0
 
-    def label(self, uuid):
+    def label(self, uuid, text=""):
         self._n += 1
         lab = "m%d" % self._n
         self.map[lab] = uuid
+        self.texts[lab] = text or ""
         return "[%s]" % lab
 
     def newest(self):
@@ -3457,15 +3487,62 @@ class _CiteMarks:
 
 
 def _split_source(text):
-    """(body, label) — split the model's final `SOURCE: mN` citation line off a distill/brief reply.
-    Lenient on shape (optional [brackets], stray whitespace) but anchored to the END of the reply, so a
-    body that merely mentions a label is never mistaken for the citation. label is None when the line
-    is absent/malformed — the kernel then falls back to its deterministic anchor."""
+    """(body, label, quote) — split the model's trailing `SOURCE: mN` citation line, and the optional
+    `QUOTE: "…"` supporting-span line (T218: the study's most common partial was the right message with
+    the supporting sentence buried deep — the span lets the landing scroll TO the sentence), off a
+    distill/brief reply. Lenient on shape (optional [brackets], either line order, stray whitespace)
+    but anchored to the END of the reply, so a body that merely mentions a label is never mistaken
+    for the citation. label/quote are None when absent/malformed — the kernel then keeps exactly the
+    pre-span behavior."""
     text = (text or "").strip()
+    quote = None
+    for _ in range(2):                                     # the two trailing lines, either order
+        mq = re.search(r"(?:^|\n)\s*QUOTE:\s*[\"\u201c]?(.+?)[\"\u201d]?\s*$", text)
+        if mq and quote is None and "\n" not in mq.group(1):
+            quote = mq.group(1).strip() or None
+            text = text[:mq.start()].strip()
+            continue
+        break
     m = re.search(r"(?:^|\n)\s*SOURCE:\s*\[?(m\d+)\]?\s*$", text)
     if not m:
-        return text, None
-    return text[:m.start()].strip(), m.group(1)
+        return text, None, quote
+    body = text[:m.start()].strip()
+    # a QUOTE line ABOVE the SOURCE line (the other order): strip it off the body tail too
+    if quote is None:
+        mq = re.search(r"(?:^|\n)\s*QUOTE:\s*[\"\u201c]?(.+?)[\"\u201d]?\s*$", body)
+        if mq and "\n" not in mq.group(1):
+            quote = mq.group(1).strip() or None
+            body = body[:mq.start()].strip()
+    return body, m.group(1), quote
+
+
+def _locate_quote(atom_text, quote):
+    """(offset, raw_span) of `quote` inside `atom_text` — exact substring first, else a whitespace-
+    collapsed case-insensitive match mapped BACK to the atom's raw span; (None, None) when absent or
+    unfindable — the landing then keeps today's whole-message behavior, never a guess (T218)."""
+    at, q = atom_text or "", (quote or "").strip()
+    if not at or not q:
+        return None, None
+    i = at.find(q)
+    if i >= 0:
+        return i, q
+    pat = re.compile(r"\s+".join(re.escape(w) for w in q.split()), re.I)
+    m = pat.search(at)
+    if m:
+        return m.start(), m.group(0)
+    return None, None
+
+
+def _store_cited_span(nd, marks, src, quote):
+    """Store the QUOTE's located span beside the anchor (T218) — ONLY when the citation itself
+    resolved (the deterministic newest() fallback anchors a different atom, so a quote there would
+    highlight text the reader isn't looking at). Unfindable/absent → None: the landing keeps today's
+    whole-message behavior, never a guess."""
+    off, span = (None, None)
+    if quote and marks.map.get(src):
+        off, span = _locate_quote(marks.texts.get(src, ""), quote)
+    nd["summaryQuote"] = span
+    nd["summaryQuoteOff"] = off
 
 
 def _node_warn(nd, kind, t, msg, detail, surface=None):
@@ -10032,7 +10109,10 @@ DISTILL_SYS = (
     "your takeaway: the most informative and most current one, usually the message that wrapped up the "
     "work, never an early plan, analysis, or superseded attempt when a later message reflects how it "
     "actually ended, and never a line that merely announces or hands off work about to start, however "
-    "closely it names the goal. This line is parsed off and never shown.")
+    "closely it names the goal. This line is parsed off and never shown. When one sentence of the "
+    "cited message most directly supports your takeaway, add one more final line after SOURCE: "
+    "QUOTE: \"<that sentence, copied verbatim, under 25 words>\", exactly as it appears, never "
+    "paraphrased; omit the line when no single sentence carries it. It is parsed off too.")
 
 
 def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None, frame=None,
@@ -10316,8 +10396,12 @@ BLOCK_BRIEF_SYS = (
     "context on the decision, usually where the question and its options were actually laid out; never a "
     "line that merely announces or hands off work about to start, however closely it names the goal. This "
     "line is parsed off and never shown.\n\n"
-    "One last check before you send: if any [mN] labels appeared in <work>, the final line of your reply "
-    "must be exactly SOURCE: mN. Do not stop at the takeaway; the SOURCE line always comes last.")
+    "One last check before you send: if any [mN] labels appeared in <work>, your reply must end with a "
+    "line that is exactly SOURCE: mN. When one sentence of the cited message most directly supports "
+    "what you wrote, you may add one more final line after it: QUOTE: \"<that sentence, copied "
+    "verbatim, under 25 words>\", exactly as it appears, never paraphrased; omit it when no single "
+    "sentence carries it. Do not stop at the takeaway; SOURCE (and the optional QUOTE) come last, and "
+    "both are parsed off and never shown.")
 
 
 def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None, shortfall=None):
@@ -10417,8 +10501,12 @@ STALL_BRIEF_SYS = (
     "on the line and nothing after it. Never omit it while labels are present, and never invent a label "
     "you weren't shown. It cites the single message the user should open to see where the work stopped, "
     "usually the most recent substantive one. This line is parsed off and never shown.\n\n"
-    "One last check before you send: if any [mN] labels appeared in <work>, the final line of your reply "
-    "must be exactly SOURCE: mN. Do not stop at the takeaway; the SOURCE line always comes last.")
+    "One last check before you send: if any [mN] labels appeared in <work>, your reply must end with a "
+    "line that is exactly SOURCE: mN. When one sentence of the cited message most directly supports "
+    "what you wrote, you may add one more final line after it: QUOTE: \"<that sentence, copied "
+    "verbatim, under 25 words>\", exactly as it appears, never paraphrased; omit it when no single "
+    "sentence carries it. Do not stop at the takeaway; SOURCE (and the optional QUOTE) come last, and "
+    "both are parsed off and never shown.")
 
 
 def stall_llm(goal_text, work_text, holding):
@@ -10812,11 +10900,12 @@ def _distill_session(fsid, path, now):
                 changed = True
                 continue
             raw = out
-            out, src = _split_source(out)
+            out, src, _quote = _split_source(out)
             bg, out = _split_sections(out)
             nodes[top]["stallSummary"] = out           # full text — never truncate mid-word (the briefer's rule)
             nodes[top]["background"] = bg if bg else None
             nodes[top]["summaryAnchor"] = marks.map.get(src) or marks.newest()
+            _store_cited_span(nodes[top], marks, src, _quote)
             if marks.map and marks.map.get(src) is None:
                 _log_judge_error("staller", fsid, "cite-miss", goal=top, note="%s; %d labels offered; reply tail: %r" % (
                     ("cited unoffered label %s" % src) if src else "no SOURCE line", len(marks.map), (raw or "")[-160:]))
@@ -10939,7 +11028,7 @@ def _distill_session(fsid, path, now):
                 changed = True                          # persist the counter / the settle
                 continue
             raw = out
-            out, src = _split_source(out)
+            out, src, _quote = _split_source(out)
             bg, out = _split_sections(out)
             # OWED COVERAGE IS COUNTABLE (the user 2026-08-30): a multi-item <owed> demands one
             # paragraph per item, but the merge allowance made a dropped item look like a merge —
@@ -10967,10 +11056,10 @@ def _distill_session(fsid, path, now):
                         # never counts as a verdict (the 2026-07-03 rule, met again here)
                         changed = True
                         continue
-                    _o2, _s2 = _split_source(_r2 or "")
+                    _o2, _s2, _q2 = _split_source(_r2 or "")
                     _b2, _o2 = _split_sections(_o2)
                     if _r2 and len([p for p in re.split(r"\n\s*\n", _o2) if p.strip()]) >= len(owed):
-                        raw, out, src = _r2, _o2, _s2
+                        raw, out, src, _quote = _r2, _o2, _s2, _q2   # the retry's own citation + span replace the draft's
                         bg = _b2 or bg                 # keep the draft's orientation if the retry lost it
                     else:
                         out = "\n\n".join(
@@ -10979,6 +11068,7 @@ def _distill_session(fsid, path, now):
                         #      ^ numbered like the rule's own list shape (the review's catch: an
                         #        unnumbered fallback re-shipped the dense recap the rule kills)
                         src = None                     # verbatim recorded whys — no model citation
+                        _quote = None                  # …and no span: romp authored this text (T218)
                         _fallback_brief = True         # …so the cite-miss check below stands down:
                         #                                romp authored this text; "no SOURCE line"
                         #                                would report the stale first draft's tail
@@ -11000,6 +11090,7 @@ def _distill_session(fsid, path, now):
             # the brief's cited source, else the WRITE-TIME deterministic stamp: the newest labeled atom
             # the gather fed this very call (the user 2026-07-21) — every brief ships a stored anchor
             nodes[top]["summaryAnchor"] = marks.map.get(src) or marks.newest()
+            _store_cited_span(nodes[top], marks, src, _quote)
             if marks.map and marks.map.get(src) is None and not _fallback_brief:
                 # labels offered, no usable citation → log only (the stamp already grounded the
                 # anchor, so a card warn would be noise, the user 2026-07-21). The verbatim
@@ -11068,7 +11159,7 @@ def _distill_session(fsid, path, now):
             changed = True
             continue
         raw = out
-        out, src = _split_source(out)
+        out, src, _quote = _split_source(out)
         bg, out = _split_sections(out)
         nodes[top]["summary"] = out                 # full text — NEVER truncate a takeaway mid-word (the user 2026-07-06)
         nodes[top]["summaryParts"] = ([{"id": d["id"], "since": _done_since(d)} for d in _dsubs]
@@ -11077,6 +11168,7 @@ def _distill_session(fsid, path, now):
         # the takeaway's cited source, else the WRITE-TIME deterministic stamp: the newest labeled atom
         # this very call read (the user 2026-07-21) — every summary ships a stored anchor
         nodes[top]["summaryAnchor"] = marks.map.get(src) or marks.newest()
+        _store_cited_span(nodes[top], marks, src, _quote)
         if marks.map and marks.map.get(src) is None:       # labels offered, no usable citation → log only:
             # the stamp already grounded the anchor, so a card warn would be noise (the user 2026-07-21)
             _log_judge_error("distiller", fsid, "cite-miss", goal=top, note="%s; %d labels offered; reply tail: %r" % (

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21598,6 +21598,12 @@ def build_feed(now, tmux=None):
                                      and (nodes[nid].get("summary") or "").strip()) or None,   # the DONE twin: [{id, since}] per takeaway paragraph when the distiller split by <completed-items>; done-event times (the user 2026-07-24)
                 "background": nodes[nid].get("background"),    # the distiller's BACKGROUND section: re-orientation for a reader who forgot the thread — collapsed by default on the card (the user 2026-07-02)
                 "summaryAnchorUuid": _sa_u,    # click the summary line → the completion turn's wrap-up (completed pin), else the cited/latest prose (the user 2026-07-14)
+                # the supporting SPAN (T218): the distiller's verbatim quote, located in the cited atom at
+                # write time — shipped ONLY while the resolved anchor IS the cited atom (the fallback tiers
+                # land elsewhere, where the span would highlight the wrong text); the landing scrolls to
+                # and highlights it, and a null keeps today's whole-message behavior
+                "summaryAnchorQuote": (nodes[nid].get("summaryQuote")
+                                       if _sa_u and _sa_u == nodes[nid].get("summaryAnchor") else None),
                 "warns": nodes[nid].get("warns") or None,   # judge-stamped anomalies (judge _node_warn) → yellow "warning" chip; click shows each warn's what/why detail (the user 2026-07-02)
                 "failLog": nodes[nid].get("failLog") or None,   # the summarizer's failed attempts (judge _fail_log): model + literal error per try → the chip's hover history + modal "What was tried" (the user 2026-08-18)
                 "nudged": ({"count": int(nrec.get("count", 0)), "times": _nudge_times().get(nid, [])[-8:]}
@@ -24112,6 +24118,8 @@ def _show_on_timeline_focus(msg):
     chip in the composer (see _cite_for) → a follow-up without the explicit Follow-up button."""
     f = {"type": "focus", "id": msg["sid"], "anchor": msg.get("anchorUuid"),
          "anchorT": msg.get("t"), "anchorKind": _focus_kind(msg.get("anchor"))}
+    if msg.get("quote"):
+        f["anchorQuote"] = str(msg["quote"])[:300]   # the supporting span (T218) — the chat highlights it on landing
     cite = _cite_for(msg.get("itemId"))
     if cite:
         f["cite"] = cite

--- a/tests/test_cite_substance.py
+++ b/tests/test_cite_substance.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""T218, arm 1 + the span protocol's kernel half (the manager's 87-pair study, 2026-09-01): summary
+deep links landed on ANNOUNCEMENTS because only assistant prose was ever citable — when the substance
+was a postal ready-report or a PR link, the model could cite only the message that said the work was
+starting. Substantive non-prose atoms now take [mN] labels too: a PEER postal report at the same
+substantive-prose floor, and a tool result carrying a PR/commit link (the link IS the substance).
+And the SOURCE protocol grows a supporting-span half: the model may return a short verbatim QUOTE of
+its supporting sentence; _split_source parses it and _locate_quote finds it in the cited atom's text
+(exact, then whitespace/case-normalized; unfindable → None, never a guess). Synthetic fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+jd = SourceFileLoader("romp_judge_t218", os.path.join(BIN, "romp-judge")).load_module()
+
+LONG = " it took three passes over the synthetic corpus and the verdicts held up end to end."
+
+
+def _atom(uuid, typ, author, text, blocks=None):
+    content = ([{"type": "text", "text": text}] if text else []) + (blocks or [])
+    return {"type": typ, "uuid": uuid, "author": author, "message": {"content": content}}
+
+
+class SubstantiveAtomsAreCitable(unittest.TestCase):
+    def test_peer_report_and_pr_result_take_labels(self):
+        marks = jd._CiteMarks()
+        atoms = [
+            _atom("u-ask", "user", "human", "please ship the widget fix"),
+            # the announcement — assistant prose, citable as before
+            _atom("a-announce", "assistant", None, "Committing and shipping the widget fix now —" + LONG),
+            # the SUBSTANCE, previously invisible to citation:
+            _atom("u-peer", "user", {"peer": "22222222-3333-4444-5555-666666666666", "mid": "m.1", "kind": "coordinate"},
+                  "ready: the widget fix landed, suite green, follow-ups filed —" + LONG),
+            _atom("u-pr", "user", None, "", blocks=[{"type": "tool_result",
+                  "content": [{"type": "text", "text": "https://github.com/notes-api/web/pull/4242\nauto-merge armed"}]}]),
+        ]
+        jd._unit_text(atoms, marker=marks)
+        cited = set(marks.map.values())
+        self.assertIn("a-announce", cited, "assistant prose keeps its label")
+        self.assertIn("u-peer", cited, "a substantive PEER report is citable — the study's postal class")
+        self.assertIn("u-pr", cited, "a PR-link tool result is citable — the link IS the substance")
+
+    def test_floors_hold_stubs_and_plain_tool_noise_stay_uncitable(self):
+        marks = jd._CiteMarks()
+        atoms = [
+            _atom("u-peer-stub", "user", {"peer": "22222222-3333-4444-5555-666666666666", "mid": "m.2", "kind": "coordinate"},
+                  "on it"),                                       # sub-floor peer ping
+            _atom("u-plain-tool", "user", None, "", blocks=[{"type": "tool_result",
+                  "content": [{"type": "text", "text": "total 12\ndrwxr-xr-x 2 tests tests 4096 ."}]}]),
+        ]
+        jd._unit_text(atoms, marker=marks)
+        self.assertEqual(marks.map, {}, "stubs and linkless tool output stay uncitable by construction")
+
+
+class SupportingSpan(unittest.TestCase):
+    def test_split_source_parses_the_optional_quote(self):
+        body, src, quote = jd._split_source(
+            'The fix landed and the suite is green.\nSOURCE: m3\nQUOTE: "the suite is green end to end"')
+        self.assertEqual(src, "m3")
+        self.assertEqual(quote, "the suite is green end to end")
+        self.assertNotIn("QUOTE", body)
+        body2, src2, quote2 = jd._split_source("Take.\nSOURCE: m2")
+        self.assertEqual((src2, quote2), ("m2", None), "the quote is optional — absent stays today's shape")
+        body3, src3, quote3 = jd._split_source("Take with no citation at all.")
+        self.assertEqual((src3, quote3), (None, None))
+
+    def test_locate_quote_exact_then_normalized_then_honestly_none(self):
+        atom_text = "Multi-topic wrap.  The   Suite is GREEN end to end.\nAnd more topics follow."
+        self.assertEqual(jd._locate_quote(atom_text, "Suite is GREEN"),
+                         (atom_text.index("Suite is GREEN"), "Suite is GREEN"))
+        off, span = jd._locate_quote(atom_text, "the suite is green end to end")
+        self.assertEqual(span, "The   Suite is GREEN end to end",
+                         "normalized match maps back to the atom's RAW span")
+        self.assertEqual(off, atom_text.index("The   Suite"))
+        self.assertEqual(jd._locate_quote(atom_text, "never said this"), (None, None),
+                         "unfindable → None, never a guess (the honest-fallback rule)")
+        self.assertEqual(jd._locate_quote(atom_text, ""), (None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_distill_paragraph_contract.py
+++ b/tests/test_distill_paragraph_contract.py
@@ -157,6 +157,27 @@ class DecisionListContract(unittest.TestCase):
                          "a finished goal's takeaway is an outcome, not a status story")
 
 
+class QuoteLineJoinsTheProtocol(unittest.TestCase):
+    """T218: the SOURCE protocol grows an optional supporting-span line — the prompts offer it in all
+    three judges' words (verbatim, under 25 words, omit when no single sentence carries it), and the
+    parser peels it in either order without disturbing the body or the SOURCE label."""
+
+    def test_all_three_prompts_offer_the_quote_line(self):
+        for name, sysp in (("distiller", jd.DISTILL_SYS), ("briefer", jd.BLOCK_BRIEF_SYS),
+                           ("staller", jd.STALL_BRIEF_SYS)):
+            self.assertIn("QUOTE:", sysp, name)
+            self.assertIn("copied", sysp, name + " — verbatim, never paraphrased")
+            self.assertIn("omit", sysp.lower(), name + " — optional by instruction, absent stays honest")
+
+    def test_parser_peels_quote_in_either_order(self):
+        b1, s1, q1 = jd._split_source('take.\nSOURCE: m2\nQUOTE: "the exact sentence"')
+        self.assertEqual((b1, s1, q1), ("take.", "m2", "the exact sentence"))
+        b2, s2, q2 = jd._split_source('take.\nQUOTE: "the exact sentence"\nSOURCE: m2')
+        self.assertEqual((b2, s2, q2), ("take.", "m2", "the exact sentence"))
+        b3, s3, q3 = jd._split_source("take.\nSOURCE: m2")
+        self.assertEqual((b3, s3, q3), ("take.", "m2", None))
+
+
 class ParserKeepsTheParagraphs(unittest.TestCase):
     """The reply parser is what has to survive the new shape: a takeaway is now MULTI-paragraph, the
     trailing SOURCE line still peels off around it, and a decorated label still parses."""
@@ -167,7 +188,7 @@ class ParserKeepsTheParagraphs(unittest.TestCase):
              "SOURCE: m4")
 
     def _parse(self, reply):
-        body, src = jd._split_source(reply)
+        body, src, _q = jd._split_source(reply)
         bg, take = jd._split_sections(body)
         return bg, take, src
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -4636,6 +4636,41 @@ class DistillAtDone(unittest.TestCase):
         self.assertEqual(jd._distill_due_t(store, self.G, False), T0 + 300,
                          "no done events (pre-diary store) → the settle stamp, then mt")
 
+    def test_the_cited_span_is_located_and_stored_end_to_end(self):
+        # T218: the distiller returns QUOTE, the kernel locates it in the CITED atom's own text and
+        # stores the raw span + offset; an unfindable quote stores None (never a guess).
+        long_a = ("Shipped the widget end to end; the suite is GREEN across every case and the "
+                  "follow-ups are filed for the two edge shapes we deferred.")
+        records = [uline(T0, "build the widget", "u1", ps="typed"),
+                   aline(T0 + 10, long_a, "a1", "u1", stop="end_turn")]
+        segs = [sg for turn in build_session(records)["turns"] for sg in em.segments(turn)]
+        path = Path(self._td) / (SID + ".jsonl")
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        node = {"id": self.G, "text": "build the widget", "parentId": None, "nodeComplete": True,
+                "blocked": False, "cleared": False, "trail": [sg["id"] for sg in segs],
+                "t": T0, "mt": T0 + 30, "summary": None,
+                "log": [{"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21}]}
+        jd.save_goals(SID, {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V, "lastNode": self.G,
+                            "placements": {}, "status": {self.G: "working"},
+                            "confirming": [self.G], "nodes": {self.G: node}})
+        jd.distill_llm = (lambda *a, **k:
+                          'BACKGROUND: b.\nTAKEAWAY: shipped it.\nSOURCE: m1\nQUOTE: "the suite is green across every case"')
+        self.assertEqual(jd._distill_session(SID, str(path), NOW), 1)
+        nd = jd.load_goals(SID)["nodes"][self.G]
+        self.assertEqual(nd["summaryQuote"], "the suite is GREEN across every case",
+                         "normalized (case-insensitive) match maps back to the atom's RAW span")
+        self.assertEqual(nd["summaryQuoteOff"], long_a.index("the suite is GREEN"))
+        # unfindable → honest None (re-arm a fresh distill by clearing the episode)
+        store = jd.load_goals(SID)
+        store["nodes"][self.G]["summary"] = None
+        store["nodes"][self.G]["distilledMt"] = 0
+        jd.save_goals(SID, store)
+        jd.distill_llm = (lambda *a, **k:
+                          'TAKEAWAY: shipped it again.\nSOURCE: m1\nQUOTE: "a sentence that never appeared"')
+        self.assertEqual(jd._distill_session(SID, str(path), NOW), 1)
+        nd = jd.load_goals(SID)["nodes"][self.G]
+        self.assertIsNone(nd["summaryQuote"], "unfindable stores None — the landing keeps today's behavior")
+
     def test_a_confirming_top_distills_before_settle(self):
         path = self._write()
         jd.distill_llm = lambda *a, **k: "BACKGROUND: b.\nTAKEAWAY: shipped the widget.\nSOURCE: m1"
@@ -5092,14 +5127,14 @@ class SourceCitation(unittest.TestCase):
                          "only the substantive wrap-up is offered for citation")
 
     def test_split_source_strips_the_final_citation_line(self):
-        self.assertEqual(jd._split_source("The fix shipped.\nSOURCE: m3"), ("The fix shipped.", "m3"))
-        self.assertEqual(jd._split_source("The fix shipped.\n SOURCE: [m12] "), ("The fix shipped.", "m12"))
+        self.assertEqual(jd._split_source("The fix shipped.\nSOURCE: m3"), ("The fix shipped.", "m3", None))
+        self.assertEqual(jd._split_source("The fix shipped.\n SOURCE: [m12] "), ("The fix shipped.", "m12", None))
 
     def test_split_source_is_none_when_absent_or_not_final(self):
-        self.assertEqual(jd._split_source("No citation."), ("No citation.", None))
-        self.assertEqual(jd._split_source(""), ("", None))
+        self.assertEqual(jd._split_source("No citation."), ("No citation.", None, None))
+        self.assertEqual(jd._split_source(""), ("", None, None))
         body = "It mentions SOURCE: m2 mid-sentence and keeps going."
-        self.assertEqual(jd._split_source(body), (body, None),
+        self.assertEqual(jd._split_source(body), (body, None, None),
                          "only a citation anchored at the END of the reply is parsed off")
 
     def test_prompts_ask_for_the_source_line(self):
@@ -5143,10 +5178,11 @@ class SourceCitation(unittest.TestCase):
         # pre-decided next lever repeats the requirement as the LAST thing the model reads (recency), after
         # the section specs, so the trailing line is top-of-mind at generation time. Briefer-only: the
         # distiller was clean post-fix (0 cite-miss), so its working prompt is left untouched.
-        tail = jd.BLOCK_BRIEF_SYS[-260:]
-        self.assertIn("final line of your", tail, "the reminder rides at the very end of the briefer prompt")
+        tail = jd.BLOCK_BRIEF_SYS[-520:]           # the reminder grew the QUOTE option (T218) — same recency lever
+        self.assertIn("your reply must end with", tail, "the reminder rides at the very end of the briefer prompt")
         self.assertIn("SOURCE: mN", tail, "and it restates the exact required line")
         self.assertIn("Do not stop at the takeaway", tail, "hammering the observed miss: ending on the takeaway")
+        self.assertIn("QUOTE:", tail, "the supporting-span option rides the same end-reminder (T218)")
         # ADDITIVE, not a replacement: the detailed citation paragraph (which message to cite) still precedes it
         self.assertLess(jd.BLOCK_BRIEF_SYS.index("complete **only**"),
                         jd.BLOCK_BRIEF_SYS.rindex("SOURCE: mN"),

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -1,0 +1,48 @@
+// T218's render half (the manager's 87-pair anchor study): the summary deep link now carries the
+// distiller's located supporting SPAN, and the landing scrolls to and highlights the sentence
+// inside the (often long, multi-topic) cited message. Pins: the payload gate, the click's quote,
+// the kernel focus passthrough, the highlight's zero-DOM-surgery mechanism with honest fallbacks,
+// and the paint. The judge half (labels on substantive non-prose atoms, the QUOTE protocol, the
+// write-time locate) lives in tests/test_cite_substance.py + the distill goldens.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const FEED = fs.readFileSync(path.join(UI, "feed.ts"), "utf8");
+const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(UI, "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "judge.py"), "utf8");
+
+test("the span rides the payload only while the cited atom IS the landing", () => {
+  assert.match(KERNEL, /"summaryAnchorQuote": \(nodes\[nid\]\.get\("summaryQuote"\)\s*\n\s*if _sa_u and _sa_u == nodes\[nid\]\.get\("summaryAnchor"\) else None\)/,
+    "a fallback-tier anchor lands elsewhere — its quote would highlight the wrong text");
+  assert.match(FEED, /summaryAnchorQuote\?: string \| null;/);
+  assert.match(FEED, /anchorUuid: it\.summaryAnchorUuid, quote: it\.summaryAnchorQuote \|\| undefined/,
+    "the click carries the span");
+  assert.match(KERNEL, /f\["anchorQuote"\] = str\(msg\["quote"\]\)\[:300\]/, "the focus frame passes it through");
+});
+
+test("the landing highlights with zero DOM surgery, and falls back honestly", () => {
+  assert.match(RENDER, /pendingAnchorQuote = typeof \(m as \{ anchorQuote\?: string \}\)\.anchorQuote === "string"/);
+  assert.match(RENDER, /if \(pendingAnchorQuote\) \{ highlightCiteSpan\(target, pendingAnchorQuote\); pendingAnchorQuote = null; \}/,
+    "consumed exactly at the successful landing — an honest-fail never strands a stale span");
+  const fn = RENDER.slice(RENDER.indexOf("function highlightCiteSpan"), RENDER.indexOf("function landOn"));
+  assert.match(fn, /CSS as unknown as \{ highlights\?: Map<string, unknown> \}/,
+    "the CSS Custom Highlight API — the ever-re-rendering turn list is never mutated");
+  assert.match(fn, /if \(!H \|\| typeof Highlight === "undefined"\) return;/, "no API → today's whole-message landing");
+  assert.match(fn, /if \(!m\) return;\s*\/\/ unfindable in the rendered text → no highlight, no guess/);
+  assert.match(fn, /scrollIntoView\(\{ block: "center", behavior: "auto" \}\)/, "land ON the sentence, not the message top");
+  assert.match(CSS, /::highlight\(cite-span\) \{ background-color: rgba\(156, 210, 255, 0\.30\);/,
+    "accent-tinted, never a status colour");
+});
+
+test("substantive non-prose atoms are citable — the study's convicted classes", () => {
+  assert.match(JUDGE, /isinstance\(a\.get\("author"\), dict\)/, "a PEER postal report takes a label at the prose floor");
+  assert.match(JUDGE, /_PR_LINK_RE = re\.compile\(r"https:\/\/github\\\.com\/\\S\+\/\(\?:pull\|commit\|compare\)\/\\S\+"\)/,
+    "a PR/commit-link tool result is substance by construction");
+  assert.match(JUDGE, /out\.append\("RESULTS: " \+ " \| "\.join\(results\[:4\]\)\)/);
+  assert.match(JUDGE, /def _store_cited_span\(nd, marks, src, quote\):/, "the span stores only with a RESOLVED citation");
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -106,6 +106,7 @@ interface AskItem {
   summaryStale?: boolean;                          // the user followed up AFTER the shown takeaway (kernel: followupAt > distilledMt) → the summary section carries the stale note until the re-distill lands (the user 2026-08-19)
   background?: string | null;                      // distiller's BACKGROUND section: re-orientation for a reader who forgot the thread → the card's collapsed-by-default section above the takeaway (the user 2026-07-02)
   summaryAnchorUuid?: string | null;               // click the summary line → the completion turn's wrap-up block (kernel build_feed completed pin; cited/latest-prose fallbacks — the user 2026-07-14)
+  summaryAnchorQuote?: string | null;              // the distiller's verbatim supporting sentence, pre-located in the cited atom (T218) — the landing scrolls to and highlights it; null keeps the whole-message landing
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
   failLog?: { t: number; line: string; model: string; note: string }[] | null;   // the summarizer's failed ATTEMPTS on this card (judge _fail_log): when, which line, which MODEL, the literal error — the chip's hover history + the modal's "What was tried" (the user 2026-08-18, who needed to SEE "tried opus — 529" ×3 to know switching the model would fix it)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
@@ -2022,7 +2023,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   if (distillShown && it.summaryAnchorUuid) {
     dl.classList.add("fask-distill-link");
     dl.title = "jump to where this was written";
-    dl.onclick = (ev: Event) => { ev.stopPropagation(); focusEcho(it.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid, t: it.t, anchor: "work", anchorUuid: it.summaryAnchorUuid }); };
+    dl.onclick = (ev: Event) => { ev.stopPropagation(); focusEcho(it.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid, t: it.t, anchor: "work", anchorUuid: it.summaryAnchorUuid, quote: it.summaryAnchorQuote || undefined }); };
   } else if (distillShown) {
     // No anchor recorded (a card minted from a postal delegate, a completion turn not yet landed) — the
     // line must still ACKNOWLEDGE the click instead of rendering as silently dead text (the user

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8000,6 +8000,7 @@ function scrollToAnchor(uuid: string): boolean {
   }
   landTrail.push("pointer-exact");
   landOn(target, uuid);
+  if (pendingAnchorQuote) { highlightCiteSpan(target, pendingAnchorQuote); pendingAnchorQuote = null; }
   return true;
 }
 
@@ -8046,6 +8047,44 @@ function landNearestMoment(t: number): boolean {
 // off its mark. So: re-align whenever the bar/ledger actually resizes, plus two
 // timed retries for late layout (images, markdown), for ~1.2s — canceled the
 // moment the user wheel-scrolls so we never fight a real gesture.
+// The supporting SPAN (T218): the distiller quoted the sentence its takeaway rests on, the kernel
+// located it in the cited atom, and the landing highlights it INSIDE the (often long, multi-topic)
+// message — the study's most common partial was the right message with the claim buried deep. The
+// CSS Custom Highlight API paints it with ZERO DOM surgery, so the ever-re-rendering turn list is
+// never mutated (the click-safety family); a browser without it, or an unfindable quote, keeps
+// today's whole-message landing exactly (the honest-fallback rule).
+let pendingAnchorQuote: string | null = null;
+function highlightCiteSpan(target: HTMLElement, quote: string): void {
+  try {
+    const H = (CSS as unknown as { highlights?: Map<string, unknown> }).highlights;
+    if (!H || typeof Highlight === "undefined") return;
+    const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT);
+    const nodes: Text[] = []; let full = "";
+    for (let n = walker.nextNode(); n; n = walker.nextNode()) { nodes.push(n as Text); full += (n as Text).data; }
+    let at = full.indexOf(quote);
+    let len = quote.length;
+    if (at < 0) {
+      const pat = new RegExp(quote.trim().split(/\s+/).map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s+"), "i");
+      const m = pat.exec(full);
+      if (!m) return;                                    // unfindable in the rendered text → no highlight, no guess
+      at = m.index; len = m[0].length;
+    }
+    const range = document.createRange();
+    let pos = 0, started = false;
+    for (const tn of nodes) {
+      const end = pos + tn.data.length;
+      if (!started && at < end) { range.setStart(tn, at - pos); started = true; }
+      if (started && at + len <= end) { range.setEnd(tn, at + len - pos); break; }
+      pos = end;
+    }
+    if (!started) return;
+    H.set("cite-span", new (Highlight as unknown as { new(...r: Range[]): unknown })(range));
+    window.setTimeout(() => { try { H.delete("cite-span"); } catch { /* gone with a nav */ } }, 6000);
+    const el0 = range.startContainer.parentElement;
+    if (el0) el0.scrollIntoView({ block: "center", behavior: "auto" });   // land ON the sentence, not the message top
+  } catch { /* highlight is chrome, never load-bearing */ }
+}
+
 function landOn(target: HTMLElement, flashKey?: string) {
   const realign = () => target.scrollIntoView({ block: "start", behavior: "auto" });
   realign();
@@ -11846,6 +11885,7 @@ window.addEventListener("message", (e: MessageEvent) => {
         const c = document.getElementById("content"); if (c) c.scrollTop = c.scrollHeight;
       });
     } else {
+      pendingAnchorQuote = typeof (m as { anchorQuote?: string }).anchorQuote === "string" ? (m as { anchorQuote?: string }).anchorQuote! : null;   // the supporting span (T218) — consumed by the landing
       setActive(m.id, m.anchor, typeof m.anchorT === "number" ? m.anchorT : undefined, typeof m.anchorKind === "string" ? m.anchorKind : undefined);
     }
     // A feed card click that resolved to a live goal → seed the composer citation chip (the user 2026-07-01).

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3382,3 +3382,8 @@ body.filebrowse-open { overflow: hidden; }
    spoke" from "something was injected" at a glance (the user 2026-08-18) */
 .scroll-marks .scroll-mark.machine { background: #8a8f98; opacity: 0.55; }
 
+
+/* the supporting-span highlight (T218): the sentence the summary rests on, painted via the CSS
+   Custom Highlight API (no DOM surgery — the turn list re-renders constantly). Accent-tinted like
+   the focus family, never a status colour. */
+::highlight(cite-span) { background-color: rgba(156, 210, 255, 0.30); color: #ffffff; }


### PR DESCRIPTION
The manager's 87-pair anchor study (T218): the citation mechanism was sound, but two structural gaps made clicks land on announcements or at the top of long reports. Both mechanical arms ship.

**Arm 1 — the substance is citable.** Only assistant prose ever took [mN] labels, so when the work's evidence was a postal ready-report or a PR link, the model could cite only the message that *announced* the work. A **peer postal report** now takes a label at the same substantive-prose floor, and a **tool result carrying a PR/commit/compare link** rides a compact RESULTS line with its own label (the link IS the substance). Plain tool output stays uncitable by construction — the floor call the dispatch left open; the fresh live specimen's plain-tool-substance blend is only partially covered by this arm and is flagged honestly.

**Arm 2 — the supporting span.** The SOURCE protocol grows an optional **QUOTE** line (all three judge prompts; verbatim, under 25 words; omit when no single sentence carries it — the briefer's end-reminder keeps its recency lever with the option folded in). `_split_source` peels it in either order; the kernel **locates it in the cited atom's own text at write time** (exact, then whitespace/case-normalized, mapped back to the raw span; unfindable stores None — never a guess) and stores span + offset beside the anchor, only when the citation itself resolved (the deterministic newest() fallback never carries a span that would highlight the wrong text). The payload ships it only while the resolved anchor IS the cited atom; the click carries it; the chat landing **scrolls to and highlights the sentence via the CSS Custom Highlight API** — zero DOM surgery on the ever-re-rendering turn list; a browser without the API or an unfindable quote keeps today's whole-message landing exactly.

Red-first goldens both arms (uncitable-substance specimen now labeled; the span located, stored, and honestly None end to end through the real distill pipeline), the parser matrix, prompt pins in their existing homes (em-dash ban honored), payload/click/landing pins — plus a **fourth `_split_source` call site** (the brief corrective retry) the suite caught, wired with the same span semantics. All fixtures synthetic. Python 6324 passed / extension 2632 passed on the pushed head; before/after span-landing screenshot (the AFTER painted by the real Highlight API) in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)