### PR TITLE
T219: a mid-tool-use restart cut never reads as the user's stop

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -279,12 +279,29 @@ def _machine_cut_cause(users, i, cut_t=0.0, cut_cause=""):
     IS that cut. Ordering alone makes this exact (the cut always precedes its resume), so a genuine stop
     made later is always past the stamp and still reads as the user's; no window, no expiry. A scan that
     reaches a terminator never consults the stamp: there the transcript already answered."""
+    passed_romp = False
     for nxt in users[i + 1:]:
         if nxt.get("author") == "romp":
             cause = _interrupt_cause(nxt)
             if cause:
                 return cause
-        elif em.is_interrupt_record(nxt) or nxt.get("author") == "human":
+            passed_romp = True                           # a cause-less romp atom is a RE-ENGAGE (a
+            #                                              nudge, a notice for some other cut): past
+            #                                              it, a later stop record is a SEPARATE
+            #                                              episode, never this record's twin
+        elif em.is_interrupt_record(nxt):
+            if passed_romp:
+                return None                              # romp re-engaged between the records → the
+            #                                              earlier stop stands on its own (the
+            #                                              notice-past-the-next-stop case)
+            # else: BACK-TO-BACK stop records are ONE cut event (T219, the user 2026-09-01: a
+            # restart cutting a turn mid-tool-use writes TWO records — 'for tool use' then plain —
+            # and the old terminator here made the first read as the user's stop without ever
+            # consulting the notice just past it or the backend's stamp; the card then claimed
+            # 'you stopped this session mid-turn' for a deploy the user never touched, twice on
+            # the live specimen). Read past the twin: the notice ahead, a real terminator, or the
+            # stamp below decides for BOTH.
+        elif nxt.get("author") == "human":
             return None                                  # the transcript settled it — the stamp says nothing new
     if cut_cause and (users[i].get("t") or 0) <= cut_t:   # notice not on disk yet → the backend's own record
         return cut_cause
@@ -299,8 +316,16 @@ def _interrupt_marks(turns, sid=""):
     it, or — before that notice reaches disk — the backend's machineCut stamp). The interrupt record
     itself authors 'human', so it's classified FIRST. `sid` is optional only so the pure-atom callers in
     the tests stay pure: pass it wherever it is known, or a cut still on its way to disk reads as a stop."""
-    users = [a for turn in turns for a in (turn.get("atoms") or []) if a.get("type") == "user"]
+    atoms = [a for turn in turns for a in (turn.get("atoms") or [])]
     cut_t, cut_cause = _last_machine_cut(sid) if sid else (0.0, "")
+    return _interrupt_marks_atoms(atoms, cut_t, cut_cause)
+
+
+def _interrupt_marks_atoms(atoms, cut_t=0.0, cut_cause=""):
+    """The pure-atom core of _interrupt_marks — `atoms` plus the backend's machineCut stamp as
+    plain arguments, so the classifier is testable without a states/ file (T219's repro rides
+    this surface)."""
+    users = [a for a in atoms if a.get("type") == "user"]
     last_intr = last_human = 0
     for i, a in enumerate(users):
         t = a.get("t", 0)

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -169,6 +169,59 @@ class MachineCutSuppression(unittest.TestCase):
                         "the notice belongs to the SECOND cut; the first stop is the user's")
 
 
+class MidToolUseCut(unittest.TestCase):
+    """T219 (the user 2026-09-01, who saw their own card claim they stopped a session a deploy
+    restart had cut): a restart cutting a turn MID-TOOL-USE writes TWO stop records back to back —
+    '[Request interrupted by user for tool use]' then '[Request interrupted by user]' — and only
+    THEN the resume notice. The first record's forward scan hits the second (a terminator) and,
+    before the fix, returned 'user stop' without consulting the notice or the backend's machineCut
+    stamp: blocked-on-you filed off a machine cut, twice on the live specimen. An adjacent stop
+    record settles NOTHING about the one before it — only a human message does — so the scan now
+    falls through to the stamp there, and the stamp decides."""
+
+    def _turns(self, atoms):
+        return [{"atoms": atoms}]
+
+    def _double_cut(self):
+        return [uatom(T0, "wire the thing"),
+                uatom(T0 + 60, "[Request interrupted by user for tool use]", author="human"),
+                intr(T0 + 63),
+                uatom(T0 + 80, sb.BOOT_RESUME_NUDGE, "romp")]
+
+    def test_a_mid_tool_use_restart_cut_is_no_user_stop(self):
+        # the stamp covers both records (the backend stamps the cut at/after the CLI writes them)
+        stop_t, human_t = km._interrupt_marks_atoms(self._double_cut(), cut_t=T0 + 64,
+                                                    cut_cause="restart")
+        self.assertEqual(stop_t, 0, "neither back-to-back record reads as the user's stop — "
+                                    "no blocked-on-you, no 'you stopped this' prose")
+
+    def test_the_notice_clears_both_twin_records_even_before_the_stamp_lands(self):
+        # the read-past-the-twin rule lets record #1's scan reach the notice just past record #2 —
+        # the notice covers its own cut's twins, so neither needs the stamp (the stamp remains the
+        # decider only inside the notice-not-yet-on-disk window, tested above)
+        atoms = self._double_cut()
+        stop_t, _ = km._interrupt_marks_atoms(atoms, cut_t=0.0, cut_cause="")
+        self.assertEqual(stop_t, 0, "the notice disowns both back-to-back records of its cut")
+
+    def test_a_genuine_double_stop_still_files(self):
+        # the user hammering Esc twice with NO machine cut behind it: still a real stop
+        atoms = [uatom(T0, "wire the thing"),
+                 uatom(T0 + 60, "[Request interrupted by user for tool use]", author="human"),
+                 intr(T0 + 63)]
+        stop_t, _ = km._interrupt_marks_atoms(atoms, cut_t=0.0, cut_cause="")
+        self.assertGreater(stop_t, 0, "no notice, no stamp → the user is driving, exactly as today")
+
+    def test_a_human_terminator_still_settles_without_the_stamp(self):
+        # the user SPOKE after the first record: the transcript answered — the stamp is never
+        # consulted, the stop tally keys on the record vs the newer human message as before
+        atoms = [uatom(T0, "wire the thing"),
+                 uatom(T0 + 60, "[Request interrupted by user for tool use]", author="human"),
+                 uatom(T0 + 90, "ok, take plan B"),
+                 intr(T0 + 120)]
+        stop_t, human_t = km._interrupt_marks_atoms(atoms, cut_t=T0 + 200, cut_cause="restart")
+        self.assertGreater(stop_t, 0)
+
+
 class _FeedHarness(unittest.TestCase):
     """Shared transcript + store + feed fixture for the tick-level classes below (no tests of its
     own): a temp project dir, a named session, redirected judge/kernel paths, and helpers to write


### PR DESCRIPTION
## Summary
The live specimen: a card said "you stopped this session mid-turn" for a deploy restart the user never touched — twice. A restart cutting a turn mid-tool-use writes TWO stop records back to back ("[Request interrupted by user for tool use]" then the plain form) and only then the resume notice. The first record's forward scan hit the second — a terminator — and returned "user stop" without consulting the notice just past it or the backend's machineCut stamp: the terminator rule assumed a following stop record meant the transcript had settled the question, true for separate episodes but false for one cut's twins. The stale stop then outranked the (much older) last human message; the interrupt-block tick filed blocked-on-you, and re-filed after auto-resume finished the work.

The scan now distinguishes the shapes by what sits **between** the records: a cause-less romp atom (a nudge, another cut's notice) is a re-engage, so a later stop record is a separate episode and the earlier stop stands (the notice-past-the-next-stop case, pinned before and still); with only wedge atoms between, back-to-back records are one cut event — the scan reads past the twin, and the notice ahead, a real terminator, or the machineCut stamp decides for both. Previously-filed false blocks self-heal: with the twins excluded, the tick's lift path clears them on its first pass.

## Test plan
- Red-first repro on the specimen's exact shape via the new pure-atom core (`_interrupt_marks_atoms`): the mid-tool-use cut clears with the stamp; the notice alone clears both twins even inside the stamp's write window; a genuine double-Esc with no notice and no stamp still files exactly as today; a human message after the first record still settles without the stamp. The existing notice-past-the-next-stop pin holds unchanged.
- Full Python suite: 6,394 passed. Extension suite: green. Local bats: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)