### PR TITLE
An upload caught by a kernel restart re-ships on reconnect instead of wedging

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32042,11 +32042,18 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "dropFile" and msg.get("name") and msg.get("b64"):
             fp = _save_dropped_file(str(msg["name"]), str(msg["b64"]))   # bytes → saved file → insert its path
             if fp:
-                _reply(client, {"type": "droppedPath", "path": fp})
+                ack = {"type": "droppedPath", "path": fp}
             else:
                 # a failed save must be NACKED, not silent (fail loudly): the client keeps a pending
                 # chip up from the moment the file was picked, and only this reply can retire it
-                _reply(client, {"type": "dropSaveFailed", "name": str(msg["name"])})
+                ack = {"type": "dropSaveFailed", "name": str(msg["name"])}
+            if msg.get("shipId"):
+                # echo the client's ship id (T215): a kernel restart between ship and ack makes the
+                # client RE-SHIP the bytes on reconnect, so duplicate acks are possible — the echoed
+                # id lets it retire exactly the chip that asked and DROP a stray twin, instead of
+                # attaching the twin to whatever tab is active
+                ack["shipId"] = str(msg["shipId"])
+            _reply(client, ack)
         elif msg and msg.get("type") == "openFile" and msg.get("path"):
             # caption / linkified path click → open it on the kernel's machine (relative → resolved vs
             # the session cwd). The web dashboard sends this only where it IS the right answer; a remote

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5328,7 +5328,12 @@ class ViewBuilder(unittest.TestCase):
         # the user 2026-08-11; source pin — the branch lives inline in the WS message loop)
         self.assertIsNone(km._save_dropped_file("bad.png", "%%%not-base64%%%"), "undecodable bytes → None")
         src = Path(BIN, "romp-kernel").read_text()
-        self.assertIn('_reply(client, {"type": "dropSaveFailed", "name": str(msg["name"])})', src)
+        self.assertIn('ack = {"type": "dropSaveFailed", "name": str(msg["name"])}', src)
+        # the ack/nack ECHOES the client's shipId when one was sent (T215): a kernel restart between
+        # ship and ack makes the client re-ship on reconnect, so duplicate acks are possible — the
+        # echoed id lets it retire exactly the chip that asked and drop a stray twin
+        self.assertIn('ack["shipId"] = str(msg["shipId"])', src)
+        self.assertIn('_reply(client, ack)', src)
 
     def test_permission_mode_cycle_presses(self):
         # shift+tab press count from current → target in the cycle (the user 2026-06-16): there's no

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""T215: a kernel restart between an attachment's ship and its ack must not wedge the upload.
+
+The wedge (verified on main before the fix): file bytes ride the ws as base64 dropFile and
+complete on a droppedPath ack sent back on the SAME socket. pendingShips is in-memory and
+nothing on romp:wsup ever re-shipped or failed it — so a kernel restart in the ship→ack window
+left the chip pulsing forever, and a send held by the ship gate ("Wait for the upload") waited
+on an ack that could no longer arrive: message plus attachment parked with no error.
+
+The fix, both faces:
+  * same-page reconnect (the served dashboard): every pending entry retains its encoded payload
+    and re-ships on romp:wsup — the exact kernel-is-back event, never a timer. The ack/nack
+    echoes the client's shipId, so a duplicate ack from a re-ship race retires exactly the chip
+    that asked, and a stray twin is DROPPED instead of attached to the active tab.
+  * reload (the VS Code pipe reloads its webview on kernel reconnect): the payload dies with
+    the page, so the ship NAMES persist beside the drafts and the next load says LOUDLY what
+    was lost — never a silent vanish.
+
+Two guards here:
+  * SourcePins — runs everywhere, CI included: the wiring above, pinned in the sources (the
+    webview-side twins live in ui/webview/pending-attach.test.ts).
+  * ServedWedge — the executed guard: boots the hermetic kernel, opens the real /chat page,
+    SIGSTOPs the kernel so the dropFile is shipped on a live socket that will never answer,
+    holds a send behind the ship gate, SIGKILLs and relaunches the kernel — and asserts the
+    reconnect re-ships, the thumbnail lands, and the held send fires. Plus the regression leg:
+    a normal ship+send against the restarted kernel behaves exactly as before. Skips LOUDLY
+    when the extension deps or a playwright browser are absent (CI installs no browsers).
+
+All fixtures synthetic.
+"""
+import base64
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+RENDER = open(os.path.join(ROOT, "ui", "webview", "render.ts")).read()
+KERNEL_SRC = open(os.path.join(BIN, "romp-kernel")).read()
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=")
+
+
+class SourcePins(unittest.TestCase):
+    def test_payload_retained_and_reshipped_on_the_reconnect_event(self):
+        self.assertIn("interface PendingShip { name: string; shipId: string; b64?: string }", RENDER)
+        self.assertIn("if (entry) entry.b64 = b64;", RENDER)
+        self.assertIn('window.addEventListener("romp:wsup", reshipPendingUploads);', RENDER)
+
+    def test_ack_echoes_shipid_and_a_stray_twin_is_dropped(self):
+        self.assertIn('ack["shipId"] = str(msg["shipId"])', KERNEL_SRC)
+        self.assertIn("if (ackShip && !shipOwner(ackShip)) return;", RENDER)
+
+    def test_a_reload_loss_is_loud_never_a_silent_vanish(self):
+        self.assertIn("shipsInFlight: [...pendingShips.values()].flat().map((p) => p.name)", RENDER)
+        self.assertIn("still uploading when this page reloaded, so it was NOT attached", RENDER)
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 900 } });
+const out = { wedge: {}, regression: {} };
+const die = async (why) => {
+  fs.writeSync(1, "RESULT:" + JSON.stringify({ ...out, died: why }) + "\n");
+  await browser.close();
+  process.exit(0);
+};
+
+// ---- wedge: SIGSTOP the kernel so the ship rides a live socket that will never answer ----
+await page.goto(cfg.url);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+const tab = await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 }).catch(() => null);
+if (!tab) await die("no session tab — the lab seed never reached the chat payload");
+await page.waitForTimeout(500);   // let the shim's ws settle onto the live kernel
+process.kill(cfg.kernelPid, "SIGSTOP");
+await page.setInputFiles("body > input[type=file]", cfg.file);
+await page.waitForSelector(".composer-file-pending", { timeout: 10000 }).catch(() => {});
+out.wedge.chipUpAfterShip = await page.locator(".composer-file-pending").count();
+await page.fill("#composer-input", cfg.msg);
+await page.click("#composer-send");
+// the ship gate: hold the send on the upload, the event this bug starved forever
+await page.waitForSelector(".confirm-btn", { timeout: 10000 }).catch(() => {});
+const waitBtn = page.locator(".confirm-btn", { hasText: "Wait for the upload" });
+out.wedge.gateOffered = await waitBtn.count();
+if (out.wedge.gateOffered) await waitBtn.click();
+out.wedge.inputHeld = await page.inputValue("#composer-input");
+out.wedge.chipStillPendingHeld = await page.locator(".composer-file-pending").count();
+// ---- the restart: the old socket dies with the ack still owed; a fresh kernel takes the port ----
+process.kill(cfg.kernelPid, "SIGKILL");
+const k2 = spawn(cfg.relaunch.cmd, [], { env: cfg.relaunch.env, detached: true,
+  stdio: ["ignore", fs.openSync(cfg.relaunch.log, "a"), fs.openSync(cfg.relaunch.log, "a")] });
+k2.unref();   // the kernel outlives this driver — an un-unref'd child held node open past RESULT
+fs.writeSync(1, "KPID:" + k2.pid + "\n");
+// today (pre-fix) this wait dies: the chip pulses forever and the held send never fires.
+// with the fix: romp:wsup re-ships, the ack retires the chip, and fireHeldSend sends the message.
+const healed = await page.waitForFunction((msg) => {
+  const input = document.getElementById("composer-input");
+  const pending = document.querySelectorAll(".composer-file-pending").length;
+  const content = document.getElementById("content");
+  return pending === 0 && input && input.value === "" &&
+         !!content && content.textContent.includes(msg);
+}, cfg.msg, { timeout: 45000 }).then(() => true).catch(() => false);
+out.wedge.healedAfterRestart = healed;
+out.wedge.pendingAfterRestart = await page.locator(".composer-file-pending").count();
+out.wedge.inputAfterRestart = await page.inputValue("#composer-input");
+out.wedge.contentHasMsg = await page.evaluate(
+  (msg) => (document.getElementById("content")?.textContent || "").includes(msg), cfg.msg);
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-wedge.png" });
+
+// ---- regression: a normal ship+send against the restarted kernel, untouched ----
+await page.reload();
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(1000);
+// the reload must NOT cry ship-loss: the wedge's ships all settled before it
+out.regression.lossToast = await page.evaluate(
+  () => (document.getElementById("warn-toasts")?.textContent || "").includes("still uploading"));
+await page.setInputFiles("body > input[type=file]", cfg.file);
+const acked = await page.waitForFunction(() =>
+  document.querySelectorAll(".composer-file-pending").length === 0 &&
+  document.querySelectorAll(".composer-file").length > 0, { timeout: 15000 })
+  .then(() => true).catch(() => false);
+out.regression.thumbnailLanded = acked;
+await page.fill("#composer-input", cfg.msg2);
+await page.click("#composer-send");
+out.regression.gateOpened = await page.locator(".confirm-btn").count();   // no pending ships → no gate
+const sent = await page.waitForFunction((msg) => {
+  const input = document.getElementById("composer-input");
+  return input && input.value === "" &&
+         (document.getElementById("content")?.textContent || "").includes(msg);
+}, cfg.msg2, { timeout: 15000 }).then(() => true).catch(() => false);
+out.regression.sentClean = sent;
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-regression.png" });
+
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");   // sync: exit must not truncate it
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedWedge(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served wedge needs them")
+        cls.lab = tempfile.mkdtemp(prefix="ship-reship-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        os.makedirs(os.path.join(cls.state, "names"), exist_ok=True)
+        os.makedirs(os.path.join(cls.state, "sdk"), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        # one synthetic SDK session so the chat page has a tab and a composer to ship into
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto",
+             "effort": "high", "lastSid": SID, "alive": True}))
+        Path(cls.state, "usage.json").write_text(json.dumps(
+            {"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))  # park sends: no CLI spawns in the lab
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        os.makedirs(proj, exist_ok=True)
+        # a CLOSED turn (user + replied assistant): an OPEN one would invite the boot
+        # reconcile to resume it — this lab must never spawn a real CLI
+        Path(proj, SID + ".jsonl").write_text(
+            json.dumps({"type": "user", "uuid": "11111111-2222-3333-4444-555555555555",
+                        "parentUuid": None, "timestamp": "2026-09-01T00:00:00.000Z",
+                        "sessionId": SID,
+                        "message": {"role": "user", "content": "hello there"}}) + "\n" +
+            json.dumps({"type": "assistant", "uuid": "22222222-3333-4444-5555-666666666666",
+                        "parentUuid": "11111111-2222-3333-4444-555555555555",
+                        "timestamp": "2026-09-01T00:00:05.000Z", "sessionId": SID,
+                        "message": {"role": "assistant", "model": "claude-sonnet-5",
+                                    "content": [{"type": "text", "text": "hi from the lab"}],
+                                    "stop_reason": "end_turn"}}) + "\n")
+        cls.png = os.path.join(cls.lab, "shot.png")
+        Path(cls.png).write_bytes(PNG)
+        cls.port = _free_port()
+        cls.token = "testtok-reship"
+        cls.env = dict(os.environ,
+                       XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
+                       CLAUDE_CONFIG_DIR=claude,
+                       ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
+                       ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
+                       ROMP_DIST_DIR=dist)
+        cls.env.pop("ROMP_STATE_DIR", None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=cls.env)
+        cls.kernel2_pid = None
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        for pid in [getattr(cls, "kernel", None) and cls.kernel.pid, getattr(cls, "kernel2_pid", None)]:
+            if pid:
+                try:
+                    os.kill(pid, signal.SIGCONT)   # a SIGSTOPped kernel ignores SIGTERM until resumed
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+        if getattr(cls, "kernel", None):
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_restart_between_ship_and_ack_reships_heals_and_releases_the_held_send(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+                       "kernelPid": self.kernel.pid,
+                       "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"),
+                                    "env": {k: v for k, v in self.env.items()}, "log": self.klog},
+                       "file": self.png, "msg": "hold this message for the upload T215",
+                       "msg2": "a normal send after the restart T215",
+                       "shots": os.environ.get("SHIP_RESHIP_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        try:
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                               env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        except subprocess.TimeoutExpired as e:
+            self.fail("driver timed out; partial output:\n%s\n%s"
+                      % ((e.stdout or b"").decode() if isinstance(e.stdout, bytes) else (e.stdout or ""),
+                         (e.stderr or b"").decode() if isinstance(e.stderr, bytes) else (e.stderr or "")))
+        kpid = next((ln for ln in p.stdout.splitlines() if ln.startswith("KPID:")), None)
+        if kpid:
+            type(self).kernel2_pid = int(kpid.split(":", 1)[1])
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the wedge needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertNotIn("died", r, "driver aborted early: %r" % r)
+        w, reg = r["wedge"], r["regression"]
+        # the ship went out on a live socket the stopped kernel will never answer
+        self.assertEqual(w["chipUpAfterShip"], 1, "the pending chip must be up after the ship: %r" % w)
+        self.assertEqual(w["gateOffered"], 1, "the ship gate must offer to wait for the upload: %r" % w)
+        self.assertEqual(w["inputHeld"], "hold this message for the upload T215",
+                         "the held send keeps the composer text until the upload settles: %r" % w)
+        self.assertEqual(w["chipStillPendingHeld"], 1, "the chip is honestly pending while held: %r" % w)
+        # the heart of T215: after the restart the reconnect re-ships, the ack lands, the send fires
+        self.assertTrue(w["healedAfterRestart"],
+                        "the reconnect must re-ship and release the held send — pre-fix this pulses "
+                        "forever and the send never fires: %r (kernel log tail: %s)"
+                        % (w, Path(self.klog).read_text()[-500:]))
+        self.assertEqual(w["pendingAfterRestart"], 0, "no chip may pulse over an upload that settled: %r" % w)
+        self.assertEqual(w["inputAfterRestart"], "", "the held send must have fired: %r" % w)
+        self.assertTrue(w["contentHasMsg"], "the sent message must be in the transcript view: %r" % w)
+        # regression: the restarted kernel serves a NORMAL ship+send exactly as before
+        self.assertFalse(reg["lossToast"], "a clean reload must not cry ship-loss: %r" % reg)
+        self.assertTrue(reg["thumbnailLanded"], "normal ship: chip → thumbnail on the ack: %r" % reg)
+        self.assertEqual(reg["gateOpened"], 0, "no pending ships → no gate: %r" % reg)
+        self.assertTrue(reg["sentClean"], "a plain send still clears and lands: %r" % reg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/composer-attach.test.ts
+++ b/ui/webview/composer-attach.test.ts
@@ -44,7 +44,7 @@ test("📎 routes the chosen files through the existing dropFile pipeline (no ne
   // gets {type:"droppedPath"} back — we reuse it rather than add a second uploader
   assert.match(RENDER, /filePicker\.files \|\| \[\]\)\.forEach\(\(f\) => shipFileToHost\(f\)\)/);
   assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";/);
-  assert.match(RENDER, /\{ type: "dropFile", name, b64 \}/);
+  assert.match(RENDER, /\{ type: "dropFile", name, b64, shipId \}/);
 });
 
 test("📎 in the VS Code webview still uses the native host dialog (pickFile)", () => {

--- a/ui/webview/composer-draft-persist.test.ts
+++ b/ui/webview/composer-draft-persist.test.ts
@@ -13,7 +13,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 test("drafts are persisted to and reloaded from the webview's saved state", () => {
   // persist: mirror the Map into setState, alongside (not replacing) whatever else is saved — plus
   // citations, files, and the staged stack (2026-08-15)
-  assert.match(RENDER, /function persistDrafts\(\): void \{[\s\S]*setState\?\.\(\{ \.\.\.\(vscodeApi\.getState\?\.\(\) \|\| \{\}\), drafts: Object\.fromEntries\(drafts\),[\s\S]*citations: Object\.fromEntries\(composerCitations\),[\s\S]*files: Object\.fromEntries\(composerFiles\),[\s\S]*staged: stagedMsgs\.entries\(\) \}\)/);
+  assert.match(RENDER, /function persistDrafts\(\): void \{[\s\S]*setState\?\.\(\{ \.\.\.\(vscodeApi\.getState\?\.\(\) \|\| \{\}\), drafts: Object\.fromEntries\(drafts\),[\s\S]*citations: Object\.fromEntries\(composerCitations\),[\s\S]*files: Object\.fromEntries\(composerFiles\),[\s\S]*staged: stagedMsgs\.entries\(\),[\s\S]*shipsInFlight: [\s\S]*\}\)/);
   // reload: hydrate the Map from saved state at startup (string values only)
   assert.match(RENDER, /const saved = \(\(vscodeApi\?\.getState\?\.\(\) \|\| \{\}\) as any\)\.drafts;/);
   assert.match(RENDER, /for \(const \[k, v\] of Object\.entries\(saved\)\) if \(typeof v === "string"\) drafts\.set\(k, v\);/);

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -41,7 +41,7 @@ test("every file arrival becomes an attachment, never raw path text in the box",
   assert.match(RENDER, /if \(p && !hostOf\(activeId \|\| ""\)\) addComposerFile\(activeId, p\);\s*\n\s*else shipFileToHost\(f\);/);
   // the window spans the popover-owned branch first (an open comment popover claims its own
   // clip's ack; the COMPOSER path below it still always lands as an attachment)
-  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,900}addComposerFile\(owner, m\.path\);/);
+  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,1500}addComposerFile\(owner, m\.path\);/);   // window covers the T215 stray-ack gate
   // the old insert-at-cursor path is gone with its last caller
   assert.doesNotMatch(RENDER, /function insertComposerText/);
 });

--- a/ui/webview/composer-ship-gate.test.ts
+++ b/ui/webview/composer-ship-gate.test.ts
@@ -71,8 +71,8 @@ test("any successful send supersedes a hold, so a spent hold can never double-se
 });
 
 test("the ack attaches to the composer that SHIPPED the file, not whatever tab is active", () => {
-  assert.match(RENDER, /function retirePendingShip\(key: string\): string \| null \{/);
-  assert.match(RENDER, /const owner = retirePendingShip\(m\.path\) \|\| activeId;/);
+  assert.match(RENDER, /function retirePendingShip\(key: string, shipId\?: string\): string \| null \{/);
+  assert.match(RENDER, /const owner = retirePendingShip\(m\.path, ackShip\) \|\| activeId;/);
   assert.match(RENDER, /addComposerFile\(owner, m\.path\);/);
 });
 

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -22,10 +22,10 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 
 test("the pending chip goes up BEFORE the encode starts — pick-to-feedback is immediate", () => {
   // registry keyed by session, like composerFiles beside it
-  assert.match(RENDER, /const pendingShips = new Map<string, string\[\]>\(\);/);
+  assert.match(RENDER, /const pendingShips = new Map<string, PendingShip\[\]>\(\);/);   // entries retain shipId + payload (T215)
   // registered at the TOP of shipFileToHost (before new FileReader), with the sid captured once —
   // at call time via the sidAt default (a pasted-path caller passes the sid it verified against)
-  assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";\s*\n\s*const sid = sidAt;.*\n\s*addPendingShip\(sid, name\);.*\n\s*const reader = new FileReader\(\);/);
+  assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";\s*\n\s*const sid = sidAt;.*\n\s*const shipId = "s".*\n\s*addPendingShip\(sid, name, shipId\);.*\n\s*const reader = new FileReader\(\);/);
 });
 
 test("the strip renders pending chips (name + pulsing dots) and shows even with no real attachments", () => {
@@ -39,8 +39,8 @@ test("the strip renders pending chips (name + pulsing dots) and shows even with 
 });
 
 test("the droppedPath ack retires the chip it answers, then attaches the thumbnail", () => {
-  assert.match(RENDER, /const owner = retirePendingShip\(m\.path\) \|\| activeId;/);
-  assert.match(RENDER, /retirePendingShip\(m\.path\)[\s\S]{0,300}addComposerFile\(owner, m\.path\)/,
+  assert.match(RENDER, /const owner = retirePendingShip\(m\.path, ackShip\) \|\| activeId;/);
+  assert.match(RENDER, /retirePendingShip\(m\.path, ackShip\)[\s\S]{0,300}addComposerFile\(owner, m\.path\)/,
     "the ack attaches to the composer that SHIPPED the file (the 2026-08-16 wrong-tab attach)");
 });
 
@@ -54,18 +54,50 @@ test("ack↔chip matching mirrors the kernel's saved-name sanitizer, FIFO as the
 
 test("a failed kernel save is NACKED and surfaces loudly — never a silent stuck chip", () => {
   // kernel: the no-path branch replies dropSaveFailed instead of nothing
-  assert.match(KERNEL, /_reply\(client, \{"type": "dropSaveFailed", "name": str\(msg\["name"\]\)\}\)/);
+  assert.match(KERNEL, /ack = \{"type": "dropSaveFailed", "name": str\(msg\["name"\]\)\}/);   // built then shipId-stamped (T215)
   // client: the nack retires the chip and says so in a toast
   assert.match(RENDER, /m\.type === "dropSaveFailed" && typeof m\.name === "string"/);
-  assert.match(RENDER, /retirePendingShip\(m\.name\) \|\| activeId;[\s\S]{0,300}warnToast\(m\.name \+ " couldn't be saved on the kernel/);
+  assert.match(RENDER, /retirePendingShip\(m\.name, nackShip\) \|\| activeId;[\s\S]{0,300}warnToast\(m\.name \+ " couldn't be saved on the kernel/);
   // a FileReader failure retires it too — an unreadable file must not pulse forever
-  assert.match(RENDER, /reader\.onerror = \(\) => retirePendingShip\(name\);/);
+  assert.match(RENDER, /reader\.onerror = \(\) => retirePendingShip\(name, shipId\);/);
 });
 
-test("pending chips are in-memory only — never persisted with drafts", () => {
-  // a reload kills the page whose socket the ack would ride; persisting the chip would
-  // revive dots that nothing can ever retire
-  assert.doesNotMatch(RENDER, /pendingShips[\s\S]{0,80}persistDrafts|persistDrafts[\s\S]{0,300}pendingShips/);
+test("chips are never revived from a reload — names persist only to say what was LOST (T215)", () => {
+  // The chips themselves stay in-memory: a reload kills the payload, so a revived chip would pulse
+  // over a file nothing can ever retire. What DOES persist is the ship NAMES (persistDrafts's
+  // shipsInFlight), read once at startup to warn that those uploads died with the page — the VS Code
+  // pipe reloads its webview on kernel reconnect, which was the silent-vanish face of the T215 wedge.
+  assert.match(RENDER, /shipsInFlight: \[\.\.\.pendingShips\.values\(\)\]\.flat\(\)\.map\(\(p\) => p\.name\)/);
+  assert.doesNotMatch(RENDER, /pendingShips\.set\([^)]*shipsInFlight/, "never rebuild chips from the persisted names");
+  assert.match(RENDER, /still uploading when this page reloaded, so it was NOT attached — attach it again\./);
+  assert.match(RENDER, /persistDrafts\(\);   \/\/ pendingShips is empty at startup → the persisted names clear here/,
+    "the loss toast fires once — the record clears with the same write path that made it");
+});
+
+test("a kernel restart between ship and ack RE-SHIPS the retained bytes on reconnect (T215)", () => {
+  // The ack rides the socket the dropFile went out on, so a restart in that window means it can
+  // never arrive: the chip pulsed forever and a held send never fired. The payload is retained on
+  // the entry and re-shipped on romp:wsup — the exact kernel-is-back event, never a timer.
+  assert.match(RENDER, /interface PendingShip \{ name: string; shipId: string; b64\?: string \}/);
+  assert.match(RENDER, /if \(entry\) entry\.b64 = b64;/);
+  assert.match(RENDER, /function reshipPendingUploads\(\): void \{/);
+  assert.match(RENDER, /window\.addEventListener\("romp:wsup", reshipPendingUploads\);/);
+  // an entry still ENCODING has no payload — its own onload ships on the fresh socket, never doubled
+  assert.match(RENDER, /if \(!p\.b64\) continue;/);
+  // the re-ship rides the same dropFile shape, same shipId, routed to the owning session
+  assert.match(RENDER, /\{ type: "dropFile", name: p\.name, b64: p\.b64, shipId: p\.shipId \}/);
+});
+
+test("duplicate acks from a re-ship race are DROPPED, never attached to the active tab (T215)", () => {
+  // kernel: the ack/nack echoes the client's shipId when one was sent
+  assert.match(KERNEL, /ack\["shipId"\] = str\(msg\["shipId"\]\)/);
+  assert.match(KERNEL, /_reply\(client, ack\)/);
+  // client: an id-carrying ack that matches NO pending entry answers a chip already retired
+  assert.match(RENDER, /function shipOwner\(shipId: string\): string \| null \{/);
+  assert.match(RENDER, /if \(ackShip && !shipOwner\(ackShip\)\) return;/);
+  assert.match(RENDER, /if \(nackShip && !shipOwner\(nackShip\)\) return;/);
+  // and an id-carrying ack retires ONLY its own entry — never a FIFO guess across sessions
+  assert.match(RENDER, /if \(shipId && i < 0\) continue;/);
 });
 
 test("the chip wears the accent loader-dots motif from styles.css", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10642,8 +10642,17 @@ const composerFiles = new Map<string, string[]>();   // sid -> attachment paths,
 // with nothing on screen it reads as a dead click (the user 2026-08-11). So the strip shows a pending
 // chip (name + pulsing dots) from the instant the file is picked, replaced by the real thumbnail when
 // the ack lands, or removed with a loud toast when the kernel nacks (dropSaveFailed). In-memory only,
-// NOT persisted with drafts: a reload kills the page whose socket the ack would ride.
-const pendingShips = new Map<string, string[]>();    // sid -> shipped names awaiting droppedPath
+// NOT persisted with drafts (a reload cannot resurrect the bytes) — but each entry RETAINS its encoded
+// payload until the ack retires it, because the ack rides the very socket the dropFile went out on: a
+// kernel restart between ship and ack means that ack can never arrive, and the chip pulsed forever
+// while a held send never fired (T215). The reconnect event (romp:wsup) re-ships every retained
+// payload; shipId lets an ack retire exactly the chip that asked, so a duplicate ack from a re-ship
+// race is dropped instead of attached to whatever tab is active. Names of ships lost to a full page
+// RELOAD persist beside the drafts and surface as a loud re-attach toast at startup (the VS Code pipe
+// reloads its webview on reconnect, so the wedge there is a vanished chip, not an eternal one).
+interface PendingShip { name: string; shipId: string; b64?: string }
+let shipSeq = 0;   // per-page mint — a shipId only ever meets acks for this page's own ships
+const pendingShips = new Map<string, PendingShip[]>();   // sid -> ships awaiting droppedPath
 
 // The kernel saves a shipped file as drops/<ms>-<sanitized name> (_save_dropped_file). Mirror its
 // sanitizer so an ack can be matched back to the pending chip it retires by basename suffix; the
@@ -10653,36 +10662,70 @@ function shipSafeName(name: string): string {
   return (name.replace(/[^\w.-]+/g, "_").slice(-80)) || "drop";
 }
 
-function addPendingShip(id: string | null, name: string): void {
+function addPendingShip(id: string | null, name: string, shipId: string): void {
   if (!id) return;
   const list = pendingShips.get(id) || [];
-  list.push(name);
+  list.push({ name, shipId });
   pendingShips.set(id, list);
+  persistDrafts();   // the NAMES ride the draft store so a reload can say what it lost (T215)
   if (id === activeId) renderComposerFiles(id);
 }
 
-// An ack (or nack) retires ONE pending chip: the entry whose sanitized name `key` ends with — `key`
-// is the saved path on ack (basename <ms>-<safe name>) or the raw name on nack, and both end with
-// the sanitized original — else the oldest (the kernel answers a connection's dropFiles in order).
-// Searched active-tab-first across all sessions because the ack carries no session id. Returns the
-// sid whose chip it retired (null if none matched), so the ack can attach the file to the composer
-// that SHIPPED it — attaching to whatever tab was active at ack time put a slow upload's file on the
-// wrong session's strip after a mid-flight tab switch (the user 2026-08-16, the send-while-uploading
-// report's second face).
-function retirePendingShip(key: string): string | null {
+// The sid holding a given shipId (null if none): the ack handler's stray-duplicate gate — an ack
+// carrying a shipId no pending entry holds answers a ship already retired (a re-ship raced the
+// original ack across a reconnect), and must be dropped, not attached to the active composer.
+function shipOwner(shipId: string): string | null {
+  for (const [id, list] of pendingShips) if (list.some((p) => p.shipId === shipId)) return id;
+  return null;
+}
+
+// An ack (or nack) retires ONE pending chip: the entry whose shipId the ack echoes (exact — new
+// kernels echo it); else the entry whose sanitized name `key` ends with — `key` is the saved path on
+// ack (basename <ms>-<safe name>) or the raw name on nack, and both end with the sanitized original —
+// else the oldest (the kernel answers a connection's dropFiles in order). Searched active-tab-first
+// across all sessions because a legacy ack carries no session id. Returns the sid whose chip it
+// retired (null if none matched), so the ack can attach the file to the composer that SHIPPED it —
+// attaching to whatever tab was active at ack time put a slow upload's file on the wrong session's
+// strip after a mid-flight tab switch (the user 2026-08-16, the send-while-uploading report's
+// second face).
+function retirePendingShip(key: string, shipId?: string): string | null {
   const k = "-" + shipSafeName(key.split("/").pop() || key);
   const ids = activeId ? [activeId, ...pendingShips.keys()] : [...pendingShips.keys()];
   for (const id of ids) {
     const list = pendingShips.get(id);
     if (!list || !list.length) continue;
-    const i = list.findIndex((n) => k.endsWith("-" + shipSafeName(n)));
+    let i = shipId ? list.findIndex((p) => p.shipId === shipId) : -1;
+    if (shipId && i < 0) continue;   // an id-carrying ack retires ONLY its own entry, wherever it lives
+    if (i < 0) i = list.findIndex((p) => k.endsWith("-" + shipSafeName(p.name)));
     list.splice(i >= 0 ? i : 0, 1);
     if (!list.length) pendingShips.delete(id);
+    persistDrafts();
     if (id === activeId) renderComposerFiles(id);
     return id;
   }
   return null;
 }
+
+// Re-ship every retained payload on the kernel-is-back event (romp:wsup — the page shim fires it when
+// this pane's socket reconnects). The old socket died with the acks still owed, so re-sending the
+// bytes is the ONLY way the chip's retiring event can still arrive; the kernel just saves a fresh
+// copy (a duplicate file in drops/ is an orphan, never attached — the shipId-matched ack retires this
+// chip and any stray twin ack is dropped by shipOwner's gate). An entry with no payload yet is one
+// whose FileReader is still encoding — its own onload ships through the fresh socket, so it is
+// deliberately skipped here, never doubled.
+function reshipPendingUploads(): void {
+  if (!vscodeApi) return;
+  for (const [id, list] of pendingShips) {
+    for (const p of list) {
+      if (!p.b64) continue;
+      const msg: { type: string; name: string; b64: string; shipId: string; id?: string } =
+        { type: "dropFile", name: p.name, b64: p.b64, shipId: p.shipId };
+      if (id) msg.id = id;
+      vscodeApi.postMessage(msg);
+    }
+  }
+}
+window.addEventListener("romp:wsup", reshipPendingUploads);
 
 // Sids whose SEND is HELD until every pending ship acks (the user 2026-08-16: sending mid-upload
 // silently dropped the attachment — the send read only the acked list). Armed by the confirm's
@@ -10707,7 +10750,13 @@ function persistDrafts(): void {
     vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), drafts: Object.fromEntries(drafts),
                             citations: Object.fromEntries(composerCitations),
                             files: Object.fromEntries(composerFiles),
-                            staged: stagedMsgs.entries() });
+                            staged: stagedMsgs.entries(),
+                            // NAMES of ships still awaiting their ack — never the bytes. A reload
+                            // cannot resurrect the upload (the payload dies with the page), so the
+                            // next load reads these to say LOUDLY what was lost (T215; the VS Code
+                            // pipe reloads its webview on kernel reconnect, taking mid-flight ships
+                            // with it — the silent-vanish face of the same wedge).
+                            shipsInFlight: [...pendingShips.values()].flat().map((p) => p.name) });
   } catch { /* ignore */ }
 }
 try {
@@ -10733,6 +10782,20 @@ try {
       }
       if (list.length) composerCitations.set(k, list);
     }
+  // Ships that were still awaiting their ack when the page died (persistDrafts's shipsInFlight): the
+  // payload died with the page, so the upload is LOST — say so loudly with the re-attach affordance
+  // spelled out, and clear the record so the toast fires once, not on every future load (T215). This
+  // is the reload face of the ship/ack wedge; the same-page reconnect face re-ships via romp:wsup.
+  const lostShips = ((vscodeApi?.getState?.() || {}) as any).shipsInFlight;
+  if (Array.isArray(lostShips)) {
+    const names = lostShips.filter((x): x is string => typeof x === "string" && !!x);
+    if (names.length) {
+      warnToast(names.join(", ") + (names.length === 1
+                ? " was still uploading when this page reloaded, so it was NOT attached — attach it again."
+                : " were still uploading when this page reloaded, so they were NOT attached — attach them again."));
+      persistDrafts();   // pendingShips is empty at startup → the persisted names clear here
+    }
+  }
 } catch { /* ignore */ }
 
 // Composer EDIT mode (per session): set when the user clicks a bubble's edit affordance — the composer
@@ -11018,11 +11081,11 @@ function renderComposerFiles(id: string | null): void {
   // In-flight ships, after the real thumbnails: name + pulsing dots until the droppedPath ack swaps
   // in the thumbnail above. The ✕ removes just the CHIP (there is no cancelling a send in flight) —
   // the escape hatch for an ack lost to a mid-ship disconnect, so a stuck chip is never trapped.
-  pending.forEach((n, i) => {
+  pending.forEach((p, i) => {
     const box = el("span", "composer-file composer-file-pending");
-    box.title = n + " — uploading";
+    box.title = p.name + " — uploading";
     const nm = el("span", "composer-file-name");
-    nm.textContent = n;
+    nm.textContent = p.name;
     const dots = el("span", "composer-ship-dots");
     dots.append(el("i"), el("i"), el("i"));
     box.append(nm, dots);
@@ -11035,6 +11098,7 @@ function renderComposerFiles(id: string | null): void {
       if (!list) return;
       list.splice(i, 1);
       if (!list.length && id) pendingShips.delete(id);
+      persistDrafts();   // the dismissed chip's name must not resurface as a reload-loss toast
       renderComposerFiles(id);
     });
     box.appendChild(x);
@@ -12025,17 +12089,21 @@ window.addEventListener("message", (e: MessageEvent) => {
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }
   }
   else if (m.type === "droppedPath" && typeof m.path === "string") {   // host-saved drop/paste/pick → a thumbnail, not path text (the user 2026-08-04)
+    const ackShip = typeof m.shipId === "string" && m.shipId ? m.shipId : undefined;
+    if (ackShip && !shipOwner(ackShip)) return;   // a duplicate of a ship already retired (a reconnect
+    //                                               re-ship raced the original ack) — attaching it again
+    //                                               would double the file on whatever tab is active (T215)
     const cbox = document.getElementById("cmt-pop")?.querySelector(".cmt-input") as HTMLTextAreaElement | null;
     if (cbox) {
       // a comment popover is open — its own clip shipped this file, so the path lands in ITS box
-      retirePendingShip(m.path);
+      retirePendingShip(m.path, ackShip);
       cbox.value = (cbox.value ? cbox.value.trimEnd() + " " : "") + m.path + " ";
       cbox.dispatchEvent(new Event("input"));   // the draft listener persists it
       if (previewKind(m.path) === "img") cmtShippedImgs.push(m.path);   // the echo's thumbnail ride
       cbox.focus();
       return;
     }
-    const owner = retirePendingShip(m.path) || activeId;               // the chip this ack answers names the OWNING composer (no-op for pickFile, which never ships)
+    const owner = retirePendingShip(m.path, ackShip) || activeId;      // the chip this ack answers names the OWNING composer (no-op for pickFile, which never ships)
     addComposerFile(owner, m.path);
     // an OPEN ship-gate dialog counts as a held send (the user 2026-08-19): the upload finishing is
     // the answer to the question it asks, so it closes itself and the send fires — no click needed
@@ -12050,7 +12118,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   } else if (m.type === "dropSaveFailed" && typeof m.name === "string") {
     // the kernel could not SAVE the shipped bytes — clear the pending chip and say so loudly,
     // never leave dots pulsing over a file that is not coming (fail loudly, don't degrade silently)
-    const owner = retirePendingShip(m.name) || activeId;
+    const nackShip = typeof m.shipId === "string" && m.shipId ? m.shipId : undefined;
+    if (nackShip && !shipOwner(nackShip)) return;   // duplicate nack for a chip already settled — the
+    //                                                 first one warned; a re-warn would double the toast
+    const owner = retirePendingShip(m.name, nackShip) || activeId;
     const held = !!owner && sendOnShip.delete(owner);    // a held send must not fire without the file it waited for
     const gateWasOpen = shipGateSid === owner;
     if (gateWasOpen) { shipGateSid = null; closeConfirm(null); }   // the question is moot — but a failed save never auto-sends
@@ -12923,17 +12994,20 @@ function shipFileToHost(f: File, sidAt: string | null = activeId) {
   // user 2026-08-11). Retired by the droppedPath ack / dropSaveFailed nack (see retirePendingShip).
   const name = f.name || "pasted.png";
   const sid = sidAt;   // captured at CALL (= ship) time via the default param — a tab switch
-  addPendingShip(sid, name);   // mid-encode (or mid-verify, for a pasted path) must not reroute
+  const shipId = "s" + Date.now().toString(36) + "." + (++shipSeq);   // page-local; the ack echoes it
+  addPendingShip(sid, name, shipId);   // mid-encode (or mid-verify, for a pasted path) must not reroute
   const reader = new FileReader();
   reader.onload = () => {
     const b64 = String(reader.result || "").split(",")[1] || "";
-    if (!b64 || !vscodeApi) { retirePendingShip(name); return; }
-    const msg: { type: string; name: string; b64: string; id?: string } =
-      { type: "dropFile", name, b64 };
+    if (!b64 || !vscodeApi) { retirePendingShip(name, shipId); return; }
+    const entry = sid ? (pendingShips.get(sid) || []).find((p) => p.shipId === shipId) : undefined;
+    if (entry) entry.b64 = b64;   // retained until the ack — the reconnect re-ship needs the bytes (T215)
+    const msg: { type: string; name: string; b64: string; shipId: string; id?: string } =
+      { type: "dropFile", name, b64, shipId };
     if (sid) msg.id = sid;   // the owning session → the owning kernel
     vscodeApi.postMessage(msg);
   };
-  reader.onerror = () => retirePendingShip(name);   // an unreadable file must not leave a stuck chip
+  reader.onerror = () => retirePendingShip(name, shipId);   // an unreadable file must not leave a stuck chip
   reader.readAsDataURL(f);
 }
 


### PR DESCRIPTION
T215: file bytes ride the ws as a base64 `dropFile` and settle on a `droppedPath` ack sent back over the SAME socket. A kernel restart between ship and ack left that ack forever undeliverable, and nothing on the reconnect event cleared or re-shipped the pending entry — so the upload chip pulsed forever, and a send held by the ship gate ("Wait for the upload") waited on an event that could no longer arrive: message plus attachment parked with no error.

**Reproduced before the fix** on the real served page (deterministic choreography: SIGSTOP the kernel so the dropFile rides a live socket it will never answer, hold a send behind the gate, SIGKILL + relaunch): 45s after the restart the chip was still pulsing, the composer still trapped the message, nothing sent, nothing surfaced.

## The fix — event-keyed, failing toward showing

- **Same-page reconnect (the served dashboard):** each `pendingShips` entry retains its encoded payload until the ack retires it, and `romp:wsup` — the page shim's kernel-is-back event — re-ships every retained payload. The old kernel died with the ack owed; a fresh save is the only way the chip's retiring event can still arrive. An entry still encoding has no payload and is skipped (its own FileReader onload ships through the fresh socket, never doubled).
- **Exact retirement:** `dropFile` now carries a page-minted `shipId`, echoed on the ack and the nack. An id-carrying ack retires exactly the chip that asked; one that matches no pending entry is a duplicate from a re-ship race and is DROPPED — the old FIFO fallback would have attached the twin to whatever tab was active. Legacy name/FIFO matching stands for id-less acks (pickFile).
- **Reload face:** a full page reload cannot resurrect the bytes (the VS Code pipe reloads its webview on kernel reconnect — the same wedge's silent-vanish face), so the ship NAMES persist beside the drafts and the next load says loudly what was lost and to re-attach it, once. Chips are still never revived from persisted state.

## Tests

- `tests/test_ship_reship.py` `ServedWedge` — the executed guard: hermetic kernel, real `/chat` page, the SIGSTOP/SIGKILL choreography, asserting the re-ship heals the chip and releases the held send, plus the regression leg (normal ship+send against the restarted kernel: no gate, no loss toast, clean send). Green here; red on the pre-fix tree at exactly `healedAfterRestart`. Skips loudly where playwright browsers are absent (CI installs none).
- `SourcePins` twins (CI-safe) here and in `ui/webview/pending-attach.test.ts`, retargeted with the rest of the anchored pins (`composer-ship-gate`, `composer-attach`, `composer-files`, `composer-draft-persist`, `tests/test_kernel.py`) to the new contract.

Suites on this head: pytest 6380 passed + 335 subtests; npm 2631 pass / 0 fail.

Deliberately unchanged: `pendingShips` stays in-memory (bytes are never persisted); the remote-host-bounce leg (owning kernel restarts while the local ws stays up) keys on the same re-ship helper but is not wired to `hostUp`, which does not identify the bounced host — a stray re-ship there was judged worse than the rare manual retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)