### PR TITLE
Deploy restarts get rarer: per-file restart classes, bus self-converge, pre-paid bundle rebuild

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3037,28 +3037,92 @@ def _main_drift_verdict(origin, checkout, running):
     return ("", "")
 
 
-KERNEL_CODE_PREFIXES = ("kernel/", "bin/", "postal/", "cli/")
-_REBUILT_FOR = [""]   # the checkout sha this RUNNING kernel already converged to by rebuilding dist
-#                       in place (UI-only change) — the drift check treats it as in-sync until a
-#                       kernel-code commit moves the target past it
+KERNEL_CODE_PREFIXES = ("kernel/", "bin/", "postal/", "cli/")   # the trees the CLASSIFIER inspects
+_REBUILT_FOR = [""]   # the checkout sha this RUNNING kernel already converged to in place (dist
+#                       rebuild / bus bounce / nothing-executed skip) — the drift check treats it as
+#                       in-sync until a kernel-code commit moves the target past it
 
 
-def _kernel_code_changed(a, b):
-    """Does a..b touch code the RUNNING PROCESS executes? UI/dist inputs, tests, docs, plans do not —
-    a build whose kernel code is unchanged converges by REBUILDING dist in place with the kernel left
-    up (the user 2026-08-23: most changes are UI-only, and every restart cuts every in-flight turn).
-    Any error reads as True: when unsure, the restart is the safe converge."""
+def _restart_class(path):
+    """Which RUNNING PROCESS a changed file's code lives in — "kernel", "bus", or "skip" (T216).
+    Verified process boundaries, not guesses: the kernel process loads exactly kernel/*.py +
+    bin/romp-kernel in-process (every kernel module rides SourceFileLoader at import; judges run
+    in-process too). postal/ is NEVER imported here — the bus is its own process with its own
+    restart verb, and bouncing the kernel for a bus change restarts the WRONG thing. cli/ is
+    loaded per `romp` invocation, never by this process — the next run picks it up. .md files
+    are docs wherever they live. Everything else in the four trees is kernel-class: when unsure,
+    the restart is the safe converge."""
+    if path.endswith(".md"):
+        return "skip"
+    if path == "bin/romp-postal-service" or path.startswith("postal/"):
+        return "bus"
+    if path.startswith(("kernel/", "bin/")):
+        return "kernel"
+    return "skip"     # cli/ + everything outside the four trees (ui, tests, docs, plans)
+
+
+def _ast_equal_blobs(a, b, path):
+    """True only when a..b PROVABLY compiles to the same semantics for `path`: both blobs readable
+    and their parsed ASTs identical (comments and formatting never enter the AST; docstrings DO,
+    so a docstring edit conservatively stays a code change). Shebang lines are comments to the
+    parser, so bin/ scripts qualify too. ANY surprise — unreadable blob (added/deleted/renamed
+    file), parse failure, non-python — is False: not provable, restart (T216)."""
+    try:
+        import ast
+        import warnings
+        blobs = []
+        for sha in (a, b):
+            r = subprocess.run(["git", "show", "%s:%s" % (sha, path)], cwd=str(ROOT),
+                               capture_output=True, timeout=20)
+            if r.returncode != 0:
+                return False
+            blobs.append(r.stdout)
+        if blobs[0] == blobs[1]:
+            return True                       # mode-only change — the content is identical
+        with warnings.catch_warnings():
+            # historical blobs raise SyntaxWarning (e.g. un-raw regex strings) — parse noise,
+            # not a verdict input; without this every probe sprays the kernel log
+            warnings.simplefilter("ignore")
+            return ast.dump(ast.parse(blobs[0])) == ast.dump(ast.parse(blobs[1]))
+    except Exception:
+        return False
+
+
+def _converge_classes(a, b):
+    """Per-file restart classes for the a..b diff: {"kernel": [...], "bus": [...], "skip": [...],
+    "ast_equal": [...]} — or None on ANY error (the caller restarts; when unsure, the restart is
+    the safe converge). kernel-class python files whose ASTs match demote to skip and are listed
+    in ast_equal so the audit row names WHY the verdict skipped them (T216)."""
     if not a or not b:
-        return True
+        return None
     try:
         r = subprocess.run(["git", "diff", "--name-only", "%s..%s" % (a, b)], cwd=str(ROOT),
                            capture_output=True, text=True, timeout=20)
         if r.returncode != 0:
-            return True
-        files = [f for f in r.stdout.splitlines() if f.strip()]
-        return any(f.startswith(KERNEL_CODE_PREFIXES) for f in files)
+            return None
+        out = {"kernel": [], "bus": [], "skip": [], "ast_equal": []}
+        for f in r.stdout.splitlines():
+            f = f.strip()
+            if not f:
+                continue
+            c = _restart_class(f)
+            if c == "kernel" and _ast_equal_blobs(a, b, f):
+                out["ast_equal"].append(f)
+                c = "skip"
+            out[c].append(f)
+        return out
     except Exception:
-        return True
+        return None
+
+
+def _kernel_code_changed(a, b):
+    """Does a..b touch code the RUNNING PROCESS executes? UI/dist inputs, tests, docs, plans, cli/,
+    postal/ (the bus's own process), and PROVABLY-equal kernel python (AST match — comment-only
+    edits) do not — those converge in place with the kernel left up (the user 2026-08-23 and T216:
+    most changes never touch what this process runs, and every restart cuts every in-flight turn).
+    Any error reads as True: when unsure, the restart is the safe converge."""
+    cc = _converge_classes(a, b)
+    return cc is None or bool(cc["kernel"])
 
 
 def _rebuild_dist():
@@ -3069,6 +3133,18 @@ def _rebuild_dist():
         r = subprocess.run(["node", "esbuild.js"], cwd=str(ROOT / "vscode-extension"),
                            capture_output=True, text=True, timeout=180)
         return r.returncode == 0, (r.stderr or r.stdout or "").strip()[-300:]
+    except Exception as e:
+        return False, str(e)
+
+
+def _bus_converge():
+    """Bounce the postal bus onto the new checkout — its OWN process, so a kernel restart would
+    converge the wrong thing (T216). The bus's restart verb is client-only-safe and pending mail
+    survives in the maildir. (ok, err_tail)."""
+    try:
+        r = subprocess.run([sys.executable, str(BIN / "romp-postal-service"), "restart"],
+                           capture_output=True, text=True, timeout=90)
+        return r.returncode == 0, (r.stderr or r.stdout or "").strip()[-200:]
     except Exception as e:
         return False, str(e)
 
@@ -3123,6 +3199,44 @@ def _dist_converge_check():
                      ok=False)
 
 
+_BUS_CONVERGED_FOR = [""]   # the target sha the bus already bounced for — the drift pass re-enters
+#                             this arm until the dist rebuild latches, and a broken esbuild must not
+#                             become a bus restart storm (one bounce per target, like _REBUILT_FOR)
+
+
+def _in_place_converge(target):
+    """The no-kernel-code converge (T216): bounce the bus if bus-class files changed (its own
+    process — see _bus_converge), rebuild dist, latch, and AUDIT the skip verdict with its per-class
+    file lists so a wrong skip is diagnosable from disk. True = converged (caller returns); False =
+    the dist build failed — fall through to the restart path, which is always the safe converge."""
+    cc = _converge_classes(_kernel_sha(), target) or \
+        {"kernel": [], "bus": [], "skip": [], "ast_equal": []}
+    if cc["bus"] and _BUS_CONVERGED_FOR[0] != target:
+        _BUS_CONVERGED_FOR[0] = target
+        ok, err = _bus_converge()
+        _audit_restart_request("bus-converge", tag=target, ok=("yes" if ok else "no"),
+                               files=",".join(cc["bus"][:20]), err=("" if ok else err))
+        if ok:
+            _sync_notice("postal bus restarted onto the new build (bus-only change — the kernel "
+                         "keeps running; a kernel restart would not have updated the bus)")
+        else:
+            _sync_notice("the postal bus needs a restart for this change and the bounce failed "
+                         "(%s) — mail may run stale until `romp refresh`" % err, ok=False)
+    ok, err = _rebuild_dist()
+    if ok:
+        _REBUILT_FOR[0] = target
+        _audit_restart_request("main-converge-skip", tag=target,
+                               why="no kernel-code change",
+                               skip=",".join(cc["skip"][:20]) or "none",
+                               bus=",".join(cc["bus"][:20]),
+                               ast_equal=",".join(cc["ast_equal"][:20]))
+        _sync_notice("new build served in place (no kernel-code change; no restart) — reload the "
+                     "dashboard to pick it up")
+        return True
+    _sync_notice("in-place update failed to build (%s) — taking the restart path" % err, ok=False)
+    return False
+
+
 def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
@@ -3138,18 +3252,14 @@ def _main_drift_check():
     if kind == "restart" and target == _REBUILT_FOR[0]:
         return                                        # already converged in place (UI-only rebuild)
     if kind == "restart" and not _kernel_code_changed(_kernel_sha(), target):
-        # UI-ONLY drift (the user 2026-08-23): the checkout moved but nothing the running process
-        # executes changed — converge by rebuilding dist in place, in EVERY mode and with no
-        # cool-down (a rebuild cuts no turns, which is the only thing the gates protect). A failed
-        # build falls through to the normal restart path, loudly.
-        ok, err = _rebuild_dist()
-        if ok:
-            _REBUILT_FOR[0] = target
-            _sync_notice("new build served in place (UI-only change; no restart) — reload the "
-                         "dashboard to pick it up")
+        # NO-KERNEL-CODE drift (the user 2026-08-23, widened T216): the checkout moved but nothing
+        # the running process executes changed — converge in place, in EVERY mode and with no
+        # cool-down (in-place converges cut no turns, which is the only thing the gates protect).
+        # A failed dist build falls through to the normal restart path, loudly. The class detail
+        # is ADVISORY here (audit + the bus arm): the skip VERDICT itself came from
+        # _kernel_code_changed, which fails toward restarting on any error.
+        if _in_place_converge(target):
             return
-        _sync_notice("UI-only update failed to build in place (%s) — taking the restart path" % err,
-                     ok=False)
     if not kind:
         _MAIN_DRIFT[0] = _MAIN_DRIFT[1] = ""          # in sync: a future drift is new information again
         return
@@ -3217,15 +3327,19 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
             _MAIN_DRIFT[0] = ""
             return
     if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):
-        # the pull only moved UI/dist inputs — same in-place converge as the restart-kind branch
-        ok, err = _rebuild_dist()
-        if ok:
-            _REBUILT_FOR[0] = _checkout_sha()
-            _sync_notice("new build served in place (UI-only change; no restart) — reload the "
-                         "dashboard to pick it up")
+        # the pull moved nothing the running process executes — same in-place converge as the
+        # restart-kind branch (bus bounce + dist rebuild + audit; T216)
+        if _in_place_converge(_checkout_sha()):
             return
-        _sync_notice("UI-only update failed to build in place (%s) — taking the restart path" % err,
-                     ok=False)
+    # Pay the bundle rebuild BEFORE the old kernel dies (T216): the checkout is already at the
+    # target here, so this builds the NEW code's bundles while the old kernel still serves — the
+    # fresh kernel's pre-bind _ensure_bundles then finds them current instead of paying esbuild
+    # inside the outage. Failure must never block the restart: proceed loudly, _ensure_bundles
+    # stays the backstop.
+    ok, err = _rebuild_dist()
+    if not ok:
+        _sync_notice("pre-restart bundle rebuild failed (%s) — restarting anyway; the new kernel "
+                     "rebuilds at boot" % err, ok=False)
     if manager_port is _PORT_FROM_ENV:
         manager_port = os.environ.get("ROMP_MANAGER_PORT")
     try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3096,13 +3096,18 @@ def _converge_classes(a, b):
     if not a or not b:
         return None
     try:
-        r = subprocess.run(["git", "diff", "--name-only", "%s..%s" % (a, b)], cwd=str(ROOT),
+        # -z: NUL-separated RAW paths — git's default core.quotePath C-quotes any non-ASCII path
+        # ("kernel/m\303\263dulo.py", leading double-quote), which defeated the prefix match and
+        # WRONG-SKIPPED a real kernel change (T216 review, reproduced). --no-renames: rename
+        # detection collapses a move to its DESTINATION only, so a kernel file moved OUT of the
+        # tree vanished from the listing and skipped — as delete+add the old path stays visible.
+        r = subprocess.run(["git", "diff", "--name-only", "-z", "--no-renames",
+                            "%s..%s" % (a, b)], cwd=str(ROOT),
                            capture_output=True, text=True, timeout=20)
         if r.returncode != 0:
             return None
         out = {"kernel": [], "bus": [], "skip": [], "ast_equal": []}
-        for f in r.stdout.splitlines():
-            f = f.strip()
+        for f in r.stdout.split("\0"):
             if not f:
                 continue
             c = _restart_class(f)
@@ -3199,20 +3204,29 @@ def _dist_converge_check():
                      ok=False)
 
 
-_BUS_CONVERGED_FOR = [""]   # the target sha the bus already bounced for — the drift pass re-enters
-#                             this arm until the dist rebuild latches, and a broken esbuild must not
-#                             become a bus restart storm (one bounce per target, like _REBUILT_FOR)
+_INPLACE_TRIED = [""]   # the target sha the in-place converge already attempted — ONE full attempt
+#                         (bus bounce + dist build) per target, the _dist_converge_check precedent:
+#                         a broken esbuild must not become a per-pass rebuild/bounce/notice storm;
+#                         a transient failure retries on the NEXT target, never a 300s loop
 
 
 def _in_place_converge(target):
     """The no-kernel-code converge (T216): bounce the bus if bus-class files changed (its own
     process — see _bus_converge), rebuild dist, latch, and AUDIT the skip verdict with its per-class
     file lists so a wrong skip is diagnosable from disk. True = converged (caller returns); False =
-    the dist build failed — fall through to the restart path, which is always the safe converge."""
-    cc = _converge_classes(_kernel_sha(), target) or \
-        {"kernel": [], "bus": [], "skip": [], "ast_equal": []}
-    if cc["bus"] and _BUS_CONVERGED_FOR[0] != target:
-        _BUS_CONVERGED_FOR[0] = target
+    fall through to the restart path, which is always the safe converge."""
+    if _INPLACE_TRIED[0] == target:
+        return False                       # already attempted this target — no storms
+    _INPLACE_TRIED[0] = target
+    cc = _converge_classes(_kernel_sha(), target)
+    if cc is None:
+        # the verdict's own classification succeeded moments ago, but THIS one failed (git flake,
+        # lock contention) — an empty mask here would silently drop the bus bounce and write a
+        # lying audit row; unprovable falls to the restart path, per the standing rule
+        _sync_notice("in-place converge could not re-read the diff — taking the restart path",
+                     ok=False)
+        return False
+    if cc["bus"]:
         ok, err = _bus_converge()
         _audit_restart_request("bus-converge", tag=target, ok=("yes" if ok else "no"),
                                files=",".join(cc["bus"][:20]), err=("" if ok else err))
@@ -3326,20 +3340,23 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
             _sync_notice("main moved at origin, but the pull step failed: %s" % e, ok=False)
             _MAIN_DRIFT[0] = ""
             return
-    if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):
-        # the pull moved nothing the running process executes — same in-place converge as the
-        # restart-kind branch (bus bounce + dist rebuild + audit; T216)
-        if _in_place_converge(_checkout_sha()):
+    if kind == "pull":
+        pulled = _checkout_sha()   # ONE read: verdict input and converge target must be the same
+        #                            sha — two reads raced a moving checkout and latched a target
+        #                            the verdict never examined (T216 review)
+        if not _kernel_code_changed(_kernel_sha(), pulled) and _in_place_converge(pulled):
             return
     # Pay the bundle rebuild BEFORE the old kernel dies (T216): the checkout is already at the
     # target here, so this builds the NEW code's bundles while the old kernel still serves — the
     # fresh kernel's pre-bind _ensure_bundles then finds them current instead of paying esbuild
     # inside the outage. Failure must never block the restart: proceed loudly, _ensure_bundles
-    # stays the backstop.
-    ok, err = _rebuild_dist()
-    if not ok:
-        _sync_notice("pre-restart bundle rebuild failed (%s) — restarting anyway; the new kernel "
-                     "rebuilds at boot" % err, ok=False)
+    # stays the backstop. Skipped when an in-place attempt for this very sha just paid (and
+    # failed) the identical build — a doomed 180s re-run would only stretch the outage.
+    if _INPLACE_TRIED[0] != _checkout_sha():
+        ok, err = _rebuild_dist()
+        if not ok:
+            _sync_notice("pre-restart bundle rebuild failed (%s) — restarting anyway; the new "
+                         "kernel rebuilds at boot" % err, ok=False)
     if manager_port is _PORT_FROM_ENV:
         manager_port = os.environ.get("ROMP_MANAGER_PORT")
     try:

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -178,25 +178,36 @@ class UiOnlyConverge(unittest.TestCase):
         self.assertEqual([b.get("drift") for b in self.banners], ["restart"])
 
     def test_the_classifier_reads_the_touched_paths(self):
-        import subprocess as sp
         from unittest.mock import patch
 
         class R:
             def __init__(self, out, rc=0):
                 self.stdout, self.returncode = out, rc
-        with patch.object(km.subprocess, "run", return_value=R("ui/webview/feed.ts\ndocs/a.md\n")):
+
+        def fake_run(names, show_rc=1):
+            # git diff answers the name list; git show (the AST-equality probe) answers show_rc —
+            # rc=1 means "blob unreadable", the not-provable arm that must read as kernel code
+            def run(argv, **kw):
+                return R(names) if argv[:2] == ["git", "diff"] else R(b"", rc=show_rc)
+            return run
+        with patch.object(km.subprocess, "run", fake_run("ui/webview/feed.ts\ndocs/a.md\n")):
             self.assertFalse(km._kernel_code_changed("a1", "b2"), "UI + docs only: rebuild in place")
-        with patch.object(km.subprocess, "run", return_value=R("ui/webview/feed.ts\nkernel/kernel.py\n")):
-            self.assertTrue(km._kernel_code_changed("a1", "b2"))
-        with patch.object(km.subprocess, "run", return_value=R("", rc=128)):
+        with patch.object(km.subprocess, "run", fake_run("ui/webview/feed.ts\nkernel/kernel.py\n")):
+            self.assertTrue(km._kernel_code_changed("a1", "b2"),
+                            "a kernel file whose blobs cannot be proven equal restarts")
+        with patch.object(km.subprocess, "run", fake_run("", show_rc=1)):
+            pass
+        with patch.object(km.subprocess, "run", lambda argv, **kw: R("", rc=128)):
             self.assertTrue(km._kernel_code_changed("a1", "b2"), "git failure: the restart is the safe converge")
         self.assertTrue(km._kernel_code_changed("", "b2"), "unknown shas: the restart is the safe converge")
 
     def test_the_pull_path_carries_the_same_in_place_converge(self):
         src = inspect.getsource(km._run_main_update)
         self.assertIn('if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):', src)
-        self.assertIn("_rebuild_dist()", src)
-        self.assertIn("_REBUILT_FOR[0] = _checkout_sha()", src)
+        self.assertIn("_in_place_converge(_checkout_sha())", src)
+        conv = inspect.getsource(km._in_place_converge)
+        self.assertIn("_rebuild_dist()", conv)
+        self.assertIn("_REBUILT_FOR[0] = target", conv)
 
 
 class ChannelGate(unittest.TestCase):

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -132,9 +132,12 @@ class UiOnlyConverge(unittest.TestCase):
         self._saved = {n: getattr(km, n) for n in
                        ("_main_drift_verdict", "_kernel_code_changed", "_rebuild_dist",
                         "_sync_notice", "_update_mode", "_send_to_app", "_kernel_sha",
-                        "_main_tracking")}
+                        "_main_tracking", "_converge_classes")}
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
+        km._INPLACE_TRIED[0] = ""
+        km._converge_classes = lambda a, b: {"kernel": [], "bus": [],
+                                             "skip": ["ui/webview/feed.ts"], "ast_equal": []}
         self.notices, self.banners, self.rebuilds = [], [], []
         km._sync_notice = lambda msg, ok=True: self.notices.append((msg, ok))
         km._send_to_app = lambda app, payload: self.banners.append(payload)
@@ -147,6 +150,7 @@ class UiOnlyConverge(unittest.TestCase):
             setattr(km, n, f)
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
+        km._INPLACE_TRIED[0] = ""
 
     def test_ui_only_restart_drift_rebuilds_in_place_and_latches(self):
         km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-ui")
@@ -179,32 +183,33 @@ class UiOnlyConverge(unittest.TestCase):
 
     def test_the_classifier_reads_the_touched_paths(self):
         from unittest.mock import patch
+        km._converge_classes = self._saved["_converge_classes"]   # the REAL classifier under test
 
         class R:
             def __init__(self, out, rc=0):
                 self.stdout, self.returncode = out, rc
 
         def fake_run(names, show_rc=1):
-            # git diff answers the name list; git show (the AST-equality probe) answers show_rc —
-            # rc=1 means "blob unreadable", the not-provable arm that must read as kernel code
+            # git diff answers the NUL-separated name list; git show (the AST-equality probe)
+            # answers show_rc — rc=1 means "blob unreadable", the not-provable arm that must
+            # read as kernel code
             def run(argv, **kw):
                 return R(names) if argv[:2] == ["git", "diff"] else R(b"", rc=show_rc)
             return run
-        with patch.object(km.subprocess, "run", fake_run("ui/webview/feed.ts\ndocs/a.md\n")):
+        with patch.object(km.subprocess, "run", fake_run("ui/webview/feed.ts\0docs/a.md\0")):
             self.assertFalse(km._kernel_code_changed("a1", "b2"), "UI + docs only: rebuild in place")
-        with patch.object(km.subprocess, "run", fake_run("ui/webview/feed.ts\nkernel/kernel.py\n")):
+        with patch.object(km.subprocess, "run", fake_run("ui/webview/feed.ts\0kernel/kernel.py\0")):
             self.assertTrue(km._kernel_code_changed("a1", "b2"),
                             "a kernel file whose blobs cannot be proven equal restarts")
-        with patch.object(km.subprocess, "run", fake_run("", show_rc=1)):
-            pass
         with patch.object(km.subprocess, "run", lambda argv, **kw: R("", rc=128)):
             self.assertTrue(km._kernel_code_changed("a1", "b2"), "git failure: the restart is the safe converge")
         self.assertTrue(km._kernel_code_changed("", "b2"), "unknown shas: the restart is the safe converge")
 
     def test_the_pull_path_carries_the_same_in_place_converge(self):
         src = inspect.getsource(km._run_main_update)
-        self.assertIn('if kind == "pull" and not _kernel_code_changed(_kernel_sha(), _checkout_sha()):', src)
-        self.assertIn("_in_place_converge(_checkout_sha())", src)
+        self.assertIn("pulled = _checkout_sha()", src)
+        self.assertIn("not _kernel_code_changed(_kernel_sha(), pulled) and _in_place_converge(pulled)",
+                      src, "verdict input and converge target are the SAME read — never raced")
         conv = inspect.getsource(km._in_place_converge)
         self.assertIn("_rebuild_dist()", conv)
         self.assertIn("_REBUILT_FOR[0] = target", conv)

--- a/tests/test_restart_classifier.py
+++ b/tests/test_restart_classifier.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""T216 — deploy restarts get RARER: the no-restart classifier reads per-file classes (not
+per-tree prefixes) so tests-only, docs-only, cli-only, postal-only, and PROVABLY-comment-only
+diffs inside the kernel trees converge in place, and postal-only changes bounce the BUS (its own
+process — a kernel restart converges the wrong thing). The standing constraint is HARD and
+pinned here from both directions: anything unprovable restarts (mixed diffs, docstring edits,
+new/renamed files, git failures), every skip verdict writes an audit row naming its files, and
+the restart path pays the bundle rebuild BEFORE the old kernel dies.
+
+Every verdict below is driven through a REAL throwaway git repo — the exact diff shapes the
+dispatch names — never a mocked file list. Synthetic content only; hermetic state."""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+os.environ["ROMP_MANAGER_PORT"] = "1"
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_rclass", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _git(repo, *args):
+    r = subprocess.run(["git", "-C", str(repo)] + list(args), capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+class RealDiffShapes(unittest.TestCase):
+    """The dispatch's diff shapes, verbatim, against a real repo."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        repo = Path(cls.td.name)
+        cls.repo = repo
+        for sub in ("kernel", "bin", "postal", "cli", "docs", "tests", "ui/webview"):
+            (repo / sub).mkdir(parents=True)
+        _git(repo, "init", "-q")
+        _git(repo, "config", "user.email", "t@TESTHOST")
+        _git(repo, "config", "user.name", "t")
+        (repo / "kernel/mod.py").write_text('def f():\n    """doc."""\n    return 1  # one\n')
+        (repo / "bin/tool").write_text("#!/usr/bin/env python3\n# a tool\nx = 1\n")
+        (repo / "postal/postal_service.py").write_text("BUS = 1\n")
+        (repo / "cli/version.py").write_text("V = 1\n")
+        (repo / "docs/a.md").write_text("# docs\n")
+        (repo / "kernel/README.md").write_text("# kernel docs\n")
+        (repo / "tests/test_x.py").write_text("def test_x():\n    assert True\n")
+        (repo / "ui/webview/feed.ts").write_text("export const x = 1\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "base")
+        cls.base = _git(repo, "rev-parse", "HEAD")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def _commit(self, msg):
+        _git(self.repo, "add", "-A")
+        _git(self.repo, "commit", "-qm", msg)
+        return _git(self.repo, "rev-parse", "HEAD")
+
+    def _verdict(self, a, b):
+        saved = km.ROOT
+        km.ROOT = self.repo
+        try:
+            return km._kernel_code_changed(a, b), km._converge_classes(a, b)
+        finally:
+            km.ROOT = saved
+
+    def _reset(self):
+        # detach back to base so each shape's commit hangs off the SAME parent — a paths-only
+        # checkout leaks files other shapes committed (tracked adds survive it)
+        _git(self.repo, "checkout", "-qf", "--detach", self.base)
+
+    def test_comment_only_kernel_file_skips(self):
+        self._reset()
+        (self.repo / "kernel/mod.py").write_text('def f():\n    """doc."""\n    return 1  # reworded\n')
+        sha = self._commit("comment only")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed, "a comment-only kernel .py compiles identically — no bounce")
+        self.assertEqual(cc["ast_equal"], ["kernel/mod.py"], "the audit names WHY it skipped")
+
+    def test_tests_only_skips(self):
+        self._reset()
+        (self.repo / "tests/test_x.py").write_text("def test_x():\n    assert 1 + 1 == 2\n")
+        sha = self._commit("tests only")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed)
+        self.assertEqual(cc["skip"], ["tests/test_x.py"])
+
+    def test_docs_only_skips_even_inside_kernel_tree(self):
+        self._reset()
+        (self.repo / "docs/a.md").write_text("# docs v2\n")
+        (self.repo / "kernel/README.md").write_text("# kernel docs v2\n")
+        sha = self._commit("docs only")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed)
+        self.assertEqual(sorted(cc["skip"]), ["docs/a.md", "kernel/README.md"])
+
+    def test_postal_only_is_bus_class_not_kernel(self):
+        self._reset()
+        (self.repo / "postal/postal_service.py").write_text("BUS = 2\n")
+        sha = self._commit("postal only")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed, "the bus is its own process — a kernel bounce converges the wrong thing")
+        self.assertEqual(cc["bus"], ["postal/postal_service.py"])
+
+    def test_the_bus_entry_script_is_bus_class(self):
+        self._reset()
+        (self.repo / "bin/romp-postal-service").write_text("#!/usr/bin/env python3\nSERVE = 1\n")
+        sha = self._commit("bus entry")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed)
+        self.assertEqual(cc["bus"], ["bin/romp-postal-service"])
+
+    def test_cli_only_skips(self):
+        self._reset()
+        (self.repo / "cli/version.py").write_text("V = 2\n")
+        sha = self._commit("cli only")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed, "cli/ loads per `romp` invocation — the next run picks it up")
+        self.assertEqual(cc["skip"], ["cli/version.py"])
+
+    def test_mixed_diff_must_restart(self):
+        self._reset()
+        (self.repo / "tests/test_x.py").write_text("def test_x():\n    assert 2 + 2 == 4\n")
+        (self.repo / "kernel/mod.py").write_text('def f():\n    """doc."""\n    return 2  # one\n')
+        sha = self._commit("mixed")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertTrue(changed, "any kernel-code file in the diff wins — mixed MUST restart")
+        self.assertEqual(cc["kernel"], ["kernel/mod.py"])
+
+    def test_docstring_change_conservatively_restarts(self):
+        self._reset()
+        (self.repo / "kernel/mod.py").write_text('def f():\n    """doc v2."""\n    return 1  # one\n')
+        sha = self._commit("docstring")
+        changed, _ = self._verdict(self.base, sha)
+        self.assertTrue(changed, "docstrings live in the AST — not provably comment-only")
+
+    def test_new_kernel_file_restarts(self):
+        self._reset()
+        (self.repo / "kernel/newmod.py").write_text("Y = 1\n")
+        sha = self._commit("new module")
+        changed, _ = self._verdict(self.base, sha)
+        self.assertTrue(changed, "an added file has no old blob to prove equality against")
+
+    def test_bin_script_comment_only_skips(self):
+        self._reset()
+        (self.repo / "bin/tool").write_text("#!/usr/bin/env python3\n# a better-described tool\nx = 1\n")
+        sha = self._commit("bin comment")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertFalse(changed, "shebang scripts parse as python — comment edits prove equal")
+        self.assertEqual(cc["ast_equal"], ["bin/tool"])
+
+    def test_renamed_kernel_file_restarts(self):
+        self._reset()
+        _git(self.repo, "mv", "kernel/mod.py", "kernel/mod2.py")
+        sha = self._commit("rename")
+        changed, _ = self._verdict(self.base, sha)
+        self.assertTrue(changed, "a rename is never provably equal — restart")
+
+    def test_unknown_shas_and_git_failure_restart(self):
+        self.assertTrue(km._kernel_code_changed("", "abc"), "unknown shas: restart")
+        changed, cc = self._verdict("0" * 40, "1" * 40)
+        self.assertTrue(changed, "git failure: restart")
+        self.assertIsNone(cc)
+
+
+class ConvergeArms(unittest.TestCase):
+    """The drift-check skip arm: bus bounce for bus-class files, audit rows for every skip."""
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_main_drift_verdict", "_kernel_code_changed", "_converge_classes",
+                        "_rebuild_dist", "_bus_converge", "_sync_notice", "_update_mode",
+                        "_send_to_app", "_kernel_sha", "_main_tracking", "_audit_restart_request")}
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        km._REBUILT_FOR[0] = ""
+        km._BUS_CONVERGED_FOR[0] = ""
+        self.notices, self.banners, self.audits, self.bus = [], [], [], []
+        km._sync_notice = lambda msg, ok=True: self.notices.append((msg, ok))
+        km._send_to_app = lambda app, payload: self.banners.append(payload)
+        km._audit_restart_request = lambda action, **kw: self.audits.append((action, kw))
+        km._update_mode = lambda: "ask"
+        km._kernel_sha = lambda: "cur-sha"
+        km._main_tracking = lambda: True
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        km._REBUILT_FOR[0] = ""
+
+    def test_bus_only_drift_bounces_the_bus_not_the_kernel(self):
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-bus")
+        km._kernel_code_changed = lambda a, b: False
+        km._converge_classes = lambda a, b: {"kernel": [], "bus": ["postal/postal_service.py"],
+                                             "skip": [], "ast_equal": []}
+        km._bus_converge = lambda: (self.bus.append(1), (True, ""))[1]
+        km._rebuild_dist = lambda: (True, "")
+        km._main_drift_check()
+        self.assertEqual(len(self.bus), 1, "the bus bounced")
+        self.assertEqual(self.banners, [], "no kernel restart banner")
+        self.assertEqual(km._REBUILT_FOR[0], "tgt-bus")
+        self.assertIn("bus-converge", [a for a, _ in self.audits])
+        self.assertTrue(any("bus" in m for m, _ in self.notices))
+
+    def test_a_broken_dist_build_never_becomes_a_bus_restart_storm(self):
+        # the skip arm re-enters on every drift pass until the dist rebuild latches — the bus
+        # bounce must latch on its own target, or a broken esbuild bounces the bus per pass
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-storm")
+        km._kernel_code_changed = lambda a, b: False
+        km._converge_classes = lambda a, b: {"kernel": [], "bus": ["postal/postal_service.py"],
+                                             "skip": [], "ast_equal": []}
+        km._bus_converge = lambda: (self.bus.append(1), (True, ""))[1]
+        km._rebuild_dist = lambda: (False, "esbuild broken")
+        km._main_drift_check()
+        km._MAIN_DRIFT[1] = ""          # let the next pass re-enter the arm (banner already sent)
+        km._main_drift_check()
+        self.assertEqual(len(self.bus), 1, "one bounce per target, however many passes")
+
+    def test_a_failed_bus_bounce_is_loud_but_never_forces_a_kernel_restart(self):
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-bus2")
+        km._kernel_code_changed = lambda a, b: False
+        km._converge_classes = lambda a, b: {"kernel": [], "bus": ["postal/postal_service.py"],
+                                             "skip": [], "ast_equal": []}
+        km._bus_converge = lambda: (False, "port held")
+        km._rebuild_dist = lambda: (True, "")
+        km._main_drift_check()
+        self.assertEqual(self.banners, [], "a kernel restart cannot fix the bus — never offered")
+        self.assertTrue(any(not ok and "port held" in m for m, ok in self.notices),
+                        "the failure is loud")
+
+    def test_every_skip_writes_a_diagnosable_audit_row(self):
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-skip")
+        km._kernel_code_changed = lambda a, b: False
+        km._converge_classes = lambda a, b: {"kernel": [], "bus": [],
+                                             "skip": ["tests/test_x.py", "docs/a.md"],
+                                             "ast_equal": ["kernel/mod.py"]}
+        km._rebuild_dist = lambda: (True, "")
+        km._main_drift_check()
+        acts = dict((a, kw) for a, kw in self.audits)
+        self.assertIn("main-converge-skip", acts)
+        row = acts["main-converge-skip"]
+        self.assertEqual(row["tag"], "tgt-skip")
+        self.assertIn("tests/test_x.py", row["skip"])
+        self.assertIn("kernel/mod.py", row["ast_equal"], "a wrong skip is diagnosable from disk")
+
+
+class PreDeathRebuild(unittest.TestCase):
+    """The restart path pays esbuild BEFORE the old kernel dies — never inside the outage."""
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_rebuild_dist", "_sync_notice", "_audit_restart_request",
+                        "_kernel_code_changed")}
+        self.order, self.notices = [], []
+        km._sync_notice = lambda msg, ok=True: self.notices.append((msg, ok))
+        km._audit_restart_request = lambda action, **kw: None
+        km._kernel_code_changed = lambda a, b: True
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+
+    def _run(self, rebuild_ok):
+        from unittest.mock import patch
+        km._rebuild_dist = lambda: (self.order.append("rebuild"), (rebuild_ok, "boom"))[1]
+
+        def fake_urlopen(req, timeout=0):
+            self.order.append("post")
+            class R:
+                def read(self):
+                    return b""
+            return R()
+        with patch("urllib.request.urlopen", fake_urlopen):
+            km._run_main_update("restart", immediate=True, manager_port="1")
+
+    def test_the_rebuild_lands_before_the_restart_post(self):
+        self._run(rebuild_ok=True)
+        self.assertEqual(self.order, ["rebuild", "post"],
+                         "the new kernel must find fresh bundles, not pay esbuild in the outage")
+
+    def test_a_failed_rebuild_never_blocks_the_restart(self):
+        self._run(rebuild_ok=False)
+        self.assertEqual(self.order, ["rebuild", "post"], "proceed — _ensure_bundles is the backstop")
+        self.assertTrue(any(not ok and "boom" in m for m, ok in self.notices), "loudly")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_classifier.py
+++ b/tests/test_restart_classifier.py
@@ -169,6 +169,30 @@ class RealDiffShapes(unittest.TestCase):
         changed, _ = self._verdict(self.base, sha)
         self.assertTrue(changed, "a rename is never provably equal — restart")
 
+    def test_non_ascii_kernel_path_still_restarts(self):
+        # git's default core.quotePath C-quotes non-ASCII paths ('"kernel/m\303\263dulo.py"') —
+        # the quoted form defeated the prefix match and a REAL kernel change wrong-skipped
+        # (T216 review, reproduced). The -z listing carries raw paths.
+        self._reset()
+        (self.repo / "kernel/módulo.py").write_text("X = 1\n")
+        base2 = self._commit("non-ascii module lands")
+        (self.repo / "kernel/módulo.py").write_text("X = 2\n")
+        sha = self._commit("non-ascii module changes")
+        changed, cc = self._verdict(base2, sha)
+        self.assertTrue(changed, "a quoted path must never fall through to skip")
+        self.assertEqual(cc["kernel"], ["kernel/módulo.py"])
+
+    def test_kernel_file_moved_out_of_tree_still_restarts(self):
+        # rename detection collapses a move to its DESTINATION path — a kernel file moved out
+        # of kernel/ vanished from the listing and the diff wrong-skipped (T216 review,
+        # reproduced). --no-renames keeps the old path visible as a delete.
+        self._reset()
+        _git(self.repo, "mv", "kernel/mod.py", "ui/webview/mod.py")
+        sha = self._commit("moved out")
+        changed, cc = self._verdict(self.base, sha)
+        self.assertTrue(changed, "the running kernel LOSES a module it loaded — restart")
+        self.assertIn("kernel/mod.py", cc["kernel"])
+
     def test_unknown_shas_and_git_failure_restart(self):
         self.assertTrue(km._kernel_code_changed("", "abc"), "unknown shas: restart")
         changed, cc = self._verdict("0" * 40, "1" * 40)
@@ -183,16 +207,19 @@ class ConvergeArms(unittest.TestCase):
         self._saved = {n: getattr(km, n) for n in
                        ("_main_drift_verdict", "_kernel_code_changed", "_converge_classes",
                         "_rebuild_dist", "_bus_converge", "_sync_notice", "_update_mode",
-                        "_send_to_app", "_kernel_sha", "_main_tracking", "_audit_restart_request")}
+                        "_send_to_app", "_kernel_sha", "_main_tracking", "_audit_restart_request",
+                        "_origin_main_sha", "_checkout_sha")}
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
-        km._BUS_CONVERGED_FOR[0] = ""
+        km._INPLACE_TRIED[0] = ""
         self.notices, self.banners, self.audits, self.bus = [], [], [], []
         km._sync_notice = lambda msg, ok=True: self.notices.append((msg, ok))
         km._send_to_app = lambda app, payload: self.banners.append(payload)
         km._audit_restart_request = lambda action, **kw: self.audits.append((action, kw))
         km._update_mode = lambda: "ask"
         km._kernel_sha = lambda: "cur-sha"
+        km._origin_main_sha = lambda: "tgt"     # stubbed: the real one runs `git ls-remote` —
+        km._checkout_sha = lambda: "tgt"        # a NETWORK call per test (T216 review)
         km._main_tracking = lambda: True
 
     def tearDown(self):
@@ -200,6 +227,7 @@ class ConvergeArms(unittest.TestCase):
             setattr(km, n, f)
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
+        km._INPLACE_TRIED[0] = ""
 
     def test_bus_only_drift_bounces_the_bus_not_the_kernel(self):
         km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-bus")
@@ -215,19 +243,34 @@ class ConvergeArms(unittest.TestCase):
         self.assertIn("bus-converge", [a for a, _ in self.audits])
         self.assertTrue(any("bus" in m for m, _ in self.notices))
 
-    def test_a_broken_dist_build_never_becomes_a_bus_restart_storm(self):
-        # the skip arm re-enters on every drift pass until the dist rebuild latches — the bus
-        # bounce must latch on its own target, or a broken esbuild bounces the bus per pass
+    def test_a_broken_dist_build_never_becomes_a_converge_storm(self):
+        # ONE full in-place attempt per target (the _dist_converge_check precedent): a broken
+        # esbuild must not re-bounce the bus, re-classify, and re-build on every 300s pass
         km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-storm")
         km._kernel_code_changed = lambda a, b: False
         km._converge_classes = lambda a, b: {"kernel": [], "bus": ["postal/postal_service.py"],
                                              "skip": [], "ast_equal": []}
         km._bus_converge = lambda: (self.bus.append(1), (True, ""))[1]
-        km._rebuild_dist = lambda: (False, "esbuild broken")
+        self.builds = []
+        km._rebuild_dist = lambda: (self.builds.append(1), (False, "esbuild broken"))[1]
         km._main_drift_check()
         km._MAIN_DRIFT[1] = ""          # let the next pass re-enter the arm (banner already sent)
         km._main_drift_check()
         self.assertEqual(len(self.bus), 1, "one bounce per target, however many passes")
+        self.assertEqual(len(self.builds), 1, "one build attempt per target, however many passes")
+
+    def test_an_unreadable_second_classification_falls_to_the_restart_path(self):
+        # the verdict's classify succeeded; the converge's re-read flaked — an empty mask would
+        # silently drop the bus bounce and write a lying audit row. Unprovable restarts.
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-flake")
+        km._kernel_code_changed = lambda a, b: False
+        km._converge_classes = lambda a, b: None
+        km._bus_converge = lambda: self.fail("no classes — nothing may act")
+        km._rebuild_dist = lambda: self.fail("no classes — nothing may act")
+        km._main_drift_check()
+        self.assertEqual(km._REBUILT_FOR[0], "", "never latched")
+        self.assertEqual([b.get("drift") for b in self.banners], ["restart"],
+                         "the restart offer is the safe converge")
 
     def test_a_failed_bus_bounce_is_loud_but_never_forces_a_kernel_restart(self):
         km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-bus2")
@@ -263,7 +306,8 @@ class PreDeathRebuild(unittest.TestCase):
     def setUp(self):
         self._saved = {n: getattr(km, n) for n in
                        ("_rebuild_dist", "_sync_notice", "_audit_restart_request",
-                        "_kernel_code_changed")}
+                        "_kernel_code_changed", "_checkout_sha")}
+        km._checkout_sha = lambda: "other-sha"
         self.order, self.notices = [], []
         km._sync_notice = lambda msg, ok=True: self.notices.append((msg, ok))
         km._audit_restart_request = lambda action, **kw: None
@@ -295,6 +339,17 @@ class PreDeathRebuild(unittest.TestCase):
         self._run(rebuild_ok=False)
         self.assertEqual(self.order, ["rebuild", "post"], "proceed — _ensure_bundles is the backstop")
         self.assertTrue(any(not ok and "boom" in m for m, ok in self.notices), "loudly")
+
+    def test_a_just_failed_in_place_build_is_not_paid_twice(self):
+        # the in-place converge already paid (and failed) this exact esbuild — a doomed 180s
+        # re-run before the POST would only stretch the outage
+        km._INPLACE_TRIED[0] = "cur-checkout"
+        km._checkout_sha = lambda: "cur-checkout"
+        try:
+            self._run(rebuild_ok=True)
+            self.assertEqual(self.order, ["post"], "straight to the restart — no second build")
+        finally:
+            km._INPLACE_TRIED[0] = ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What (T216, restart-menu layer 1)

**The classifier** (`_kernel_code_changed`): the per-tree prefix check becomes per-file classes built from verified process boundaries. The kernel process loads exactly `kernel/*.py` + `bin/romp-kernel` in-process; `postal/` is never imported here — the bus is its own process with its own client-only-safe restart verb, which the converge now calls for bus-class changes (a kernel bounce for a bus change restarts the wrong thing); `cli/` loads per `romp` invocation; `.md` files are docs wherever they live. A kernel-class python file whose two blobs parse to identical ASTs is provably the same compiled semantics — comment-only diffs skip; docstring edits, adds, renames, and anything unreadable conservatively restart. The hard constraint is unchanged and pinned from both directions: **anything unprovable restarts** — mixed diffs, git failures, a flaked reclassify, unknown shas.

**Auditability**: every skip writes a `restart-audit.jsonl` row (`main-converge-skip` / `bus-converge`) with per-class file lists, so a wrong skip is diagnosable from disk.

**Pre-paid rebuild**: `_run_main_update` runs esbuild *before* the `/restart-all` POST — the fresh kernel's pre-bind `_ensure_bundles` finds current bundles instead of paying the build inside the outage. Failure proceeds loudly; `_ensure_bundles` stays the backstop; a just-failed in-place build is never paid twice.

## Adversarial round (4 lenses, 17 findings, 12 verified real)

Two **reproduced wrong skips** — the one failure mode that matters — fixed and pinned: git's default `core.quotePath` C-quotes non-ASCII paths, defeating every prefix match (listing now rides `-z`, NUL-separated raw paths); and default rename detection collapses a move to its destination, so a kernel file moved *out* of the tree vanished from the listing (`--no-renames` keeps the old path visible as a delete). Also fixed: the pull arm's raced double read of `_checkout_sha` (verdict and target are one read now), the converge masking a flaked reclassify with empty classes (unprovable falls to the restart path), the broken-esbuild per-pass storm (one full in-place attempt per target, the `_dist_converge_check` precedent), and network-in-unit-tests + a dead assertion block in the fixtures.

Accepted residue, documented: an AST-equal skip leaves the on-disk file's line numbers shifted relative to the running code objects, so stderr tracebacks can quote stale source lines until the next real restart — cosmetic, and inherent to any in-place skip.

## Evidence (real merge history, the dispatch's required count)

Last 30 days of merges to main (664): **8 restarts avoided of 425** — 6 postal-only merges now bounce only the bus, 2 comment-only kernel merges skip via AST equality. Last 7 days: 0 of 112 — every kernel-tree merge genuinely carried kernel code, because this repo's test-with-code policy makes mixed diffs the norm. The honest expectation: ~2 avoided restarts/week at current merge patterns, plus the wrong-process bounce class eliminated, plus every remaining restart's outage shortened by the pre-paid esbuild. The larger lever on restart volume stays with batching and the menu's later layers.

Every dispatch shape is pinned against a real throwaway git repo in `tests/test_restart_classifier.py` (22 tests): comment-only kernel file, tests-only, docs-only, postal-only, cli-only, bin-script comment-only, and the must-restart family (mixed, docstring, new file, rename, moved-out-of-tree, non-ASCII path, git failure), plus the converge arms and rebuild ordering.

Suites: 6339 passed + 34 skipped (pytest), vscode-extension npm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)