### PR TITLE
Each summary paragraph lands on its own grounding — hover says so

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2636,7 +2636,7 @@ def _rebase_onto_disk(fsid, store):
         # (the ""→None null keeps its old briefedMt on purpose).
         for _stamp, _fields in (("distilledMt", ("summary", "summaryParts", "background",
                                                  "summaryAnchor", "summaryQuote", "summaryQuoteOff",
-                                                 "distillFails")),
+                                                 "summaryAnchors", "distillFails")),
                                 ("briefedMt", ("blockSummary", "briefParts", "briefFails")),
                                 ("stalledMt", ("stallSummary", "stallFails"))):
             if int(dnd.get(_stamp) or 0) > int(mnd.get(_stamp) or 0):
@@ -3494,34 +3494,78 @@ class _CiteMarks:
         return self.map.get("m%d" % self._n)
 
 
-def _split_source(text):
-    """(body, label, quote) — split the model's trailing `SOURCE: mN` citation line, and the optional
-    `QUOTE: "…"` supporting-span line (T218: the study's most common partial was the right message with
-    the supporting sentence buried deep — the span lets the landing scroll TO the sentence), off a
-    distill/brief reply. Lenient on shape (optional [brackets], either line order, stray whitespace)
-    but anchored to the END of the reply, so a body that merely mentions a label is never mistaken
-    for the citation. label/quote are None when absent/malformed — the kernel then keeps exactly the
-    pre-span behavior."""
+def _split_sources(text):
+    """(body, cites) — the FULL citation parse (T220, the user's per-paragraph ruling): peel every
+    trailing citation line off a distill/brief reply, in any order —
+        SOURCE: mN            the whole-summary citation (T218's shape, unchanged)
+        QUOTE: "…"            its optional supporting span
+        SOURCE k: mN          paragraph k's own citation (k counts the TAKEAWAY's paragraphs, top to
+        QUOTE k: "…"          bottom) and its optional span
+    cites = {"whole": (label|None, quote|None), "paras": {k: (label, quote|None)}}. Parsing stops at
+    the first non-citation line from the end, so a body that merely mentions a label is never
+    mistaken for one. Malformed lines drop the parse back to the body — the callers' fallbacks stay
+    exactly T218's."""
     text = (text or "").strip()
-    quote = None
-    for _ in range(2):                                     # the two trailing lines, either order
-        mq = re.search(r"(?:^|\n)\s*QUOTE:\s*[\"\u201c]?(.+?)[\"\u201d]?\s*$", text)
-        if mq and quote is None and "\n" not in mq.group(1):
-            quote = mq.group(1).strip() or None
-            text = text[:mq.start()].strip()
+    whole_label, whole_quote = None, None
+    paras = {}
+    para_quotes = {}
+    line_re = re.compile(r"(?:^|\n)\s*(SOURCE|QUOTE)(?:\s+(\d+))?:\s*(.+?)\s*$")
+    while True:
+        m = line_re.search(text)
+        if not m or m.end() != len(text):
+            break
+        kind, num, val = m.group(1), m.group(2), m.group(3).strip()
+        if kind == "SOURCE":
+            lm = re.fullmatch(r"\[?(m\d+)\]?", val)
+            if not lm:
+                break                                   # malformed tail line → leave it on the body
+            if num:
+                paras.setdefault(int(num), lm.group(1))
+            elif whole_label is None:
+                whole_label = lm.group(1)
+        else:
+            q = val.strip("\"\u201c\u201d").strip()
+            if not q or "\n" in q:
+                break
+            if num:
+                para_quotes.setdefault(int(num), q)
+            elif whole_quote is None:
+                whole_quote = q
+        text = text[:m.start()].rstrip()
+    return text.strip(), {"whole": (whole_label, whole_quote),
+                          "paras": {k: (lab, para_quotes.get(k)) for k, lab in paras.items()}}
+
+
+def _split_source(text):
+    """(body, label, quote) — the whole-summary view of _split_sources: T218's shape, kept for every
+    caller with no per-paragraph story (the stall note, the corrective-retry check)."""
+    body, cites = _split_sources(text)
+    lab, quote = cites["whole"]
+    return body, lab, quote
+
+
+def _store_para_cites(nd, marks, body, para_cites):
+    """Store per-paragraph anchors aligned to the TAKEAWAY's paragraphs (T220): entry k-1 carries
+    paragraph k's cited atom + its located span; an invalid k, an unoffered label, or an uncited
+    paragraph stays None — the feed then falls back to the whole-summary landing for that paragraph,
+    never a dead or guessed one. Nothing valid → None (the pre-T220 shape, so old single-anchor
+    stores read identically forever — no migration sweep)."""
+    paras = [pp for pp in re.split(r"\n\s*\n", body or "") if pp.strip()]
+    anchors = [None] * len(paras)
+    any_set = False
+    for k, (lab, quote) in (para_cites or {}).items():
+        u = marks.map.get(lab)
+        if not u or not (isinstance(k, int) and 1 <= k <= len(paras)):
             continue
-        break
-    m = re.search(r"(?:^|\n)\s*SOURCE:\s*\[?(m\d+)\]?\s*$", text)
-    if not m:
-        return text, None, quote
-    body = text[:m.start()].strip()
-    # a QUOTE line ABOVE the SOURCE line (the other order): strip it off the body tail too
-    if quote is None:
-        mq = re.search(r"(?:^|\n)\s*QUOTE:\s*[\"\u201c]?(.+?)[\"\u201d]?\s*$", body)
-        if mq and "\n" not in mq.group(1):
-            quote = mq.group(1).strip() or None
-            body = body[:mq.start()].strip()
-    return body, m.group(1), quote
+        entry = {"a": u}
+        if quote:
+            off, span = _locate_quote(marks.texts.get(lab, ""), quote)
+            if span:
+                entry["q"] = span
+                entry["off"] = off
+        anchors[k - 1] = entry
+        any_set = True
+    nd["summaryAnchors"] = anchors if any_set else None
 
 
 def _locate_quote(atom_text, quote):
@@ -10120,7 +10164,11 @@ DISTILL_SYS = (
     "closely it names the goal. This line is parsed off and never shown. When one sentence of the "
     "cited message most directly supports your takeaway, add one more final line after SOURCE: "
     "QUOTE: \"<that sentence, copied verbatim, under 25 words>\", exactly as it appears, never "
-    "paraphrased; omit the line when no single sentence carries it. It is parsed off too.")
+    "paraphrased; omit the line when no single sentence carries it. It is parsed off too. And when "
+    "your takeaway has more than one paragraph resting on DIFFERENT messages, cite per paragraph "
+    "instead: one line per paragraph, SOURCE k: mN, where k is that paragraph's number in the "
+    "takeaway from the top, each optionally followed by its own QUOTE k: \"…\"; keep the plain "
+    "SOURCE line too as the summary-wide citation. All of these lines are parsed off.")
 
 
 def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None, frame=None,
@@ -10408,8 +10456,10 @@ BLOCK_BRIEF_SYS = (
     "line that is exactly SOURCE: mN. When one sentence of the cited message most directly supports "
     "what you wrote, you may add one more final line after it: QUOTE: \"<that sentence, copied "
     "verbatim, under 25 words>\", exactly as it appears, never paraphrased; omit it when no single "
-    "sentence carries it. Do not stop at the takeaway; SOURCE (and the optional QUOTE) come last, and "
-    "both are parsed off and never shown.")
+    "sentence carries it. When your reply has several paragraphs resting on different messages, you "
+    "may also cite each: SOURCE k: mN with an optional QUOTE k, k counting your paragraphs from the "
+    "top. Do not stop at the takeaway; the citation lines come last, and all are parsed off and "
+    "never shown.")
 
 
 def brief_llm(goal_text, work_text, owed, frame=None, user_ask=None, shortfall=None):
@@ -10513,8 +10563,10 @@ STALL_BRIEF_SYS = (
     "line that is exactly SOURCE: mN. When one sentence of the cited message most directly supports "
     "what you wrote, you may add one more final line after it: QUOTE: \"<that sentence, copied "
     "verbatim, under 25 words>\", exactly as it appears, never paraphrased; omit it when no single "
-    "sentence carries it. Do not stop at the takeaway; SOURCE (and the optional QUOTE) come last, and "
-    "both are parsed off and never shown.")
+    "sentence carries it. When your reply has several paragraphs resting on different messages, you "
+    "may also cite each: SOURCE k: mN with an optional QUOTE k, k counting your paragraphs from the "
+    "top. Do not stop at the takeaway; the citation lines come last, and all are parsed off and "
+    "never shown.")
 
 
 def stall_llm(goal_text, work_text, holding):
@@ -11036,7 +11088,8 @@ def _distill_session(fsid, path, now):
                 changed = True                          # persist the counter / the settle
                 continue
             raw = out
-            out, src, _quote = _split_source(out)
+            out, _bcites = _split_sources(out)
+            src, _quote = _bcites["whole"]
             bg, out = _split_sections(out)
             # OWED COVERAGE IS COUNTABLE (the user 2026-08-30): a multi-item <owed> demands one
             # paragraph per item, but the merge allowance made a dropped item look like a merge —
@@ -11099,6 +11152,7 @@ def _distill_session(fsid, path, now):
             # the gather fed this very call (the user 2026-07-21) — every brief ships a stored anchor
             nodes[top]["summaryAnchor"] = marks.map.get(src) or marks.newest()
             _store_cited_span(nodes[top], marks, src, _quote)
+            _store_para_cites(nodes[top], marks, out, {} if _fallback_brief else _bcites["paras"])   # (T220)
             if marks.map and marks.map.get(src) is None and not _fallback_brief:
                 # labels offered, no usable citation → log only (the stamp already grounded the
                 # anchor, so a card warn would be noise, the user 2026-07-21). The verbatim
@@ -11167,9 +11221,11 @@ def _distill_session(fsid, path, now):
             changed = True
             continue
         raw = out
-        out, src, _quote = _split_source(out)
+        out, _cites = _split_sources(out)
+        src, _quote = _cites["whole"]
         bg, out = _split_sections(out)
         nodes[top]["summary"] = out                 # full text — NEVER truncate a takeaway mid-word (the user 2026-07-06)
+        _store_para_cites(nodes[top], marks, out, _cites["paras"])   # per-paragraph landings (T220)
         nodes[top]["summaryParts"] = ([{"id": d["id"], "since": _done_since(d)} for d in _dsubs]
                                       if len(_dsubs) > 1 else None)   # same order as <completed-items>; the feed's count-match gate decides whether the model actually split
         nodes[top]["background"] = bg if bg else None   # re-orientation for a reader who forgot the thread (2026-07-02)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21843,6 +21843,14 @@ def build_feed(now, tmux=None):
                 # and highlights it, and a null keeps today's whole-message behavior
                 "summaryAnchorQuote": (nodes[nid].get("summaryQuote")
                                        if _sa_u and _sa_u == nodes[nid].get("summaryAnchor") else None),
+                # per-paragraph landings (T220, the user's ruling): each cited paragraph's own atom +
+                # located span, aligned to the takeaway's paragraphs (None = that paragraph falls back
+                # to the whole-summary landing). Gated exactly like the quote above: the cited tier
+                # must hold authority (the T153 outrun rule) — absent on old stores forever, no sweep.
+                "summaryAnchorsPara": ([({"u": e["a"], **({"q": e["q"]} if e.get("q") else {})} if e else None)
+                                        for e in nodes[nid].get("summaryAnchors") or []]
+                                       if (nodes[nid].get("summaryAnchors")
+                                           and _sa_u and _sa_u == nodes[nid].get("summaryAnchor")) else None),
                 "warns": nodes[nid].get("warns") or None,   # judge-stamped anomalies (judge _node_warn) → yellow "warning" chip; click shows each warn's what/why detail (the user 2026-07-02)
                 "failLog": nodes[nid].get("failLog") or None,   # the summarizer's failed attempts (judge _fail_log): model + literal error per try → the chip's hover history + modal "What was tried" (the user 2026-08-18)
                 "nudged": ({"count": int(nrec.get("count", 0)), "times": _nudge_times().get(nid, [])[-8:]}

--- a/tests/test_cite_substance.py
+++ b/tests/test_cite_substance.py
@@ -82,5 +82,51 @@ class SupportingSpan(unittest.TestCase):
         self.assertEqual(jd._locate_quote(atom_text, ""), (None, None))
 
 
+
+class PerParagraphCitations(unittest.TestCase):
+    """T220 (the user's ruling, 2026-09-01): a multi-paragraph takeaway's paragraphs may rest on
+    DIFFERENT messages — the protocol grows numbered per-paragraph citations (SOURCE k: mN, each
+    with an optional QUOTE k), parsed off the tail in any order, mixed freely with the whole-summary
+    SOURCE line. Invalid paragraph numbers and unoffered labels drop honestly; an uncited paragraph
+    stays None (the feed falls back to the whole-summary landing, never a dead or guessed one)."""
+
+    def test_parse_numbered_cites_both_orders_and_mixed(self):
+        body, cites = jd._split_sources(
+            "Para one outcome.\n\nPara two outcome.\n\n"
+            'SOURCE 1: m2\nQUOTE 1: "the first grounding sentence"\nSOURCE 2: m5\nSOURCE: m5')
+        self.assertEqual(body, "Para one outcome.\n\nPara two outcome.")
+        self.assertEqual(cites["whole"], ("m5", None))
+        self.assertEqual(cites["paras"][1], ("m2", "the first grounding sentence"))
+        self.assertEqual(cites["paras"][2], ("m5", None))
+        # the other order, quote after its source at the very end
+        body2, cites2 = jd._split_sources(
+            "P1.\n\nP2.\n\nSOURCE: m1\nSOURCE 2: m3\nQUOTE 2: “second span”")
+        self.assertEqual(cites2["whole"], ("m1", None))
+        self.assertEqual(cites2["paras"][2], ("m3", "second span"))
+        # legacy single-line replies parse exactly as before through the compat wrapper
+        b3, s3, q3 = jd._split_source("Take.\nSOURCE: m2\nQUOTE: \"x y z\"")
+        self.assertEqual((b3, s3, q3), ("Take.", "m2", "x y z"))
+
+    def test_store_aligns_anchors_to_takeaway_paragraphs_with_honest_gaps(self):
+        marks = jd._CiteMarks()
+        marks.label("uuid-a", "alpha work wrapped; the alpha suite is green end to end")
+        marks.label("uuid-b", "beta shipped separately with its own follow-ups")
+        nd = {}
+        body = "Alpha done.\n\nBeta done.\n\nStill open: gamma."
+        jd._store_para_cites(nd, marks, body,
+                             {1: ("m1", "the ALPHA suite is green"), 2: ("m9", None), 3: ("m2", None)})
+        a = nd["summaryAnchors"]
+        self.assertEqual(len(a), 3, "aligned to the takeaway's paragraphs")
+        self.assertEqual(a[0]["a"], "uuid-a")
+        self.assertEqual(a[0]["q"], "the alpha suite is green", "the span locates in ITS paragraph's cited atom (raw casing)")
+        self.assertIsNone(a[1], "an unoffered label (m9) drops — never a guessed anchor")
+        self.assertEqual(a[2], {"a": "uuid-b"}, "a cite with no quote stores the anchor alone")
+
+    def test_no_valid_cites_stores_none_old_shape_forever(self):
+        nd = {}
+        jd._store_para_cites(nd, jd._CiteMarks(), "One para.", {5: ("m1", None)})
+        self.assertIsNone(nd["summaryAnchors"], "out-of-range k → nothing stored; absent = today's whole-summary behavior")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -4671,6 +4671,39 @@ class DistillAtDone(unittest.TestCase):
         nd = jd.load_goals(SID)["nodes"][self.G]
         self.assertIsNone(nd["summaryQuote"], "unfindable stores None — the landing keeps today's behavior")
 
+    def test_per_paragraph_cites_store_aligned_end_to_end(self):
+        # T220: two takeaway paragraphs resting on two different messages — each cited with its own
+        # SOURCE k (+ a QUOTE for the first), stored aligned; the third (uncited) paragraph stays None.
+        a1 = ("Alpha wrapped end to end; the alpha suite is green across every case and both "
+              "follow-ups are filed under their own items.")
+        a2 = ("Beta shipped separately this afternoon; its bundle went out with the compat shim "
+              "and the rollout notes were posted to the thread.")
+        records = [uline(T0, "ship alpha and beta", "u1", ps="typed"),
+                   aline(T0 + 10, a1, "aa", "u1"),
+                   aline(T0 + 20, a2, "ab", "aa", stop="end_turn")]
+        segs = [sg for turn in build_session(records)["turns"] for sg in em.segments(turn)]
+        path = Path(self._td) / (SID + ".jsonl")
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        node = {"id": self.G, "text": "ship alpha and beta", "parentId": None, "nodeComplete": True,
+                "blocked": False, "cleared": False, "trail": [sg["id"] for sg in segs],
+                "t": T0, "mt": T0 + 30, "summary": None,
+                "log": [{"src": "planner", "kind": "done", "ev_t": T0 + 25, "at": T0 + 26}]}
+        jd.save_goals(SID, {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V, "lastNode": self.G,
+                            "placements": {}, "status": {self.G: "working"},
+                            "confirming": [self.G], "nodes": {self.G: node}})
+        jd.distill_llm = (lambda *a, **k:
+                          "TAKEAWAY: Alpha done.\n\nBeta done.\n\nStill open: the smoke pass.\n"
+                          'SOURCE: m2\nSOURCE 1: m1\nQUOTE 1: "the alpha suite is green"\nSOURCE 2: m2')
+        self.assertEqual(jd._distill_session(SID, str(path), NOW), 1)
+        nd = jd.load_goals(SID)["nodes"][self.G]
+        anchors = nd["summaryAnchors"]
+        self.assertEqual(len(anchors), 3, "aligned to the takeaway's three paragraphs")
+        self.assertEqual(anchors[0]["a"], "aa")
+        self.assertEqual(anchors[0]["q"], "the alpha suite is green", "paragraph 1's span, located in ITS atom")
+        self.assertEqual(anchors[1], {"a": "ab"})
+        self.assertIsNone(anchors[2], "the uncited leftover paragraph falls back to the whole-summary landing")
+        self.assertEqual(nd["summaryAnchor"], "ab", "the whole-summary citation stands beside them, unchanged")
+
     def test_a_confirming_top_distills_before_settle(self):
         path = self._write()
         jd.distill_llm = lambda *a, **k: "BACKGROUND: b.\nTAKEAWAY: shipped the widget.\nSOURCE: m1"
@@ -5178,8 +5211,9 @@ class SourceCitation(unittest.TestCase):
         # pre-decided next lever repeats the requirement as the LAST thing the model reads (recency), after
         # the section specs, so the trailing line is top-of-mind at generation time. Briefer-only: the
         # distiller was clean post-fix (0 cite-miss), so its working prompt is left untouched.
-        tail = jd.BLOCK_BRIEF_SYS[-520:]           # the reminder grew the QUOTE option (T218) — same recency lever
+        tail = jd.BLOCK_BRIEF_SYS[-700:]           # the reminder grew QUOTE (T218) + per-paragraph cites (T220) — same recency lever
         self.assertIn("your reply must end with", tail, "the reminder rides at the very end of the briefer prompt")
+        self.assertIn("SOURCE k: mN", tail, "…and offers the per-paragraph form (T220)")
         self.assertIn("SOURCE: mN", tail, "and it restates the exact required line")
         self.assertIn("Do not stop at the takeaway", tail, "hammering the observed miss: ending on the takeaway")
         self.assertIn("QUOTE:", tail, "the supporting-span option rides the same end-reminder (T218)")

--- a/ui/webview/brief-parts.test.ts
+++ b/ui/webview/brief-parts.test.ts
@@ -45,9 +45,9 @@ test("the judge stores one {id, since} per owed item, in order, multi-item only"
 test("the renderer gates on state-matched parts + multi-item + the paragraph-count match", () => {
   assert.ok(FEED.includes("const bp = dCompleted ? it.summaryParts : dBlocked ? it.briefParts : null;"),
     "parts must belong to the state being shown: briefParts <-> blocked brief, summaryParts <-> takeaway");
-  assert.ok(FEED.includes("if (distillShown && bp && bp.length > 1)"),
-    "multi-item only; a single ask keeps the header age");
-  assert.ok(FEED.includes("if (paras.length === bp.length || paras.length === bp.length + 1)"),
+  assert.ok(FEED.includes("if (distillShown && ((bp && bp.length > 1) || (pAnchors && pAnchors.some(Boolean))))"),
+    "multi-item stamps or per-paragraph citations (T220) — a single unstamped, uncited ask keeps the header age");
+  assert.ok(FEED.includes("const stampOk = !!(bp && bp.length > 1 && (paras.length === bp.length || paras.length === bp.length + 1));"),
     "the model may merge paragraphs — a missing stamp beats a wrong one — but ONE extra trailing "
     + "paragraph is the still-open line, which is expected, not a mismatch");
   assert.match(FEED, /split\(\/\\n\\s\*\\n\/\)/, "paragraphs split on blank lines, the brief's own separator");
@@ -58,10 +58,10 @@ test("the renderer gates on state-matched parts + multi-item + the paragraph-cou
 // <owed> row, so it must render WITHOUT an age chip — and, before this, its mere presence pushed the count
 // to items+1 and the exact-match gate silently dropped every stamp on the card.
 test("the trailing still-open paragraph renders unstamped, and only the item paragraphs get ages", () => {
-  assert.ok(FEED.includes("if (i < bp.length) {"),
+  assert.ok(FEED.includes("if (stampOk && i < bp!.length) {"),
     "the chip is appended only for paragraphs that HAVE a part; the extra one gets none");
   const block = FEED.slice(FEED.indexOf("// PER-PARAGRAPH ages"), FEED.indexOf("// The distiller line is a LINK"));
-  assert.ok(/paras\.forEach\(\(p, i\) => \{[\s\S]*?if \(i < bp\.length\) \{[\s\S]*?relAge\(nowS - \(bp\[i\]\.since/.test(block),
+  assert.ok(/paras\.forEach\(\(p, i\) => \{[\s\S]*?if \(stampOk && i < bp!\.length\) \{[\s\S]*?relAge\(nowS - \(bp!\[i\]\.since/.test(block),
     "the guard wraps the relAge lookup itself, so bp[i] is never read past the end");
   assert.ok(block.includes("ONE EXTRA TRAILING PARAGRAPH"), "the why is recorded where the gate lives");
 });
@@ -72,7 +72,7 @@ test("the trailing still-open paragraph renders unstamped, and only the item par
 
 test("each paragraph wears its own live age chip", () => {
   assert.ok(FEED.includes('el("span", "fask-para-age")'));
-  assert.ok(FEED.includes("relAge(nowS - (bp[i].since || nowS))"),
+  assert.ok(FEED.includes("relAge(nowS - (bp![i].since || nowS))"),
     "the ask's OWN block-event age, via the shared relAge vocabulary");
 });
 

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -46,3 +46,23 @@ test("substantive non-prose atoms are citable — the study's convicted classes"
   assert.match(JUDGE, /out\.append\("RESULTS: " \+ " \| "\.join\(results\[:4\]\)\)/);
   assert.match(JUDGE, /def _store_cited_span\(nd, marks, src, quote\):/, "the span stores only with a RESOLVED citation");
 });
+
+test("per-paragraph landings (T220): the user's ruling, wired end to end with honest fallbacks", () => {
+  // payload: aligned entries gated on the cited tier holding authority; absent on old stores forever
+  assert.match(KERNEL, /"summaryAnchorsPara": \(\[\(\{"u": e\["a"\], \*\*\(\{"q": e\["q"\]\} if e\.get\("q"\) else \{\}\)\} if e else None\)/);
+  assert.match(KERNEL, /if \(nodes\[nid\]\.get\("summaryAnchors"\)\s*\n\s*and _sa_u and _sa_u == nodes\[nid\]\.get\("summaryAnchor"\)\) else None\)/,
+    "the T153 outrun gate covers the whole per-paragraph list");
+  // renderer: the model's own citation beats the T153 tree-row mapping; count drift drops, never mis-maps
+  assert.match(FEED, /const cited = anchOk \? pAnchors!\[i\] : null;/);
+  assert.match(FEED, /const anchOk = !!\(pAnchors && paras\.length === pAnchors\.length\);/,
+    "a re-split that disagrees with the stored alignment drops the anchors — never a mis-mapped click");
+  assert.match(FEED, /anchorUuid: u, quote: aq/, "the paragraph's click carries ITS span — the T218 landing highlights it");
+  // the hover affordance: exactly the hovered paragraph highlights
+  const FEEDCSS = fs.readFileSync(path.join(UI, "feed.css"), "utf8");
+  assert.match(FEEDCSS, /\.fask-para-link:hover \{ background: rgba\(255, 255, 255, 0\.07\);/);
+  // judge: the parser + store helpers exist with the honest-gap discipline
+  assert.match(JUDGE, /def _split_sources\(text\):/);
+  assert.match(JUDGE, /def _store_para_cites\(nd, marks, body, para_cites\):/);
+  assert.match(JUDGE, /nd\["summaryAnchors"\] = anchors if any_set else None/,
+    "nothing valid stores None — old single-anchor stores read identically forever, no migration");
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -499,8 +499,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fask-para { margin: 0 0 6px; }
 .fask-para:last-child { margin-bottom: 0; }
 .fask-para-age { color: var(--dim); white-space: nowrap; }
-.fask-para-link { cursor: pointer; }
-.fask-para-link:hover { text-decoration: underline; text-decoration-color: var(--dim); }
+.fask-para-link { cursor: pointer; border-radius: 5px; margin-left: -4px; padding-left: 4px; margin-right: -4px; padding-right: 4px; }
+/* the per-paragraph affordance (T220, the user's ruling): hovering highlights exactly the paragraph
+   under the pointer — each clickable piece reads as its own target as the pointer moves */
+.fask-para-link:hover { background: rgba(255, 255, 255, 0.07); text-decoration: underline; text-decoration-color: var(--dim); }
 /* the card's distiller sections (the user 2026-07-07, compactness): the Background/Summary TOGGLES now ride
    the time row (row3) and are MUTUALLY EXCLUSIVE — one body shows at a time, or neither — so .fask-secs is
    just the body container (a plain block; whichever body is open runs the full card width). The toggles are

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -107,6 +107,7 @@ interface AskItem {
   background?: string | null;                      // distiller's BACKGROUND section: re-orientation for a reader who forgot the thread → the card's collapsed-by-default section above the takeaway (the user 2026-07-02)
   summaryAnchorUuid?: string | null;               // click the summary line → the completion turn's wrap-up block (kernel build_feed completed pin; cited/latest-prose fallbacks — the user 2026-07-14)
   summaryAnchorQuote?: string | null;              // the distiller's verbatim supporting sentence, pre-located in the cited atom (T218) — the landing scrolls to and highlights it; null keeps the whole-message landing
+  summaryAnchorsPara?: ({ u: string; q?: string } | null)[] | null;   // per-paragraph landings (T220, the user's ruling): aligned to the takeaway's paragraphs; null entry = that paragraph falls back to the whole-summary landing
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
   failLog?: { t: number; line: string; model: string; note: string }[] | null;   // the summarizer's failed ATTEMPTS on this card (judge _fail_log): when, which line, which MODEL, the literal error — the chip's hover history + the modal's "What was tried" (the user 2026-08-18, who needed to SEE "tried opus — 529" ×3 to know switching the model would fix it)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
@@ -1972,35 +1973,47 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // last: a bigger surplus means the model split some other way and the mapping can no longer be trusted,
   // so the gate falls through to the plain text as before.
   const bp = dCompleted ? it.summaryParts : dBlocked ? it.briefParts : null;
-  if (distillShown && bp && bp.length > 1) {
+  // Paragraph SPLIT fires for a stamped parts-takeaway (T153) OR for per-paragraph citations (T220,
+  // the user's ruling: each paragraph of a multi-topic summary is independently clickable, hover
+  // highlighting exactly the paragraph under the pointer). Anchor precedence per paragraph: the
+  // model's OWN citation (it names what the paragraph was written from) beats the T153 tree-row
+  // mapping; a paragraph with neither keeps the whole-summary landing via the card-level link.
+  const pAnchors = (distillShown && it.summaryAnchorsPara) || null;
+  if (distillShown && ((bp && bp.length > 1) || (pAnchors && pAnchors.some(Boolean)))) {
     const paras = distillShown.split(/\n\s*\n/).map((s) => s.trim()).filter(Boolean);
-    if (paras.length === bp.length || paras.length === bp.length + 1) {
+    const stampOk = !!(bp && bp.length > 1 && (paras.length === bp.length || paras.length === bp.length + 1));
+    const anchOk = !!(pAnchors && paras.length === pAnchors.length);   // count drift → drop, never mis-map
+    if (stampOk || anchOk) {
       const dle = a._distill as HTMLElement;
       dle.textContent = "";
       const nowS = Date.now() / 1000;
       paras.forEach((p, i) => {
         const para = el("div", "fask-para");
         para.textContent = p;
-        if (i < bp.length) {
+        if (stampOk && i < bp!.length) {
           const age = el("span", "fask-para-age");
-          age.textContent = relAge(nowS - (bp[i].since || nowS));
+          age.textContent = relAge(nowS - (bp![i].since || nowS));
           para.append(" ", age);
-          // Per-paragraph deep-link (the user 2026-08-28, T153): a split takeaway's paragraphs map
-          // 1:1 to <completed-items>, and each item's own tree row already carries its WORK anchor —
-          // so every paragraph can land on the stretch it is actually about, not just the card-level
-          // grounding. stopPropagation beats the whole-line summary link one level up.
-          const pid = bp[i].id;
+        }
+        // T220 first: the paragraph's own citation, with its located span riding the landing
+        const cited = anchOk ? pAnchors![i] : null;
+        let au: string | null = null, aq: string | undefined;
+        if (cited && cited.u) { au = cited.u; aq = cited.q; }
+        else if (stampOk && i < bp!.length) {
+          // T153: the item's tree row carries its WORK anchor
+          const pid = bp![i].id;
           const prow = pid ? (it.tree || []).find((r) => r.id === pid) : undefined;
-          if (prow && prow.anchorUuid) {
-            const au = prow.anchorUuid;
-            para.classList.add("fask-para-link");
-            para.title = "jump to where this piece resolved";
-            para.onclick = (ev: Event) => {
-              ev.stopPropagation(); focusEcho(it.sid);
-              vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid,
-                                       t: it.t, anchor: "work", anchorUuid: au });
-            };
-          }
+          if (prow && prow.anchorUuid) au = prow.anchorUuid;
+        }
+        if (au) {
+          const u = au;
+          para.classList.add("fask-para-link");
+          para.title = "jump to where this piece resolved";
+          para.onclick = (ev: Event) => {
+            ev.stopPropagation(); focusEcho(it.sid);
+            vscodeApi?.postMessage({ type: "showOnTimeline", itemId: it.itemId, sid: it.sid,
+                                     t: it.t, anchor: "work", anchorUuid: u, quote: aq });
+          };
         }
         dle.append(para);
       });


### PR DESCRIPTION
The user's ruling (T220, settling the multi-anchor question the anchor study left open): in a multi-paragraph summary, **each paragraph is independently clickable**, and **hover highlights exactly the paragraph under the pointer**.

The T218 protocol grows numbered per-paragraph citations: `SOURCE k: mN` (k counting the takeaway's paragraphs from the top), each with an optional `QUOTE k` riding the span machinery — offered in the distiller prompt and the briefer/staller end-reminders, parsed off the reply tail in any order and mixed freely with the whole-summary SOURCE line, which stands unchanged. `_split_sources` is the one parser; `_split_source` stays as its whole-summary view.

**Storage is per-paragraph and honest by construction**: `summaryAnchors` aligns to the takeaway's paragraphs — each entry the cited atom + its located span (exact-then-normalized, in THAT label's own text); an invalid number, unoffered label, or uncited paragraph stays None, and nothing valid stores None — old single-anchor stores read identically forever, **no migration sweep**. The payload gates the list on the cited tier holding authority (the same outrun rule the whole-summary quote rides).

**The feed's paragraph renderer generalizes**: it splits for stamped parts (T153) OR per-paragraph citations, with per-paragraph anchor precedence — the model's own citation beats the T153 tree-row mapping; a paragraph with neither keeps the whole-summary landing; a re-split disagreeing with the stored alignment drops the anchors rather than mis-mapping a click. Each anchored paragraph's click carries its own span (the T218 landing highlights the sentence); hover highlights exactly the hovered paragraph.

**Prompt cost, stated**: ~55 words per distill/brief call + one reply line per cited paragraph — negligible against the work text.

Red-first goldens: parse both orders + mixed, aligned store with honest gaps, out-of-range drops, old-store compatibility, and the end-to-end multi-paragraph distill through the real pipeline (two paragraphs, two atoms, one span each, the uncited leftover None). Stamped-parts pins retargeted to the generalized gate. All fixtures synthetic. Python 6431 passed / extension 2637 passed on the pushed head; hover + dual-landing screenshot in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)