### PR TITLE
T221: the card's hover emphasis is one paint — no seam at any zoom or renderer

### DIFF
--- a/ui/webview/card-key.test.ts
+++ b/ui/webview/card-key.test.ts
@@ -106,7 +106,11 @@ test("a cross-pane hover bolds the card's own session colour, sharing the .focus
   const i = FEEDCSS.indexOf(".fitem.ask.focused, .fitem.ask.dot-hl");
   const rule = FEEDCSS.slice(i, FEEDCSS.indexOf("}", i));
   assert.match(rule, /border-color: rgb\(var\(--card-r/, "full-opacity session colour, as on mouse hover");
-  assert.match(rule, /box-shadow: 0 0 0 1px rgb\(var\(--card-r/, "and the same 1px same-colour ring");
+  // T221: the extra 1px is the BORDER growing (one paint with the body — a box-shadow ring was a
+  // second paint whose contact with the border seamed on the user's renderer), with the negative
+  // margin keeping flow position and content box identical.
+  assert.match(rule, /border-width: 3px; margin: -1px;/, "the bolding is single-paint");
+  assert.doesNotMatch(rule, /box-shadow: 0 0 0 1px/, "…never a second ring paint laid against the border");
 });
 
 test("the white outline no longer lands on a card, only on the modal rows that have no colour", () => {

--- a/ui/webview/feed-card-border.test.ts
+++ b/ui/webview/feed-card-border.test.ts
@@ -43,11 +43,15 @@ test("the border colour is CSS-driven from the channels: 0.5α at rest", () => {
 
 test("the highlight BOLDS the same colour (no white ring): pinned 0.85α, focused full + a same-colour ring", () => {
   assert.match(CSS, /\.fitem\.ask\.pinned  \{ border-color: rgba\(var\(--card-r, 255\), var\(--card-g, 255\), var\(--card-b, 255\), 0\.85\); \}/);
-  // focused = full-opacity border AND a 1px same-colour ring (a touch bolder, no layout shift). The
+  // focused = full-opacity border, one touch bolder as a SINGLE paint: the border grows 1px with a
+  // compensating negative margin (T221 — a box-shadow ring was a second paint whose contact with the
+  // border seamed on the user's renderer; flow position and content box stay identical). The
   // selector also carries .dot-hl since 2026-07-23, so a hover from another pane looks like a mouse
   // hover instead of the old neutral white outline — matched loosely so it survives further sharing.
   assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?border-color: rgb\(var\(--card-r, 255\), var\(--card-g, 255\), var\(--card-b, 255\)\);/);
-  assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?box-shadow: 0 0 0 1px rgb\(var\(--card-r, 255\), var\(--card-g, 255\), var\(--card-b, 255\)\), 0 2px 7px/);
+  assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?border-width: 3px; margin: -1px;/);
+  assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?box-shadow: 0 2px 7px/,
+    "the lift shadow stays; the ring layer is gone");
   // no white ring anywhere in the highlight
   assert.doesNotMatch(CSS, /\.fitem\.ask\.focused[^{]*\{[^}]*#fff/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -449,8 +449,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fitem.ask { cursor: pointer; }
 .fitem.ask, .fitem.fgroup { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.5); }
 .fitem.ask.pinned  { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.85); }   /* pinned: bolded, persistent */
-/* effective focus: full-opacity same colour, thickened a touch by a 1px same-colour ring (a bolder highlight
-   without a layout-shifting border-width change), plus the hover lift — the user 2026-07-15.
+/* effective focus: full-opacity same colour, thickened a touch — plus the hover lift (the user 2026-07-15).
+   The extra 1px is the BORDER growing with a compensating negative margin, ONE paint with the card body
+   (T221, the user 2026-09-01: the old 1px box-shadow ring was a second paint laid against the border, and
+   the contact between two adjacent paints is renderer- and zoom-dependent — their Mac browser opened a
+   1px dark seam between ring and border across the whole top edge; a single paint cannot seam at any
+   zoom or radius). Under the global border-box sizing with auto width/height, border 2→3px plus
+   margin -1px grows the OUTER edge by exactly the 1px the ring occupied while the flow position and the
+   content box stay byte-identical — verified by rect comparison, so no layout-shifting border change
+   (the original rule's own constraint, kept by construction).
    A CROSS-PANE hover (a chat rail dot, a timeline bar) lands on this same rule rather than wearing a look
    of its own (the user 2026-07-23): it used to paint the neutral white .dot-hl outline, which read as a
    different kind of event from hovering the card with the mouse when it means exactly the same thing.
@@ -458,7 +465,8 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    specificity, so a pinned card still bolds to full when another pane hovers it. */
 .fitem.ask.focused, .fitem.ask.dot-hl, .fitem.fgroup.dot-hl {
   border-color: rgb(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255));
-  box-shadow: 0 0 0 1px rgb(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255)), 0 2px 7px rgba(0, 0, 0, 0.30);
+  border-width: 3px; margin: -1px;
+  box-shadow: 0 2px 7px rgba(0, 0, 0, 0.30);
 }
 
 /* decision sub-card — an OPEN question needing the user, rendered in the ask card */


### PR DESCRIPTION
## Summary
The user's screenshot showed a thin dark gap between a hovered feed card's bolded ring and the card body across the whole top edge. Pixel-decoding the specimen: fill, 2px border, and the extra 1px box-shadow ring were all present and correctly colored — but a 1-device-pixel dark seam sat **between the ring and the border**, widening slightly through the corner arcs. The ring was a second paint laid against the border's outer edge, and the contact between two adjacent paints is renderer- and zoom-dependent: headless Chromium keeps them contiguous at every device scale (1/1.25/2) and zoom (0.8–1.25) swept; the user's Mac browser rounds them apart. A pixel nudge cannot fix a rounding seam; removing the second paint can.

The emphasis is now the **border itself growing 1px (2→3px) with a compensating −1px margin** — one contiguous paint from fill to outer edge, seamless by construction at every radius, zoom, and renderer. Under the global border-box sizing with auto width/height this reproduces the ring's exact outer geometry: measured in the harness, the title's rect is byte-identical when `.focused` toggles (dx=dy=dw=0) and the outer box grows exactly the 1px the ring occupied — the original rule's own no-layout-shift constraint holds by construction. The lift shadow stays; pinned (0.85α) and rest (0.5α) dresses untouched; the shared `.dot-hl` cross-pane selector keeps riding the same rule.

## Test plan
- The two dress pins (`card-key.test.ts`, `feed-card-border.test.ts`) follow the single-paint form and now REJECT a ring layer reappearing.
- Rendered verification: focused/pinned/rest states shot from the real stylesheet; layout-shift rect proof in the harness.
- Full Python suite: 6,427 passed. Extension suite: green. (No shell touched — bats not applicable per the round's rider.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)