### PR TITLE
The upload re-ship heals federated sessions, and its loss toast fires once

### DIFF
--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -57,7 +57,11 @@ class SourcePins(unittest.TestCase):
     def test_payload_retained_and_reshipped_on_the_reconnect_event(self):
         self.assertIn("interface PendingShip { name: string; shipId: string; b64?: string }", RENDER)
         self.assertIn("if (entry) entry.b64 = b64;", RENDER)
-        self.assertIn('window.addEventListener("romp:wsup", reshipPendingUploads);', RENDER)
+        self.assertIn('window.addEventListener("romp:wsup", () => reshipPendingUploads());', RENDER)
+        # …and the federated twin events (review finding 2026-09-01): the relay's own redial and the
+        # kernel-reported tunnel recovery each re-ship THEIR host's entries — scoped by ack socket
+        self.assertIn('window.addEventListener("romp:hostRelayUp", (e) => {', RENDER)
+        self.assertIn("if (Array.isArray(m.hosts)) reshipPendingUploads(m.hosts.map(String));", RENDER)
 
     def test_ack_echoes_shipid_and_a_stray_twin_is_dropped(self):
         self.assertIn('ack["shipId"] = str(msg["shipId"])', KERNEL_SRC)
@@ -165,7 +169,9 @@ process.exit(0);
 """
 
 
-class ServedWedge(unittest.TestCase):
+class _ShipLab(unittest.TestCase):
+    """Shared hermetic lab: one kernel, one seeded SDK session, the real /chat page. Subclasses
+    carry the choreography; each gets its own kernel (setUpClass per class)."""
     maxDiff = None
 
     @classmethod
@@ -245,36 +251,49 @@ class ServedWedge(unittest.TestCase):
             cls.kernel.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
-    def test_restart_between_ship_and_ack_reships_heals_and_releases_the_held_send(self):
+    def _run_driver(self, driver_src, cfg_obj, timeout=300):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
-                       "kernelPid": self.kernel.pid,
-                       "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"),
-                                    "env": {k: v for k, v in self.env.items()}, "log": self.klog},
-                       "file": self.png, "msg": "hold this message for the upload T215",
-                       "msg2": "a normal send after the restart T215",
-                       "shots": os.environ.get("SHIP_RESHIP_SHOTS", "")}, f)
+            json.dump(cfg_obj, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
-            f.write(DRIVER)
+            f.write(driver_src)
         try:
-            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=timeout,
                                env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
         except subprocess.TimeoutExpired as e:
-            self.fail("driver timed out; partial output:\n%s\n%s"
-                      % ((e.stdout or b"").decode() if isinstance(e.stdout, bytes) else (e.stdout or ""),
-                         (e.stderr or b"").decode() if isinstance(e.stderr, bytes) else (e.stderr or "")))
+            so = (e.stdout or b"").decode() if isinstance(e.stdout, bytes) else (e.stdout or "")
+            se = (e.stderr or b"").decode() if isinstance(e.stderr, bytes) else (e.stderr or "")
+            # the driver may have relaunched the lab kernel before hanging — reap it via tearDownClass
+            # (review finding 2026-09-01: this path leaked the detached replacement kernel)
+            kpid = next((ln for ln in so.splitlines() if ln.startswith("KPID:")), None)
+            if kpid:
+                type(self).kernel2_pid = int(kpid.split(":", 1)[1])
+            self.fail("driver timed out; partial output:\n%s\n%s" % (so, se))
+            return None
         kpid = next((ln for ln in p.stdout.splitlines() if ln.startswith("KPID:")), None)
         if kpid:
             type(self).kernel2_pid = int(kpid.split(":", 1)[1])
         if p.returncode == 3:
-            raise unittest.SkipTest("no playwright browser on this box — the wedge needs one (CI installs none)")
+            raise unittest.SkipTest("no playwright browser on this box — the served leg needs one (CI installs none)")
         self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
         r = json.loads(line[len("RESULT:"):])
         self.assertNotIn("died", r, "driver aborted early: %r" % r)
+        return r
+
+
+class ServedWedge(_ShipLab):
+    def test_restart_between_ship_and_ack_reships_heals_and_releases_the_held_send(self):
+        r = self._run_driver(DRIVER, {
+            "url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+            "kernelPid": self.kernel.pid,
+            "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"),
+                         "env": {k: v for k, v in self.env.items()}, "log": self.klog},
+            "file": self.png, "msg": "hold this message for the upload T215",
+            "msg2": "a normal send after the restart T215",
+            "shots": os.environ.get("SHIP_RESHIP_SHOTS", "")})
         w, reg = r["wedge"], r["regression"]
         # the ship went out on a live socket the stopped kernel will never answer
         self.assertEqual(w["chipUpAfterShip"], 1, "the pending chip must be up after the ship: %r" % w)
@@ -295,6 +314,71 @@ class ServedWedge(unittest.TestCase):
         self.assertTrue(reg["thumbnailLanded"], "normal ship: chip → thumbnail on the ack: %r" % reg)
         self.assertEqual(reg["gateOpened"], 0, "no pending ships → no gate: %r" % reg)
         self.assertTrue(reg["sentClean"], "a plain send still clears and lands: %r" % reg)
+
+
+DRIVER_RELOAD = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 900 } });
+const out = {};
+const die = async (why) => {
+  fs.writeSync(1, "RESULT:" + JSON.stringify({ ...out, died: why }) + "\n");
+  await browser.close();
+  process.exit(0);
+};
+await page.goto(cfg.url);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+const tab = await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 }).catch(() => null);
+if (!tab) await die("no session tab — the lab seed never reached the chat payload");
+await page.waitForTimeout(500);
+// stop the kernel so the ship's ack cannot land, then WALK AWAY mid-flight: the loss shape.
+// No restart needed — determinism comes from the page dying before any ack or re-ship can settle.
+process.kill(cfg.kernelPid, "SIGSTOP");
+await page.setInputFiles("body > input[type=file]", cfg.file);
+await page.waitForSelector(".composer-file-pending", { timeout: 10000 }).catch(() => {});
+out.chipUp = await page.locator(".composer-file-pending").count();
+await page.goto("about:blank");            // the page dies with the ship pending — no client left to ack
+process.kill(cfg.kernelPid, "SIGCONT");    // the buffered dropFile answers a dead socket, harmlessly
+// load 1: the persisted names must warn LOUDLY — and clear
+await page.goto(cfg.url);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(800);
+out.toastOnFirstLoad = await page.evaluate(
+  () => (document.getElementById("warn-toasts")?.textContent || "").includes("still uploading"));
+// load 2: silence — pre-fix, persistDrafts' swallowed TDZ throw left the record, re-toasting forever
+await page.goto(cfg.url);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(800);
+out.toastOnSecondLoad = await page.evaluate(
+  () => (document.getElementById("warn-toasts")?.textContent || "").includes("still uploading"));
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ReloadLossToast(_ShipLab):
+    """The reload face, executed: a ship lost to a page death warns ONCE at the next load, then the
+    record clears. Red on the pre-fix tree: the startup clear rode persistDrafts, whose stagedMsgs
+    read sits below the restore block — the TDZ throw died in persistDrafts' own catch, the clear
+    silently never ran, and the toast re-fired on every load (review finding 2026-09-01, verified
+    on the emitted bundle)."""
+
+    def test_reload_loss_toasts_once_then_clears(self):
+        r = self._run_driver(DRIVER_RELOAD, {
+            "url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+            "kernelPid": self.kernel.pid, "file": self.png})
+        self.assertEqual(r["chipUp"], 1, "the ship must be pending when the page dies: %r" % r)
+        self.assertTrue(r["toastOnFirstLoad"],
+                        "the lost upload must warn loudly on the next load — never a silent vanish: %r" % r)
+        self.assertFalse(r["toastOnSecondLoad"],
+                         "the loss record must clear with the toast — one warning, not one per load: %r" % r)
 
 
 if __name__ == "__main__":

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -871,7 +871,17 @@ export class FederationManager {
       return;
     }
     conn.ws = ws;
-    ws.onopen = () => this.diag("hostconn", { host: conn.host, ev: "open" });
+    ws.onopen = () => {
+      this.diag("hostconn", { host: conn.host, ev: "open" });
+      // this host's owed replies just became reachable again — the chat re-ships its pending
+      // uploads on exactly this event (T215 review finding 2026-09-01: a remote kernel's restart
+      // redials HERE, firing neither romp:wsup nor hostUp, so nothing else could heal them).
+      // Fired on every open, not just re-opens: at boot the listener's map is empty (a no-op),
+      // and a detach/re-add mints a fresh Conn whose FIRST open is that heal event.
+      try {
+        window.dispatchEvent(new CustomEvent("romp:hostRelayUp", { detail: { host: conn.host } }));
+      } catch (e) { /* dispatch must never break the relay */ }
+    };
     ws.onmessage = (ev: MessageEvent) => {
       let msg: any;
       try {

--- a/ui/webview/flicker-diag.test.ts
+++ b/ui/webview/flicker-diag.test.ts
@@ -27,7 +27,7 @@ test("feed: an item entering/leaving the model posts an itemset breadcrumb (ids 
 });
 
 test("federation: every remote socket open/close/detach posts a hostconn breadcrumb", () => {
-  assert.match(FED, /ws\.onopen = \(\) => this\.diag\("hostconn", \{ host: conn\.host, ev: "open" \}\);/);
+  assert.match(FED, /ws\.onopen = \(\) => \{\s*\n\s*this\.diag\("hostconn", \{ host: conn\.host, ev: "open" \}\);/);   // block body since the T215 relay-up dispatch joined it
   assert.match(FED, /this\.diag\("hostconn", \{ host: conn\.host, ev: "close", code: ev\.code, clean: ev\.wasClean, detached: conn\.closed \}\);/);
   assert.match(FED, /this\.diag\("hostconn", \{ host, ev: "detach" \}\);/);
   // breadcrumbs ride the LOCAL kernel socket into the same client-diag journal the feed writes

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -43,7 +43,8 @@ test("render.ts's message listener heals previews unconditionally at the top, so
 
 // ── RECONNECT-class heals go further than the per-message retry (the user 2026-08-24) ───────────
 test("hostUp also drains the settled chips and un-parks the path-image chips", () => {
-  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{ refreshSettledPreviews\(\); healPathImgs\(\); \}/,
+  // block form since T215's review round: the recovered hosts' pending uploads re-ship here too
+  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{\s*\n\s*refreshSettledPreviews\(\); healPathImgs\(\);/,
     "a tunnel recovery re-attempts spent budgets and imgFailed paths — bounded by the event's rarity");
 });
 

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -70,8 +70,15 @@ test("chips are never revived from a reload — names persist only to say what w
   assert.match(RENDER, /shipsInFlight: \[\.\.\.pendingShips\.values\(\)\]\.flat\(\)\.map\(\(p\) => p\.name\)/);
   assert.doesNotMatch(RENDER, /pendingShips\.set\([^)]*shipsInFlight/, "never rebuild chips from the persisted names");
   assert.match(RENDER, /still uploading when this page reloaded, so it was NOT attached — attach it again\./);
-  assert.match(RENDER, /persistDrafts\(\);   \/\/ pendingShips is empty at startup → the persisted names clear here/,
-    "the loss toast fires once — the record clears with the same write path that made it");
+  // the clear is a DIRECT setState with no dependency on later declarations: v1 rode persistDrafts,
+  // whose stagedMsgs read sits below this block — the TDZ throw died in its own catch and the clear
+  // never ran, so the toast re-fired on every reload (review finding 2026-09-01)
+  assert.match(RENDER, /vscodeApi\?\.setState\?\.\(\{ \.\.\.\(vscodeApi\.getState\?\.\(\) \|\| \{\}\), shipsInFlight: \[\] \}\);/,
+    "the loss toast fires once — the record clears directly, immune to module-eval order");
+  // …reached from the toast WITHOUT crossing a persistDrafts call: the clear must never ride it
+  // (stagedMsgs is not initialized yet at module-eval; its TDZ throw dies in persistDrafts' catch)
+  assert.match(RENDER, /attach (?:it|them) again\."\)\);(?:(?!persistDrafts\(\);)[\s\S]){0,600}?setState\?\.\(\{ \.\.\.\(vscodeApi\.getState\?\.\(\) \|\| \{\}\), shipsInFlight: \[\] \}\)/,
+    "the startup clear must be the direct setState, not a persistDrafts ride");
 });
 
 test("a kernel restart between ship and ack RE-SHIPS the retained bytes on reconnect (T215)", () => {
@@ -80,8 +87,8 @@ test("a kernel restart between ship and ack RE-SHIPS the retained bytes on recon
   // the entry and re-shipped on romp:wsup — the exact kernel-is-back event, never a timer.
   assert.match(RENDER, /interface PendingShip \{ name: string; shipId: string; b64\?: string \}/);
   assert.match(RENDER, /if \(entry\) entry\.b64 = b64;/);
-  assert.match(RENDER, /function reshipPendingUploads\(\): void \{/);
-  assert.match(RENDER, /window\.addEventListener\("romp:wsup", reshipPendingUploads\);/);
+  assert.match(RENDER, /function reshipPendingUploads\(hosts\?: readonly string\[\]\): void \{/);
+  assert.match(RENDER, /window\.addEventListener\("romp:wsup", \(\) => reshipPendingUploads\(\)\);/);
   // an entry still ENCODING has no payload — its own onload ships on the fresh socket, never doubled
   assert.match(RENDER, /if \(!p\.b64\) continue;/);
   // the re-ship rides the same dropFile shape, same shipId, routed to the owning session
@@ -106,4 +113,23 @@ test("the chip wears the accent loader-dots motif from styles.css", () => {
   assert.match(CSS, /@keyframes ship-bnc/);
   // staggered like the romp loader's dots
   assert.match(CSS, /\.composer-ship-dots i:nth-child\(3\) \{ animation-delay: 0\.32s; \}/);
+});
+
+test("federated sessions heal too: every ack socket's comeback re-ships ITS entries (T215 review)", () => {
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  // a remote session's ack rides that host's relay, so the re-ship is SCOPED to the socket that
+  // reconnected: no scope = the local kernel's own entries; a hosts list = exactly those relays'
+  assert.match(RENDER, /if \(hosts \? hosts\.indexOf\(h\) < 0 : h\) continue;/);
+  // the relay's own redial is the one event a remote kernel restart fires — federation dispatches
+  // it, the chat re-ships on it (v1 listened to romp:wsup alone and never healed federated wedges)
+  assert.match(FED, /window\.dispatchEvent\(new CustomEvent\("romp:hostRelayUp", \{ detail: \{ host: conn\.host \} \}\)\);/);
+  assert.match(RENDER, /window\.addEventListener\("romp:hostRelayUp", \(e\) => \{/);
+  // and the kernel-reported tunnel recovery re-ships the recovered hosts' entries alongside
+  assert.match(RENDER, /if \(Array\.isArray\(m\.hosts\)\) reshipPendingUploads\(m\.hosts\.map\(String\)\);/);
+});
+
+test("dismissing the LAST pending chip settles an armed hold loudly — never a forever-wait (T215 review)", () => {
+  // the ✕ removed the very entry whose ack the hold was waiting for; same contract as the nack:
+  // cancelled loudly, never auto-sent
+  assert.match(RENDER, /const held = sendOnShip\.delete\(id\);\s*\n\s*const gateWasOpen = shipGateSid === id;\s*\n\s*if \(gateWasOpen\) \{ shipGateSid = null; closeConfirm\(null\); \}\s*\n\s*if \(held \|\| gateWasOpen\) warnToast\("The pending upload was dismissed — your held message was NOT sent\."\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10745,16 +10745,22 @@ function retirePendingShip(key: string, shipId?: string): string | null {
   return null;
 }
 
-// Re-ship every retained payload on the kernel-is-back event (romp:wsup — the page shim fires it when
-// this pane's socket reconnects). The old socket died with the acks still owed, so re-sending the
-// bytes is the ONLY way the chip's retiring event can still arrive; the kernel just saves a fresh
-// copy (a duplicate file in drops/ is an orphan, never attached — the shipId-matched ack retires this
-// chip and any stray twin ack is dropped by shipOwner's gate). An entry with no payload yet is one
-// whose FileReader is still encoding — its own onload ships through the fresh socket, so it is
-// deliberately skipped here, never doubled.
-function reshipPendingUploads(): void {
+// Re-ship the retained payloads whose ack socket just came back. That socket died with the acks
+// still owed, so re-sending the bytes is the ONLY way the chip's retiring event can still arrive;
+// the kernel just saves a fresh copy (a duplicate file in drops/ is an orphan, never attached — the
+// shipId-matched ack retires this chip and any stray twin ack is dropped by shipOwner's gate). An
+// entry with no payload yet is one whose FileReader is still encoding — its own onload ships through
+// the fresh socket, so it is deliberately skipped here, never doubled.
+// SCOPED to the socket that reconnected: a remote session's ack rides that host's RELAY, not the
+// pane socket, so romp:wsup re-ships local entries only, and the host-back events below carry their
+// hosts (review finding 2026-09-01: v1 listened to romp:wsup alone, whose entries-of-every-host
+// re-ship both missed the remote relay's own redial — which fires neither romp:wsup nor hostUp — and
+// re-sent remote payloads into a relay that was still down).
+function reshipPendingUploads(hosts?: readonly string[]): void {
   if (!vscodeApi) return;
   for (const [id, list] of pendingShips) {
+    const h = hostOf(id);
+    if (hosts ? hosts.indexOf(h) < 0 : h) continue;   // no scope → the local kernel's own entries
     for (const p of list) {
       if (!p.b64) continue;
       const msg: { type: string; name: string; b64: string; shipId: string; id?: string } =
@@ -10764,7 +10770,13 @@ function reshipPendingUploads(): void {
     }
   }
 }
-window.addEventListener("romp:wsup", reshipPendingUploads);
+window.addEventListener("romp:wsup", () => reshipPendingUploads());
+// federation dispatches this on a host relay socket (re)connect — the exact event that makes that
+// host's owed acks reachable again; the detail names the host, so only its entries re-ship
+window.addEventListener("romp:hostRelayUp", (e) => {
+  const h = String((((e as CustomEvent).detail || {}) as any).host || "");
+  if (h) reshipPendingUploads([h]);
+});
 
 // Sids whose SEND is HELD until every pending ship acks (the user 2026-08-16: sending mid-upload
 // silently dropped the attachment — the send read only the acked list). Armed by the confirm's
@@ -10832,7 +10844,11 @@ try {
       warnToast(names.join(", ") + (names.length === 1
                 ? " was still uploading when this page reloaded, so it was NOT attached — attach it again."
                 : " were still uploading when this page reloaded, so they were NOT attached — attach them again."));
-      persistDrafts();   // pendingShips is empty at startup → the persisted names clear here
+      // clear the record DIRECTLY — v1 called persistDrafts() here, which reads stagedMsgs, declared
+      // BELOW this block: the TDZ throw landed in persistDrafts' own catch and the clear silently
+      // never ran, so this toast re-fired on every reload until an unrelated composer gesture
+      // (review finding 2026-09-01, verified on the emitted bundle). No eval-order dependency now.
+      vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), shipsInFlight: [] });
     }
   }
 } catch { /* ignore */ }
@@ -11138,6 +11154,15 @@ function renderComposerFiles(id: string | null): void {
       list.splice(i, 1);
       if (!list.length && id) pendingShips.delete(id);
       persistDrafts();   // the dismissed chip's name must not resurface as a reload-loss toast
+      // dismissing the LAST chip settles an armed hold the same way a nack does — cancelled
+      // LOUDLY, never auto-sent: the ✕ removed the very entry whose ack the hold was waiting
+      // for, so left armed it would wait forever (review finding 2026-09-01)
+      if (id && !(pendingShips.get(id) || []).length) {
+        const held = sendOnShip.delete(id);
+        const gateWasOpen = shipGateSid === id;
+        if (gateWasOpen) { shipGateSid = null; closeConfirm(null); }
+        if (held || gateWasOpen) warnToast("The pending upload was dismissed — your held message was NOT sent.");
+      }
       renderComposerFiles(id);
     });
     box.appendChild(x);
@@ -11908,7 +11933,12 @@ window.addEventListener("message", (e: MessageEvent) => {
   // a RECONNECT-class event goes further: settled chips (budget spent) re-attempt regardless of
   // their error text, and the path-image chips parked in imgFailed get one fresh host round-trip
   // (bounded: reconnects are rare events, never a per-push loop)
-  if (m.type === "hostUp") { refreshSettledPreviews(); healPathImgs(); }
+  if (m.type === "hostUp") {
+    refreshSettledPreviews(); healPathImgs();
+    // the recovered hosts' owed acks are reachable again — re-ship their retained uploads too
+    // (the relay's own redial also heals via romp:hostRelayUp; both are idempotent by shipId)
+    if (Array.isArray(m.hosts)) reshipPendingUploads(m.hosts.map(String));
+  }
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {
     globalRetryPaused = !!m.value;


### PR DESCRIPTION
Follow-up to the T215 re-ship change, fixing everything its adversarial review confirmed (each finding verified by execution against the emitted bundle or the live code):

1. **The startup clear of the persisted `shipsInFlight` names was dead code.** The restore block called `persistDrafts()` above `stagedMsgs`' declaration; the TDZ throw died inside persistDrafts' own catch, the clear silently never ran, and the "X was still uploading… attach it again" toast re-fired on every reload until an unrelated composer gesture happened to persist. The clear is now a direct `setState` write with no module-eval-order dependency. Executed red-first: the new `ReloadLossToast` leg (SIGSTOP the kernel, ship, walk away mid-flight, then two fresh loads) fails on the pre-fix tree at exactly `toastOnSecondLoad` and passes here.

2. **Re-ship never fired for federated sessions.** A remote session's ack rides that host's relay socket, whose redial fires neither `romp:wsup` nor `hostUp` — the wedge persisted there unhealed, and v1 also re-sent remote payloads into relays that were still down. Re-ship is now scoped to the socket that reconnected: `romp:wsup` re-ships the local kernel's own entries; federation's relay `onopen` dispatches a new `romp:hostRelayUp` naming its host; the kernel-reported `hostUp` recovery list re-ships those hosts' entries. All idempotent by shipId.

3. **Dismissing the last pending chip while a held send was armed left the hold waiting forever** (the ✕ removed the very entry whose ack the hold needed). It now settles the hold the way a nack does: cancelled loudly, never auto-sent.

4. **The wedge test's driver-timeout path leaked the relaunched lab kernel** — the KPID line was never parsed from the TimeoutExpired exception's partial stdout. The shared driver runner reaps it via tearDownClass on every path.

Pins retargeted with the behavior they anchor (`pending-attach`, `flicker-diag`, `heal-on-hostup`, the SourcePins twins). Suites on this head: pytest 6432 passed + 335 subtests; npm 2639 pass / 0 fail.

Known residual, deliberate: a re-ship attempted while its relay is still down rides federation's existing loud dropWarn and is retried by the next relay-up event; no queueing was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)