### PR TITLE
The model pickers pull their version list from the Models API; Fable 5.1 seeded

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -560,6 +560,10 @@ def _version_info():
             # counters, no paths — safe for the auth-exempt route. Deploy verification reads the live
             # fold rate here instead of trusting an offline replay number (T210).
             "parse": dict(em._ASM_STATS),
+            # T222: where the model pickers' version list came from (seed / cache / api), when, what
+            # the API added beyond the shipped seed, and the last refresh failure — so a stale list
+            # is a visible fact in `romp version`, never a guess
+            "modelCatalog": _catalog_public_status(),
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
             "compactSuggest": _compact_suggest_on(),   # T208+: its gear checkbox rides the same read
             "conserveMemory": _conserve_on(),   # the T148 toggle: close idle tab-less claude processes
@@ -827,7 +831,8 @@ MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label"
 # (model-picks.json below), else the newest. Full ids ride every set path verbatim already — the
 # alias table stops at the family names, so a version pick needs no new transport.
 MODEL_VERSIONS = {
-    "fable":  [{"value": "claude-fable-5", "label": "Fable 5"}],
+    "fable":  [{"value": "claude-fable-5-1", "label": "Fable 5.1"},   # verified live 2026-09-01 (Models API + CLI 2.1.257)
+               {"value": "claude-fable-5", "label": "Fable 5"}],
     "opus":   [{"value": "claude-opus-5", "label": "Opus 5"},
                {"value": "claude-opus-4-8", "label": "Opus 4.8"},
                {"value": "claude-opus-4-7", "label": "Opus 4.7"},
@@ -841,23 +846,286 @@ MODEL_VERSIONS = {
 _VERSION_FAMILY = {v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v in vs}
 MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pref all surfaces read, like colormap
 
+# ── the LIVE model catalog (T222, the user 2026-09-01: romp must stop needing a hand edit when
+# Anthropic ships a model). The table above is the SEED and the loud fallback. The kernel queries the
+# Models API (GET /v1/models — the documented programmatic source) on its OWN credential and merges
+# new version ids into the families, ADD-ONLY: an id the API omits but the seed knows stays (key-scoped
+# visibility differs per account); a dated snapshot, a suffixed variant (-fast) or the pre-4 naming
+# never joins (routing ids, not versions — the alias-table lesson); every family stays newest-first.
+# Cached durably (STATE/model-catalog.json) so a dead API never blanks a picker. Refreshed on exact
+# EVENTS — boot, and a claude-* id reaching a set path or the pick store that the merged list does not
+# know (the very moment staleness bites) — never on a timer. Unreachable API = serve seed+cache and
+# SAY SO (stderr + /version), never a quietly stale list. ROMP_MODEL_CATALOG=off disables the fetch
+# outright — hermetic labs must never reach the network; ROMP_MODELS_URL points tests at a fake.
+MODEL_CATALOG_FILE_NAME = "model-catalog.json"
+MODELS_API_URL = os.environ.get("ROMP_MODELS_URL") or "https://api.anthropic.com/v1/models"
+_MODEL_SEED = {fam: [dict(v) for v in vs] for fam, vs in MODEL_VERSIONS.items()}   # the shipped table, frozen
+_MODEL_ID_RE = re.compile(r"^claude-(fable|opus|sonnet|haiku)-(\d+(?:-\d+)*)$")
+_catalog_lock = threading.Lock()
+_catalog_status = {"source": "seed", "fetchedAt": None, "lastError": None, "added": [], "inflight": False}
+_catalog_asked = set()   # unknown ids that already fired a refresh this kernel life (event dedup, no clock)
+
+
+def _catalog_family(mid):
+    """The picker family a Models-API id belongs to, or None for ids that are not pickable VERSIONS:
+    dated snapshots (claude-opus-4-5-20251101), suffixed variants (claude-opus-4-6-fast), the pre-4
+    naming (claude-3-5-sonnet-…) — deployment/routing ids the seed deliberately never lists."""
+    m = _MODEL_ID_RE.match(str(mid or ""))
+    if not m or any(len(p) >= 8 for p in m.group(2).split("-")):
+        return None
+    return m.group(1)
+
+
+def _version_key(mid):
+    """Numeric version tuple of a family id, for newest-first ordering ('claude-opus-4-8' → (4, 8);
+    'claude-opus-5' → (5,) sorts above it, 'claude-fable-5-1' → (5, 1) above (5,))."""
+    m = _MODEL_ID_RE.match(str(mid or ""))
+    return tuple(int(p) for p in m.group(2).split("-")) if m else ()
+
+
+def _catalog_label(display_name, mid):
+    """The seed's label style from the API's display_name ('Claude Fable 5.1' → 'Fable 5.1'); an
+    absent display_name derives from the id ('claude-opus-4-9' → 'Opus 4.9')."""
+    d = str(display_name or "").strip()
+    if d.lower().startswith("claude "):
+        d = d[7:].strip()
+    if d:
+        return d
+    fam = _catalog_family(mid) or ""
+    return (fam[:1].upper() + fam[1:] + " " + ".".join(str(n) for n in _version_key(mid))).strip()
+
+
+def merge_model_catalog(seed, rows):
+    """ADD-ONLY merge of Models-API rows ({id, display_name, created_at}) into a seed
+    {family: [{value, label}, …]}. Every seed entry survives; an unknown pickable id joins its family
+    with its display label; non-version ids are skipped; each family is re-sorted newest-first by
+    the id's own version tuple (seed and API entries alike — no created_at needed, and the seed's
+    dateless aliases sort exactly where they belong). Pure: returns a NEW dict, tests drive it."""
+    merged = {fam: [dict(v) for v in vs] for fam, vs in seed.items()}
+    for r in rows or []:
+        mid = str((r or {}).get("id") or "")
+        fam = _catalog_family(mid)
+        if not fam or fam not in merged or any(v["value"] == mid for v in merged[fam]):
+            continue
+        merged[fam].append({"value": mid, "label": _catalog_label((r or {}).get("display_name"), mid)})
+    for fam in merged:
+        merged[fam].sort(key=lambda v: _version_key(v["value"]), reverse=True)
+    return merged
+
+
+def _apply_model_catalog(merged, source):
+    """Install a merged catalog IN PLACE — the family lists, the reverse map and the judge setters'
+    allowed set are mutated, never rebound — so every consumer (the /models route, _model_picks'
+    validity check, setJudgeModel's validation) sees it with no re-import. Returns the ids that
+    were new to the running table."""
+    with _catalog_lock:
+        added = []
+        for fam, vs in merged.items():
+            if fam not in MODEL_VERSIONS:
+                continue
+            known = {v["value"] for v in MODEL_VERSIONS[fam]}
+            added += [v["value"] for v in vs if v["value"] not in known]
+            MODEL_VERSIONS[fam][:] = [dict(v) for v in vs]
+        _VERSION_FAMILY.clear()
+        _VERSION_FAMILY.update({v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v in vs})
+        jv, mv = globals().get("_JUDGE_MODEL_VALUES"), globals().get("_MODEL_VALUES")   # defined further
+        if isinstance(jv, set) and isinstance(mv, set):   # down the module; absent only during import
+            jv.clear()                                   # rebuilt, not grown: the set mirrors the table exactly
+            jv.update(mv)
+            jv.update(_VERSION_FAMILY)
+        seed_ids = {v["value"] for vs in _MODEL_SEED.values() for v in vs}
+        _catalog_status["added"] = sorted(v for v in _VERSION_FAMILY if v not in seed_ids)
+        _catalog_status["source"] = source
+    return added
+
+
+def _catalog_cache_path():
+    return jd.STATE / MODEL_CATALOG_FILE_NAME
+
+
+def _load_model_catalog_cache():
+    """Boot: install the last fetched catalog BEFORE any picker asks, so a dead API never blanks a
+    picker and the seed alone is only what this build shipped with. Returns the cached row count."""
+    try:
+        d = json.loads(_catalog_cache_path().read_text())
+        rows = d.get("models") if isinstance(d, dict) else None
+        if not isinstance(rows, list):
+            return 0
+    except Exception:
+        return 0
+    _apply_model_catalog(merge_model_catalog(_MODEL_SEED, rows), "cache")
+    _catalog_status["fetchedAt"] = d.get("fetchedAt")
+    return len(rows)
+
+
+def _models_api_credential():
+    """(header, value) for the kernel's OWN credential path, or None when the box has none the kernel
+    may use: the manager-env API key the SDK backend claimed out of os.environ (sdk_backend.work_api_key
+    — the key the judges ride), else an ANTHROPIC_AUTH_TOKEN bearer. A login-only box (Claude Code's
+    OAuth, no key) has no HTTP credential the kernel can borrow: the refresh says so once and serves
+    the seed — the CLI's own alias table still tracks each family's newest there."""
+    fn = getattr(jd, "_WORK_KEY_FN", None)
+    key = ""
+    if fn is not None:
+        try:
+            key = fn() or ""
+        except Exception:
+            key = ""
+    key = key or os.environ.get("ANTHROPIC_API_KEY", "") or ""
+    if key:
+        return ("x-api-key", key)
+    tok = os.environ.get("ANTHROPIC_AUTH_TOKEN", "") or ""
+    if tok:
+        return ("Authorization", "Bearer " + tok)
+    return None
+
+
+def _fetch_models_api(cred, timeout=8):
+    """Every page of GET /v1/models as [{id, display_name, created_at}] (after_id / has_more paging per
+    the API reference). Raises on ANY failure — the caller owns the loudness."""
+    import urllib.request
+    rows, after, pages = [], None, 0
+    while pages < 10:
+        url = MODELS_API_URL + "?limit=100" + ("&after_id=" + urllib.parse.quote(after) if after else "")
+        hdrs = {"anthropic-version": "2023-06-01", cred[0]: cred[1]}
+        if cred[0] == "Authorization":
+            hdrs["anthropic-beta"] = "oauth-2025-04-20"     # OAuth bearers ride this beta, per the reference
+        with urllib.request.urlopen(urllib.request.Request(url, headers=hdrs), timeout=timeout) as r:
+            d = json.loads(r.read().decode("utf-8", "replace"))
+        data = d.get("data") if isinstance(d, dict) else None
+        if not isinstance(data, list):
+            raise ValueError("Models API returned no data list (keys=%r)"
+                             % (sorted(d)[:8] if isinstance(d, dict) else type(d).__name__))
+        rows += [{"id": str(m.get("id") or ""), "display_name": m.get("display_name"),
+                  "created_at": m.get("created_at")} for m in data if isinstance(m, dict) and m.get("id")]
+        pages += 1
+        if not d.get("has_more") or not d.get("last_id"):
+            break
+        after = str(d["last_id"])
+    return rows
+
+
+def _refresh_model_catalog(reason, _async=True):
+    """Fetch the live list, install the add-only merge, cache it durably. Single-flight; off entirely
+    under ROMP_MODEL_CATALOG=off. LOUD on every failure path — a stderr line naming the reason and
+    what is being served instead, mirrored into /version's modelCatalog — never a silently stale picker."""
+    if (os.environ.get("ROMP_MODEL_CATALOG") or "").strip().lower() == "off":
+        return False
+    with _catalog_lock:
+        if _catalog_status["inflight"]:
+            return False
+        _catalog_status["inflight"] = True
+
+    def go():
+        try:
+            cred = _models_api_credential()
+            if cred is None:
+                _catalog_status["lastError"] = "no API credential in the kernel's environment"
+                sys.stderr.write("model catalog (%s): no API credential the kernel can use — serving the "
+                                 "%s list; new models need ANTHROPIC_API_KEY in the manager env (or a "
+                                 "MODEL_VERSIONS edit)\n" % (reason, _catalog_status["source"]))
+                return
+            try:
+                rows = _fetch_models_api(cred)
+            except Exception as e:
+                _catalog_status["lastError"] = "%s: %s" % (type(e).__name__, str(e)[:200])
+                sys.stderr.write("model catalog (%s): Models API unreachable (%s) — serving the %s list "
+                                 "(%d extra id(s) beyond the seed)\n"
+                                 % (reason, _catalog_status["lastError"], _catalog_status["source"],
+                                    len(_catalog_status["added"])))
+                return
+            added = _apply_model_catalog(merge_model_catalog(_MODEL_SEED, rows), "api")
+            now = int(time.time())
+            _catalog_status["fetchedAt"] = now
+            _catalog_status["lastError"] = None
+            try:
+                _atomic_write(_catalog_cache_path(), json.dumps({"fetchedAt": now, "models": rows}))
+            except Exception:
+                sys.stderr.write("model catalog: cache write failed: %s\n" % traceback.format_exc())
+            if added:
+                sys.stderr.write("model catalog (%s): %d new version id(s) joined the pickers: %s\n"
+                                 % (reason, len(added), ", ".join(added)))
+                try:
+                    _push_soon()                          # pickers re-read /models on the next frame
+                except Exception:
+                    pass
+        finally:
+            _catalog_status["inflight"] = False
+
+    if _async:
+        threading.Thread(target=go, name="model-catalog", daemon=True).start()
+    else:
+        go()
+    return True
+
+
+def _note_unknown_model(mid):
+    """The staleness EVENT: a claude-* version id reached a set path or the pick store and the merged
+    list does not know it — exactly when a hand-updated table used to go quietly stale. Fires ONE
+    refresh per unknown id per kernel life (dedup by id, never a clock); aliases, dated snapshots
+    and garbage never fire. Returns whether a refresh was started."""
+    mid = str(mid or "")
+    if not _catalog_family(mid) or mid in _VERSION_FAMILY or mid in _catalog_asked:
+        return False
+    _catalog_asked.add(mid)
+    return _refresh_model_catalog("unknown model id %s" % mid)
+
+
+def _catalog_public_status():
+    """/version's modelCatalog block — where the list came from, when, what it added, and the last
+    failure (so `romp version` and a curl can see a stale-list problem instead of guessing)."""
+    return {"source": _catalog_status["source"], "fetchedAt": _catalog_status["fetchedAt"],
+            "lastError": _catalog_status["lastError"], "added": list(_catalog_status["added"])}
+
+
+def _cli_model_blocks():
+    """{model id: {needs, cli, t}} — versions the INSTALLED CLI refused by minimum version, written by
+    the SDK backend from the CLI's own error at the first attempt (sdk_backend.note_cli_model_block)
+    and cleared by the first real reply on that model. The catalog can list ids newer than the CLI
+    (the API is the source; the CLI gates by version), so the refusal is surfaced on the version row
+    the moment it is known rather than only at pick time (T222)."""
+    try:
+        d = json.loads((jd.STATE / "cli-model-blocks.json").read_text())
+        return d if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+def _with_cli_block(version, blocks):
+    """A /models version row stamped with its CLI refusal, if any: cliNeeds (the minimum version the
+    CLI named) and a label suffix every picker renders as-is — no client change, honest everywhere."""
+    b = blocks.get(version.get("value")) if blocks else None
+    if isinstance(b, dict) and b.get("needs"):
+        version["cliNeeds"] = str(b["needs"])
+        version["label"] = "%s — needs CLI ≥ %s" % (version.get("label", version.get("value")), b["needs"])
+    return version
+
 
 def _model_picks():
     """The per-family last-picked map. Only known version ids survive the read (a stale or hand-edited
     entry falls back to the family's newest rather than poisoning the default)."""
     try:
         d = json.loads((jd.STATE / MODEL_PICKS_FILE_NAME).read_text())
-        return {f: v for f, v in d.items() if isinstance(v, str) and _VERSION_FAMILY.get(v) == f} \
-            if isinstance(d, dict) else {}
+        if not isinstance(d, dict):
+            return {}
+        out = {}
+        for f, v in d.items():
+            if isinstance(v, str) and _VERSION_FAMILY.get(v) == f:
+                out[f] = v
+            elif isinstance(v, str):
+                _note_unknown_model(v)   # a pick this list doesn't know → the catalog staleness event (T222)
+        return out
     except Exception:
         return {}
 
 
 def _note_model_pick(value):
     """Record a version pick as its family's new default (write-on-change). Family shorthands and
-    unknown strings record nothing — they are not version picks."""
+    unknown strings record nothing — they are not version picks (an unknown claude-* id does fire
+    the catalog's staleness refresh: it may be a model newer than this list)."""
     fam = _VERSION_FAMILY.get(str(value or ""))
     if not fam:
+        _note_unknown_model(value)
         return
     picks = _model_picks()
     if picks.get(fam) == value:
@@ -8242,6 +8510,13 @@ def _sdk_locked():
             # the unwired judges inherited the post-claim env on a login-less host and every call
             # refused "Not logged in" for 13 hours while the cards sat parked in Working).
             jd._WORK_KEY_FN = sbmod.work_api_key
+            # T222: the live model catalog — the last fetched list installs before any picker asks,
+            # then the BOOT event refreshes it (async; the key is claimable from here on)
+            try:
+                _load_model_catalog_cache()
+                _refresh_model_catalog("boot")
+            except Exception:
+                sys.stderr.write("model catalog boot: %s\n" % traceback.format_exc())
             _sdk_backend = sbmod.SdkBackend(
                 jd.STATE, _claude_bin(), _send_to_app,
                 poke=_producer_wake.set, push=_pusher_wake.set,
@@ -30629,10 +30904,16 @@ class Handler(BaseHTTPRequestHandler):
                 # DEFAULT — the last version the user picked for that family, else the newest (the
                 # user 2026-08-25: family click = remembered pick; the submenu holds the rest).
                 _picks = _model_picks()
+                # a version the INSTALLED CLI has refused by minimum version says so on its own row
+                # (T222): the refusal is learned from the CLI's own error at the first attempt
+                # (sdk_backend.note_cli_model_block) and cleared by the first real reply on that
+                # model — so every picker shows the reason before the next pick, not only after it
+                _blocks = _cli_model_blocks()
                 return self._send(200, json.dumps(
                     {"models": [dict(c, color=_model_color(c["value"], _stops),
                                      tone=_model_tone(c["value"]),
-                                     versions=[dict(v) for v in MODEL_VERSIONS.get(c["value"]) or []],
+                                     versions=[_with_cli_block(dict(v), _blocks)
+                                               for v in MODEL_VERSIONS.get(c["value"]) or []],
                                      default=_picks.get(c["value"])
                                          or ((MODEL_VERSIONS.get(c["value"]) or [{}])[0].get("value")
                                              or c["value"]))

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -576,6 +576,71 @@ def append_retry_gave_up(state_dir: Path, sid: str, retries: int, kind: str = ""
         f.write(json.dumps(rec) + "\n")
 
 
+CLI_MODEL_BLOCKS_FILE = "cli-model-blocks.json"
+# The CLI's own refusal when a model id is valid on the API but newer than the installed binary
+# (verified live 2026-09-01 on 2.1.221 vs claude-fable-5-1): the ONLY shape this recognises, so a
+# different error can never be misfiled as a version block.
+_CLI_MIN_VERSION_RE = re.compile(
+    r"Claude Code (\S+) does not support this model; version (\S+) or newer is required")
+
+
+def _assistant_text(msg) -> str:
+    """The text blocks of an AssistantMessage joined — the error settle's own words."""
+    out = []
+    for b in (getattr(msg, "content", None) or []):
+        t = getattr(b, "text", None)
+        if isinstance(t, str):
+            out.append(t)
+        elif isinstance(b, dict) and isinstance(b.get("text"), str):
+            out.append(b["text"])
+    return "".join(out)
+
+
+def _rewrite_json(p: Path, obj) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj))
+    os.replace(tmp, p)
+
+
+def note_cli_model_block(state_dir, model_id, error_text) -> bool:
+    """Record that the INSTALLED CLI refused `model_id` by minimum version (T222): the live model
+    catalog can list ids newer than the binary — the API is the catalog's source, the CLI gates by
+    version — so the kernel's /models stamps the refusal on that version row the moment it is known,
+    not only after the next pick fails. Durable ({model: {needs, cli, t}} in STATE/cli-model-blocks.json)
+    and event-cleared by the first real reply on that model (clear_cli_model_block). Returns whether the
+    text was the version refusal; anything else records nothing."""
+    m = _CLI_MIN_VERSION_RE.search(error_text or "")
+    mid = str(model_id or "")
+    if not m or "claude" not in mid.lower():
+        return False
+    p = Path(state_dir) / CLI_MODEL_BLOCKS_FILE
+    try:
+        d = json.loads(p.read_text())
+        d = d if isinstance(d, dict) else {}
+    except Exception:
+        d = {}
+    d[mid] = {"needs": m.group(2), "cli": m.group(1), "t": int(time.time())}
+    _rewrite_json(p, d)
+    return True
+
+
+def clear_cli_model_block(state_dir, model_id) -> bool:
+    """A real reply on `model_id` proves the installed CLI serves it now — drop its block (the CLI was
+    updated; event-based, never a timer). Returns whether a block was removed."""
+    mid = str(model_id or "")
+    p = Path(state_dir) / CLI_MODEL_BLOCKS_FILE
+    try:
+        d = json.loads(p.read_text())
+    except Exception:
+        return False
+    if not isinstance(d, dict) or mid not in d:
+        return False
+    del d[mid]
+    _rewrite_json(p, d)
+    return True
+
+
 ORPHAN_REPLY_CAP = 8000   # text cap per orphan marker — a lost reply is worth keeping, but bound the file
 
 
@@ -2742,8 +2807,23 @@ class SdkSession:
                 if self.retrying and self.retry_count:
                     append_retry_gave_up(self.backend.state_dir, self.sid, self.retry_count,
                                          kind=str(msg.error))
+                # the installed CLI refusing a model by MINIMUM VERSION is worth remembering for every
+                # picker (T222): the model catalog can list ids newer than the binary
+                try:
+                    note_cli_model_block(self.backend.state_dir, self.chosen_model or self.model,
+                                         _assistant_text(msg))
+                except Exception:
+                    pass
             elif self.retrying and self.retry_count:   # first real output after a storm → durable recovery marker
                 append_retry_recovered(self.backend.state_dir, self.sid, self.retry_count)
+            if not getattr(msg, "error", None):
+                # a real reply on a model proves the CLI serves it — its block (if any) lifts on the event
+                try:
+                    for _mid in {str(getattr(msg, "model", None) or ""), str(self.chosen_model or "")}:
+                        if "claude" in _mid.lower():
+                            clear_cli_model_block(self.backend.state_dir, _mid)
+                except Exception:
+                    pass
             self.retrying = False                      # either way the storm is over (recovered, or settled in error)
             self.retry_count = 0
             self.retry_info = None

--- a/tests/test_gear_select_matrix.py
+++ b/tests/test_gear_select_matrix.py
@@ -156,7 +156,8 @@ class ServedMatrix(unittest.TestCase):
                    CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
                    ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
                    ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
-                   ROMP_DIST_DIR=dist)
+                   ROMP_DIST_DIR=dist,
+                   ROMP_MODEL_CATALOG="off")   # hermetic: the T222 catalog fetch must never reach the network
         env.pop("ROMP_STATE_DIR", None)
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(os.path.join(cls.lab, "kernel.log"), "w"),

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -67,7 +67,10 @@ class JudgeSettings(unittest.TestCase):
         # the shared lists, each choice carrying its colormap tint (the user 2026-08-17) — and,
         # since the version submenus (the user 2026-08-25), each family's versions + default too
         self.assertIn('{"models": [dict(c, color=_model_color(c["value"], _stops),', ksrc)
-        self.assertIn('versions=[dict(v) for v in MODEL_VERSIONS.get(c["value"]) or []]', ksrc)
+        # …each version row stamped with any CLI minimum-version refusal (T222, 2026-09-01: the live
+        # catalog can list ids newer than the installed binary, so the row says so before a pick)
+        self.assertIn('versions=[_with_cli_block(dict(v), _blocks)', ksrc)
+        self.assertIn('for v in MODEL_VERSIONS.get(c["value"]) or []]', ksrc)
 
     # ---- per-tier overrides honored + validated ----
     def test_judge_tiers_accept_version_ids(self):

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""T222 (the user 2026-09-01): romp stops needing a hand edit when Anthropic ships a model.
+
+MODEL_VERSIONS is now the SEED of a live catalog: the kernel queries the Models API on its own
+credential and merges new version ids into the families — ADD-ONLY (an id the API omits but the seed
+knows stays; key-scoped visibility differs per account), newest-first by each id's own version tuple,
+labels from display_name. The seed is also the LOUD fallback: an unreachable API or a credential-less
+box serves seed+cache and says so (stderr + /version.modelCatalog), never a quietly stale list. The
+refresh is EVENT-keyed — boot, plus the exact staleness event of a claude-* id reaching a set path or
+the pick store that the merged list does not know — never a timer. A durable cache
+(STATE/model-catalog.json) means a dead API never blanks a picker.
+
+The Models API leg runs against a HERMETIC fake here (a local HTTP server; the kernel's fetch URL is
+redirected), never the network: CI has no credential and must never make one. Synthetic fixtures
+throughout (a made-up "claude-opus-9-9" stands in for a future release).
+"""
+import io
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from contextlib import redirect_stderr
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load — bin/romp-kernel resolves its state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["ROMP_MODELS_URL"] = "http://127.0.0.1:9/v1/models"   # a dead port until a test points it at the fake
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_mc", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_mc", os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+jd = km.jd
+
+# The rows a live account might see (2026-09-01 shape): a genuinely new version, dated snapshots, a
+# suffixed variant, the pre-4 naming — every kind the merge must classify. Synthetic future id included.
+FAKE_ROWS = [
+    {"id": "claude-opus-9-9", "display_name": "Claude Opus 9.9", "created_at": "2027-01-01T00:00:00Z"},
+    {"id": "claude-fable-5-1", "display_name": "Claude Fable 5.1", "created_at": "2026-08-28T00:00:00Z"},
+    {"id": "claude-opus-4-5-20251101", "display_name": "Claude Opus 4.5", "created_at": "2025-11-24T00:00:00Z"},
+    {"id": "claude-opus-4-6-fast", "display_name": "Opus 4.6 Fast", "created_at": "2026-02-10T00:00:00Z"},
+    {"id": "claude-3-5-sonnet-20241022", "display_name": "Claude Sonnet 3.5 (New)", "created_at": "2024-10-22T00:00:00Z"},
+    {"id": "claude-haiku-4-5-20251001", "display_name": "Claude Haiku 4.5", "created_at": "2025-10-15T00:00:00Z"},
+]
+
+
+def _reset_catalog():
+    """Back to the shipped seed — every test starts from what the build carries."""
+    km._apply_model_catalog(km._MODEL_SEED, "seed")
+    km._catalog_status.update({"fetchedAt": None, "lastError": None, "inflight": False})
+    km._catalog_asked.clear()
+
+
+class MergeRules(unittest.TestCase):
+    """merge_model_catalog is pure — the rules, red-first."""
+
+    def test_a_new_version_joins_its_family_newest_first_with_the_api_label(self):
+        merged = km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS)
+        self.assertEqual(merged["opus"][0], {"value": "claude-opus-9-9", "label": "Opus 9.9"})
+        self.assertEqual([v["value"] for v in merged["opus"]][1:],
+                         [v["value"] for v in km._MODEL_SEED["opus"]], "the seed order survives beneath it")
+
+    def test_add_only_a_seed_id_the_api_omits_stays(self):
+        # the live list (2026-09-01) carries claude-opus-4-5-20251101 but NOT the dateless
+        # claude-opus-4-5 the seed lists — key-scoped visibility; the seed entry must never vanish
+        merged = km.merge_model_catalog(km._MODEL_SEED, [r for r in FAKE_ROWS if r["id"] != "claude-opus-9-9"])
+        self.assertIn("claude-opus-4-5", [v["value"] for v in merged["opus"]])
+        for fam, vs in km._MODEL_SEED.items():
+            for v in vs:
+                self.assertIn(v["value"], [m["value"] for m in merged[fam]], "%s dropped" % v["value"])
+
+    def test_routing_ids_never_join(self):
+        merged = km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS)
+        flat = [v["value"] for vs in merged.values() for v in vs]
+        for bad in ("claude-opus-4-5-20251101", "claude-opus-4-6-fast", "claude-3-5-sonnet-20241022",
+                    "claude-haiku-4-5-20251001"):
+            self.assertNotIn(bad, flat, "%s is a deployment/routing id, not a pickable version" % bad)
+        self.assertIsNone(km._catalog_family("claude-opus-4-5-20251101"))
+        self.assertIsNone(km._catalog_family("claude-opus-4-6-fast"))
+        self.assertIsNone(km._catalog_family("claude-3-5-sonnet-20241022"))
+        self.assertIsNone(km._catalog_family("opus"))
+        self.assertEqual(km._catalog_family("claude-fable-5-1"), "fable")
+
+    def test_an_already_seeded_id_is_not_doubled(self):
+        merged = km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS)
+        self.assertEqual([v["value"] for v in merged["fable"]].count("claude-fable-5-1"), 1)
+        self.assertEqual(merged["fable"][0]["label"], "Fable 5.1", "the seed's own label stands")
+
+    def test_version_ordering_is_by_the_ids_own_tuple(self):
+        self.assertGreater(km._version_key("claude-opus-5"), km._version_key("claude-opus-4-8"))
+        self.assertGreater(km._version_key("claude-fable-5-1"), km._version_key("claude-fable-5"))
+        self.assertGreater(km._version_key("claude-opus-4-10"), km._version_key("claude-opus-4-9"),
+                           "numeric, not lexical")
+
+    def test_labels_derive_from_display_name_or_the_id(self):
+        self.assertEqual(km._catalog_label("Claude Sonnet 6", "claude-sonnet-6"), "Sonnet 6")
+        self.assertEqual(km._catalog_label("", "claude-sonnet-6-2"), "Sonnet 6.2")
+        self.assertEqual(km._catalog_label(None, "claude-haiku-5"), "Haiku 5")
+
+    def test_merge_is_pure(self):
+        before = json.dumps(km._MODEL_SEED, sort_keys=True)
+        km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS)
+        self.assertEqual(json.dumps(km._MODEL_SEED, sort_keys=True), before)
+
+
+class ApplyInPlace(unittest.TestCase):
+    """The running table is mutated in place, so every consumer sees the merge without re-import."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        _reset_catalog()
+
+    def tearDown(self):
+        _reset_catalog()
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def test_every_consumer_sees_a_newly_applied_id(self):
+        opus_list = km.MODEL_VERSIONS["opus"]           # a reference held before the apply
+        self.assertNotIn("claude-opus-9-9", km._VERSION_FAMILY)
+        self.assertNotIn("claude-opus-9-9", km._JUDGE_MODEL_VALUES)
+        added = km._apply_model_catalog(km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS), "api")
+        self.assertEqual(added, ["claude-opus-9-9"])
+        self.assertIs(km.MODEL_VERSIONS["opus"], opus_list, "the list object is mutated, never rebound")
+        self.assertEqual(opus_list[0]["value"], "claude-opus-9-9")
+        self.assertEqual(km._VERSION_FAMILY["claude-opus-9-9"], "opus")
+        self.assertIn("claude-opus-9-9", km._JUDGE_MODEL_VALUES, "the judge setters accept it now")
+        self.assertEqual(km._catalog_status["added"], ["claude-opus-9-9"])
+        self.assertEqual(km._catalog_status["source"], "api")
+
+    def test_a_pick_unknown_before_the_refresh_is_honored_after_it(self):
+        # pick-migration, the forward direction: the user's pin names a model this build never heard
+        # of — dropped as foreign today; honored the moment the catalog learns the id
+        (jd.STATE / km.MODEL_PICKS_FILE_NAME).write_text(json.dumps({"opus": "claude-opus-9-9"}))
+        self.assertEqual(km._model_picks(), {}, "unknown before the refresh")
+        km._apply_model_catalog(km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS), "api")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-9-9"})
+
+    def test_a_legacy_fable_pin_stays_valid_and_is_moved_by_a_new_pick(self):
+        # pick-migration, the other direction (the switch sweep's contract): claude-fable-5 remains a
+        # KNOWN version after 5.1 joins, so a lingering pin is honored, not auto-dropped — the sweep
+        # must actively re-pick 5.1 for family-newest to win; and one pick of 5.1 moves the pin
+        (jd.STATE / km.MODEL_PICKS_FILE_NAME).write_text(json.dumps({"fable": "claude-fable-5"}))
+        self.assertEqual(km._model_picks(), {"fable": "claude-fable-5"})
+        km._note_model_pick("claude-fable-5-1")
+        self.assertEqual(km._model_picks(), {"fable": "claude-fable-5-1"})
+        self.assertEqual(km.MODEL_VERSIONS["fable"][0]["value"], "claude-fable-5-1",
+                         "no pin at all → family-newest is 5.1")
+
+
+class _FakeModelsAPI(BaseHTTPRequestHandler):
+    rows = list(FAKE_ROWS)
+    status = 200
+    seen = []          # (path, x-api-key present, anthropic-version) per request
+    page_size = 100
+
+    def do_GET(self):
+        type(self).seen.append((self.path, bool(self.headers.get("x-api-key")),
+                                self.headers.get("anthropic-version")))
+        if self.status != 200:
+            self.send_response(self.status); self.end_headers(); self.wfile.write(b'{"type":"error"}')
+            return
+        if not self.headers.get("x-api-key"):
+            self.send_response(401); self.end_headers(); self.wfile.write(b'{"type":"error"}')
+            return
+        rows = list(type(self).rows)
+        after = None
+        if "after_id=" in self.path:
+            after = urllib.parse.unquote(self.path.split("after_id=", 1)[1].split("&")[0])
+            ids = [r["id"] for r in rows]
+            rows = rows[ids.index(after) + 1:] if after in ids else []
+        page = rows[:self.page_size]
+        body = {"data": page, "has_more": len(rows) > len(page),
+                "first_id": page[0]["id"] if page else None, "last_id": page[-1]["id"] if page else None}
+        out = json.dumps(body).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers(); self.wfile.write(out)
+
+    def log_message(self, *a):
+        pass
+
+
+class FetchAndFallback(unittest.TestCase):
+    """The Models API leg against a hermetic fake — success caches and merges; every failure is loud."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), _FakeModelsAPI)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        self._url, self._fn = km.MODELS_API_URL, getattr(jd, "_WORK_KEY_FN", None)
+        self._env_key = os.environ.get("ANTHROPIC_API_KEY")
+        os.environ["ANTHROPIC_API_KEY"] = "synthetic-test-credential"   # the fake sees only this (never a key-shaped string: the pre-commit scanner)
+        jd._WORK_KEY_FN = None
+        km.MODELS_API_URL = "http://127.0.0.1:%d/v1/models" % self.port
+        _FakeModelsAPI.rows, _FakeModelsAPI.status, _FakeModelsAPI.page_size = list(FAKE_ROWS), 200, 100
+        _FakeModelsAPI.seen = []
+        os.environ.pop("ROMP_MODEL_CATALOG", None)
+        _reset_catalog()
+
+    def tearDown(self):
+        _reset_catalog()
+        km.MODELS_API_URL = self._url
+        jd._WORK_KEY_FN = self._fn
+        if self._env_key is None:
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+        else:
+            os.environ["ANTHROPIC_API_KEY"] = self._env_key
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def _refresh(self, reason="test"):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            started = km._refresh_model_catalog(reason, _async=False)
+        return started, err.getvalue()
+
+    def test_success_merges_caches_and_announces_the_additions(self):
+        started, log = self._refresh()
+        self.assertTrue(started)
+        self.assertEqual(km.MODEL_VERSIONS["opus"][0]["value"], "claude-opus-9-9")
+        self.assertEqual(km._catalog_status["source"], "api")
+        self.assertIsNone(km._catalog_status["lastError"])
+        self.assertIsInstance(km._catalog_status["fetchedAt"], int)
+        self.assertIn("claude-opus-9-9", log, "the additions are announced, not silent")
+        cache = json.loads((jd.STATE / km.MODEL_CATALOG_FILE_NAME).read_text())
+        self.assertEqual([r["id"] for r in cache["models"]], [r["id"] for r in FAKE_ROWS])
+        path, keyed, ver = _FakeModelsAPI.seen[0]
+        self.assertTrue(keyed, "the kernel's own credential rides the request")
+        self.assertEqual(ver, "2023-06-01")
+        self.assertIn("limit=100", path)
+
+    def test_paging_follows_has_more(self):
+        _FakeModelsAPI.page_size = 2
+        started, _ = self._refresh()
+        self.assertTrue(started)
+        self.assertEqual(len(_FakeModelsAPI.seen), 3, "6 rows / 2 per page = 3 requests")
+        self.assertTrue(any("after_id=" in p for p, _, _ in _FakeModelsAPI.seen))
+        self.assertEqual(km.MODEL_VERSIONS["opus"][0]["value"], "claude-opus-9-9")
+
+    def test_a_server_error_is_loud_and_leaves_the_seed_standing(self):
+        _FakeModelsAPI.status = 500
+        started, log = self._refresh("boot")
+        self.assertTrue(started)
+        self.assertEqual(km.MODEL_VERSIONS["opus"][0]["value"], "claude-opus-5", "seed intact")
+        self.assertEqual(km._catalog_status["source"], "seed")
+        self.assertIn("HTTPError", km._catalog_status["lastError"])
+        self.assertIn("Models API unreachable", log)
+        self.assertIn("serving the seed list", log)
+        self.assertFalse((jd.STATE / km.MODEL_CATALOG_FILE_NAME).exists(), "no cache is written from a failure")
+
+    def test_a_dead_endpoint_is_loud_too(self):
+        km.MODELS_API_URL = "http://127.0.0.1:%d/v1/models" % _free_port()
+        started, log = self._refresh()
+        self.assertTrue(started)
+        self.assertIn("URLError", km._catalog_status["lastError"])
+        self.assertIn("Models API unreachable", log)
+
+    def test_no_credential_says_so_and_serves_the_seed(self):
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+        started, log = self._refresh("boot")
+        self.assertTrue(started)
+        self.assertEqual(_FakeModelsAPI.seen, [], "no request without a credential")
+        self.assertIn("no API credential", km._catalog_status["lastError"])
+        self.assertIn("no API credential the kernel can use", log)
+        self.assertEqual(km.MODEL_VERSIONS["fable"][0]["value"], "claude-fable-5-1", "seed still serves")
+
+    def test_the_cache_serves_when_the_api_later_dies(self):
+        # a dead API never blanks a picker: the previous fetch's rows install at boot from the cache
+        self._refresh()
+        _reset_catalog()
+        self.assertNotIn("claude-opus-9-9", km._VERSION_FAMILY)
+        n = km._load_model_catalog_cache()
+        self.assertEqual(n, len(FAKE_ROWS))
+        self.assertIn("claude-opus-9-9", km._VERSION_FAMILY)
+        self.assertEqual(km._catalog_status["source"], "cache")
+        _FakeModelsAPI.status = 500
+        started, log = self._refresh("boot")
+        self.assertIn("claude-opus-9-9", km._VERSION_FAMILY, "the failure never rolls the cache back")
+        self.assertIn("serving the cache list (1 extra id(s) beyond the seed)", log)
+
+    def test_off_switch_never_fetches(self):
+        os.environ["ROMP_MODEL_CATALOG"] = "off"
+        try:
+            started, log = self._refresh()
+        finally:
+            os.environ.pop("ROMP_MODEL_CATALOG", None)
+        self.assertFalse(started)
+        self.assertEqual(_FakeModelsAPI.seen, [])
+        self.assertEqual(log, "")
+
+    def test_version_route_reports_the_catalog(self):
+        self._refresh()
+        v = km._version_info()["modelCatalog"]
+        self.assertEqual(v["source"], "api")
+        self.assertEqual(v["added"], ["claude-opus-9-9"])
+        self.assertIsNone(v["lastError"])
+
+
+class StalenessEvent(unittest.TestCase):
+    """The refresh fires on the exact event — an unknown claude-* id — once per id, never on a clock."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        os.environ["ROMP_MODEL_CATALOG"] = "off"   # the event's FIRING is what these test, not the fetch
+        _reset_catalog()
+        self.fired = []
+        self._orig = km._refresh_model_catalog
+        km._refresh_model_catalog = lambda reason, _async=True: (self.fired.append(reason), True)[1]
+
+    def tearDown(self):
+        km._refresh_model_catalog = self._orig
+        os.environ.pop("ROMP_MODEL_CATALOG", None)
+        _reset_catalog()
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def test_an_unknown_version_id_fires_exactly_once(self):
+        self.assertTrue(km._note_unknown_model("claude-opus-9-9"))
+        self.assertFalse(km._note_unknown_model("claude-opus-9-9"), "dedup by id — no second refresh")
+        self.assertEqual(self.fired, ["unknown model id claude-opus-9-9"])
+
+    def test_known_ids_aliases_snapshots_and_garbage_never_fire(self):
+        for v in ("claude-opus-5", "claude-fable-5-1", "opus", "default", "claude-opus-4-5-20251101",
+                  "claude-opus-4-6-fast", "total-nonsense", "", None):
+            self.assertFalse(km._note_unknown_model(v), repr(v))
+        self.assertEqual(self.fired, [])
+
+    def test_the_pick_store_and_the_set_path_are_wired(self):
+        (jd.STATE / km.MODEL_PICKS_FILE_NAME).write_text(json.dumps({"opus": "claude-opus-9-9"}))
+        km._model_picks()
+        self.assertEqual(self.fired, ["unknown model id claude-opus-9-9"])
+        km._note_model_pick("claude-sonnet-7")          # the choke point every set surface flows through
+        self.assertEqual(self.fired[-1], "unknown model id claude-sonnet-7")
+
+
+class CliBlocks(unittest.TestCase):
+    """A version the installed CLI refuses by minimum version says so on its /models row (T222)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        _reset_catalog()
+
+    def tearDown(self):
+        _reset_catalog()
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    REFUSAL = ("API Error: 400 Claude Code 2.1.221 does not support this model; version 2.1.251 or "
+               "newer is required. Run 'claude update', or update the Claude desktop app, then try again.")
+
+    def test_the_backend_records_the_refusal_and_a_real_reply_clears_it(self):
+        self.assertTrue(sb.note_cli_model_block(jd.STATE, "claude-fable-5-1", self.REFUSAL))
+        d = json.loads((jd.STATE / sb.CLI_MODEL_BLOCKS_FILE).read_text())
+        self.assertEqual(d["claude-fable-5-1"]["needs"], "2.1.251")
+        self.assertEqual(d["claude-fable-5-1"]["cli"], "2.1.221")
+        self.assertFalse(sb.note_cli_model_block(jd.STATE, "claude-fable-5-1", "API Error: 529 Overloaded"),
+                         "only the version refusal records — never another error")
+        self.assertFalse(sb.note_cli_model_block(jd.STATE, "opus", self.REFUSAL), "aliases are not version rows")
+        self.assertTrue(sb.clear_cli_model_block(jd.STATE, "claude-fable-5-1"))
+        self.assertFalse(sb.clear_cli_model_block(jd.STATE, "claude-fable-5-1"))
+        self.assertEqual(json.loads((jd.STATE / sb.CLI_MODEL_BLOCKS_FILE).read_text()), {})
+
+    def test_the_models_row_wears_the_block_until_it_lifts(self):
+        sb.note_cli_model_block(jd.STATE, "claude-fable-5-1", self.REFUSAL)
+        row = km._with_cli_block({"value": "claude-fable-5-1", "label": "Fable 5.1"}, km._cli_model_blocks())
+        self.assertEqual(row["cliNeeds"], "2.1.251")
+        self.assertEqual(row["label"], "Fable 5.1 — needs CLI ≥ 2.1.251")
+        plain = km._with_cli_block({"value": "claude-fable-5", "label": "Fable 5"}, km._cli_model_blocks())
+        self.assertNotIn("cliNeeds", plain)
+        self.assertEqual(plain["label"], "Fable 5")
+        sb.clear_cli_model_block(jd.STATE, "claude-fable-5-1")
+        lifted = km._with_cli_block({"value": "claude-fable-5-1", "label": "Fable 5.1"}, km._cli_model_blocks())
+        self.assertEqual(lifted["label"], "Fable 5.1")
+
+    def test_the_stream_hook_is_wired_at_the_error_settle(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        self.assertIn("note_cli_model_block(self.backend.state_dir, self.chosen_model or self.model,", src)
+        self.assertIn("clear_cli_model_block(self.backend.state_dir, _mid)", src)
+
+
+class ModelsRoute(unittest.TestCase):
+    """GET /models serves the MERGED list plus any CLI block — every picker reads this one route."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        os.environ["ROMP_MODEL_CATALOG"] = "off"
+        _reset_catalog()
+
+    def tearDown(self):
+        _reset_catalog()
+        os.environ.pop("ROMP_MODEL_CATALOG", None)
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def _models(self):
+        req = urllib.request.Request("http://127.0.0.1:%d/models" % self.port,
+                                     headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode())
+
+    def test_the_route_serves_the_merged_versions_and_the_block(self):
+        km._apply_model_catalog(km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS), "api")
+        sb.note_cli_model_block(jd.STATE, "claude-opus-9-9", CliBlocks.REFUSAL)
+        rows = {m["value"]: m for m in self._models()["models"]}
+        opus = rows["opus"]["versions"]
+        self.assertEqual(opus[0]["value"], "claude-opus-9-9")
+        self.assertEqual(opus[0]["cliNeeds"], "2.1.251")
+        self.assertIn("needs CLI ≥ 2.1.251", opus[0]["label"])
+        self.assertEqual(rows["fable"]["versions"][0], {"value": "claude-fable-5-1", "label": "Fable 5.1"})
+        self.assertEqual(rows["fable"]["default"], "claude-fable-5-1", "no pin → family-newest is 5.1")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -43,6 +43,11 @@ class Catalog(unittest.TestCase):
                 self.assertNotRegex(v["value"], r"-20\d{6}$", "dated snapshot id leaked in")
         self.assertEqual(km.MODEL_VERSIONS["opus"][0]["value"], "claude-opus-5")
         self.assertEqual(km.MODEL_VERSIONS["sonnet"][0]["value"], "claude-sonnet-5")
+        # T222 (the user 2026-09-01): Fable 5.1 heads the fable family — verified live against the
+        # Models API (created 2026-08-28) and the installed CLI (2.1.257) before it was seeded
+        self.assertEqual(km.MODEL_VERSIONS["fable"][0], {"value": "claude-fable-5-1", "label": "Fable 5.1"})
+        self.assertIn("claude-fable-5", [v["value"] for v in km.MODEL_VERSIONS["fable"]],
+                      "the legacy fable stays pickable (add-only, never a silent drop)")
         self.assertIn("claude-opus-4-8", [v["value"] for v in km.MODEL_VERSIONS["opus"]],
                       "legacy versions live on the API stay pickable")
 

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -221,7 +221,8 @@ class _ShipLab(unittest.TestCase):
                        CLAUDE_CONFIG_DIR=claude,
                        ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
                        ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
-                       ROMP_DIST_DIR=dist)
+                       ROMP_DIST_DIR=dist,
+                       ROMP_MODEL_CATALOG="off")   # hermetic: the T222 catalog fetch must never reach the network
         cls.env.pop("ROMP_STATE_DIR", None)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],


### PR DESCRIPTION
T222: Fable 5.1 everywhere, and romp stops needing a hand edit when Anthropic ships a model.

## Seed
The fable family gains `claude-fable-5-1` / "Fable 5.1", newest-first. Verified before seeding against the live Models API (`GET /v1/models`: id present, display "Claude Fable 5.1", created 2026-08-28, newest on the account) and against the installed CLI on a throwaway SDK session that ran a real turn end to end. That CLI check is what found the gap this feature exists for: the binary installed at the time (2.1.221) refused the id with "version 2.1.251 or newer is required" — valid on the API is not the same as usable — so the catalog now surfaces exactly that on the row.

## The live catalog
`MODEL_VERSIONS` is now the **seed** and the loud fallback. The kernel queries the Models API on its own credential (the manager-env key the SDK backend claims, else an auth-token bearer) and merges new version ids into the families **add-only**: an id the API omits but the seed knows stays (key-scoped visibility differs per account); dated snapshots, `-fast` variants and the pre-4 naming never join (routing ids, not versions — the alias-table lesson); each family sorts newest-first by the id's own version tuple, labels from `display_name`. Applied **in place** (family lists, reverse map, judge-setter allowed set mutated, never rebound), so `/models`, `_model_picks` validity and `setJudgeModel` all see the merge without re-import — every picker surface keeps reading the one route. Cached durably (`STATE/model-catalog.json`) so a dead API never blanks a picker; the cache installs before the boot fetch.

**Refresh is event-keyed, never a timer**: boot, plus the exact staleness event — a `claude-*` version id reaching the set choke point or the pick store that the merged list does not know — one refresh per unknown id per kernel life. Unreachable API or a credential-less box serves seed+cache and **says so** (stderr line + `/version.modelCatalog`). `ROMP_MODEL_CATALOG=off` disables the fetch (every hermetic lab kernel sets it; CI never reaches the network); `ROMP_MODELS_URL` points tests at a fake.

**CLI refusals on the row**: the SDK backend records the CLI's own minimum-version refusal at the first attempt (only that exact error shape) and the first real reply on the model lifts it; `/models` stamps `cliNeeds` and a label suffix ("— needs CLI ≥ 2.1.251") every picker renders as-is, so the reason shows before the next pick.

## Tests
`tests/test_model_catalog.py` (hermetic; the API leg against a local fake server): merge rules red-first, in-place apply reaching every consumer, pick migration both directions (an unknown pin honored after refresh; the legacy fable pin stays valid and moves on one pick of 5.1 — the sweep's contract), fetch + paging + cache, every failure path loud with the seed standing, the off switch, staleness-event dedup and wiring, the CLI block round-trip and its `/models` rendering. Anchors retargeted in `test_model_versions` / `test_kernel_judge_model`; lab kernels in `test_gear_select_matrix` / `test_ship_reship` boot with the catalog off.

Suites on this head: pytest 6457 passed + 335 subtests; npm 2639 pass / 0 fail.

## Rollout notes (not in this diff)
CLI updated on the devbox 2.1.221 → 2.1.257 (npm-global; pin-back `sudo npm install -g @anthropic-ai/claude-code@2.1.221`), verified end to end before the sweep. All 46 live fable sessions were set to the full `claude-fable-5-1` id kernel-mediated; each applies at its next turn. The lingering `fable: claude-fable-5` pick pin migrates kernel-mediated once this kernel deploys (the running kernel's table predates 5.1, so it records nothing for the id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)