### PR TITLE
hostUp no longer re-ships uploads — the relay's own open is the one exact event

### DIFF
--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -58,10 +58,11 @@ class SourcePins(unittest.TestCase):
         self.assertIn("interface PendingShip { name: string; shipId: string; b64?: string }", RENDER)
         self.assertIn("if (entry) entry.b64 = b64;", RENDER)
         self.assertIn('window.addEventListener("romp:wsup", () => reshipPendingUploads());', RENDER)
-        # …and the federated twin events (review finding 2026-09-01): the relay's own redial and the
-        # kernel-reported tunnel recovery each re-ship THEIR host's entries — scoped by ack socket
+        # …and the federated twin (review finding 2026-09-01): the relay's own (re)open re-ships THAT
+        # host's entries — scoped by ack socket. The kernel-reported hostUp does NOT: it fires in the
+        # tick federation re-dials the relay, before the socket is open (second review, same day)
         self.assertIn('window.addEventListener("romp:hostRelayUp", (e) => {', RENDER)
-        self.assertIn("if (Array.isArray(m.hosts)) reshipPendingUploads(m.hosts.map(String));", RENDER)
+        self.assertNotIn("reshipPendingUploads(m.hosts", RENDER)
 
     def test_ack_echoes_shipid_and_a_stray_twin_is_dropped(self):
         self.assertIn('ack["shipId"] = str(msg["shipId"])', KERNEL_SRC)

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -43,8 +43,7 @@ test("render.ts's message listener heals previews unconditionally at the top, so
 
 // ── RECONNECT-class heals go further than the per-message retry (the user 2026-08-24) ───────────
 test("hostUp also drains the settled chips and un-parks the path-image chips", () => {
-  // block form since T215's review round: the recovered hosts' pending uploads re-ship here too
-  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{\s*\n\s*refreshSettledPreviews\(\); healPathImgs\(\);/,
+  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{ refreshSettledPreviews\(\); healPathImgs\(\); \}/,
     "a tunnel recovery re-attempts spent budgets and imgFailed paths — bounded by the event's rarity");
 });
 

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -124,8 +124,11 @@ test("federated sessions heal too: every ack socket's comeback re-ships ITS entr
   // it, the chat re-ships on it (v1 listened to romp:wsup alone and never healed federated wedges)
   assert.match(FED, /window\.dispatchEvent\(new CustomEvent\("romp:hostRelayUp", \{ detail: \{ host: conn\.host \} \}\)\);/);
   assert.match(RENDER, /window\.addEventListener\("romp:hostRelayUp", \(e\) => \{/);
-  // and the kernel-reported tunnel recovery re-ships the recovered hosts' entries alongside
-  assert.match(RENDER, /if \(Array\.isArray\(m\.hosts\)\) reshipPendingUploads\(m\.hosts\.map\(String\)\);/);
+  // …and NOT the kernel-reported hostUp: federation dispatches it in the tick it re-dials the relay,
+  // so the socket is still CONNECTING and a re-ship there raised a false "unreachable" toast an RTT
+  // before the relay's own onopen re-shipped correctly (review finding 2026-09-01, reverted here)
+  assert.doesNotMatch(RENDER, /m\.hosts\.map\(String\)/, "hostUp must not re-ship — romp:hostRelayUp is the event");
+  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{ refreshSettledPreviews\(\); healPathImgs\(\); \}/);
 });
 
 test("dismissing the LAST pending chip settles an armed hold loudly — never a forever-wait (T215 review)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10752,10 +10752,11 @@ function retirePendingShip(key: string, shipId?: string): string | null {
 // entry with no payload yet is one whose FileReader is still encoding — its own onload ships through
 // the fresh socket, so it is deliberately skipped here, never doubled.
 // SCOPED to the socket that reconnected: a remote session's ack rides that host's RELAY, not the
-// pane socket, so romp:wsup re-ships local entries only, and the host-back events below carry their
-// hosts (review finding 2026-09-01: v1 listened to romp:wsup alone, whose entries-of-every-host
-// re-ship both missed the remote relay's own redial — which fires neither romp:wsup nor hostUp — and
-// re-sent remote payloads into a relay that was still down).
+// pane socket, so romp:wsup re-ships local entries only, and the relay's own (re)open event below
+// carries its host (review finding 2026-09-01: v1 listened to romp:wsup alone, whose entries-of-
+// every-host re-ship both missed the remote relay's own redial — which fires no romp:wsup — and
+// re-sent remote payloads into a relay that was still down; the kernel-reported hostUp is NOT a
+// re-ship event either — see the handler — because it precedes the relay's open by a round trip).
 function reshipPendingUploads(hosts?: readonly string[]): void {
   if (!vscodeApi) return;
   for (const [id, list] of pendingShips) {
@@ -11933,12 +11934,12 @@ window.addEventListener("message", (e: MessageEvent) => {
   // a RECONNECT-class event goes further: settled chips (budget spent) re-attempt regardless of
   // their error text, and the path-image chips parked in imgFailed get one fresh host round-trip
   // (bounded: reconnects are rare events, never a per-push loop)
-  if (m.type === "hostUp") {
-    refreshSettledPreviews(); healPathImgs();
-    // the recovered hosts' owed acks are reachable again — re-ship their retained uploads too
-    // (the relay's own redial also heals via romp:hostRelayUp; both are idempotent by shipId)
-    if (Array.isArray(m.hosts)) reshipPendingUploads(m.hosts.map(String));
-  }
+  // hostUp deliberately does NOT re-ship pending uploads (review finding 2026-09-01): federation
+  // dispatches it in the same synchronous tick it re-dials a recovered host's relay, so the socket is
+  // still CONNECTING — a re-ship here hit outbound's readyState gate and raised a false "unreachable —
+  // dropFile was not delivered" toast (and tore down an in-flight provisional create) an RTT before
+  // the relay's own onopen re-shipped correctly. romp:hostRelayUp IS that onopen — the one exact event.
+  if (m.type === "hostUp") { refreshSettledPreviews(); healPathImgs(); }
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {
     globalRetryPaused = !!m.value;


### PR DESCRIPTION
Follow-up to the T215 re-ship change (PR 863), fixing the one real regression the T222 adversarial review confirmed (both verifiers upheld the chain by code reading).

**The bug.** Federation's recovery poll marks a recovered host live and calls `connect()` — `new WebSocket(...)`, so the relay sits at CONNECTING — then dispatches `{type:"hostUp", hosts}` in the same synchronous tick. The `hostUp` handler's re-ship posted each retained `dropFile` immediately; `outbound`'s readyState gate refused the CONNECTING socket and `dropWarn`ed, so the user saw a false "H is unreachable — dropFile was not delivered" toast per pending upload at the exact moment the host came back (and, with a session create in flight, the warn was taken as the create's verdict and tore the provisional tab down). One round trip later the relay's own `onopen` fired `romp:hostRelayUp` and re-shipped correctly, retiring the chip: loud false failure, then silent success.

**The fix is a deletion.** `romp:hostRelayUp` is dispatched by that relay's own `onopen` — including the open the recovery poll just triggered — so it already covers every case `hostUp` was meant to. `hostUp` goes back to its preview heals only, with the reason left at the handler. Pins retargeted to assert the absence with the why (`pending-attach`, `heal-on-hostup`, the SourcePins twin in `test_ship_reship`).

Suites run on this head before merge (auto-merge gates on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)