### PR TITLE
A comment thread's name opens the thread, never a namesake tab; threads stay dormant at boot; closed threads never reopen

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1807,7 +1807,11 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp new: kernel not reachable on :$_kport (is romp running?). \`romp new -t $session_arg\` starts a terminal session without it." >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
-        if [[ "$_resp" == *'"existing"'* ]]; then
+        if [[ "$_resp" == *'"thread": true'* || "$_resp" == *'"thread":true'* ]]; then
+            # a comment THREAD owns this name (T223): nothing was created — the ask landed on the
+            # thread itself, which has no tab; it is reached from its parent session's comments
+            echo "romp new: \"$session_arg\" is a comment thread (no tab) — nothing created; open it from its session's comments"
+        elif [[ "$_resp" == *'"existing"'* ]]; then
             echo "romp new: \"$session_arg\" is already running; see the dashboard (romp)"
         else
             echo "romp new: started \"$session_arg\" (SDK session, working in $_dir)"
@@ -1830,10 +1834,15 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         # session EXISTS by now (the /new above acked), so a failed send names the exact
         # retry command instead of pretending the spawn failed.
         if [[ -n "$msg_arg" ]]; then
+            # address the send by the ID the kernel just answered with, never by name: a comment
+            # thread's name resolves to no live session by design, so a by-name send to it used to
+            # ack ok and land nowhere (T223)
             _mpayload="$(python3 -c 'import json,sys
-d = {"name": sys.argv[1], "text": sys.argv[2]}
+r = json.loads(sys.argv[4]) if len(sys.argv) > 4 and sys.argv[4] else {}
+d = ({"id": r["id"]} if r.get("id") else {"name": sys.argv[1]})
+d["text"] = sys.argv[2]
 if len(sys.argv) > 3 and sys.argv[3]: d["tag"] = sys.argv[3]
-print(json.dumps(d))' "$session_arg" "$msg_arg" "$tag_arg")"
+print(json.dumps(d))' "$session_arg" "$msg_arg" "$tag_arg" "$_resp")"
             _mresp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/send" \
                           -H 'Content-Type: application/json' -d "$_mpayload")" \
                 || { echo "romp new: session is up but the message did NOT land (kernel send failed). Retry: romp send $session_arg '<text>'" >&2; exit 1; }

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -939,6 +939,25 @@ def _apply_model_catalog(merged, source):
     return added
 
 
+def _family_newest_model(mid):
+    """The family's newest FULL id when `mid` is a superseded full id of that family (claude-fable-5 →
+    claude-fable-5-1), else None: a bare alias (fable) has no family here and auto-tracks on its own;
+    the newest id itself, an unknown id, or a non-version id (dated snapshot) remaps to nothing. The
+    thread WAKE path uses this (T223 rider, the user 2026-09-01): a dormant comment thread registered
+    on a superseded full id comes up on family-newest at its next EXPLICIT open — nothing may wake it
+    just to fix the id, so the remap happens only when it is being woken anyway."""
+    fam = _catalog_family(mid)
+    if not fam:
+        return None
+    with _catalog_lock:
+        rows = list(MODEL_VERSIONS.get(fam) or [])
+    full = [v["value"] for v in rows if _catalog_family(v.get("value"))]   # versioned ids only
+    if not full or mid not in full:
+        return None                          # an id the catalog does not list is not ours to remap
+    newest = max(full, key=_version_key)
+    return newest if _version_key(newest) > _version_key(mid) else None
+
+
 def _catalog_cache_path():
     return jd.STATE / MODEL_CATALOG_FILE_NAME
 
@@ -7569,6 +7588,8 @@ def _comment_status_refusal(prior):
         return "this thread is being relayed back to the session; give it a moment."
     if prior == "merged":
         return "this discussion was already relayed; reply in the thread to continue it."
+    if prior == "resolved":
+        return "this thread was closed; start a new comment to continue the conversation."
     return "that thread is gone."
 
 
@@ -8090,12 +8111,16 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
 
 
 def _comment_reply(parent_sid, tid, text):
-    """Send the user's next message into an existing thread. A resolved thread reopens — replying IS
-    the reopen gesture (event-based; no separate arm). Returns an error string or None."""
+    """Send the user's next message into a thread. A thread the user CLOSED (resolved) never reopens
+    (the user 2026-09-01, standing rule: closed threads stay on disk, never revived) — the reply is
+    refused with the reason, and a new comment starts a new thread; this retires the 2026-08-22
+    "replying reopens a resolved thread" arm. A RELAYED (merged) thread is not closed: T145 (the user
+    2026-08-28) keeps it talkable — a reply is the explicit gesture that continues it, and the next
+    relay carries only the new tail. Returns an error string or None."""
     be = Sessions.backend_for(parent_sid)
     if not hasattr(be, "fork"):
         return "threads need the SDK backend."
-    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved", "merged"),
+    prior, th = _comment_update_if(parent_sid, tid, ("open", "merged"),
                                    status="open", lastSeenT=int(time.time()))
     if th is None:
         if prior == "promoted":
@@ -8103,9 +8128,9 @@ def _comment_reply(parent_sid, tid, text):
             return "this thread is now the session '%s'; continue there." % (row.get("promotedName") or "")
         return _comment_status_refusal(prior)
     tsid = th["sid"]
-    if prior in ("resolved", "merged"):
-        # a RELAYED thread stays talkable (T145): replying reopens it exactly like a resolved one —
-        # the conversation continues, and a later relay sends only the new tail past relayedT
+    if prior == "merged":
+        # a RELAYED thread stays talkable (T145): the explicit reply continues it — the CLI comes
+        # back for exactly this gesture, and a later relay sends only the new tail past relayedT
         reg = _thread_reg(tsid)
         be.resume(reg.get("name") or ("thread-" + tsid[:8]), tsid)   # alive again; names/ untouched
     if not be.send(tsid, str(text)):
@@ -8187,7 +8212,11 @@ def _comment_merge(parent_sid, tid):
         be.send(parent_sid, body)
     except Exception as e:
         return _revert("the merge message could not be delivered: %s" % e)
-    _comment_update(parent_sid, tid, status="merged",
+    _comment_update(parent_sid, tid,
+                    # a thread the user CLOSED stays closed after its content is sent back (the user
+                    # 2026-09-01) — "merged" is the talkable status, and resolved→relay→reply must
+                    # not become the reopen door the direct reply refuses
+                    status=("resolved" if prior == "resolved" else "merged"),
                     relayedT=max((m.get("t") or 0) for m in msgs))
     if hasattr(be, "kill"):
         try:
@@ -8533,6 +8562,10 @@ def _sdk_locked():
             # store names no signed-in account — the same authority the usage bars trust, so the
             # pick can never sit in the UI as applied fact on a box that demonstrably cannot apply it
             _sdk_backend.login_ok = lambda: bool(_claude_account())
+            # a dormant comment thread registered on a superseded full model id comes up on its
+            # family's newest at its next EXPLICIT wake (T223 rider) — the catalog is the kernel's,
+            # so the backend consults this hook instead of importing it
+            _sdk_backend.thread_wake_model = _family_newest_model
             # silent mid-turn model swaps mint a completed card (the user 2026-08-23) — the backend
             # observes the transition; the judge store owns the card; the kernel wires the two
             type(_sdk_backend).on_model_fallback = staticmethod(
@@ -9475,7 +9508,8 @@ def _drive(msg, client):
         # Fork this conversation into a NEW parallel session (the user 2026-08-13). uuid (optional) is the
         # user message the fork cuts just BEFORE — absent means the whole conversation. LOUD on refusal;
         # on success the new tab arrives focused via _fork_session's own push.
-        err = _fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]), client=client)
+        err = _thread_name_refusal(str(msg["name"]).strip(), _thread_names()) \
+            or _fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]), client=client)
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "commentCreate" and msg.get("uuid") and msg.get("exact") and msg.get("text"):
@@ -9551,6 +9585,8 @@ def _drive(msg, client):
         new = str(msg["name"]).strip()
         if not NAME_RE.match(new):
             client["send"](json.dumps({"type": "warn", "text": "session names use letters, digits, . _ - only."}))
+        elif _thread_name_refusal(new, _thread_names()):     # a thread's name — never relabel onto it (T223)
+            client["send"](json.dumps({"type": "warn", "text": _thread_name_refusal(new, _thread_names())}))
         elif be.rename(sid, new):                         # live → tmux rename hook / SDK reg; dead → names file
             client["send"](json.dumps({"type": "renamed", "id": sid, "name": new}))
     else:
@@ -14019,6 +14055,52 @@ def _thread_rows():
     return out
 
 
+def _thread_names():
+    """name -> (tsid, parent) for every comment thread that is NOT promoted — every name it answers
+    to (the comments-store name AND the registry name; a pre-naming thread's reg says
+    "thread-<hash>" while its row has no name), dormant or alive (a thread whose parent was ended
+    is alive=False with its row still open, and a revived parent finds it again). The CREATE doors
+    (POST /new, WS createSession) and the RELABEL doors (/fork, /rename and their WS twins) must
+    consult this: a thread's name is taken, and minting or renaming a top-level session onto it
+    makes a NAMESAKE — a real session with its own CLI process, listed as a tab, poisoning every
+    by-name surface (T223, 2026-09-01: a model-set sweep drove `romp new --model … <name>` over
+    every reg incl. 20 dormant threads and minted 18 such namesakes). Returns None when the stores
+    cannot be read: callers REFUSE on None — an unverifiable name must never mint (fail toward
+    refusing, the standing rule; the first cut returned {} and silently reopened the door)."""
+    out = {}
+    try:
+        cdir = jd.STATE / "comments"
+        files = sorted(cdir.glob("*.json")) if cdir.is_dir() else []
+        for f in files:
+            parent = f.stem
+            for t in (_load_comments(parent).get("threads") or []):
+                if (t.get("status") or "open") == "promoted":
+                    continue
+                tsid = str(t.get("sid") or t.get("tid") or "")
+                if not tsid:
+                    continue
+                for nm in (str(t.get("name") or tsid[:8]),        # the row's name, or the bare hash
+                           str(_thread_reg(tsid).get("name") or "")):   # _thread_rows shows for a nameless row
+                    if nm:
+                        out.setdefault(nm, (tsid, parent))
+    except Exception:
+        sys.stderr.write("thread names: cannot read the comments stores — create/rename doors "
+                         "refuse until they can: %s\n" % traceback.format_exc())
+        return None
+    return out
+
+
+def _thread_name_refusal(nm, names):
+    """The refusal text for a create/relabel door hitting a thread's name (None names = unverifiable)."""
+    if names is None:
+        return "couldn't verify \"%s\" against the comment threads — try again in a moment" % nm
+    hit = names.get(nm)
+    if not hit:
+        return ""
+    return ("\"%s\" is a comment thread of %s — open it from that session's comments, or pick another "
+            "name" % (nm, _name_of(hit[1]) or hit[1][:8]))
+
+
 # ── inbox-socket delivery (Claude Code ≥ 2.1.224) ──
 # The CLI binds a per-session Unix inbox socket and registers it — with its own session id and pid —
 # in ~/.claude/sessions/<pid>.json. One JSON line {"type":"user","message":{"role":"user","content":…}}
@@ -14557,7 +14639,13 @@ def _sid_of(who):
     if _name_of(who):
         return who
     live = Sessions.live()
-    return who if who in live else _live_names(live).get(who, who)
+    if who in live:
+        return who
+    hit = _live_names(live).get(who)
+    if hit:
+        return hit
+    th = (_thread_names() or {}).get(who)     # a comment thread's name: the explicit send reaches
+    return th[0] if th else who               # the THREAD (T223) — not a phantom sid spelled like a name
 
 
 def _optimistic_echo(sid, text, author="human"):
@@ -31438,6 +31526,18 @@ class Handler(BaseHTTPRequestHandler):
                     extra = _apply_new_session_prefs(live[nm], b)
                     return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True, **extra}),
                                       "application/json")
+                names = _thread_names()
+                if names is None:
+                    return self._send(503, json.dumps({"ok": False, "error": _thread_name_refusal(nm, None)}),
+                                      "application/json")
+                th = names.get(nm)
+                if th:
+                    # a comment THREAD owns this name: the idempotent open lands on the thread (prefs
+                    # applied to it — the sweep's intent) and no namesake is ever minted (T223)
+                    extra = _apply_new_session_prefs(th[0], b)
+                    return self._send(200, json.dumps({"ok": True, "id": th[0], "existing": True,
+                                                       "thread": True, "parent": th[1], **extra}),
+                                      "application/json")
                 if (b.get("backend") or "sdk") == "sdk":
                     if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
                         return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
@@ -31475,6 +31575,9 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": False, "error":
                         'a session named "%s" is already running — pick another name' % nm}),
                                       "application/json")
+                tref = _thread_name_refusal(nm, _thread_names())
+                if tref:                             # a comment thread's name — the same poisoning (T223)
+                    return self._send(200, json.dumps({"ok": False, "error": tref}), "application/json")
                 psid = live.get(parent) or ""
                 if not psid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", parent):
                     psid = parent                 # a sid: _fork_session validates it owns a transcript
@@ -31514,6 +31617,9 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": False, "error":
                         'a session named "%s" is already running — pick another name' % nm}),
                                       "application/json")
+                tref = _thread_name_refusal(nm, _thread_names())
+                if tref:                             # a comment thread's name — never relabel onto it (T223)
+                    return self._send(200, json.dumps({"ok": False, "error": tref}), "application/json")
                 tsid = live.get(target) or ""
                 if not tsid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", target):
                     tsid = target
@@ -32435,6 +32541,8 @@ class Handler(BaseHTTPRequestHandler):
                 elif nm in live:                 # already running → its tab is already up; just focus it
                     _reveal_chat_for(client, {"type": "focus", "id": live[nm]})
                     _mark_views_dirty()          # pusher ships the tab; never a synchronous fleet build here
+                elif _thread_name_refusal(nm, _thread_names()):   # a thread's name (or unverifiable): never mint a namesake tab (T223)
+                    client["send"](json.dumps({"type": "warn", "text": _thread_name_refusal(nm, _thread_names())}))
                 elif msg.get("backend") == "sdk":   # non-tmux: drive via the Agent SDK
                     # _sdk_ready(), not _sdk(): the backend object exists even with the dependency
                     # missing, so the old check took it as a yes and created a session that could never

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3811,6 +3811,9 @@ class SdkBackend:
                  log=None, reconcile: bool = False):
         self.state_dir = Path(state_dir)
         self.claude_bin = claude_bin
+        self.thread_wake_model = None      # kernel-installed: model_id -> replacement or None, consulted
+        #                                    ONLY when a comment THREAD is explicitly woken (T223 rider) —
+        #                                    the catalog lives in the kernel; the backend never imports it
         self._notify = notify              # notify(app, msg) -> push to clients (kernel._send_to_app)
         self._poke_cb = poke               # wake the kernel's producer/judges (optional)
         self._push_cb = push               # wake the kernel's PUSHER → immediate chat push (live tail)
@@ -3968,6 +3971,14 @@ class SdkBackend:
                     if r.get("effortPending") or r.get("modelPending"):
                         self._update_reg(sid, effortPending=False, modelPending=False)
                     queued = [t for t in (r.get("queue") or []) if isinstance(t, str) and t]
+                    if r.get("threadOf") and not queued:
+                        # a comment THREAD is never auto-resumed at boot (the user 2026-09-01: threads
+                        # persist on disk and come alive only on an explicit reply/branch; a deploy
+                        # boot resuming a cut thread turn put dormant threads back in RAM). Its
+                        # orphaned CLI was reaped above and its pending flags healed just now; only a
+                        # PERSISTED QUEUE — the user's own typed reply the CLI never started — earns
+                        # the resume, because delivering it IS honoring an explicit gesture.
+                        continue
                     # A cut turn is any MACHINE-ACTIVE last state, not just "working" (the user
                     # 2026-08-19, whose figure session sat blocked-on-you after every restart that
                     # landed mid-API-retry): "retrying" is a long-lived open-turn state — the CLI is
@@ -5131,6 +5142,23 @@ class SdkBackend:
                 _settled_now()
                 return None
             reg["sid"] = sid
+            if reg.get("threadOf") and reg.get("spawnedAt") and self.thread_wake_model is not None:
+                # A DORMANT comment thread (spawnedAt: it has run before — a fresh fork's FIRST connect
+                # keeps the model the dialog explicitly chose) registered on a SUPERSEDED full model
+                # id comes up on its family's newest at this explicit wake (T223 rider, the user
+                # 2026-09-01) — the one moment a dormant thread may be touched. Persisted with the
+                # label the popover reads, so the next wake needs no remap; no chat note (the model
+                # badge already shows what it runs on).
+                try:
+                    nm = self.thread_wake_model(reg.get("model") or "")
+                except Exception:
+                    nm = None
+                if nm and nm != reg.get("model"):
+                    self._log("thread %s wakes on %s (registered on superseded %s)"
+                              % (sid[:8], nm, reg.get("model")))
+                    reg["model"] = nm
+                    reg["liveModel"] = _alias_label(nm)
+                    self._update_reg(sid, model=nm, liveModel=_alias_label(nm))   # _reg_lock, not self._lock
             s = SdkSession(self, reg)
             s.on_boot_settled = on_boot_settled
             self.sessions[sid] = s

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -167,6 +167,32 @@ MOCK
     grep '/send' "$MOCK_LOG" | grep 'ideabox' | grep -q 'look into the flaky test'
 }
 
+@test "new: a comment thread's name creates nothing, says so, and -m addresses the thread by id" {
+    # T223: /new answers a thread's name with the THREAD (thread:true + its id). The CLI must not
+    # call it "already running" (a thread has no tab), and a -m prompt must ride the returned id —
+    # a by-name /send to a thread resolved to no live session and acked while landing nowhere.
+    cat > "$MOCK_DIR/curl" << 'MOCK'
+#!/usr/bin/env bash
+echo "curl $*" >> "$MOCK_LOG"
+url=""
+for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
+if [[ "$url" == */new ]]; then
+  echo '{"ok": true, "id": "66666666-7777-8888-9999-000000000000", "existing": true, "thread": true, "parent": "11111111-2222-3333-4444-555555555555"}'
+else
+  echo '{"ok": true}'
+fi
+MOCK
+    chmod +x "$MOCK_DIR/curl"
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp new -m "one more question" web-comment-1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"comment thread"* ]]
+    [[ "$output" != *"already running"* ]]
+    grep '/send' "$MOCK_LOG" | grep -q '"id": "66666666-7777-8888-9999-000000000000"'
+    ! grep '/send' "$MOCK_LOG" | grep -q '"name": "web-comment-1"'
+}
+
 @test "fork: POST /fork with parent, new name and optional --at cut" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -647,16 +647,50 @@ class CommentOps(CommentBase):
         self.assertEqual(km._load_comments(PARENT).get("threads", []), [])
         self.assertEqual(self.be.calls, [])
 
-    def test_reply_reaches_the_thread_and_reopens_a_resolved_one(self):
+    def test_reply_reaches_an_open_thread(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        err = km._comment_reply(PARENT, tid, "one more question")
+        self.assertIsNone(err)
+        self.assertEqual(self.be.sent[-1], (tid, "one more question"))
+
+    def test_a_closed_thread_never_reopens(self):
+        # the user's standing rule (2026-09-01): a thread they closed stays on disk and is never
+        # revived — replying is refused with the reason (this retires the 2026-08-22/T145
+        # "replying IS the reopen gesture" arm, which resumed the CLI and flipped the row open)
         _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
         km._comment_resolve(PARENT, tid)
         self.assertEqual(km._comment_thread(PARENT, tid)["status"], "resolved")
-        self.assertIn(("kill", tid), self.be.calls)
+        n_sent = len(self.be.sent)
         err = km._comment_reply(PARENT, tid, "one more question")
+        self.assertTrue(err and "closed" in err, err)
+        self.assertNotIn(("resume", tid), self.be.calls, "nothing wakes a closed thread")
+        self.assertEqual(len(self.be.sent), n_sent, "nothing is delivered to it either")
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "resolved", "the row stays closed")
+
+    def test_relaying_a_resolved_thread_keeps_it_closed(self):
+        # resolved -> relay -> reply must not become the reopen door the direct reply refuses
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_resolve(PARENT, tid)
+        saved = km._thread_messages
+        km._thread_messages = lambda tsid, cut, floor_t=0: [{"who": "user", "text": "the ask", "t": 5},
+                                                             {"who": "assistant", "text": "the answer", "t": 6}]
+        try:
+            self.assertIsNone(km._comment_merge(PARENT, tid))
+        finally:
+            km._thread_messages = saved
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "resolved", "sent back, still closed")
+        err = km._comment_reply(PARENT, tid, "one more")
+        self.assertTrue(err and "closed" in err, err)
+
+    def test_a_relayed_thread_stays_talkable(self):
+        # T145 (the user 2026-08-28): a relay is NOT a close — the explicit reply continues the
+        # thread, so only RESOLVED threads fall under the never-reopen rule
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_update(PARENT, tid, status="merged")
+        err = km._comment_reply(PARENT, tid, "afterthought")
         self.assertIsNone(err)
-        self.assertIn(("resume", tid), self.be.calls, "replying IS the reopen gesture")
+        self.assertIn(("resume", tid), self.be.calls, "the reply is the explicit gesture that wakes it")
         self.assertEqual(km._comment_thread(PARENT, tid)["status"], "open")
-        self.assertEqual(self.be.sent[-1], (tid, "one more question"))
 
     def test_delete_interrupts_the_inflight_reply_before_the_kill(self):
         # deleting a thread mid-generation must STOP the work, not just its cue (the user 2026-08-17)

--- a/tests/test_sdk_boot_stagger.py
+++ b/tests/test_sdk_boot_stagger.py
@@ -104,6 +104,111 @@ class StaggerBoundsConcurrency(unittest.TestCase):
                         "the backstop path is LOUD, never silent")
 
 
+class ThreadsStayDormant(unittest.TestCase):
+    """Comment threads are never auto-resumed at boot (the user 2026-09-01: threads persist on disk
+    and come alive only on an explicit reply/branch). A cut thread turn or a persisted thread queue
+    stays lazy; top-level sessions with the same shape still resume."""
+
+    def test_boot_reconcile_skips_a_cut_thread_but_heals_its_flags(self):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        ensured = []
+        be._ensure = lambda sid, on_boot_settled=None: (ensured.append(sid), on_boot_settled and on_boot_settled())[0]
+        regs = _cut_regs(d, 2)
+        tsid = "11111111-bbbb-0000-0000-00000000dead"
+        regs.append(_reg(d, tsid, threadOf="11111111-bbbb-0000-0000-000000000000", modelPending=True))
+        sb.append_state(Path(d), tsid, "working")     # a cut thread turn, no queue
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout="")):
+            be._boot_reconcile(regs)
+        self.assertEqual(sorted(ensured), sorted(r["sid"] for r in regs[:2]),
+                         "the two top-level cut sessions resume; the thread stays dormant")
+        self.assertFalse(sb.read_reg(Path(d), tsid).get("modelPending"),
+                         "the pending-flag heal still runs for a dormant thread")
+
+    def test_a_threads_persisted_queue_earns_the_resume(self):
+        # the user's own typed reply the CLI never started: delivering it honors an explicit gesture
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        ensured = []
+        be._ensure = lambda sid, on_boot_settled=None: (ensured.append(sid), on_boot_settled and on_boot_settled())[0]
+        tsid = "11111111-bbbb-0000-0000-00000000beef"
+        regs = [_reg(d, tsid, threadOf="11111111-bbbb-0000-0000-000000000000", queue=["a queued reply"])]
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout="")):
+            be._boot_reconcile(regs)
+        self.assertEqual(ensured, [tsid])
+
+    def test_the_orphan_reap_still_covers_a_threads_leftover_cli(self):
+        # the skip sits INSIDE the resume loop, after the reap built its sid list from every alive
+        # reg — a dead kernel's thread CLI is still a zombie writer nobody manages
+        import inspect
+        src = inspect.getsource(sb.SdkBackend._boot_reconcile)
+        reap, skip = 'lastsids = [str(r.get("lastSid")', 'if r.get("threadOf") and not queued:'
+        self.assertIn(reap, src)
+        self.assertIn(skip, src)
+        self.assertLess(src.index(reap), src.index(skip), "reap first over every alive reg, then the skip")
+
+
+class ThreadWakeRemap(unittest.TestCase):
+    """T223 rider: a thread registered on a superseded full model id comes up on the replacement the
+    kernel's hook names, persisted, at its explicit wake — and only threads, only when a hook is set."""
+
+    class _Rec:
+        made = []
+
+        def __init__(self, backend, reg):
+            self.reg = dict(reg)
+            self.thread = mock.Mock(is_alive=lambda: True)
+            self.on_boot_settled = None
+            ThreadWakeRemap._Rec.made.append(self.reg)
+
+        def start(self):
+            pass
+
+    def _wake(self, reg_extra, hook):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        be.thread_wake_model = hook
+        sid = "11111111-bbbb-0000-0000-0000000000aa"
+        _reg(d, sid, model="claude-fable-5", **reg_extra)
+        self._Rec.made = []
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            be._ensure(sid)
+        return self._Rec.made[0]["model"], sb.read_reg(Path(d), sid).get("model")
+
+    THREAD = {"threadOf": "11111111-bbbb-0000-0000-000000000000", "spawnedAt": 1700000000}
+
+    def test_a_dormant_threads_superseded_id_remaps_and_persists(self):
+        spawned, on_disk = self._wake(dict(self.THREAD),
+                                      lambda m: "claude-fable-5-1" if m == "claude-fable-5" else None)
+        self.assertEqual((spawned, on_disk), ("claude-fable-5-1", "claude-fable-5-1"))
+
+    def test_the_label_the_popover_reads_is_refreshed_too(self):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        be.thread_wake_model = lambda m: "claude-fable-5-1"
+        sid = "11111111-bbbb-0000-0000-0000000000ab"
+        _reg(d, sid, model="claude-fable-5", liveModel="Fable 5", **self.THREAD)
+        self._Rec.made = []
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            be._ensure(sid)
+        self.assertNotEqual(sb.read_reg(Path(d), sid).get("liveModel"), "Fable 5", "no stale label")
+
+    def test_a_fresh_forks_first_connect_keeps_the_dialogs_pick(self):
+        # no spawnedAt = it has never run: the model is the fork dialog's explicit choice, not a
+        # dormant registration to modernize
+        spawned, on_disk = self._wake({"threadOf": "11111111-bbbb-0000-0000-000000000000"},
+                                      lambda m: "claude-fable-5-1")
+        self.assertEqual((spawned, on_disk), ("claude-fable-5", "claude-fable-5"))
+
+    def test_a_top_level_session_is_never_remapped_here(self):
+        spawned, on_disk = self._wake({"spawnedAt": 1700000000}, lambda m: "claude-fable-5-1")
+        self.assertEqual((spawned, on_disk), ("claude-fable-5", "claude-fable-5"))
+
+    def test_no_hook_means_no_remap(self):
+        spawned, on_disk = self._wake(dict(self.THREAD), None)
+        self.assertEqual((spawned, on_disk), ("claude-fable-5", "claude-fable-5"))
+
+
 class FireBootSettled(unittest.TestCase):
     def _session(self, d=None):
         d = d or tempfile.mkdtemp()

--- a/tests/test_thread_rows.py
+++ b/tests/test_thread_rows.py
@@ -25,7 +25,57 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 PARENT = "11111111-2222-3333-4444-555555555555"
+PARENT_NAME = "web"
 TSID = "66666666-7777-8888-9999-000000000000"
+
+
+def _mk_thread(parent, tsid, name="web-comment-1", status="open", reg_name=None, alive=True, root=None):
+    """A comment thread as the kernel keeps it: a row in the parent's comments store + an SDK reg
+    carrying threadOf (reg_name None = the row's name, the modern shape). `root` defaults to the
+    kernel's own state dir (the HTTP doors read it); a test that drives a backend INSTANCE passes
+    its private dir — km.jd.STATE is a shared module object every test module's load re-points."""
+    root = root or km.jd.STATE
+    cdir = root / "comments"
+    cdir.mkdir(parents=True, exist_ok=True)
+    row = {"tid": tsid, "sid": tsid, "status": status, "createdT": 1, "lastSeenT": 1}
+    if name:
+        row["name"] = name
+    (cdir / (parent + ".json")).write_text(json.dumps({"threads": [row]}))
+    sdir = root / "sdk"
+    sdir.mkdir(parents=True, exist_ok=True)
+    reg = {"sid": tsid, "cwd": "/tmp", "alive": alive, "threadOf": parent, "lastSid": tsid}
+    if reg_name or name:
+        reg["name"] = reg_name or name
+    (sdir / (tsid + ".json")).write_text(json.dumps(reg))
+
+
+def _rm_threads():
+    for f in list((km.jd.STATE / "comments").glob("*.json")) + list((km.jd.STATE / "sdk").glob("*.json")):
+        f.unlink()
+
+
+class RealListingSplit(unittest.TestCase):
+    """Both directions of the design against the REAL backend filter (the user 2026-08-22): a threadOf
+    reg is absent from live_sessions/_session_rows — what GET /sessions and the pusher's tab payload
+    are built from — and present under thread_sessions/?threads=1."""
+
+    def test_a_thread_reg_splits_the_real_way(self):
+        # a hermetic backend INSTANCE over a PRIVATE state dir — never km._sdk() (its lazy build runs
+        # boot reconcile inside the test process) and never the shared km.jd.STATE (a module object
+        # every later test module's load re-points at its own tempdir)
+        from pathlib import Path
+        sb = SourceFileLoader("romp_sdk_backend_rows", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        root = Path(tempfile.mkdtemp())
+        be = sb.SdkBackend(root, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        _mk_thread(PARENT, TSID, name="web-comment-1", root=root)
+        saved = km._sdk
+        km._sdk = lambda: be
+        try:
+            self.assertNotIn(TSID, be.live_sessions(), "hidden from the tab/listing source")
+            self.assertIn(TSID, be.thread_sessions(), "served only to callers that ask")
+            self.assertNotIn(TSID, [r["id"] for r in km._session_rows()])
+        finally:
+            km._sdk = saved
 
 
 class ThreadRowsRoute(unittest.TestCase):
@@ -55,6 +105,162 @@ class ThreadRowsRoute(unittest.TestCase):
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read().decode())
 
+    def _post(self, path, body):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method="POST",
+                                     data=json.dumps(body).encode(),
+                                     headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"],
+                                              "Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode())
+
+    def test_new_with_a_threads_name_opens_the_thread_never_a_namesake(self):
+        # T223 (2026-09-01): a model-set sweep drove `romp new --model … <name>` over every reg,
+        # threads included; /new's already-live check hides threads by design, so for 20 dormant
+        # thread names it CREATED 18 namesake top-level sessions (each with its own CLI process,
+        # each a tab). A thread's name must answer as the existing thread — prefs applied to it,
+        # nothing minted.
+        created, prefs = [], []
+        saved = (km._sdk_ready, km._create_sdk_session, km._apply_new_session_prefs, km._live_names)
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, **kw: (created.append(nm), ("99999999-0000-0000-0000-000000000000", {}))[1]
+        km._apply_new_session_prefs = lambda sid, b: (prefs.append((sid, b.get("model"))), {"model": b.get("model")})[1]
+        km._live_names = lambda tmux: {}
+        _mk_thread(PARENT, TSID, name="web-comment-1")
+        try:
+            out = self._post("/new", {"name": "web-comment-1", "dir": "/tmp", "model": "claude-fable-5-1"})
+        finally:
+            km._sdk_ready, km._create_sdk_session, km._apply_new_session_prefs, km._live_names = saved
+            _rm_threads()
+        self.assertEqual(created, [], "a thread's name must never mint a namesake session")
+        self.assertTrue(out.get("ok") and out.get("existing"), out)
+        self.assertEqual(out.get("id"), TSID, "the idempotent open lands on the thread")
+        self.assertTrue(out.get("thread"), "the caller learns it addressed a thread")
+        self.assertEqual(out.get("parent"), PARENT)
+        self.assertEqual(prefs, [(TSID, "claude-fable-5-1")], "the sweep's intent — prefs on the thread")
+
+    def test_new_with_a_fresh_name_still_creates(self):
+        created = []
+        saved = (km._sdk_ready, km._create_sdk_session, km._live_names)
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, **kw: (created.append(nm), ("99999999-0000-0000-0000-000000000000", {}))[1]
+        km._live_names = lambda tmux: {}
+        try:
+            out = self._post("/new", {"name": "brand-new", "dir": "/tmp"})
+        finally:
+            km._sdk_ready, km._create_sdk_session, km._live_names = saved
+        self.assertEqual(created, ["brand-new"])
+        self.assertFalse(out.get("thread"))
+
+    def test_a_legacy_threads_registry_name_is_gated_too(self):
+        # the review's catch: a pre-naming thread's store row has NO name — its reg says
+        # "thread-<hash>" (what the sweep read) and _thread_rows shows the bare hash; both must
+        # refuse, or the exact three "thread-<hash>" namesakes of T223 recur
+        created = []
+        saved = (km._sdk_ready, km._create_sdk_session, km._live_names)
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, **kw: (created.append(nm), ("99999999-0000-0000-0000-000000000000", {}))[1]
+        km._live_names = lambda tmux: {}
+        _mk_thread(PARENT, TSID, name=None, reg_name="thread-" + TSID[:8])
+        try:
+            for nm in ("thread-" + TSID[:8], TSID[:8]):
+                out = self._post("/new", {"name": nm, "dir": "/tmp"})
+                self.assertTrue(out.get("thread"), (nm, out))
+                self.assertEqual(out.get("id"), TSID)
+        finally:
+            km._sdk_ready, km._create_sdk_session, km._live_names = saved
+            _rm_threads()
+        self.assertEqual(created, [])
+
+    def test_a_dormant_thread_whose_parent_was_ended_is_still_gated(self):
+        # _comment_kill_all flips open threads alive=False with their rows still open — a revived
+        # parent finds them again, so their names stay taken
+        created = []
+        saved = (km._sdk_ready, km._create_sdk_session, km._live_names)
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, **kw: (created.append(nm), ("99999999-0000-0000-0000-000000000000", {}))[1]
+        km._live_names = lambda tmux: {}
+        _mk_thread(PARENT, TSID, name="web-comment-1", alive=False)
+        try:
+            out = self._post("/new", {"name": "web-comment-1", "dir": "/tmp"})
+        finally:
+            km._sdk_ready, km._create_sdk_session, km._live_names = saved
+            _rm_threads()
+        self.assertTrue(out.get("thread"))
+        self.assertEqual(created, [])
+
+    def test_a_promoted_threads_old_name_is_free(self):
+        created = []
+        saved = (km._sdk_ready, km._create_sdk_session, km._live_names)
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, **kw: (created.append(nm), ("99999999-0000-0000-0000-000000000000", {}))[1]
+        km._live_names = lambda tmux: {}
+        _mk_thread(PARENT, TSID, name="web-comment-1", status="promoted")
+        try:
+            self._post("/new", {"name": "web-comment-1", "dir": "/tmp"})
+        finally:
+            km._sdk_ready, km._create_sdk_session, km._live_names = saved
+            _rm_threads()
+        self.assertEqual(created, ["web-comment-1"], "promoted = a real session now; its old row holds nothing")
+
+    def test_an_unreadable_store_refuses_instead_of_minting(self):
+        # the first cut returned {} on any exception — a silently reopened door. Unverifiable refuses.
+        created = []
+        saved = (km._sdk_ready, km._create_sdk_session, km._live_names, km._thread_names)
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, **kw: (created.append(nm), ("99999999-0000-0000-0000-000000000000", {}))[1]
+        km._live_names = lambda tmux: {}
+        km._thread_names = lambda: None
+        try:
+            with self.assertRaises(urllib.error.HTTPError) as cm:
+                self._post("/new", {"name": "anything", "dir": "/tmp"})
+            self.assertEqual(cm.exception.code, 503)
+        finally:
+            km._sdk_ready, km._create_sdk_session, km._live_names, km._thread_names = saved
+        self.assertEqual(created, [])
+
+    def test_fork_and_rename_refuse_a_threads_name(self):
+        saved = km._live_names
+        km._live_names = lambda tmux: {PARENT_NAME: PARENT}
+        _mk_thread(PARENT, TSID, name="web-comment-1")
+        try:
+            out = self._post("/fork", {"parent": PARENT_NAME, "name": "web-comment-1"})
+            self.assertFalse(out.get("ok"))
+            self.assertIn("comment thread", out.get("error") or "")
+            out = self._post("/rename", {"target": PARENT_NAME, "name": "web-comment-1"})
+            self.assertFalse(out.get("ok"))
+            self.assertIn("comment thread", out.get("error") or "")
+        finally:
+            km._live_names = saved
+            _rm_threads()
+
+    def test_the_ws_doors_wear_the_same_gate_before_they_act(self):
+        import inspect
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        self.assertLess(src.index("elif _thread_name_refusal(nm, _thread_names())"),
+                        src.index('elif msg.get("backend") == "sdk":'),
+                        "the create dialog refuses a thread's name BEFORE the sdk create arm")
+        ws = inspect.getsource(km._drive) if hasattr(km, "_drive") else ""
+        src2 = ws or inspect.getsource(km.Handler._dispatch_ws)
+        self.assertIn("_thread_name_refusal(str(msg[\"name\"]).strip(), _thread_names())", src2 + ws,
+                      "forkSession refuses a thread's name")
+        self.assertIn("elif _thread_name_refusal(new, _thread_names()):", src2 + ws,
+                      "renameSession refuses a thread's name")
+
+    def test_sid_of_reaches_a_thread_by_name(self):
+        _mk_thread(PARENT, TSID, name="web-comment-1")
+        try:
+            self.assertEqual(km._sid_of("web-comment-1"), TSID, "an explicit send by name lands on the thread")
+            self.assertEqual(km._sid_of("no-such-name"), "no-such-name")
+        finally:
+            _rm_threads()
+
+    def test_thread_names_maps_every_name_a_thread_answers_to(self):
+        _mk_thread(PARENT, TSID, name="web-comment-1", reg_name="web-comment-1")
+        try:
+            self.assertEqual(km._thread_names(), {"web-comment-1": (TSID, PARENT)})
+        finally:
+            _rm_threads()
+
     def test_default_listing_hides_threads(self):
         rows = self._get("/sessions")
         self.assertEqual([r["id"] for r in rows], [PARENT], "every existing consumer sees exactly what it saw")
@@ -65,6 +271,36 @@ class ThreadRowsRoute(unittest.TestCase):
         t = rows[1]
         self.assertTrue(t.get("thread"), "flagged so the bus can mark it as a minor player")
         self.assertEqual(t.get("parent"), PARENT, "the parent sid rides for reply resolution")
+
+
+class ThreadWakeModel(unittest.TestCase):
+    """T223 rider (the user 2026-09-01): a thread registered on a superseded FULL id comes up on its
+    family's newest at its next explicit wake; bare aliases auto-track and are left alone."""
+
+    def setUp(self):
+        self._saved = {fam: [dict(v) for v in vs] for fam, vs in km.MODEL_VERSIONS.items()}
+        km.MODEL_VERSIONS["fable"][:] = [{"value": "claude-fable-5-1", "label": "Fable 5.1"},
+                                         {"value": "claude-fable-5", "label": "Fable 5"},
+                                         {"value": "fable", "label": "Fable (newest)"}]
+
+    def tearDown(self):
+        for fam, vs in self._saved.items():
+            km.MODEL_VERSIONS[fam][:] = vs
+
+    def test_superseded_full_id_remaps_to_family_newest(self):
+        self.assertEqual(km._family_newest_model("claude-fable-5"), "claude-fable-5-1")
+
+    def test_newest_alias_and_unknown_remap_to_nothing(self):
+        self.assertIsNone(km._family_newest_model("claude-fable-5-1"), "already newest")
+        self.assertIsNone(km._family_newest_model("claude-fable-4"), "an id the catalog never listed is not ours")
+        self.assertIsNone(km._family_newest_model("fable"), "a bare alias auto-tracks — untouched")
+        self.assertIsNone(km._family_newest_model("claude-opus-4-5-20251101"), "a dated snapshot is not a version")
+        self.assertIsNone(km._family_newest_model(""))
+
+    def test_the_backend_hook_is_installed_at_build(self):
+        import inspect
+        src = inspect.getsource(km._sdk_locked)
+        self.assertIn("thread_wake_model = _family_newest_model", src)
 
 
 class ThreadRowsBuilder(unittest.TestCase):

--- a/ui/webview/comment-merge.test.ts
+++ b/ui/webview/comment-merge.test.ts
@@ -33,9 +33,10 @@ test("relayed is a first-class status, and the thread STAYS TALKABLE", () => {
   assert.match(RENDER, /th\.status === "resolved" \|\| th\.status === "merged" \? " resolved" : ""/);
   // the composer invites the next message instead of declaring the thread done
   assert.match(RENDER, /Reply to continue — the discussion so far was relayed to the session…/);
-  // …and the kernel reopens a relayed thread on reply exactly like a resolved one
-  assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "resolved", "merged"\),\n\s*status="open"/);
-  assert.match(KERNEL, /if prior in \("resolved", "merged"\):/);
+  // …and the kernel reopens a relayed thread on reply. A RESOLVED thread no longer does (the user
+  // 2026-09-01: a thread they closed never reopens) — only the relayed status stays talkable (T223).
+  assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "merged"\),\n\s*status="open"/);
+  assert.match(KERNEL, /if prior == "merged":/);
 });
 
 test("the persistent sent-back marker sits at the relay's place in time and survives reopens", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6739,7 +6739,7 @@ function styleCommentMark(m: HTMLElement, th: CommentThread): void {
   m.classList.toggle("busy", commentInFlight(th));
   m.title = th.status === "promoted" ? "thread, now the session '" + th.promotedName + "'"
     : th.status === "merged" ? "relayed thread: its discussion was sent back into the session"
-    : th.status === "resolved" ? "resolved thread: click to read or reopen"
+    : th.status === "resolved" ? "resolved thread: closed — click to read; a new comment continues the conversation"
     : "thread: click to open";
 }
 


### PR DESCRIPTION
## What happened (T223)

Eighteen comment-thread names appeared as top-level chat tabs. Convicted from the registry and the caller's own transcript: they were **not** thread sids leaking — every thread reg was intact and hidden from the default listing. They were eighteen brand-new first-class sessions, each with its own CLI process, minted through `POST /new` in a 2-minute burst by a model-set sweep that drove `romp new --model … -d <cwd> <name>` over every alive bare-alias reg, dormant threads included. `/new`'s idempotent already-live check reads `_live_names`, which hides threads *by design*, so for twenty thread names it saw no live session and created a namesake carrying the thread's own cwd and the sweep's prefs — the exact fingerprint on every leaked reg. The three `thread-<hash>` tabs were namesakes of real Aug-14/15 highlight comments whose store rows predate thread naming — not test artifacts.

## Fixes, each pinned red-first

- **Every door that mints or relabels a session consults `_thread_names()`** — every name a thread answers to (store name, registry name, the bare hash shown for a pre-naming row), every non-promoted thread, dormant or alive. `POST /new` answers a thread's name as the existing thread (prefs applied to *it* — the sweep's actual intent) and mints nothing; the dashboard's create dialog, `/fork`, `/rename` and their WS twins refuse with the reason. An unreadable store **refuses** (503) rather than silently reopening the door. `_sid_of` resolves a thread's name, so an explicit send reaches the thread instead of acking into a phantom.
- **Boot reconcile never auto-resumes a `threadOf` reg** (its pending-flag heal still runs; a *persisted queue* — the user's own typed reply — still earns the resume). The orphan-CLI reap still covers a thread's leftover writer.
- **A thread the user closed (resolved) never reopens** — the reply refuses with the reason, and relaying a resolved thread keeps it resolved. A *relayed* (merged) thread stays talkable per T145 (the user's own 08-28 decision that a relay is not a close).
- **Rider**: a *dormant* thread (has run before) registered on a superseded full model id the catalog lists comes up on its family's newest at its next explicit wake, persisted with the popover's label refreshed; a fresh fork's first connect keeps the dialog's pick; bare aliases auto-track.
- **CLI**: `romp new <thread-name>` says it hit a thread (no tab) and a `-m` prompt rides the returned id — a by-name send to a thread used to ack while landing nowhere. Popover copy stops advertising reopen on resolved threads.
- Both directions of the listing design pinned against the real backend filter (hermetic instance, private state root).

## Review round (4 lenses, 27 findings, 16 verified real)

Caught two holes in the first cut — the gate keyed on the store name while legacy threads' registry name is `thread-<hash>` (the exact three tabs would have recurred), and the gate returning `{}` on any exception — plus the ungated fork/rename doors, the silent CLI `-m` drop, resolved→relay→reply as a reopen path, the remap firing on a fresh fork's first connect and on ids the catalog never listed, the boot skip swallowing pending-flag heals and queued replies, and a stale `liveModel` label. All fixed and pinned here.

CI note: the first push's Python 3.13 job hit the 15-minute job timeout while 3.10–3.12 passed in ~3 min; the hang point was the tunnel-test region, and the current tree passes the full 3.13 suite locally with per-test timeouts.

Suites: 6482 passed + 34 skipped (pytest, 3.12 and 3.13), vscode-extension 2639, bats 82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)