### PR TITLE
The /busy drain arm is a write: gate it on an explicit serve token, presented by the manager

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -323,19 +323,86 @@ function quietGate(st, busy, now, opts) {
   return { action: 'wait', reason: `${busy} turn(s) in flight` };
 }
 
-let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer}
+let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer, drainRefusedCount, drainArmedCount}
+
+// The primary kernel's serve token. The drain arm of '/busy?drain=1' is a WRITE — it holds every
+// session's new turn starts — so the kernel now requires the token for it (a drive-by loopback page
+// or a tailnet client, holding no token, can no longer freeze turns by looping the poll). We are the
+// same-user local daemon: read the 0600 token file (the kernel writes it under its state root on
+// startup), or the env a profile baked in. Absent/unreadable → the poll still reads the count (the
+// read stays auth-exempt), the drain hold just does not arm; the quiet-window gate still works off
+// the count. Read fresh each poll so a kernel that reminted its token is picked up.
+//
+// FAIL LOUDLY, NOT DIFFERENTLY: left silent, both halves of that degrade disappear — a token-read
+// failure collapses to '' with zero log, and the kernel's `draining` answer (the refusal signal
+// it returns in the same /busy response) gets parsed out and dropped — so a parked deploy would
+// believe new turn starts were held while the kernel armed nothing; busy never quiets, and the
+// 15-minute backstop SIGTERMs the kernel MID-TURN (the exact cut the quiet window exists to
+// prevent) with no line anywhere naming the cause. The degrade BEHAVIOR is deliberate
+// (count-only polling keeps working; the /busy read arm needs no token) — these notices
+// make it visible, once per refusal EPISODE, not per 3s poll: queueQuietRestart re-arms them when
+// a fresh park begins, and an ARMED drain answer re-arms the refusal notice mid-park
+// (kernelToken() reads fresh per poll, so a hold can recover when the token file
+// comes back and be refused AGAIN when it goes; each transition is new information, said once).
+let tokenNoticed = false;   // the serve-token read failed → said once
+let drainNoticed = false;   // the kernel answered a drain=1 poll with draining:false → said once per episode
+function resetDrainNotices() { tokenNoticed = false; drainNoticed = false; }
+
+function kernelToken() {
+  const t = (process.env.ROMP_SERVE_TOKEN || '').trim();
+  if (t) return t;
+  const file = path.join(STATE_ROOT, 'serve-token');
+  try { return fs.readFileSync(file, 'utf8').trim(); }
+  catch (e) {
+    if (!tokenNoticed) {
+      tokenNoticed = true;
+      log(`kernel serve token unreadable (${file}: ${e && e.message}) — polling token-less: the busy count still reads, but the kernel will refuse to arm the drain hold`);
+    }
+    return '';
+  }
+}
 
 function fetchBusy(port, cb, path) {
   // the PARKED quiet poll passes '/busy?drain=1' (T121): the same probe that reads the count also
   // refreshes the kernel's drain lease, so new turn starts hold while the restart is parked and
   // the count falls on turn-end events. The lease dies by itself (~12s) when this manager stops
-  // polling — no off-switch to forget — and a fresh kernel boots clear by construction.
-  const req = http.get({ host: HOST, port, path: path || '/busy', timeout: 2000 }, (res) => {
+  // polling — no off-switch to forget — and a fresh kernel boots clear by construction. The drain
+  // arm is a gated WRITE, so present the token (X-Romp-Token, the local-daemon header form); a
+  // plain read needs none, but carrying it costs nothing.
+  // The callback gets (busy, draining): `draining` is the kernel's own answer for whether the
+  // hold is armed — true/false from the response, null when unknown (an older kernel without the
+  // field, an unreachable kernel, unparsable body). A drain=1 poll answered draining:false is a
+  // REFUSED drain (token missing/rejected — the kernel still serves the exempt count): said once
+  // per refusal episode — an armed answer after a noticed refusal logs the recovery and re-arms
+  // the notice, so a hold lost AGAIN later is not swallowed by the first episode's line. `null`
+  // never cries refusal — no field is no evidence, not a rejection.
+  const tok = kernelToken();
+  const headers = tok ? { 'X-Romp-Token': tok } : {};
+  const wantDrain = /[?&]drain=1(?:&|$)/.test(path || '');
+  const req = http.get({ host: HOST, port, path: path || '/busy', timeout: 2000, headers }, (res) => {
     let b = ''; res.on('data', (d) => (b += d));
-    res.on('end', () => { let n = null; try { const v = JSON.parse(b).busy; n = Number.isFinite(v) ? v : null; } catch { n = null; } cb(n); });
+    res.on('end', () => {
+      let n = null, draining = null;
+      try {
+        const j = JSON.parse(b);
+        n = Number.isFinite(j.busy) ? j.busy : null;
+        draining = typeof j.draining === 'boolean' ? j.draining : null;
+      } catch { n = null; }
+      if (wantDrain && n !== null && draining === false && !drainNoticed) {
+        drainNoticed = true;
+        log(`kernel refused the drain hold (asked via /busy?drain=1 ${tok ? 'but it rejected the token' : 'holding no token'}) — new turn starts are NOT held; the quiet window runs count-only and its backstop may cut turns mid-flight`);
+      } else if (wantDrain && n !== null && draining === true && drainNoticed) {
+        // recovery: the hold armed after the refusal above — put that on record and re-arm the
+        // notice (event-keyed: the arm is the new information), so a SECOND refusal episode in
+        // the same park logs again instead of hiding behind the first episode's line.
+        drainNoticed = false;
+        log('kernel armed the drain hold after the refusal above — new turn starts are held from here');
+      }
+      cb(n, draining);
+    });
   });
-  req.on('timeout', () => { req.destroy(); cb(null); });
-  req.on('error', () => cb(null));
+  req.on('timeout', () => { req.destroy(); cb(null, null); });
+  req.on('error', () => cb(null, null));
 }
 
 function clearPendingQuiet() {
@@ -379,11 +446,29 @@ function queueQuietRestart(mode) {
     log(`refresh queued behind the pending one (${pendingQuiet.count} coalesced — one bounce will deliver all)`);
     return pendingQuiet.count;
   }
-  pendingQuiet = { since: Date.now(), count: 1, mode, timer: null };
+  pendingQuiet = { since: Date.now(), count: 1, mode, timer: null,
+                   drainRefusedCount: 0, drainArmedCount: 0 };
+  resetDrainNotices();                   // the token/refusal notices re-arm when a fresh park begins
   log(`refresh queued — applying at the next quiet window (no SDK turn in flight; backstop ${Math.round(QUIET_MAX_DEFER_MS / 60000)} min)`);
   const tick = () => quietTick({
     pending: () => pendingQuiet,
-    fetchBusy: (cb) => fetchBusy(KERNEL_PORT, cb, '/busy?drain=1'),   // parked → hold new turn starts (T121)
+    fetchBusy: (done) => {
+      // record the kernel's drain answers as EVIDENCE ON THE PARK THAT ISSUED THIS POLL — the
+      // park is captured here, at issue time, never read back from pendingQuiet when the response
+      // lands (an in-flight probe from a just-cleared park must not stamp a brand-new park that
+      // never polled). Refusals and arms are COUNTED, not latched into one bit: kernelToken()
+      // reads fresh per poll, so a refusal can be transient (a token restored mid-park arms every
+      // later poll), and the apply line below renders what this park's counts actually show.
+      const park = pendingQuiet;
+      const cb = (busy, draining) => {
+        if (park && busy !== null) {
+          if (draining === false) park.drainRefusedCount++;
+          else if (draining === true) park.drainArmedCount++;
+        }
+        done(busy);
+      };
+      fetchBusy(KERNEL_PORT, cb, '/busy?drain=1');   // parked → hold new turn starts (T121)
+    },
     now: Date.now,
     opts: { maxDeferMs: QUIET_MAX_DEFER_MS },
     log,
@@ -391,7 +476,15 @@ function queueQuietRestart(mode) {
     apply: (g) => {
       const p = pendingQuiet;
       clearPendingQuiet();               // also disarms the pre-armed next tick
-      log(`applying deferred refresh — ${g.reason} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
+      // On a backstop cut, say what this park's drain evidence shows (a wrong cause misleads the
+      // reader worse than none): every answer refused → the hold never armed; refused then armed
+      // → the hold arrived late, so turns started before it may still be cut. No refusals → no
+      // suffix (and draining:null answers are no evidence either way, so they count nowhere).
+      const cause = g.reason !== 'backstop cap' || p.drainRefusedCount === 0 ? ''
+        : p.drainArmedCount === 0
+          ? ' — the kernel never armed the drain hold for this park (see the refusal line above), so in-flight turns may be cut'
+          : ` — the drain hold was refused ${p.drainRefusedCount} time(s) before arming for this park, so turns started before it armed may be cut`;
+      log(`applying deferred refresh — ${g.reason}${cause} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
       if (p.mode === 'all') restartAllOrSelf(); else restartKernel(p.mode);
     },
   });
@@ -546,7 +639,8 @@ function ensureUp() {
 // ── dispatch ────────────────────────────────────────────────────────────────
 // Exported for unit tests (restartGate = the pure storm-cap decision). The CLI dispatch runs only when this
 // file is executed directly, so require()-ing it from a test has no side effects.
-module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileStamp };
+module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileStamp,
+                   kernelToken, fetchBusy, resetDrainNotices, queueQuietRestart, clearPendingQuiet };
 if (require.main === module) {
   const cmd = process.argv[2];
   // `restart-all` (the `romp refresh` deploy path) bounces IMMEDIATELY by default (T160, the user

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30629,6 +30629,20 @@ class Handler(BaseHTTPRequestHandler):
             return False, None, "cross-site origin"
         return False, None, "token required (loopback included; token file: ~/.local/state/romp/serve-token)"
 
+    def _write_token_ok(self, q):
+        """An EXPLICITLY PRESENTED serve token — ?token= or the X-Romp-Token header — and nothing
+        else. STRICTER than _authorize on purpose: it does NOT accept the ambient romp_token cookie,
+        because the cookie is the one credential the browser attaches for you, so a drive-by
+        loopback subresource GET (an <img>/<script>/no-cors fetch to this route) rides it with no
+        Origin, and _authorize takes that pair as authorized. A state-changing GET must require
+        proof the caller is not a drive-by page — the reason _authorize's own docstring gives for
+        preferring the token — and only an explicit token clears BOTH the cross-origin-fetch and the
+        cookie-carrying-subresource vectors (a custom header forces a CORS preflight no-cors cannot
+        send, and no subresource load can set it or guess ?token=). Local daemons (the manager) read
+        the 0600 token file and send X-Romp-Token — exactly this."""
+        return bool(TOKEN) and (_ct_eq((q.get("token") or [""])[0], TOKEN)
+                                or _ct_eq(self.headers.get("X-Romp-Token") or "", TOKEN))
+
     def _file_preview(self, q, head=False):
         """GET/HEAD /file — the preview bytes behind a chat path-thumbnail (the
         user 2026-07-08). Same path resolution as click-to-open (~ expanded, relative → the session's
@@ -30853,16 +30867,22 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, json.dumps(_version_info()), "application/json", cache="no-cache")
             if p == "/busy":
                 # In-flight SDK turn count — the manager's quiet-window gate for deferred deploy
-                # refreshes (it polls this only while a refresh is pending). Auth-exempt like
-                # /healthz: the manager holds no token, and a bare count leaks nothing.
+                # refreshes (it polls this only while a refresh is pending). The READ is auth-exempt
+                # like /healthz: a bare count leaks nothing and healthz-style probes rely on it.
                 # ?drain=1 (T121): the PARKED poll also refreshes the kernel's drain lease — new
                 # turn starts hold so this count falls to 0 on turn-end events instead of only via
-                # the manager's backstop cut. One round-trip arms both; a plain /busy never holds.
+                # the manager's backstop cut. THE DRAIN ARM IS A WRITE — it holds EVERY session's
+                # new turn starts, refreshable forever — so it is GATED on an explicit token
+                # (_write_token_ok), unlike the exempt read. Before this gate it armed in the
+                # exempt block: a drive-by loopback page's no-cors GET or a tailnet client could
+                # loop it and freeze all turn starts (the _authorize docstring's drive-by-loopback
+                # adversary). An unauthorized drain still returns the count (the read stays exempt)
+                # but arms nothing; the manager reads the serve-token file and sends X-Romp-Token.
                 be = _sdk()
                 n = be.busy_count() if be and hasattr(be, "busy_count") else 0
                 draining = False
                 if be is not None and hasattr(be, "refresh_drain_hold"):
-                    if parse_qs(urlparse(self.path).query).get("drain", [""])[0] == "1":
+                    if q.get("drain", [""])[0] == "1" and self._write_token_ok(q):
                         be.refresh_drain_hold()
                     draining = be.drain_holding()
                 return self._send(200, json.dumps({"busy": n, "draining": draining}),

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,9 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
   `vscode-extension/src/*.test.ts`, run with `npm test` from
   `vscode-extension/`. Many pin lines of `kernel/kernel.py` as strings — run
   BOTH this and pytest on every kernel change.
-- **`manager-restart.test.js`** — the node supervisor (`bin/romp-manager`).
+- **`manager-*.test.js`** — the node supervisor (`bin/romp-manager`): restart
+  gating, the kernel registry, and the drain-poll handshake. Run:
+  `node --test tests/manager-*.test.js`.
 
 `fixtures/` must stay SYNTHETIC: invented prompts, placeholder UUIDs, hostname
 `TESTHOST` — never real session data.

--- a/tests/manager-drain.test.js
+++ b/tests/manager-drain.test.js
@@ -1,0 +1,300 @@
+// The drain gate's silent-degradation risk: were kernelToken() to swallow a
+// token-read failure into '' with zero log, or fetchBusy to parse only `.busy` out of the kernel's
+// response, DISCARDING the `draining` field — the kernel's own refusal signal — a parked deploy
+// would believe new turn starts were held while the kernel armed nothing; busy never quiets, and
+// the 15-minute backstop SIGTERMs the kernel MID-TURN with no line anywhere naming the cause.
+// The degrade BEHAVIOR is deliberate (count-only polling keeps working; the /busy read
+// arm needs no token) — these tests pin that the degradation is VISIBLE, once per park.
+// Run: node --test tests/manager-drain.test.js
+'use strict';
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// STATE_ROOT bakes from env when the manager module loads — point it at a temp dir BEFORE the
+// require (this file runs in its own process under node --test, so no other suite is disturbed).
+const STATE = fs.mkdtempSync(path.join(os.tmpdir(), 'romp-mgr-drain-'));
+process.env.ROMP_STATE_DIR = STATE;
+delete process.env.ROMP_SERVE_TOKEN;
+delete process.env.ROMP_SUPERVISED;            // a park's apply must never take the supervised-exit arm
+process.env.ROMP_QUIET_POLL_MS = '25';         // the park tests run REAL parks: fast polls…
+process.env.ROMP_QUIET_MAX_DEFER_MS = '250';   // …and a near backstop (both bake at require time)
+
+// KERNEL_PORT bakes at require time too, and the park tests below poll it for real — so the
+// manager loads in before(), once the scripted kernel stub owns a port to bake in.
+let kernelToken, fetchBusy, resetDrainNotices, queueQuietRestart, clearPendingQuiet;
+let kstub;
+
+const TOKEN_FILE = path.join(STATE, 'serve-token');
+
+// One /busy stub per test: records the request, answers with a fixed body.
+function serve(body) {
+  return new Promise((resolve) => {
+    const seen = [];
+    const srv = http.createServer((req, res) => {
+      seen.push({ url: req.url, token: req.headers['x-romp-token'] || null });
+      res.setHeader('Content-Type', 'application/json');
+      res.end(body);
+    });
+    srv.listen(0, '127.0.0.1', () =>
+      resolve({ port: srv.address().port, seen, close: () => new Promise((r) => srv.close(r)) }));
+  });
+}
+
+// The park tests' kernel: each request consumes the next scripted answer (a JSON body, or HOLD to
+// park the response server-side for a later release(body) — an in-flight probe, made repeatable);
+// an exhausted script answers with `fallback`.
+const HOLD = Symbol('hold');
+function scriptedStub() {
+  return new Promise((resolve) => {
+    const stub = { answers: [], fallback: JSON.stringify({ busy: 0, draining: true }),
+                   held: [], seen: [] };
+    const srv = http.createServer((req, res) => {
+      stub.seen.push(req.url);
+      res.setHeader('Content-Type', 'application/json');
+      const next = stub.answers.length ? stub.answers.shift() : stub.fallback;
+      if (next === HOLD) { stub.held.push(res); return; }
+      res.end(next);
+    });
+    srv.listen(0, '127.0.0.1', () => {
+      stub.port = srv.address().port;
+      stub.release = (body) => { const r = stub.held.shift(); if (r) r.end(body); };
+      stub.close = () => new Promise((r) => { stub.held.splice(0).forEach((h) => h.destroy()); srv.close(r); });
+      resolve(stub);
+    });
+  });
+}
+
+before(async () => {
+  kstub = await scriptedStub();
+  process.env.ROMP_SERVE_PORT = String(kstub.port);
+  ({ kernelToken, fetchBusy, resetDrainNotices, queueQuietRestart, clearPendingQuiet } =
+    require(path.join(__dirname, '..', 'bin', 'romp-manager')));
+});
+after(async () => { await kstub.close(); });
+
+const poll = (port, p) =>
+  new Promise((resolve) => fetchBusy(port, (busy, draining) => resolve({ busy, draining }), p));
+
+// The notices go through the manager's log() → process.stderr; capture around each probe.
+async function captured(fn) {
+  const orig = process.stderr.write;
+  let out = '';
+  process.stderr.write = (chunk) => { out += chunk; return true; };
+  try { await fn(); } finally { process.stderr.write = orig; }
+  return out;
+}
+
+beforeEach(() => {
+  resetDrainNotices();
+  if (typeof clearPendingQuiet === 'function') clearPendingQuiet();   // no park leaks across tests
+  kstub.answers.length = 0;
+  kstub.fallback = JSON.stringify({ busy: 0, draining: true });
+  kstub.held.splice(0).forEach((r) => r.destroy());
+  kstub.seen.length = 0;
+  try { fs.unlinkSync(TOKEN_FILE); } catch (e) { /* absent is fine */ }
+});
+
+// Capture stderr while `run` executes, resolving with everything captured once `untilRe` matches
+// (the park tests wait on the apply line this way — event-keyed, no fixed sleep).
+function capturedUntil(untilRe, run, ms) {
+  return new Promise((resolve, reject) => {
+    const orig = process.stderr.write;
+    let out = '';
+    let settled = false;
+    const done = (err) => {
+      if (settled) return;
+      settled = true;
+      process.stderr.write = orig;
+      clearTimeout(tm);
+      if (err) reject(err); else resolve(out);
+    };
+    const tm = setTimeout(() => done(new Error(`never logged ${untilRe} — captured:\n${out}`)), ms || 8000);
+    process.stderr.write = (chunk) => { out += chunk; if (untilRe.test(out)) setImmediate(() => done()); return true; };
+    Promise.resolve().then(run).catch(done);
+  });
+}
+
+const waitFor = (cond, ms = 2000) => new Promise((resolve, reject) => {
+  const t0 = Date.now();
+  const iv = setInterval(() => {
+    if (cond()) { clearInterval(iv); resolve(); }
+    else if (Date.now() - t0 > ms) { clearInterval(iv); reject(new Error('condition never held')); }
+  }, 5);
+});
+
+test('a readable token file rides every poll as X-Romp-Token, with no notice', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  const s = await serve(JSON.stringify({ busy: 1, draining: true }));
+  let logged = '';
+  let got;
+  try {
+    logged = await captured(async () => { got = await poll(s.port, '/busy?drain=1'); });
+  } finally { await s.close(); }
+  assert.equal(s.seen[0].token, 'drain-probe-credential', 'the 0600 token file is read fresh and attached');
+  assert.equal(got.busy, 1);
+  assert.equal(got.draining, true, 'the callback now carries the kernel’s draining answer');
+  assert.equal(logged, '', 'a healthy handshake logs nothing');
+});
+
+test('an unreadable token file polls token-less and says so ONCE, naming path and error', async () => {
+  const s = await serve(JSON.stringify({ busy: 0, draining: false }));
+  let logged = '';
+  let first, second;
+  try {
+    logged = await captured(async () => {
+      first = await poll(s.port);          // plain /busy — the read arm, no drain ask
+      second = await poll(s.port);
+    });
+  } finally { await s.close(); }
+  assert.equal(s.seen[0].token, null, 'no invented header — the poll goes token-less');
+  assert.equal(first.busy, 0, 'count-only polling still works (degrade behavior unchanged)');
+  assert.equal(second.busy, 0);
+  const lines = logged.split('\n').filter((l) => /serve token/.test(l));
+  assert.equal(lines.length, 1, 'ONE clear line, not one per 3s poll');
+  assert.match(lines[0], /serve-token/, 'the line names the token path');
+  assert.match(lines[0], /ENOENT|no such file/i, 'the line names the read error');
+});
+
+test('a drain=1 poll the kernel answers draining:false logs the refusal ONCE per park', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  const s = await serve(JSON.stringify({ busy: 3, draining: false }));
+  let logged = '';
+  let got;
+  try {
+    logged = await captured(async () => {
+      got = await poll(s.port, '/busy?drain=1');
+      await poll(s.port, '/busy?drain=1');   // the 3s re-poll must not repeat the line
+    });
+  } finally { await s.close(); }
+  assert.equal(got.busy, 3, 'the count still reads — the refusal degrades, never breaks, the poll');
+  assert.equal(got.draining, false);
+  const lines = logged.split('\n').filter((l) => /refused the drain/i.test(l));
+  assert.equal(lines.length, 1, 'rate-limited: once per park, not per poll');
+  assert.match(lines[0], /not held/i, 'the line says what the refusal means: no hold armed');
+});
+
+test('a fresh park re-arms the refusal notice (resetDrainNotices is the per-park seam)', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  const s = await serve(JSON.stringify({ busy: 2, draining: false }));
+  let logged = '';
+  try {
+    logged = await captured(async () => {
+      await poll(s.port, '/busy?drain=1');
+      resetDrainNotices();                   // queueQuietRestart calls this when a new park begins
+      await poll(s.port, '/busy?drain=1');
+    });
+  } finally { await s.close(); }
+  assert.equal(logged.split('\n').filter((l) => /refused the drain/i.test(l)).length, 2);
+});
+
+test('a plain /busy read never cries refusal — only a poll that ASKED for the drain', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  const s = await serve(JSON.stringify({ busy: 5, draining: false }));
+  let logged = '';
+  try {
+    logged = await captured(async () => { await poll(s.port); });
+  } finally { await s.close(); }
+  assert.equal(logged, '', 'draining:false on a read-only poll is normal, not a refusal');
+});
+
+test('an older kernel without the draining field stays silent (unknown is not refused)', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  const s = await serve(JSON.stringify({ busy: 2 }));
+  let logged = '';
+  let got;
+  try {
+    logged = await captured(async () => { got = await poll(s.port, '/busy?drain=1'); });
+  } finally { await s.close(); }
+  assert.equal(got.busy, 2);
+  assert.equal(got.draining, null);
+  assert.equal(logged, '', 'no field is no evidence — never a false refusal line against an old kernel');
+});
+
+test('kernelToken prefers the env, then the token file', () => {
+  fs.writeFileSync(TOKEN_FILE, 'file-credential\n');
+  assert.equal(kernelToken(), 'file-credential');
+  process.env.ROMP_SERVE_TOKEN = 'env-credential';
+  try { assert.equal(kernelToken(), 'env-credential'); }
+  finally { delete process.env.ROMP_SERVE_TOKEN; }
+});
+
+// ── the park's drain EVIDENCE ───────────────────────────────────────────────────────────────────
+// A single latched boolean (drainRefused, set on the first draining:false answer, never cleared)
+// would be WRONG here: kernelToken() reads the token fresh per poll, so a refusal can be TRANSIENT
+// (token restored mid-park → every later poll arms the hold), and the backstop line would then
+// claim the hold was 'never armed' — false. And a stamp that read pendingQuiet at RESPONSE time
+// would let an in-flight probe from a just-cleared park mark a brand-new park that never polled.
+// These tests drive REAL parks against the scripted kernel stub (fast polls + a near backstop,
+// baked above): evidence is counted per park, stamped only on the park that issued the poll, and
+// the apply line renders what the counts actually show.
+
+test('a transient refusal (the hold arms later) renders the armed-after-refusal cause, never "never armed"', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  kstub.answers = [JSON.stringify({ busy: 1, draining: false })];   // first poll: hold refused once…
+  kstub.fallback = JSON.stringify({ busy: 1, draining: true });     // …every later poll arms it
+  let logged;
+  try {
+    logged = await capturedUntil(/applying deferred refresh/, () => { queueQuietRestart('ghost'); });
+  } finally { clearPendingQuiet(); }
+  const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
+  assert.match(applyLine, /backstop cap/, 'busy never quiets, so the backstop applies');
+  assert.match(applyLine, /refused 1 time\(s\) before arming/,
+    'the cause is the truth this park saw: refused once, then armed');
+  assert.doesNotMatch(applyLine, /never armed/,
+    'a transient refusal must not read as a hold that never armed');
+});
+
+test('an in-flight probe from a cleared park never stamps the park that replaced it', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  kstub.answers = [HOLD];                                           // park A's first probe parks server-side
+  kstub.fallback = JSON.stringify({ busy: 1, draining: true });     // park B's own polls all arm the hold
+  let logged;
+  try {
+    logged = await capturedUntil(/applying deferred refresh/, async () => {
+      queueQuietRestart('ghost');                 // park A issues the probe the stub is holding
+      await waitFor(() => kstub.held.length === 1);
+      clearPendingQuiet();                        // an immediate restart satisfies A mid-flight
+      queueQuietRestart('ghost');                 // park B begins; it never sees a refusal itself
+      kstub.release(JSON.stringify({ busy: 1, draining: false }));  // A's stale refusal lands during B
+    });
+  } finally { clearPendingQuiet(); }
+  const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
+  assert.match(applyLine, /backstop cap/);
+  assert.doesNotMatch(applyLine, /never armed|refused/,
+    'park B armed on every poll it issued — park A\'s stale answer is not B\'s evidence');
+});
+
+test('a second refusal episode after a recovery logs again (the armed poll re-arms the notice)', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  kstub.answers = [
+    JSON.stringify({ busy: 2, draining: false }),   // episode 1: refused → the loud line
+    JSON.stringify({ busy: 2, draining: true }),    // recovery: the hold armed
+    JSON.stringify({ busy: 2, draining: false }),   // episode 2: refused again → new information
+  ];
+  const logged = await captured(async () => {
+    await poll(kstub.port, '/busy?drain=1');
+    await poll(kstub.port, '/busy?drain=1');
+    await poll(kstub.port, '/busy?drain=1');
+  });
+  const refusals = logged.split('\n').filter((l) => /refused the drain/i.test(l));
+  assert.equal(refusals.length, 2,
+    'one line per refusal EPISODE — a lost-recovered-lost hold is two events, not one');
+  assert.match(logged, /armed the drain hold/i, 'the recovery itself goes on the record');
+});
+
+// The park half of the wiring lives inside queueQuietRestart's closures (module state: pendingQuiet,
+// KERNEL_PORT), so the probe spelling is pinned at the source like the suite's other closure pins
+// (T121/T160); the park's evidence behavior itself is driven for real above.
+test('the park records drain evidence and the backstop line names it (source pin)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
+  assert.match(src, /drainRefusedCount/, 'the park counts refusals, never latching one bit');
+  assert.match(src, /drainArmedCount/, 'the park counts arms, so a transient refusal reads true');
+  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')"),
+    'the parked poll still binds the drain-refresh spelling of the probe');
+  assert.match(src, /never armed/, 'the backstop apply line can still say the hold never armed');
+  assert.match(src, /resetDrainNotices\(\)/, 'a fresh park re-arms the once-per-episode notices');
+});

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -68,8 +68,10 @@ class DrainLease(unittest.TestCase):
 
     def test_the_kernel_route_and_the_deploy_paths_ride_the_gate(self):
         ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
-        self.assertIn('parse_qs(urlparse(self.path).query).get("drain", [""])[0] == "1"', ksrc,
-                      "/busy?drain=1 refreshes the lease in the same round-trip that reads the count")
+        self.assertIn('q.get("drain", [""])[0] == "1" and self._write_token_ok(q)', ksrc,
+                      "/busy?drain=1 refreshes the lease in the same round-trip that reads the count — "
+                      "but the arm is a WRITE, gated on an explicit token (the behavioral pins live "
+                      "in tests/test_kernel_auth_hardening.py::BusyDrainWriteGate); the READ stays exempt")
         self.assertIn('json.dumps({"busy": n, "draining": draining})', ksrc,
                       "the payload says when the box is draining — glanceable, never mysterious")
         self.assertIn("'http://127.0.0.1:%d/restart-all'", ksrc,

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -15,6 +15,8 @@
 Synthetic only — no real session data; the gate decision touches no session state.
 Mirrors tests/test_kernel_ws_auth.py's module load order.
 """
+import io
+import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -44,6 +46,36 @@ def _inst(peer="127.0.0.1", headers=None):
     h.client_address = None if peer is None else (peer, 0)
     h.headers = dict(headers or {})
     return h
+
+
+def _serve_get(path, headers=None):
+    """Drive the REAL do_GET dispatcher over a fake socket and return (status, body).
+
+    Asserting on a route's position in the source cannot catch a route served on the wrong side of
+    the gate; asking the handler is the only thing that can."""
+    h = km.Handler.__new__(km.Handler)
+    h.client_address = ("127.0.0.1", 0)
+    h.headers = dict(headers or {})
+    h.path = path
+    h.command = "GET"
+    h.request_version = "HTTP/1.1"
+    h.wfile = io.BytesIO()
+    h.rfile = io.BytesIO()
+    h.close_connection = True
+    captured = {}
+
+    def send_response(code, *a):
+        captured["status"] = code
+
+    def send_header(k, v):
+        captured.setdefault("headers", {})[k] = v
+
+    h.send_response = send_response
+    h.send_header = send_header
+    h.end_headers = lambda: None
+    h.log_message = lambda *a: None
+    h.do_GET()
+    return captured.get("status"), h.wfile.getvalue().decode("utf-8", "replace")
 
 
 def _auth(peer="127.0.0.1", headers=None, token=None):
@@ -185,6 +217,89 @@ class ResponseHardeningHeaders(unittest.TestCase):
         # the type must not be READ from the remote (a comment may still name it as "never this")
         self.assertNotIn("ctype = resp.getheader", src)
         self.assertNotIn('resp.status, resp.getheader("Content-Type")', src)
+
+
+class _DrainSpy:
+    """A stand-in SDK backend: reports a busy count and records every drain-hold arm, like the
+    real SdkBackend's busy_count / refresh_drain_hold / drain_holding."""
+
+    def __init__(self):
+        self.refreshed = 0
+        self.holding = False
+
+    def busy_count(self):
+        return 3
+
+    def refresh_drain_hold(self):
+        self.refreshed += 1
+        self.holding = True
+
+    def drain_holding(self):
+        return self.holding
+
+
+class BusyDrainWriteGate(unittest.TestCase):
+    """The /busy READ stays auth-EXEMPT (a bare count leaks nothing and healthz-style probes rely
+    on it), but the ?drain=1 arm is a WRITE — it arms a lease that holds EVERY session's new turn
+    starts (T121) — so it is gated on an EXPLICITLY PRESENTED serve token (?token= or the manager's
+    X-Romp-Token), never the ambient romp_token cookie. Before this gate the arm ran
+    unconditionally in the exempt block: a drive-by loopback page's no-cors GET, or any tailnet
+    client, could loop /busy?drain=1 and freeze all turn starts — the exact drive-by-loopback
+    adversary _authorize's docstring names. The cookie is NOT sufficient here because a cross-origin
+    subresource GET (an <img>/<script> to this route) carries it with no Origin, and _authorize
+    accepts that pair for a READ; a state-changing GET must demand a token no such load can attach.
+    Synthetic only — the gate touches no session state."""
+
+    def setUp(self):
+        self._saved_sdk = km._sdk
+        self.spy = _DrainSpy()
+        km._sdk = lambda: self.spy
+
+    def tearDown(self):
+        km._sdk = self._saved_sdk
+
+    def test_a_tokenless_drain_reads_the_count_but_arms_nothing(self):
+        status, body = _serve_get("/busy?drain=1")
+        self.assertEqual(status, 200, "the READ stays auth-exempt")
+        self.assertEqual(json.loads(body).get("busy"), 3, "…and still returns the count")
+        self.assertEqual(self.spy.refreshed, 0,
+                         "a token-less drive-by GET must not arm the turn-start hold")
+
+    def test_the_cookie_alone_does_not_arm_the_drain(self):
+        # the <img>/subresource drive-by: cookies are host- not port-scoped, so a page served by
+        # anything else on loopback rides the dashboard's romp_token cookie with NO Origin header.
+        status, body = _serve_get("/busy?drain=1", headers={"Cookie": "romp_token=" + TOK})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.spy.refreshed, 0,
+                         "the ambient cookie is not proof the caller is not a drive-by page")
+
+    def test_a_cross_origin_fetch_does_not_arm_the_drain(self):
+        # the no-cors fetch() form: it DOES carry a cross-site Origin (and cannot set X-Romp-Token —
+        # no-cors forbids custom headers), so even with the cookie it must not arm.
+        status, _ = _serve_get("/busy?drain=1",
+                               headers={"Cookie": "romp_token=" + TOK,
+                                        "Origin": "http://127.0.0.1:5173",
+                                        "Host": "127.0.0.1:%d" % km.PORT})
+        self.assertEqual(status, 200, "the read still answers")
+        self.assertEqual(self.spy.refreshed, 0, "a cross-site drive-by GET arms nothing")
+
+    def test_an_explicit_header_token_arms_the_drain(self):
+        # the LEGITIMATE caller: the manager reads the 0600 serve-token and sends X-Romp-Token.
+        status, body = _serve_get("/busy?drain=1", headers={"X-Romp-Token": TOK})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.spy.refreshed, 1, "the manager's X-Romp-Token authorizes the write")
+        self.assertTrue(json.loads(body).get("draining"), "…and the arm shows in the read")
+
+    def test_a_query_token_also_arms_the_drain(self):
+        status, _ = _serve_get("/busy?drain=1&token=" + TOK)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.spy.refreshed, 1, "an explicit ?token= arms it too")
+
+    def test_the_bare_busy_read_stays_exempt_and_never_arms(self):
+        status, body = _serve_get("/busy")
+        self.assertEqual(status, 200, "the count is a healthz-style probe — no token needed")
+        self.assertEqual(json.loads(body).get("busy"), 3)
+        self.assertEqual(self.spy.refreshed, 0, "a plain /busy never holds")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
T121's deploy-drain gave the auth-exempt `GET /busy` route a write side effect: `?drain=1` calls `be.refresh_drain_hold()` in the exempt block before `_authorize` runs, arming or extending a ~12s lease (`DRAIN_HOLD_TTL`) that holds new turn starts for every session, and the lease is refreshable forever. Any drive-by web page can reach it with a no-cors GET to loopback (no preflight, no token), and any tailnet client can when the dashboard is tailscale-served. Looping the request every ~10s freezes all new turn starts indefinitely, with only a stderr line as the tell. This is the drive-by-loopback adversary that `_authorize`'s own docstring names.

## The gate

- The `/busy` read stays auth-exempt: a bare count leaks nothing, and healthz-style probes rely on it. Only the drain arm is gated.
- The gate is an explicit token (`?token=` or `X-Romp-Token`), deliberately not the full `_authorize` check. `_authorize`'s cookie branch requires only the cookie plus `_origin_ok`, and `_origin_ok` accepts an absent Origin (non-browser clients), so a cookie-carrying subresource load (an `<img>` or `<script>` pointed at this route, which sends no Origin and rides the host-scoped cookie: RFC 6265 §8.5, cookies are port-blind) would still arm it. An explicit token clears both vectors: a no-cors request cannot set a custom header, and a subresource load cannot guess `?token=`.
- A refused drain returns the plain read response without arming. That is expected traffic, not a fail-loud case.

## The manager keeps arming, and degrades loudly

The manager is the legitimate drain caller, and it held no token. It now reads the serve token (env first, then the 0600 state file) and sends `X-Romp-Token` on its parked poll, so the deploy-drain flow keeps arming. When it cannot, the failure is visible instead of silent:

- One line per park when the token read fails, naming the path and the error.
- One refused-drain line per refusal episode: `fetchBusy` now parses the `draining` field the kernel already returns. `null` means an older kernel without the field, which is no evidence and raises no alarm.
- An armed answer after a refusal logs the recovery and re-arms the notice, so a hold lost again later is reported again.
- The park counts refusals and arms, stamped only on the park that issued the poll, so a backstop cut's cause line reports what its own park saw: the hold never armed, or it was refused N times before arming (turns started before a late arm may still be cut).

## Tests

- `tests/test_kernel_auth_hardening.py::BusyDrainWriteGate` drives the real `do_GET` dispatcher over a fake socket. The token-less drain, the cookie-only subresource drive-by, and the cross-origin fetch each read the count but arm nothing (all three red at b878b1ad before the fix); `X-Romp-Token` and `?token=` arm it; the bare read never holds.
- `tests/manager-drain.test.js` covers the token attach, both loud-degradation lines, episode re-arming, null-field silence, and real parks (fast polls, near backstop) for the evidence counters and the issue-time stamping rule.
- `tests/test_deploy_drain.py`'s source pin follows the gated spelling.

Note for reviewers: `tests/manager-*.test.js` is not wired into CI (`npm test` bundles only the `.test.ts` suites, and the shell job runs bats). Run `node --test tests/manager-drain.test.js`, the same convention as the existing `manager-restart.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)