### PR TITLE
T225: the awaiting box renders from the chip's own frame, and both agree in number

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12595,7 +12595,7 @@ def _watch_awaiting(sid):
         return None
     since = min([r.get("at") for r in rows + prs if r.get("at")] or [None])
     why = ("waiting on " + descs[0]) if len(descs) == 1 else         ("waiting on %d armed watches — %s, …" % (len(descs), descs[0]))
-    return {"kind": "job", "why": why, "since": since, "tasks": descs}
+    return {"kind": "job", "why": why, "since": since, "tasks": descs, "count": len(descs)}
 
 
 def _watch_notice(kind, row, detail=""):
@@ -15515,6 +15515,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # normally runs inside an open turn → idle=False → this branch never ran) — count via len().
         n = len(subs)
         return {"kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s"),
+                "count": n,   # how many are awaited — the chip/box word agrees in number with THIS (T225)
                 "since": min([s.get("since") for s in subs if s.get("since")] or [None])}   # the oldest live agent's start — the wait has held at least this long
     tasks = _bg_live_norm(sid, path)
     if tasks:
@@ -15529,9 +15530,9 @@ def _session_awaiting(sid, path, idle, stamp=False):
                                     for t in pending) else "task")
             since = min([t.get("t") for t in pending if t.get("t")] or [None])   # the oldest pending dispatch
             if len(pending) == 1:
-                return {"kind": kind, "since": since,
+                return {"kind": kind, "since": since, "count": 1,
                         "why": "waiting on a background task%s" % ((": " + d0) if d0 else "")}
-            return {"kind": kind, "since": since,
+            return {"kind": kind, "since": since, "count": len(pending),
                     "why": "waiting on %d background tasks%s"
                            % (len(pending), (" — " + d0 + ", …") if d0 else "")}
     # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
@@ -15547,6 +15548,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
         ovk = ov.get("kind")
         return {"kind": ovk if ovk in jd.AWAIT_KINDS else None,
                 "since": ov.get("t") or None,          # the overlay row's own stamp — when the hook declared the wait
+                "count": ov["count"] if isinstance(ov.get("count"), int) and ov["count"] > 0 else None,   # only when the producer said (no parsing the why)
                 "why": ov.get("why") or "waiting on dispatched work"}
     # An awaiting:false overlay row is NOT a veto — it says only that THIS channel has nothing to add.
     # The SDK Stop hook has written an unconditional false at every turn end since 2026-07-07 while
@@ -15573,10 +15575,11 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # and nobody else's (the user 2026-08-08): the three surfaces answered one question two ways.
         y = _owned_yield_why(sid, path)
         if y:
-            return {"kind": "task", "why": y, "since": None}   # a live owned dispatch — in-harness work (no single event time to show)
+            return {"kind": "task", "why": y, "since": None, "count": 1}   # a live owned dispatch — in-harness work (no single event time to show)
         _gid, _at, st_why, st_kind, st_peers = _session_stamp_full(sid)
         if st_why:
-            out = {"kind": st_kind, "why": st_why, "since": _at or None}   # the judge's own classification rides the stamp, with its awaitingAt
+            out = {"kind": st_kind, "why": st_why, "since": _at or None,   # the judge's own classification rides the stamp, with its awaitingAt
+                   "count": len(st_peers) if st_peers else None}   # a peer stamp knows its peers; other stamps carry no count
             if st_kind == "peer" and st_peers:
                 # the stamp RECORDS who the wait is on (judge awaitPeers) — name them (2026-08-26);
                 # `peers` rides only when known, so every other arm's shape is byte-identical
@@ -15588,6 +15591,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
             pi = _session_delegated_identities(sid)
             if pi:
                 out["peers"] = pi
+                out["count"] = len(pi)
             return out
     return None
 
@@ -20171,6 +20175,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # WHO a peer-kind wait is on — [{name, host, sid, color}], the same identities the feed
                   # box wears, so the chat chip + awaiting box name the actual session (2026-08-26)
                   "awaitingPeers": ((_aw or {}).get("peers") or None),
+                  # HOW MANY things are awaited (T225; the user 2026-09-02 wants the label to agree in
+                  # number — a single agent is not "agents") — the chip and the box derive the word from
+                  # this one number; None when the source cannot know (an untyped stamp, a bare overlay)
+                  "awaitingCount": ((_aw or {}).get("count") if isinstance((_aw or {}).get("count"), int) else None),
                   "awaitingTasks": (((_awaiting_task_descs(sid, sess["path"]) or
                                       (_aw or {}).get("tasks") or [])) if awaiting_why else []),
                   # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
@@ -20979,7 +20987,7 @@ def _provisional_card(s, name, color, fsid, live, now, store=None):
             "provisional": True, "judging": not turn_open, "tree": []}
 
 
-def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None):
+def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None, count=None):
     """A lightweight WORKING-column placeholder for a LIVE, IDLE session AWAITING a dispatched BACKGROUND
     TASK when there is NO open goal to floor to awaiting (the user 2026-07-13). The turn ended and every
     card is done/cleared/placed, so the goal loop has nothing to floor AND _provisional_card bows out (its
@@ -21014,6 +21022,7 @@ def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None):
             # 2026-07-13). judging False: this session is idle-awaiting, not analyzing — the pill, not a
             # "Working…"/"Analyzing…" chip, carries the state (feed.ts defers the provisional chip when awaiting).
             "awaiting": {"why": why, "kind": kind, "since": since,
+                         "count": count if isinstance(count, int) else None,   # the feed pill's word agrees in number (T225)
                          "tasks": _awaiting_task_descs(fsid, s["path"])},
             "provisional": True, "judging": False, "tree": []}
 
@@ -21707,6 +21716,7 @@ def build_feed(now, tmux=None):
         sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
         sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
         sess_awaiting_since = _sess_aw.get("since") if _sess_aw else None   # the wait's own event time (the user 2026-08-23)
+        sess_awaiting_count = _sess_aw.get("count") if _sess_aw else None   # how many are awaited — the pill's word agrees in number (T225)
         sess_awaiting_peers = _sess_aw.get("peers") if _sess_aw else None   # named identities when the arm knows them (2026-08-26)
         if sess_awaiting_why and not who_working:
             awaiting.append(name)                    # the AWAITING dot list (await-green, the user 2026-07-13) — the
@@ -22327,7 +22337,8 @@ def build_feed(now, tmux=None):
                 # awaiting card so the wait shows in the FEED, not just on the timeline — the hole the user
                 # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
                 asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
-                                           kind=sess_awaiting_kind, since=sess_awaiting_since))
+                                           kind=sess_awaiting_kind, since=sess_awaiting_since,
+                                           count=sess_awaiting_count))
     # THE SERVING FOLD, commit side (T137): join each candidate's rows under its dispatch's
     # tracker row — a read-only render-time join across stores (the node itself stays in the
     # WORKER's store, where plan-sync completion, nudge freshness, and clears live; node ids are

--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -13,9 +13,11 @@ Two guards:
     and the number-agreeing word rides one count (the webview-side twins live in
     ui/webview/awaiting-box-sync.test.ts and spin-caption.test.ts).
   * ServedSync — the executed guard: a hermetic kernel, the real /chat page, MutationObservers on the
-    chip and the box; the SDK Stop hook's own awaiting overlay row (source 1) is appended to
-    states/<sid>.jsonl, and the box must show within one frame of the chip — then an awaiting:false
-    row must clear both together. Skips LOUDLY without the extension deps or a playwright browser
+    chip and the box; a SYNTHETIC awaiting overlay row is appended to states/<sid>.jsonl — the reader's
+    source 1, in the shape sdk_backend.append_awaiting writes plus the optional kind + count fields the
+    reader accepts (no live producer writes those two today; the row exercises the reader → chip → box
+    path, the same path a real producer's row would take) — and the box must show within one frame of
+    the chip; then an awaiting:false row must clear both together. Skips LOUDLY without the extension deps or a playwright browser
     (CI installs none).
 
 All fixtures synthetic.
@@ -90,7 +92,8 @@ await page.evaluate(() => {
   };
   new MutationObserver(tick).observe(document.body, { subtree: true, childList: true, characterData: true, attributes: true });
 });
-// the SDK Stop hook's own overlay row (sdk_backend.append_awaiting's shape, plus kind + count)
+// a synthetic overlay row for the reader's source 1: append_awaiting's shape plus the optional kind + count
+// fields the reader accepts (no live producer writes those two today — this drives the reader's path)
 fs.appendFileSync(cfg.states, JSON.stringify({ t: Math.floor(Date.now() / 1000), awaiting: true, kind: "agents",
   count: 1, why: "1 background agent still working" }) + "\n");
 await page.waitForFunction(() => window.__t.chipOn !== null, null, { timeout: 30000 }).catch(() => {});

--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""T225 (the user 2026-09-02): the awaiting box appears the moment the chip says "Awaiting".
+
+Convicted at the source: the kernel assembles the chip state and the box's fields in ONE status
+payload and ships a status-only change to a caught-up client as a chatTail DELTA (empty event suffix +
+full status; _send_chat). The client's chatTail handler assigned the status and repainted tabs and
+statusline — the chip — but rendered the box (renderBgTasks → renderAwaitWhy) only from the full-session
+frame path, which a quiet session never sends. Measured here before the fix: the chip read "Awaiting
+agents" and the box never appeared in 40s; with the fix, the same frame renders both.
+
+Two guards:
+  * SourcePins — CI-safe: every status-carrying handler re-renders the box when the awaiting fields change,
+    and the number-agreeing word rides one count (the webview-side twins live in
+    ui/webview/awaiting-box-sync.test.ts and spin-caption.test.ts).
+  * ServedSync — the executed guard: a hermetic kernel, the real /chat page, MutationObservers on the
+    chip and the box; the SDK Stop hook's own awaiting overlay row (source 1) is appended to
+    states/<sid>.jsonl, and the box must show within one frame of the chip — then an awaiting:false
+    row must clear both together. Skips LOUDLY without the extension deps or a playwright browser
+    (CI installs none).
+
+All fixtures synthetic.
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+RENDER = open(os.path.join(ROOT, "ui", "webview", "render.ts")).read()
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+class SourcePins(unittest.TestCase):
+    def test_every_status_carrying_frame_renders_the_box_on_an_awaiting_change(self):
+        # chatTail is the frame a status-only change rides to a caught-up client (kernel _send_chat: empty
+        # suffix + full status); `update` and the host-side `status` frame assign status the same way
+        for fn in ("function chatTail(msg: any) {", "function update(msg: any) {", "function statusOnly(msg: any) {"):
+            body = RENDER.split(fn)[1].split("\n}")[0]
+            self.assertIn("const before = awaitKey(s.status);", body, fn)
+            self.assertIn("if (awaitKey(s.status) !== before) renderBgTasks();", body, fn)
+
+    def test_the_chip_and_the_gist_agree_in_number_from_one_count(self):
+        self.assertIn("kindWord(s.status.awaitingKind, s.status.awaitingCount)", RENDER)
+        self.assertIn("kindWord(s!.status.awaitingKind, s!.status.awaitingCount)", RENDER)
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 700 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector("#statusline .chip", { timeout: 20000 });
+await page.waitForTimeout(800);
+await page.evaluate(() => {
+  const w = window; w.__t = { chipOn: null, boxOn: null, chipOff: null, boxOff: null, chipText: "", boxText: "" };
+  const chipRead = () => (document.querySelector("#statusline .chip")?.textContent || "");
+  const box = () => document.getElementById("bg-tasks");
+  const boxVisible = () => { const b = box(); return !!b && b.style.display !== "none" && (b.textContent || "").includes("Awaiting"); };
+  const tick = () => {
+    const c = chipRead(); const now = performance.now();
+    if (/Awaiting/.test(c)) { if (w.__t.chipOn === null) { w.__t.chipOn = now; w.__t.chipText = c; } }
+    else if (w.__t.chipOn !== null && w.__t.chipOff === null) w.__t.chipOff = now;
+    if (boxVisible()) { if (w.__t.boxOn === null) { w.__t.boxOn = now; w.__t.boxText = (box().textContent || "").slice(0, 160); } }
+    else if (w.__t.boxOn !== null && w.__t.boxOff === null) w.__t.boxOff = now;
+  };
+  new MutationObserver(tick).observe(document.body, { subtree: true, childList: true, characterData: true, attributes: true });
+});
+// the SDK Stop hook's own overlay row (sdk_backend.append_awaiting's shape, plus kind + count)
+fs.appendFileSync(cfg.states, JSON.stringify({ t: Math.floor(Date.now() / 1000), awaiting: true, kind: "agents",
+  count: 1, why: "1 background agent still working" }) + "\n");
+await page.waitForFunction(() => window.__t.chipOn !== null, null, { timeout: 30000 }).catch(() => {});
+await page.waitForFunction(() => window.__t.boxOn !== null, null, { timeout: 15000 }).catch(() => {});
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-awaiting.png" });
+// click the box head: the gist must open into the details (never a dead end)
+const head = page.locator("#bg-tasks .bg-fold-head").first();
+let detail = false;
+if (await head.count()) { await head.click(); await page.waitForTimeout(300); detail = (await page.locator("#bg-tasks .bg-await-detail").count()) > 0; }
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-expanded.png" });
+fs.appendFileSync(cfg.states, JSON.stringify({ t: Math.floor(Date.now() / 1000), awaiting: false }) + "\n");
+await page.waitForFunction(() => window.__t.chipOff !== null, null, { timeout: 30000 }).catch(() => {});
+await page.waitForFunction(() => window.__t.boxOff !== null, null, { timeout: 15000 }).catch(() => {});
+const all = await page.evaluate(() => window.__t);
+const r = (a, b) => (a === null || b === null) ? null : Math.round(b - a);
+fs.writeSync(1, "RESULT:" + JSON.stringify({ chipText: all.chipText, boxText: all.boxText, detail,
+  boxLagMs: r(all.chipOn, all.boxOn), boxAppeared: all.boxOn !== null, chipAppeared: all.chipOn !== null,
+  clearLagMs: r(all.chipOff, all.boxOff), boxCleared: all.boxOff !== null, chipCleared: all.chipOff !== null }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedSync(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served sync needs them")
+        cls.lab = tempfile.mkdtemp(prefix="awaiting-sync-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        os.makedirs(proj, exist_ok=True)
+        # a CLOSED turn: an open one would invite the boot reconcile to resume it — no real CLI here
+        Path(proj, SID + ".jsonl").write_text(
+            json.dumps({"type": "user", "uuid": "11111111-2222-3333-4444-555555555555", "parentUuid": None,
+                        "timestamp": "2026-09-02T00:00:00.000Z", "sessionId": SID,
+                        "message": {"role": "user", "content": "hello there"}}) + "\n" +
+            json.dumps({"type": "assistant", "uuid": "22222222-3333-4444-5555-666666666666",
+                        "parentUuid": "11111111-2222-3333-4444-555555555555",
+                        "timestamp": "2026-09-02T00:00:05.000Z", "sessionId": SID,
+                        "message": {"role": "assistant", "model": "claude-fable-5-1",
+                                    "content": [{"type": "text", "text": "hi from the lab"}],
+                                    "stop_reason": "end_turn"}}) + "\n")
+        cls.port = _free_port()
+        cls.token = "testtok-awaitsync"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist,
+                   ROMP_MODEL_CATALOG="off")   # hermetic: never reach the network
+        env.pop("ROMP_STATE_DIR", None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_box_shows_within_one_frame_of_the_chip_and_clears_with_it(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+                       "states": os.path.join(self.state, "states", SID + ".jsonl"),
+                       "shots": os.environ.get("AWAITING_SYNC_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served sync needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertTrue(r["chipAppeared"], "the overlay row must flip the chip: %r" % r)
+        self.assertEqual(r["chipText"], "Awaiting agent", "one agent → singular (T225 rider): %r" % r)
+        # THE FIX: the box renders from the SAME status frame — pre-fix it never appeared here at all
+        self.assertTrue(r["boxAppeared"], "the box must appear with the chip — pre-fix it waited for a full frame: %r" % r)
+        self.assertLessEqual(r["boxLagMs"], 250, "same frame, not the next full push: %r" % r)
+        self.assertIn("Awaiting agent · 1 background agent still working", r["boxText"], "the gist agrees in number and carries the why: %r" % r)
+        self.assertTrue(r["detail"], "clicking the gist opens the details — never a dead end: %r" % r)
+        # the other direction: awaiting:false clears both in the same frame
+        self.assertTrue(r["chipCleared"] and r["boxCleared"], "chip cleared ⇒ box gone: %r" % r)
+        self.assertLessEqual(r["clearLagMs"], 250, "cleared together: %r" % r)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_awaiting_count.py
+++ b/tests/test_awaiting_count.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""T225 rider (the user 2026-09-02): the chip must agree in number — "Awaiting agent" for exactly one,
+"Awaiting agents" only for two or more — and the box must show the same count. So every source of
+_session_awaiting (bin/romp-kernel) now carries `count` beside why/kind/since: the live agent count,
+the pending-task count, one per armed watch, the peers a stamp or delegation names; None when the
+source cannot know (a bare overlay row, an untyped stamp) — never parsed out of the why. The status
+payload ships it as awaitingCount, the ONE number the chip, the box gist, the feed pill and the spin
+caption derive their word from (ui kindWord). Synthetic inputs only, sources stubbed like
+test_awaiting_since.
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_awaitcount", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class AwaitingCount(unittest.TestCase):
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_tmux_sessions", "_bg_live_norm", "_bg_pending", "_states_awaiting_overlay",
+                        "_owned_yield_why", "_session_stamp_full", "_session_delegated_why",
+                        "_session_delegated_identities", "_watch_awaiting", "_peer_identity")}
+        km._tmux_sessions = lambda: {SID: {}}
+        km._bg_live_norm = lambda sid, path: []
+        km._bg_pending = lambda sid, path, tasks: []
+        km._states_awaiting_overlay = lambda sid: None
+        km._owned_yield_why = lambda sid, path: None
+        km._session_stamp_full = lambda sid: (None, 0, None, None, ())
+        km._session_delegated_why = lambda sid: None
+        km._session_delegated_identities = lambda sid: []
+        km._watch_awaiting = lambda sid: None
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+
+    def test_one_live_agent_counts_one(self):
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "a", "since": 500}]}}
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["count"]), ("agents", 1))
+        self.assertEqual(aw["why"], "1 background agent still working", "the why already agrees in number")
+
+    def test_several_live_agents_count_them_all(self):
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "a", "since": 1}, {"type": "b", "since": 2},
+                                                         {"type": "c", "since": 3}]}}
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual(aw["count"], 3)
+        self.assertIn("3 background agents", aw["why"])
+
+    def test_pending_tasks_count_the_pending_ones(self):
+        tasks = [{"tid": "1", "desc": "watching CI", "t": 7, "type": "bash"},
+                 {"tid": "2", "desc": "polling deploy", "t": 3, "type": "bash"}]
+        km._bg_live_norm = lambda sid, path: tasks
+        km._bg_pending = lambda sid, path, ts: ts[:1]
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True)["count"], 1)
+        km._bg_pending = lambda sid, path, ts: ts
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True)["count"], 2)
+
+    def test_watches_count_one_per_row(self):
+        km._watch_awaiting = self._saved["_watch_awaiting"]   # the real one, over stubbed registries
+        saved = (km._watches, km._pr_watches)
+        try:
+            km._watches = [{"sid": SID, "cmd": "grep -q DONE /tmp/a.log", "at": 10},
+                           {"sid": SID, "cmd": "test -f /tmp/b", "note": "the build", "at": 12}]
+            km._pr_watches = [{"sid": SID, "pr": 42, "repo": "notes-api/web", "at": 14}]
+            aw = km._session_awaiting(SID, "/tmp/x", True)
+            self.assertEqual((aw["kind"], aw["count"]), ("job", 3))
+            self.assertEqual(len(aw["tasks"]), 3)
+        finally:
+            km._watches, km._pr_watches = saved
+
+    def test_an_overlay_row_carries_a_count_only_when_its_producer_said(self):
+        km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "2 background agents still working",
+                                                   "kind": "agents", "t": 4321}
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", True)["count"],
+                          "never parsed out of the why — data, not a heuristic")
+        km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "waiting on a build",
+                                                   "kind": "job", "t": 4321, "count": 1}
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True)["count"], 1)
+        km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "x", "kind": "job", "t": 1, "count": 0}
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", True)["count"], "a non-positive count is no count")
+
+    def test_a_peer_stamp_counts_its_peers_and_an_untyped_stamp_none(self):
+        km._peer_identity = lambda p: {"name": str(p), "host": "", "sid": str(p), "color": None}
+        km._session_stamp_full = lambda sid: ("g1", 8765, "delegated to two peers", "peer", ("p-a", "p-b"))
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertEqual((aw["kind"], aw["count"]), ("peer", 2))
+        km._session_stamp_full = lambda sid: ("g1", 8765, "waiting on the test suite", "task", ())
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", True, stamp=True)["count"])
+
+    def test_a_delegation_wait_counts_the_identified_peers(self):
+        km._session_delegated_why = lambda sid: "delegated to web, api; waiting on their replies"
+        km._session_delegated_identities = lambda sid: [{"name": "web"}, {"name": "api"}]
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertEqual((aw["kind"], aw["count"]), ("peer", 2))
+
+    def test_an_owned_yield_is_one_dispatch(self):
+        km._owned_yield_why = lambda sid, path: "waiting on a background task: the GPU batch"
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True, stamp=True)["count"], 1)
+
+    def test_the_status_payload_ships_the_count_beside_the_kind(self):
+        src = inspect.getsource(km)
+        self.assertIn('"awaitingKind": awaiting_kind,', src)
+        self.assertIn('"awaitingCount": ((_aw or {}).get("count") if isinstance((_aw or {}).get("count"), int) else None),',
+                      src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1579,7 +1579,8 @@ class ViewBuilder(unittest.TestCase):
                         "awaiting:true with no later work turn stays awaiting")
         self.assertEqual(km._session_awaiting(SID, str(self.tpath), True),
                          {"kind": None, "since": 200,   # the overlay row's own stamp → the chips' elapsed readout (the user 2026-08-23)
-                          "why": "Waiting on 2 background jobs it launched."},
+                          "why": "Waiting on 2 background jobs it launched.",
+                          "count": None},   # a bare overlay row names no count — never parsed from the why (T225)
                          "the genuine awaiting badge still shows")
 
     def test_blocked_rolls_up_the_card_tree_so_a_buried_block_is_visible(self):
@@ -1671,21 +1672,24 @@ class ViewBuilder(unittest.TestCase):
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "agents", "why": "2 background agents still working",
-                              "since": T0},   # the oldest live agent's start → the chips' elapsed readout (the user 2026-08-23)
+                              "since": T0,   # the oldest live agent's start → the chips' elapsed readout (the user 2026-08-23)
+                              "count": 2},   # the live agent count — the chip's number agreement rides it (T225)
                              "a live subagent DOES leave an idle session awaiting (a working flavor)")
             # source 0.5: the live bg-task set — one task shows its description verbatim
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task", "since": T0 + 9,   # the dispatch stamp (the user 2026-08-23)
-                              "why": "waiting on a background task: 20-minute timer for campaign-start check"})
+                              "why": "waiting on a background task: 20-minute timer for campaign-start check",
+                              "count": 1})
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer, dict(timer, desc="power watcher")]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task", "since": T0 + 9,
-                              "why": "waiting on 2 background tasks — 20-minute timer for campaign-start check, …"})
+                              "why": "waiting on 2 background tasks — 20-minute timer for campaign-start check, …",
+                              "count": 2})
             # subagents outrank bg tasks when both run (they're the bigger dispatch)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}], "bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             {"kind": "agents", "why": "1 background agent still working", "since": T0})
+                             {"kind": "agents", "why": "1 background agent still working", "since": T0, "count": 1})
         finally:
             km._tmux_sessions = saved
 
@@ -1701,7 +1705,7 @@ class ViewBuilder(unittest.TestCase):
         ]) + "\n")
         self.assertEqual(km._session_awaiting(SID, "/nonexistent", True),
                          {"kind": None, "why": "3 agents in flight",
-                          "since": T0 + 1},   # the overlay row's own stamp (the user 2026-08-23)
+                          "since": T0 + 1, "count": None},   # the overlay row's own stamp (the user 2026-08-23)
                          "the latest awaiting overlay (interleaved with state records) drives the badge")
         self.assertIsNone(km._session_awaiting(SID, "/nonexistent", False),
                           "a WORKING session is not 'awaiting' (idle=False short-circuits)")

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -73,7 +73,7 @@ class MergeCarriesBgTasks(unittest.TestCase):
         finally:
             km._tmux_sessions = saved_sessions
         self.assertEqual(why, {"kind": "task", "since": 1,   # the dispatch stamp → the chips' elapsed readout (the user 2026-08-23)
-                               "why": "waiting on a background task: 20-minute timer for campaign-start check"})
+                               "why": "waiting on a background task: 20-minute timer for campaign-start check", "count": 1})
 
 
 class NudgeFailedRespectsAwaiting(unittest.TestCase):

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -155,7 +155,8 @@ class SessionLevelStamp(unittest.TestCase):
             "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": "job", "why": "slurm 4821 regenerating the parts",
-                          "since": 200})   # the stamp's awaitingAt → the chips' elapsed readout (the user 2026-08-23)
+                          "since": 200,   # the stamp's awaitingAt → the chips' elapsed readout (the user 2026-08-23)
+                          "count": None})   # a stamp naming no peers carries no count (T225)
         self.assertEqual(km._session_stamp_full(SID),
                          ("g1", 200, "slurm 4821 regenerating the parts", "job", ()))
 
@@ -168,7 +169,7 @@ class SessionLevelStamp(unittest.TestCase):
         self._seed(("g1", "the watcher it armed; files the clip when it triggers", 200))
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": None, "since": 200,
-                          "why": "the watcher it armed; files the clip when it triggers"})
+                          "why": "the watcher it armed; files the clip when it triggers", "count": None})
 
     def test_stamp_false_stays_none_so_the_feed_scopes_per_goal(self):
         # the crux: the feed calls stamp=False, so the session-level signal is None for a stamp-only session
@@ -257,7 +258,8 @@ class SessionLevelDelegation(unittest.TestCase):
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": "peer", "why": "delegated to probe; waiting on their result",
                           "since": None,   # the handoff graph has no single event time here → no duration
-                          "peers": [{"name": "probe", "host": "", "sid": self.PEER, "color": None}]})
+                          "peers": [{"name": "probe", "host": "", "sid": self.PEER, "color": None}],
+                          "count": 1})   # one identified peer → "Awaiting peer" (T225)
 
     def test_handoff_peer_identities_carry_name_host_and_colour_for_the_card(self):
         # the card's awaiting box names the peers the way the origin line does (the user 2026-08-23):
@@ -289,7 +291,7 @@ class SessionLevelDelegation(unittest.TestCase):
         nodes["g1"]["awaitingWhy"], nodes["g1"]["awaitingAt"] = "the sweep it launched", 200
         self._seed(nodes)
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "the sweep it launched", "since": 200})
+                         {"kind": None, "why": "the sweep it launched", "since": 200, "count": None})
 
     def test_a_pure_delegation_top_stays_dark_matching_its_suppressed_card(self):
         # EVERY leaf a handoff → the feed suppresses the card in every column, so its dot never lights;
@@ -365,7 +367,7 @@ class KindScopedRules(unittest.TestCase):
     def test_a_peer_answer_supersedes_only_peer_waits(self):
         self._seed("job")
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": "job", "why": "the wait", "since": 200},
+                         {"kind": "job", "why": "the wait", "since": 200, "count": None},
                          "unrelated mail cannot end a wait on an external job")
         self._seed("peer")
         self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True),
@@ -434,14 +436,14 @@ class OverlayDoesNotVeto(unittest.TestCase):
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": None, "why": "a dispatched release watch; tags when green",
-                          "since": 200},
+                          "since": 200, "count": None},
                          "the Stop hook's ambient false must not hide the judge's stamp")
 
     def test_a_live_true_row_still_wins_with_its_own_why(self):
         self._overlay({"t": 100, "awaiting": True, "why": "a job the hook reported"})
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "a job the hook reported", "since": 100},
+                         {"kind": None, "why": "a job the hook reported", "since": 100, "count": None},
                          "a positive overlay row keeps its channel")
 
     def test_false_row_and_no_stamp_is_plain_none(self):

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -435,7 +435,7 @@ class DurableAwaitingSource(unittest.TestCase):
             self._restore(saved)
             os.unlink(path)
         self.assertEqual(why, {"kind": "task", "why": "waiting on a background task: power watcher",
-                               "since": None})   # the transcript scan carries no dispatch stamp → no duration, never a guess
+                               "since": None, "count": 1})   # the transcript scan carries no dispatch stamp → no duration, never a guess
 
     def test_the_notification_landing_ends_it(self):
         path = _write([_launch(), _notif_str(tid=TUSE)])

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -114,7 +114,8 @@ class OwnedYieldAwaiting(unittest.TestCase):
         self._store()
         self.assertEqual(km._session_awaiting(SID, self.path, True, stamp=True),
                          {"kind": "task", "why": "waiting on a background task: " + DESC,
-                          "since": None},   # the owned-yield read has no single event time → no duration
+                          "since": None,   # the owned-yield read has no single event time → no duration
+                          "count": 1},   # one owned dispatch (T225)
                          "the lane/chip say awaiting instead of READY")
 
     def test_the_feed_path_is_unchanged_no_session_wide_floor(self):

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -1,0 +1,88 @@
+// T225 (the user 2026-09-02): the awaiting box must be there the moment the chip says "Awaiting".
+//
+// Convicted at the source, twice over. The kernel assembles the chip's state AND the box's fields
+// (awaitingWhy / awaitingKind / awaitingCount / awaitingTasks / awaitingTaskIds / awaitingPeers) in the
+// SAME status payload — and ships a status-only change to a caught-up client as a chatTail DELTA: an
+// empty event suffix plus the full status (kernel _send_chat). The client's chatTail handler assigned
+// the status and repainted tabs + statusline (the chip), but the box (renderBgTasks → renderAwaitWhy)
+// rendered only from the FULL-session frame path, which a quiet session never sends. So the chip read
+// "Awaiting agents" for 31s+ with no box (the user's screenshot); in the served lab, without the fix the
+// box never appeared in 40s; with it, the same frame. (A first attempt hooked only the host-side
+// "status" frame — which the served page never receives; the WebSocket sniff in the lab showed the flip
+// riding a chatTail. That handler, its `update` sibling and statusOnly now all render the box.)
+//
+// The fix is one call per handler, keyed on the awaiting fields CHANGING — never on the per-second ticks
+// that touch nothing the box shows. No provisional box is needed: the descriptions are available at chip
+// time (same payload), and the gist ("Awaiting agents · 2 background agents still working") IS the
+// one-line version.
+//
+// Rider (the user, same morning): the chip agrees in NUMBER — "Awaiting agent" for exactly one,
+// "Awaiting agents" only for two or more — from ONE count the kernel ships (awaitingCount), the same
+// count the box gist, the feed pill and the spin caption derive their word from (kindWord).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const SPIN = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "spin-caption.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("a status-only frame re-renders the awaiting box when its fields change — the chip's own flip included", () => {
+  // the chatTail delta is the frame a status-only change actually rides (kernel _send_chat)
+  const tail = RENDER.split("function chatTail(msg: any) {")[1].split("\n}")[0];
+  assert.match(tail, /const before = awaitKey\(s\.status\);\s*\n\s*if \(msg\.status\) s\.status = msg\.status;/);
+  assert.match(tail, /appendActive\(\);\s*\n\s*renderLedger\(\);[\s\S]{0,900}?if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/,
+    "the box renders from the SAME chatTail frame that flipped the chip");
+  // the `update` delta and the host-side status frame render it the same way
+  const upd = RENDER.split("function update(msg: any) {")[1].split("\n}")[0];
+  assert.match(upd, /const before = awaitKey\(s\.status\);\s*\n\s*s\.status = msg\.status \|\| s\.status;/);
+  assert.match(upd, /if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/);
+  const body = RENDER.split("function statusOnly(msg: any) {")[1].split("\n}")[0];
+  assert.match(body, /const before = awaitKey\(s\.status\);/);
+  assert.match(body, /if \(msg\.id === activeId\) \{\s*\n\s*updateStatusline\(\);/, "the chip repaint stays");
+  assert.match(body, /if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/);
+  // …and the kernel's delta carries the full status the box reads from
+  assert.match(KERNEL, /tail = \{"type": "chatTail", "id": sid, "from": change_from,\s*\n\s*"events": evs\[change_from:\], "total": total, "status": m\.get\("status"\)\}/);
+});
+
+test("the await key covers every field the box renders from, and nothing that ticks per second", () => {
+  const key = RENDER.split("function awaitKey(")[1].split("\n}")[0];
+  for (const f of ["st.state", "st.awaitingWhy", "st.awaitingKind", "st.awaitingCount", "st.awaitingTasks",
+                   "st.awaitingTaskIds", "st.awaitingPeers"]) {
+    assert.ok(key.includes(f), f + " must be in the key");
+  }
+  assert.doesNotMatch(key, /sinceEpoch|ctx\b|modelPending|effortPending/, "timer/ctx ticks must not rebuild the box");
+});
+
+test("the box's render condition is unchanged: awaited content present ⇒ box; absent ⇒ hidden", () => {
+  const why = RENDER.split("function renderAwaitWhy(")[1].split("\n}")[0];
+  assert.match(why, /if \(!why \|\| !activeId\) \{ host\.style\.display = "none"; return; \}/,
+    "chip cleared (awaitingWhy gone) ⇒ the same status frame hides the box");
+  assert.match(why, /host\.style\.display = "";/);
+});
+
+test("the chip and the box gist take the kind word from ONE count (T225 rider)", () => {
+  assert.match(RENDER, /import \{ KIND_WORD, kindWord \} from "\.\/spin-caption";/);
+  assert.match(RENDER, /awaitingCount\?: number \| null;/, "the Status shape carries the kernel's count");
+  assert.match(RENDER, /chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(kw \? " " \+ kindWord\(s\.status\.awaitingKind, s\.status\.awaitingCount\) : ""\);/);
+  assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(kw \? " " \+ kindWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount\) : ""\)/);
+  // the feed pill and the spin caption derive their word the same way
+  assert.match(FEED, /import \{ spinFor, KIND_WORD, kindWord, waitedSuffix \} from "\.\/spin-caption";/);
+  assert.match(FEED, /kindWord\(awKind, 1\)/);
+  assert.match(FEED, /kindWord\(awKind, taskList\.length\)/);
+  assert.match(SPIN, /const word = kindWord\(aw\.kind, aw\.count\);/);
+  assert.match(SPIN, /export function kindWord\(kind: string \| null \| undefined, count: number \| null \| undefined\): string \{/);
+});
+
+test("the kernel ships the count beside the kind, from every awaiting source", () => {
+  assert.match(KERNEL, /"awaitingCount": \(\(_aw or \{\}\)\.get\("count"\) if isinstance\(\(_aw or \{\}\)\.get\("count"\), int\) else None\),/);
+  assert.match(KERNEL, /"why": "%d background agent%s still working" % \(n, "" if n == 1 else "s"\),\s*\n\s*"count": n,/,
+    "live subagents: the count is the live agent count");
+  assert.match(KERNEL, /"kind": kind, "since": since, "count": 1,/, "one pending task");
+  assert.match(KERNEL, /"kind": kind, "since": since, "count": len\(pending\),/, "several pending tasks");
+  assert.match(KERNEL, /"tasks": descs, "count": len\(descs\)\}/, "armed watches: one per row");
+  assert.match(KERNEL, /"count": ov\["count"\] if isinstance\(ov\.get\("count"\), int\) and ov\["count"\] > 0 else None,/,
+    "an overlay row carries a count only when its producer said so — never parsed from the why");
+});

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -80,7 +80,7 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   // several, and a plain-words note on what the state means. No Stop — nothing untracked is killable.
   assert.match(RENDER, /\{ renderAwaitWhy\(host, s \|\| null\); return; \}/);
   assert.match(RENDER, /"bg-fold-head bg-await"/);
-  assert.match(RENDER, /"Awaiting" \+ \(kw \? " " \+ kw : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
+  assert.match(RENDER, /"Awaiting" \+ \(kw \? " " \+ kindWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount\) : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
   // …the kind word rides the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA
   assert.match(RENDER, /KIND_WORD\[\(s!\.status\.awaitingKind \|\| ""\)\]/);
   assert.match(RENDER, /chip-awaiting-" \+ \(s\.status\.awaitingKind \|\| "untyped"\)/);

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -21,7 +21,7 @@ test("the swirl element is built in the body, right after the distiller line, an
 });
 
 test("the swirl is driven by spinFor's caption — shown when there is one, else hidden", () => {
-  assert.match(FEED, /import \{ spinFor, KIND_WORD, waitedSuffix \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, KIND_WORD, kindWord, waitedSuffix \} from "\.\/spin-caption";/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
@@ -35,7 +35,7 @@ test("a bg-task wait wears the compact 'Awaiting task' pill that expands the tas
   assert.match(FEED, /"bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none"/);
   // "Awaiting task", never "Waiting on task": one word per state across every surface — the chat chip
   // and timeline badge already say Awaiting for this exact state (the user 2026-08-13)
-  assert.match(FEED, /taskList\.length === 1 \? "Awaiting " \+ one\s*\n?\s*: "Awaiting " \+ taskList\.length \+ " "/);
+  assert.match(FEED, /taskList\.length === 1 \? "Awaiting " \+ \(awKind \? kindWord\(awKind, 1\) : kw\)\s*\n?\s*: "Awaiting " \+ taskList\.length \+ " "/);
   assert.doesNotMatch(FEED, /"Waiting on task"/);
   // the pill carries the wait's elapsed time, same readout as the awaiting box (the user 2026-08-23)
   assert.match(FEED, /\+ pillWaited;/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -7,7 +7,7 @@
 // pushes and updated in place — never torn down — so hovering one doesn't flicker
 // when the fleet streams new deliverables in.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
-import { spinFor, KIND_WORD, waitedSuffix } from "./spin-caption";
+import { spinFor, KIND_WORD, kindWord, waitedSuffix } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
 import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
@@ -1523,14 +1523,14 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   taskBtn.style.display = hasTasks ? "" : "none";
   // the KIND words the pill (the user 2026-08-15): "Awaiting job", "Awaiting 3 agents" — the wait's
   // class in the visible label (tooltips are dead on the touch PWA); kindless keeps the classic "task"
-  const kw = KIND_WORD[(it.awaiting && it.awaiting.kind) || ""] || "task";
-  const one = kw === "agents" ? "agent" : kw;   // singular form: "Awaiting agent", plural "N agents"
+  const awKind = (it.awaiting && it.awaiting.kind) || "";
+  const kw = KIND_WORD[awKind] || "task";
   // the wait's elapsed time rides the pill exactly as it rides the awaiting box and the working
   // narration — a stuck wait must be glanceable everywhere the state shows (the user 2026-08-23)
   const pillWaited = waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000);
   (a._taskLbl as HTMLElement).textContent =
-    (taskList.length === 1 ? "Awaiting " + one
-                           : "Awaiting " + taskList.length + " " + (one === kw ? kw + "s" : kw)) + pillWaited;
+    (taskList.length === 1 ? "Awaiting " + (awKind ? kindWord(awKind, 1) : kw)
+                           : "Awaiting " + taskList.length + " " + (awKind ? kindWord(awKind, taskList.length) : kw + "s")) + pillWaited;   // one number-agreeing vocabulary (T225)
   taskBtn.classList.toggle("on", choice === "tasks");
   taskBtn.setAttribute("aria-pressed", choice === "tasks" ? "true" : "false");
   taskBtn.title = choice === "tasks" ? "hide the tasks" : "show the tasks";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -24,7 +24,7 @@ import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { senderKind } from "./sender-identity";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
-import { KIND_WORD } from "./spin-caption";
+import { KIND_WORD, kindWord } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
@@ -229,7 +229,7 @@ interface TodoTask { id: string; subject: string; activeForm?: string; status: s
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
 type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -9481,7 +9481,7 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
     });
     lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
   } else {
-    lab.textContent = "Awaiting" + (kw ? " " + kw : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+    lab.textContent = "Awaiting" + (kw ? " " + kindWord(s!.status.awaitingKind, s!.status.awaitingCount) : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
   }
   head.appendChild(lab);
   host.appendChild(head);
@@ -10567,7 +10567,7 @@ function updateStatusline() {
         if (chipPeers[0].color && chipPeers[0].color.bg) nm.style.color = chipPeers[0].color.bg;
         chip.appendChild(nm);
       } else chip.append(chipPeers.length + " peers");
-    } else chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kw : "");
+    } else chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kindWord(s.status.awaitingKind, s.status.awaitingCount) : "");   // "Awaiting agent" for one, "agents" for more (T225)
     chip.title = (s.status.awaitingWhy || "idle, waiting on background work it dispatched")
                + " — clears when the result lands";
     sl.appendChild(chip);
@@ -11654,6 +11654,7 @@ function update(msg: any) {
   const s = sessions.get(msg.id);
   if (!s) return;
   s.events = msg.events || s.events;
+  const before = awaitKey(s.status);
   s.status = msg.status || s.status;
   reconcileRewind(s);                    // pending-rewind overlay + the editable-bubble set, from the fresh payload
   reconcileOptimistic(s);                // re-assert (or retire) any in-flight optimistic sends on this push
@@ -11661,6 +11662,7 @@ function update(msg: any) {
   if (msg.id === activeId) {
     appendActive();
     renderLedger(); // refresh the summary box (ages + any new items) as the active session works
+    if (awaitKey(s.status) !== before) renderBgTasks();   // the box rides the chip's own frame (T225; see chatTail)
   } else {
     const v = views.get(msg.id);
     if (v) v.stale = true; // re-render its current turn when it's next shown
@@ -11729,6 +11731,7 @@ function chatTail(msg: any) {
   // view stale so the window is rebuilt from the events that actually remain.
   const shrank = s.events.length < wasLen;
   if (typeof msg.total === "number") s.headTotal = msg.total;
+  const before = awaitKey(s.status);
   if (msg.status) s.status = msg.status;
   if ("ledger" in msg) ledgers.set(msg.id, msg.ledger ?? null);
   renderTabs();
@@ -11740,6 +11743,12 @@ function chatTail(msg: any) {
     }
     appendActive();
     renderLedger();
+    // THIS is the frame that flips the chip (T225): a status-only change reaches a caught-up client as a
+    // chatTail with an empty suffix and the full status — awaitingWhy/Kind/Count/Tasks included. The box
+    // rendered only from the full-session path, so the chip read "Awaiting agents" with no box until a
+    // transcript change happened to send a full frame (31s+ in the user's shot; never, in the quiet lab).
+    // Render the box from the SAME frame, keyed on the awaited fields CHANGING — never on the per-second ticks.
+    if (awaitKey(s.status) !== before) renderBgTasks();
   } else {
     const v = views.get(msg.id);
     if (v) v.stale = true;
@@ -11830,12 +11839,30 @@ function requestOlder(sid: string, v: View, content: HTMLElement): void {
   vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.headFrom });
 }
 
+// The awaiting fields the #bg-tasks box renders from (renderAwaitWhy / the awaited-row outline) — one
+// key per status, so a status-only frame re-renders the box exactly when THESE change (the chip's own
+// flip is one of them) and never on the per-second ticks that touch nothing the box shows.
+function awaitKey(st: Status | undefined): string {
+  if (!st) return "";
+  return JSON.stringify([st.state, st.awaitingWhy || "", st.awaitingKind || "", st.awaitingCount ?? null,
+                         st.awaitingTasks || [], st.awaitingTaskIds || [],
+                         (st.awaitingPeers || []).map((p) => [p.host || "", p.name || ""])]);
+}
+
 function statusOnly(msg: any) {
   const s = sessions.get(msg.id);
   if (!s) return;
+  const before = awaitKey(s.status);
   s.status = msg.status || s.status;
   renderTabs();                          // status-only push → repaint the chip; order is untouched
-  if (msg.id === activeId) updateStatusline();
+  if (msg.id === activeId) {
+    updateStatusline();
+    // T225 (the user 2026-09-02): the awaiting BOX must be there the moment the chip says so. Both read
+    // this one payload, but the box was rendered only by the full-session frame path, so a status-only
+    // flip to Awaiting left the chip on and the box absent until the next transcript change or tab
+    // switch (31s+ observed). Same frame, same data — re-render the box when its fields changed.
+    if (awaitKey(s.status) !== before) renderBgTasks();
+  }
 }
 
 // The ✕'s own path: drop the tab now, THEN remember the close (see closingTabs). The order matters and

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { spinFor } from "./spin-caption";
+import { spinFor, kindWord } from "./spin-caption";
 import { distillInputs, distillText, distillPending } from "./distiller-line";
 
 // --- THE REGRESSION: a re-judging card always spins ----------------------------------------------
@@ -166,7 +166,7 @@ test("a settled card displaced to Working loses its line but never its caption",
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("feed.ts routes the card's swirl through spinFor and keeps no inline copy of the ladder", () => {
-  assert.match(FEED, /import \{ spinFor, KIND_WORD, waitedSuffix \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, KIND_WORD, kindWord, waitedSuffix \} from "\.\/spin-caption";/);
   // the elapsed readout reaches the OTHER two awaiting surfaces through the same helper: the
   // "Awaiting task" pill and the "Awaiting <peer>" chip (the user 2026-08-23)
   assert.match(FEED, /const pillWaited = waitedSuffix\(it\.awaiting && it\.awaiting\.since, Date\.now\(\) \/ 1000\);/);
@@ -278,4 +278,38 @@ test("awaiting WITH tracked tasks says it ONCE — no caption, and never the pau
   // …and so do the richer in-motion stories (a re-judge under an awaiting pill is worth a line)
   const rj = spinFor({ awaiting: { tasks: ["t"] }, rejudging: true, column: "working" }, false, false);
   assert.equal(rj.caption, "Analyzing…");
+});
+
+// --- T225 rider (the user 2026-09-02): the kind word agrees in NUMBER, from one count -------------
+test("kindWord: exactly one agent is 'agent'; two or more are 'agents'", () => {
+  assert.equal(kindWord("agents", 1), "agent");
+  assert.equal(kindWord("agents", 2), "agents");
+  assert.equal(kindWord("agents", 7), "agents");
+});
+
+test("kindWord: the other kinds pluralize by count too", () => {
+  assert.equal(kindWord("task", 1), "task");
+  assert.equal(kindWord("task", 3), "tasks");
+  assert.equal(kindWord("job", 2), "jobs");
+  assert.equal(kindWord("peer", 1), "peer");
+  assert.equal(kindWord("peer", 2), "peers");
+  assert.equal(kindWord("timer", 4), "timers");
+});
+
+test("kindWord: an unknown count keeps the surfaces' historic default; an unknown kind stays agents", () => {
+  assert.equal(kindWord("agents", null), "agents");
+  assert.equal(kindWord("agents", undefined), "agents");
+  assert.equal(kindWord("task", null), "task");
+  assert.equal(kindWord(null, 1), "agent");
+  assert.equal(kindWord("", 2), "agents");
+  assert.equal(kindWord("nonsense", 2), "agents");
+});
+
+test("the spin caption derives its word from the kernel's count", () => {
+  const one = spinFor({ awaiting: { why: "", kind: "agents", count: 1 }, column: "working" }, false, false);
+  assert.equal(one.caption, "Awaiting agent");
+  const two = spinFor({ awaiting: { why: "", kind: "agents", count: 2 }, column: "working" }, false, false);
+  assert.equal(two.caption, "Awaiting agents");
+  const legacy = spinFor({ awaiting: { why: "", kind: "agents" }, column: "working" }, false, false);
+  assert.equal(legacy.caption, "Awaiting agents", "an older kernel with no count reads as before");
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -37,7 +37,7 @@
 
 /** The card fields the ladder reads. Structural, so the test can pass plain objects. */
 export interface SpinItem {
-  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: unknown[] | null } | null;   // since = the wait's own event time (kernel or-chain / _session_awaiting; the user 2026-08-23)
+  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; count?: number | null; tasks?: unknown[] | null } | null;   // count = how many things are awaited (T225: the label agrees in number)   // since = the wait's own event time (kernel or-chain / _session_awaiting; the user 2026-08-23)
   waitingOn?: unknown;
   provisional?: boolean;
   column?: string;
@@ -65,6 +65,18 @@ const NONE: Spin = { caption: null, tip: "", awaitingBg: false };
 export const KIND_WORD: Record<string, string> = {
   agents: "agents", task: "task", job: "job", peer: "peer", timer: "timer",
 };
+
+/** The kind word AGREEING IN NUMBER with how many things are awaited (T225; the user 2026-09-02,
+ *  who wants one awaited agent labelled as one, not as "agents"). One helper feeds the
+ *  chat chip, the awaiting box gist, the feed pill and the spin caption, so every surface derives the
+ *  word from the same count. An unknown count (null/undefined — an older kernel, a kindless stamp)
+ *  keeps the plural KIND_WORD default the surfaces have always worn; an unknown kind stays "agents". */
+export function kindWord(kind: string | null | undefined, count: number | null | undefined): string {
+  const base = KIND_WORD[kind || ""] || "agents";
+  if (typeof count !== "number" || !Number.isFinite(count)) return base;
+  if (count === 1) return base === "agents" ? "agent" : base;
+  return base === "agents" ? base : base + "s";
+}
 
 /** dCompleted/dBlocked come from distillInputs(distillState, column) — the GENUINE resolution state, not
  *  the transient column. distillPending is passed in (rather than recomputed) so the two modules keep one
@@ -104,7 +116,7 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // actively-working cases, so the glyph needn't also freeze). A why that already leads with
     // "waiting on" is shown verbatim (capitalized); the kind word is the fallback frame.
     const why = aw.why || "";
-    const word = KIND_WORD[aw.kind || ""] || "agents";   // kindless = the box's historic default
+    const word = kindWord(aw.kind, aw.count);   // kindless = the box's historic default; agrees in number (T225)
     // how long the wait has held, from the kernel's event time — the same live readout the working
     // narration wears, so a stuck wait is visible at a glance (the user 2026-08-23)
     const waited = waitedSuffix(aw.since, nowS);


### PR DESCRIPTION
## Summary
The chip read "Awaiting agents" while the awaiting box beneath the transcript stayed absent for 31s+ (the user's screenshot). Convicted at the source: the kernel assembles the chip state and every box field in ONE status payload and ships a status-only change to a caught-up client as a `chatTail` delta (empty suffix + full status, `_send_chat`). The client's `chatTail` handler assigned that status and repainted tabs + statusline but rendered the box only from the full-session path, which a quiet session never sends.

**Fix.** `chatTail`, `update` and `statusOnly` each snapshot `awaitKey(status)` (the awaited fields only, never the per-second ticks) and call `renderBgTasks()` when it changed. No provisional box: the descriptions ride the same payload; the gist is the one-line version. Pinned both ways: chip awaiting ⇒ box in the same frame; awaiting cleared ⇒ box gone in the same frame.

**Rider: number agreement.** Every `_session_awaiting` source carries `count` (live agents, pending tasks, one per armed watch, the peers a stamp/delegation names; `None` when the producer cannot know — never parsed from the why). The status payload ships `awaitingCount`, the feed card `awaiting.count`, and one client helper `kindWord()` words the chip, the box gist, the feed pill and the spin caption: "Awaiting agent" for exactly one, "Awaiting agents" for two or more.

## Measured (hermetic served lab, MutationObservers on chip + box, Stop-hook overlay row injected)
| | box appeared | chip→box lag | clear lag |
|---|---|---|---|
| before | never within 40s | — | — |
| after | same frame | 0 ms | 0 ms |

A WebSocket sniff showed the flip riding a `chatTail` with 0 events (a first attempt hooked only the host-side `status` frame, which the served page never receives).

## Tests
- `tests/test_awaiting_box_sync.py` — CI-safe SourcePins + ServedSync (hermetic kernel, real /chat, count 1 → "Awaiting agent"; skips loudly without a browser)
- `tests/test_awaiting_count.py` — count per source + payload pin
- `ui/webview/awaiting-box-sync.test.ts`, kindWord unit tests in `spin-caption.test.ts`
- anchored pins retargeted: `awaiting-state`, `feed-awaiting-swirl`, `spin-caption` tests; exact-dict awaiting asserts in `test_kernel*.py` gained `count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
