### PR TITLE
T227: the recovery line counts its own episode; the backstop cause knows which order happened

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -323,7 +323,7 @@ function quietGate(st, busy, now, opts) {
   return { action: 'wait', reason: `${busy} turn(s) in flight` };
 }
 
-let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer, drainRefusedCount, drainArmedCount, drainLostAfterArm}
+let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer, drainRefusedCount, drainArmedCount, drainRefusedAfterArm}
 
 // The primary kernel's serve token. The drain arm of '/busy?drain=1' is a WRITE — it holds every
 // session's new turn starts — so the kernel now requires the token for it (a drive-by loopback page
@@ -460,7 +460,7 @@ function queueQuietRestart(mode) {
     return pendingQuiet.count;
   }
   pendingQuiet = { since: Date.now(), count: 1, mode, timer: null,
-                   drainRefusedCount: 0, drainArmedCount: 0, drainLostAfterArm: false };
+                   drainRefusedCount: 0, drainArmedCount: 0, drainRefusedAfterArm: 0 };
   resetDrainNotices();                   // the token/refusal notices re-arm when a fresh park begins
   log(`refresh queued — applying at the next quiet window (no SDK turn in flight; backstop ${Math.round(QUIET_MAX_DEFER_MS / 60000)} min)`);
   const tick = () => quietTick({
@@ -478,8 +478,10 @@ function queueQuietRestart(mode) {
           if (draining === false) {
             park.drainRefusedCount++;
             // ORDER matters for the apply line (T227): two bare counters cannot tell "refused, then
-            // armed" from "armed, then LOST" — a refusal that lands AFTER any arm is the loss
-            if (park.drainArmedCount > 0) park.drainLostAfterArm = true;
+            // armed" from "armed, then LOST" — a refusal that lands AFTER any arm is the loss, and
+            // it is COUNTED on its own (the review's catch: a boolean here let the line report the
+            // park's whole refusal total as "after arming", pre-arm refusals included)
+            if (park.drainArmedCount > 0) park.drainRefusedAfterArm++;
           } else if (draining === true) park.drainArmedCount++;
         }
         done(busy);
@@ -502,8 +504,8 @@ function queueQuietRestart(mode) {
       const cause = g.reason !== 'backstop cap' || p.drainRefusedCount === 0 ? ''
         : p.drainArmedCount === 0
           ? ' — the kernel never armed the drain hold for this park (see the refusal line above), so in-flight turns may be cut'
-          : p.drainLostAfterArm
-            ? ` — the drain hold armed and was then LOST for this park (refused ${p.drainRefusedCount} time(s) after arming), so turns started after the loss may be cut`
+          : p.drainRefusedAfterArm > 0
+            ? ` — the drain hold armed and was then LOST for this park (refused ${p.drainRefusedAfterArm} time(s) after arming, ${p.drainRefusedCount - p.drainRefusedAfterArm} before), so turns started after the loss may be cut`
             : ` — the drain hold was refused ${p.drainRefusedCount} time(s) before arming for this park, so turns started before it armed may be cut`;
       log(`applying deferred refresh — ${g.reason}${cause} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
       if (p.mode === 'all') restartAllOrSelf(); else restartKernel(p.mode);

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -323,7 +323,7 @@ function quietGate(st, busy, now, opts) {
   return { action: 'wait', reason: `${busy} turn(s) in flight` };
 }
 
-let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer, drainRefusedCount, drainArmedCount}
+let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer, drainRefusedCount, drainArmedCount, drainLostAfterArm}
 
 // The primary kernel's serve token. The drain arm of '/busy?drain=1' is a WRITE — it holds every
 // session's new turn starts — so the kernel now requires the token for it (a drive-by loopback page
@@ -460,7 +460,7 @@ function queueQuietRestart(mode) {
     return pendingQuiet.count;
   }
   pendingQuiet = { since: Date.now(), count: 1, mode, timer: null,
-                   drainRefusedCount: 0, drainArmedCount: 0 };
+                   drainRefusedCount: 0, drainArmedCount: 0, drainLostAfterArm: false };
   resetDrainNotices();                   // the token/refusal notices re-arm when a fresh park begins
   log(`refresh queued — applying at the next quiet window (no SDK turn in flight; backstop ${Math.round(QUIET_MAX_DEFER_MS / 60000)} min)`);
   const tick = () => quietTick({
@@ -475,8 +475,12 @@ function queueQuietRestart(mode) {
       const park = pendingQuiet;
       const cb = (busy, draining) => {
         if (park && busy !== null) {
-          if (draining === false) park.drainRefusedCount++;
-          else if (draining === true) park.drainArmedCount++;
+          if (draining === false) {
+            park.drainRefusedCount++;
+            // ORDER matters for the apply line (T227): two bare counters cannot tell "refused, then
+            // armed" from "armed, then LOST" — a refusal that lands AFTER any arm is the loss
+            if (park.drainArmedCount > 0) park.drainLostAfterArm = true;
+          } else if (draining === true) park.drainArmedCount++;
         }
         done(busy);
       };
@@ -491,12 +495,16 @@ function queueQuietRestart(mode) {
       clearPendingQuiet();               // also disarms the pre-armed next tick
       // On a backstop cut, say what this park's drain evidence shows (a wrong cause misleads the
       // reader worse than none): every answer refused → the hold never armed; refused then armed
-      // → the hold arrived late, so turns started before it may still be cut. No refusals → no
-      // suffix (and draining:null answers are no evidence either way, so they count nowhere).
+      // → the hold arrived late, so turns started before it may still be cut; armed then LOST
+      // (T227: a refusal after any arm) → the hold covered the early part of the park only, so
+      // turns started after the loss may be cut. No refusals → no suffix (and draining:null
+      // answers are no evidence either way, so they count nowhere).
       const cause = g.reason !== 'backstop cap' || p.drainRefusedCount === 0 ? ''
         : p.drainArmedCount === 0
           ? ' — the kernel never armed the drain hold for this park (see the refusal line above), so in-flight turns may be cut'
-          : ` — the drain hold was refused ${p.drainRefusedCount} time(s) before arming for this park, so turns started before it armed may be cut`;
+          : p.drainLostAfterArm
+            ? ` — the drain hold armed and was then LOST for this park (refused ${p.drainRefusedCount} time(s) after arming), so turns started after the loss may be cut`
+            : ` — the drain hold was refused ${p.drainRefusedCount} time(s) before arming for this park, so turns started before it armed may be cut`;
       log(`applying deferred refresh — ${g.reason}${cause} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
       if (p.mode === 'all') restartAllOrSelf(); else restartKernel(p.mode);
     },

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -560,8 +560,9 @@ def _version_info():
             # counters, no paths — safe for the auth-exempt route. Deploy verification reads the live
             # fold rate here instead of trusting an offline replay number (T210).
             "parse": dict(em._ASM_STATS),
-            "drainRefused": dict(_DRAIN_REFUSED),   # T224: refused /busy?drain=1 arms — count, open
-            #                                          episode, last time; the silent degrade made visible
+            "drainRefused": dict(_DRAIN_REFUSED),   # T224: refused /busy?drain=1 arms — count (lifetime
+            #                                          total), episodeCount (the current/last episode),
+            #                                          open episode, last time; the silent degrade made visible
             # T222: where the model pickers' version list came from (seed / cache / api), when, what
             # the API added beyond the shipped seed, and the last refresh failure — so a stale list
             # is a visible fact in `romp version`, never a guess
@@ -26330,15 +26331,23 @@ def _broadcast_restarting(budget_s=0.8):
 # storm), a running count, and re-arm on the next SUCCESSFUL arm (the event that ends the episode),
 # so a second refusal episode is new information said again. The facts ride /version beside the
 # parse counters — bare numbers, safe for the auth-exempt route — so `romp version` shows them.
-_DRAIN_REFUSED = {"count": 0, "episode": False, "lastT": 0}
+# Fields (T227, the user 2026-09-02): `count` is the LIFETIME total of refused requests across every
+# episode this kernel life has seen; `episodeCount` is the refusals in the CURRENT (or, once closed,
+# the most recent) episode — the number the recovery line reports, since "the episode above is over
+# after N" must mean THAT episode, not the running total (a second episode of one refusal used to
+# read "after 2"); `episode` is whether one is open; `lastT` the latest refusal.
+_DRAIN_REFUSED = {"count": 0, "episodeCount": 0, "episode": False, "lastT": 0}
 
 
 def _note_drain_refused():
     try:
         _DRAIN_REFUSED["count"] += 1
         _DRAIN_REFUSED["lastT"] = int(time.time())
-        if not _DRAIN_REFUSED["episode"]:
+        if _DRAIN_REFUSED["episode"]:
+            _DRAIN_REFUSED["episodeCount"] += 1
+        else:
             _DRAIN_REFUSED["episode"] = True
+            _DRAIN_REFUSED["episodeCount"] = 1     # a fresh episode starts its own count
             sys.stderr.write("romp-kernel: REFUSED a drain hold — /busy?drain=1 arrived without a valid "
                              "serve token (an old manager, or a drive-by client): new turn starts are NOT "
                              "held while it polls; the exempt count still answers. Said once per refusal "
@@ -26352,7 +26361,8 @@ def _note_drain_armed():
         if _DRAIN_REFUSED["episode"]:
             _DRAIN_REFUSED["episode"] = False
             sys.stderr.write("romp-kernel: drain hold armed again after %d refused request(s) — the "
-                             "refusal episode above is over\n" % _DRAIN_REFUSED["count"])
+                             "refusal episode above is over (%d refused in total this kernel life)\n"
+                             % (_DRAIN_REFUSED["episodeCount"], _DRAIN_REFUSED["count"]))
     except Exception:
         pass
 

--- a/tests/manager-drain.test.js
+++ b/tests/manager-drain.test.js
@@ -253,8 +253,12 @@ test('a hold that ARMED and was then LOST renders the lost-after-arming cause, n
   // away mid-park). Two bare counters read this as "refused N before arming" — the ordering flag
   // says what actually happened.
   fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
-  kstub.answers = [JSON.stringify({ busy: 1, draining: true })];    // first poll: the hold arms…
-  kstub.fallback = JSON.stringify({ busy: 1, draining: false });    // …then every later poll is refused
+  // two refusals BEFORE the arm, then the hold arms, then every later poll is refused: the line must
+  // count the post-arm refusals on their own and name the pre-arm ones separately (the review's
+  // catch: a boolean flag let the whole total read as "after arming")
+  kstub.answers = [JSON.stringify({ busy: 1, draining: false }), JSON.stringify({ busy: 1, draining: false }),
+                   JSON.stringify({ busy: 1, draining: true })];
+  kstub.fallback = JSON.stringify({ busy: 1, draining: false });
   let logged;
   try {
     logged = await capturedUntil(/applying deferred refresh/, () => { queueQuietRestart('ghost'); });
@@ -262,7 +266,10 @@ test('a hold that ARMED and was then LOST renders the lost-after-arming cause, n
   const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
   assert.match(applyLine, /backstop cap/);
   assert.match(applyLine, /armed and was then LOST/, 'the cause states the order that happened');
-  assert.match(applyLine, /after arming/, '…and counts the refusals AFTER the arm');
+  const m = /refused (\d+) time\(s\) after arming, (\d+) before/.exec(applyLine);
+  assert.ok(m, 'the line splits post-arm from pre-arm refusals: ' + applyLine);
+  assert.equal(Number(m[2]), 2, 'exactly the two scripted pre-arm refusals read as "before"');
+  assert.ok(Number(m[1]) >= 1, 'the post-arm count is the loss itself, never inflated by the pre-arm two');
   assert.doesNotMatch(applyLine, /before arming|never armed/,
     'the reversed order must not borrow the other cause');
 });

--- a/tests/manager-drain.test.js
+++ b/tests/manager-drain.test.js
@@ -248,6 +248,25 @@ test('a transient refusal (the hold arms later) renders the armed-after-refusal 
     'a transient refusal must not read as a hold that never armed');
 });
 
+test('a hold that ARMED and was then LOST renders the lost-after-arming cause, never "before arming" (T227)', async () => {
+  // the other order: the first poll arms the hold, every later poll is refused (the token file went
+  // away mid-park). Two bare counters read this as "refused N before arming" — the ordering flag
+  // says what actually happened.
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  kstub.answers = [JSON.stringify({ busy: 1, draining: true })];    // first poll: the hold arms…
+  kstub.fallback = JSON.stringify({ busy: 1, draining: false });    // …then every later poll is refused
+  let logged;
+  try {
+    logged = await capturedUntil(/applying deferred refresh/, () => { queueQuietRestart('ghost'); });
+  } finally { clearPendingQuiet(); }
+  const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
+  assert.match(applyLine, /backstop cap/);
+  assert.match(applyLine, /armed and was then LOST/, 'the cause states the order that happened');
+  assert.match(applyLine, /after arming/, '…and counts the refusals AFTER the arm');
+  assert.doesNotMatch(applyLine, /before arming|never armed/,
+    'the reversed order must not borrow the other cause');
+});
+
 test('an in-flight probe from a cleared park never stamps the park that replaced it', async () => {
   fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
   kstub.answers = [HOLD];                                           // park A's first probe parks server-side

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -301,7 +301,7 @@ class BusyDrainWriteGate(unittest.TestCase):
 
     def test_a_refused_drain_logs_once_per_episode_and_counts_every_request(self):
         import io, contextlib
-        km._DRAIN_REFUSED.update(count=0, episode=False, lastT=0)
+        km._DRAIN_REFUSED.update(count=0, episodeCount=0, episode=False, lastT=0)
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             _serve_get("/busy?drain=1")
@@ -315,7 +315,7 @@ class BusyDrainWriteGate(unittest.TestCase):
 
     def test_an_armed_drain_ends_the_episode_and_a_later_refusal_logs_again(self):
         import io, contextlib
-        km._DRAIN_REFUSED.update(count=0, episode=False, lastT=0)
+        km._DRAIN_REFUSED.update(count=0, episodeCount=0, episode=False, lastT=0)
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             _serve_get("/busy?drain=1")                                  # refused → episode opens
@@ -325,10 +325,26 @@ class BusyDrainWriteGate(unittest.TestCase):
                         "the flag must flip back, not just the counter (the review's vacuous-pin catch)")
         self.assertEqual(err.getvalue().count("REFUSED a drain hold"), 2,
                          "the successful arm re-arms the notice: a second episode is new information")
-        self.assertIn("armed again", err.getvalue(), "the recovery is on the record too")
+        self.assertIn("armed again after 1 refused request(s)", err.getvalue(),
+                      "the recovery names the EPISODE's count (one refusal), never the running total "
+                      "(T227: a second episode of one refusal used to read 'after 2')")
+        self.assertEqual(self._refusals()["count"], 2, "…while the lifetime total keeps counting")
+        self.assertEqual(self._refusals()["episodeCount"], 1, "the re-opened episode restarts at one")
+
+    def test_a_longer_first_episode_reports_its_own_count_on_recovery(self):
+        import io, contextlib
+        km._DRAIN_REFUSED.update(count=0, episodeCount=0, episode=False, lastT=0)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            _serve_get("/busy?drain=1"); _serve_get("/busy?drain=1"); _serve_get("/busy?drain=1")
+            _serve_get("/busy?drain=1", headers={"X-Romp-Token": TOK})
+            _serve_get("/busy?drain=1")
+        self.assertIn("armed again after 3 refused request(s)", err.getvalue())
+        self.assertEqual(self._refusals()["count"], 4)
+        self.assertEqual(self._refusals()["episodeCount"], 1)
 
     def test_the_refusal_facts_ride_the_version_route(self):
-        km._DRAIN_REFUSED.update(count=0, episode=False, lastT=0)
+        km._DRAIN_REFUSED.update(count=0, episodeCount=0, episode=False, lastT=0)
         import io, contextlib
         with contextlib.redirect_stderr(io.StringIO()):
             _serve_get("/busy?drain=1")


### PR DESCRIPTION
## Summary
Two T224 residues, both from reviews:

1. **Per-episode count.** `_DRAIN_REFUSED["count"]` was a lifetime total, and the recovery line printed it as the episode's count — a second episode of one refusal read "armed again after 2". The record now carries both: `count` (lifetime total across episodes this kernel life) and `episodeCount` (the current, or once closed the most recent, episode), which is what the recovery line reports — the lifetime total follows in parentheses. `/version` documents both fields.
2. **Ordering flag.** The manager's backstop apply line derived its cause from two order-blind counters, so a hold that ARMED first and was then LOST read "refused N time(s) before arming". The park now carries `drainLostAfterArm` — set by a refusal landing after any arm — and the line states the order that happened: never armed / refused-then-armed / armed-then-LOST (refusals counted after the arm).

## Test plan
- Kernel pins with exact numbers: a one-refusal first episode closes "after 1" (count 2, episodeCount 1 after the re-open); a three-refusal first episode closes "after 3".
- Manager real-park stub, both orders: refused-then-armed (existing) and armed-then-lost (new), each rejecting the other's wording. `node --test tests/manager-*.test.js`: 40 pass (also runs inside the required Shell CI job).
- Full Python suite: 6,492 passed. Extension suite: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)