### PR TITLE
Light mode: every dropdown wears the menu skin as theme tokens; dark byte-identical (T226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,16 +263,27 @@ follow-up header rendering as a soup of 0.74/0.78/0.9em fragments.
 ### Menus and dropdowns wear ONE vocabulary (user rule, 2026-08-09)
 Every dropdown on every romp surface — the chat tab context menu, the statusline
 meta menus, the timeline's lane gear + model/effort pickers, and any future one —
-wears the same skin: `#252526` card, `rgba(255,255,255,0.12)` hairline border, 6px
-radius, `0 4px 12px rgba(0,0,0,0.35)` shadow, 12px romp sans, sub-lines `0.82em`
-at 0.6 opacity, and the `#1EA1EB` ✓-in-circle current mark. The chat pane's
-`.ctx-menu`/`.meta-menu` (`ui/webview/styles.css`) is the reference spec; the
-timeline inlines the same values as `MENU_STYLE`/`MENU_CHECK_STYLE` in
-`ui/romp-timeline-view.js`. A surface that cannot load styles.css (the timeline
-also runs inside Obsidian) MUST declare `font-family` explicitly — an adopted
-element inherits the host app's font otherwise, which is exactly how the timeline
-gear menu drifted off-brand (triggered 2026-08-09: bluish `#1c2430` card, host
-font, its own radii and sub-sizes).
+wears the same skin, expressed through the menu TOKENS each theme defines
+(`ui/webview/styles.css` `:root` + `body.theme-light`, mirrored in `feed.css`):
+`--menu-bg` card, `--menu-fg` text, `--menu-border` hairline, `--menu-hover` row
+wash, `--radius-menu`, `--shadow-menu`, and the `--check-bg` ✓-in-circle current
+mark — plus 12px romp sans and sub-lines `0.82em` at 0.6 opacity (geometry, not
+theme). The DARK themes resolve those to the values the rule always named, byte
+for byte: `#252526` card, `rgba(255,255,255,0.12)` hairline, 6px radius,
+`0 4px 12px rgba(0,0,0,0.35)` shadow, `#cccccc` text, `#1EA1EB` ✓; the light
+theme resolves them in its own palette (cream card, clay ✓). Never write those
+hex values into a menu rule or inline menu string except as a `var()` FALLBACK
+(a file:// harness or a foreign host loads no sheet) — the 2026-09-02 light-mode
+bug was exactly that: pickers hardcoding the dark card stayed dark, and the theme
+select's own options were unreadable (`menu-theme-tokens.test.ts` bans it). The
+chat pane's `.ctx-menu`/`.meta-menu` is the reference spec; the timeline inlines
+the RESOLVED twin as `MENU_STYLE`/`MENU_CHECK_STYLE` from its `PAL_DARK`/`PAL_LIGHT`
+palettes in `ui/romp-timeline-view.js`, because a surface that cannot load
+styles.css (the timeline also runs inside Obsidian) has no vars to read — and it
+MUST declare `font-family` explicitly there: an adopted element inherits the host
+app's font otherwise, which is exactly how the timeline gear menu drifted
+off-brand (triggered 2026-08-09: bluish `#1c2430` card, host font, its own radii
+and sub-sizes).
 The romp accent is light blue `#9cd2ff` (`--accent` in `ui/webview/styles.css`, with
 `--accent-fg: #0c1a2e` for text on it). Use it for accent/highlight chrome — selected
 toggles, in-progress loading dots, the Fleet pill, focus cues — anywhere you want "the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27375,10 +27375,19 @@ _CHAT_MOBILE_CSS = (
     "#mtag-slot{flex:0 0 auto;display:flex;align-items:center;gap:5px}"   # T161: the tag control's slot, sized by the shared button's own inline metrics
     "#madd{flex:0 0 auto;width:36px;display:flex;align-items:center;justify-content:center;cursor:pointer;"
     "background:#2a2a2a;color:#bbbbbb;border:1px solid #3a3a3a;border-radius:6px;font-size:16px;line-height:1}"
+    # the mobile session picker IS a dropdown (T226 review): its card + hairline read the menu tokens
+    # (dark: --menu-bg → #252526 and --hairline → #3a3a3a, byte-identical to the literals they replace)
     "#mlist{display:none;position:absolute;left:8px;right:8px;top:100%;margin-top:4px;z-index:200;"
-    "max-height:60vh;overflow:auto;background:#252526;border:1px solid #3a3a3a;border-radius:8px;"
+    "max-height:60vh;overflow:auto;background:var(--menu-bg,#252526);border:1px solid var(--hairline,#3a3a3a);border-radius:8px;"
     "box-shadow:0 8px 24px #000000aa}"
     "#mlist.open{display:block}"
+    # the light theme re-skins what has no byte-identical dark token (a light block, like the kernel's
+    # loader/toast light rules — the dark values above stay exactly as they were)
+    "body.theme-light #mlist{box-shadow:var(--shadow-menu)}"
+    "body.theme-light .mrow{border-bottom-color:var(--menu-border)}"
+    "body.theme-light .mrow .nm{color:var(--menu-fg)}"
+    "body.theme-light .mrow .mclose{color:var(--text-muted)}"
+    "body.theme-light .mrow.active{background:var(--accent-wash)}"
     ".mrow{display:flex;align-items:center;gap:9px;padding:10px 12px;cursor:pointer;"
     "border-bottom:1px solid #ffffff12;font:600 13px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     ".mrow:last-child{border-bottom:0}"

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -226,11 +226,13 @@ const FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-ser
 // The ONE menu vocabulary every romp dropdown wears (CLAUDE.md rule, the user 2026-08-09) — the chat
 // pane's .ctx-menu/.meta-menu spec (ui/webview/styles.css), inlined with its values RESOLVED because
 // this pane may live in a foreign document (Obsidian) that loads neither styles.css nor its vars, and
-// would otherwise hand the menus the host app's own font. Card #252526, hairline border, 6px radius,
+// would otherwise hand the menus the host app's own font. Card, hairline border, 6px radius,
 // 12px romp sans; the current-choice mark is the same ✓-in-circle the chat meta menus use.
-// Composed from the palette at applyPal() time (see PAL below): dark stays the chat spec verbatim
-// (card #252526, hairline rgba(255,255,255,0.12), shadow rgba(0,0,0,0.35), text #cccccc, ✓ #1EA1EB);
-// the light theme re-skins the same card (white, black hairline, clay ✓).
+// Composed from the palette at applyPal() time (see PAL below) — the RESOLVED twin of the sheets'
+// menu tokens (--menu-bg/--menu-fg/--menu-border/--menu-hover/--check-bg, T226): PAL_DARK carries
+// the dark spec verbatim (card #252526, hairline rgba(255,255,255,0.12), shadow rgba(0,0,0,0.35),
+// text #cccccc, ✓ #1EA1EB) and PAL_LIGHT the light block's values (card #FBF6EF, clay ✓). The
+// palette is this pane's fallback mechanism: Obsidian loads no sheet and no vars at all.
 const menuStyleFor = (p) => 'padding:4px;background:' + p.menuBg + ';border:1px solid ' + p.hairline + ';'
   + 'border-radius:6px;box-shadow:0 4px 12px ' + p.menuShadow + ';font:12px/1.4 ' + FONT + ';'
   + 'color:' + p.menuFg + ';user-select:none;';

--- a/ui/webview/css-census.test.ts
+++ b/ui/webview/css-census.test.ts
@@ -33,7 +33,7 @@ const rawDims = (css: string) => {
 // EXACT counts, not ceilings (PR #763 item 7: a <= pin with slack lets new raw hexes arrive
 // unnoticed) — a count that moves in EITHER direction is a deliberate change to name here.
 const EXACT: Record<string, number> = {
-  "gear.css": 16,
+  "gear.css": 14,   // T226 review: the colormap/palette dropdowns' two `0 8px 24px #000000aa` shadows moved onto var(--shadow-menu)
   "strip.css": 8,
   "fleet-pane.css": 9,
   "timeline-pane.css": 10,

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -43,6 +43,8 @@
   --menu-fg: var(--vscode-menu-foreground, #cccccc);
   --menu-border: rgba(255, 255, 255, 0.12);
   --menu-hover: rgba(255, 255, 255, 0.09);
+  --menu-ring: #fff;
+  --check-ring: rgba(30, 161, 235, 0.55);
   --surface-raised: #252526;  /* the transient-notice vocabulary — mirrors styles.css */
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(0, 0, 0, 0.45);
@@ -150,6 +152,8 @@ body.theme-light {
   --menu-fg: #1F1E1D;
   --menu-border: rgba(0, 0, 0, 0.12);
   --menu-hover: rgba(0, 0, 0, 0.06);
+  --menu-ring: #1F1E1D;
+  --check-ring: rgba(194, 65, 12, 0.55);
   --surface-raised: #FAF5EE;
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(31, 26, 20, 0.18);
@@ -601,7 +605,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    prevents). Outline pill in the done-check blue (--check-bg), the same family as the ✓ it will wear. */
 .fask-doneconfirming { flex: 0 0 auto; font-size: 0.66em; font-weight: 700; letter-spacing: 0.04em;
   padding: 1px 6px; border-radius: var(--radius-pill); line-height: 1.4;
-  color: var(--check-bg); border: 1px solid rgba(30, 161, 235, 0.55); }
+  color: var(--check-bg); border: 1px solid var(--check-ring); }   /* the ring follows the themed ✓ (T226 review) */
 /* "nudge failed" — the one auto-nudge didn't resolve the stall and is never re-asked (design/
    stalled-open-todos-nudge.md); red pill: this thread is waiting on the human now */
 .fask-nudgefailed { flex: 0 0 auto; font-size: 0.66em; font-weight: 700; letter-spacing: 0.04em;
@@ -1125,7 +1129,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   box-shadow: var(--shadow-menu); }
 .feed-sessmenu .fsm-row { display: flex; align-items: center; gap: 7px; padding: 4px 9px;
   border-radius: 4px; cursor: pointer; font-size: 11px; white-space: nowrap; }
-.feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
+.feed-sessmenu .fsm-row:hover { background: var(--menu-hover); }   /* the one menu hover (T226 review): 0.07 was drift, and a white wash vanished in light */
 .feed-sessmenu .fsm-row.on { background: var(--accent-wash); }
 /* TAG CHIPS on the combobox's session rows (the user 2026-08-25 — the smaller unification variant):
    the dialog's own outline-pill vocabulary at the row's scale, NON-interactive (grouping made
@@ -1566,8 +1570,8 @@ a.fileview-btn[hidden] { display: none; }
    you or completes; the armed state is the quiet accent bell beside Clear. */
 .ctx-menu {
   position: fixed; z-index: 100; min-width: 110px; padding: 4px;
-  background: var(--vscode-menu-background, #252526);
-  color: var(--vscode-menu-foreground, var(--fg));
+  background: var(--menu-bg);   /* mirrors styles.css .ctx-menu — the menu tokens (T226) */
+  color: var(--menu-fg);
   border: 1px solid var(--box-border); border-radius: var(--radius-menu);
   box-shadow: var(--shadow-menu);
   font-size: 0.92em;

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -39,6 +39,10 @@
                        behind every selected/hovered accent chrome */
   --radius-menu: 6px;  /* the menu vocabulary (CLAUDE.md) — mirrors styles.css */
   --shadow-menu: 0 4px 12px rgba(0, 0, 0, 0.35);
+  --menu-bg: var(--vscode-menu-background, #252526);   /* the menu SKIN tokens (T226) — mirror styles.css */
+  --menu-fg: var(--vscode-menu-foreground, #cccccc);
+  --menu-border: rgba(255, 255, 255, 0.12);
+  --menu-hover: rgba(255, 255, 255, 0.09);
   --surface-raised: #252526;  /* the transient-notice vocabulary — mirrors styles.css */
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(0, 0, 0, 0.45);
@@ -121,7 +125,9 @@ body.theme-light {
   --dim: #5D574E;
   --rail: rgba(0, 0, 0, 0.14);
   --green: #3E7D0E;
-  --check-bg: #1EA1EB;   /* the session-identity default blue is BRAND, same in both themes */
+  --check-bg: #C2410C;   /* the ✓ mark is THEMED (T226 ruling, 2026-09-02): every check on every surface
+                            wears the theme's own mark — dark keeps the #1EA1EB brand blue, light wears
+                            its clay accent (what the timeline's PAL_LIGHT already drew) */
   --code-fg: #8C4A00;
   --code-bg: rgba(180, 83, 9, 0.08);
   --box-bg: rgba(0, 0, 0, 0.03);
@@ -140,6 +146,10 @@ body.theme-light {
   --st-blocked-bg: #e5484d; --st-blocked-fg: #ffffff;
   --radius-menu: 6px;
   --shadow-menu: 0 4px 12px rgba(31, 26, 20, 0.16);
+  --menu-bg: #FBF6EF;
+  --menu-fg: #1F1E1D;
+  --menu-border: rgba(0, 0, 0, 0.12);
+  --menu-hover: rgba(0, 0, 0, 0.06);
   --surface-raised: #FAF5EE;
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(31, 26, 20, 0.18);

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -71,8 +71,8 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 /* feed-colormap dropdown: the button shows the picked map's gradient bar; the list is one bar per map. */
 #rs-cmap { position: relative; margin-top: 5px; }
 #rs-cmap-btn { width: 100%; height: 20px; border-radius: 5px; border: 1px solid var(--hairline, #3a3a3a); cursor: pointer; padding: 0; display: block; }
-#rs-cmap-list { position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px; z-index: 20; background: var(--bg, #1e1e1e);
-  border: 1px solid var(--hairline, #3a3a3a); border-radius: 6px; padding: 4px; box-shadow: 0 8px 24px #000000aa; }
+#rs-cmap-list { position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px; z-index: 20; background: var(--menu-bg, #252526);
+  border: 1px solid var(--menu-border, rgba(255,255,255,0.12)); border-radius: var(--radius-menu, 6px); padding: 4px; box-shadow: var(--shadow-menu, 0 4px 12px rgba(0,0,0,0.35)); }   /* the menu card (T226 review): it wore the PAGE colour beside the tokenised pickers */
 #rs-cmap-list[hidden] { display: none; }
 .rs-cmap-opt { height: 18px; border-radius: 4px; border: 1px solid var(--hairline, #3a3a3a); cursor: pointer; margin: 4px 0; }
 .rs-cmap-opt:first-child { margin-top: 0; }
@@ -82,8 +82,8 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #rs-pal { position: relative; margin-top: 5px; }
 #rs-pal-btn { width: 100%; border: 1px solid var(--hairline, #3a3a3a); border-radius: 5px; cursor: pointer; background: var(--bg, #1e1e1e);
   display: flex; gap: 5px; align-items: center; padding: 4px 7px; min-height: 20px; }
-#rs-pal-list { position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px; z-index: 20; background: var(--bg, #1e1e1e);
-  border: 1px solid var(--hairline, #3a3a3a); border-radius: 6px; padding: 4px; box-shadow: 0 8px 24px #000000aa; }
+#rs-pal-list { position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px; z-index: 20; background: var(--menu-bg, #252526);
+  border: 1px solid var(--menu-border, rgba(255,255,255,0.12)); border-radius: var(--radius-menu, 6px); padding: 4px; box-shadow: var(--shadow-menu, 0 4px 12px rgba(0,0,0,0.35)); }
 #rs-pal-list[hidden] { display: none; }
 .rs-pal-opt { display: flex; gap: 5px; align-items: center; border: 1px solid var(--hairline, #3a3a3a); border-radius: 4px;
   cursor: pointer; margin: 4px 0; padding: 4px 7px; }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -376,7 +376,7 @@ function initGear(post) {
     { id: 'never', name: 'Never' }
   ];
   function tabCtxRowHTML(o) {
-    return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--fg, #ccc)">' + o.name + '</span>';
+    return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--menu-fg, #ccc)">' + o.name + '</span>';
   }
   var tcDrop = housePick(document.getElementById('rs-tabctx-pick'), 'tabctx', tabCtxRowHTML, function (id) {
     if (tc) { tc.value = id; tc.dispatchEvent(new Event('change')); }
@@ -405,7 +405,7 @@ function initGear(post) {
     wrap.setAttribute('style', 'position:relative;' + wrapStyle);
     sel.parentNode.insertBefore(wrap, sel.nextSibling);
     var rowHTML = function (o) {
-      return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--fg, #ccc)">' + o.name + '</span>';
+      return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--menu-fg, #ccc)">' + o.name + '</span>';
     };
     var drop = housePick(wrap, 'val', rowHTML, function (id) {
       sel.value = id; sel.dispatchEvent(new Event('change')); paint();

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -249,8 +249,9 @@ function initGear(post) {
   // ran off the card's right edge). Progressive disclosure: the CLOSED state is ONE row — the
   // current option's name + its description/preview, ellipsized so it can never overrun — and the
   // options are one click away in the house menu vocabulary (the chat .ctx-menu spec; versionMenu
-  // below inlines the same values: #252526 card, hairline border, 6px radius, the 0 4px 12px
-  // shadow, 12px text, 0.82em sub-lines, the #1EA1EB \u2713-in-circle current mark). NOT a native
+  // below inlines the same values through the menu TOKENS — var(--menu-bg/--menu-fg/--menu-border/
+  // --menu-hover, --radius-menu, --shadow-menu, --check-bg) with the dark literals as fallbacks
+  // (T226: the literals alone left every picker a dark card in the light theme). NOT a native
   // <select> like the Context-gauge row above: these options carry rich row content — the scheme
   // rows preview their own colored tiers (the user 2026-08-24: "I need to see a preview") — which
   // <option> cannot render. The open menu is position:absolute inside the row's wrapper (the
@@ -274,8 +275,8 @@ function initGear(post) {
     var menu = document.createElement('div');
     menu.hidden = true;
     menu.style.cssText = 'position:absolute;left:0;right:0;top:100%;margin-top:4px;z-index:30;padding:4px;' +
-      'background:#252526;border:1px solid rgba(255,255,255,0.12);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.35);' +
-      'font-size:12px;line-height:1.4;color:#cccccc;user-select:none';
+      'background:var(--menu-bg, #252526);border:1px solid var(--menu-border, rgba(255,255,255,0.12));border-radius:var(--radius-menu, 6px);box-shadow:var(--shadow-menu, 0 4px 12px rgba(0,0,0,0.35));' +
+      'font-size:12px;line-height:1.4;color:var(--menu-fg, #cccccc);user-select:none';
     wrap.appendChild(btn); wrap.appendChild(menu);
     var close = function () { menu.hidden = true; if (openHousePick === menu) openHousePick = null; };
     btn.addEventListener('click', function (e) {
@@ -309,10 +310,10 @@ function initGear(post) {
         row.innerHTML = rowHTML(o);
         if (cur && o.id === cur.id) {
           var ck = document.createElement('span'); ck.textContent = '\u2713';
-          ck.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
+          ck.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:var(--check-bg, #1EA1EB);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
           row.appendChild(ck);
         }
-        row.addEventListener('mouseenter', function () { row.style.background = 'rgba(255,255,255,0.09)'; });
+        row.addEventListener('mouseenter', function () { row.style.background = 'var(--menu-hover, rgba(255,255,255,0.09))'; });
         row.addEventListener('mouseleave', function () { row.style.background = 'transparent'; });
         row.addEventListener('click', function (e) { e.stopPropagation(); close(); pick(o.id); });
         menu.appendChild(row);
@@ -375,7 +376,7 @@ function initGear(post) {
     { id: 'never', name: 'Never' }
   ];
   function tabCtxRowHTML(o) {
-    return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#ccc">' + o.name + '</span>';
+    return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--fg, #ccc)">' + o.name + '</span>';
   }
   var tcDrop = housePick(document.getElementById('rs-tabctx-pick'), 'tabctx', tabCtxRowHTML, function (id) {
     if (tc) { tc.value = id; tc.dispatchEvent(new Event('change')); }
@@ -404,7 +405,7 @@ function initGear(post) {
     wrap.setAttribute('style', 'position:relative;' + wrapStyle);
     sel.parentNode.insertBefore(wrap, sel.nextSibling);
     var rowHTML = function (o) {
-      return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#ccc">' + o.name + '</span>';
+      return '<span style="flex:1 1 auto;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--fg, #ccc)">' + o.name + '</span>';
     };
     var drop = housePick(wrap, 'val', rowHTML, function (id) {
       sel.value = id; sel.dispatchEvent(new Event('change')); paint();
@@ -548,9 +549,9 @@ function initGear(post) {
     document.addEventListener('keydown', function (e) { if (e.key === 'Escape') closeAll(); });
     try { window.addEventListener('storage', function (e) { if (e.key === 'romp:menu-echo' && e.newValue) closeAll(); }); } catch (e) {}
     var pick = function (val) { sel.value = val; sel.dispatchEvent(new Event('change')); syncBtn(); closeAll(); };
-    var MSTYLE = 'position:fixed;z-index:1001;min-width:130px;padding:4px;background:#252526;'
-      + 'border:1px solid rgba(255,255,255,0.12);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.35);'
-      + 'font-size:12px;line-height:1.4;color:#cccccc;user-select:none;';
+    var MSTYLE = 'position:fixed;z-index:1001;min-width:130px;padding:4px;background:var(--menu-bg, #252526);'
+      + 'border:1px solid var(--menu-border, rgba(255,255,255,0.12));border-radius:var(--radius-menu, 6px);box-shadow:var(--shadow-menu, 0 4px 12px rgba(0,0,0,0.35));'
+      + 'font-size:12px;line-height:1.4;color:var(--menu-fg, #cccccc);user-select:none;';
     var rowStyle = 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;display:flex;align-items:center;';
     btn.addEventListener('click', function (e) {
       e.stopPropagation();
@@ -567,7 +568,7 @@ function initGear(post) {
         var famCur = sel.value === fam.value || versions.some(function (v) { return v.value === sel.value; });
         if (famCur) {
           var ck = document.createElement('span'); ck.textContent = '\u2713';
-          ck.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
+          ck.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:var(--check-bg, #1EA1EB);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
           row.appendChild(ck);
         }
         var openSub = versions.length > 1 ? function () {
@@ -581,10 +582,10 @@ function initGear(post) {
             r2.appendChild(document.createTextNode(v.label));
             if (sel.value === v.value) {
               var c2 = document.createElement('span'); c2.textContent = '\u2713';
-              c2.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
+              c2.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:var(--check-bg, #1EA1EB);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
               r2.appendChild(c2);
             }
-            r2.addEventListener('mouseenter', function () { r2.style.background = 'rgba(255,255,255,0.09)'; });
+            r2.addEventListener('mouseenter', function () { r2.style.background = 'var(--menu-hover, rgba(255,255,255,0.09))'; });
             r2.addEventListener('mouseleave', function () { r2.style.background = 'transparent'; });
             r2.addEventListener('click', function (e2) { e2.stopPropagation(); pick(v.value); });
             r2.addEventListener('keydown', function (e2) {
@@ -608,9 +609,9 @@ function initGear(post) {
           caret.textContent = '\u25B8';   // ALWAYS right-facing — it marks "expandable", not the side
           caret.setAttribute('style', 'margin-left:auto;padding-left:10px;opacity:0.55;');
           row.appendChild(caret);
-          row.addEventListener('mouseenter', function () { row.style.background = 'rgba(255,255,255,0.09)'; openSub(); });
+          row.addEventListener('mouseenter', function () { row.style.background = 'var(--menu-hover, rgba(255,255,255,0.09))'; openSub(); });
         } else {
-          row.addEventListener('mouseenter', function () { row.style.background = 'rgba(255,255,255,0.09)'; if (sub) { sub.remove(); sub = null; } });
+          row.addEventListener('mouseenter', function () { row.style.background = 'var(--menu-hover, rgba(255,255,255,0.09))'; if (sub) { sub.remove(); sub = null; } });
         }
         row.addEventListener('mouseleave', function () { row.style.background = 'transparent'; });
         row.addEventListener('click', function (e2) { e2.stopPropagation(); pick(fam.default || fam.value); });

--- a/ui/webview/menu-theme-tokens.test.ts
+++ b/ui/webview/menu-theme-tokens.test.ts
@@ -1,0 +1,167 @@
+// T226 (the user 2026-09-02, screenshot: in the light theme the settings' Theme select opened a
+// near-black card with dark-on-dark options — the way back to dark was unreadable). The menu
+// vocabulary (CLAUDE.md "Menus and dropdowns wear ONE vocabulary") had been pinned as LITERAL hex
+// in every inline menu string (the settings pickers, the tag menu), so the light block could never
+// reach it. The skin is TOKENS now — --menu-bg / --menu-fg / --menu-border / --menu-hover beside the
+// existing --radius-menu / --shadow-menu / --check-bg — defined in both theme blocks of both
+// self-sufficient sheets; dark resolves byte-for-byte to the literals the rule always named, the
+// light block re-skins in its own palette, and inline strings carry the dark literal only as the
+// var() FALLBACK (a file:// harness / a foreign host loads no sheet). The ✓ mark is themed too (the
+// manager's ruling): dark keeps #1EA1EB, light wears the clay the timeline's palette already drew.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const CHAT = ui("webview", "styles.css");
+const FEED = ui("webview", "feed.css");
+const GEAR = ui("webview", "gear.js");
+const MENU = ui("webview", "tag-menu.ts");
+const TIMELINE = ui("romp-timeline-view.js");
+
+/** The body of the FIRST rule whose selector line starts with `selector {` — brace-depth scan, so a
+ *  comment containing braces inside the block cannot end it early. */
+function block(css: string, selector: string): string {
+  const at = css.indexOf("\n" + selector + " {");
+  assert.ok(at >= 0, "rule present: " + selector);
+  let i = css.indexOf("{", at), depth = 0;
+  for (let j = i; j < css.length; j++) {
+    if (css[j] === "{") depth++;
+    else if (css[j] === "}" && --depth === 0) return css.slice(i + 1, j);
+  }
+  throw new Error("unterminated rule: " + selector);
+}
+/** `var(--x, <fallback>)` → `var(--x)`: the fallback is the DARK literal every inline string may
+ *  carry for sheet-less hosts; what is left must reference tokens only. One level of nested parens
+ *  (an rgba() fallback) is understood. */
+const stripFallbacks = (s: string) => s.replace(/var\((--[\w-]+)\s*,\s*(?:[^()]|\([^()]*\))*\)/g, "var($1)");
+const slice = (src: string, from: string, to: string) => {
+  const a = src.indexOf(from), b = src.indexOf(to, a + 1);
+  assert.ok(a >= 0 && b > a, "slice anchors present: " + from.slice(0, 40) + " … " + to.slice(0, 40));
+  return src.slice(a, b);
+};
+const norm = (s: string) => s.replace(/\s+/g, "").toLowerCase();
+
+const MENU_TOKENS = ["--menu-bg", "--menu-fg", "--menu-border", "--menu-hover"];
+// the dark spec — the literals the CLAUDE.md rule always named, now the dark theme's token values
+const DARK = {
+  "--menu-bg": "var(--vscode-menu-background, #252526)",
+  "--menu-fg": "var(--vscode-menu-foreground, #cccccc)",
+  "--menu-border": "rgba(255, 255, 255, 0.12)",
+  "--menu-hover": "rgba(255, 255, 255, 0.09)",
+  "--check-bg": "#1EA1EB",
+};
+const LIGHT = {
+  "--menu-bg": "#FBF6EF",           // the light block's own menu card (its --vscode-menu-background stand-in)
+  "--menu-fg": "#1F1E1D",
+  "--menu-border": "rgba(0, 0, 0, 0.12)",
+  "--menu-hover": "rgba(0, 0, 0, 0.06)",
+  "--check-bg": "#C2410C",          // the light theme's clay — the mark the timeline's PAL_LIGHT already drew
+};
+
+test("the menu skin tokens live in BOTH theme blocks of BOTH sheets — dark byte-for-byte the old literals", () => {
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    const root = block(css, ":root"), light = block(css, "body.theme-light");
+    for (const [tok, val] of Object.entries(DARK))
+      assert.ok(root.includes(`${tok}: ${val};`), `${name} :root ${tok} = ${val}`);
+    for (const [tok, val] of Object.entries(LIGHT))
+      assert.ok(light.includes(`${tok}: ${val};`), `${name} body.theme-light ${tok} = ${val}`);
+    // key parity for the menu set: a token one block defines and the other forgets is a theme leak
+    for (const tok of MENU_TOKENS) {
+      assert.equal((root.match(new RegExp(tok + ":", "g")) || []).length, 1, `${name} :root defines ${tok} once`);
+      assert.equal((light.match(new RegExp(tok + ":", "g")) || []).length, 1, `${name} light defines ${tok} once`);
+    }
+  }
+});
+
+// Every menu SURFACE: the sheets' menu rules and the inline-styled menus. Each is stripped of its
+// var() fallbacks and must then carry none of the dark spec's literals — those belong to the theme
+// definitions (the two blocks above; PAL_DARK in the timeline) and nowhere else.
+const DARK_LITERALS: Array<[string, RegExp]> = [
+  ["#252526 card", /#252526/i],
+  ["rgba(255,255,255,0.12) hairline", /rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*0?\.12\s*\)/],
+  ["rgba(255,255,255,0.09) hover", /rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*0?\.09\s*\)/],
+  ["rgba(0,0,0,0.35) shadow", /rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0?\.35\s*\)/],
+  ["#cccccc text", /#cccccc\b/i],
+  ["#ccc text", /#ccc\b/i],
+  ["#1EA1EB check", /#1EA1EB/i],
+  ["#1e1e1e input", /#1e1e1e\b/i],
+  ["#3a3a3a input border", /#3a3a3a\b/i],
+];
+const SURFACES: Array<[string, string]> = [
+  ["styles.css .ctx-menu", block(CHAT, ".ctx-menu")],
+  ["styles.css .ctx-item:hover", block(CHAT, ".ctx-item:hover")],
+  ["styles.css .ctx-tag-input", CHAT.slice(CHAT.indexOf("\n.ctx-tag-input {"), CHAT.indexOf("}", CHAT.indexOf("\n.ctx-tag-input {")))],
+  ["styles.css .meta-menu", block(CHAT, ".meta-menu")],
+  ["styles.css .meta-item", block(CHAT, ".meta-item")],
+  ["styles.css .meta-item:hover", CHAT.slice(CHAT.indexOf("\n.meta-item:hover {"), CHAT.indexOf("}", CHAT.indexOf("\n.meta-item:hover {")))],
+  ["styles.css .meta-item.current::after", block(CHAT, ".meta-item.current::after")],
+  ["styles.css .ctx-sub .ctx-item.current::after", block(CHAT, ".ctx-sub .ctx-item.current::after")],
+  ["feed.css .ctx-menu", block(FEED, ".ctx-menu")],
+  ["feed.css .ctx-item:hover", block(FEED, ".ctx-item:hover")],
+  ["gear.js housePick (the settings pickers — the Theme select)", slice(GEAR, "function housePick(", "var SCHEMES = [")],
+  ["gear.js versionMenu (model pickers + version submenus)", slice(GEAR, "function versionMenu(", "versionMenu(jm);")],
+  ["tag-menu.ts openTagMenu", slice(MENU, "export function openTagMenu", "export function tagMenuButton")],
+  ["timeline menuStyleFor/menuCheckStyleFor", slice(TIMELINE, "const menuStyleFor", "let MENU_STYLE")],
+];
+
+test("no menu surface carries a raw dark literal outside the theme definitions (the fallback slot excepted)", () => {
+  for (const [name, src] of SURFACES) {
+    const bare = stripFallbacks(src);
+    for (const [what, re] of DARK_LITERALS)
+      assert.doesNotMatch(bare, re, `${name}: ${what} written raw — it belongs in the theme blocks; reference the token`);
+  }
+});
+
+test("the inline menus wear the tokens — card, text, hairline, hover, radius, shadow, ✓ — with the dark literal as fallback", () => {
+  const pick = slice(GEAR, "function housePick(", "var SCHEMES = [");
+  const vers = slice(GEAR, "function versionMenu(", "versionMenu(jm);");
+  const tag = slice(MENU, "export function openTagMenu", "export function tagMenuButton");
+  for (const [name, src] of [["housePick", pick], ["versionMenu", vers], ["tag menu", tag]] as const) {
+    assert.match(src, /background:\s*var\(--menu-bg, #252526\)/, name + " card");
+    assert.match(src, /color:\s*var\(--menu-fg, #cccccc\)/, name + " text");
+    assert.match(src, /border:\s*1px solid var\(--menu-border, rgba\(255,255,255,0\.12\)\)/, name + " hairline");
+    assert.match(src, /border-radius:\s*var\(--radius-menu, 6px\)/, name + " radius");
+    assert.match(src, /box-shadow:\s*var\(--shadow-menu, 0 4px 12px rgba\(0,0,0,0\.35\)\)/, name + " shadow");
+    assert.match(src, /var\(--menu-hover, rgba\(255,255,255,0\.09\)\)/, name + " row hover");
+    assert.match(src, /background:\s*var\(--check-bg, #1EA1EB\)/, name + " ✓ mark");
+  }
+  // fallback PARITY: every inline fallback equals the dark theme's resolved value (whitespace aside),
+  // so a sheet-less host renders exactly the dark spec — never a third skin
+  // a token whose dark value COMPOSES a VS Code var (--menu-bg/--menu-fg) resolves, sheet-less, to its own
+  // innermost fallback; a literal value (rgba/hex) is already the resolved value
+  const innermost = (v: string) => { const m = v.startsWith("var(") ? v.match(/,\s*(.+)\)\s*$/) : null; return m ? m[1] : v; };
+  for (const src of [pick, vers, tag]) {
+    for (const m of src.matchAll(/var\((--menu-[\w-]+|--check-bg|--radius-menu|--shadow-menu),\s*((?:[^()]|\([^()]*\))*)\)/g)) {
+      const tok = m[1] as keyof typeof DARK, fb = m[2];
+      const want = tok === "--radius-menu" ? "6px" : tok === "--shadow-menu" ? "0 4px 12px rgba(0, 0, 0, 0.35)" : innermost(DARK[tok]);
+      assert.equal(norm(fb), norm(want), `${tok} fallback ${fb} must equal the dark token value ${want}`);
+    }
+  }
+});
+
+test("the ✓ mark is themed through --check-bg on every surface: dark #1EA1EB, light the clay the timeline draws", () => {
+  // the sheets' checks read the token
+  assert.match(block(CHAT, ".meta-item.current::after"), /background: var\(--check-bg\)/);
+  assert.match(block(CHAT, ".ctx-sub .ctx-item.current::after"), /background: var\(--check-bg\)/);
+  assert.match(FEED, /\.feed-viewmenu \.ctx-item\.current::after \{[^}]*var\(--check-bg\)/s, "the feed's view menu check");
+  // the timeline's palette IS its theme definition — its two values are the two blocks' values
+  assert.match(TIMELINE, /const PAL_DARK = \{[\s\S]*?accentSolid: '#1EA1EB'/, "PAL_DARK ✓ = the dark token");
+  assert.match(TIMELINE, /const PAL_LIGHT = \{[\s\S]*?accentSolid: '#C2410C'/, "PAL_LIGHT ✓ = the light token");
+  assert.match(TIMELINE, /background:' \+ p\.accentSolid \+ '/, "menuCheckStyleFor reads the palette, never a literal");
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.ok(block(css, ":root").includes("--check-bg: #1EA1EB;"), name + " dark ✓ pinned byte-for-byte");
+    assert.ok(block(css, "body.theme-light").includes("--check-bg: #C2410C;"), name + " light ✓ = the clay accent");
+    assert.ok(block(css, "body.theme-light").includes("--accent: #C2410C;"), name + " …which IS the light accent (one clay)");
+  }
+});
+
+test("the CLAUDE.md rule names the tokens and keeps the hex as the dark theme's values", () => {
+  const md = fs.readFileSync(path.resolve(process.cwd(), "..", "CLAUDE.md"), "utf8");
+  const rule = md.slice(md.indexOf("### Menus and dropdowns wear ONE vocabulary"), md.indexOf("The romp accent is light blue"));
+  for (const tok of ["--menu-bg", "--menu-fg", "--menu-border", "--menu-hover", "--radius-menu", "--shadow-menu", "--check-bg"])
+    assert.ok(rule.includes("`" + tok + "`"), "the rule names " + tok);
+  assert.ok(rule.includes("`#252526`") && rule.includes("`#1EA1EB`"), "the dark values stay documented");
+  assert.match(rule, /FALLBACK/, "the one sanctioned place for a raw hex in a menu string");
+});

--- a/ui/webview/menu-theme-tokens.test.ts
+++ b/ui/webview/menu-theme-tokens.test.ts
@@ -19,6 +19,8 @@ const FEED = ui("webview", "feed.css");
 const GEAR = ui("webview", "gear.js");
 const MENU = ui("webview", "tag-menu.ts");
 const TIMELINE = ui("romp-timeline-view.js");
+const GEAR_CSS = ui("webview", "gear.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 /** The body of the FIRST rule whose selector line starts with `selector {` — brace-depth scan, so a
  *  comment containing braces inside the block cannot end it early. */
@@ -43,7 +45,7 @@ const slice = (src: string, from: string, to: string) => {
 };
 const norm = (s: string) => s.replace(/\s+/g, "").toLowerCase();
 
-const MENU_TOKENS = ["--menu-bg", "--menu-fg", "--menu-border", "--menu-hover"];
+const MENU_TOKENS = ["--menu-bg", "--menu-fg", "--menu-border", "--menu-hover", "--menu-ring", "--check-ring"];
 // the dark spec — the literals the CLAUDE.md rule always named, now the dark theme's token values
 const DARK = {
   "--menu-bg": "var(--vscode-menu-background, #252526)",
@@ -51,6 +53,8 @@ const DARK = {
   "--menu-border": "rgba(255, 255, 255, 0.12)",
   "--menu-hover": "rgba(255, 255, 255, 0.09)",
   "--check-bg": "#1EA1EB",
+  "--menu-ring": "#fff",
+  "--check-ring": "rgba(30, 161, 235, 0.55)",
 };
 const LIGHT = {
   "--menu-bg": "#FBF6EF",           // the light block's own menu card (its --vscode-menu-background stand-in)
@@ -58,6 +62,8 @@ const LIGHT = {
   "--menu-border": "rgba(0, 0, 0, 0.12)",
   "--menu-hover": "rgba(0, 0, 0, 0.06)",
   "--check-bg": "#C2410C",          // the light theme's clay — the mark the timeline's PAL_LIGHT already drew
+  "--menu-ring": "#1F1E1D",
+  "--check-ring": "rgba(194, 65, 12, 0.55)",
 };
 
 test("the menu skin tokens live in BOTH theme blocks of BOTH sheets — dark byte-for-byte the old literals", () => {
@@ -80,8 +86,8 @@ test("the menu skin tokens live in BOTH theme blocks of BOTH sheets — dark byt
 // definitions (the two blocks above; PAL_DARK in the timeline) and nowhere else.
 const DARK_LITERALS: Array<[string, RegExp]> = [
   ["#252526 card", /#252526/i],
-  ["rgba(255,255,255,0.12) hairline", /rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*0?\.12\s*\)/],
-  ["rgba(255,255,255,0.09) hover", /rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*0?\.09\s*\)/],
+  // ANY white-alpha wash is dark-only by construction (review round: the 0.12/0.09-only pair let a 0.25 through)
+  ["white-alpha hairline/hover/wash", /rgba\(\s*255\s*,\s*255\s*,\s*255\s*,/i],
   ["rgba(0,0,0,0.35) shadow", /rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0?\.35\s*\)/],
   ["#cccccc text", /#cccccc\b/i],
   ["#ccc text", /#ccc\b/i],
@@ -101,7 +107,13 @@ const SURFACES: Array<[string, string]> = [
   ["feed.css .ctx-menu", block(FEED, ".ctx-menu")],
   ["feed.css .ctx-item:hover", block(FEED, ".ctx-item:hover")],
   ["gear.js housePick (the settings pickers — the Theme select)", slice(GEAR, "function housePick(", "var SCHEMES = [")],
-  ["gear.js versionMenu (model pickers + version submenus)", slice(GEAR, "function versionMenu(", "versionMenu(jm);")],
+  // from MSTYLE: the menu CARD and its rows — the trigger BUTTON above it is a closed-state control, not a menu
+  ["gear.js versionMenu (model pickers + version submenus)", slice(GEAR, "    var MSTYLE = ", "versionMenu(jm);")],
+  ["gear.css #rs-cmap-list", GEAR_CSS.slice(GEAR_CSS.indexOf("\n#rs-cmap-list {"), GEAR_CSS.indexOf("}", GEAR_CSS.indexOf("\n#rs-cmap-list {")))],
+  ["gear.css #rs-pal-list", GEAR_CSS.slice(GEAR_CSS.indexOf("\n#rs-pal-list {"), GEAR_CSS.indexOf("}", GEAR_CSS.indexOf("\n#rs-pal-list {")))],
+  ["feed.css .feed-sessmenu .fsm-row:hover", FEED.slice(FEED.indexOf("\n.feed-sessmenu .fsm-row:hover {"), FEED.indexOf("}", FEED.indexOf("\n.feed-sessmenu .fsm-row:hover {")))],
+  ["styles.css .ctx-swatch.sel", CHAT.slice(CHAT.indexOf("\n.ctx-swatch.sel {"), CHAT.indexOf("}", CHAT.indexOf("\n.ctx-swatch.sel {")))],
+  ["kernel.py mobile session picker (#mlist)", KERNEL.slice(KERNEL.indexOf('"#mlist{display:none;'), KERNEL.indexOf('".mrow.ph'))],
   ["tag-menu.ts openTagMenu", slice(MENU, "export function openTagMenu", "export function tagMenuButton")],
   ["timeline menuStyleFor/menuCheckStyleFor", slice(TIMELINE, "const menuStyleFor", "let MENU_STYLE")],
 ];
@@ -132,10 +144,11 @@ test("the inline menus wear the tokens — card, text, hairline, hover, radius, 
   // a token whose dark value COMPOSES a VS Code var (--menu-bg/--menu-fg) resolves, sheet-less, to its own
   // innermost fallback; a literal value (rgba/hex) is already the resolved value
   const innermost = (v: string) => { const m = v.startsWith("var(") ? v.match(/,\s*(.+)\)\s*$/) : null; return m ? m[1] : v; };
+  const GEOMETRY: Record<string, string> = { "--radius-menu": "6px", "--shadow-menu": "0 4px 12px rgba(0, 0, 0, 0.35)" };
   for (const src of [pick, vers, tag]) {
     for (const m of src.matchAll(/var\((--menu-[\w-]+|--check-bg|--radius-menu|--shadow-menu),\s*((?:[^()]|\([^()]*\))*)\)/g)) {
-      const tok = m[1] as keyof typeof DARK, fb = m[2];
-      const want = tok === "--radius-menu" ? "6px" : tok === "--shadow-menu" ? "0 4px 12px rgba(0, 0, 0, 0.35)" : innermost(DARK[tok]);
+      const tok: string = m[1], fb = m[2];
+      const want = GEOMETRY[tok] ?? innermost(DARK[tok as keyof typeof DARK]);
       assert.equal(norm(fb), norm(want), `${tok} fallback ${fb} must equal the dark token value ${want}`);
     }
   }
@@ -147,8 +160,8 @@ test("the ✓ mark is themed through --check-bg on every surface: dark #1EA1EB, 
   assert.match(block(CHAT, ".ctx-sub .ctx-item.current::after"), /background: var\(--check-bg\)/);
   assert.match(FEED, /\.feed-viewmenu \.ctx-item\.current::after \{[^}]*var\(--check-bg\)/s, "the feed's view menu check");
   // the timeline's palette IS its theme definition — its two values are the two blocks' values
-  assert.match(TIMELINE, /const PAL_DARK = \{[\s\S]*?accentSolid: '#1EA1EB'/, "PAL_DARK ✓ = the dark token");
-  assert.match(TIMELINE, /const PAL_LIGHT = \{[\s\S]*?accentSolid: '#C2410C'/, "PAL_LIGHT ✓ = the light token");
+  assert.match(TIMELINE, /const PAL_DARK = \{[^}]*?accentSolid: '#1EA1EB'/, "PAL_DARK ✓ = the dark token");
+  assert.match(TIMELINE, /const PAL_LIGHT = \{[^}]*?accentSolid: '#C2410C'/, "PAL_LIGHT ✓ = the light token");
   assert.match(TIMELINE, /background:' \+ p\.accentSolid \+ '/, "menuCheckStyleFor reads the palette, never a literal");
   for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
     assert.ok(block(css, ":root").includes("--check-bg: #1EA1EB;"), name + " dark ✓ pinned byte-for-byte");
@@ -159,9 +172,38 @@ test("the ✓ mark is themed through --check-bg on every surface: dark #1EA1EB, 
 
 test("the CLAUDE.md rule names the tokens and keeps the hex as the dark theme's values", () => {
   const md = fs.readFileSync(path.resolve(process.cwd(), "..", "CLAUDE.md"), "utf8");
-  const rule = md.slice(md.indexOf("### Menus and dropdowns wear ONE vocabulary"), md.indexOf("The romp accent is light blue"));
+  const rule = slice(md, "### Menus and dropdowns wear ONE vocabulary", "The romp accent is light blue");
   for (const tok of ["--menu-bg", "--menu-fg", "--menu-border", "--menu-hover", "--radius-menu", "--shadow-menu", "--check-bg"])
     assert.ok(rule.includes("`" + tok + "`"), "the rule names " + tok);
   assert.ok(rule.includes("`#252526`") && rule.includes("`#1EA1EB`"), "the dark values stay documented");
-  assert.match(rule, /FALLBACK/, "the one sanctioned place for a raw hex in a menu string");
+  assert.match(rule, /fallback/i, "the one sanctioned place for a raw hex in a menu string");
+});
+
+test("the sheets' reference menu rules wear the tokens too — one card, one hover, one ring (review round)", () => {
+  // .ctx-menu is the rule the CLAUDE.md text names as the spec; it and .meta-menu read --menu-bg/--menu-fg
+  // (served dark: byte-identical — the token composes the VS Code colour they always followed).
+  // .ctx-item:hover stays on --vscode-menu-selectionBackground BY DESIGN: the tab menu is "themed
+  // like VS Code's own menus" and the served dark hover is its blue selection — the one sanctioned
+  // divergence, named here so it cannot be mistaken for an oversight.
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    assert.match(block(css, ".ctx-menu"), /background: var\(--menu-bg\);/, name + " .ctx-menu card");
+    assert.match(block(css, ".ctx-menu"), /color: var\(--menu-fg\);/, name + " .ctx-menu text");
+  }
+  assert.match(block(CHAT, ".meta-menu"), /background: var\(--menu-bg\);/, ".meta-menu card");
+  assert.match(CHAT, /\.ctx-swatch\.sel \{ box-shadow: 0 0 0 2px var\(--menu-bg\), 0 0 0 3\.5px var\(--menu-ring\); \}/, "the current-swatch halo is themed");
+  assert.match(CHAT, /\.ctx-tag-input \{[^}]*color: var\(--menu-fg\)/, "the New-tag input reads the MENU text (scheme-invariant, = the old #ccc in dark)");
+  assert.match(FEED, /\.feed-sessmenu \.fsm-row:hover \{ background: var\(--menu-hover\); \}/, "the session combobox rows hover with the one wash");
+  assert.match(FEED, /\.fask-doneconfirming \{[^}]*border: 1px solid var\(--check-ring\)/, "the done-confirming ring follows the themed ✓");
+  for (const id of ["#rs-cmap-list", "#rs-pal-list"]) {
+    const at = GEAR_CSS.indexOf("\n" + id + " {"); const rule = GEAR_CSS.slice(at, GEAR_CSS.indexOf("}", at));
+    assert.match(rule, /background: var\(--menu-bg, #252526\)/, id + " card"); assert.match(rule, /var\(--shadow-menu, /, id + " shadow");
+  }
+  // the picker rows this change retokenised read the MENU text, not the chat scheme's --fg
+  assert.equal((GEAR.match(/color:var\(--menu-fg, #ccc\)/g) || []).length, 2, "tabCtx + selectPick rows");
+  // the mobile session picker (kernel _CHAT_MOBILE_CSS) is a dropdown too: card + hairline on the tokens,
+  // and a light block for the values that have no byte-identical dark token
+  const mob = KERNEL.slice(KERNEL.indexOf('"#mlist{display:none;'), KERNEL.indexOf('".mrow.ph'));
+  assert.match(mob, /background:var\(--menu-bg,#252526\)/, "#mlist card");
+  assert.match(mob, /border:1px solid var\(--hairline,#3a3a3a\)/, "#mlist hairline (dark #3a3a3a byte-identical)");
+  assert.match(KERNEL, /body\.theme-light #mlist\{/, "the light block re-skins the mobile picker");
 });

--- a/ui/webview/settings-dropdown.test.ts
+++ b/ui/webview/settings-dropdown.test.ts
@@ -45,16 +45,19 @@ test("the descriptions ellipsize in BOTH states, and the row chain can actually 
 });
 
 test("the open menu wears the house vocabulary and cannot overflow the panel", () => {
-  assert.match(pickBody, /background:#252526;border:1px solid rgba\(255,255,255,0\.12\);border-radius:6px;box-shadow:0 4px 12px rgba\(0,0,0,0\.35\)/,
-    "the .ctx-menu reference values, inlined like versionMenu's MSTYLE");
-  assert.match(pickBody, /font-size:12px;line-height:1\.4;color:#cccccc;user-select:none/);
+  // the .ctx-menu reference values, inlined like versionMenu's MSTYLE — through the menu TOKENS
+  // since T226 (the dark literal rides only as the var() fallback; menu-theme-tokens.test.ts owns
+  // the theme story: in light the same string resolves to the cream card)
+  assert.match(pickBody, /background:var\(--menu-bg, #252526\);border:1px solid var\(--menu-border, rgba\(255,255,255,0\.12\)\);border-radius:var\(--radius-menu, 6px\);box-shadow:var\(--shadow-menu, 0 4px 12px rgba\(0,0,0,0\.35\)\)/,
+    "the .ctx-menu reference values, inlined like versionMenu's MSTYLE (tokens + dark fallbacks)");
+  assert.match(pickBody, /font-size:12px;line-height:1\.4;color:var\(--menu-fg, #cccccc\);user-select:none/);
   assert.match(pickBody, /position:absolute;left:0;right:0;top:100%/,
     "anchored inside the row wrapper (the #rs-cmap/#rs-pal mechanic): width = the card's content width, no sideways overflow");
   assert.match(pickBody, /menu\.scrollIntoView\(\{ block: 'nearest' \}\)/,
     "opening reveals the menu inside the scrolling card — the bottom edge never clips it");
-  assert.match(pickBody, /background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px/,
-    "the current option wears the ✓-in-circle mark");
-  assert.match(pickBody, /rgba\(255,255,255,0\.09\)/, "row hover, the shared menu hover wash");
+  assert.match(pickBody, /background:var\(--check-bg, #1EA1EB\);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px/,
+    "the current option wears the ✓-in-circle mark (themed through --check-bg since T226)");
+  assert.match(pickBody, /var\(--menu-hover, rgba\(255,255,255,0\.09\)\)/, "row hover, the shared menu hover wash (themed)");
 });
 
 test("the tab-theme sub-lines wear the menu vocabulary's sub scale", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -91,6 +91,18 @@ body.scheme-solarized-dark {
      2026-08-26. Mirrored in feed.css (own :root). */
   --radius-menu: 6px;
   --shadow-menu: 0 4px 12px rgba(0, 0, 0, 0.35);
+  /* the menu SKIN, as tokens (T226, 2026-09-02: in the light theme every inline-styled dropdown —
+     the settings pickers, the tag menu — stayed a #252526 card with #cccccc text, unreadable): the
+     card, its text, its hairline, its row-hover wash. Dark values = the literals the vocabulary
+     always named, byte-for-byte; the light block re-skins them in its own palette. The card and
+     text COMPOSE the VS Code menu tokens, so the extension's webview keeps following the editor's
+     menu colours exactly as .ctx-menu always did, and the served THEME_CSS resolves them to the
+     dark spec. Inline menu strings reference these with the dark literal as the var() FALLBACK
+     (a file:// harness or a foreign host loads no sheet). Mirrored in feed.css (own :root). */
+  --menu-bg: var(--vscode-menu-background, #252526);
+  --menu-fg: var(--vscode-menu-foreground, #cccccc);
+  --menu-border: rgba(255, 255, 255, 0.12);
+  --menu-hover: rgba(255, 255, 255, 0.09);
   /* the transient-notice (toast/banner) vocabulary — one raised surface, radius and shadow for
      every self-dismissing notice; five variants had drifted in before 2026-08-26. Mirrored in
      feed.css (own :root); the kernel's banners carry the same values as literals. */
@@ -174,7 +186,9 @@ body.theme-light {
   --dim: #5D574E;
   --rail: rgba(0, 0, 0, 0.14);
   --green: #3E7D0E;
-  --check-bg: #1EA1EB;   /* the session-identity default blue is BRAND, same in both themes */
+  --check-bg: #C2410C;   /* the ✓ mark is THEMED (T226 ruling, 2026-09-02): every check on every surface
+                            wears the theme's own mark — dark keeps the #1EA1EB brand blue, light wears
+                            its clay accent (what the timeline's PAL_LIGHT already drew) */
   --code-fg: #8C4A00;
   --code-bg: rgba(180, 83, 9, 0.08);
   --box-bg: rgba(0, 0, 0, 0.03);
@@ -193,6 +207,10 @@ body.theme-light {
   --st-blocked-bg: #e5484d; --st-blocked-fg: #ffffff;
   --radius-menu: 6px;
   --shadow-menu: 0 4px 12px rgba(31, 26, 20, 0.16);
+  --menu-bg: #FBF6EF;
+  --menu-fg: #1F1E1D;
+  --menu-border: rgba(0, 0, 0, 0.12);
+  --menu-hover: rgba(0, 0, 0, 0.06);
   --surface-raised: #FAF5EE;
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(31, 26, 20, 0.18);
@@ -533,7 +551,7 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .ctx-tag-x { flex: 0 0 auto; background: none; border: none; color: var(--dim); cursor: pointer; font: inherit; padding: 0 2px; }
 .ctx-tag-x:hover { color: var(--fg); }
 .ctx-item-newtag { cursor: default; }
-.ctx-tag-input { width: 100%; background: #1e1e1e; color: #ccc; border: 1px solid #3a3a3a; border-radius: 5px; padding: 3px 6px; font: inherit; }
+.ctx-tag-input { width: 100%; background: var(--vscode-editor-background, #1e1e1e); color: var(--fg); border: 1px solid var(--hairline); border-radius: 5px; padding: 3px 6px; font: inherit; }   /* themed (T226): the dark values resolve byte-equal */
 .ctx-tag-input:focus { outline: none; border-color: var(--accent); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
@@ -1224,7 +1242,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   padding: 4px 22px 4px 8px; border-radius: 4px; cursor: pointer;
   color: var(--fg); position: relative; white-space: nowrap;
 }
-.meta-item:hover { background: rgba(255, 255, 255, 0.09); }
+.meta-item:hover { background: var(--menu-hover); }   /* the themed row wash (T226) */
 /* second line for a choice whose consequence its label doesn't carry (Bypass permissions). Same
    0.82em / 0.6 opacity as .ctx-item-sub — one sub-line size across every romp menu. */
 .meta-item-sub { font-size: 0.82em; opacity: 0.6; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -103,6 +103,8 @@ body.scheme-solarized-dark {
   --menu-fg: var(--vscode-menu-foreground, #cccccc);
   --menu-border: rgba(255, 255, 255, 0.12);
   --menu-hover: rgba(255, 255, 255, 0.09);
+  --menu-ring: #fff;                 /* the current-swatch halo in a menu's colour grid (review round, T226) */
+  --check-ring: rgba(30, 161, 235, 0.55);   /* the ✓ family's translucent ring — --check-bg at 0.55 */
   /* the transient-notice (toast/banner) vocabulary — one raised surface, radius and shadow for
      every self-dismissing notice; five variants had drifted in before 2026-08-26. Mirrored in
      feed.css (own :root); the kernel's banners carry the same values as literals. */
@@ -211,6 +213,8 @@ body.theme-light {
   --menu-fg: #1F1E1D;
   --menu-border: rgba(0, 0, 0, 0.12);
   --menu-hover: rgba(0, 0, 0, 0.06);
+  --menu-ring: #1F1E1D;
+  --check-ring: rgba(194, 65, 12, 0.55);
   --surface-raised: #FAF5EE;
   --radius-toast: 8px;
   --shadow-toast: 0 8px 28px rgba(31, 26, 20, 0.18);
@@ -525,8 +529,9 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 /* right-click context menu on a tab — themed like VS Code's own menus */
 .ctx-menu {
   position: fixed; z-index: 100; min-width: 110px; padding: 4px;
-  background: var(--vscode-menu-background, #252526);
-  color: var(--vscode-menu-foreground, var(--fg));
+  background: var(--menu-bg);   /* the reference spec reads the menu tokens it names (T226); the token
+                                   composes the VS Code menu colour this rule always followed */
+  color: var(--menu-fg);
   border: 1px solid var(--box-border); border-radius: var(--radius-menu);
   box-shadow: var(--shadow-menu);
   font-size: 0.92em;
@@ -551,7 +556,7 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .ctx-tag-x { flex: 0 0 auto; background: none; border: none; color: var(--dim); cursor: pointer; font: inherit; padding: 0 2px; }
 .ctx-tag-x:hover { color: var(--fg); }
 .ctx-item-newtag { cursor: default; }
-.ctx-tag-input { width: 100%; background: var(--vscode-editor-background, #1e1e1e); color: var(--fg); border: 1px solid var(--hairline); border-radius: 5px; padding: 3px 6px; font: inherit; }   /* themed (T226): the dark values resolve byte-equal */
+.ctx-tag-input { width: 100%; background: var(--vscode-editor-background, #1e1e1e); color: var(--menu-fg); border: 1px solid var(--hairline); border-radius: 5px; padding: 3px 6px; font: inherit; }   /* themed (T226): the dark values resolve byte-equal */
 .ctx-tag-input:focus { outline: none; border-color: var(--accent); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
@@ -575,7 +580,7 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25); }
 .ctx-swatch:hover { transform: scale(1.12); }
 /* the session's current color: a white ring with a gap (the menu-bg fills the gap so it reads as a halo) */
-.ctx-swatch.sel { box-shadow: 0 0 0 2px var(--vscode-menu-background, #252526), 0 0 0 3.5px #fff; }
+.ctx-swatch.sel { box-shadow: 0 0 0 2px var(--menu-bg), 0 0 0 3.5px var(--menu-ring); }   /* themed halo (T226 review): a white ring vanished on the light card */
 
 .tab-close { opacity: 0; font-size: 1.1em; line-height: 1; padding: 0 2px; border-radius: 3px; color: var(--dim); }
 .tab:hover .tab-close { opacity: 0.7; }
@@ -1229,7 +1234,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 @keyframes meta-dots { 0%, 70%, 100% { opacity: 0.3; } 35% { opacity: 1; } }
 .meta-menu {
   position: fixed; z-index: 60; min-width: 96px;
-  background: var(--vscode-editorWidget-background, #252526);
+  background: var(--menu-bg);   /* one card across every menu (T226); served dark unchanged */
   border: 1px solid var(--box-border); border-radius: var(--radius-menu);
   padding: 4px; box-shadow: var(--shadow-menu);
   font-family: var(--sans); font-size: 0.92em;

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -67,7 +67,10 @@ if (typeof document !== "undefined") {
 }
 
 /** Open (or toggle shut) the lens menu anchored under `anchor`. The ctx-family skin — the chat
- *  pane's .ctx-menu is the reference spec (CLAUDE.md menu vocabulary). */
+ *  pane's .ctx-menu is the reference spec (CLAUDE.md menu vocabulary), worn here through the menu
+ *  TOKENS (--menu-bg/--menu-fg/--menu-border/--menu-hover + --radius-menu/--shadow-menu/--check-bg)
+ *  with the dark literals as var() fallbacks — every mounting page loads styles.css or feed.css,
+ *  so the light theme's block re-skins the card (T226, 2026-09-02). */
 export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
   const reopen = !!openMenu && openMenu.dataset.tagMenu === "1";
   closeTagMenu();
@@ -75,9 +78,9 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
   const menu = document.createElement("div");
   menu.dataset.tagMenu = "1";
   menu.setAttribute("style",
-    "position:fixed;z-index:1001;min-width:180px;padding:4px;background:#252526;" +
-    "border:1px solid rgba(255,255,255,0.12);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.35);" +
-    "font-size:12px;line-height:1.4;color:#cccccc;user-select:none;");
+    "position:fixed;z-index:1001;min-width:180px;padding:4px;background:var(--menu-bg, #252526);" +
+    "border:1px solid var(--menu-border, rgba(255,255,255,0.12));border-radius:var(--radius-menu, 6px);box-shadow:var(--shadow-menu, 0 4px 12px rgba(0,0,0,0.35));" +
+    "font-size:12px;line-height:1.4;color:var(--menu-fg, #cccccc);user-select:none;");
   menu.addEventListener("click", (e) => e.stopPropagation());
   const build = () => {
     menu.textContent = "";
@@ -98,11 +101,11 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
         const c = document.createElement("span");
         c.textContent = "✓";
         c.setAttribute("style", "position:absolute;right:6px;top:50%;transform:translateY(-50%);"
-          + "background:#1EA1EB;color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;"
+          + "background:var(--check-bg, #1EA1EB);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;"
           + "font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;");
       r.appendChild(c);
       }
-      r.addEventListener("mouseenter", () => { r.style.background = "rgba(255,255,255,0.09)"; });
+      r.addEventListener("mouseenter", () => { r.style.background = "var(--menu-hover, rgba(255,255,255,0.09))"; });
       r.addEventListener("mouseleave", () => { r.style.background = "transparent"; });
       menu.appendChild(r);
       return r;
@@ -115,7 +118,7 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
         .addEventListener("click", () => { opts.onApply(toggleLens(lens, { tag: u.name }), false); build(); });
     if (opts.onConfigure) {
       const s = document.createElement("div");
-      s.setAttribute("style", "height:1px;margin:4px 6px;background:rgba(255,255,255,0.12);");
+      s.setAttribute("style", "height:1px;margin:4px 6px;background:var(--menu-border, rgba(255,255,255,0.12));");
       menu.appendChild(s);
       row("Configure tags…", false, null, true).addEventListener("click", () => { closeTagMenu(); opts.onConfigure!(); });
     }


### PR DESCRIPTION
## The bug (user report 7:42 AM PT, 2026-09-02)

In the light theme, dropdown menus still rendered dark — the Theme select's own open menu was a near-black card with dark-on-dark option text, so the way back to a dark theme was unreadable (only the ✓ was visible).

## Cause (verified on a served page)

The menu vocabulary was pinned as LITERAL hex in every inline-styled menu: `gear.js` `housePick` (the Theme select and every settings picker), `versionMenu` (model pickers + version submenus) and `tag-menu.ts` hardcoded `#252526` / `rgba(255,255,255,0.12)` / `#cccccc` / `rgba(0,0,0,0.35)`, so the light block could never reach them. The chat's `.ctx-menu`/`.meta-menu` already resolved through VS Code tokens the light block defines, and the timeline already swapped its palette — the one vocabulary had quietly become three. Two dark-only literals inside the sheets' own menu rules (`.meta-item:hover`'s white wash, `.ctx-tag-input`'s dark input) went invisible in light too.

## The fix

The skin is TOKENS now, defined in both theme blocks of both self-sufficient sheets (`styles.css`, `feed.css`): `--menu-bg`, `--menu-fg`, `--menu-border`, `--menu-hover` beside the existing `--radius-menu` / `--shadow-menu` / `--check-bg`.

- Dark resolves byte-for-byte to the literals the rule always named. `--menu-bg`/`--menu-fg` COMPOSE the VS Code menu tokens, so the extension's webview keeps following the editor's menu colours exactly as `.ctx-menu` always did, and the served `THEME_CSS` resolves them to the dark spec.
- The light block re-skins in its own palette: `#FBF6EF` card, `#1F1E1D` text, `rgba(0,0,0,0.12)` hairline, `rgba(0,0,0,0.06)` hover.
- Every inline menu string references the tokens with the dark literal as the `var()` FALLBACK (a file:// harness or a foreign host loads no sheet).
- The timeline keeps its resolved JS palette: Obsidian gives it no vars to read, so `PAL_DARK`/`PAL_LIGHT` ARE its theme definitions (comment updated).
- **The ✓ mark is themed** (manager's ruling): `--check-bg` stays `#1EA1EB` in the dark themes and becomes the light theme's clay accent `#C2410C` — the mark the timeline's `PAL_LIGHT` already drew — so every check on every surface wears one mark WITHIN a theme. The sheets' light-mode checks change deliberately.
- `CLAUDE.md`'s rule now names the tokens, keeping the hex documented as the dark theme's values.

## Evidence (hermetic kernels + playwright, real clicks)

- Theme picker menu open in all three themes, BEFORE (unpatched `b62fd765`) vs AFTER: **classic IDENTICAL, yatharth IDENTICAL** (Pillow RGB pixel compare of the element crops); yatharth-light differs on 44,526 of 44,548 pixels — the whole card re-skinned. Computed styles: before-light `rgb(37,37,38)`/`rgb(204,204,204)` (the bug); after-light `rgb(251,246,239)`/`rgb(31,30,29)`.
- One menu per surface class in light, all legible on the cream card: version menu + submenu, chat tab context menu, statusline mode meta menu (clay ✓), tag menu, timeline corner menu (lifted into the shell doc).

## Review round (three-lens adversarial review, findings verified against source)

- **CI typecheck**: the new test had two TS2367 comparisons that `npm test` could not see (esbuild strips types) but CI's `npm run typecheck` fails on — fixed; typecheck now runs in my pre-push chain.
- **Missed menu surfaces now themed**: the mobile session picker (`kernel.py` `_CHAT_MOBILE_CSS` `#mlist`: card/hairline on the tokens, byte-identical in dark, plus a light block for text/ring/shadow/active), the settings colormap and session-palette dropdowns (`gear.css` `#rs-cmap-list`/`#rs-pal-list`), the feed session-combobox row hover, the tab menu's current-swatch halo (new `--menu-ring`), the done-confirming pill's ring (new `--check-ring`, follows the themed ✓), and `.ctx-tag-input` + the retokenised picker rows now read `--menu-fg` (scheme-invariant — `--fg` would have followed the chat text schemes).
- **The reference rules read the tokens**: `.ctx-menu` (both sheets) and `.meta-menu` now read `--menu-bg`/`--menu-fg` — served dark byte-identical by construction (the token composes the same VS Code colour). `.ctx-item:hover` deliberately stays on `--vscode-menu-selectionBackground` (the tab menu is "themed like VS Code's own menus"); the test names that exception.
- **Deliberate dark deltas, disclosed**: (1) the feed session-combobox row hover goes from a 0.07 white wash to the vocabulary's 0.09 (`--menu-hover`) — it was drift; (2) the two settings colormap/palette dropdowns move from the PAGE colour (`#1e1e1e`, `#3a3a3a` border, `0 8px 24px #000000aa` shadow) onto the menu card (`#252526`, hairline, menu shadow) — they never wore the skin; (3) in the VS Code EXTENSION webview only, the inline menus and `.meta-menu` now follow the editor's `menu.background`/`menu.foreground` like `.ctx-menu` always did (previously always-`#252526`). The served dashboard's dark themes are unchanged everywhere else — pixel-compared for the theme picker menu.
- Test hardening: any white-alpha `rgba(255,255,255,…)` in a menu surface is banned (not just 0.12/0.09); the versionMenu slice starts at the card (the trigger button is not a menu); the CLAUDE.md slice is anchor-guarded; the sheets' reference rules and every review-round surface are asserted on the tokens.

## Tests

- `ui/webview/menu-theme-tokens.test.ts` (new): the token set in all four blocks with dark values pinned byte-for-byte; every menu surface (sheet rules + inline strings + the timeline's style builders) stripped of `var()` fallbacks and banned from carrying a dark literal; fallback PARITY (each inline fallback equals the dark token value); the themed ✓ across sheets and palette; the CLAUDE.md rule names the tokens.
- `settings-dropdown.test.ts` pins updated to the token form.

Suites on this head (bbf6c635, rebased on origin/main): pytest 6503 passed + 335 subtests (34 skipped), vscode-extension `npm run typecheck` clean + npm test 2654/2654. No shell surfaces touched (bats not run). Kernel change is CSS-only (the mobile picker strings in `_CHAT_MOBILE_CSS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
