### PR TITLE
T228: one awaited count on every surface — the goal card and the timeline lane too

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21905,13 +21905,16 @@ def build_feed(now, tmux=None):
             await_kind = None                        # the winning why's KIND and SINCE ride beside it,
             await_since = None                       # mirroring the or-chain exactly (a kindless winner
             await_peers = None                       # stays kindless; since = the wait's own event time).
-            if col == "awaiting":                    # peers = structured identities, delegation arm only
-                for _w, _k, _s, _p in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers),
-                                       (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers),
-                                       (_deleg_why, "peer", _deleg_since, _deleg_peers),
-                                       (_owned_why, "task", _owned_since, None)):
+            await_count = None                       # how many are awaited — the SAME number the chat chip words itself
+            if col == "awaiting":                    # from (T228, the user's one-count rule): the live snapshot's own
+                # count, the peers a stamp or delegation names, one owned dispatch; None when the arm cannot know
+                for _w, _k, _s, _p, _n in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count),
+                                           (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None)),
+                                           (_deleg_why, "peer", _deleg_since, _deleg_peers, (len(_deleg_peers) if _deleg_peers else None)),
+                                           (_owned_why, "task", _owned_since, None, 1)):
                     if _w:
                         await_kind, await_since, await_peers = _k, _s, _p
+                        await_count = _n if isinstance(_n, int) and _n > 0 else None
                         break
             # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
             # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent
@@ -22198,6 +22201,7 @@ def build_feed(now, tmux=None):
                 # when present the card wears the compact "Waiting on task" pill (expands to this list, like
                 # Sub-goals) instead of the boxed why; empty for subagent/overlay flavors, which keep the box.
                 "awaiting": ({"why": await_why, "kind": await_kind, "since": await_since,
+                              "count": await_count,   # the one number every surface words itself from (T228)
                               "peers": await_peers,   # delegation wait → [{name, host, sid, color}] for the identity-coloured box (the user 2026-08-23)
                               "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
@@ -24348,6 +24352,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         sessions.append({
             "id": sid, "name": name, "live": live, "state": state, "awaitingBg": awaiting_bg,
             "awaitingKind": awaiting_kind,
+            "awaitingCount": ((_aw_bg or {}).get("count") if isinstance((_aw_bg or {}).get("count"), int) else None),   # the lane badge agrees in number (T228)
             "awaitingPeers": ((_aw_bg or {}).get("peers") or None),   # named identities for a peer wait (2026-08-26)
             # the live bg-task descriptions behind awaitingBg (the user 2026-07-13): the lane draws the
             # idle-but-waiting stretch as a thin dashed segment whose hover lists exactly what's pending

--- a/tests/test_awaiting_count.py
+++ b/tests/test_awaiting_count.py
@@ -115,6 +115,17 @@ class AwaitingCount(unittest.TestCase):
         self.assertIn('"awaitingCount": ((_aw or {}).get("count") if isinstance((_aw or {}).get("count"), int) else None),',
                       src)
 
+    def test_every_other_surface_ships_the_same_count(self):
+        # T228: the one-count rule reaches the timeline lane and the goal-floored feed card too (the
+        # placeholder card already threaded it); each surface words itself from THIS number, never its own
+        src = inspect.getsource(km)
+        self.assertIn('"awaitingCount": ((_aw_bg or {}).get("count") if isinstance((_aw_bg or {}).get("count"), int) else None),',
+                      src, "the timeline lane payload")
+        self.assertIn('"count": await_count,', src, "the goal card's awaiting object")
+        self.assertIn('(_owned_why, "task", _owned_since, None, 1)', src, "one owned dispatch counts one")
+        self.assertIn('(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None))', src,
+                      "a stamp counts the peers it names")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1341,6 +1341,35 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(card["awaiting"]["why"], "Waiting on the 3 research agents it dispatched.")
         self.assertIsNone(card["blocked"], "an awaiting goal is not a live block")
 
+    def test_feed_awaiting_card_carries_the_live_snapshots_count(self):
+        # T228 (the user's one-count rule, 2026-09-02): the goal-floored card's awaiting object carries the
+        # same `count` the chat chip words itself from — one live subagent reads "Awaiting agent" on the
+        # chip AND on the card (the feed's spin caption / pill derive the word from awaiting.count). Before,
+        # only the no-open-goal placeholder card threaded the count; a goal card stayed a bare plural.
+        top = SID + ":top"
+        def gn(nid, text, parent, **kw):
+            d = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+                 "blocked": False, "cleared": False, "trail": [], "t": T0, "mt": T0}
+            d.update(kw); return d
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "lastNode": top,
+            "nodes": {top: gn(top, "research the API", None, why="user asked for the research")},
+            "placements": {}, "status": {top: "working"}}))
+        saved = km._session_awaiting
+        try:
+            for n in (1, 3):
+                km._session_awaiting = lambda sid, path, idle, stamp=False, n=n: {
+                    "kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s"),
+                    "since": T0, "count": n}
+                card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+                self.assertEqual(card["awaiting"]["kind"], "agents")
+                self.assertEqual(card["awaiting"]["count"], n, "the card's count is the snapshot's own")
+            km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": None, "why": "waiting on dispatched work", "since": None}
+            card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+            self.assertIsNone(card["awaiting"]["count"], "a source that cannot count ships None, never a guess")
+        finally:
+            km._session_awaiting = saved
+
     def _blocked_card_with_bg_task(self, since, owner="blocked", second_top=False):
         """A GENUINELY blocked top (ask at T0+100) on a session running a LIVE background task, end to
         end through the REAL machinery: the task's toolUseId is the fixture transcript's actual launch

--- a/tests/test_kernel_timeline_awaiting.py
+++ b/tests/test_kernel_timeline_awaiting.py
@@ -106,6 +106,27 @@ class TimelineAwaiting(unittest.TestCase):
         self.assertEqual(lane["awaitingBg"], "waiting on a background task: Watch for round3 copy")
         self.assertEqual(lane["awaitingTasks"], ["Watch for round3 copy"])
 
+    def test_the_lane_ships_the_awaited_count_beside_the_kind(self):
+        # T228 (the user's one-count rule): the lane badge words its kind from the SAME count the chat chip
+        # uses — one live task/agent reads "Awaiting task"/"Awaiting agent" on the lane too. The number is
+        # the snapshot's own; a source that cannot count ships None (the view keeps its historic plural).
+        base = {"state": "waiting", "since": NOW - 100, "model": "", "effort": "", "context": None,
+                "compactPct": None, "color": None, "mode": ""}
+        km._tmux_sessions = lambda: {SID: dict(base, bgTasks=[{"task_id": "t1", "desc": "Watch for round3 copy"}])}
+        lane = self._lane()
+        self.assertEqual((lane["awaitingKind"], lane["awaitingCount"]), ("task", 1))
+        km._tmux_sessions = lambda: {SID: dict(base, bgTasks=[{"task_id": "t1", "desc": "Watch for round3 copy"},
+                                                              {"task_id": "t2", "desc": "poll the deploy"}])}
+        self.assertEqual(self._lane()["awaitingCount"], 2)
+        km._tmux_sessions = lambda: {SID: dict(base, subagents=[{"type": "explore", "since": T0 + 5}])}
+        lane = self._lane()
+        self.assertEqual((lane["awaitingKind"], lane["awaitingCount"]), ("agents", 1), "one agent → the badge reads singular")
+        km._tmux_sessions = lambda: {SID: dict(base)}
+        self.states.write_text(json.dumps({"t": T0 + 21, "awaiting": True, "why": "bg agents"}) + "\n")
+        lane = self._lane()
+        self.assertEqual(lane["awaitingBg"], "bg agents")
+        self.assertIsNone(lane["awaitingCount"], "a bare overlay row names no count — never parsed from the why")
+
     def test_overlay_flavor_awaiting_carries_no_task_rows(self):
         self.states.write_text(json.dumps({"t": T0 + 21, "awaiting": True, "why": "bg agents"}) + "\n")
         self.assertEqual(self._lane()["awaitingTasks"], [], "no live tasks → the stretch hover falls back to the why")

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -441,6 +441,19 @@ function idleGaps(merged, gapCT, now) {
   return gaps;
 }
 
+// The awaited KIND worded to agree in NUMBER (T228, the user's one-count rule: a single awaited agent is
+// "agent", never "agents"). This is the RESOLVED twin of ui/webview/spin-caption.ts kindWord()/KIND_WORD —
+// this file runs standalone (Obsidian too) and cannot import it, so the table and the rule are mirrored
+// here byte for byte and timeline-awaiting.test.ts holds the two together. An unknown count (an older
+// kernel ships none) keeps the plural default each kind always wore; an unknown kind stays "agents".
+const KIND_WORD = { agents: 'agents', task: 'task', job: 'job', peer: 'peer', timer: 'timer' };
+function tlKindWord(kind, count) {
+  const base = KIND_WORD[kind || ''] || 'agents';
+  if (typeof count !== 'number' || !Number.isFinite(count)) return base;
+  if (count === 1) return base === 'agents' ? 'agent' : base;
+  return base === 'agents' ? base : base + 's';
+}
+
 function badgeFor(s) {
   if (!s || !s.live) return null;
   let m = null;
@@ -462,9 +475,9 @@ function badgeFor(s) {
   // s.awaitingBg why-field key stays as
   // the fallback (a remote host on an older kernel still reports state 'working' + the field).
   // (The LEGACY lane state 'awaiting' above means blocked-on-you — this name dodges that.)
-  // The KIND rides the label ('Awaiting job', the user 2026-08-15) — the enum values ARE the words;
-  // an older kernel ships no awaitingKind and the badge reads plain 'Awaiting' as before.
-  else if (s.state === 'awaitingBg' || s.awaitingBg) m = { label: 'Awaiting' + (s.awaitingKind ? ' ' + s.awaitingKind : ''), kind: 'awaitbg' };
+  // The KIND rides the label ('Awaiting job', the user 2026-08-15), worded by tlKindWord so one agent reads
+  // 'Awaiting agent' (T228); an older kernel ships no awaitingKind and the badge reads plain 'Awaiting' as before.
+  else if (s.state === 'awaitingBg' || s.awaitingBg) m = { label: 'Awaiting' + (s.awaitingKind ? ' ' + tlKindWord(s.awaitingKind, s.awaitingCount) : ''), kind: 'awaitbg' };   // agrees in number with the chip (T228)
   else if (s.state === 'ready' || s.state === 'waiting' || s.state === 'idle') m = { label: 'Ready', kind: 'ready' };
   if (!m) return null;
   return { label: m.label, bg: BADGE[m.kind].bg, fg: BADGE[m.kind].fg };

--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -53,8 +53,8 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
 });
 
 test("the kernel ships identities on every arm — the or-chain's hardcoded Nones are gone", () => {
-  assert.match(KERNEL, /\(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers\)/, "the judge-stamp arm");
-  assert.match(KERNEL, /\(sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers\)/,
+  assert.match(KERNEL, /\(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, \(len\(_stamp_peers\) if _stamp_peers else None\)\)/, "the judge-stamp arm (identities + their count, T228)");
+  assert.match(KERNEL, /\(sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count\)/,
     "the session-snapshot arm");
   assert.match(KERNEL, /"awaitingPeers": \(\(_aw or \{\}\)\.get\("peers"\) or None\)/, "the chat status payload");
   assert.match(KERNEL, /"awaitingPeers": \(\(_aw_bg or \{\}\)\.get\("peers"\) or None\)/, "the timeline sessions payload");

--- a/ui/webview/timeline-awaiting.test.ts
+++ b/ui/webview/timeline-awaiting.test.ts
@@ -9,11 +9,15 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { kindWord, KIND_WORD } from "./spin-caption";
+
 const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 test("an awaitingBg lane renders an Awaiting badge in the romp brand green (the user 2026-07-22)", () => {
   // keyed on the chip state (the shared _session_chip split) OR the legacy why-field (older remote kernels)
-  assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting' \+ \(s\.awaitingKind \? ' ' \+ s\.awaitingKind : ''\), kind: 'awaitbg' \};/);
+  // the kind word agrees in NUMBER with the kernel's count (T228) — via the standalone twin of kindWord()
+  assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting' \+ \(s\.awaitingKind \? ' ' \+ tlKindWord\(s\.awaitingKind, s\.awaitingCount\) : ''\), kind: 'awaitbg' \};/);
   // brand green, matching --st-awaitbg-bg in styles.css (this file loads standalone, so the hex is mirrored)
   assert.match(TL, /awaitbg: \{ bg: '#54B204', fg: '#0c1a00' \}/);
   // an awaitingBg lane still reads ACTIVE (full opacity / ongoing treatment), like working/compacting/clearing
@@ -46,4 +50,31 @@ test("an idle awaitingBg lane draws a full-thickness FADED stretch (0.4 alpha), 
   assert.match(TL, /ln\.setAttribute\('stroke-width', String\(BAR_H\)\); ln\.setAttribute\('opacity', '0\.4'\); this\.hideTip\(\);/);
   // the stretch keeps empty-row behaviors: drag to pan/reorder, click to select/open
   assert.match(TL, /wh\.addEventListener\('mousedown', \(e\) => this\._beginDrag\(s\.id, e\)\);/);
+});
+
+// --- T228 (the user's one-count rule): the lane badge words the kind from the SAME count as the chip -------
+function tlKindWordFromSource(): (kind: unknown, count: unknown) => string {
+  // this file runs standalone (Obsidian too) and cannot import spin-caption.ts, so it carries a RESOLVED
+  // twin; execute that twin from its source text and hold it to the webview helper below
+  const table = TL.match(/const KIND_WORD = \{[^}]*\};/);
+  const fn = TL.match(/function tlKindWord\(kind, count\) \{[\s\S]*?\n\}/);
+  assert.ok(table && fn, "the timeline carries the KIND_WORD table and the tlKindWord twin");
+  return new Function(table![0] + "\n" + fn![0] + "\nreturn tlKindWord;")() as (kind: unknown, count: unknown) => string;
+}
+
+test("the timeline's tlKindWord twin agrees with spin-caption's kindWord on every kind × count", () => {
+  const tl = tlKindWordFromSource();
+  const kinds = [...Object.keys(KIND_WORD), "", null, undefined, "nonsense"];
+  const counts = [null, undefined, 0, 1, 2, 7, NaN];
+  for (const k of kinds) for (const c of counts) {
+    assert.equal(tl(k, c), kindWord(k as any, c as any), `kind=${String(k)} count=${String(c)}`);
+  }
+  assert.equal(tl("agents", 1), "agent", "one awaited agent reads singular on the lane, as on the chip");
+  assert.equal(tl("agents", 2), "agents");
+  assert.equal(tl("task", 3), "tasks");
+  assert.equal(tl("agents", null), "agents", "an older kernel with no count keeps the historic plural");
+});
+
+test("the kernel's lane payload ships awaitingCount beside awaitingKind, from the same snapshot", () => {
+  assert.match(KERNEL, /"awaitingKind": awaiting_kind,\s*\n\s*"awaitingCount": \(\(_aw_bg or \{\}\)\.get\("count"\) if isinstance\(\(_aw_bg or \{\}\)\.get\("count"\), int\) else None\),/);
 });


### PR DESCRIPTION
## Summary
Follow-up to the T225 rider (a single awaited agent reads "Awaiting agent", never "agents"). Two surfaces still worded the raw plural; both re-verified from the code:

- **Goal-floored feed card.** `build_feed`'s awaiting or-chain carried why/kind/since/peers but no count; only the no-open-goal placeholder card threaded `sess_awaiting_count`. So the card's spin caption read "Awaiting agents" for one live subagent while the chat chip read "Awaiting agent". The or-chain now carries the winning arm's count (the live snapshot's own, the peers a stamp or delegation names, one owned dispatch; `None` when the arm cannot know) and the card's awaiting object ships it as `count`.
- **Timeline lane.** The lane payload shipped `awaitingKind`/`awaitingPeers` but no `awaitingCount`, and the badge printed the raw enum. The payload now ships `awaitingCount` from the same snapshot; the standalone view (also runs inside Obsidian, cannot import spin-caption.ts) words the badge through `tlKindWord`, a resolved twin of `kindWord`, and the test executes the twin from its source and holds it equal to the webview helper on every kind × count.

## Tests
- `tests/test_kernel.py` — goal card carries the snapshot's count (red first: `KeyError: 'count'`), None when the source cannot count
- `tests/test_kernel_timeline_awaiting.py` — behavioral lane count over one/two live tasks, one live agent, and a bare overlay row
- `tests/test_awaiting_count.py` — source pins for the lane payload and the or-chain arms
- `ui/webview/timeline-awaiting.test.ts` — badge label pin retargeted to the twin; twin ≡ `kindWord` equivalence; payload pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
