### PR TITLE
list_regs: a never-written state root lists empty, and the whole-listing fault serve stays within its own root

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1294,19 +1294,33 @@ def list_regs(state_dir: Path) -> list[dict]:
     out = []
     try:
         entries = list(os.scandir(d))
+    except FileNotFoundError:
+        # a MISSING sdk/ dir is genuine emptiness (a fresh state root the first write hasn't
+        # created yet), not a transient fault — scandir RAISES on it, it does not yield []. The
+        # OSError arm below misread this as a failed scan and served the module cache's rows,
+        # which in a process holding backends over SEVERAL state roots (the test suite's shape)
+        # resurrected another root's sessions into this one. The unlink rule holds: a dir that
+        # is gone took its regs with it, so the honest answer is [].
+        return out
     except OSError:
         # the WHOLE-LISTING twin of the per-entry contract (review find 2026-09-01): a transient
         # enumeration failure blanked every row at once — the loudest possible false-death signal
-        # under this very docstring. Serve every reg's last good row instead; a genuinely empty or
-        # missing dir enumerates FINE (scandir yields []/raises only on real faults), so truth is
-        # untouched. A fresh process with an empty cache still returns [] — it has nothing to claim.
-        if _REG_CACHE:
-            if "\x00scan" not in _REG_SERVE_WARNED:   # sentinel key: incidents log once, not per scan
-                _REG_SERVE_WARNED.add("\x00scan")
-                sys.stderr.write("list_regs: scan of %s failed — serving every last good row\n" % d)
-            return [dict(v[1]) for v in _REG_CACHE.values()]
+        # under this very docstring. Serve every reg's last good row instead — of THIS ROOT ONLY:
+        # _REG_CACHE is module-global across every backend in the process, so an unfiltered serve
+        # hands a PermissionError/EMFILE-class fault on one root the rows cached from OTHER state
+        # roots — the same cross-root session resurrection the arm above closes for the
+        # missing-dir case. A genuinely empty dir enumerates FINE (scandir yields []; a missing
+        # one is the arm above), so truth is untouched, and a fresh process with an empty cache
+        # still returns [] — nothing to claim.
+        mine = [dict(v[1]) for p, v in _REG_CACHE.items() if p.startswith(str(d) + os.sep)]
+        if mine:
+            skey = "\x00scan:%s" % d                  # sentinel key, PER ROOT: incidents log once
+            if skey not in _REG_SERVE_WARNED:         # per root, not per scan
+                _REG_SERVE_WARNED.add(skey)
+                sys.stderr.write("list_regs: scan of %s failed — serving this root's last good rows\n" % d)
+            return mine
         return out
-    _REG_SERVE_WARNED.discard("\x00scan")             # healed → the next scan incident logs afresh
+    _REG_SERVE_WARNED.discard("\x00scan:%s" % d)      # healed → the next scan incident logs afresh
     seen = set()
     for de in entries:
         if not de.name.endswith(".json"):

--- a/tests/test_sdk_live_rows.py
+++ b/tests/test_sdk_live_rows.py
@@ -104,9 +104,22 @@ class ListingCompleteness(unittest.TestCase):
             rows = {r["sid"] for r in sb.list_regs(self.be.state_dir)}
         finally:
             sb.os.scandir = saved
-            sb._REG_SERVE_WARNED.discard("\x00scan")
+            for k in [k for k in sb._REG_SERVE_WARNED if str(k).startswith("\x00scan")]:
+                sb._REG_SERVE_WARNED.discard(k)
         self.assertIn(self.SID, rows, "a transient enumeration failure must not blank the listing")
         self.assertIn(self.SID, {r["sid"] for r in sb.list_regs(self.be.state_dir)}, "healed scan is live")
+
+    def test_a_missing_dir_is_empty_truth_never_another_roots_rows(self):
+        # scandir RAISES FileNotFoundError on a missing sdk/ dir — it does not yield [] — so the
+        # transient-fault arm above misread "not created yet" as a failed scan and served the
+        # module cache's rows: a process holding backends over SEVERAL state roots (this suite)
+        # listed one root's sessions under another. A missing dir took its regs with it: the
+        # honest answer is [], and the last-good contract is untouched for real faults.
+        warm = {r["sid"] for r in sb.list_regs(self.be.state_dir)}
+        self.assertIn(self.SID, warm, "cache warmed from this root")
+        fresh = tempfile.mkdtemp()                # a state root whose sdk/ dir does not exist yet
+        self.assertEqual(sb.list_regs(fresh), [],
+                         "a never-written root lists empty — never another root's cached rows")
 
     def test_a_healed_stat_blip_unlatches_the_incident_log(self):
         # review find 2026-09-01: the once-per-incident latch only cleared on the re-READ path, but
@@ -159,6 +172,49 @@ class ListingCompleteness(unittest.TestCase):
         finally:
             stop.set()
             t.join()
+
+
+class FaultServeRootScope(unittest.TestCase):
+    """The whole-listing fault serve is ROOT-SCOPED: _REG_CACHE is a module global keyed by
+    absolute reg path and shared by every backend in the process, so the OSError arm's 'serve every
+    last good row' handed a PermissionError on ONE root the cached rows of every OTHER root — the
+    same cross-root session resurrection the missing-dir arm closed, still open for every
+    non-FileNotFoundError enumeration fault (PermissionError, EMFILE, transient I/O). The last-good
+    purpose is untouched: a fault on this root still serves THIS root's cached rows. Synthetic;
+    hermetic roots."""
+
+    SID_A = "aaaaaaaa-2222-3333-4444-555555555555"
+    SID_B = "bbbbbbbb-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.root_a, self.root_b = tempfile.mkdtemp(), tempfile.mkdtemp()
+        sb.write_reg(self.root_a, self.SID_A, {"sid": self.SID_A, "name": "web", "alive": True})
+        sb.write_reg(self.root_b, self.SID_B, {"sid": self.SID_B, "name": "api", "alive": True})
+
+    def tearDown(self):
+        for k in [k for k in sb._REG_SERVE_WARNED if str(k).startswith("\x00scan")]:
+            sb._REG_SERVE_WARNED.discard(k)
+
+    def test_a_fault_on_one_root_serves_only_that_roots_rows(self):
+        self.assertIn(self.SID_A, {r["sid"] for r in sb.list_regs(self.root_a)}, "cache warm: A")
+        self.assertIn(self.SID_B, {r["sid"] for r in sb.list_regs(self.root_b)}, "cache warm: B")
+        saved = sb.os.scandir
+        sdk_a = os.path.join(self.root_a, "sdk")
+
+        def faulty(p):
+            if str(p) == sdk_a:
+                raise PermissionError("mode bits blinked")   # any non-FileNotFoundError fault
+            return saved(p)
+
+        sb.os.scandir = faulty
+        try:
+            rows = {r["sid"] for r in sb.list_regs(self.root_a)}
+        finally:
+            sb.os.scandir = saved
+        self.assertIn(self.SID_A, rows, "this root's last good rows still serve through the fault")
+        self.assertNotIn(self.SID_B, rows, "another root's cached rows never resurrect here")
+        self.assertEqual({r["sid"] for r in sb.list_regs(self.root_a)}, {self.SID_A},
+                         "the healed scan is the fresh truth again")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What breaks

`list_regs` (`kernel/sdk_backend.py`) gained a whole-listing last-good arm in #843's review round, on top of the per-entry completeness contract from #830: when `os.scandir` on a root's `sdk/` dir raises, the listing serves every cached row instead of blanking every session at once. `_REG_CACHE` and `_REG_SERVE_WARNED` are module globals keyed by absolute reg path and shared by every `SdkBackend` in the process, and that arm has two paths by which one state root's listing ends up carrying ANOTHER root's sessions:

1. **A missing `sdk/` dir is treated as a transient fault.** `os.scandir` raises `FileNotFoundError` on a directory that does not exist; the arm's comment says it yields `[]`, which is true only of an EMPTY dir. A state root whose first reg write has not happened yet therefore takes the fault arm, and if any other root has warmed the cache in the same process, the never-written root lists that root's sessions.
2. **The fault serve is unscoped.** Any real enumeration fault on one root (`PermissionError`, EMFILE, transient I/O) returns the ENTIRE cache: rows from every root the process has scanned.

Exposure: production mostly runs one backend per process and `sdk/` exists once anything has been written, so the common case avoids both. A fresh install's first scan before its first write takes path 1; any process holding backends over several state roots (the test suite's own shape, or a future multi-root embedding) inherits both. Found when a test in one root listed sessions written by another root's backend earlier in the same process.

## Reproduction

In one process, after `root_a/sdk/` holds a reg:

```python
sb.list_regs(root_a)              # cache warms with root_a's row
sb.list_regs(tempfile.mkdtemp())  # base: returns root_a's row; expected []
```

and, with both roots warm and a `PermissionError` injected for `root_a/sdk` only:

```python
sb.list_regs(root_a)              # base: root_a's AND root_b's rows; expected root_a's only
```

## The fix (one commit, `list_regs` only)

- A `FileNotFoundError` arm ahead of `OSError` returns `[]`. This is the listing's own unlink rule: a dir that is gone took its regs with it.
- The surviving `OSError` arm filters the cache to reg paths under this root's `sdk/` dir (cache keys are the `scandir` paths, so the prefix `str(d) + os.sep` is exact) and keys the once-per-incident sentinel per root (`"\x00scan:<dir>"`), with the matching healed-scan discard. The last-good purpose is unchanged for the faulting root's own rows; a fresh process with an empty cache still returns `[]`.

The stderr line changes from "serving every last good row" to "serving this root's last good rows". Nothing in the repo asserts on the old text.

## Tests (`tests/test_sdk_live_rows.py`)

- `ListingCompleteness.test_a_missing_dir_is_empty_truth_never_another_roots_rows`: warm the cache from one root, list a fresh `mkdtemp` root, expect `[]`.
- `FaultServeRootScope.test_a_fault_on_one_root_serves_only_that_roots_rows`: two roots warmed, `PermissionError` injected only for root A's `sdk/`; root A's rows served, root B's absent, and the healed scan is exactly root A's set.
- The existing `test_a_failed_enumeration_serves_every_last_good_row` teardown now sweeps the per-root sentinel keys by prefix.

Both new tests fail on the base commit (the first returns the warm root's row instead of `[]`; the second finds root B's sid in root A's faulted listing) and pass with the fix. Full suite: 6495 passed, 44 skipped.

Synthetic sids and names throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)