### PR TITLE
Arm the ask future before presenting the ask, so a synchronous answer is not dropped

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1812,6 +1812,10 @@ class SdkSession:
             self._clearing = True
         self._input_wake: asyncio.Event | None = None
         self._cur_ask_fut: asyncio.Future | None = None
+        self._ask_serial = asyncio.Lock()            # ONE live ask per session: the SDK dispatches every control
+        #   request as its own detached task, so two asks CAN overlap; unserialized, the second would either
+        #   overwrite the first's future (a hang) or share it (one click answering both — a silently wrong
+        #   permission). Each ask site holds this from present to resolve (PR #875 review, 2026-09-02).
         self._lock = threading.Lock()
         self._ready = threading.Event()
         # Boot-stagger hook (see BOOT_RESUME_CONCURRENCY): fired exactly once when this session's CLI
@@ -2303,7 +2307,10 @@ class SdkSession:
         lands between _emit_ask and the coroutine's first await must already find the future armed —
         otherwise it is reported lost and the ask waits forever. Before T214 that read was deferred
         into the loop, which hid the gap; every ask site now calls this right before _emit_ask, and
-        _next_ask_action awaits the armed future rather than minting a second one."""
+        _next_ask_action awaits the armed future rather than minting a second one. The keep branch
+        exists for _next_ask_action alone: the sites hold _ask_serial from present to resolve, so a
+        site never finds another ask's live future here (two overlapping asks sharing one future
+        would let a single click answer both)."""
         fut = self._cur_ask_fut
         if fut is None or fut.done():
             self._cur_ask_fut = asyncio.get_running_loop().create_future()
@@ -2997,24 +3004,25 @@ class SdkSession:
         # ordinal so we map it back to the action here.
         ask = permission_to_live(tool_name, tool_input, context)
         remember_n = 2 if getattr(context, "suggestions", None) else None
-        self._mark("permission")
-        self._arm_ask()
-        self.backend._emit_ask(self, ask)
         decision = "deny"
-        try:
-            while True:
-                kind, payload = await self._next_ask_action()
-                if kind == "answer":
-                    n = str(payload)
-                    decision = "allow" if n == "1" else "remember" if n == str(remember_n) else "deny"
-                    break
-                if kind == "cancel":
-                    decision = "deny"
-                    break
-        finally:
-            self.backend._clear_ask(self)
-            if self.inflight:
-                self._mark("working")
+        async with self._ask_serial:                  # one live ask at a time (see _ask_serial)
+            self._mark("permission")
+            self._arm_ask()
+            self.backend._emit_ask(self, ask)
+            try:
+                while True:
+                    kind, payload = await self._next_ask_action()
+                    if kind == "answer":
+                        n = str(payload)
+                        decision = "allow" if n == "1" else "remember" if n == str(remember_n) else "deny"
+                        break
+                    if kind == "cancel":
+                        decision = "deny"
+                        break
+            finally:
+                self.backend._clear_ask(self)
+                if self.inflight:
+                    self._mark("working")
         if decision == "remember":
             return PermissionResultAllow(behavior="allow", updated_permissions=list(context.suggestions))
         if decision == "allow":
@@ -3041,21 +3049,22 @@ class SdkSession:
         }
         if pv:
             ask["previewKind"], ask["preview"] = pv[0], pv[1]
-        self._mark("permission")
-        self._arm_ask()
-        self.backend._emit_ask(self, ask)
         choice = "3"
-        try:
-            while True:
-                kind, payload = await self._next_ask_action()
-                if kind == "answer":
-                    choice = str(payload); break
-                if kind == "cancel":
-                    choice = "3"; break
-        finally:
-            self.backend._clear_ask(self)
-            if self.inflight:
-                self._mark("working")
+        async with self._ask_serial:                  # one live ask at a time (see _ask_serial)
+            self._mark("permission")
+            self._arm_ask()
+            self.backend._emit_ask(self, ask)
+            try:
+                while True:
+                    kind, payload = await self._next_ask_action()
+                    if kind == "answer":
+                        choice = str(payload); break
+                    if kind == "cancel":
+                        choice = "3"; break
+            finally:
+                self.backend._clear_ask(self)
+                if self.inflight:
+                    self._mark("working")
         if choice == "1":
             return PermissionResultAllow(behavior="allow")
         if choice == "2":
@@ -3079,6 +3088,10 @@ class SdkSession:
         return build_answers(questions, picks)
 
     async def _ask_one(self, question: dict, qi: int, total: int):
+        async with self._ask_serial:                  # one live ask at a time (see _ask_serial)
+            return await self._ask_one_locked(question, qi, total)
+
+    async def _ask_one_locked(self, question: dict, qi: int, total: int):
         multi = bool(question.get("multiSelect"))
         nreal = len(question.get("options") or [])
         selected: set[int] = set()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2296,9 +2296,21 @@ class SdkSession:
             return True
         return False
 
+    def _arm_ask(self):
+        """Create (or keep) the future an answer lands on. INVARIANT: an ask is never PRESENTED before
+        this future exists. resolve_ask reads _cur_ask_fut synchronously on the caller's thread and
+        reports False when nothing is waiting (T214's truthful delivery outcome), so an answer that
+        lands between _emit_ask and the coroutine's first await must already find the future armed —
+        otherwise it is reported lost and the ask waits forever. Before T214 that read was deferred
+        into the loop, which hid the gap; every ask site now calls this right before _emit_ask, and
+        _next_ask_action awaits the armed future rather than minting a second one."""
+        fut = self._cur_ask_fut
+        if fut is None or fut.done():
+            self._cur_ask_fut = asyncio.get_running_loop().create_future()
+        return self._cur_ask_fut
+
     async def _next_ask_action(self):
-        fut = asyncio.get_running_loop().create_future()
-        self._cur_ask_fut = fut
+        fut = self._arm_ask()
         try:
             return await fut
         finally:
@@ -2986,6 +2998,7 @@ class SdkSession:
         ask = permission_to_live(tool_name, tool_input, context)
         remember_n = 2 if getattr(context, "suggestions", None) else None
         self._mark("permission")
+        self._arm_ask()
         self.backend._emit_ask(self, ask)
         decision = "deny"
         try:
@@ -3029,6 +3042,7 @@ class SdkSession:
         if pv:
             ask["previewKind"], ask["preview"] = pv[0], pv[1]
         self._mark("permission")
+        self._arm_ask()
         self.backend._emit_ask(self, ask)
         choice = "3"
         try:
@@ -3070,6 +3084,7 @@ class SdkSession:
         selected: set[int] = set()
         customs: list[str] = []                       # free-text answers the user typed (multi accumulates)
         def emit():
+            self._arm_ask()
             self.backend._emit_ask(self, ask_question_to_live(question, qi, total, selected, customs))
         emit()
         while True:

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1386,6 +1386,49 @@ class LiveAskReplay(unittest.TestCase):
         self.assertIsNone(self.backend.current_ask(sess.sid))       # answered/cancelled → gone
 
 
+class AskArmedBeforePresent(unittest.TestCase):
+    """An ask is never PRESENTED before the future its answer lands on exists. resolve_ask reads
+    _cur_ask_fut synchronously on the caller's thread and reports False when nothing is waiting (T214's
+    truthful delivery outcome), so an answer that arrives between _emit_ask and the coroutine's first
+    await must already find the future armed — or it is reported lost and the coroutine waits forever.
+    Production dodges the gap by microseconds (only the kernel's click handlers answer, from another
+    thread); an answer delivered synchronously INSIDE the presentation callback hits it every time. That
+    is exactly how the SDK-gated round-trip classes below drive their asks, and CI does not install the
+    SDK, so the hang was never seen there. Pinned WITHOUT the SDK: _ask_one needs none, so the standard
+    runner and CI exercise the invariant. The answer rides on_ask -> resolve_ask, the kernel's own path."""
+
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def test_an_answer_delivered_inside_the_presentation_callback_is_not_lost(self):
+        import asyncio
+        outcomes = []
+
+        def notify(app, msg):
+            if msg.get("type") == "askLive":
+                # same call stack as _emit_ask: the future must ALREADY exist here
+                outcomes.append(self.backend.on_ask(msg["id"], "answer", 2))
+
+        d = tempfile.mkdtemp()
+        self.backend = sb.SdkBackend(d, "/bin/true", notify)
+        sess = sb.SdkSession(self.backend, {"sid": self.SID, "name": "n", "cwd": d})
+        self.backend.sessions[self.SID] = sess
+        q = {"question": "Cats or dogs?", "header": "Pet", "multiSelect": False,
+             "options": [{"label": "cats"}, {"label": "dogs"}]}
+
+        async def go():
+            sess.loop = asyncio.get_running_loop()
+            return await asyncio.wait_for(sess._ask_one(q, 0, 1), timeout=5)
+
+        try:
+            res = asyncio.run(go())
+        except asyncio.TimeoutError:
+            self.fail("the answer was dropped: _ask_one presented its ask before arming the future, "
+                      "so resolve_ask found nothing waiting and the coroutine never returned")
+        self.assertEqual(res, "dogs")
+        self.assertEqual(outcomes, [True], "resolve_ask must report the answer DELIVERED (T214), not lost")
+        self.assertIsNone(sess._cur_ask_fut, "the armed future clears once the ask is answered")
+
+
 # --- Runner + can_use_tool bridge (needs the SDK message classes) ---
 try:
     import claude_agent_sdk as _sdk

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1429,6 +1429,51 @@ class AskArmedBeforePresent(unittest.TestCase):
         self.assertIsNone(sess._cur_ask_fut, "the armed future clears once the ask is answered")
 
 
+class OverlappingAsksAnswerInTurn(unittest.TestCase):
+    """Two asks presented concurrently on one session (the SDK dispatches every control request as its
+    own detached task) must each get THEIR OWN answer. Before the per-session lock, arming at the sites
+    let the second ask find the first's live future and share it — one click resolved both, so an Allow
+    given to tool B was applied to tool A silently (PR #875 review). Now the second ask is not even
+    PRESENTED until the first resolves, and the answers land on the asks they were given to."""
+
+    SID = "11111111-2222-3333-4444-777777777777"
+
+    def test_the_second_ask_waits_and_each_gets_its_own_answer(self):
+        import asyncio
+        presented = []                                    # askLive ids in presentation order
+
+        def notify(app, msg):
+            if msg.get("type") == "askLive":
+                presented.append(msg["id"])
+
+        d = tempfile.mkdtemp()
+        backend = sb.SdkBackend(d, "/bin/true", notify)
+        sess = sb.SdkSession(backend, {"sid": self.SID, "name": "n", "cwd": d})
+        backend.sessions[self.SID] = sess
+        qa = {"question": "First?", "header": "A", "multiSelect": False, "options": [{"label": "a1"}, {"label": "a2"}]}
+        qb = {"question": "Second?", "header": "B", "multiSelect": False, "options": [{"label": "b1"}, {"label": "b2"}]}
+
+        async def go():
+            sess.loop = asyncio.get_running_loop()
+            ta = asyncio.ensure_future(sess._ask_one(qa, 0, 1))
+            tb = asyncio.ensure_future(sess._ask_one(qb, 0, 1))
+            await asyncio.sleep(0)                        # both tasks start; only ONE may be presented
+            self.assertEqual(len(presented), 1, "the second ask waits for the first — never two live at once")
+            self.assertTrue(backend.on_ask(presented[0], "answer", 2), "answer the FIRST ask: option 2")
+            await asyncio.wait_for(ta, timeout=5)        # the first ask resolves and releases the lock…
+            for _ in range(10):                           # …and the second acquires it within a few loop hops
+                if len(presented) == 2:
+                    break
+                await asyncio.sleep(0)
+            self.assertEqual(len(presented), 2, "the second ask is presented only after the first resolved")
+            self.assertTrue(backend.on_ask(presented[1], "answer", 1), "answer the SECOND ask: option 1")
+            return await asyncio.wait_for(asyncio.gather(ta, tb), timeout=5)
+
+        ra, rb = asyncio.run(go())
+        self.assertEqual((ra, rb), ("a2", "b1"), "each ask got the answer given to IT — no shared future")
+        self.assertIsNone(sess._cur_ask_fut)
+
+
 # --- Runner + can_use_tool bridge (needs the SDK message classes) ---
 try:
     import claude_agent_sdk as _sdk


### PR DESCRIPTION
## What breaks

An answer that arrives between an ask's presentation and the arming of its future is dropped, and the ask never completes. Since 8ab85123 (T214), `SdkSession.resolve_ask` reads `_cur_ask_fut` synchronously on the caller's thread and returns `False` when it is `None` or done, so the caller can report the answer lost. But every ask coroutine presents first and arms second: the permission branch of `_can_use_tool`, `_approve_plan`, and `_ask_one`'s `emit()` each call `self.backend._emit_ask(...)` and only then `await self._next_ask_action()`, which is where the future was created. An answer landing in that gap gets `False` back, no `_set` is scheduled, and the coroutine awaits a future nothing will resolve. Before 8ab85123 the read was deferred onto the loop, which hid the ordering.

Live, the gap is microseconds, because only the kernel's websocket click handlers answer asks, from another thread. When it is hit, the user sees the `askLost` toast (the question was lost with a restart) while the question is still on screen, and that question stays open.

In tests the gap is hit every time. The repo's own SDK-gated round-trip classes answer synchronously inside the `askLive` notify callback, on `_emit_ask`'s call stack: `AskRoundTrip` (`notify` calls `on_ask(msg["id"], "answer", 1)`), `CustomAnswerRoundTrip`, and `PermissionAndPlanRoundTrip`. With `claude_agent_sdk` importable at 70a36077, the three `AskRoundTrip` tests that send a prompt and wait for the answer fail at their 6 s bound ("can_use_tool never returned an answer"), and `CustomAnswerRoundTrip` hangs the process (`asyncio.run` with no timeout). CI installs only `pytest` and `cryptography`, so all three classes skip there and none of this was visible.

## Reproduction

At 70a36077 with the SDK importable:

```
timeout 120 python -m pytest tests/test_sdk_backend.py -q \
  -k "AskRoundTrip or CustomAnswerRoundTrip or PermissionAndPlanRoundTrip"
```

prints `.F.FF` (the three `AskRoundTrip` failures), then hangs on `CustomAnswerRoundTrip` until `timeout` kills it (exit 124).

Without the SDK, the new test in this PR reproduces it: `AskArmedBeforePresent` drives the real `_ask_one` with a `notify` that answers through `backend.on_ask` inside the `askLive` callback. Against 70a36077 it fails after its 5 s bound: "the answer was dropped: _ask_one presented its ask before arming the future".

## The fix

`SdkSession._arm_ask()` creates the future, or keeps a live one, and every ask site calls it immediately before `_emit_ask`. `_next_ask_action` awaits the armed future and clears it in `finally` as before. The invariant, stated in the docstring: an ask is never presented before the future its answer lands on exists. `resolve_ask` is untouched, so 8ab85123's outcomes hold (`None` or done gives `False`; a live future gives `True` and delivers), and `tests/test_ask_lost.py` and `tests/test_mode_truth.py` stay green. Two files change; the kernel part is 17 net lines.

## Tests

- New SDK-free regression test `AskArmedBeforePresent::test_an_answer_delivered_inside_the_presentation_callback_is_not_lost`: red at 70a36077, green with the fix (0.2 s). It needs no SDK, so CI exercises the invariant.
- The three existing round-trip classes, SDK importable, no test edits: from `.F.FF` plus a hang to `14 passed in 0.88s`.
- The rest of `tests/test_sdk_backend.py` under the SDK is unchanged by this PR: the same five tests fail before and after (`OptionsAssembly::test_ultracode_is_a_choice_everywhere_but_never_the_seeded_default`, both `ApiRetryState` tests, `ReconnectReconcilesInflight::test_reconnect_settles_a_turn_stranded_by_the_teardown`, `PushSessionCallback::test_without_the_callback_it_falls_back_to_the_pusher_wake`), none ask-related.
- Full suite, `python -m pytest -n 8 -q`: 6494 passed, 44 skipped.

## Companion suggestion (not in this PR)

Install `claude-agent-sdk` in the CI test job, or keep an SDK-free test next to each `_HAVE_SDK`-gated class as this PR does, so those classes stop reading as green when they skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)