### PR TITLE
The paste sequence reads tmux's exit codes: a server that dies after the clear aborts loudly instead of reporting success

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9954,6 +9954,27 @@ class TmuxBackend(sb.SessionBackend):
     def paste_buffer(self, name):
         self._run(["paste-buffer", "-b", "rompkernel", "-d", "-p", "-t", name])
 
+    # CHECKED variants of the three paste-critical primitives: the same argv as their forgiving twins,
+    # but the exit code is READ. _run/_fire swallow exec errors and ignore nonzero exits — right for the
+    # read-side chrome, fatal for the steps that ARE a delivery: a tmux server that died after
+    # _tmux_send's clear made set-buffer, paste-buffer and the submitting Enter silent no-ops while the
+    # send looked complete. tmux's exit codes are a sane contract for all three (verified on tmux 3.4:
+    # dead server → 1 "no server running" / "error connecting", dead session → 1 "can't find pane",
+    # missing buffer → 1 "no buffer"; success → 0). True iff tmux itself answered 0; an exec failure, a
+    # timeout, a missing tmux, or a nonzero exit all read as NOT done. Other callers keep the forgiving
+    # twins on purpose (_inject verifies its paste landed by re-reading the box).
+    def set_buffer_checked(self, text):
+        r = self._run(["set-buffer", "-b", "rompkernel", text])
+        return r is not None and r.returncode == 0
+
+    def paste_buffer_checked(self, name):
+        r = self._run(["paste-buffer", "-b", "rompkernel", "-d", "-p", "-t", name])
+        return r is not None and r.returncode == 0
+
+    def send_keys_checked(self, name, *keys, t=3):
+        r = self._run(["send-keys", "-t", name, *keys], t)
+        return r is not None and r.returncode == 0
+
     def kill_by_name(self, name, t=4):
         self._fire(["kill-session", "-t", name], t)
 
@@ -14559,7 +14580,8 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
     Enter, the old TmuxBackend.send sequence (a 250ms gap lets the bracketed paste land before Enter
     submits). name = the tmux session name. Drives the chat composer, /compact, and the model/effort
     pickers. Runs in a daemon thread so the WS recv loop isn't blocked by the gaps. model_cmd: /model opens
-    a confirm that needs a second Enter."""
+    a confirm that needs a second Enter. A delivery step that tmux answers nonzero (set-buffer, paste-buffer,
+    the submitting Enter) aborts the send with a line on stderr — see the checked primitives."""
     if not name or not text:
         return
 
@@ -14579,8 +14601,19 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
             sys.stderr.write("tmux send: %s holds input that would not clear — NOT pasting, the message "
                              "would have been concatenated onto it\n" % name)
             return
-        _TMUX.set_buffer(text)
-        _TMUX.paste_buffer(name)                                    # bracketed (-p), delete buf (-d)
+        # The three steps that ARE the delivery run CHECKED: the forgiving primitives swallow exec errors and
+        # ignore exit codes, so a tmux server or session that died after the clear made set-buffer,
+        # paste-buffer and the submitting Enter silent no-ops while the send looked complete — the message
+        # vanished with no trace. Any failure aborts here, loudly, in the same shape as the clear-guard
+        # refusal above (exit codes verified sane on tmux 3.4 — see the checked variants). Success-path
+        # sequencing and timing are unchanged.
+        if not _TMUX.set_buffer_checked(text):
+            sys.stderr.write("tmux send: %s's set-buffer failed — the message was never staged\n" % name)
+            return
+        if not _TMUX.paste_buffer_checked(name):                    # bracketed (-p), delete buf (-d)
+            sys.stderr.write("tmux send: %s's paste-buffer failed — the message never reached the input\n"
+                             % name)
+            return
         paths = _injected_img_paths(text)
         if paths:
             # Claude Code reads each pasted image PATH asynchronously and rewrites it to "[Image #N]" in the
@@ -14595,7 +14628,10 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
             time.sleep(0.2)
         else:
             time.sleep(0.25)
-        _TMUX.send_keys(name, "Enter")
+        if not _TMUX.send_keys_checked(name, "Enter"):
+            sys.stderr.write("tmux send: %s's submitting Enter failed — the message was pasted but never "
+                             "submitted\n" % name)
+            return
         if model_cmd:
             time.sleep(0.85)
             _TMUX.send_keys(name, "Enter")                          # accept the hookless /model confirm

--- a/tests/test_kernel_inject.py
+++ b/tests/test_kernel_inject.py
@@ -4,6 +4,8 @@ pastes a message, and CLEARS the prompt Claude Code restores on interrupt — so
 longer concatenate a recalled prompt with the new message. Self-contained: drives the tmux helpers with a
 fake subprocess so it doesn't share test_kernel.py's setUp.
 """
+import contextlib
+import io
 import os
 import unittest
 from unittest import mock
@@ -124,6 +126,28 @@ class Inject(unittest.TestCase):
         km._tmux_send("", "hello", _async=False)
         km._tmux_send("sess", "", _async=False)
         self.assertEqual(self.calls, [])
+
+    def test_inject_aborts_when_tmux_answers_set_buffer_nonzero(self):
+        # a tmux server that died AFTER the clear: set-buffer exits 1 and reaches no pane. The real
+        # TmuxBackend reads that exit code (argv-level, through the subprocess stub) and the send stops
+        # there — no paste onto a buffer that was never staged, no Enter into an empty box, stderr names it.
+        self.box_lines = []
+
+        def rec(args, **kw):
+            self.calls.append(list(args))
+            if args[1:2] == ["set-buffer"]:
+                return _Res("", returncode=1)
+            if args[:2] == ["tmux", "capture-pane"]:
+                return _Res(_pane(self.box_lines))
+            return _Res("")
+        err = io.StringIO()
+        with mock.patch.object(km.subprocess, "run", side_effect=rec), contextlib.redirect_stderr(err):
+            km._tmux_send("sess", "hello", _async=False)
+        cmds = self._cmds()
+        self.assertTrue(any(c[:1] == ["set-buffer"] for c in cmds), "set-buffer was attempted")
+        self.assertEqual([c for c in cmds if c[:1] == ["paste-buffer"]], [], "nothing is pasted")
+        self.assertNotIn(["send-keys", "-t", "sess", "Enter"], cmds, "and nothing is submitted")
+        self.assertIn("set-buffer failed", err.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_pane_clear.py
+++ b/tests/test_kernel_pane_clear.py
@@ -15,9 +15,12 @@ the message apart, which is the only safe outcome. The fake pane below models ex
 semantics; the live-CLI measurement is what it stands in for. Synthetic pane text throughout.
 
 XDG_STATE_HOME is redirected before the kernel loads so no test state leaks into the live store."""
+import contextlib
+import io
 import os
 import tempfile
 import threading
+import types
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -138,9 +141,15 @@ class SendRefusesToConcatenate(unittest.TestCase):
         km._TMUX = self._saved_tmux
 
     class _RecordingPane(_FakePane):
-        def __init__(self, box_lines, honors_kill=True):
+        """`fail` names the checked delivery steps ("set_buffer" / "paste_buffer" / "enter") that answer False
+        WITHOUT acting — what a real tmux whose server died after the clear does (exit 1, and the command
+        reached no pane). By default the pane is healthy: each checked step delegates to its forgiving twin
+        and answers True, so the recorders below see exactly what a live pane would receive."""
+
+        def __init__(self, box_lines, honors_kill=True, fail=()):
             super().__init__(box_lines, honors_kill)
             self.buffers, self.pastes = [], []
+            self.fail = set(fail)
 
         def pane_in_mode(self, name, t=2):
             return False
@@ -150,6 +159,24 @@ class SendRefusesToConcatenate(unittest.TestCase):
 
         def paste_buffer(self, name):
             self.pastes.append(name)
+
+        def set_buffer_checked(self, text):
+            if "set_buffer" in self.fail:
+                return False
+            self.set_buffer(text)
+            return True
+
+        def paste_buffer_checked(self, name):
+            if "paste_buffer" in self.fail:
+                return False
+            self.paste_buffer(name)
+            return True
+
+        def send_keys_checked(self, name, *keys, t=3):
+            if "enter" in self.fail:
+                return False
+            self.send_keys(name, *keys, t=t)
+            return True
 
     def test_an_unclearable_box_blocks_the_paste_and_the_Enter(self):
         pane = self._RecordingPane(["a draft typed straight into the terminal"], honors_kill=False)
@@ -166,6 +193,116 @@ class SendRefusesToConcatenate(unittest.TestCase):
         self.assertEqual(pane.buffers, ["the composer message"])
         self.assertEqual(pane.pastes, [SESSION])
         self.assertIn(("Enter",), pane.keys_sent)
+
+
+class SendAbortsWhenTmuxAnswersNonzero(unittest.TestCase):
+    """The clear-guard covers a death BEFORE the clear; these cover one after it. set-buffer, paste-buffer and
+    the submitting Enter used to run through primitives that swallow every subprocess error and never read
+    the exit code, so a tmux server or session that died once the clear had passed made all three silent
+    no-ops — the send looked complete and the message vanished with no trace. Each step now reads tmux's own
+    exit code and a nonzero answer aborts the sequence there, loudly, in the same shape as the clear-guard
+    refusal. The box is EMPTY in every case so the clear itself succeeds and the checked step is the only
+    thing that can refuse."""
+
+    TEXT = "the composer message"
+    _RecordingPane = SendRefusesToConcatenate._RecordingPane
+
+    def setUp(self):
+        self._saved_tmux = km._TMUX
+
+    def tearDown(self):
+        km._TMUX = self._saved_tmux
+
+    def _send(self, pane, **kw):
+        km._TMUX = pane
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._tmux_send(SESSION, self.TEXT, _async=False, **kw)
+        return err.getvalue()
+
+    def test_a_dead_server_at_set_buffer_stages_pastes_and_submits_nothing(self):
+        pane = self._RecordingPane([""], fail=("set_buffer",))
+        err = self._send(pane)
+        self.assertEqual(pane.buffers, [], "the failed set-buffer staged nothing")
+        self.assertEqual(pane.pastes, [], "and nothing is pasted after it")
+        self.assertNotIn(("Enter",), pane.keys_sent, "and nothing is submitted")
+        self.assertIn("set-buffer failed", err, "the abort names the step on stderr")
+
+    def test_a_dead_server_at_paste_buffer_never_submits(self):
+        pane = self._RecordingPane([""], fail=("paste_buffer",))
+        err = self._send(pane)
+        self.assertEqual(pane.buffers, [self.TEXT], "the text was staged…")
+        self.assertEqual(pane.pastes, [], "…but the paste refused, so nothing reached the input")
+        self.assertNotIn(("Enter",), pane.keys_sent, "and Enter is never pressed on an empty box")
+        self.assertIn("paste-buffer failed", err)
+
+    def test_a_failed_submitting_Enter_is_reported_not_swallowed(self):
+        # the fake records only the keys it actually sent, so a refused Enter leaves no ("Enter",) behind
+        pane = self._RecordingPane([""], fail=("enter",))
+        err = self._send(pane)
+        self.assertEqual(pane.buffers, [self.TEXT])
+        self.assertEqual(pane.pastes, [SESSION], "the paste itself landed")
+        self.assertNotIn(("Enter",), pane.keys_sent)
+        self.assertIn("submitting Enter failed", err)
+
+    def test_a_failed_first_Enter_never_sends_the_model_confirm_Enter(self):
+        # /model's second Enter accepts a confirm dialog; with the first Enter refused there is no dialog,
+        # and a stray Enter into whatever IS up would be the concatenation class of bug all over again
+        pane = self._RecordingPane([""], fail=("enter",))
+        err = self._send(pane, model_cmd=True)
+        self.assertNotIn(("Enter",), pane.keys_sent, "neither Enter is sent")
+        self.assertIn("submitting Enter failed", err)
+
+    def test_a_healthy_pane_sends_exactly_as_before_and_says_nothing(self):
+        # the success path is untouched: same three steps, same order, no extra tmux calls, silent stderr
+        pane = self._RecordingPane([""])
+        err = self._send(pane)
+        self.assertEqual(pane.buffers, [self.TEXT])
+        self.assertEqual(pane.pastes, [SESSION])
+        self.assertEqual(pane.keys_sent, [("Enter",)], "one Enter, and no keystroke the clear did not need")
+        self.assertEqual(err, "")
+
+
+class CheckedPrimitivesReadTheExitCode(unittest.TestCase):
+    """The contract of TmuxBackend's checked variants, on the real class: True iff tmux itself answered 0.
+    An exec failure or a timeout (`_run` → None), a missing tmux (the same None) and a nonzero exit all read
+    as NOT done — and the argv is byte-identical to the forgiving twin's, so the two cannot drift apart."""
+
+    TEXT = "the composer message"
+
+    def _backend(self, result):
+        tb = km.TmuxBackend()
+        seen = []
+        tb._run = lambda args, t=3: seen.append(list(args)) or result
+        tb._fire = lambda args, t=3: seen.append(list(args))
+        return tb, seen
+
+    def _checked(self, tb):
+        return [tb.set_buffer_checked(self.TEXT), tb.paste_buffer_checked(SESSION),
+                tb.send_keys_checked(SESSION, "Enter")]
+
+    def test_a_zero_exit_is_done_and_the_argv_matches_the_forgiving_twin(self):
+        tb, seen = self._backend(types.SimpleNamespace(returncode=0, stdout="", stderr=""))
+        self.assertEqual(self._checked(tb), [True, True, True])
+        checked_argv = list(seen)
+        del seen[:]
+        tb.set_buffer(self.TEXT)
+        tb.paste_buffer(SESSION)
+        tb.send_keys(SESSION, "Enter")
+        self.assertEqual(checked_argv, seen, "the checked variant issues exactly what its twin issues")
+        self.assertEqual(checked_argv[0][:1], ["set-buffer"])
+        self.assertEqual(checked_argv[1][:1], ["paste-buffer"])
+        self.assertEqual(checked_argv[2], ["send-keys", "-t", SESSION, "Enter"])
+
+    def test_a_nonzero_exit_is_not_done(self):
+        # tmux 3.4: a dead server, a missing session and a missing buffer all exit 1
+        tb, _ = self._backend(types.SimpleNamespace(returncode=1, stdout="", stderr="no server running"))
+        self.assertEqual(self._checked(tb), [False, False, False])
+
+    def test_an_exec_failure_or_absent_tmux_is_not_done(self):
+        # `_run` answers None when tmux is unavailable, when the exec raises, and when the child times out
+        tb, _ = self._backend(None)
+        self.assertEqual(self._checked(tb), [False, False, False])
 
 
 class PaneLockSerializesInterruptAndSend(unittest.TestCase):


### PR DESCRIPTION
## What breaks

`_tmux_send` injects a message into a tmux pane as clear, `set-buffer`, bracketed `paste-buffer`, Enter. Since #741 the clear refuses loudly when the input box will not empty. The three steps after the clear still run through `TmuxBackend._run` and `_fire`, which swallow every subprocess error and never read the exit code. When the tmux server or the target session dies after the clear has passed, all three become silent no-ops: nothing is staged, pasted or submitted, nothing reaches stderr, and the message is gone. The only later signal is the composer echo settling as never-delivered, and only when a later send overtakes it.

## Reproduction

On tmux 3.4 against a socket with no server (`tmux -L scratch ...`):

- `tmux set-buffer -b rompkernel hello` exits 1 (`error connecting ... No such file or directory`) and does not start a server, so a dead server stays dead across the whole sequence.
- `tmux paste-buffer -b rompkernel -d -p -t web` exits 1.
- `tmux send-keys -t web Enter` exits 1.

A live server with no session `web` answers 1 (`can't find pane`) to the last two; a missing buffer answers 1 (`no buffer`); success answers 0. In the kernel, `_run` returns the `CompletedProcess` and `set_buffer`/`paste_buffer` discard it; `send_keys` goes through `_fire`, which returns nothing. From the kernel's side a server that died between the clear and the Enter is indistinguishable from a delivered message.

Without a tmux, `tests/test_kernel_pane_clear.py::SendAbortsWhenTmuxAnswersNonzero` and `tests/test_kernel_inject.py::Inject::test_inject_aborts_when_tmux_answers_set_buffer_nonzero` reproduce it: on the unfixed tree the paste and the Enter proceed after a set-buffer that answered nonzero.

## The fix

tmux's exit code is a sound contract for all three steps, so the delivery steps read it.

- `TmuxBackend` gains `set_buffer_checked`, `paste_buffer_checked` and `send_keys_checked`: the same argv as their forgiving twins, returning True iff tmux answered 0. An exec failure, a timeout or an absent tmux (`_run` returns None in all three cases) and a nonzero exit all read as not done. The methods live inside the class, so the raw-tmux lint in `tests/test_session_api.py` still holds.
- `_tmux_send` drives set-buffer, paste-buffer and the submitting Enter through them and aborts at the first failure with a stderr line naming the step (`set-buffer failed — the message was never staged`, `paste-buffer failed — the message never reached the input`, `submitting Enter failed — the message was pasted but never submitted`), the same shape as the clear-guard refusal. A failed first Enter also skips the `/model` confirm's second Enter.
- Success-path sequencing and timing are unchanged; no tmux call is added.
- Every other caller keeps the forgiving primitives on purpose: the `/model` confirm Enter, and `TmuxBackend._inject` (mail delivery), which already verifies its paste landed by re-reading the box and returns False to the drain.

One failure-side behavior changes. `_run` returns None when a tmux child exceeds its 3 s timeout; before, `go()` pressed on to Enter regardless, and now it aborts with the stderr line. On a pathologically slow tmux a message that might have landed is refused instead. The failure stays stderr-only, as the clear-guard's does: this turns a silent loss into a visible one at the point where it can be known. It does not add a delivery verdict to callers (`TmuxBackend.send` still returns True meaning accepted for paste) and does not retry.

## Tests

`tests/test_kernel_pane_clear.py`
- `SendRefusesToConcatenate._RecordingPane`, the one fake assigned to `km._TMUX` that reaches `_tmux_send`, gains the checked methods and a `fail` knob. The default is healthy and delegates to the forgiving twins, so the existing tests are untouched.
- `SendAbortsWhenTmuxAnswersNonzero`: a nonzero set-buffer stages, pastes and submits nothing; a nonzero paste-buffer stages but never submits; a nonzero Enter is reported and, under `model_cmd=True`, never sends the confirm Enter; a healthy pane sends exactly as before with an empty stderr.
- `CheckedPrimitivesReadTheExitCode`, on the real class with `_run` stubbed: exit 0 gives True and the recorded argv is identical to the forgiving twin's; exit 1 gives False; None gives False.

`tests/test_kernel_inject.py`
- `test_inject_aborts_when_tmux_answers_set_buffer_nonzero`: argv-level through the subprocess stub, the real backend reads exit 1 from set-buffer and the sequence stops there.

Eight of the nine new tests fail on the unfixed tree; the healthy-pane test is the no-change pin and passes on both. The raw-tmux lint and the no-tmux inertness suite (`tests/test_tmux_optional.py`) stay green. Full suite: 6502 passed, 44 skipped.

Exit codes were verified on tmux 3.4 only. Nonzero on these errors and 0 on success has been tmux behavior across versions, but only 3.4 was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)