### PR TITLE
The test suite floors ROMP_MODEL_CATALOG=off: no test kernel fetches the Models API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,34 @@ def _dead_manager_port():
 # own resolution pop this var themselves (test_judge.py), as they always had to.
 os.environ["ROMP_CLAUDE_BIN"] = "/bin/false"
 
+# No test kernel may fetch the Models API (2026-09-02): the kernel's lazy _sdk() build (_sdk_locked)
+# fires the T222 catalog refresh, `_refresh_model_catalog("boot")` — an async GET to
+# api.anthropic.com on any credential the process carries: the manager-env key
+# sdk_backend.work_api_key claimed, else a bare ANTHROPIC_API_KEY, else an ANTHROPIC_AUTH_TOKEN
+# bearer. A DEFENSIVE floor: no test reached the network before this line (checked, not assumed —
+# the one in-process _sdk() driver, test_kernel_headless_ops' SdkSingleFlight, runs the refresh
+# inside the test process with the module loader mocked, and it stopped only because the mocked
+# module's work_api_key handed http.client a credential it rejects before a socket opens), but any
+# in-process _sdk() call is one exported key away from a real request no test asserts on, on a key
+# the test never chose. The kernel-SPAWNING tests floor it in their subprocess env
+# (test_gear_select_matrix, test_ship_reship, test_awaiting_box_sync); this floors every test,
+# whatever the developer's shell exports.
+# Set, not setdefault: "off" is the only value the switch recognises, so no outer intent is being
+# overridden. The catalog suite unsets the var inside its own tests — FetchAndFallback pops it in
+# setUp to drive the fetch against a local fake server; StalenessEvent and ModelsRoute set it in
+# setUp and pop it in tearDown — leaving it absent for every test after that module in a serial
+# run; hence the per-test re-assert below, on the same reasoning as the manager-port one
+# (tests/test_model_catalog_floor.py pins both). Those pops still win inside their own tests:
+# pytest fills every fixture, autouse included, in the item's setup phase, before runtest hands
+# the case to TestCase.run(), which is what calls setUp.
+os.environ["ROMP_MODEL_CATALOG"] = "off"
+
+
+@pytest.fixture(autouse=True)
+def _no_model_catalog_fetch():
+    os.environ["ROMP_MODEL_CATALOG"] = "off"
+    yield
+
 
 @pytest.fixture(autouse=True)
 def _stub_place_llm(monkeypatch):

--- a/tests/test_model_catalog_floor.py
+++ b/tests/test_model_catalog_floor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""The suite-wide model-catalog floor (tests/conftest.py, 2026-09-02): no test kernel fetches the
+Models API. The kernel's lazy `_sdk()` build fires the T222 catalog refresh — an async GET on any
+credential the process carries — so under pytest the switch is off for every test as a DEFENSIVE floor
+(no test reached the network before it, but only because none carried a credential the fetch could
+use; a developer's exported key must not change that), and it STAYS off across a test that pops it
+(the catalog suite's own fetch tests do exactly that in setUp/tearDown, and a module-level pop would
+otherwise hold for the rest of the run). Synthetic throughout; the kernel is loaded only to prove the
+refresh is inert under the floor."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_catalog_floor", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class CatalogFloor(unittest.TestCase):
+    """Ordered on purpose (unittest runs methods by name): the first test pops the switch the way the
+    catalog suite's tearDown does; the second proves the per-test re-assert put it back before the
+    next test ran, and that the refresh does nothing under it."""
+
+    def test_1_a_test_may_pop_the_switch(self):
+        self.assertEqual(os.environ.get("ROMP_MODEL_CATALOG"), "off", "conftest's import-time floor")
+        os.environ.pop("ROMP_MODEL_CATALOG", None)
+
+    def test_2_the_floor_is_back_and_the_refresh_is_inert(self):
+        self.assertEqual(os.environ.get("ROMP_MODEL_CATALOG"), "off",
+                         "conftest's per-test re-assert must restore the switch a test popped")
+        # Synchronous so a missing floor would show as True (a credential lookup and a stderr line),
+        # never as a thread that outlives the assertion.
+        self.assertFalse(km._refresh_model_catalog("floor probe", _async=False))
+        self.assertFalse(km._catalog_status["inflight"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The kernel's lazy SDK-backend build (`_sdk_locked`) fires the T222 catalog refresh, `_refresh_model_catalog("boot")`: an async GET to the Models API on whatever credential the process carries — the manager-env key `work_api_key` claimed, else a bare `ANTHROPIC_API_KEY`, else an `ANTHROPIC_AUTH_TOKEN` bearer. The kernel-spawning tests floor it per file in their subprocess env (`test_gear_select_matrix.py`, `test_ship_reship.py`, and since T225 `test_awaiting_box_sync.py`), but nothing floors an in-process `_sdk()` call, and the next spawning test has to remember the line again.

This PR floors the switch for the whole suite in `tests/conftest.py`, in the same two-part shape as the `ROMP_MANAGER_PORT` floor from #737, and pins it with a new test. Test-only; no kernel line changes.

## What happens today

No request reaches the network in the suite's own environment, but not by design. The one in-process `_sdk()` driver, `tests/test_kernel_headless_ops.py::SdkSingleFlight`, already runs the boot refresh inside the test process (six racing `_sdk()` calls with the module loader mocked). It stops before a socket opens only because the mocked module's `work_api_key` yields a `Mock` that `http.client` rejects at header encoding — and it writes this to stderr on every run:

```
model catalog (boot): Models API unreachable (TypeError: expected string or bytes-like object, got 'Mock') — serving the seed list (0 extra id(s) beyond the seed)
```

That is a floor by accident. On a developer machine whose shell exports a key, any future in-process test would make a real request no test asserts on, on a key the test never chose. With this change the refresh returns before starting its thread, and the stderr line is gone (nothing asserted on it).

## Why two parts

- Import-time `os.environ["ROMP_MODEL_CATALOG"] = "off"` covers collection-time code.
- An autouse fixture re-asserts it per test, because the catalog suite's fetch tests pop the variable in `setUp` (to drive the refresh against a local fake server) and pop it again in `tearDown`, leaving it absent. Without the re-assert the first such test erases the floor for every test after `tests/test_model_catalog.py` in a serial run — verified: with only the import-time write, running the catalog suite and then the pin fails both pin methods.
- Set, not `setdefault`: "off" is the only value the switch recognises, so no outer intent is overridden.
- The catalog suite keeps working unchanged: pytest fills every fixture, autouse included, in the item's setup phase, before runtest hands the case to `TestCase.run()`, which is what calls `setUp` — so the suite's own handling (one class pops the variable in `setUp` to drive the fetch against a local fake server; two others set it in `setUp` and pop it in `tearDown`) still runs after conftest's re-assert inside those tests.

## The pin

`tests/test_model_catalog_floor.py`: two name-ordered methods in one class. The first asserts the import-time floor and pops the switch the way the catalog suite's `tearDown` does; the second asserts the per-test re-assert put it back, and that `_refresh_model_catalog("floor probe", _async=False)` returns `False` with `_catalog_status["inflight"]` still `False`. Synchronous on purpose, so a missing floor shows as an assertion failure, never as a thread outliving the test.

Red first:
- No floor at all: both methods fail (`None != 'off'`).
- Import-time write only, pin alone: the second method fails (the first popped the switch and nothing put it back).
- Import-time write only, catalog suite first: both methods fail (the suite's `tearDown` pops erased the floor).

Under xdist the two methods can land on different workers, in which case the second passes trivially (the env is still "off" from conftest); it can never fail falsely. CI runs `python -m pytest -q` serially, where the ordering pin is real.

## Not changed

- The three inline `ROMP_MODEL_CATALOG="off"` entries in the spawning tests stay: they document intent and defend bare `python3 tests/test_x.py` runs, which skip conftest.
- `tools/romp-lab/lab.sh` exports the dead manager port but not this switch, although the catalog's header comment says hermetic labs must never reach the network. Left alone here since the lab may want live pickers; happy to add the export if you want it.

## Testing

- `tests/test_model_catalog_floor.py` alone, and after `tests/test_model_catalog.py` (CI's alphabetical order): pass; the catalog suite's fake-server fetches still run.
- `tests/test_kernel_headless_ops.py -k SdkSingleFlight -s`: passes, and the "Models API unreachable" stderr line no longer appears.
- `tests/test_gear_select_matrix.py tests/test_ship_reship.py tests/test_awaiting_box_sync.py`: 7 passed, 4 skipped.
- Full suite, serial (as CI runs it): 6495 passed, 44 skipped. Same counts under `-n 8`.
- No kernel line changed, so the node string-pins on `kernel/kernel.py` are unaffected; bats and node suites untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)