### PR TITLE
Two boot-reconcile fixes for dormant sessions: the sweep reads each registry fresh, and a dormant thread hears its dead life's notices at its explicit wake

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3933,7 +3933,8 @@ class SdkBackend:
             a USER interrupt but was exactly the silent purgatory for a kernel-death cut (2026-07-05:
             every SDK session stranded mid-turn until hand-resumed).
           * A session with a persisted queue (reg['queue'], the _persist_queue mirror): resume it so the
-            queue delivers via the __init__ seed.
+            queue delivers via the __init__ seed. Each reg is read FRESH inside the loop — the boot
+            reseed may have re-queued a lost send after `regs` was listed.
         Everything else stays lazy/dormant. Loud one-line summary whenever anything was recovered."""
         try:
             alive = [r for r in regs if r.get("alive") and r.get("sid")]
@@ -3962,6 +3963,17 @@ class SdkBackend:
                 # session killed two whole reconcile passes.
                 try:
                     sid = str(r["sid"])
+                    # Read the reg FRESH: `regs` is __init__'s listing from BEFORE _reseed_echoes ran,
+                    # and its re-delivery arm (_mark_dropped_echoes) may since have put a lost human
+                    # send back into this reg's queue ON DISK — a row listed before that write still
+                    # shows the old queue, so a session whose only reason to resume was the re-queued
+                    # text read `queued` empty here and stayed dormant until the next spawn or boot
+                    # (re-queued, never delivered). The same fresh read the RMW arm below already
+                    # does; a failed read keeps the listed row (per-session isolation still applies).
+                    fresh = read_reg(self.state_dir, sid)
+                    if fresh is not None:
+                        fresh.setdefault("sid", sid)      # a raw reg file may omit it; list_regs added it
+                        r = fresh
                     # A /model / /effort switch mid-flight at the kernel's death can never clear its
                     # pending flags (the in-memory switch died) — and the dormant path serves them
                     # verbatim, so the badge's switching-dots sat there forever (the user 2026-07-11).

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3987,9 +3987,11 @@ class SdkBackend:
                         # a comment THREAD is never auto-resumed at boot (the user 2026-09-01: threads
                         # persist on disk and come alive only on an explicit reply/branch; a deploy
                         # boot resuming a cut thread turn put dormant threads back in RAM). Its
-                        # orphaned CLI was reaped above and its pending flags healed just now; only a
-                        # PERSISTED QUEUE — the user's own typed reply the CLI never started — earns
-                        # the resume, because delivering it IS honoring an explicit gesture.
+                        # orphaned CLI was reaped above and its switch flags healed just now; a killed
+                        # question or dead background tasks (the arm below) wait for its explicit
+                        # wake, where _ensure reports and clears them. Only a PERSISTED QUEUE — the
+                        # user's own typed reply the CLI never started — earns the resume, because
+                        # delivering it IS honoring an explicit gesture.
                         continue
                     # A cut turn is any MACHINE-ACTIVE last state, not just "working" (the user
                     # 2026-08-19, whose figure session sat blocked-on-you after every restart that
@@ -5171,6 +5173,40 @@ class SdkBackend:
                     reg["model"] = nm
                     reg["liveModel"] = _alias_label(nm)
                     self._update_reg(sid, model=nm, liveModel=_alias_label(nm))   # _reg_lock, not self._lock
+            if reg.get("threadOf"):
+                # A dormant thread's DEAD LIFE, reported at its explicit wake. The boot sweep never
+                # resumes a thread for it (T223), so what the sweep tells a resumed top-level session
+                # — a question the kernel's death killed (pendingAsk, T214), background tasks that
+                # died with the process (the bgTasks mirror) — a thread hears here, once, ahead of the
+                # reply that woke it; the flags clear with the report. Not at the boot skip: a notice
+                # persisted there would read as a queue at the next boot and earn the very resume T223
+                # forbids, and clearing silently would drop true information (a watcher the thread
+                # still waits on is dead). Nothing else reads these flags, so before this they rode
+                # across every boot and wake until a later boot found the thread WITH a queued reply
+                # and prepended the stale notices ahead of it. A flagless wake writes nothing.
+                dead_tasks = [t for t in (reg.get("bgTasks") or []) if isinstance(t, dict)]
+                ask_died = bool(reg.get("pendingAsk"))
+                if dead_tasks or ask_died:
+                    notices = ([ASK_DIED_NOTICE] if ask_died else []) \
+                            + ([task_death_notice(dead_tasks)] if dead_tasks else [])
+                    with self._reg_lock:                   # _lock → _reg_lock: the rider's order above
+                        cur = read_reg(self.state_dir, sid) or dict(reg)
+                        rest = [t for t in (cur.get("queue") or [])
+                                if isinstance(t, str) and t and t not in notices]
+                        # a resume nudge at the head stays there — continuation context first, then
+                        # the notices, the sweep's order; the crash resume prepends one before it
+                        # calls here
+                        head = rest[:1] if rest and rest[0] in (BOOT_RESUME_NUDGE, CRASH_RESUME_NUDGE) else []
+                        cur["queue"] = head + notices + rest[len(head):]
+                        cur["bgTasks"] = []                # reported — never re-notify for the same deaths
+                        cur["pendingAsk"] = False          # asked once per death
+                        write_reg(self.state_dir, sid, cur)
+                    reg["queue"] = cur["queue"]            # SdkSession seeds its queue from THIS dict
+                    reg["bgTasks"] = []
+                    reg["pendingAsk"] = False
+                    self._log("thread %s wakes to its dead life: %s" % (sid[:8], ", ".join(
+                        (["a killed question"] if ask_died else [])
+                        + (["%d dead background task(s)" % len(dead_tasks)] if dead_tasks else []))))
             s = SdkSession(self, reg)
             s.on_boot_settled = on_boot_settled
             self.sessions[sid] = s

--- a/tests/test_restart_redelivery.py
+++ b/tests/test_restart_redelivery.py
@@ -8,7 +8,10 @@ and a landed-but-unpruned echo never re-delivers (the scan is the duplicate guar
 import json
 import os
 import tempfile
+import threading
 import unittest
+from pathlib import Path
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -105,6 +108,74 @@ class Redelivery(unittest.TestCase):
         self.be._mark_dropped_echoes(SID, ["still queued text"])
         self.assertEqual(self._reg_queue(), ["still queued text", "lost text"],
                          "the surviving queue keeps its place; the re-delivery lands behind it")
+
+
+class BootDeliversARefedSend(unittest.TestCase):
+    """The boot half, end to end. SdkBackend.__init__ lists the registries ONCE, runs the echo
+    reseed — whose re-delivery arm above puts a lost human send back into a registry's queue ON
+    DISK — and then hands the SAME listing to _boot_reconcile. A row listed before that write
+    still shows the old queue, so a session whose only reason to resume was the re-queued text
+    read an empty queue in the sweep and stayed dormant: re-queued, but delivered only at the next
+    spawn or boot. The sweep must decide from the registry as it is on disk. SYNTHETIC; no SDK."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.state = Path(self.td)
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.td, "claude")
+        self.cwd = os.path.join(self.td, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        open(tp, "w").close()                          # an empty transcript: the text never landed
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def _boot(self, echoes, queue=(), **reg_extra):
+        """Construct the backend the way the kernel does (reconcile=True) over one alive registry
+        whose turn FINISHED ('waiting' tail — not a cut), and wait for the sweep to end. Returns the
+        sids the sweep resumed. Waits on the sweep's own completion, never on a sleep."""
+        sb.write_reg(self.state, SID, {"sid": SID, "alive": True, "cwd": self.cwd, "lastSid": SID,
+                                       "queue": list(queue), "echoes": echoes, **reg_extra})
+        sb.append_state(self.state, SID, "waiting")
+        ensured, done = [], threading.Event()
+        real = sb.SdkBackend._boot_reconcile
+
+        def swept(be, regs):
+            try:
+                real(be, regs)
+            finally:
+                done.set()
+
+        with mock.patch.object(sb.SdkBackend, "_boot_reconcile", swept), \
+             mock.patch.object(sb.SdkBackend, "_ensure",
+                               lambda be, sid, on_boot_settled=None:
+                               (ensured.append(sid), on_boot_settled and on_boot_settled())[0]), \
+             mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout="")):
+            sb.SdkBackend(self.td, "/bin/true", lambda *a, **k: None, reconcile=True)
+            self.assertTrue(done.wait(10), "the boot sweep ran to its end")
+        return ensured
+
+    def _reg_queue(self):
+        return (sb.read_reg(self.state, SID) or {}).get("queue") or []
+
+    def test_a_re_queued_send_earns_the_resume_the_same_boot(self):
+        ensured = self._boot([{"t": 100, "text": "typed just before the restart", "author": "human"}])
+        self.assertEqual(self._reg_queue(), ["typed just before the restart"],
+                         "the reseed re-queued the lost send (the half that already worked)")
+        self.assertEqual(ensured, [SID], "…and the same boot's sweep resumes the session to deliver it")
+
+    def test_a_dormant_threads_re_queued_reply_earns_the_resume_too(self):
+        # a comment thread is never auto-resumed at boot EXCEPT for a queued reply of the user's own
+        # — and a re-queued reply is exactly that
+        ensured = self._boot([{"t": 100, "text": "a reply the thread never started", "author": "human"}],
+                             threadOf="11111111-2222-3333-4444-000000000000")
+        self.assertEqual(self._reg_queue(), ["a reply the thread never started"])
+        self.assertEqual(ensured, [SID])
+
+    def test_a_finished_session_with_nothing_re_queued_stays_lazy(self):
+        # the resume is keyed on the re-queued text, not on every alive registry
+        self.assertEqual(self._boot([]), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -17,6 +17,7 @@ import time
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -3039,6 +3040,40 @@ class BgTaskLifecycle(unittest.TestCase):
         be2._on_session_gone(s2)
         self.assertEqual(be2._ensured, [])
         self.assertEqual([t["desc"] for t in sb.read_reg(be2.state_dir, s2.sid)["bgTasks"]], ["timer"])
+
+    def test_a_threads_crash_resume_hears_dead_tasks_once_after_the_nudge(self):
+        # a comment thread's CLI dies mid-turn with the kernel alive: the crash resume spawns the
+        # fresh session through _ensure, whose thread-wake report (the boot sweep never resumes a
+        # thread, so a thread's dead life is reported at its wake) queues the task-death notice from
+        # the reg mirror — and this method's own report from the in-memory set follows with the
+        # identical text. The session hears it ONCE, after the continuation nudge: the order the
+        # boot sweep gives a top-level session.
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-00000000c0de"
+        reg = {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True,
+               "threadOf": "11111111-2222-3333-4444-000000000000"}
+        sb.write_reg(be.state_dir, sid, reg)
+        s = sb.SdkSession(be, reg)
+        self._feed(s, "task_started", {"task_id": "b1", "description": "release watcher"})
+        note = sb.task_death_notice(s._live_bg_tasks())
+        s.inflight = 1                                       # mid-turn: the crash-resume path
+        made = []
+
+        class _Rec:
+            def __init__(self, backend, reg):
+                made.append(dict(reg))
+                self.thread = mock.Mock(is_alive=lambda: True)
+                self.on_boot_settled = None
+
+            def start(self):
+                pass
+
+        with mock.patch.object(sb, "SdkSession", _Rec):
+            be._on_session_gone(s)
+        self.assertEqual(made[0].get("queue"), [sb.CRASH_RESUME_NUDGE, note], "nudge first, the notice once")
+        reg = sb.read_reg(be.state_dir, sid)
+        self.assertEqual(reg["queue"], [sb.CRASH_RESUME_NUDGE, note], "the persisted queue agrees")
+        self.assertEqual(reg["bgTasks"], [])
 
     def test_construction_heals_stranded_pending_switch_flags(self):
         # a pending /model / /effort switch that died with the previous process must not strand the

--- a/tests/test_sdk_boot_stagger.py
+++ b/tests/test_sdk_boot_stagger.py
@@ -137,6 +137,26 @@ class ThreadsStayDormant(unittest.TestCase):
             be._boot_reconcile(regs)
         self.assertEqual(ensured, [tsid])
 
+    def test_boot_leaves_a_dormant_threads_death_flags_for_its_wake(self):
+        # a killed question / dead background tasks are reported at the thread's explicit wake
+        # (ThreadWakeHearsItsDeadLife below), so the sweep neither resumes the thread for them nor
+        # clears them: the flags stay on disk and nothing is queued — a notice persisted here would
+        # read as a queue at the next boot and earn the very resume this skip forbids
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        ensured = []
+        be._ensure = lambda sid, on_boot_settled=None: (ensured.append(sid), on_boot_settled and on_boot_settled())[0]
+        tsid = "11111111-bbbb-0000-0000-00000000f1a6"
+        tasks = [{"desc": "release watcher", "since": 1}]
+        regs = [_reg(d, tsid, threadOf="11111111-bbbb-0000-0000-000000000000", pendingAsk=True, bgTasks=tasks)]
+        sb.append_state(Path(d), tsid, "waiting")
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout="")):
+            be._boot_reconcile(regs)
+        self.assertEqual(ensured, [], "no resume for a thread's dead life alone")
+        reg = sb.read_reg(Path(d), tsid)
+        self.assertEqual((reg.get("queue") or [], bool(reg.get("pendingAsk")), reg.get("bgTasks")),
+                         ([], True, tasks), "nothing queued; both flags left for the wake to report")
+
     def test_the_orphan_reap_still_covers_a_threads_leftover_cli(self):
         # the skip sits INSIDE the resume loop, after the reap built its sid list from every alive
         # reg — a dead kernel's thread CLI is still a zombie writer nobody manages
@@ -207,6 +227,94 @@ class ThreadWakeRemap(unittest.TestCase):
     def test_no_hook_means_no_remap(self):
         spawned, on_disk = self._wake(dict(self.THREAD), None)
         self.assertEqual((spawned, on_disk), ("claude-fable-5", "claude-fable-5"))
+
+
+class ThreadWakeHearsItsDeadLife(unittest.TestCase):
+    """The boot sweep leaves a dormant thread alone (ThreadsStayDormant), so the two things it tells
+    a resumed top-level session about its dead life — a question the kernel's death killed
+    (pendingAsk) and background tasks that died with the process (the bgTasks mirror) — reach a
+    thread at its EXPLICIT wake instead, in _ensure: once, ahead of the reply that woke it, and the
+    flags clear with the report. Before this nothing on the wake path read either flag: they rode
+    across every boot and wake until a later boot found the thread WITH a queued reply, and that
+    sweep prepended the stale notices ahead of the reply the user had just typed."""
+
+    class _Rec:                       # stands in for SdkSession: records the reg it was built from
+        made = []
+        fed = []
+
+        def __init__(self, backend, reg):
+            self.thread = mock.Mock(is_alive=lambda: True)
+            self.on_boot_settled = None
+            ThreadWakeHearsItsDeadLife._Rec.made.append(dict(reg))
+
+        def start(self):
+            pass
+
+        def enqueue(self, text):
+            ThreadWakeHearsItsDeadLife._Rec.fed.append(text)
+
+    PARENT = "11111111-bbbb-0000-0000-000000000000"
+    TASKS = [{"desc": "release watcher", "since": 1}]
+
+    def setUp(self):
+        self._Rec.made, self._Rec.fed = [], []
+        self.d = tempfile.mkdtemp()
+        self.be = _backend(self.d)
+
+    def _flags(self, sid):
+        reg = sb.read_reg(Path(self.d), sid)
+        return bool(reg.get("pendingAsk")), reg.get("bgTasks") or []
+
+    def test_the_explicit_wake_prepends_both_notices_and_clears_the_flags_once(self):
+        sid = "11111111-bbbb-0000-0000-0000000000b1"
+        _reg(self.d, sid, threadOf=self.PARENT, pendingAsk=True, bgTasks=list(self.TASKS))
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            self.be._ensure(sid)
+            self.assertEqual((self._Rec.made[0].get("queue") or []),
+                             [sb.ASK_DIED_NOTICE, sb.task_death_notice(self.TASKS)],
+                             "the fresh session is seeded with both notices, question first")
+            self.assertEqual(self._flags(sid), (False, []), "reported → cleared on disk")
+            self.be._update_reg(sid, queue=[])           # the life feeds its queue (_persist_queue)…
+            self.be.sessions.pop(sid)                    # …and ends
+            self.be._ensure(sid)                         # the next wake owes nothing
+        self.assertEqual((self._Rec.made[1].get("queue") or []), [], "once per death, never a nag")
+
+    def test_the_reply_that_woke_it_follows_the_notices(self):
+        sid = "11111111-bbbb-0000-0000-0000000000b2"
+        _reg(self.d, sid, threadOf=self.PARENT, pendingAsk=True)
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            self.assertTrue(self.be.send(sid, "the reply that woke it"))
+        self.assertEqual((self._Rec.made[0].get("queue") or []), [sb.ASK_DIED_NOTICE], "the seed carries the notice…")
+        self.assertEqual(self._Rec.fed, ["the reply that woke it"], "…and the reply enqueues behind it")
+
+    def test_a_top_level_wake_is_the_boot_sweeps_business(self):
+        sid = "11111111-bbbb-0000-0000-0000000000b3"
+        _reg(self.d, sid, pendingAsk=True, bgTasks=list(self.TASKS))
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            self.be._ensure(sid)
+        self.assertEqual((self._Rec.made[0].get("queue") or []), [])
+        self.assertEqual(self._flags(sid), (True, self.TASKS),
+                         "a top-level session's flags are the sweep's to report, at the next boot")
+
+    def test_a_thread_resumed_at_boot_for_its_reply_hears_each_notice_once(self):
+        # the sweep DOES resume a thread with a queued reply, reports and clears the flags itself,
+        # then spawns through the real _ensure — which must find nothing left to report
+        sid = "11111111-bbbb-0000-0000-0000000000b4"
+        regs = [_reg(self.d, sid, threadOf=self.PARENT, queue=["the reply"],
+                     pendingAsk=True, bgTasks=list(self.TASKS))]
+        with mock.patch.object(sb, "SdkSession", self._Rec), \
+             mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout="")):
+            self.be._boot_reconcile(regs)
+        self.assertEqual((self._Rec.made[0].get("queue") or []),
+                         [sb.ASK_DIED_NOTICE, sb.task_death_notice(self.TASKS), "the reply"])
+
+    def test_a_flagless_thread_wake_writes_nothing(self):
+        sid = "11111111-bbbb-0000-0000-0000000000b5"
+        _reg(self.d, sid, threadOf=self.PARENT)
+        before = sb._reg_path(Path(self.d), sid).read_bytes()
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            self.be._ensure(sid)
+        self.assertEqual(sb._reg_path(Path(self.d), sid).read_bytes(), before, "no reg churn on a plain wake")
 
 
 class FireBootSettled(unittest.TestCase):

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -222,6 +222,19 @@ class BootReconcile(unittest.TestCase):
         self.assertFalse(reg.get("modelPending"))
         self.assertEqual(be._ensured, [], "the heal alone never wakes a session")
 
+    def test_the_sweep_reads_each_registry_fresh_not_the_listing_it_was_handed(self):
+        # __init__ lists the registries, then the echo reseed may re-queue a lost send into one of
+        # them ON DISK, then the sweep walks that same listing: a row listed before the write still
+        # showed an empty queue, so the session sat dormant with a message waiting in its registry.
+        d, be = self._setup()
+        sid = "11111111-aaaa-0000-0000-00000000000f"
+        regs = [_reg(d, sid, queue=[])]                    # the listing: nothing queued yet
+        sb.write_reg(Path(d), sid, {**regs[0], "queue": ["re-queued after the listing"]})   # the reseed's write
+        sb.append_state(Path(d), sid, "waiting")
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout="")):
+            be._boot_reconcile(regs)
+        self.assertEqual(be._ensured, [sid], "the sweep decides from the registry on disk, not the stale row")
+
     def test_reaps_orphans_but_never_tmux(self):
         d, be = self._setup()
         sid = "11111111-aaaa-0000-0000-00000000000b"


### PR DESCRIPTION
## Two boot-reconcile fixes for dormant sessions

Both defects live in `SdkBackend._boot_reconcile`'s handling of sessions that stay dormant, and both come from the sweep acting on registry state that is not the live state: a listing taken before a later write, and two flags nobody reads on the one path a thread wakes through. They ship as two commits so each reads on its own. The re-read lands first: the second commit's once-only guard (a thread the sweep resumes for a queued reply must hear each notice exactly once) relies on the sweep reading `pendingAsk`/`bgTasks` fresh rather than off the boot listing.

### Commit 1 — Boot reconcile reads each registry fresh

**What breaks.** `SdkBackend.__init__` lists the registries once (`regs = list_regs(...)`), runs `_reseed_echoes(regs)`, then hands the same list to `_boot_reconcile`. The reseed's re-delivery arm (`_mark_dropped_echoes`) puts a provably lost human send back into a registry's persisted queue by `read_reg` → append → `write_reg` — on disk. `list_regs` hands out shallow copies and `read_reg` is uncached, so the row the sweep walks still shows the queue from before that write. A session whose turn had finished (`waiting` tail, no dead background tasks, no killed ask) reads `queued` empty off the stale row and takes the stays-lazy `continue`: the re-queued message sits in its registry until the next spawn or the next boot. The dormant-thread guard (`if r.get("threadOf") and not queued`) reads the same stale row, so a thread whose re-queued reply is exactly the gesture the guard's own comment says earns the resume is skipped too. The summary line's `restored` count omits the re-queued texts.

Reachable shapes: a session the user interrupted (tail `idle`) whose forwarded message the CLI discarded when the kernel died; a message forwarded as the next turn after the previous turn's result wrote `waiting`, with the kernel dying before the CLI produced output; a dormant comment thread in either state.

**Reproduction** (the new tests do exactly this): one alive registry with an unlanded human echo, an empty queue and a `waiting` tail; construct the backend with `reconcile=True`. The reseed re-queues the text; the sweep does not resume the session.

**Fix.** At the top of the per-session body, re-read the registry from disk and use that row for the rest of the iteration (a failed read keeps the listed row). This is the same fresh read the read-modify-write arm further down already performs. No other line in the loop changes: reap-before-skip order, the ask and background-task riders, and the machine-cut stamp are untouched and their source pins pass. Cost: one `read_reg` per alive registry, once per boot.

One behavior change to call out: a dormant comment thread with a re-queued human reply now resumes at boot, where before only a queue the previous life had persisted did. That follows the guard's stated rule.

### Commit 2 — A dormant comment thread hears its dead life's notices at its explicit wake

**What breaks.** The dormant-thread skip runs before the arm that reports and clears two flags: `pendingAsk` (a question was up when the kernel died) and `bgTasks` (the mirror of background tasks that died with the process). Its comment said the thread's "pending flags healed just now", which is true only of the effort/model switch flags healed above it. Nothing on the wake path reads the two flags either: `_ensure` (the door an explicit reply comes through) and `SdkSession.__init__` never look at them, and `_clear_ask` runs in the ask handlers' `finally`, so a stale `pendingAsk` is exactly the kernel-death case the flag exists for.

Trace: the thread asks a question → the kernel restarts → the boot sweep skips the thread with both flags intact → the user replies (an explicit wake; nothing reads the flags) → any number of further wakes and boots → a restart lands while the thread holds a queued reply → that boot's sweep prepends `ASK_DIED_NOTICE` and the task-death notice, from a life possibly several wakes old, ahead of the reply the user just typed.

**Fix.** The explicit wake is a dormant thread's resume event, so `_ensure` now does for a thread what the sweep does for a resumed top-level session. When the registry it read carries either flag, it prepends the same two notices to the persisted queue (behind a leading resume nudge if one is there — the sweep's order; the crash resume prepends one before it calls `_ensure`), clears both flags, and seeds the fresh `SdkSession` from the updated queue: once per death, ahead of the reply that woke it. A flagless wake writes nothing. The skip's comment now says where the flags go; the skip line itself and every line of the sweep's arm are unchanged (both are source-pinned by existing tests).

Why at the wake and not at the skip — three shapes were weighed:
- (A) Report at the skip by persisting the notices into the thread's queue. Rejected: a persisted queue is what earns a resume at the next boot, so the thread would be resumed for machine notices — the resume the skip exists to prevent.
- (B) Clear at the skip, silently, like the switch-flag heal. Rejected as the primary shape: it discards true information (a watcher the thread still waits on is dead; a question was never answered). If you prefer silence here, say so and I'll reshape the commit.
- (C) Report and clear at the explicit wake, in `_ensure`. Chosen: it is the thread's own resume event and the place the existing thread-wake rider already treats as the one moment a dormant thread may be touched.

Scope and residuals:
- Thread-gated. Top-level sessions keep the sweep's arm; a test pins that a top-level wake leaves the flags alone.
- A thread promoted to a full session has `threadOf` cleared before it is connected, so a promoted thread's stale flags fall to the next boot's top-level arm — the same deferral any top-level session has today.
- On a thread CLI crash with the kernel alive, `_heal_cut_session` spawns through `_ensure` before `_on_session_gone`'s own report from the in-memory set. The identical notice text dedups, so the session hears it once, nudge first (pinned).
- Lock order is `_lock` → `_reg_lock`, the order the existing thread-wake rider already uses.
- No new injected copy: the existing notices and their voice test are untouched. `ASK_DIED_NOTICE` says "the restart"; at a thread woken later that is loose but true (the last life ended in a kernel death — `_clear_ask`'s `finally` rules out other endings).

Observation, not addressed here: on a **top-level** crash-resume with live background tasks, `_on_session_gone` writes its task-death notice to the registry after `_heal_cut_session` has already seeded the fresh session, so the in-memory queue never carries it and the fresh session's next `_persist_queue` overwrites it. For threads, this commit's wake report covers that path from the registry mirror; the top-level shape is unchanged and worth a separate look.

### Tests

All synthetic (placeholder uuids, invented task descriptions), SDK-free (a recording stand-in for `SdkSession`, `/bin/true` backend), and run under `python -m pytest -q`.

Commit 1:
- `tests/test_restart_redelivery.py::BootDeliversARefedSend` — constructs the backend with `reconcile=True` over a registry holding an unlanded human echo, an empty queue and a `waiting` tail, waits on the sweep's own completion event (no sleeps, no thread-name lookup), and asserts both that the text was re-queued and that the session was resumed: for a top-level session and for a dormant comment thread. Both red before the change (re-queued, not resumed). Plus the negative: nothing re-queued → stays lazy.
- `tests/test_sdk_lifecycle_hardening.py::BootReconcile::test_the_sweep_reads_each_registry_fresh_not_the_listing_it_was_handed` — hands the sweep a listing and writes a queue behind it. Red before.

Commit 2:
- `tests/test_sdk_boot_stagger.py::ThreadWakeHearsItsDeadLife` — the explicit wake prepends both notices and clears the flags once (red before: empty seed, flags still set); the reply that woke it enqueues behind the notices (red before); a top-level wake leaves the flags to the sweep; a thread the sweep resumes for its queued reply hears each notice exactly once; a flagless wake writes nothing to the registry.
- `tests/test_sdk_boot_stagger.py::ThreadsStayDormant::test_boot_leaves_a_dormant_threads_death_flags_for_its_wake` — the sweep neither resumes a queue-less thread for its dead life nor clears its flags.
- `tests/test_sdk_backend.py::BgTaskLifecycle::test_a_threads_crash_resume_hears_dead_tasks_once_after_the_nudge` — crash resume of a thread with a live background task: seed is `[CRASH_RESUME_NUDGE, notice]`, the persisted queue agrees, `bgTasks` cleared (red before: the seed held the nudge alone).

Existing source pins on the skip line, the sweep's arm, and the machine-cut stamp all still pass; the full suite is green apart from two pre-existing goal-store ordering flakes in unrelated files that pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)