### PR TITLE
Kernel settings survive socket churn: queue per host and flush on open, and the store applies them in gesture order

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2859,6 +2859,85 @@ def _nudge_text(count, stalled=False):
 _autonudge_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 
+# ── kernel settings: gesture-time ordering (2026-08-29) ──────────────────────────────────────────
+# A setting message can reach this kernel long after the click that made it: federation queues
+# KERNEL_SETTING sends per host while a socket is down and flushes them on reconnect
+# (ui/webview/federation.ts sendRemote/flushPending), and that queue is latest-per-TAB — a frozen
+# dashboard tab (a backgrounded phone, a throttled browser tab) re-dials hours later and flushes a
+# pick the user has since superseded from another device. This kernel used to apply whatever
+# arrived, and the judge tiers RE-PROPAGATE what they apply (_propagate_judge_settings), so one
+# stale flush could walk the whole mesh back to an hours-old pick — and with every kernel then
+# agreeing, the gear's mixed-marks disagreement surface showed nothing. The writer's evidence
+# predated the store's newer state, so it stands down at the write moment (the standing card rule,
+# applied to settings). Ordering is enforced HERE, at the authoritative store, so every path is
+# covered at once: live sends, queue flushes, racing dashboards, and the propagation legs.
+#   - Every dashboard gesture carries `gt`: epoch ms captured ONCE where the message is built (the
+#     gear's change handlers, the file viewer's consent post, the feed's judge-limit switch), so a
+#     queued flush delivers the ORIGINAL gesture's time, never its send time.
+#   - Each setting's store persists the last-APPLIED gt beside the value (auto-nudge.json /
+#     file-editing.json gain a "gt" field; the bare judge-tier stores gain a `<name>.gt` sidecar);
+#     an arriving stamp older-or-equal to it stands down — no apply, no propagation, one loud
+#     stderr line naming both stamps.
+#   - A message with NO stamp (an older dashboard, a direct HTTP caller) applies as it always did
+#     and records its arrival time, so stamped and unstamped writers still order against each other.
+# Clock skew: cross-device wall clocks (NTP) are the ordering source. Gestures contend at human
+# timescales — the flush that motivated this arrived hours late, and a two-dashboard race is
+# seconds apart — so sub-second NTP skew is immaterial; equal stamps keep the STORED value (stand
+# down) for determinism.
+
+def _gesture_ms(msg):
+    """The gesture stamp riding `msg` (epoch ms), or None when the sender didn't stamp one."""
+    gt = msg.get("gt") if isinstance(msg, dict) else None
+    return int(gt) if isinstance(gt, (int, float)) and gt > 0 else None
+
+
+def _gt_int(v):
+    """A stored stamp, defensively: anything unreadable orders as 0, so it never blocks an apply."""
+    try:
+        return int(v or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _setting_stale(name, gt, applied_gt):
+    """True when gesture `gt` must stand down against the store's last-applied stamp — loudly.
+    A stand-down is also recorded on THIS thread (_pop_stale_notice) so the WS branch that
+    delivered the gesture can answer its own socket with a settingStale frame: the stderr line
+    alone left the refusing kernel's verdict invisible to the dashboard that made the gesture
+    (the open gear kept showing the refused pick, and with the mesh AGREEING on the kept value
+    the mixed marks showed nothing). Every check clears the previous verdict first, so a popped
+    notice is always the CURRENT call's."""
+    _stale_seen.last = None
+    if gt is None or gt > applied_gt:
+        return False
+    _stale_seen.last = {"setting": name, "storedGt": applied_gt}
+    sys.stderr.write("setting %s: stale gesture stood down (gesture %d <= applied %d) — "
+                     "no apply, no propagation\n" % (name, gt, applied_gt))
+    return True
+
+
+_stale_seen = threading.local()   # per-thread: the last _setting_stale stand-down (the WS reply seam)
+
+
+def _pop_stale_notice():
+    """The current thread's last stand-down verdict, consumed. The gt-gated setters run
+    synchronously on the thread that dispatched the message, so this is exact — no id plumbing."""
+    d = getattr(_stale_seen, "last", None)
+    _stale_seen.last = None
+    return d
+
+
+# ONE lock for every gt-gated setting's read-check-write span (2026-08-29): the stores read the
+# stamp, check _setting_stale, then write, on a ThreadingHTTPServer — with no lock, two
+# near-simultaneous flushes of one setting (two dashboards flushing on a host's recovery) could
+# both pass the check against the same stored stamp and then land in SOCKET order, the exact
+# inversion the gesture-time mechanism exists to prevent. The critical sections are tiny (a stat
+# + small read, a compare, an atomic write), so one module-level lock covers them all;
+# _set_auto_nudge is the one exception — its file doubles as the nudge ledger, whose other
+# writers already serialize on _NUDGE_LOCK, so it keeps that lock across the same span.
+_SETTINGS_LOCK = threading.RLock()
+
+
 # ONE lock for the nudge ledger's read-modify-write spans (2026-08-19 audit: a live episode
 # record vanished with no state-visible writer — the ledger's writers run on the producer tick,
 # judge callbacks, and WS handlers concurrently, and two overlapping dict(read)…write() spans
@@ -2984,10 +3063,25 @@ def _write_auto_nudge(d):
     _atomic_write(jd.STATE / "auto-nudge.json", json.dumps(d))
 
 
-def _set_auto_nudge(enabled):
-    d = dict(_auto_nudge_data())
-    d["enabled"] = bool(enabled)
-    _write_auto_nudge(d)
+def _set_auto_nudge(enabled, gt=None):
+    """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down —
+    see the gesture-time ordering block above _NUDGE_LOCK — or the store write failed (OSError:
+    loud on stderr, nothing applied). The catch lives HERE, like _set_update_mode's and
+    _set_judge_state's: a raised OSError reaches the WS reader loop, which classifies it as a
+    socket failure and re-raises into a silent pass — a full-disk gear toggle tearing the whole
+    dashboard WebSocket down with zero log output."""
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        if _setting_stale("auto-nudge", gt, _gt_int(d.get("gt"))):
+            return None
+        d["enabled"] = bool(enabled)
+        d["gt"] = gt if gt is not None else int(time.time() * 1000)
+        try:
+            _write_auto_nudge(d)
+        except OSError as e:
+            sys.stderr.write("setting auto-nudge: write failed (%s) — nothing applied\n" % e)
+            return None
+        return d["gt"]
 
 
 def _compact_suggest_on():
@@ -2998,10 +3092,25 @@ def _compact_suggest_on():
     return bool(_auto_nudge_data().get("compactSuggestEnabled"))
 
 
-def _set_compact_suggest(enabled):
-    d = dict(_auto_nudge_data())
-    d["compactSuggestEnabled"] = bool(enabled)
-    _write_auto_nudge(d)
+def _set_compact_suggest(enabled, gt=None):
+    """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down or the
+    store write failed (OSError: loud on stderr, nothing applied, nothing ticked) —
+    _set_auto_nudge's contract exactly (same blob, same _NUDGE_LOCK), but the
+    stamp is PER SETTING (`compactSuggestGt`): the two checkboxes share a file, not a clock, so a
+    queued compact-suggest flush can never stand down against a newer auto-nudge gesture or steal
+    authority from one (the gesture-time ordering block above _gesture_ms)."""
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        if _setting_stale("compact-suggest", gt, _gt_int(d.get("compactSuggestGt"))):
+            return None
+        d["compactSuggestEnabled"] = bool(enabled)
+        d["compactSuggestGt"] = gt if gt is not None else int(time.time() * 1000)
+        try:
+            _write_auto_nudge(d)
+        except OSError as e:
+            sys.stderr.write("setting compact-suggest: write failed (%s) — nothing applied\n" % e)
+            return None
+        return d["compactSuggestGt"]
 
 
 def _file_editing_on():
@@ -3019,8 +3128,29 @@ def _file_editing_on():
         return False
 
 
-def _set_file_editing(enabled):
-    _atomic_write(jd.STATE / "file-editing.json", json.dumps({"enabled": bool(enabled)}))
+def _set_file_editing(enabled, gt=None):
+    """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down —
+    see the gesture-time ordering block above _NUDGE_LOCK — or the store write failed (OSError:
+    loud on stderr, nothing applied; caught HERE like _set_update_mode's, because a raised OSError
+    reads as a socket failure to the WS reader loop and silently tears the connection down).
+    A file without the field (written before the mechanism) reads as gt 0, so any stamped gesture
+    applies over it. The whole read-check-write span holds _SETTINGS_LOCK: without it, two racing
+    flushes could both check against the same stored stamp and land in socket order (see the
+    lock's own comment)."""
+    with _SETTINGS_LOCK:
+        try:
+            prev = json.loads((jd.STATE / "file-editing.json").read_text())
+        except Exception:
+            prev = None
+        if _setting_stale("file-editing", gt, _gt_int(prev.get("gt")) if isinstance(prev, dict) else 0):
+            return None
+        stamp = gt if gt is not None else int(time.time() * 1000)
+        try:
+            _atomic_write(jd.STATE / "file-editing.json", json.dumps({"enabled": bool(enabled), "gt": stamp}))
+        except OSError as e:
+            sys.stderr.write("setting file-editing: write failed (%s) — nothing applied\n" % e)
+            return None
+        return stamp
 
 
 # ── automatic updates of THIS machine (the user 2026-08-09) ───────────────────────────────────────
@@ -3053,9 +3183,36 @@ def _update_mode():
         return "ask"
 
 
-def _set_update_mode(mode):
-    if mode in _UPDATE_MODES:
-        _atomic_write(jd.STATE / "update-mode.json", json.dumps({"mode": mode}))
+def _update_mode_gt():
+    """Last-applied gesture stamp for the update mode — a file without the field (written before
+    the mechanism), or no file at all, reads as 0, so any stamped gesture applies over it."""
+    try:
+        d = json.loads((jd.STATE / "update-mode.json").read_text())
+        return _gt_int(d.get("gt")) if isinstance(d, dict) else 0
+    except (OSError, ValueError):
+        return 0
+
+
+def _set_update_mode(mode, gt=None):
+    """Returns the applied gesture stamp (epoch ms); None when the mode is invalid, a stale `gt`
+    stood down, or the write failed (loud — nothing applied). setUpdateMode rides federation's
+    queued KERNEL_SETTING class like the rest of the gear, so it is gt-gated exactly like
+    _set_file_editing: a frozen tab's hours-late flush must not silently revert how this machine
+    self-updates at boot (ask/auto/off). Value + stamp live in one json, read-check-write under
+    _SETTINGS_LOCK; an unstamped set (older dashboard, direct caller) applies as it always did
+    and records its arrival time."""
+    if mode not in _UPDATE_MODES:
+        return None
+    with _SETTINGS_LOCK:
+        if _setting_stale("update-mode", gt, _update_mode_gt()):
+            return None
+        stamp = gt if gt is not None else int(time.time() * 1000)
+        try:
+            _atomic_write(jd.STATE / "update-mode.json", json.dumps({"mode": mode, "gt": stamp}))
+        except OSError as e:
+            sys.stderr.write("setting update-mode: write failed (%s) — nothing applied\n" % e)
+            return None
+        return stamp
 
 
 def _semver(tag):
@@ -25058,29 +25215,72 @@ def _set_colormap(name):
 # _triage_effort / _index_effort read these on the judge's NEXT pass; no restart). Models validate against the
 # shared MODEL_CHOICES; efforts against EFFORT_CHOICES, with "" clearing the file back to the default (no
 # --effort). Ignore anything else, so a stale/garbage value can't reach `claude --model`.
-def _set_judge_state(fname, value, allowed, allow_empty=False):
-    if value in allowed or (allow_empty and value == ""):
+def _set_judge_state(fname, value, allowed, allow_empty=False, gt=None):
+    """Returns the applied gesture stamp (epoch ms); None in exactly three cases, all of which
+    the callers' `_jgt is not None` gates convert into NO propagation:
+      - the value is invalid (not in `allowed`) — refused before the ordering check, so a
+        refused value never burns its stamp;
+      - a stale `gt` stood down (the gesture-time ordering block above _SETTINGS_LOCK);
+      - the store could not be written (OSError) — loud on stderr, and deliberately still
+        unpropagated: a value the LOCAL store never took must not fan out to the mesh
+        (consistency over delivery — the mesh converging on a value its origin doesn't hold
+        would be the stale-flush revert in a new costume; the next applied change re-fans).
+    The stamp lives in a `<fname>.gt` sidecar because these stores are bare values other readers
+    (jd._state_str) parse raw — an absent sidecar reads as 0, so pre-existing picks yield to any
+    stamped one. The read-check-write span holds _SETTINGS_LOCK (racing flushes must land in
+    gesture order, not socket order), and both files publish via _atomic_write, SIDECAR FIRST: a
+    crash between the two leaves the new stamp guarding the old value, which errs safe — a
+    legitimate re-send stands down once and the next change heals — where value-first left the
+    new value guarded by the OLD stamp, letting a later stale gesture invert the ordering."""
+    if not (value in allowed or (allow_empty and value == "")):
+        return None
+    with _SETTINGS_LOCK:
+        if _setting_stale(fname, gt, _judge_state_gt(fname)):
+            return None
+        stamp = gt if gt is not None else int(time.time() * 1000)
         try:
             jd.STATE.mkdir(parents=True, exist_ok=True)
-            (jd.STATE / fname).write_text(value)
-        except OSError:
-            pass
+            _atomic_write(jd.STATE / (fname + ".gt"), str(stamp))
+        except OSError as e:
+            sys.stderr.write("setting %s: could not write the gesture stamp (%s) — nothing "
+                             "applied, nothing propagated\n" % (fname, e))
+            return None
+        try:
+            _atomic_write(jd.STATE / fname, value)
+        except OSError as e:
+            # rollback is impossible (the sidecar already published), so be LOUD about the exact
+            # half-applied state: the stamp advanced without its value, which only ever errs
+            # toward one extra stand-down — change the setting again to heal both files.
+            sys.stderr.write("setting %s: HALF-APPLIED — stamp %d landed but the value write "
+                             "failed (%s); the store keeps its previous value guarded by the new "
+                             "stamp. Not applied for the judges, not propagated; the next change "
+                             "heals it.\n" % (fname, stamp, e))
+            return None
+    return stamp
+
+
+def _judge_state_gt(fname):
+    """Last-applied gesture stamp for a judge-tier store — absent or garbled orders as 0."""
+    try:
+        return _gt_int((jd.STATE / (fname + ".gt")).read_text().strip())
+    except Exception:
+        return 0
 
 
 # judge tiers accept VERSION ids too (the user 2026-08-25: the settings pickers mirror the
 # family+version submenus) — a version rides the SDK model param verbatim, like session picks
 _JUDGE_MODEL_VALUES = _MODEL_VALUES | set(_VERSION_FAMILY)
-def _set_judge_model(v):  _set_judge_state("judge-model", v, _JUDGE_MODEL_VALUES)
-def _set_index_model(v):  _set_judge_state("index-model", v, _JUDGE_MODEL_VALUES)
-def _set_judge_effort(v): _set_judge_state("judge-effort", v, _EFFORT_VALUES, allow_empty=True)
-def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True)
+def _set_judge_model(v, gt=None):  return _set_judge_state("judge-model", v, _JUDGE_MODEL_VALUES, gt=gt)
+def _set_index_model(v, gt=None):  return _set_judge_state("index-model", v, _JUDGE_MODEL_VALUES, gt=gt)
+def _set_judge_effort(v, gt=None): return _set_judge_state("judge-effort", v, _EFFORT_VALUES, allow_empty=True, gt=gt)
+def _set_index_effort(v, gt=None): return _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True, gt=gt)
 # The distilling pair accepts extra sentinels (resolved by jd._distill_model/_distill_effort at call
 # time): "triage" (the default) means FOLLOW the triage pick live — exactly what the distiller/briefer/
 # staller did before the split (the user 2026-08-14) — and effort's "none" pins no-flag. "none" exists
 # because "" cannot: _state_str folds an empty file into the default, so an allow_empty pin here would
 # read back as "follow" (caught by test_distill_tier before it shipped).
-def _set_distill_model(v):  _set_judge_state("distill-model", v, _JUDGE_MODEL_VALUES | {"triage"})
-def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES | {"triage", "none"})
+def _set_distill_model(v, gt=None):  return _set_judge_state("distill-model", v, _JUDGE_MODEL_VALUES | {"triage"}, gt=gt)
+def _set_distill_effort(v, gt=None): return _set_judge_state("distill-effort", v, _EFFORT_VALUES | {"triage", "none"}, gt=gt)
 # The default-COMMENT-THREAD trio (the user 2026-08-29, who wanted every new comment thread on one
 # model/effort/fast pick regardless of the session it branches from). Sentinel "session" — the shipped
 # default — means SAME AS THE SESSION: resolved to the empty override at create time
@@ -25088,9 +25288,9 @@ def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES
 # (clear to the account default) so the setting speaks the create dialog's exact value space; fast is
 # "on" or the sentinel — a checkbox has no third state, and forcing a thread SLOW from a fast parent
 # stays a per-thread dialog pick, never a standing default.
-def _set_comment_model(v):  _set_judge_state("comment-model", v, _JUDGE_MODEL_VALUES | {"session", "default"})
-def _set_comment_effort(v): _set_judge_state("comment-effort", v, _EFFORT_VALUES | {"session"})
-def _set_comment_fast(v):   _set_judge_state("comment-fast", v, {"session", "on"})
+def _set_comment_model(v, gt=None):  return _set_judge_state("comment-model", v, _JUDGE_MODEL_VALUES | {"session", "default"}, gt=gt)
+def _set_comment_effort(v, gt=None): return _set_judge_state("comment-effort", v, _EFFORT_VALUES | {"session"}, gt=gt)
+def _set_comment_fast(v, gt=None):   return _set_judge_state("comment-fast", v, {"session", "on"}, gt=gt)
 
 
 # The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
@@ -25101,7 +25301,10 @@ def _set_comment_fast(v):   _set_judge_state("comment-fast", v, {"session", "on"
 # machine's judges. The receiving kernel's /judge-settings route applies WITHOUT re-propagating, so
 # the machines converge in one hop from the machine the user touched and can never ping-pong. A
 # machine reachable only through a relay holds no admin path from here; it adopts when the pick is
-# made from (or forwarded via) the machine that owns its tunnel.
+# made from (or forwarded via) the machine that owns its tunnel. Every fan-out body carries the
+# ORIGIN gesture's `gt` (the WS handlers forward the stamp the local store just applied), so a
+# stale pick can never win at any receiver by arriving via this second hop — each receiver's
+# _apply_judge_settings orders by it exactly as the first hop did.
 
 _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_index_model),
                          ("judgeEffort", _set_judge_effort), ("indexEffort", _set_index_effort),
@@ -25112,25 +25315,13 @@ _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_i
                          ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
                          ("commentFast", _set_comment_fast))
 
-# field -> its STATE file, for the per-field PICK STAMPS below (the user 2026-08-30, whose distill
-# pick kept "resetting": authority between kernels must be per field and per pick time, never
-# whichever machine spoke last).
-_JUDGE_SETTING_FILES = {"judgeModel": "judge-model", "indexModel": "index-model",
-                        "judgeEffort": "judge-effort", "indexEffort": "index-effort",
-                        "distillModel": "distill-model", "distillEffort": "distill-effort",
-                        "commentModel": "comment-model", "commentEffort": "comment-effort",
-                        "commentFast": "comment-fast"}
-
-
-def _setting_stamp(field):
-    """WHEN a kernel-side setting was last picked = its STATE file's mtime. The write IS the pick
-    event (every setter writes the file at pick time), and a propagated apply preserves the ORIGIN's
-    stamp via utime below — so the stamp is the pick's own event time on every machine, and recency
-    comparisons stay honest across hops. None = never picked here."""
-    try:
-        return (jd.STATE / _JUDGE_SETTING_FILES[field]).stat().st_mtime
-    except (OSError, KeyError):
-        return None
+# The per-field PICK STAMPS this leg carried from 2026-08-30 (each field's STATE-file mtime in a
+# body "stamps" dict, preserved by utime at the receiver — the distill-pick stomp fix) are
+# superseded by the gesture stamp: one clock decides every write. Two recency clocks deciding the
+# same write would fight, and mtime only guarded THIS hop — a stale WS flush was still applied
+# locally at a fresh mtime and then fanned out as the newest pick. The body-level `gt` covers the
+# same stomp (older-or-equal never overwrites newer, a refused value never steals recency, a
+# stampless body keeps the legacy apply) at both hops, decided in the setter under one lock.
 
 
 def _apply_judge_settings(body):
@@ -25138,36 +25329,17 @@ def _apply_judge_settings(body):
     never reaches the state files or `claude --model`), and answer with the CURRENT values —
     the ack shows what actually landed, since an invalid value is deliberately ignored. The
     distill pair answers RAW ("triage" = following the triage pick), matching /version: the
-    gear shows the user's choice, not its resolution."""
+    gear shows the user's choice, not its resolution. A body-level `gt` (the origin gesture's
+    stamp, forwarded by every propagation leg) covers each field the body carries: a field
+    whose stored stamp is newer stands down individually (_setting_stale) — and the ack then
+    shows the newer value still standing."""
     _dm_before = jd._distill_model()
-    # Per-field PICK AUTHORITY (the user 2026-08-30, whose Distilling pick "continually gets reset"):
-    # a propagated body stamps each field with its pick time, and an OLDER (or same-moment) value
-    # never overwrites a newer local pick — the stomp was any later-arriving propagation replacing a
-    # fresher pick wholesale. A stampless body (an older kernel, a manual curl) keeps the legacy
-    # apply-unconditionally behavior; the protection needs both ends on this code. An applied
-    # stamped field keeps the ORIGIN's pick time (utime) so recency survives re-fans, and the stamp
-    # is copied only when the value actually LANDED (a rejected/garbage value must not steal the
-    # newer time onto the old content).
-    stamps = body.get("stamps") if isinstance(body, dict) and isinstance(body.get("stamps"), dict) else {}
+    _gt = _gesture_ms(body)
     for key, setter in _JUDGE_SETTING_FIELDS:
         if isinstance(body, dict) and key in body:
-            st = stamps.get(key)
-            try:
-                st = float(st) if st is not None else None
-            except (TypeError, ValueError):
-                st = None
-            if st is not None:
-                local = _setting_stamp(key)
-                if local is not None and local >= st:
-                    continue                          # older never overwrites newer (the fix's whole point)
-            setter(str(body.get(key) or ""))
-            if st is not None:
-                try:
-                    p = jd.STATE / _JUDGE_SETTING_FILES[key]
-                    if p.exists() and p.read_text().strip() == str(body.get(key) or "").strip():
-                        os.utime(p, (st, st))
-                except OSError:
-                    pass
+            setter(str(body.get(key) or ""), gt=_gt)
+    _pop_stale_notice()   # HTTP legs have no delivering dashboard socket — discard the verdict so
+    #                       no later message handled on a kept-alive connection's thread inherits it
     if jd._distill_model() != _dm_before:
         # Switching the distill tier's EFFECTIVE model is a discrete recovery event (the user
         # 2026-08-18, who pointed the tier away from an outage-scoped model and expected the failed
@@ -25200,12 +25372,6 @@ def _propagate_judge_settings(body):
     itself never blocks on the machines. A miss is LOUD (a machine that missed the pick would
     silently run its judges on another model forever) but not retried — the next change re-fans,
     and /judge-settings with {"propagate": true} re-syncs on demand."""
-    # Every fanned field carries its PICK STAMP (the local STATE file's mtime — the pick event
-    # itself, or the origin's preserved time on a re-fan), so the receiving side can refuse an
-    # older value over a newer pick (the user 2026-08-30). Computed once, at fan time.
-    body = dict(body)
-    _st = {f: _setting_stamp(f) for f in body if f in _JUDGE_SETTING_FILES}
-    body["stamps"] = {f: t for f, t in _st.items() if t is not None}
     with _remotes_lock:
         rows = [dict(r) for r in _remotes.values()
                 if r.get("status") == "up" and r.get("local_port") and r.get("token")]
@@ -25223,6 +25389,36 @@ def _reply(c, msg):
         c["send"](json.dumps(msg))
     except Exception:
         c["alive"] = False
+
+
+def _setting_kept_value(name):
+    """The value a stood-down gesture lost to — read at reply time only (one cheap store read on
+    the stand-down path, never on the apply path). Booleans stay booleans; the gear words them."""
+    if name == "auto-nudge":
+        return bool(_auto_nudge_data().get("enabled"))
+    if name == "compact-suggest":
+        return _compact_suggest_on()
+    if name == "file-editing":
+        return _file_editing_on()
+    if name == "update-mode":
+        return _update_mode()
+    return jd._state_str(name, "")   # the judge-tier stores are bare value files
+
+
+def _tell_stale_gesture(client):
+    """A gt-gated setter just refused: if that refusal was a stale STAND-DOWN (recorded on this
+    thread by _setting_stale), answer the DELIVERING socket with a small settingStale frame — the
+    same targeted _reply idiom the saveFile acks use, never a broadcast. Without it the refusal
+    was one kernel stderr line: the dashboard that made the gesture kept displaying the refused
+    pick as applied (the gear fills only on open), and with the mesh AGREEING on the kept value
+    the mixed marks showed nothing. The gear toasts the frame and re-fills if open — event-keyed,
+    the frame IS the deciding event; no polling. A refusal for any other cause (invalid value,
+    OSError) records no notice and sends nothing."""
+    st = _pop_stale_notice()
+    if not st:
+        return
+    _reply(client, {"type": "settingStale", "setting": st["setting"],
+                    "storedGt": st["storedGt"], "kept": _setting_kept_value(st["setting"])})
 
 
 # ---- pasted-image hydration + dropped-file handling (ported from the old TS kernel chat-view/src/
@@ -32285,7 +32481,8 @@ class Handler(BaseHTTPRequestHandler):
                 # Applies via the validated setters, answers with the CURRENT four values.
                 # {"propagate": true} additionally fans the pick out from THIS machine (the manual /
                 # scripted re-sync); forwarded bodies never carry it, so propagation is one hop and
-                # can never ping-pong around the mesh.
+                # can never ping-pong around the mesh. A body-level `gt` is kept in the forward —
+                # the origin gesture's stamp orders the apply at every receiver (_setting_stale).
                 try:
                     body = json.loads(raw_body or b"{}")
                 except Exception:
@@ -32467,19 +32664,30 @@ class Handler(BaseHTTPRequestHandler):
             _set_conserve(bool(msg.get("enabled")))
             _push_soon()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
-            _set_auto_nudge(bool(msg["enabled"]))   # feed gear → server-side Auto Nudge on/off
+            # feed gear → server-side Auto Nudge on/off; a stale gesture stamp stands down (no
+            # apply), and the dashboard that made the losing gesture hears it
+            if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
-            _set_compact_suggest(bool(msg["enabled"]))   # T208 opt-in — kernel-side like autoNudge
-            # act immediately on turn-on (don't wait 4s) — but skip the dead-wait sweep: the
-            # death transition has ONE observer (the pusher's tick; see _auto_nudge_tick), and
-            # this WS thread racing its prev-swap could spend a transition uncorroborated
-            _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+            # T208 opt-in — kernel-side like autoNudge, gt-gated like every queued setting. Only a
+            # real apply acts immediately on turn-on (don't wait 4s) — a stood-down toggle is not
+            # new information — and the tick skips the dead-wait sweep: the death transition has
+            # ONE observer (the pusher's tick; see _auto_nudge_tick), and this WS thread racing
+            # its prev-swap could spend a transition uncorroborated
+            if _set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
+                _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:
-            _set_update_mode(str(msg["mode"]))      # feed gear → how romp handles new releases at boot
+            # feed gear → how romp handles new releases at boot; gt-gated like every queued setting
+            if _set_update_mode(str(msg["mode"]), gt=_gesture_ms(msg)) is None:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setFileEditing" and msg.get("enabled") is not None:
             # The viewer's Edit consent popup (the user 2026-08-22) — a kernel-side setting like
             # setAutoNudge, broadcast by federation.ts KERNEL_SETTING so one yes answers the mesh.
-            _set_file_editing(bool(msg["enabled"]))
+            # A stale gesture stamp stands down (a queued flush must not undo a newer choice).
+            if _set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
             # a cleared card drops any composer citation chip pointing INTO it (the user 2026-07-01) — the
             # goal is gone, so following up on it makes no sense. Chips can cite a SUB-goal of the card
@@ -32933,42 +33141,76 @@ class Handler(BaseHTTPRequestHandler):
             _set_colormap(str(msg["name"]))    # recency colormap chooser → recolours the feed on next push
         elif msg and msg.get("type") == "setPalette" and msg.get("name"):
             _set_palette(str(msg["name"]))     # gear "Session colors" → remap the fleet onto the chosen set
+        # The judge-tier picks below share one shape: apply through the validated setter with the
+        # message's gesture stamp (_gesture_ms — a stale stamp stands down; see _setting_stale),
+        # and only an APPLIED pick fans out, carrying the applied stamp `_jgt` so it orders the
+        # same way at every receiver. A stood-down or invalid pick propagates NOTHING — the
+        # re-propagation leg is exactly how one stale flush used to revert the whole mesh — and a
+        # STOOD-DOWN one additionally answers the delivering socket (_tell_stale_gesture) so the
+        # dashboard that made the losing gesture hears it.
         elif msg and msg.get("type") == "setJudgeModel" and msg.get("model"):
-            _set_judge_model(str(msg["model"]))     # gear "Triage model" dropdown → the judge uses it next pass
-            threading.Thread(target=_propagate_judge_settings,   # …and every linked kernel's judges with it
-                             args=({"judgeModel": str(msg["model"])},), daemon=True).start()
+            _jgt = _set_judge_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Triage model" dropdown → the judge uses it next pass
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,   # …and every linked kernel's judges with it
+                                 args=({"judgeModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setIndexModel" and msg.get("model"):
-            _set_index_model(str(msg["model"]))     # gear "Indexing model" dropdown
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"indexModel": str(msg["model"])},), daemon=True).start()
+            _jgt = _set_index_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Indexing model" dropdown
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"indexModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setJudgeEffort":
-            _set_judge_effort(str(msg.get("effort") or ""))   # gear "Triage effort" ("" = default/none)
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"judgeEffort": str(msg.get("effort") or "")},), daemon=True).start()
+            _jgt = _set_judge_effort(str(msg.get("effort") or ""), gt=_gesture_ms(msg))   # gear "Triage effort" ("" = default/none)
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"judgeEffort": str(msg.get("effort") or ""), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setIndexEffort":
-            _set_index_effort(str(msg.get("effort") or ""))   # gear "Indexing effort"
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"indexEffort": str(msg.get("effort") or "")},), daemon=True).start()
+            _jgt = _set_index_effort(str(msg.get("effort") or ""), gt=_gesture_ms(msg))   # gear "Indexing effort"
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"indexEffort": str(msg.get("effort") or ""), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setDistillModel" and msg.get("model"):
-            _set_distill_model(str(msg["model"]))   # gear "Distilling model" ("triage" = follow the triage pick)
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"distillModel": str(msg["model"])},), daemon=True).start()
+            _jgt = _set_distill_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Distilling model" ("triage" = follow the triage pick)
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"distillModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setDistillEffort" and msg.get("effort"):
-            _set_distill_effort(str(msg["effort"]))   # gear "Distilling effort" ("triage" = follow; "none" = pinned no-flag)
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"distillEffort": str(msg["effort"])},), daemon=True).start()
+            _jgt = _set_distill_effort(str(msg["effort"]), gt=_gesture_ms(msg))   # gear "Distilling effort" ("triage" = follow; "none" = pinned no-flag)
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"distillEffort": str(msg["effort"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setCommentModel" and msg.get("model"):
-            _set_comment_model(str(msg["model"]))   # gear "Comment model" ("session" = same as the session)
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"commentModel": str(msg["model"])},), daemon=True).start()
+            _jgt = _set_comment_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Comment model" ("session" = same as the session)
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"commentModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setCommentEffort" and msg.get("effort"):
-            _set_comment_effort(str(msg["effort"]))   # gear "Comment effort"
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"commentEffort": str(msg["effort"])},), daemon=True).start()
+            _jgt = _set_comment_effort(str(msg["effort"]), gt=_gesture_ms(msg))   # gear "Comment effort"
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"commentEffort": str(msg["effort"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
         elif msg and msg.get("type") == "setCommentFast" and msg.get("fast"):
-            _set_comment_fast(str(msg["fast"]))     # gear "Fast comment threads" ("on" / "session")
-            threading.Thread(target=_propagate_judge_settings,
-                             args=({"commentFast": str(msg["fast"])},), daemon=True).start()
+            _jgt = _set_comment_fast(str(msg["fast"]), gt=_gesture_ms(msg))     # gear "Fast comment threads" ("on" / "session")
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"commentFast": str(msg["fast"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client)
 
     def _ws(self):
         key = self.headers.get("Sec-WebSocket-Key")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3242,6 +3242,8 @@ def _gt_int(v):
 
 def _setting_stale(name, gt, applied_gt):
     """True when gesture `gt` must stand down against the store's last-applied stamp — loudly.
+    (The one QUIET case — an equal stamp carrying the same value, the gesture's own echo — is
+    decided by the callers through _gesture_echo BEFORE this check, so it never reaches here.)
     A stand-down is also recorded on THIS thread (_pop_stale_notice) so the WS branch that
     delivered the gesture can answer its own socket with a settingStale frame: the stderr line
     alone left the refusing kernel's verdict invisible to the dashboard that made the gesture
@@ -3255,6 +3257,17 @@ def _setting_stale(name, gt, applied_gt):
     sys.stderr.write("setting %s: stale gesture stood down (gesture %d <= applied %d) — "
                      "no apply, no propagation\n" % (name, gt, applied_gt))
     return True
+
+
+def _gesture_echo(gt, applied_gt, same_value):
+    """The gesture's own ECHO: an equal stamp carrying the value the store already holds. A judge
+    pick reaches every remote kernel twice with one gt — the dashboard's broadcast and the origin
+    kernel's fan-out — and whichever copy lands second is not stale news, it is the same news
+    again: nothing to apply, no settingStale toast for the user's own pick, no stand-down line on
+    every ordinary pick in a mesh (PR #879 review). Callers return None on True, BEFORE the
+    _setting_stale check, which keeps its loud verdict for an equal stamp carrying a DIFFERENT
+    value (determinism under identical clocks, never a coin flip)."""
+    return gt is not None and gt == applied_gt and bool(same_value)
 
 
 _stale_seen = threading.local()   # per-thread: the last _setting_stale stand-down (the WS reply seam)
@@ -3413,6 +3426,8 @@ def _set_auto_nudge(enabled, gt=None):
     dashboard WebSocket down with zero log output."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
+        if _gesture_echo(gt, _gt_int(d.get("gt")), bool(d.get("enabled")) == bool(enabled)):
+            return None                                # the same pick again: quietly nothing to do
         if _setting_stale("auto-nudge", gt, _gt_int(d.get("gt"))):
             return None
         d["enabled"] = bool(enabled)
@@ -3442,6 +3457,8 @@ def _set_compact_suggest(enabled, gt=None):
     authority from one (the gesture-time ordering block above _gesture_ms)."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
+        if _gesture_echo(gt, _gt_int(d.get("compactSuggestGt")), bool(d.get("compactSuggestEnabled")) == bool(enabled)):
+            return None
         if _setting_stale("compact-suggest", gt, _gt_int(d.get("compactSuggestGt"))):
             return None
         d["compactSuggestEnabled"] = bool(enabled)
@@ -3483,7 +3500,10 @@ def _set_file_editing(enabled, gt=None):
             prev = json.loads((jd.STATE / "file-editing.json").read_text())
         except Exception:
             prev = None
-        if _setting_stale("file-editing", gt, _gt_int(prev.get("gt")) if isinstance(prev, dict) else 0):
+        prev_gt = _gt_int(prev.get("gt")) if isinstance(prev, dict) else 0
+        if _gesture_echo(gt, prev_gt, isinstance(prev, dict) and bool(prev.get("enabled")) == bool(enabled)):
+            return None
+        if _setting_stale("file-editing", gt, prev_gt):
             return None
         stamp = gt if gt is not None else int(time.time() * 1000)
         try:
@@ -3545,6 +3565,8 @@ def _set_update_mode(mode, gt=None):
     if mode not in _UPDATE_MODES:
         return None
     with _SETTINGS_LOCK:
+        if _gesture_echo(gt, _update_mode_gt(), _update_mode() == mode):
+            return None
         if _setting_stale("update-mode", gt, _update_mode_gt()):
             return None
         stamp = gt if gt is not None else int(time.time() * 1000)
@@ -25682,6 +25704,8 @@ def _set_judge_state(fname, value, allowed, allow_empty=False, gt=None):
     if not (value in allowed or (allow_empty and value == "")):
         return None
     with _SETTINGS_LOCK:
+        if _gesture_echo(gt, _judge_state_gt(fname), jd._state_str(fname, "") == value):
+            return None
         if _setting_stale(fname, gt, _judge_state_gt(fname)):
             return None
         stamp = gt if gt is not None else int(time.time() * 1000)

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -36,10 +36,11 @@ class ApplySettings(unittest.TestCase):
         for f in ("judge-model", "index-model", "judge-effort", "index-effort",
                   "distill-model", "distill-effort",
                   "comment-model", "comment-effort", "comment-fast"):
-            try:
-                (km.jd.STATE / f).unlink()
-            except OSError:
-                pass
+            for name in (f, f + ".gt"):   # the value and its gesture-stamp sidecar (gesture ordering)
+                try:
+                    (km.jd.STATE / name).unlink()
+                except OSError:
+                    pass
 
     def test_distill_pair_applies_pins_and_reports_raw(self):
         # the ack answers the RAW stored value ("triage" = following the triage pick), matching
@@ -73,36 +74,39 @@ class ApplySettings(unittest.TestCase):
                          "garbage never reaches the files or `claude --model`")
 
     def test_an_older_propagated_value_never_overwrites_a_newer_pick(self):
-        # THE REPORTED STOMP (the user 2026-08-30): their Distilling pick kept resetting — any
-        # later-arriving propagation replaced a fresher local pick wholesale, because the apply had
-        # no notion of WHEN each value was picked. Now every propagated field carries its pick
-        # stamp, and older-or-equal never lands.
-        km._apply_judge_settings({"distillModel": "claude-opus-4-8"})   # the user's pick, mtime = now
-        res = km._apply_judge_settings({"distillModel": "triage",
-                                        "stamps": {"distillModel": time.time() - 3600}})
+        # THE REPORTED STOMP (the user 2026-08-30, whose Distilling pick kept resetting): any
+        # later-arriving propagation replaced a fresher local pick wholesale, because the apply
+        # had no notion of WHEN each value was picked. Every apply now orders by the ORIGIN
+        # GESTURE's stamp (the body-level `gt` every propagation leg forwards); older-or-equal
+        # stands down at the store. The per-field mtime "stamps" that first fixed this stomp are
+        # re-pinned here in gesture-stamp terms — one clock decides every write, at both hops.
+        now_ms = int(time.time() * 1000)
+        km._apply_judge_settings({"distillModel": "claude-opus-4-8", "gt": now_ms})
+        res = km._apply_judge_settings({"distillModel": "triage", "gt": now_ms - 3600 * 1000})
         self.assertEqual(res["distillModel"], "claude-opus-4-8",
                          "an hour-old peer value must not stomp the fresh pick")
-        newer = time.time() + 60
-        res = km._apply_judge_settings({"distillModel": "triage", "stamps": {"distillModel": newer}})
+        res = km._apply_judge_settings({"distillModel": "triage", "gt": now_ms + 60000})
         self.assertEqual(res["distillModel"], "triage", "a genuinely newer pick still lands")
-        self.assertAlmostEqual((km.jd.STATE / "distill-model").stat().st_mtime, newer, delta=1,
-                               msg="the ORIGIN's pick time rides the file, so recency survives re-fans")
+        self.assertEqual(km._judge_state_gt("distill-model"), now_ms + 60000,
+                         "the ORIGIN's gesture stamp rides the sidecar, so recency survives re-fans")
 
     def test_a_stampless_body_keeps_the_legacy_apply(self):
-        # an older kernel (or a manual curl) sends no stamps — it applies unconditionally, exactly
+        # an older kernel (or a manual curl) sends no gt — it applies unconditionally, exactly
         # as before; the stomp protection needs both ends on this code
         km._apply_judge_settings({"distillModel": "claude-opus-4-8"})
         res = km._apply_judge_settings({"distillModel": "haiku"})
         self.assertEqual(res["distillModel"], "haiku")
 
     def test_a_rejected_value_never_steals_the_stamp(self):
-        # garbage with a newer stamp: the setter refuses it, and the utime must NOT re-stamp the
-        # surviving old content with the new time (that would shadow-block the next honest pick)
-        km._apply_judge_settings({"judgeModel": "fable"})
-        t0 = (km.jd.STATE / "judge-model").stat().st_mtime
-        km._apply_judge_settings({"judgeModel": "gpt-99", "stamps": {"judgeModel": time.time() + 999}})
+        # garbage with a newer stamp: the setter refuses it BEFORE the ordering check
+        # (_set_judge_state validates first), so the sidecar must NOT advance — a burned stamp
+        # would shadow-block the next honest pick
+        now_ms = int(time.time() * 1000)
+        km._apply_judge_settings({"judgeModel": "fable", "gt": now_ms})
+        km._apply_judge_settings({"judgeModel": "gpt-99", "gt": now_ms + 999000})
         self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
-        self.assertEqual((km.jd.STATE / "judge-model").stat().st_mtime, t0)
+        self.assertEqual(km._judge_state_gt("judge-model"), now_ms,
+                         "a refused value never burns its gesture stamp")
 
     def test_distill_sentinel_returns_the_pair_to_follow_mode(self):
         km._apply_judge_settings({"distillModel": "haiku", "distillEffort": "high"})
@@ -169,24 +173,20 @@ class PropagateFansOut(unittest.TestCase):
     def test_every_up_kernel_with_an_admin_path_gets_the_pick(self):
         km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
             self.calls.append((r["host"], m, p, payload)) or (200, {"ok": True}, None))
-        try:
-            (km.jd.STATE / "judge-model").unlink()   # never picked here -> no stamp to carry
-        except OSError:
-            pass
         km._propagate_judge_settings({"judgeModel": "fable"})
         self.assertEqual(self.calls,
-                         [("boxup", "POST", "/judge-settings", {"judgeModel": "fable", "stamps": {}})],
+                         [("boxup", "POST", "/judge-settings", {"judgeModel": "fable"})],
                          "up + token only; a down row or one with no token is not an admin path")
 
-    def test_the_fanned_body_stamps_each_field_with_its_pick_time(self):
-        # the user 2026-08-30 ("my Distilling pick continually gets reset"): authority is per field
-        # and per PICK TIME — the stamp is the STATE file's own mtime, the pick event itself
+    def test_the_fanned_body_carries_the_origin_gesture_stamp(self):
+        # the user 2026-08-30 (whose Distilling pick kept resetting): authority is per PICK TIME.
+        # The fan forwards the BODY unchanged — including the origin gesture's `gt`, the same
+        # stamp the local store just applied — so every receiver orders by the one clock
+        # (test_setting_gesture_order.py pins the receiver side).
         km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
             self.calls.append(payload) or (200, {"ok": True}, None))
-        km._set_distill_model("claude-opus-4-8")
-        want = (km.jd.STATE / "distill-model").stat().st_mtime
-        km._propagate_judge_settings({"distillModel": "claude-opus-4-8"})
-        self.assertEqual(self.calls[0]["stamps"], {"distillModel": want})
+        km._propagate_judge_settings({"distillModel": "claude-opus-4-8", "gt": 1725000000000})
+        self.assertEqual(self.calls[0], {"distillModel": "claude-opus-4-8", "gt": 1725000000000})
 
     def test_a_miss_is_loud_and_names_the_machine(self):
         km._remote_kernel_call = lambda *a, **k: (None, None, "could not reach boxup's kernel: boom")
@@ -212,14 +212,22 @@ class OneHopNeverALoop(unittest.TestCase):
                       "a forwarded body never carries the flag — one hop, never a mesh loop")
 
     def test_every_gear_op_propagates_its_own_field(self):
-        for frag in ('args=({"judgeModel": str(msg["model"])},)',
-                     'args=({"indexModel": str(msg["model"])},)',
-                     'args=({"judgeEffort": str(msg.get("effort") or "")},)',
-                     'args=({"indexEffort": str(msg.get("effort") or "")},)',
-                     'args=({"commentModel": str(msg["model"])},)',
-                     'args=({"commentEffort": str(msg["effort"])},)',
-                     'args=({"commentFast": str(msg["fast"])},)'):
+        # each fan-out body carries the APPLIED gesture stamp `_jgt` (gesture-time ordering,
+        # 2026-08-29: receivers order by it too — see test_setting_gesture_order.py), and only
+        # an applied pick fans out at all (`_jgt is not None`): a stood-down or invalid one
+        # propagates nothing, since re-propagation is how a stale flush once reverted the mesh
+        for frag in ('args=({"judgeModel": str(msg["model"]), "gt": _jgt},)',
+                     'args=({"indexModel": str(msg["model"]), "gt": _jgt},)',
+                     'args=({"judgeEffort": str(msg.get("effort") or ""), "gt": _jgt},)',
+                     'args=({"indexEffort": str(msg.get("effort") or ""), "gt": _jgt},)',
+                     'args=({"distillModel": str(msg["model"]), "gt": _jgt},)',
+                     'args=({"distillEffort": str(msg["effort"]), "gt": _jgt},)',
+                     'args=({"commentModel": str(msg["model"]), "gt": _jgt},)',
+                     'args=({"commentEffort": str(msg["effort"]), "gt": _jgt},)',
+                     'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)'):
             self.assertIn(frag, self.src, frag)
+        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 9,
+                                "every judge-tier fan-out is gated on the pick actually applying")
 
     def test_the_gear_copy_says_the_pick_follows(self):
         with open(os.path.join(os.path.dirname(HERE), "ui", "webview", "gear.js")) as f:

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -475,7 +475,9 @@ class Wiring(unittest.TestCase):
         self.assertIn("id=rs-updates", self.gear)
         for opt in ("value=ask", "value=auto", "value=off"):
             self.assertIn(opt, self.gear)
-        self.assertIn("post({ type: 'setUpdateMode', mode: upm.value })", self.gear)
+        # the post is gesture-stamped (2026-08-29): setUpdateMode rides federation's queued
+        # KERNEL_SETTING class, so the kernel orders applies by the click's own time
+        self.assertIn("post({ type: 'setUpdateMode', mode: upm.value, gt: Date.now() })", self.gear)
         # fill() renders through setShow now (2026-09-01): the same silent write, plus the
         # honest marked-option injection when a stored value is off this page's list
         self.assertIn("setShow(upm, v.updateMode)", self.gear)

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -128,6 +128,30 @@ class GestureOrderAtTheStore(_Base):
         self.assertEqual(km._set_judge_model("fable", gt=T_NEW + 1), T_NEW + 1, "any newer stamp applies")
         self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
 
+    def test_an_equal_stamp_with_the_same_value_is_a_silent_echo(self):
+        # a judge pick reaches a remote kernel twice with one gt (dashboard broadcast + the origin
+        # kernel's fan-out); the second copy is the gesture's own echo — no stand-down line, no
+        # settingStale notice — while an equal stamp carrying a DIFFERENT value still stands down loudly
+        km._set_judge_model("opus", gt=T_NEW)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_judge_model("opus", gt=T_NEW), "nothing to apply")
+        self.assertEqual(err.getvalue(), "", "the echo is silent")
+        self.assertIsNone(km._pop_stale_notice(), "…and leaves no settingStale notice for the socket")
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "opus")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_judge_model("fable", gt=T_NEW))
+        self.assertIn("stale gesture stood down", err.getvalue(), "a differing equal-stamp gesture is still loud")
+        self.assertIsNotNone(km._pop_stale_notice())
+        # the same rule on a boolean setter
+        self.assertEqual(km._set_auto_nudge(False, gt=T_NEW), T_NEW)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_auto_nudge(False, gt=T_NEW))
+        self.assertEqual(err.getvalue(), "")
+        self.assertIsNone(km._pop_stale_notice())
+
     def test_auto_nudge_and_file_editing_order_the_same_way(self):
         self.assertEqual(km._set_auto_nudge(False, gt=T_NEW), T_NEW)
         with contextlib.redirect_stderr(io.StringIO()):

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""A kernel setting applies in GESTURE order, not arrival order (2026-08-29).
+
+Federation queues KERNEL_SETTING sends per host while a socket is down and flushes them on
+reconnect (ui/webview/federation.ts sendRemote/flushPending) — latest per TYPE, but only per TAB.
+A dashboard tab frozen for hours (a backgrounded phone, a throttled browser tab) can therefore
+re-dial and deliver a pick the user superseded from another device long ago. The kernel used to
+apply whatever arrived, and the judge tiers RE-PROPAGATE what they apply, so one stale flush
+walked every linked kernel back to the hours-old pick — and with the mesh then AGREEING, the
+gear's mixed-marks disagreement surface showed nothing. The standing rule (CLAUDE.md, cards):
+a writer whose evidence predates newer filed state stands down at the write moment.
+
+The mechanism under test (kernel/kernel.py), enforced at the authoritative store so every path
+is covered at once — live sends, queue flushes, racing dashboards, propagation legs:
+- dashboards stamp every setting gesture with `gt` (epoch ms captured at the click; a queued
+  flush carries the ORIGINAL stamp — pinned in ui/webview/federation-send-queue.test.ts),
+- each setting's store persists the last-APPLIED stamp beside the value (auto-nudge.json /
+  file-editing.json gain a "gt" field; the bare judge-tier stores gain a `<name>.gt` sidecar;
+  a store without the field reads as gt 0),
+- an arriving stamp older-or-equal to the stored one STANDS DOWN: no apply, no propagation,
+  one loud stderr line naming both stamps; a message with NO stamp (older dashboard, direct
+  HTTP caller) applies as it always did and records its arrival time.
+
+Synthetic everything: hermetic XDG state, placeholder hosts/tokens, stubbed transport. The WS
+handlers fan propagation out on a daemon thread; these tests swap the kernel's `threading`
+binding for a delegating namespace whose Thread runs inline, so every fan-out is observed
+synchronously and nothing sleeps.
+"""
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import threading as _real_threading
+import time
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_gestureorder", os.path.join(BIN, "romp-kernel")).load_module()
+
+T_OLD, T_NEW = 1_700_000_000_000, 1_700_000_360_000   # two gestures six minutes apart
+
+
+class _InlineThread:
+    """Thread stand-in for the WS handlers' propagation fan-out: start() runs the target
+    synchronously, so a test sees every propagation call without waiting on a real thread."""
+
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+        self._target, self._args, self._kwargs = target, args, (kwargs or {})
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+def _inline_threading():
+    """A namespace that answers like the real threading module except Thread runs inline.
+    Swapped onto km's MODULE GLOBAL only — the stdlib module itself is never touched, so
+    nothing outside the kernel module can pick the fake up."""
+    ns = types.SimpleNamespace(**{k: getattr(_real_threading, k)
+                                  for k in dir(_real_threading) if not k.startswith("_")})
+    ns.Thread = _InlineThread
+    return ns
+
+
+class _Base(unittest.TestCase):
+    """Fresh STATE per test; the WS handlers' side effects stubbed (nudge tick, tmux, threads,
+    the propagation fan-out recorded)."""
+
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        self._saved_state = km.jd.STATE
+        km.jd.STATE = Path(self._td)
+        km.jd._state_cache.clear()
+        km._autonudge_cache.clear()
+        self._saved = {n: getattr(km, n) for n in
+                       ("_propagate_judge_settings", "_auto_nudge_tick", "_tmux_sessions", "threading")}
+        self.propagated = []
+        km._propagate_judge_settings = self.propagated.append
+        km._auto_nudge_tick = lambda *a, **k: None
+        km._tmux_sessions = lambda: {}
+        km.threading = _inline_threading()
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            setattr(km, n, v)
+        km.jd.STATE = self._saved_state
+        km.jd._state_cache.clear()
+        km._autonudge_cache.clear()
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def dispatch(self, msg):
+        """Drive the real WS handler; returns what it wrote to stderr."""
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, {})
+        return err.getvalue()
+
+
+class GestureOrderAtTheStore(_Base):
+    """The setters themselves enforce the ordering, so every caller is covered."""
+
+    def test_a_stale_judge_pick_stands_down_loudly(self):
+        self.assertEqual(km._set_judge_model("opus", gt=T_NEW), T_NEW)
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "opus")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_judge_model("fable", gt=T_OLD), "older stamp must not apply")
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "opus", "the newer pick stands")
+        for needle in ("judge-model", str(T_OLD), str(T_NEW), "stood down"):
+            self.assertIn(needle, err.getvalue(), "the stand-down names the setting and both stamps")
+
+    def test_equal_stamps_keep_the_stored_value(self):
+        # determinism under identical clocks: equal gt → stand down, never a coin flip
+        km._set_judge_model("opus", gt=T_NEW)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_judge_model("fable", gt=T_NEW))
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "opus")
+        self.assertEqual(km._set_judge_model("fable", gt=T_NEW + 1), T_NEW + 1, "any newer stamp applies")
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+
+    def test_auto_nudge_and_file_editing_order_the_same_way(self):
+        self.assertEqual(km._set_auto_nudge(False, gt=T_NEW), T_NEW)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_auto_nudge(True, gt=T_OLD))
+        km._autonudge_cache.clear()
+        self.assertFalse(km._auto_nudge_on(), "the newer OFF survives the stale ON")
+        self.assertEqual(km._set_file_editing(True, gt=T_NEW), T_NEW)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_file_editing(False, gt=T_OLD))
+        self.assertTrue(km._file_editing_on(), "the newer consent survives the stale revoke")
+
+    def test_compact_suggest_orders_the_same_way_on_its_own_clock(self):
+        # T208 (2026-09-01): it shares auto-nudge.json but wears its
+        # OWN stamp key (compactSuggestGt) — ordering is per SETTING, so a compact-suggest gesture
+        # never outranks an auto-nudge one, or vice versa, just because they share a file.
+        self.assertEqual(km._set_compact_suggest(True, gt=T_NEW), T_NEW)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_compact_suggest(False, gt=T_OLD))
+        km._autonudge_cache.clear()
+        self.assertTrue(km._compact_suggest_on(), "the newer ON survives the stale OFF")
+        # the sibling setting's clock is untouched: an older-stamped auto-nudge gesture still
+        # applies, because the compact-suggest stamps above never landed on ITS key
+        self.assertEqual(km._set_auto_nudge(True, gt=T_OLD), T_OLD)
+
+    def test_an_unstamped_apply_still_arms_the_store_against_stale_flushes(self):
+        # compat is one-way on purpose: no gt applies as today (arrival-stamped), and that arrival
+        # stamp then outranks any hours-old stamped flush that shows up later
+        before = int(time.time() * 1000)
+        applied = km._set_judge_model("haiku")
+        self.assertIsInstance(applied, int)
+        self.assertGreaterEqual(applied, before, "an unstamped apply records its arrival time")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_judge_model("fable", gt=T_OLD))
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "haiku")
+
+    def test_an_invalid_value_never_writes_a_stamp(self):
+        self.assertIsNone(km._set_judge_model("gpt-99", gt=T_NEW), "garbage is refused, stamped or not")
+        self.assertFalse((km.jd.STATE / "judge-model").exists())
+        self.assertFalse((km.jd.STATE / "judge-model.gt").exists(),
+                         "a refused value must not burn its stamp — the store never heard it")
+
+
+class PreexistingStoresReadAsZero(_Base):
+    """File-format compat: every store written before this mechanism has no stamp, and must
+    read as gt 0 so the FIRST stamped gesture wins over it."""
+
+    def test_auto_nudge_json_without_the_field(self):
+        (km.jd.STATE / "auto-nudge.json").write_text(json.dumps(
+            {"enabled": True, "nudged": {"g1": {"count": 1}}}))
+        km._autonudge_cache.clear()
+        self.assertEqual(km._set_auto_nudge(False, gt=1), 1, "gt 1 beats the absent field's 0")
+        d = json.loads((km.jd.STATE / "auto-nudge.json").read_text())
+        self.assertFalse(d["enabled"])
+        self.assertEqual(d["gt"], 1)
+        self.assertEqual(d["nudged"], {"g1": {"count": 1}}, "the ledger the file also carries survives")
+
+    def test_file_editing_json_without_the_field(self):
+        (km.jd.STATE / "file-editing.json").write_text(json.dumps({"enabled": True}))
+        self.assertEqual(km._set_file_editing(False, gt=1), 1)
+        d = json.loads((km.jd.STATE / "file-editing.json").read_text())
+        self.assertEqual((d["enabled"], d["gt"]), (False, 1))
+
+    def test_judge_store_without_a_sidecar(self):
+        (km.jd.STATE / "judge-model").write_text("opus")
+        self.assertEqual(km._judge_state_gt("judge-model"), 0, "no sidecar reads as 0")
+        self.assertEqual(km._set_judge_model("fable", gt=1), 1)
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+
+
+class TheIncidentReplay(_Base):
+    """The failure that motivated this, driven through the real WS handler: host X was down when
+    the pick queued; the tab froze; a newer pick from another device ran the mesh; hours later the
+    old tab re-dialed and flushed the original pick."""
+
+    def test_a_stale_flush_cannot_walk_the_pick_back(self):
+        # the newer gesture (from the phone) landed first…
+        self.dispatch({"type": "setJudgeModel", "model": "fable", "gt": T_NEW})
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+        self.assertEqual(self.propagated, [{"judgeModel": "fable", "gt": T_NEW}],
+                         "an applied pick fans out carrying its own gesture stamp")
+        # …then the frozen tab woke and flushed the superseded one
+        err = self.dispatch({"type": "setJudgeModel", "model": "opus", "gt": T_OLD})
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable", "the store keeps the newer pick")
+        self.assertEqual(len(self.propagated), 1,
+                         "the stale flush propagates NOTHING — re-propagation is how one flush reverted a mesh")
+        for needle in ("judge-model", str(T_OLD), str(T_NEW), "stood down"):
+            self.assertIn(needle, err, "the stand-down is loud and names the stale and stored stamps")
+
+    def test_reverse_arrival_order_newest_gesture_wins(self):
+        # the race variant: same setting changed from two dashboards during one outage — both
+        # flush on recovery and SOCKET order used to decide; gesture order must decide instead
+        self.dispatch({"type": "setAutoNudge", "enabled": False, "gt": T_NEW})
+        self.dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_OLD})
+        km._autonudge_cache.clear()
+        self.assertFalse(km._auto_nudge_on(), "the newest gesture wins regardless of arrival order")
+        self.dispatch({"type": "setFileEditing", "enabled": True, "gt": T_NEW})
+        self.dispatch({"type": "setFileEditing", "enabled": False, "gt": T_OLD})
+        self.assertTrue(km._file_editing_on())
+
+    def test_an_unstamped_message_applies_exactly_as_before(self):
+        # full compat: an older dashboard, a peer kernel on older code, a direct HTTP caller
+        before = int(time.time() * 1000)
+        self.dispatch({"type": "setDistillModel", "model": "haiku"})
+        self.assertEqual((km.jd.STATE / "distill-model").read_text(), "haiku")
+        self.assertEqual(len(self.propagated), 1)
+        self.assertEqual(self.propagated[0]["distillModel"], "haiku")
+        self.assertGreaterEqual(self.propagated[0]["gt"], before,
+                                "the fan-out carries the arrival stamp so receivers stay ordered too")
+        # …and an unstamped message even beats a newer STORED stamp: old senders keep working
+        self.dispatch({"type": "setDistillModel", "model": "triage"})
+        self.assertEqual((km.jd.STATE / "distill-model").read_text(), "triage")
+
+
+class PropagationCarriesTheStamp(_Base):
+    """End to end: the origin's gt rides the /judge-settings leg, so a stale value can never win
+    at any receiver by arriving via a second hop."""
+
+    def setUp(self):
+        super().setUp()
+        km._propagate_judge_settings = self._saved["_propagate_judge_settings"]   # the real fan-out
+        self._saved_rkc, self._saved_rem = km._remote_kernel_call, dict(km._remotes)
+        km._remotes.clear()
+        km._remotes.update({"boxup": {"host": "boxup", "status": "up", "local_port": 1, "token": "t1"}})
+        self.calls = []
+        km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
+            self.calls.append((r["host"], m, p, payload)) or (200, {"ok": True}, None))
+
+    def tearDown(self):
+        km._remote_kernel_call = self._saved_rkc
+        km._remotes.clear()
+        km._remotes.update(self._saved_rem)
+        super().tearDown()
+
+    def test_the_forwarded_payload_carries_the_origin_gesture(self):
+        self.dispatch({"type": "setJudgeModel", "model": "fable", "gt": T_NEW})
+        self.assertEqual(self.calls, [("boxup", "POST", "/judge-settings",
+                                       {"judgeModel": "fable", "gt": T_NEW})])
+
+    def test_the_receiving_route_orders_by_the_forwarded_stamp(self):
+        # play the RECEIVER: /judge-settings applies through _apply_judge_settings, which must
+        # gate each field on the body-level gt — and never re-propagate (the one-hop contract,
+        # pinned in test_judge_settings_sync.py)
+        res = km._apply_judge_settings({"judgeModel": "fable", "gt": T_NEW})
+        self.assertEqual(res["judgeModel"], "fable")
+        with contextlib.redirect_stderr(io.StringIO()):
+            res = km._apply_judge_settings({"judgeModel": "opus", "gt": T_OLD})
+        self.assertEqual(res["judgeModel"], "fable", "the ack shows the newer pick still standing")
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+        self.assertEqual(self.calls, [], "a receiver applies without re-propagating")
+
+
+class UpdateModeOrders(_Base):
+    """setUpdateMode is in federation's queued KERNEL_SETTING class, so a frozen tab's flush can
+    deliver it hours late — and it used to apply unconditionally: a stale flush silently reverted
+    how this machine self-updates at boot (ask/auto/off). Gated exactly like _set_file_editing:
+    the stamp persists in update-mode.json beside the mode, a file without the field reads as 0."""
+
+    def test_a_stale_update_mode_flush_stands_down_loudly(self):
+        self.assertEqual(km._set_update_mode("auto", gt=T_NEW), T_NEW)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_update_mode("off", gt=T_OLD), "older stamp must not apply")
+        self.assertEqual(km._update_mode(), "auto", "the newer mode stands")
+        for needle in ("update-mode", str(T_OLD), str(T_NEW), "stood down"):
+            self.assertIn(needle, err.getvalue(), "the stand-down names the setting and both stamps")
+
+    def test_the_dispatch_branch_hands_the_stamp_over(self):
+        self.dispatch({"type": "setUpdateMode", "mode": "auto", "gt": T_NEW})
+        err = self.dispatch({"type": "setUpdateMode", "mode": "off", "gt": T_OLD})
+        self.assertEqual(km._update_mode(), "auto")
+        self.assertIn("stood down", err)
+
+    def test_the_stamp_persists_beside_the_mode(self):
+        km._set_update_mode("auto", gt=T_NEW)
+        d = json.loads((km.jd.STATE / "update-mode.json").read_text())
+        self.assertEqual((d["mode"], d["gt"]), ("auto", T_NEW))
+
+    def test_a_file_without_the_field_reads_as_zero(self):
+        # file-format compat: a mode written before the mechanism yields to any stamped gesture
+        (km.jd.STATE / "update-mode.json").write_text(json.dumps({"mode": "auto"}))
+        self.assertEqual(km._set_update_mode("off", gt=1), 1, "gt 1 beats the absent field's 0")
+        self.assertEqual(km._update_mode(), "off")
+
+    def test_an_unstamped_set_applies_and_arms_the_store(self):
+        before = int(time.time() * 1000)
+        applied = km._set_update_mode("off")
+        self.assertIsInstance(applied, int)
+        self.assertGreaterEqual(applied, before, "an unstamped apply records its arrival time")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_update_mode("auto", gt=T_OLD))
+        self.assertEqual(km._update_mode(), "off")
+
+    def test_an_invalid_mode_never_writes_a_stamp(self):
+        self.assertIsNone(km._set_update_mode("banana", gt=T_NEW))
+        self.assertFalse((km.jd.STATE / "update-mode.json").exists(),
+                         "a refused mode must not burn its stamp — the store never heard it")
+
+
+class TwoFlushRace(_Base):
+    """Check-then-write must be ATOMIC per setting: the stores read the stamp, check
+    _setting_stale, then write, on a ThreadingHTTPServer — so two near-simultaneous flushes
+    (two dashboards flushing one setting on a host's recovery) could both pass the check against
+    the same stored stamp and then land in SOCKET order, the exact inversion the mechanism
+    promises away. Deterministic, events only: the OLDER gesture is held between its check and
+    its write until the NEWER one has either fully landed (unserialized code — the bug) or
+    provably blocked on the settings lock (serialized code); no schedule depends on timing."""
+
+    def _race(self, older_call, newer_call):
+        old_checked = _real_threading.Event()
+        newer_progress = _real_threading.Event()
+        orig_check = km._setting_stale
+
+        def gated(name, gt, applied_gt):
+            r = orig_check(name, gt, applied_gt)
+            if _real_threading.current_thread().name == "older":
+                old_checked.set()          # the older gesture has read + checked the stored stamp…
+                newer_progress.wait(10)    # …and stalls before writing, until the newer one moves
+            return r
+
+        km._setting_stale = gated
+        real_lock = getattr(km, "_SETTINGS_LOCK", None)
+        if real_lock is not None:
+            class _Probe:                  # detect the newer flush BLOCKING on the held lock —
+                def __enter__(self):       # the event that releases the older one's stall
+                    if not real_lock.acquire(blocking=False):
+                        newer_progress.set()
+                        real_lock.acquire()
+                def __exit__(self, *a):
+                    real_lock.release()
+            km._SETTINGS_LOCK = _Probe()
+        try:
+            errs = []
+
+            def guarded(fn):
+                def run():
+                    try:
+                        fn()
+                    except Exception as e:   # base-shape signature errors must not hang the schedule
+                        errs.append(e)
+                    finally:
+                        old_checked.set()
+                        newer_progress.set()
+                return run
+
+            told = _real_threading.Thread(target=guarded(older_call), name="older")
+            told.start()
+            self.assertTrue(old_checked.wait(10), "the older gesture reached its ordering check")
+            tnew = _real_threading.Thread(
+                target=guarded(lambda: (newer_call(), newer_progress.set())), name="newer")
+            tnew.start()
+            told.join(10)
+            tnew.join(10)
+            self.assertFalse(told.is_alive() or tnew.is_alive(), "both flushes finished")
+        finally:
+            km._setting_stale = orig_check
+            if real_lock is not None:
+                km._SETTINGS_LOCK = real_lock
+
+    def test_judge_store_racing_flushes_land_in_gesture_order(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._race(lambda: km._set_judge_model("opus", gt=T_OLD),
+                       lambda: km._set_judge_model("fable", gt=T_NEW))
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable",
+                         "socket order must never beat gesture order between two racing flushes")
+        self.assertEqual(km._judge_state_gt("judge-model"), T_NEW)
+
+    def test_file_editing_racing_flushes_land_in_gesture_order(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._race(lambda: km._set_file_editing(False, gt=T_OLD),
+                       lambda: km._set_file_editing(True, gt=T_NEW))
+        d = json.loads((km.jd.STATE / "file-editing.json").read_text())
+        self.assertEqual((d["enabled"], d["gt"]), (True, T_NEW))
+
+    def test_update_mode_racing_flushes_land_in_gesture_order(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._race(lambda: km._set_update_mode("off", gt=T_OLD),
+                       lambda: km._set_update_mode("auto", gt=T_NEW))
+        self.assertEqual(km._update_mode(), "auto")
+
+
+class SidecarCrashSafety(_Base):
+    """The judge value file and its .gt sidecar are two writes. They must publish atomically and
+    SIDECAR FIRST: a crash between them then leaves the new stamp guarding the old value — a
+    legitimate re-send stands down once and the next change heals — where value-first left the
+    new value guarded by the OLD stamp, so a later stale gesture could invert the ordering. And
+    any write failure must be LOUD: the old `except OSError: return None` was a mute third
+    meaning of None (the callers' no-propagation gates silently skip the fan-out on it)."""
+
+    def _crash_on_write(self, n):
+        """Patch Path.write_text to raise OSError on call number `n` from now (both the raw
+        write_text shape and _atomic_write's temp-file write funnel through it)."""
+        import pathlib
+        counter = {"n": 0}
+        orig = pathlib.Path.write_text
+
+        def failing(p, *a, **k):
+            counter["n"] += 1
+            if counter["n"] == n:
+                raise OSError("simulated crash between the store's two writes")
+            return orig(p, *a, **k)
+
+        pathlib.Path.write_text = failing
+        return lambda: setattr(pathlib.Path, "write_text", orig)
+
+    def test_a_crash_between_the_writes_cannot_let_a_stale_gesture_invert(self):
+        self.assertEqual(km._set_judge_model("opus", gt=T_OLD), T_OLD)
+        restore = self._crash_on_write(2)
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertIsNone(km._set_judge_model("fable", gt=T_NEW),
+                                  "the interrupted pick reports not-applied")
+        finally:
+            restore()
+        # THE property: after the crash, a gesture older than the interrupted pick stands down
+        t_mid = (T_OLD + T_NEW) // 2
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._set_judge_model("haiku", gt=t_mid),
+                              "a stale gesture must never apply, whatever a crash left behind")
+        self.assertNotEqual((km.jd.STATE / "judge-model").read_text(), "haiku")
+        # …and the next legitimate change heals both files
+        self.assertEqual(km._set_judge_model("fable", gt=T_NEW + 1), T_NEW + 1)
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+        self.assertEqual(km._judge_state_gt("judge-model"), T_NEW + 1)
+
+    def test_the_crash_errs_toward_stand_down_never_inversion(self):
+        # the state a crash may leave: the STAMP advanced, the VALUE kept — never the reverse
+        self.assertEqual(km._set_judge_model("opus", gt=T_OLD), T_OLD)
+        restore = self._crash_on_write(2)
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                km._set_judge_model("fable", gt=T_NEW)
+        finally:
+            restore()
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "opus",
+                         "the value write never landed")
+        self.assertEqual(km._judge_state_gt("judge-model"), T_NEW,
+                         "the sidecar published FIRST — the safe direction")
+
+    def test_the_half_applied_state_is_loud(self):
+        km._set_judge_model("opus", gt=T_OLD)
+        restore = self._crash_on_write(2)
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._set_judge_model("fable", gt=T_NEW))
+        finally:
+            restore()
+        for needle in ("judge-model", "half-applied"):
+            self.assertIn(needle, err.getvalue().lower(),
+                          "the half-apply names itself on stderr — rollback is impossible, so be loud")
+
+    def test_a_failed_first_write_is_loud_and_applies_nothing(self):
+        restore = self._crash_on_write(1)
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._set_judge_model("fable", gt=T_NEW))
+        finally:
+            restore()
+        self.assertIn("judge-model", err.getvalue(), "an OSError refusal is never silent")
+        self.assertFalse((km.jd.STATE / "judge-model").exists())
+        self.assertFalse((km.jd.STATE / "judge-model.gt").exists())
+
+    def test_a_value_the_store_never_took_does_not_fan_out(self):
+        # KEPT behavior, now documented in the docstring: consistency over delivery — the mesh
+        # must never adopt a value the origin's own store refused.
+        restore = self._crash_on_write(2)
+        try:
+            err_txt = self.dispatch({"type": "setJudgeModel", "model": "fable", "gt": T_NEW})
+        finally:
+            restore()
+        self.assertEqual(self.propagated, [], "no propagation for a pick the store never took")
+        self.assertIn("judge-model", err_txt, "…and the refusal says so on stderr")
+
+
+class StoreWriteFailureIsLoudAndContained(_Base):
+    """A store write that fails (ENOSPC, a read-only STATE) must die INSIDE the setter — one loud
+    stderr line naming the setting, None returned (stood-down semantics: no apply, no tick, no
+    propagation) — and never escape it: the WS reader loop classifies a raised OSError as a
+    presumed socket failure and re-raises it into an outer silent pass, so a full-disk gear
+    toggle used to tear the dashboard's entire WebSocket down with zero log output.
+    _set_judge_state and _set_update_mode already hold this contract; these tests pin
+    _set_auto_nudge and _set_file_editing onto the same one."""
+
+    def _fail_writes(self):
+        """Patch Path.write_text to raise OSError on every call from now (both stores publish
+        via _atomic_write, whose temp-file write funnels through it)."""
+        import pathlib
+        orig = pathlib.Path.write_text
+
+        def failing(p, *a, **k):
+            raise OSError("simulated full disk")
+
+        pathlib.Path.write_text = failing
+        return lambda: setattr(pathlib.Path, "write_text", orig)
+
+    def test_auto_nudge_write_failure_is_loud_none_and_applies_nothing(self):
+        self.assertEqual(km._set_auto_nudge(True, gt=T_OLD), T_OLD)
+        restore = self._fail_writes()
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._set_auto_nudge(False, gt=T_NEW),
+                                  "a failed write reports not-applied — it never raises")
+        finally:
+            restore()
+        self.assertIn("auto-nudge", err.getvalue(), "the refusal names the setting on stderr")
+        km._autonudge_cache.clear()
+        self.assertTrue(km._auto_nudge_on(), "nothing applied — the store keeps the old value")
+
+    def test_file_editing_write_failure_is_loud_none_and_applies_nothing(self):
+        self.assertEqual(km._set_file_editing(True, gt=T_OLD), T_OLD)
+        restore = self._fail_writes()
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._set_file_editing(False, gt=T_NEW),
+                                  "a failed write reports not-applied — it never raises")
+        finally:
+            restore()
+        self.assertIn("file-editing", err.getvalue(), "the refusal names the setting on stderr")
+        self.assertTrue(km._file_editing_on(), "the consent the store holds survives the failed revoke")
+
+    def test_a_full_disk_gear_toggle_does_not_tear_the_ws_down(self):
+        # the incident shape, through the REAL dispatch: an OSError escaping the setter reaches
+        # the reader loop's `except (BrokenPipeError, ConnectionResetError, OSError): raise`,
+        # which hands it to an outer silent `pass` — connection dead, nothing logged. The
+        # setter's own stderr line must be the loudest thing that happens.
+        ticks = []
+        km._auto_nudge_tick = lambda *a, **k: ticks.append(a)
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        restore = self._fail_writes()
+        try:
+            for msg, name in (({"type": "setFileEditing", "enabled": True, "gt": T_NEW}, "file-editing"),
+                              ({"type": "setAutoNudge", "enabled": False, "gt": T_NEW}, "auto-nudge")):
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    try:
+                        km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+                    except OSError:
+                        self.fail("an OSError escaped _dispatch_ws (%s) — the reader loop "
+                                  "re-raises it as a socket failure and silently tears the "
+                                  "WebSocket down" % name)
+                self.assertIn(name, err.getvalue(), "the failure is loud and names the setting")
+        finally:
+            restore()
+        self.assertTrue(client["alive"], "the delivering client survives the failed write")
+        self.assertEqual(ticks, [], "a stood-down toggle fires no nudge tick — no new information")
+        self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [],
+                         "a write failure is not a stale gesture — no settingStale frame")
+
+
+class StaleGestureAnswersTheDeliveringSocket(_Base):
+    """A stood-down gesture used to be invisible to the dashboard that made it: one kernel stderr
+    line, while the open gear kept displaying the refused pick as applied — and with the mesh
+    AGREEING on the kept value, the mixed marks showed nothing. The WS branch that stands a
+    gesture down now answers the DELIVERING socket with a settingStale frame (the _reply idiom
+    the saveFile acks use); the gear toasts it and re-fills if open (ui/webview
+    setting-stale.test.ts pins that side). Event-keyed: the frame is the deciding event — no
+    polling, no timer."""
+
+    def dispatch_rec(self, msg):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        return sent
+
+    def test_a_stood_down_judge_pick_answers_settingStale(self):
+        self.dispatch_rec({"type": "setJudgeModel", "model": "fable", "gt": T_NEW})
+        sent = self.dispatch_rec({"type": "setJudgeModel", "model": "opus", "gt": T_OLD})
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(len(frames), 1, "the delivering socket hears exactly one stand-down frame")
+        self.assertEqual(frames[0]["setting"], "judge-model")
+        self.assertEqual(frames[0]["storedGt"], T_NEW)
+        self.assertEqual(frames[0]["kept"], "fable", "the kept value rides along (cheap: one store read)")
+
+    def test_every_gt_gated_setting_answers(self):
+        cases = [({"type": "setAutoNudge", "enabled": False}, {"type": "setAutoNudge", "enabled": True},
+                  "auto-nudge", False),
+                 # T208 rides the same door beside Auto Nudge
+                 ({"type": "setCompactSuggest", "enabled": True}, {"type": "setCompactSuggest", "enabled": False},
+                  "compact-suggest", True),
+                 ({"type": "setFileEditing", "enabled": True}, {"type": "setFileEditing", "enabled": False},
+                  "file-editing", True),
+                 ({"type": "setUpdateMode", "mode": "auto"}, {"type": "setUpdateMode", "mode": "off"},
+                  "update-mode", "auto"),
+                 ({"type": "setIndexEffort", "effort": "high"}, {"type": "setIndexEffort", "effort": "low"},
+                  "index-effort", "high"),
+                 ({"type": "setDistillModel", "model": "haiku"}, {"type": "setDistillModel", "model": "triage"},
+                  "distill-model", "haiku"),
+                 # the default-comment trio (2026-08-29) rides the same queued-class door, so it
+                 # gt-gates and answers the same way
+                 ({"type": "setCommentModel", "model": "haiku"}, {"type": "setCommentModel", "model": "session"},
+                  "comment-model", "haiku"),
+                 ({"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentEffort", "effort": "session"},
+                  "comment-effort", "high"),
+                 ({"type": "setCommentFast", "fast": "on"}, {"type": "setCommentFast", "fast": "session"},
+                  "comment-fast", "on")]
+        for newer, older, store, kept in cases:
+            sent = self.dispatch_rec(dict(newer, gt=T_NEW))
+            self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [],
+                             "an APPLIED gesture sends no frame (%s)" % store)
+            sent = self.dispatch_rec(dict(older, gt=T_OLD))
+            frames = [m for m in sent if m.get("type") == "settingStale"]
+            self.assertEqual(len(frames), 1, store)
+            self.assertEqual(frames[0]["setting"], store)
+            self.assertEqual(frames[0]["storedGt"], T_NEW)
+            self.assertEqual(frames[0]["kept"], kept, store)
+
+    def test_no_frame_for_invalid_or_unstamped(self):
+        sent = self.dispatch_rec({"type": "setJudgeModel", "model": "gpt-99", "gt": T_NEW})
+        self.assertEqual(sent, [], "a refused VALUE is not a stale gesture — no frame")
+        sent = self.dispatch_rec({"type": "setJudgeModel", "model": "haiku"})
+        self.assertEqual(sent, [], "the unstamped compat path applies — no frame")
+
+
+class WiringPins(unittest.TestCase):
+    """Source pins on the non-judge WS branches (the judge branches' propagation args are
+    pinned in test_judge_settings_sync.py): each must hand the message's stamp to its setter —
+    a branch that drops it reopens the unconditional-apply hole for that setting."""
+
+    def setUp(self):
+        import inspect
+        self.src = inspect.getsource(km.Handler._dispatch_ws)
+
+    def test_auto_nudge_branch_passes_the_stamp(self):
+        self.assertIn('_set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None', self.src,
+                      "the branch hands the stamp over and gates on the apply")
+
+    def test_file_editing_branch_passes_the_stamp(self):
+        self.assertIn('_set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg))', self.src)
+
+    def test_compact_suggest_branch_gates_on_the_stamp_and_skips_the_tick_on_stand_down(self):
+        # T208's WS branch mirrors setAutoNudge's: gt-gated, immediate tick only on a real apply
+        self.assertIn('_set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None', self.src)
+
+    def test_update_mode_branch_passes_the_stamp(self):
+        self.assertIn('_set_update_mode(str(msg["mode"]), gt=_gesture_ms(msg))', self.src)
+
+    def test_every_stood_down_branch_tells_the_delivering_socket(self):
+        self.assertGreaterEqual(self.src.count("_tell_stale_gesture(client)"), 13,
+                                "all thirteen gt-gated branches (four toggles + nine judge tiers) "
+                                "answer the delivering socket on a stand-down")
+
+    def test_the_docstring_names_all_three_none_causes(self):
+        doc = km._set_judge_state.__doc__ or ""
+        for needle in ("invalid", "stale", "OSError"):
+            self.assertIn(needle, doc, "None has exactly three named causes")
+        self.assertIn("propagat", doc, "the no-propagate-on-OSError behavior is documented, with its why")
+
+    def test_the_toggle_docstrings_name_the_write_failure_stand_down(self):
+        # the same contract _set_judge_state documents: None's write-failure cause is named, so a
+        # caller reading the docstring knows a full disk stands the gesture down rather than raising
+        for fn in (km._set_auto_nudge, km._set_compact_suggest, km._set_file_editing):
+            self.assertIn("OSError", fn.__doc__ or "",
+                          "%s documents the write-failure cause of None" % fn.__name__)
+
+    def test_both_judge_files_publish_atomically_sidecar_first(self):
+        import inspect
+        src = inspect.getsource(km._set_judge_state)
+        self.assertIn('_atomic_write(jd.STATE / (fname + ".gt")', src, "the sidecar publishes via _atomic_write")
+        self.assertIn("_atomic_write(jd.STATE / fname,", src, "the value publishes via _atomic_write")
+        self.assertNotIn(".write_text(", src, "no raw write_text — a torn write must not tear the store")
+        self.assertLess(src.index('fname + ".gt"'), src.index("_atomic_write(jd.STATE / fname,"),
+                        "the sidecar publishes FIRST — a crash between the two errs toward stand-down")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ui/webview/federation-send-queue.test.ts
+++ b/ui/webview/federation-send-queue.test.ts
@@ -1,0 +1,292 @@
+// Outbound kernel settings must survive socket churn (the user 2026-08-28, whose file-viewer Edit
+// consent vanished into a restarting kernel): during a kernel restart every federated socket churns
+// for a few seconds, and outbound() used to DROP any message routed to a host whose socket wasn't
+// OPEN — a warn toast, nothing in the client-diag journal, and no second chance. For the gear's
+// KERNEL_SETTING broadcasts that is a real loss: the Edit consent was OK'd mid-churn, the
+// setFileEditing broadcast rode a closed socket into the void, and the save was later refused by a
+// kernel that never heard the yes — with refusal copy pointing back at a popup already answered.
+//
+// The fix, two-sided:
+// - KERNEL_SETTING messages queue per connection while the socket is down — LATEST per type only
+//   (settings are latest-wins by nature; a reconnect must never replay a stale older value over the
+//   one chosen last) — and flush on the socket's OPEN event, before any post-reconnect traffic.
+//   That keeps the file viewer's "the consent lands before the save" ordering (file-view.ts posts
+//   setFileEditing, then enters edit mode) intact across a down-socket window.
+// - Non-setting messages keep their delivery behavior (replaying an arbitrary action minutes later
+//   can be worse than dropping it — a deliberate non-goal) but the drop leaves a client-diag
+//   breadcrumb naming the message type and target host, next to the warn toast: never silent.
+//
+// End-to-end through the real FederationManager (the withManager precedent in
+// multi-kernel-merge.test.ts): stub window/location/WebSocket, dial real conns, drive the sockets.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { FederationManager, REMOTE_STALE_MS, REMOTE_REDIAL_MS } from "./federation";
+
+const U = "11111111-2222-3333-4444-555555555555";
+
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+  readyState = 0; // CONNECTING, like a real just-dialed WebSocket
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) {
+    FakeSocket.instances.push(this);
+  }
+  send(s: string): void {
+    // the real browser refuses a send on a non-open socket — a fake that accepted one would hide
+    // exactly the misdelivery this suite exists to catch
+    if (this.readyState !== 1) throw new Error("send() on a socket that is not OPEN");
+    this.sent.push(s);
+  }
+  close(): void { this.readyState = 3; }
+  open(): void { this.readyState = 1; if (this.onopen) this.onopen(); }
+  types(): string[] { return this.sent.map((s) => JSON.parse(s).type); }
+}
+
+function withFed(fn: (fm: any, winEvents: any[], localSends: any[]) => void): void {
+  const g: any = globalThis;
+  const keys = ["window", "location", "WebSocket"] as const;
+  const had: Record<string, boolean> = {}, prev: Record<string, any> = {};
+  for (const k of keys) { had[k] = k in g; prev[k] = g[k]; }
+  const winEvents: any[] = [];
+  const localSends: any[] = [];
+  FakeSocket.instances = [];
+  g.window = {
+    dispatchEvent: (ev: any) => { if (ev && ev.data) winEvents.push(ev.data); return true; },
+    __rompLocalSend: (m: any) => localSends.push(m),
+  };
+  g.location = { protocol: "http:", host: "127.0.0.1:0", search: "" };
+  g.WebSocket = FakeSocket;
+  try {
+    fn(new FederationManager() as any, winEvents, localSends);
+  } finally {
+    for (const k of keys) { if (had[k]) g[k] = prev[k]; else delete g[k]; }
+  }
+}
+
+/** Dial a remote host through the real openRemote/connect path; returns its (CONNECTING) socket. */
+function attach(fm: any, host: string): FakeSocket {
+  fm.openRemote(host, "token-" + host, true);
+  return fm.conns.get(host).ws as FakeSocket;
+}
+
+/** The poll's re-dial (federation.ts's `if (c.live && …) this.connect(c)`), minus the fetch. */
+function redial(fm: any, host: string): FakeSocket {
+  fm.connect(fm.conns.get(host));
+  return fm.conns.get(host).ws as FakeSocket;
+}
+
+const diags = (localSends: any[], what: string) =>
+  localSends.filter((m) => m && m.type === "clientDiag" && m.surface === "federation" && m.what === what);
+
+test("a kernel setting sent while the socket is still CONNECTING is delivered on the open event", () => {
+  withFed((fm, _win, localSends) => {
+    const sock = attach(fm, "TESTHOSTA");
+    assert.equal(sock.readyState, 0, "just dialed — not open yet");
+    fm.outbound({ type: "setFileEditing", enabled: true });
+    // the LOCAL kernel's copy goes out at once (the pane shim's own queue covers the local socket)
+    assert.deepEqual(localSends.filter((m) => m.type === "setFileEditing"),
+      [{ type: "setFileEditing", enabled: true }]);
+    assert.deepEqual(sock.types(), [], "nothing can ride a CONNECTING socket");
+    sock.open();
+    assert.deepEqual(sock.types(), ["setFileEditing"], "the open event itself delivers the queued setting");
+    assert.deepEqual(JSON.parse(sock.sent[0]), { type: "setFileEditing", enabled: true });
+  });
+});
+
+test("a kernel setting sent while the socket is CLOSED rides the next reconnect (the re-dial path)", () => {
+  withFed((fm) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3; // the relay dropped (kernel restart) — the state the /tunnels poll re-dials on
+    fm.outbound({ type: "setAutoNudge", enabled: false });
+    assert.deepEqual(s1.sent.length, 0, "the dead socket carried nothing");
+    const s2 = redial(fm, "TESTHOSTA");
+    assert.notEqual(s2, s1, "the re-dial made a fresh socket");
+    s2.open();
+    assert.deepEqual(s2.types(), ["setAutoNudge"], "the queued setting flushes on the fresh socket's open");
+  });
+});
+
+test("latest-wins: two sends of one setting type while down deliver only the newest value", () => {
+  withFed((fm) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "setFileEditing", enabled: true });
+    fm.outbound({ type: "setJudgeModel", model: "m1" });
+    fm.outbound({ type: "setFileEditing", enabled: false }); // the user changed their mind while down
+    sock.open();
+    const msgs = sock.sent.map((s) => JSON.parse(s));
+    assert.deepEqual(msgs.map((m: any) => m.type).sort(), ["setFileEditing", "setJudgeModel"],
+      "one message per setting type, distinct types both flush");
+    const fe = msgs.filter((m: any) => m.type === "setFileEditing");
+    assert.equal(fe.length, 1, "the stale older value is never replayed");
+    assert.equal(fe[0].enabled, false, "the newest value wins");
+  });
+});
+
+test("a setting queued for one host never leaks to another, and a host that heard it live hears it once", () => {
+  withFed((fm) => {
+    const a = attach(fm, "TESTHOSTA"); // still CONNECTING — down at send time
+    const b = attach(fm, "TESTHOSTB");
+    b.open();
+    fm.outbound({ type: "setDistillModel", model: "m2" });
+    assert.deepEqual(b.types(), ["setDistillModel"], "the reachable host hears the broadcast live");
+    assert.deepEqual(a.types(), [], "the down host holds it queued");
+    a.open();
+    assert.deepEqual(a.types(), ["setDistillModel"], "the queued copy reaches its own host on open");
+    assert.deepEqual(b.types(), ["setDistillModel"], "…and the other host is not re-sent what it already heard");
+  });
+});
+
+test("a NON-setting drop stays a drop — but leaves a client-diag breadcrumb and the warn toast", () => {
+  withFed((fm, winEvents, localSends) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3;
+    fm.outbound({ type: "openSession", id: "TESTHOSTA:" + U });
+    const dg = diags(localSends, "senddrop");
+    assert.equal(dg.length, 1, "the drop is journaled, never silent");
+    assert.equal(dg[0].data.host, "TESTHOSTA");
+    assert.equal(dg[0].data.msgType, "openSession");
+    assert.ok(winEvents.some((m) => m.type === "warn" && /TESTHOSTA/.test(m.text || "")),
+      "the user-visible warn toast stays");
+    const s2 = redial(fm, "TESTHOSTA");
+    s2.open();
+    assert.deepEqual(s2.types(), [],
+      "a dropped action is never replayed later — a stale action can be worse than a dropped one");
+  });
+});
+
+test("the undoClear send site drops loudly too: diag + warn on a down socket", () => {
+  withFed((fm, winEvents, localSends) => {
+    attach(fm, "TESTHOSTA"); // still CONNECTING
+    fm.lastClearHost = "TESTHOSTA";
+    fm.outbound({ type: "undoClear" });
+    const dg = diags(localSends, "senddrop");
+    assert.equal(dg.length, 1);
+    assert.equal(dg[0].data.msgType, "undoClear");
+    assert.ok(winEvents.some((m) => m.type === "warn"), "the toast fires for this site as well");
+  });
+});
+
+test("flush ordering: a queued setting lands before any message sent after the reconnect", () => {
+  withFed((fm) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3;
+    fm.outbound({ type: "setFileEditing", enabled: true }); // the consent click, mid-churn
+    const s2 = redial(fm, "TESTHOSTA");
+    s2.open();
+    assert.deepEqual(s2.types(), ["setFileEditing"],
+      "the flush is synchronous with the open event — no timer, no later tick");
+    // the very next post-reconnect send (e.g. the file viewer retrying its save) must find the
+    // flag already landed — the same-ordered-socket guarantee, now across the down window
+    fm.outbound({ type: "fileSave", sid: "TESTHOSTA:" + U, text: "x" });
+    assert.deepEqual(s2.types(), ["setFileEditing", "fileSave"]);
+  });
+});
+
+// ── gesture stamps (2026-08-29): the queue's "latest per type" is latest per TAB only. A tab
+// frozen for hours (iOS always; Chrome tab-freeze) re-dials and flushes a pick the user has since
+// superseded from another device, and the kernel used to apply whatever arrived — so every
+// KERNEL_SETTING message now carries `gt`, epoch ms minted ONCE at the user's gesture, and the
+// kernel stands a stale stamp down at the store. That only works if this queue delivers the
+// ORIGINAL stamp: a re-stamp at send/flush time would forge freshness onto an hours-old pick.
+
+test("a queued setting's gesture stamp survives the queue and the flush unchanged", () => {
+  withFed((fm) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "setJudgeModel", model: "m1", gt: 1111 });
+    sock.open();
+    assert.deepEqual(JSON.parse(sock.sent[0]), { type: "setJudgeModel", model: "m1", gt: 1111 },
+      "the flush delivers the message byte-identical — gt is the kernel's ordering key");
+  });
+});
+
+test("latest-wins keeps the newest gesture's OWN stamp — never a blend of two messages", () => {
+  withFed((fm) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "setJudgeModel", model: "m1", gt: 1000 });
+    fm.outbound({ type: "setJudgeModel", model: "m2", gt: 2000 });
+    sock.open();
+    assert.deepEqual(sock.sent.map((s) => JSON.parse(s)),
+      [{ type: "setJudgeModel", model: "m2", gt: 2000 }]);
+  });
+});
+
+// ── composing with the relay sockets' liveness watchdog (2026-09-02): a socket OPEN but silent past
+// the keepalive bound is ABANDONED — handlers detached, closed for hygiene — and a fresh one dialed in
+// the same tick, so the redial itself opens exactly the window this queue exists for (the fresh socket
+// is CONNECTING). The queue lives on the Conn, not the socket: nothing sent in that window is lost, and
+// the flush rides the fresh socket's open like any other reconnect's.
+
+test("a setting sent after the watchdog abandons a quiet socket queues on the conn and flushes on the fresh socket's open", () => {
+  withFed((fm, _win, localSends) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    fm.watchdog(Date.now() + REMOTE_STALE_MS + 1);   // silent past the bound since its open → abandoned, redialed now
+    const s2 = FakeSocket.instances[1];
+    assert.ok(s2 && s2 !== s1, "the watchdog dialed a fresh socket in the same pass");
+    assert.equal(s2.readyState, 0, "…still CONNECTING: the window a send used to drop in");
+    assert.equal(fm.conns.get("TESTHOSTA").ws, s2, "the conn owns the fresh socket");
+    fm.outbound({ type: "setFileEditing", enabled: true, gt: 1234 });
+    assert.deepEqual(s1.sent, [], "nothing rides the abandoned socket");
+    assert.deepEqual(s2.sent, [], "nothing can ride a CONNECTING socket");
+    assert.equal(diags(localSends, "senddrop").length, 0, "a setting is queued, never dropped");
+    s2.open();
+    assert.deepEqual(s2.sent.map((s) => JSON.parse(s)), [{ type: "setFileEditing", enabled: true, gt: 1234 }],
+      "the fresh socket's open delivers it, stamp intact");
+    const open = diags(localSends, "hostconn").filter((d) => d.data.ev === "open").pop();
+    assert.deepEqual(open.data, { host: "TESTHOSTA", ev: "open", flushed: ["setFileEditing"] },
+      "the open breadcrumb names what the redial carried");
+  });
+});
+
+test("a setting queued on a CLOSED socket survives the watchdog's lost-timer redial and flushes on the fresh open", () => {
+  withFed((fm) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3;                                // closed under us with no onclose — no 2s retry armed
+    fm.outbound({ type: "setAutoNudge", enabled: false, gt: 5 });
+    assert.deepEqual(s1.sent, [], "the dead socket carried nothing");
+    fm.watchdog(Date.now() + REMOTE_REDIAL_MS + 1);  // the watchdog's own redial, not the onclose path
+    const s2 = FakeSocket.instances[1];
+    assert.ok(s2 && s2 !== s1, "redialed by the watchdog");
+    s2.open();
+    assert.deepEqual(s2.sent.map((s) => JSON.parse(s)), [{ type: "setAutoNudge", enabled: false, gt: 5 }]);
+  });
+});
+
+// Source pins, in the federation-remote-gate.test.ts style: the properties above hold only while
+// every remote send routes through the ONE queue-aware helper, and the flush hangs on the open
+// event itself — a raw `ws.send` site or a timer-based flush would reopen the hole quietly.
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+
+test("the queue and the flush never mint a timestamp — gt is stamped at the gesture, upstream of here", () => {
+  const seg = FED.slice(FED.indexOf("private sendRemote"), FED.indexOf("private dropWarn"));
+  assert.ok(seg.length > 0, "sendRemote + flushPending located");
+  assert.doesNotMatch(seg, /Date\.now\(/,
+    "a queued message's gt must be the ORIGINAL gesture's time — no re-stamp in the send path");
+});
+
+test("both outbound remote send sites route through sendRemote — no raw inline drop path remains", () => {
+  const outb = FED.slice(FED.indexOf("outbound(m: any): void {"), FED.indexOf("private dropWarn"));
+  assert.match(outb, /this\.sendRemote\(this\.lastClearHost, m\);/);
+  assert.match(outb, /this\.sendRemote\(r\.host, r\.msg\);/);
+  assert.doesNotMatch(outb, /readyState === 1\) c\.ws\.send/,
+    "the old drop-if-not-open inline sends must not come back");
+});
+
+test("the pending-settings flush rides the socket's open event, never a timer", () => {
+  const connectFn = FED.slice(FED.indexOf("private connect(conn: Conn)"));
+  const onopen = connectFn.slice(connectFn.indexOf("ws.onopen"), connectFn.indexOf("ws.onmessage"));
+  assert.match(onopen, /flushPending/, "onopen is the flush hook");
+  const flushFn = FED.slice(FED.indexOf("private flushPending"), FED.indexOf("private connect(conn: Conn)"));
+  assert.ok(flushFn.length > 0, "flushPending exists");
+  assert.doesNotMatch(flushFn, /setTimeout|setInterval/, "no timer anywhere in the flush");
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -593,6 +593,11 @@ interface Conn {
   live: boolean; // kernel reports this tunnel "up" — the only state in which its port is dialed
   lastRecv: number; // epoch ms of the last frame on the CURRENT socket (keepalives count); 0 = none yet
   connT: number;    // when the current socket's connect() attempt started — the watchdog's reference point
+  // KERNEL_SETTING messages that arrived while this host's socket was down, newest per type only —
+  // flushed on the socket's open event (sendRemote/flushPending). Bounded by construction: at most
+  // one entry per setting type. Lives on the CONN, not the socket, so it survives every re-dial —
+  // the onclose retry, the poll's, and the liveness watchdog's abandon-and-dial (watchdog()).
+  pending: Map<string, any>;
 }
 
 export class FederationManager {
@@ -679,7 +684,7 @@ export class FederationManager {
         dead.onopen = dead.onmessage = dead.onclose = dead.onerror = null;
         try { dead.close(); } catch (e) { /* already dying */ }
         c.ws = null;
-        this.connect(c);
+        this.connect(c);   // settings queued on the conn meanwhile ride the fresh socket's open (flushPending)
       } else if (v === "redial") {
         this.connect(c);
       }
@@ -865,9 +870,7 @@ export class FederationManager {
     // undoClear undoes the LAST clear, which may have gone to a remote kernel — follow it there.
     // (The kernel keeps its own cleared.jsonl; only the kernel that took the clear can undo it.)
     if (m && m.type === "undoClear" && this.lastClearHost !== LOCAL) {
-      const c = this.conns.get(this.lastClearHost);
-      if (c && c.ws && c.ws.readyState === 1) c.ws.send(JSON.stringify(m));
-      else this.dropWarn(this.lastClearHost, m);
+      this.sendRemote(this.lastClearHost, m);
       this.lastClearHost = LOCAL;
       return;
     }
@@ -878,11 +881,52 @@ export class FederationManager {
         const s = (window as any).__rompLocalSend;
         if (typeof s === "function") s(r.msg);
       } else {
-        const c = this.conns.get(r.host);
-        if (c && c.ws && c.ws.readyState === 1) c.ws.send(JSON.stringify(r.msg));
-        else this.dropWarn(r.host, r.msg);
+        this.sendRemote(r.host, r.msg);
       }
     }
+  }
+
+  // The ONE remote send path (the user 2026-08-28, whose mid-restart Edit consent never reached the
+  // file's kernel: during a kernel restart every socket churns for a few seconds, and a send in that
+  // window used to drop with only a toast). The liveness watchdog opens the same window on purpose —
+  // it abandons a quiet socket and dials a fresh one, CONNECTING for a moment — so this path covers a
+  // redial from any cause. When the socket isn't OPEN:
+  // - a KERNEL_SETTING queues on the conn, LATEST per type — settings are latest-wins by nature, so
+  //   the reconnect must never replay a stale older value over the one the user chose last — and
+  //   flushes on the socket's open event, before any post-reconnect traffic (flushPending).
+  //   "Latest per type" is latest per TAB only: another dashboard may pick again while this one is
+  //   frozen, so every KERNEL_SETTING carries `gt` (epoch ms minted at the user's gesture, where
+  //   the message is built) and the KERNEL orders applies by it, standing stale flushes down. The
+  //   queue's contract here is to deliver the message UNCHANGED — never re-stamp at send or flush
+  //   time, which would forge freshness onto an hours-old pick;
+  // - anything else keeps its behavior (replaying an arbitrary action minutes later can be worse
+  //   than dropping it — a deliberate non-goal) but the drop lands a client-diag breadcrumb naming
+  //   the type and host, beside the existing warn toast: a drop is never silent.
+  private sendRemote(host: string, msg: any): void {
+    const c = this.conns.get(host);
+    if (c && c.ws && c.ws.readyState === 1) {
+      c.ws.send(JSON.stringify(msg));
+      return;
+    }
+    if (c && msg && typeof msg.type === "string" && KERNEL_SETTING.has(msg.type)) {
+      c.pending.set(msg.type, msg); // not dropped — it rides the next open, so no toast here
+      return;
+    }
+    this.diag("senddrop", { host, msgType: (msg && msg.type) || "" });
+    this.dropWarn(host, msg);
+  }
+
+  /** Deliver the settings that arrived while this host's socket was down, on the open event itself —
+   *  synchronously, so they precede ANY post-reconnect traffic. The file viewer's consent flow relies
+   *  on exactly that: its setFileEditing broadcast must land before the save that follows the yes
+   *  (the same-socket ordering the save route's gate assumes), now across a down-socket window too.
+   *  Returns the flushed types for the open breadcrumb. */
+  private flushPending(conn: Conn): string[] {
+    if (!conn.pending.size || !conn.ws || conn.ws.readyState !== 1) return [];
+    const types = [...conn.pending.keys()];
+    for (const m of conn.pending.values()) conn.ws.send(JSON.stringify(m));
+    conn.pending.clear();
+    return types;
   }
 
   // A route to a host whose socket isn't open would otherwise VANISH — creating a session on an
@@ -964,7 +1008,7 @@ export class FederationManager {
     const w = dashboardWid();
     const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`
       + (w ? `&wid=${encodeURIComponent(w)}` : "");
-    const conn: Conn = { host, ws: null, url, closed: false, live, lastRecv: 0, connT: 0 };
+    const conn: Conn = { host, ws: null, url, closed: false, live, lastRecv: 0, connT: 0, pending: new Map() };
     this.conns.set(host, conn);
     this.ensureHost(host);
     this.connect(conn);
@@ -993,7 +1037,13 @@ export class FederationManager {
     }
     conn.ws = ws;
     ws.onopen = () => {
-      this.diag("hostconn", { host: conn.host, ev: "open" });
+      // settings queued while the socket was down go out FIRST — on the open event itself, never a
+      // timer — so nothing sent after the reconnect can overtake them (see flushPending). That is
+      // also why the relay-up dispatch below comes AFTER the flush: the chat's upload re-ship rides
+      // that event, and a re-shipped dropFile must not get ahead of a queued setting on this socket.
+      const flushed = this.flushPending(conn);
+      this.diag("hostconn", flushed.length ? { host: conn.host, ev: "open", flushed }
+                                           : { host: conn.host, ev: "open" });
       conn.lastRecv = Date.now();   // the watchdog measures this socket's silence from ITS open
       // this host's owed replies just became reachable again — the chat re-ships its pending
       // uploads on exactly this event (T215 review finding 2026-09-01: a remote kernel's restart
@@ -1029,7 +1079,11 @@ export class FederationManager {
   private closeRemote(host: string): void {
     const c = this.conns.get(host);
     if (!c) return;
-    this.diag("hostconn", { host, ev: "detach" });   // /tunnels no longer lists it → its cards drop NOW
+    // /tunnels no longer lists it → its cards drop NOW. A detach also discards any settings still
+    // queued for the host (the user removed it from the mesh; a later reattach re-syncs through the
+    // gear's mixed marks) — named in the breadcrumb, because a drop is never silent.
+    this.diag("hostconn", c.pending.size ? { host, ev: "detach", pendingDropped: [...c.pending.keys()] }
+                                         : { host, ev: "detach" });
     c.closed = true;
     try {
       c.ws && c.ws.close();

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -35,7 +35,8 @@ test("the banner is build-once, acknowledges, and offers Opus only for the Fable
     "built once — the button survives re-renders (click-safety)");
   assert.match(FEED, /btn\.textContent = "Switching…";\s*\n\s*\/\/ ?.*|btn\.textContent = "Switching…";/,
     "acknowledges before the kernel round-trip");
-  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setJudgeModel", model: "opus" \}\)/);
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setJudgeModel", model: "opus", gt: Date\.now\(\) \}\)/,
+    "the switch is a settings gesture like any gear pick — stamped so the kernel can order it");
   assert.match(FEED, /btn\.style\.display = fable \? "" : "none";/, "the switch offer is Fable-specific");
   assert.match(FEED, /The account's usage window is full/, "general exhaustion states it plainly");
   assert.match(FEED, /paintJudgeLimit\(\);   \/\/ the usage-limit banner above the columns/,

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4252,7 +4252,8 @@ function ensureJudgeLimit(): HTMLElement {
   btn.onclick = () => {
     btn.disabled = true;
     btn.textContent = "Switching…";                      // acknowledge before the round-trip
-    vscodeApi?.postMessage({ type: "setJudgeModel", model: "opus" });
+    // gt: a settings gesture like any gear pick — stamped at the click so the kernel can order it
+    vscodeApi?.postMessage({ type: "setJudgeModel", model: "opus", gt: Date.now() });
   };
   b.appendChild(btn);
   const sess = el("span", "jl-sess"); b.appendChild(sess);   // who the window actually touches (2026-08-28)

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -353,8 +353,10 @@ test("Edit is consent-gated, and the gate is the KERNEL's flag, not the button (
   assert.match(VIEW, /fetch\(kernelUrl\("\/version"\), \{ cache: "no-store" \}\)/);
   assert.match(VIEW, /\.fileEditing;/);
   // no flag → a plain-words popup; only a YES posts the opt-in, and it broadcasts (KERNEL_SETTING)
+  // — stamped with the gesture's own time, so a copy queued for a down host and flushed hours
+  // later can never outrank a newer pick at the kernel (the store orders applies by gt)
   assert.match(VIEW, /window\.confirm\(\s*\n?\s*"Allow editing files from the dashboard\?/);
-  assert.match(VIEW, /post\(\{ type: "setFileEditing", enabled: true \}\);/);
+  assert.match(VIEW, /post\(\{ type: "setFileEditing", enabled: true, gt: Date\.now\(\) \}\);/);
   // the popup's promise of a gear off-switch is real, and the save route refuses server-side
   const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
   assert.ok(GEAR.includes("'setFileEditing'"), "the gear can turn it back off");

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -342,7 +342,9 @@ export function openFileView(path: string, sid?: string | null): void {
       "Saves write straight to disk on the file's machine — and this applies on every machine " +
       "connected here. A session working in that folder is told when you edit under it.\n\n" +
       "You can turn this off later in the settings gear.")) return false;
-    post({ type: "setFileEditing", enabled: true });
+    // gt = the consent's own click time: federation queues this per host across a down socket, and
+    // the kernel orders applies by the stamp — a flush hours later must not outrank a newer gesture
+    post({ type: "setFileEditing", enabled: true, gt: Date.now() });
     return true;
   }
   editBtn.addEventListener("click", () => {

--- a/ui/webview/flicker-diag.test.ts
+++ b/ui/webview/flicker-diag.test.ts
@@ -27,9 +27,20 @@ test("feed: an item entering/leaving the model posts an itemset breadcrumb (ids 
 });
 
 test("federation: every remote socket open/close/detach posts a hostconn breadcrumb", () => {
-  assert.match(FED, /ws\.onopen = \(\) => \{\s*\n\s*this\.diag\("hostconn", \{ host: conn\.host, ev: "open" \}\);/);   // block body since the T215 relay-up dispatch joined it
+  // the open breadcrumb also names any queued settings it flushed, and the detach any it discarded
+  // (federation-send-queue.test.ts owns that queue's behavior) — the events themselves stay pinned here
+  assert.match(FED, /this\.diag\("hostconn", flushed\.length \? \{ host: conn\.host, ev: "open", flushed \}\s*\n\s*: \{ host: conn\.host, ev: "open" \}\);/);
+  // the open handler is a block body shared with the T215 relay-up dispatch (pending-attach.test.ts
+  // owns that event's wiring); the breadcrumb stays inside it, AFTER the flush and BEFORE the dispatch
+  // — a re-shipped upload rides that event and must not overtake a queued setting on this socket
+  const onopen = FED.slice(FED.indexOf("ws.onopen = () => {"), FED.indexOf("ws.onmessage"));
+  assert.ok(onopen.length > 0, "ws.onopen block located");
+  const flushAt = onopen.indexOf("this.flushPending(conn)");
+  const crumbAt = onopen.indexOf('this.diag("hostconn"');
+  const relayAt = onopen.indexOf('"romp:hostRelayUp"');
+  assert.ok(flushAt >= 0 && crumbAt > flushAt && relayAt > crumbAt, "onopen order: flush, breadcrumb, relay-up dispatch");
   assert.match(FED, /this\.diag\("hostconn", \{ host: conn\.host, ev: "close", code: ev\.code, clean: ev\.wasClean, detached: conn\.closed \}\);/);
-  assert.match(FED, /this\.diag\("hostconn", \{ host, ev: "detach" \}\);/);
+  assert.match(FED, /this\.diag\("hostconn", c\.pending\.size \? \{ host, ev: "detach", pendingDropped: \[\.\.\.c\.pending\.keys\(\)\] \}\s*\n\s*: \{ host, ev: "detach" \}\);/);
   // breadcrumbs ride the LOCAL kernel socket into the same client-diag journal the feed writes
   assert.match(FED, /s\(\{ type: "clientDiag", surface: "federation", what, data \}\);/);
 });

--- a/ui/webview/gear-judge-versions.test.ts
+++ b/ui/webview/gear-judge-versions.test.ts
@@ -32,5 +32,5 @@ test("caret faces RIGHT everywhere; the submenu side is measured with the right 
 
 test("the kernel accepts version ids on every judge tier", () => {
   assert.match(KERNEL, /_JUDGE_MODEL_VALUES = _MODEL_VALUES \| set\(_VERSION_FAMILY\)/);
-  assert.match(KERNEL, /_set_judge_state\("distill-model", v, _JUDGE_MODEL_VALUES \| \{"triage"\}\)/);
+  assert.match(KERNEL, /_set_judge_state\("distill-model", v, _JUDGE_MODEL_VALUES \| \{"triage"\}, gt=gt\)/);
 });

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -142,6 +142,28 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 .ra-li b { color: var(--text-bright, #e8eaed); font-weight: 600; }
 .ra-sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; flex: 0 0 auto; }
 .ra-note { color: var(--text-muted, #9aa0a6); font-size: 11px; border-top: 1px solid var(--hairline, #3a3a3a); padding-top: 7px; }
+/* settingStale toasts (gear.js staleToast): the kernel stood a settings gesture down because a
+   newer one had already applied — the same top-right warn-toast treatment the chat uses, carried
+   HERE because the gear ships to panes that load only this sheet. Above the modal dim (z 60/70)
+   so the notice reads over an open gear. Dismissal is the family standard too (the user
+   2026-08-25): visible ✕, Escape, fade — copied from styles.css .warn-toast/.warn-toast-x in this
+   sheet's literal palette, since the gear's hosts don't load styles.css's vars. */
+#rs-stale-toasts { position: fixed; top: 44px; right: 14px; z-index: 80;
+  display: flex; flex-direction: column; gap: 8px; max-width: 340px; }
+.rs-stale-toast { display: flex; align-items: flex-start; gap: 8px;
+  padding: 8px 12px; border-radius: 6px; cursor: pointer; background: var(--surface-raised, #252526);
+  border: 1px solid var(--vscode-errorForeground, #f48771); color: var(--fg, #ccc);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  font: 12px/1.5 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  transition: opacity 0.7s ease; }
+.rs-stale-toast-msg { min-width: 0; }
+/* the dismiss ✕ — the family's chip-✕ dress (dim at rest, separate, hover-brightens); the whole
+   toast still click-dismisses, this makes the way out VISIBLE (the user 2026-08-25) */
+.rs-stale-toast-x { flex: 0 0 auto; border: none; background: none; cursor: pointer;
+  color: var(--text-muted, #9aa0a6);
+  font-size: 11px; line-height: 1.4; padding: 2px 4px; border-radius: 8px; }
+.rs-stale-toast-x:hover { color: var(--fg, #fff); background: rgba(255, 255, 255, 0.08); }
+.rs-stale-toast.fade { opacity: 0; }
 
 /* the login paste-code MODAL (the user 2026-08-30): the panel treatment — centered card over a
    translucent backdrop, everything behind dimmed but visible; menus vocabulary card chrome. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -434,13 +434,18 @@ function initGear(post) {
   // Each attached kernel keeps its own copy, so the post goes to all of them
   // (federation.ts KERNEL_SETTING) — which is also what resolves a split box:
   // the click picks one answer and every machine takes it.
+  // Every KERNEL_SETTING post carries `gt`: epoch ms minted HERE, at the click. Federation queues
+  // these per host while a socket is down and flushes them on reconnect, so a delayed copy must
+  // carry the ORIGINAL gesture's time — the kernel orders applies by it and stands a stale flush
+  // down instead of walking the mesh back to an hours-old pick (a frozen tab's flush did exactly
+  // that). Stamp in the message literal, never at send/flush time.
   if (an) an.addEventListener('change', function () {
     clearAutoNudgeSplit();
-    post({ type: 'setAutoNudge', enabled: an.checked });
+    post({ type: 'setAutoNudge', enabled: an.checked, gt: Date.now() });
   });
-  if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked }); });
+  if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked, gt: Date.now() }); });
   if (cvm) cvm.addEventListener('change', function () { post({ type: 'setConserve', enabled: cvm.checked }); });
-  if (csg) csg.addEventListener('change', function () { post({ type: 'setCompactSuggest', enabled: csg.checked }); });
+  if (csg) csg.addEventListener('change', function () { post({ type: 'setCompactSuggest', enabled: csg.checked, gt: Date.now() }); });
   // ── the in-dashboard LOGIN flow (T157): the dashboard is already on the phone over Tailscale,
   // so streaming the CLI's paste-code OAuth URL here IS the phone login. The code input is a pure
   // pass-through to the kernel's PTY — nothing is stored or logged on any side.
@@ -513,7 +518,7 @@ function initGear(post) {
   });
   if (lgI) lgI.addEventListener('keydown', function (e) { if (e.key === 'Enter' && lgSend) lgSend.click(); });
   if (lgX) lgX.addEventListener('click', function () { lgModal(false); post({ type: 'loginCancel' }); if (lgTimer) { clearTimeout(lgTimer); lgTimer = null; } lgRender({ login: { state: '' } }); });
-  if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
+  if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value, gt: Date.now() }); });
   // The judge MODEL pickers mirror the session pickers (the user 2026-08-25): families top-level,
   // clicking a family sends its /models `default` (the user's remembered version), hover or
   // ArrowRight reveals a side submenu of versions. The native select stays (hidden) as the VALUE
@@ -640,12 +645,12 @@ function initGear(post) {
     versionMenu(cmm, [{ value: 'session', label: 'Same as the session', versions: [] },
                       { value: 'default', label: 'Default', versions: [] }]);
   });
-  if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value }); });
-  if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
-  if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value }); });
-  if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value }); });
-  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value }); });
-  if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value }); });
+  if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value, gt: Date.now() }); });
+  if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value, gt: Date.now() }); });
+  if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value, gt: Date.now() }); });
+  if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value, gt: Date.now() }); });
+  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value, gt: Date.now() }); });
+  if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value, gt: Date.now() }); });
   // Fast is an Opus-only research preview (render.ts fastAvailable, the same rule): a pinned
   // non-Opus comment model makes the box a dead control, so it disables — and a model pick that
   // strands a checked box also unchecks it, visibly, as part of the user's own gesture (never a
@@ -658,12 +663,12 @@ function initGear(post) {
     cmf.disabled = !can;
     if (!can && cmf.checked && fromModelPick) {
       cmf.checked = false;
-      post({ type: 'setCommentFast', fast: 'session' });
+      post({ type: 'setCommentFast', fast: 'session', gt: Date.now() });
     }
   }
-  if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value }); cmtFastGate(true); });
-  if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value }); });
-  if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session' }); });
+  if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value, gt: Date.now() }); cmtFastGate(true); });
+  if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value, gt: Date.now() }); });
+  if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session', gt: Date.now() }); });
   // feed-colormap preview bar: a horizontal gradient of the SELECTED map's stops (mirrors render.ts COLORMAPS).
   var CMAPS = { aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],
     hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -719,6 +719,64 @@ function initGear(post) {
       dd.value = m.path; dd.dispatchEvent(new Event('change'));
     }
   });
+  // A stood-down gesture must be visible to the dashboard that made it (2026-08-29). When a
+  // settings gesture loses the ordering race (a frozen tab's queued flush, or a click here that a
+  // newer pick elsewhere outranks), the kernel answers the DELIVERING socket with a settingStale
+  // frame — without it the refusal was one kernel stderr line: this modal kept displaying the
+  // refused pick as applied (fill() runs only on open), and with every kernel AGREEING on the
+  // kept value the mixed marks show nothing. Event-keyed: the frame IS the deciding event — toast
+  // it in plain words and re-read the kernel's actual values if the modal is up. No polling.
+  var STALE_LABELS = { 'auto-nudge': 'Auto Nudge', 'compact-suggest': 'Suggest /compact',
+    'file-editing': 'File editing',
+    'update-mode': 'Automatic updates', 'judge-model': 'Triage model', 'judge-effort': 'Triage effort',
+    'index-model': 'Indexing model', 'index-effort': 'Indexing effort',
+    'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
+    'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
+    'comment-fast': 'Fast comment threads' };
+  // Dismissal is the warn-toast FAMILY treatment (the user 2026-08-25: a notice with no visible
+  // way out gets in the way — worst on touch, and this toast's mint site is a frozen phone tab
+  // flushing on recovery): a visible ✕ in the chip-✕ dress, the whole toast still click-dismisses,
+  // Escape clears the stack, and the fade precedes the auto-remove. COPIED from the family home
+  // (render.ts warnToast + styles.css .warn-toast-x) because the gear is its own document, loaded
+  // by panes that ship only this sheet — keep the two in step (setting-stale.test.ts pins this copy).
+  function staleToast(text) {
+    var box = document.getElementById('rs-stale-toasts');
+    if (!box) {   // created once; dismissal delegated to the STABLE container (click-safe rule)
+      box = document.createElement('div'); box.id = 'rs-stale-toasts';
+      box.addEventListener('click', function (e2) {
+        var t = e2.target;
+        while (t && t !== box && !(t.classList && t.classList.contains('rs-stale-toast'))) t = t.parentNode;
+        if (t && t !== box) t.remove();
+      });
+      // Escape clears the stack, additively — never stopPropagation: clearing a toast is
+      // noise-removal, not a key any other surface loses (family rule, render.ts warnToast)
+      document.addEventListener('keydown', function (e2) {
+        if (e2.key === 'Escape') Array.prototype.slice.call(box.children).forEach(function (w) { w.remove(); });
+      });
+      document.body.appendChild(box);
+    }
+    var t = document.createElement('div');
+    t.className = 'rs-stale-toast'; t.setAttribute('role', 'status'); t.title = 'click to dismiss';
+    var txt = document.createElement('span');
+    txt.className = 'rs-stale-toast-msg'; txt.textContent = text;
+    var x = document.createElement('button');
+    x.className = 'rs-stale-toast-x'; x.setAttribute('aria-label', 'Dismiss'); x.title = 'dismiss (Esc)';
+    x.textContent = '✕';   // clicks bubble to the container's delegated dismiss, like the family's
+    t.appendChild(txt); t.appendChild(x);
+    box.appendChild(t);
+    setTimeout(function () { t.classList.add('fade'); }, 11000);   // the family fade first…
+    setTimeout(function () { t.remove(); }, 12000);   // …then the self-clearing backstop; a click/Esc dismisses sooner
+  }
+  window.addEventListener('message', function (e) {
+    var m = e.data;
+    if (!m || m.type !== 'settingStale') return;
+    var label = STALE_LABELS[m.setting] || String(m.setting || 'A setting');
+    var kept = m.kept === true ? 'on' : m.kept === false ? 'off'
+      : (typeof m.kept === 'string' && m.kept ? m.kept : '');
+    staleToast(label + ' changed more recently somewhere else — keeping the newer choice'
+      + (kept ? ' (' + kept + ')' : '') + '.');
+    if (!p.hidden) fill();   // the open modal re-reads the kernel's values so it stops showing the refused pick
+  });
   // The model/effort <option>s come from /models — the same single source the
   // chat + timeline pickers use. Cached after the first successful fetch.
   var choices = null;

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -50,6 +50,43 @@ test("the gear posts kernel ops through ONE shared channel (never re-acquires th
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 
+test("EVERY queued-class kernel setting is emitted with its gesture time (completeness-pinned to federation's own set)", () => {
+  // federation queues KERNEL_SETTING sends per host across a down socket and flushes them on
+  // reconnect (federation-send-queue.test.ts), and the kernel orders applies by `gt`, standing
+  // stale stamps down — so the stamp must be minted at the CLICK, inside the message literal
+  // itself, never at send or flush time (a late flush must carry the original gesture's time).
+  // This pin reads federation.ts's ACTUAL KERNEL_SETTING set rather than enumerating literals:
+  // an earlier six-literal enumeration let three members (setJudgeEffort, setIndexEffort,
+  // setUpdateMode) ship unstamped, and an unstamped member is WORSE than the pre-gt world — its
+  // stale flush takes the no-stamp compat path, records a forged-fresh arrival stamp, and the
+  // judge tiers fan that stamp mesh-wide over genuinely newer gestures. Adding a member without
+  // a stamped emitter goes red here: zero emitters found, or an emitter literal without gt.
+  const FED = read("ui", "webview", "federation.ts");
+  const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(setSrc, "federation.ts's KERNEL_SETTING set located");
+  const members = Array.from(setSrc![1].matchAll(/"([A-Za-z]+)"/g)).map((m) => m[1]);
+  assert.ok(members.length >= 9, `the set parsed (${members.length} members)`);
+  // scan every webview source that could emit one (the gear, the file viewer's consent post,
+  // the feed's judge-limit switch, and any future emitter under ui/webview)
+  const srcDir = path.join(ROOT, "ui", "webview");
+  const sources = fs.readdirSync(srcDir)
+    .filter((f) => (f.endsWith(".ts") || f.endsWith(".js")) && !f.endsWith(".test.ts") && f !== "federation.ts")
+    .map((f) => ({ f, text: fs.readFileSync(path.join(srcDir, f), "utf8") }));
+  for (const type of members) {
+    let emitters = 0;
+    for (const { f, text } of sources) {
+      const re = new RegExp(`\\{\\s*type:\\s*['"]${type}['"][^}]*\\}`, "g");
+      for (const lit of text.match(re) || []) {
+        emitters++;
+        assert.match(lit, /\bgt:\s*Date\.now\(\)/,
+          `${f} must stamp the gesture time inside the ${type} message literal itself: ${lit}`);
+      }
+    }
+    assert.ok(emitters >= 1,
+      `a stamped emitter exists for ${type} — a queued setting nobody stamps rides the compat path with a forged-fresh stamp`);
+  }
+});
+
 test("model/effort options are written exactly once — the single-flight /models fetch (2026-08-30)", () => {
   // The user's "my Distilling pick keeps resetting": fillChoices memoized its RESULT, so a settings
   // open racing the page-load fetch fired a second /models fetch, and whichever resolved last
@@ -147,8 +184,9 @@ test("the /compact suggestion is a real settings checkbox beside Auto Nudge (the
   assert.ok(GEAR.indexOf("id=rs-autonudge") < at && at < GEAR.indexOf("id=rs-conserve"),
     "…directly after Auto Nudge, where the user asked for it");
   assert.ok(/csg\.addEventListener\('change'/.test(GEAR)
-    && GEAR.includes("post({ type: 'setCompactSuggest', enabled: csg.checked })"),
-    "the click posts the kernel's designed setCompactSuggest message");
+    && GEAR.includes("post({ type: 'setCompactSuggest', enabled: csg.checked, gt: Date.now() })"),
+    "the click posts the kernel's designed setCompactSuggest message — gesture-stamped, like "
+    + "every kernel-side setting the gear emits");
   assert.ok(GEAR.includes("csg.checked = !!v.compactSuggest"),
     "…and the box always shows the kernel's persisted answer, never a page default");
   assert.ok(GEAR.includes("['compactSuggest', csg]"),

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -1,0 +1,82 @@
+// A stood-down settings gesture must be visible to the dashboard that made it (2026-08-29).
+// The kernel's gesture-time ordering (tests/test_setting_gesture_order.py) stands a stale
+// gesture down at the store — but the only output used to be one kernel stderr line: the open
+// gear kept displaying the refused pick as applied (fill() runs only on openSettings), and since
+// the mesh then AGREES on the kept value, the mixed marks show nothing either. Event-keyed fix,
+// no polling: the WS branch that stands a gesture down answers the DELIVERING socket with a
+// small {type:"settingStale", setting, storedGt, kept} frame (the same targeted _reply idiom the
+// saveFile acks use), and the gear — the shared module both hosts load — toasts it in plain
+// words and re-fills itself if it is open. The kernel-side semantics are behavior-tested in
+// test_setting_gesture_order.py; no jsdom harness for these renderers, so the wiring is pinned
+// at the source (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
+const GEAR = read("ui", "webview", "gear.js");
+const GEAR_CSS = read("ui", "webview", "gear.css");
+const KERNEL = read("kernel", "kernel.py");
+
+test("the kernel answers the delivering socket with a settingStale frame — the _reply idiom", () => {
+  assert.match(KERNEL, /def _tell_stale_gesture\(client\)/, "the reply helper exists");
+  assert.ok(KERNEL.includes('"type": "settingStale"'), "the frame is the settingStale type");
+  const helper = KERNEL.slice(KERNEL.indexOf("def _tell_stale_gesture"), KERNEL.indexOf("def _tell_stale_gesture") + 2000);
+  assert.match(helper, /_reply\(client,/, "targeted reply on ONE socket — never a broadcast");
+  // every queued-class WS branch answers on its stand-down path (9 = autoNudge, fileEditing,
+  // updateMode + the six judge tiers)
+  const sites = KERNEL.match(/_tell_stale_gesture\(client\)/g) || [];
+  assert.ok(sites.length >= 9, `every gt-gated branch tells the delivering socket (got ${sites.length})`);
+});
+
+test("the gear hears the frame: a plain-words toast, and a re-fill only while the modal is open", () => {
+  assert.ok(GEAR.includes("'settingStale'"), "the gear listens for the frame");
+  // re-engagement is event-keyed: the frame triggers the re-fill; no timer, no polling
+  const seg = GEAR.slice(GEAR.indexOf("'settingStale'") - 600, GEAR.indexOf("'settingStale'") + 1600);
+  assert.match(seg, /if \(!p\.hidden\) fill\(\);/, "an OPEN gear re-reads the kernel's actual values; a closed one fills on its next open anyway");
+  assert.doesNotMatch(seg, /setInterval|setTimeout\(fill/, "no polling — the frame IS the event");
+  assert.ok(GEAR.includes("changed more recently"), "the toast says what happened in plain words");
+  assert.ok(GEAR.includes("staleToast"), "the dropWarn-style toast renderer exists");
+});
+
+test("the toast is click-safe and self-clearing, styled by the gear's own sheet (both hosts load it)", () => {
+  // container created once, dismissal delegated to it (the standing click-safe rule); each toast
+  // auto-retires so a wall of stale notices can never accrete
+  assert.ok(GEAR.includes("rs-stale-toasts"), "one stable container");
+  assert.ok(GEAR.includes("rs-stale-toast'"), "per-notice toast node");
+  assert.match(GEAR, /box\.addEventListener\('click'/, "dismissal rides the stable container, not the rebuilt child");
+  for (const sel of ["#rs-stale-toasts", ".rs-stale-toast"])
+    assert.ok(GEAR_CSS.includes(sel), `gear.css styles ${sel} — the chat pane loads gear.css, not feed.css`);
+});
+
+test("the toast wears the family dismissal: a visible ✕ in the chip-✕ dress, Escape clears, fade", () => {
+  // The family's dismissal standard (the user 2026-08-25, after a notice with no visible way out;
+  // warn-toast.test.ts pins the family home, render.ts warnToast + styles.css .warn-toast-x): a
+  // visible ✕, Escape clears the stack, and the fade before the auto-remove. This toast's mint
+  // site is a frozen tab flushing on recovery — touch devices, exactly where an invisible
+  // whole-toast click and hoverless ✕-less copy help least. gear.js is its own document (panes
+  // that load only this sheet), so the treatment is COPIED from the family home; these pins keep
+  // the copy in step with it.
+  assert.match(GEAR, /x\.className = 'rs-stale-toast-x'/, "a visible ✕ button rides every toast");
+  assert.match(GEAR, /x\.setAttribute\('aria-label', 'Dismiss'\)/, "the ✕ is named for assistive tech");
+  assert.match(GEAR, /x\.title = 'dismiss \(Esc\)'/, "the ✕ teaches the keyboard way out");
+  // Escape clears the stack, additively — no stopPropagation, so no other surface loses the key
+  assert.ok(GEAR.includes("e2.key === 'Escape'"), "Escape clears the stack");
+  const esc = GEAR.slice(GEAR.indexOf("e2.key === 'Escape'"), GEAR.indexOf("e2.key === 'Escape'") + 200);
+  assert.doesNotMatch(esc, /stopPropagation/, "clearing toasts is additive noise-removal");
+  // the fade precedes the auto-remove, on the family's timings
+  assert.match(GEAR, /t\.classList\.add\('fade'\); \}, 11000\)/, "the fade arms first");
+  assert.match(GEAR, /t\.remove\(\); \}, 12000\)/, "the self-clearing backstop stays");
+  // the ✕ wears the chip-✕ dress through gear.css's token-with-fallback idiom (the census sheet:
+  // tokens resolve in a themed host; the literal fallbacks keep the standalone gear looking right)
+  assert.match(GEAR_CSS, /\.rs-stale-toast-x \{ flex: 0 0 auto; border: none; background: none; cursor: pointer;\n\s*color: var\(--text-muted, #9aa0a6\);/);
+  assert.match(GEAR_CSS, /\.rs-stale-toast-x:hover \{ color: var\(--fg, #fff\); background: rgba\(255, 255, 255, 0\.08\); \}/);
+  assert.match(GEAR_CSS, /\.rs-stale-toast\.fade \{ opacity: 0; \}/, "the fade class actually fades");
+  assert.match(GEAR_CSS, /\.rs-stale-toast \{[^}]*transition: opacity/, "…through a real transition");
+});
+
+test("the kept value rides when cheap, and reads as words (booleans become on/off)", () => {
+  assert.match(KERNEL, /def _setting_kept_value\(name\)/, "one cheap store read at reply time, never on the apply path");
+  assert.ok(GEAR.includes("m.kept === true ? 'on'"), "a boolean setting's kept value reads as on/off in the toast");
+});

--- a/ui/webview/warn-toast.test.ts
+++ b/ui/webview/warn-toast.test.ts
@@ -53,9 +53,10 @@ test("the specimen's copy is untouched — only the trap was the bug", () => {
 });
 
 test("federation surfaces a dropped route instead of vanishing it", () => {
-  // both send sites carry the else — the undoClear fast path and the main route loop
-  const drops = FEDERATION.match(/else this\.dropWarn\(/g) || [];
-  assert.equal(drops.length, 2, "every not-open host socket send has a dropWarn else");
+  // both send sites (the undoClear fast path and the main route loop) route through sendRemote —
+  // federation-send-queue.test.ts pins that — whose not-open fall-through pairs the toast with a
+  // client-diag breadcrumb. Kernel settings take neither: they queue for the reconnect instead.
+  assert.match(FEDERATION, /this\.diag\("senddrop", \{ host, msgType: \(msg && msg\.type\) \|\| "" \}\);\s*\n\s*this\.dropWarn\(host, msg\);/);
   assert.match(FEDERATION, /private dropWarn\(host: string, msg: any\)/);
   assert.match(FEDERATION, /was not delivered/);
 });


### PR DESCRIPTION
## What breaks

Two related losses, both reproduced with a synthetic `TESTHOST` remote.

1. `FederationManager.outbound()` drops any message routed to a host whose socket is not OPEN: a warn toast, no client-diag record, no retry. During a kernel restart every remote socket churns for a few seconds, so a settings gesture made in that window vanishes. The file viewer's Edit consent, OK'd mid-churn, lost its `setFileEditing` broadcast; the save that followed was refused by a kernel that never heard the yes, with refusal copy pointing back at a popup already answered. Every `KERNEL_SETTING` broadcast loses the same way and leaves the machines silently disagreeing until the next gear touch.

2. The queue's dual: a delayed replay is as dangerous as a drop. The kernel applies any arriving setting unconditionally, and the judge tiers re-propagate what they apply. A dashboard tab frozen for hours (a backgrounded phone, a throttled tab) that re-dials and flushes a superseded pick reverts every linked kernel to the hours-old value, and because every kernel then agrees, the gear's disagreement marks show nothing. The same race decides two dashboards flushing one setting on a host's recovery by socket order rather than gesture order.

## Reproduction

Sender: attach a remote, close its socket (devtools offline), toggle any gear setting, reconnect. Before this change: a warn toast, and the remote never hears the setting. `ui/webview/federation-send-queue.test.ts` drives this sequence through the real `FederationManager` over stubbed sockets.

Ordering: two dashboards on one kernel with a linked remote. Pick a judge model on dashboard A. On dashboard B, whose remote socket you closed, pick a different value, then restore the socket. Before this change: the flush lands, applies, and fans out, and every kernel converges on B's older pick. `tests/test_setting_gesture_order.py::TheIncidentReplay` runs the same sequence through the real WS handler.

## The fix (three commits)

**Sender (a0ac0dda).** All remote sends go through one path, `sendRemote`. `KERNEL_SETTING` messages queue per connection while the socket is down, latest per type, and flush synchronously on the socket's open event before any post-reconnect traffic (ahead of the `romp:hostRelayUp` dispatch, so a re-shipped upload cannot overtake a queued setting). Non-setting drops keep the toast and gain a `senddrop` client-diag breadcrumb; replaying arbitrary actions after a long disconnect stays a deliberate non-goal. The open and detach `hostconn` breadcrumbs name what was flushed or discarded.

**Ordering at the store (356c6a81).** Every `KERNEL_SETTING` emitter (all gear change handlers including the comment trio and `cmtFastGate`'s inner post, the file viewer's consent post, the feed's judge-limit switch) stamps `gt`, epoch ms at the click, inside the message literal; the queue delivers it unchanged. Each store persists the last-applied stamp beside the value: `auto-nudge.json` gains `gt` and `compactSuggestGt`, `file-editing.json` and `update-mode.json` gain `gt`, the bare judge-tier files gain a `<name>.gt` sidecar; absent reads 0. An arriving older-or-equal stamp stands down: no apply, no propagation, one stderr line. The fan-out body carries the applied `gt`, so a stale value cannot win via the second hop either. Unstamped messages (older dashboards, direct HTTP) apply as before and record arrival time.

This supersedes the per-field mtime `stamps` added on 2026-08-30 for the distill-pick stomp (`_JUDGE_SETTING_FILES`, `_setting_stamp`, the `stamps`/`utime` block in `_apply_judge_settings`). That mechanism guards the `/judge-settings` hop only: a stale WS flush is still applied locally at a fresh mtime and then fans out as the newest pick. Two recency clocks deciding one write would also fight. One clock now decides every write, and the earlier tests' semantics (older never overwrites newer, a refused value never steals recency, a stampless body keeps the legacy apply) are re-pinned in gesture-stamp terms in `tests/test_judge_settings_sync.py`. If you would rather keep the `stamps` wire vocabulary, that is a small rename on top.

Store hardening in the same commit: every gt-gated read-check-write span holds one `_SETTINGS_LOCK` (auto-nudge keeps `_NUDGE_LOCK`), so racing flushes land in gesture order; the judge value and sidecar publish via `_atomic_write`, sidecar first, so a crash between the two errs toward one extra stand-down rather than an inversion; setter OSError paths are loud on stderr and never propagate a value the local store did not take (`_set_judge_state` previously swallowed OSError silently and wrote with `write_text`).

Scope note: `setAutoNudge` keeps its current handler shape (gt-gated only, no re-tick); `setCompactSuggest` keeps its act-now tick, on a real apply only.

**The losing dashboard is told (20dc3193).** A stand-down answers the delivering socket with a `settingStale` frame (the saveFile-ack `_reply` idiom). The gear toasts it in plain words with the kept value and re-fills if open, so it never keeps displaying a refused pick as applied. The toast uses the warn-toast family's dismissal (visible ✕, Escape, fade), copied into gear.js/gear.css because the gear is its own document loaded by panes that ship only that sheet.

## Relation to #883 (relay-socket reconnect)

#883 and this PR close different halves of the same loss. #883 bounds how long a relay socket stays dead: its watchdog abandons a socket that is OPEN but silent past the keepalive bound (or stuck CONNECTING), dials a fresh one in the same tick, and every surface shows which hosts are still coming. It leaves `outbound()` unchanged, so both remote send sites still drop any message routed to a socket that is not OPEN, and the abandon-and-dial itself puts the fresh socket through a CONNECTING window in which a gear gesture is lost. This PR is the outbound half. A `KERNEL_SETTING` sent into any not-OPEN window (restart churn, the onclose retry, the poll's redial, or #883's watchdog redial) queues on the connection and flushes on the fresh socket's open event, ahead of the `romp:hostRelayUp` dispatch and before the watchdog's `lastRecv` stamp. Two tests cover the composition directly: a send after the abandon-and-dial, and a setting queued before the lost-timer redial. The branch is rebased onto #883's merge commit; the overlap was textual only (the `Conn` fields, the `Conn` literal, the `onopen` block). The `hostconn` breadcrumb family gains `flushed` and `pendingDropped` beside #883's `watchdog-close`. With only this PR's test hunks applied to the #883 merge commit, the 26 tests this PR adds or rewrites fail and the other 2668 pass, so #883 covers none of these cases.

## Compatibility

- File format additions are additive and read-as-0 compatible. A downgrade to an older kernel leaves `.gt` sidecars orphaned (harmless).
- Mixed-version meshes: a kernel on this code treats an old kernel's `stamps` body as unstamped and applies it unconditionally, as before 2026-08-30. The ordering protection needs both ends on this code, as the mtime version did.
- Clocks: cross-device wall clocks order gestures. Contention is at human timescales (the motivating flush arrived hours late; a two-dashboard race is seconds apart), so sub-second skew is immaterial; equal stamps keep the stored value.

## Tests

New: `ui/webview/federation-send-queue.test.ts` (14: queue, latest-wins, per-host isolation, flush ordering, drop diagnostics, gt survives the flush un-restamped, both send sites route through `sendRemote`, no timer in the flush, and two watchdog-composition cases: a send after the abandon-and-dial, a setting queued across the lost-timer redial), `ui/webview/setting-stale.test.ts` (5), `tests/test_setting_gesture_order.py` (42: incident replay through the real WS handler, reverse-arrival race, no-gt compat, propagation carries the stamp end to end, pre-gt file formats read as 0, update-mode and compact-suggest gating, deterministic two-flush lock race, sidecar-crash safety, OSError loudness, the `settingStale` reply), and a `gear.test.ts` completeness pin that reads federation's actual `KERNEL_SETTING` set and requires a stamped emitter per member.

Updated pins: flicker-diag, warn-toast, gear-judge-versions, feed-limit-banner, file-view, test_kernel_update, test_judge_settings_sync (the stamps tests rewritten on `gt`).

Every new test fails on the base commit without the code hunks. Full suites on the rebased branch (on the #883 merge commit): `npm run typecheck` clean, `npm test` 2694/2694, pytest 6574 passed and 40 skipped, bats 364/364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
