### PR TITLE
FallbackCard mints under its own sid: a journaled follow-up against the shared placeholder can reopen the card mid-run

### DIFF
--- a/tests/test_model_fallback_card.py
+++ b/tests/test_model_fallback_card.py
@@ -24,14 +24,31 @@ SID = "11111111-2222-3333-4444-555555555555"
 
 
 class FallbackCard(unittest.TestCase):
+    """OWN sid, like DedupeBackstop below and for the same reason: load_goals replays the per-sid
+    user-override journal on every load, other test modules journal user gestures against the shared
+    placeholder SID, and a fresh store's first node id collides ("<sid>:g1"). The collision is live
+    in the default serial order, not latent: by the time this file runs, earlier modules have left a
+    resolve on <SID>:g1 plus restore and unclear rows for other node ids in the journal, and
+    replaying them plants two foreign nodes in the freshly minted store. The assertions held only
+    because none of those ops touches g1's nodeComplete or status; a journaled followup or move on
+    <SID>:g1 replays as a reopen and turns them red, which a downstream tree carrying more test
+    modules hit under parallel ordering. A sid nobody else touches keeps these tests about the mint,
+    not the journal."""
+
+    FSID = "5a5a5a5a-6b6b-7c7c-8d8d-9e9e9e9e9e9e"
+
     def tearDown(self):
         for f in jd.GOALDIR.glob("*"):
             f.unlink()
+        try:
+            (jd._overrides_dir() / (self.FSID + ".jsonl")).unlink()
+        except OSError:
+            pass
 
     def test_mints_a_completed_top_naming_the_swap(self):
-        gid = jd.mint_fallback_card(SID, "claude-fable-5", "claude-sonnet-5", ev_t=1_787_500_000)
+        gid = jd.mint_fallback_card(self.FSID, "claude-fable-5", "claude-sonnet-5", ev_t=1_787_500_000)
         self.assertTrue(gid)
-        store = jd.load_goals(SID)
+        store = jd.load_goals(self.FSID)
         nd = store["nodes"][gid]
         self.assertTrue(nd["nodeComplete"])
         self.assertIn("fell back to claude-sonnet-5", nd["doneWhy"])


### PR DESCRIPTION
Test-only, one file, no behavior change.

## What breaks

`FallbackCard.test_mints_a_completed_top_naming_the_swap` (`tests/test_model_fallback_card.py`) mints its card under the shared placeholder sid `11111111-2222-3333-4444-555555555555` that most of the suite uses, then asserts the card is a completed top. Three facts make that fragile:

- `load_goals` replays the per-sid override journal (`overrides/<sid>.jsonl`) on every load.
- `mint_fallback_card` names a fresh store's card `<sid>:g1` — the id every other module's first node also takes.
- A journaled `followup` (or `move`) row replays as `_reopen` on any node id the store has. The minted card carries only a `romp` done event, so neither the later-user-event guard nor the twin guard stops it.

So a follow-up any earlier test journaled against `<sid>:g1` reopens the just-minted card, and `assertTrue(nd["nodeComplete"])` / `status == "completed"` fail.

The journal is shared across modules: test files load `bin/romp-judge` under one module name, `romp_judge` (and `bin/romp-kernel` binds its judge the same way), so `GOALDIR` and `_overrides_dir()` are one object per process (the `_overrides_dir` docstring describes this). `tests/conftest.py` floors `XDG_STATE_HOME` once per run and does not isolate the overrides dir per test.

## Why CI is green today

Not because the test is isolated. In the default serial order the collision is already live: when this file runs, `overrides/<SID>.jsonl` holds seven rows — a `resolve` on `<SID>:g1` left by `tests/test_kernel_resolve_node.py`, and three `restore` plus three `unclear` rows on `<SID>:n1` left by `tests/test_kernel_undo_restore_completed.py`. Both sort after the two modules whose tearDowns wipe the overrides dir (`test_distill_rearm.py`, `test_kernel_redistill.py`), so no wipe reaches those rows. Replaying them plants two foreign nodes (`<SID>:n1`, `<SID>:n2`) in the freshly minted store during the test; the assertions pass only because none of those ops touches `g1`'s `nodeComplete` or `status`. A `followup` or `move` row on `<SID>:g1` would flip them — that is what a downstream tree carrying additional test modules hit under pytest-xdist ordering. No upstream module leaves such a row today, and three `-n 8` runs of the unfixed tree at this base did not fail this test, so upstream is green because of what the journal happens to contain.

Measured with a read-only pytest plugin that snapshots the journal after every test in a full serial run. Replaying the captured seven rows against a fresh mint in a tempdir yields store nodes `[g1, n1, n2]` with `g1` still completed; appending one `followup` row on `<SID>:g1` flips it to `nodeComplete: False`, `status: working`.

This is the collision `DedupeBackstop`, at the bottom of the same file, already documents and avoids with its own sid — and CLAUDE.md's "Goal-store fixtures use a PRIVATE synthetic sid" section names `DedupeBackstop` as the precedent. `FallbackCard`, two classes above it, predates that fix.

## Reproduction (synthetic)

Plant one journal row before the mint:

```python
od = jd._overrides_dir(); od.mkdir(parents=True, exist_ok=True)
(od / (SID + ".jsonl")).write_text(
    json.dumps({"node": SID + ":g1", "op": "followup", "t": 1_787_500_050}) + "\n")
```

Unfixed: `assertTrue(nd["nodeComplete"])` fails (`False is not true`). Fixed, with the plant still aimed at `SID`: passes — the card now lives under a sid the planted journal never touches. Aiming the plant at `<FSID>:g1` instead fails again, so the replay path is live under the new sid too; the isolation rests on nobody else using `FSID`, which grep confirms.

## The fix

`FallbackCard` gets:

- a class docstring saying why it has its own sid;
- `FSID = "5a5a5a5a-6b6b-7c7c-8d8d-9e9e9e9e9e9e"`, a uuid with no other use anywhere in the tree (grep-verified);
- `self.FSID` in place of `SID` for the two sid arguments in the minting test;
- a `tearDown` that also unlinks `overrides/<FSID>.jsonl`.

Same shape as `DedupeBackstop`. The module-level `SID` stays: `SidechainNeverLearns` uses it as a session id and never touches a store, and `test_the_backend_transition_gates_are_pinned` is a source pin with no sid.

## Tests

- `pytest tests/test_model_fallback_card.py -q`: 12 passed.
- Full suite, serial (`python -m pytest -q`, CI's shape), locally: 6495 passed, 42 skipped. CI on the same tree: 6499 passed, 38 skipped on each of Python 3.10–3.13 (the difference is environment-dependent skips; totals agree).
- Full suite `pytest -q -n 8`, locally, several runs: this file green every time. Some runs showed unrelated xdist-only failures in `tests/test_kernel_trust.py::PairsSnapshot` and `tests/test_judge.py` (shared-module-state leaks of the same general class), not touched here.
- bats (364/364), `node --test tests/manager-*.test.js` (39/39), vscode-extension typecheck + test (2648/2648): unaffected by a Python test-only change; run for completeness.

## Not in this PR

A structural fix — isolating the overrides dir per test in `conftest.py` — would remove the whole class of collision; this PR only brings the one known violator in line with the documented rule and its neighbor. The audit also showed the shared overrides dir moves mid-run (`GOALDIR` is rebound and not restored by `test_distill_rearm::KernelRearmWiring` and `test_timeline_lineage::BranchOnTheTimeline`), another argument for per-test isolation in conftest; per-class private sids are the documented stopgap. One more observation, deliberately left alone: `DedupeBackstop`'s `DSID` is reused as a peer/session id by four other modules (none mints goals under it today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)