### PR TITLE
Model pickers: a family click floats on the alias, a typed /model reaches the registry, and a refused pick unwinds only its own write

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -633,7 +633,7 @@ EOF
     _romp_cmd "romp new -t <name>"         -            "Start it as a terminal (tmux) session and attach (--detach: don't attach)"
     _romp_cmd "romp new -d <dir> <name>"   -            "Working directory for the new session (default: the current folder)"
     _romp_cmd "romp new -m <text> <name>"  -            "Start it AND deliver <text> as its first prompt (one command, idea to working)"
-    _romp_cmd "romp new --model <id> <name>" -          "Model for the SDK session, as a FULL id (e.g. claude-fable-5); re-asserted if <name> already runs"
+    _romp_cmd "romp new --model <id> <name>" -          "Model for the SDK session: a family alias (fable — follows the newest) or a full id (claude-fable-5 — a pin); re-asserted if <name> already runs"
     _romp_cmd "romp new --effort <level> <name>" -      "Reasoning effort for the SDK session (e.g. high, ultracode); re-asserted if <name> already runs"
     _romp_cmd "romp resume [<id>]"         -            "Resume a past conversation (full-screen picker; or an exact UUID)"
     _romp_cmd "romp status"                romp-manager "Show manager + kernel status"
@@ -1685,8 +1685,10 @@ case "${1:-}" in
                 --model)   shift
                            # per-spawn model, riding POST /new (the user 2026-08-14: the nightly
                            # optimizer must always run fable, and a headless script has no WS).
-                           # FULL id as the picker sends it (claude-fable-5) — the alias table
-                           # stops at opus/sonnet/haiku and quietly resolved "fable" to Opus 5.
+                           # VERBATIM: a family alias (fable — the CLI resolves it live, so it
+                           # follows the family's newest) or a full id (claude-fable-5, a pin). A
+                           # note here once said the CLI resolved "fable" to Opus 5 and so required
+                           # full ids; that is not reproducible on any installed CLI.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
                                echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -838,8 +838,9 @@ MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label"
 # picked for it (model-picks.json below), else the family ALIAS itself. The CLI resolves an alias
 # live, so a bare family click follows the family's newest release exactly as the CLI's own default
 # does. (Before this the default fell to this table's head, which pinned every picker-set session
-# to claude-fable-5 while `fable` moved on.) Full ids ride every set path verbatim already — the
-# CLI's alias table stops at the family names, so a version pick needs no new transport.
+# to claude-fable-5 while `fable` moved on; see _model_alias_boot_pass for the state that left
+# behind.) Full ids ride every set path verbatim already — the CLI's alias table stops at the
+# family names, so a version pick needs no new transport.
 MODEL_VERSIONS = {
     "fable":  [{"value": "claude-fable-5-1", "label": "Fable 5.1"},   # verified live 2026-09-01 (Models API + CLI 2.1.257)
                {"value": "claude-fable-5", "label": "Fable 5"}],
@@ -1377,6 +1378,123 @@ def _model_pick_refused(sid, value):
     fam = _version_family(value)
     if fam:
         _forget_model_pick(fam, only=value)
+
+
+# The id a bare family click RECORDED before the alias became the default — each family's seed head as
+# it stood then, frozen here on purpose (the table above moves; this must not). A stored model equal to
+# one of these is, in nearly every case, that artefact rather than a deliberate pin: a version-submenu
+# pick of the same id was indistinguishable from a family click, and the migration treats the head as
+# alias-worthy exactly as the CLI's own 2.1.257 `migration_fable5_to_fable_alias` treats a user setting
+# of claude-fable-5 (its strings name the migration and the id; verified in the installed binary).
+_SEED_PINS = {"claude-fable-5": "fable", "claude-opus-5": "opus", "claude-sonnet-5": "sonnet",
+              "claude-haiku-4-5": "haiku"}
+MODEL_ALIAS_MIGRATION_MARKER = "model-alias-migration.done"   # STATE/…: stamped once the pass below ran clean
+
+
+def _model_alias_boot_pass():
+    """ONE-TIME state migration at kernel boot, marker-gated like _rewind_migration_bg: every stored
+    model equal to a PRE-FIX seed head (_SEED_PINS) becomes its family alias, in the three places the
+    pin lived —
+    - sdk-defaults.json's remembered model (what the next NEW session seeds from);
+    - model-picks.json, where a head recorded as a family's pick is DROPPED: that store holds version
+      ids only, and an absent pick is exactly how /models falls to the alias;
+    - every session reg's `model` — what _options hands the CLI as --model on the next reconnect, so
+      the session follows the CLI's newest from then on. Dead regs too: a revival launches from the
+      same field. A LIVE session is not re-pointed mid-turn (no set_model fires here); the rewrite is
+      picked up by its next reconnect, exactly as a set_model on a dormant session is.
+    WHY ONCE, AND WHY A MARKER: the head ids are not retired — three of the four are the CURRENT
+    releases, exactly what a user pins from the version submenu against a future .1 — so after the fix
+    a stored head is a deliberate pin, indistinguishable from pre-fix residue by value alone. Without a
+    completion record the pass would re-run at every restart and undo those picks, against the "an
+    explicit pin stands" guarantee. The marker (STATE/model-alias-migration.done, {"t","moved"}) is
+    what tells the two apart: absent → the state predates the fix and the pass runs; present → it ran,
+    and every head found from then on is the user's. The way BACK to floating for a pinned family is a
+    picker gesture, never a boot pass: the version submenu's "Latest" row (_set_model_or_park
+    `floating`) forgets the pin and sends the alias.
+    Stamped only after a CLEAN pass — "returned" is not "succeeded": a store or reg the pass could not
+    READ is one it did not migrate, so no marker is written and the pass re-arms at the next boot (an
+    absent file is nothing to migrate). Two failures are not one: a read the OS refused is TRANSIENT —
+    the file is there, this boot could not open it — and withholds the marker; a file json.loads cannot
+    parse is PERMANENT garbage — it holds no pin ANY reader can see (read_reg, read_sdk_defaults and the
+    picks loader all return None/{} over it), so retrying over it could never migrate anything, and
+    counting it a failure would withhold the marker forever and re-float every deliberate post-fix pin
+    at every boot without ever naming the file. Garbage is named loudly, by path, and treated as
+    nothing to migrate; the marker still lands. Loud (one stderr line naming what moved, nothing when
+    nothing did) and blind to any non-head value — an explicit legacy pin, or a post-fix head such as
+    claude-fable-5-1, stands. Runs before the SDK backend constructs, which is when regs become
+    chosen_model (main()'s ordering, pinned by test); a rewrite lost to a concurrent write during a
+    restart handoff simply recurs at the next boot, since no marker lands until the pass completes.
+    Returns the number of rewrites; 0 without a word once the marker exists."""
+    marker = jd.STATE / MODEL_ALIAS_MIGRATION_MARKER
+    if marker.exists():
+        return 0
+    n = 0
+    moved = []
+    fails = 0
+
+    def _load(p):
+        # a dict (or whatever the file holds) — None for an ABSENT file (nothing to migrate), for one the
+        # OS would not let us READ (transient: counted, named, withholds the marker so the next boot
+        # retries) and for one that is not JSON (permanent: named, nothing to migrate, never counted).
+        # Read as BYTES and let json.loads decode: read_text() decodes, and a file holding non-UTF-8
+        # bytes raises UnicodeDecodeError there — a ValueError, not an OSError — which would escape both
+        # arms, abort the whole pass at that file and re-arm it every boot. Decoding belongs to the parse
+        # arm: a file no reader can decode holds no pin any reader can see, exactly like one that is not
+        # JSON.
+        nonlocal fails
+        try:
+            data = p.read_bytes()
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            fails += 1
+            sys.stderr.write("romp-kernel: model-alias migration: could not read %s (%s) — retrying next "
+                             "boot\n" % (p, e))
+            return None
+        try:
+            return json.loads(data)
+        except ValueError as e:              # json's own errors and UnicodeDecodeError alike
+            sys.stderr.write("romp-kernel: model-alias migration: %s is not JSON (%s) — no reader can see a "
+                             "pin in it, so there is nothing there to migrate; left as is\n" % (p, e))
+            return None
+    p = jd.STATE / "sdk-defaults.json"
+    d = _load(p)
+    if isinstance(d, dict) and d.get("model") in _SEED_PINS:
+        d["model"] = _SEED_PINS[d["model"]]
+        _atomic_write(p, json.dumps(d))
+        n += 1
+        moved.append("sdk-defaults model → %s" % d["model"])
+    p = jd.STATE / MODEL_PICKS_FILE_NAME
+    d = _load(p)
+    if isinstance(d, dict):
+        stale = sorted(f for f, v in d.items() if v in _SEED_PINS)
+        if stale:
+            for f in stale:
+                d.pop(f)
+            _atomic_write(p, json.dumps(d))
+            n += len(stale)
+            moved.append("model-picks dropped %s" % ", ".join(stale))
+    try:
+        regs = sorted((jd.STATE / "sdk").glob("*.json"))
+    except OSError:
+        regs = []
+    for rp in regs:
+        reg = _load(rp)
+        if isinstance(reg, dict) and reg.get("model") in _SEED_PINS:
+            reg["model"] = _SEED_PINS[reg["model"]]
+            _atomic_write(rp, json.dumps(reg))
+            n += 1
+            moved.append("session %s → %s" % (reg.get("name") or rp.stem, reg["model"]))
+    if n:
+        sys.stderr.write("romp-kernel: model-alias migration: %s (a session takes the alias at its "
+                         "next reconnect)\n" % "; ".join(moved))
+    if fails:
+        sys.stderr.write("romp-kernel: model-alias migration could not read %d file(s) — no marker "
+                         "written, retrying next boot\n" % fails)
+    else:
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        _atomic_write(marker, json.dumps({"t": int(time.time()), "moved": n}))
+    return n
 # "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
 # standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
 # SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
@@ -33719,6 +33837,10 @@ def main():
             sys.stderr.write("romp-kernel: re-armed %d given-up summary line(s) at startup\n" % _n)   # promised this since 07-03; now wired)
     except Exception:
         sys.stderr.write("startup rearm: %s\n" % traceback.format_exc())
+    try:                                                      # a stored model pinned to a family's PRE-FIX seed
+        _model_alias_boot_pass()                              # head (claude-fable-5) → the family alias, so the
+    except Exception:                                         # next reconnect follows the CLI's newest.
+        sys.stderr.write("model-alias migration: %s\n" % traceback.format_exc())   # MUST precede _sdk: regs → chosen_model there
     _write_palette_mirror()                                   # keep bin/romp's palette-colors mirror current across code updates
     _boot_warm()                                              # pre-parse the live fleet during the reconnect gap (fast first paint)
     threading.Thread(target=_sdk, daemon=True).start()        # construct the SDK backend NOW so its boot

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -830,7 +830,10 @@ MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label"
 # opus became Opus 5 — silently losing the legacy versions that remain live on the API). Newest
 # first; values are the API's DATELESS aliases, verified against the claude-api reference
 # 2026-08-25 (deprecated 4.1/4.0-era models excluded on purpose — they are retiring). This table is
-# the SEED the live catalog below grows. The catalog owns the LIST; the alias owns the DEFAULT:
+# the SEED the live catalog below grows, completed with the ids running sessions' CLIs actually
+# report ahead of it (_learned_versions) — the CLI is the authoritative source for what it serves,
+# and a table alone lagged a release the day Fable 5.1 shipped. The catalog owns the LIST; the alias
+# owns the DEFAULT:
 # clicking a family in a picker sends that family's DEFAULT — the most recent VERSION the user
 # picked for it (model-picks.json below), else the family ALIAS itself. The CLI resolves an alias
 # live, so a bare family click follows the family's newest release exactly as the CLI's own default
@@ -853,6 +856,7 @@ MODEL_VERSIONS = {
 _VERSION_FAMILY = {v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v in vs}
 MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pref all surfaces read, like colormap
 _model_picks_lock = threading.Lock()   # its read-modify-writes run on the WS-handler, producer AND SDK-loop threads
+_learned_announced = set()   # ids already announced on stderr as outside the catalog (once per process)
 
 # ── the LIVE model catalog (T222, the user 2026-09-01: romp must stop needing a hand edit when
 # Anthropic ships a model). The table above is the SEED and the loud fallback. The kernel queries the
@@ -1094,12 +1098,20 @@ def _note_unknown_model(mid):
     """The staleness EVENT: a claude-* version id reached a set path or the pick store and the merged
     list does not know it — exactly when a hand-updated table used to go quietly stale. Fires ONE
     refresh per unknown id per kernel life (dedup by id, never a clock); aliases, dated snapshots
-    and garbage never fire. Returns whether a refresh was started."""
+    and garbage never fire. Returns whether a refresh was started.
+    The id is marked asked only when its refresh actually STARTS: the refresh is single-flight, so a
+    sighting while one is inflight — the boot fetch, exactly when a running session's CLI first
+    reports a new release — starts nothing, and marking it then spent the id's one refresh on a
+    no-op. Unmarked, the next sighting after the inflight fetch lands (every /models read re-derives
+    the learned list) asks for real if the catalog still lacks the id; a catalog that caught up
+    short-circuits on _VERSION_FAMILY first."""
     mid = str(mid or "")
     if not _catalog_family(mid) or mid in _VERSION_FAMILY or mid in _catalog_asked:
         return False
-    _catalog_asked.add(mid)
-    return _refresh_model_catalog("unknown model id %s" % mid)
+    started = _refresh_model_catalog("unknown model id %s" % mid)
+    if started:
+        _catalog_asked.add(mid)
+    return started
 
 
 def _catalog_public_status():
@@ -1163,30 +1175,121 @@ def _model_id_label(value):
     return "%s %d" % (fam.capitalize(), maj) + (".%d" % minor if minor else "")
 
 
-def _model_picks():
-    """The per-family last-picked map. Only known version ids survive the read (a stale or hand-edited
-    entry falls back to the family alias rather than poisoning the default)."""
+def _learned_versions():
+    """{family: [{"value", "label", "learned": True}, …]} — every model id a session's CLI has actually
+    REPORTED (reg.liveModelId, persisted by the SDK backend's _learn_model from the init / assistant
+    `model` fields) that the CATALOG does not list — the seed table as the Models API fetch and its
+    cache have grown it (T222). The CLI is the authoritative source for what it serves; this is the
+    catalog's live lookahead, so a new release appears in the pickers the moment any session runs on
+    it, and each sighting is also T222's staleness EVENT (_note_unknown_model: one refresh per id per
+    kernel life, spent only when it actually starts), so the catalog catches up and the row's mark
+    drops. A dated snapshot of a known version shares its label and adds nothing (the dateless alias
+    covers it); provider-prefixed and synthetic ids are not the shape the pickers send and are
+    skipped. Reads the same reg files _thread_reg does. A first sighting is announced once on stderr —
+    and the pickers mark the row — so an unlisted model is LOUD, never a silent gap behind a stale
+    menu (the fail-loudly rule)."""
+    out = {}
+    fams = {c["value"] for c in MODEL_CHOICES}
+    with _catalog_lock:                          # the catalog is rebuilt in place on its own thread
+        known = set(_VERSION_FAMILY)
+        labels = {fam: {v["label"].lower() for v in vs} for fam, vs in MODEL_VERSIONS.items()}
+    try:
+        regs = sorted((jd.STATE / "sdk").glob("*.json"))
+    except OSError:
+        return out
+    for p in regs:
+        try:
+            reg = json.loads(p.read_text())
+        except (OSError, ValueError):
+            continue
+        mid = reg.get("liveModelId") if isinstance(reg, dict) else None
+        parts = _model_id_parts(mid)
+        if not parts or parts[0] not in fams:
+            continue
+        fam, maj, minor = parts
+        # the DATELESS alias is what the row offers: a CLI may report the -YYYYMMDD snapshot it runs,
+        # and a snapshot retires while the alias follows the version
+        value = "claude-%s-%d" % (fam, maj) + ("-%d" % minor if minor else "")
+        label = _model_id_label(value)
+        if value in known or label.lower() in labels.setdefault(fam, set()):
+            continue
+        labels[fam].add(label.lower())
+        out.setdefault(fam, []).append({"value": value, "label": label, "learned": True})
+        _note_unknown_model(value)               # the catalog lacks an id a CLI serves: refresh it (dedup by id)
+        if value not in _learned_announced:
+            _learned_announced.add(value)
+            sys.stderr.write("romp-kernel: model %s (%s) is not in the built-in version list — a running "
+                             "session's CLI reports it, so the pickers offer it marked new\n" % (value, label))
+    return out
+
+
+def _versions_catalog(learned=None):
+    """{family: versions} the pickers show — the CATALOG (the seed table as the Models API fetch and its
+    cache have grown it in place, T222) ∪ the LEARNED ids (what a running session's CLI reports that
+    the catalog does not list yet, marked), deduped by id, newest first by each id's own version tuple
+    (one ordering rule, the catalog's _version_key). The catalog owns the list; the learned rows are
+    its live lookahead until the next refresh folds them in."""
+    learned = _learned_versions() if learned is None else learned
+    with _catalog_lock:                          # snapshot: the catalog is rebuilt in place on its own thread
+        cat = {fam: [dict(v) for v in vs] for fam, vs in MODEL_VERSIONS.items()}
+    out = {}
+    for fam, rows in cat.items():
+        seen = {v["value"] for v in rows}
+        for v in learned.get(fam) or []:
+            if v["value"] not in seen:
+                seen.add(v["value"])
+                rows.append(dict(v))
+        rows.sort(key=lambda v: _version_key(v["value"]), reverse=True)
+        out[fam] = rows
+    return out
+
+
+def _version_family(value, learned=None):
+    """The family a VERSION id belongs to — a catalog id (the seed table, or one the Models API fetch
+    added to it), or one a session's CLI has reported (learned) — and '' for anything else: a family
+    alias, 'default', a never-seen id. This is what makes a value a pin the pick memory may record;
+    read at CALL time, so an id the catalog learned after boot is a pin from that moment on."""
+    v = str(value or "")
+    with _catalog_lock:
+        fam = _VERSION_FAMILY.get(v)
+    if fam:
+        return fam
+    for f, vs in (_learned_versions() if learned is None else learned).items():
+        if any(x["value"] == v for x in vs):
+            return f
+    return ""
+
+
+def _model_picks(learned=None):
+    """The per-family last-picked map. Only known version ids — catalog or learned — survive the read (a
+    stale or hand-edited entry falls back to the family alias rather than poisoning the default); a
+    pick NO list knows is the catalog's staleness event (T222): it may name a model newer than the
+    list, so it fires one refresh, and is honored the moment the catalog learns the id."""
     try:
         d = json.loads((jd.STATE / MODEL_PICKS_FILE_NAME).read_text())
-        if not isinstance(d, dict):
-            return {}
-        out = {}
-        for f, v in d.items():
-            if isinstance(v, str) and _VERSION_FAMILY.get(v) == f:
-                out[f] = v
-            elif isinstance(v, str):
-                _note_unknown_model(v)   # a pick this list doesn't know → the catalog staleness event (T222)
-        return out
     except Exception:
         return {}
+    if not isinstance(d, dict):
+        return {}
+    learned = _learned_versions() if learned is None else learned
+    out = {}
+    for f, v in d.items():
+        if not isinstance(v, str):
+            continue
+        if _version_family(v, learned) == f:
+            out[f] = v
+        else:
+            _note_unknown_model(v)   # a pick no list knows → the catalog staleness event (T222)
+    return out
 
 
 def _note_model_pick(value):
     """Record a version pick as its family's new default (write-on-change). Family shorthands and
     unknown strings record nothing — they are not version picks — so a bare family click (which
     carries the alias) can never downgrade an explicit legacy pin (an unknown claude-* id does fire
-    the catalog's staleness refresh: it may be a model newer than this list, T222)."""
-    fam = _VERSION_FAMILY.get(str(value or ""))
+    the catalog's staleness refresh: it may be a model newer than this list, T222). A version is a
+    catalog id (seed, or one the Models API fetch added) or a learned one (_version_family)."""
+    fam = _version_family(value)
     if not fam:
         _note_unknown_model(value)
         return
@@ -18687,10 +18790,10 @@ def _route_meta_command(be, sid, text, client=None, floating=False):
 
 
 def _vouched_model(value):
-    """A model value the kernel will stand behind persisting: a family alias, 'default', a catalog
-    version id, or any well-formed first-party id of a known family (the CLI validates the exact
-    version; romp's job is keeping the registry in step). A typo is none of these."""
-    if value in _MODEL_VALUES or value == "default" or _VERSION_FAMILY.get(value):
+    """A model value the kernel will stand behind persisting: a family alias, 'default', a catalog or
+    learned version id, or any well-formed first-party id of a known family (the CLI validates the
+    exact version; romp's job is keeping the registry in step). A typo is none of these."""
+    if value in _MODEL_VALUES or value == "default" or _version_family(value):
         return True
     if _model_id_clean(value) in _MODEL_VALUES:   # the CLI's own 1M-context spelling of a family (fable[1m])
         return True                                # — vouched like the tagged id below
@@ -25200,9 +25303,14 @@ def _set_judge_state(fname, value, allowed, allow_empty=False):
 
 # judge tiers accept VERSION ids too (the user 2026-08-25: the settings pickers mirror the
 # family+version submenus) — a version rides the SDK model param verbatim, like session picks
-_JUDGE_MODEL_VALUES = _MODEL_VALUES | set(_VERSION_FAMILY)
-def _set_judge_model(v):  _set_judge_state("judge-model", v, _JUDGE_MODEL_VALUES)
-def _set_index_model(v):  _set_judge_state("index-model", v, _JUDGE_MODEL_VALUES)
+_JUDGE_MODEL_VALUES = _MODEL_VALUES | set(_VERSION_FAMILY)   # the catalog half; _judge_model_values() adds the learned
+def _judge_model_values():
+    """What a judge tier may run — a family alias, a catalog version id, or a version some session's CLI
+    has reported (learned): the same list /models hands the gear's selects, so the kernel never refuses
+    a value it offered. Computed per call — the learned half is live."""
+    return _JUDGE_MODEL_VALUES | {v["value"] for vs in _learned_versions().values() for v in vs}
+def _set_judge_model(v):  _set_judge_state("judge-model", v, _judge_model_values())
+def _set_index_model(v):  _set_judge_state("index-model", v, _judge_model_values())
 def _set_judge_effort(v): _set_judge_state("judge-effort", v, _EFFORT_VALUES, allow_empty=True)
 def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True)
 # The distilling pair accepts extra sentinels (resolved by jd._distill_model/_distill_effort at call
@@ -25210,7 +25318,7 @@ def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, al
 # staller did before the split (the user 2026-08-14) — and effort's "none" pins no-flag. "none" exists
 # because "" cannot: _state_str folds an empty file into the default, so an allow_empty pin here would
 # read back as "follow" (caught by test_distill_tier before it shipped).
-def _set_distill_model(v):  _set_judge_state("distill-model", v, _JUDGE_MODEL_VALUES | {"triage"})
+def _set_distill_model(v):  _set_judge_state("distill-model", v, _judge_model_values() | {"triage"})
 def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES | {"triage", "none"})
 # The default-COMMENT-THREAD trio (the user 2026-08-29, who wanted every new comment thread on one
 # model/effort/fast pick regardless of the session it branches from). Sentinel "session" — the shipped
@@ -25219,7 +25327,7 @@ def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES
 # (clear to the account default) so the setting speaks the create dialog's exact value space; fast is
 # "on" or the sentinel — a checkbox has no third state, and forcing a thread SLOW from a fast parent
 # stays a per-thread dialog pick, never a standing default.
-def _set_comment_model(v):  _set_judge_state("comment-model", v, _JUDGE_MODEL_VALUES | {"session", "default"})
+def _set_comment_model(v):  _set_judge_state("comment-model", v, _judge_model_values() | {"session", "default"})
 def _set_comment_effort(v): _set_judge_state("comment-effort", v, _EFFORT_VALUES | {"session"})
 def _set_comment_fast(v):   _set_judge_state("comment-fast", v, {"session", "on"})
 
@@ -31216,12 +31324,17 @@ class Handler(BaseHTTPRequestHandler):
                 # selectors wear the same colors the statusline badges do, for ANY pick — the badge
                 # colors only cover the current value, so the list is where the shared tint belongs)
                 _stops = cm.stops_for(_colormap())
-                # each family also carries its VERSIONS (newest first, the family's tint) and its
-                # DEFAULT — the last version the user picked for that family, else the family ALIAS
-                # (the user 2026-08-25: family click = remembered pick; the submenu holds the rest).
-                # The alias, never the list's head: the CLI resolves an alias live, and the head
-                # pinned every picker-set session to claude-fable-5 while `fable` moved on.
-                _picks = _model_picks()
+                # each family also carries its VERSIONS (newest first, the family's tint): the CATALOG
+                # — the seed table as the Models API fetch and its cache have grown it (T222) — plus
+                # every id a running session's CLI reports that the catalog lacks yet, those marked
+                # `learned`; and its DEFAULT — the last version the user picked for that family, else
+                # the family ALIAS (the user 2026-08-25: family click = remembered pick; the submenu
+                # holds the rest). The alias, never the list's head: the CLI resolves an alias live,
+                # and the head pinned every picker-set session to claude-fable-5 while `fable` moved
+                # on. The catalog owns the LIST, the alias the DEFAULT.
+                _learned = _learned_versions()
+                _picks = _model_picks(_learned)
+                _cat = _versions_catalog(_learned)
                 # a version the INSTALLED CLI has refused by minimum version says so on its own row
                 # (T222): the refusal is learned from the CLI's own error at the first attempt
                 # (sdk_backend.note_cli_model_block) and cleared by the first real reply on that
@@ -31231,7 +31344,7 @@ class Handler(BaseHTTPRequestHandler):
                     {"models": [dict(c, color=_model_color(c["value"], _stops),
                                      tone=_model_tone(c["value"]),
                                      versions=[_with_cli_block(dict(v), _blocks)
-                                               for v in MODEL_VERSIONS.get(c["value"]) or []],
+                                               for v in _cat.get(c["value"]) or []],
                                      default=_picks.get(c["value"]) or c["value"])
                                 for c in MODEL_CHOICES],
                      "efforts": [dict(c, color=_effort_color(c["value"], _stops), tone=_effort_tone(c["value"]))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28019,7 +28019,7 @@ post({type:"deepLink",session:q.get("session"),anchor:q.get("anchor")||undefined
 if(window.parent!==window)window.parent.postMessage({romp:"reveal",pane:"chat"},"*");return;}}catch(e){}window.open(url,"_blank");};
 window.__rompTimelineWriteOrder=function(order){if(window.__rompWriteOrder)window.__rompWriteOrder(order);};
 window.__rompTimelineCompact=function(name){post({type:"compact",name:name});};
-window.__rompTimelineSendCommand=function(name,cmd){post({type:"sendCommand",name:name,cmd:cmd});};
+window.__rompTimelineSendCommand=function(name,cmd,extra){post(Object.assign({type:"sendCommand",name:name,cmd:cmd},extra||{}));};
 window.__rompTimelineSetFlag=function(id,flag,value){post({type:"setSessionFlag",id:id,flag:flag,value:!!value});};
 window.__rompTimelineSetViews=function(views){post({type:"setTimelineViews",views:views});};
 window.__rompTimelineEditTag=function(edit){post({type:"editTag",edit:edit});};

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -857,6 +857,12 @@ _VERSION_FAMILY = {v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v i
 MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pref all surfaces read, like colormap
 _model_picks_lock = threading.Lock()   # its read-modify-writes run on the WS-handler, producer AND SDK-loop threads
 _learned_announced = set()   # ids already announced on stderr as outside the catalog (once per process)
+# Bumps on every pick-memory change and every catalog growth; rides the models frame (_models_changed) AND
+# the /models payload, so a picker can drop a response older than one it has applied. Seeded from the clock
+# rather than 0: the counter is per process, and a kernel restart must never hand a page that kept its
+# high-water mark a LOWER rev, or that page would ignore every re-read until the count caught up — a silent
+# stale list. Milliseconds leave room for one bump per ms across a restart.
+_models_rev = [int(time.time() * 1000)]
 
 # ── the LIVE model catalog (T222, the user 2026-09-01: romp must stop needing a hand edit when
 # Anthropic ships a model). The table above is the SEED and the loud fallback. The kernel queries the
@@ -1081,7 +1087,11 @@ def _refresh_model_catalog(reason, _async=True):
                 sys.stderr.write("model catalog (%s): %d new version id(s) joined the pickers: %s\n"
                                  % (reason, len(added), ", ".join(added)))
                 try:
-                    _push_soon()                          # pickers re-read /models on the next frame
+                    # the models frame: every open picker re-reads /models on it (chat/comment, the
+                    # timeline lanes, the gear). Nothing re-reads the choice lists on its own after
+                    # page load — a session-list push (the line this replaced) told the pickers
+                    # nothing, so an open dashboard kept the page-load list until a reload
+                    _models_changed()
                 except Exception:
                     pass
         finally:
@@ -1283,6 +1293,25 @@ def _model_picks(learned=None):
     return out
 
 
+def _models_changed():
+    """The pick memory MOVED — a version pinned, a family un-pinned (Latest), a refused pin dropped — or the
+    version LIST grew (the catalog fetch added ids, T222), so every open picker's cached /models list is
+    stale, and its `default` is what a family click SENDS. Tell every client that hosts a picker now with a
+    models frame (the palette frame's idiom; each re-fetches /models on it) — event-keyed on the change
+    itself, never a poll. A counter rides it so a client can tell frames apart, and the same counter stamps
+    the /models payload so a late response never overwrites a newer one. (Without it, after Latest
+    un-pinned a family on the kernel the same tab's next family click sent the STALE pinned id and silently
+    re-pinned; a second dashboard's pick moved the default without the first tab knowing.) The FEED app is
+    on the list because the settings gear lives in the feed bundle (feed.ts requires gear.js; the shell's
+    rail gear and VS Code's settings command both open it in the feed pane). The feed shim and the VS Code
+    pipe hand every non-keepalive frame to the window as a message; feed.ts's own listener ignores a type
+    it does not know."""
+    _models_rev[0] += 1
+    frame = {"type": "models", "rev": _models_rev[0]}
+    for app in ("chat", "timeline", "feed"):
+        _send_to_app(app, frame)
+
+
 def _note_model_pick(value):
     """Record a version pick as its family's new default (write-on-change). Family shorthands and
     unknown strings record nothing — they are not version picks — so a bare family click (which
@@ -1309,6 +1338,8 @@ def _note_model_pick(value):
             _atomic_write(jd.STATE / MODEL_PICKS_FILE_NAME, json.dumps(picks))
         except Exception:
             sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
+            return
+    _models_changed()
 
 
 def _forget_model_pick(fam, only=None):
@@ -1332,6 +1363,8 @@ def _forget_model_pick(fam, only=None):
             _atomic_write(jd.STATE / MODEL_PICKS_FILE_NAME, json.dumps(picks))
         except Exception:
             sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
+            return
+    _models_changed()
 # "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
 # standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
 # SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
@@ -27978,6 +28011,7 @@ else if(m.type==="hover"&&panel.setHover)panel.setHover(m);
 // this inline copy serves the browser, that one the VS Code webview. net-popover-known.test.ts's sibling
 // timeline-boot.test.ts pins the pair.
 else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);
+else if(m.type==="models"&&panel.refreshModels)panel.refreshModels();
 else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);
 else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);});
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
@@ -31332,6 +31366,7 @@ class Handler(BaseHTTPRequestHandler):
                 # holds the rest). The alias, never the list's head: the CLI resolves an alias live,
                 # and the head pinned every picker-set session to claude-fable-5 while `fable` moved
                 # on. The catalog owns the LIST, the alias the DEFAULT.
+                _rev = _models_rev[0]
                 _learned = _learned_versions()
                 _picks = _model_picks(_learned)
                 _cat = _versions_catalog(_learned)
@@ -31341,7 +31376,12 @@ class Handler(BaseHTTPRequestHandler):
                 # model — so every picker shows the reason before the next pick, not only after it
                 _blocks = _cli_model_blocks()
                 return self._send(200, json.dumps(
-                    {"models": [dict(c, color=_model_color(c["value"], _stops),
+                    # `rev` is the pick memory's revision — the models frame's counter (_models_changed),
+                    # read here BEFORE the picks so a payload never carries a rev newer than its list: a
+                    # picker keeps the highest rev it applied and drops a response that lands late with a
+                    # lower one (two overlapping fetches can resolve out of order)
+                    {"rev": _rev,
+                     "models": [dict(c, color=_model_color(c["value"], _stops),
                                      tone=_model_tone(c["value"]),
                                      versions=[_with_cli_block(dict(v), _blocks)
                                                for v in _cat.get(c["value"]) or []],

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8906,10 +8906,17 @@ def _sdk_locked():
             # store names no signed-in account — the same authority the usage bars trust, so the
             # pick can never sit in the UI as applied fact on a box that demonstrably cannot apply it
             _sdk_backend.login_ok = lambda: bool(_claude_account())
-            # a dormant comment thread registered on a superseded full model id comes up on its
-            # family's newest at its next EXPLICIT wake (T223 rider) — the catalog is the kernel's,
-            # so the backend consults this hook instead of importing it
-            _sdk_backend.thread_wake_model = _family_newest_model
+            # NO thread-wake model remap. The T223 rider installed _family_newest_model as the
+            # backend's wake hook, so a dormant comment thread registered on a superseded full id came
+            # up on its family's newest at its next explicit wake — built for the artefact where a
+            # FAMILY click wrote the head's full id into the reg, an accidental pin. With the alias as
+            # the family default a full id in reg.model is a DELIBERATE pin (the version submenu writes
+            # the pick verbatim, the create dialog sends a pinned family's id, the marker-gated
+            # _model_alias_boot_pass treats every post-migration head as the user's; the way back to
+            # floating is the Latest gesture), so the remap would override only deliberate pins. The
+            # backend's hook stays at its None default and its consult in _ensure stays inert;
+            # _family_newest_model stays as a helper. Pinned in tests/test_thread_rows.py
+            # (ThreadWakePinsStand).
             # silent mid-turn model swaps mint a completed card (the user 2026-08-23) — the backend
             # observes the transition; the judge store owns the card; the kernel wires the two
             type(_sdk_backend).on_model_fallback = staticmethod(

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1387,7 +1387,10 @@ def _model_pick_refused(sid, value):
 # alias-worthy exactly as the CLI's own 2.1.257 `migration_fable5_to_fable_alias` treats a user setting
 # of claude-fable-5 (its strings name the migration and the id; verified in the installed binary).
 _SEED_PINS = {"claude-fable-5": "fable", "claude-opus-5": "opus", "claude-sonnet-5": "sonnet",
-              "claude-haiku-4-5": "haiku"}
+              "claude-haiku-4-5": "haiku",
+              # fable's head moved to 5.1 on 2026-09-01 and every family click since wrote THAT id — the
+              # exact artefact this pass exists for, and the one the seed set first missed (PR #882 review)
+              "claude-fable-5-1": "fable"}
 MODEL_ALIAS_MIGRATION_MARKER = "model-alias-migration.done"   # STATE/…: stamped once the pass below ran clean
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1365,6 +1365,18 @@ def _forget_model_pick(fam, only=None):
             sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
             return
     _models_changed()
+
+
+def _model_pick_refused(sid, value):
+    """The SDK backend's on_model_refused hook: the CLI ANSWERED a set_model with an error, so `value` —
+    recorded as its family's pin at the choke point, BEFORE the CLI ruled — is an id the CLI will not
+    run. Forget it, but only while it is still the pin (a newer accepted pick for the family is not this
+    refusal's to touch); the forget emits the models frame, so every picker's family row stops sending
+    the refused id instead of re-ringing the problem on each click. An alias or an unknown string was
+    never a pin: no-op."""
+    fam = _version_family(value)
+    if fam:
+        _forget_model_pick(fam, only=value)
 # "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
 # standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
 # SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
@@ -8784,6 +8796,9 @@ def _sdk_locked():
             # observes the transition; the judge store owns the card; the kernel wires the two
             type(_sdk_backend).on_model_fallback = staticmethod(
                 lambda sid, frm, to: (jd.mint_fallback_card(sid, frm, to), _push_soon()))
+            # a version the CLI REFUSED must leave the pick memory too: the backend rules on the CLI's
+            # answer, the kernel owns model-picks.json — the same wiring shape
+            type(_sdk_backend).on_model_refused = staticmethod(_model_pick_refused)
             # The judge parses the SAME cut world the display parse does (jd._PENDING_CUT_FN): during
             # an armed bare rollback the planner must not see — and mint from — the deleted tail.
             # getattr-guarded like every other backend probe (a test fake without the affordance
@@ -18201,7 +18216,8 @@ def _alias_reflects(live_pretty, alias):
         return False
     if not alias or alias == "default":
         return True
-    a = alias.lower()
+    a = re.sub(r"\[[^\]]*\]$", "", alias.lower().strip())   # fable[1m] → fable: the CLI's context tag is
+    #                                                          never part of the pretty name
     a = a.split("-")[1] if a.startswith("claude-") and "-" in a else a   # claude-opus-4-8 → opus
     return a in live_pretty.lower()
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -829,10 +829,14 @@ MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label"
 # Every version a family can pin (the user 2026-08-25: shorthand aliases resolve to the NEWEST —
 # opus became Opus 5 — silently losing the legacy versions that remain live on the API). Newest
 # first; values are the API's DATELESS aliases, verified against the claude-api reference
-# 2026-08-25 (deprecated 4.1/4.0-era models excluded on purpose — they are retiring). Clicking a
-# family in a picker sends that family's DEFAULT: the most recent version the user picked for it
-# (model-picks.json below), else the newest. Full ids ride every set path verbatim already — the
-# alias table stops at the family names, so a version pick needs no new transport.
+# 2026-08-25 (deprecated 4.1/4.0-era models excluded on purpose — they are retiring). This table is
+# the SEED the live catalog below grows. The catalog owns the LIST; the alias owns the DEFAULT:
+# clicking a family in a picker sends that family's DEFAULT — the most recent VERSION the user
+# picked for it (model-picks.json below), else the family ALIAS itself. The CLI resolves an alias
+# live, so a bare family click follows the family's newest release exactly as the CLI's own default
+# does. (Before this the default fell to this table's head, which pinned every picker-set session
+# to claude-fable-5 while `fable` moved on.) Full ids ride every set path verbatim already — the
+# CLI's alias table stops at the family names, so a version pick needs no new transport.
 MODEL_VERSIONS = {
     "fable":  [{"value": "claude-fable-5-1", "label": "Fable 5.1"},   # verified live 2026-09-01 (Models API + CLI 2.1.257)
                {"value": "claude-fable-5", "label": "Fable 5"}],
@@ -848,6 +852,7 @@ MODEL_VERSIONS = {
 }
 _VERSION_FAMILY = {v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v in vs}
 MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pref all surfaces read, like colormap
+_model_picks_lock = threading.Lock()   # its read-modify-writes run on the WS-handler, producer AND SDK-loop threads
 
 # ── the LIVE model catalog (T222, the user 2026-09-01: romp must stop needing a hand edit when
 # Anthropic ships a model). The table above is the SEED and the loud fallback. The kernel queries the
@@ -863,6 +868,10 @@ MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pr
 MODEL_CATALOG_FILE_NAME = "model-catalog.json"
 MODELS_API_URL = os.environ.get("ROMP_MODELS_URL") or "https://api.anthropic.com/v1/models"
 _MODEL_SEED = {fam: [dict(v) for v in vs] for fam, vs in MODEL_VERSIONS.items()}   # the shipped table, frozen
+# THE one grammar for a first-party model id (family, then the version's numeric parts — a -YYYYMMDD
+# snapshot date is just a long last part, which _catalog_family refuses and _model_id_parts drops).
+# The catalog's helpers and the pick memory's id helpers all read it; a second regex of this name
+# would shadow it.
 _MODEL_ID_RE = re.compile(r"^claude-(fable|opus|sonnet|haiku)-(\d+(?:-\d+)*)$")
 _catalog_lock = threading.Lock()
 _catalog_status = {"source": "seed", "fetchedAt": None, "lastError": None, "added": [], "inflight": False}
@@ -1123,9 +1132,40 @@ def _with_cli_block(version, blocks):
     return version
 
 
+def _model_id_clean(value):
+    """The id without a trailing [1m]-style context tag, lower-cased — what the pickers send back."""
+    return re.sub(r"\[[^\]]*\]$", "", str(value or "").strip().lower())
+
+
+def _model_id_parts(value):
+    """('fable', 5, 1) for 'claude-fable-5-1' — and for the [1m]-tagged and -YYYYMMDD-dated spellings a
+    CLI reports (the tag is stripped, the date dropped: the version is what precedes it); None for
+    anything that is not a first-party VERSION id of a picker family (a provider-prefixed id, a family
+    alias, a -fast variant, '<synthetic>'). Reads the catalog's one id grammar (_MODEL_ID_RE)."""
+    m = _MODEL_ID_RE.match(_model_id_clean(value))
+    if not m:
+        return None
+    nums = m.group(2).split("-")
+    if len(nums[-1]) >= 8:                       # a dated snapshot: claude-opus-4-5-20251101 → (4, 5)
+        nums = nums[:-1]
+    if not 1 <= len(nums) <= 2:                  # major[.minor] only — three numeric parts is no version
+        return None
+    return (m.group(1), int(nums[0]), int(nums[1]) if len(nums) > 1 else 0)
+
+
+def _model_id_label(value):
+    """The badge label for a first-party id — the SDK backend's pretty_model rule: 'Fable 5.1'; '' for
+    anything that is not one (a module-level helper never raises on junk)."""
+    parts = _model_id_parts(value)
+    if not parts:
+        return ""
+    fam, maj, minor = parts
+    return "%s %d" % (fam.capitalize(), maj) + (".%d" % minor if minor else "")
+
+
 def _model_picks():
     """The per-family last-picked map. Only known version ids survive the read (a stale or hand-edited
-    entry falls back to the family's newest rather than poisoning the default)."""
+    entry falls back to the family alias rather than poisoning the default)."""
     try:
         d = json.loads((jd.STATE / MODEL_PICKS_FILE_NAME).read_text())
         if not isinstance(d, dict):
@@ -1143,20 +1183,52 @@ def _model_picks():
 
 def _note_model_pick(value):
     """Record a version pick as its family's new default (write-on-change). Family shorthands and
-    unknown strings record nothing — they are not version picks (an unknown claude-* id does fire
-    the catalog's staleness refresh: it may be a model newer than this list)."""
+    unknown strings record nothing — they are not version picks — so a bare family click (which
+    carries the alias) can never downgrade an explicit legacy pin (an unknown claude-* id does fire
+    the catalog's staleness refresh: it may be a model newer than this list, T222)."""
     fam = _VERSION_FAMILY.get(str(value or ""))
     if not fam:
         _note_unknown_model(value)
         return
-    picks = _model_picks()
-    if picks.get(fam) == value:
-        return
-    picks[fam] = value
-    try:
-        _atomic_write(jd.STATE / MODEL_PICKS_FILE_NAME, json.dumps(picks))
-    except Exception:
-        sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
+    # Merge into the RAW file, never the filtered read: an entry the read filter hides (one the
+    # catalog cannot vouch for right now) is not erased by another family's write — it resolves
+    # again the moment the catalog learns the id.
+    with _model_picks_lock:
+        try:
+            picks = json.loads((jd.STATE / MODEL_PICKS_FILE_NAME).read_text())
+        except Exception:
+            picks = {}
+        picks = picks if isinstance(picks, dict) else {}
+        if picks.get(fam) == value:
+            return
+        picks[fam] = value
+        try:
+            _atomic_write(jd.STATE / MODEL_PICKS_FILE_NAME, json.dumps(picks))
+        except Exception:
+            sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
+
+
+def _forget_model_pick(fam, only=None):
+    """Drop a family's remembered pin, so /models falls back to the alias and a family click follows the
+    CLI's newest again — the version submenu's "Latest" row, an explicit user gesture carried as
+    `floating` on the set op. Merges into the RAW file like _note_model_pick (other families' pins,
+    vouched-for or not, stay); a family with no pin is a no-op. `only` drops the pin only while it still
+    holds that exact id — the refusal path's compare-and-swap, so a late refusal never drops a NEWER pin
+    the user has since accepted."""
+    with _model_picks_lock:
+        try:
+            picks = json.loads((jd.STATE / MODEL_PICKS_FILE_NAME).read_text())
+        except Exception:
+            return
+        if not isinstance(picks, dict) or fam not in picks:
+            return
+        if only is not None and picks.get(fam) != only:
+            return                                   # a newer pin — not this writer's to drop
+        picks.pop(fam, None)
+        try:
+            _atomic_write(jd.STATE / MODEL_PICKS_FILE_NAME, json.dumps(picks))
+        except Exception:
+            sys.stderr.write("model-picks save: %s\n" % traceback.format_exc())
 # "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
 # standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
 # SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
@@ -7323,9 +7395,12 @@ def _pick_identity_color(now=None):
 def _apply_new_session_prefs(sid, body):
     """POST /new's optional per-spawn "model"/"effort" (the user 2026-08-14): applied through the SAME
     park-aware setters as the dashboard's setModel/setEffort ops, and echoed back so the caller can be
-    loud when a kernel ignores them. Values pass through VERBATIM — full model ids as the picker sends
-    them (claude-fable-5), never a short alias: the CLI alias table stops at opus/sonnet/haiku and
-    quietly resolved "fable" to Opus 5 (observed live 2026-08-14). Runs on the idempotent existing:true
+    loud when a kernel ignores them. Values pass through VERBATIM — a family alias (fable: the CLI
+    resolves it live, so it follows the family's newest release) or a full version id (claude-fable-5,
+    a deliberate pin), whichever the caller sends. (A note here once claimed the CLI resolved "fable"
+    to Opus 5 and so required full ids; that is not reproducible on any installed CLI from 2.1.224 on
+    — each resolves `fable` to the Fable family's newest — and was most likely a misread server-side
+    fallback.) Runs on the idempotent existing:true
     open too, so a nightly re-brief re-asserts them on the standing session — ultracode is per-session
     by design (never a write_sdk_default seed), and a headless script has no WS, so this is the
     sanctioned door."""
@@ -9253,8 +9328,13 @@ def _drive(msg, client):
         return True                                       # consumed: refused, reported, and recorded
     be = Sessions.backend_for(sid)
     if t == "sendMessage" and msg.get("text"):
-
-        _send_or_park(be, sid, str(msg["text"]), echo="human"); _push_soon()  # idle → instant echo; SDK busy → queued bubble forwarded mid-turn + folded (but a SLASH COMMAND parks to fire alone at turn end — mid-turn it would land as text, not execute); tmux busy → held + merged at turn end
+        # a typed "/model X" / "/effort X" / "/fast X" is a SETTING, not a message: it takes the kernel's
+        # own setter — registry, sdk-defaults, pick memory and the reconnect's --model all follow — never
+        # the CLI as literal text (see _route_meta_command). Everything else is the CLI's.
+        if _route_meta_command(be, sid, str(msg["text"]), client):
+            _push_soon()
+        else:
+            _send_or_park(be, sid, str(msg["text"]), echo="human"); _push_soon()  # idle → instant echo; SDK busy → queued bubble forwarded mid-turn + folded (but a SLASH COMMAND parks to fire alone at turn end — mid-turn it would land as text, not execute); tmux busy → held + merged at turn end
     elif t == "rewindSend" and msg.get("uuid") and msg.get("text"):
         # Edit a past message (SDK sessions): rewind the conversation to just before it and send the
         # edited text as the branch's next turn. NO optimistic kernel echo — the edit lands mid-chat
@@ -9288,13 +9368,9 @@ def _drive(msg, client):
         _compact_or_park(be, sid)                        # parked → queued chip; quiet → now + the instant cue
     elif t == "sendCommand" and msg.get("cmd"):
         cmd = str(msg["cmd"]).strip()                     # the timeline lane menu sends "/model X" / "/effort X"
-        if cmd.startswith("/model "):
-            _set_model_or_park(be, sid, cmd[len("/model "):].strip())   # mid-compaction → parked as a queued command
-        elif cmd.startswith("/effort "):
-            _set_effort_or_park(be, sid, cmd[len("/effort "):].strip())   # mid-compaction → parked as a queued command
-        elif cmd.startswith("/fast "):
-            _set_fast_or_park(be, sid, cmd[len("/fast "):].strip())   # mid-compaction → parked as a queued command
-        else:
+        # /model, /effort, /fast → the setters (mid-compaction → parked); `floating` is the lane
+        # submenu's Latest row (forget the family's pin)
+        if not _route_meta_command(be, sid, cmd, client, floating=bool(msg.get("floating"))):
             _send_or_park(be, sid, cmd)   # mid-compaction → parked as a queued command
     elif t == "askFollowUp":
         iid = str(msg.get("itemId") or "")
@@ -9456,7 +9532,9 @@ def _drive(msg, client):
         # manual Retry-now button and the dashboard tick's redundant asks, both idempotent against it).
         _fire_api_retry(sid, be, manual=bool(msg.get("manual")))
     elif t == "setModel" and msg.get("value"):
-        _set_model_or_park(be, sid, str(msg["value"])); _push_soon()   # mid-compaction → parked as a queued command
+        # mid-compaction → parked as a queued command; `floating` is the version submenu's Latest row —
+        # forget the family's remembered pin and send the alias
+        _set_model_or_park(be, sid, str(msg["value"]), floating=bool(msg.get("floating"))); _push_soon()
     elif t == "setEffort" and msg.get("value"):
         _set_effort_or_park(be, sid, str(msg["value"])); _push_soon()   # tmux: /effort; SDK: reconnect with --effort; mid-compaction → parked
     elif t == "setFast" and msg.get("value") in ("on", "off"):
@@ -18521,10 +18599,18 @@ def _compact_request(who):
     return {"ok": True, "queued": _compact_or_park(Sessions.backend_for(sid), sid)}
 
 
-def _set_model_or_park(be, sid, value):
+def _set_model_or_park(be, sid, value, floating=False):
     """Apply a model change now — or park it in the sid's FIFO op queue while the session compacts. Either
     way, the pick is ACCEPTED now: stamp the shared pending signal (_mark_model_pending) so chat + timeline
-    both show switching-dots immediately, from whichever surface the click came from (the user 2026-07-03)."""
+    both show switching-dots immediately, from whichever surface the click came from (the user 2026-07-03).
+    `value` is a family alias (a bare family click — the CLI resolves it live) or an explicit version id
+    (a submenu pick, remembered as the family's pin); both ride to the backend verbatim. `floating` is the
+    version submenu's "Latest" row: the value is a family alias AND the family's remembered pin is
+    forgotten, so the family follows the CLI's newest again — the one picker gesture back from a pin (the
+    family row sends the pin, the version rows pin, and a typed bare alias leaves the memory alone by
+    design). Meaningless on a non-alias value."""
+    if floating and value in _MODEL_VALUES:
+        _forget_model_pick(value)
     _mark_model_pending(sid, value)
     _note_model_pick(value)          # a version pick becomes its family's remembered default (2026-08-25)
     if _ops_gate(sid):
@@ -18565,6 +18651,51 @@ def _set_fast_or_park(be, sid, value):
         _park_op(sid, ("fast", value))
         return True
     return be.set_fast(sid, value)
+
+
+def _route_meta_command(be, sid, text, client=None, floating=False):
+    """A "/model X", "/effort X" or "/fast on|off" — typed into the chat composer or sent by the timeline
+    lane menu — goes through the kernel's OWN setters (_set_*_or_park), never to the CLI as literal text.
+    `floating` rides the lane menu's "Latest" row to _set_model_or_park (forget the family's pin).
+    The CLI would execute the text (verified on 2.1.257), but that path bypasses romp: the registry,
+    sdk-defaults.json, the pick memory and the reconnect's --model all kept the OLD value, so a switch
+    typed into the composer silently reverted at the next reconnect or restart. The setters are also
+    what parks the change mid-compaction. Returns True when it took the command. Anything else —
+    another slash command, a bare "/model" (the CLI's own picker), plain text that merely contains one
+    — is the caller's to send verbatim: the CLI owns what executes. A refused fast toggle is told to
+    the client (fail loudly): a dormant SDK session has no live CLI to apply it, and the typed text
+    used to at least draw the CLI's own refusal."""
+    head, _, rest = (text or "").strip().partition(" ")
+    value = rest.strip()
+    # ONE token, and one the kernel can vouch for: the setters PERSIST their value — set_model's lands
+    # in sdk-defaults.json as the seed for every future session — so a typo ("/model opsu"), a
+    # multiline message that merely opens with the command, or a fast value outside on/off is not
+    # ours to swallow: it stays the CLI's, verbatim, and the user sees the CLI's own error.
+    if not value or len(value.split()) != 1:
+        return False
+    if head == "/model" and _vouched_model(value):
+        _set_model_or_park(be, sid, value, floating=floating)     # mid-compaction → parked as a queued command
+    elif head == "/effort" and value in _EFFORT_VALUES:
+        _set_effort_or_park(be, sid, value)    # mid-compaction → parked as a queued command
+    elif head == "/fast" and value in ("on", "off"):
+        if not _set_fast_or_park(be, sid, value) and client:   # mid-compaction → parked
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "Couldn't toggle fast mode — the session isn't connected right now."}))
+    else:
+        return False
+    return True
+
+
+def _vouched_model(value):
+    """A model value the kernel will stand behind persisting: a family alias, 'default', a catalog
+    version id, or any well-formed first-party id of a known family (the CLI validates the exact
+    version; romp's job is keeping the registry in step). A typo is none of these."""
+    if value in _MODEL_VALUES or value == "default" or _VERSION_FAMILY.get(value):
+        return True
+    if _model_id_clean(value) in _MODEL_VALUES:   # the CLI's own 1M-context spelling of a family (fable[1m])
+        return True                                # — vouched like the tagged id below
+    parts = _model_id_parts(value)
+    return bool(parts and parts[0] in _MODEL_VALUES)
 
 
 def _deliver_send_batch(be, sid, run):
@@ -31086,8 +31217,10 @@ class Handler(BaseHTTPRequestHandler):
                 # colors only cover the current value, so the list is where the shared tint belongs)
                 _stops = cm.stops_for(_colormap())
                 # each family also carries its VERSIONS (newest first, the family's tint) and its
-                # DEFAULT — the last version the user picked for that family, else the newest (the
-                # user 2026-08-25: family click = remembered pick; the submenu holds the rest).
+                # DEFAULT — the last version the user picked for that family, else the family ALIAS
+                # (the user 2026-08-25: family click = remembered pick; the submenu holds the rest).
+                # The alias, never the list's head: the CLI resolves an alias live, and the head
+                # pinned every picker-set session to claude-fable-5 while `fable` moved on.
                 _picks = _model_picks()
                 # a version the INSTALLED CLI has refused by minimum version says so on its own row
                 # (T222): the refusal is learned from the CLI's own error at the first attempt
@@ -31099,9 +31232,7 @@ class Handler(BaseHTTPRequestHandler):
                                      tone=_model_tone(c["value"]),
                                      versions=[_with_cli_block(dict(v), _blocks)
                                                for v in MODEL_VERSIONS.get(c["value"]) or []],
-                                     default=_picks.get(c["value"])
-                                         or ((MODEL_VERSIONS.get(c["value"]) or [{}])[0].get("value")
-                                             or c["value"]))
+                                     default=_picks.get(c["value"]) or c["value"])
                                 for c in MODEL_CHOICES],
                      "efforts": [dict(c, color=_effort_color(c["value"], _stops), tone=_effort_tone(c["value"]))
                                  for c in EFFORT_CHOICES],
@@ -31528,8 +31659,11 @@ class Handler(BaseHTTPRequestHandler):
                 # in by a local tool while the account is rate-limited — or while the session compacts —
                 # waits its turn instead of buying a red API-error card. ok:true still means ACCEPTED,
                 # which is all it ever meant on this route. No optimistic echo: an external/postal send
-                # isn't a human composer bubble.
-                _send_or_park(Sessions.backend_for(sid), sid, body["text"])
+                # isn't a human composer bubble. A typed /model, /effort or /fast takes the setters,
+                # exactly as the composer's does — same door, same registry.
+                be = Sessions.backend_for(sid)
+                if not _route_meta_command(be, sid, body["text"]):
+                    _send_or_park(be, sid, body["text"])
                 return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path in ("/fork-comment", "/fork-promote"):
                 # Parallel review dispatch (the user 2026-08-31, via the Obsidian track-changes

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -116,6 +116,7 @@ def _alias_label(alias: str) -> str:
     label model_label falls back to (pretty id, or capitalised alias, '' for default)."""
     if not alias or alias == "default":
         return ""
+    alias = re.sub(r"\[[^\]]*\]$", "", alias)   # fable[1m] → Fable: the context tag is not part of the name
     return pretty_model(alias) if alias.startswith("claude-") else alias.capitalize()
 
 
@@ -145,7 +146,9 @@ def _model_reflects_alias(live_pretty: str, alias: str) -> bool:
         return False
     if not alias or alias == "default":
         return True
-    a = alias.lower()
+    # fable[1m] → fable: the CLI's 1M-context tag is never part of the pretty name, so the literal
+    # never matched and a tagged pick's switching-dots stuck until the thread died
+    a = re.sub(r"\[[^\]]*\]$", "", alias.lower().strip())
     a = a.split("-")[1] if a.startswith("claude-") and "-" in a else a   # claude-opus-4-8 → opus
     return a in live_pretty.lower()
 
@@ -1427,16 +1430,93 @@ def read_sdk_defaults(state_dir: Path) -> dict:
         return {}
 
 
-def write_sdk_default(state_dir: Path, **fields) -> None:
-    """Merge {model?, effort?} into the remembered defaults (atomic tmp+rename). Only non-None keys passed
-    are touched, so remembering a model never clobbers the remembered effort and vice-versa."""
-    d = read_sdk_defaults(state_dir)
-    d.update({k: v for k, v in fields.items() if v is not None})
+_defaults_lock = threading.Lock()   # serializes the read-modify-writes below: the kernel thread (set_model, the
+#                                     parked-op replay) and the SDK loop thread (_revert_model) both write the file
+
+
+def _write_sdk_defaults(state_dir: Path, d: dict) -> None:
+    """The one writer: atomic tmp+rename. Callers hold _defaults_lock."""
     p = _defaults_path(state_dir)
     p.parent.mkdir(parents=True, exist_ok=True)
     tmp = p.with_suffix(".tmp")
     tmp.write_text(json.dumps(d))
     os.replace(tmp, p)
+
+
+# The remembered `model` carries the IDENTITY of the write that put it there: `modelTok`, a fresh token
+# stamped by every writer of that key. The store is shared across sessions and a live set_model writes it
+# BEFORE the CLI has ruled, so a refusal has to ask "is the value in the store still MY write?" — and by
+# value that question has no answer: another session's accepted pick of the same id looks exactly like
+# this session's pending one, a foreign pending write looks like a baseline, and an id this session
+# refused long ago is indistinguishable from the same id another session accepted since. The token
+# answers it exactly (SdkBackend._seed_write_*). Only `model` carries one — effort/mode/auth have no
+# live refusal path through this store.
+_TOKENED_DEFAULTS = frozenset({"model"})
+
+
+def _mint_write_tok() -> str:
+    return uuid.uuid4().hex
+
+
+def write_sdk_default(state_dir: Path, **fields) -> None:
+    """Merge {model?, effort?} into the remembered defaults (atomic tmp+rename). Only non-None keys passed
+    are touched, so remembering a model never clobbers the remembered effort and vice-versa. A `model`
+    written here is SETTLED as it lands (a dormant session's pick, applied at its next connect; nothing
+    can refuse it now), and its fresh `modelTok` says so to any pending write it replaced: that write is
+    no longer the store's head, so its refusal leaves the store alone."""
+    with _defaults_lock:
+        d = read_sdk_defaults(state_dir)
+        d.update({k: v for k, v in fields.items() if v is not None})
+        for k in _TOKENED_DEFAULTS:
+            if fields.get(k) is not None:
+                d[k + "Tok"] = _mint_write_tok()
+        _write_sdk_defaults(state_dir, d)
+
+
+def _swap_sdk_default_locked(state_dir: Path, key: str, value):
+    """swap_sdk_default's body, for a caller that already holds _defaults_lock and has more to do under
+    the same hold (SdkBackend._seed_write_pending inserts the write's node before letting go: with the
+    swap and the insert in two holds, a refusal of the write this one replaced could run between them,
+    re-point only the nodes that existed, and leave the new node pointing at the refused pair). Callers
+    hold _defaults_lock."""
+    d = read_sdk_defaults(state_dir)
+    prior, prior_tok = d.get(key), d.get(key + "Tok")
+    tok = _mint_write_tok()
+    d[key] = value
+    d[key + "Tok"] = tok
+    _write_sdk_defaults(state_dir, d)
+    return prior, prior_tok, tok
+
+
+def swap_sdk_default(state_dir: Path, key: str, value):
+    """Write one remembered default under a FRESH write token and return the (value, token) it REPLACED
+    (None, None = the key was absent) plus the token minted — the read and the write in ONE lock hold.
+    A setter that read its snapshot, released, and then took the lock to write let a writer on the
+    other thread (a revert, another session's pick) land in between, so the snapshot described a value
+    the write never replaced. The optimistic setter's read-modify-write; the prior pair is what
+    SdkBackend._seed_write_refused puts back when this write is refused while it is still the store's
+    head."""
+    with _defaults_lock:
+        return _swap_sdk_default_locked(state_dir, key, value)
+
+
+def _cli_refusal(e: BaseException) -> bool:
+    """Did the CLI ANSWER a control request with an error — or did the answer never arrive? The SDK
+    (claude_agent_sdk 0.2.132, _internal/query.py) raises a BARE Exception for both, so the type alone says
+    nothing; the construction does:
+    - a CLI error response: `Exception(response["error"])`, built in the reader from the control_response
+      frame — exact Exception, no cause, the CLI's own text ("Unknown model: …"; "Unknown error" when the
+      frame carried none);
+    - no answer: `Exception("Control request timeout: <subtype>") from TimeoutError` when fail_after expires
+      — which is also how a request STRANDED by Query.close() ends, since close() cancels the reader without
+      resolving pending requests (a reconnect teardown does exactly that);
+    - a reader that dies fans ITS OWN exception (ProcessError, CLIJSONDecodeError, …) into every pending
+      request, and a client already disconnected raises CLIConnectionError — typed, never a bare Exception.
+    Verified by probe against the installed package. Only the first is a verdict on the VALUE; the others
+    say nothing about it, and a setter must not revert on them. A future SDK that types these exceptions
+    makes this conservative (never a revert) — the safe failure."""
+    return (type(e) is Exception and e.__cause__ is None
+            and not str(e).startswith("Control request timeout"))
 
 
 _WORK_KEY: str | None = None   # process-lifetime stash; None = not yet claimed from the environment
@@ -1699,6 +1779,16 @@ class SdkSession:
         self._sub_lock = threading.Lock()            #   hooks mutate on the loop thread; snapshot() reads from the kernel thread
         #                                                (guards _subagents AND _bg_tasks)
         self.chosen_model = reg.get("model") or ""   # the alias the user picked (opus/sonnet/…); self.model is the display name
+        # The last model the CLI ACCEPTED for THIS session — the target its own layers (chosen_model, the
+        # reg's `model`) revert to when a set_model is refused. None = absent (the account default). The
+        # reg's value at construction is asserted by the connect (--model rides _options), so it starts
+        # here; it then moves only on a verdict: the CLI accepting a pick (_do_set_model), a connect
+        # reporting the model it launched with (the init message), a lost answer (the pick stands and the
+        # next connect asserts it). Every writer of those two layers is this session, so the last accepted
+        # value IS the baseline. The SHARED sdk-defaults `model` is a different matter — other sessions
+        # write it too — and is ruled per WRITE, by token, in SdkBackend._seed_write_*: no per-session
+        # view of that layer exists here on purpose (see _seed_write_refused). Under self._lock.
+        self._model_accepted = reg.get("model")
         self._model_pending = ""                     # target ALIAS while a /model switch is resolving: the badge shows
         #   animated dots until the LIVE model actually reflects the pick (the user 2026-07-03: a switch stamped the
         #   chosen alias but left liveModel stale, and model_label PREFERS liveModel → the badge kept the OLD name).
@@ -1930,12 +2020,24 @@ class SdkSession:
             self.backend._log("interrupt (%s): CLI pid %d already gone" % (self.name, pid))
         self.backend._poke()
 
-    def set_model_live(self, model):
+    def set_model_live(self, model, prev=None):
         """Change the model on a CONNECTED session via the SDK control channel. No-op if not yet
-        connected — _options applies chosen_model on connect instead."""
+        connected — _options applies chosen_model on connect instead. `prev` is what set_model wrote
+        (`picked`) and the token of its shared-defaults write (`tok`) — the keys every layer's revert
+        compares against if the CLI refuses the switch (_do_set_model, the mode path's T139 rule)."""
         if self.loop and self.client:
             self.loop.call_soon_threadsafe(
-                lambda: asyncio.ensure_future(self._do_set_model(model)))
+                lambda: asyncio.ensure_future(self._do_set_model(model, prev)))
+
+    # ---- the accepted model (see __init__) ----
+
+    def _model_accept(self, picked):
+        """The CLI accepted `picked` (or a connect launched with it, or its answer was lost and the pick
+        stands): it is what this session's own layers revert to from here on. Says nothing about the
+        shared defaults — a connect vouches for the reg it launched from, and a write to the shared store
+        is settled by its own token (SdkBackend._seed_write_settled)."""
+        with self._lock:
+            self._model_accepted = picked
 
     def set_mode_live(self, mode, prev="default"):
         """Change the permission mode on a CONNECTED session via the SDK control channel. `prev` is
@@ -2084,11 +2186,95 @@ class SdkSession:
             self._interrupted = False
             self.backend._poke()
 
-    async def _do_set_model(self, model):
+    async def _do_set_model(self, model, prev=None):
         try:
             await self.client.set_model(model)
         except Exception as e:
-            self.backend._log("set_model (%s -> %s) refused by the SDK: %s: %s" % (self.name, model, type(e).__name__, e))
+            # The mode path's rule (_do_set_mode, T139), applied to models: set_model PERSISTED its value
+            # before the CLI accepted it — sdk-defaults.json (the seed for every future session), the reg
+            # (the reconnect's --model) and chosen_model — and a refusal here only logged, so a well-formed
+            # id the CLI's catalog rejects poisoned all three and the next reconnect re-asserted it. Revert
+            # every layer and ring the problems so the failed switch is unmissable. The refresh below then
+            # re-reads the model the CLI actually kept.
+            #
+            # But only on a VERDICT — an exception here is one of three worlds:
+            # - SUPERSEDED: a newer pick owns chosen_model (this session picked again while the request
+            #   was out). This request's evidence predates the diary — stand down entirely, ring nothing:
+            #   the user's later pick already answered whatever this one would have said.
+            # - NO ANSWER (_cli_refusal False: a timeout, a request stranded by a reconnect teardown, a
+            #   dead reader, a disconnected client) says nothing about the value. Reproduced: a model and
+            #   an effort picked mid-turn, parked, replayed back-to-back at turn end — set_model's request
+            #   went to the OLD CLI and set_effort's reconnect tore that client down with the answer
+            #   unread; the new connection ran the pick (--model rides _options) and 60s later the strand
+            #   timed out. Reverting there flips every layer back to the previous model while the CLI runs
+            #   the new one — the registry/argv divergence this change closes, re-minted, plus a false
+            #   fallback card for a cheaper prev. Leave the optimistic state (it IS what the next connect
+            #   asserts) and say once, on the log and not the ring, that the answer was lost. If the CLI
+            #   had in fact refused and the answer was lost, the next connect's --model fails LOUDLY
+            #   through the launch-error path.
+            # - A REFUSAL: revert, ring, and tell the kernel to forget the pin it recorded (below).
+            # Where this session's own layers go BACK to is the last ACCEPTED model (_model_accepted),
+            # never the values this pick's writes happened to replace — with two picks in flight the
+            # second's snapshot held the first, and two refusals in a row would write the first REFUSED id
+            # back. The SHARED defaults are unwound by this write's token (_seed_write_refused): the store
+            # goes back only where this write is still what it holds.
+            picked = prev.get("picked") if prev else None
+            tok = prev.get("tok") if prev else None
+            refusal = _cli_refusal(e)
+            with self._lock:
+                superseded = prev is not None and self.chosen_model != picked
+            if superseded:
+                # Standing down from the SESSION's layers — the newer pick owns chosen_model and the reg.
+                # Not from the shared store: this write's node still sits under the newer pick's. A REFUSAL
+                # splices it out — a refusal of THAT pick would otherwise unwind onto this refused id;
+                # spliced, the newer pick's unwind lands on what this write replaced — and moves the store
+                # only if this write is somehow still its head (the newer write already unwound): a refused
+                # value must not stay the seed just because it lost a race. A LOST answer says nothing
+                # about the id: its node goes the way a settled write's does, and the newer pick's unwind
+                # lands on THIS write — a lost pick stands, as a thread's death leaves it standing
+                # (_seed_writes_dropped).
+                if refusal:
+                    self.backend._seed_write_refused(tok)
+                else:
+                    self.backend._seed_write_settled(tok)
+                self.backend._log("set_model (%s -> %s): %s (%s: %s) after a newer pick (%s) — "
+                                  "standing down; the newer pick owns every layer"
+                                  % (self.name, picked, "the CLI answered" if refusal else "the CLI's answer was lost",
+                                     type(e).__name__, e, self.chosen_model or "the account default"), problem=False)
+            elif not refusal:
+                if prev is not None:
+                    self._model_accept(picked)   # the pick stands as the baseline the next connect asserts
+                    self.backend._seed_write_settled(tok)
+                self.backend._log("set_model (%s -> %s): the CLI's answer was lost (%s: %s) — not a refusal; "
+                                  "the pick stands and the next connect asserts it"
+                                  % (self.name, picked if prev else model, type(e).__name__, e), problem=False)
+            else:
+                back = "the account default"
+                if prev is not None:
+                    back = self.backend._revert_model(self, prev) or back
+                self.backend._log("set_model (%s -> %s) refused by the SDK: %s: %s — the switch did NOT apply; "
+                                  "the model reverted to %s" % (self.name, model, type(e).__name__, e, back),
+                                  problem=True)
+            # The kernel recorded a version as its family's pin BEFORE the CLI ruled (_note_model_pick at
+            # its choke point), and the revert never reached that memory — so the family row kept sending
+            # the refused id and re-ringing this on every click. Class-level hook, the on_model_fallback
+            # idiom: the backend rules on the CLI's answer, the kernel owns the store. Fired for a
+            # SUPERSEDED refusal too: the CLI did rule on the id, and the pin it left in the kernel's
+            # memory is the refused id's, not the newer pick's — the newer pick recorded its own. The hook
+            # compares-and-swaps by value (_forget_model_pick(fam, only=id)), so a newer pin for the same
+            # family is never this refusal's to drop. A lost answer says nothing about the id and forgets
+            # nothing — superseded or not.
+            if refusal:
+                hook = getattr(type(self.backend), "on_model_refused", None)
+                if hook and picked:
+                    try:
+                        hook(self.sid, picked)
+                    except Exception as e2:
+                        self.backend._log("model-pick forget (%s): %s" % (self.name, e2), problem=True)
+        else:
+            if prev is not None:
+                self._model_accept(prev.get("picked"))   # the verdict that moves the accepted state
+                self.backend._seed_write_settled(prev.get("tok"))
         # Pull the real new name NOW rather than waiting for the next turn's assistant message — an idle
         # session the user switched but doesn't drive again would otherwise sit on the switching-dots
         # indefinitely (the user 2026-07-03). get_context_usage reports the current model, so this
@@ -2680,6 +2866,13 @@ class SdkSession:
             #                             is over, so the boot-stagger slot (if any) frees NOW
             d = msg.data if isinstance(msg.data, dict) else {}
             self._learn_model(pretty_model(d.get("model")), raw=str(d.get("model") or ""))
+            # the connect launched with chosen_model (--model rides _options) and the CLI is up on it: the
+            # verdict for a pick whose control request never resolved (its task died with the previous
+            # thread) — it is the accepted model now, so a later refused pick reverts to IT. The reg's
+            # layer only: the connect says nothing about the SHARED defaults, which another session may
+            # have moved since (the store is ruled per write, by token).
+            if hasattr(self, "_model_accepted"):   # __new__-built test doubles skip __init__
+                self._model_accept(self.chosen_model or None)
             self.perm_mode = d.get("permissionMode") or self.perm_mode
             # Fast-mode truth rides the init payload — the AUTHORITATIVE re-assert behind set_fast's
             # optimistic flip, shared with the connect-time initialize response (_adopt_fast_state).
@@ -3849,6 +4042,9 @@ class SdkBackend:
         self._log_cb = log
         self.sessions: dict[str, SdkSession] = {}
         self._lock = threading.Lock()
+        self._seed_writes: dict = {}              # tok → {sid, value, prior, priorTok}: set_model's optimistic
+        #                                             writes to the SHARED sdk-defaults `model`, pending the
+        #                                             CLI's verdict (see _seed_write_pending); under _defaults_lock
         self._reg_lock = threading.Lock()         # serializes _update_reg read-modify-writes (queue mirror
         #                                           writes come from kernel AND loop threads)
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
@@ -5885,50 +6081,203 @@ class SdkBackend:
 
     def set_model(self, sid: str, value: str) -> bool:
         """Change the session's model. Persisted in the registry (so a reconnect keeps it) and applied
-        LIVE on a connected session via the SDK control channel — NOT a /model slash injection, which the
-        SDK input stream does not interpret. 'default' resets to the CLI default (set_model(None))."""
-        if not read_reg(self.state_dir, sid):
+        LIVE on a connected session via the SDK control channel (set_model_live) — the designed API,
+        preferred over a '/model X' text send. (An earlier note here said the SDK input stream does not
+        interpret a literal /model; the CLI does execute one arriving as a top-level prompt — verified on
+        2.1.257 — but that path BYPASSES this registry: the reg, sdk-defaults.json and the reconnect's
+        --model keep the old value, and the switch silently reverts at the next reconnect. So every
+        surface, the typed composer command included, comes through here — kernel _route_meta_command.)
+        `value` is a family alias (fable — the CLI resolves it live, so it follows the family's newest)
+        or an explicit version id (claude-fable-5, a deliberate pin); either rides verbatim. 'default'
+        resets to the CLI default (set_model(None)).
+
+        The writes below are OPTIMISTIC — they land before the CLI has accepted the value — and a live
+        refusal reverts every layer (_do_set_model). The session's OWN layers (chosen_model, the reg) go
+        back to its last ACCEPTED model (_model_accepted), not to whatever the writes replaced: with two
+        picks in flight the second's snapshot held the first, so two refusals in a row would write the
+        first REFUSED id back. The SHARED sdk-defaults `model` is written under a fresh token
+        (swap_sdk_default, one lock hold for the read and the write — a snapshot read outside the hold
+        could describe a value the write never replaced) and remembered as a pending write
+        (_seed_write_pending) until the CLI rules; its refusal unwinds exactly that write by token
+        (_seed_write_refused), never a by-value guess. `prev` carries the value written (`picked`) for
+        the session layers' compare-and-swap and the token (`tok`) for the store's. A dormant session
+        has no CLI to refuse, and its value applies at the next connect."""
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
             return False
-        write_sdk_default(self.state_dir, model=value)   # remember as the seed for the NEXT new session (the user 2026-06-27)
         s = self.sessions.get(sid)
         if s:
-            s.chosen_model = value
-            # PENDING: show switching-dots, NOT a premature/stale name, until the LIVE model reflects the
-            # pick (the user 2026-07-03). The old code stamped s.model = value.capitalize() ("Opus"), but
-            # left reg.liveModel stale — and model_label PREFERS liveModel, so a session that hadn't yet run
-            # a turn in the new model kept showing the OLD name. Now the pick marks pending; _do_set_model
-            # pulls the real name, which clears it (and the dormant/never-driven trap can't happen — the
-            # refresh resolves an idle session, and _on_session_gone resolves a thread that exits mid-switch).
-            already = _model_reflects_alias(s.model, value)
-            s._model_pending = "" if already else value
-            self._update_reg(sid, model=value, modelPending=bool(s._model_pending))   # locked RMW — see set_effort
-            s.set_model_live(None if value in ("", "default") else value)
-            # Synthesize the INVOCATION atom the CLI never streams (it streams only the stdout
-            # confirmation): the chat gets the same "/model sonnet" command chip the tmux path reads from
-            # its transcript, and the timeline's dot lands in REAL TIME instead of after the next disk
-            # write (the user 2026-07-02). _echo_text lets the disk's own command record retire it by
-            # text match if one ever lands; the human-floor prune covers a session that never writes one.
-            t = int(time.time())
-            disp = "/model " + value
-            uid = "cmd:%d:model" % t
-            self._live.setdefault(sid, {})[uid] = {
-                "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
-                "t": t, "author": "human", "command": "/model", "_echo_text": disp,
-                "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
-            # The DURABLE twin of the live chip (the user 2026-08-14): same t and text, so build_session
-            # can dedup while the chip is live and take over seamlessly once stale_cmd retires it.
-            append_cmd_gesture(self.state_dir, sid, disp, t=t)
-            self._wake_push()
+            with s._lock:
+                s.chosen_model = value
+                # PENDING: show switching-dots, NOT a premature/stale name, until the LIVE model reflects the
+                # pick (the user 2026-07-03). The old code stamped s.model = value.capitalize() ("Opus"), but
+                # left reg.liveModel stale — and model_label PREFERS liveModel, so a session that hadn't yet run
+                # a turn in the new model kept showing the OLD name. Now the pick marks pending; _do_set_model
+                # pulls the real name, which clears it (and the dormant/never-driven trap can't happen — the
+                # refresh resolves an idle session, and _on_session_gone resolves a thread that exits mid-switch).
+                already = _model_reflects_alias(s.model, value)
+                s._model_pending = "" if already else value
+                pending = bool(s._model_pending)
+            # remember as the seed for the NEXT new session (the user 2026-06-27) — pending the CLI's verdict
+            tok = self._seed_write_pending(sid, value)
+            prev = {"picked": value, "tok": tok}   # what the layers hold until the CLI rules — the revert's CAS keys
+            self._update_reg(sid, model=value, modelPending=pending)   # locked RMW — see set_effort
+            s.set_model_live(None if value in ("", "default") else value, prev=prev)
         else:
+            write_sdk_default(self.state_dir, model=value)   # the seed for the NEXT new session (the user 2026-06-27)
             # DORMANT (no live thread): no turn is coming to report a real name, so resolve to the chosen
             # alias's best-effort label immediately — never leave the badge on a stale liveModel or trapped
             # on dots. The value applies for real on the next connect (chosen_model → _options).
             self._update_reg(sid, model=value, liveModel=_alias_label(value), modelPending=False)
+        # the acknowledging chip — live OR dormant (see _ack_cmd_chip)
+        self._ack_cmd_chip(sid, "/model", "/model " + value, s.resume_sid if s else reg.get("lastSid"))
         return True
+
+    def _revert_model(self, sess: "SdkSession", prev: dict) -> str:
+        """Undo set_model's optimistic writes after the CLI refused the value: chosen_model, the pending
+        marker and the reg's `model` go back to the session's last ACCEPTED model (_model_accepted: the
+        CLI's last accepted pick, or the model a connect launched with — never a value this session wrote
+        and the CLI then refused; see __init__). A None there means the key was ABSENT, and absence is
+        restored (a null would read as a pick, and a leftover refused value is the poison this exists to
+        remove). Locked RMW on the reg, like _update_reg. The SHARED sdk-defaults `model` is unwound by
+        this write's TOKEN (_seed_write_refused): back to what the write replaced, only while the write is
+        still what the store holds. Returns the model the session went back to ("" for the account
+        default), for the log line.
+
+        COMPARE-AND-SWAP per layer: a layer goes back only while it still holds the refused write — by
+        value for the session's own layers (`prev["picked"]`, what set_model wrote; every writer of those
+        layers is this session), by token for the shared store (a value compare cannot tell this write
+        from another session's write of the same id). A refusal that lands after a newer accepted pick
+        (this session's next pick; another session's pick in the SHARED defaults store) must not roll
+        that pick back: a writer whose evidence predates the diary stands down. The compare and the
+        assign of chosen_model sit in one hold of the session lock — set_model assigns it from the kernel
+        thread under the same lock, so the swap cannot tear."""
+        picked = prev.get("picked")
+        with sess._lock:
+            back_model = sess._model_accepted
+            if sess.chosen_model == picked:
+                sess.chosen_model = back_model or ""
+                sess._model_pending = ""
+        with self._reg_lock:
+            reg = read_reg(self.state_dir, sess.sid) or {"sid": sess.sid}
+            if reg.get("model") == picked:
+                if back_model is None:
+                    reg.pop("model", None)
+                else:
+                    reg["model"] = back_model
+                reg["modelPending"] = False
+                write_reg(self.state_dir, sess.sid, reg)
+        self._seed_write_refused(prev.get("tok"))
+        return back_model or ""
+
+    # ---- the shared defaults' `model`, ruled per WRITE ----
+    # sdk-defaults.json seeds every NEW session, and every session's set_model writes it BEFORE the CLI has
+    # ruled on the value. A refusal must then put the store back — but only where the store still holds
+    # THIS write. Deciding that by VALUE, from a per-session picture of the layer, is wrong three ways:
+    # picking the value the store ALREADY holds (another session's accepted pick — the common case) cannot
+    # be adopted as the baseline, so a refusal restores a stale one over that session's pick; an id this
+    # session refused long ago stays unadoptable even after another session accepted it; and another
+    # session's PENDING write, not yet ruled on, gets adopted as a baseline — two cross-session refusals
+    # then seed a refused id. Identity instead: every write of the key carries a fresh token (`modelTok`),
+    # and a live set_model's write is remembered here, by token, with the (value, token) pair it replaced,
+    # until the CLI rules. Pending writes form a chain — each one's prior is the write it landed on — and a
+    # verdict touches exactly its own node: accepted → the node goes (a newer write above it unwinds onto
+    # an accepted value); refused → the store goes back to the node's prior IF the write is still the head,
+    # and a newer node that replaced it now points past it (so ITS unwind never lands on a refused id).
+    # A write that is not the head and that no pending node replaced was written over by a settled writer
+    # (a dormant pick, another kernel, a hand edit): that writer holds the store, and the refusal leaves
+    # it alone. The chain lives in memory: after a kernel restart no verdict can reach a write made
+    # before it (the reconnect asserts the reg's model and a launch refusal is loud on its own path), and
+    # a token in the file that no node knows can never be matched — fail-safe. All under _defaults_lock.
+
+    def _seed_write_pending(self, sid: str, value: str) -> str:
+        """set_model's optimistic write of the shared `model`: land it under a fresh token and remember
+        what it replaced, until the session's own _do_set_model rules. Returns the token. The write and
+        its node land in ONE hold of the lock: in two, a refusal of the write this one replaced — on the
+        loop thread, through _revert_model — could run between them, pop its node and re-point only the
+        nodes that EXISTED, and this node would be inserted still pointing at the refused pair (the head
+        check standing down: the file's head is this write). This write's own refusal would then restore
+        the refused id under a token no node knew — unwindable by nothing, and the seed of every new
+        session."""
+        with _defaults_lock:
+            prior, prior_tok, tok = _swap_sdk_default_locked(self.state_dir, "model", value)
+            self._seed_writes[tok] = {"sid": sid, "value": value, "prior": prior, "priorTok": prior_tok}
+        return tok
+
+    def _seed_write_settled(self, tok) -> None:
+        """The CLI accepted the write (or its answer was lost and the pick stands): nothing will unwind
+        it. Its node goes; a pending write above it keeps pointing at it, so that write's refusal
+        restores this ACCEPTED value."""
+        if tok is None:
+            return
+        with _defaults_lock:
+            self._seed_writes.pop(tok, None)
+
+    def _seed_write_refused(self, tok) -> bool:
+        """The CLI refused the write (a refusal a newer pick of the same session superseded included):
+        leave the store as if the write had never happened. Head → back to the (value, token) it
+        replaced, absence included; a pending write that replaced it now points past it; not the head
+        and not under a pending write → stand down (a settled writer holds the store). Returns whether
+        the file moved."""
+        if tok is None:
+            return False
+        with _defaults_lock:
+            node = self._seed_writes.pop(tok, None)
+            if node is None:
+                return False
+            for other in self._seed_writes.values():
+                if other["priorTok"] == tok:            # the write that landed on this one unwinds past it now
+                    other["prior"], other["priorTok"] = node["prior"], node["priorTok"]
+            d = read_sdk_defaults(self.state_dir)
+            if d.get("modelTok") != tok:                # a newer writer's, or an untokened file's: not ours to move
+                return False
+            if node["prior"] is None:
+                d.pop("model", None)
+            else:
+                d["model"] = node["prior"]
+            if node["priorTok"] is None:
+                d.pop("modelTok", None)
+            else:
+                d["modelTok"] = node["priorTok"]
+            _write_sdk_defaults(self.state_dir, d)
+            return True
+
+    def _seed_writes_dropped(self, sid: str) -> None:
+        """The session's thread died: every verdict its pending writes were waiting for died with it (a
+        stranded request is a lost answer at most, never a refusal), so the nodes are garbage. Drop
+        them; the store keeps whatever it holds — the reconnect asserts the reg's model."""
+        with _defaults_lock:
+            for t in [t for t, n in self._seed_writes.items() if n["sid"] == sid]:
+                self._seed_writes.pop(t, None)
+
+    def _ack_cmd_chip(self, sid: str, command: str, disp: str, fsid) -> None:
+        """Synthesize the INVOCATION atom the CLI never streams (it streams only the stdout confirmation)
+        for a /model-, /effort- or /auth-style pick: the chat gets the same "/model sonnet" command chip
+        the tmux path reads from its transcript, and the timeline's dot lands in REAL TIME instead of
+        after the next disk write (the user 2026-07-02). _echo_text lets the disk's own command record
+        retire it by text match if one ever lands; the human-floor prune covers a session that never
+        writes one. Then the DURABLE twin (the user 2026-08-14): same t and text, so build_session can
+        dedup while the chip is live and take over seamlessly once stale_cmd retires it — on disk BEFORE
+        the push that rebuilds the chat.
+
+        Fired whatever the session's LIVENESS: the chip is the acknowledgment the composer's optimistic
+        bubble retires against. On a dormant session nothing landed, so a typed "/model X" sat as an
+        unconfirmed dashed bubble for its TTL and then vanished with no trace — though the pick had
+        applied to the reg. `fsid` is the live session's resume target, or the reg's last known one for
+        a dormant session."""
+        t = int(time.time())
+        uid = "cmd:%d:%s" % (t, command.lstrip("/"))
+        self._live.setdefault(sid, {})[uid] = {
+            "type": "user", "uuid": uid, "session_id": sid, "fsid": fsid, "parentUuid": None,
+            "t": t, "author": "human", "command": command, "_echo_text": disp,
+            "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+        append_cmd_gesture(self.state_dir, sid, disp, t=t)
+        self._wake_push()
 
     def set_fast(self, sid: str, value: str) -> bool:
         """Toggle fast mode ('on'|'off'). The CLI's /fast descriptor is marked supportsNonInteractive,
-        so the SDK input stream DOES interpret the literal '/fast on|off' text (unlike /model — see
+        so the SDK input stream DOES interpret the literal '/fast on|off' text (as it does /model —
+        which romp still routes through the control channel for the registry's sake, see
         set_model) — but only on a connection made with the `fastMode` flag-settings opt-in; without
         it the CLI refuses the command outright ("Fast mode is not available in the Agent SDK",
         verified against claude 2.1.224). So this is a hybrid:
@@ -6030,7 +6379,8 @@ class SdkBackend:
         if the session is idle, at the end of the current turn if it's busy. The label updates at once."""
         if value not in EFFORT_LEVELS:
             return False
-        if not read_reg(self.state_dir, sid):
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
             return False
         # LOCKED read-modify-write (_update_reg), never the bare read→mutate→write this used to do: the
         # loop threads run their own locked RMWs on the same reg (queue/echo mirrors, liveCtx), and an
@@ -6052,20 +6402,12 @@ class SdkBackend:
             s.effort = value        # picker label reflects it now; the reconnect makes it real
             s._effort_pending = value   # switching-dots on the effort badge + "Reloading session…" notice until the reconnect lands
             s.request_reconnect()
-            # Synthesize the "/effort X" invocation atom, exactly as set_model does for "/model X": the
-            # reconnect leaves NO transcript record at all, so without this an idle-session effort change
-            # showed nothing in the chat while a busy one (parked) showed a queued chip — the same pick,
-            # visibly acknowledged or not depending on timing (the user 2026-07-05, who called it somewhat
-            # inconsistent). One chip, both paths.
-            t = int(time.time())
-            disp = "/effort " + value
-            uid = "cmd:%d:effort" % t
-            self._live.setdefault(sid, {})[uid] = {
-                "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
-                "t": t, "author": "human", "command": "/effort", "_echo_text": disp,
-                "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
-            append_cmd_gesture(self.state_dir, sid, disp, t=t)   # durable twin — see set_model
-            self._wake_push()
+        # Synthesize the "/effort X" invocation atom, exactly as set_model does for "/model X": the
+        # reconnect leaves NO transcript record at all, so without this an idle-session effort change
+        # showed nothing in the chat while a busy one (parked) showed a queued chip — the same pick,
+        # visibly acknowledged or not depending on timing (the user 2026-07-05, who called it somewhat
+        # inconsistent). One chip, both paths — and a dormant session's too.
+        self._ack_cmd_chip(sid, "/effort", "/effort " + value, s.resume_sid if s else reg.get("lastSid"))
         return True
 
     def set_auth(self, sid: str, value: str) -> bool:
@@ -6103,15 +6445,7 @@ class SdkBackend:
             # Acknowledge the pick in the chat exactly as set_effort does: the reconnect writes no
             # transcript record, so without a synthesized chip an idle session's auth change shows
             # nothing at all.
-            t = int(time.time())
-            disp = "/auth " + value
-            uid = "cmd:%d:auth" % t
-            self._live.setdefault(sid, {})[uid] = {
-                "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
-                "t": t, "author": "human", "command": "/auth", "_echo_text": disp,
-                "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
-            append_cmd_gesture(self.state_dir, sid, disp, t=t)   # durable twin — see set_model
-            self._wake_push()
+            self._ack_cmd_chip(sid, "/auth", "/auth " + value, s.resume_sid)
         return True
 
     def default_auth(self, reg: dict | None = None) -> str:
@@ -6694,6 +7028,7 @@ class SdkBackend:
                 self._update_reg(sess.sid, liveModel=_alias_label(sess.chosen_model), modelPending=False)
             except Exception as e:
                 self._log("session gone (%s): model-pending clear failed: %s" % (sess.name, e))
+        self._seed_writes_dropped(sess.sid)   # no verdict can reach its pending shared-model writes now
         if sess._effort_pending:          # an /effort reconnect that never landed before the thread died → clear the dots/notice
             sess._effort_pending = ""
             try:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1673,6 +1673,8 @@ class SdkSession:
         self.since = 0
         self.model = reg.get("liveModel") or ""   # seed from the last-known model so the badge/picker show on
         #                                           OPEN (even once eager-connected, before init/a turn reports)
+        self._model_id = reg.get("liveModelId") or ""   # the RAW id behind that name (claude-fable-5-1), the
+        #                                           kernel's learned-versions source (see _learn_model)
         _lc0 = reg.get("liveCtx")                 # context-window fill %, as the SDK reports it (see _ctx_pct).
         self._ctx: int | None = _lc0 if isinstance(_lc0, (int, float)) else None  # seeded from the last persisted
         #   value so the bar survives idle/restart; refreshed live from get_context_usage() on connect + each turn.
@@ -2138,14 +2140,19 @@ class SdkSession:
         tt = cu.get("totalTokens")
         if isinstance(tt, (int, float)) and int(tt) != self._ctx_tokens:
             self._ctx_tokens, changed = int(tt), True
-        pm = pretty_model(cu.get("model"))
+        raw = str(cu.get("model") or "").strip()
+        pm = pretty_model(raw)
         if pm and self._resolve_model_pending(pm):
             changed = True
         if pm and pm != self.model:
             self.model, changed = pm, True
+        if raw and raw != getattr(self, "_model_id", ""):   # getattr: __new__-built test doubles skip __init__
+            self._model_id, changed = raw, True
         upd = {}
         if self.model:
             upd["liveModel"] = self.model
+        if getattr(self, "_model_id", ""):
+            upd["liveModelId"] = self._model_id
         upd["modelPending"] = bool(self._model_pending)
         if self._ctx is not None:
             upd["liveCtx"] = self._ctx
@@ -2551,7 +2558,7 @@ class SdkSession:
         self.backend._rewind_resolved(self.sid, "failed")
         self.backend._poke()
 
-    def _learn_model(self, pm):
+    def _learn_model(self, pm, raw=""):
         """Record a freshly-observed display model (from the init message or an assistant turn). Updates the
         live value AND persists it to the registry as `liveModel`, so a DORMANT / post-restart session still
         shows its model via live_sessions' registry path — the registry's `model` field is the user's CHOSEN
@@ -2559,11 +2566,24 @@ class SdkSession:
         the effort too) goes blank whenever the session isn't actively running (the user 2026-06-24). Pokes a
         push so the badge updates promptly. No-op when unchanged, so it doesn't rewrite the reg every turn.
         Also resolves a pending /model switch: once the observed name reflects the chosen alias, the
-        switching-dots clear (the user 2026-07-03)."""
+        switching-dots clear (the user 2026-07-03).
+
+        `raw` is the id the CLI actually reported (claude-fable-5-1), persisted beside the name as
+        `liveModelId`: the kernel's version pickers are SEEDED from a table and completed from these —
+        the CLI is the authoritative source for what it serves, and a table alone went stale the day
+        Fable 5.1 shipped. Written whenever it is newly known, even under an unchanged name, so a
+        long-running session contributes its version without a model change."""
         if not pm:
             return
         cleared = self._resolve_model_pending(pm)
+        raw = (raw or "").strip()
         if pm == self.model:
+            if raw and raw != getattr(self, "_model_id", ""):   # getattr: __new__-built test doubles skip __init__
+                self._model_id = raw
+                try:
+                    self.backend._update_reg(self.sid, liveModelId=raw)
+                except Exception as e:
+                    self.backend._log("model learn (%s): registry write failed: %s" % (self.name, e))
             if cleared:
                 self.backend._poke()
             return
@@ -2584,8 +2604,12 @@ class SdkSession:
                 except Exception as e:
                     self.backend._log("model-fallback card (%s): %s" % (self.name, e), problem=True)
         self.model = pm
+        fields = {"liveModel": pm, "modelPending": bool(self._model_pending)}
+        if raw:
+            self._model_id = raw
+            fields["liveModelId"] = raw
         try:
-            self.backend._update_reg(self.sid, liveModel=pm, modelPending=bool(self._model_pending))
+            self.backend._update_reg(self.sid, **fields)
         except Exception as e:
             self.backend._log("model learn (%s): registry write failed: %s" % (self.name, e))
         self.backend._poke()
@@ -2655,7 +2679,7 @@ class SdkSession:
             self._fire_boot_settled()   # the CLI is up and streaming — its transcript catch-up burst
             #                             is over, so the boot-stagger slot (if any) frees NOW
             d = msg.data if isinstance(msg.data, dict) else {}
-            self._learn_model(pretty_model(d.get("model")))
+            self._learn_model(pretty_model(d.get("model")), raw=str(d.get("model") or ""))
             self.perm_mode = d.get("permissionMode") or self.perm_mode
             # Fast-mode truth rides the init payload — the AUTHORITATIVE re-assert behind set_fast's
             # optimistic flip, shared with the connect-time initialize response (_adopt_fast_state).
@@ -2843,7 +2867,7 @@ class SdkSession:
             # so an unguarded assign would CORRUPT the model badge to "<synthetic>". A real id always contains
             # "claude" (claude-opus-4-8, us.anthropic.claude-…); keep the last good one otherwise.
             if m and "claude" in m.lower():
-                self._learn_model(pretty_model(m))
+                self._learn_model(pretty_model(m), raw=str(m))
         elif isinstance(msg, ResultMessage):
             # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
             # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole

--- a/tests/test_kernel_cmd_gesture.py
+++ b/tests/test_kernel_cmd_gesture.py
@@ -69,13 +69,17 @@ class CmdGestureSourcePins(unittest.TestCase):
     def test_backend_writes_the_marker_beside_each_synthesized_live_chip(self):
         # every setter that synthesizes a live command chip (set_model / set_effort / set_auth) writes the
         # durable twin with the SAME t and disp, so build_session's (t, text) dedup holds while the chip is
-        # live and the durable event takes over seamlessly once stale_cmd retires it.
-        self.assertEqual(BACKEND_SRC.count("append_cmd_gesture(self.state_dir, sid, disp, t=t)"), 3)
-        for uid_tag in ('"cmd:%d:model"', '"cmd:%d:effort"', '"cmd:%d:auth"'):
-            i = BACKEND_SRC.index(uid_tag)
-            j = BACKEND_SRC.index("append_cmd_gesture(self.state_dir, sid, disp, t=t)", i)
-            k = BACKEND_SRC.index("self._wake_push()", i)
-            self.assertLess(j, k, "the marker is on disk before the push that rebuilds the chat")
+        # live and the durable event takes over seamlessly once stale_cmd retires it. The three share ONE
+        # builder (_ack_cmd_chip — so the chip fires on a dormant session too); the property is pinned on
+        # the builder, and every setter must go through it.
+        for cmd in ("/model", "/effort", "/auth"):
+            self.assertEqual(BACKEND_SRC.count('self._ack_cmd_chip(sid, "%s", "%s " + value, ' % (cmd, cmd)), 1, cmd)
+        i = BACKEND_SRC.index("def _ack_cmd_chip(")
+        self.assertIn('uid = "cmd:%d:%s" % (t, command.lstrip("/"))', BACKEND_SRC[i:i + 3000])
+        j = BACKEND_SRC.index("append_cmd_gesture(self.state_dir, sid, disp, t=t)", i)
+        k = BACKEND_SRC.index("self._wake_push()", i)
+        self.assertLess(j, k, "the marker is on disk before the push that rebuilds the chat")
+        self.assertEqual(BACKEND_SRC.count("append_cmd_gesture(self.state_dir, sid, disp, t=t)"), 1, "one builder, no stray copies")
 
     def test_build_session_interleaves_and_dedups_against_the_live_chip(self):
         src = inspect.getsource(km.build_session)

--- a/tests/test_kernel_effort_reconnect.py
+++ b/tests/test_kernel_effort_reconnect.py
@@ -78,7 +78,7 @@ class EffortReconnect(unittest.TestCase):
                     'self._update_reg(sid, mode=mode)',
                     'self._update_reg(sid, fast=(value == "on"), liveFast=value)',
                     'self._update_reg(sid, name=new_name,',   # + the rename ping rides the same locked RMW when owed (2026-08-24/25)
-                    'self._update_reg(sid, model=value, modelPending=bool(s._model_pending))',
+                    'self._update_reg(sid, model=value, modelPending=pending)',   # the live model write
                     'self._update_reg(sid, model=value, liveModel=_alias_label(value), modelPending=False)'):
             self.assertIn(pin, BACKEND_SRC)
 

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -68,7 +68,10 @@ class JudgeSettings(unittest.TestCase):
         # since the version submenus (the user 2026-08-25), each family's versions + default too:
         # the default is the family's remembered pin, else its ALIAS — never the list's head, which
         # pinned every picker-set session to the head id while the CLI's alias moved on
-        self.assertIn('{"models": [dict(c, color=_model_color(c["value"], _stops),', ksrc)
+        # (the payload leads with `rev`, the pick memory's revision, so a picker can drop a /models
+        # response older than one it applied — the models frame's counter)
+        self.assertIn('{"rev": _rev,', ksrc)
+        self.assertIn('"models": [dict(c, color=_model_color(c["value"], _stops),', ksrc)
         self.assertIn('default=_picks.get(c["value"]) or c["value"])', ksrc)
         # …each version row stamped with any CLI minimum-version refusal (T222, 2026-09-01: the live
         # catalog can list ids newer than the installed binary, so the row says so before a pick)

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -65,8 +65,11 @@ class JudgeSettings(unittest.TestCase):
         ksrc = inspect.getsource(km)
         self.assertIn('if p == "/models":', ksrc)
         # the shared lists, each choice carrying its colormap tint (the user 2026-08-17) — and,
-        # since the version submenus (the user 2026-08-25), each family's versions + default too
+        # since the version submenus (the user 2026-08-25), each family's versions + default too:
+        # the default is the family's remembered pin, else its ALIAS — never the list's head, which
+        # pinned every picker-set session to the head id while the CLI's alias moved on
         self.assertIn('{"models": [dict(c, color=_model_color(c["value"], _stops),', ksrc)
+        self.assertIn('default=_picks.get(c["value"]) or c["value"])', ksrc)
         # …each version row stamped with any CLI minimum-version refusal (T222, 2026-09-01: the live
         # catalog can list ids newer than the installed binary, so the row says so before a pick)
         self.assertIn('versions=[_with_cli_block(dict(v), _blocks)', ksrc)

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -72,8 +72,10 @@ class JudgeSettings(unittest.TestCase):
         self.assertIn('default=_picks.get(c["value"]) or c["value"])', ksrc)
         # …each version row stamped with any CLI minimum-version refusal (T222, 2026-09-01: the live
         # catalog can list ids newer than the installed binary, so the row says so before a pick)
+        # …the versions from the CATALOG (the seed table as the Models API fetch grew it, T222) ∪ what
+        # running sessions' CLIs report (_versions_catalog), deduped by id, newest first
         self.assertIn('versions=[_with_cli_block(dict(v), _blocks)', ksrc)
-        self.assertIn('for v in MODEL_VERSIONS.get(c["value"]) or []]', ksrc)
+        self.assertIn('for v in _cat.get(c["value"]) or []],', ksrc)
 
     # ---- per-tier overrides honored + validated ----
     def test_judge_tiers_accept_version_ids(self):

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -371,8 +371,8 @@ class SendPathsPark(unittest.TestCase):
         self.assertIn("_send_or_park(be, sid, cmd)", src, "the timeline sendCommand parks mid-compaction")
         self.assertIn('_set_effort_or_park(be, sid, str(msg["value"]))', src,
                       "the setEffort drive op parks mid-compaction (the user 2026-07-02: it slipped through)")
-        self.assertIn('_set_effort_or_park(be, sid, cmd[len("/effort "):].strip())', src,
-                      "the timeline /effort parks mid-compaction")
+        self.assertIn("_set_effort_or_park(be, sid, value)    # mid-compaction → parked as a queued command", src,
+                      "the timeline's and the composer's /effort park mid-compaction (_route_meta_command)")
 
 
 class QueuedBubble(unittest.TestCase):

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -357,6 +357,44 @@ class StalenessEvent(unittest.TestCase):
         km._note_model_pick("claude-sonnet-7")          # the choke point every set surface flows through
         self.assertEqual(self.fired[-1], "unknown model id claude-sonnet-7")
 
+    def test_a_reported_id_the_catalog_lacks_fires_the_refresh(self):
+        # a running session's CLI reporting an id the catalog does not list is exactly the staleness
+        # the event names: the id joins the pickers marked `learned` at once AND the catalog is asked
+        # to catch up, once per id — after which the mark drops
+        _reg(jd.STATE, "11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        learned = km._learned_versions()
+        self.assertEqual([v["value"] for v in learned["opus"]], ["claude-opus-5-1"])
+        self.assertEqual(self.fired, ["unknown model id claude-opus-5-1"])
+        km._learned_versions()
+        self.assertEqual(len(self.fired), 1, "once per id per kernel life — every /models read re-derives the list")
+
+    def test_a_sighting_during_an_inflight_refresh_is_not_spent(self):
+        # the refresh is single-flight: an id first sighted WHILE one is inflight (the boot fetch —
+        # exactly when a running session's CLI first reports a new release) gets no refresh started
+        # for it. Its one refresh per kernel life must not be spent on that no-op: if the inflight
+        # fetch lands without the id (a failed fetch, a key that cannot see it), the next sighting is
+        # the id's own refresh. The REAL gate first, then the landing.
+        km._refresh_model_catalog = self._orig
+        os.environ.pop("ROMP_MODEL_CATALOG", None)
+        km._catalog_status["inflight"] = True
+        try:
+            self.assertFalse(km._note_unknown_model("claude-opus-9-9"), "inflight → nothing started")
+        finally:
+            km._catalog_status["inflight"] = False
+            os.environ["ROMP_MODEL_CATALOG"] = "off"
+        self.assertNotIn("claude-opus-9-9", km._catalog_asked, "nothing started, so nothing spent")
+        km._refresh_model_catalog = lambda reason, _async=True: (self.fired.append(reason), True)[1]
+        self.assertTrue(km._note_unknown_model("claude-opus-9-9"), "the next sighting asks for real")
+        self.assertEqual(self.fired, ["unknown model id claude-opus-9-9"])
+        self.assertFalse(km._note_unknown_model("claude-opus-9-9"), "…and THAT was the id's one refresh")
+
+
+def _reg(state, sid, **fields):
+    """A synthetic session reg under STATE/sdk — what _learned_versions reads liveModelId from."""
+    d = state / "sdk"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / (sid + ".json")).write_text(json.dumps({"sid": sid, "name": "web", "cwd": "/tmp", "alive": True, **fields}))
+
 
 class CliBlocks(unittest.TestCase):
     """A version the installed CLI refuses by minimum version says so on its /models row (T222)."""
@@ -459,6 +497,26 @@ class ModelsRoute(unittest.TestCase):
         self.assertEqual(rows["opus"]["versions"][0]["value"], "claude-opus-9-9", "the catalog's head leads the list")
         for fam in ("fable", "opus", "sonnet", "haiku"):
             self.assertEqual(rows[fam]["default"], fam, "%s: no pick → the alias" % fam)
+
+    def test_versions_are_the_catalog_union_the_learned_ids_deduped_by_id(self):
+        km._apply_model_catalog(km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS), "api")
+        _reg(jd.STATE, "11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-9-9")   # the catalog knows it
+        _reg(jd.STATE, "11111111-2222-3333-4444-555555555502", liveModelId="claude-opus-5-1")   # the catalog lacks it
+        vs = {m["value"]: m for m in self._models()["models"]}["opus"]["versions"]
+        self.assertEqual([v["value"] for v in vs],
+                         ["claude-opus-9-9", "claude-opus-5-1", "claude-opus-5", "claude-opus-4-8",
+                          "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5"],
+                         "one list, newest first, the learned id slotted by its own version tuple")
+        self.assertFalse(vs[0].get("learned"), "a reported id the catalog lists is the catalog's row — not doubled, not marked")
+        self.assertTrue(vs[1].get("learned"), "a reported id the catalog lacks joins, marked")
+        # the catalog catches up (the refresh the sighting fired lands): the mark drops, still one row
+        km._apply_model_catalog(km.merge_model_catalog(
+            km._MODEL_SEED, FAKE_ROWS + [{"id": "claude-opus-5-1", "display_name": "Claude Opus 5.1"}]), "api")
+        vs = {m["value"]: m for m in self._models()["models"]}["opus"]["versions"]
+        rows51 = [v for v in vs if v["value"] == "claude-opus-5-1"]
+        self.assertEqual(len(rows51), 1)
+        self.assertFalse(rows51[0].get("learned"), "the catalog owns the row now")
+        self.assertEqual(rows51[0]["label"], "Opus 5.1")
 
 
 def _free_port():

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -230,6 +230,21 @@ class FetchAndFallback(unittest.TestCase):
         jd.STATE = self._state
         self.td.cleanup()
 
+    def _clients(self):
+        """Fake dashboard clients on the kernel's client list — one per app that hosts a picker — so the
+        models frame's fan-out can be asserted (the test_model_versions idiom)."""
+        got = []
+        fakes = [{"app": app, "wid": "w-" + app, "alive": True,
+                  "send": (lambda s, a=app: got.append((a, json.loads(s))))} for app in ("chat", "timeline", "feed")]
+        with km._clients_lock:
+            km._clients.extend(fakes)
+
+        def drop():
+            with km._clients_lock:
+                km._clients[:] = [c for c in km._clients if c not in fakes]
+        self.addCleanup(drop)
+        return got
+
     def _refresh(self, reason="test"):
         err = io.StringIO()
         with redirect_stderr(err):
@@ -286,6 +301,25 @@ class FetchAndFallback(unittest.TestCase):
         self.assertIn("no API credential", km._catalog_status["lastError"])
         self.assertIn("no API credential the kernel can use", log)
         self.assertEqual(km.MODEL_VERSIONS["fable"][0]["value"], "claude-fable-5-1", "seed still serves")
+
+    def test_a_fetch_that_adds_ids_tells_every_open_picker_to_re_read_models(self):
+        # the refresh used to call _push_soon() here, its comment claiming the pickers re-read /models
+        # on the next frame — but nothing re-reads the choice lists after page load, so an open
+        # dashboard kept the page-load list until a reload. The event the pickers DO act on is the
+        # models frame (chat/comment loadModelChoices, the timeline's refreshModels, the gear's
+        # adoptChoices/paintChoices): the fetch that grows the list emits it, with the rev the payload carries.
+        got = self._clients()
+        rev0 = km._models_rev[0]
+        started, _ = self._refresh("boot")
+        self.assertTrue(started)
+        frames = [(a, f) for a, f in got if f.get("type") == "models"]
+        self.assertEqual(sorted(a for a, _ in frames), ["chat", "feed", "timeline"],
+                         "one frame to every app that hosts a picker")
+        self.assertTrue(all(f["rev"] > rev0 for _, f in frames), "the frame carries a rev newer than before")
+        self.assertEqual({f["rev"] for _, f in frames}, {km._models_rev[0]}, "the /models payload's counter")
+        got.clear()
+        self._refresh("boot")                    # the same rows again: nothing joined, so nothing rings
+        self.assertEqual([f for _, f in got if f.get("type") == "models"], [], "a fetch that adds nothing is silent")
 
     def test_the_cache_serves_when_the_api_later_dies(self):
         # a dead API never blanks a picker: the previous fetch's rows install at boot from the cache

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -406,7 +406,8 @@ class CliBlocks(unittest.TestCase):
 
 
 class ModelsRoute(unittest.TestCase):
-    """GET /models serves the MERGED list plus any CLI block — every picker reads this one route."""
+    """GET /models serves the MERGED list plus any CLI block — every picker reads this one route. The
+    catalog owns the version LIST; the alias owns the DEFAULT."""
 
     @classmethod
     def setUpClass(cls):
@@ -446,7 +447,18 @@ class ModelsRoute(unittest.TestCase):
         self.assertEqual(opus[0]["cliNeeds"], "2.1.251")
         self.assertIn("needs CLI ≥ 2.1.251", opus[0]["label"])
         self.assertEqual(rows["fable"]["versions"][0], {"value": "claude-fable-5-1", "label": "Fable 5.1"})
-        self.assertEqual(rows["fable"]["default"], "claude-fable-5-1", "no pin → family-newest is 5.1")
+        self.assertEqual(rows["fable"]["default"], "fable",
+                         "no pin → the family ALIAS, which the CLI resolves to its newest live — never the list's head")
+
+    def test_a_family_default_is_the_alias_even_when_the_catalog_knows_a_newer_head(self):
+        # the catalog may lead a family with an id newer than the seed knew, and a bare family click
+        # STILL sends the alias — a pinned head was the bug (every picker-set session stayed on
+        # claude-fable-5 while `fable` moved on)
+        km._apply_model_catalog(km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS), "api")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["versions"][0]["value"], "claude-opus-9-9", "the catalog's head leads the list")
+        for fam in ("fable", "opus", "sonnet", "haiku"):
+            self.assertEqual(rows[fam]["default"], fam, "%s: no pick → the alias" % fam)
 
 
 def _free_port():

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -481,6 +481,8 @@ class ModelsRoute(unittest.TestCase):
     """GET /models serves the MERGED list plus any CLI block — every picker reads this one route. The
     catalog owns the version LIST; the alias owns the DEFAULT."""
 
+    SID = "11111111-2222-3333-4444-555555555555"
+
     @classmethod
     def setUpClass(cls):
         cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
@@ -551,6 +553,23 @@ class ModelsRoute(unittest.TestCase):
         self.assertEqual(len(rows51), 1)
         self.assertFalse(rows51[0].get("learned"), "the catalog owns the row now")
         self.assertEqual(rows51[0]["label"], "Opus 5.1")
+
+    def test_a_catalog_id_is_pickable_as_a_pin_and_a_refusal_forgets_it(self):
+        # an id only the catalog knows (no seed row, no session reporting it) is a version the pick
+        # memory may record — read at call time, so it counts from the moment the catalog learned it —
+        # and the CLI refusing it forgets the pin like any other (the on_model_refused hook)
+        km._apply_model_catalog(km.merge_model_catalog(km._MODEL_SEED, FAKE_ROWS), "api")
+        self.assertTrue(km._vouched_model("claude-opus-9-9"), "the composer's /model vouches for a catalog id")
+        self.assertEqual(km._version_family("claude-opus-9-9"), "opus")
+        km._note_model_pick("claude-opus-9-9")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-9-9"})
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["default"], "claude-opus-9-9", "the family row sends the pin")
+        self.assertEqual(rows["sonnet"]["default"], "sonnet", "other families: still the alias")
+        km._model_pick_refused(self.SID, "claude-opus-9-9")       # the backend's hook, on the CLI's error
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["default"], "opus", "forgotten → the alias again")
+        self.assertEqual(km._model_picks(), {})
 
 
 def _free_port():

--- a/tests/test_model_fallback_card.py
+++ b/tests/test_model_fallback_card.py
@@ -127,6 +127,9 @@ class SidechainNeverLearns(unittest.TestCase):
         s.sid = SID
         s.name = "web"
         s.model = "Fable 5"
+        s._model_id = "claude-fable-5"                  # the id behind that name, as a reg-seeded session carries it
+        #                                                 (a FIRST-known id is persisted even under an unchanged
+        #                                                 name — test_sdk_backend covers that write)
         s._model_pending = ""
         s.retrying = False
         s.retry_count = 0

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -9,6 +9,7 @@ for the alias, so a bare family click pinned every session to claude-fable-5 whi
 through (_set_model_or_park). The seed table is a SEED: ids a running session's CLI reports
 (reg.liveModelId) join the version lists, marked `learned`, until the catalog fetch folds them in.
 Synthetic only — hermetic temp STATE."""
+import inspect
 import json
 import os
 import tempfile
@@ -195,6 +196,44 @@ class PickMemory(unittest.TestCase):
         km._forget_model_pick("sonnet")
         self.assertEqual([f["type"] for f in got["feed"]], ["models", "models"], "…and the un-pin")
 
+    def test_a_refused_version_is_forgotten_only_while_it_is_still_the_pin(self):
+        # the CLI's refusal reaches the kernel through the backend's on_model_refused hook; the family's
+        # pin goes ONLY if it still holds the refused id — a newer accepted pin for the family is not
+        # this refusal's to touch (a writer whose evidence predates the diary stands down)
+        got = self._clients()
+        sid = "11111111-2222-3333-4444-555555555555"
+        km._note_model_pick("claude-opus-4-8")
+        km._model_pick_refused(sid, "claude-opus-4-8")
+        self.assertEqual(km._model_picks(), {}, "the refused pin is forgotten")
+        self.assertEqual([f["type"] for f in got["chat"]], ["models", "models"], "…and the pickers hear it")
+        km._note_model_pick("claude-opus-4-8")
+        km._note_model_pick("claude-opus-4-7")             # the newer pick
+        km._model_pick_refused(sid, "claude-opus-4-8")     # the older one's refusal lands late
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-7"}, "the newer pin stands")
+        km._model_pick_refused(sid, "opus")                # an alias was never a pin: no-op
+        km._model_pick_refused(sid, "total-nonsense")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-7"})
+        # the kernel installs the hook where it wires the fallback card — pinned like that one
+        src = inspect.getsource(km._sdk_locked)
+        self.assertIn("on_model_refused = staticmethod(_model_pick_refused)", src)
+
+    def test_a_superseded_refusals_forget_drops_only_the_refused_pin_the_newer_pick_survives(self):
+        # the backend fires on_model_refused for a refusal the session's own NEWER pick superseded too
+        # (test_sdk_backend pins that). Safe for the newer pick because this side compares-and-swaps by
+        # value: the newer pick's pin — same family or another — is untouched, and only the refused
+        # id's own pin goes.
+        sid = "11111111-2222-3333-4444-555555555555"
+        km._note_model_pick("claude-fable-9-9")             # A, refused later
+        km._note_model_pick("claude-sonnet-4-6")            # B, the newer pick, another family
+        km._model_pick_refused(sid, "claude-fable-9-9")     # A's refusal lands after B
+        self.assertEqual(km._model_picks(), {"sonnet": "claude-sonnet-4-6"},
+                         "A's pin goes — a family click no longer sends the refused id; B's stands")
+        km._note_model_pick("claude-fable-9-9")             # A again
+        km._note_model_pick("claude-fable-5-1")             # B in the SAME family: the pin is B now
+        km._model_pick_refused(sid, "claude-fable-9-9")
+        self.assertEqual(km._model_picks(), {"sonnet": "claude-sonnet-4-6", "fable": "claude-fable-5-1"},
+                         "the newer pick's pin survives its predecessor's refusal")
+
 
 class _ModelsServer(unittest.TestCase):
     """A kernel HTTP handler on a loopback port + a hermetic STATE, for the /models route tests."""
@@ -296,6 +335,22 @@ class ModelsRoute(_ModelsServer):
         self.assertEqual(rows["opus"]["default"], "claude-opus-4-8", "the explicit pin survives the alias click")
 
 
+class RefusedPick(_ModelsServer):
+    """The CLI refused a version the picker recorded as its family's pin."""
+
+    def test_a_refused_version_pick_returns_the_family_default_to_the_alias(self):
+        class _BE:
+            def set_model(self, sid, value):
+                return True
+        sid = "11111111-2222-3333-4444-555555555555"
+        km._set_model_or_park(_BE(), sid, "claude-opus-4-8")
+        opus = next(m for m in self._models()["models"] if m["value"] == "opus")
+        self.assertEqual(opus["default"], "claude-opus-4-8", "recorded before the CLI rules, as designed")
+        km._model_pick_refused(sid, "claude-opus-4-8")      # the backend's hook, on the CLI's error
+        opus = next(m for m in self._models()["models"] if m["value"] == "opus")
+        self.assertEqual(opus["default"], "opus", "the family row sends the alias again — not the refused id")
+
+
 class LearnedVersions(_ModelsServer):
     """The seed table is a SEED, not the catalog: a model id a running session's CLI actually reported
     (reg.liveModelId, persisted by the SDK backend's _learn_model) joins its family's version list —
@@ -374,7 +429,15 @@ class LearnedVersions(_ModelsServer):
 
 class RoutedContextTag(unittest.TestCase):
     """The CLI spells a 1M-context variant with a [1m] tail (`fable[1m]`, `claude-opus-4-8[1m]`). The
-    kernel vouches for the tagged family alias like the tagged id."""
+    kernel vouches for the tagged family alias like the tagged id, and its pending-switch check reads
+    through the tag — the pretty live name never carries one."""
+
+    def test_the_kernels_pending_check_reads_through_the_tag(self):
+        # the literal "fable[1m]" is never a substring of "Fable 5.1", so the switching-dots would ride
+        # the kernel's stamp to its cap instead of resolving on the event
+        self.assertTrue(km._alias_reflects("Fable 5.1", "fable[1m]"))
+        self.assertTrue(km._alias_reflects("Opus 4.8", "claude-opus-4-8[1m]"))
+        self.assertFalse(km._alias_reflects("Fable 5.1", "opus[1m]"))
 
     def test_a_tagged_family_alias_is_vouched_for(self):
         # `claude-fable-5-1[1m]` routes (the id parser strips the tag); `fable[1m]` must too, or it

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -9,7 +9,9 @@ for the alias, so a bare family click pinned every session to claude-fable-5 whi
 through (_set_model_or_park). The seed table is a SEED: ids a running session's CLI reports
 (reg.liveModelId) join the version lists, marked `learned`, until the catalog fetch folds them in.
 Synthetic only — hermetic temp STATE."""
+import contextlib
 import inspect
+import io
 import json
 import os
 import tempfile
@@ -19,6 +21,7 @@ import urllib.request
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -425,6 +428,214 @@ class LearnedVersions(_ModelsServer):
                          {"opus": "claude-opus-5-1", "sonnet": "claude-sonnet-4-6"}, "still on disk")
         self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
         self.assertEqual(km._model_picks(), {"opus": "claude-opus-5-1", "sonnet": "claude-sonnet-4-6"})
+
+
+class AliasMigration(unittest.TestCase):
+    """One-time boot pass, mirroring the CLI's own 2.1.257 `migration_fable5_to_fable_alias`: a stored
+    model equal to a family's PRE-FIX seed head (what a bare family click used to record) becomes the
+    family alias, so the next reconnect spawns `--model fable` and follows the CLI's newest. An explicit
+    non-head pick is a deliberate pin and is left alone. Idempotent, loud, synthetic state."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        (jd.STATE / "sdk").mkdir(parents=True)
+        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"model": "claude-fable-5", "effort": "xhigh"}))
+        (jd.STATE / km.MODEL_PICKS_FILE_NAME).write_text(json.dumps({"fable": "claude-fable-5", "opus": "claude-opus-4-8"}))
+        self._reg("a", model="claude-fable-5", liveModel="Fable 5", alive=True)
+        self._reg("b", model="claude-opus-4-8", alive=True)
+        self._reg("c", alive=False)
+        self._reg("d", model="claude-sonnet-5", alive=False)
+        self._reg("e", model="claude-fable-5-1")
+
+    def tearDown(self):
+        jd.STATE = self._state
+        self.td.cleanup()
+
+    def _reg(self, sid, **fields):
+        (jd.STATE / "sdk" / (sid + ".json")).write_text(json.dumps({"sid": sid, "name": sid, "cwd": "/tmp", **fields}))
+
+    def _read(self, sid):
+        return json.loads((jd.STATE / "sdk" / (sid + ".json")).read_text())
+
+    def _snapshot(self):
+        return {p.name: p.read_text() for p in jd.STATE.rglob("*.json")}
+
+    def test_seed_heads_become_aliases_everywhere_and_explicit_pins_stand(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            n = km._model_alias_boot_pass()
+        self.assertEqual(n, 4, "defaults + the fable pick + regs a and d")
+        self.assertEqual(json.loads((jd.STATE / "sdk-defaults.json").read_text()), {"model": "fable", "effort": "xhigh"},
+                         "the remembered default follows the alias; effort untouched")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8"},
+                         "a head recorded as a pick is dropped — an absent pick IS the alias in that store")
+        a = self._read("a")
+        self.assertEqual(a["model"], "fable", "the next reconnect spawns --model fable")
+        self.assertEqual((a["liveModel"], a["alive"], a["name"]), ("Fable 5", True, "a"), "nothing else on the reg moves")
+        self.assertEqual(self._read("b")["model"], "claude-opus-4-8", "an explicit legacy pin is deliberate")
+        self.assertNotIn("model", self._read("c"), "a session on the account default stays that way")
+        self.assertEqual(self._read("d")["model"], "sonnet", "every family's pre-fix head migrates, dead regs too")
+        self.assertEqual(self._read("e")["model"], "claude-fable-5-1",
+                         "a post-fix head was never a family-click artefact — an explicit pin, untouched")
+        self.assertIn("model-alias", err.getvalue())
+        self.assertIn("fable", err.getvalue(), "the stderr line names what moved")
+
+    def test_idempotent_and_silent_once_done(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._model_alias_boot_pass()
+        before = self._snapshot()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._model_alias_boot_pass(), 0)
+        self.assertEqual(self._snapshot(), before)
+        self.assertEqual(err.getvalue(), "", "nothing to say when nothing moved")
+
+    def test_nothing_to_migrate_on_a_fresh_state(self):
+        for p in list(jd.STATE.rglob("*.json")):
+            p.unlink()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._model_alias_boot_pass(), 0)
+        self.assertTrue((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists(),
+                        "a clean pass over nothing is still the one run — stamped, so it never re-arms")
+
+    def test_a_post_fix_explicit_pick_of_a_seed_head_survives_the_next_boot(self):
+        # without a completion record EVERY kernel restart would rewrite any stored model equal to a
+        # seed head — including a deliberate post-fix submenu pick of that very id (three of the four
+        # heads are the CURRENT releases a user pins against a future .1). That contradicts the
+        # "an explicit legacy pin stands" guarantee. A migration runs once.
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._model_alias_boot_pass()
+        # the user now pins Fable 5 from the submenu — on a session, as the remembered default, and it
+        # lands in sdk-defaults as every set_model does
+        self._reg("f", model="claude-fable-5", alive=True)
+        km._note_model_pick("claude-fable-5")
+        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"model": "claude-fable-5", "effort": "xhigh"}))
+        before = self._snapshot()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._model_alias_boot_pass(), 0, "the next boot is not a migration")
+        self.assertEqual(self._snapshot(), before, "the explicit pick stands everywhere it was written")
+        self.assertEqual(self._read("f")["model"], "claude-fable-5")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8", "fable": "claude-fable-5"})
+        self.assertEqual(err.getvalue(), "")
+
+    def test_the_marker_gates_the_pass_and_is_stamped_after_the_first_run(self):
+        marker = jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER
+        self.assertFalse(marker.exists(), "a state that never booted the fix carries no marker")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._model_alias_boot_pass(), 4)
+        rec = json.loads(marker.read_text())
+        self.assertIsInstance(rec.get("t"), int, "stamped with the completion time")
+        self.assertEqual(rec.get("moved"), 4)
+        # a marker from a previous boot means SKIP ENTIRELY — even over state that looks migratable
+        # (a head pinned on purpose after the fix looks exactly like pre-fix residue; the marker is
+        # what tells them apart)
+        self._reg("g", model="claude-opus-5")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._model_alias_boot_pass(), 0)
+        self.assertEqual(self._read("g")["model"], "claude-opus-5")
+        self.assertEqual(err.getvalue(), "")
+
+    def test_a_failed_read_withholds_the_marker_so_the_next_boot_retries(self):
+        # "returned" is not "succeeded" (the rewind migration's rule): a reg the pass could not READ is
+        # a reg it did not migrate, so no marker is written and the pass re-arms at the next boot. A
+        # TRANSIENT failure — the file is there, this boot could not open it (a garbled file is the
+        # other kind, see the next test).
+        self._reg("locked", model="claude-fable-5")
+        real_text, real_bytes = Path.read_text, Path.read_bytes
+
+        def refuse(p):
+            if p.name == "locked.json":
+                raise PermissionError(13, "Permission denied", str(p))
+
+        def read_text(p, *a, **k):
+            refuse(p)
+            return real_text(p, *a, **k)
+
+        def read_bytes(p, *a, **k):        # the pass reads bytes — the OS refuses either way
+            refuse(p)
+            return real_bytes(p, *a, **k)
+        err = io.StringIO()
+        with mock.patch.object(Path, "read_text", read_text), mock.patch.object(Path, "read_bytes", read_bytes), \
+                contextlib.redirect_stderr(err):
+            n = km._model_alias_boot_pass()
+        self.assertEqual(n, 4, "everything readable still migrates")
+        self.assertFalse((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists())
+        self.assertIn("no marker written", err.getvalue())
+        self.assertIn("locked.json", err.getvalue(), "the line names the file the next boot will retry")
+        self.assertEqual(self._read("locked")["model"], "claude-fable-5", "untouched — it will migrate when readable")
+
+    def test_a_garbled_store_is_named_loudly_and_never_withholds_the_marker(self):
+        # a file json.loads cannot parse holds no pin ANY reader can see — read_reg, read_sdk_defaults
+        # and the picks loader all return None/{} over it — so retrying over it can never migrate
+        # anything; counting it a failure would never stamp, and re-float every deliberate post-fix pin
+        # at every boot without ever naming the file. Garbage is PERMANENT: name the path loudly, treat
+        # it as nothing to migrate, and stamp.
+        (jd.STATE / "sdk" / "broken.json").write_text("{not json")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            n = km._model_alias_boot_pass()
+        self.assertEqual(n, 4, "everything readable migrates")
+        self.assertTrue((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists(), "stamped — the pass is done")
+        self.assertIn("broken.json", err.getvalue(), "the garbled file is NAMED")
+        self.assertNotIn("no marker written", err.getvalue())
+        self.assertEqual((jd.STATE / "sdk" / "broken.json").read_text(), "{not json", "never rewritten by the pass")
+        # the same for a garbled defaults store, and the next boot is silent: the user's post-fix
+        # pin of a seed head stands (the very re-float a missing marker would cause)
+        for p in list(jd.STATE.rglob("*.json")):
+            p.unlink()
+        (jd.STATE / "sdk-defaults.json").write_text("garbage")
+        self._reg("f", model="claude-fable-5")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._model_alias_boot_pass(), 0, "the marker gates it")
+        self.assertEqual(err.getvalue(), "")
+        self.assertEqual(self._read("f")["model"], "claude-fable-5")
+        (jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).unlink()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._model_alias_boot_pass(), 1)
+        self.assertIn("sdk-defaults.json", err.getvalue())
+        self.assertTrue((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists())
+
+    def test_a_store_that_is_not_utf8_is_garbage_named_loudly_and_the_rest_still_migrates(self):
+        # splitting reading (catching OSError) from parsing (catching ValueError) misses a file holding
+        # non-UTF-8 bytes: Path.read_text raises UnicodeDecodeError in the READ — a ValueError, not an
+        # OSError — which would escape both arms, abort the whole pass at that file (every later reg
+        # unmigrated), print a traceback, and re-arm at every boot since the marker never stamps. No
+        # reader can see a pin in such a file (read_reg, read_sdk_defaults and the picks loader all
+        # return None/{} over it), so it is garbage like any other: named by path, nothing to migrate,
+        # and the pass runs to completion and stamps.
+        (jd.STATE / "sdk-defaults.json").write_bytes(b'{"model": "claude-fable-5", "note": "caf\xe9"}')   # Latin-1 byte
+        (jd.STATE / "sdk" / "latin.json").write_bytes(b'{"sid": "latin", "model": "claude-fable-5\xe9"}')
+        self._reg("z", model="claude-opus-5")     # sorts after latin.json — must still migrate
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            n = km._model_alias_boot_pass()
+        self.assertEqual(n, 4, "the fable pick + regs a, d and z — everything readable migrates")
+        self.assertEqual(self._read("z")["model"], "opus", "a reg sorted AFTER the garbled one still migrates")
+        self.assertEqual(self._read("a")["model"], "fable")
+        self.assertTrue((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists(), "stamped — the pass is done")
+        out = err.getvalue()
+        self.assertNotIn("Traceback", out, "a garbled file is a named line, never a crash")
+        self.assertIn("latin.json", out, "the garbled reg is NAMED")
+        self.assertIn("sdk-defaults.json", out, "so is the garbled defaults store")
+        self.assertNotIn("no marker written", out)
+        self.assertEqual((jd.STATE / "sdk" / "latin.json").read_bytes(), b'{"sid": "latin", "model": "claude-fable-5\xe9"}',
+                         "never rewritten by the pass")
+
+    def test_the_pass_is_wired_into_main_before_the_backend_constructs(self):
+        # the ordering IS the correctness: the pass rewrites reg `model` fields, which become
+        # chosen_model the moment the SDK backend constructs — and _boot_warm's alive-session read
+        # constructs it. main() must run the pass first, and once.
+        src = inspect.getsource(km.main)
+        i = src.index("_model_alias_boot_pass()")
+        self.assertLess(i, src.index("_boot_warm()"), "before _boot_warm constructs the backend")
+        self.assertLess(i, src.index("target=_sdk"), "and before the explicit _sdk thread")
+        self.assertEqual(src.count("_model_alias_boot_pass("), 1, "called from exactly one place")
 
 
 class RoutedContextTag(unittest.TestCase):

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -466,7 +466,7 @@ class AliasMigration(unittest.TestCase):
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             n = km._model_alias_boot_pass()
-        self.assertEqual(n, 4, "defaults + the fable pick + regs a and d")
+        self.assertEqual(n, 5, "defaults + the fable pick + regs a, d and e")
         self.assertEqual(json.loads((jd.STATE / "sdk-defaults.json").read_text()), {"model": "fable", "effort": "xhigh"},
                          "the remembered default follows the alias; effort untouched")
         self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8"},
@@ -477,8 +477,8 @@ class AliasMigration(unittest.TestCase):
         self.assertEqual(self._read("b")["model"], "claude-opus-4-8", "an explicit legacy pin is deliberate")
         self.assertNotIn("model", self._read("c"), "a session on the account default stays that way")
         self.assertEqual(self._read("d")["model"], "sonnet", "every family's pre-fix head migrates, dead regs too")
-        self.assertEqual(self._read("e")["model"], "claude-fable-5-1",
-                         "a post-fix head was never a family-click artefact — an explicit pin, untouched")
+        self.assertEqual(self._read("e")["model"], "fable",
+                         "fable's 5.1 head: every family click since 2026-09-01 wrote it, so it migrates like the others")
         self.assertIn("model-alias", err.getvalue())
         self.assertIn("fable", err.getvalue(), "the stderr line names what moved")
 
@@ -525,10 +525,10 @@ class AliasMigration(unittest.TestCase):
         marker = jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER
         self.assertFalse(marker.exists(), "a state that never booted the fix carries no marker")
         with contextlib.redirect_stderr(io.StringIO()):
-            self.assertEqual(km._model_alias_boot_pass(), 4)
+            self.assertEqual(km._model_alias_boot_pass(), 5)
         rec = json.loads(marker.read_text())
         self.assertIsInstance(rec.get("t"), int, "stamped with the completion time")
-        self.assertEqual(rec.get("moved"), 4)
+        self.assertEqual(rec.get("moved"), 5)
         # a marker from a previous boot means SKIP ENTIRELY — even over state that looks migratable
         # (a head pinned on purpose after the fix looks exactly like pre-fix residue; the marker is
         # what tells them apart)
@@ -562,7 +562,7 @@ class AliasMigration(unittest.TestCase):
         with mock.patch.object(Path, "read_text", read_text), mock.patch.object(Path, "read_bytes", read_bytes), \
                 contextlib.redirect_stderr(err):
             n = km._model_alias_boot_pass()
-        self.assertEqual(n, 4, "everything readable still migrates")
+        self.assertEqual(n, 5, "everything readable still migrates")
         self.assertFalse((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists())
         self.assertIn("no marker written", err.getvalue())
         self.assertIn("locked.json", err.getvalue(), "the line names the file the next boot will retry")
@@ -578,7 +578,7 @@ class AliasMigration(unittest.TestCase):
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             n = km._model_alias_boot_pass()
-        self.assertEqual(n, 4, "everything readable migrates")
+        self.assertEqual(n, 5, "everything readable migrates")
         self.assertTrue((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists(), "stamped — the pass is done")
         self.assertIn("broken.json", err.getvalue(), "the garbled file is NAMED")
         self.assertNotIn("no marker written", err.getvalue())
@@ -615,7 +615,7 @@ class AliasMigration(unittest.TestCase):
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             n = km._model_alias_boot_pass()
-        self.assertEqual(n, 4, "the fable pick + regs a, d and z — everything readable migrates")
+        self.assertEqual(n, 5, "the fable pick + regs a, d, e and z — everything readable migrates")
         self.assertEqual(self._read("z")["model"], "opus", "a reg sorted AFTER the garbled one still migrates")
         self.assertEqual(self._read("a")["model"], "fable")
         self.assertTrue((jd.STATE / km.MODEL_ALIAS_MIGRATION_MARKER).exists(), "stamped — the pass is done")

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -114,6 +114,58 @@ class PickMemory(unittest.TestCase):
         self.assertEqual(km._model_picks(), {"haiku": "claude-haiku-4-5"},
                          "unknown ids and cross-family entries never poison the default")
 
+    def _clients(self):
+        """Three fake connected clients — a chat, a timeline and a FEED client (the feed bundle is where the
+        settings gear's pickers live) — on the kernel's live roster; the frames they receive, decoded.
+        Removed again in tearDown-order by the returned callable."""
+        got = {"chat": [], "timeline": [], "feed": []}
+        fakes = [{"app": app, "wid": "w1", "alive": True,
+                  "send": (lambda s, _a=app: got[_a].append(json.loads(s)))} for app in got]
+        with km._clients_lock:
+            km._clients.extend(fakes)
+
+        def drop():
+            with km._clients_lock:
+                km._clients[:] = [c for c in km._clients if c not in fakes]
+        self.addCleanup(drop)
+        return got
+
+    def test_a_pick_or_a_forget_tells_every_open_picker_to_re_read_models(self):
+        # both webviews read a family's `default` from a /models list fetched ONCE at page load and
+        # never refreshed, and nothing mutated it after a pick. So after Latest un-pinned a family on
+        # the kernel, the same tab's next family click still sent the stale pinned id and silently
+        # RE-PINNED; another dashboard's pick moved the default without this tab knowing. The kernel
+        # emits a models frame whenever the pick memory CHANGES — event-keyed, never a poll — and
+        # every picker re-fetches on it.
+        got = self._clients()
+        km._note_model_pick("claude-opus-4-8")
+        for app in ("chat", "timeline", "feed"):
+            self.assertEqual([f["type"] for f in got[app]], ["models"], app)
+            self.assertIsInstance(got[app][0]["rev"], int)
+        rev = got["chat"][0]["rev"]
+        km._note_model_pick("claude-opus-4-8")            # write-on-change: nothing moved, nothing said
+        km._note_model_pick("opus")                        # an alias records nothing
+        km._forget_model_pick("sonnet")                    # no pin to forget
+        self.assertEqual(len(got["chat"]), 1)
+        km._forget_model_pick("opus")                      # the Latest gesture
+        self.assertEqual([f["type"] for f in got["chat"]], ["models", "models"])
+        self.assertEqual(got["chat"][1]["rev"], rev + 1, "a moving counter — a client can tell frames apart")
+        self.assertEqual(len(got["timeline"]), 2)
+        self.assertEqual(len(got["feed"]), 2)
+
+    def test_the_frame_reaches_the_feed_bundle_where_the_settings_gear_lives(self):
+        # the settings gear, whose judge-tier family rows send the cached list's `default`, is part of
+        # the FEED bundle (feed.ts requires gear.js; the web shell's rail gear and VS Code's settings
+        # command both post openSettings into the feed pane). A frame to the chat and timeline apps
+        # alone never reaches the gear where it actually opens, and its first-open cache keeps sending
+        # a stale pinned default after another picker un-pinned. Every app that hosts a picker hears it.
+        got = self._clients()
+        km._note_model_pick("claude-sonnet-4-6")
+        self.assertEqual([f["type"] for f in got["feed"]], ["models"], "the feed client hears the pin")
+        self.assertEqual(got["feed"][0], got["chat"][0], "the same frame every picker host gets")
+        km._forget_model_pick("sonnet")
+        self.assertEqual([f["type"] for f in got["feed"]], ["models", "models"], "…and the un-pin")
+
 
 class _ModelsServer(unittest.TestCase):
     """A kernel HTTP handler on a loopback port + a hermetic STATE, for the /models route tests."""
@@ -154,6 +206,33 @@ class ModelsRoute(_ModelsServer):
         self.assertEqual([v["value"] for v in rows["opus"]["versions"]],
                          [v["value"] for v in km.MODEL_VERSIONS["opus"]])
         self.assertIn("color", rows["opus"], "the colormap tint still rides every family row")
+
+    def test_the_payload_carries_the_pick_memorys_revision_the_frame_announces(self):
+        # every picker answers a models frame with a fresh GET /models and applies whatever lands — so
+        # two overlapping fetches (a frame during the page-load fetch; two quick frames) can resolve
+        # out of order and the STALE list wins until the next change. The payload carries the same
+        # `rev` the frame does, so a consumer can keep the newest it has applied and drop an older
+        # response that lands late.
+        got = self._clients()
+        d = self._models()
+        self.assertIsInstance(d.get("rev"), int, "the payload is stamped")
+        self.assertEqual(d["rev"], km._models_rev[0])
+        km._note_model_pick("claude-opus-4-8")
+        self.assertEqual(self._models()["rev"], got["chat"][0]["rev"],
+                         "after a change the payload's rev IS the frame's — one counter, two carriers")
+        self.assertGreater(self._models()["rev"], d["rev"])
+
+    def _clients(self):
+        got = {"chat": []}
+        fakes = [{"app": "chat", "wid": "w1", "alive": True, "send": lambda s: got["chat"].append(json.loads(s))}]
+        with km._clients_lock:
+            km._clients.extend(fakes)
+
+        def drop():
+            with km._clients_lock:
+                km._clients[:] = [c for c in km._clients if c not in fakes]
+        self.addCleanup(drop)
+        return got
 
     def test_a_family_with_no_pick_defaults_to_its_alias_not_the_seed_head(self):
         # THE BUG: the default fell to MODEL_VERSIONS[fam][0], so a bare "Fable" click pinned the

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -3,8 +3,10 @@
 opus became Opus 5 — silently losing legacy versions that remain live on the API. The kernel's
 /models now carries each family's versions (dateless alias ids, verified against the claude-api
 reference) plus a DEFAULT: the most recent version the user picked for that family (model-picks.json,
-a viewer pref like colormap), else the newest. The pick memory hooks the ONE choke point every set
-path flows through (_set_model_or_park). Synthetic only — hermetic temp STATE."""
+a viewer pref like colormap), else the family ALIAS itself (the seed table's head used to stand in
+for the alias, so a bare family click pinned every session to claude-fable-5 while the CLI's own
+`fable` alias moved on to Fable 5.1). The pick memory hooks the ONE choke point every set path flows
+through (_set_model_or_park). Synthetic only — hermetic temp STATE."""
 import json
 import os
 import tempfile
@@ -56,6 +58,14 @@ class Catalog(unittest.TestCase):
             for v in vs:
                 self.assertEqual(km._VERSION_FAMILY[v["value"]], fam)
 
+    def test_id_helpers_tolerate_anything(self):
+        self.assertEqual(km._model_id_parts("claude-fable-5-1[1m]"), ("fable", 5, 1))
+        self.assertEqual(km._model_id_parts("claude-opus-4-5-20251101"), ("opus", 4, 5))
+        self.assertIsNone(km._model_id_parts("us.anthropic.claude-opus-4-8-v1:0"))
+        self.assertIsNone(km._model_id_parts("opus"))
+        self.assertEqual(km._model_id_label("claude-fable-5-1"), "Fable 5.1")
+        self.assertEqual(km._model_id_label("<synthetic>"), "", "a module-level helper never raises on junk")
+
 
 class PickMemory(unittest.TestCase):
     """Per-family last-picked defaults: written at the choke point, read into /models."""
@@ -103,8 +113,8 @@ class PickMemory(unittest.TestCase):
                          "unknown ids and cross-family entries never poison the default")
 
 
-class ModelsRoute(unittest.TestCase):
-    """GET /models carries versions + default per family."""
+class _ModelsServer(unittest.TestCase):
+    """A kernel HTTP handler on a loopback port + a hermetic STATE, for the /models route tests."""
 
     @classmethod
     def setUpClass(cls):
@@ -132,20 +142,61 @@ class ModelsRoute(unittest.TestCase):
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read().decode())
 
+
+class ModelsRoute(_ModelsServer):
+    """GET /models carries versions + default per family."""
+
     def test_each_family_carries_versions_and_a_default(self):
         d = self._models()
         rows = {m["value"]: m for m in d["models"]}
         self.assertEqual([v["value"] for v in rows["opus"]["versions"]],
                          [v["value"] for v in km.MODEL_VERSIONS["opus"]])
-        self.assertEqual(rows["opus"]["default"], "claude-opus-5",
-                         "no pick yet → the family's newest")
         self.assertIn("color", rows["opus"], "the colormap tint still rides every family row")
+
+    def test_a_family_with_no_pick_defaults_to_its_alias_not_the_seed_head(self):
+        # THE BUG: the default fell to MODEL_VERSIONS[fam][0], so a bare "Fable" click pinned the
+        # session to claude-fable-5 — and when the CLI's `fable` alias advanced to Fable 5.1, every
+        # picker-set session stayed behind. The alias is what the CLI resolves LIVE (the authoritative
+        # source for "newest"), so a family click sends the alias.
+        rows = {m["value"]: m for m in self._models()["models"]}
+        for fam in ("fable", "opus", "sonnet", "haiku"):
+            self.assertEqual(rows[fam]["default"], fam, "no pick yet → the family alias, never a pinned id")
 
     def test_the_default_follows_the_users_last_pick(self):
         km._note_model_pick("claude-opus-4-8")
         rows = {m["value"]: m for m in self._models()["models"]}
         self.assertEqual(rows["opus"]["default"], "claude-opus-4-8")
-        self.assertEqual(rows["sonnet"]["default"], "claude-sonnet-5", "other families unaffected")
+        self.assertEqual(rows["sonnet"]["default"], "sonnet", "other families unaffected: still the alias")
+
+    def test_an_explicit_version_pick_pins_and_a_family_click_never_downgrades_it(self):
+        # the version submenu is the ONE place a pin comes from; a later family click (which now
+        # carries the alias) records nothing, so the remembered pin stands
+        class _BE:
+            calls = []
+
+            def set_model(self, sid, value):
+                self.calls.append(value)
+                return True
+        be = _BE()
+        sid = "11111111-2222-3333-4444-555555555555"
+        km._set_model_or_park(be, sid, "claude-opus-4-8")
+        km._set_model_or_park(be, sid, "opus")
+        self.assertEqual(be.calls, ["claude-opus-4-8", "opus"], "both reach the backend verbatim")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["default"], "claude-opus-4-8", "the explicit pin survives the alias click")
+
+
+class RoutedContextTag(unittest.TestCase):
+    """The CLI spells a 1M-context variant with a [1m] tail (`fable[1m]`, `claude-opus-4-8[1m]`). The
+    kernel vouches for the tagged family alias like the tagged id."""
+
+    def test_a_tagged_family_alias_is_vouched_for(self):
+        # `claude-fable-5-1[1m]` routes (the id parser strips the tag); `fable[1m]` must too, or it
+        # falls to the CLI as literal text — the registry bypass the routing exists to close
+        self.assertTrue(km._vouched_model("fable[1m]"))
+        self.assertTrue(km._vouched_model("claude-fable-5-1[1m]"))
+        self.assertFalse(km._vouched_model("fable[2m]x"), "a tag is a trailing [..] only")
+        self.assertFalse(km._vouched_model("opsu[1m]"))
 
 
 if __name__ == "__main__":

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -114,6 +114,35 @@ class PickMemory(unittest.TestCase):
         self.assertEqual(km._model_picks(), {"haiku": "claude-haiku-4-5"},
                          "unknown ids and cross-family entries never poison the default")
 
+    def test_the_floating_gesture_clears_the_familys_pin_and_sends_the_alias(self):
+        # once a family carried a pin there was NO picker gesture back to floating: the family row
+        # sends the pin, the submenu lists only explicit ids, and a typed "/model opus" leaves the
+        # pick memory alone by design. The submenu's "Latest" row is that gesture — an explicit user
+        # act, so it may move state — carried as `floating` on the op.
+        class _BE:
+            calls = []
+
+            def set_model(self, sid, value):
+                self.calls.append(value)
+                return True
+        be = _BE()
+        sid = "11111111-2222-3333-4444-555555555555"
+        km._set_model_or_park(be, sid, "claude-opus-4-8")
+        km._set_model_or_park(be, sid, "claude-sonnet-4-6")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-4-6"})
+        km._set_model_or_park(be, sid, "opus", floating=True)
+        self.assertEqual(be.calls[-1], "opus", "the alias rides to the backend — the CLI resolves it live")
+        self.assertEqual(km._model_picks(), {"sonnet": "claude-sonnet-4-6"}, "only THAT family's pin is forgotten")
+        # the flag means nothing on a non-alias value: a version id with it pins as usual, and a
+        # floating alias with no pin to clear is a plain alias send
+        km._set_model_or_park(be, sid, "claude-opus-4-8", floating=True)
+        self.assertEqual(km._model_picks().get("opus"), "claude-opus-4-8")
+        km._set_model_or_park(be, sid, "haiku", floating=True)
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-4-6"})
+        # and without the flag the alias still never touches the memory (the standing design)
+        km._set_model_or_park(be, sid, "opus")
+        self.assertEqual(km._model_picks().get("opus"), "claude-opus-4-8")
+
     def _clients(self):
         """Three fake connected clients — a chat, a timeline and a FEED client (the feed bundle is where the
         settings gear's pickers live) — on the kernel's live roster; the frames they receive, decoded.

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -6,7 +6,9 @@ reference) plus a DEFAULT: the most recent version the user picked for that fami
 a viewer pref like colormap), else the family ALIAS itself (the seed table's head used to stand in
 for the alias, so a bare family click pinned every session to claude-fable-5 while the CLI's own
 `fable` alias moved on to Fable 5.1). The pick memory hooks the ONE choke point every set path flows
-through (_set_model_or_park). Synthetic only — hermetic temp STATE."""
+through (_set_model_or_park). The seed table is a SEED: ids a running session's CLI reports
+(reg.liveModelId) join the version lists, marked `learned`, until the catalog fetch folds them in.
+Synthetic only — hermetic temp STATE."""
 import json
 import os
 import tempfile
@@ -184,6 +186,82 @@ class ModelsRoute(_ModelsServer):
         self.assertEqual(be.calls, ["claude-opus-4-8", "opus"], "both reach the backend verbatim")
         rows = {m["value"]: m for m in self._models()["models"]}
         self.assertEqual(rows["opus"]["default"], "claude-opus-4-8", "the explicit pin survives the alias click")
+
+
+class LearnedVersions(_ModelsServer):
+    """The seed table is a SEED, not the catalog: a model id a running session's CLI actually reported
+    (reg.liveModelId, persisted by the SDK backend's _learn_model) joins its family's version list —
+    the CLI is the authoritative source for what it serves — and is marked so the pickers can say it
+    is new rather than hide a live model behind a stale menu."""
+
+    def _reg(self, sid, **fields):
+        d = jd.STATE / "sdk"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / (sid + ".json")).write_text(json.dumps({"sid": sid, "name": "web", "cwd": "/tmp", "alive": True, **fields}))
+
+    def test_a_reported_id_outside_the_seed_table_joins_its_family_marked_learned(self):
+        self._reg("11111111-2222-3333-4444-555555555501", liveModel="Opus 5.1", liveModelId="claude-opus-5-1")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        vs = rows["opus"]["versions"]
+        self.assertEqual(vs[0], {"value": "claude-opus-5-1", "label": "Opus 5.1", "learned": True},
+                         "newest first — the learned 5.1 lands ahead of the seed's 5")
+        self.assertEqual([v["value"] for v in vs[1:]], [v["value"] for v in km.MODEL_VERSIONS["opus"]])
+        self.assertEqual(rows["opus"]["default"], "opus", "a learned id changes nothing about the alias default")
+
+    def test_a_learned_id_is_pickable_and_remembered_like_a_seed_one(self):
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        km._note_model_pick("claude-opus-5-1")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-5-1"})
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["default"], "claude-opus-5-1")
+
+    def test_ids_the_seed_already_covers_or_that_are_not_first_party_add_nothing(self):
+        # a dated snapshot of a seed version shares its label → the seed's dateless alias covers it;
+        # a provider-prefixed id and a non-model string are not the shape the pickers send
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-4-5-20251101")
+        self._reg("11111111-2222-3333-4444-555555555502", liveModelId="us.anthropic.claude-opus-4-8-v1:0")
+        self._reg("11111111-2222-3333-4444-555555555503", liveModelId="<synthetic>")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual([v["value"] for v in rows["opus"]["versions"]],
+                         [v["value"] for v in km.MODEL_VERSIONS["opus"]])
+
+    def test_a_context_tag_is_stripped_and_duplicates_collapse(self):
+        # the CLI spells a 1M-context variant with a [1m] tail; two sessions on the same id → one row
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-sonnet-5-1[1m]")
+        self._reg("11111111-2222-3333-4444-555555555502", liveModelId="claude-sonnet-5-1")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        learned = [v for v in rows["sonnet"]["versions"] if v.get("learned")]
+        self.assertEqual(learned, [{"value": "claude-sonnet-5-1", "label": "Sonnet 5.1", "learned": True}])
+
+    def test_a_dated_snapshot_report_offers_the_dateless_alias(self):
+        # a CLI may report the dated snapshot it is running; the pickable value is the DATELESS
+        # alias — the snapshot retires, the alias follows the version
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-sonnet-5-1-20260901")
+        rows = {m["value"]: m for m in self._models()["models"]}
+        learned = [v for v in rows["sonnet"]["versions"] if v.get("learned")]
+        self.assertEqual(learned, [{"value": "claude-sonnet-5-1", "label": "Sonnet 5.1", "learned": True}])
+
+    def test_the_judge_tiers_accept_a_learned_version_the_gear_offers(self):
+        # the gear's judge/index/distill/comment selects are built from /models' versions, learned
+        # rows included — so the kernel must accept what it offered, and still refuse an id nobody
+        # has ever served (the setter is effect-only: assert the state file)
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        km._set_judge_model("claude-opus-5-1")
+        self.assertEqual(jd._state_str("judge-model", ""), "claude-opus-5-1", "offered → accepted")
+        km._set_judge_model("claude-opus-9-9")
+        self.assertEqual(jd._state_str("judge-model", ""), "claude-opus-5-1", "never served → refused, nothing changes")
+
+    def test_a_pin_whose_reporting_session_is_gone_survives_on_disk(self):
+        # the read filter hides a pin its family can't currently vouch for; the WRITE must not erase
+        # it — a later pick for another family merges into the raw file, so the pin resolves again
+        # the moment a session reports the id
+        (jd.STATE / km.MODEL_PICKS_FILE_NAME).write_text(json.dumps({"opus": "claude-opus-5-1"}))
+        self.assertEqual(km._model_picks(), {}, "no session vouches for it → hidden on read")
+        km._note_model_pick("claude-sonnet-4-6")
+        self.assertEqual(json.loads((jd.STATE / km.MODEL_PICKS_FILE_NAME).read_text()),
+                         {"opus": "claude-opus-5-1", "sonnet": "claude-sonnet-4-6"}, "still on disk")
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-5-1", "sonnet": "claude-sonnet-4-6"})
 
 
 class RoutedContextTag(unittest.TestCase):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -11,6 +11,7 @@ Two layers:
     PermissionResultAllow(updated_input={questions, answers}) goes back.
 """
 import asyncio
+import inspect
 import os
 import json
 import threading
@@ -19,6 +20,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -450,14 +452,21 @@ class LiveTail(unittest.TestCase):
         self.assertEqual(cmds[0]["message"]["content"], [{"type": "text", "text": "/effort high"}])
         self.assertEqual(cmds[0]["author"], "human")
 
-    def test_set_effort_on_a_dormant_session_stays_quiet(self):
-        # no live thread → the value applies on the next connect; nothing to echo into (no _live entry)
+    def test_set_effort_on_a_dormant_session_still_leaves_the_acknowledging_chip(self):
+        # no live thread → the value applies on the next connect — but the pick is still acknowledged
+        # (reversing this test's earlier "stays quiet" pin): the chip is what the composer's optimistic
+        # bubble retires against, and with nothing landing on a dormant session a typed "/effort low"
+        # sat as an unconfirmed dashed bubble and then vanished without a trace
         d = tempfile.mkdtemp()
         be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
         sid = "11111111-2222-3333-4444-666666666666"
         sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
         self.assertTrue(be.set_effort(sid, "low"))
-        self.assertEqual(be.live_atoms(sid), [])
+        cmds = [a for a in be.live_atoms(sid) if a.get("command") == "/effort"]
+        self.assertEqual(len(cmds), 1)
+        self.assertEqual(cmds[0]["message"]["content"], [{"type": "text", "text": "/effort low"}])
+        self.assertIsNone(cmds[0]["fsid"], "no live thread and no last resume target → none")
+        self.assertEqual(sb.read_reg(d, sid)["effort"], "low", "and the value still applies at the next connect")
 
     def _live_fast_session(self, d, sid, unlocked=False):
         """A constructed SdkSession whose thread READS alive (set_fast's gate) without spawning a CLI.
@@ -1251,6 +1260,704 @@ class SetModelModePure(unittest.TestCase):
         self.assertFalse(sb._model_reflects_alias("Fable 5", "opus"), "the OLD name does not reflect the new pick")
         self.assertTrue(sb._model_reflects_alias("anything", "default"), "default matches the resolved name")
         self.assertFalse(sb._model_reflects_alias("", "opus"), "no live name yet → not resolved")
+
+    def test_a_context_tagged_pick_resolves_its_pending_switch(self):
+        # "/model fable[1m]" — the CLI's 1M-context spelling — routes through the setter, but the literal
+        # "fable[1m]" is never a substring of the pretty live name "Fable 5.1", so the switching-dots
+        # stuck until the thread died. The check reads through the tag.
+        self.assertTrue(sb._model_reflects_alias("Fable 5.1", "fable[1m]"))
+        self.assertTrue(sb._model_reflects_alias("Opus 4.8", "claude-opus-4-8[1m]"))
+        self.assertFalse(sb._model_reflects_alias("Fable 5.1", "opus[1m]"), "still the family that must match")
+        sess = sb.SdkSession(self.be, {"sid": "q", "name": "n", "cwd": self.d, "model": "fable[1m]"})
+        sess.model = "Opus 4.8"
+        sess._model_pending = "fable[1m]"
+        sess._learn_model("Fable 5.1", raw="claude-fable-5-1[1m]")
+        self.assertEqual(sess._model_pending, "", "the new name clears the tagged switch — dots stop")
+
+    def test_a_refused_set_model_reverts_every_layer_and_warns(self):
+        # set_model PERSISTED before the CLI accepted — sdk-defaults.json (the seed for every future
+        # session), the reg (the reconnect's --model) and chosen_model — and a refusal only LOGGED,
+        # unlike _do_set_mode, which reverts every layer. A well-formed id the CLI's catalog rejects
+        # poisoned all three. The refusal now restores what was there and rings the problems.
+        sid = self.be.spawn("m", self.d)
+        self.assertTrue(self.be.set_model(sid, "opus"))                      # the prior, accepted pick
+        sess = sb.SdkSession(self.be, sb.read_reg(self.d, sid))
+        sess.model = "Opus 4.8"
+        self.be.sessions[sid] = sess
+
+        class _RefusingClient:
+            async def set_model(self, model=None):
+                raise Exception("Unknown model: %s" % model)   # the SDK's shape for a CLI error response (_cli_refusal)
+
+            async def get_context_usage(self):
+                return {"percentage": 3, "model": "claude-opus-4-8"}       # the CLI stayed where it was
+        sess.client = _RefusingClient()
+        scheduled = []
+        sess.set_model_live = lambda model, prev=None: scheduled.append((model, prev))   # the loop hop, stubbed
+        # a well-formed id of a known family that the CLI's catalog rejects (another family than the
+        # live one, so the switch is genuinely pending until the CLI answers)
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "claude-fable-9-9", "accepted optimistically, as before")
+        self.assertEqual(sess._model_pending, "claude-fable-9-9")
+        self.assertEqual(len(scheduled), 1)
+        asyncio.run(sess._do_set_model(*scheduled[0]))
+        reg = sb.read_reg(self.d, sid)
+        self.assertEqual(reg["model"], "opus", "the reg — the reconnect's --model — is back to the accepted pick")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus", "the seed for future sessions too")
+        self.assertEqual(sess.chosen_model, "opus")
+        self.assertEqual(sess._model_pending, "", "nothing is coming to resolve dots for a refused switch")
+        self.assertFalse(reg.get("modelPending"))
+        probs = [p["text"] for p in self.be.problems()]
+        self.assertEqual(len(probs), 1, "loud: the refusal rings the problems, the mode path's idiom")
+        self.assertIn("claude-fable-9-9", probs[0])
+        self.assertIn("did NOT apply", probs[0])
+        self.assertIn("opus", probs[0].rsplit("reverted", 1)[-1], "and names what it reverted to")
+
+    def test_a_refused_set_model_with_no_prior_pick_leaves_no_residue(self):
+        # the prior state may be ABSENT (a session on the account default, no remembered model):
+        # the revert removes the keys it wrote rather than parking a null or the refused value
+        sid = self.be.spawn("m", self.d)
+        self.assertNotIn("model", sb.read_reg(self.d, sid))
+        self.assertNotIn("model", sb.read_sdk_defaults(self.d))
+        sess = sb.SdkSession(self.be, sb.read_reg(self.d, sid))
+        self.be.sessions[sid] = sess
+
+        class _RefusingClient:
+            async def set_model(self, model=None):
+                raise Exception("Unknown model: %s" % model)
+
+            async def get_context_usage(self):
+                return {"percentage": 3, "model": "claude-fable-5-1"}
+        sess.client = _RefusingClient()
+        scheduled = []
+        sess.set_model_live = lambda model, prev=None: scheduled.append((model, prev))
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))
+        asyncio.run(sess._do_set_model(*scheduled[0]))
+        self.assertNotIn("model", sb.read_reg(self.d, sid), "no pick before → no pick after")
+        self.assertNotIn("model", sb.read_sdk_defaults(self.d))
+        self.assertEqual(sess.chosen_model, "")
+        self.assertEqual(sb.read_reg(self.d, sid)["liveModel"], "Fable 5.1", "the badge shows what the CLI runs")
+
+    # ── refusal vs no-answer ──────────────────────────────────────────────────────────────────────
+    # The installed SDK (claude_agent_sdk 0.2.132, _internal/query.py) raises a BARE Exception for two
+    # different worlds: the CLI ANSWERED a control request with an error (`Exception(response["error"])`,
+    # built from the control_response frame — no cause), and the answer NEVER CAME (`Exception("Control
+    # request timeout: set_model") from TimeoutError` after fail_after; Query.close() cancels the reader
+    # without resolving pending requests, so a request stranded by a reconnect teardown ends the same
+    # way). A reader that dies re-raises ITS OWN typed error into every pending request; a disconnected
+    # client raises CLIConnectionError. Verified by probe against the installed package. The fakes below
+    # reproduce those exact shapes.
+
+    def _live(self, prior="opus", live="Opus 4.8"):
+        sid = self.be.spawn("m", self.d)
+        if prior:
+            self.assertTrue(self.be.set_model(sid, prior))
+        sess = sb.SdkSession(self.be, sb.read_reg(self.d, sid))
+        sess.model = live
+        self.be.sessions[sid] = sess
+        scheduled = []
+        sess.set_model_live = lambda model, prev=None: scheduled.append((model, prev))
+        return sid, sess, scheduled
+
+    def test_the_refusal_discriminator_matches_the_installed_sdks_shapes(self):
+        refusal = Exception("Unknown model: claude-fable-9-9")                 # control_response subtype=error
+        self.assertTrue(sb._cli_refusal(refusal))
+        self.assertTrue(sb._cli_refusal(Exception("Unknown error")), "the SDK's default text when the CLI's error is empty")
+        try:
+            raise Exception("Control request timeout: set_model") from TimeoutError()   # fail_after expired / stranded
+        except Exception as e:
+            self.assertFalse(sb._cli_refusal(e), "a timeout is no answer")
+        self.assertFalse(sb._cli_refusal(Exception("Control request timeout: set_model")),
+                         "…even read without its cause: the prefix alone says no answer")
+
+        class ProcessError(Exception):                                          # a typed SDK error the dying reader
+            pass                                                                # fans out to pending requests
+        self.assertFalse(sb._cli_refusal(ProcessError("exit 1")), "a reader death is no answer")
+        self.assertFalse(sb._cli_refusal(RuntimeError("stream broke")))
+
+    def test_a_lost_answer_is_not_a_refusal_the_pick_stands_and_nothing_rings(self):
+        # the reproduced strand: a model AND an effort picked while the session worked, both parked,
+        # replayed back-to-back at turn end — set_model's control request went to the OLD CLI and
+        # set_effort's reconnect tore that client down with the answer unread. The NEW connection came
+        # up with --model <new> (chosen_model rides _options) and ran it; 60s later the stranded request
+        # timed out and a revert flipped chosen_model, the reg and sdk-defaults back to the PREVIOUS
+        # model while the CLI ran the new one — the registry/argv divergence this change exists to
+        # close, re-minted, plus a false "did NOT apply" problem and, for a cheaper prev, a false
+        # model-fallback card at the next reconnect.
+        sid, sess, scheduled = self._live()
+        logs = []
+        self.be._log_cb = logs.append
+
+        class _NeverAnswers:
+            async def set_model(self, model=None):
+                raise Exception("Control request timeout: set_model") from TimeoutError()
+
+            async def get_context_usage(self):
+                return {"percentage": 3, "model": "claude-fable-5-1"}    # the reconnect runs the pick
+        sess.client = _NeverAnswers()
+        self.assertTrue(self.be.set_model(sid, "fable"))
+        asyncio.run(sess._do_set_model(*scheduled[0]))
+        self.assertEqual(sess.chosen_model, "fable", "the pick stands — the next connect's _options asserts it")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "fable", "the reg (the reconnect's --model) keeps the pick")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "fable", "so does the seed for future sessions")
+        self.assertEqual(self.be.problems(), [], "a lost answer is not a failed switch — nothing rings")
+        lost = [m for m in logs if "set_model" in m and "fable" in m]
+        self.assertEqual(len(lost), 1, "one line says the answer was lost")
+        self.assertNotIn("refused", lost[0])
+        self.assertNotIn("did NOT apply", lost[0])
+        self.assertIn("lost", lost[0])
+        # the same for a client that was already disconnected when the request was made (the SDK's
+        # typed CLIConnectionError), and for a reader death fanned out to the pending request
+        for exc in (type("CLIConnectionError", (Exception,), {})("Not connected. Call connect() first."),
+                    type("ProcessError", (Exception,), {})("Command failed with exit code 1")):
+            sid2, sess2, sched2 = self._live()
+
+            class _Typed:
+                async def set_model(self, model=None, _e=exc):
+                    raise _e
+
+                async def get_context_usage(self):
+                    return {"percentage": 3, "model": "claude-sonnet-4-6"}
+            sess2.client = _Typed()
+            self.assertTrue(self.be.set_model(sid2, "sonnet"))
+            asyncio.run(sess2._do_set_model(*sched2[0]))
+            self.assertEqual(sess2.chosen_model, "sonnet", type(exc).__name__)
+            self.assertEqual(sb.read_reg(self.d, sid2)["model"], "sonnet", type(exc).__name__)
+        self.assertEqual(self.be.problems(), [])
+
+    def test_a_refusal_landing_after_a_newer_pick_stands_down_entirely(self):
+        # same session, A then B: A's control request answers late with the CLI's error AFTER B was
+        # accepted. A revert that wrote A's captured snapshots back unconditionally rolled the ACCEPTED
+        # pick B back to the pre-A model in every layer while the CLI ran B. A writer whose evidence
+        # predates the diary stands down.
+        sid, sess, scheduled = self._live()
+
+        class _Client:
+            def __init__(self):
+                self.b_done = asyncio.Event()
+                self.accepted = None
+
+            async def set_model(self, model=None):
+                if model == "claude-fable-9-9":          # pick A — the CLI answers with an error, late
+                    await self.b_done.wait()
+                    raise Exception("Unknown model: %s" % model)
+                self.accepted = model                    # pick B — accepted at once
+                self.b_done.set()
+
+            async def get_context_usage(self):
+                return {"percentage": 3, "model": "claude-sonnet-4-6"}
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))     # A: prev = opus
+        self.assertTrue(self.be.set_model(sid, "sonnet"))               # B: prev = A
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "sonnet")
+
+        async def drive():
+            cl = _Client()
+            sess.client = cl
+            ta = asyncio.ensure_future(sess._do_set_model(*scheduled[0]))   # one task per pick, as set_model_live does
+            tb = asyncio.ensure_future(sess._do_set_model(*scheduled[1]))
+            await asyncio.gather(ta, tb)
+            return cl
+        cl = asyncio.run(drive())
+        self.assertEqual(cl.accepted, "sonnet")
+        self.assertEqual(sess.chosen_model, "sonnet", "B stands: the late refusal of A owns nothing any more")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "sonnet")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "sonnet")
+        self.assertEqual(self.be.problems(), [], "a superseded refusal is not the user's problem — B applied")
+
+    def test_a_revert_leaves_a_layer_a_newer_writer_holds(self):
+        # the cross-session twin: sdk-defaults.json is SHARED. S1 picks X (later refused); S2 — dormant,
+        # no CLI to refuse — picks Y, which lands in the defaults as every set_model does. X's refusal
+        # must not restore S1's captured default over Y. Each layer reverts only while it still holds
+        # the refused value (compare-and-swap).
+        s1, sess1, sched1 = self._live()
+        s2 = self.be.spawn("two", self.d)
+        self.assertTrue(self.be.set_model(s1, "claude-fable-9-9"))     # X: captures default = opus
+        self.assertTrue(self.be.set_model(s2, "haiku"))                # Y: defaults.model = haiku
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "haiku")
+
+        class _Refusing:
+            async def set_model(self, model=None):
+                raise Exception("Unknown model: %s" % model)
+
+            async def get_context_usage(self):
+                return {"percentage": 3, "model": "claude-opus-4-8"}
+        sess1.client = _Refusing()
+        asyncio.run(sess1._do_set_model(*sched1[0]))
+        self.assertEqual(sess1.chosen_model, "opus", "S1's own layers revert — they still held X")
+        self.assertEqual(sb.read_reg(self.d, s1)["model"], "opus")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "haiku", "S2's newer default survives")
+        self.assertEqual(sb.read_reg(self.d, s2)["model"], "haiku")
+        self.assertEqual(len(self.be.problems()), 1, "S1's refusal is still loud")
+
+    def test_a_refusal_tells_the_kernel_to_forget_the_pick_superseded_or_not_a_lost_answer_does_not(self):
+        """The kernel records a version as its family's pin BEFORE the CLI rules (_set_model_or_park →
+        _note_model_pick), and the revert never reached that memory: after a refusal the family row kept
+        sending the refused id, re-ringing the problem on every click. The backend tells the kernel through
+        a class-level hook, the on_model_fallback idiom — on a VERDICT.
+
+        A SUPERSEDED refusal forgets too: the newer pick owns chosen_model and the reg, but the pin the
+        kernel recorded for the REFUSED id is its own — a pick in another family, or the same family's
+        pin when the newer pick is an alias — and the CLI did rule on it. Left in place, a family click
+        re-sent the refused id. Firing the hook is safe for the newer pick because the kernel's forget
+        compares-and-swaps by value (_forget_model_pick(fam, only=id)): a newer pin for the same family
+        is never this refusal's to drop (test_model_versions pins that side). A LOST answer forgets
+        nothing — it says nothing about the id."""
+        calls = []
+        type(self.be).on_model_refused = staticmethod(lambda sid, value: calls.append((sid, value)))
+        try:
+            sid, sess, scheduled = self._live()
+
+            class _Refusing:
+                async def set_model(self, model=None):
+                    raise Exception("Unknown model: %s" % model)
+
+                async def get_context_usage(self):
+                    return {"percentage": 3, "model": "claude-opus-4-8"}
+            sess.client = _Refusing()
+            self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))
+            asyncio.run(sess._do_set_model(*scheduled[0]))
+            self.assertEqual(calls, [(sid, "claude-fable-9-9")], "the refused id, as the kernel recorded it")
+            # a lost answer: no call
+            sid2, sess2, sched2 = self._live()
+
+            class _Lost:
+                async def set_model(self, model=None):
+                    raise Exception("Control request timeout: set_model") from TimeoutError()
+
+                async def get_context_usage(self):
+                    return {"percentage": 3, "model": "claude-fable-5-1"}
+            sess2.client = _Lost()
+            self.assertTrue(self.be.set_model(sid2, "claude-fable-5-1"))
+            asyncio.run(sess2._do_set_model(*sched2[0]))
+            self.assertEqual(len(calls), 1, "a lost answer forgets nothing")
+            # a superseded refusal: the CLI ruled on the id, so its pin goes too — the newer pick (another
+            # family here) recorded its own pin, which this forget cannot reach (CAS by value, kernel side)
+            sid3, sess3, sched3 = self._live()
+            sess3.client = _Refusing()
+            rang = len(self.be.problems())
+            self.assertTrue(self.be.set_model(sid3, "claude-fable-9-9"))
+            self.assertTrue(self.be.set_model(sid3, "claude-sonnet-4-6"))
+            asyncio.run(sess3._do_set_model(*sched3[0]))
+            self.assertEqual(calls[1:], [(sid3, "claude-fable-9-9")], "a superseded refusal forgets the refused id")
+            self.assertEqual(sess3.chosen_model, "claude-sonnet-4-6", "…and touches nothing the newer pick owns")
+            self.assertEqual(sb.read_reg(self.d, sid3)["model"], "claude-sonnet-4-6")
+            self.assertEqual(len(self.be.problems()), rang, "and rings nothing — the user already picked again")
+        finally:
+            del type(self.be).on_model_refused
+
+    def test_a_superseded_write_whose_answer_was_lost_forgets_nothing_and_drops_its_node(self):
+        # superseded is computed from chosen_model alone — so a superseded write whose answer was LOST
+        # (a timeout, a request stranded by a reconnect teardown) must not forget the user's pin for it:
+        # a lost answer says nothing about the id. The hook fires on a refusal alone. The superseded lost
+        # write's node goes the way a settled write's does (dropped ≡ settled, the dead-thread rule): the
+        # store keeps the newer pick, and the newer pick's own unwind lands on this write — a lost pick
+        # stands, it was never refused.
+        calls = []
+        type(self.be).on_model_refused = staticmethod(lambda sid, value: calls.append((sid, value)))
+        try:
+            sid, sess, sched = self._live()                                     # accepted: opus
+
+            class _LostThenRefuses:
+                async def set_model(self, model=None):
+                    if model == "claude-fable-9-9":
+                        raise Exception("Control request timeout: set_model") from TimeoutError()
+                    raise Exception("Unknown model: %s" % model)
+
+                async def get_context_usage(self):
+                    return {"percentage": 3, "model": "claude-opus-4-8"}
+            sess.client = _LostThenRefuses()
+            self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))         # A: a version pin
+            self.assertTrue(self.be.set_model(sid, "claude-sonnet-4-6"))        # B: the newer pick
+            rang = len(self.be.problems())
+            asyncio.run(sess._do_set_model(*sched[0]))                         # A's answer: lost, superseded by B
+            self.assertEqual(calls, [], "a lost answer forgets nothing, superseded or not")
+            self.assertEqual(sess.chosen_model, "claude-sonnet-4-6", "the newer pick owns the session's layers")
+            self.assertEqual(sb.read_reg(self.d, sid)["model"], "claude-sonnet-4-6")
+            self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-sonnet-4-6", "the store keeps the newer write")
+            self.assertEqual(len(self.be.problems()), rang, "and rings nothing — the user already picked again")
+            nodes = {n["value"]: n for n in self.be._seed_writes.values()}
+            self.assertEqual(set(nodes), {"claude-sonnet-4-6"}, "A's node is dropped; B's stays pending")
+            self.assertEqual(nodes["claude-sonnet-4-6"]["prior"], "claude-fable-9-9",
+                             "B still points at A's write — lost, not refused, so it is what B unwinds onto")
+            asyncio.run(sess._do_set_model(*sched[1]))                         # B refused — the head
+            self.assertEqual(calls, [(sid, "claude-sonnet-4-6")], "B's refusal is a verdict: it forgets B alone")
+            self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-9-9")
+            self.assertEqual(sess.chosen_model, "opus", "the session's own layers go back to the last ACCEPTED model")
+            self.assertEqual(self.be._seed_writes, {})
+        finally:
+            del type(self.be).on_model_refused
+
+    # ── the revert target is the last ACCEPTED state ──────────────────────────────────────────────
+    class _RefusesAll:
+        """A CLI that answers every set_model with an error and keeps running Opus 4.8."""
+        async def set_model(self, model=None):
+            raise Exception("Unknown model: %s" % model)
+
+        async def get_context_usage(self):
+            return {"percentage": 3, "model": "claude-opus-4-8"}
+
+    def test_two_refusals_in_a_row_restore_the_accepted_model_never_the_first_refused_pick(self):
+        # A then B, BOTH refused. A's answer lands after B's optimistic writes and stands down
+        # (superseded) — right. But B's snapshot was captured AFTER A's writes, so it held A, and a
+        # revert to "what the write replaced" would compare-and-swap A — a REFUSED id — back into
+        # chosen_model, the reg and the shared defaults: the poison the revert exists to remove,
+        # embedded by the revert. The revert restores the last state the CLI ACCEPTED (opus, before
+        # either pick), never the last state WRITTEN. First with NO accepted pick anywhere (a fresh
+        # store, a session on the account default): every layer returns to ABSENCE, never to A.
+        sid0, sess0, sched0 = self._live(prior="")
+        self.assertNotIn("model", sb.read_reg(self.d, sid0))
+        sess0.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid0, "claude-fable-9-9"))        # A
+        self.assertTrue(self.be.set_model(sid0, "claude-sonnet-9-9"))       # B, written over A
+
+        async def drive0():
+            await asyncio.gather(sess0._do_set_model(*sched0[0]), sess0._do_set_model(*sched0[1]))
+        asyncio.run(drive0())
+        self.assertEqual(sess0.chosen_model, "")
+        self.assertNotIn("model", sb.read_reg(self.d, sid0), "no accepted pick before → none after")
+        self.assertNotIn("model", sb.read_sdk_defaults(self.d))
+        self.assertEqual(len(self.be.problems()), 1, "B's refusal rings once; A's stood down")
+        # then with an accepted pick before A (opus, set while the session was dormant — the connect asserts
+        # it): every layer returns to opus
+        sid, sess, scheduled = self._live()                                 # accepted: opus
+        sess.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))         # A
+        self.assertTrue(self.be.set_model(sid, "claude-sonnet-9-9"))        # B, written over A
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "claude-sonnet-9-9")
+
+        async def drive():
+            await asyncio.gather(sess._do_set_model(*scheduled[0]), sess._do_set_model(*scheduled[1]))
+        asyncio.run(drive())
+        self.assertEqual(sess.chosen_model, "opus", "not A — a refused id is never a revert target")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "opus")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus")
+        self.assertFalse(sb.read_reg(self.d, sid).get("modelPending"))
+        probs = [p["text"] for p in self.be.problems()]
+        self.assertEqual(len(probs), 2, "one ring per session — B's refusal; A's stood down")
+        self.assertIn("opus", probs[1].rsplit("reverted", 1)[-1], "and names the ACCEPTED model it went back to")
+
+    def test_a_late_acceptance_becomes_the_revert_target_of_the_pick_after_it(self):
+        # the accepted state moves on ACCEPTANCE, whenever it lands: A accepted after B was already
+        # written, then B refused → B reverts to A (the CLI runs A), not to the pre-A model
+        sid, sess, scheduled = self._live()                                 # accepted: opus
+
+        class _Client:
+            async def set_model(self, model=None):
+                if model != "claude-fable-5-1":
+                    raise Exception("Unknown model: %s" % model)         # B refused; A accepted
+
+            async def get_context_usage(self):
+                return {"percentage": 3, "model": "claude-fable-5-1"}
+        sess.client = _Client()
+        self.assertTrue(self.be.set_model(sid, "claude-fable-5-1"))         # A
+        self.assertTrue(self.be.set_model(sid, "claude-sonnet-9-9"))        # B
+
+        async def drive():
+            await asyncio.gather(sess._do_set_model(*scheduled[0]), sess._do_set_model(*scheduled[1]))
+        asyncio.run(drive())
+        self.assertEqual(sess.chosen_model, "claude-fable-5-1")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "claude-fable-5-1")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-5-1")
+
+    def test_a_connect_asserts_the_pick_whose_answer_died_with_its_thread(self):
+        # a pick written optimistically whose control request never resolved (the thread died) is what
+        # the NEXT connect launches with (--model rides _options); the CLI's init reporting it is the
+        # acceptance — so a later refused pick reverts to IT, not to the model accepted before it
+        sid, sess, scheduled = self._live()                                 # accepted: opus
+        self.assertTrue(self.be.set_model(sid, "claude-fable-5-1"))         # A — never driven: its task died
+
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+
+        async def _noop(): pass
+        sess._do_refresh_context = _noop
+
+        async def connect():
+            sess._on_message(_Sys({"model": "claude-fable-5-1"}), _AssistantMessage, _ResultMessage, _Sys)
+            await asyncio.sleep(0)
+        asyncio.run(connect())
+        sess.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid, "claude-sonnet-9-9"))        # B, refused
+        asyncio.run(sess._do_set_model(*scheduled[1]))
+        self.assertEqual(sess.chosen_model, "claude-fable-5-1", "the connect made A the accepted model")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "claude-fable-5-1")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-5-1")
+
+    # ── the SHARED defaults are ruled per write, by token ─────────────────────────────────────────
+    # sdk-defaults.json is one store for every session. Deciding "is the value in it still my write?" by
+    # VALUE from a per-session picture of the layer is wrong three ways, each reproduced below; the store
+    # carries the identity of the write that set it (`modelTok`), and a refusal unwinds exactly its own write.
+    class _AcceptsAll:
+        """A CLI that accepts every set_model and reports the picked model."""
+        def __init__(self, live="claude-sonnet-5-2"):
+            self.live = live
+
+        async def set_model(self, model=None):
+            return None
+
+        async def get_context_usage(self):
+            return {"percentage": 3, "model": self.live}
+
+    def test_picking_the_value_the_shared_default_already_holds_then_being_refused_leaves_it_in_place(self):
+        # The most common pick of all: the value another session's ACCEPTED pick left in the shared
+        # defaults — a new session seeds from it, and picking it again is one click. A by-value scheme
+        # cannot adopt it as the baseline (the value is in this session's own unaccepted set the moment
+        # it is picked), so the refusal restores a STALE baseline over the other session's pick.
+        sid, sess, sched = self._live()                                    # accepted opus; defaults = opus
+        other = self.be.spawn("two", self.d)
+        self.assertTrue(self.be.set_model(other, "claude-sonnet-5-2"))     # dormant: accepted where it stands
+        self.assertEqual(sb.read_sdk_defaults(self.d)["model"], "claude-sonnet-5-2")
+        sess.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid, "claude-sonnet-5-2"))       # the SAME value; this CLI refuses it
+        asyncio.run(sess._do_set_model(*sched[-1]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-sonnet-5-2",
+                         "the other session's accepted pick stays the seed")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "opus", "this session's own layers revert")
+        self.assertEqual(sess.chosen_model, "opus")
+        self.assertEqual(sb.read_reg(self.d, other)["model"], "claude-sonnet-5-2")
+        # the same with the other session LIVE and its CLI accepting — its accepted pick, literally
+        s3, sess3, sched3 = self._live()
+        s4, sess4, sched4 = self._live()
+        sess4.client = self._AcceptsAll()
+        self.assertTrue(self.be.set_model(s4, "claude-sonnet-5-2"))
+        asyncio.run(sess4._do_set_model(*sched4[-1]))                      # accepted
+        sess3.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(s3, "claude-sonnet-5-2"))
+        asyncio.run(sess3._do_set_model(*sched3[-1]))                      # refused
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-sonnet-5-2")
+        self.assertEqual(sb.read_reg(self.d, s3)["model"], "opus")
+        self.assertEqual(sb.read_reg(self.d, s4)["model"], "claude-sonnet-5-2")
+
+    def test_an_id_this_session_once_refused_stays_when_another_session_has_since_accepted_it(self):
+        # a by-value scheme keeps a refused id in the session's unaccepted set FOREVER, so the shared
+        # default holding it — put there later by another session whose CLI accepted it (a newer CLI,
+        # another account) — can never be adopted as a baseline, and this session's next refusal restores
+        # its own stale baseline over that accepted pick
+        sid, sess, sched = self._live()                                    # accepted opus
+        sess.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))        # X, refused here
+        asyncio.run(sess._do_set_model(*sched[-1]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus")
+        other, sess2, sched2 = self._live()
+        sess2.client = self._AcceptsAll("claude-fable-9-9")
+        self.assertTrue(self.be.set_model(other, "claude-fable-9-9"))      # X again, on a CLI that takes it
+        asyncio.run(sess2._do_set_model(*sched2[-1]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-9-9")
+        self.assertTrue(self.be.set_model(sid, "claude-sonnet-9-9"))       # Y, refused
+        asyncio.run(sess._do_set_model(*sched[-1]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-9-9",
+                         "the other session's accepted X stands; this session's old refusal is not evidence")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "opus")
+
+    def test_two_cross_session_refusals_never_seed_a_refused_id_in_either_order(self):
+        # Two live sessions pick concurrently: b's write lands on a's PENDING one. A by-value scheme
+        # adopts a's pending value as b's baseline (it is not in b's own unaccepted set), so when both
+        # are refused — a first, whose compare-and-swap stands down because b holds the store — b's
+        # revert restores a's REFUSED id as the seed every new session launches with.
+        a, sa, qa = self._live()
+        b, sb_, qb = self._live()
+        sa.client = sb_.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(a, "claude-fable-9-9"))          # Va, pending
+        self.assertTrue(self.be.set_model(b, "claude-sonnet-9-9"))         # Vb on top of it
+        asyncio.run(sa._do_set_model(*qa[-1]))                             # Va refused — not the head: spliced out
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-sonnet-9-9", "b's write still pending")
+        asyncio.run(sb_._do_set_model(*qb[-1]))                            # Vb refused — head: back past Va
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus", "neither refused id is the seed")
+        self.assertEqual((sb.read_reg(self.d, a)["model"], sb.read_reg(self.d, b)["model"]), ("opus", "opus"))
+        # the other order: b's refusal first unwinds onto a's pending Va (honest — a's verdict is still out),
+        # then a's refusal takes it back to opus
+        self.assertTrue(self.be.set_model(a, "claude-fable-9-9"))
+        self.assertTrue(self.be.set_model(b, "claude-sonnet-9-9"))
+        asyncio.run(sb_._do_set_model(*qb[-1]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-9-9", "a's write, still pending")
+        asyncio.run(sa._do_set_model(*qa[-1]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus")
+        self.assertEqual(len(self.be.problems()), 4, "every refusal rang once")
+        # and an ACCEPTED write under a refused one is what the refusal unwinds onto
+        sa.client = self._AcceptsAll("claude-fable-9-9")
+        self.assertTrue(self.be.set_model(a, "claude-fable-9-9"))
+        self.assertTrue(self.be.set_model(b, "claude-sonnet-9-9"))
+        asyncio.run(sa._do_set_model(*qa[-1]))                             # Va accepted
+        asyncio.run(sb_._do_set_model(*qb[-1]))                            # Vb refused
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-fable-9-9")
+        self.assertEqual(sb.read_reg(self.d, a)["model"], "claude-fable-9-9")
+        self.assertEqual(sb.read_reg(self.d, b)["model"], "opus")
+
+    def test_the_store_carries_the_writes_token_and_a_seed_never_does(self):
+        # every writer of `model` stamps a fresh token; the spawn seed copies the model alone
+        sid = self.be.spawn("m", self.d)
+        self.assertTrue(self.be.set_model(sid, "opus"))                    # dormant path
+        d = sb.read_sdk_defaults(self.d)
+        self.assertEqual(d["model"], "opus")
+        t0 = d.get("modelTok")
+        self.assertTrue(t0 and isinstance(t0, str))
+        s2 = self.be.spawn("n", self.d)
+        self.assertEqual(sb.read_reg(self.d, s2)["model"], "opus")
+        self.assertNotIn("modelTok", sb.read_reg(self.d, s2), "the token is the store's, not the session's")
+        sess = sb.SdkSession(self.be, sb.read_reg(self.d, sid))
+        self.be.sessions[sid] = sess
+        sess.set_model_live = lambda model, prev=None: None
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))        # live path
+        d = sb.read_sdk_defaults(self.d)
+        self.assertTrue(d["modelTok"] and d["modelTok"] != t0, "a new write, a new token")
+        self.be.set_effort(sid, "low")
+        self.assertEqual(sb.read_sdk_defaults(self.d)["modelTok"], d["modelTok"], "an effort write leaves it alone")
+        self.assertNotIn("effortTok", sb.read_sdk_defaults(self.d), "only the model carries one")
+
+    def test_a_defaults_file_without_a_token_is_never_reverted(self):
+        # compat, fail-safe: a file an older kernel or a hand edit wrote carries no `modelTok` — no
+        # token, no match, and the revert leaves the store alone rather than guess
+        sid, sess, sched = self._live()                                    # accepted opus
+        sess.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))
+        self.assertTrue(sb.read_sdk_defaults(self.d).get("modelTok"))
+        sb._defaults_path(self.d).write_text(json.dumps({"model": "claude-fable-9-9", "effort": "low"}))
+        asyncio.run(sess._do_set_model(*sched[-1]))                        # refused
+        self.assertEqual(sb.read_sdk_defaults(self.d), {"model": "claude-fable-9-9", "effort": "low"},
+                         "untokened: not this write's to move")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "opus", "the session's own layers still revert")
+        self.assertEqual(sess.chosen_model, "opus")
+        # and a write whose verdict never came (the thread died) leaves no node behind to unwind later
+        sid2, sess2, sched2 = self._live()
+        self.assertTrue(self.be.set_model(sid2, "claude-sonnet-9-9"))
+        self.assertEqual(len(self.be._seed_writes), 1)
+        self.be._on_session_gone(sess2)
+        self.assertEqual(self.be._seed_writes, {}, "dropped with the thread; the store keeps the value")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-sonnet-9-9")
+
+    def test_a_refusal_landing_between_the_shared_write_and_its_node_never_seeds_the_refused_id(self):
+        # If _seed_write_pending wrote the store under the lock, RELEASED it, and took it again to insert
+        # the node, a refusal for the write it replaced — on the SDK loop thread, through _revert_model —
+        # could run in that gap: it would pop its own node and re-point only the nodes that EXISTED, so
+        # the new node would be inserted afterwards still pointing at the refused (value, token); the
+        # head check would stand down (the file's head is the new write). The new write's own refusal
+        # would then restore the refused id under a token no node knew — unwindable by nothing, and the
+        # seed of every new session. Deterministic stand-in for "the other thread takes the lock the
+        # instant this one lets go": a lock whose RELEASE runs an armed action once — A's refusal — so it
+        # lands wherever the first release inside set_model falls. The write and the insert are one hold.
+        a, sa, qa = self._live()
+        b, sb_, qb = self._live()
+        sa.client = sb_.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(a, "claude-fable-9-9"))          # Va pending, the head
+
+        class _ReleaseRuns:
+            """_defaults_lock stand-in: the first release after arming runs the armed action."""
+            def __init__(self):
+                self._l, self.armed = threading.Lock(), None
+
+            def locked(self):
+                return self._l.locked()
+
+            def __enter__(self):
+                self._l.acquire()
+                return self
+
+            def __exit__(self, *exc):
+                self._l.release()
+                fn, self.armed = self.armed, None
+                if fn:
+                    fn()
+        lock = _ReleaseRuns()
+        lock.armed = lambda: asyncio.run(sa._do_set_model(*qa[-1]))       # Va refused, at the first release
+        with mock.patch.object(sb, "_defaults_lock", lock):
+            self.assertTrue(self.be.set_model(b, "claude-sonnet-9-9"))     # Vb on top of Va
+        self.assertIsNone(lock.armed, "the refusal ran inside b's set_model")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "claude-sonnet-9-9", "b's write is the head")
+        self.assertEqual(sb.read_reg(self.d, a)["model"], "opus", "a's own layers reverted")
+        (nb,) = self.be._seed_writes.values()
+        self.assertEqual((nb["value"], nb["prior"]), ("claude-sonnet-9-9", "opus"),
+                         "b's node points PAST the refused write: the refusal saw it")
+        asyncio.run(sb_._do_set_model(*qb[-1]))                            # Vb refused — the head: back to opus
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus", "neither refused id is the seed")
+        self.assertEqual(self.be._seed_writes, {})
+        self.assertEqual(len(self.be.problems()), 2, "every refusal rang once")
+
+    # ── snapshot and write in ONE lock hold; chosen_model compare-and-assign under the session lock ──
+    def test_a_defaults_or_reg_read_taken_outside_the_store_lock_never_feeds_the_revert(self):
+        # A set_model that captured its snapshots (read_reg, read_sdk_defaults) OUTSIDE _reg_lock /
+        # _defaults_lock and only then took the locks to write let a writer on the other thread (a
+        # revert, another session's pick) land between the read and the write, so the snapshot described
+        # a world the write never replaced. Deterministic stand-in for that interleave: a read made
+        # WITHOUT the store lock held reports a phantom value. If any such read feeds the revert, the
+        # phantom lands in the store; a read-modify-write under one hold never sees it.
+        sid, sess, scheduled = self._live()                                 # accepted: opus
+        sess.client = self._RefusesAll()
+        real_defaults, real_reg = sb.read_sdk_defaults, sb.read_reg
+        be = self.be
+
+        def phantom_defaults(state_dir):
+            d = real_defaults(state_dir)
+            return d if sb._defaults_lock.locked() else {**d, "model": "phantom-unlocked-read"}
+
+        def phantom_reg(state_dir, s):
+            r = real_reg(state_dir, s)
+            return r if (r is None or be._reg_lock.locked()) else {**r, "model": "phantom-unlocked-read"}
+        with mock.patch.object(sb, "read_sdk_defaults", phantom_defaults), mock.patch.object(sb, "read_reg", phantom_reg):
+            self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "claude-fable-9-9", "the optimistic write landed")
+        asyncio.run(sess._do_set_model(*scheduled[0]))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("model"), "opus", "the defaults snapshot was read under the lock")
+        self.assertEqual(sb.read_reg(self.d, sid)["model"], "opus", "so was the reg snapshot")
+        self.assertEqual(sess.chosen_model, "opus")
+
+    def test_chosen_model_is_written_only_under_the_session_lock(self):
+        # _revert_model compares and assigns sess.chosen_model while the kernel thread's set_model
+        # assigns it — a torn compare-and-swap unless both writers hold the session's lock around the
+        # compare-and-assign; a property stand-in records any write made without it.
+        sid = self.be.spawn("m", self.d)
+        self.assertTrue(self.be.set_model(sid, "opus"))
+        unlocked = []
+
+        class _Guarded(sb.SdkSession):
+            @property
+            def chosen_model(self):
+                return self.__dict__.get("_chosen", "")
+
+            @chosen_model.setter
+            def chosen_model(self, v):
+                lk = self.__dict__.get("_lock")           # absent during __init__'s own seed (before the lock exists)
+                if lk is not None and not lk.locked():
+                    unlocked.append(v)
+                self.__dict__["_chosen"] = v
+        sess = _Guarded(self.be, sb.read_reg(self.d, sid))
+        sess.model = "Opus 4.8"
+        self.be.sessions[sid] = sess
+        scheduled = []
+        sess.set_model_live = lambda model, prev=None: scheduled.append((model, prev))
+        sess.client = self._RefusesAll()
+        self.assertTrue(self.be.set_model(sid, "claude-fable-9-9"))
+        self.assertEqual(sess.chosen_model, "claude-fable-9-9")
+        asyncio.run(sess._do_set_model(*scheduled[0]))
+        self.assertEqual(sess.chosen_model, "opus")
+        self.assertEqual(unlocked, [], "every write — the optimistic one and the revert — held the lock")
+        # the compare half of the revert's compare-and-swap sits in the SAME hold as its assign
+        src = inspect.getsource(sb.SdkBackend._revert_model)
+        hold = src.index("with sess._lock:")
+        self.assertLess(hold, src.index("sess.chosen_model == picked"), "the compare is inside the hold")
+        self.assertLess(src.index("sess.chosen_model == picked"), src.index("with self._reg_lock:"),
+                        "…and the hold is released before the reg lock (no nesting)")
+
+    def test_set_model_and_effort_on_a_dormant_session_leave_an_acknowledgment_chip(self):
+        # a composer "/model X" on a LIVE session lands the synthesized command chip and the webview's
+        # optimistic bubble retires against it; on a DORMANT session nothing landed, so the dashed
+        # bubble sat as "unconfirmed" and vanished with no trace. The chip — and its durable gesture
+        # twin — are the acknowledgment, whatever the session's liveness.
+        sid = self.be.spawn("m", self.d)                  # a reg, no thread: dormant
+        self.assertTrue(self.be.set_model(sid, "fable"))
+        self.assertTrue(self.be.set_effort(sid, "high"))
+        chips = {a["command"]: a for a in self.be.live_atoms(sid) if a.get("command")}
+        self.assertEqual(set(chips), {"/model", "/effort"})
+        for cmd, disp in (("/model", "/model fable"), ("/effort", "/effort high")):
+            a = chips[cmd]
+            self.assertTrue(a["uuid"].startswith("cmd:"), a["uuid"])
+            self.assertEqual((a["type"], a["author"], a["_echo_text"]), ("user", "human", disp))
+            self.assertEqual(a["message"]["content"][0]["text"], disp, "the text the optimistic bubble retires against")
+            self.assertEqual(a["session_id"], sid)
+        gestures = [json.loads(l).get("cmdGesture") for l in (Path(self.d) / "states" / (sid + ".jsonl")).read_text().splitlines()]
+        self.assertEqual([g for g in gestures if g], ["/model fable", "/effort high"], "the durable twin, so the history keeps the gesture")
+        # the dormant resolution is unchanged: the badge shows the pick now, no dots
+        reg = sb.read_reg(self.d, sid)
+        self.assertEqual((reg["model"], reg["liveModel"], reg.get("modelPending")), ("fable", "Fable", False))
 
     def test_learn_model_clears_pending_only_when_the_new_name_lands(self):
         sess = sb.SdkSession(self.be, {"sid": "p", "name": "n", "cwd": self.d, "model": "fable"})

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -10,6 +10,7 @@ Two layers:
     AskUserQuestion -> it surfaces as an askLive picker -> the UI answers ->
     PermissionResultAllow(updated_input={questions, answers}) goes back.
 """
+import asyncio
 import os
 import json
 import threading
@@ -1193,6 +1194,51 @@ class SetModelModePure(unittest.TestCase):
         self.assertEqual(reg["liveModel"], "Fable", "the dormant badge reflects the pick, not the stale prior")
         self.assertFalse(reg.get("modelPending"), "nothing is coming to resolve dots → resolve immediately, no trap")
         self.assertEqual(sb.model_label(reg["liveModel"], reg["model"]), "Fable")
+
+    def test_learn_model_persists_the_raw_id_beside_the_pretty_name(self):
+        # the pickers' version lists are seeded from a table and COMPLETED from what the CLI actually
+        # reports (the authoritative source for what it serves) — that needs the raw id, not just
+        # the badge text, persisted where the kernel reads regs (liveModelId)
+        sid = self.be.spawn("m", self.d)
+        sess = sb.SdkSession(self.be, sb.read_reg(self.d, sid))
+        sess._learn_model("Fable 5.1", raw="claude-fable-5-1")
+        reg = sb.read_reg(self.d, sid)
+        self.assertEqual((reg["liveModel"], reg["liveModelId"]), ("Fable 5.1", "claude-fable-5-1"))
+        # a pre-fix reg knows the NAME but not the id: the first report of an unchanged name still
+        # lands the id (otherwise a long-running session would never contribute its version)
+        sid2 = self.be.spawn("n", self.d)
+        sb.write_reg(self.d, sid2, {**sb.read_reg(self.d, sid2), "liveModel": "Fable 5"})
+        sess2 = sb.SdkSession(self.be, sb.read_reg(self.d, sid2))
+        self.assertEqual(sess2.model, "Fable 5")
+        sess2._learn_model("Fable 5", raw="claude-fable-5")
+        self.assertEqual(sb.read_reg(self.d, sid2)["liveModelId"], "claude-fable-5")
+        # the seeded id survives construction, so an unchanged report writes nothing new
+        sess3 = sb.SdkSession(self.be, sb.read_reg(self.d, sid2))
+        self.assertEqual(sess3._model_id, "claude-fable-5")
+
+    def test_refresh_context_persists_the_live_model_id(self):
+        # _do_refresh_context is the pre-turn source (get_context_usage answers on connect, before any
+        # init message), so an eager-connected session that never runs a turn still contributes its
+        # version to the pickers
+        sid = self.be.spawn("m", self.d)
+        sess = sb.SdkSession(self.be, sb.read_reg(self.d, sid))
+
+        class _Client:
+            async def get_context_usage(self):
+                return {"percentage": 41.6, "model": "claude-fable-5-1"}
+        sess.client = _Client()
+        asyncio.run(sess._do_refresh_context())
+        reg = sb.read_reg(self.d, sid)
+        self.assertEqual((reg["liveModelId"], reg["liveModel"], reg["liveCtx"]), ("claude-fable-5-1", "Fable 5.1", 42))
+        self.assertEqual(sess._model_id, "claude-fable-5-1")
+
+        # a [1m] variant is persisted as reported — the kernel's picker strips the tag on read
+        class _Client1m:
+            async def get_context_usage(self):
+                return {"percentage": 41.6, "model": "claude-fable-5-1[1m]"}
+        sess.client = _Client1m()
+        asyncio.run(sess._do_refresh_context())
+        self.assertEqual(sb.read_reg(self.d, sid)["liveModelId"], "claude-fable-5-1[1m]")
 
     def test_alias_label_and_model_reflects_alias(self):
         self.assertEqual(sb._alias_label("opus"), "Opus")

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -53,6 +53,9 @@ class FakeBackend:
     def set_effort(self, sid, v):
         self.calls.append(("set_effort", sid, v)); return True
 
+    def set_fast(self, sid, v):
+        self.calls.append(("set_fast", sid, v)); return True
+
     def rename(self, sid, n):
         self.calls.append(("rename", sid, n)); return True
 
@@ -149,6 +152,51 @@ class KernelWiring(unittest.TestCase):
         self._route({"type": "setModel", "id": "sid-sdk", "value": "opus"})
         self.assertIn(("set_model", "sid-sdk", "opus"), self.be.calls)
         self.assertFalse(any(c == ("send", "sid-sdk", "/model opus") for c in self.be.calls))
+
+    def test_a_typed_slash_model_effort_fast_routes_through_the_setters_not_literal_text(self):
+        # THE BUG: the chat composer's "/model X" went to the backend as literal text; the CLI
+        # executed it, but romp's registry, sdk-defaults.json and the reconnect's --model still said
+        # the OLD model — so the user's switch silently reverted at the next reconnect. The composer
+        # now takes the same door the timeline's sendCommand does (set_model & co).
+        self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/model claude-fable-5-1"})
+        self._route({"type": "sendMessage", "id": "sid-sdk", "text": " /effort high "})
+        self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/fast on"})
+        self.assertIn(("set_model", "sid-sdk", "claude-fable-5-1"), self.be.calls)
+        self.assertIn(("set_effort", "sid-sdk", "high"), self.be.calls)
+        self.assertIn(("set_fast", "sid-sdk", "on"), self.be.calls)
+        self.assertEqual([c for c in self.be.calls if c[0] == "send"], [], "none of them reach the CLI as text")
+        # …and the version pick lands in the shared pick memory exactly as a menu click would
+        self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/model claude-opus-4-8"})
+        self.assertEqual(km._model_picks().get("opus"), "claude-opus-4-8")
+
+    def test_other_slash_commands_and_plain_text_still_go_through_verbatim(self):
+        # only the three the kernel has a setter for are intercepted; the CLI owns everything else,
+        # and a bare "/model" (no value) is the CLI's own picker, not a set
+        for text in ("/compact", "/model", "/clear", "hi /model opus", "/models please"):
+            self._route({"type": "sendMessage", "id": "sid-sdk", "text": text})
+            self.assertIn(("send", "sid-sdk", text), self.be.calls, text)
+        self.assertEqual([c for c in self.be.calls if c[0] in ("set_model", "set_effort", "set_fast")], [])
+
+    def test_a_setter_takes_only_a_value_it_can_vouch_for_the_rest_stays_the_clis(self):
+        # the composer can type ANYTHING, and set_model persists its value as the seed for every
+        # future session — so a typo, a multiline message that merely starts with the command, or a
+        # fast value outside on/off must NOT be swallowed: it goes to the CLI verbatim, whose own
+        # error the user then sees (as before the routing existed)
+        for text in ("/model opsu", "/model opus\nnow refactor the parser", "/model opus please",
+                     "/effort turbo", "/effort high\nand hurry", "/fast maybe", "/fast on off"):
+            self._route({"type": "sendMessage", "id": "sid-sdk", "text": text})
+            self.assertIn(("send", "sid-sdk", text), self.be.calls, text)
+        self.assertEqual([c for c in self.be.calls if c[0] in ("set_model", "set_effort", "set_fast")], [])
+        # what IS vouched for: a family alias, 'default', a catalog version id, and any well-formed
+        # first-party id (the CLI validates the exact version; romp keeps the registry)
+        for v in ("fable", "default", "claude-opus-4-8", "claude-opus-4-1"):
+            self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/model " + v})
+            self.assertIn(("set_model", "sid-sdk", v), self.be.calls, v)
+        self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/effort ultracode"})
+        self.assertIn(("set_effort", "sid-sdk", "ultracode"), self.be.calls)
+        # the CLI's own 1M-context spelling of a family is vouched for like the tagged id
+        self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/model fable[1m]"})
+        self.assertIn(("set_model", "sid-sdk", "fable[1m]"), self.be.calls)
 
     def test_setmodel_mid_compaction_parks_as_a_queued_command(self):
         # the user 2026-07-01: switching the model while a compaction ran broke the compaction — the

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -198,6 +198,30 @@ class KernelWiring(unittest.TestCase):
         self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/model fable[1m]"})
         self.assertIn(("set_model", "sid-sdk", "fable[1m]"), self.be.calls)
 
+    def test_the_floating_flag_clears_the_pin_from_both_picker_doors(self):
+        # the submenu's "Latest" row: the chat/comment pickers post setModel with `floating`, the
+        # timeline lane menu sends its "/model X" command with the same flag — both forget the
+        # family's remembered pin and send the alias, so the family follows the CLI's newest again.
+        # A plain alias (no flag) keeps leaving the memory alone.
+        picks = km.jd.STATE / km.MODEL_PICKS_FILE_NAME
+        picks.unlink(missing_ok=True)
+        # the timeline keys sendCommand by session NAME (_sid_of resolves it through the live map)
+        self._route({"type": "setModel", "id": "sid-sdk", "value": "claude-sonnet-4-6"})
+        self.assertTrue(self._route({"type": "sendCommand", "name": "sid-sdk", "cmd": "/model claude-opus-4-8"}))
+        self.assertEqual(km._model_picks(), {"sonnet": "claude-sonnet-4-6", "opus": "claude-opus-4-8"})
+        self._route({"type": "setModel", "id": "sid-sdk", "value": "sonnet"})
+        self._route({"type": "sendCommand", "name": "sid-sdk", "cmd": "/model opus"})
+        self.assertEqual(km._model_picks(), {"sonnet": "claude-sonnet-4-6", "opus": "claude-opus-4-8"},
+                         "a bare alias send never downgrades a pin (the standing design)")
+        self._route({"type": "setModel", "id": "sid-sdk", "value": "sonnet", "floating": True})
+        self.assertEqual(km._model_picks(), {"opus": "claude-opus-4-8"})
+        self._route({"type": "sendCommand", "name": "sid-sdk", "cmd": "/model opus", "floating": True})
+        self.assertEqual(km._model_picks(), {})
+        self.assertEqual([c for c in self.be.calls if c[0] == "set_model"][-2:],
+                         [("set_model", "sid-sdk", "sonnet"), ("set_model", "sid-sdk", "opus")],
+                         "the alias itself is what reaches the backend")
+        picks.unlink(missing_ok=True)
+
     def test_setmodel_mid_compaction_parks_as_a_queued_command(self):
         # the user 2026-07-01: switching the model while a compaction ran broke the compaction — the
         # kernel now PARKS the change (a queued '/model …' bubble) and _apply_pending_models fires it

--- a/tests/test_thread_rows.py
+++ b/tests/test_thread_rows.py
@@ -10,6 +10,7 @@ import threading
 import unittest
 import urllib.request
 from importlib.machinery import SourceFileLoader
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -273,11 +274,35 @@ class ThreadRowsRoute(unittest.TestCase):
         self.assertEqual(t.get("parent"), PARENT, "the parent sid rides for reply resolution")
 
 
-class ThreadWakeModel(unittest.TestCase):
-    """T223 rider (the user 2026-09-01): a thread registered on a superseded FULL id comes up on its
-    family's newest at its next explicit wake; bare aliases auto-track and are left alone."""
+class ThreadWakePinsStand(unittest.TestCase):
+    """A dormant comment thread wakes on the model its reg holds — PINS STAND. The T223 rider had the
+    backend's `_ensure` consult a kernel-installed hook (`SdkBackend.thread_wake_model`) that re-points a
+    dormant thread registered on a SUPERSEDED full id to its family's newest at its next explicit wake.
+    That targeted the artefact where a FAMILY click wrote the head's full id into the reg — an
+    accidental pin. With the alias as the family default a full id in reg.model is a DELIBERATE one: the
+    version submenu writes the pick verbatim, the create dialog sends a pinned family's id, and the
+    marker-gated boot pass treats every post-migration head as the user's (the way back to floating is
+    the Latest gesture, never a pass). With no accidental heads left to heal, the remap would override
+    only deliberate pins — so the kernel wires no wake hook, and a thread pinned to a legacy version
+    comes up ON that version; a thread on an alias floats as before. The backend's consult in `_ensure`
+    stays as it is (inert with no hook installed)."""
+
+    THREAD = {"threadOf": PARENT, "spawnedAt": 1700000000}   # has run before: dormant, not a fresh fork
+
+    class _Rec:
+        made = []
+
+        def __init__(self, backend, reg):
+            self.reg = dict(reg)
+            self.thread = mock.Mock(is_alive=lambda: True)
+            self.on_boot_settled = None
+            ThreadWakePinsStand._Rec.made.append(self.reg)
+
+        def start(self):
+            pass
 
     def setUp(self):
+        # a catalog in which claude-fable-5 IS superseded — the one shape a wake remap would act on
         self._saved = {fam: [dict(v) for v in vs] for fam, vs in km.MODEL_VERSIONS.items()}
         km.MODEL_VERSIONS["fable"][:] = [{"value": "claude-fable-5-1", "label": "Fable 5.1"},
                                          {"value": "claude-fable-5", "label": "Fable 5"},
@@ -287,20 +312,46 @@ class ThreadWakeModel(unittest.TestCase):
         for fam, vs in self._saved.items():
             km.MODEL_VERSIONS[fam][:] = vs
 
-    def test_superseded_full_id_remaps_to_family_newest(self):
-        self.assertEqual(km._family_newest_model("claude-fable-5"), "claude-fable-5-1")
+    @staticmethod
+    def _kernel_wired_hook():
+        """The wake hook exactly as the kernel installs it on the backend it builds, read off
+        `_sdk_locked`'s source (building the real backend in-process runs a boot reconcile — this
+        file's first test says why not) and resolved against the kernel module: None when the kernel
+        wires none. So the wake below runs under whatever hook the kernel would give a live backend."""
+        import inspect
+        import re
+        m = re.search(r"thread_wake_model\s*=\s*(\w+)", inspect.getsource(km._sdk_locked))
+        return getattr(km, m.group(1)) if m else None
 
-    def test_newest_alias_and_unknown_remap_to_nothing(self):
-        self.assertIsNone(km._family_newest_model("claude-fable-5-1"), "already newest")
-        self.assertIsNone(km._family_newest_model("claude-fable-4"), "an id the catalog never listed is not ours")
-        self.assertIsNone(km._family_newest_model("fable"), "a bare alias auto-tracks — untouched")
-        self.assertIsNone(km._family_newest_model("claude-opus-4-5-20251101"), "a dated snapshot is not a version")
-        self.assertIsNone(km._family_newest_model(""))
+    def _wake(self, model):
+        """Wake a dormant thread registered on `model` through a hermetic backend INSTANCE wired the
+        kernel's way; returns (the model the spawned session got, the model the reg holds after)."""
+        from pathlib import Path
+        sb = SourceFileLoader("romp_sdk_backend_rows", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        root = Path(tempfile.mkdtemp())
+        be = sb.SdkBackend(root, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        be.thread_wake_model = self._kernel_wired_hook()
+        sb.write_reg(root, TSID, {"sid": TSID, "name": "web-comment-1", "cwd": "/tmp", "alive": True,
+                                  "lastSid": TSID, "model": model, **self.THREAD})
+        self._Rec.made = []
+        with mock.patch.object(sb, "SdkSession", self._Rec):
+            be._ensure(TSID)
+        return self._Rec.made[0]["model"], sb.read_reg(root, TSID).get("model")
 
-    def test_the_backend_hook_is_installed_at_build(self):
+    def test_a_dormant_thread_pinned_to_a_legacy_version_wakes_on_it(self):
+        self.assertEqual(self._wake("claude-fable-5"), ("claude-fable-5", "claude-fable-5"),
+                         "a full id in the reg is the user's pin — it stands at the wake, on disk too")
+
+    def test_a_dormant_thread_on_an_alias_wakes_floating(self):
+        self.assertEqual(self._wake("fable"), ("fable", "fable"),
+                         "an alias auto-tracks in the CLI; nothing to do at the wake")
+
+    def test_the_kernel_wires_no_wake_remap(self):
         import inspect
         src = inspect.getsource(km._sdk_locked)
-        self.assertIn("thread_wake_model = _family_newest_model", src)
+        self.assertNotIn("thread_wake_model = _family_newest_model", src,
+                         "the remap would re-point deliberate pins")
+        self.assertIsNone(self._kernel_wired_hook(), "no hook at all: the backend's consult stays inert")
 
 
 class ThreadRowsBuilder(unittest.TestCase):

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2540,11 +2540,13 @@ class TimelinePanel {
   // one Enter only OPENS the dialog and the model never changes. The extra Enter accepts the default
   // "Yes". /effort and /compact apply directly (no cache-invalidation confirmation), so they don't pass
   // it. The extra Enter is harmless even if a build skips the dialog (an empty composer submit is a no-op).
-  _sendCommand(name, cmd, confirm) {
+  _sendCommand(name, cmd, confirm, extra) {
     if (!name || !cmd) return;
     try {
+      // `extra` is op flags for the kernel bridge (the Latest row's `{ floating: true }`); the direct
+      // tmux paste below has no kernel to carry them to, so it sends the bare command
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSendCommand === 'function') {
-        window.__rompTimelineSendCommand(name, cmd); return;
+        window.__rompTimelineSendCommand(name, cmd, extra || undefined); return;
       }
       const cp = require('child_process'), tmux = this._tmuxPath();
       const env = Object.assign({}, process.env, { LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8', LC_CTYPE: 'en_US.UTF-8' });
@@ -2602,8 +2604,10 @@ class TimelinePanel {
     menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu._kind = kind; menu._sid = s.id;
     const h = this._menuHost(anchorEl.getBoundingClientRect());
-    const pick = (value) => {
-      this._sendCommand(s.name, '/' + kind + ' ' + value, kind === 'model');
+    const pick = (value, floating) => {
+      // `floating` is the version submenu's Latest row: the flag rides the command to the kernel,
+      // which forgets the family's remembered pin
+      this._sendCommand(s.name, '/' + kind + ' ' + value, kind === 'model', floating ? { floating: true } : null);
       const now = (typeof Date !== 'undefined' && Date.now) ? Date.now() : 0;
       this._metaPending[s.id + ':' + kind] = { was: (kind === 'model' ? s.model : s.effort) || '', until: now + 20000 };
       this._closeMetaMenu();
@@ -2626,7 +2630,27 @@ class TimelinePanel {
         closeSub();
         const sub = document.body.createDiv();
         sub.setAttribute('style', 'position:fixed;z-index:1002;min-width:96px;' + MENU_STYLE);
-    sub.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
+        sub.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213) — the Latest row rides inside
+        // "Latest" heads the submenu: the one gesture back to floating once a family carries a pin —
+        // the family row sends the pin, the rows below pin, and a typed alias leaves the pick memory
+        // alone by design. It sends the alias with the `floating` flag, which the kernel's sendCommand
+        // arm hands to _set_model_or_park to forget the family's remembered pin, so the family follows
+        // the CLI's newest release again. ✓ when unpinned and current.
+        const pinned = !!c.default && c.default !== c.value;
+        const latest = sub.createDiv();
+        latest.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;');
+        latest.setAttribute('tabindex', '0');
+        latest.createDiv({ text: 'Latest' });
+        const lsub = latest.createDiv({ text: pinned ? 'unpins — follows the newest ' + c.label : 'follows the newest ' + c.label });
+        lsub.setAttribute('style', 'font-size:0.82em;opacity:0.6;');
+        if (!pinned && cur) { const ck = latest.createSpan({ text: '✓' }); ck.setAttribute('style', MENU_CHECK_STYLE); }
+        latest.addEventListener('mouseenter', () => { latest.style.background = HOVER_BG; });
+        latest.addEventListener('mouseleave', () => { latest.style.background = 'transparent'; });
+        latest.addEventListener('click', (e) => { e.stopPropagation(); pick(c.value, true); });
+        latest.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); pick(c.value, true); }
+          else if (e.key === 'ArrowLeft') { e.preventDefault(); closeSub(); item.focus(); }
+        });
         for (const v of versions) {
           const cv = ((s.model || '').toLowerCase() === v.label.toLowerCase());
           const row = sub.createDiv({ text: v.label });

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -729,12 +729,28 @@ const LANE_TOGGLES = [
 // on load so _openMetaMenu keeps its reference; the lane picker appends its own 'Default' sentinel (not a model).
 const MODEL_CHOICES = [];
 const EFFORT_CHOICES = [];
-try {
-  if (typeof fetch !== 'undefined') fetch('/models', { cache: 'no-store' }).then((r) => r.json()).then((d) => {
-    if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; for (const m of d.models) MODEL_CHOICES.push(m); MODEL_CHOICES.push({ label: 'Default', value: 'default' }); }
-    if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; for (const e of d.efforts) EFFORT_CHOICES.push(e); }
-  }).catch(() => {});
-} catch (e) {}
+// Loaded once at page load and RE-LOADED on the kernel's {type:"models"} frame (TimelinePanel.refreshModels,
+// the frame's arm in both boots): the pick memory moved — a version pinned, a family un-pinned by Latest, a
+// refused pin dropped, from any surface or dashboard — or the catalog grew, and a family's `default` is
+// what its row SENDS, so a list fetched once went stale the moment anything changed it (after Latest
+// un-pinned a family, the lane's next family click sent the old pinned id and silently re-pinned). Refilled
+// IN PLACE so _openMetaMenu's reference holds. Event-keyed on the frame, never a poll. A response is applied
+// only if it is not OLDER than one already applied: its `rev` is the pick memory's revision — the frame's
+// counter — and two overlapping fetches (a frame during the page-load fetch; two quick frames) can resolve
+// out of order, so without the check the STALE list won until the next change. A payload without a rev (an
+// older kernel) always applies.
+let modelChoicesRev = -1;
+function loadModelChoices() {
+  try {
+    if (typeof fetch !== 'undefined') return fetch('/models', { cache: 'no-store' }).then((r) => r.json()).then((d) => {
+      if (typeof d.rev === 'number') { if (d.rev < modelChoicesRev) return; modelChoicesRev = d.rev; }
+      if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; for (const m of d.models) MODEL_CHOICES.push(m); MODEL_CHOICES.push({ label: 'Default', value: 'default' }); }
+      if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; for (const e of d.efforts) EFFORT_CHOICES.push(e); }
+    }).catch(() => {});
+  } catch (e) {}
+  return Promise.resolve();
+}
+loadModelChoices();
 // Is this menu entry the lane's CURRENT value? Effort matches exactly; the model var holds a display
 // name ("Opus 4.8"), so match on the leading word — same rule as the chat view's isCurrentMeta.
 function isCurrentMeta(kind, s, value) {
@@ -2547,6 +2563,9 @@ class TimelinePanel {
   }
 
   _closeMetaMenu() { if (this._metaMenu) { if (this._metaMenu._sub) this._metaMenu._sub.remove(); this._metaMenu.remove(); this._metaMenu = null; } }
+  // the kernel's models frame: the pick memory moved or the catalog grew → re-read /models so the lane
+  // picker's family rows send the fresh default (see loadModelChoices). Returns the fetch promise for the tests.
+  refreshModels() { return loadModelChoices(); }
 
   // Where a drop-down should live and be measured: the tip's host document (the topmost same-origin
   // window — in the web shell that's the whole page, so a menu taller than the timeline band gets the
@@ -5006,4 +5025,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion, lensAll, lensToggle, lensVisible, lensLabel, timelineLens };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion, lensAll, lensToggle, lensVisible, lensLabel, timelineLens, loadModelChoices, MODEL_CHOICES };

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2613,6 +2613,14 @@ class TimelinePanel {
           const row = sub.createDiv({ text: v.label });
           row.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;');
           row.setAttribute('tabindex', '0');
+          if (v.learned) {
+            // LOUD, per the fail-loudly rule: this version is in no catalog list — a running session's
+            // CLI reported it (kernel /models `learned`) — so the row says so instead of a stale menu
+            // hiding a live model. The chat's .meta-item-sub treatment, inlined for a foreign document.
+            const tag = row.createSpan({ text: ' new' });
+            tag.setAttribute('style', 'font-size:0.82em;opacity:0.6;margin-left:4px;');
+            row.setAttribute('title', "Reported by a running session's Claude Code; not yet in romp's version list");
+          }
           if (cv) { const ck = row.createSpan({ text: '✓' }); ck.setAttribute('style', MENU_CHECK_STYLE); }
           row.addEventListener('mouseenter', () => { row.style.background = HOVER_BG; });
           row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -481,6 +481,38 @@ test("the lane model menu labels a family by its own label and marks a learned v
   assert.match(SRC, /if \(v\.learned\) \{[\s\S]{0,600}font-size:0\.82em;opacity:0\.6/, "the menu vocabulary's sub-line size and opacity");
 });
 
+test("executed: the lane picker's /models list re-fetches IN PLACE on the kernel's models frame", async () => {
+  // the list was fetched once at load and never refreshed, so after a Latest un-pin the lane's next
+  // family click sent the stale pinned id and silently re-pinned. loadModelChoices is the one loader
+  // (page load is its first call); refreshModels — the frame's arm in both boots — calls it again,
+  // and the array keeps its reference so _openMetaMenu reads the fresh `default`.
+  const { loadModelChoices, MODEL_CHOICES } = requireCjs(VIEW_PATH);
+  const realFetch = (globalThis as any).fetch;
+  let served: any = { models: [{ label: "Fable", value: "fable", default: "claude-fable-5", versions: [] }], efforts: [{ label: "High", value: "high" }] };
+  (globalThis as any).fetch = async () => ({ json: async () => served });
+  try {
+    const ref = MODEL_CHOICES;
+    await loadModelChoices();
+    assert.equal(MODEL_CHOICES, ref, "same array — the menu builder's reference");
+    assert.equal(MODEL_CHOICES[0].default, "claude-fable-5", "pinned");
+    assert.deepEqual(MODEL_CHOICES[MODEL_CHOICES.length - 1], { label: "Default", value: "default" }, "the lane's own sentinel still appended");
+    served = { models: [{ label: "Fable", value: "fable", default: "fable", versions: [] }], efforts: [] };
+    const p: any = Object.create(TimelinePanel.prototype);
+    await p.refreshModels();                       // what the models frame calls
+    assert.equal(MODEL_CHOICES, ref);
+    assert.equal(MODEL_CHOICES[0].default, "fable", "un-pinned: the next family click sends the alias");
+    assert.equal(MODEL_CHOICES.length, 2);
+  } finally {
+    (globalThis as any).fetch = realFetch;
+  }
+  // both boots dispatch the frame to it — the VS Code glue and the kernel's inline browser twin
+  const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(BOOT, /if \(m\.type === "models" && panel\.refreshModels\) \{ panel\.refreshModels\(\); return true; \}/);
+  assert.match(KERNEL, /else if\(m\.type==="models"&&panel\.refreshModels\)panel\.refreshModels\(\);/);
+  assert.match(SRC, /^loadModelChoices\(\);$/m, "page load is the first call");
+});
+
 test("the lane model menu exposes VERSIONS: submenu affordance, remembered default, keyboard (the user 2026-08-25)", () => {
   // families with >1 live version wear a side submenu — hover or ArrowRight reveals it, every
   // version directly pickable with the current-✓; clicking the family picks its remembered DEFAULT

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -481,6 +481,28 @@ test("the lane model menu labels a family by its own label and marks a learned v
   assert.match(SRC, /if \(v\.learned\) \{[\s\S]{0,600}font-size:0\.82em;opacity:0\.6/, "the menu vocabulary's sub-line size and opacity");
 });
 
+test("the lane version submenu opens with a Latest row that clears the family's pin through the command bridge", () => {
+  // the chat picker's floating gesture, on the lane menu: Latest sends "/model <family>" with the
+  // `floating` flag, which the kernel's sendCommand arm hands to _set_model_or_park to forget the
+  // family's remembered pin — the one gesture back to floating once a family is pinned
+  const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(SRC, /const pick = \(value, floating\) => \{/);
+  assert.match(SRC, /this\._sendCommand\(s\.name, '\/' \+ kind \+ ' ' \+ value, kind === 'model', floating \? \{ floating: true \} : null\);/);
+  assert.match(SRC, /const pinned = !!c\.default && c\.default !== c\.value;/);
+  assert.match(SRC, /latest\.createDiv\(\{ text: 'Latest' \}\);/);
+  assert.match(SRC, /pick\(c\.value, true\)/, "sends the ALIAS with the flag");
+  assert.match(SRC, /lsub\.setAttribute\('style', 'font-size:0\.82em;opacity:0\.6;'\);[\s\S]{0,1200}for \(const v of versions\)/,
+    "heads the submenu, ahead of the versions, wearing the sub-line vocabulary");
+  assert.match(SRC, /if \(!pinned && cur\) \{ const ck = latest\.createSpan\(\{ text: '✓' \}\)/, "✓ when unpinned and the lane runs the family");
+  // the bridge carries the flag in every host: the VS Code boot glue and the kernel's shell page
+  assert.match(SRC, /_sendCommand\(name, cmd, confirm, extra\) \{/);
+  assert.match(SRC, /window\.__rompTimelineSendCommand\(name, cmd, extra \|\| undefined\); return;/);
+  assert.match(BOOT, /__rompTimelineSendCommand: \(name: string, cmd: string, extra\?: Record<string, unknown>\) => post\(\{ type: "sendCommand", name, cmd, \.\.\.\(extra \|\| \{\}\) \}\)/);
+  assert.match(KERNEL, /window\.__rompTimelineSendCommand=function\(name,cmd,extra\)\{post\(Object\.assign\(\{type:"sendCommand",name:name,cmd:cmd\},extra\|\|\{\}\)\);\};/);
+  assert.match(KERNEL, /_route_meta_command\(be, sid, cmd, client, floating=bool\(msg\.get\("floating"\)\)\)/);
+});
+
 test("executed: the lane picker's /models list re-fetches IN PLACE on the kernel's models frame", async () => {
   // the list was fetched once at load and never refreshed, so after a Latest un-pin the lane's next
   // family click sent the stale pinned id and silently re-pinned. loadModelChoices is the one loader

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -470,6 +470,17 @@ test("the lane gear carries the SAME tag editor — the shared builders, never a
   assert.match(SRC, /this\._tagJoinMenu\(am, \[s\.id\], build\);/);
 });
 
+test("the lane model menu labels a family by its own label and marks a learned version as new", () => {
+  // the family row's text is the family label from /models — no version-table lookup — so the
+  // kernel's alias default ("fable") renders exactly as a pinned id did; ✓ matches the leading word
+  assert.match(SRC, /const item = menu\.createDiv\(\{ text: c\.label \}\);/);
+  assert.match(SRC, /return kind === 'effort' \? cur === value : cur\.startsWith\(value\);/);
+  // a version a running session's CLI reported that the seed table lacks (kernel /models `learned`)
+  // is offered AND marked — same treatment as the chat's meta-menu, inlined for the foreign document
+  assert.match(SRC, /if \(v\.learned\) \{[\s\S]{0,600}row\.createSpan\(\{ text: ' new' \}\)/);
+  assert.match(SRC, /if \(v\.learned\) \{[\s\S]{0,600}font-size:0\.82em;opacity:0\.6/, "the menu vocabulary's sub-line size and opacity");
+});
+
 test("the lane model menu exposes VERSIONS: submenu affordance, remembered default, keyboard (the user 2026-08-25)", () => {
   // families with >1 live version wear a side submenu — hover or ArrowRight reveals it, every
   // version directly pickable with the current-✓; clicking the family picks its remembered DEFAULT

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -92,6 +92,19 @@ test("the pulse is exchange-scoped (T102): send-gesture latch, reply-record clea
   // the frame handler already repaints marks AND the open popover per frame — the live wire
   assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) \{/);
 });
+test("a family click sends the kernel's alias default; a version the seed table lacks renders LOUDLY as new", () => {
+  // the family row's label is the family's OWN label — never a version-table lookup — so an alias
+  // default ("fable") renders the same as a pinned id did; the ✓ matches on the leading word
+  assert.match(RENDER, /item\.textContent = c\.label;/);
+  assert.match(RENDER, /return \(st\.model \|\| ""\)\.toLowerCase\(\)\.startsWith\(value\);/);
+  // a version a running session's CLI reported that no seed table lists (kernel /models `learned`)
+  // is offered AND marked, per the fail-loudly rule — a stale menu would hide a live model
+  assert.match(RENDER, /learned\?: boolean/);
+  assert.match(RENDER, /if \(v\.learned\) \{[\s\S]{0,600}el\("span", "meta-item-sub"\)/,
+    "the marker wears the menu vocabulary's sub-line size and opacity");
+  assert.match(RENDER, /if \(v\.learned\) \{[\s\S]{0,600}row\.title = /, "and says where the version came from");
+});
+
 test("the model meta-menu exposes VERSIONS: submenu, remembered default, keyboard (the user 2026-08-25)", () => {
   // families with >1 live version wear a side submenu (leftward — the menu anchors bottom-right):
   // hover or an arrow key reveals every version, each pickable with the current-✓; clicking the

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -181,6 +181,33 @@ test("the popover resizes from ANY edge or corner, macOS-style; the old grip kee
   assert.match(CSSs, /resize: both/, "the native grip stays");
 });
 
+test("the pickers re-read /models on the kernel's models frame — the pick memory moved", () => {
+  // Both pickers read a family's `default` from a /models list fetched ONCE at page load; nothing
+  // mutated it after a pick and no push carried it. So after Latest un-pinned a family on the kernel,
+  // the same tab's next family click sent the STALE pinned id and silently re-pinned; another
+  // dashboard's pick moved the default unseen. Event-keyed: the kernel emits a models frame whenever
+  // model-picks.json changes (a pin, a Latest un-pin, a refused pin dropped) or the catalog grows,
+  // and the list is re-fetched IN PLACE on it — META_CHOICES keeps its reference, so the next family
+  // click reads the fresh default. Never a poll.
+  assert.match(RENDER, /function loadModelChoices\(\): void \{/);
+  const loader = RENDER.split("function loadModelChoices(): void {")[1].split("\n}\n")[0];
+  assert.ok(loader.includes('fetch(kernelUrl("/models"), { cache: "no-store" })'), "the same fetch as page load");
+  assert.ok(loader.includes("MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models"), "refilled in place — the shared reference holds");
+  assert.match(RENDER, /^loadModelChoices\(\);$/m, "…and page load is just the first call");
+  assert.match(RENDER, /else if \(m\.type === "models"\) loadModelChoices\(\);/, "the frame arm");
+  // the kernel side: one emitter, fired by every writer of the pick memory, to EVERY app that hosts a
+  // picker — chat, timeline, and the feed, where the settings gear's judge-tier pickers live
+  assert.match(KERNEL, /frame = \{"type": "models", "rev": _models_rev\[0\]\}/);
+  assert.match(KERNEL, /for app in \("chat", "timeline", "feed"\):\s*\n\s*_send_to_app\(app, frame\)/);
+  // …and the payload carries the same counter, so a consumer can drop a response older than one applied
+  assert.match(KERNEL, /\{"rev": _rev,\s*\n\s*"models": \[/);
+  assert.match(KERNEL, /_rev = _models_rev\[0\]\s*\n\s*_learned = _learned_versions\(\)/, "read before the list, never after it");
+  const note = KERNEL.split("def _note_model_pick(")[1].split("\ndef ")[0];
+  const forget = KERNEL.split("def _forget_model_pick(")[1].split("\ndef ")[0];
+  assert.ok(note.includes("_models_changed()"), "a pin emits");
+  assert.ok(forget.includes("_models_changed()"), "a forget emits");
+});
+
 test("the create name input wears no underline at rest (the user 2026-08-25)", () => {
   assert.match(CSS, /\.cmt-name \{[^}]*border-bottom: 1px solid transparent;/s);
   assert.doesNotMatch(CSS, /\.cmt-name \{[^}]*dashed/s);

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -105,6 +105,30 @@ test("a family click sends the kernel's alias default; a version the seed table 
   assert.match(RENDER, /if \(v\.learned\) \{[\s\S]{0,600}row\.title = /, "and says where the version came from");
 });
 
+test("the create dialog's model menu sends the family's remembered default, like the other two pickers", () => {
+  // the new-thread dialog sent `c.value` — the family ALIAS — and never `c.default`, so with alias
+  // semantics the same click FLOATED a new thread while it PINNED on the chat statusline and the
+  // timeline lane. One rule on all three surfaces: the remembered pin, else the alias.
+  assert.match(RENDER, /pendingCommentAnchor\[kind\] = kind === "model" \? \(c\.default \|\| c\.value\) : c\.value;/);
+});
+
+test("the version submenu opens with a Latest row: the one gesture back to floating once a family is pinned", () => {
+  // the family row sends the pin, the version rows pin, and a typed "/model fable" leaves the pick
+  // memory alone by design — so a pinned family had no way back. Latest clears the family's
+  // remembered pin (the op carries `floating`; kernel _set_model_or_park forgets the pick) and
+  // sends the alias, so the family follows the CLI's newest release again. An explicit user
+  // gesture, so it may move state.
+  assert.match(RENDER, /const pickValue = \(value: string, floating = false\) =>/);
+  assert.match(RENDER, /if \(floating\) op\.floating = true;/, "the flag rides the setModel op");
+  assert.match(RENDER, /const pinned = !!c\.default && c\.default !== c\.value;/, "pinned = the default is not the alias");
+  assert.match(RENDER, /lhead\.textContent = "Latest";/);
+  assert.match(RENDER, /pickValue\(c\.value, true\)/, "sends the ALIAS with the flag");
+  assert.match(RENDER, /sub\.appendChild\(latest\);[\s\S]{0,300}for \(const v of versions\)/, "heads the submenu, ahead of the versions");
+  assert.match(RENDER, /!pinned && isCurrentMeta\(kind, s\.status, c\.value\) \? " current" : ""/,
+    "✓ when the family is unpinned and the session runs it");
+  assert.match(RENDER, /const lsub = el\("div", "meta-item-sub"\);/, "the consequence line wears the menu vocabulary's sub-line");
+});
+
 test("the model meta-menu exposes VERSIONS: submenu, remembered default, keyboard (the user 2026-08-25)", () => {
   // families with >1 live version wear a side submenu (leftward — the menu anchors bottom-right):
   // hover or an arrow key reveals every version, each pickable with the current-✓; clicking the
@@ -206,6 +230,22 @@ test("the pickers re-read /models on the kernel's models frame — the pick memo
   const forget = KERNEL.split("def _forget_model_pick(")[1].split("\ndef ")[0];
   assert.ok(note.includes("_models_changed()"), "a pin emits");
   assert.ok(forget.includes("_models_changed()"), "a forget emits");
+});
+
+test("the create dialog offers Latest for a pinned family — a new thread can start on the alias from here too", () => {
+  // The dialog's menu is FLAT (no submenu, so no Latest row): once a family carried a pin, the family
+  // row launched on the pin and nothing here launched on the alias. A pinned family now names its pin
+  // on the family row and grows a "<Family> · Latest" row that sends the bare alias — a per-thread
+  // launch pref, never the family's memory (an alias records nothing at the kernel's choke point).
+  const dialog = RENDER.split("const buildMetaRow = (): HTMLElement => {")[1].split("\n    };\n")[0];
+  assert.ok(dialog.includes("const pinnedTo = kind === \"model\" ? (c.default || \"\") : \"\";"), "the pin, from the /models default");
+  assert.ok(dialog.includes("const pinned = !!pinnedTo && pinnedTo !== c.value;"));
+  assert.ok(dialog.includes("pinSub.textContent = modelChoiceLabel(pinnedTo).label;"), "the family row names the pin it launches on");
+  assert.ok(dialog.includes('lh.textContent = c.label + " · Latest";'), "the extra row");
+  assert.ok(dialog.includes("if (pendingCommentAnchor) pendingCommentAnchor[kind] = c.value;"), "…sends the ALIAS");
+  assert.ok(dialog.includes('latest = el("div", "meta-item" + (effVal === c.value ? " current" : ""))'), "✓ when the thread is set to float");
+  assert.ok(dialog.includes("pinned ? effVal === pinnedTo :"), "the family row's ✓ means the pin, once there is a Latest row beside it");
+  assert.ok(!dialog.includes("op.floating"), "no floating flag: the dialog never moves the family's memory");
 });
 
 test("the create name input wears no underline at rest (the user 2026-08-25)", () => {

--- a/ui/webview/gear-judge-versions.test.ts
+++ b/ui/webview/gear-judge-versions.test.ts
@@ -30,7 +30,26 @@ test("caret faces RIGHT everywhere; the submenu side is measured with the right 
   assert.match(GEAR, /e\.key === 'romp:menu-echo' && e\.newValue/, "cross-pane dismissal adopted");
 });
 
-test("the kernel accepts version ids on every judge tier", () => {
-  assert.match(KERNEL, /_JUDGE_MODEL_VALUES = _MODEL_VALUES \| set\(_VERSION_FAMILY\)/);
-  assert.match(KERNEL, /_set_judge_state\("distill-model", v, _JUDGE_MODEL_VALUES \| \{"triage"\}\)/);
+test("the kernel accepts version ids — catalog AND learned — on every judge tier", () => {
+  // the gear's selects are built from /models' versions, learned rows included, so every tier
+  // validates against the LIVE set (_judge_model_values: the catalog half ∪ what running sessions'
+  // CLIs report) — the kernel never refuses a value it offered
+  assert.match(KERNEL, /_JUDGE_MODEL_VALUES = _MODEL_VALUES \| set\(_VERSION_FAMILY\)/, "the catalog half");
+  assert.match(KERNEL, /def _judge_model_values\(\):[\s\S]{0,700}return _JUDGE_MODEL_VALUES \| \{v\["value"\] for vs in _learned_versions\(\)\.values\(\) for v in vs\}/,
+    "…plus every learned id, computed per call");
+  for (const tier of ["judge-model", "index-model"]) {
+    assert.match(KERNEL, new RegExp(`_set_judge_state\\("${tier}", v, _judge_model_values\\(\\)\\)`), tier);
+  }
+  assert.match(KERNEL, /_set_judge_state\("distill-model", v, _judge_model_values\(\) \| \{"triage"\}\)/);
+  assert.match(KERNEL, /_set_judge_state\("comment-model", v, _judge_model_values\(\) \| \{"session", "default"\}\)/);
+  assert.ok(!/_set_judge_state\("[a-z]+-model", v, _JUDGE_MODEL_VALUES/.test(KERNEL),
+    "no tier validates against the catalog-only set — a learned pick would be refused there");
+});
+
+test("the gear's version rows mark a learned version as new, like the chat and timeline pickers", () => {
+  // the chat/timeline submenus wear the marker; the gear's judge/index/distill/comment selects
+  // render the same learned rows — the fail-loudly marker on every surface
+  assert.match(GEAR, /if \(v\.learned\) \{[\s\S]{0,600}tag\.textContent = ' new'/);
+  assert.match(GEAR, /if \(v\.learned\) \{[\s\S]{0,600}font-size:0\.82em;opacity:0\.6/, "the menu vocabulary's sub-line size and opacity");
+  assert.match(GEAR, /if \(v\.learned\) \{[\s\S]{0,600}r2\.title = /, "and says where the version came from");
 });

--- a/ui/webview/gear-judge-versions.test.ts
+++ b/ui/webview/gear-judge-versions.test.ts
@@ -54,6 +54,20 @@ test("the gear's version rows mark a learned version as new, like the chat and t
   assert.match(GEAR, /if \(v\.learned\) \{[\s\S]{0,600}r2\.title = /, "and says where the version came from");
 });
 
+test("the gear's version submenu opens with a Latest row that sends the bare family alias", () => {
+  // the session pickers' floating gesture, on the judge tiers too: a tier set to a version stays
+  // there until picked off it, and the family row sends the remembered pin — Latest is the row that
+  // sends the alias itself, so the tier follows the CLI's newest again
+  assert.match(GEAR, /latest\.appendChild\(document\.createTextNode\('Latest'\)\)/);
+  assert.match(GEAR, /latest\.addEventListener\('click', function \(e2\) \{ e2\.stopPropagation\(\); pick\(fam\.value\); \}\)/);
+  assert.match(GEAR, /sub\.appendChild\(latest\);[\s\S]{0,300}versions\.forEach\(function \(v\)/, "heads the submenu, ahead of the versions");
+  // the Latest row wears the same themed tokens as every other row (T226) — no raw dark literal
+  const at = GEAR.indexOf("latest.appendChild(document.createTextNode('Latest'))");
+  const seg = GEAR.slice(at, at + 1200);
+  assert.match(seg, /var\(--menu-hover, rgba\(255,255,255,0\.09\)\)/, "row hover through the token");
+  assert.match(seg, /background:var\(--check-bg, #1EA1EB\)/, "the ✓ mark through the token");
+});
+
 test("the gear's cached /models list re-reads on the kernel's models frame", () => {
   // fillChoices caches the list after its first fetch and the family rows send `fam.default` from
   // that cache at click time — so a pin or a Latest un-pin made anywhere (this dashboard's chat

--- a/ui/webview/gear-judge-versions.test.ts
+++ b/ui/webview/gear-judge-versions.test.ts
@@ -53,3 +53,22 @@ test("the gear's version rows mark a learned version as new, like the chat and t
   assert.match(GEAR, /if \(v\.learned\) \{[\s\S]{0,600}font-size:0\.82em;opacity:0\.6/, "the menu vocabulary's sub-line size and opacity");
   assert.match(GEAR, /if \(v\.learned\) \{[\s\S]{0,600}r2\.title = /, "and says where the version came from");
 });
+
+test("the gear's cached /models list re-reads on the kernel's models frame", () => {
+  // fillChoices caches the list after its first fetch and the family rows send `fam.default` from
+  // that cache at click time — so a pin or a Latest un-pin made anywhere (this dashboard's chat
+  // picker, another dashboard) left the gear's family rows sending a stale default. Event-keyed on
+  // the kernel's models frame, like the settingStale listener beside it; never a poll. The cache
+  // moving repaints the selects through the ONE painter fillChoices uses (paintChoices, which hands
+  // each select its value back), so a frame that lands before the page-load fill has painted still
+  // leaves populated pickers.
+  assert.match(GEAR, /if \(!m \|\| m\.type !== 'models'\) return;/);
+  const at = GEAR.indexOf("m.type !== 'models'");
+  const seg = GEAR.slice(at, at + 400);
+  assert.ok(seg.includes("fetch(ku('/models'), { cache: 'no-store' })"), "the same endpoint fillChoices reads");
+  assert.ok(seg.includes("if (d && Array.isArray(d.models) && adoptChoices(d)) paintChoices();"),
+    "replaces the cache the rows read at click time — through the rev gate — and repaints from it (gear-models-frame.test.ts runs both)");
+  assert.ok(!seg.includes("innerHTML"), "no second option writer: the painter is shared with fillChoices");
+  assert.ok(GEAR.includes("var held = sel.value;") && GEAR.includes("if (held) setShow(sel, held);"),
+    "the painter gives every select its value back — through the one off-list-aware write path, so a value the new list lacks is re-injected rather than blanked (gear-models-frame.test.ts runs it)");
+});

--- a/ui/webview/gear-models-frame.test.ts
+++ b/ui/webview/gear-models-frame.test.ts
@@ -1,0 +1,216 @@
+// The settings gear's cached /models list follows the kernel's models frame — and is never overwritten by
+// an OLDER response that lands late. BEHAVIORAL: the cache block of gear.js (`var choices` through the
+// models listener) is lifted out and run against a fake window and a controllable fetch, so these pin
+// what the code DOES. A pin that only matched the listener's text would prove nothing about the frame
+// reaching the gear or the cache moving: the gear lives in the FEED bundle, and the kernel must send the
+// frame there too (test_model_versions.py pins the kernel side).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
+const tick = () => new Promise((r) => setImmediate(r));
+
+// A <select> stand-in with the spec's value semantics the paint relies on: rewriting the options selects
+// the FIRST one (the selectedness setting algorithm); assigning a value selects it only if an option
+// carries it, else NOTHING — selectedIndex -1, value "" (a repaint that hands a held value straight back
+// blanks the select when the new list lacks it); appendChild adds an option the way setShow's off-list
+// injection does. `values` is the option values in order, for the assertions. Null selects (fillChoices
+// guards each with `if (jm) …`) cannot show pickers left empty — nothing is there to be empty.
+type Opt = { value: string; textContent: string };
+type Sel = { innerHTML: string; value: string; options: Opt[]; values: string[]; appendChild(o: Opt): void };
+function sel(): Sel {
+  const s: any = { _html: "", _v: "" };
+  const parse = (): Opt[] =>
+    [...s._html.matchAll(/<option value="([^"]*)">([^<]*)<\/option>/g)].map((m) => ({ value: m[1], textContent: m[2] }));
+  Object.defineProperty(s, "innerHTML", { get() { return s._html; }, set(h: string) { s._html = h; const o = parse(); s._v = o.length ? o[0].value : ""; } });
+  Object.defineProperty(s, "options", { get: parse });
+  Object.defineProperty(s, "values", { get() { return parse().map((o) => o.value); } });
+  Object.defineProperty(s, "value", { get() { return s._v; }, set(v: string) { s._v = parse().some((o) => o.value === v) ? v : ""; } });
+  s.appendChild = (o: Opt) => { s._html += '<option value="' + o.value + '">' + o.textContent + "</option>"; };
+  return s as Sel;
+}
+// the one document call the block makes: setShow's injected <option>
+const DOC = { createElement: (tag: string): Opt => { assert.equal(tag, "option"); return { value: "", textContent: "" }; } };
+const SELECTS = ["jm", "im", "je", "ie", "dm", "de", "cmm", "cme"] as const;
+
+// The block, evaluated with the closure variables it reads passed in: `window` (the listener's target),
+// `document` (the injected option), `fetch`/`ku` (the read), and the eight <select>s — real stand-ins by
+// default, or null (the guards).
+function lift(withSelects = true) {
+  const start = GEAR.indexOf("  var choices = null");
+  const at = GEAR.indexOf("m.type !== 'models'", start);
+  const stop = GEAR.indexOf("\n  });\n", at) + "\n  });\n".length;
+  assert.ok(start > 0 && at > start && stop > at, "anchors not found — the gear's models cache block moved; re-anchor");
+  const src = GEAR.slice(start, stop);
+  const listeners: Array<(e: any) => void> = [];
+  const win = { addEventListener: (type: string, fn: (e: any) => void) => { if (type === "message") listeners.push(fn); } };
+  const pending: Array<(d: any) => void> = [];        // one resolver per fetch, in request order
+  const fetchStub = (url: string) => {
+    assert.equal(url, "/models");
+    return new Promise<any>((res) => pending.push((d: any) => res({ json: async () => d })));
+  };
+  const S: Record<(typeof SELECTS)[number], Sel | null> = Object.fromEntries(SELECTS.map((k) => [k, withSelects ? sel() : null])) as any;
+  const fn = new Function("window", "document", "fetch", "ku", ...SELECTS,
+    src + "\n  return { fillChoices: fillChoices, choices: function () { return choices; } };");
+  const api = fn(win, DOC, fetchStub, (p: string) => p, ...SELECTS.map((k) => S[k]));
+  const frame = (rev: number) => listeners.forEach((l) => l({ data: { type: "models", rev } }));
+  return { api, listeners, pending, frame, S };
+}
+const list = (rev: number | undefined, def: string, versions: Array<{ value: string; label: string }> = []) =>
+  ({ ...(rev === undefined ? {} : { rev }), models: [{ label: "Fable", value: "fable", default: def, versions }],
+     efforts: [{ label: "High", value: "high" }] });
+
+test("executed: the models frame re-reads /models and replaces the cache the family rows read at click time", async () => {
+  const { api, listeners, pending, frame } = lift();
+  assert.equal(listeners.length, 1, "the listener is registered on the window");
+  const first = api.fillChoices();
+  assert.equal(pending.length, 1, "the first fill fetches");
+  pending[0](list(1, "claude-fable-5"));
+  await first;
+  assert.equal(api.choices().models[0].default, "claude-fable-5", "pinned");
+  frame(2);                                              // the kernel: Latest un-pinned the family
+  assert.equal(pending.length, 2, "the frame fetches again");
+  pending[1](list(2, "fable"));
+  await tick(); await tick();
+  assert.equal(api.choices().models[0].default, "fable", "the next family click sends the alias");
+  // a frame that names no type the gear knows, or an unrelated frame, fetches nothing
+  listeners[0]({ data: { type: "palette" } });
+  listeners[0]({ data: null });
+  assert.equal(pending.length, 2);
+});
+
+test("executed: an OLDER /models response landing after a newer one is dropped — the newest rev applied wins", async () => {
+  // the frame's re-read can overlap the first fill (or two quick frames each other), and the two responses
+  // can resolve out of order: without the rev check the stale list overwrote the fresh one
+  const { api, pending, frame } = lift();
+  const first = api.fillChoices();                       // request 1, in flight
+  frame(5);                                              // request 2
+  assert.equal(pending.length, 2);
+  pending[1](list(5, "fable"));                          // the newer answers first
+  await tick(); await tick();
+  assert.equal(api.choices().models[0].default, "fable");
+  pending[0](list(4, "claude-fable-5"));                 // the older lands late
+  await first; await tick();
+  assert.equal(api.choices().models[0].default, "fable", "the stale first fill did not win");
+  // and the same when two frames' reads cross
+  frame(6); frame(7);
+  pending[3](list(7, "claude-fable-5-1"));
+  pending[2](list(6, "fable"));
+  await tick(); await tick();
+  assert.equal(api.choices().models[0].default, "claude-fable-5-1", "rev 7 applied; rev 6 dropped");
+  assert.equal(api.choices().rev, 7);
+});
+
+test("a payload without a rev (an older kernel) always applies", async () => {
+  const { api, pending, frame } = lift();
+  const first = api.fillChoices();
+  pending[0](list(3, "claude-fable-5"));
+  await first;
+  frame(4);
+  pending[1](list(undefined, "fable"));
+  await tick(); await tick();
+  assert.equal(api.choices().models[0].default, "fable");
+});
+
+test("the guards still hold with no selects in the document", async () => {
+  const { api, pending } = lift(false);
+  const first = api.fillChoices();
+  pending[0](list(1, "fable"));
+  assert.equal((await first).models[0].default, "fable", "a fill with nothing to paint still returns the list");
+});
+
+test("executed: when the frame's re-read overtakes the page-load fill, every picker is still painted — from the list that won", async () => {
+  // a page-load fill that returned early because the frame's re-read had already applied a newer list,
+  // BEFORE writing any <option>s, left every later fill() short-circuiting on the cache — eight empty
+  // pickers for the life of the page. The paint keys on the list, not on which fetch carried it.
+  const V = [{ value: "claude-fable-5", label: "Fable 5" }];
+  const { api, pending, frame, S } = lift();
+  const first = api.fillChoices();                       // page load: request 1
+  frame(6);                                              // a pick elsewhere during it: request 2
+  pending[1](list(6, "fable", V));                       // request 2 resolves first
+  await tick(); await tick();
+  pending[0](list(5, "claude-fable-5", V));              // request 1 lands late, older
+  await first; await tick();
+  assert.equal(api.choices().models[0].default, "fable", "the newer list is the cache");
+  for (const k of SELECTS) assert.ok(S[k]!.innerHTML.length > 0, `${k} is painted`);
+  assert.deepEqual(S.jm!.values, ["fable", "claude-fable-5"], "family + version options, from the list that won");
+  assert.deepEqual(S.je!.values, ["", "high"]);
+  assert.deepEqual(S.dm!.values, ["triage", "fable", "claude-fable-5"], "the distilling sentinel leads");
+  assert.deepEqual(S.de!.values, ["triage", "none", "high"]);
+  assert.deepEqual(S.cmm!.values, ["session", "default", "fable", "claude-fable-5"], "the comment sentinels lead");
+  assert.deepEqual(S.cme!.values, ["session", "high"]);
+  // a later modal open (fill → fillChoices) is a cache hit and the pickers stay painted
+  assert.equal((await api.fillChoices()).models[0].default, "fable");
+  assert.equal(pending.length, 2, "no third fetch");
+  S.jm!.value = "fable";
+  assert.equal(S.jm!.value, "fable", "a pick can land on the painted options");
+});
+
+test("executed: a frame's repaint keeps the value each select held while the modal is up", async () => {
+  // a rewrite resets a select to its first option, which is why a listener that only re-fetched could
+  // not repaint; the paint gives every select its value back when the new list still offers it
+  const V = [{ value: "claude-fable-5", label: "Fable 5" }];
+  const { api, pending, frame, S } = lift();
+  const first = api.fillChoices();
+  pending[0](list(1, "claude-fable-5", V));
+  await first;
+  S.jm!.value = "claude-fable-5"; S.je!.value = "high"; S.dm!.value = "fable"; S.cme!.value = "session";
+  frame(2);                                              // Latest un-pinned the family elsewhere; a session learned 5.1
+  const V2 = V.concat([{ value: "claude-fable-5-1", label: "Fable 5.1" }]);
+  pending[1](list(2, "fable", V2));
+  await tick(); await tick();
+  assert.equal(api.choices().models[0].default, "fable", "the cache moved");
+  assert.deepEqual(S.jm!.values, ["fable", "claude-fable-5", "claude-fable-5-1"], "…and so did the options");
+  assert.deepEqual(S.cmm!.values, ["session", "default", "fable", "claude-fable-5", "claude-fable-5-1"]);
+  assert.equal(S.jm!.value, "claude-fable-5", "the pinned version the user had selected is still selected");
+  assert.equal(S.je!.value, "high");
+  assert.equal(S.dm!.value, "fable");
+  assert.equal(S.cme!.value, "session");
+  // a stale response repaints nothing (the list did not move), so a value is never disturbed for no reason
+  const html = S.jm!.innerHTML;
+  frame(3); frame(4);
+  pending[3](list(4, "fable", V2));                      // the newer, same list
+  pending[2](list(3, "claude-fable-5", V));              // the older, dropped
+  await tick(); await tick();
+  assert.equal(api.choices().rev, 4);
+  assert.equal(S.jm!.innerHTML, html);
+  assert.equal(S.jm!.value, "claude-fable-5");
+});
+
+test("executed: a repaint keeps a held value the new list LACKS — as a marked off-list option, never a blank select", async () => {
+  // per the spec a select assigned a value none of its options carries deselects everything — value "",
+  // the version menu's label read from it empty. So a stored value fill() had injected (the kernel's
+  // truth, ahead of this page's list) or a learned version that has since left the list would go BLANK
+  // on the next frame. The held value is re-injected the way fill() injects it: marked, selected, once.
+  const V = [{ value: "claude-fable-5", label: "Fable 5" }, { value: "claude-fable-5-1", label: "Fable 5.1" }];
+  const { api, pending, frame, S } = lift();
+  const first = api.fillChoices();
+  pending[0](list(1, "fable", V));
+  await first;
+  // fill(): the stored judge model is one this list lacks → setShow injected it, marked, and selected it
+  S.jm!.appendChild({ value: "claude-fable-6", textContent: "claude-fable-6 — not in this kernel's list" });
+  S.jm!.value = "claude-fable-6";
+  S.im!.value = "claude-fable-5-1";                      // a learned version, picked
+  S.je!.value = "high";
+  frame(2);
+  pending[1](list(2, "fable", V.slice(0, 1)));           // the learned 5.1 left the list
+  await tick(); await tick();
+  assert.equal(S.jm!.value, "claude-fable-6", "the stored value the kernel holds is still selected");
+  assert.deepEqual(S.jm!.values, ["fable", "claude-fable-5", "claude-fable-6"], "…re-injected after the rewrite, last");
+  assert.match(S.jm!.options[2].textContent, /not in this kernel's list/, "…and marked as off-list");
+  assert.equal(S.im!.value, "claude-fable-5-1", "so is the version that left the list");
+  assert.deepEqual(S.im!.values, ["fable", "claude-fable-5", "claude-fable-5-1"]);
+  assert.equal(S.je!.value, "high", "an in-list value is given back plainly");
+  assert.deepEqual(S.je!.values, ["", "high"], "nothing injected for it");
+  // the next repaint injects the off-list value once more — never a second copy
+  frame(3);
+  pending[2](list(3, "fable", V.slice(0, 1)));
+  await tick(); await tick();
+  assert.deepEqual(S.jm!.values, ["fable", "claude-fable-5", "claude-fable-6"]);
+  assert.equal(S.jm!.value, "claude-fable-6");
+  // a select nobody has picked on holds its first option; a repaint leaves it there, injecting nothing
+  assert.equal(S.dm!.value, "triage");
+  assert.deepEqual(S.dm!.values, ["triage", "fable", "claude-fable-5"]);
+});

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -580,6 +580,14 @@ function initGear(post) {
             r2.setAttribute('style', rowStyle);
             r2.tabIndex = 0;
             r2.appendChild(document.createTextNode(v.label));
+            if (v.learned) {
+              // LOUD, per the fail-loudly rule: a version no catalog list carries — a running session's
+              // CLI reported it (kernel /models `learned`) — says so, as the chat and timeline pickers do
+              var tag = document.createElement('span'); tag.textContent = ' new';
+              tag.setAttribute('style', 'font-size:0.82em;opacity:0.6;margin-left:4px;');
+              r2.appendChild(tag);
+              r2.title = "Reported by a running session's Claude Code; not yet in romp's version list";
+            }
             if (sel.value === v.value) {
               var c2 = document.createElement('span'); c2.textContent = '\u2713';
               c2.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:var(--check-bg, #1EA1EB);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -724,33 +724,94 @@ function initGear(post) {
   });
   // The model/effort <option>s come from /models — the same single source the
   // chat + timeline pickers use. Cached after the first successful fetch.
-  var choices = null;
-  var choicesP = null;   // the single-flight promise — options are written exactly once per page
+  var choices = null, choicesRev = -1;   // the list, and the highest /models `rev` applied to it
+  // A /models response is applied only if it is not OLDER than one already applied: its `rev` is the
+  // pick memory's revision — the models frame's counter — and the frame's re-read can overlap the first
+  // fill, or two quick frames each other, with the responses landing out of order; without the check the
+  // STALE list won until the next change. A payload without a rev (an older kernel) always applies.
+  // Returns whether `choices` moved.
+  function adoptChoices(d) {
+    if (d && typeof d.rev === 'number') { if (d.rev < choicesRev) return false; choicesRev = d.rev; }
+    choices = d || { models: [], efforts: [] };
+    return true;
+  }
+  // The ONE write path for kernel-backed selects — fill()'s (the user 2026-09-01, whose stored distill
+  // pick displayed as the default) and paintChoices': a value the option list doesn't carry is INJECTED
+  // as a marked option and selected — the row shows the truth (an off-list value, named) rather than
+  // silently falling to its first option or, on a repaint, to NOTHING: per the spec a select assigned a
+  // value none of its options carries deselects every option (value ''), so a repaint that handed the
+  // held value straight back would leave the select blank, and the version menu's label with it,
+  // whenever the value was one fill() had injected or a learned version that has since left the list.
+  // Values are validated at write time by the kernel, so an injection here means THIS page's list is
+  // behind the store — worth seeing, never worth hiding.
+  function setShow(sel, val) {
+    if (!sel) return;
+    if (val && !Array.prototype.some.call(sel.options, function (o) { return o.value === val; })) {
+      var o = document.createElement('option');
+      o.value = val;
+      o.textContent = val + " — not in this kernel's list";
+      sel.appendChild(o);
+    }
+    sel.value = val;
+  }
+  // Write every select's <option>s from the CURRENT list — whichever response won — and give each select
+  // back the value it held, through setShow: plainly when the list still offers it, as a marked off-list
+  // option when it no longer does. Rewriting a select's options resets it to its first option, which is
+  // why a re-read alone could never repaint; and a page-load fill that skipped its paint because the
+  // frame's re-read had applied a newer list first left every later fill() short-circuiting on the cache
+  // — eight empty pickers for the life of the page. The paint keys on the list, not on which fetch
+  // carried it.
+  function paintChoices() {
+    var mo = (choices.models || []).map(function (m) {
+      var vs = (m.versions || []).map(function (v) { return '<option value="' + v.value + '">' + v.label + '</option>'; }).join('');
+      return '<option value="' + m.value + '">' + m.label + '</option>' + vs;   // versions ride as options too — the hidden select stays the value holder for any pick
+    }).join('');
+    var eff = (choices.efforts || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
+    var eo = '<option value="">Default</option>' + eff;
+    function put(sel, html) {
+      if (!sel) return;
+      var held = sel.value;
+      sel.innerHTML = html;
+      if (held) setShow(sel, held);   // a held value the new list lacks stays, marked — never a blank select
+    }
+    put(jm, mo); put(im, mo);
+    put(je, eo); put(ie, eo);
+    // the distilling pair leads with the follow-triage sentinel — its default, so a fresh kernel
+    // shows "Follow triage" rather than a model nobody picked. Its Default (no effort flag) is the
+    // stored sentinel "none", never "" — an empty state file reads back as the default ("follow").
+    put(dm, '<option value="triage">Follow triage</option>' + mo);
+    put(de, '<option value="triage">Follow triage</option><option value="none">Default</option>' + eff);
+    // the comment pair leads with the same-as-the-session sentinel — its default, so a fresh
+    // kernel shows the inherit behavior, not a model nobody picked; "default" = the account default
+    put(cmm, '<option value="session">Same as the session</option><option value="default">Default</option>' + mo);
+    put(cme, '<option value="session">Same as the session</option>' + eff);
+  }
+  // The promise is the memo, not the list: a settings open racing the page-load fetch used to fire a
+  // SECOND /models fetch, and whichever resolved last rewrote every select's options after fill() had
+  // set their values. One live fetch per page; a failed one clears the memo for retry.
+  var choicesP = null;
   function fillChoices() {
     if (choicesP) return choicesP;
     choicesP = fetch(ku('/models'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
-      choices = d || { models: [], efforts: [] };
-      var mo = (choices.models || []).map(function (m) {
-        var vs = (m.versions || []).map(function (v) { return '<option value="' + v.value + '">' + v.label + '</option>'; }).join('');
-        return '<option value="' + m.value + '">' + m.label + '</option>' + vs;   // versions ride as options too — the hidden select stays the value holder for any pick
-      }).join('');
-      var eff = (choices.efforts || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
-      var eo = '<option value="">Default</option>' + eff;
-      if (jm) jm.innerHTML = mo; if (im) im.innerHTML = mo;
-      if (je) je.innerHTML = eo; if (ie) ie.innerHTML = eo;
-      // the distilling pair leads with the follow-triage sentinel — its default, so a fresh kernel
-      // shows "Follow triage" rather than a model nobody picked. Its Default (no effort flag) is the
-      // stored sentinel "none", never "" — an empty state file reads back as the default ("follow").
-      if (dm) dm.innerHTML = '<option value="triage">Follow triage</option>' + mo;
-      if (de) de.innerHTML = '<option value="triage">Follow triage</option><option value="none">Default</option>' + eff;
-      // the comment pair leads with the same-as-the-session sentinel — its default, so a fresh
-      // kernel shows the inherit behavior, not a model nobody picked; "default" = the account default
-      if (cmm) cmm.innerHTML = '<option value="session">Same as the session</option><option value="default">Default</option>' + mo;
-      if (cme) cme.innerHTML = '<option value="session">Same as the session</option>' + eff;
+      adoptChoices(d);   // a frame's re-read may have applied a NEWER list while this one was in flight: paint from whichever won
+      paintChoices();
       return choices;
     }).catch(function () { choicesP = null; return null; });   // retry on the next open, never a second live fetch
     return choicesP;
   }
+  // The kernel's models frame: the pick memory moved — a version pinned, a family un-pinned by Latest, a
+  // refused pin dropped, from any surface or dashboard — or the catalog grew, so the cached list's
+  // `default` (what a family row SENDS, read from `choices` at click time) is stale. Re-read on the
+  // event, like the browseResult listener above; never a poll. The list moving repaints the selects too
+  // (paintChoices keeps their values), so a frame that lands before the page-load fill has painted still
+  // leaves populated pickers. The frame reaches this document because the kernel sends it to the FEED
+  // app too (the gear lives in the feed bundle).
+  window.addEventListener('message', function (e) {
+    var m = e.data;
+    if (!m || m.type !== 'models') return;
+    fetch(ku('/models'), { cache: 'no-store' }).then(function (r) { return r.json(); })
+      .then(function (d) { if (d && Array.isArray(d.models) && adoptChoices(d)) paintChoices(); }).catch(function () {});
+  });
   function lv() { var t = document.querySelector('script[src*="feed.js"]');
     var m = t && t.getAttribute('src').match(/[?&]v=(\d+)/); return m ? +m[1] : 0; }
   function clearAutoNudgeSplit() {
@@ -812,21 +873,8 @@ function initGear(post) {
       mark.hidden = false;
     });
   }
-  // fill()'s ONE write path for kernel-backed selects (the user 2026-09-01, whose stored distill
-  // pick displayed as the default): a stored value the option list doesn't carry is INJECTED as a
-  // marked option and selected — the row shows the truth (an off-list value, named) rather than
-  // silently falling to its first option. Values are validated at write time by the kernel, so an
-  // injection here means THIS page's list is behind the store — worth seeing, never worth hiding.
-  function setShow(sel, val) {
-    if (!sel) return;
-    if (val && !Array.prototype.some.call(sel.options, function (o) { return o.value === val; })) {
-      var o = document.createElement('option');
-      o.value = val;
-      o.textContent = val + " — not in this kernel's list";
-      sel.appendChild(o);
-    }
-    sel.value = val;
-  }
+  // setShow — fill()'s write path for every kernel-backed select below — sits beside paintChoices, which
+  // shares it.
   function fill() { fillChoices().then(function () { return fetch(ku('/version'), { cache: 'no-store' }); }).then(function (r) { return r.json(); }).then(function (v) {
     // ONE /tunnels fetch feeds every cross-machine comparison: the autoNudge box and the select marks.
     // A failed /tunnels leaves the local answers standing, unmarked — same fallback as before.

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -575,6 +575,26 @@ function initGear(post) {
           if (sub) { sub.remove(); sub = null; }
           sub = document.createElement('div');
           sub.setAttribute('style', MSTYLE + 'z-index:1002;');
+          // "Latest" heads the submenu — the session pickers' floating gesture, on the judge tiers
+          // too: the family row sends the remembered pin and the rows below pin, so this is the row
+          // that sends the bare alias, and the tier follows the CLI's newest again
+          var latest = document.createElement('div');
+          latest.setAttribute('style', rowStyle);
+          latest.tabIndex = 0;
+          latest.appendChild(document.createTextNode('Latest'));
+          if (sel.value === fam.value) {
+            var c0 = document.createElement('span'); c0.textContent = '\u2713';
+            c0.setAttribute('style', 'position:absolute;right:6px;top:50%;transform:translateY(-50%);background:var(--check-bg, #1EA1EB);color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;');
+            latest.appendChild(c0);
+          }
+          latest.addEventListener('mouseenter', function () { latest.style.background = 'var(--menu-hover, rgba(255,255,255,0.09))'; });
+          latest.addEventListener('mouseleave', function () { latest.style.background = 'transparent'; });
+          latest.addEventListener('click', function (e2) { e2.stopPropagation(); pick(fam.value); });
+          latest.addEventListener('keydown', function (e2) {
+            if (e2.key === 'Enter' || e2.key === ' ') { e2.preventDefault(); e2.stopPropagation(); pick(fam.value); }
+            else if (e2.key === 'ArrowLeft') { e2.preventDefault(); sub.remove(); sub = null; row.focus(); }
+          });
+          sub.appendChild(latest);
           versions.forEach(function (v) {
             var r2 = document.createElement('div');
             r2.setAttribute('style', rowStyle);

--- a/ui/webview/models-rev.test.ts
+++ b/ui/webview/models-rev.test.ts
@@ -1,0 +1,90 @@
+// Every picker answers the kernel's models frame with a fresh GET /models — and two of those fetches can
+// overlap (a frame during the page-load fetch; two quick frames) and resolve OUT OF ORDER, so a stale list
+// could land last and win until the next change. The payload carries `rev` (the pick memory's revision,
+// the frame's own counter) and each consumer keeps the highest rev it applied, dropping an older response
+// that lands late. EXECUTED against the chat's loader (lifted out of render.ts and transpiled) and the
+// timeline's (the real module); the gear's twin runs in gear-models-frame.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(__filename);
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const VIEW_PATH = path.join(ROOT, "ui", "romp-timeline-view.js");
+const tick = () => new Promise((r) => setImmediate(r));
+const list = (rev: number | undefined, def: string) =>
+  ({ ...(rev === undefined ? {} : { rev }), models: [{ label: "Fable", value: "fable", default: def, versions: [] }], efforts: [] });
+
+// A fetch whose responses the test resolves by hand, in any order.
+function deferredFetch() {
+  const pending: Array<(d: any) => void> = [];
+  const fetch = () => new Promise<any>((res) => pending.push((d: any) => res({ json: async () => d })));
+  return { fetch, pending };
+}
+
+// The chat's loader: MODEL_CHOICES/EFFORT_CHOICES and loadModelChoices, lifted from render.ts and
+// transpiled (TS → JS) with esbuild at run time — required dynamically so the test bundle does not try to
+// bundle esbuild itself. The page-load call that follows the function is deliberately left out.
+function liftRender() {
+  const start = RENDER.indexOf("const MODEL_CHOICES: {");
+  const fnAt = RENDER.indexOf("function loadModelChoices(): void {", start);
+  const stop = RENDER.indexOf("\n}\n", fnAt) + 3;
+  assert.ok(start > 0 && fnAt > start && stop > fnAt, "anchors not found — render.ts's models loader moved; re-anchor");
+  const js = requireCjs("esbuild").transformSync(RENDER.slice(start, stop), { loader: "ts" }).code;
+  const { fetch, pending } = deferredFetch();
+  const adopted: any[] = [];
+  const fn = new Function("kernelUrl", "fetch", "adoptCommentDefaults",
+    js + "\nreturn { loadModelChoices, MODEL_CHOICES, EFFORT_CHOICES };");
+  const api = fn((p: string) => p, fetch, (d: any) => adopted.push(d));
+  return { api, pending, adopted };
+}
+
+test("executed: the chat's loader keeps the newest rev it applied and drops an older response landing late", async () => {
+  const { api, pending } = liftRender();
+  const ref = api.MODEL_CHOICES;
+  api.loadModelChoices();                                // page load, in flight
+  api.loadModelChoices();                                // a frame arrives before it lands
+  assert.equal(pending.length, 2);
+  pending[1](list(8, "fable"));                          // the newer answers first
+  await tick(); await tick();
+  assert.equal(api.MODEL_CHOICES[0].default, "fable");
+  pending[0](list(7, "claude-fable-5"));                 // the older lands late
+  await tick(); await tick();
+  assert.equal(api.MODEL_CHOICES[0].default, "fable", "the stale page-load list did not win");
+  assert.equal(api.MODEL_CHOICES, ref, "still refilled in place — the shared reference holds");
+  assert.deepEqual(api.MODEL_CHOICES[api.MODEL_CHOICES.length - 1], { label: "Default", value: "default" });
+  // in order, a newer rev applies; equal revs apply (the same state re-read); no rev applies (older kernel)
+  api.loadModelChoices(); pending[2](list(9, "claude-fable-5-1")); await tick(); await tick();
+  assert.equal(api.MODEL_CHOICES[0].default, "claude-fable-5-1");
+  api.loadModelChoices(); pending[3](list(9, "claude-fable-5")); await tick(); await tick();
+  assert.equal(api.MODEL_CHOICES[0].default, "claude-fable-5", "an equal rev is the same state — applied");
+  api.loadModelChoices(); pending[4](list(undefined, "fable")); await tick(); await tick();
+  assert.equal(api.MODEL_CHOICES[0].default, "fable", "a payload without a rev always applies");
+});
+
+test("executed: the timeline's loader keeps the newest rev it applied and drops an older response landing late", async () => {
+  const { loadModelChoices, MODEL_CHOICES } = requireCjs(VIEW_PATH);
+  const realFetch = (globalThis as any).fetch;
+  const { fetch, pending } = deferredFetch();
+  (globalThis as any).fetch = fetch;
+  try {
+    const ref = MODEL_CHOICES;
+    const p1 = loadModelChoices();                       // page load, in flight
+    const p2 = loadModelChoices();                       // the frame's re-read (TimelinePanel.refreshModels)
+    assert.equal(pending.length, 2);
+    pending[1](list(8, "fable"));
+    await p2;
+    assert.equal(MODEL_CHOICES[0].default, "fable");
+    pending[0](list(7, "claude-fable-5"));
+    await p1;
+    assert.equal(MODEL_CHOICES[0].default, "fable", "the stale page-load list did not win");
+    assert.equal(MODEL_CHOICES, ref, "the menu builder's reference holds");
+    const p3 = loadModelChoices(); pending[2](list(undefined, "claude-fable-5")); await p3;
+    assert.equal(MODEL_CHOICES[0].default, "claude-fable-5", "a payload without a rev always applies");
+  } finally {
+    (globalThis as any).fetch = realFetch;
+  }
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10006,7 +10006,9 @@ type MetaKind = "mode" | "model" | "effort" | "fast";
 // One dropdown entry. `sub` is the second line for a choice whose consequence is not obvious from its
 // label; `sdkOnly` drops the entry on a tmux session, whose backend cannot apply it.
 interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean; color?: number[] | null;
-  versions?: { label: string; value: string }[]; default?: string }   // model families only (the user 2026-08-25)
+  versions?: { label: string; value: string; learned?: boolean }[]; default?: string }   // model families only (the
+  // user 2026-08-25). `default` is the family's remembered version pin, else the family ALIAS; `learned`
+  // marks a version the catalog lacks — a running session's CLI reported it (kernel /models).
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
@@ -10349,6 +10351,15 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
         const row = el("div", "meta-item" + (cur ? " current" : ""));
         row.tabIndex = 0;
         row.textContent = v.label;
+        if (v.learned) {
+          // LOUD, per the fail-loudly rule: this version is in no catalog list — a running session's CLI
+          // reported it (kernel /models `learned`) — so the row says so instead of a stale menu hiding
+          // a live model. The marker wears the menu vocabulary's sub-line size and opacity.
+          const tag = el("span", "meta-item-sub");
+          tag.textContent = " new";
+          row.appendChild(tag);
+          row.title = "Reported by a running session's Claude Code; not yet in romp's version list";
+        }
         row.addEventListener("click", (e) => { e.stopPropagation(); pickValue(v.value); });
         row.addEventListener("keydown", (e) => {
           if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); pickValue(v.value); }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10015,11 +10015,26 @@ interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boo
 // keeps its reference; the session picker appends its own "Default" (use-the-CLI-default) sentinel — not a model.
 const MODEL_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
 const EFFORT_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
-fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
-  if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models, { label: "Default", value: "default" }); }
-  if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; EFFORT_CHOICES.push(...d.efforts); }
-  if (d.commentDefaults) adoptCommentDefaults(d.commentDefaults);
-}).catch(() => { /* picker stays empty until it lands */ });
+// Loaded at page load and RE-LOADED on the kernel's {type:"models"} frame — the pick memory moved (a
+// version pinned, a family un-pinned by Latest, a refused pin dropped; from this tab, another dashboard,
+// or the kernel itself) or the catalog grew. A family's `default` is what its row SENDS, so a list
+// fetched once went stale the moment anything changed it: after Latest un-pinned a family, this tab's
+// next family click sent the old pinned id and silently re-pinned. Refilled IN PLACE so META_CHOICES
+// keeps its reference; event-keyed on the frame, never a poll.
+// A response is applied only if it is not OLDER than one already applied: its `rev` is the pick memory's
+// revision — the same counter the models frame carries — and two fetches can overlap (a frame during the
+// page-load fetch; two quick frames) and resolve out of order, so without the check the STALE list won
+// until the next change. A payload without a rev (an older kernel) always applies.
+let modelChoicesRev = -1;
+function loadModelChoices(): void {
+  fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
+    if (typeof d.rev === "number") { if (d.rev < modelChoicesRev) return; modelChoicesRev = d.rev; }
+    if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models, { label: "Default", value: "default" }); }
+    if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; EFFORT_CHOICES.push(...d.efforts); }
+    if (d.commentDefaults) adoptCommentDefaults(d.commentDefaults);
+  }).catch(() => { /* picker stays as it was until it lands */ });
+}
+loadModelChoices();
 // The kernel's default-comment settings, RAW ("session" = same as the session — the user 2026-08-29):
 // what a new comment thread launches on when the dialog is left untouched. Pre-read so the create
 // dialog SHOWS the effective default and a pick stays a deviation; the kernel re-resolves at create,
@@ -12094,6 +12109,9 @@ window.addEventListener("message", (e: MessageEvent) => {
   // The identity palette changed (gear → Session colors): refresh the right-click menu's swatch set so a
   // menu opened after the switch offers the NEW palette (the kernel remaps + repaints sessions itself).
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
+  // The kernel's pick memory moved (a pin, a Latest un-pin, a refused pin dropped) or its catalog grew:
+  // re-read /models so the family rows send the fresh default — the models-list twin of the palette frame.
+  else if (m.type === "models") loadModelChoices();
   else if (m.type === "sessionList") {
     // Whose list is this? federation stamps the source host; a local reply carries none. A reply for a
     // host the picker has since switched away from is dropped rather than painted over the current one

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7350,20 +7350,50 @@ function renderCommentPopover(): void {
           closeMetaMenu();
           const menu = el("div", "meta-menu");
           for (const c of META_CHOICES[kind]) {
+            // a PINNED model family (its /models default is a version, not the alias) — see the Latest row below
+            const pinnedTo = kind === "model" ? (c.default || "") : "";
+            const pinned = !!pinnedTo && pinnedTo !== c.value;
             const cur = kind === "fast"
               ? c.value === ((effVal || st?.fast || "off").toLowerCase() === "on" ? "on" : "off")
-              : effVal ? (c.value === effVal || !!c.versions?.some((v) => v.value === effVal))
+              : effVal ? (pinned ? effVal === pinnedTo : (c.value === effVal || !!c.versions?.some((v) => v.value === effVal)))
               : (st ? isCurrentMeta(kind, st, c.value) : false);
             const item = el("div", "meta-item" + (cur ? " current" : ""));
             item.textContent = c.label;
             item.addEventListener("click", (ev) => {
               ev.stopPropagation();
-              if (pendingCommentAnchor) pendingCommentAnchor[kind] = c.value;
+              // a model family sends its remembered DEFAULT — the pinned version, else the alias —
+              // exactly as the chat statusline and the timeline lane do (this dialog sent the bare
+              // alias, so the same click floated here and pinned there)
+              if (pendingCommentAnchor) pendingCommentAnchor[kind] = kind === "model" ? (c.default || c.value) : c.value;
               closeMetaMenu();
               document.getElementById("cmt-pop")?.remove();   // full rebuild shows the pick
               renderCommentPopover();
             });
             menu.appendChild(item);
+            if (pinned) {
+              // This menu is FLAT — no submenu, so no Latest row — and once a family carried a pin the
+              // family row launched on the pin and nothing here launched on the alias. The family row
+              // names the pin it launches on, and a "<Family> · Latest" row beside it sends the bare
+              // alias: a per-thread launch pref, never the family's memory (an alias records nothing at
+              // the kernel's choke point, so no floating flag rides it).
+              const pinSub = el("div", "meta-item-sub");
+              pinSub.textContent = modelChoiceLabel(pinnedTo).label;
+              item.appendChild(pinSub);
+              const latest = el("div", "meta-item" + (effVal === c.value ? " current" : ""));
+              const lh = el("div");
+              lh.textContent = c.label + " · Latest";
+              const ls = el("div", "meta-item-sub");
+              ls.textContent = "follows the newest " + c.label;
+              latest.append(lh, ls);
+              latest.addEventListener("click", (ev) => {
+                ev.stopPropagation();
+                if (pendingCommentAnchor) pendingCommentAnchor[kind] = c.value;
+                closeMetaMenu();
+                document.getElementById("cmt-pop")?.remove();
+                renderCommentPopover();
+              });
+              menu.appendChild(latest);
+            }
           }
           document.body.appendChild(menu);
           const r2 = btn.getBoundingClientRect();
@@ -10312,9 +10342,11 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
   const s = { status };
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
-  const pickValue = (value: string) => {
+  const pickValue = (value: string, floating = false) => {
     if (vscodeApi) {
-      vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: opSid, value });
+      const op: Record<string, unknown> = { type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: opSid, value };
+      if (floating) op.floating = true;   // the submenu's Latest row: the kernel forgets the family's pin
+      vscodeApi.postMessage(op);
       const was = metaCurrent(kind, s.status);
       metaPending.set(`${opSid}:${kind}`, { was, until: Date.now() + 20_000 });
       btn.classList.add("meta-pending");
@@ -10361,6 +10393,26 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
     const openSub = versions.length > 1 ? () => {
       closeSub();
       const sub = el("div", "meta-menu meta-sub");
+      // "Latest" heads the submenu: the one gesture back to floating once a family carries a pin — the
+      // family row sends the pin, the rows below pin, and a typed "/model fable" leaves the pick memory
+      // alone by design. It sends the ALIAS with the `floating` flag, which the kernel's setModel arm
+      // hands to _set_model_or_park to forget the family's remembered pin, so the family follows the
+      // CLI's newest release again. An explicit user gesture, so it may move state. ✓ when the family
+      // is unpinned and the session runs it.
+      const pinned = !!c.default && c.default !== c.value;
+      const latest = el("div", "meta-item" + (!pinned && isCurrentMeta(kind, s.status, c.value) ? " current" : ""));
+      latest.tabIndex = 0;
+      const lhead = el("div");
+      lhead.textContent = "Latest";
+      const lsub = el("div", "meta-item-sub");
+      lsub.textContent = pinned ? "unpins — follows the newest " + c.label : "follows the newest " + c.label;
+      latest.append(lhead, lsub);
+      latest.addEventListener("click", (e) => { e.stopPropagation(); pickValue(c.value, true); });
+      latest.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); pickValue(c.value, true); }
+        else if (e.key === "ArrowLeft") { e.preventDefault(); closeSub(); item.focus(); }
+      });
+      sub.appendChild(latest);
       for (const v of versions) {
         const cur = (s.status.model || "").toLowerCase() === v.label.toLowerCase();
         const row = el("div", "meta-item" + (cur ? " current" : ""));

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -49,20 +49,23 @@ test("dispatchFrame routes kernel frames to the panel", () => {
     applyBars: (m: any) => calls.push(["applyBars", m.type]),
     setActiveChat: (a: any) => calls.push(["setActiveChat", a]),
     setHover: (m: any) => calls.push(["setHover", m.type]),
+    refreshModels: () => calls.push(["refreshModels"]),   // the kernel's models frame: the pick memory moved
   };
   assert.equal(dispatchFrame(panel, { type: "data", data: { lanes: [] } }), true);
   assert.equal(dispatchFrame(panel, { type: "bars" }), true);
   assert.equal(dispatchFrame(panel, { type: "activeChat", activeChat: "s1" }), true);
   assert.equal(dispatchFrame(panel, { type: "hover", sid: "s1" }), true);
+  assert.equal(dispatchFrame(panel, { type: "models", rev: 3 }), true);
   assert.equal(dispatchFrame(panel, { type: "ka" }), false);
   assert.equal(dispatchFrame(null, { type: "data" }), false);
-  assert.deepEqual(calls.map((c) => c[0]), ["update", "applyBars", "setActiveChat", "setHover"]);
+  assert.deepEqual(calls.map((c) => c[0]), ["update", "applyBars", "setActiveChat", "setHover", "refreshModels"]);
 });
 
 test("dispatchFrame tolerates a panel without the optional methods", () => {
   const panel = { update: () => {} };
   assert.equal(dispatchFrame(panel, { type: "bars" }), false);
   assert.equal(dispatchFrame(panel, { type: "hover" }), false);
+  assert.equal(dispatchFrame(panel, { type: "models" }), false);
 });
 
 test("openExternalMessage unwraps a vscode:// deep link into the kernel deepLink op", () => {

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -42,6 +42,9 @@ export function dispatchFrame(panel: any, m: any): boolean {
   // `focus` path: focusEvent also drives openChat, and the click came FROM the chat, so that would be a
   // round trip back into the pane the user is already looking at. revealEvent pans + pulses only.
   if (m.type === "revealEvent" && panel.revealEvent) { panel.revealEvent(m.sid, m.t, m.id); return true; }
+  // the kernel's pick memory moved (a pin, a Latest un-pin, a refused pin dropped — from any surface or
+  // dashboard) or its catalog grew: the lane picker re-reads /models so its family rows send the fresh default
+  if (m.type === "models" && panel.refreshModels) { panel.refreshModels(); return true; }
   if (m.type === "tagEditFailed" && panel.tagEditFailed) { panel.tagEditFailed(m); return true; }
   return false;
 }

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -84,7 +84,9 @@ export function bridgeFunctions(post: Post): Record<string, (...a: any[]) => voi
     __rompTimelineWriteOrder: (order: unknown) =>
       writeViewOrder(Array.isArray(order) ? order.filter((x): x is string => typeof x === "string") : []),
     __rompTimelineCompact: (name: string) => post({ type: "compact", name }),
-    __rompTimelineSendCommand: (name: string, cmd: string) => post({ type: "sendCommand", name, cmd }),
+    // `extra` rides op flags beside the command text — the lane submenu's Latest row sends
+    // `{ floating: true }` so the kernel forgets the family's remembered pin
+    __rompTimelineSendCommand: (name: string, cmd: string, extra?: Record<string, unknown>) => post({ type: "sendCommand", name, cmd, ...(extra || {}) }),
     __rompTimelineSetFlag: (id: string, flag: string, value: unknown) => post({ type: "setSessionFlag", id, flag, value: !!value }),
     __rompTimelineSetViews: (views: unknown) => post({ type: "setTimelineViews", views }),
     __rompTimelineEditTag: (edit: unknown) => post({ type: "editTag", edit }),


### PR DESCRIPTION
Two defects, both reproducible on `main`, plus the supporting changes they need. Seven commits, each separable; the last is a design decision for you. If one review is too much, I can split this into two PRs: the pickers (commits 1 to 4 and 6) first, then the backend verdict path (commit 5), which depends on commit 1's `_forget_model_pick(only=)` and the `on_model_refused` wiring.

## What breaks

1. **A family click pins an exact id.** `GET /models` computes each family's `default` as the user's remembered pick, else the head of the version list. Clicking "Fable" in any picker (chat statusline, comment popover, timeline lane, gear judge tiers) therefore sends `--model claude-fable-5-1`, an exact pin, while the CLI's own `fable` alias follows the family's newest release. Before Fable 5.1 was seeded, this left every picker-set session on `claude-fable-5` after the CLI had moved on. It recurs at every release, for every family.

   To reproduce: on a fresh state, `curl /models` returns `"default": "claude-fable-5-1"` for fable. Click Fable, then read `reg.model` and `sdk-defaults.json`.

2. **A typed `/model X` bypasses the registry.** The composer's `sendMessage` arm hands `/model X` to the CLI as literal text. The CLI executes it, but the reg, `sdk-defaults.json` and the reconnect's `--model` keep the old value, so the switch silently reverts at the next reconnect or kernel restart. Only the timeline's `sendCommand` arm routed `/model` through the setter.

   To reproduce: type `/model sonnet` in the chat composer of an SDK session. `reg.model` is unchanged. Restart the kernel; the session comes back on the old model.

## What changes, per commit

1. **Alias default and one router.** `default = pick or family alias`. `sendMessage`, `sendCommand` and `POST /send` share `_route_meta_command`: `/model`, `/effort` and `/fast on|off` take the kernel's park-aware setters, but only for a value the kernel can vouch for (`_vouched_model`: an alias, `default`, a catalog id, or a well-formed first-party id of a known family; the CLI validates the exact version). A typo, a multiline message that opens with the command, or a bare `/model` (the CLI's own picker) stays the CLI's, verbatim. The pick memory's writes take a lock. `_forget_model_pick(fam, only=)` and a `floating` flag on the set ops land here for later commits. The stale "fable resolved to Opus 5" rationale in `bin/romp` and `_apply_new_session_prefs` is corrected; it is not reproducible on any installed CLI.
2. **Learned versions.** The SDK backend persists the raw id the CLI reports (`reg.liveModelId`, from `_learn_model` and `_do_refresh_context`). The kernel completes each family's list with the ids the catalog lacks, marked `learned: true`, and every picker marks them " new". A sighting is T222's staleness event (`_note_unknown_model`), so the catalog fetch runs and the mark drops. `_note_unknown_model` now marks an id asked only when its refresh actually started; a sighting during the inflight boot fetch used to spend the id's one refresh on a no-op. The judge-tier setters validate against the live set, so the kernel never refuses a value the gear offered.
3. **The models frame.** The kernel sends `{type:"models", rev}` to chat, timeline and feed (the gear lives in the feed bundle) whenever the pick memory moves or the catalog fetch adds ids. Every picker re-reads `/models` in place on it, keeps the highest `rev` it applied, and drops an older response that lands late. This also replaces `_refresh_model_catalog`'s `_push_soon()`, whose comment claimed a re-read no client performed. The gear repaints its selects from whichever list won and hands each select its held value back through `setShow`, so a re-read that overtakes the page-load fill never blanks the pickers.
4. **Latest row and create-dialog parity.** Every version submenu opens with "Latest", the one gesture back to floating once a family is pinned; it sends the alias with `floating`. The new-comment dialog sends the family's remembered default like the other pickers, names the pin on the family row, and offers "<Family> · Latest". The gear rows use the T226 tokens.
5. **`set_model` reverts on the CLI's verdict.** The mode path's T139 rule, applied to models with three refinements. Revert only on a verdict: `_cli_refusal` tells a CLI error response from a lost answer (the installed SDK, `claude_agent_sdk` 0.2.132, raises the same bare `Exception` for both), and a lost answer leaves the optimistic state, which the next connect asserts. The session's own layers go back to the last ACCEPTED model (`_model_accepted`), never to what the refused write replaced; two refusals in a row would otherwise write the first refused id back. The shared `sdk-defaults.json` `model` is ruled per write by a `modelTok` token (`_seed_write_*`), so another session's accepted pick is never rolled back and two cross-session refusals never seed a refused id. A refused version leaves the pick memory (`on_model_refused` to `_model_pick_refused`, a compare-and-swap). The ack chip fires on a dormant session too (`_ack_cmd_chip`, the one builder `set_model`, `set_effort` and `set_auth` share). Both reflect checks strip the `[1m]` tag.
6. **One-time boot migration.** `_model_alias_boot_pass`, gated by the marker `STATE/model-alias-migration.done`, turns stored pre-fix seed heads into the family alias in `sdk-defaults.json`, `model-picks.json` and every reg, mirroring the CLI's own `migration_fable5_to_fable_alias`. The marker matters because three of the four heads are current releases a user legitimately pins after this change. Permanent garbage (an unparseable or undecodable store) is named and skipped; a transient read failure withholds the marker so the next boot retries.
7. **Design decision: the T223 thread-wake remap.** After commits 1 to 6, a full id in a reg is a deliberate pin, so `thread_wake_model = _family_newest_model` would re-point only deliberate pins at a dormant thread's next wake. This commit unwires the hook (the helper and the `_ensure` consult stay) and rewrites the thread-rows test to "pins stand". Drop this commit if you would rather keep the remap. Then a version pinned on a comment thread is re-pointed at its next wake, and "pins stand" does not hold for threads.

## Notes for review

- `/models` gains a leading `rev` and version rows gain `learned`; both are additive. A client on an older kernel still works, because a payload without `rev` always applies.
- `_learned_versions` globs `STATE/sdk/*.json` on every `/models` read. That is fine at ordinary session counts; reusing `list_regs` would be an improvement if that lands.
- `_cli_refusal` depends on the behavior of `claude_agent_sdk` 0.2.132's `_internal/query.py`. A future SDK that types these exceptions makes it conservative (never a revert), which is the safe failure.
- The credential path for the Models API fetch is untouched.
- No `docs/reference.md` change: there is no `romp new --model` row to update.

## Tests

All fixtures are synthetic (placeholder uuids, `TESTHOST`, the notes-api demo names). Each commit's tests were red against the base first: the alias default and typed-`/model` routing (`test_model_versions.py` ModelsRoute, `test_sdk_kernel.py`); learned versions and the staleness event (`LearnedVersions`, `test_model_catalog.py` StalenessEvent); the models frame (kernel fan-out and `rev`, plus executed loader tests in `ui/webview/models-rev.test.ts` and `ui/webview/gear-models-frame.test.ts`); the Latest row pins; about 20 backend verdict and token tests in `test_sdk_backend.py`; `AliasMigration`; `ThreadWakePinsStand`.

Final counts on the finished stack: `pytest -n 8 tests`, 6563 passed and 40 skipped; `npm test` in vscode-extension, 2676 passed; `npx tsc --noEmit`, clean; `bats tests/romp.bats tests/romp-headless.bats`, 100 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)