### PR TITLE
Reconnect UX: bound the relay sockets' silence, show every surface which hosts are still coming

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28660,6 +28660,18 @@ var _pendTrust={},_pendMirror={};
 // tunnel, so it never rides the 3s poll itself: refresh() kicks it, one in flight at a time
 // (_pairsBusy), and the answer repaints from the poll's cached args (_lastArgs) — no fetch loop.
 var _pendPair={},_pairs=null,_pairsBusy=false,_lastArgs=null,_lastUp=0;
+// HOSTS THE BOARD HAS NOT HEARD FROM YET (the user 2026-09-02): this panel reads the kernel's /tunnels,
+// where a host whose ssh tunnel is fine says "connected" — while the panes behind it can show no trace of
+// that host for a while after a kernel restart or a phone re-foreground (their relay sockets are still
+// (re)dialing, the first payload has not landed). Each pane's federation manager posts the hosts IT is
+// still waiting on ({romp:'hostsPending', app, hosts}, on change); a host any pane still pends wears
+// "connected · loading sessions…" with the loader here, so the panel never contradicts the blank board.
+// Retired by the pane's own first payload from that host (its next post drops the name) — no timer.
+var _pend={};
+function pendingIn(h){for(var k in _pend){if(_pend[k].indexOf(h)>=0)return true;}return false;}
+window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='hostsPending')return;
+_pend[m.app||'?']=(m.hosts||[]).filter(function(h){return typeof h==='string';});
+if(!back.hidden&&_lastArgs)render.apply(null,_lastArgs);});
 // ITS CONNECTIONS (the user 2026-08-11): every up host's row expands into THAT machine's own
 // attached-host list — same row treatment, working controls — so what's connected to what is
 // managed from one dashboard. Rows come from /tunnels/of (its own /tunnels over your tunnel + its
@@ -28974,7 +28986,7 @@ row.innerHTML='<span class=rnet-dot style=\"'+dot+'\" title=\"'+(TIP[t.status]||
 // A host mid-attach gets the romp loader inline (the user 2026-07-29): the swirl glyph spinning beside
 // the status word, so "connecting" reads as something HAPPENING rather than a label that might be stuck.
 // The repo's loading rule spelled small: same glyph, same reverse spin as the composer's slash spinner.
-'<span class=nm><b>'+t.host+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(busyStatus(t.status)?spin():'')+(LBL[t.status]||t.status)+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.token?'':' \\u00b7 no token')+(again?' \\u00b7 '+again:'')+ver+'</span></span>'+
+'<span class=nm><b>'+t.host+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(busyStatus(t.status)?spin():'')+(LBL[t.status]||t.status)+((t.status==='up'&&pendingIn(t.host))?' \\u00b7 <span class=rnet-pend title=\"The tunnel is up; this dashboard is still loading '+t.host+'\\u2019s sessions. They appear the moment its first payload lands.\">'+spin()+'loading sessions\\u2026</span>':'')+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.token?'':' \\u00b7 no token')+(again?' \\u00b7 '+again:'')+ver+'</span></span>'+
 retry+pull+ask+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>'+
 // ITS CONNECTIONS toggle — the keyed expand (progressive disclosure): compact row by default,
 // that machine's own attached list one click deeper, fetched on the click, never the poll.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27338,6 +27338,14 @@ var SK="romp-vscode-state-%s";   // persist webview state to localStorage so UI 
 window.acquireVsCodeApi=function(){return{postMessage:function(m){if(window.__rompFed){window.__rompFed.outbound(m);}else{send(m);}},
 getState:function(){try{return JSON.parse(localStorage.getItem(SK)||"null");}catch(e){return null;}},
 setState:function(s){try{localStorage.setItem(SK,JSON.stringify(s));}catch(e){}}};};connect();
+// ABANDON a dead socket rather than wait for it (2026-09-02): close() on a socket whose far side is gone
+// starts a closing handshake nobody answers, and the browser holds CLOSING for ~60s before onclose fires —
+// the audited phone panes came back 64s after their own watchdog-close for exactly this reason (a pane's
+// quiet socket → close() → nothing → the reconnect only when the browser gave up). Detach its handlers
+// (its eventual onclose is nobody's event — it must not fire wsdown or a second redial), close it for
+// hygiene, do what onclose did (flag the shell, re-show the loader), and let the caller dial NOW.
+function abandon(){var d=ws;if(!d)return;d.onopen=d.onmessage=d.onclose=d.onerror=null;try{d.close();}catch(e){}ws=null;
+netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}
 // progress watchdog (state-keyed, one per socket state): OPEN but silent past STALE_MS = half-open, no
 // onclose will ever fire — force-close (the user 2026-06-29). CONNECTING past its deadline = the browser is
 // holding the attempt (Firefox delays re-admitting a recently-failed endpoint, and a handshake can hang) and
@@ -27345,7 +27353,7 @@ setState:function(s){try{localStorage.setItem(SK,JSON.stringify(s));}catch(e){}}
 // "Disconnected — reconnecting…" banner sat until a manual refresh). CLOSED with no fresh attempt = the 1.5s
 // retry timer was lost (throttled/killed) — re-dial directly; connect()'s own guard makes this idempotent.
 setInterval(function(){if(!ws)return;
-if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");try{ws.close();}catch(e){}}return;}
+if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");abandon();connect();}return;}
 if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}
 if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // visibility fast-path (the user 2026-07-05): a BACKGROUNDED tab has its timers throttled, so the 5s watchdog
@@ -27354,7 +27362,7 @@ if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // prompt at once AND force a reconnect (which resyncs live), rather than leaving the user on a frozen frame.
 document.addEventListener("visibilitychange",function(){if(document.visibilityState!=="visible"||!everConnected)return;
 if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;
-try{if(ws&&ws.readyState<=1)ws.close();}catch(e){}   // OPEN or stuck-CONNECTING both die here → onclose retries
+if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}   // OPEN-but-quiet → abandoned + redialed below, now; stuck-CONNECTING → aborted, onclose retries
 if(!ws||ws.readyState===3)connect();}});})();
 """ % (app, int(v), app, app)
 

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -97,12 +97,19 @@ class DisconnectBanner(unittest.TestCase):
         # connect() is idempotent (one live attempt at a time) and stamps its start time
         self.assertIn("function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;", js)
         self.assertIn("connT=Date.now();", js)
-        # the watchdog handles EVERY socket state: half-open OPEN, stuck CONNECTING, and lost-timer CLOSED
-        self.assertIn('if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");try{ws.close();}catch(e){}}return;}', js)
+        # the watchdog handles EVERY socket state: half-open OPEN, stuck CONNECTING, and lost-timer CLOSED.
+        # A quiet OPEN socket is ABANDONED and redialed in the same tick (2026-09-02): close() alone
+        # starts a closing handshake a dead far side never answers, and the browser holds CLOSING ~60s
+        # before onclose — the audited phone panes came back 64s after their own watchdog-close.
+        self.assertIn('if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");abandon();connect();}return;}', js)
+        self.assertIn("function abandon(){var d=ws;if(!d)return;d.onopen=d.onmessage=d.onclose=d.onerror=null;try{d.close();}catch(e){}ws=null;", js)
+        self.assertIn('netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}', js,
+                      "the abandoned socket's onclose is disowned, so abandon() itself does what onclose did (banner + loader)")
         self.assertIn("if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}", js)
         self.assertIn("if(ws.readyState===3&&Date.now()-connT>8000){connect();}", js)
-        # the foregrounding fast-path tears down a stuck CONNECTING socket too, and re-dials a closed one
-        self.assertIn("if(ws&&ws.readyState<=1)ws.close();", js)
+        # the foregrounding fast-path abandons an OPEN-but-quiet socket and redials it NOW (same 60s
+        # CLOSING stall otherwise), aborts a stuck CONNECTING one, and re-dials a closed one
+        self.assertIn("if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}", js)
         self.assertIn("if(!ws||ws.readyState===3)connect();", js)
 
     def test_error_popover_has_no_reload_button(self):

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -86,7 +86,8 @@ function fetch(url, opts){
 const ALERTS = [];
 function alert(m){ ALERTS.push(String(m)); }
 const setTimeout_ = setTimeout;
-const window = { addEventListener(){}, location:{reload(){}} };
+// listeners are RECORDED so a test can deliver a pane's postMessage (the hostsPending row copy)
+const window = { _l:{}, addEventListener(k,f){ (this._l[k]=this._l[k]||[]).push(f); }, location:{reload(){}} };
 const console_err = [];
 const console = { error(...a){ console_err.push(a.map(String).join(' ')); }, log(){}, warn(){} };
 
@@ -356,6 +357,44 @@ class RemotesPanelRender(unittest.TestCase):
         self.assertIn("select[data-pt-on]", js)
         self.assertIn("/tunnels/trust-remote", js)
         self.assertIn("/tunnels/pairs", js)
+
+
+class PendingHostsRowCopy(RemotesPanelRender):
+    """The panel must not contradict a blank board (the user 2026-09-02): after a kernel restart or a
+    phone re-foreground the panes can show no trace of an attached host for a while (their relay
+    sockets are still (re)dialing, the first payload has not landed) while this panel's row, read off
+    the kernel's /tunnels, says a bare 'connected'. Each pane's federation manager posts the hosts IT
+    still waits on ({romp:'hostsPending', app, hosts}); a host any pane still pends wears
+    'connected · loading sessions…' with the loader until that pane's next post drops it."""
+
+    DELIVER = ("(window._l.message||[]).forEach(function(f){f({data:{romp:'hostsPending',app:'feed',"
+               "hosts:['TESTHOST']}});});")
+    RETIRE = ("(window._l.message||[]).forEach(function(f){f({data:{romp:'hostsPending',app:'feed',"
+              "hosts:[]}});});")
+
+    def test_a_pane_still_waiting_on_an_up_host_marks_its_row_as_loading(self):
+        out = self._run(drive=self.DELIVER)
+        self.assertEqual(out["rows"], 1)
+        self.assertIn("loading sessions\u2026", out["html"])
+        self.assertIn("rnet-spin", out["html"], "the romp loader, not a bare word that could equally be stuck")
+        self.assertIn("connected", out["html"], "the kernel's own truth stays: the tunnel IS up")
+
+    def test_the_mark_leaves_when_the_pane_reports_the_payload_landed(self):
+        out = self._run(drive=self.DELIVER + self.RETIRE)
+        self.assertNotIn("loading sessions", out["html"])
+
+    def test_a_host_no_pane_pends_wears_no_mark(self):
+        out = self._run()
+        self.assertNotIn("loading sessions", out["html"])
+
+    def test_a_down_host_never_wears_the_loading_mark(self):
+        # the kernel's own status word covers a down tunnel ("reconnecting…"); the pane-side mark is
+        # only for the case where the tunnel is FINE and the dashboard is the one still catching up
+        t = json.loads(json.dumps(TUNNELS))
+        t["tunnels"][0]["status"] = "down"
+        out = self._run(drive=self.DELIVER, tunnels=t)
+        self.assertNotIn("loading sessions", out["html"])
+        self.assertIn("reconnecting", out["html"])
 
 
 if __name__ == "__main__":

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3944,7 +3944,15 @@ class TimelinePanel {
     const jShow = !!(shownJudges.length && data.judging && data.judging.some((e) => shownKeys.has(e.judge) && inWin(e.t)));
     const bandH = jShow ? (JB_TOPGAP + shownJudges.length * JROW + JB_BOTGAP) : 0;
     const W = Math.max(640, this.wrap.clientWidth || 900);
-    const plotW = W - M.left - M.right, H = M.top + Math.max(1, vis.length) * LANE_GAP + bandH + M.bottom;
+    // PENDING HOSTS (the user 2026-09-02): attached hosts whose lanes have not arrived yet (the merged
+    // payload's pendingHosts — federation.ts: listed by /tunnels, no lanes payload from it on this pane
+    // yet) each reserve ONE placeholder row under the lanes, so a restart or a phone re-foreground never
+    // reads as those hosts having vanished. Retired by the host's first lanes payload or its detach —
+    // the merge's events, never a timer here. Not lanes: never in vis/vidx, no hit targets, no drag.
+    const pend = Array.isArray(data.pendingHosts) ? data.pendingHosts.filter((h) => typeof h === 'string') : [];
+    const pendDead = Array.isArray(data.pendingDead) ? data.pendingDead : [];
+    const pendBase = Math.max(1, vis.length);   // the first placeholder row sits under the last lane (or the empty-window line)
+    const plotW = W - M.left - M.right, H = M.top + (Math.max(1, vis.length) + pend.length) * LANE_GAP + bandH + M.bottom;
     svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H); svg.setAttribute('height', H); svg.setAttribute('width', W);
     // x is LINEAR in compressed time → smooth pan (only zoom rescales). Identity compress = plain linear.
     const x = (t) => M.left + (compress(t) - cT0) / winSec * plotW;
@@ -4008,6 +4016,20 @@ class TimelinePanel {
     const compactSeen = new Set();   // sids whose compacting scan-bar is live this draw → reconcile the overlay after
     const workSeen = new Set();      // sids whose WORKING label overlay is live this draw → reconcile after (persistent pulse)
     const metaSeen = new Set();      // sids showing the "model switching…" dots this draw → reconcile the overlay after
+    // the pending-host placeholder rows (see `pend` above): the romp swirl glyph, reverse-spun like every
+    // romp loader, then the host named in the quiet italic the "host:" prefix wears on a real lane. A
+    // dead link says "reconnecting to" (the kernel is redialing it); an open one still waiting on its
+    // first payload says "loading sessions from". Drawn before the lanes — its own y band, no overlap.
+    pend.forEach((h, k) => {
+      const y = laneY(pendBase + k), sz = 13, cx = PADL + sz / 2;
+      const img = el('image', { x: PADL, y: y - sz / 2, width: sz, height: sz, href: mediaUrl('romp-swirl-glyph.svg'), 'pointer-events': 'none' });
+      img.appendChild(el('animateTransform', { attributeName: 'transform', type: 'rotate', from: '360 ' + cx + ' ' + y, to: '0 ' + cx + ' ' + y, dur: '2.4s', repeatCount: 'indefinite' }));
+      svg.appendChild(img);
+      const t = el('text', { x: PADL + sz + 6, y: y + 3.5, 'text-anchor': 'start', 'font-weight': 400, 'font-style': 'italic', 'font-size': 12, fill: MODEL_FG, 'pointer-events': 'none' });
+      t.setAttribute('data-pending-host', h);
+      t.textContent = (pendDead.indexOf(h) >= 0 ? 'reconnecting to ' : 'loading sessions from ') + h + '\u2026';
+      svg.appendChild(t);
+    });
     vis.forEach((s, i) => {
       const y = laneY(i);
       // perceptual idle fade: faded lanes blend their colors toward bgRGB to a uniform low luminance.
@@ -4798,7 +4820,7 @@ class TimelinePanel {
     // by the SESSION it acted on; adjacent same-session marks merge into a stretch of attention. A mark
     // within ~8s of the live edge is "running now" (white-outlined). (docs/judges.md; data.judging.)
     if (jShow) {
-      const jb0 = M.top + vis.length * LANE_GAP + JB_TOPGAP;     // top of the first judge row, under the lanes
+      const jb0 = M.top + (vis.length + pend.length) * LANE_GAP + JB_TOPGAP;     // top of the first judge row, under the lanes (+ the pending-host rows)
       const jY = (i) => jb0 + i * JROW + JROW * 0.5;
       const nameOf = (sid) => { const s = data.sessions.find((z) => z.id === sid); return s ? s.name : sid; };
       const sepY = jb0 - JB_TOPGAP * 0.5;

--- a/ui/timeline-pending-hosts.test.ts
+++ b/ui/timeline-pending-hosts.test.ts
@@ -1,0 +1,127 @@
+// Pending-host placeholder rows on the timeline (the user 2026-09-02): an attached host whose lanes
+// have not arrived yet — a kernel restart, a phone re-foreground, a fresh attach — used to leave NO
+// trace on the board, and the user read the blank as wiped state. The merged lanes payload now names
+// such hosts (federation.ts mergeHostTimelines.pendingHosts, retired only by the host's first lanes
+// payload or its detach), and draw() reserves one placeholder row per name under the lanes: the romp
+// swirl (reverse-spun) + "loading sessions from <host>…" (or "reconnecting to <host>…" on a dead link).
+// Executed through the real draw() on the headless DOM shim timeline-render.test.ts uses. Synthetic only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) { c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    addEventListener() {}, removeEventListener() {}, querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 1400, height: 420, left: 0, top: 0, right: 1400, bottom: 420 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+g.requestAnimationFrame = () => 0;
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+
+const LANE_GAP = 26;   // the view's lane pitch (romp-timeline-view.js) — one placeholder row = one lane slot
+function synthData(): any {
+  const now = 1_781_000_000;
+  const turn = (id: string, dt0: number, dt1: number) => ({
+    id, promptId: id + "#p", workId: id + "#w", start: now - dt0, end: now - dt1, prompt: "do the thing", src: "typed", mids: [],
+    pending: false, summary: "did the thing", reply: "did it", tid: "fork-" + id, uuid: "u-" + id, workUuid: "w-" + id, replyUuid: "r-" + id,
+  });
+  const sess = (id: string, name: string) => ({
+    id, name, color: "#7aa2f7", state: "working", live: true, model: "Opus 4.8", effort: "xhigh",
+    context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+  });
+  return { now, sessions: [sess("S1", "web"), sess("S2", "api")],
+           turns: { S1: [turn("S1:1:aa", 300, 60)], S2: [turn("S2:1:cc", 200, 30)] },
+           messages: [], activeChat: null, focus: null, hover: null, usage: null };
+}
+function findAll(node: any, pred: (n: any) => boolean, out: any[] = []): any[] {
+  if (pred(node)) out.push(node);
+  for (const c of node.children || []) findAll(c, pred, out);
+  return out;
+}
+const pendingTexts = (svg: any) => findAll(svg, (n) => n.tag === "text" && n._attrs["data-pending-host"]);
+const svgH = (svg: any) => Number(svg.getAttribute("height"));
+
+test("a pending host draws ONE placeholder row under the lanes — swirl + 'loading sessions from <host>…' — and _vis stays the real lanes", () => {
+  const panel = new TimelinePanel(makeNode("div"));
+  const base: any = synthData();
+  panel.data = base;
+  panel.draw();
+  const h0 = svgH(panel.svg);
+  const data: any = Object.assign(synthData(), { pendingHosts: ["TESTHOST"], pendingDead: [] });
+  panel.data = data;
+  assert.doesNotThrow(() => panel.draw());
+  const rows = pendingTexts(panel.svg);
+  assert.equal(rows.length, 1, "one row per pending host");
+  assert.equal(rows[0].textContent, "loading sessions from TESTHOST…");
+  assert.equal(rows[0]._attrs["font-style"], "italic", "the quiet italic the host: prefix wears — chrome, not a lane name");
+  assert.equal(panel._vis.length, 2, "the placeholder is NOT a lane: vis/vidx untouched");
+  assert.equal(svgH(panel.svg), h0 + LANE_GAP, "the SVG grew by exactly one lane slot");
+  // the swirl: the shared romp glyph, reverse-spun (360 → 0), sitting in the name column of that row
+  const imgs = findAll(panel.svg, (n) => n.tag === "image" && /romp-swirl-glyph\.svg/.test(String(n._attrs.href)));
+  assert.equal(imgs.length, 1);
+  const spin = imgs[0].children.find((c: any) => c.tag === "animateTransform");
+  assert.ok(spin && spin._attrs.type === "rotate" && /^360 /.test(String(spin._attrs.from)) && /^0 /.test(String(spin._attrs.to)),
+    "reverse spin, like every romp loader");
+  assert.equal(Number(rows[0]._attrs.y) > Number(imgs[0]._attrs.y), true, "text baseline sits below the glyph's top edge (same row)");
+  // the row sits UNDER the last lane, never over one
+  const laneNames = findAll(panel.svg, (n) => n.tag === "text" && (n.textContent === "web" || n.textContent === "api"));
+  const maxLaneY = Math.max(...laneNames.map((n) => Number(n._attrs.y)));
+  assert.ok(Number(rows[0]._attrs.y) > maxLaneY, "placeholder row below every real lane");
+});
+
+test("a pending host on a DEAD link says it is reconnecting — and the row leaves on the host's first lanes payload", () => {
+  const panel = new TimelinePanel(makeNode("div"));
+  const dead: any = Object.assign(synthData(), { pendingHosts: ["TESTHOST"], pendingDead: ["TESTHOST"] });
+  panel.data = dead;
+  panel.draw();
+  assert.equal(pendingTexts(panel.svg)[0].textContent, "reconnecting to TESTHOST…");
+  // the retire event is the MERGE dropping the name (its first lanes payload / detach) — nothing here ages it out
+  const arrived: any = Object.assign(synthData(), { pendingHosts: [], pendingDead: [] });
+  panel.data = arrived;
+  panel.draw();
+  assert.equal(pendingTexts(panel.svg).length, 0, "gone the moment the merge stops naming it");
+  const h1 = svgH(panel.svg);
+  panel.data = synthData();   // a payload with no field at all (single-kernel path) is identical
+  panel.draw();
+  assert.equal(svgH(panel.svg), h1, "no pendingHosts field = no rows = the byte-for-byte single-kernel geometry");
+});
+
+test("two pending hosts stack — one row each, in the merge's order", () => {
+  const panel = new TimelinePanel(makeNode("div"));
+  panel.data = Object.assign(synthData(), { pendingHosts: ["HOSTB", "TESTHOST"], pendingDead: [] });
+  panel.draw();
+  const rows = pendingTexts(panel.svg);
+  assert.deepEqual(rows.map((r) => r._attrs["data-pending-host"]), ["HOSTB", "TESTHOST"]);
+  assert.equal(Number(rows[1]._attrs.y) - Number(rows[0]._attrs.y), LANE_GAP, "one lane pitch apart");
+});

--- a/ui/webview/federation-reconnect.test.ts
+++ b/ui/webview/federation-reconnect.test.ts
@@ -1,0 +1,247 @@
+// The relay sockets' liveness watchdog + the timeline's pending-host signal (the user 2026-09-02).
+//
+// The audited two-minute gap: after a phone re-foreground the dashboard's relay sockets to two attached,
+// healthy hosts OPENED and then delivered nothing — dead on arrival — and, unlike the pane shim's LOCAL
+// socket (30s keepalive watchdog), federation.ts's remote sockets had no liveness check at all, so the
+// hosts rendered as simply absent until TCP gave up ~104s later. Executed against the real manager with
+// a fake WebSocket: the verdict table, the close+redial on silence, the foreground fast-path, the
+// breadcrumb, and the pending set the panes and the shell read while a host is still coming. Synthetic
+// only (host TESTHOST, placeholder uuids).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FederationManager, mergeHostTimelines, socketVerdict,
+         REMOTE_STALE_MS, REMOTE_CONNECT_MS, REMOTE_REDIAL_MS } from "./federation";
+
+const U = "11111111-2222-3333-4444-555555555555";
+
+// ── the pure verdict ─────────────────────────────────────────────────────────────────────────────
+test("socketVerdict: an OPEN socket silent past the keepalive bound is closed; a fresh one is left alone", () => {
+  const t = 1_000_000;
+  assert.equal(socketVerdict(1, t, t - 5000, t + REMOTE_STALE_MS + 1), "close", "31s of silence since open");
+  assert.equal(socketVerdict(1, t, t - 5000, t + REMOTE_STALE_MS), "", "at the bound, not past it");
+  assert.equal(socketVerdict(1, t + 20000, t, t + 25000), "", "a frame 5s ago keeps it");
+  // silence is measured from THIS socket's own open (lastRecv stamped at onopen), never an earlier socket's traffic
+  assert.equal(socketVerdict(1, 0, t, t + REMOTE_STALE_MS + 1), "close", "no frame at all → the connect stamp is the reference");
+});
+
+test("socketVerdict: a hung handshake is aborted; a CLOSED socket with no fresh attempt is redialed", () => {
+  const t = 1_000_000;
+  assert.equal(socketVerdict(0, 0, t, t + REMOTE_CONNECT_MS + 1), "close", "CONNECTING past 15s");
+  assert.equal(socketVerdict(0, 0, t, t + 3000), "", "a young handshake is left to finish");
+  assert.equal(socketVerdict(3, 0, t, t + REMOTE_REDIAL_MS + 1), "redial", "CLOSED 8s+ with no new connect = a lost retry timer");
+  assert.equal(socketVerdict(3, 0, t, t + 1000), "", "the 2s onclose redial is still coming");
+  assert.equal(socketVerdict(2, 0, t, t + 99999), "", "CLOSING is in flight — onclose will follow");
+});
+
+test("the bounds are the pane shim's, byte for byte (kernel keepalive 10s → stale at 30s)", () => {
+  assert.equal(REMOTE_STALE_MS, 30000);
+  assert.equal(REMOTE_CONNECT_MS, 15000);
+  assert.equal(REMOTE_REDIAL_MS, 8000);
+});
+
+// ── the manager, end to end, with a fake WebSocket ──────────────────────────────────────────────
+class FakeWS {
+  static made: FakeWS[] = [];
+  readyState = 0;
+  closed = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: any) => void) | null = null;
+  onclose: ((ev: any) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) { FakeWS.made.push(this); }
+  open(): void { this.readyState = 1; this.onopen && this.onopen(); }
+  frame(data: any): void { this.onmessage && this.onmessage({ data: JSON.stringify(data) }); }
+  close(): void { this.closed++; this.readyState = 3; }
+  die(code = 1006): void { this.readyState = 3; this.onclose && this.onclose({ code, wasClean: false }); }
+}
+
+// the test owns the clock: the manager stamps connT/lastRecv with Date.now(), and the watchdog is
+// ticked with an explicit `now`, so silence is advanced by hand rather than waited out
+let clock = 1_000_000_000;
+async function withManager(fn: (fm: any, emitted: any[], diag: any[], posted: any[]) => void | Promise<void>): Promise<void> {
+  const emitted: any[] = [], diag: any[] = [], posted: any[] = [];
+  const g: any = globalThis;
+  const saved: Record<string, any> = {};
+  const set = (k: string, v: any) => { saved[k] = { had: k in g, v: g[k] }; g[k] = v; };
+  FakeWS.made = [];
+  const realNow = Date.now;
+  Date.now = () => clock;
+  set("WebSocket", FakeWS);
+  set("location", { protocol: "http:", host: "TESTHOST.local:1" });
+  set("localStorage", { getItem: () => null, setItem: () => {} });
+  const parent = { postMessage: (m: any) => { posted.push(m); } };
+  set("window", {
+    dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); },
+    __rompLocalSend: (m: any) => { if (m && m.type === "clientDiag") diag.push(m); },
+    sessionStorage: { getItem: () => "" },
+    parent,
+  });
+  try {
+    await fn(new FederationManager(), emitted, diag, posted);   // awaited: the globals must outlive an async poll
+  } finally {
+    Date.now = realNow;
+    for (const [k, r] of Object.entries(saved)) { if (r.had) g[k] = r.v; else delete g[k]; }
+  }
+}
+const localFeed = { type: "feed", asks: [], items: [], working: [], ledgers: [], order: [], sessions: [], now: 1000, buildId: 1 };
+
+test("a relay socket that opens and then goes silent past the bound is force-closed with a breadcrumb, and redialed", async () => {
+  await withManager((fm, _emitted, diag) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    assert.equal(FakeWS.made.length, 1, "an up host is dialed at once");
+    const ws = FakeWS.made[0];
+    assert.match(ws.url, /\/remote\/TESTHOST\/ws\?app=chat&token=tok/, "the dial goes through the local kernel's relay");
+    ws.open();
+    clock += 10_000;
+    fm.watchdog(clock);
+    assert.equal(ws.closed, 0, "10s after open: still inside the keepalive bound");
+    clock += 15_000;
+    ws.frame({ type: "ka", dv: 1 });                       // a keepalive counts as life — that IS the heartbeat
+    clock += 20_000;                                        // 45s since open, but only 20s since the last frame
+    fm.watchdog(clock);
+    assert.equal(ws.closed, 0, "the keepalive 20s ago reset the clock");
+    clock += REMOTE_STALE_MS;                               // 50s of silence since that frame
+    fm.watchdog(clock);
+    assert.equal(ws.closed, 1, "silent past the bound → the watchdog puts the dead-on-arrival socket down");
+    const crumb = diag.find((d) => d.what === "hostconn" && d.data && d.data.ev === "watchdog-close");
+    assert.ok(crumb, "the close lands in the hostconn breadcrumb family, so client-diag says WHO closed it");
+    assert.equal(crumb.data.host, "TESTHOST");
+    assert.equal(crumb.data.why, "quiet");
+    assert.ok(crumb.data.quietMs > REMOTE_STALE_MS, "…and how long it had been silent");
+    // the browser fires onclose for our own close(); the manager's existing onclose path redials
+    ws.die(1005);
+    const conn = fm.conns.get("TESTHOST");
+    conn.closed = true;   // stop the 2s retry timer from dialing after the test (closeRemote would also emit)
+  });
+});
+
+test("the foreground fast-path kills a socket still CONNECTING, whatever its age — the sleeping tab's unfinished handshake", async () => {
+  await withManager((fm, _e, diag) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    const ws = FakeWS.made[0];              // never opens (readyState 0)
+    clock += 1000;
+    fm.watchdog(clock);
+    assert.equal(ws.closed, 0, "a 1s-old handshake is left to finish on a plain tick");
+    fm.watchdog(clock, true);
+    assert.equal(ws.closed, 1, "…but a foreground pass closes it now rather than waiting the handshake bound out");
+    assert.equal(diag.filter((d) => d.data && d.data.ev === "watchdog-close" && d.data.why === "connecting" && d.data.foreground).length, 1);
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+test("a CLOSED socket whose retry timer was lost is redialed directly (the throttled-tab case)", async () => {
+  await withManager((fm) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    const conn = fm.conns.get("TESTHOST");
+    conn.ws.readyState = 3;                 // closed under us with no onclose → no 2s timer armed
+    clock += REMOTE_REDIAL_MS + 1000;
+    fm.watchdog(clock);
+    assert.equal(FakeWS.made.length, 2, "the watchdog dialed a fresh socket");
+    conn.closed = true;
+  });
+});
+
+test("a detached host is never touched by the watchdog, and a DOWN tunnel is never dialed by it", async () => {
+  await withManager((fm) => {
+    fm.openRemote("TESTHOST", "tok", false);   // /tunnels says not up → no socket
+    assert.equal(FakeWS.made.length, 0);
+    clock += 999_999;
+    fm.watchdog(clock);
+    assert.equal(FakeWS.made.length, 0, "no dial against a tunnel the kernel calls down");
+    fm.openRemote("HOSTB", "tok", true);
+    fm.closeRemote("HOSTB");                  // detach → closed:true
+    const n = FakeWS.made.length;
+    clock += 999_999;
+    fm.watchdog(clock);
+    assert.equal(FakeWS.made.length, n, "a detached conn is skipped, never redialed");
+  });
+});
+
+// ── the pending-host signal: what the panes and the shell read while a host is still coming ────
+test("mergeHostTimelines names attached hosts that have no lanes payload yet, and which of those sit on a dead link", () => {
+  const local = { sessions: [{ id: U, name: "web" }], turns: {}, messages: [], judging: [], now: 1000 };
+  const before = mergeHostTimelines({ "": local }, ["", "TESTHOST"], [], []);
+  assert.deepEqual(before.pendingHosts, ["TESTHOST"], "listed by /tunnels, no lanes yet — the placeholder window");
+  assert.deepEqual(before.pendingDead, []);
+  const dead = mergeHostTimelines({ "": local }, ["", "TESTHOST"], [], ["TESTHOST"]);
+  assert.deepEqual(dead.pendingDead, ["TESTHOST"], "pending on a closed socket = named as reconnecting");
+  const after = mergeHostTimelines({ "": local, TESTHOST: { sessions: [], turns: {}, now: 1000 } }, ["", "TESTHOST"], [], []);
+  assert.deepEqual(after.pendingHosts, [], "the first lanes payload — even an EMPTY one — is the retire event");
+  assert.deepEqual(mergeHostTimelines({ "": local }, [""]).pendingHosts, [], "the local kernel never pends");
+});
+
+test("the merged lanes emission carries the pending set, so the timeline can draw its placeholder rows", async () => {
+  await withManager((fm, emitted) => {
+    fm.app = "timeline";
+    fm.openRemote("TESTHOST", "tok", true);
+    fm.inbound("", { type: "data", data: { sessions: [{ id: U, name: "web" }], turns: {}, messages: [], judging: [], now: 1000 } });
+    const lanes = emitted.filter((m) => m.type === "data").pop();
+    assert.deepEqual(lanes.data.pendingHosts, ["TESTHOST"]);
+    assert.deepEqual(lanes.data.pendingDead, [], "the socket is dialed (CONNECTING), not dead");
+    fm.inbound("TESTHOST", { type: "data", data: { sessions: [], turns: {}, messages: [], judging: [], now: 1000 } });
+    const after = emitted.filter((m) => m.type === "data").pop();
+    assert.deepEqual(after.data.pendingHosts, [], "retired by that host's own first lanes payload");
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+test("each pane tells the shell which hosts IT still waits on — by its own channel, on change only", async () => {
+  await withManager((fm, _e, _d, posted) => {
+    fm.app = "feed";
+    fm.openRemote("TESTHOST", "tok", true);
+    fm.inbound("", localFeed);
+    assert.deepEqual(posted.pop(), { romp: "hostsPending", app: "feed", hosts: ["TESTHOST"] },
+      "the feed pane pends TESTHOST until its feed payload lands");
+    fm.inbound("", { ...localFeed, buildId: 2 });
+    assert.equal(posted.length, 0, "unchanged set → nothing re-posted");
+    fm.inbound("TESTHOST", { type: "feed", asks: [], items: [], working: [], order: [], sessions: [], now: 1000 });
+    assert.deepEqual(posted.pop(), { romp: "hostsPending", app: "feed", hosts: [] }, "the payload retires it");
+    fm.closeRemote("TESTHOST");
+  });
+  await withManager((fm, _e, _d, posted) => {
+    fm.app = "timeline";
+    fm.openRemote("TESTHOST", "tok", true);
+    fm.inbound("", { type: "data", data: { sessions: [], turns: {}, messages: [], judging: [], now: 1000 } });
+    assert.deepEqual(posted.pop(), { romp: "hostsPending", app: "timeline", hosts: ["TESTHOST"] },
+      "the timeline pends on the LANES channel, not the feed");
+    fm.inbound("TESTHOST", localFeed);   // a feed payload from that host means nothing to the timeline pane
+    assert.equal(posted.length, 0, "still pending: no lanes from it yet");
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+test("a host that ATTACHES is pending from that moment: the poll re-emits the merged payloads it can complete", async () => {
+  const g: any = globalThis;
+  const hadFetch = "fetch" in g, prevFetch = g.fetch;
+  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", token: "tok", localPort: 5, status: "up" }] }) });
+  try {
+    await withManager(async (fm, emitted) => {
+      fm.app = "feed";
+      fm.inbound("", localFeed);
+      const n = emitted.length;
+      await fm.poll();
+      const feed = emitted.slice(n).filter((m) => m.type === "feed").pop();
+      assert.ok(feed, "the attach itself re-emitted the merged feed");
+      assert.deepEqual(feed.pendingHosts, ["TESTHOST"], "…already naming the host as coming");
+      fm.conns.get("TESTHOST").closed = true;
+    });
+  } finally {
+    if (hadFetch) g.fetch = prevFetch; else delete g.fetch;
+  }
+});
+
+test("…but never drops an EMPTY merged feed onto a page still waiting for its local kernel", async () => {
+  const g: any = globalThis;
+  const hadFetch = "fetch" in g, prevFetch = g.fetch;
+  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", token: "tok", localPort: 5, status: "up" }] }) });
+  try {
+    await withManager(async (fm, emitted) => {
+      fm.app = "feed";
+      await fm.poll();
+      assert.equal(emitted.filter((m) => m.type === "feed").length, 0, "no local feed yet → the feed hold stands (the loader stays up)");
+      fm.conns.get("TESTHOST").closed = true;
+    });
+  } finally {
+    if (hadFetch) g.fetch = prevFetch; else delete g.fetch;
+  }
+});

--- a/ui/webview/federation-reconnect.test.ts
+++ b/ui/webview/federation-reconnect.test.ts
@@ -85,7 +85,7 @@ async function withManager(fn: (fm: any, emitted: any[], diag: any[], posted: an
 }
 const localFeed = { type: "feed", asks: [], items: [], working: [], ledgers: [], order: [], sessions: [], now: 1000, buildId: 1 };
 
-test("a relay socket that opens and then goes silent past the bound is force-closed with a breadcrumb, and redialed", async () => {
+test("a relay socket that opens and then goes silent past the bound is abandoned with a breadcrumb, and a fresh one dialed at once", async () => {
   await withManager((fm, _emitted, diag) => {
     fm.openRemote("TESTHOST", "tok", true);
     assert.equal(FakeWS.made.length, 1, "an up host is dialed at once");
@@ -108,10 +108,17 @@ test("a relay socket that opens and then goes silent past the bound is force-clo
     assert.equal(crumb.data.host, "TESTHOST");
     assert.equal(crumb.data.why, "quiet");
     assert.ok(crumb.data.quietMs > REMOTE_STALE_MS, "…and how long it had been silent");
-    // the browser fires onclose for our own close(); the manager's existing onclose path redials
-    ws.die(1005);
+    // NOT waited for: a dead socket's closing handshake never completes (the browser holds CLOSING
+    // ~60s before onclose) — the fresh dial happens in the same pass, and the corpse is disowned
+    assert.equal(FakeWS.made.length, 2, "a fresh socket is dialed at once");
     const conn = fm.conns.get("TESTHOST");
-    conn.closed = true;   // stop the 2s retry timer from dialing after the test (closeRemote would also emit)
+    assert.equal(conn.ws, FakeWS.made[1], "the conn now owns the new socket");
+    assert.equal(ws.onclose, null, "the abandoned socket's handlers are detached — its late onclose redials nothing");
+    assert.equal(ws.onmessage, null);
+    FakeWS.made[1].open();
+    FakeWS.made[1].frame({ type: "feed", asks: [] });
+    assert.equal(diag.filter((d) => d.data && d.data.ev === "watchdog-close").length, 1, "one crumb per abandonment");
+    conn.closed = true;
   });
 });
 
@@ -125,6 +132,7 @@ test("the foreground fast-path kills a socket still CONNECTING, whatever its age
     fm.watchdog(clock, true);
     assert.equal(ws.closed, 1, "…but a foreground pass closes it now rather than waiting the handshake bound out");
     assert.equal(diag.filter((d) => d.data && d.data.ev === "watchdog-close" && d.data.why === "connecting" && d.data.foreground).length, 1);
+    assert.equal(FakeWS.made.length, 2, "…and dials a fresh one in the same pass");
     fm.conns.get("TESTHOST").closed = true;
   });
 });

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -669,7 +669,17 @@ export class FederationManager {
         // WHICH socket the watchdog put down and how long it had been silent
         this.diag("hostconn", { host: c.host, ev: "watchdog-close", why: rs === 1 ? "quiet" : "connecting",
                                 quietMs: c.lastRecv ? now - c.lastRecv : -1, foreground });
-        try { c.ws.close(); } catch (e) { /* already dying — onclose redials either way */ }
+        // ABANDON it, don't wait for it: close() on a socket whose far side is gone starts a closing
+        // handshake nobody answers, and the browser holds CLOSING for ~60s before onclose fires (the
+        // audited panes came back 64s after their own watchdog-close for exactly this reason; the
+        // served-page harness reproduced it against a silent far end). Detach its handlers — its
+        // eventual onclose is nobody's event, and must not redial a second time — close it for
+        // hygiene, and dial a fresh socket NOW. connect() gates on `live` and on `closed` as always.
+        const dead = c.ws;
+        dead.onopen = dead.onmessage = dead.onclose = dead.onerror = null;
+        try { dead.close(); } catch (e) { /* already dying */ }
+        c.ws = null;
+        this.connect(c);
       } else if (v === "redial") {
         this.connect(c);
       }

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -504,7 +504,7 @@ export function stitchMessages(messages: any[], sessions: readonly any[]): any[]
  *  Scalar chrome (now/usage/focus/hover/cmapGrad…) stays LOCAL — the browser's own kernel is the
  *  clock + chrome authority, same as the feed merge. */
 export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readonly string[],
-                                   view: readonly string[] = []): any {
+                                   view: readonly string[] = [], deadHosts: readonly string[] = []): any {
   const local = perHost[LOCAL] || {};
   const offsets = hostOffsets(perHost);   // each host's clock vs the local authority, this merge
   const merged: any = { ...local, sessions: [], turns: {}, messages: [], judging: [] };
@@ -519,6 +519,14 @@ export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readon
   // the same way, before the message stitch, which pairs postal arrows against the lane list.
   merged.sessions = applyViewOrderTo(merged.sessions, view, (x: any) => String((x && x.id) || ""));
   merged.messages = rebaseExecs(stitchMessages(merged.messages, merged.sessions), offsets);
+  // Hosts ATTACHED but yet to contribute a lanes payload — the feed merge's pendingHosts rule, applied
+  // to the lanes channel (the user 2026-09-02: after a restart or a phone re-foreground the remote
+  // hosts' lanes were simply absent for two minutes, with nothing on the board saying they were
+  // coming). Presence in perHost is the event: the host's first lanes payload (an empty one included)
+  // retires it, a detach deletes the entry, and the view draws a placeholder row per name until then.
+  // No timers anywhere in this signal. The local kernel never pends.
+  merged.pendingHosts = hostSeq.filter((h) => h !== LOCAL && !(h in perHost));
+  merged.pendingDead = merged.pendingHosts.filter((h: string) => deadHosts.includes(h));
   return merged;
 }
 
@@ -543,6 +551,33 @@ export function mergeHostBars(perHost: Record<string, any>, hostSeq: readonly st
   return merged;
 }
 
+// ── remote-socket liveness (the user 2026-09-02) ─────────────────────────────────────────────────
+// The kernel heartbeats EVERY WebSocket it serves — `ka` frames every KEEPALIVE_S (10s) — and those
+// frames ride the /remote/<host>/ws relay too, so a remote socket that is truly open hears from its
+// kernel at least every ~10s. The pane shim already keys a watchdog on exactly that beat for the LOCAL
+// socket (STALE_MS): a half-open socket fires no onclose, ever, so a missing heartbeat is the only
+// evidence there is. The remote sockets here had NO such check: on the audited phone re-foreground
+// both relay sockets OPENED (handshake complete) and then delivered nothing — dead on arrival — and
+// nothing bounded the wait until TCP gave up ~104s later (close 1006), so two attached, healthy hosts
+// rendered as simply absent for two minutes, which the user read as wiped state. Same bounds as the
+// shim, byte for byte: 30s of silence on an OPEN socket, 15s stuck CONNECTING, 8s CLOSED with no
+// fresh attempt (a lost retry timer — a throttled tab).
+export const REMOTE_STALE_MS = 30000;
+export const REMOTE_CONNECT_MS = 15000;
+export const REMOTE_REDIAL_MS = 8000;
+
+/** What the watchdog should do about ONE remote socket, from its state alone (pure, unit-tested):
+ *  "close" — force-close so the onclose→redial chain runs (open but silent past the keepalive bound,
+ *  or a hung handshake); "redial" — CLOSED with no fresh attempt: dial directly; "" — leave it be.
+ *  `lastRecv` is stamped at open and on every frame, so an open socket's silence is measured from
+ *  its own open, never from an earlier socket's traffic. */
+export function socketVerdict(readyState: number, lastRecv: number, connT: number, now: number): "close" | "redial" | "" {
+  if (readyState === 1) return now - (lastRecv || connT) > REMOTE_STALE_MS ? "close" : "";
+  if (readyState === 0) return now - connT > REMOTE_CONNECT_MS ? "close" : "";
+  if (readyState === 3) return now - connT > REMOTE_REDIAL_MS ? "redial" : "";
+  return "";
+}
+
 // ── the wiring: WebSockets per kernel + the attach UI ────────────────────────────────────────────
 // Thin glue over the pure functions above. The LOCAL kernel stays the shim's existing single WS — this
 // manager only ADDS connections to attached remote kernels, so with no remotes attached the dashboard is
@@ -556,6 +591,8 @@ interface Conn {
   url: string;
   closed: boolean;
   live: boolean; // kernel reports this tunnel "up" — the only state in which its port is dialed
+  lastRecv: number; // epoch ms of the last frame on the CURRENT socket (keepalives count); 0 = none yet
+  connT: number;    // when the current socket's connect() attempt started — the watchdog's reference point
 }
 
 export class FederationManager {
@@ -607,6 +644,36 @@ export class FederationManager {
       writeViewOrder(Array.isArray(order) ? order.filter((x: unknown): x is string => typeof x === "string") : []);
     this.poll();
     setInterval(() => this.poll(), 4000); // converge on attach/detach made from the shell's network panel
+    // the remote sockets' liveness watchdog (socketVerdict above) — the shim's 5s tick, for the relay side
+    setInterval(() => this.watchdog(Date.now()), 5000);
+    // …and the shim's visibility fast-path, for the relay side: a backgrounded tab's timers are
+    // throttled and its sockets may have died in its sleep, so the instant it is foregrounded every
+    // remote socket that is not open, or has gone quiet past the bound, is closed and redialed now
+    // rather than waited out — the phone's re-foreground is exactly the audited case.
+    try {
+      document.addEventListener("visibilitychange", () => { if (document.visibilityState === "visible") this.watchdog(Date.now(), true); });
+    } catch (e) { /* no document — the node tests construct the manager bare */ }
+  }
+
+  /** One pass of the remote-socket watchdog (public so the tests can tick it with their own clock):
+   *  apply socketVerdict to every dialed connection. `foreground` (the visibility fast-path) also
+   *  kills a socket still CONNECTING, whatever its age — a handshake the sleeping tab never finished. */
+  watchdog(now: number, foreground = false): void {
+    for (const c of this.conns.values()) {
+      if (c.closed || !c.ws) continue;
+      const rs = c.ws.readyState;
+      let v = socketVerdict(rs, c.lastRecv, c.connT, now);
+      if (foreground && rs === 0) v = "close";
+      if (v === "close") {
+        // the same breadcrumb family as open/close/detach, so a "cards came back late" report reads
+        // WHICH socket the watchdog put down and how long it had been silent
+        this.diag("hostconn", { host: c.host, ev: "watchdog-close", why: rs === 1 ? "quiet" : "connecting",
+                                quietMs: c.lastRecv ? now - c.lastRecv : -1, foreground });
+        try { c.ws.close(); } catch (e) { /* already dying — onclose redials either way */ }
+      } else if (v === "redial") {
+        this.connect(c);
+      }
+    }
   }
 
   // kernel → browser: prefix this host's ids, merge tab orders, hand the rest to the panes.
@@ -675,15 +742,46 @@ export class FederationManager {
       this.lastFeedCounts = sig;
       this.diag("feedmerge", { counts });
     }
-    const dead = this.hostSeq.filter((h) => {
+    this.publishPending();
+    const dead = this.deadHosts();
+    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead) }));
+  }
+
+  // the hosts whose link is DOWN right now (this manager knows its sockets) — the merges' pendingDead input
+  private deadHosts(): string[] {
+    return this.hostSeq.filter((h) => {
       if (h === LOCAL) return false;
       const c = this.conns.get(h);
       return !c || !c.ws || c.ws.readyState === 3;   // no socket / closed = a dead link right now
     });
-    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead) }));
+  }
+
+  private lastPendingSig = "";
+
+  /** Which attached hosts THIS pane is still waiting on, by the channel it renders: the chat reads the
+   *  tab list, the feed and fleet the feed payload, the timeline the lanes skeleton. */
+  private pendingFor(): string[] {
+    const src = this.app === "timeline" ? this.perHostTl : this.app === "chat" ? this.perHostOrder : this.perHostFeed;
+    return this.hostSeq.filter((h) => h !== LOCAL && !(h in src));
+  }
+
+  // Tell the SHELL which hosts this pane has not heard from yet (the user 2026-09-02): the network
+  // panel reads the kernel's /tunnels, where a host whose tunnel is fine says "connected" — while the
+  // board behind it shows no trace of that host. The shell folds every pane's list and the panel row
+  // says "connected · loading sessions…" until this pane's first payload from that host retires it.
+  // Posted on CHANGE only, and only to a same-origin parent (a cross-origin host has no network panel).
+  private publishPending(): void {
+    const hosts = this.pendingFor();
+    const sig = hosts.join("\u0000");
+    if (sig === this.lastPendingSig) return;
+    this.lastPendingSig = sig;
+    try {
+      if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "hostsPending", app: this.app, hosts }, "*");
+    } catch (e) { /* a cross-origin parent throws on access — nothing there to tell */ }
   }
 
   private emitMergedTimeline(bars: boolean): void {
+    this.publishPending();   // before the holds: a pane still waiting on its LOCAL lanes is waiting on the remotes too
     // HOLD until the LOCAL lanes snapshot exists. The merges take `now` (the clock authority) from the
     // local payload, so a remote host winning the connect race would emit now:undefined — which the
     // panel's fitWindow turned into a permanently-NaN window (every bar/axis x = NaN; the "stub lane
@@ -700,7 +798,7 @@ export class FederationManager {
     const data = bars
       // the bars message carries no lanes — hand the merged lane list in for the connector stitch
       ? mergeHostBars(this.perHostTlBars, this.hostSeq, mergeHostTimelines(this.perHostTl, this.hostSeq, this.view()).sessions)
-      : { type: "data", data: mergeHostTimelines(this.perHostTl, this.hostSeq, this.view()) };
+      : { type: "data", data: mergeHostTimelines(this.perHostTl, this.hostSeq, this.view(), this.deadHosts()) };
     window.dispatchEvent(new MessageEvent("message", { data }));
   }
 
@@ -712,6 +810,7 @@ export class FederationManager {
   private emitMergedOrder(): void {
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
+    this.publishPending();
     window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs, views: this.localViews ?? undefined } }));
   }
 
@@ -797,8 +896,18 @@ export class FederationManager {
       return;
     }
     const want = new Map<string, any>(tunnels.filter((t) => t.token && t.localPort).map((t) => [t.host, t]));
-    for (const [host, t] of want) if (!this.conns.has(host)) this.openRemote(host, t.token, t.status === "up");
+    let opened = false;
+    for (const [host, t] of want) if (!this.conns.has(host)) { this.openRemote(host, t.token, t.status === "up"); opened = true; }
     for (const host of [...this.conns.keys()]) if (!want.has(host)) this.closeRemote(host);
+    // A host just ATTACHED is pending from this moment, not from the next push that happens to land:
+    // re-emit the merged payloads so the placeholders appear at the attach event. Each emission holds
+    // until the LOCAL payload exists (the feed's hold is here; the timeline's is its own), so a page
+    // still booting never gets an empty merged feed dropped onto its loader.
+    if (opened) {
+      if (LOCAL in this.perHostFeed) this.emitMergedFeed();
+      this.emitMergedTimeline(false);
+      this.publishPending();
+    }
     // The kernel's tunnel state gates dialing: it health-checks its own ssh tunnels, so "up" is
     // authoritative for whether anything listens on the local port at all. Blind 2s retries against
     // a dead tunnel port feed the browser's per-host WebSocket failure backoff (Firefox delays
@@ -845,7 +954,7 @@ export class FederationManager {
     const w = dashboardWid();
     const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`
       + (w ? `&wid=${encodeURIComponent(w)}` : "");
-    const conn: Conn = { host, ws: null, url, closed: false, live };
+    const conn: Conn = { host, ws: null, url, closed: false, live, lastRecv: 0, connT: 0 };
     this.conns.set(host, conn);
     this.ensureHost(host);
     this.connect(conn);
@@ -864,6 +973,8 @@ export class FederationManager {
     if (conn.closed || !conn.live) return;
     if (conn.ws && (conn.ws.readyState === 0 || conn.ws.readyState === 1)) return; // already connecting/open
     let ws: WebSocket;
+    conn.connT = Date.now();
+    conn.lastRecv = 0;
     try {
       ws = new WebSocket(conn.url);
     } catch (e) {
@@ -873,6 +984,7 @@ export class FederationManager {
     conn.ws = ws;
     ws.onopen = () => {
       this.diag("hostconn", { host: conn.host, ev: "open" });
+      conn.lastRecv = Date.now();   // the watchdog measures this socket's silence from ITS open
       // this host's owed replies just became reachable again — the chat re-ships its pending
       // uploads on exactly this event (T215 review finding 2026-09-01: a remote kernel's restart
       // redials HERE, firing neither romp:wsup nor hostUp, so nothing else could heal them).
@@ -883,6 +995,7 @@ export class FederationManager {
       } catch (e) { /* dispatch must never break the relay */ }
     };
     ws.onmessage = (ev: MessageEvent) => {
+      conn.lastRecv = Date.now();   // every frame counts, the keepalive included — that is the heartbeat
       let msg: any;
       try {
         msg = JSON.parse(ev.data);

--- a/ui/webview/fleet-pane.css
+++ b/ui/webview/fleet-pane.css
@@ -99,3 +99,14 @@ color:var(--vscode-descriptionForeground,#9a9a9a);font-size:12px;user-select:non
 /* .fl-back's navy chip reads clay-on-navy at ~2.3:1 in light (PR #763 item 10) — a light chip */
 body.theme-light .fl-back{background:#F3E0D5;color:#8A3A10;border-color:#E0C4B0}
 body.theme-light .fl-back:hover{background:#EBD2C2;color:#6E2D0A}
+/* The per-host loading strip (the user 2026-09-02): a host the kernel lists that this pane has not heard
+   from yet — one quiet line per host, the shared reverse-spin swirl glyph LEFT of the text, at the feed
+   strip's own scale (feed.css #feed-hostload / .hostload-line / .fask-awaiting-swirl, mirrored here
+   because this page loads styles.css + this sheet, never feed.css). Retired only by that host's first
+   payload or its detach — never a timer. */
+#fleet-hostload{display:flex;flex-direction:column;gap:4px;padding:8px 14px}
+.hostload-line{display:flex;align-items:center;gap:7px;color:var(--dim,#9a9a9a);font-size:0.82em}
+.fask-awaiting-swirl{width:14px;height:14px;flex:0 0 auto;background:url(../media/romp-swirl-glyph.svg) center / contain no-repeat;
+animation:fask-swirl-spin 2.4s linear infinite}
+@keyframes fask-swirl-spin{to{transform:rotate(-360deg)}}
+@media (prefers-reduced-motion: reduce){.fask-awaiting-swirl{animation:none}}

--- a/ui/webview/fleet.test.ts
+++ b/ui/webview/fleet.test.ts
@@ -305,3 +305,38 @@ test("an ARCHIVED node's zones deep-link too: fleetNode searches archivedTops, n
   assert.match(KERNEL, /"promptAnchorUuid": None if jd\.junk_quote\(nd\.get\("quote"\)\) else nd\.get\("promptUuid"\),/);
   assert.match(KERNEL, /"anchorUuid": nd\.get\("summaryAnchor"\),/);
 });
+
+// ── the pending-host strip (the user 2026-09-02) ─────────────────────────────────────────────────
+// After a kernel restart or a phone re-foreground, an attached host's sessions were simply ABSENT from
+// this pane for up to two minutes — no row, no cue — and read as wiped state. The feed merge names such
+// hosts (pendingHosts / pendingDead, riding the same feed message the ledgers do); this pane wears the
+// feed's own strip for them, and it leaves only on the merge's events. Source pins (no jsdom here).
+test("the fleet reads pendingHosts/pendingDead off the feed payload — the merge is the ONLY writer", () => {
+  assert.match(SRC, /pendingHosts = Array\.isArray\(m\.pendingHosts\) \? m\.pendingHosts\.filter\(\(h: any\) => typeof h === "string"\) : \[\];/);
+  assert.match(SRC, /pendingDead = Array\.isArray\(m\.pendingDead\) \? m\.pendingDead\.filter\(\(h: any\) => typeof h === "string"\) : \[\];/);
+  assert.doesNotMatch(SRC, /setTimeout\([^)]*pendingHosts/, "no timer ever edits the pending set");
+});
+
+test("one quiet line per pending host LEADS the list, the feed's copy family, swirl left of the text", () => {
+  assert.match(SRC, /if \(pendingHosts\.length\) list\.appendChild\(hostLoadStrip\(\)\);   \/\/ leads the list: what is still coming/);
+  assert.match(SRC, /strip\.id = "fleet-hostload";/);
+  assert.match(SRC, /const line = el\("div", "hostload-line"\);/);
+  assert.match(SRC, /const swirl = el\("span", "fask-awaiting-swirl"\);/);
+  assert.match(SRC, /"reconnecting to " \+ h \+ "\\u2026"/, "a dead link names itself (fail loudly)");
+  assert.match(SRC, /"loading sessions from " \+ h \+ "\\u2026"/, "an open link still waiting on its first payload");
+  assert.match(SRC, /line\.append\(swirl, txt\);/);
+  // the inbox-zero wordmark must not claim "every session is clear" while a host is still coming
+  assert.match(SRC, /\} else if \(!any && !pendingHosts\.length\) \{/);
+});
+
+test("the strip's styles live in the fleet's own sheet, mirroring feed.css — this page never loads feed.css", () => {
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "fleet-pane.css"), "utf8");
+  const FEEDCSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+  assert.match(CSS, /#fleet-hostload\{display:flex;flex-direction:column;gap:4px;padding:8px 14px\}/);
+  assert.match(CSS, /\.hostload-line\{display:flex;align-items:center;gap:7px;color:var\(--dim,#9a9a9a\);font-size:0\.82em\}/,
+    "same geometry + scale as feed.css's .hostload-line");
+  assert.match(CSS, /\.fask-awaiting-swirl\{width:14px;height:14px;flex:0 0 auto;background:url\(\.\.\/media\/romp-swirl-glyph\.svg\) center \/ contain no-repeat;\s*animation:fask-swirl-spin 2\.4s linear infinite\}/);
+  assert.match(CSS, /@keyframes fask-swirl-spin\{to\{transform:rotate\(-360deg\)\}\}/, "reverse spin, like every romp loader");
+  assert.match(FEEDCSS, /\.hostload-line \{ display: flex; align-items: center; gap: 7px; color: var\(--dim\); font-size: 0\.82em; \}/,
+    "the feed's rule this mirrors is still the reference");
+});

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -39,6 +39,14 @@ let sessions: FleetSession[] = [];
 // the page's romp loader (_pane_spin) stays up, exactly like the other panes, until real data arrives.
 let loaded = false;
 let emptyShown = false;   // the romp wordmark is currently showing → don't replay its fade-in every push
+// Attached hosts whose feed payload this pane has not merged yet (federation.ts pendingHosts, riding the
+// same feed message the ledgers do), and which of those sit on a dead link right now (pendingDead). The
+// user 2026-09-02: after a kernel restart or a phone re-foreground the remote hosts' sessions were
+// simply ABSENT from this pane for two minutes — no row, no cue — and read as wiped state. One quiet
+// line per pending host (the feed's own strip, mirrored) says they are coming; it leaves ONLY on that
+// host's first payload or its detach, the events the merge keys on — never a timer.
+let pendingHosts: string[] = [];
+let pendingDead: string[] = [];
 let searchQuery = "";     // #fleet-search filter (the user 2026-06-29): show only sessions whose NAME matches
 let fleetViews: SessionViews | null = null;   // the rendered views blob off the feed payload — the outline lens reads it (2026-08-25)
 let syncFleetTagBtn: (() => void) | null = null;   // re-dress the tag button per the shared convention on each render
@@ -349,6 +357,26 @@ function renderFleetNode(ctx: SessCtx, n: LedgerNode, depth: number, container: 
   if (expandable && !isFolded) for (const cid of n.children!) { const c = byId.get(cid); if (c) renderFleetNode(ctx, c, depth + 1, container, now, flat); }
 }
 
+// The per-host loading strip (the user 2026-09-02): the feed's #feed-hostload, worn here — one line per
+// pending host, the shared reverse-spin swirl LEFT of the text, at the top so it announces what is
+// COMING before the sessions already here. Non-interactive, so the per-render rebuild is click-safe.
+// The copy names a dead link honestly (fail loudly) instead of an open-ended "loading".
+function hostLoadStrip(): HTMLElement {
+  const strip = el("div", "");
+  strip.id = "fleet-hostload";
+  for (const h of pendingHosts) {
+    const line = el("div", "hostload-line");
+    const swirl = el("span", "fask-awaiting-swirl");
+    const txt = el("span", "");
+    txt.textContent = pendingDead.includes(h)
+      ? "reconnecting to " + h + "\u2026"
+      : "loading sessions from " + h + "\u2026";
+    line.append(swirl, txt);
+    strip.appendChild(line);
+  }
+  return strip;
+}
+
 function render() {
   syncFleetTagBtn?.();
   const list = document.getElementById("fleet-list");
@@ -359,6 +387,7 @@ function render() {
   // 2026-06-29). A WS drop / kernel restart re-shows that same loader (romp:wsdown), so a restart shows the
   // swirl, not "no tasks".
   if (!loaded) { emptyShown = false; return; }
+  if (pendingHosts.length) list.appendChild(hostLoadStrip());   // leads the list: what is still coming
   const sd = showDone();
   const grouped = isGrouped();
   curFoldMode = foldMode();   // snapshot the sticky Collapse/Expand mode once for this render
@@ -556,7 +585,7 @@ function render() {
     nr.textContent = "No results for “" + searchQuery.trim() + "”";
     list.appendChild(nr);
     emptyShown = false;
-  } else if (!any) {
+  } else if (!any && !pendingHosts.length) {
     // GENUINELY empty (data loaded, no open work): the romp tri-color WORDMARK, centered + faded in — the
     // same calm inbox-zero treatment as the feed (the user 2026-06-29). The fade plays ONCE on the
     // not-empty→empty transition (emptyShown guard), not on every push, since render() rebuilds each time.
@@ -641,6 +670,9 @@ window.addEventListener("message", (e: MessageEvent) => {
   // that as loaded would drop the loader onto an empty pane (the user 2026-06-29). Until ledgers land, keep the
   // loader up (render() bails, leaving the list empty so _pane_spin holds).
   if (m.views && typeof m.views === "object") fleetViews = m.views as SessionViews;   // rides the feed payload (2026-08-25)
+  // the attached-but-not-yet-merged hosts, from the merge itself (the ONLY writer; absent = none pending)
+  pendingHosts = Array.isArray(m.pendingHosts) ? m.pendingHosts.filter((h: any) => typeof h === "string") : [];
+  pendingDead = Array.isArray(m.pendingDead) ? m.pendingDead.filter((h: any) => typeof h === "string") : [];
   if (!Array.isArray(m.ledgers)) return;
   loaded = true;
   sessions = m.ledgers as FleetSession[];

--- a/vscode-extension/src/timeline-host-gap.test.ts
+++ b/vscode-extension/src/timeline-host-gap.test.ts
@@ -15,5 +15,8 @@ test("timeline lanes are uniform — no host-boundary offsets in any geometry pa
   assert.ok(TL.includes("const laneY = (i) => M.top + i * LANE_GAP + LANE_GAP * 0.5;"), "draw");
   assert.ok(TL.includes("const ly = this._geom.top + i * LANE_GAP + LANE_GAP / 2;"), "drag invert");
   assert.ok(TL.includes("const y = g.top + i * LANE_GAP + LANE_GAP * 0.5;"), "focus pulse");
-  assert.ok(TL.includes("const jb0 = M.top + vis.length * LANE_GAP + JB_TOPGAP;"), "judge band top");
+  // the band clears the pending-host placeholder rows too (2026-09-02) — a whole-band shift by a row
+  // COUNT, the same for every lane, never a per-host offset inside the lane list
+  assert.ok(TL.includes("const jb0 = M.top + (vis.length + pend.length) * LANE_GAP + JB_TOPGAP;"), "judge band top");
+  assert.ok(TL.includes("H = M.top + (Math.max(1, vis.length) + pend.length) * LANE_GAP + bandH + M.bottom;"), "svg height reserves those rows");
 });


### PR DESCRIPTION
## Reconnect UX: bound the relay sockets' silence, and show every surface which hosts are still coming

**User report (2026-09-02, from their phone, relayed by a peer session):** after kernel restarts, attached hosts' sessions vanished from the dashboard for about two minutes with no reconnecting cue, and it read as wiped state ("did romp lose my MacBook and devbox?").

### Mechanism (from the recorded client-diag + tunnel-dials trail, not guessed)
The kernel's ssh tunnels were up the whole window. The dashboard's relay sockets to the two hosts OPENED and then delivered nothing (dead on arrival, a re-foregrounded phone). The pane shim's LOCAL socket has a 30s keepalive watchdog; federation.ts's remote sockets had no liveness check at all, so nothing bounded time-to-first-payload until TCP gave up (close 1006 at ~104s). Meanwhile only the feed's per-host strip said anything: the Outline and Sessions panes simply lacked the hosts, and the network panel said "connected".

A second stall showed up in the served-page harness and in the same trail: `close()` on a dead socket starts a closing handshake nobody answers, and the browser holds CLOSING for ~60s before `onclose` fires. The phone's panes came back 64s after their own watchdog-close for exactly this reason.

### Change
1. **Relay sockets get the shim's watchdog, byte for byte** (`socketVerdict`, pure): open + silent 30s (the kernel's 10s `ka` rides the relay too) → abandon + dial now; connecting 15s → abort; closed 8s with no attempt → dial; foreground → redial a quiet or connecting socket at once. A `hostconn watchdog-close` breadcrumb lands in client-diag.
2. **Abandon, don't wait**, in both watchdogs (federation.ts and the pane shim): the dead socket's handlers are detached (its late `onclose` fires no second redial and no false wsdown), it is closed for hygiene, and a fresh socket is dialed in the same tick. Worst case goes from ~104s (or 35s + 60s) to ~35s.
3. **A placeholder per attached-but-not-yet-merged host on every surface**, keyed on the merge's events only (that host's first payload on the surface's channel, or its detach — no timers): the timeline merge names `pendingHosts`/`pendingDead` like the feed merge and `draw()` reserves a placeholder row per host (romp swirl + "loading sessions from <host>…" / "reconnecting to <host>…" on a dead link); the Outline pane wears the feed's per-host strip; each pane posts the hosts it still waits on to the shell (`{romp:'hostsPending'}`) and the network panel row says "connected · loading sessions…" instead of contradicting a blank board. A freshly attached host is pending from the attach event itself (the poll re-emits the merged payloads it can complete; the feed hold keeps an empty merged feed off a still-booting page).

Not touched: the tunnel supervisor, the kernel WS handlers, the chat tab strip (a placeholder tab would be a fake session; the rail/net panel carry the state there).

### Evidence
- Served-page harness (hermetic kernel + a fake attached host whose first socket per pane is dead on arrival): placeholders on Outline / Sessions / Feed and the network panel's loading mark at t+1s; `watchdog-close` + fresh open at t+35s; the host's first payload merged in the same second; placeholders and the panel mark gone. Desktop and phone-viewport shots attached to the ship mail.
- Executed tests: `federation-reconnect.test.ts` (verdict table; silence → abandon + crumb + fresh dial; foreground fast-path; lost-timer redial; detached/down never touched; pending set per channel; attach re-emit and its hold), `timeline-pending-hosts.test.ts` (placeholder row, dead copy, retire, stacking, `_vis` untouched, single-kernel geometry byte-identical), fleet pins, and an executed network-panel test delivering `hostsPending`. The shim's disconnect-banner pins and the timeline host-gap geometry pin move with the change, with the reason in each.
- Suites: `npm run typecheck` + `npm test` (2674 pass), full pytest (6538 pass) on the pushed head.

Deliberate deltas to call out: the pane shim's quiet-watchdog and visibility fast-path now redial immediately instead of waiting for `onclose` (same abandon path); the judge band shifts down by the pending-host row count (a whole-band shift, never a per-host offset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
