### PR TITLE
The live subagent count retires failed agents: the CLI's stop hook only fires for clean finishes

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3621,7 +3621,9 @@ class SdkSession:
                                                             len(died), "" if len(died) == 1 else "s", reason))
             self.backend._poke()
 
-    _RECONNECT_CAUSE = "a settings switch restarted it"   # the death notice's cause on a reconnect
+    _RECONNECT_CAUSE = "its process was restarted by a settings switch or a rewind"   # the death notice's cause on
+    #   a reconnect: every trigger of the reconnect loop (effort/fast/auth/mode switches, edit-message rewinds and
+    #   rollbacks) is named truthfully — the loop cannot tell them apart here, so the notice names the family
 
     _WF_AGENT_ENDED = frozenset(("done", "error"))
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1054,20 +1054,21 @@ def is_launch_limit(text: str) -> bool:
     return bool(text and _LAUNCH_LIMIT_RE.search(text))
 
 
-def task_death_notice(tasks: list) -> str:
+def task_death_notice(tasks: list, cause: str = "a restart or crash") -> str:
     """The visible romp notice for BACKGROUND TASKS that died with their claude process. Bg tasks are
     the CLI's children, so a kernel restart or CLI crash silently kills a session's timers/watchers —
     and a session idle-waiting on one would wait FOREVER for a completion notification that can never
     arrive (nimbus's dead campaign watcher, the user 2026-07-11). The notice names what was lost (the
     task descriptions from the lifecycle stream) so the session can relaunch exactly what still
-    matters. Enqueued by _on_session_gone (CLI died, kernel alive) or the boot reconcile (kernel died;
-    read from the reg's bgTasks mirror)."""
+    matters. Enqueued by _on_session_gone (CLI died, kernel alive), the boot reconcile (kernel died;
+    read from the reg's bgTasks mirror), and _drop_live_work (a settings switch reconnected the CLI —
+    `cause` names that, so the session is told the truth about why its work vanished)."""
     n = len(tasks)
     descs = "; ".join(d for d in ((t.get("desc") or "").strip() for t in tasks[:4]) if d)
     return ("<!-- romp-injected --><!-- romp-system -->[romp] %d background task%s this session had "
-            "running died with its claude process (a restart or crash)%s. Their completion "
+            "running died with its claude process (%s)%s. Their completion "
             "notifications will never arrive — relaunch any that are still needed, or carry on if "
-            "they aren't." % (n, "" if n == 1 else "s", (": " + descs) if descs else ""))
+            "they aren't." % (n, "" if n == 1 else "s", cause, (": " + descs) if descs else ""))
 
 # The marker only SDK-driven claude CLIs carry (the kernel drives them over stdin); a tmux session's
 # interactive `claude --resume` never has it, so the orphan reap can never touch a tmux CLI.
@@ -1686,9 +1687,11 @@ class SdkSession:
         self.retry_info = None                        # the CURRENT storm's latest api_retry detail (attempt/max, error status+message, next-attempt epoch) → the chat retrying element's extra context (the user 2026-07-10); lives and dies with `retrying`
         self._interrupted = False                    # user interrupted the in-flight turn → snapshot reads 'waiting' (display only; inflight stays event-driven)
         self._intr_level = 0                         # interrupt escalation rung this episode (interrupt_action); reset on settle / fresh turn
-        self._subagents: dict[str, dict] = {}        # LIVE Task-spawned subagents: agent_id -> {"type","since"}. Fed
-        #   by the SubagentStart/SubagentStop hooks — the exact, event-based "what's running right now" signal the
-        #   tmux backend never had. Keeps the session 'working' while any run and surfaces a live count on the lane.
+        self._subagents: dict[str, dict] = {}        # LIVE subagents (Task/Agent AND Workflow-run agents): agent_id ->
+        #   {"type","since"}. Fed by the SubagentStart hook — the exact, event-based "what's running right now"
+        #   signal the tmux backend never had; drained by SubagentStop, a Workflow run's per-agent progress list,
+        #   the agent's own task end, and the client teardown (see _reconcile_workflow_agents / _drop_live_work).
+        #   Keeps the session 'working' while any run and surfaces a live count on the lane.
         self._bg_tasks: dict[str, dict] = {}         # LIVE background tasks (a run_in_background Bash, a bg agent):
         #   task_id -> {"desc","type","since","toolUseId","lastTool"}. Fed by the CLI's DESIGNED task lifecycle
         #   stream (system/task_started..task_updated — see _on_message), terminal statuses clear — so an idle
@@ -1696,6 +1699,12 @@ class SdkSession:
         #   2026-07-11: nimbus's 20-minute campaign timer). Replaces transcript-scrape liveness for SDK sessions.
         self._sub_lock = threading.Lock()            #   hooks mutate on the loop thread; snapshot() reads from the kernel thread
         #                                                (guards _subagents AND _bg_tasks)
+        self._wf_agents: dict[str, set] = {}         # LIVE Workflow runs: task_id -> the agent ids its progress
+        #   lists have named (the roster). The CLI fires SubagentStart for every workflow agent but SubagentStop
+        #   ONLY for the ones that finish cleanly (probe-verified on CLI 2.1.257, 2026-09-02: a failed agent
+        #   leaves no stop hook), so a run's own per-agent list is what retires the rest — _reconcile_workflow_agents.
+        self._wf_slots: dict[str, dict] = {}         # task_id -> {slot index: the agent id it last held}: a retried
+        #   slot is re-minted with a NEW id, and the displaced id is over the moment the slot changes hands
         self.chosen_model = reg.get("model") or ""   # the alias the user picked (opus/sonnet/…); self.model is the display name
         self._model_pending = ""                     # target ALIAS while a /model switch is resolving: the badge shows
         #   animated dots until the LIVE model actually reflects the pick (the user 2026-07-03: a switch stamped the
@@ -2412,6 +2421,9 @@ class SdkSession:
             self._wake.clear()
             self._reconnect = False
             self._ping_feeding = False   # a reconnect restarts the feed — a stale hold must not wedge it
+            # the abandoned client's live subagents and background tasks died with it — retire them on
+            # the teardown event itself (and tell the session what it lost, as a CLI death does)
+            self._drop_live_work("reconnect")
             # settle + recover anything the abandoned client stranded — see _reconcile_stranded
             self._reconcile_stranded()
             opts = self.backend._options(self, ClaudeAgentOptions)
@@ -3547,9 +3559,10 @@ class SdkSession:
         return {}
 
     async def _subagent_start_hook(self, inp, tool_use_id, context):
-        """A Task-spawned subagent just STARTED. Record it live (agent_id -> type + start time) so the session
-        reads 'working' while it runs and the lane can show how many are in flight. The SDK's SubagentStart
-        hook input carries agent_id + agent_type. Best-effort; never raises inside the hook."""
+        """A subagent just STARTED — a Task/Agent one or a Workflow run's (agent_type "workflow-subagent").
+        Record it live (agent_id -> type + start time) so the session reads 'working' while it runs and the
+        lane can show how many are in flight. The SDK's SubagentStart hook input carries agent_id +
+        agent_type. Best-effort; never raises inside the hook."""
         aid = inp.get("agent_id") if isinstance(inp, dict) else None
         if aid:
             with self._sub_lock:
@@ -3558,9 +3571,11 @@ class SdkSession:
         return {}
 
     async def _subagent_stop_hook(self, inp, tool_use_id, context):
-        """A Task-spawned subagent FINISHED — drop it from the live set (SubagentStop carries the same agent_id).
-        When the last one clears, the session falls back to its real state (working if the main turn is still in
-        flight, else idle)."""
+        """A subagent FINISHED CLEANLY — drop it from the live set (SubagentStop carries the same agent_id).
+        The CLI fires this only for clean finishes; a failed agent's end arrives through its run's progress
+        list or its own task end instead (see _reconcile_workflow_agents / _on_task_event). When the last
+        one clears, the session falls back to its real state (working if the main turn is still in flight,
+        else idle)."""
         aid = inp.get("agent_id") if isinstance(inp, dict) else None
         if aid:
             with self._sub_lock:
@@ -3574,6 +3589,92 @@ class SdkSession:
         with self._sub_lock:
             return sorted((dict(v) for v in self._subagents.values()), key=lambda d: d.get("since") or 0)
 
+    def _drop_live_work(self, reason: str):
+        """The CLI process is gone — a reconnect (an effort/fast/auth switch) abandons the old client — so
+        the live work INSIDE it is gone too: forget every subagent (and every run's roster and slots), and
+        retire every lifecycle background task, telling the session which ones it lost the way
+        _on_session_gone does when a CLI dies under a live kernel (their completion notifications can
+        never arrive on the new connection; a session idle-waiting on one would wait forever) — with the
+        cause named truthfully. Event-based on the teardown itself, not on age. Left alone on purpose:
+        the launch ledger (reg bgLedger), which the next Stop hook reconciles as before. Logged when it
+        actually dropped something, so a stale count that healed here stays visible."""
+        with self._sub_lock:
+            n = len(self._subagents)
+            self._subagents.clear()
+            self._wf_agents.clear()
+            self._wf_slots.clear()
+            died = sorted((dict(v) for v in self._bg_tasks.values()), key=lambda d: d.get("since") or 0)
+            self._bg_tasks.clear()
+        if died:
+            note = task_death_notice(died, cause=self._RECONNECT_CAUSE)
+            with self._lock:
+                if note not in self._pending:      # a flapping reconnect must not stack the same notice
+                    self._pending.append(note)
+            self._persist_queue()
+            try:
+                self.backend._update_reg(self.sid, bgTasks=[])   # reported — never re-notify these deaths
+            except Exception as e:
+                self.backend._log("live work (%s): bgTasks mirror clear failed: %s" % (self.name, e))
+        if n or died:
+            self.backend._log("live work (%s): dropped %d subagent%s and %d background task%s on %s — they ran "
+                              "inside the abandoned CLI" % (self.name, n, "" if n == 1 else "s",
+                                                            len(died), "" if len(died) == 1 else "s", reason))
+            self.backend._poke()
+
+    _RECONNECT_CAUSE = "a settings switch restarted it"   # the death notice's cause on a reconnect
+
+    _WF_AGENT_ENDED = frozenset(("done", "error"))
+
+    def _reconcile_workflow_agents(self, tid: str, progress, terminal: bool):
+        """Retire the live workflow-subagent entries the Workflow run `tid` has finished with, from the run's
+        OWN per-agent progress list — the `workflow_progress` the CLI ships on the run's task_progress
+        events: one slot per agent (`index`, `agentId`, `state`), updated in place from start → progress →
+        done/error and never capped (only the run's log lines are trimmed), the full list re-sent on every
+        state change. Called on the run's task-stream events, never a timer.
+
+        Why not the stop hook alone: the CLI fires SubagentStart for every workflow agent but SubagentStop
+        only for the ones that finish CLEANLY (probe-verified on 2.1.257, 2026-09-02: a run with one agent
+        on a nonexistent model got one stop hook; the failed agent's slot read state "error" and nothing
+        else). Left to the hooks the live set only grows — three sessions carried 192, 37 and 10 stale
+        entries, each EXACTLY the number of agents its runs recorded as failed, and read Working with
+        "37 subagents" for hours (the user 2026-09-02).
+
+        Three exact ends: a slot's done/error state; a slot re-minted with a NEW agent id (a retried
+        attempt — the displaced id is over the moment the slot changes hands); and the run's END, which
+        ends every agent it ever listed whatever state it last showed. An agent NO run has listed is left
+        alone on purpose: retiring it because "no run is live any more" would infer its death from the
+        absence of something else rather than from an event about the agent, and every retirement here
+        keys on an exact event (an earlier draft had that inference; review 2026-09-02). Such an agent
+        ends on its own stop hook, its task's end, or the client teardown."""
+        ended = set()
+        with self._sub_lock:
+            seen = self._wf_agents.setdefault(tid, set())
+            slots = self._wf_slots.setdefault(tid, {})
+            for e in (progress if isinstance(progress, list) else []):
+                if not isinstance(e, dict) or e.get("type") != "workflow_agent":
+                    continue
+                aid = str(e.get("agentId") or "")
+                if not aid:
+                    continue
+                seen.add(aid)
+                idx = e.get("index")
+                if isinstance(idx, int):
+                    prev = slots.get(idx)
+                    if prev and prev != aid:
+                        ended.add(prev)          # the slot was re-minted — its previous attempt is over
+                    slots[idx] = aid
+                if e.get("state") in self._WF_AGENT_ENDED:
+                    ended.add(aid)
+            drop = [a for a in ended if a in self._subagents]
+            if terminal:
+                drop += [a for a in seen if a in self._subagents and a not in ended]
+                self._wf_agents.pop(tid, None)
+                self._wf_slots.pop(tid, None)
+            for a in drop:
+                self._subagents.pop(a, None)
+        if drop:
+            self.backend._poke()
+
     # ---- background-task tracking (the CLI's task lifecycle stream) ----
 
     _TERMINAL_TASK = frozenset(("killed", "failed", "stopped", "completed"))
@@ -3582,11 +3683,20 @@ class SdkSession:
         """One system/task_* lifecycle message → the live _bg_tasks set. task_started adds; task_progress
         refreshes (and SELF-HEALS an unknown id — a backend that attached mid-task still converges);
         task_notification always ends its task; task_updated ends it only on a terminal patch.status.
-        Pokes a push only when the set actually changed, so progress chatter stays cheap."""
+        Pokes a push only when the set actually changed, so progress chatter stays cheap.
+
+        Two live-subagent retirements ride the same stream (2026-09-02), for the agents whose
+        SubagentStop never comes (a failed agent leaves none — see _reconcile_workflow_agents): a
+        Task/Agent subagent's lifecycle task carries the AGENT ID as its task_id (probe-verified on
+        2.1.257), so the task's end is the agent's end; and a Workflow run's progress events carry its
+        per-agent list, its end the roster's end."""
         tid = str(d.get("task_id") or "")
         if not tid:
             return
         changed = False
+        ended = False            # this event ENDED the task (a notification, or a terminal patch status)
+        wf = False               # the task is a Workflow run — its agents report through its progress list
+        sub_changed = False
         with self._sub_lock:
             if subtype in ("task_started", "task_progress"):
                 entry = self._bg_tasks.get(tid)
@@ -3599,11 +3709,25 @@ class SdkSession:
                     entry["desc"] = str(d.get("description"))
                 if d.get("last_tool_name"):
                     entry["lastTool"] = str(d.get("last_tool_name"))
+                if isinstance(d.get("workflow_progress"), list) and not entry.get("type"):
+                    # only a Workflow run ships a per-agent list; a self-healed entry (no task_started seen)
+                    # learns its type from it, so the run's later events reach _reconcile_workflow_agents
+                    entry["type"] = "local_workflow"
+                wf = entry.get("type") == "local_workflow" or tid in self._wf_agents
             else:
                 status = (d.get("status") if subtype == "task_notification"
                           else (d.get("patch") or {}).get("status") if isinstance(d.get("patch"), dict) else None)
                 if subtype == "task_notification" or (isinstance(status, str) and status in self._TERMINAL_TASK):
-                    changed = self._bg_tasks.pop(tid, None) is not None
+                    gone = self._bg_tasks.pop(tid, None)
+                    changed = gone is not None
+                    ended = True
+                    wf = (gone or {}).get("type") == "local_workflow" or tid in self._wf_agents
+            if ended and self._subagents.pop(tid, None) is not None:
+                sub_changed = True   # a Task agent's own task ended — with or without its SubagentStop
+        if wf and (ended or isinstance(d.get("workflow_progress"), list)):
+            # pokes when it retires anything; a progress event without the list (a throttled
+            # pure-progress tick) carries no agent states and is skipped
+            self._reconcile_workflow_agents(tid, d.get("workflow_progress"), terminal=ended)
         if changed:
             # MIRROR the live set to the reg: bg tasks die with the CLI, and the in-memory set dies with
             # the backend — the persisted mirror is what lets a later boot's reconcile tell the session
@@ -3615,6 +3739,7 @@ class SdkSession:
                 self.backend._update_reg(self.sid, bgTasks=self._live_bg_tasks())
             except Exception as e:
                 self.backend._log("background tasks (%s): registry mirror write failed: %s" % (self.name, e))
+        if changed or sub_changed:
             self.backend._poke()
 
     def request_stop_task(self, tool_use_id: str) -> bool:

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -3197,5 +3197,199 @@ class PushSessionCallback(unittest.TestCase):
                         "the failure is reported, not swallowed: %r" % logs)
 
 
+class LiveSubagentsRetire(unittest.TestCase):
+    """The lane's live subagent count only ever GREW (the user 2026-09-02, whose session read Working with
+    37 subagents for hours). The CLI fires SubagentStart for every workflow agent but SubagentStop only
+    for the ones that finish cleanly (probe-verified on CLI 2.1.257: a run with one agent on a nonexistent
+    model got one stop hook; the failed agent's slot in the run's `workflow_progress` list read state
+    "error" and nothing else), so the set is retired on the events that DO arrive: a run's per-agent
+    progress list (an end state, or a slot re-minted for a retry), the run's end, a Task agent's own
+    task end (its task_id IS the agent id), and the client teardown. Every id and uuid here is synthetic."""
+
+    SID = "11111111-2222-3333-4444-666666666666"
+
+    def _sess(self):
+        self.logs, self.pokes = [], []
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=self.logs.append,
+                           poke=lambda: self.pokes.append(1))
+        s = sb.SdkSession(be, {"sid": self.SID, "name": "web", "cwd": "/tmp"})
+        s.inflight = 0                                          # the main turn is idle throughout
+        return s
+
+    def _start(self, s, aid, kind="workflow-subagent"):
+        import asyncio
+        asyncio.run(s._subagent_start_hook({"agent_id": aid, "agent_type": kind}, None, None))
+
+    @staticmethod
+    def _wf(index, aid, state, label="reader"):
+        e = {"type": "workflow_agent", "index": index, "label": label, "state": state, "queuedAt": 1}
+        if aid:
+            e["agentId"] = aid
+            e["startedAt"] = 2
+        return e
+
+    def test_a_failed_workflow_agent_retires_on_the_runs_progress_list(self):
+        """The shape the probe recorded: the run's task_progress re-ships the whole per-agent list on every
+        state change; the failed agent's slot flips to "error" with no SubagentStop ever following."""
+        s = self._sess()
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow", "description": "review"})
+        self._start(s, "a1"); self._start(s, "a2")
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [
+            self._wf(1, "a1", "start"), self._wf(2, "a2", "start"), self._wf(3, None, "start")]})   # 3rd still queued
+        self.assertEqual(set(s._subagents), {"a1", "a2"}, "start states retire nothing")
+        self.assertEqual(s.snapshot()["state"], "working", "live agents keep the session working")
+        n0 = len(self.pokes)
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [
+            self._wf(1, "a1", "progress"), self._wf(2, "a2", "error"), self._wf(3, None, "start")]})
+        self.assertEqual(set(s._subagents), {"a1"}, "the failed agent retires on its error state — no stop hook came")
+        self.assertGreater(len(self.pokes), n0, "the retirement pushes a build now, not at the backstop")
+        n1 = len(self.pokes)
+        s._on_task_event("task_progress", {"task_id": "w1"})   # a throttled tick without the list changes nothing
+        self.assertEqual(set(s._subagents), {"a1"})
+        self.assertEqual(len(self.pokes), n1, "…and a tick that changed nothing pushes nothing")
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [
+            self._wf(1, "a1", "done"), self._wf(2, "a2", "error")]})
+        self.assertEqual(s._subagents, {}, "a done state retires too (its stop hook would only be a no-op)")
+        self.assertEqual(s.snapshot()["state"], "waiting", "and the session idles once the set empties")
+
+    def test_b_the_runs_end_retires_every_agent_it_listed(self):
+        """A run's end is the end of everything it ever listed, whatever state the slot last showed."""
+        s = self._sess()
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow"})
+        self._start(s, "a1"); self._start(s, "a2")
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [
+            self._wf(1, "a1", "start"), self._wf(2, "a2", "progress")]})
+        s._on_task_event("task_notification", {"task_id": "w1", "status": "completed"})
+        self.assertEqual(s._subagents, {}, "both listed agents retire at the run's end")
+        self.assertNotIn("w1", s._wf_agents, "the run's roster is dropped with it")
+        self.assertEqual(s.snapshot()["state"], "waiting")
+
+    def test_c_an_agent_no_run_listed_is_never_inferred_dead(self):
+        """Every retirement keys on an event about the agent. An agent no run has listed yet is NOT retired
+        because some other run ended and "no run is live any more" — that is inference from absence, and an
+        earlier draft that did it would have retired a live agent had the events ever landed in this order
+        (review 2026-09-02). It stays until its own end arrives: here its run's list naming it done."""
+        s = self._sess()
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow"})
+        self._start(s, "b1")                                    # w2's first agent — its task_started still queued
+        s._on_task_event("task_notification", {"task_id": "w1", "status": "completed"})
+        self.assertEqual(set(s._subagents), {"b1"}, "w1's end says nothing about an agent w1 never listed")
+        self.assertEqual(s.snapshot()["state"], "working", "the live agent still holds the session working")
+        s._on_task_event("task_started", {"task_id": "w2", "task_type": "local_workflow"})
+        s._on_task_event("task_progress", {"task_id": "w2", "workflow_progress": [self._wf(1, "b1", "done")]})
+        self.assertEqual(s._subagents, {}, "its own run's list is what ends it")
+
+    def test_c2_a_retried_slot_ends_the_attempt_it_displaced(self):
+        """A retried workflow agent is re-minted with a NEW id in the SAME slot; the first attempt got a
+        SubagentStart and nothing else, so the slot changing hands is its end."""
+        s = self._sess()
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow"})
+        self._start(s, "a1")
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [self._wf(1, "a1", "start")]})
+        self._start(s, "a1r")                                   # the retry, same slot
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [self._wf(1, "a1r", "start")]})
+        self.assertEqual(set(s._subagents), {"a1r"}, "the displaced attempt is over; the retry is live")
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [self._wf(1, "a1r", "done")]})
+        self.assertEqual(s._subagents, {})
+        s._on_task_event("task_notification", {"task_id": "w1", "status": "completed"})
+        self.assertNotIn("w1", s._wf_slots, "the run's slots are dropped with it")
+
+    def test_d_a_task_agents_own_task_end_retires_it(self):
+        """A Task/Agent subagent's lifecycle task carries the agent id as its task_id (probe-verified), so
+        the task ending — here as a failure, which leaves no SubagentStop — retires the agent."""
+        s = self._sess()
+        self._start(s, "t1", "general-purpose")
+        s._on_task_event("task_started", {"task_id": "t1", "task_type": "local_agent", "subagent_type": "general-purpose"})
+        self.assertEqual(s.snapshot()["state"], "working")
+        s._on_task_event("task_notification", {"task_id": "t1", "status": "failed"})
+        self.assertEqual(s._subagents, {}, "the task's end is the agent's end")
+        self.assertEqual(s._bg_tasks, {}, "the task itself cleared as before")
+        self.assertEqual(s.snapshot()["state"], "waiting")
+
+    def test_e_a_task_agents_progress_never_touches_the_workflow_path(self):
+        """A local_agent task's progress is not a workflow list; nothing retires and nothing raises."""
+        s = self._sess()
+        self._start(s, "t1", "Explore")
+        s._on_task_event("task_started", {"task_id": "t1", "task_type": "local_agent"})
+        s._on_task_event("task_progress", {"task_id": "t1", "last_tool_name": "Read"})
+        self.assertEqual(set(s._subagents), {"t1"})
+        self.assertEqual(s._wf_agents, {}, "no roster is minted for a non-workflow task")
+
+    def test_f_the_client_teardown_drops_the_abandoned_clients_agents_and_tasks(self):
+        """A reconnect abandons the CLI process the agents and background tasks ran inside: they died with
+        it and their hooks/notifications can never arrive, so the loop top forgets the agents, retires the
+        tasks, queues the same death notice a CLI death does (once), clears the reg mirror, and logs."""
+        s = self._sess()
+        sb.write_reg(s.backend.state_dir, self.SID, {"sid": self.SID, "name": "web", "cwd": "/tmp", "alive": True})
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow", "description": "review sweep"})
+        s._on_task_event("task_started", {"task_id": "b1", "task_type": "local_bash", "description": "watch the build"})
+        self._start(s, "a1"); self._start(s, "a2")
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [self._wf(1, "a1", "start")]})
+        self.assertEqual(s.snapshot()["state"], "working")
+        s._drop_live_work("reconnect")
+        self.assertEqual(s._subagents, {})
+        self.assertEqual(s._wf_agents, {})
+        self.assertEqual(s._wf_slots, {})
+        self.assertEqual(s._bg_tasks, {}, "the tasks died with the CLI too — their notifications can never arrive")
+        self.assertEqual(s.snapshot()["state"], "waiting")
+        self.assertEqual(s.snapshot()["bgTasks"], [])
+        notes = [q for q in s.pending() if "background task" in q]
+        self.assertEqual(len(notes), 1, "the session is told what it lost: %r" % s.pending())
+        self.assertEqual(notes[0], sb.task_death_notice([{"desc": "review sweep"}, {"desc": "watch the build"}],
+                                                        cause=sb.SdkSession._RECONNECT_CAUSE),
+                         "the very copy the session reads, with the cause named truthfully")
+        self.assertIn("settings switch", notes[0])
+        self.assertNotIn("crash", notes[0], "a reconnect is neither a crash nor an unexplained restart")
+        self.assertEqual(sb.read_reg(s.backend.state_dir, self.SID).get("bgTasks"), [], "mirror cleared: reported once")
+        self.assertTrue(any("dropped 2 subagents and 2 background tasks on reconnect" in str(m) for m in self.logs), self.logs)
+        self.logs.clear()
+        s._drop_live_work("reconnect")
+        self.assertFalse(self.logs, "an empty set drops silently — the first connect is not an event worth a line")
+        self.assertEqual(len([q for q in s.pending() if "background task" in q]), 1, "no second notice for nothing")
+
+    def test_f2_a_flapping_reconnect_does_not_stack_the_same_notice(self):
+        s = self._sess()
+        for _ in range(2):
+            s._on_task_event("task_started", {"task_id": "b1", "task_type": "local_bash", "description": "watch"})
+            s._drop_live_work("reconnect")
+        self.assertEqual(len([q for q in s.pending() if "background task" in q]), 1, s.pending())
+
+    def test_g_the_reconnect_loop_top_calls_the_drop_before_reconciling(self):
+        """Pin the wiring: the drop runs at the loop top, before _reconcile_stranded, every iteration."""
+        src = open(os.path.join(BIN, "romp_sdk_backend.py"), encoding="utf-8").read()
+        i = src.index('self._drop_live_work("reconnect")')
+        j = src.index("self._reconcile_stranded()")
+        self.assertLess(i, j, "the drop precedes the stranded-turn reconcile at the loop top")
+        k = src.rfind("while not self.ended:", 0, i)
+        self.assertGreater(k, 0)
+        self.assertNotIn("async with ClaudeSDKClient", src[k:i], "…inside the reconnect loop, before the connect")
+
+    def test_i_a_run_seen_only_through_its_progress_list_still_retires(self):
+        """A backend that attached mid-run never saw the run's task_started (the self-heal path); the
+        per-agent list is shipped only by Workflow runs, so its presence types the entry and the run's
+        error states and end retire its agents like any other."""
+        s = self._sess()
+        self._start(s, "a1"); self._start(s, "a2")
+        s._on_task_event("task_progress", {"task_id": "w7", "workflow_progress": [
+            self._wf(1, "a1", "error"), self._wf(2, "a2", "progress")]})
+        self.assertEqual(s._bg_tasks["w7"]["type"], "local_workflow", "the entry learned what it is from the list")
+        self.assertEqual(set(s._subagents), {"a2"}, "the failed agent retired on the first list seen")
+        s._on_task_event("task_notification", {"task_id": "w7", "status": "completed"})
+        self.assertEqual(s._subagents, {}, "the run's end retires the rest")
+
+    def test_h_a_clean_stop_hook_still_retires_exactly_its_own_agent(self):
+        """The designed path is untouched: a SubagentStop retires its agent and no other, and a later
+        progress list naming it as done is a harmless no-op."""
+        import asyncio
+        s = self._sess()
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow"})
+        self._start(s, "a1"); self._start(s, "a2")
+        asyncio.run(s._subagent_stop_hook({"agent_id": "a1", "agent_type": "workflow-subagent"}, None, None))
+        self.assertEqual(set(s._subagents), {"a2"})
+        s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [
+            self._wf(1, "a1", "done"), self._wf(2, "a2", "progress")]})
+        self.assertEqual(set(s._subagents), {"a2"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What you saw

The timeline's working badge read things like `Working · 37 subagents` on sessions with nothing running, and those sessions stayed "working" forever. The number only ever went up.

## Why

The SDK backend keeps a per-session set of live subagents, filled by the CLI's `SubagentStart` hook and emptied only by `SubagentStop`. Claude CLI 2.1.257 fires `SubagentStop` **only for agents that finish cleanly**. A workflow agent that fails leaves a start and nothing else.

Two independent measurements agree:

- On a live kernel, every stale entry was a workflow agent and every one was hours old. Counting the `failed` rows in each session's workflow journals gave the same numbers exactly: three sessions carried 192, 37 and 10 stale entries against 192, 37 and 10 failed agents.
- A standalone SDK probe reproduced it on demand: a two-agent workflow with one agent on a nonexistent model produced two start hooks, one stop hook, and a `state: "error"` slot for the failed agent in the run's own progress list.

## What changes

Entries are retired on events that do arrive, never on age or inference:

- A Workflow run's `task_progress` carries `workflow_progress`: one slot per agent with its latest state, never capped (only the run's log lines are trimmed), the full list re-sent on every state change. A `done`/`error` state retires the agent, and a slot re-minted with a new id for a retry ends the attempt it displaced.
- The run's end retires everything it ever listed.
- A Task/Agent subagent's lifecycle task carries the agent id as its `task_id`, so the task ending (failed or not) is the agent's end.
- The reconnect-loop teardown drops the abandoned CLI's agents and lifecycle tasks together, queuing the existing death notice with the cause named truthfully (a settings switch, not a crash).

An agent no run has listed is deliberately left alone rather than retired because "no run is live any more": that would infer death from the absence of something else instead of an event about the agent. It ends on its own stop hook, its task's end, or the teardown.

## Tests and verification

- `LiveSubagentsRetire` in `tests/test_sdk_backend.py` (11 tests), payload shapes taken from the probe recordings, synthetic ids only.
- Full Python suite and the node suite green on the branch.
- The recorded probe streams replayed through the patched session end at zero live agents, with the failed agent retired at the moment the CLI reported it.
- An adversarial review pass (three lenses, two refuters per finding) produced eleven findings; all were either folded into this branch or shown to describe pre-existing behaviour.

## Not in this PR

- A stale `_bg_tasks` entry can still be re-created by a `task_progress` that arrives for an already-ended task (pre-existing self-heal behaviour, untouched).
- The CLI also emits a `background_tasks_changed` level signal with replace semantics; consuming it as the task-set authority would remove the need for that self-heal. Left for a separate change.
- The launch ledger is not tombstoned on a reconnect (pre-existing; the next Stop hook reconciles it as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)