### PR TITLE
Codex session backend: run OpenAI Codex agents beside Claude Code sessions

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# romp — direct a fleet of Claude Code sessions; the dashboard is the front door
+# romp — direct your Claude Code and Codex sessions; the dashboard is the front door
 #
 # Usage (see `romp help`):
 #   romp                     # open the dashboard in your browser
@@ -624,12 +624,13 @@ if [[ "${1:-}" == "help" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
         printf '  %-28s %s\n' "$inv" "$*"
     }
     cat <<'EOF'
-romp — direct a fleet of Claude Code sessions; the dashboard is the front door
+romp — direct your Claude Code and Codex sessions; the dashboard is the front door
 
 Usage:
 EOF
     _romp_cmd "romp"                       -            "Open the dashboard in your browser (prints the link too)"
-    _romp_cmd "romp new <name>"            -            "Start a session (SDK; lives in the kernel, watch it on the dashboard)"
+    _romp_cmd "romp new <name>"            -            "Start a session (SDK by default; \`romp engine\` sets the machine default)"
+    _romp_cmd "romp new --codex <name>"    -            "Start it as an OpenAI Codex session (docs/codex.md)"
     _romp_cmd "romp new -t <name>"         -            "Start it as a terminal (tmux) session and attach (--detach: don't attach)"
     _romp_cmd "romp new -d <dir> <name>"   -            "Working directory for the new session (default: the current folder)"
     _romp_cmd "romp new -m <text> <name>"  -            "Start it AND deliver <text> as its first prompt (one command, idea to working)"
@@ -667,6 +668,7 @@ EOF
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
     _romp_cmd "romp end <session>"         -            "End a session"
     _romp_cmd "romp checkin <host>"        -            "Publish this machine to an attached hub (romp checkout withdraws)"
+    _romp_cmd "romp engine claude|codex"   -            "One switch: which vendor runs the judges + what new sessions default to"
     _romp_cmd "romp default-dir [PATH]"    -            "Default working dir for new sessions (no arg prints; \"\" clears)"
     _romp_cmd "romp debug [on|off|status]" -            "Judge debug mode (rejection rows carry full input+reply)"
     exit 0
@@ -1518,6 +1520,53 @@ fi
 # access rides tailnet device auth + TLS rather than a token in a URL.
 # See docs/guide.md#from-your-phone.
 
+# ── romp engine [claude|codex|status]: one switch for the machine's vendor posture ──────────────
+# Sets BOTH knobs together (docs/codex.md): which harness the JUDGES call (STATE/judge-engine —
+# read live per call, no restart) and which backend a NEW session defaults to
+# (STATE/default-backend — honored by `romp new` and the kernel's POST /new; the dashboard's
+# + dialog keeps its own per-create toggle). Running sessions are never touched.
+if [[ "${1:-}" == "engine" ]]; then
+    shift
+    _eng_state="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"
+    case "${1:-status}" in
+        claude)
+            mkdir -p "$_eng_state"
+            printf 'claude\n' > "$_eng_state/judge-engine"
+            printf 'sdk\n'    > "$_eng_state/default-backend"
+            if ! command -v claude >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/claude" ]; then
+                echo "[romp] note: no claude binary found — install Claude Code and sign in, or judges + new sessions will fail loudly" >&2
+            fi
+            echo "[romp] engine CLAUDE — judges run on Claude; new sessions default to the Claude Agent SDK"
+            echo "[romp] running sessions are unaffected; judges pick this up on their next call" ;;
+        codex)
+            mkdir -p "$_eng_state"
+            printf 'codex\n' > "$_eng_state/judge-engine"
+            printf 'codex\n' > "$_eng_state/default-backend"
+            _cx="$(command -v codex 2>/dev/null || true)"
+            [ -z "$_cx" ] && [ -x "$HOME/.local/bin/codex" ] && _cx="$HOME/.local/bin/codex"
+            # the bundled binary lives INSIDE codexvenv (no PATH entry point) — ccodex-setup links
+            # it out, but probe the venv too so this note never cries wolf on a bundled-only box
+            [ -z "$_cx" ] && _cx="$(ls -d "$_eng_state"/codexvenv/lib/python3.*/site-packages/codex_cli_bin/bin/codex 2>/dev/null | head -n1 || true)"
+            if [ -z "$_cx" ] || [ ! -x "$_cx" ]; then
+                echo "[romp] note: no codex binary found — run ccodex-setup, then: codex login" >&2
+            elif ! "$_cx" login status 2>&1 | grep -qi '^logged in'; then   # the status goes to STDERR; "Not logged in" must not match
+                echo "[romp] note: codex isn't logged in — run: codex login (or codex login --device-auth)" >&2
+            fi
+            echo "[romp] engine CODEX — judges run on Codex; new sessions default to the Codex backend"
+            echo "[romp] running sessions are unaffected; judges pick this up on their next call" ;;
+        status)
+            # `|| true`: an absent file under set -euo pipefail otherwise kills the script
+            # mid-substitution, printing nothing at all
+            _je="$(cat "$_eng_state/judge-engine" 2>/dev/null | tr -d '[:space:]' || true)"
+            _db="$(cat "$_eng_state/default-backend" 2>/dev/null | tr -d '[:space:]' || true)"
+            echo "judges:               ${_je:-claude}"
+            echo "new-session default:  ${_db:-sdk}" ;;
+        *)
+            echo "usage: romp engine [claude|codex|status]" >&2; exit 2 ;;
+    esac
+    exit 0
+fi
+
 # ── romp debug [on|off|status]: judge debug mode ────────────────────────────────
 # When on, every judge-failure row in judge-errors.jsonl carries the failing call's
 # full input + reply, and the feed joins those rows onto each card: the card modal
@@ -1648,6 +1697,7 @@ dir_arg=""
 model_arg=""
 effort_arg=""
 use_tmux=false
+use_codex=false
 msg_arg=""
 tag_arg=""
 
@@ -1657,10 +1707,11 @@ case "${1:-}" in
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 -t|--tmux) use_tmux=true; shift ;;
+                --codex)   use_codex=true; shift ;;   # an OpenAI Codex session (docs/codex.md)
                 --detach)  detach=true; shift ;;
                 -d)        shift
                            if [[ $# -eq 0 || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            dir_arg="$1"; shift ;;
                 -m|--message) shift
@@ -1669,7 +1720,7 @@ case "${1:-}" in
                            # last two-step on the idea-to-working path). Empty text is a usage
                            # error, not a silent no-op.
                            if [[ $# -eq 0 || -z "$1" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            msg_arg="$1"; shift ;;
                 --tag)     shift
@@ -1679,7 +1730,7 @@ case "${1:-}" in
                            # as the user's typed words. Rides POST /send's "tag" field — the
                            # kernel validates and appends the render-hint marker itself.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            tag_arg="$1"; shift ;;
                 --model)   shift
@@ -1688,25 +1739,44 @@ case "${1:-}" in
                            # FULL id as the picker sends it (claude-fable-5) — the alias table
                            # stops at opus/sonnet/haiku and quietly resolved "fable" to Opus 5.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            model_arg="$1"; shift ;;
                 --effort)  shift
                            # per-spawn effort (e.g. high, ultracode) — ultracode is per-session
                            # by design, never a machine default, so /new is its sanctioned door.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            effort_arg="$1"; shift ;;
                 -*)        echo "romp new: unknown option: $1" >&2; exit 2 ;;
                 *)         if [[ -n "$session_arg" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            session_arg="$1"; shift ;;
             esac
         done
         if [[ -z "$session_arg" ]]; then
-            echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+            echo "usage: romp new [-t|--codex] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+        fi
+        if $use_tmux && $use_codex; then
+            echo "romp new: --codex and -t are different session kinds — pick one" >&2; exit 2
+        fi
+        # The EFFECTIVE backend decides flag validity — the machine default (`romp engine`,
+        # STATE/default-backend) counts exactly like an explicit --codex. Resolved HERE, before
+        # any flag guard: validating against the flag alone let `romp new --model …` on an
+        # engine-codex machine sail past, create the Codex session, silently ignore the
+        # preference and warn only afterward (the user's audit, 2026-08-17).
+        # `|| true`: an absent file under set -euo pipefail otherwise kills the whole command.
+        _be="$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/default-backend" 2>/dev/null | tr -d '[:space:]' || true)"
+        case "$_be" in sdk|codex) ;; *) _be="sdk" ;; esac
+        $use_codex && _be="codex"
+        if [[ -n "$model_arg$effort_arg" && "$_be" == "codex" ]] && ! $use_tmux; then
+            # per-spawn model/effort ride /new for SDK sessions only; the codex spawn takes the
+            # account default and the pickers change it after. Refuse loudly (no silent drop),
+            # naming which door made this spawn Codex.
+            _why="--codex"; $use_codex || _why="this machine's \`romp engine codex\` default"
+            echo "romp new: --model/--effort need an SDK session, and $_why makes this a Codex one — set them from the dashboard instead" >&2; exit 2
         fi
         if [[ -n "$tag_arg" && -z "$msg_arg" ]]; then
             # a tag labels the -m text; without -m there is nothing to label
@@ -1802,7 +1872,9 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         echo "romp new: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`), or use \`romp new -t $session_arg\` for a terminal session." >&2
         exit 1
     fi
-    _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}; sys.argv[3] and d.update(model=sys.argv[3]); sys.argv[4] and d.update(effort=sys.argv[4]); print(json.dumps(d))' "$session_arg" "$_dir" "$model_arg" "$effort_arg")"
+    # $_be — the effective backend — was resolved at parse time (the `new` case), where the
+    # model/effort guards needed it; an explicit --codex already won there.
+    _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1], "dir": sys.argv[2], "backend": sys.argv[3]}; sys.argv[4] and d.update(model=sys.argv[4]); sys.argv[5] and d.update(effort=sys.argv[5]); print(json.dumps(d))' "$session_arg" "$_dir" "$_be" "$model_arg" "$effort_arg")"
     _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/new" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp new: kernel not reachable on :$_kport (is romp running?). \`romp new -t $session_arg\` starts a terminal session without it." >&2; exit 1; }
@@ -1814,7 +1886,8 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         elif [[ "$_resp" == *'"existing"'* ]]; then
             echo "romp new: \"$session_arg\" is already running; see the dashboard (romp)"
         else
-            echo "romp new: started \"$session_arg\" (SDK session, working in $_dir)"
+            _kind="SDK"; [ "$_be" = "codex" ] && _kind="Codex"
+            echo "romp new: started \"$session_arg\" ($_kind session, working in $_dir)"
             echo "romp new: watch it on the dashboard: romp"
         fi
         # --model/--effort: report what the kernel APPLIED — it echoes them back (the same park-aware

--- a/bin/romp-codex-setup
+++ b/bin/romp-codex-setup
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# romp-codex-setup — provision the OpenAI Codex SDK for romp's Codex backend (plans/codex-backend.md).
+#
+# Same shape as romp-sdk-setup, same reasons: the dependency lives in a DEDICATED venv under romp's
+# state dir ($STATE/codexvenv) and the kernel adds its site-packages to sys.path (ensure_codex_sdk in
+# kernel/codex_backend.py) — never the system python. The package is PINNED: `codex app-server`
+# self-describes as experimental, so upgrades are deliberate (bump the pin here and in
+# kernel/codex_backend.py SDK_PIN together). openai-codex bundles its own codex binary via the
+# openai-codex-cli-bin dependency, so no separate CLI install is required — though a machine still
+# needs `codex login` once before sessions can run. Idempotent; other backends are unaffected.
+set -euo pipefail
+STATE="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"
+VENV="$STATE/codexvenv"
+PIN="openai-codex==0.144.4"
+
+# KEEP IN SYNC with bin/romp-serve's pick_python (same contract as romp-sdk-setup: the kernel must
+# run the interpreter this venv is built with).
+pick_python() {
+    if [[ -n "${ROMP_PYTHON:-}" ]]; then echo "$ROMP_PYTHON"; return; fi
+    local v c
+    for v in 3.14 3.13 3.12 3.11 3.10; do
+        for c in "python$v" "$HOME/.local/bin/python$v"; do
+            if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return; fi
+        done
+    done
+    command -v python3 || { echo "romp: no python3 on PATH" >&2; exit 1; }
+}
+PY="$(pick_python)"
+
+pyver() { "$1" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo "?"; }
+if ! "$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)'; then
+  echo "romp-codex-setup: best python found is $PY ($(pyver "$PY")) but openai-codex needs >= 3.10." >&2
+  echo "romp-codex-setup: install one (e.g. 'uv python install 3.12') and re-run. Other backends are unaffected." >&2
+  exit 1
+fi
+
+make_venv() {
+  # Never download and execute a mutable bootstrap script during installation. Distro pythons that
+  # split ensurepip into python3-venv fail with a precise package remedy below.
+  "$PY" -c 'import ensurepip' >/dev/null 2>&1 || return 1
+  "$PY" -m venv "$VENV"
+}
+
+mkdir -p "$STATE"
+if [ -x "$VENV/bin/python" ] && [ "$(pyver "$VENV/bin/python")" != "$(pyver "$PY")" ]; then
+  echo "romp-codex-setup: venv python $(pyver "$VENV/bin/python") != kernel python $(pyver "$PY") — rebuilding"
+  rm -rf "$VENV"
+fi
+if [ ! -x "$VENV/bin/python" ] || [ ! -x "$VENV/bin/pip" ]; then
+  echo "romp-codex-setup: creating venv at $VENV (python: $PY)"
+  rm -rf "$VENV"
+  if ! make_venv; then
+    rm -rf "$VENV"
+    echo "romp-codex-setup: could not build a venv with pip in it." >&2
+    if ! "$PY" -c 'import ensurepip' >/dev/null 2>&1; then
+      echo "  $PY has no 'ensurepip'; romp will not execute an unverified downloaded pip bootstrap." >&2
+      echo "  Debian/Ubuntu: sudo apt install python$(pyver "$PY")-venv   (or: sudo apt install python3-venv)" >&2
+    fi
+    echo "  Then re-run: $0" >&2
+    echo "  romp still runs without this; only the Codex backend is disabled." >&2
+    exit 1
+  fi
+fi
+# Ignore ambient pip configuration/index overrides and refuse source distributions: dependency
+# installation must not run an arbitrary setup backend on the host.  The direct SDK is version-pinned;
+# its resolved wheel dependencies remain isolated inside this disposable venv.
+"$VENV/bin/pip" --isolated install -q --disable-pip-version-check --only-binary=:all: "$PIN"
+"$VENV/bin/python" - <<'PY'
+import openai_codex as m, sys
+v = getattr(m, "__version__", "?")
+print("romp-codex-setup: openai-codex %s ready (python %s)" % (v, ".".join(map(str, sys.version_info[:3]))))
+PY
+
+# Expose the BUNDLED codex CLI (2026-08-14 proofread finding): openai-codex ships the binary
+# INSIDE the venv (site-packages/codex_cli_bin/bin/codex) with no entry point on PATH — so
+# `codex login`, the very next setup step, was command-not-found on any machine without a
+# separate CLI install. An existing `codex` on PATH is respected (never clobbered); otherwise
+# the bundled one is symlinked to ~/.local/bin/codex, the spot the judges and `romp engine`
+# already probe.
+if command -v codex >/dev/null 2>&1; then
+    echo "romp-codex-setup: codex CLI already on PATH ($(command -v codex)) — leaving it be"
+else
+    _bundled="$(ls -d "$VENV"/lib/python3.*/site-packages/codex_cli_bin/bin/codex 2>/dev/null | head -n1 || true)"
+    if [ -n "$_bundled" ] && [ -x "$_bundled" ]; then
+        mkdir -p "$HOME/.local/bin"
+        ln -sf "$_bundled" "$HOME/.local/bin/codex"
+        echo "romp-codex-setup: bundled codex CLI linked to ~/.local/bin/codex"
+        case ":$PATH:" in
+            *":$HOME/.local/bin:"*) : ;;
+            *) echo "romp-codex-setup: note — ~/.local/bin isn't on this shell's PATH; add it, or call ~/.local/bin/codex directly" ;;
+        esac
+    else
+        echo "romp-codex-setup: warning — no bundled codex binary found in the venv; install the CLI yourself (npm i -g @openai/codex) before \`codex login\`" >&2
+    fi
+fi
+
+echo "romp-codex-setup: done. If this machine hasn't logged in yet, run: codex login"
+echo "romp-codex-setup: no restart needed — the kernel and judges pick this up automatically."

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,157 @@
+# Codex sessions
+
+romp runs **OpenAI Codex** agents alongside — or instead of — Claude Code
+sessions: same board, same cards, chat, timeline, and postal bus. A Codex
+session is just another kind of session: pick **Codex** in the new-session
+dialog's Backend toggle (or set it as the gear's Default backend). The
+`romp` command and the `romp` command are the same program — romp is
+built on romp, and either name works everywhere below.
+
+Under the hood, romp drives Codex through the official `codex app-server`
+protocol and materializes each thread as a transcript romp's read side already
+understands — design in `plans/codex-backend.md`.
+
+## Setup
+
+Codex sessions need, once per machine:
+
+1. **The Codex SDK:**
+
+        romp-codex-setup
+
+    This provisions a dedicated, pinned venv under romp's state dir (it never
+    touches your system Python) and bundles the Codex binary.
+
+2. **A Codex login:**
+
+        codex login          # or: codex login --device-auth on a headless box
+
+    Codex sessions bill the ChatGPT plan (or API key) this login carries.
+
+If either is missing, creating a Codex session tells you exactly what to run —
+romp never silently substitutes a different backend.
+
+By default romp's *own* intelligence — the judges that caption work, build the
+cards, and route your attention — runs on Claude, so the machine also wants a
+Claude Code login. On a Codex-only machine, switch the judges to Codex instead
+(next section) and no Claude login is needed at all.
+
+## Running the judges on Codex
+
+    romp engine codex      # back: romp engine claude — current posture: romp engine status
+
+One switch, two knobs: the judges move to Codex, and new sessions (`romp new`,
+the kernel API) default to the Codex backend — the dashboard's + dialog keeps
+its own per-create toggle. No restart needed: judges read the setting on their
+next call, and running sessions are never touched. Every judge becomes a
+one-shot `codex exec` call — ephemeral (no session files), using romp's custom
+`romp_judge` permission profile, and billing the machine's Codex login. The
+profile grants only Codex's minimal runtime files plus read access to the fresh
+empty scratch workspace supplied by `-C`; it denies writes, network access, and
+host-wide reads. Verified live: the real caption and gist
+judges answer correctly in ~5–6s per call.
+
+Honest caveats while this is new:
+
+- **Quality**: the judge prompts were tuned on Claude models; on Codex they
+  validate well but have less mileage. If cards read oddly, switch back —
+  it's one command.
+- **Cost/quota**: judges make many small calls (every turn gets captioned);
+  on a ChatGPT plan they draw from the same usage pool as your Codex sessions.
+- **Accounting**: `codex exec` doesn't report token counts, so the analytics
+  show judge call counts and durations but not token costs; and the
+  Claude-account rate-limit gate doesn't apply (Codex limits surface per call
+  instead).
+- Model picks in the gear's judge-model settings are Claude aliases; on the
+  codex engine they're ignored (ChatGPT-plan accounts only allow the account's
+  default model — a `gpt-*` value in `~/.local/state/romp/judge-model` is
+  honored where the plan permits).
+
+## Sandboxing
+
+Codex runs its commands inside its own Linux sandbox (bubblewrap). Every
+thread and turn selects romp's custom `romp_workspace` permission profile
+and supplies exactly that session's working directory in
+`runtimeWorkspaceRoots`. The profile permits only Codex's minimal runtime
+files plus that workspace, so other user files on the host are not readable.
+Network remains enabled so git and web work keep working.
+
+There is an important pinned-runtime limitation: Codex 0.144.4 does not enforce
+narrower child rules against arbitrary processes inside a custom writable root.
+A shell command can therefore still modify `.git`, `.agents`, and `.codex`.
+The built-in `:workspace` profile enforces the metadata masks, but also grants
+read access to the whole host; romp currently chooses user-file
+confidentiality and documents this
+remaining metadata-integrity gap rather than silently restoring host-wide
+reads. Two host notes:
+
+- The sandbox needs **unprivileged user namespaces**. Some images (notably
+  newer GCP Ubuntu) restrict them; every command then fails visibly with
+  `bwrap: … Permission denied`. To enable:
+
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+    (persist it in `/etc/sysctl.d/` to survive reboots).
+
+- There is no permission-prompt flow yet (approvals are pinned off; the
+  sandbox is the guardrail). Codex approval prompts surfacing as romp's
+  needs-you cards is planned.
+
+## What works, what's coming
+
+Working today: lanes and status, task cards and judging, full chat (prompts,
+replies, thinking, commands, file diffs, web searches), steering a running
+turn, interrupts, model and reasoning-effort switches, resume after restarts,
+and postal delivery into Codex sessions.
+
+Not yet (tracked in `plans/codex-backend.md`): approval prompts as needs-you
+cards, Codex plan items on the card checklist, subagent lanes, rate-limit
+gating, and MCP server management from the dashboard (Codex sessions read MCP
+servers from `~/.codex/config.toml`).
+
+## Installing romp
+
+This repo is the distribution — the installer takes any repo and directory, and
+checks out the newest romp release tag:
+
+    curl -fsSL https://raw.githubusercontent.com/lczh/romp/main/bootstrap.sh | \
+      ROMP_REPO=https://github.com/lczh/romp.git ROMP_DIR=$HOME/romp bash
+
+Releases from v1.2.2 onward are SSH-signed; with a trust root configured,
+verification is a hard gate (recommended — see
+[Release signature trust](install.md#release-signature-trust)). Without one,
+verification is attempted and its outcome noted, never a dead end.
+
+Then, in a new terminal, the two setup steps above (`romp-codex-setup`,
+`codex login`) — and `romp engine codex` if the machine should run
+Codex-only. `romp` opens the dashboard.
+
+## Updates
+
+Installed machines learn about new releases on their own: the kernel checks
+this repo's tags at boot and every few hours, and the dashboard offers the
+update as a banner — one click fetches the release, reinstalls, and restarts.
+Updates follow the same rule as installs: with a trust root configured,
+`git verify-tag` at Git's **full** trust level is a hard gate — a bad or
+unknown signature stops before any code moves, never falling back — and
+without one, verification is attempted and its outcome noted in the update
+log; see [Release signature trust](install.md#release-signature-trust).
+The gear's **Updates** setting picks the behavior: *Check and ask* (default),
+*Install automatically*, or *Off*.
+
+Cutting a release (for whoever maintains this repo) is handled by the release
+script. It derives and validates the GitHub repository from the remote that receives
+the tag, runs the test and macOS gates, creates a signed annotated tag using Git's
+configured signing key, verifies it locally, and publishes the matching release:
+
+    scripts/release.sh patch       # or minor, major, or an explicit X.Y.Z
+
+The maintainer must configure `user.signingKey` (and `gpg.format ssh` plus an
+allowed-signers file when using SSH signing) before running the script, and upload the
+same public signing key to GitHub and publish its fingerprint independently for installers.
+The historical `v1.0.0`, `v1.1.0`, and `v1.2.0` tags are unsigned; cut a newer signed
+stable release rather than weakening verification.
+
+romp versions on its own line (v1.0.0 and up); upstream romp's tags stay
+behind it and are never pushed here, so the updater always resolves the
+newest romp release.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -111,47 +111,9 @@ servers from `~/.codex/config.toml`).
 
 ## Installing romp
 
-This repo is the distribution — the installer takes any repo and directory, and
-checks out the newest romp release tag:
+Install romp itself as described in [install.md](install.md). Then, in a new
+terminal, the two setup steps above (`romp-codex-setup`, `codex login`) — and
+`romp engine codex` if the machine should run Codex-only. `romp` opens the
+dashboard; a machine that never runs these steps is unaffected and defaults to
+Claude Code.
 
-    curl -fsSL https://raw.githubusercontent.com/lczh/romp/main/bootstrap.sh | \
-      ROMP_REPO=https://github.com/lczh/romp.git ROMP_DIR=$HOME/romp bash
-
-Releases from v1.2.2 onward are SSH-signed; with a trust root configured,
-verification is a hard gate (recommended — see
-[Release signature trust](install.md#release-signature-trust)). Without one,
-verification is attempted and its outcome noted, never a dead end.
-
-Then, in a new terminal, the two setup steps above (`romp-codex-setup`,
-`codex login`) — and `romp engine codex` if the machine should run
-Codex-only. `romp` opens the dashboard.
-
-## Updates
-
-Installed machines learn about new releases on their own: the kernel checks
-this repo's tags at boot and every few hours, and the dashboard offers the
-update as a banner — one click fetches the release, reinstalls, and restarts.
-Updates follow the same rule as installs: with a trust root configured,
-`git verify-tag` at Git's **full** trust level is a hard gate — a bad or
-unknown signature stops before any code moves, never falling back — and
-without one, verification is attempted and its outcome noted in the update
-log; see [Release signature trust](install.md#release-signature-trust).
-The gear's **Updates** setting picks the behavior: *Check and ask* (default),
-*Install automatically*, or *Off*.
-
-Cutting a release (for whoever maintains this repo) is handled by the release
-script. It derives and validates the GitHub repository from the remote that receives
-the tag, runs the test and macOS gates, creates a signed annotated tag using Git's
-configured signing key, verifies it locally, and publishes the matching release:
-
-    scripts/release.sh patch       # or minor, major, or an explicit X.Y.Z
-
-The maintainer must configure `user.signingKey` (and `gpg.format ssh` plus an
-allowed-signers file when using SSH signing) before running the script, and upload the
-same public signing key to GitHub and publish its fingerprint independently for installers.
-The historical `v1.0.0`, `v1.1.0`, and `v1.2.0` tags are unsigned; cut a newer signed
-stable release rather than weakening verification.
-
-romp versions on its own line (v1.0.0 and up); upstream romp's tags stay
-behind it and are never pushed here, so the updater always resolves the
-newest romp release.

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -1,0 +1,1397 @@
+#!/usr/bin/env python3
+"""codex_backend — the Codex SessionBackend (plans/codex-backend.md).
+
+Drives OpenAI Codex sessions through the official openai-codex Python SDK's sync CodexClient
+(JSON-RPC to `codex app-server` over stdio) and materializes each thread as Claude-transcript-shaped
+JSONL via kernel/codex_events.ThreadNormalizer, so romp's entire read side parses Codex sessions
+unchanged. Duck-types the SessionBackend ABC exactly like SdkBackend does (the kernel loads backends
+via SourceFileLoader; a conformance test asserts every abstract method exists).
+
+Shape of the machine:
+- ONE CodexClient per backend — the app-server hosts many threads, unlike Claude's one-CLI-per-
+  session. One GLOBAL pump thread drains thread-level notifications (tokenUsage, rateLimits);
+  each session gets a WORKER thread that drains its send-queue into turns and consumes that turn's
+  own notification queue (the SDK routes a started turn's events there, not to the global queue).
+- The worker and global pump serialize through one per-session normalizer/file lock:
+  notification → normalizer → append → poke the kernel.
+- Sends NEVER block on a running turn: mid-turn they steer (turn/steer with the active turn id as
+  precondition), racing a just-ended turn falls back to the queue, and the queue drains into the
+  next turn_start — that is forwards_sends() on this backend.
+- Auth is machine-global (`codex login`): a missing login is surfaced PER SESSION via launch_error,
+  loudly, the moment a session tries to run (the 2026-07-28 rule: never a silent non-start).
+
+Everything Claude-only returns its documented empty value and the kernel stays loud about it:
+set_fast/set_mode/set_auth/stop_task/rewind_files → False, on_ask → False, current_ask → None.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import sys
+import threading
+import time
+import traceback
+import uuid as uuidlib
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = Path(os.path.dirname(os.path.realpath(__file__)))
+_events = SourceFileLoader("romp_codex_events", str(HERE / "codex_events.py")).load_module()
+
+SDK_PIN = "openai-codex==0.144.4"     # bin/romp-codex-setup installs exactly this into codexvenv
+SETUP_HINT = ("Session not created: the Codex backend isn't installed. "
+              "Run romp-codex-setup, then try again.")
+LOGIN_HINT = "Codex isn't logged in on this machine — run: codex login"
+
+# The phase-1 posture: sandboxed full-auto (plans/codex-backend.md). In pinned 0.144.4, BOTH legacy
+# workspaceWrite and the built-in :workspace profile include `:root = read`; runtimeWorkspaceRoots
+# only adds roots and cannot subtract that host-wide read. Define a fail-closed custom profile:
+# minimal runtime files are readable, the session workspace is writable, and network remains enabled
+# for git/web. Pinned 0.144.4 cannot enforce narrower child access inside a custom writable root, so
+# metadata directories remain writable (documented in docs/codex.md) rather than carrying misleading
+# read-only entries that its arbitrary-process sandbox ignores.
+WORKSPACE_PERMISSION = "romp_workspace"
+_WORKSPACE_PROFILE_OVERRIDE = (
+    'permissions.romp_workspace={ filesystem = { ":minimal" = "read", '
+    '":workspace_roots" = { "." = "write" } }, network = { enabled = true } }')
+# 0.144.4 rejects any custom [permissions] table unless default_permissions is also selected.
+# Selecting it globally is a defense in depth; thread/resume/turn still name it explicitly.
+CODEX_CONFIG_OVERRIDES = (_WORKSPACE_PROFILE_OVERRIDE,
+                          'default_permissions="romp_workspace"')
+TURN_SANDBOX = None   # explicit smoke-only legacy override (for hosts unable to run the sandbox)
+APPROVAL_POLICY = "never"
+# romp effort names → Codex ReasoningEffort. Identity for the shared four; max/ultracode are
+# Claude-only knobs and set_effort refuses them (False → the kernel warns instead of pretending).
+EFFORTS = ("low", "medium", "high", "xhigh")
+
+SEED_TAIL = 200   # records whose uuids seed the normalizer's dedup on re-attach (replay guard)
+CLIENT_RETRY_MIN = 0.25
+CLIENT_RETRY_MAX = 5.0
+WORKER_JOIN_TIMEOUT = 2.0
+
+_PERMANENT_RPC_ERRORS = {"ParseError", "InvalidRequestError", "MethodNotFoundError",
+                         "InvalidParamsError"}
+_PERMANENT_RPC_TEXT = (
+    re.compile(r"\b(?:unknown|unsupported|invalid) (?:model|permission|approval|sandbox)\b", re.I),
+    re.compile(r"\bmodel\b.*\b(?:does not exist|is not supported|not allowed)\b", re.I),
+    re.compile(r"\bpermission profile\b.*\b(?:not found|does not exist|is not supported)\b", re.I),
+)
+
+
+def _is_permanent_request_rejection(error):
+    """Whether an app-server request reached Codex and was rejected non-retryably.
+
+    The pinned SDK gives request-shape/method/parameter failures distinct types. InternalRpcError,
+    ServerBusyError and unknown numeric app codes can recover without changing the request, so they
+    deliberately remain on automatic backoff. A few app-specific model/policy rejections arrive as
+    generic CodexRpcError; park only their unambiguous text. Keep this duck-typed so the backend can
+    import before the optional SDK is installed.
+    """
+    name = error.__class__.__name__
+    if name in _PERMANENT_RPC_ERRORS:
+        return True
+    if name not in {"JsonRpcError", "CodexRpcError"}:
+        return False
+    message = str(getattr(error, "message", "") or error)
+    return any(pattern.search(message) for pattern in _PERMANENT_RPC_TEXT)
+
+
+# Compatibility for focused probes written against the first durable-queue implementation.
+_is_permanent_turn_rejection = _is_permanent_request_rejection
+
+
+class _PermanentRequestRejection(RuntimeError):
+    def __init__(self, cause, operation, change_generation, client_generation):
+        super().__init__(str(cause) or cause.__class__.__name__)
+        self.operation = operation
+        self.change_generation = change_generation
+        self.client_generation = client_generation
+
+
+def _execution_permissions(cwd, thread_start=False):
+    """Pinned-runtime execution policy. TURN_SANDBOX remains only for the live smoke's explicit
+    dangerFullAccess escape hatch; normal sessions select the named profile and exactly one root."""
+    if TURN_SANDBOX is not None:
+        if thread_start:
+            modes = {"dangerFullAccess": "danger-full-access", "readOnly": "read-only",
+                     "workspaceWrite": "workspace-write"}
+            return {"sandbox": modes.get(TURN_SANDBOX.get("type"), "workspace-write")}
+        return {"sandboxPolicy": TURN_SANDBOX}
+    root = str(Path(cwd or ".").resolve())
+    return {"permissions": WORKSPACE_PERMISSION, "runtimeWorkspaceRoots": [root]}
+
+
+def _codex_config(config_cls, codex_bin):
+    """Build the pinned SDK launch config in one testable place.
+
+    In 0.144.4, custom profiles are process config while each thread/turn supplies its runtime root.
+    """
+    return config_cls(codex_bin=codex_bin, client_name="romp",
+                      config_overrides=CODEX_CONFIG_OVERRIDES)
+
+
+def ensure_codex_sdk(state_dir):
+    """Make openai_codex importable: an already-installed copy wins, else the dedicated venv built
+    by bin/romp-codex-setup ($STATE/codexvenv — never system python). True when importable."""
+    import importlib.util
+    import glob
+    if importlib.util.find_spec("openai_codex"):
+        return True
+    for sp in sorted(glob.glob(str(Path(state_dir) / "codexvenv" / "lib" / "python3.*" / "site-packages"))):
+        if sp not in sys.path:
+            sys.path.insert(0, sp)
+    return importlib.util.find_spec("openai_codex") is not None
+
+
+def _enc_cwd(cwd):
+    """The transcript dir name for a cwd — the same encoding the Claude CLI uses for
+    ~/.claude/projects (realpath, every non-alphanumeric → '-'), so tooling that already
+    understands one layout understands the other."""
+    return re.sub(r"[^A-Za-z0-9]", "-", str(Path(cwd or "/").resolve()))
+
+
+def _dump(payload):
+    """A notification payload → the camelCase wire dict the normalizer speaks. Known methods parse
+    into pydantic models (model_dump by_alias restores the wire names); unknown ones keep raw params."""
+    fn = getattr(payload, "model_dump", None)
+    if fn:
+        try:
+            return fn(by_alias=True, mode="json")
+        except Exception:
+            return fn(by_alias=True)
+    return getattr(payload, "params", None) or {}
+
+
+def _tail_state(path):
+    """(last_uuid, recent uuids) off a materialized file, to re-anchor the normalizer's chain and
+    seed its replay dedup after a restart. Reads the whole file once; keeps only the tail's uuids —
+    replay across a reconnect only ever re-delivers recent items."""
+    last, tail = None, []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    u = json.loads(line).get("uuid")
+                except Exception:
+                    continue
+                if u:
+                    last = u
+                    tail.append(u)
+                    if len(tail) > SEED_TAIL:
+                        tail.pop(0)
+    except OSError:
+        pass
+    return last, set(tail)
+
+
+class _Session:
+    """One Codex session: registry row + runtime state. The worker thread owns the normalizer and
+    the file; everything else only reads or enqueues."""
+
+    def __init__(self, sid, tid, name, cwd, model="", effort="", color=""):
+        self.sid = sid
+        self.tid = tid                # Codex thread id == fsid == transcript filename stem
+        self.name = name
+        self.cwd = cwd
+        self.model = model
+        self.effort = effort
+        self.color = color            # identity bg — also in names/<sid> (fields 3/4), the shared store
+        self.dead = False
+        self.state = "waiting"        # waiting | working (the two states this backend can know)
+        self.since = time.time()
+        self.queue = []               # pending sends (persisted); drained into the next turn
+        self.queue_ids = []           # stable durable identity parallel to queue (public API stays text-only)
+        self.echoes = []              # optimistic user-atom echoes ahead of the materialized file
+        self.turn_id = None           # the active turn (interrupt/steer target), else None
+        self.loaded = False           # thread/resume done in THIS process
+        self.launch_error = None      # {text, at, limit} — why the session can't run, or None
+        self.norm = None              # ThreadNormalizer, built by the worker on first need
+        self.worker = None
+        self.kick = threading.Event() # wake the worker (new send / resume / shutdown)
+        self.change_generation = 0    # explicit send/model/effort/resume changes that may fix a rejection
+        self.turn_rejection = None    # rejected request generations; parked until either one changes
+        self.note = ""                # postal working-note
+        self.lock = threading.RLock()  # queue/turn/worker/state fields; lifecycle calls can nest
+        self.norm_lock = threading.Lock()  # the turn worker and global pump share one normalizer
+
+
+class CodexBackend:
+    def __init__(self, state_dir, notify=None, poke=None, push=None, push_session=None,
+                 codex_bin=None, log=None, client_factory=None):
+        self.state = Path(state_dir)
+        self.root = self.state / "codex"
+        self.projects = self.root / "projects"
+        self.projects.mkdir(parents=True, exist_ok=True)
+        self.notify = notify or (lambda *a, **k: None)
+        self.poke = poke or (lambda: None)
+        self.push = push or (lambda: None)
+        self.push_session = push_session or (lambda sid: None)
+        self.codex_bin = codex_bin
+        self.log = log or (lambda m: sys.stderr.write("codex-backend: %s\n" % m))
+        self._client_factory = client_factory   # tests inject a fake; None → real CodexClient
+        self._client = None
+        self._client_err = None       # why the client can't be built/authed (str), or None
+        self._client_retry_at = 0.0
+        self._client_failures = 0
+        self._client_generation = 0   # successful app-server client installations
+        self._catalog = None          # model_catalog() cache — fetched once per process
+        self._client_lock = threading.Lock()
+        self._sessions = {}           # sid → _Session
+        self._sessions_lock = threading.RLock()
+        self._reg_lock = threading.Lock()
+        self._load_registry()
+        # A kernel restart must not strand a durable backend queue until the user happens to send
+        # again. Re-arm every live queued session immediately; client retry backoff keeps failures cool.
+        for _, s in self._session_items():
+            with s.lock:
+                recover = bool(s.queue) and not s.dead
+            if recover:
+                self._ensure_worker(s)
+                s.kick.set()
+
+    # ── registry persistence ─────────────────────────────────────────────────────────────────────
+    def _reg_path(self):
+        return self.root / "registry.json"
+
+    def _reg_lock_path(self):
+        # Persistent sidecar, never unlinked: unlinking can split contenders across two lock inodes.
+        return self.root / "registry.lock"
+
+    def _load_registry(self):
+        try:
+            rows = json.loads(self._reg_path().read_text())
+            if not isinstance(rows, dict):
+                raise ValueError("registry root is not an object")
+        except FileNotFoundError:
+            rows = {}
+        except Exception as e:
+            # as LOUD at load as saves are: _save_registry refuses to overwrite an unreadable
+            # registry, but a silent {} here made every session vanish at boot and surface later
+            # as unrelated-looking spawn/send errors (2026-08-14 review)
+            self.log("codex registry unreadable at load — existing sessions will be missing "
+                     "until it is repaired: %s" % e)
+            rows = {}
+        with self._sessions_lock:
+            for sid, r in rows.items():
+                if not isinstance(r, dict) or not isinstance(r.get("tid"), str):
+                    self.log("ignoring malformed Codex registry row: %s" % sid)
+                    continue
+                s = _Session(sid, r["tid"], r.get("name", ""), r.get("cwd", ""),
+                             r.get("model", ""), r.get("effort", ""), r.get("color", ""))
+                s.dead = bool(r.get("dead"))
+                queue_entries = self._registry_queue_entries(sid, r.get("queue"))
+                s.queue = [entry["text"] for entry in queue_entries]
+                s.queue_ids = [entry["id"] for entry in queue_entries]
+                s.note = r.get("note", "")
+                s.launch_error = r.get("launchError") if isinstance(r.get("launchError"), dict) else None
+                self._sessions[sid] = s
+
+    def _session(self, sid):
+        with self._sessions_lock:
+            return self._sessions.get(sid)
+
+    def _session_items(self):
+        with self._sessions_lock:
+            return list(self._sessions.items())
+
+    def _put_session(self, s):
+        with self._sessions_lock:
+            self._sessions[s.sid] = s
+
+    _names_lock = threading.Lock()   # serializes this backend's names/<sid> read-modify-writes
+
+    @staticmethod
+    def _legacy_queue_id(sid, index, text, repair=""):
+        """A deterministic identity lets every overlapping loader agree on old string-only rows."""
+        seed = "%s\0%d\0%s\0%s" % (sid, index, text, repair)
+        return "legacy-%s" % uuidlib.uuid5(uuidlib.NAMESPACE_URL, seed).hex
+
+    @classmethod
+    def _registry_queue_entries(cls, sid, raw_queue):
+        """Canonical [{id,text}] entries, including lazy migration of the former [text] schema."""
+        if not isinstance(raw_queue, list):
+            return []
+        entries, used = [], set()
+        for index, raw in enumerate(raw_queue):
+            if isinstance(raw, str):
+                text = raw
+                entry_id = cls._legacy_queue_id(sid, index, text)
+            elif isinstance(raw, dict):
+                text, entry_id = raw.get("text"), raw.get("id")
+            else:
+                continue
+            if not isinstance(text, str) or not text:
+                continue
+            if not isinstance(entry_id, str) or not entry_id or entry_id in used:
+                # Repair malformed/duplicate ids deterministically so two processes still agree.
+                entry_id = cls._legacy_queue_id(sid, index, text, str(entry_id or "repair"))
+                salt = 0
+                while entry_id in used:
+                    salt += 1
+                    entry_id = cls._legacy_queue_id(sid, index, text, "repair-%d" % salt)
+            used.add(entry_id)
+            entries.append({"id": entry_id, "text": text})
+        return entries
+
+    @staticmethod
+    def _registry_snapshot(s):
+        with s.lock:
+            if len(s.queue_ids) != len(s.queue):
+                raise RuntimeError("Codex in-memory queue identity invariant failed for %s" % s.sid)
+            return {"tid": s.tid, "name": s.name, "cwd": s.cwd,
+                    "model": s.model, "effort": s.effort, "dead": s.dead,
+                    "queue": [{"id": entry_id, "text": text}
+                              for entry_id, text in zip(s.queue_ids, s.queue)],
+                    "note": s.note, "color": s.color,
+                    "launchError": s.launch_error}
+
+    def _registry_rows_for_update(self):
+        try:
+            rows = json.loads(self._reg_path().read_text())
+        except FileNotFoundError:
+            return {}
+        except Exception as e:
+            # Never turn corruption into an empty registry and overwrite every durable queue.
+            raise RuntimeError("Codex registry is unreadable: %s" % e) from e
+        if not isinstance(rows, dict):
+            raise RuntimeError("Codex registry root is not an object")
+        return rows
+
+    def _write_registry_locked(self, rows):
+        """Atomic, durable write. Caller owns the persistent cross-process sidecar lock."""
+        tmp = self._reg_path().with_name(
+            "registry.tmp.%d.%s" % (os.getpid(), uuidlib.uuid4().hex[:8]))
+        try:
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(json.dumps(rows, indent=1))
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self._reg_path())
+            try:
+                dfd = os.open(str(self.root), os.O_RDONLY)
+                try:
+                    os.fsync(dfd)
+                finally:
+                    os.close(dfd)
+            except OSError:
+                pass                       # some filesystems do not support directory fsync
+        finally:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+    def _save_registry(self, s, *, fields=(), create=False, queue_append=None, queue_ack=None):
+        """Apply ONE row transaction against the latest on-disk registry.
+
+        A former whole-memory snapshot let an overlapping old kernel erase a newer kernel's queued
+        sends during an unrelated rename/save. The thread lock serializes this backend; flock
+        serializes processes. Under both, reload the authoritative file and touch only the named
+        metadata fields. Queue mutations are operations over stable entry ids: append one newly
+        accepted send, or remove the exact ids whose turn/start was ACKed. Thus a concurrent append
+        survives an ACK even when its text repeats an earlier send. Every production mutator retains
+        its session RLock through this transaction, so same-process snapshots cannot commit out of
+        order. Snapshotting still happens before the registry lock, so no reverse lock edge exists.
+        """
+        allowed = {"tid", "name", "cwd", "model", "effort", "dead", "note", "color",
+                   "launchError"}
+        fields = set(fields)
+        unknown = fields - allowed
+        if unknown:
+            raise ValueError("unknown Codex registry fields: %s" % sorted(unknown))
+        snapshot = self._registry_snapshot(s)  # before registry locks: no reg-lock ↔ session-lock cycle
+        ack_mismatch = False
+        with self._reg_lock:
+            lock_fd = os.open(str(self._reg_lock_path()), os.O_RDWR | os.O_CREAT, 0o600)
+            try:
+                os.fchmod(lock_fd, 0o600)
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                rows = self._registry_rows_for_update()
+                current = rows.get(s.sid)
+                reconstructed = not isinstance(current, dict) or not isinstance(current.get("tid"), str)
+                if create or reconstructed:
+                    row = dict(snapshot)
+                else:
+                    row = dict(current)
+                    for field in fields:
+                        row[field] = snapshot[field]
+
+                # Normalizing every touched row lazily migrates the former raw-string queue schema.
+                queue_now = self._registry_queue_entries(s.sid, row.get("queue"))
+                if queue_append is not None:
+                    if not (isinstance(queue_append, dict)
+                            and isinstance(queue_append.get("id"), str)
+                            and queue_append.get("id")
+                            and isinstance(queue_append.get("text"), str)
+                            and queue_append.get("text")):
+                        raise ValueError("Codex queue append requires a nonempty {id,text} entry")
+                    append_entry = {"id": queue_append["id"], "text": queue_append["text"]}
+                    prior = next((entry for entry in queue_now
+                                  if entry["id"] == append_entry["id"]), None)
+                    if prior is None:
+                        queue_now.append(append_entry)
+                    elif prior != append_entry:
+                        raise RuntimeError("Codex queue id collision for %s" % s.sid)
+                if queue_ack is not None:
+                    batch_ids = list(queue_ack)
+                    if not all(isinstance(entry_id, str) and entry_id for entry_id in batch_ids):
+                        raise ValueError("Codex queue ACK requires stable entry ids")
+                    if [entry["id"] for entry in queue_now[:len(batch_ids)]] == batch_ids:
+                        del queue_now[:len(batch_ids)]
+                        row["queue"] = queue_now
+                    elif queue_now:
+                        # Preserve at-least-once delivery on an overlap instead of deleting a queue
+                        # whose provenance we cannot prove. The mismatch is actionable and visible.
+                        ack_mismatch = True
+                row["queue"] = queue_now
+                rows[s.sid] = row
+                self._write_registry_locked(rows)
+            finally:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                finally:
+                    os.close(lock_fd)
+        # The ACK caller may deliberately retain s.lock through this transaction. Return the warning
+        # bit so it can invoke the arbitrary log callback only after every persistence lock is gone.
+        return ack_mismatch
+
+    # ── client lifecycle ─────────────────────────────────────────────────────────────────────────
+    def available(self):
+        """Can this backend actually RUN a session right now? (The creation gate — mirrors
+        _sdk_ready's contract.) Building the client is the real probe; a failure is surfaced and
+        retried after bounded exponential backoff, never in a hot loop."""
+        return self._get_client() is not None
+
+    def _get_client(self):
+        with self._client_lock:
+            if self._client is not None:
+                return self._client
+            if time.monotonic() < self._client_retry_at:
+                return None           # remembered only until the retry deadline, not for the process
+            candidate = None
+            try:
+                if self._client_factory:
+                    candidate = self._client_factory()
+                else:
+                    if not ensure_codex_sdk(self.state):
+                        raise RuntimeError(SETUP_HINT)
+                    from openai_codex.client import CodexClient, CodexConfig
+                    cfg = _codex_config(CodexConfig, self.codex_bin)
+                    candidate = CodexClient(config=cfg)
+                    candidate.start()
+                    candidate.initialize()
+                self._check_auth(candidate)
+                self._client = candidate
+                self._client_err = None
+                self._client_retry_at = 0.0
+                self._client_failures = 0
+                self._client_generation += 1
+                # A replacement app-server can make a previously deterministic rejection obsolete.
+                # Wake parked queued workers; their generation gate decides whether to retry.
+                for _, s in self._session_items():
+                    s.kick.set()
+                threading.Thread(target=self._global_pump, args=(candidate,), daemon=True,
+                                 name="codex-pump").start()
+                return candidate
+            except Exception as e:
+                self._record_client_failure_locked(e, candidate)
+                return None
+
+    def _record_client_failure_locked(self, error, candidate=None):
+        """Record one failed client generation. Caller owns _client_lock."""
+        self._client_err = str(error) or error.__class__.__name__
+        self._client_failures += 1
+        delay = min(CLIENT_RETRY_MAX,
+                    CLIENT_RETRY_MIN * (2 ** min(self._client_failures - 1, 8)))
+        self._client_retry_at = time.monotonic() + delay
+        if candidate is None:
+            candidate = self._client
+        if candidate is self._client and self._client is not None:
+            # Invalidation is itself a generation edge. The global pump wakes queued workers after
+            # releasing this lock, so a permanently parked request can build the replacement client
+            # automatically rather than waiting for an unrelated user action.
+            self._client_generation += 1
+            self._client = None
+        if candidate is not None:
+            try:
+                candidate.close()
+            except Exception:
+                pass
+        self.log("client unavailable: %s (retry in %.2fs)" % (self._client_err, delay))
+
+    def _client_retry_remaining(self):
+        with self._client_lock:
+            return max(0.0, self._client_retry_at - time.monotonic())
+
+    def _client_generation_now(self):
+        with self._client_lock:
+            return self._client_generation
+
+    def _client_generation_for(self, client):
+        with self._client_lock:
+            # If it was invalidated between _get_client and turn/start, use a deliberately stale
+            # sentinel. The worker then sees the generation mismatch and rebuilds automatically.
+            return self._client_generation if self._client is client else -1
+
+    def _check_auth(self, client):
+        """A missing `codex login` must surface as text on the session, not as a hung turn."""
+        try:
+            acct = client.account_read()
+        except Exception as e:
+            self.log("account_read failed: %s" % e)
+            return
+        needs = getattr(acct, "requires_openai_auth", None)
+        if needs and not getattr(acct, "account", None):
+            raise RuntimeError(LOGIN_HINT)
+
+    def _global_pump(self, client):
+        """Drain notifications NOT routed to a registered turn (thread status, rate limits, token
+        usage between turns). Feeds the owning session's normalizer so nothing is dropped."""
+        while True:
+            try:
+                n = client.next_notification()
+            except Exception as e:
+                self.log("global pump stopped: %s" % e)
+                with self._client_lock:
+                    if self._client is client:
+                        self._record_client_failure_locked(e, client)
+                for _, s in self._session_items():
+                    with s.lock:
+                        queued = bool(s.queue) and not s.dead
+                    if queued:
+                        self._ensure_worker(s)
+                        s.kick.set()
+                return
+            try:
+                p = _dump(getattr(n, "payload", None))
+                tid = p.get("threadId")
+                s = next((s for _, s in self._session_items() if s.tid == tid), None)
+                if s:
+                    wrote = False
+                    with s.norm_lock:
+                        # Placeholder recovery replaces the normalizer under this same lock. Recheck
+                        # after acquiring it: a pre-lock `s.norm` test could race to None here.
+                        if s.norm:
+                            recs = s.norm.handle(getattr(n, "method", ""), p)
+                            if recs:
+                                self._append(s, recs)
+                                wrote = True
+                    if wrote:                     # notify OUTSIDE norm_lock (see _append)
+                        self.poke()
+                        self.push_session(s.sid)
+            except Exception:
+                self.log("global pump: %s" % traceback.format_exc())
+
+    # ── the materialized transcript ──────────────────────────────────────────────────────────────
+    def transcript_path(self, sid):
+        s = self._session(sid)
+        if not s:
+            return None
+        with s.lock:
+            cwd, tid = s.cwd, s.tid
+        d = self.projects / _enc_cwd(cwd)
+        d.mkdir(parents=True, exist_ok=True)
+        return d / ("%s.jsonl" % tid)
+
+    def _ensure_norm(self, s):
+        with s.norm_lock:
+            if s.norm is None:
+                path = self.transcript_path(s.sid)
+                last, seen = _tail_state(path)
+                s.norm = _events.ThreadNormalizer(s.tid, cwd=s.cwd, model=s.model,
+                                                  version="codex", last_uuid=last,
+                                                  seen_uuids=seen)
+            return s.norm
+
+    def _append(self, s, recs):
+        """File IO + echo-prune ONLY — never notifies. Every caller holds s.norm_lock, and the
+        kernel's push_session synchronously re-enters live_sessions(), which takes every session's
+        norm_lock: a push from in here self-deadlocked the worker on its first appended record and
+        wedged the whole liveness merge behind it (2026-08-14 review, reproduced live). Callers
+        poke/push AFTER releasing the lock — and an RLock would not save a push-under-lock: two
+        workers pushing concurrently AB-BA across their sessions' locks."""
+        path = self.transcript_path(s.sid)
+        with open(path, "a", encoding="utf-8") as f:
+            for r in recs:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+        # a landed user record replaces its optimistic echo (uuid-independent: match by text)
+        landed = {self._rec_text(r) for r in recs if r.get("type") == "user"}
+        if landed:
+            with s.lock:
+                s.echoes = [e for e in s.echoes if e["text"] not in landed]
+
+    @staticmethod
+    def _rec_text(rec):
+        c = (rec.get("message") or {}).get("content")
+        if isinstance(c, list):
+            return " ".join(b.get("text", "") for b in c
+                            if isinstance(b, dict) and b.get("type") == "text").strip()
+        return (c or "").strip() if isinstance(c, str) else ""
+
+    # ── liveness / identity ──────────────────────────────────────────────────────────────────────
+    def owns(self, sid):
+        s = self._session(sid)
+        if not s:
+            return False
+        with s.lock:
+            return not s.dead
+
+    def live_sessions(self):
+        out = {}
+        for sid, s in self._session_items():
+            with s.lock:
+                if s.dead:
+                    continue
+                row = {"state": s.state, "model": s.model, "effort": s.effort,
+                       "mode": "sandboxed", "since": s.since, "context": None,
+                       "compactPct": None, "backend": "codex", "name": s.name,
+                       "cwd": s.cwd, "color": s.color or None}
+            with s.norm_lock:
+                if s.norm and s.norm.context and s.norm.context[1]:
+                    used, window = s.norm.context
+                    row["context"] = max(0, min(100, round(100 * used / window)))
+            out[sid] = row
+        return out
+
+    def busy(self, sid):
+        s = self._session(sid)
+        if not s:
+            return None
+        with s.lock:
+            return None if s.dead else bool(s.turn_id or s.queue)
+
+    # ── control ──────────────────────────────────────────────────────────────────────────────────
+    def send(self, sid, text):
+        s = self._session(sid)
+        if not s or not text:
+            return False
+        c = self._get_client()
+        with s.lock:
+            if s.dead:
+                return False
+            s.echoes.append({"text": text.strip(), "t": time.time(),
+                             "uuid": "echo-%s" % uuidlib.uuid4().hex[:8]})
+            turn_id = s.turn_id
+            tid = s.tid
+        if c is not None and turn_id:
+            # mid-turn: steer, with the active turn as precondition; a race with the turn's end
+            # falls through to the queue (the worker delivers it in the next turn)
+            try:
+                c.turn_steer(tid, turn_id, [{"type": "text", "text": text}])
+                return True
+            except Exception:
+                pass
+        with s.lock:
+            if s.dead:
+                s.echoes = [e for e in s.echoes if e["text"] != text.strip()]
+                return False
+            entry_id = "q-%s" % uuidlib.uuid4().hex
+            s.queue.append(text)
+            s.queue_ids.append(entry_id)
+            s.change_generation += 1
+            # Keep append order identical in memory and on disk. _save_registry snapshots this RLock
+            # reentrantly before taking either registry lock; it never takes a session lock afterward.
+            self._save_registry(s, queue_append={"id": entry_id, "text": text})
+        self._ensure_worker(s)
+        s.kick.set()
+        return True
+
+    def interrupt(self, sid):
+        s = self._session(sid)
+        if not s:
+            return False
+        with s.lock:
+            if s.dead or not s.turn_id:
+                return False
+            tid, turn_id = s.tid, s.turn_id
+        c = self._client
+        if c is None:
+            return False
+        try:
+            c.turn_interrupt(tid, turn_id)
+            return True
+        except Exception as e:
+            self.log("interrupt %s: %s" % (s.name, e))
+            return False
+
+    def set_model(self, sid, value):
+        s = self._session(sid)
+        if not s or not value or not str(value).startswith("gpt"):
+            # a Claude alias (the other engine's vocabulary — a mis-aimed menu or script) would ride
+            # the next turn_start straight into a 400 that breaks the session's next turn; refusing
+            # here keeps the failure a loud kernel warn instead (2026-08-14 UI review)
+            return False
+        with s.lock:
+            s.model = value                # applied on the next turn_start; Codex persists it
+            s.change_generation += 1
+            queued = bool(s.queue) and not s.dead
+            self._save_registry(s, fields=("model",))
+        with s.norm_lock:
+            if s.norm:
+                # A later set_model may have completed while this caller waited for norm_lock.
+                # Publish the current persisted value, never this caller's possibly-stale argument.
+                with s.lock:               # norm_lock → session lock matches _ensure_norm/_append
+                    s.norm.model = s.model
+        if queued:
+            self._ensure_worker(s)
+            s.kick.set()
+        return True
+
+    def model_catalog(self):
+        """[{value,label}] for the UI's model picker — the app-server's own model list (the ONE
+        authoritative source), fetched once per process and cached. [] when the client is
+        unavailable (the picker then shows nothing rather than another vendor's list). A plan
+        account may still refuse some listed models per turn — that failure surfaces loudly as
+        the turn's error card, and switching back is one click."""
+        if self._catalog is not None:
+            return self._catalog
+        c = self._get_client()
+        if c is None:
+            return []
+        try:
+            ms = c.model_list()
+            self._catalog = [{"value": m.id, "label": getattr(m, "display_name", None) or m.id}
+                             for m in (getattr(ms, "data", None) or [])
+                             if not getattr(m, "hidden", False)]
+        except Exception as e:
+            self.log("model_list failed: %s" % e)
+            return []
+        return self._catalog
+
+    def set_mode(self, sid, mode):
+        return False   # phase 1 pins approval never + the custom permission profile; no live knob
+
+    def set_effort(self, sid, value):
+        s = self._session(sid)
+        if not s or value not in EFFORTS:
+            return False                   # max/ultracode are Claude-only — refuse loudly
+        with s.lock:
+            s.effort = value
+            s.change_generation += 1
+            queued = bool(s.queue) and not s.dead
+            self._save_registry(s, fields=("effort",))
+        if queued:
+            self._ensure_worker(s)
+            s.kick.set()
+        return True
+
+    def set_fast(self, sid, value):
+        return False   # no Codex equivalent
+
+    # ── lifecycle ────────────────────────────────────────────────────────────────────────────────
+    def _publish_spawn_name(self, s, bg="", fg=""):
+        """spawn's names/ write, transactional: the durable row already landed, so a raising
+        names write would leave a live row that holds no name — a retry of the same name then
+        mints a duplicate live session (the v1.3.12 audit's hole, re-opened on exactly this
+        raising path — the r29 verification). Retire the row, loudly."""
+        try:
+            self._write_name(s, bg, fg)
+        except BaseException:
+            with s.lock:
+                s.dead = True
+                try:
+                    self._save_registry(s, fields=("dead",))
+                except Exception as e2:
+                    self.log("codex spawn: could not retire %s after its name write failed (%s)"
+                             % (s.sid, e2))
+            with self._sessions_lock:
+                self._sessions.pop(s.sid, None)
+            raise
+
+    def _write_name(self, s, bg="", fg=""):
+        """The shared identity/discovery file names/<sid> (name, cwd, bg, fg) — the same four-field
+        format both other backends write, so name/identity surfaces read Codex sessions for free.
+        Discovery itself finds Codex transcripts via the codex registry, not this file.
+        ATOMIC (tmp + os.replace, like sdk_backend.write_name): the old in-place write_text was
+        torn-readable mid-write and its crash residue armed a decode landmine every later reader
+        tripped on; the corrupt-read catch below also HEALS that residue by rewriting whole (the
+        r31 verification). The backend lock serializes backend writers — kernel-side writers
+        (_set_session_color, _set_palette) write atomically themselves, so cross-module races
+        degrade to last-writer-wins of a whole valid file, never a torn one."""
+        d = self.state / "names"
+        d.mkdir(parents=True, exist_ok=True)
+        with self._names_lock:
+            try:
+                old = (d / s.sid).read_text().rstrip("\n").split("\t")
+            except (OSError, UnicodeDecodeError):
+                old = []
+            bg = bg or (old[2] if len(old) > 2 else "")
+            fg = fg or (old[3] if len(old) > 3 else "")
+            tmp = d / (s.sid + ".tmp")
+            try:
+                tmp.unlink(missing_ok=True)   # a planted FIFO at the fixed staging name blocks
+            except OSError:                   # open(); a leaked stray must not shadow the write
+                pass
+            try:
+                tmp.write_text("%s\t%s\t%s\t%s\n" % (s.name, s.cwd, bg, fg))
+                os.replace(str(tmp), str(d / s.sid))
+            finally:
+                tmp.unlink(missing_ok=True)   # never LEAK the staging file: names consumers
+                #                               read the dir, and a stray .tmp rendered as a
+                #                               phantom session (the r32 verification)
+
+    def spawn(self, name, cwd, bg="", fg="", sid=None, auth=""):
+        sid = sid or str(uuidlib.uuid4())
+        c = self._get_client()
+        if c is None:
+            # the entry still exists so the failure is VISIBLE on the lane (launch_error),
+            # never a silently-missing session
+            s = _Session(sid, "pending-%s" % sid[:8], name, cwd)
+            s.launch_error = {"text": self._client_err or SETUP_HINT, "at": time.time(),
+                              "limit": False}
+            with s.lock:
+                self._put_session(s)
+                try:
+                    self._save_registry(s, create=True)
+                except BaseException:
+                    # no durable row → no in-memory row: the phantom rendered as a live lane
+                    # with NO names file, so a retry of the same name minted a duplicate — the
+                    # r27 hole re-opened on exactly the raising path (the r28 verification)
+                    with self._sessions_lock:
+                        self._sessions.pop(sid, None)
+                    raise
+            self._publish_spawn_name(s)    # a LIVE launch-error row without a shared name let a
+            #                                retry mint a duplicate live "web" (the v1.3.12 audit)
+            return sid
+        try:
+            resp = c.thread_start({"cwd": cwd, "approvalPolicy": APPROVAL_POLICY,
+                                   **_execution_permissions(cwd, thread_start=True)})
+            tid = resp.thread.id
+            model = getattr(resp, "model", "") or ""
+        except Exception as e:
+            s = _Session(sid, "failed-%s" % sid[:8], name, cwd)
+            s.launch_error = {"text": "codex thread/start failed: %s" % e, "at": time.time(),
+                              "limit": False}
+            with s.lock:
+                self._put_session(s)
+                try:
+                    self._save_registry(s, create=True)
+                except BaseException:
+                    with self._sessions_lock:
+                        self._sessions.pop(sid, None)
+                    raise
+            self._publish_spawn_name(s)    # same rule as the client-missing branch above
+            return sid
+        s = _Session(sid, tid, name, cwd, model=model, color=bg)
+        s.loaded = True
+        with s.lock:
+            self._put_session(s)
+            try:
+                self._save_registry(s, create=True)
+            except BaseException:
+                with self._sessions_lock:
+                    self._sessions.pop(sid, None)
+                raise
+        self._ensure_norm(s)
+        # touch the materialized transcript NOW: discovery lists real files, and an empty jsonl
+        # parses to an empty session — the tab opens immediately instead of waiting for turn one
+        self.transcript_path(sid).touch()
+        self._publish_spawn_name(s, bg, fg)
+        self.push()
+        return sid
+
+    def resume(self, name, sid, cwd=None):
+        s = self._session(sid)
+        if not s:
+            return False
+        with s.lock:
+            prior = (s.dead, s.loaded, s.name, s.cwd, s.state, s.since, s.change_generation)
+            s.dead = False
+            s.loaded = False               # the worker thread/resumes before the next turn
+            if name and not s.name:
+                s.name = name              # ADVISORY only: adopting the caller's echo overwrote
+            #                                a rename that landed while the revive was in flight,
+            #                                silently reverting the acked new name in the durable
+            #                                registry (the r37 verification); the registry's own
+            #                                name is fresher by construction
+            if cwd:
+                s.cwd = cwd
+            s.state = "waiting"
+            s.since = time.time()
+            s.change_generation += 1
+            queued = bool(s.queue)
+            try:
+                self._save_registry(s, fields=("dead", "name", "cwd"))
+            except BaseException:
+                # roll the flip back: with dead=False already published in memory, a FAILED
+                # revive rendered a live lane beside its own reviveFailed message, and the next
+                # kernel restart silently killed it again (the r28 verification, executed)
+                (s.dead, s.loaded, s.name, s.cwd, s.state, s.since,
+                 s.change_generation) = prior
+                raise
+        if queued:
+            self._ensure_worker(s)
+            s.kick.set()
+        return True
+
+    def kill(self, sid):
+        s = self._session(sid)
+        if not s:
+            return False
+        save_error = None
+        with s.lock:
+            s.dead = True
+            turn_id, tid, worker = s.turn_id, s.tid, s.worker
+            # Persist the lifecycle mutation before releasing the session lock. A concurrent resume
+            # must order after this write instead of being overwritten by a delayed kill snapshot.
+            try:
+                self._save_registry(s, fields=("dead",))
+            except Exception as e:
+                save_error = e
+        c = self._client
+        if turn_id and c is not None:
+            try:
+                c.turn_interrupt(tid, turn_id)
+            except Exception as e:
+                self.log("kill interrupt %s: %s" % (s.name, e))
+        s.kick.set()                       # wake a retry wait or idle worker so it can exit
+        if worker and worker is not threading.current_thread():
+            worker.join(WORKER_JOIN_TIMEOUT)
+        worker_stopped = not worker or not worker.is_alive()
+        if not worker_stopped:
+            self.log("worker did not stop after kill: %s" % s.name)
+        if worker_stopped:
+            drained = False
+            with s.norm_lock:
+                held = s.norm.drain() if s.norm else []
+                if held:
+                    self._append(s, held)  # never eat a held final message; serialize file appends
+                    drained = True
+            if drained:                    # notify OUTSIDE norm_lock (see _append)
+                self.poke()
+                self.push_session(s.sid)
+        if save_error is not None:
+            raise save_error
+        return True
+
+    def rename(self, sid, new_name):
+        s = self._session(sid)
+        if not s:
+            return False
+        with s.lock:
+            old_name = s.name
+            s.name = new_name
+            tid = s.tid
+            try:
+                self._save_registry(s, fields=("name",))
+            except BaseException:
+                # durable registry FIRST, and a raising write publishes NOTHING: the old order
+                # moved the shared names file and the in-memory name before the raise, so three
+                # stores disagreed under a false "keeps its old name" message (the r28
+                # verification — the r28 kernel-layer reorder missed this layer)
+                s.name = old_name
+                raise
+            nf = self.state / "names" / s.sid
+            try:
+                old_line = nf.read_bytes()
+            except OSError:
+                old_line = None
+            try:
+                self._write_name(s)       # keep the shared identity file in sync (colours preserved)
+            except BaseException:
+                s.name = old_name         # compensate: the registry write above is re-run with
+                #                           the old name so the stores stay agreed; the raise
+                #                           still reaches the caller (loud)
+                if old_line is not None:
+                    try:
+                        nf.write_bytes(old_line)   # write_text TRUNCATES before it fails — an
+                        #                            ENOSPC left the identity file (and its
+                        #                            colours) empty (the r29 verification)
+                    except OSError as e2:
+                        self.log("codex rename: names/%s left truncated by a failed write (%s)"
+                                 % (s.sid, e2))
+                else:
+                    try:
+                        nf.unlink(missing_ok=True)  # _write_name may have CREATED a partial file
+                        #                             holding the NEW name — a failed rename must
+                        #                             not stay published (the r30 verification)
+                    except OSError as e2:
+                        self.log("codex rename: a partial names/%s could not be removed (%s)"
+                                 % (s.sid, e2))
+                try:
+                    self._save_registry(s, fields=("name",))
+                except Exception as e2:
+                    # a silent pass here hid the ONE moment the code knows the stores disagree:
+                    # the durable registry alone holds the NEW name and will apply the rename
+                    # the caller was told failed at the next restart (the r29 verification)
+                    self.log("codex rename compensation failed for %s: the registry alone holds "
+                             "the new name and will apply it at the next restart (%s)"
+                             % (s.sid, e2))
+                raise
+        c = self._client
+        if c is not None:
+            try:
+                c.thread_set_name(tid, new_name)
+            except Exception:
+                pass                       # cosmetic on the Codex side; romp's registry is the truth
+        return True
+
+    # ── the per-session worker: queue → turns → records ────────────────────────────────────────
+    def _ensure_worker(self, s):
+        with s.lock:
+            if s.worker and s.worker.is_alive():
+                return
+            s.worker = threading.Thread(target=self._work, args=(s,), daemon=True,
+                                        name="codex-%s" % s.name)
+            s.worker.start()
+
+    def _prepare_thread(self, s, c):
+        """Resume a durable thread, or turn a visible pending/failed placeholder into a real one."""
+        with s.lock:
+            if s.dead:
+                return False
+            tid, cwd = s.tid, s.cwd
+            create = tid.startswith("pending-") or tid.startswith("failed-")
+        if create:
+            resp = c.thread_start({"cwd": cwd, "approvalPolicy": APPROVAL_POLICY,
+                                   **_execution_permissions(cwd, thread_start=True)})
+            with s.lock:
+                if s.dead:
+                    return False
+                prior = (s.tid, s.model, s.loaded)
+                s.tid = resp.thread.id
+                s.model = getattr(resp, "model", "") or s.model
+                s.loaded = True
+                try:
+                    self._save_registry(s, fields=("tid", "model"))
+                except BaseException:
+                    # publish NOTHING on a raise: with the real tid only in memory, every retry
+                    # took the resume path and never re-saved it — the next kernel restart
+                    # loaded 'pending-…' and silently started a FRESH Codex thread (the r29
+                    # verification). Rolled back, the loud retry re-runs thread_start; an
+                    # orphaned server-side thread beats a silently forked conversation.
+                    (s.tid, s.model, s.loaded) = prior
+                    raise
+            with s.norm_lock:
+                s.norm = None
+            self._ensure_norm(s)
+            self.transcript_path(s.sid).touch()
+            nf = self.state / "names" / s.sid
+            try:
+                old_line = nf.read_bytes()
+            except OSError:
+                old_line = None
+            try:
+                self._write_name(s)
+            except (OSError, UnicodeDecodeError) as e:
+                # the thread is HEALTHY — failing the turn over a cosmetic identity write would
+                # be worse (a decode failure from crash residue sailed through an OSError-only
+                # catch and DID fail the turn, unhealed forever — the r31 verification) — but
+                # the write must not leave residue either. Restore the old line, or remove the
+                # partial file.
+                try:
+                    if old_line is not None:
+                        nf.write_bytes(old_line)
+                        self.log("codex: names/%s write failed after thread start (%s) — the "
+                                 "identity file was restored; it refreshes on the next rename"
+                                 % (s.sid, e))
+                    else:
+                        nf.unlink(missing_ok=True)
+                        self.log("codex: names/%s could not be published after thread start "
+                                 "(%s) — the session runs UNNAMED on shared surfaces until a "
+                                 "rename lands; a same-name create may collide meanwhile"
+                                 % (s.sid, e))
+                except OSError:
+                    self.log("codex: names/%s left in an unknown state by a failed write (%s)"
+                             % (s.sid, e))
+            self.push()
+            return True
+        c.thread_resume(tid, {"cwd": cwd, **_execution_permissions(cwd, thread_start=True)})
+        with s.lock:
+            if s.dead:
+                return False
+            s.loaded = True
+        return True
+
+    def _work(self, s):
+        retry_delay = CLIENT_RETRY_MIN
+        try:
+            while True:
+                s.kick.wait()
+                s.kick.clear()
+                while True:
+                    with s.lock:
+                        if s.dead:
+                            return
+                        queued = bool(s.queue)
+                        rejection = s.turn_rejection
+                        change_generation = s.change_generation
+                    if not queued:
+                        break
+                    client_generation = self._client_generation_now()
+                    if rejection == (change_generation, client_generation):
+                        # A background wake/push is not evidence that the rejected request changed.
+                        # Park without a timer; the four explicit session changes above or a newly
+                        # installed client generation set kick and make this tuple differ.
+                        break
+                    if rejection is not None:
+                        with s.lock:
+                            if s.turn_rejection == rejection:
+                                s.turn_rejection = None
+                    try:
+                        progressed = self._run_turn(s)
+                    except _PermanentRequestRejection as e:
+                        self.log("%s rejected (%s): %s" % (e.operation, s.name, e))
+                        try:
+                            with s.lock:
+                                s.launch_error = {"text": "codex %s rejected: %s" % (e.operation, e),
+                                                  "at": time.time(), "limit": False}
+                                s.state = "waiting"
+                                s.turn_id = None
+                                # Record the generations of the REJECTED request, not whatever is
+                                # current after its RPC returned. A send/model change racing the RPC
+                                # must remain a fresh kick and immediately retry the new request.
+                                s.turn_rejection = (e.change_generation, e.client_generation)
+                                self._save_registry(s, fields=("launchError",))
+                        except Exception:
+                            self.log("turn rejection registry save: %s" % traceback.format_exc())
+                        self.push_session(s.sid)
+                        break
+                    except Exception as e:
+                        self.log("turn failed (%s): %s" % (s.name, traceback.format_exc()))
+                        try:
+                            with s.lock:
+                                s.launch_error = {"text": "codex turn failed: %s" % e,
+                                                  "at": time.time(), "limit": False}
+                                s.state = "waiting"
+                                s.turn_id = None
+                                self._save_registry(s, fields=("launchError",))
+                        except Exception:
+                            self.log("turn failure registry save: %s" % traceback.format_exc())
+                        self.push_session(s.sid)
+                        progressed = False
+                    if progressed:
+                        retry_delay = CLIENT_RETRY_MIN
+                        continue
+                    delay = max(retry_delay, self._client_retry_remaining())
+                    retry_delay = min(CLIENT_RETRY_MAX, retry_delay * 2)
+                    # Clear stale send kicks before the backoff. A concurrent kill sets dead and/or
+                    # wakes this wait, so shutdown stays prompt while repeated sends cannot spin it.
+                    s.kick.clear()
+                    with s.lock:
+                        if s.dead:
+                            return
+                    s.kick.wait(delay)
+                    s.kick.clear()
+        finally:
+            with s.lock:
+                if s.worker is threading.current_thread():
+                    s.worker = None
+
+    def _run_turn(self, s):
+        c = self._get_client()
+        if c is None:
+            try:
+                with s.lock:
+                    s.launch_error = {"text": self._client_err or SETUP_HINT, "at": time.time(),
+                                      "limit": False}
+                    self._save_registry(s, fields=("launchError",))
+            except Exception:
+                self.log("client failure registry save: %s" % traceback.format_exc())
+            self.push_session(s.sid)
+            return False                   # queue stays parked; worker retries after the deadline
+        with s.lock:
+            loaded = s.loaded
+            prepare_change_generation = s.change_generation
+        if not loaded:
+            prepare_client_generation = self._client_generation_for(c)
+            try:
+                prepared = self._prepare_thread(s, c)
+            except Exception as e:
+                if _is_permanent_request_rejection(e):
+                    raise _PermanentRequestRejection(
+                        e, "thread preparation", prepare_change_generation,
+                        prepare_client_generation) from e
+                raise
+            if not prepared:
+                return True                # killed while the resume/create RPC was in flight
+        norm = self._ensure_norm(s)
+        with s.lock:
+            if s.dead:
+                return True
+            batch = list(s.queue)           # retain the durable prefix until turn/start ACKs
+            batch_ids = list(s.queue_ids)
+            if len(batch_ids) != len(batch):
+                raise RuntimeError("Codex in-memory queue identity invariant failed for %s" % s.sid)
+            if not batch:
+                return True
+            params = {"approvalPolicy": APPROVAL_POLICY, "cwd": s.cwd,
+                      **_execution_permissions(s.cwd)}
+            if s.model:
+                params["model"] = s.model
+            if s.effort:
+                params["effort"] = s.effort
+            tid = s.tid
+            change_generation = s.change_generation
+        # Do not hold the lifecycle lock across an app-server RPC: kill must stay prompt even when
+        # turn/start itself stalls. Sends may append meanwhile; the snapshotted prefix stays in place.
+        client_generation = self._client_generation_for(c)
+        try:
+            started = c.turn_start(tid, [{"type": "text", "text": t} for t in batch], params)
+        except Exception as e:
+            if _is_permanent_request_rejection(e):
+                raise _PermanentRequestRejection(
+                    e, "turn", change_generation, client_generation) from e
+            raise
+        turn_id = started.turn.id
+        ack_persisted = False
+        try:
+            with s.lock:
+                if s.queue[:len(batch)] != batch or s.queue_ids[:len(batch_ids)] != batch_ids:
+                    raise RuntimeError("Codex send queue prefix changed during turn/start")
+                del s.queue[:len(batch)]
+                del s.queue_ids[:len(batch_ids)]
+                s.turn_id = turn_id
+                s.state = "working"
+                s.since = time.time()
+                s.launch_error = None
+                s.turn_rejection = None
+                killed_during_start = s.dead
+                try:
+                    ack_mismatch = self._save_registry(
+                        s, fields=("launchError",), queue_ack=batch_ids)
+                except Exception:
+                    # turn/start already succeeded, but the durable ACK did not. Restore the exact
+                    # prefix before retrying so this process agrees with the still-queued disk row.
+                    s.queue[:0] = batch
+                    s.queue_ids[:0] = batch_ids
+                    raise
+                ack_persisted = True
+            if ack_mismatch:
+                self.log("registry queue ACK mismatch for %s; preserving durable queue" % s.sid)
+            self.push_session(s.sid)
+            if killed_during_start:
+                try:
+                    c.turn_interrupt(tid, turn_id)
+                except Exception as e:
+                    self.log("kill interrupt %s: %s" % (s.name, e))
+            while True:
+                n = c.next_turn_notification(turn_id)
+                method = getattr(n, "method", "")
+                wrote = False
+                with s.norm_lock:
+                    recs = norm.handle(method, _dump(getattr(n, "payload", None)))
+                    if recs:
+                        self._append(s, recs)
+                        wrote = True
+                if wrote:                          # notify OUTSIDE norm_lock (see _append)
+                    self.poke()
+                    self.push_session(s.sid)
+                if method == "turn/completed":
+                    break
+        except Exception:
+            if not ack_persisted:
+                # The request is still durable, so prevent an untracked acknowledged turn from
+                # continuing alongside its retry. unregister in finally always releases routing.
+                try:
+                    c.turn_interrupt(tid, turn_id)
+                except Exception as e:
+                    self.log("unpersisted turn interrupt %s: %s" % (s.name, e))
+            raise
+        finally:
+            try:
+                c.unregister_turn_notifications(turn_id)
+            except Exception:
+                pass
+            with s.lock:
+                s.turn_id = None
+                s.state = "waiting"
+                s.since = time.time()
+            self.push_session(s.sid)
+        return True
+
+    # ── chat tail ────────────────────────────────────────────────────────────────────────────────
+    def pending_queued(self, sid):
+        s = self._session(sid)
+        if not s:
+            return []
+        with s.lock:
+            return list(s.queue)
+
+    def live_atoms(self, sid):
+        s = self._session(sid)
+        if not s:
+            return []
+        with s.lock:
+            return [{"type": "user", "uuid": e["uuid"], "session_id": sid, "fsid": s.tid,
+                     "t": e["t"], "parentUuid": None, "author": "human",
+                     "message": {"role": "user",
+                                 "content": [{"type": "text", "text": e["text"]}]}}
+                    for e in s.echoes]
+
+    def prune_live(self, sid, tx_uuids, tx_user_texts=()):
+        s = self._session(sid)
+        if not s:
+            return
+        texts = {t.strip() for t in tx_user_texts or ()}
+        with s.lock:
+            s.echoes = [e for e in s.echoes
+                        if e["uuid"] not in (tx_uuids or ()) and e["text"] not in texts]
+
+    # ── ask picker (no Codex equivalent in phase 1) ─────────────────────────────────────────────
+    def on_ask(self, sid, kind, payload=None):
+        return False
+
+    def current_ask(self, sid):
+        return None
+
+    # ── the loud degradations ────────────────────────────────────────────────────────────────────
+    def launch_error(self, sid):
+        s = self._session(sid)
+        if not s:
+            return None
+        with s.lock:
+            return s.launch_error
+
+    def forwards_sends(self):
+        return True    # sends steer mid-turn or queue; the kernel hands them over immediately
+
+    def set_auth(self, sid, value):
+        return False   # Codex auth is machine-global (codex login); no per-session pick
+
+    def stop_task(self, sid, task_id):
+        return False
+
+    def mcp_status(self, sid):
+        return [], ("Codex sessions load MCP servers from ~/.codex/config.toml; "
+                    "per-session MCP controls aren't available here yet")
+
+    def mcp_action(self, sid, name, action, enabled=True):
+        return "Codex sessions load MCP servers from ~/.codex/config.toml; edit that file instead"
+
+    def rewind_files(self, sid, uuid):
+        return False
+
+    # ── coordination ─────────────────────────────────────────────────────────────────────────────
+    def working_note(self, sid):
+        s = self._session(sid)
+        if not s:
+            return ""
+        with s.lock:
+            return s.note
+
+    def set_working_note(self, sid, text):
+        s = self._session(sid)
+        if s:
+            with s.lock:
+                s.note = text or ""
+                self._save_registry(s, fields=("note",))
+
+    def wake(self, sid):
+        s = self._session(sid)
+        if not s:
+            return False
+        with s.lock:
+            if s.dead or not s.queue:
+                return False
+        self._ensure_worker(s)
+        s.kick.set()
+        return True
+
+    def deliver(self, sid, text):
+        """Postal deliver-time wake: a busy session gets the banner steered into the running turn;
+        an idle one gets a turn started with it — either way the mail is in front of the agent NOW."""
+        return self.send(sid, text)

--- a/kernel/codex_events.py
+++ b/kernel/codex_events.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""codex_events — Codex app-server v2 notifications → transcript-shaped records (plans/codex-backend.md).
+
+The Codex backend materializes each thread as transcript JSONL under $STATE/codex/projects/, in the
+SAME record vocabulary the Claude CLI writes, so the entire read side — the event model, the judges,
+all three panes — parses Codex sessions unchanged. This module is that mapping: one per-thread state
+machine over plain wire dicts, no IO and no SDK import, so the goldens run anywhere.
+
+Wire shapes come from the openai-codex SDK's generated bindings (openai_codex/generated/v2_all.py,
+pinned 0.144.4) — dicts exactly as received over JSON-RPC, camelCase field names. The mapping table
+and what phase 1 deliberately skips live in plans/codex-backend.md; skipped item types are COUNTED
+(`skipped`), never silently dropped, so the backend can log the vocabulary it isn't rendering yet.
+
+Chain discipline (adversarial review 2026-08-13): every record's uuid is minted through _mint, which
+refuses duplicates and self-parents — a colliding uuid silently ORPHANS all prior history in the
+FileAdapter's backward walk (by_uuid keeps the last record; the walk crosses the shared uuid once),
+which is the worst possible failure for an append-only transcript. Synthesized uuids (boundaries,
+error settles) carry a monotonic sequence for the same reason.
+"""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+
+# A runaway command's aggregatedOutput could balloon the materialized transcript; the Claude CLI
+# caps tool results too, so a cap keeps parity. The marker says what was dropped, per house rule.
+TOOL_OUTPUT_CAP = 30000
+
+# The Claude CLI's own interrupt settle — event_model.is_interrupt_record keys on this prefix and
+# ENDS the turn it lands in. Without it, an interrupt mid-tool leaves the turn open and the NEXT
+# prompt is absorbed as mid-turn input instead of opening its own turn (review finding #2).
+INTERRUPT_TEXT = "[Request interrupted by user]"
+
+
+def _cap(text):
+    if len(text) <= TOOL_OUTPUT_CAP:
+        return text
+    return text[:TOOL_OUTPUT_CAP] + "\n… [romp: output truncated at %d chars]" % TOOL_OUTPUT_CAP
+
+
+def _iso(ms, clock):
+    """Record timestamps, Claude transcript format (…T…S.mmmZ). Codex stamps item lifecycles with
+    epoch millis (startedAtMs/completedAtMs); events with no wire time (thread/compacted) take the
+    injected clock, so the goldens run on a fixed one."""
+    if ms is None:
+        ms = int(clock() * 1000)
+    dt = datetime.fromtimestamp(ms / 1000, timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + ("%03dZ" % (ms % 1000))
+
+
+def _user_input_text(content):
+    """The prompt text of a userMessage item's UserInput list. Non-text inputs keep a readable
+    placeholder (the Claude CLI does the same for pasted images)."""
+    parts = []
+    for c in content or []:
+        t = (c or {}).get("type")
+        if t == "text" and c.get("text"):
+            parts.append(c["text"])
+        elif t in ("image", "localImage"):
+            parts.append("[Image: %s]" % (c.get("path") or c.get("url") or "pasted"))
+        elif t in ("skill", "mention") and c.get("name"):
+            parts.append(c["name"])
+    return "\n".join(p for p in parts if p).strip()
+
+
+def _mcp_text(item):
+    """One text blob for an mcpToolCall's outcome: the error message when it failed, else the
+    result's MCP content blocks (text kept, the rest summarized by type)."""
+    err = item.get("error") or {}
+    if err.get("message"):
+        return err["message"]
+    res = item.get("result") or {}
+    parts = []
+    for b in res.get("content") or []:
+        if isinstance(b, dict) and b.get("type") == "text" and b.get("text"):
+            parts.append(b["text"])
+        elif isinstance(b, dict) and b.get("type"):
+            parts.append("[%s]" % b["type"])
+    if not parts and res.get("structuredContent") is not None:
+        parts.append(json.dumps(res["structuredContent"], ensure_ascii=False, default=str))
+    return "\n".join(parts)
+
+
+def usage_from_token_usage(token_usage):
+    """ThreadTokenUsage.last → the Anthropic usage keys the cost/token readers already understand
+    (kernel _session_tokens). reasoningOutputTokens is folded into output (that is what it is)."""
+    last = (token_usage or {}).get("last") or {}
+    if not last:
+        return None
+    return {"input_tokens": last.get("inputTokens", 0),
+            "output_tokens": last.get("outputTokens", 0) + last.get("reasoningOutputTokens", 0),
+            "cache_read_input_tokens": last.get("cachedInputTokens", 0),
+            "cache_creation_input_tokens": 0}
+
+
+class ThreadNormalizer:
+    """One Codex thread's notification → record state machine (single writer, append-only file).
+
+    The one stateful trick: a turn's FINAL agentMessage must land already stamped
+    stop_reason:"end_turn" — records are append-only, there is no retro-stamp — so a completed
+    agentMessage is HELD and flushed by whatever comes next: a further item flushes it
+    stop_reason:null (mid-turn text, exactly how the Claude CLI writes it), turn/completed flushes
+    it "end_turn" (+ usage). Everything else is a straight mapping; see plans/codex-backend.md.
+
+    Restart/resume: the backend re-anchors `last_uuid` on the materialized file's tail and seeds
+    `seen_uuids` with every uuid already in the file, so a notification re-delivered across a
+    restart (or an item spanning it) can neither re-mint an existing record nor self-parent.
+    """
+
+    def __init__(self, thread_id, cwd="", version="", model="", last_uuid=None, clock=time.time,
+                 seen_uuids=None):
+        self.thread_id = thread_id
+        self.cwd = cwd
+        self.version = version        # codex CLI version, stamped like the Claude CLI's `version`
+        self.model = model            # kept current by the backend; assistant records carry it
+        self.clock = clock
+        self.last_uuid = last_uuid    # chain anchor; the backend re-anchors on the file tail at resume
+        self.turn_id = None
+        self.turn_open = False        # turn/started..turn/completed bracket (the backend's busy signal)
+        self.skipped = {}             # phase-2 item vocabulary seen on the wire: type -> count
+        self._usage = None            # newest thread/tokenUsage/updated, stamped onto the turn's settle
+        self.context = None           # (last-call total tokens, model context window) — the fill %
+        self._pending = None          # the held agentMessage: (uuid, ts_ms, text)
+        self._minted = set(seen_uuids or ())    # every uuid this FILE already carries
+        self._tool_open = set(self._minted)     # item ids whose tool_use record is already on disk
+        self._seen_user = set(self._minted)     # userMessage ids already written (started+completed)
+        self._error_settled = set()   # turn ids whose failure card is already written (error → turn/completed dedup)
+        self._seq = 0                 # uniquifier for synthesized/colliding uuids
+        self._last_ms = 0             # newest timestamp emitted — the floor for clock-stamped records
+
+    # ── record builders (every record advances the uuid chain) ────────────────────────────────
+    def _mint(self, uuid):
+        """A unique, never-self-parenting uuid. A collision (same uuid twice, or a re-delivered id
+        after restart) would orphan the whole prior chain in the parser's walk — refuse it."""
+        base = uuid or "cx"
+        while uuid in self._minted or uuid == self.last_uuid or not uuid:
+            self._seq += 1
+            uuid = "%s~%d" % (base, self._seq)
+        self._minted.add(uuid)
+        return uuid
+
+    def _stamp(self, ts_ms):
+        """Timestamps are ordering: a record with no wire time (an interrupt/error settle, a
+        boundary) takes the clock FLOORED at the newest emitted timestamp — the wall clock can sit
+        behind the wire's item stamps (skew, or a frozen test clock), and a settle stamped earlier
+        than the record it follows re-sorts mid-turn in the parse and ends the turn in the wrong
+        place. Same-instant is fine (the parser tie-breaks on file order); earlier is not."""
+        if ts_ms is None:
+            ts_ms = max(int(self.clock() * 1000), self._last_ms)
+        self._last_ms = max(self._last_ms, ts_ms)
+        return ts_ms
+
+    def _base(self, rtype, uuid, ts_ms):
+        uuid = self._mint(uuid)
+        r = {"type": rtype, "uuid": uuid, "parentUuid": self.last_uuid,
+             "timestamp": _iso(self._stamp(ts_ms), self.clock), "sessionId": self.thread_id,
+             "cwd": self.cwd, "version": self.version}
+        self.last_uuid = uuid
+        return r
+
+    def _user(self, uuid, ts_ms, blocks, prompt_source="sdk"):
+        r = self._base("user", uuid, ts_ms)
+        r["message"] = {"role": "user", "content": blocks}
+        if prompt_source:
+            # "sdk" = the human on a programmatic session — author_of(sdk_human=True) renders it
+            # as the human bubble, the same convention the SDK backend's sessions use.
+            r["promptSource"] = prompt_source
+        return r
+
+    def _assistant(self, uuid, ts_ms, blocks, stop=None, usage=None):
+        m = {"role": "assistant", "content": blocks, "stop_reason": stop}
+        if self.model:
+            m["model"] = self.model
+        if usage:
+            m["usage"] = usage
+        r = self._base("assistant", uuid, ts_ms)
+        r["message"] = m
+        return r
+
+    def _tool_use(self, iid, ts_ms, name, tool_input):
+        self._tool_open.add(iid)
+        return self._assistant(iid, ts_ms,
+                               [{"type": "tool_use", "id": iid, "name": name, "input": tool_input}])
+
+    def _tool_result(self, iid, ts_ms, text, is_error=False, raw=None):
+        # content is a plain STRING — the dominant Claude CLI shape and what the kernel's output
+        # fills render directly; a block list would display as a JSON dump (review finding #3)
+        block = {"type": "tool_result", "tool_use_id": iid, "content": text}
+        if is_error:
+            block["is_error"] = True
+        r = self._user(iid + "-r", ts_ms, [block], prompt_source=None)
+        if raw is not None:
+            r["toolUseResult"] = raw   # the raw Codex payload, where the kernel's readers look for it
+        return r
+
+    def _flush(self, stop=None, usage=None):
+        """Write out the held agentMessage (see class docstring)."""
+        if not self._pending:
+            return []
+        uuid, ts_ms, text = self._pending
+        self._pending = None
+        return [self._assistant(uuid, ts_ms, [{"type": "text", "text": text}],
+                                stop=stop, usage=usage)]
+
+    def drain(self):
+        """Backend shutdown hook: write out anything held so process death never eats the turn's
+        final message. stop stays null — the turn genuinely didn't settle."""
+        return self._flush()
+
+    # ── the dispatcher ─────────────────────────────────────────────────────────────────────────
+    def handle(self, method, params):
+        """Map one notification to the records to APPEND (possibly []). The caller owns the file."""
+        p = params or {}
+        if method == "turn/started":
+            self.turn_id = (p.get("turn") or {}).get("id")
+            self.turn_open = True
+            return []
+        if method == "item/started":
+            return self._item(p.get("item") or {}, p.get("startedAtMs"), started=True)
+        if method == "item/completed":
+            return self._item(p.get("item") or {}, p.get("completedAtMs"), started=False)
+        if method == "turn/completed":
+            self.turn_open = False
+            return self._turn_completed(p.get("turn") or {})
+        if method == "thread/compacted":
+            return self._compacted(p)
+        if method == "thread/tokenUsage/updated":
+            tu = p.get("tokenUsage") or {}
+            self._usage = usage_from_token_usage(tu)
+            # context fill is the LAST call's footprint (what occupies the window right now);
+            # `total` is thread-cumulative — a cost number that exceeds the window within a few
+            # turns (review finding #7; codex's own TUI meters on `last` too)
+            last_total = (tu.get("last") or {}).get("totalTokens")
+            if last_total is not None:
+                self.context = (last_total, tu.get("modelContextWindow"))
+            return []
+        if method == "error":
+            return self._error(p)
+        return []
+
+    def _item(self, item, ts_ms, started):
+        t = item.get("type")
+        iid = item.get("id") or ""
+        if t == "userMessage":
+            if iid in self._seen_user:
+                return []
+            self._seen_user.add(iid)
+            text = _user_input_text(item.get("content"))
+            if not text:
+                return []
+            # a user item mid-turn is a steer — close any held text first, then the prompt record
+            return self._flush() + [self._user(iid, ts_ms, [{"type": "text", "text": text}])]
+        if started:
+            # calls whose INVOCATION should show the moment it starts (long commands stay visible
+            # while they run, like a Claude tool_use does); results land at completed.
+            if t == "commandExecution":
+                return self._flush() + [self._tool_use(iid, ts_ms, "Bash",
+                                                       {"command": item.get("command") or ""})]
+            if t == "webSearch":
+                return self._flush() + [self._tool_use(iid, ts_ms, "WebSearch",
+                                                       {"query": item.get("query") or ""})]
+            if t == "mcpToolCall":
+                name = "mcp__%s__%s" % (item.get("server") or "?", item.get("tool") or "?")
+                args = item.get("arguments")
+                return self._flush() + [self._tool_use(iid, ts_ms, name,
+                                                       args if isinstance(args, dict) else
+                                                       ({"arguments": args} if args is not None else {}))]
+            return []   # everything else is written at completed, when its content is final
+        # ── item/completed ──
+        if t == "agentMessage":
+            out = self._flush()
+            if item.get("text"):
+                self._pending = (iid, ts_ms, item["text"])
+            return out
+        if t == "reasoning":
+            parts = [s for s in (item.get("content") or []) if s] or \
+                    [s for s in (item.get("summary") or []) if s]
+            if not parts:
+                return []
+            return self._flush() + [self._assistant(iid, ts_ms,
+                                                    [{"type": "thinking",
+                                                      "thinking": "\n\n".join(parts)}])]
+        if t == "commandExecution":
+            out = self._flush()
+            if iid not in self._tool_open:   # attached mid-turn: write the invocation first
+                out.append(self._tool_use(iid, ts_ms, "Bash", {"command": item.get("command") or ""}))
+            exit_code = item.get("exitCode")
+            status = item.get("status")
+            # declined/failed commands arrive with exitCode None — the status is the error signal;
+            # a sandbox refusal must never read as a clean success (review finding #8)
+            failed = (exit_code not in (0, None)) or status in ("declined", "failed")
+            text = item.get("aggregatedOutput") or ""
+            if not text and status in ("declined", "failed"):
+                text = "[command %s]" % status
+            out.append(self._tool_result(iid, ts_ms, _cap(text), is_error=failed,
+                                         raw={"exitCode": exit_code, "status": status,
+                                              "durationMs": item.get("durationMs")}))
+            return out
+        if t == "fileChange":
+            out = self._flush()
+            status = item.get("status")
+            failed = status in ("failed", "declined")
+            for i, ch in enumerate(item.get("changes") or []):
+                cid = "%s-%d" % (iid, i)
+                kind = ch.get("kind")
+                kind = kind.get("type") if isinstance(kind, dict) else kind
+                name = "Write" if kind == "add" else "Edit"
+                out.append(self._tool_use(cid, ts_ms, name, {"file_path": ch.get("path") or ""}))
+                text = ch.get("diff") or ""
+                if failed:
+                    text = ("[patch %s]\n" % status) + text
+                out.append(self._tool_result(cid, ts_ms, _cap(text), is_error=failed,
+                                             raw={"kind": kind, "status": status}))
+            return out
+        if t == "mcpToolCall":
+            out = self._flush()
+            if iid not in self._tool_open:
+                name = "mcp__%s__%s" % (item.get("server") or "?", item.get("tool") or "?")
+                args = item.get("arguments")
+                out.append(self._tool_use(iid, ts_ms, name,
+                                          args if isinstance(args, dict) else
+                                          ({"arguments": args} if args is not None else {})))
+            out.append(self._tool_result(iid, ts_ms, _cap(_mcp_text(item)),
+                                         is_error=bool(item.get("error"))))
+            return out
+        if t == "webSearch":
+            out = self._flush()
+            if iid not in self._tool_open:
+                out.append(self._tool_use(iid, ts_ms, "WebSearch", {"query": item.get("query") or ""}))
+            out.append(self._tool_result(iid, ts_ms, "done"))
+            return out
+        if t == "contextCompaction":
+            return []   # thread/compacted writes the boundary; two writers would double it
+        # phase-2 vocabulary (plan, subAgentActivity, collabAgentToolCall, imageView, …) — counted
+        if t:
+            self.skipped[t] = self.skipped.get(t, 0) + 1
+        return []
+
+    def _turn_completed(self, turn):
+        status = turn.get("status")
+        err = turn.get("error") or {}
+        tid = turn.get("id") or self.turn_id or "turn"
+        if status == "failed" or err.get("message"):
+            self._usage = None   # never stamp this turn's numbers on a later settle (finding #9)
+            out = self._flush()
+            if tid in self._error_settled:
+                return out       # the terminal `error` notification already wrote this failure card
+            rec = self._assistant("%s-err" % tid, None,
+                                  [{"type": "text", "text": err.get("message") or "turn failed"}],
+                                  stop="end_turn")
+            rec["isApiErrorMessage"] = True
+            out.append(rec)
+            return out
+        if status == "interrupted":
+            # partial text lands mid-turn-shaped (stop null); the CLI-convention interrupt record
+            # then ENDS the turn (is_interrupt_record), so the next prompt opens its own turn
+            # instead of being absorbed into this one (review finding #2)
+            self._usage = None
+            out = self._flush()
+            out.append(self._user("%s-int" % tid, None,
+                                  [{"type": "text", "text": INTERRUPT_TEXT}], prompt_source=None))
+            return out
+        usage, self._usage = self._usage, None
+        return self._flush(stop="end_turn", usage=usage)
+
+    def _compacted(self, p):
+        # the held reply is PRE-compaction content — it must land before the boundary so the stitch
+        # points at the true leaf and file order stays chronological (review finding #4)
+        out = self._flush()
+        uuid = self._mint("cb-%s" % (p.get("turnId") or self.turn_id or "0"))
+        rec = {"type": "system", "subtype": "compact_boundary", "uuid": uuid, "parentUuid": None,
+               "logicalParentUuid": self.last_uuid, "timestamp": _iso(self._stamp(None), self.clock),
+               "sessionId": self.thread_id, "cwd": self.cwd, "version": self.version,
+               "isMeta": False, "compactMetadata": {"trigger": "auto"}}
+        # Codex exposes no compaction summary text — no isCompactSummary record follows, and the
+        # card's "what compaction kept" stays absent for Codex sessions (absent, not faked).
+        self.last_uuid = uuid
+        out.append(rec)
+        return out
+
+    def _error(self, p):
+        if p.get("willRetry"):
+            return []   # transient — the backend may chip it; the transcript records outcomes
+        err = (p.get("error") or {})
+        tid = p.get("turnId") or self.turn_id or "0"
+        self._error_settled.add(tid)   # turn/completed(failed) for the same turn stands down
+        out = self._flush()
+        rec = self._assistant("err-%s" % tid, None,
+                              [{"type": "text", "text": err.get("message") or "error"}],
+                              stop="end_turn")
+        rec["isApiErrorMessage"] = True
+        out.append(rec)
+        return out

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1219,9 +1219,12 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             outp = os.path.join(JUDGE_SCRATCH, "codex-%d-%d.out" % (os.getpid(), rid))
             try:
                 try:
+                    # another vendor's process has no use for the Anthropic key (_judge_env re-injects
+                    # it for key-billed sessions); strip it from the child's environment (PR #885 review)
+                    cenv = {k: v for k, v in env.items() if k != "ANTHROPIC_API_KEY"}
                     p = subprocess.run(_judge_cmd_codex(model, _codex_effort(effort, tier), outp),
                                        input=(sys_prompt or "") + "\n\n" + (user or ""),
-                                       capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=env,
+                                       capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=cenv,
                                        timeout=CALL_ALARM_S + 5)
                 except Exception as e:
                     _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -60,6 +60,7 @@ GONEDIR  = STATE / "gone"                # session-death markers {t, by[, endedA
                                          #   read by a CLOSED list: _cli_epoch, run_close's death-pending drain, and the writers'
                                          #   own idempotence check (2026-08-13; the reader list is test-pinned so it cannot creep)
 SDKDIR   = STATE / "sdk"                 # the SDK backend's per-session registry — lastSid tracks the CURRENT transcript fsid
+CODEXDIR = STATE / "codex"               # the Codex backend's root (plans/codex-backend.md): registry.json +
 # Judge scratch cwd (the user 2026-07-20): every one-shot `claude -p` judge call writes a transcript
 # under the project dir of its CWD. With cwd=/tmp those piled into the SHARED -private-tmp project
 # dir (~4,600/day, 51k files) mixed with anything else ever run from /tmp — unprunable without
@@ -106,7 +107,7 @@ def _rebind_state(path):
     save_goals wrote synthetic fixtures into the live goals/ and the triage pass then stormed
     judge-errors.jsonl over those orphans every pass forever (the user 2026-06-24). A test must call this
     instead of assigning jd.STATE alone. Not used in production (STATE is bound once at import)."""
-    global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR, EPIDIR, GONEDIR, JUDGE_AUTH
+    global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR, EPIDIR, GONEDIR, JUDGE_AUTH, CODEXDIR
     global JUDGE_SCRATCH
     STATE = path
     JUDGE_SCRATCH = str(STATE / "judge-scratch")   # state-rooted now, so it rebinds with the rest
@@ -118,6 +119,7 @@ def _rebind_state(path):
     global JUDGE_LIMIT
     JUDGE_LIMIT = STATE / "judge-limit.json"
     SDKDIR = STATE / "sdk"
+    CODEXDIR = STATE / "codex"
     EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
     _episode_memo.clear()   # ...and so are the episode-log reads
@@ -165,6 +167,9 @@ def _triage_model():  return _state_str("judge-model", TRIAGE_MODEL)   # gear "T
 def _index_model():   return _state_str("index-model", INDEX_MODEL)    # gear "Indexing model" → STATE/index-model
 def _triage_effort(): return _state_str("judge-effort", "")   # "" → pass NO --effort (the long-standing default)
 def _index_effort():  return _state_str("index-effort", "")
+def _judge_engine():  return _state_str("judge-engine", "claude")   # "claude" | "codex" — which model
+#   harness runs the judges (docs/codex.md §judges). "codex" lets a machine with no Claude login keep
+#   the board thinking: every judge becomes a one-shot `codex exec` billing the machine's codex login.
 
 
 # The DISTILLING tier (the user 2026-08-14): the card-prose writers — distiller, briefer, staller — get
@@ -996,6 +1001,68 @@ def _limit_clear():
         pass
 
 
+def _judge_codex_bin():
+    """The codex binary for engine-"codex" judge calls — the claude one's resolution ladder (env
+    override, PATH, the standard user spot) plus the BUNDLED binary inside codexvenv: openai-codex
+    ships it at site-packages/codex_cli_bin/bin/codex with no PATH entry point (2026-08-14
+    proofread). romp-codex-setup links it to ~/.local/bin, but a kernel started over non-login ssh may
+    not have that dir on PATH — the same failure mode _judge_claude_bin's docstring records."""
+    import glob
+    p = (os.environ.get("ROMP_CODEX_BIN") or shutil.which("codex")
+         or os.path.expanduser("~/.local/bin/codex"))
+    if os.path.exists(p):
+        return p
+    for c in sorted(glob.glob(str(STATE / "codexvenv" / "lib" / "python3.*" /
+                                  "site-packages" / "codex_cli_bin" / "bin" / "codex"))):
+        return c
+    return p
+# Hard wall-clock cap on ONE judge call (perl alarm → SIGALRM, logged as "empty stdout (exit -14)").
+# Was 45s until 2026-07-27, when an API slow patch killed a burst of healthy-but-slow calls across four
+# sessions in one morning and the coerce floor minted a card titled with the user's raw message head from
+# the wreckage. A slow call that lands beats a killed one on both cost and heal latency (the kill burns
+# the tokens AND leaves the pass to re-run next tick), so be permissive (the user 2026-07-27): the alarm
+# guards a truly hung exec, not a slow model. The subprocess timeout below it is the backstop for a perl
+# that never ran; it tracks this constant so the two can't drift apart.
+
+def _judge_cmd_codex(model, effort, outpath):
+    """The `codex exec` argv for ONE judge call when STATE/judge-engine is "codex" (docs/codex.md).
+    The same isolation goals as the claude argv, by different means: --ephemeral (no session files —
+    the scratch-pruning problem doesn't exist), an invocation-local custom permission profile that
+    grants only Codex's minimal runtime paths plus READ access to the scratch workspace (the built-in
+    `:read-only` profile deliberately grants read access to the whole host), --skip-git-repo-check +
+    -C scratch (never the user's repo), the prompt on stdin (exec has no separate system-prompt flag
+    — system + user are concatenated), and the reply written to `outpath` via -o (the final agent
+    message alone; no event-stream parsing).
+    Model: only an explicit gpt-* override is passed — a ChatGPT-plan account 400-refuses every
+    non-default model (probed live 2026-08-14), so the account's default is THE default and a
+    claude alias (the other engine's vocabulary, incl. the classify arms') is ignored rather than
+    sent to certain failure."""
+    judge_permissions = (
+        'permissions.romp_judge={ filesystem = { ":minimal" = "read", '
+        '":workspace_roots" = { "." = "read" } }, network = { enabled = false } }'
+    )
+    cmd = ["perl", "-e", "alarm %d; exec @ARGV" % CALL_ALARM_S, _judge_codex_bin(), "exec",
+           "--ephemeral", "--ignore-user-config", "--ignore-rules", "--strict-config",
+           "--skip-git-repo-check", "-c", judge_permissions,
+           "-c", 'default_permissions="romp_judge"', "--color", "never",
+           "-C", JUDGE_SCRATCH, "-o", outpath]
+    if model and str(model).startswith("gpt"):
+        cmd += ["-m", model]
+    if effort:
+        cmd += ["-c", "model_reasoning_effort=%s" % effort]
+    return cmd
+
+def _codex_effort(effort, tier):
+    """Map a judge effort onto what codex accepts for the plan-account model family: low/medium/
+    high/xhigh pass through; minimal/none 400 there (probed) → low; max/ultracode are Claude-only →
+    xhigh/None. No explicit effort: index-tier work is mechanical → low (the cost lever, standing in
+    for the claude path's MAX_THINKING_TOKENS=0); triage keeps the model's default reasoning."""
+    m = {"low": "low", "medium": "medium", "high": "high", "xhigh": "xhigh",
+         "minimal": "low", "none": "low", "max": "xhigh"}
+    if effort:
+        return m.get(effort)
+    return "low" if tier == "index" else None
+
 def _judge_env(tier, auth="login"):
     """The subprocess env for ONE judge call. Drops the TMUX vars (so the child isn't taken for a live
     pane) and trips the Stop-hook recursion guard. For the INDEX tier it also disables extended thinking
@@ -1087,6 +1154,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
     except Exception:
         pass
     fsid = getattr(_judge_ctx, "fsid", None)
+    engine = _judge_engine()                          # "claude" | "codex" (docs/codex.md §judges)
     auth = _judge_auth(fsid)                          # this call bills what the judged session bills
     try:
         # RATE-LIMIT GATE (the user 2026-07-07), scoped to the calls it can actually starve (the user
@@ -1142,6 +1210,45 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
     sent = time.time()                                # literal wall-clock: the prompt goes to the API now
     rid = _active_begin(judge or tier, fsid, sent)    # live bar starts NOW (deregistered in finally below)
     try:
+        if engine == "codex":
+            # docs/codex.md §Running the judges on Codex — the same bracket (pause skip, debug stash,
+            # live bar), a different one-shot engine. The reply lands in a temp file (-o); `codex exec`
+            # reports no token usage, so the usage row keeps the call's bracket + engine for the
+            # timeline and counts, and leaves tokens/cost null (absent, not faked).
+            os.makedirs(JUDGE_SCRATCH, exist_ok=True)
+            outp = os.path.join(JUDGE_SCRATCH, "codex-%d-%d.out" % (os.getpid(), rid))
+            try:
+                try:
+                    p = subprocess.run(_judge_cmd_codex(model, _codex_effort(effort, tier), outp),
+                                       input=(sys_prompt or "") + "\n\n" + (user or ""),
+                                       capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=env,
+                                       timeout=CALL_ALARM_S + 5)
+                except Exception as e:
+                    _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)
+                    return ""
+                recv = time.time()
+                try:
+                    with open(outp, "r", encoding="utf-8") as f:
+                        reply = f.read().strip()
+                except OSError:
+                    reply = ""
+                if not reply:
+                    # dead/refused call — the -o file is the only success signal; record the evidence
+                    _log_judge_error(judge or tier, fsid, "call",
+                                     note="codex empty reply (exit %s): %s"
+                                          % (getattr(p, "returncode", "?"),
+                                             ((p.stderr or "") + (p.stdout or "")).strip()[-200:] or "no output"))
+                    return ""
+                _judge_ctx.last["reply"] = _mid_elide(reply)
+                _log_judge_usage(judge or tier, tier, (model if str(model).startswith("gpt") else "codex-default"),
+                                 fsid, {"duration_ms": int((recv - sent) * 1000)}, sent, recv)
+                _auth_down_clear(fsid)                # a successful billed call clears either engine's latch
+                return reply
+            finally:
+                try:
+                    os.unlink(outp)
+                except OSError:
+                    pass
         try:
             _ensure_judge_scratch()                     # 0700 and ours; recreate per call (a purge/rm mid-run)
         except OSError as e:
@@ -5208,6 +5315,44 @@ _namefp_memo = {}    # names/ entry -> (its mtime, resolved project dir or None)
 #                      the number of live names/ entries, never by uptime.
 
 
+def _codex_rows(cutoff, seen):
+    """Discovery rows for Codex sessions — (fsid=STABLE SID, materialized path, anchor sid, name),
+    read from the Codex backend's registry (plans/codex-backend.md). The names/ loop above skips
+    these naturally (no <sid>.jsonl under the Claude roots); this is the ONE extra fact the read
+    side needs. Dead sessions keep discovering like dead tmux/SDK ones do — history stays browsable;
+    the WINDOW cutoff is what ages them out. No forks: a Codex thread id is stable across resumes.
+
+    The identity slot is the STABLE SID, never the app-server thread id: liveness
+    (CodexBackend.live_sessions) keys on the SID, so a TID here meant live Codex rows never joined
+    the alive set, the picker offered a not-running TID row, and reviving it shelled
+    `romp resume <TID>` through the tmux path — the TID rides only in the transcript PATH, which
+    is the one place it means anything to a reader (the v1.3.13 audit's P1, executed)."""
+    try:
+        reg = json.loads((CODEXDIR / "registry.json").read_text())
+    except Exception:
+        return []
+    rows = []
+    for sid, r in sorted(reg.items()):
+        if not isinstance(r, dict):
+            continue                      # the corrupt-row shape the migrations survive must
+        #                                   not kill every cold discover() one call later (the
+        #                                   r39 verification, executed: feed/picker/judge all
+        #                                   share this walk)
+        tid, cwd = r.get("tid"), r.get("cwd") or ""
+        if not tid or not cwd:
+            continue
+        p = CODEXDIR / "projects" / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)) / (tid + ".jsonl")
+        ps = str(p)
+        try:
+            mt = p.stat().st_mtime
+        except OSError:
+            continue
+        if mt >= cutoff and ps not in seen:
+            seen.add(ps)
+            rows.append((sid, p, sid, r.get("name", "")))
+    return rows
+
+
 def _discover_fingerprint():
     """A cheap structural signature of the transcript namespace that changes EXACTLY when discover()'s
     output would: a session ADDED/RENAMED (a names/ entry's set or mtime changes) or a FORK appearing (a
@@ -5229,7 +5374,7 @@ def _discover_fingerprint():
     MTIME is re-stat'd every call without exception: that is the fork signal this whole fingerprint exists to
     catch, and caching it would blind discover() to new forks."""
     try:
-        entries = sorted(NAMES.iterdir())
+        entries = sorted(e for e in NAMES.iterdir() if not e.name.endswith(".tmp"))
     except OSError:
         return None
     fp = []
@@ -5260,6 +5405,12 @@ def _discover_fingerprint():
         live = {row[0] for row in fp}                           # walk → evict it, so the memo stays bounded
         for name in [k for k in _namefp_memo if k not in live]:  # by the sessions that currently EXIST
             del _namefp_memo[name]
+    # the Codex namespace: a session add/rename/kill rewrites registry.json (its mtime is the
+    # signal) — the same add-not-append semantics as the Claude roots above.
+    try:
+        fp.append(("codex-reg", (CODEXDIR / "registry.json").stat().st_mtime))
+    except OSError:
+        pass
     return tuple(fp)
 
 
@@ -5339,6 +5490,8 @@ def _discover_impl(now, window=None, forks=True):
 
     for f in sorted(NAMES.iterdir()):
         sid = f.name
+        if sid.endswith(".tmp"):
+            continue                      # a writer's staging file, never a session
         try:
             parts = f.read_text().rstrip("\n").split("\t")
         except Exception:
@@ -5377,6 +5530,7 @@ def _discover_impl(now, window=None, forks=True):
                 t = _custom_title(path_str); title_memo[path_str] = t
             if t == name:
                 seen.add(path_str); out.append((stem, Path(path_str), sid, name))
+    out.extend(_codex_rows(cutoff, seen))   # Codex sessions join discovery (docs/codex.md)
     return out
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8670,6 +8670,17 @@ def _codex_ready():
         return False
 
 
+def _judge_engine_name():
+    """Which vendor runs the judges — `romp engine` writes STATE/judge-engine ("claude" | "codex");
+    absent/unknown → claude. Read here (not through the judge module) so the /models handler can gate
+    its Codex consult without importing the judge."""
+    try:
+        v = (jd.STATE / "judge-engine").read_text().strip()
+    except OSError:
+        return "claude"
+    return v if v in ("claude", "codex") else "claude"
+
+
 def _default_backend():
     """The machine default for a NEW session when the caller names none — `romp engine` writes
     STATE/default-backend ("sdk" | "codex"); absent/unknown → sdk, the long-standing default.
@@ -31245,7 +31256,12 @@ class Handler(BaseHTTPRequestHandler):
                 # vendor's models); efforts are the four Codex accepts — max/ultracode are Claude-only.
                 cx = _codex()
                 cx_models = []
-                if cx:
+                # Codex is consulted ONLY where this machine opted in — the Codex default backend, the
+                # Codex judge engine, or a live Codex session. model_catalog() builds the client, which
+                # SPAWNS `codex app-server`; unconditional, every dashboard load spawned (or repeatedly
+                # failed to spawn) it on every install, the opposite of off-by-default (PR #885 review).
+                if cx and (_default_backend() == "codex" or _judge_engine_name() == "codex"
+                           or bool(cx.live_sessions())):
                     try:
                         cx_models = cx.model_catalog()
                     except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1256,7 +1256,12 @@ def _session_backend(sid, tm):
     if tm and tm.get("backend"):
         return tm["backend"]
     be = _sdk()
-    return "sdk" if (be and be.owns(sid)) else "tmux"
+    if be and be.owns(sid):
+        return "sdk"
+    cx = _codex()
+    if cx is not None and cx.owns(sid):
+        return "codex"                        # a Codex-backed session (docs/codex.md)
+    return "tmux"
 
 
 def _open_leaf_bullets(nodes, subs, cap=12, indent="  "):
@@ -7389,7 +7394,35 @@ def _create_sdk_session(nm, cwd, auth="", prefs=None, client=None):
     return sid, extra
 
 
+def _create_codex_session(nm, cwd, client=None):
+    return _create_codex_session_inner(nm, cwd, client=client)
+
+
+def _create_codex_session_inner(nm, cwd, client=None):
+    """Create + open a new Codex-backed session — the same ACK-FAST shape as _create_sdk_session
+    (focus first, dirty-mark wake, one direct push; never a synchronous fleet build here). spawn()
+    starts the app-server thread, touches the materialized transcript (so discover() lists it
+    immediately) and writes the shared names/ identity file. Focus rides _reveal_chat_for — the
+    v1.3.6 merge renamed _reveal_chat and this caller kept the old name, so every Codex create
+    raised NameError AFTER spawning (an orphan session + a failed /new; the user's audit,
+    2026-08-19, ruff's sole F821)."""
+    bg, fg = _pick_identity_color()
+    sid = _codex().spawn(nm, cwd, bg, fg)
+    if client is not None:
+        # like _create_sdk_session/_fork_session: a client-less caller (POST /new — a headless
+        # `romp new`) reveals to NOBODY; None fell through to the legacy every-window broadcast,
+        # the retired chats-kept-jumping bug (the adversarial check, 2026-08-19)
+        _reveal_chat_for(client, {"type": "focus", "id": sid})
+    _mark_views_dirty()
+    _push_session_now(sid)
+    return sid
+
+
 def _fork_session(parent_sid, cut_msg_uuid, new_name, now=None, client=None):
+    return _fork_session_inner(parent_sid, cut_msg_uuid, new_name, now=now, client=client)
+
+
+def _fork_session_inner(parent_sid, cut_msg_uuid, new_name, now=None, client=None):
     """Fork `parent_sid`'s conversation into a NEW parallel session named `new_name` — from just BEFORE
     user message `cut_msg_uuid` when given (the chat's fork button; same _rewind_target resolution and
     guards as the edit/delete rewind, so "before this message" means the same thing everywhere), the
@@ -8591,6 +8624,62 @@ def _sdk_locked():
             _sdk_backend = False
             _mark_boot("reconcileDone")            # unavailable = the reconcile phase is over too
     return _sdk_backend or None
+
+
+# --- optional Codex session backend (plans/codex-backend.md) ------------------------------------------
+# A THIRD SessionBackend that drives OpenAI Codex threads via `codex app-server` and materializes
+# Claude-shaped transcripts under STATE/codex/projects/ (judge._codex_rows discovers them). Built
+# lazily like _sdk(); an absent dependency is a loud refusal at creation, never a silent tmux fallback.
+CODEX_SETUP_HINT = ("Session not created: the Codex backend isn't installed. "
+                    "Run romp-codex-setup, then try again.")
+
+_codex_backend = None   # None = not built yet, False = module unavailable, else the CodexBackend
+_codex_lock = threading.Lock()
+
+
+def _codex():
+    """The CodexBackend singleton, or None when the MODULE is unavailable. Like _sdk(), the backend
+    object existing is not proof it can run a session (the openai-codex dep or `codex login` may be
+    missing) — gate CREATION on _codex_ready(); per-session failures surface via launch_error."""
+    global _codex_backend
+    with _codex_lock:
+        if _codex_backend is None:
+            try:
+                cxmod = SourceFileLoader("romp_codex_backend", str(HERE / "codex_backend.py")).load_module()
+                _codex_backend = cxmod.CodexBackend(
+                    jd.STATE, notify=_send_to_app,
+                    poke=_producer_wake.set, push=_pusher_wake.set,
+                    push_session=_push_session_now,
+                    codex_bin=shutil.which("codex"),   # None → the SDK's bundled binary resolver
+                    log=lambda m: sys.stderr.write("codex-backend: %s\n" % m))
+            except Exception:
+                sys.stderr.write("codex-backend unavailable: %s\n" % traceback.format_exc())
+                _codex_backend = False
+        return _codex_backend or None
+
+
+def _codex_ready():
+    """Can the Codex backend RUN a session right now (dep importable, app-server up, logged in)?
+    The truthful gate for session creation — same contract as _sdk_ready()."""
+    be = _codex()
+    if not be:
+        return False
+    try:
+        return bool(be.available())
+    except Exception:
+        return False
+
+
+def _default_backend():
+    """The machine default for a NEW session when the caller names none — `romp engine` writes
+    STATE/default-backend ("sdk" | "codex"); absent/unknown → sdk, the long-standing default.
+    The dashboard's + dialog always names a backend (its own toggle), so this governs the
+    headless paths: `romp new` and POST /new."""
+    try:
+        v = (jd.STATE / "default-backend").read_text().strip()
+    except OSError:
+        return "sdk"
+    return v if v in ("sdk", "codex") else "sdk"
 
 
 # ── SDK problems → the dashboard's error center (the user 2026-07-28) ─────────────────────────────────────
@@ -9804,9 +9893,18 @@ def _revive_session(sid, client=None):
     ok, detail = False, ""
     _commands_for_cwd(_cwd_of(sid))   # pre-warm the slash-command list — a revival predicts a composer (the user 2026-08-13)
     try:
+        cx = _codex()
         if be and be.owns(sid):
             ok = bool(be.resume(name, sid) and be.connect(sid))
             detail = "" if ok else "the SDK backend could not resume it (see the kernel log)"
+        elif cx is not None and cx._session(sid) is not None:
+            # a DEAD Codex session: owns() is live-only by design, so the tmux fallback would build
+            # `claude --resume` for it — resume it through the Codex backend instead (docs/codex.md)
+            if not _codex_ready():
+                detail = (getattr(cx, "_client_err", "") or CODEX_SETUP_HINT)
+            else:
+                ok = bool(cx.resume(name, sid, cwd=_cwd_of(sid)))
+                detail = "" if ok else "the Codex backend could not resume it (see the kernel log)"
         else:
             cwd = _cwd_of(sid)
             workdir = cwd if cwd and os.path.isdir(cwd) else os.path.expanduser("~")
@@ -10370,7 +10468,12 @@ class Sessions:
     def backend_for(sid):
         be = _sdk()
         sid = str(sid)
-        return be if (be and be.owns(sid)) else _TMUX
+        if be and be.owns(sid):
+            return be
+        cx = _codex()
+        if cx is not None and cx.owns(sid):
+            return cx                          # the Codex backend owns it (docs/codex.md)
+        return _TMUX
 
     @staticmethod
     def live():
@@ -10410,6 +10513,19 @@ class Sessions:
                                 "bgTasks": st.get("bgTasks") or []}
             except Exception:
                 sys.stderr.write("sdk live_sessions merge: %s\n" % traceback.format_exc())
+        cx = _codex()
+        if cx:
+            try:
+                for sid, st in cx.live_sessions().items():
+                    # the Codex backend reports the fields it truly has; everything Claude-only
+                    # (fast, auth, compaction %) stays absent rather than faked (plan doc)
+                    out[sid] = {"state": st.get("state", ""), "since": _num(str(st.get("since") or "")),
+                                "model": st.get("model", ""), "effort": st.get("effort", ""),
+                                "context": st.get("context") if isinstance(st.get("context"), (int, float)) else None,
+                                "compactPct": None, "color": (st.get("color") or None),
+                                "mode": st.get("mode", ""), "backend": "codex"}
+            except Exception:
+                sys.stderr.write("codex live_sessions merge: %s\n" % traceback.format_exc())
         _unify_model_labels(out)
         return out
 
@@ -10466,6 +10582,13 @@ def _rename_session(sid, name):
         if live != name:
             _TMUX.rename_by_name(live, name)
     else:
+        cx = _codex()
+        if cx is not None and cx._session(sid) is not None:
+            try:
+                cx.rename(sid, name)                   # the Codex registry's durable name (docs/codex.md)
+            except Exception as e:
+                sys.stderr.write("codex rename '%s': %s\n" % (sid, e))
+                return None
         _set_name(sid, name)                           # dead tab → names file directly
     return name
 
@@ -17256,7 +17379,9 @@ def _parse(path, sid, now):
         cands.append(anchor)
     session = em.parse_session(path, rompuuid=sid, candidate_files=cands,
                                postal_log=str(jd.MESSAGES), now=now,
-                               sdk_human=bool(_be and _be.owns(sid)),   # SDK session: composer input is promptSource "sdk"
+                               # SDK/Codex session: composer input arrives programmatic (promptSource "sdk"),
+                               # so the unmarked prompt is the HUMAN — same flag for both backends
+                               sdk_human=bool((_be and _be.owns(sid)) or ((_cx := _codex()) and _cx.owns(sid))),
                                states=str(states) if states.exists() else None,   # idle transitions → idle atoms (see above)
                                leaf_override=cut or None)   # pending bare rollback → render the cut conversation NOW
     if key is not None:
@@ -31114,6 +31239,17 @@ class Handler(BaseHTTPRequestHandler):
                 # (sdk_backend.note_cli_model_block) and cleared by the first real reply on that
                 # model — so every picker shows the reason before the next pick, not only after it
                 _blocks = _cli_model_blocks()
+                # the codex section rides along untinted: what a CODEX session's pickers offer
+                # (docs/codex.md) — models from the app-server's own list via the backend (the
+                # authoritative source; [] until the backend runs, so no picker ever shows another
+                # vendor's models); efforts are the four Codex accepts — max/ultracode are Claude-only.
+                cx = _codex()
+                cx_models = []
+                if cx:
+                    try:
+                        cx_models = cx.model_catalog()
+                    except Exception:
+                        pass
                 return self._send(200, json.dumps(
                     {"models": [dict(c, color=_model_color(c["value"], _stops),
                                      tone=_model_tone(c["value"]),
@@ -31125,6 +31261,9 @@ class Handler(BaseHTTPRequestHandler):
                                 for c in MODEL_CHOICES],
                      "efforts": [dict(c, color=_effort_color(c["value"], _stops), tone=_effort_tone(c["value"]))
                                  for c in EFFORT_CHOICES],
+                     "codex": {"models": cx_models,
+                               "efforts": [{"value": v, "label": v}
+                                           for v in ("low", "medium", "high", "xhigh")]},
                      # the create dialog's pre-read (the user 2026-08-29): what a new comment thread
                      # gets when the dialog is left untouched — RAW ("session" = same as the session),
                      # so the dialog shows the effective default and a pick stays a deviation
@@ -31655,13 +31794,34 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": True, "id": th[0], "existing": True,
                                                        "thread": True, "parent": th[1], **extra}),
                                       "application/json")
-                if (b.get("backend") or "sdk") == "sdk":
+                be_req = (b.get("backend") or _default_backend())
+                if be_req == "codex":             # parity with the WS op: same gate, same loud refusal
+                    if not _codex_ready():
+                        cxbe = _codex()
+                        why = (getattr(cxbe, "_client_err", "") or CODEX_SETUP_HINT) if cxbe else CODEX_SETUP_HINT
+                        return self._send(200, json.dumps({"ok": False, "error": why}),
+                                          "application/json")
+                    sid = _create_codex_session(nm, cwd)
+                    if not sid:
+                        return self._send(200, json.dumps({"ok": False,
+                                                           "error": "the Codex session could not "
+                                                                    "be created — is the codex "
+                                                                    "app-server running?"}),
+                                          "application/json")
+                    return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd}),
+                                      "application/json")
+                if be_req == "sdk":
                     if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
                         return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
                                           "application/json")
                     a = (b or {}).get("auth")
                     sid, extra = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""),
                                                      prefs=b)   # pins ride the FIRST connect — see the def
+                    if not sid:
+                        return self._send(200, json.dumps({"ok": False,
+                                                           "error": (extra or {}).get("error")
+                                                           or "the session could not be created"}),
+                                          "application/json")
                     return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd, **extra}),
                                       "application/json")
                 threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
@@ -32673,6 +32833,28 @@ class Handler(BaseHTTPRequestHandler):
                         # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
                         # session on a remote host without the venv, 2026-07-02). Say what's missing.
                         client["send"](json.dumps({"type": "warn", "text": SDK_SETUP_HINT}))
+                elif msg.get("backend") == "codex":   # an OpenAI Codex thread (plans/codex-backend.md)
+                    if _codex_ready():
+                        try:
+                            _create_codex_session(nm, cwd, client=client)
+                        except Exception as e:
+                            # the generic dispatcher handler logs to stderr only — the picker's
+                            # "Opening…" cue got no answer (the r28 verification). stderr FIRST:
+                            # a raising send must not erase the error from every record.
+                            sys.stderr.write("codex create '%s' failed: %s\n" % (nm, e))
+                            try:
+                                client["send"](json.dumps({"type": "warn",
+                                                           "text": "creating the Codex session "
+                                                                   "failed: %s" % e}))
+                            except Exception:
+                                pass
+                    else:
+                        # same rule as SDK: the user asked for Codex — refuse loudly, never a
+                        # mystery tmux session. _codex_ready is False for a missing dep, a dead
+                        # app-server, or a machine with no `codex login`.
+                        be = _codex()
+                        why = (getattr(be, "_client_err", "") or CODEX_SETUP_HINT) if be else CODEX_SETUP_HINT
+                        client["send"](json.dumps({"type": "warn", "text": why}))
                 else:
                     threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
         elif msg and msg.get("type") == "cancelCreate" and msg.get("name"):

--- a/plans/codex-backend.md
+++ b/plans/codex-backend.md
@@ -1,0 +1,177 @@
+# The Codex session backend
+
+A third `SessionBackend` that drives **OpenAI Codex** sessions, so Codex agents
+sit on the same board as Claude sessions — same lanes, cards, chat, judges, and
+postal bus. Follows the SDK-backend playbook (`plans/sdk-backend.md`): an exact,
+event-based control channel, no TUI scraping.
+
+**Decision: the official `openai-codex` Python SDK** (PyPI, published from
+`github.com/openai/codex`, versioned in lockstep with the CLI; it bundles its
+own `codex` binary via the `openai-codex-cli-bin` dependency). Its sync
+`CodexClient` speaks JSON-RPC to `codex app-server` over stdio and matches the
+ABC's sync surface — no asyncio bridge needed. Rejected alternatives:
+
+- **TS SDK** (`@openai/codex-sdk`): wrong language for the kernel.
+- **Driving the Codex TUI in tmux**: re-creates the screen-scraping layer the
+  SDK backend exists to retire, against a TUI we know even less well.
+- **Tailing Codex's own rollout JSONL** (`~/.codex/sessions/...`): a lossy
+  reconstruction of an internal format, when a designed API exists. The
+  authoritative-sources rule says use the API.
+- **The unofficial `codex-sdk` / `openai-codex-sdk` PyPI packages**: the first
+  is an unrelated product, the second an OpenAI-mimicking wrapper with no
+  provenance. Neither is OpenAI's.
+
+Pin `openai-codex==0.144.4` in a dedicated venv (`$STATE/codexvenv`, a sibling
+of `sdkvenv`, built by `bin/romp-codex-setup`), because `codex app-server`
+self-describes as *experimental*: version drift is a real risk and the pin
+makes upgrades deliberate.
+
+## The load-bearing move: normalize at write time
+
+romp's entire read side — the event model, the judges, all three panes — consumes
+transcript JSONL. The SDK backend already converts live SDK messages into
+**transcript-shaped dicts** so the live stream and the file agree
+(`sdk_backend.py` `_msg_to_atom`). The Codex backend extends that one step:
+it converts app-server notifications into the same transcript-shaped records
+and **materializes them as the session's JSONL on disk**, at
+
+    $STATE/codex/projects/<enc-cwd>/<thread-id>.jsonl
+
+- **fsid := the Codex thread id** (UUIDv7). One file per thread, append-only,
+  a linear `uuid → parentUuid` chain (no forks in phase 1). Resume appends to
+  the same file — Codex thread ids are stable across resumes.
+- The source is the **designed API** (app-server notifications), not a scrape;
+  the materialized file is romp's own event log, exactly like the
+  `states/<sid>.jsonl` idle atoms the parser already reads. Codex's rollout
+  file remains the resume source of truth (`thread/resume` by id); we never
+  parse it.
+- The read side then needs ONE new fact — a second transcript root — learned in
+  one helper (a root LIST), not a fourth copy of the cwd-encoding.
+
+## Verified mechanics
+
+Probed against **CLI 0.147.0** and the **generated protocol bindings** shipped
+in `openai-codex` 0.144.4 (`openai_codex/generated/v2_all.py` +
+`notification_registry.py`) — the bindings are generated from the server's own
+schema, so field names below are wire-exact.
+
+**Live-verified against the running app-server (2026-08-13, no login):**
+`CodexClient.start()` + `initialize` handshake (SDK 0.144.4 ↔ CLI 0.147.0),
+`account_read` on a login-less box returns exactly the auth-gate signature the
+backend keys on (`requiresOpenaiAuth: true`, `account: null`), `model_list`
+works unauthenticated (gpt-5.6-sol/terra/luna, 5.5, 5.2). That live probe also
+showed that `thread_start` accepts the legacy `sandbox:workspace-write`
+spelling, but it is not the shipped policy: in pinned 0.144.4 both that legacy
+policy and built-in `:workspace` include `:root=read`. romp injects a custom
+`romp_workspace` profile (`:minimal=read`, runtime workspace `.=write`,
+network enabled), then passes
+`permissions:"romp_workspace"` and `runtimeWorkspaceRoots:[cwd]`. The SDK
+passes those raw dict fields and profile config overrides through unchanged.
+Pinned 0.144.4 does confine arbitrary-process reads to the workspace plus its
+minimal platform roots, but its direct custom-policy process sandbox does not
+enforce narrower child access under a writable root: live probes could still
+write all three metadata paths. Built-in `:workspace` protected the metadata
+paths but retained `:root=read`. Until the runtime can enforce both properties,
+the backend prioritizes host user-file confidentiality and records the metadata
+integrity limitation explicitly.
+
+**Live smoke, logged in (2026-08-13, `tests/smoke_codex_live.py`):** two real
+turns end-to-end — a file-writing task whose Write items materialized as
+tool_use/tool_result pairs and whose settle carried usage + context %, and a
+genuinely-running `sleep 300` interrupted live (`turn/interrupt` → interrupted
+settle → the `[Request interrupted by user]` record → the NEXT prompt opens
+its own parsed turn). Both turns parse ended through the real event model;
+the uuid chain stays linear; the normalizer's skipped-vocabulary counter came
+back empty. Failed patches on a sandbox-less box rendered as `is_error`
+results with the failure text — visible, never a fake success.
+
+**Host requirement (found live):** Codex's Linux sandbox is bubblewrap, which
+needs unprivileged user namespaces. Newer GCP/Ubuntu images restrict them
+(`kernel.apparmor_restrict_unprivileged_userns=1`) and then EVERY command and
+patch under a sandboxed profile fails with `bwrap: setting up uid map: Permission
+denied` — loudly, as error-flagged results. Sandboxed operation needs the
+sysctl flipped (persist via /etc/sysctl.d); the smoke's
+`ROMP_SMOKE_SANDBOX=danger-full-access` override exercises the same protocol
+machinery on such boxes without it.
+
+- **Client**: `CodexClient` — `thread_start/resume/fork/list/read/set_name/
+  compact`, `turn_start(thread_id, input, params)`, `turn_interrupt(thread_id,
+  turn_id)`, `turn_steer`, `model_list`, `next_notification()` queues, login
+  APIs (`account_login_start`, API-key and ChatGPT device-code flows).
+- **Per-turn params**: model, reasoning effort, cwd, `approvalPolicy`
+  (never/onRequest/unlessTrusted), custom named `permissions`,
+  `runtimeWorkspaceRoots`, output schema. The legacy `sandboxPolicy` shape is
+  retained only by the explicit danger-full-access live-smoke override.
+- **Notifications** (exact methods): `turn/started`, `turn/completed`,
+  `item/started`, `item/completed` (+ delta streams), `thread/compacted`,
+  `thread/tokenUsage/updated`, `account/rateLimits/updated`, `error`
+  (with `willRetry`), `thread/status/changed`, approval server-requests.
+- **Item vocabulary** (`ThreadItem` variants): `userMessage`, `agentMessage`,
+  `reasoning`, `commandExecution` (command, cwd, aggregatedOutput, exitCode,
+  durationMs, status), `fileChange` (changes: [{path, kind, diff}], status),
+  `mcpToolCall` (server, tool, arguments, result, error), `webSearch`, `plan`,
+  `subAgentActivity`, `collabAgentToolCall` (Codex's own multi-agent channel),
+  `contextCompaction`, `imageView`, `imageGeneration`, review-mode markers.
+- **Timestamps**: items carry `startedAtMs`/`completedAtMs`; turns carry
+  `completedAt` (s) — records get real times, no clock guessing.
+
+## The mapping (codex_events.py, pure + golden-tested)
+
+| Codex event | Transcript record |
+|---|---|
+| `item/*` userMessage | `user` record, `promptSource:"sdk"` (human on a programmatic session, same as the SDK backend) |
+| `item/completed` agentMessage | assistant text — HELD, flushed with `stop_reason:null` when more items follow, `"end_turn"` at `turn/completed` (records are append-only; the turn's last message must land already-stamped) |
+| `item/completed` reasoning | assistant `thinking` block |
+| `item/started` commandExecution | assistant `tool_use` (name `Bash`, input {command}) |
+| `item/completed` commandExecution | user `tool_result` (aggregatedOutput, exit code) + raw item under `toolUseResult` |
+| `item/*` fileChange | per change: `tool_use` (add→`Write`, else `Edit`, input {file_path}) + `tool_result` carrying the diff |
+| `item/*` mcpToolCall | `tool_use` named `mcp__<server>__<tool>` + `tool_result` (result or error) |
+| `item/*` webSearch | `tool_use` `WebSearch` {query} + result |
+| `thread/compacted` | `system`/`compact_boundary` with `logicalParentUuid` = pre-compaction leaf (the stitch the FileAdapter follows) |
+| turn failed / terminal `error` | assistant record flagged `isApiErrorMessage` (the error-card tag) |
+| `thread/tokenUsage/updated` | not a record — feeds `live_sessions().context` |
+| `plan`, `subAgentActivity`, `collabAgentToolCall` | **phase 2** (skipped, logged once) |
+
+`uuid` = the Codex item id; `parentUuid` = previous record in the file (the
+writer re-anchors on the file's last uuid at resume/restart).
+
+## ABC coverage (phase 1)
+
+Real: `owns`, `live_sessions` (state from turn/thread notifications — never the
+file), `send` (turn_start; mid-turn → `turn/steer`), `interrupt`, `busy`,
+`spawn`, `resume`, `kill` (close + archive), `rename` (`thread/setName`),
+`set_model`, `set_effort` (low/medium/high pass through per-turn),
+`pending_queued`, `live_atoms`, `prune_live`, `launch_error` (missing
+login/binary surfaces as text, incl. `limit:true` on out-of-usage),
+`working_note`/`set_working_note`/`wake`/`deliver` (kernel-side store +
+enqueue, as the SDK backend).
+
+Documented-empty (loud, not faked): `set_fast` False (no Codex equivalent),
+`set_mode` False in phase 1 — spawn pins `approvalPolicy:never` +
+`permissions:"romp_workspace"` + exactly one `runtimeWorkspaceRoots` entry;
+the client launch defines that fail-closed filesystem profile with network on
+(sandboxed full-auto with user-file reads confined to the workspace; the
+approval→ask-picker bridge is phase 2), `set_auth` False (Codex auth is machine-global via
+`codex login`), `stop_task`/`rewind_files` False, `mcp_status` explains Codex
+MCP servers live in `~/.codex/config.toml`, `on_ask`/`current_ask` None.
+
+## Phase 2 (explicitly out)
+
+Approval server-requests → the `permission` chip + ask picker; plan items →
+the card checklist; `subAgentActivity`/collab → subagent pills; rate-limit
+gating from `account/rateLimits/updated`; `usage` stamping for the cost view;
+unified-diff → `structuredPatch` rows; per-backend model catalogs in `/models`;
+postal MCP auto-registration into `~/.codex/config.toml`; the new-session
+picker's agent choice UI polish.
+
+## Risks / open questions
+
+- `codex app-server` is labeled experimental; the venv pin keeps upgrades
+  deliberate. (A boot version check against a tested floor was considered and
+  is NOT implemented — the pin alone bounds drift while the SDK and its
+  bundled binary move together.)
+- A turn that ends with no final agentMessage (interrupt mid-tool) leaves the
+  file turn unterminated; state stays correct (it comes from notifications).
+  Revisit if it confuses the judges.
+- Codex compaction exposes no summary text — the card's "what compaction kept"
+  tab stays empty for Codex sessions (absent, not faked).

--- a/tests/romp-engine.bats
+++ b/tests/romp-engine.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+# `romp engine [claude|codex|status]` — one switch for the machine's vendor posture
+# (docs/codex.md): writes STATE/judge-engine (judges read it live per call) and
+# STATE/default-backend (`romp new` + POST /new default) together. Running sessions
+# are never touched; the notes about missing binaries/logins are warnings, not gates.
+# `status` must survive ABSENT files (set -euo pipefail killed it mid-substitution once).
+
+BIN="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)"
+ROMP_SCRIPT="$BIN/romp"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export HOME="$TEST_DIR/home"
+    export XDG_STATE_HOME="$HOME/.local/state"
+    export PATH="$TEST_DIR/bin:/usr/bin:/bin"   # a controlled PATH so binary probes are deterministic
+    mkdir -p "$XDG_STATE_HOME/romp" "$TEST_DIR/bin"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "romp engine: status defaults on a fresh state, codex writes both knobs, claude flips back" {
+    run "$ROMP_SCRIPT" engine status
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"judges:               claude"* ]]
+    [[ "$output" == *"new-session default:  sdk"* ]]
+
+    run "$ROMP_SCRIPT" engine codex
+    [ "$status" -eq 0 ]
+    [ "$(cat "$XDG_STATE_HOME/romp/judge-engine")" = "codex" ]
+    [ "$(cat "$XDG_STATE_HOME/romp/default-backend")" = "codex" ]
+    [[ "$output" == *"engine CODEX"* ]]
+
+    run "$ROMP_SCRIPT" engine status
+    [[ "$output" == *"judges:               codex"* ]]
+    [[ "$output" == *"new-session default:  codex"* ]]
+
+    run "$ROMP_SCRIPT" engine claude
+    [ "$status" -eq 0 ]
+    [ "$(cat "$XDG_STATE_HOME/romp/judge-engine")" = "claude" ]
+    [ "$(cat "$XDG_STATE_HOME/romp/default-backend")" = "sdk" ]
+}
+
+@test "romp engine codex: warns (never refuses) on a missing binary, and on a logged-out codex" {
+    run "$ROMP_SCRIPT" engine codex
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no codex binary found"* ]]
+
+    # a fake codex that reports Not logged in (real codex prints status on stderr; the check
+    # merges streams and anchors on ^logged so "Not logged in" can't false-match)
+    cat > "$TEST_DIR/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+echo "Not logged in" >&2
+EOF
+    chmod +x "$TEST_DIR/bin/codex"
+    run "$ROMP_SCRIPT" engine codex
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"codex isn't logged in"* ]]
+
+    # logged in → no note at all
+    cat > "$TEST_DIR/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+echo "Logged in using ChatGPT" >&2
+EOF
+    chmod +x "$TEST_DIR/bin/codex"
+    run "$ROMP_SCRIPT" engine codex
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"note:"* ]]
+}
+
+@test "romp engine: an unknown arg is a usage error" {
+    run "$ROMP_SCRIPT" engine gemini
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp engine"* ]]
+}
+
+@test "romp new: --model/--effort refuse UP FRONT when the engine default makes the spawn codex" {
+    # validating against the --codex flag alone let these sail through on an engine-codex
+    # machine: the codex session got created and the preference silently dropped, warned only
+    # afterward (the user's audit, 2026-08-17). The refusal must come at parse time — exit 2,
+    # BEFORE any kernel/token probing (exit 1 would mean it got past validation).
+    run "$ROMP_SCRIPT" engine codex
+    [ "$status" -eq 0 ]
+    run "$ROMP_SCRIPT" new --model some-model mysess
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"romp engine codex"* ]]
+    run "$ROMP_SCRIPT" new --effort high mysess
+    [ "$status" -eq 2 ]
+
+    # the explicit flag still refuses, naming the flag
+    run "$ROMP_SCRIPT" engine claude
+    run "$ROMP_SCRIPT" new --codex --model some-model mysess
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--codex"* ]]
+
+    # and an SDK spawn keeps taking them past validation (fails later only on the dead kernel)
+    run "$ROMP_SCRIPT" new --model some-model mysess
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel"* ]]
+}

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""LIVE smoke test for the Codex backend — drives REAL turns against the real `codex app-server`.
+
+Deliberately not named test_* : it needs a `codex login` on the machine and bills two small turns
+to the logged-in account, so CI never runs it. Run by hand when validating the backend against a
+new Codex release:
+
+    uv run --with 'openai-codex==0.144.4' python tests/smoke_codex_live.py
+
+Exercises the seams the unit tests fake: a real turn's notification stream materializing the
+transcript (items → tokenUsage → completed), the parse of that file into ended turns, live
+interrupt of a running command, and the normalizer's skipped-vocabulary counter on real payloads.
+Uses a scratch state dir + a scratch cwd; touches nothing live.
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+cb = SourceFileLoader("romp_codex_backend_live", os.path.join(ROOT, "kernel", "codex_backend.py")).load_module()
+em = SourceFileLoader("romp_event_model_live", os.path.join(ROOT, "bin", "romp-event-model")).load_module()
+
+
+def until(fn, timeout, step=0.25, what=""):
+    dl = time.time() + timeout
+    while time.time() < dl:
+        if fn():
+            return True
+        time.sleep(step)
+    print("TIMEOUT waiting for %s" % what)
+    return False
+
+
+def main():
+    state = Path(tempfile.mkdtemp(prefix="romp-codex-smoke-state-"))
+    workdir = Path(tempfile.mkdtemp(prefix="romp-codex-smoke-cwd-"))
+    codex_bin = os.path.expanduser("~/.local/bin/codex")
+    if os.environ.get("ROMP_SMOKE_SANDBOX") == "danger-full-access":
+        # Boxes whose kernel restricts unprivileged user namespaces can't run Codex's bwrap
+        # sandbox at all (bwrap: setting up uid map: Permission denied) — every command/patch
+        # fails. This override exercises the SAME protocol machinery without the sandbox; the
+        # shipped default stays romp's custom profile with one runtime workspace root.
+        # Fix the box for sandboxed operation:
+        #   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0   (+ persist in sysctl.d)
+        cb.TURN_SANDBOX = {"type": "dangerFullAccess"}
+        print("(sandbox override: dangerFullAccess — bwrap unavailable on this box)")
+    be = cb.CodexBackend(str(state), codex_bin=(codex_bin if os.path.exists(codex_bin) else None))
+    if not be.available():
+        print("SMOKE SKIPPED: %s" % (be._client_err or "codex backend unavailable"))
+        return 2
+
+    print("== spawn")
+    sid = be.spawn("smoke", str(workdir))
+    err = be.launch_error(sid)
+    assert not err, "spawn launch_error: %r" % err
+    print("   sid=%s tid=%s model=%s" % (sid, be._sessions[sid].tid, be._sessions[sid].model))
+
+    print("== turn 1: file-writing task")
+    be.send(sid, "Create a file named hello.txt in the current directory containing exactly "
+                 "'hello from codex', then reply with one short sentence confirming it.")
+    assert until(lambda: be.live_sessions()[sid]["state"] == "working", 60, what="turn 1 start")
+    assert until(lambda: be.live_sessions()[sid]["state"] == "waiting" and not be.busy(sid), 300,
+                 what="turn 1 settle")
+    path = Path(be.transcript_path(sid))
+    recs = [json.loads(l) for l in path.read_text().splitlines()]
+    types = [(r["type"], (r.get("message") or {}).get("stop_reason")) for r in recs]
+    print("   %d records: %s" % (len(recs), types))
+    assert recs, "no records materialized"
+    assert recs[0]["type"] == "user" and recs[0].get("promptSource") == "sdk"
+    settles = [r for r in recs if r["type"] == "assistant"
+               and (r.get("message") or {}).get("stop_reason") == "end_turn"]
+    assert settles, "no end_turn settle record"
+    if settles[-1].get("message", {}).get("usage"):
+        print("   usage on settle: %s" % settles[-1]["message"]["usage"])
+    hello = workdir / "hello.txt"
+    print("   hello.txt exists: %s (%r)" % (hello.exists(), hello.read_text().strip() if hello.exists() else ""))
+    ctx = be.live_sessions()[sid]["context"]
+    print("   context%%: %s" % ctx)
+
+    print("== parse through the real event model")
+    s = em.parse_session(str(path), rompuuid=sid, candidate_files=[str(path)],
+                         now=time.time(), sdk_human=True)
+    ended = [t.get("ended") for t in s["turns"]]
+    print("   turns=%d ended=%s" % (len(s["turns"]), ended))
+    assert s["turns"] and all(ended), "turn 1 did not parse as ended"
+    assert s["turns"][0]["atoms"][0].get("author") == "human"
+
+    print("== turn 2: interrupt a long-running command")
+    be.send(sid, "Run the shell command `sleep 300` and wait for it to finish.")
+    assert until(lambda: be.live_sessions()[sid]["state"] == "working", 60, what="turn 2 start")
+    # wait for the sleep command's tool_use to MATERIALIZE (the command is genuinely running),
+    # then cut it — a fixed grace raced turns that settled early (a sandbox-refused sleep)
+    assert until(lambda: "sleep 300" in path.read_text(), 90, what="sleep tool_use record")
+    assert be.live_sessions()[sid]["state"] == "working", "turn settled before interrupt"
+    assert be.interrupt(sid), "interrupt refused"
+    assert until(lambda: be.live_sessions()[sid]["state"] == "waiting", 120, what="turn 2 settle")
+    recs = [json.loads(l) for l in path.read_text().splitlines()]
+    tail_txt = json.dumps(recs[-3:])
+    print("   interrupt record present: %s" % ("[Request interrupted" in tail_txt))
+    s = em.parse_session(str(path), rompuuid=sid, candidate_files=[str(path)],
+                         now=time.time(), sdk_human=True)
+    print("   turns=%d all ended=%s" % (len(s["turns"]), all(t.get("ended") for t in s["turns"])))
+    assert len(s["turns"]) >= 2, "interrupted turn merged with the next parse"
+
+    norm = be._sessions[sid].norm
+    print("== normalizer skipped vocabulary (phase-2 items seen live): %s" % (norm.skipped or "{}"))
+    print("== chain check")
+    prev = None
+    for r in recs:
+        if r.get("subtype") == "compact_boundary":
+            assert r["logicalParentUuid"] == prev
+        else:
+            assert r.get("parentUuid") == prev, "chain break at %s" % r["uuid"]
+        prev = r["uuid"]
+    print("   linear, %d records, no breaks" % len(recs))
+
+    be.kill(sid)
+    print("SMOKE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1,0 +1,1323 @@
+#!/usr/bin/env python3
+"""CodexBackend contract tests — a scripted FAKE client (no SDK, no network, no login) drives the
+backend through spawn/send/steer/interrupt/kill/resume and pins: the worker's turn loop writes the
+materialized transcript, state transitions are event-based, the uuid chain survives a backend
+restart (the _tail_state re-anchor), Claude-only knobs refuse loudly, and a missing `codex login`
+surfaces as launch_error text instead of a silent non-start. All data synthetic per CLAUDE.md.
+
+Run:    python3 tests/test_codex_backend.py
+"""
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+cb = SourceFileLoader("romp_codex_backend", os.path.join(ROOT, "kernel", "codex_backend.py")).load_module()
+sb = SourceFileLoader("romp_session_backend", os.path.join(ROOT, "kernel", "session_backend.py")).load_module()
+
+
+def until(fn, timeout=5.0, step=0.01):
+    dl = time.time() + timeout
+    while time.time() < dl:
+        if fn():
+            return True
+        time.sleep(step)
+    return False
+
+
+def registry_queue_entries(rows, sid):
+    """Canonical durable entries; tests that seed the legacy schema may still contain strings."""
+    return [entry if isinstance(entry, dict) else {"id": None, "text": entry}
+            for entry in rows[sid].get("queue", [])]
+
+
+def registry_queue_texts(rows, sid):
+    return [entry["text"] for entry in registry_queue_entries(rows, sid)]
+
+
+class _Payload:
+    def __init__(self, d):
+        self._d = d
+
+    def model_dump(self, by_alias=True, mode=None):
+        return self._d
+
+
+def note(method, params):
+    return SimpleNamespace(method=method, payload=_Payload(params))
+
+
+class FakeClient:
+    """Scripted app-server: turn_start opens a queue and streams either the injected script or a
+    default echo turn (userMessage + agentMessage + tokenUsage + completed)."""
+
+    def __init__(self):
+        self.calls = []
+        self.turn_queues = {}
+        self.scripts = []           # each turn_start pops one, [] → default echo turn
+        self.hold_open = False      # script the turn to stay open (steer/interrupt tests)
+        self._n = 0
+        self._global = queue.Queue()
+
+    # bookkeeping helpers ------------------------------------------------------------------
+    def _rec(self, name, *a):
+        self.calls.append((name,) + a)
+
+    def called(self, name):
+        return [c for c in self.calls if c[0] == name]
+
+    # client surface the backend uses ------------------------------------------------------
+    def account_read(self, *a, **k):
+        self._rec("account_read")
+        return SimpleNamespace(requires_openai_auth=False, account={"ok": True})
+
+    def initialize(self):
+        self._rec("initialize")
+
+    def close(self):
+        self._rec("close")
+
+    def thread_start(self, params=None):
+        self._rec("thread_start", params)
+        return SimpleNamespace(thread=SimpleNamespace(id="T-%d" % len(self.called("thread_start"))),
+                               model="gpt-5-test")
+
+    def thread_resume(self, tid, params=None):
+        self._rec("thread_resume", tid, params)
+        return SimpleNamespace(thread=SimpleNamespace(id=tid))
+
+    def thread_set_name(self, tid, name):
+        self._rec("thread_set_name", tid, name)
+
+    def model_list(self, *a, **k):
+        self._rec("model_list")
+        return SimpleNamespace(data=[
+            SimpleNamespace(id="gpt-5-test", display_name="GPT-5 Test", hidden=False),
+            SimpleNamespace(id="gpt-5-hidden", display_name="Hidden", hidden=True)])
+
+    def turn_start(self, tid, input_items, params=None):
+        self._n += 1
+        turn_id = "t-%d" % self._n
+        self._rec("turn_start", tid, input_items, params, turn_id)
+        q = queue.Queue()
+        self.turn_queues[turn_id] = q
+        script = self.scripts.pop(0) if self.scripts else None
+        ms = 1781100000000 + self._n * 100000
+        text = " ".join(i.get("text", "") for i in input_items)
+        if script is None:
+            script = [
+                ("item/completed", {"threadId": tid, "turnId": turn_id, "completedAtMs": ms,
+                                    "item": {"type": "userMessage", "id": "u-%d" % self._n,
+                                             "content": [{"type": "text", "text": text}]}}),
+                ("item/completed", {"threadId": tid, "turnId": turn_id, "completedAtMs": ms + 1000,
+                                    "item": {"type": "agentMessage", "id": "a-%d" % self._n,
+                                             "text": "ack: " + text}}),
+                ("thread/tokenUsage/updated",
+                 {"threadId": tid, "turnId": turn_id,
+                  "tokenUsage": {"last": {"inputTokens": 900, "outputTokens": 40,
+                                          "cachedInputTokens": 500, "reasoningOutputTokens": 10,
+                                          "totalTokens": 54400},
+                                 "total": {"inputTokens": 9000, "outputTokens": 400,
+                                           "cachedInputTokens": 5000,
+                                           "reasoningOutputTokens": 100, "totalTokens": 500000},
+                                 "modelContextWindow": 272000}}),
+                ("turn/completed", {"threadId": tid,
+                                    "turn": {"id": turn_id, "items": [], "status": "completed"}}),
+            ]
+        for m, p in script:
+            q.put(note(m, p))
+        if not self.hold_open and not any(m == "turn/completed" for m, _ in script):
+            q.put(note("turn/completed", {"threadId": tid,
+                                          "turn": {"id": turn_id, "items": [],
+                                                   "status": "completed"}}))
+        return SimpleNamespace(turn=SimpleNamespace(id=turn_id))
+
+    def next_turn_notification(self, turn_id):
+        return self.turn_queues[turn_id].get(timeout=10)
+
+    def unregister_turn_notifications(self, turn_id):
+        self._rec("unregister", turn_id)
+
+    def turn_steer(self, tid, expected_turn_id, input_items):
+        self._rec("turn_steer", tid, expected_turn_id, input_items)
+
+    def turn_interrupt(self, tid, turn_id):
+        self._rec("turn_interrupt", tid, turn_id)
+        self.turn_queues[turn_id].put(note("turn/completed",
+                                           {"threadId": tid,
+                                            "turn": {"id": turn_id, "items": [],
+                                                     "status": "interrupted"}}))
+
+    def next_notification(self):
+        return self._global.get()   # blocks forever — the global pump just parks in tests
+
+
+def build(tmp=None, factory=None):
+    tmp = tmp or tempfile.mkdtemp()
+    fake = FakeClient()
+    be = cb.CodexBackend(tmp, client_factory=(factory or (lambda: fake)))
+    return be, fake, tmp
+
+
+class Conformance(unittest.TestCase):
+    def test_every_abstract_method_exists(self):
+        missing = [m for m in sb.SessionBackend.__abstractmethods__
+                   if not callable(getattr(cb.CodexBackend, m, None))]
+        self.assertEqual(missing, [], "CodexBackend must duck-type the full ABC")
+
+    def test_only_deterministic_rpc_rejections_park(self):
+        def error_type(name, code, message):
+            cls = type(name, (RuntimeError,), {})
+            err = cls(message)
+            err.code, err.message = code, message
+            return err
+
+        self.assertTrue(cb._is_permanent_request_rejection(
+            error_type("InvalidParamsError", -32602, "invalid model")))
+        self.assertTrue(cb._is_permanent_request_rejection(
+            error_type("CodexRpcError", -32000, "model gpt-x is not supported for this account")))
+        self.assertFalse(cb._is_permanent_request_rejection(
+            error_type("InternalRpcError", -32603, "internal error")))
+        self.assertFalse(cb._is_permanent_request_rejection(
+            error_type("CodexRpcError", -32001, "temporary backend failure")))
+
+
+class Lifecycle(unittest.TestCase):
+    def test_spawn_send_turn_materializes_transcript(self):
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.owns(sid))
+        self.assertEqual(be.live_sessions()[sid]["state"], "waiting")
+        self.assertTrue(be.send(sid, "hello codex"))
+        self.assertTrue(until(lambda: be.live_sessions()[sid]["state"] == "waiting"
+                              and not be.busy(sid)))
+        path = be.transcript_path(sid)
+        recs = [json.loads(l) for l in Path(path).read_text().splitlines()]
+        self.assertEqual([r["type"] for r in recs], ["user", "assistant"])
+        self.assertEqual(recs[0]["promptSource"], "sdk")
+        self.assertEqual(recs[1]["message"]["stop_reason"], "end_turn")
+        self.assertEqual(recs[1]["parentUuid"], recs[0]["uuid"])
+        # the optimistic echo was pruned when its record landed
+        self.assertTrue(until(lambda: be.live_atoms(sid) == []))
+        # context % from tokenUsage: 54400/272000 = 20
+        self.assertEqual(be.live_sessions()[sid]["context"], 20)
+        # Both thread creation and each turn carry the pinned runtime's named workspace profile.
+        # The stale legacy workspaceWrite shape has unrestricted reads and must never reappear.
+        thread_params = fake.called("thread_start")[0][1]
+        self.assertEqual(thread_params["permissions"], "romp_workspace")
+        self.assertEqual(thread_params["runtimeWorkspaceRoots"], ["/TESTDIR"])
+        self.assertNotIn("sandbox", thread_params)
+        _, tid, items, params, _ = fake.called("turn_start")[0]
+        self.assertEqual(params["approvalPolicy"], "never")
+        self.assertEqual(params["permissions"], "romp_workspace")
+        self.assertEqual(params["runtimeWorkspaceRoots"], ["/TESTDIR"])
+        self.assertNotIn("sandboxPolicy", params)
+
+    def test_send_during_open_turn_steers(self):
+        be, fake, _ = build()
+        fake.hold_open = True
+        fake.scripts = [[("item/completed",
+                          {"threadId": "T-1", "turnId": "t-1", "completedAtMs": 1781100000000,
+                           "item": {"type": "userMessage", "id": "u-1",
+                                    "content": [{"type": "text", "text": "long job"}]}})]]
+        sid = be.spawn("web", "/TESTDIR")
+        be.send(sid, "long job")
+        # wait for the TURN to open (busy() is already true while merely queued — a steer needs
+        # the active turn id)
+        self.assertTrue(until(lambda: be.live_sessions()[sid]["state"] == "working"))
+        self.assertTrue(be.send(sid, "also check the docs"))
+        self.assertEqual(len(fake.called("turn_steer")), 1)
+        _, tid, expected_turn_id, input_items = fake.called("turn_steer")[0]
+        self.assertEqual(expected_turn_id, "t-1")
+        self.assertEqual(input_items, [{"type": "text", "text": "also check the docs"}])
+        fake.turn_queues["t-1"].put(note("turn/completed",
+                                         {"threadId": tid,
+                                          "turn": {"id": "t-1", "items": [],
+                                                   "status": "completed"}}))
+        self.assertTrue(until(lambda: not be.busy(sid)))
+
+    def test_interrupt_targets_active_turn_and_settles(self):
+        be, fake, _ = build()
+        fake.hold_open = True
+        fake.scripts = [[("item/completed",
+                          {"threadId": "T-1", "turnId": "t-1", "completedAtMs": 1781100000000,
+                           "item": {"type": "userMessage", "id": "u-1",
+                                    "content": [{"type": "text", "text": "run forever"}]}})]]
+        sid = be.spawn("web", "/TESTDIR")
+        be.send(sid, "run forever")
+        self.assertTrue(until(lambda: be.live_sessions()[sid]["state"] == "working"))
+        self.assertTrue(be.interrupt(sid))
+        self.assertEqual(fake.called("turn_interrupt")[0][2], "t-1")
+        self.assertTrue(until(lambda: not be.busy(sid)))
+        recs = [json.loads(l) for l in Path(be.transcript_path(sid)).read_text().splitlines()]
+        self.assertTrue(any("[Request interrupted" in json.dumps(r) for r in recs))
+
+    def test_kill_resume_roundtrip(self):
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        be.send(sid, "one")
+        self.assertTrue(until(lambda: not be.busy(sid)))
+        self.assertTrue(be.kill(sid))
+        self.assertFalse(be.owns(sid))
+        self.assertNotIn(sid, be.live_sessions())
+        self.assertTrue(be.resume("web", sid))
+        self.assertTrue(be.owns(sid))
+        be.send(sid, "two")
+        self.assertTrue(until(lambda: len(fake.called("thread_resume")) == 1))
+        resume_params = fake.called("thread_resume")[0][2]
+        self.assertEqual(resume_params["permissions"], "romp_workspace")
+        self.assertEqual(resume_params["runtimeWorkspaceRoots"], ["/TESTDIR"])
+        self.assertNotIn("sandbox", resume_params)
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+
+    def test_turn_start_failure_keeps_the_unacknowledged_batch_for_retry(self):
+        class FailOnceClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.attempts = []
+                self.failed = threading.Event()
+                self.retry_entered = threading.Event()
+                self.allow_retry = threading.Event()
+
+            def turn_start(self, tid, input_items, params=None):
+                self.attempts.append([i["text"] for i in input_items])
+                if len(self.attempts) == 1:
+                    self.failed.set()
+                    raise RuntimeError("synthetic pre-ack failure")
+                self.retry_entered.set()
+                self.allow_retry.wait(5)
+                return super().turn_start(tid, input_items, params)
+
+        fake = FailOnceClient()
+        be, _, tmp = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        # Build one deterministic two-message batch before allowing the worker to start.
+        ensure = be._ensure_worker
+        be._ensure_worker = lambda s: None
+        self.assertTrue(be.send(sid, "first"))
+        self.assertTrue(be.send(sid, "second"))
+        be._ensure_worker = ensure
+        self.assertTrue(be.wake(sid))
+        self.assertTrue(fake.failed.wait(2))
+        self.assertEqual(be.pending_queued(sid), ["first", "second"])
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["first", "second"])
+        self.assertTrue(fake.retry_entered.wait(2))
+        fake.allow_retry.set()
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        self.assertEqual(fake.attempts, [["first", "second"], ["first", "second"]])
+
+    def test_turn_ack_persistence_failure_cleans_up_and_retries_the_durable_batch(self):
+        class BlockingRetryClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.start_attempts = 0
+                self.retry_entered = threading.Event()
+                self.allow_retry = threading.Event()
+
+            def turn_start(self, tid, input_items, params=None):
+                self.start_attempts += 1
+                if self.start_attempts == 2:
+                    self.retry_entered.set()
+                    self.allow_retry.wait(5)
+                return super().turn_start(tid, input_items, params)
+
+        fake = BlockingRetryClient()
+        be, _, tmp = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        save = be._save_registry
+        failed = threading.Event()
+
+        def fail_first_ack(s, **kwargs):
+            if kwargs.get("queue_ack") is not None and not failed.is_set():
+                failed.set()
+                raise OSError("synthetic registry ACK failure")
+            return save(s, **kwargs)
+
+        be._save_registry = fail_first_ack
+        self.assertTrue(be.send(sid, "survive ACK failure"))
+        self.assertTrue(failed.wait(2))
+        self.assertTrue(fake.retry_entered.wait(2))
+        self.assertEqual(fake.called("unregister"), [("unregister", "t-1")])
+        self.assertEqual(fake.called("turn_interrupt")[0][2], "t-1")
+        self.assertEqual(be.pending_queued(sid), ["survive ACK failure"])
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["survive ACK failure"])
+
+        fake.allow_retry.set()
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        self.assertEqual(fake.start_attempts, 2)
+        self.assertEqual([call[1] for call in fake.called("unregister")], ["t-1", "t-2"])
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), [])
+
+    def test_permanent_turn_rejection_parks_without_spin_until_explicit_change(self):
+        class InvalidParamsError(RuntimeError):
+            def __init__(self, message):
+                super().__init__(message)
+                self.code = -32602
+
+        class RejectingClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.attempts = []
+
+            def turn_start(self, tid, input_items, params=None):
+                self.attempts.append((list(input_items), dict(params or {})))
+                raise InvalidParamsError("model is not available")
+
+        fake = RejectingClient()
+        be, _, _ = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "keep this durable"))
+        self.assertTrue(until(lambda: len(fake.attempts) == 1))
+        time.sleep(0.65)  # exceeds the old 0.25s retry; a permanent rejection has no timer
+        self.assertEqual(len(fake.attempts), 1)
+        self.assertEqual(be.pending_queued(sid), ["keep this durable"])
+        self.assertIn("model is not available", be.launch_error(sid)["text"])
+        self.assertTrue(be.wake(sid))
+        time.sleep(0.35)
+        self.assertEqual(len(fake.attempts), 1, "an ordinary wake must not repeat a rejected RPC")
+        self.assertTrue(be.set_model(sid, "gpt-5-fixed"))
+        self.assertTrue(until(lambda: len(fake.attempts) == 2))
+        self.assertEqual(fake.attempts[1][1]["model"], "gpt-5-fixed")
+        time.sleep(0.65)
+        self.assertEqual(len(fake.attempts), 2, "the replacement request parks if it is rejected too")
+        self.assertTrue(be.kill(sid))
+
+    def test_permanent_placeholder_prepare_parks_until_cwd_change(self):
+        class InvalidParamsError(RuntimeError):
+            code = -32602
+
+        class CwdRejectingClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.prepare_attempts = []
+
+            def thread_start(self, params=None):
+                self.prepare_attempts.append(dict(params or {}))
+                if (params or {}).get("cwd") != "/FIXED":
+                    raise InvalidParamsError("unknown permission profile for cwd")
+                return super().thread_start(params)
+
+        fake = CwdRejectingClient()
+        be, _, tmp = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")       # visible failed-* placeholder
+        self.assertTrue(be.send(sid, "keep this durable"))
+        self.assertTrue(until(lambda: len(fake.prepare_attempts) == 2))
+        time.sleep(0.65)                          # exceeds the old automatic retry
+        self.assertEqual(len(fake.prepare_attempts), 2)
+        self.assertEqual(be.pending_queued(sid), ["keep this durable"])
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["keep this durable"])
+        self.assertIn("thread preparation rejected", be.launch_error(sid)["text"])
+        self.assertTrue(be.wake(sid))
+        time.sleep(0.35)
+        self.assertEqual(len(fake.prepare_attempts), 2,
+                         "an ordinary wake must not repeat rejected thread preparation")
+        self.assertTrue(be.resume("web", sid, cwd="/FIXED"))
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        self.assertEqual(len(fake.prepare_attempts), 3)
+        self.assertEqual(fake.prepare_attempts[-1]["cwd"], "/FIXED")
+
+    def test_permanent_resume_prepare_retries_on_new_client_generation(self):
+        class InvalidRequestError(RuntimeError):
+            code = -32600
+
+        class ResumeRejectingClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.resume_attempts = 0
+
+            def thread_resume(self, tid, params=None):
+                self.resume_attempts += 1
+                raise InvalidRequestError("stored thread is unavailable on this server")
+
+        old, replacement = ResumeRejectingClient(), FakeClient()
+        clients = [old, replacement]
+        be, _, tmp = build(factory=lambda: clients.pop(0))
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.resume("web", sid))
+        self.assertTrue(be.send(sid, "retry after replacement"))
+        self.assertTrue(until(lambda: old.resume_attempts == 1))
+        time.sleep(0.65)
+        self.assertEqual(old.resume_attempts, 1)
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["retry after replacement"])
+        with be._client_lock:
+            be._record_client_failure_locked(RuntimeError("replace generation"), old)
+            be._client_retry_at = 0.0
+        self.assertTrue(be.available())
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        self.assertEqual(len(replacement.called("thread_resume")), 1)
+        self.assertEqual(len(replacement.called("turn_start")), 1)
+
+    def test_transient_thread_prepare_still_retries(self):
+        class ResumeFailsOnceClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.resume_attempts = 0
+
+            def thread_resume(self, tid, params=None):
+                self.resume_attempts += 1
+                if self.resume_attempts == 1:
+                    raise RuntimeError("synthetic transient resume failure")
+                return super().thread_resume(tid, params)
+
+        fake = ResumeFailsOnceClient()
+        be, _, _ = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.resume("web", sid))
+        self.assertTrue(be.send(sid, "retry transient prepare"))
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid), timeout=3))
+        self.assertEqual(fake.resume_attempts, 2)
+
+    def test_new_client_generation_retries_a_parked_permanent_rejection(self):
+        class InvalidRequestError(RuntimeError):
+            code = -32600
+
+        class RejectOnceClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.rejected = threading.Event()
+
+            def turn_start(self, tid, input_items, params=None):
+                self.rejected.set()
+                raise InvalidRequestError("old server rejected request")
+
+        old, replacement = RejectOnceClient(), FakeClient()
+        clients = [old, replacement]
+        be, _, _ = build(factory=lambda: clients.pop(0))
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "retry on replacement"))
+        self.assertTrue(old.rejected.wait(2))
+        with be._client_lock:
+            be._record_client_failure_locked(RuntimeError("replace generation"), old)
+            be._client_retry_at = 0.0
+        self.assertTrue(be.available())
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        self.assertEqual(len(replacement.called("turn_start")), 1)
+
+    def test_client_factory_failure_backs_off_then_recovers_queued_session(self):
+        fake = FakeClient()
+        attempts = []
+
+        def flaky_factory():
+            attempts.append(time.monotonic())
+            if len(attempts) == 1:
+                raise RuntimeError("synthetic unavailable client")
+            return fake
+
+        # a HUGE backoff floor makes the no-hot-spin phase DETERMINISTIC (the r48 release
+        # gate, twice on the same runner): the real 0.25s floor raced the main thread — a
+        # descheduled runner let the LEGITIMATE 250ms retry fire before the assertion ran,
+        # and the test read its own backoff expiring as a hot spin. With the floor pinned
+        # high, a second attempt inside the observation window can only be a real hot spin;
+        # the recovery phase then releases the backoff EXPLICITLY instead of racing a timer.
+        saved_floor = cb.CLIENT_RETRY_MIN
+        cb.CLIENT_RETRY_MIN = 30.0
+        self.addCleanup(setattr, cb, "CLIENT_RETRY_MIN", saved_floor)
+        be, _, _ = build(factory=flaky_factory)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "retry me"))
+        self.assertTrue(until(lambda: len(attempts) == 1), "the first attempt fires")
+        time.sleep(0.05)
+        self.assertEqual(len(attempts), 1, "unavailable client must not hot-spin")
+        with be._client_lock:
+            be._client_retry_at = 0.0                  # the explicit release, not a timer race
+        for _, s in be._session_items():
+            s.kick.set()
+        # a GENEROUS bound: the recovery is event-shaped (the explicit release above is
+        # the event), so only "eventually" matters — the 3s bound starved the worker
+        # thread on a runner at load 20+ (the r63 release gate: a 55-minute full suite)
+        self.assertTrue(until(lambda: len(attempts) >= 2 and not be.busy(sid), timeout=20))
+        self.assertEqual(len(fake.called("thread_start")), 1,
+                         "the pending placeholder must become a real Codex thread")
+        self.assertFalse(be.pending_queued(sid))
+
+    def test_kill_interrupts_an_active_turn_and_worker_exits(self):
+        be, fake, _ = build()
+        fake.hold_open = True
+        fake.scripts = [[("item/completed",
+                          {"threadId": "T-1", "turnId": "t-1", "completedAtMs": 1781100000000,
+                           "item": {"type": "userMessage", "id": "u-1",
+                                    "content": [{"type": "text", "text": "keep running"}]}})]]
+        sid = be.spawn("web", "/TESTDIR")
+        be.send(sid, "keep running")
+        self.assertTrue(until(lambda: be.live_sessions()[sid]["state"] == "working"))
+        worker = be._sessions[sid].worker
+        self.assertTrue(be.kill(sid))
+        self.assertEqual(fake.called("turn_interrupt")[0][2], "t-1")
+        self.assertTrue(until(lambda: not worker.is_alive()))
+        self.assertFalse(be.owns(sid))
+
+    def test_kill_cleans_up_an_active_turn_when_dead_registry_write_fails(self):
+        be, fake, tmp = build()
+        fake.hold_open = True
+        fake.scripts = [[("item/completed",
+                          {"threadId": "T-1", "turnId": "t-1", "completedAtMs": 1781100000000,
+                           "item": {"type": "userMessage", "id": "u-1",
+                                    "content": [{"type": "text", "text": "keep running"}]}})]]
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "keep running"))
+        self.assertTrue(until(lambda: be.live_sessions()[sid]["state"] == "working"))
+        worker = be._session(sid).worker
+        save = be._save_registry
+
+        def fail_dead_save(s, **kwargs):
+            if "dead" in kwargs.get("fields", ()):
+                raise OSError("synthetic dead-state persistence failure")
+            return save(s, **kwargs)
+
+        be._save_registry = fail_dead_save
+        with self.assertRaisesRegex(OSError, "synthetic dead-state persistence failure"):
+            be.kill(sid)
+        self.assertEqual(fake.called("turn_interrupt")[0][2], "t-1")
+        self.assertTrue(until(lambda: not worker.is_alive()))
+        self.assertFalse(be.owns(sid))
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertFalse(rows[sid]["dead"], "the failed durable mutation must not pretend it landed")
+
+    def test_kill_can_mark_dead_while_turn_start_is_in_flight_then_interrupts_the_ack(self):
+        class BlockingStartClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.start_entered = threading.Event()
+                self.release_start = threading.Event()
+
+            def turn_start(self, tid, input_items, params=None):
+                self.start_entered.set()
+                self.release_start.wait(2)
+                return super().turn_start(tid, input_items, params)
+
+        fake = BlockingStartClient()
+        be, _, _ = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "start slowly"))
+        self.assertTrue(fake.start_entered.wait(1))
+        result = []
+        killer = threading.Thread(target=lambda: result.append(be.kill(sid)))
+        killer.start()
+        self.assertTrue(until(lambda: not be.owns(sid), timeout=0.5),
+                        "turn/start must not hold the session lock needed by kill")
+        fake.release_start.set()
+        killer.join(2)
+        self.assertFalse(killer.is_alive())
+        self.assertEqual(result, [True])
+        self.assertEqual(fake.called("turn_interrupt")[0][2], "t-1",
+                         "an ACK that races kill must be interrupted as soon as its id exists")
+
+    def test_concurrent_worker_ensure_starts_exactly_one_thread(self):
+        be, _, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._sessions[sid]
+        started = []
+        release = threading.Event()
+
+        def parked_worker(session):
+            started.append(threading.get_ident())
+            release.wait(5)
+
+        be._work = parked_worker
+        callers = [threading.Thread(target=be._ensure_worker, args=(s,)) for _ in range(20)]
+        for t in callers:
+            t.start()
+        for t in callers:
+            t.join(2)
+        self.assertEqual(len(started), 1)
+        release.set()
+        self.assertTrue(until(lambda: not s.worker.is_alive()))
+
+    def test_registry_and_chain_survive_backend_restart(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        be.send(sid, "first")
+        self.assertTrue(until(lambda: not be.busy(sid)))
+        # a NEW backend over the same state dir (kernel restart): same session, resumed lazily,
+        # and the file's uuid chain continues off the pre-restart tail (_tail_state re-anchor)
+        be2 = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertTrue(be2.owns(sid))
+        be2.send(sid, "second")
+        self.assertTrue(until(lambda: not be2.busy(sid) and not be2.pending_queued(sid)))
+        recs = [json.loads(l) for l in Path(be2.transcript_path(sid)).read_text().splitlines()]
+        for prev, r in zip(recs, recs[1:]):
+            self.assertEqual(r["parentUuid"], prev["uuid"],
+                             "chain broke across the restart at %s" % r["uuid"])
+        self.assertEqual(len({r["uuid"] for r in recs}), len(recs))
+
+    def test_load_registry_logs_malformed_json_and_falls_back_empty(self):
+        tmp = tempfile.mkdtemp()
+        root = Path(tmp) / "codex"
+        root.mkdir(parents=True)
+        (root / "registry.json").write_text("{synthetic malformed json")
+        logs = []
+
+        be = cb.CodexBackend(tmp, client_factory=lambda: None, log=logs.append)
+
+        self.assertEqual(be._session_items(), [])
+        self.assertEqual(len(logs), 1)
+        self.assertIn("codex registry unreadable at load", logs[0])
+        self.assertIn("existing sessions will be missing until it is repaired", logs[0])
+
+    def test_load_registry_logs_valid_non_object_roots_and_falls_back_empty(self):
+        for value in ([], None, True, 7, "synthetic-root"):
+            with self.subTest(value=value):
+                tmp = tempfile.mkdtemp()
+                root = Path(tmp) / "codex"
+                root.mkdir(parents=True)
+                (root / "registry.json").write_text(json.dumps(value))
+                logs = []
+
+                be = cb.CodexBackend(tmp, client_factory=lambda: None, log=logs.append)
+
+                self.assertEqual(be._session_items(), [])
+                self.assertEqual(len(logs), 1)
+                self.assertIn("codex registry unreadable at load", logs[0])
+                self.assertIn("registry root is not an object", logs[0])
+
+    def test_stale_backend_metadata_save_cannot_erase_newer_durable_queue(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        stale = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        ensure = be._ensure_worker
+        be._ensure_worker = lambda s: None
+        self.assertTrue(be.send(sid, "must survive stale save"))
+        be._ensure_worker = ensure
+        self.assertEqual(be.pending_queued(sid), ["must survive stale save"])
+        self.assertTrue(stale.rename(sid, "web-renamed"))
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["must survive stale save"])
+        self.assertEqual(rows[sid]["name"], "web-renamed")
+
+    def test_same_process_metadata_mutations_commit_in_session_order(self):
+        be, _, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        snapshotted, release = threading.Event(), threading.Event()
+        snapshot = be._registry_snapshot
+
+        def gated_snapshot(s):
+            row = snapshot(s)
+            if row["model"] == "gpt-a" and not snapshotted.is_set():
+                snapshotted.set()
+                release.wait(5)
+            return row
+
+        be._registry_snapshot = gated_snapshot
+        first = threading.Thread(target=be.set_model, args=(sid, "gpt-a"))
+        second = threading.Thread(target=be.set_model, args=(sid, "gpt-b"))
+        first.start()
+        self.assertTrue(snapshotted.wait(2))
+        second.start()
+        time.sleep(0.05)
+        self.assertTrue(second.is_alive(), "the later mutation must wait through the first save")
+        release.set()
+        first.join(2)
+        second.join(2)
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(be._session(sid).model, "gpt-b")
+        self.assertEqual(rows[sid]["model"], "gpt-b")
+
+    def test_delayed_ack_cannot_delete_a_new_identical_text_send(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        be._ensure_worker = lambda s: None
+        self.assertTrue(be.send(sid, "same text"))
+        self.assertTrue(be.kill(sid))          # let the stale backend load without consuming the queue
+        stale = cb.CodexBackend(tmp, client_factory=lambda: fake)
+
+        current = be._session(sid)
+        with current.lock:
+            old_id = current.queue_ids[0]
+            del current.queue[:1]
+            del current.queue_ids[:1]
+            self.assertFalse(be._save_registry(current, queue_ack=[old_id]))
+        self.assertTrue(be.resume("web", sid))
+        self.assertTrue(be.send(sid, "same text"))
+        with current.lock:
+            new_id = current.queue_ids[0]
+        self.assertNotEqual(new_id, old_id)
+
+        old = stale._session(sid)
+        with old.lock:
+            self.assertEqual(old.queue_ids, [old_id])
+            del old.queue[:1]
+            del old.queue_ids[:1]
+            mismatch = stale._save_registry(old, queue_ack=[old_id])
+        self.assertTrue(mismatch, "the delayed ACK must reject the newer entry id")
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["same text"])
+        self.assertEqual([entry["id"] for entry in registry_queue_entries(rows, sid)], [new_id])
+
+        self.assertTrue(be.kill(sid))          # a dead restart leaves the surviving queue observable
+        restarted = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertEqual(restarted.pending_queued(sid), ["same text"])
+        self.assertEqual(restarted._session(sid).queue_ids, [new_id])
+
+    def test_legacy_string_queue_migrates_with_stable_ids_across_restart(self):
+        tmp = tempfile.mkdtemp()
+        root = Path(tmp) / "codex"
+        root.mkdir(parents=True)
+        sid = "legacy-session"
+        (root / "registry.json").write_text(json.dumps({sid: {
+            "tid": "legacy-thread", "name": "old", "cwd": "/TESTDIR", "dead": True,
+            "queue": ["repeat", "repeat"],
+        }}))
+        first = cb.CodexBackend(tmp, client_factory=lambda: None)
+        overlap = cb.CodexBackend(tmp, client_factory=lambda: None)
+        self.assertEqual(first.pending_queued(sid), ["repeat", "repeat"])
+        ids = list(first._session(sid).queue_ids)
+        self.assertEqual(overlap._session(sid).queue_ids, ids)
+        self.assertEqual(len(set(ids)), 2)
+
+        self.assertTrue(first.rename(sid, "migrated"))  # any transaction lazily upgrades the row
+        rows = json.loads((root / "registry.json").read_text())
+        entries = registry_queue_entries(rows, sid)
+        self.assertTrue(all(entry["id"] and entry["text"] for entry in entries))
+        self.assertEqual([entry["id"] for entry in entries], ids)
+        restarted = cb.CodexBackend(tmp, client_factory=lambda: None)
+        self.assertEqual(restarted.pending_queued(sid), ["repeat", "repeat"])
+        self.assertEqual(restarted._session(sid).queue_ids, ids)
+
+    def test_other_backend_append_survives_exact_prefix_ack(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        other = cb.CodexBackend(tmp, client_factory=lambda: fake)  # stale before the queue changes
+        ensure = be._ensure_worker
+        be._ensure_worker = lambda s: None
+        self.assertTrue(be.send(sid, "accepted prefix"))
+        be._ensure_worker = ensure
+        other._save_registry(other._session(sid),
+                             queue_append={"id": "other-suffix", "text": "concurrent suffix"})
+        s = be._session(sid)
+        with s.lock:
+            self.assertEqual(s.queue, ["accepted prefix"])
+            prefix_id = s.queue_ids[0]
+            del s.queue[:1]                 # the same mutation made after turn/start ACK
+            del s.queue_ids[:1]
+            be._save_registry(s, fields=("launchError",), queue_ack=[prefix_id])
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(registry_queue_texts(rows, sid), ["concurrent suffix"])
+
+    def test_concurrent_local_sends_keep_memory_and_registry_order(self):
+        be, _, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        be._ensure_worker = lambda s: None
+        entered, release = threading.Event(), threading.Event()
+        save = be._save_registry
+
+        def gated_save(s, **kwargs):
+            if (kwargs.get("queue_append") or {}).get("text") == "first":
+                entered.set()
+                release.wait(5)
+            return save(s, **kwargs)
+
+        be._save_registry = gated_save
+        first = threading.Thread(target=be.send, args=(sid, "first"))
+        second = threading.Thread(target=be.send, args=(sid, "second"))
+        first.start()
+        self.assertTrue(entered.wait(2))
+        second.start()
+        time.sleep(0.05)
+        self.assertTrue(second.is_alive(), "the second append must wait behind the first transaction")
+        release.set()
+        first.join(2)
+        second.join(2)
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        self.assertEqual(be.pending_queued(sid), ["first", "second"])
+        self.assertEqual(registry_queue_texts(rows, sid), ["first", "second"])
+
+    def test_registry_queue_appends_are_atomic_across_processes(self):
+        be, _, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.kill(sid))       # child backends load it without starting queue workers
+        code = r'''
+import sys
+from importlib.machinery import SourceFileLoader
+cb = SourceFileLoader("codex_child", sys.argv[1]).load_module()
+be = cb.CodexBackend(sys.argv[2], client_factory=lambda: None, log=lambda message: None)
+s = be._session(sys.argv[3])
+for i in range(20):
+    text = "%s:%d" % (sys.argv[4], i)
+    be._save_registry(s, queue_append={"id": "child-" + text, "text": text})
+'''
+        backend_path = str(Path(ROOT) / "kernel" / "codex_backend.py")
+        procs = [subprocess.Popen([sys.executable, "-c", code, backend_path, tmp, sid, str(n)])
+                 for n in range(4)]
+        for p in procs:
+            self.assertEqual(p.wait(timeout=15), 0)
+        rows = json.loads((Path(tmp) / "codex" / "registry.json").read_text())
+        entries = registry_queue_entries(rows, sid)
+        self.assertEqual(len(entries), 80)
+        self.assertEqual(len({entry["id"] for entry in entries}), 80)
+        self.assertEqual(len({entry["text"] for entry in entries}), 80)
+
+    def test_backend_restart_rearms_a_persisted_queue_without_another_send(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        ensure = be._ensure_worker
+        be._ensure_worker = lambda s: None
+        self.assertTrue(be.send(sid, "survive restart"))
+        be._ensure_worker = ensure
+        self.assertEqual(be.pending_queued(sid), ["survive restart"])
+        be2 = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertTrue(until(lambda: not be2.busy(sid) and not be2.pending_queued(sid)))
+        self.assertIn("survive restart", Path(be2.transcript_path(sid)).read_text())
+
+    def test_launch_error_survives_backend_restart(self):
+        def bad_factory():
+            raise RuntimeError(cb.LOGIN_HINT)
+        be, _, tmp = build(factory=bad_factory)
+        sid = be.spawn("web", "/TESTDIR")
+        be2 = cb.CodexBackend(tmp, client_factory=bad_factory)
+        self.assertIn("codex login", be2.launch_error(sid)["text"])
+
+    def test_missing_login_is_loud_not_silent(self):
+        def bad_factory():
+            raise RuntimeError(cb.LOGIN_HINT)
+        be, _, _ = build(factory=bad_factory)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertIsNotNone(sid)                       # the session EXISTS, visibly broken
+        err = be.launch_error(sid)
+        self.assertIn("codex login", err["text"])
+        self.assertFalse(err["limit"])
+        self.assertFalse(be.available())
+
+    def test_claude_only_knobs_refuse(self):
+        be, _, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.set_effort(sid, "xhigh"))    # Codex takes xhigh natively
+        self.assertFalse(be.set_effort(sid, "max"))     # Claude-only → loud refusal
+        self.assertFalse(be.set_fast(sid, "on"))
+        self.assertFalse(be.set_mode(sid, "plan"))
+        self.assertFalse(be.set_auth(sid, "key"))
+        self.assertFalse(be.rewind_files(sid, "u1"))
+        self.assertTrue(be.set_model(sid, "gpt-5-codex"))
+        self.assertEqual(be.live_sessions()[sid]["model"], "gpt-5-codex")
+        # a Claude alias would 400 the next turn — refused here so the kernel warns instead
+        self.assertFalse(be.set_model(sid, "sonnet"))
+        self.assertEqual(be.live_sessions()[sid]["model"], "gpt-5-codex")
+
+    def test_client_launch_defines_the_fail_closed_workspace_profile(self):
+        captured = []
+
+        class CaptureConfig:
+            def __init__(self, **kwargs):
+                captured.append(kwargs)
+
+        cb._codex_config(CaptureConfig, "/opt/codex")
+        self.assertEqual(captured[0]["codex_bin"], "/opt/codex")
+        self.assertEqual(captured[0]["client_name"], "romp")
+        overrides = captured[0]["config_overrides"]
+        self.assertEqual(overrides, cb.CODEX_CONFIG_OVERRIDES)
+        profile = overrides[0]
+        self.assertIn('":minimal" = "read"', profile)
+        self.assertIn('"." = "write"', profile)
+        for metadata in (".git", ".agents", ".codex"):
+            self.assertNotIn('"%s"' % metadata, profile)
+        self.assertIn("network = { enabled = true }", profile)
+        self.assertEqual(overrides[1], 'default_permissions="romp_workspace"')
+
+    def test_model_catalog_from_app_server(self):
+        be, fake, _ = build()
+        cat = be.model_catalog()
+        self.assertEqual(cat, [{"value": "gpt-5-test", "label": "GPT-5 Test"}])
+        be.model_catalog()
+        self.assertEqual(len(fake.called("model_list")), 1, "catalog is fetched once, then cached")
+
+    def test_deliver_and_wake_reach_the_agent(self):
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.deliver(sid, "you have mail from web"))
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        texts = Path(be.transcript_path(sid)).read_text().splitlines()
+        self.assertTrue(any("you have mail" in t for t in texts))
+
+    def test_push_session_may_reenter_live_sessions(self):
+        # The kernel's push_session synchronously re-enters Sessions.live() → live_sessions(),
+        # which takes every session's norm_lock. A notify issued while holding norm_lock
+        # self-deadlocked the worker on its first appended record and wedged the whole liveness
+        # merge behind it (2026-08-14 review, reproduced live). Wiring the reentrant push here is
+        # the regression: with the notify under the lock, this test hangs and times out.
+        tmp = tempfile.mkdtemp()
+        fake = FakeClient()
+        be = cb.CodexBackend(tmp, client_factory=lambda: fake,
+                             push_session=lambda sid: be.live_sessions())
+        sid = be.spawn("web", "/TESTDIR")
+        be.send(sid, "hello reentrant push")
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid), timeout=10),
+                        "worker wedged — a notify ran under a lock live_sessions() needs")
+        recs = [json.loads(l) for l in Path(be.transcript_path(sid)).read_text().splitlines()]
+        self.assertTrue(any(r["type"] == "assistant" for r in recs))
+        self.assertTrue(be.kill(sid))   # kill's held-final drain notifies too — same reentry
+
+
+class LaunchErrorNames(unittest.TestCase):
+    """A LIVE launch-error row without a shared name let a retry mint a duplicate live session
+    under the same name (the v1.3.12 audit's P2) — both failure branches now write names/."""
+
+    def test_a_clientless_spawn_writes_its_shared_name(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            name_file = os.path.join(td, "names", sid)
+            self.assertTrue(os.path.exists(name_file),
+                            "the launch-error session claims its name slot")
+            self.assertIn("webby", open(name_file).read())
+
+    def test_a_thread_start_failure_writes_its_shared_name(self):
+        import tempfile
+
+        class BoomClient(FakeClient):
+            def thread_start(self, params):
+                raise RuntimeError("no threads today")
+        with tempfile.TemporaryDirectory() as td:
+            fake = BoomClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            sid = be.spawn("webby", "/tmp")
+            name_file = os.path.join(td, "names", sid)
+            self.assertTrue(os.path.exists(name_file))
+            self.assertIn("webby", open(name_file).read())
+
+
+class RaisingRegistryTransactions(unittest.TestCase):
+    """The r28 verification, executed on the real backend: every durable-write failure must
+    publish NOTHING — no moved names file, no in-memory lifecycle flip, no phantom row."""
+
+    def _corrupt(self, td):
+        os.makedirs(os.path.join(td, "codex"), exist_ok=True)
+        with open(os.path.join(td, "codex", "registry.json"), "w") as f:
+            f.write("{ not json")
+
+    def test_a_raising_registry_rename_moves_no_store(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            self._corrupt(td)
+            with self.assertRaises(RuntimeError):
+                be.rename(sid, "newname")
+            s = be._session(sid)
+            self.assertEqual(s.name, "webby", "the in-memory name never moved")
+            self.assertIn("webby", open(os.path.join(td, "names", sid)).read(),
+                          "the shared names file never moved — three stores stay agreed")
+
+    def test_a_raising_registry_resume_rolls_the_flip_back(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            s = be._session(sid)
+            s.dead = True
+            prior_state = s.state
+            self._corrupt(td)
+            with self.assertRaises(RuntimeError):
+                be.resume("webby", sid)
+            self.assertTrue(s.dead,
+                            "a FAILED revive must not come up as a live lane beside its own "
+                            "failure message")
+            self.assertEqual(s.state, prior_state)
+
+    def test_a_raising_registry_spawn_leaves_no_phantom(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            self._corrupt(td)
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            with self.assertRaises(RuntimeError):
+                be.spawn("webby", "/tmp")
+            self.assertEqual(len(be._sessions), 0,
+                             "no durable row means no in-memory row — a phantom live lane with "
+                             "no names file re-opened the duplicate-name hole")
+            self.assertFalse(os.path.exists(os.path.join(td, "names")) and
+                             os.listdir(os.path.join(td, "names")))
+
+    def test_a_raising_registry_success_path_spawn_leaves_no_phantom(self):
+        # the r29 verification: only the two ERROR branches were pinned — a wrong-key mutant in
+        # the success branch's rollback survived every test
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            self._corrupt(td)
+            fake = FakeClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            with self.assertRaises(RuntimeError):
+                be.spawn("webby", "/tmp")
+            self.assertEqual(len(be._sessions), 0,
+                             "the success branch rolls back like its two siblings")
+
+    def test_a_names_write_failure_retires_the_spawned_row(self):
+        # the r29 verification: the durable row landed, then the UNGUARDED names write raised —
+        # a live row holding no name is the duplicate-name hole (the v1.3.12 audit) re-opened
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            with open(os.path.join(td, "names"), "w") as f:
+                f.write("not a dir")               # names/ is uncreatable: mkdir raises
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            with self.assertRaises(Exception):
+                be.spawn("webby", "/tmp")
+            self.assertEqual(len(be._sessions), 0,
+                             "no live row without a shared name — the row is retired, loudly")
+            import json as _json
+            rows = _json.loads(open(os.path.join(td, "codex", "registry.json")).read())
+            self.assertTrue(all(r.get("dead") for r in rows.values()),
+                            "the durable row is retired too: %r" % rows)
+
+    def test_a_names_write_failure_in_rename_keeps_all_three_stores_agreed(self):
+        # the r29 verification: the compensation branch was unpinned — deleting it entirely
+        # stayed green while the registry alone moved to the new name under a false
+        # "keeps its old name" message
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            nf = os.path.join(td, "names", sid)
+            os.chmod(os.path.dirname(nf), 0o555)   # the ATOMIC write's tmp create raises; the
+            try:                                    # file survives untouched (r32 made the write
+                with self.assertRaises(Exception):  # tmp+replace, so a read-only FILE no longer
+                    be.rename(sid, "newname")       # fails it — only the dir does)
+            finally:
+                os.chmod(os.path.dirname(nf), 0o755)
+            self.assertEqual(be._session(sid).name, "webby", "memory kept the old name")
+            self.assertIn("webby", open(nf).read(), "the names file kept the old name")
+            import json as _json
+            rows = _json.loads(open(os.path.join(td, "codex", "registry.json")).read())
+            self.assertEqual(rows[sid]["name"], "webby",
+                             "the COMPENSATION re-ran the registry write with the old name — "
+                             "without it the registry alone holds the new name and applies the "
+                             "'failed' rename at the next restart")
+
+    def test_a_truncating_names_write_in_rename_is_restored(self):
+        # the r30 mutant hunt: the chmod-0444 fixture fails AT OPEN without truncating, so
+        # deleting the bytes-restore stayed green — this drives the ENOSPC shape the fix names
+        # (write_text truncates, THEN fails)
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            nf = os.path.join(td, "names", sid)
+            old_line = open(nf).read()
+
+            def truncating_write(s2, bg="", fg=""):
+                open(nf, "w").close()              # the open('w') truncation
+                raise OSError(28, "No space left on device")
+            with mock.patch.object(be, "_write_name", side_effect=truncating_write):
+                with self.assertRaises(OSError):
+                    be.rename(sid, "newname")
+            self.assertEqual(open(nf).read(), old_line,
+                             "the compensation restores the truncated identity line")
+            self.assertEqual(be._session(sid).name, "webby")
+
+    def test_a_failed_rename_of_an_absent_names_file_stays_unpublished(self):
+        # the r30 verification: with no file to snapshot, _write_name CREATED a partial file
+        # holding the NEW name — the failed rename stayed published, silently
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            nf = os.path.join(td, "names", sid)
+            os.unlink(nf)                          # a legacy row predating the names write
+
+            def partial_write(s2, bg="", fg=""):
+                with open(nf, "w") as f:
+                    f.write("newname\t")           # partial line lands, then the write dies
+                raise OSError(28, "No space left on device")
+            with mock.patch.object(be, "_write_name", side_effect=partial_write):
+                with self.assertRaises(OSError):
+                    be.rename(sid, "newname")
+            self.assertFalse(os.path.exists(nf),
+                             "the partial NEW-name file is removed — a failed rename must not "
+                             "stay published")
+
+    def test_a_names_write_failure_after_thread_start_is_restored_not_fatal(self):
+        # the r30 verification: _prepare_thread's unguarded names write truncated the identity
+        # file permanently — no later path rewrites it (resume skips the create branch)
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            fake = FakeClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            sid = be.spawn("webby", "/tmp")
+            s = be._session(sid)
+            nf = os.path.join(td, "names", sid)
+            old_line = open(nf).read()
+            s.tid = "pending-%s" % sid[:8]         # force the create path
+            s.loaded = False
+
+            def truncating_write(s2, bg="", fg=""):
+                open(nf, "w").close()
+                raise OSError(28, "No space left on device")
+            with mock.patch.object(be, "_write_name", side_effect=truncating_write):
+                ok = be._prepare_thread(s, fake)
+            self.assertTrue(ok, "the thread is healthy — the turn proceeds")
+            self.assertEqual(open(nf).read(), old_line,
+                             "the truncation cannot outlive the failure")
+            self.assertTrue(s.loaded)
+
+    def test_a_corrupt_names_file_is_healed_by_the_next_write(self):
+        # the r31 verification: non-UTF-8 names bytes sailed through _write_name's OSError-only
+        # read catch, failed the turn with a wrong-subsystem error, and no path ever healed the
+        # file — the session's identity vanished from every kernel surface
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            fake = FakeClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            sid = be.spawn("webby", "/tmp")
+            s = be._session(sid)
+            nf = os.path.join(td, "names", sid)
+            with open(nf, "wb") as f:
+                # tab-shaped residue: a mutant that decodes the corrupt parts leniently would
+                # CARRY the bad bg forward (the r33 mutant hunt) — exact-equality catches it
+                f.write(b"webby\t/tmp\t\xff\xfe\t\x80fg")
+            s.tid = "pending-%s" % sid[:8]         # force the create path
+            s.loaded = False
+            ok = be._prepare_thread(s, fake)
+            self.assertTrue(ok)
+            healed = open(nf, "rb").read()
+            self.assertEqual(healed, b"webby\t/tmp\t\t\n",
+                             "healed means CLEAN and WHOLE — a heal that decoded the corrupt "
+                             "parts leniently carried the bad colours forward, re-arming the "
+                             "landmine (the r32/r33 mutant hunts)")
+
+    def test_the_names_write_is_atomic(self):
+        # the r31 verification: the in-place write_text was torn-readable mid-write and its
+        # crash residue armed the decode landmine — tmp+os.replace, like sdk_backend.write_name
+        import inspect
+        src = inspect.getsource(cb.CodexBackend._write_name)
+        self.assertIn("tmp.write_text", src, "the payload lands on a TMP file first")
+        self.assertIn("os.replace", src, "and moves into place atomically")
+
+    def test_the_names_staging_file_never_leaks(self):
+        # the r32 verification: a failing replace left names/<sid>.tmp behind, and NAMES
+        # consumers read the stray as a phantom session forever
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("webby", "/tmp")
+            s = be._session(sid)
+            names_dir = os.path.join(td, "names")
+            os.unlink(os.path.join(names_dir, sid))
+            os.mkdir(os.path.join(names_dir, sid))   # os.replace onto a non-empty dir raises
+            os.mkdir(os.path.join(names_dir, sid, "x"))
+            try:
+                with self.assertRaises(OSError):
+                    be._write_name(s)
+            finally:
+                os.rmdir(os.path.join(names_dir, sid, "x"))
+                os.rmdir(os.path.join(names_dir, sid))
+            self.assertEqual([n for n in os.listdir(names_dir) if n.endswith(".tmp")], [],
+                             "the staging file is unlinked on every path")
+
+    def test_an_unpublishable_name_after_thread_start_says_so(self):
+        # the r31 verification: the no-prior-file leg logged "was restored" when the partial
+        # file was actually unlinked — and the state it leaves (live row, no published name) is
+        # the duplicate-name hole, which the log must NAME
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            fake = FakeClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            sid = be.spawn("webby", "/tmp")
+            s = be._session(sid)
+            nf = os.path.join(td, "names", sid)
+            os.unlink(nf)                          # no prior file to restore
+            s.tid = "pending-%s" % sid[:8]
+            s.loaded = False
+            logs = []
+            with mock.patch.object(be, "log", side_effect=lambda m: logs.append(m)):
+                with mock.patch.object(be, "_write_name",
+                                       side_effect=OSError(28, "No space left on device")):
+                    ok = be._prepare_thread(s, fake)
+            self.assertTrue(ok, "the healthy turn still proceeds")
+            self.assertTrue(any("could not be published" in m for m in logs), logs)
+            self.assertFalse(any("was restored" in m for m in logs),
+                             "the log must not claim a restore that never happened")
+
+    def test_resume_never_overwrites_a_fresher_registry_name(self):
+        # the r37 verification: a rename landing during an in-flight revive was silently
+        # reverted in the durable registry by resume's adoption of the caller's stale echo
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("web", "/tmp")
+            s = be._session(sid)
+            s.dead = True
+            be.rename(sid, "api")                      # the rename that landed mid-revive
+            self.assertTrue(be.resume("web", sid),
+                            "the revive resolved its name BEFORE the rename")
+            self.assertEqual(be._session(sid).name, "api",
+                             "the registry's fresher name survives the stale echo")
+
+    def test_resume_adopts_the_echo_only_for_a_nameless_row(self):
+        # the r38 mutant hunt: only the negative leg was pinned — deleting the adoption
+        # entirely stayed green (the SDK twin pins both directions)
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            be = cb.CodexBackend(td, client_factory=lambda: None)
+            sid = be.spawn("web", "/tmp")
+            s = be._session(sid)
+            s.dead = True
+            s.name = ""                                # a nameless registry row (legacy load)
+            self.assertTrue(be.resume("adopted", sid))
+            self.assertEqual(be._session(sid).name, "adopted",
+                             "a nameless row ADOPTS the caller's echo — that half must hold too")
+
+    def test_a_raising_tid_save_rolls_the_thread_flip_back(self):
+        # the r29 verification: with the real tid only in memory, every retry took the resume
+        # path and never re-saved it — the next restart loaded 'pending-…' and silently started
+        # a FRESH Codex thread (server-side context lost, nothing looking wrong)
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            fake = FakeClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            sid = be.spawn("webby", "/tmp")
+            s = be._session(sid)
+            s.tid = "pending-%s" % sid[:8]         # force the create path
+            s.loaded = False
+            prior_model = s.model
+
+            class OtherModel(type(fake)):
+                def thread_start(self2, params):
+                    resp = super().thread_start(params)
+                    resp.model = "gpt-other"       # a DIFFERENT answer, so the model half of
+                    return resp                    # the rollback is observable (the r30 hunt)
+            fake2 = OtherModel()
+            self._corrupt(td)
+            with self.assertRaises(RuntimeError):
+                be._prepare_thread(s, fake2)
+            self.assertTrue(s.tid.startswith("pending-"),
+                            "the real tid is never published to memory alone")
+            self.assertFalse(s.loaded)
+            self.assertEqual(s.model, prior_model, "all THREE rolled-back fields, not two")
+
+    def test_a_raising_registry_thread_start_failure_spawn_leaves_no_phantom(self):
+        import tempfile
+
+        class BoomClient(FakeClient):
+            def thread_start(self, params):
+                raise RuntimeError("no threads today")
+        with tempfile.TemporaryDirectory() as td:
+            self._corrupt(td)
+            fake = BoomClient()
+            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            with self.assertRaises(RuntimeError):
+                be.spawn("webby", "/tmp")
+            self.assertEqual(len(be._sessions), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_codex_discovery.py
+++ b/tests/test_codex_discovery.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Codex transcript-root discovery (kernel/judge.py _codex_rows): sessions materialized under
+STATE/codex/projects are discovered alongside the Claude roots — same (fsid, path, anchor_sid, name)
+tuple contract — and the discover cache's fingerprint sees a registry change exactly when the list
+would change. Synthetic data throughout per CLAUDE.md.
+
+Run:    python3 tests/test_codex_discovery.py
+"""
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+jd = SourceFileLoader("romp_judge_codexdisc", os.path.join(ROOT, "bin", "romp-judge")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+TID = "01911111-2222-7333-8444-555555555555"
+
+
+class CodexDiscovery(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.tmp)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+
+    def _mint(self, cwd="/TESTDIR", name="cx", sid=SID, tid=TID, dead=False, mtime=None):
+        enc = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd))
+        proj = jd.CODEXDIR / "projects" / enc
+        proj.mkdir(parents=True, exist_ok=True)
+        p = proj / (tid + ".jsonl")
+        p.write_text(json.dumps({"type": "user", "uuid": "u1", "parentUuid": None,
+                                 "timestamp": "2026-06-10T14:00:00.000Z",
+                                 "message": {"role": "user", "content": "synthetic prompt"}}) + "\n")
+        os.utime(p, (mtime or NOW, mtime or NOW))
+        reg = {}
+        try:
+            reg = json.loads((jd.CODEXDIR / "registry.json").read_text())
+        except Exception:
+            pass
+        reg[sid] = {"tid": tid, "name": name, "cwd": cwd, "dead": dead}
+        (jd.CODEXDIR / "registry.json").write_text(json.dumps(reg))
+        return p
+
+    def test_codex_session_discovered_with_tuple_contract(self):
+        # the STABLE SID is the identity slot (the v1.3.13 audit's P1: the app-server TID there
+        # meant live rows never joined liveness — keyed on SID — the picker offered a not-running
+        # TID row, and reviving it shelled `romp resume <TID>` through the tmux path); the TID
+        # rides only in the transcript PATH
+        p = self._mint()
+        rows = jd._discover_impl(NOW)
+        cx = [r for r in rows if r[0] == SID]
+        self.assertEqual(len(cx), 1)
+        fsid, path, anchor, name = cx[0]
+        self.assertEqual((fsid, str(path), anchor, name), (SID, str(p), SID, "cx"))
+        self.assertFalse(any(r[0] == TID for r in rows),
+                         "the thread id is transcript metadata, never a session identity")
+
+    def test_window_ages_out(self):
+        self._mint(mtime=NOW - 10 * 24 * 3600)
+        rows = jd._discover_impl(NOW)          # default window is far shorter than 10 days
+        self.assertEqual([r for r in rows if r[2] == SID], [],
+                         "aged out by the window — the old filter-by-TID was unsatisfiable by "
+                         "construction after the identity fix and passed with age-out broken "
+                         "(the r37 mutant hunt)")
+
+    def test_registry_change_invalidates_discover_cache(self):
+        self._mint()
+        first = jd.discover(NOW)
+        self.assertEqual(len([r for r in first if r[0] == SID]), 1)
+        # a second session lands: only the registry + a new file change — the fingerprint must move
+        time.sleep(0.02)
+        tid2 = TID.replace("01911111", "01922222")
+        sid2 = SID.replace("1111", "2222", 1)
+        self._mint(name="cx2", sid=sid2, tid=tid2)
+        # bump the registry mtime past same-second granularity for the stat-based signature
+        os.utime(jd.CODEXDIR / "registry.json", (NOW + 5, NOW + 5))
+        second = jd.discover(NOW)
+        self.assertEqual(len([r for r in second if r[0] == sid2]), 1,
+                         "new codex session invisible — fingerprint missed the registry change")
+
+    def test_missing_or_broken_registry_is_harmless(self):
+        self.assertEqual(jd._codex_rows(0, set()), [])
+        jd.CODEXDIR.mkdir(parents=True, exist_ok=True)
+        (jd.CODEXDIR / "registry.json").write_text("{not json")
+        self.assertEqual(jd._codex_rows(0, set()), [])
+
+
+class StagingStraysNeverDiscovered(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.tmp)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+
+    def test_a_leaked_names_tmp_is_not_a_session(self):
+        # the r33 verification: discover() is THE primary NAMES consumer and read a leaked
+        # staging stray as a phantom session — it even stole a live session's fork lane. The
+        # stray is RESOLVABLE here (its transcript exists on disk): with the filter removed —
+        # or filtering the wrong variable, f.stem, which strips the suffix (the r34 mutant
+        # hunt) — discover returns the phantom and this test fails
+        stray = "99999999-8888-7777-6666-555555555555.tmp"
+        (jd.NAMES / "11111111-2222-3333-4444-555555555555").write_text("web\t/TESTDIR\t\t\n")
+        (jd.NAMES / stray).write_text("phantom\t/TESTDIR\t\t\n")
+        import re as _re
+        with tempfile.TemporaryDirectory() as pd:
+            proj = Path(pd) / _re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath("/TESTDIR"))
+            proj.mkdir(parents=True)
+            tr = proj / (stray + ".jsonl")
+            tr.write_text(json.dumps({"type": "user", "uuid": "u1", "parentUuid": None,
+                                      "timestamp": "2026-06-10T14:00:00.000Z",
+                                      "message": {"role": "user",
+                                                  "content": "synthetic prompt"}}) + "\n")
+            os.utime(tr, (NOW, NOW))
+            from unittest import mock
+            with mock.patch.object(jd, "PROJECTS", Path(pd)):
+                found = jd.discover(NOW)
+        sids = [t[2] for t in found]
+        self.assertNotIn(stray, sids)
+        self.assertFalse(any(str(s).endswith(".tmp") for s in sids), sids)
+        # and the fingerprint ignores it too: a stray appearing must not invalidate caches
+        fp1 = jd._discover_fingerprint()
+        (jd.NAMES / "99999999-8888-7777-6666-555555555555.tmp").write_text("changed\t/x\t\t\n")
+        self.assertEqual(fp1, jd._discover_fingerprint(),
+                         "staging churn is invisible to the discovery fingerprint")

--- a/tests/test_codex_discovery.py
+++ b/tests/test_codex_discovery.py
@@ -133,3 +133,15 @@ class StagingStraysNeverDiscovered(unittest.TestCase):
         (jd.NAMES / "99999999-8888-7777-6666-555555555555.tmp").write_text("changed\t/x\t\t\n")
         self.assertEqual(fp1, jd._discover_fingerprint(),
                          "staging churn is invisible to the discovery fingerprint")
+
+
+class ModelsRouteConsultsCodexOnlyWhenOptedIn(unittest.TestCase):
+    """GET /models spawns `codex app-server` through model_catalog(); on the default (Claude) path it
+    must not be consulted at all (PR #885 review: every dashboard load spawned or failed to spawn it)."""
+
+    def test_the_gate_reads_opt_in_state_not_readiness(self):
+        src = open(os.path.join(ROOT, "kernel", "kernel.py")).read()
+        self.assertIn('if cx and (_default_backend() == "codex" or _judge_engine_name() == "codex"', src)
+        self.assertIn("or bool(cx.live_sessions())):", src)
+        self.assertNotIn("if cx:\n                    try:\n                        cx_models = cx.model_catalog()", src)
+        self.assertIn("def _judge_engine_name():", src)

--- a/tests/test_codex_events_golden.py
+++ b/tests/test_codex_events_golden.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Contract tests for the Codex notification → transcript-record normalizer (kernel/codex_events.py).
+
+Each scenario feeds SYNTHETIC app-server v2 notifications (invented prompts, placeholder ids — never
+real session data, per CLAUDE.md) through ThreadNormalizer and pins the records it emits: the uuid
+chain, the held-final-message flush (stop_reason placement), tool_use/tool_result pairing, the
+compaction stitch, and the error settle. The integration class then writes a full stream's records
+to disk and runs the REAL parse_session over the file — the property the whole design rests on:
+a Codex-materialized transcript parses into the same Session→Turn→Atom tree a Claude one does.
+
+Run:    python3 tests/test_codex_events_golden.py
+"""
+import os
+import sys
+import tempfile
+import json
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+# Hermetic state BEFORE the loads (same floor as test_event_model_golden.py).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+em = SourceFileLoader("romp_event_model", os.path.join(ROOT, "bin", "romp-event-model")).load_module()
+cx = SourceFileLoader("romp_codex_events", os.path.join(ROOT, "kernel", "codex_events.py")).load_module()
+
+NOW = 1781100000                                   # fixed test clock
+TID = "01911111-2222-7333-8444-555555555555"       # synthetic Codex thread id (UUIDv7-shaped)
+SID = "11111111-2222-3333-4444-555555555555"       # the session's stable romp uuid
+MS = NOW * 1000
+
+
+def norm(**kw):
+    kw.setdefault("thread_id", TID)
+    kw.setdefault("cwd", "/TESTDIR")
+    kw.setdefault("version", "codex-cli 0.0.0-test")
+    kw.setdefault("model", "gpt-5-test")
+    kw.setdefault("clock", lambda: NOW)
+    return cx.ThreadNormalizer(**kw)
+
+
+# ── synthetic wire builders (camelCase, the shapes v2_all.py pins) ──
+def item_started(item, ms=MS, turn="t1"):
+    return "item/started", {"threadId": TID, "turnId": turn, "startedAtMs": ms, "item": item}
+
+
+def item_completed(item, ms=MS, turn="t1"):
+    return "item/completed", {"threadId": TID, "turnId": turn, "completedAtMs": ms, "item": item}
+
+
+def turn_started(turn="t1"):
+    return "turn/started", {"threadId": TID, "turn": {"id": turn, "items": []}}
+
+
+def turn_completed(turn="t1", status="completed", error=None):
+    t = {"id": turn, "items": [], "status": status}
+    if error:
+        t["error"] = error
+    return "turn/completed", {"threadId": TID, "turn": t}
+
+
+def token_usage(inp=1000, out=50, cached=800, reasoning=25, last_total=1875, window=272000,
+                cum_total=999999):
+    # last != total on purpose: `last` is the context-occupancy proxy, `total` the thread-cumulative
+    # cost number — a fixture where they coincide would hide a reader picking the wrong one
+    return "thread/tokenUsage/updated", {
+        "threadId": TID, "turnId": "t1",
+        "tokenUsage": {"last": {"inputTokens": inp, "outputTokens": out,
+                                "cachedInputTokens": cached, "reasoningOutputTokens": reasoning,
+                                "totalTokens": last_total},
+                       "total": {"inputTokens": inp * 10, "outputTokens": out * 10,
+                                 "cachedInputTokens": cached * 10,
+                                 "reasoningOutputTokens": reasoning * 10, "totalTokens": cum_total},
+                       "modelContextWindow": window}}
+
+
+def assert_chain(tc, recs, seed=None):
+    """The linearity invariant every stream must hold: uuids unique, each record parented on the
+    one before it (compact boundaries via logicalParentUuid, parentUuid null by design), never a
+    self-parent. Collisions orphan prior history in the FileAdapter walk (review finding #1)."""
+    seen = set()
+    prev = seed
+    for r in recs:
+        tc.assertNotIn(r["uuid"], seen, "duplicate uuid %s" % r["uuid"])
+        tc.assertNotEqual(r["uuid"], r.get("parentUuid"), "self-parent %s" % r["uuid"])
+        if r.get("subtype") == "compact_boundary":
+            tc.assertIsNone(r["parentUuid"])
+            tc.assertEqual(r["logicalParentUuid"], prev)
+        else:
+            tc.assertEqual(r.get("parentUuid"), prev, "chain break at %s" % r["uuid"])
+        seen.add(r["uuid"])
+        prev = r["uuid"]
+
+
+def user_item(text, iid="u1"):
+    return {"type": "userMessage", "id": iid, "content": [{"type": "text", "text": text}]}
+
+
+def agent_item(text, iid="a1"):
+    return {"type": "agentMessage", "id": iid, "text": text}
+
+
+def feed(n, *events):
+    out = []
+    for method, params in events:
+        out.extend(n.handle(method, params))
+    return out
+
+
+class Chain(unittest.TestCase):
+    def test_simple_turn(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started(),
+                    item_completed(user_item("fix the flaky test")),
+                    item_completed(agent_item("Done — the sleep is now an event wait.")),
+                    token_usage(),
+                    turn_completed())
+        self.assertEqual([r["type"] for r in recs], ["user", "assistant"])
+        u, a = recs
+        self.assertEqual(u["promptSource"], "sdk")
+        self.assertIsNone(u["parentUuid"])
+        self.assertEqual(a["parentUuid"], u["uuid"])
+        self.assertEqual(a["message"]["stop_reason"], "end_turn")     # held, flushed by turn end
+        self.assertEqual(a["message"]["model"], "gpt-5-test")
+        self.assertEqual(a["message"]["usage"]["input_tokens"], 1000)
+        self.assertEqual(a["message"]["usage"]["output_tokens"], 75)  # output + reasoning folded
+        self.assertEqual(a["message"]["usage"]["cache_read_input_tokens"], 800)
+        self.assertEqual(u["cwd"], "/TESTDIR")
+        self.assertTrue(u["timestamp"].endswith("Z"))
+
+    def test_mid_turn_text_flushes_null(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(agent_item("Looking at the config first.", "a1")),
+                    item_started({"type": "commandExecution", "id": "c1", "command": "cat cfg.toml"}),
+                    item_completed({"type": "commandExecution", "id": "c1", "command": "cat cfg.toml",
+                                    "aggregatedOutput": "key=1", "exitCode": 0}),
+                    item_completed(agent_item("The config is fine.", "a2")),
+                    turn_completed())
+        stops = [(r["message"]["content"][0].get("type"), r["message"].get("stop_reason"))
+                 for r in recs if r["type"] == "assistant"]
+        # mid-turn text: stop null (flushed by the command); final text: end_turn (flushed by turn end)
+        self.assertEqual(stops, [("text", None), ("tool_use", None), ("text", "end_turn")])
+
+    def test_command_execution_pairs(self):
+        n = norm()
+        recs = feed(n,
+                    item_started({"type": "commandExecution", "id": "c1", "command": "pytest -x"}),
+                    item_completed({"type": "commandExecution", "id": "c1", "command": "pytest -x",
+                                    "aggregatedOutput": "1 failed", "exitCode": 1,
+                                    "durationMs": 1200}))
+        use, res = recs
+        blk = use["message"]["content"][0]
+        self.assertEqual((blk["type"], blk["name"], blk["input"]["command"]),
+                         ("tool_use", "Bash", "pytest -x"))
+        rblk = res["message"]["content"][0]
+        self.assertEqual(rblk["tool_use_id"], blk["id"])
+        self.assertEqual(rblk["content"], "1 failed")         # plain string — the shape the readers render
+        self.assertTrue(rblk["is_error"])
+        self.assertEqual(res["toolUseResult"]["exitCode"], 1)
+        self.assertNotIn("promptSource", res)                 # a tool_result is not a prompt
+
+    def test_command_output_capped(self):
+        n = norm()
+        big = "x" * (cx.TOOL_OUTPUT_CAP + 500)
+        recs = feed(n, item_completed({"type": "commandExecution", "id": "c1",
+                                       "command": "yes", "aggregatedOutput": big, "exitCode": 0}))
+        text = recs[-1]["message"]["content"][0]["content"]
+        self.assertLess(len(text), len(big))
+        self.assertIn("truncated", text)
+
+    def test_file_change_kinds(self):
+        n = norm()
+        recs = feed(n, item_completed({"type": "fileChange", "id": "f1", "status": "completed",
+                                       "changes": [
+                                           {"path": "/TESTDIR/new.py", "kind": "add", "diff": "+print(1)"},
+                                           {"path": "/TESTDIR/old.py", "kind": {"type": "update"},
+                                            "diff": "-a\n+b"}]}))
+        names = [r["message"]["content"][0]["name"] for r in recs if r["type"] == "assistant"]
+        self.assertEqual(names, ["Write", "Edit"])
+        diffs = [r["message"]["content"][0]["content"] for r in recs if r["type"] == "user"]
+        self.assertEqual(diffs, ["+print(1)", "-a\n+b"])
+        assert_chain(self, recs)
+
+    def test_mcp_and_reasoning(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed({"type": "reasoning", "id": "r1",
+                                    "content": ["The failure is in the fixture."], "summary": []}),
+                    item_completed({"type": "mcpToolCall", "id": "m1", "server": "postal",
+                                    "tool": "send_message", "arguments": {"to": "web"},
+                                    "status": "failed",
+                                    "error": {"message": "no such peer"}}))
+        think = recs[0]["message"]["content"][0]
+        self.assertEqual((think["type"], think["thinking"]),
+                         ("thinking", "The failure is in the fixture."))
+        use = recs[1]["message"]["content"][0]
+        self.assertEqual(use["name"], "mcp__postal__send_message")
+        self.assertEqual(use["input"], {"to": "web"})
+        self.assertTrue(recs[2]["message"]["content"][0]["is_error"])
+
+    def test_user_message_dedup(self):
+        n = norm()
+        recs = feed(n,
+                    item_started(user_item("hello", "u1")),
+                    item_completed(user_item("hello", "u1")))
+        self.assertEqual(len(recs), 1)
+
+    def test_compaction_stitch(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(user_item("start", "u1")),
+                    item_completed(agent_item("ok", "a1")),
+                    turn_completed(),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t2"}),
+                    item_completed(user_item("continue", "u2")))
+        cb = recs[2]
+        self.assertEqual((cb["type"], cb["subtype"]), ("system", "compact_boundary"))
+        self.assertIsNone(cb["parentUuid"])
+        self.assertEqual(cb["logicalParentUuid"], recs[1]["uuid"])   # the pre-compaction leaf
+        self.assertEqual(recs[3]["parentUuid"], cb["uuid"])          # the chain continues off it
+
+    def test_turn_failed_is_error_card(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(user_item("do a thing")),
+                    turn_completed(status="failed", error={"message": "quota exhausted"}))
+        err = recs[-1]
+        self.assertTrue(err["isApiErrorMessage"])
+        self.assertEqual(err["message"]["content"][0]["text"], "quota exhausted")
+        self.assertEqual(err["message"]["stop_reason"], "end_turn")
+
+    def test_retryable_error_writes_nothing(self):
+        n = norm()
+        self.assertEqual(feed(n, ("error", {"threadId": TID, "turnId": "t1", "willRetry": True,
+                                            "error": {"message": "overloaded"}})), [])
+
+    def test_phase2_vocabulary_counted_not_silent(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed({"type": "plan", "id": "p1", "text": "1. look 2. fix"}),
+                    item_completed({"type": "subAgentActivity", "id": "s1", "kind": "spawned",
+                                    "agentPath": "x", "agentThreadId": "t9"}))
+        self.assertEqual(recs, [])
+        self.assertEqual(n.skipped, {"plan": 1, "subAgentActivity": 1})
+
+    def test_interrupt_materializes_settle_record(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(user_item("run it")),
+                    item_started({"type": "commandExecution", "id": "c1", "command": "sleep 99"}),
+                    turn_completed(status="interrupted"))
+        # the CLI-convention interrupt record ends the turn (is_interrupt_record) — without it the
+        # NEXT prompt is absorbed into this turn instead of opening its own (review finding #2)
+        self.assertEqual([r["type"] for r in recs], ["user", "assistant", "user"])
+        last = recs[-1]
+        self.assertTrue(em._text_of(last["message"]["content"]).startswith("[Request interrupted"))
+        self.assertNotIn("promptSource", last)
+        self.assertFalse(n.turn_open)
+        assert_chain(self, recs)
+
+    def test_context_tracking_uses_last_not_cumulative(self):
+        n = norm()
+        feed(n, token_usage(last_total=54000, window=272000, cum_total=500000))
+        self.assertEqual(n.context, (54000, 272000))   # `total` would read 184% full by turn ten
+
+
+class ReviewRegressions(unittest.TestCase):
+    """Record-level pins for the 2026-08-13 adversarial-review findings."""
+
+    def test_double_compaction_unique_boundaries(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("start the refactor", "u1")),
+                    item_completed(agent_item("chunk one", "a1")),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t1"}),
+                    item_completed(agent_item("chunk two", "a2")),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t1"}),
+                    item_completed(agent_item("done", "a3")),
+                    turn_completed("t1"))
+        cbs = [r["uuid"] for r in recs if r.get("subtype") == "compact_boundary"]
+        self.assertEqual(len(cbs), 2)
+        self.assertEqual(len(set(cbs)), 2, "boundary uuids must not collide")
+        assert_chain(self, recs)
+
+    def test_compaction_flushes_held_reply_first(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(user_item("go", "u1")),
+                    item_completed(agent_item("all done", "a1")),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t1"}))
+        # the held reply is pre-compaction content: it lands BEFORE the boundary, and the stitch
+        # points at it (review finding #4 — a same-second tie otherwise steals the reply)
+        self.assertEqual([r["type"] for r in recs], ["user", "assistant", "system"])
+        self.assertEqual(recs[2]["logicalParentUuid"], recs[1]["uuid"])
+
+    def test_terminal_error_then_failed_settle_single_card(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("do a thing", "u1")),
+                    ("error", {"threadId": TID, "turnId": "t1", "willRetry": False,
+                               "error": {"message": "quota exhausted"}}),
+                    turn_completed("t1", status="failed", error={"message": "quota exhausted"}))
+        cards = [r for r in recs if r.get("isApiErrorMessage")]
+        self.assertEqual(len(cards), 1, "one failure, one card (review finding #5)")
+        assert_chain(self, recs)
+
+    def test_two_terminal_errors_keep_chain(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("try it", "u1")),
+                    ("error", {"threadId": TID, "turnId": "t1", "willRetry": False,
+                               "error": {"message": "err one"}}),
+                    ("error", {"threadId": TID, "turnId": "t1", "willRetry": False,
+                               "error": {"message": "err two"}}))
+        assert_chain(self, recs)   # the second settle must uniquify, never self-parent
+
+    def test_declined_command_is_error(self):
+        n = norm()
+        recs = feed(n, item_completed({"type": "commandExecution", "id": "c1",
+                                       "command": "rm -rf /", "status": "declined",
+                                       "exitCode": None, "aggregatedOutput": ""}))
+        blk = recs[-1]["message"]["content"][0]
+        self.assertTrue(blk["is_error"], "a sandbox refusal must never read as success")
+        self.assertIn("declined", blk["content"])
+
+    def test_failed_patch_is_error(self):
+        n = norm()
+        recs = feed(n, item_completed({"type": "fileChange", "id": "f1", "status": "failed",
+                                       "changes": [{"path": "/TESTDIR/x.py", "kind": "update",
+                                                    "diff": "-a\n+b"}]}))
+        blk = recs[-1]["message"]["content"][0]
+        self.assertTrue(blk["is_error"])
+        self.assertIn("failed", blk["content"])
+
+    def test_usage_never_leaks_across_turns(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("one", "u1")),
+                    token_usage(inp=111),
+                    turn_completed("t1", status="failed", error={"message": "boom"}),
+                    turn_started("t2"),
+                    item_completed(user_item("two", "u2")),
+                    item_completed(agent_item("fine now", "a2")),
+                    turn_completed("t2"))
+        settle = [r for r in recs if r["type"] == "assistant" and
+                  r["message"].get("stop_reason") == "end_turn" and
+                  not r.get("isApiErrorMessage")][-1]
+        self.assertNotIn("usage", settle["message"], "turn 1's usage on turn 2's settle (finding #9)")
+
+    def test_restart_seed_prevents_replay_damage(self):
+        # the file already carries u1 + the c1 tool_use; the process restarted between the
+        # command's started and completed (review finding #6)
+        n = norm(last_uuid="c1", seen_uuids={"u1", "c1"})
+        recs = feed(n,
+                    item_completed(user_item("run the suite", "u1")),       # replayed → dropped
+                    item_completed({"type": "commandExecution", "id": "c1", "command": "pytest",
+                                    "aggregatedOutput": "ok", "exitCode": 0}))
+        self.assertEqual(len(recs), 1)                    # just the result — no re-minted call
+        self.assertEqual(recs[0]["parentUuid"], "c1")
+        self.assertNotEqual(recs[0]["uuid"], "c1")
+        assert_chain(self, recs, seed="c1")
+
+    def test_drain_flushes_held_message(self):
+        n = norm()
+        feed(n, item_completed(agent_item("almost forgot this", "a1")))
+        recs = n.drain()
+        self.assertEqual(len(recs), 1)
+        self.assertIsNone(recs[0]["message"]["stop_reason"])   # the turn genuinely didn't settle
+        self.assertEqual(n.drain(), [])
+
+
+class ParseIntegration(unittest.TestCase):
+    """The design's load-bearing property: the materialized file parses like a Claude transcript."""
+
+    def _parse(self, recs):
+        d = Path(tempfile.mkdtemp())
+        p = d / ("%s.jsonl" % TID)
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        return em.parse_session(str(p), rompuuid=SID, name="cx", dir="/TESTDIR",
+                                candidate_files=[str(p)], now=NOW, sdk_human=True)
+
+    def test_two_turns_with_tools(self):
+        n = norm()
+        ms = MS
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("add a retry to the fetcher", "u1"), ms),
+                    item_completed({"type": "reasoning", "id": "r1", "content": ["Find the fetcher."]},
+                                   ms + 1000),
+                    item_started({"type": "commandExecution", "id": "c1",
+                                  "command": "grep -rn fetch src/"}, ms + 2000),
+                    item_completed({"type": "commandExecution", "id": "c1",
+                                    "command": "grep -rn fetch src/",
+                                    "aggregatedOutput": "src/f.py:12", "exitCode": 0}, ms + 3000),
+                    item_completed(agent_item("Added the retry with backoff.", "a1"), ms + 4000),
+                    turn_completed("t1"),
+                    turn_started("t2"),
+                    item_completed(user_item("now add a test for it", "u2"), ms + 60000),
+                    item_completed(agent_item("Test added and passing.", "a2"), ms + 61000),
+                    turn_completed("t2"))
+        s = self._parse(recs)
+        self.assertEqual(len(s["turns"]), 2)
+        t1, t2 = s["turns"]
+        self.assertTrue(t1["ended"] and t2["ended"])
+        self.assertEqual(t1["atoms"][0]["author"], "human")          # sdk_human: the human bubble
+        types = [b for a in t1["atoms"] for b in em._block_types(a["message"]["content"])]
+        self.assertIn("thinking", types)
+        self.assertIn("tool_use", types)
+        self.assertIn("tool_result", types)
+        self.assertEqual(t2["atoms"][-1]["message"]["stop_reason"], "end_turn")
+
+    def test_compaction_survives_parse(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(user_item("long refactor", "u1"), MS),
+                    item_completed(agent_item("chunk one done", "a1"), MS + 1000),
+                    turn_completed("t1"),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t2"}),
+                    item_completed(user_item("keep going", "u2"), MS + 9000),
+                    item_completed(agent_item("chunk two done", "a2"), MS + 10000),
+                    turn_completed("t2"))
+        s = self._parse(recs)
+        texts = [em._text_of(a["message"]["content"])
+                 for t in s["turns"] for a in t["atoms"] if a.get("message")]
+        # the stitch holds: pre-compaction turns are still on the active path
+        self.assertTrue(any("long refactor" in x for x in texts))
+        self.assertTrue(any("chunk two done" in x for x in texts))
+
+    def test_error_settle_becomes_error_atom(self):
+        n = norm()
+        recs = feed(n,
+                    item_completed(user_item("do a thing", "u1"), MS),
+                    turn_completed("t1", status="failed", error={"message": "boom"}))
+        s = self._parse(recs)
+        flags = [a.get("isApiError") for t in s["turns"] for a in t["atoms"]]
+        self.assertIn(True, flags)
+
+    def test_interrupt_then_next_prompt_opens_its_own_turn(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("run it", "u1"), MS),
+                    item_started({"type": "commandExecution", "id": "c1", "command": "sleep 99"},
+                                 MS + 1000),
+                    turn_completed("t1", status="interrupted"),
+                    turn_started("t2"),
+                    item_completed(user_item("never mind, just lint", "u2"), MS + 9000),
+                    item_completed(agent_item("Linted.", "a2"), MS + 10000),
+                    turn_completed("t2"))
+        s = self._parse(recs)
+        # without the interrupt record the second prompt was ABSORBED into the interrupted turn
+        # (review finding #2) — it must be its own trigger
+        self.assertEqual(len(s["turns"]), 2)
+        self.assertEqual(s["turns"][1]["trigger"]["uuid"], "u2")
+        self.assertTrue(s["turns"][0]["ended"] and s["turns"][1]["ended"])
+
+    def test_double_compaction_keeps_early_history(self):
+        n = norm()
+        recs = feed(n,
+                    turn_started("t1"),
+                    item_completed(user_item("start the refactor", "u1"), MS),
+                    item_completed(agent_item("chunk one", "a1"), MS + 1000),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t1"}),
+                    item_completed(agent_item("chunk two", "a2"), MS + 9000),
+                    ("thread/compacted", {"threadId": TID, "turnId": "t1"}),
+                    item_completed(agent_item("done", "a3"), MS + 20000),
+                    turn_completed("t1"))
+        s = self._parse(recs)
+        texts = [em._text_of(a["message"]["content"])
+                 for t in s["turns"] for a in t["atoms"] if a.get("message")]
+        # colliding boundary uuids used to orphan everything before the first compaction
+        self.assertTrue(any("start the refactor" in x for x in texts))
+        self.assertTrue(any("done" in x for x in texts))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_judge_engine.py
+++ b/tests/test_judge_engine.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""The judge engine switch (STATE/judge-engine, kernel/judge.py): "codex" runs every judge as a
+one-shot `codex exec` instead of `claude -p`, so a machine with no Claude login keeps the board
+thinking. Pins: the codex argv's isolation flags, the stdin prompt concatenation, the reply coming
+off the -o file, model/effort mapping (claude aliases never sent to codex; plan accounts refuse
+them), the Claude-account rate gate NOT gating codex calls, and the usage row's honest shape
+(bracket + engine, no faked tokens). A stub binary stands in for codex; nothing hits a network.
+
+Run:    python3 tests/test_judge_engine.py
+"""
+import json
+import os
+import stat
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+jd = SourceFileLoader("romp_judge_engine_t", os.path.join(ROOT, "bin", "romp-judge")).load_module()
+
+STUB = r"""#!/usr/bin/env bash
+# stub codex: record argv + stdin, honor -o, reply with canned JSON
+rec="$STUB_RECORD"
+printf '%s\n' "$@" > "$rec/argv"
+cat > "$rec/stdin"
+out=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-o" ]; then out="$a"; fi
+  prev="$a"
+done
+[ -n "$out" ] && printf '{"caption":"stub-reply"}' > "$out"
+exit 0
+"""
+
+
+class JudgeEngine(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.tmp)
+        jd._state_cache.clear()
+        self.rec = self.tmp / "rec"
+        self.rec.mkdir()
+        stub = self.tmp / "codex-stub"
+        stub.write_text(STUB)
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+        os.environ["ROMP_CODEX_BIN"] = str(stub)
+        os.environ["STUB_RECORD"] = str(self.rec)
+
+    def tearDown(self):
+        os.environ.pop("ROMP_CODEX_BIN", None)
+        os.environ.pop("STUB_RECORD", None)
+
+    def _engine(self, name):
+        p = self.tmp / "judge-engine"
+        p.write_text(name)
+        os.utime(p, (time.time() + 60, time.time() + 60))   # defeat same-second _state_cache reuse
+        jd._state_cache.clear()
+
+    def _argv(self):
+        return (self.rec / "argv").read_text().splitlines()
+
+    def test_codex_engine_runs_the_stub_and_returns_its_reply(self):
+        self._engine("codex")
+        out = jd._judge_run("sonnet", "SYS PROMPT", "USER TEXT", judge="captioner", tier="index")
+        self.assertEqual(out, '{"caption":"stub-reply"}')
+        argv = self._argv()
+        for flag in ("exec", "--ephemeral", "--ignore-user-config", "--ignore-rules",
+                     "--strict-config", "--skip-git-repo-check",
+                     'default_permissions="romp_judge"', "--color"):
+            self.assertIn(flag, argv)
+        profile = next((x for x in argv if x.startswith("permissions.romp_judge=")), "")
+        self.assertIn('":minimal" = "read"', profile)
+        self.assertIn('":workspace_roots" = { "." = "read"', profile)
+        self.assertIn("network = { enabled = false }", profile)
+        self.assertNotIn('":root"', profile, "judge profile must not restore host-wide reads")
+        self.assertNotIn("-s", argv, "legacy read-only permits host-wide reads")
+        self.assertNotIn("-m", argv, "a claude alias must never be sent to codex (plan accounts 400)")
+        self.assertIn("model_reasoning_effort=low", argv, "index tier defaults to low effort")
+        self.assertEqual((self.rec / "stdin").read_text(), "SYS PROMPT\n\nUSER TEXT")
+
+    def test_successful_codex_call_clears_the_sessions_auth_latch(self):
+        self._engine("codex")
+        sid = "11111111-2222-3333-4444-555555555555"
+        jd._judge_ctx.fsid = sid
+        jd._auth_down_mark(sid, "login", "Not logged in")
+        self.assertIn(sid, jd._auth_down_map())
+        try:
+            self.assertTrue(jd._judge_run("sonnet", "S", "U", judge="planner", tier="triage"))
+        finally:
+            del jd._judge_ctx.fsid
+        self.assertNotIn(sid, jd._auth_down_map())
+
+    def test_gpt_override_and_triage_default_effort(self):
+        self._engine("codex")
+        jd._judge_run("gpt-5.6-sol", "S", "U", judge="planner", tier="triage")
+        argv = self._argv()
+        self.assertIn("-m", argv)
+        self.assertIn("gpt-5.6-sol", argv)
+        self.assertFalse(any(a.startswith("model_reasoning_effort=") for a in argv),
+                         "triage keeps the model's default reasoning unless an effort is set")
+
+    def test_usage_row_is_honest(self):
+        self._engine("codex")
+        jd._judge_run("sonnet", "S", "U", judge="captioner", tier="index")
+        rows = [json.loads(l) for l in (self.tmp / "judge-usage.jsonl").read_text().splitlines()]
+        self.assertEqual(rows[-1]["model"], "codex-default")
+        self.assertEqual(rows[-1]["judge"], "captioner")
+        self.assertIsNone(rows[-1]["in"], "codex exec reports no tokens — absent, not faked")
+        self.assertIsNone(rows[-1]["cost"])
+        self.assertIsInstance(rows[-1]["ms"], int)
+
+    def test_empty_reply_logs_a_call_error(self):
+        self._engine("codex")
+        # a stub that writes NO -o file (a refused/dead call)
+        dead = self.tmp / "codex-dead"
+        dead.write_text("#!/usr/bin/env bash\ncat >/dev/null\nexit 1\n")
+        dead.chmod(dead.stat().st_mode | stat.S_IEXEC)
+        os.environ["ROMP_CODEX_BIN"] = str(dead)
+        out = jd._judge_run("sonnet", "S", "U", judge="captioner", tier="index")
+        self.assertEqual(out, "")
+        rows = [json.loads(l) for l in (self.tmp / "judge-errors.jsonl").read_text().splitlines()]
+        self.assertEqual(rows[-1]["err"], "call")
+        self.assertIn("codex empty reply", rows[-1]["note"])
+
+    def test_effort_mapping(self):
+        self.assertEqual(jd._codex_effort(None, "index"), "low")
+        self.assertIsNone(jd._codex_effort(None, "triage"))
+        self.assertEqual(jd._codex_effort("minimal", "triage"), "low")
+        self.assertEqual(jd._codex_effort("max", "triage"), "xhigh")
+        self.assertEqual(jd._codex_effort("xhigh", "index"), "xhigh")
+        self.assertIsNone(jd._codex_effort("ultracode", "triage"))
+
+    def test_default_engine_is_claude_and_cmd_unchanged(self):
+        jd._state_cache.clear()
+        self.assertEqual(jd._judge_engine(), "claude")
+        cmd = jd._judge_cmd("sonnet", "S", None)
+        self.assertIn("--safe-mode", cmd)
+        self.assertIn("--output-format", cmd)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_judge_engine.py
+++ b/tests/test_judge_engine.py
@@ -10,6 +10,8 @@ Run:    python3 tests/test_judge_engine.py
 """
 import json
 import os
+import io
+import contextlib
 import stat
 import tempfile
 import time
@@ -52,8 +54,15 @@ class JudgeEngine(unittest.TestCase):
         stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
         os.environ["ROMP_CODEX_BIN"] = str(stub)
         os.environ["STUB_RECORD"] = str(self.rec)
+        # the judge folds the machine's standing user notes into prose judges' prompts (_with_user_notes
+        # reads a file OUTSIDE the rebound state dir) — isolate, or a developer's real notes land in the
+        # stdin pin and the byte-exact prompt assertion fails on their box while CI stays green
+        from unittest import mock
+        self._notes = mock.patch.object(jd, "_user_notes", return_value="")
+        self._notes.start()
 
     def tearDown(self):
+        self._notes.stop()
         os.environ.pop("ROMP_CODEX_BIN", None)
         os.environ.pop("STUB_RECORD", None)
 
@@ -147,3 +156,40 @@ class JudgeEngine(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class CodexChildEnvIsVendorScoped(unittest.TestCase):
+    """The Anthropic key never reaches the codex judge child (PR #885 review): _judge_env re-injects it
+    for key-billed sessions, and another vendor's process has no use for it."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.tmp)
+        jd._state_cache.clear()
+        (jd.STATE / "judge-engine").write_text("codex")
+
+    def test_the_codex_subprocess_env_lacks_the_anthropic_key(self):
+        from unittest import mock
+        seen = {}
+
+        class _P:
+            returncode = 0; stdout = ""; stderr = ""
+
+        def fake_run(cmd, **kw):
+            seen["env"] = kw.get("env")
+            outp = [a for a in cmd if str(a).endswith(".out")]
+            if outp:
+                Path(outp[-1]).write_text("ok")
+            return _P()
+
+        fake_env = dict(os.environ, ANTHROPIC_API_KEY="sk-test-not-real", ROMP_SUMMARIZING="1")
+        with mock.patch.object(jd, "_judge_env", return_value=fake_env), \
+             mock.patch.object(jd.subprocess, "run", side_effect=fake_run), \
+             contextlib.redirect_stderr(io.StringIO()):
+            try:
+                jd._judge_run("gpt-5", "SYS", "payload", judge="captioner", tier="index")
+            except Exception:
+                pass                                  # the reply shape is not under test here
+        self.assertIsNotNone(seen.get("env"), "the codex branch ran through subprocess.run")
+        self.assertNotIn("ANTHROPIC_API_KEY", seen["env"], "the Anthropic key is stripped from the codex child")
+        self.assertEqual(seen["env"].get("ROMP_SUMMARIZING"), "1", "…and the rest of the judge env rides as before")

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import threading
 import unittest
+from unittest import mock
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
 
@@ -153,6 +154,54 @@ class SdkResumePreservesLastSid(unittest.TestCase):
     def test_empty_lastsid_falls_back_to_the_sid(self):
         reg = self._resume({"sid": SID, "name": "testsess", "cwd": "/tmp", "lastSid": "", "alive": False})
         self.assertEqual(reg["lastSid"], SID, "a never-relaunched session resumes from its own transcript")
+
+
+class CodexRevive(unittest.TestCase):
+    """A dead Codex session revives through CodexBackend.resume — owns() is live-only, so the
+    tmux fallback used to build `claude --resume` for it and the registry stayed dead (the
+    v1.3.12 audit's P1, real-backend probe)."""
+
+    def setUp(self):
+        self.saved = (km._sdk, km._codex, km._codex_ready, km._name_of, km._cwd_of,
+                      km._push_all, km._reveal_chat_for, km._send_to_view, km._tmux_sessions,
+                      km._commands_for_cwd)
+        self.sent, self.focused = [], []
+        km._sdk = lambda: None
+        km._name_of = lambda sid: "webby"
+        km._cwd_of = lambda sid: "/tmp"
+        km._push_all = lambda: None
+        km._commands_for_cwd = lambda cwd: None
+        km._tmux_sessions = lambda: {}
+        km._reveal_chat_for = lambda client, msg: self.focused.append(msg)
+        km._send_to_view = lambda app, msg, wid: self.sent.append(msg)
+
+    def tearDown(self):
+        (km._sdk, km._codex, km._codex_ready, km._name_of, km._cwd_of, km._push_all,
+         km._reveal_chat_for, km._send_to_view, km._tmux_sessions,
+         km._commands_for_cwd) = self.saved
+
+    def test_a_dead_codex_session_resumes_through_the_codex_backend(self):
+        cx = mock.MagicMock()
+        cx._session.return_value = object()            # the registry knows the dead row
+        cx.resume.return_value = True
+        km._codex = lambda: cx
+        km._codex_ready = lambda: True
+        km._revive_session("11111111-2222-3333-4444-555555555555", {"wid": "w1", "send": lambda m: None})
+        cx.resume.assert_called_once_with("webby", "11111111-2222-3333-4444-555555555555",
+                                          cwd="/tmp")
+        self.assertTrue(self.focused, "success focuses the asker's chat")
+        self.assertFalse(self.sent, "and no failure event fires")
+
+    def test_a_dead_codex_session_with_no_app_server_fails_loudly(self):
+        cx = mock.MagicMock()
+        cx._session.return_value = object()
+        cx._client_err = "codex app-server is not running"
+        km._codex = lambda: cx
+        km._codex_ready = lambda: False
+        km._revive_session("11111111-2222-3333-4444-555555555555", {"wid": "w1", "send": lambda m: None})
+        self.assertFalse(cx.resume.called, "nothing resumes without the app server")
+        self.assertTrue(any(m.get("type") == "reviveFailed" for m in self.sent),
+                        "the asker hears the refusal: %r" % self.sent)
 
 
 if __name__ == "__main__":

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -729,10 +729,16 @@ const LANE_TOGGLES = [
 // on load so _openMetaMenu keeps its reference; the lane picker appends its own 'Default' sentinel (not a model).
 const MODEL_CHOICES = [];
 const EFFORT_CHOICES = [];
+// A CODEX lane's menus speak Codex's vocabulary (the payload's codex section) — never Claude's,
+// whose aliases the codex backend refuses. Empty until the codex backend has run (docs/codex.md).
+const CODEX_MODEL_CHOICES = [];
+const CODEX_EFFORT_CHOICES = [];
 try {
   if (typeof fetch !== 'undefined') fetch('/models', { cache: 'no-store' }).then((r) => r.json()).then((d) => {
     if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; for (const m of d.models) MODEL_CHOICES.push(m); MODEL_CHOICES.push({ label: 'Default', value: 'default' }); }
     if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; for (const e of d.efforts) EFFORT_CHOICES.push(e); }
+    if (d.codex && Array.isArray(d.codex.models)) { CODEX_MODEL_CHOICES.length = 0; for (const m of d.codex.models) CODEX_MODEL_CHOICES.push(m); }
+    if (d.codex && Array.isArray(d.codex.efforts)) { CODEX_EFFORT_CHOICES.length = 0; for (const e of d.codex.efforts) CODEX_EFFORT_CHOICES.push(e); }
   }).catch(() => {});
 } catch (e) {}
 // Is this menu entry the lane's CURRENT value? Effort matches exactly; the model var holds a display
@@ -2591,7 +2597,12 @@ class TimelinePanel {
       this.draw();
     };
     const closeSub = () => { if (menu._sub) { menu._sub.remove(); menu._sub = null; } };
-    for (const c of (kind === 'model' ? MODEL_CHOICES : EFFORT_CHOICES)) {
+    // a CODEX lane's pickers speak its own vocabulary (docs/codex.md) — those choices carry no
+    // versions, so the family submenus below simply never arm for them
+    const choices = s.backend === 'codex'
+      ? (kind === 'model' ? CODEX_MODEL_CHOICES : CODEX_EFFORT_CHOICES)
+      : (kind === 'model' ? MODEL_CHOICES : EFFORT_CHOICES);
+    for (const c of choices) {
       const cur = isCurrentMeta(kind, s, c.value);
       const versions = kind === 'model' ? (c.versions || []) : [];
       const item = menu.createDiv({ text: c.label });

--- a/ui/webview/codex-meta-choices.test.ts
+++ b/ui/webview/codex-meta-choices.test.ts
@@ -1,0 +1,34 @@
+// A CODEX session's statusline menus speak Codex's vocabulary (docs/codex.md): the model/effort
+// pickers read the /models payload's codex section, the fixed sandbox mode shows as an
+// informational badge (no Claude permission-cycle menu opens under it), and the mode label says
+// "Sandboxed" instead of falling through to "Normal". Source-pin over render.ts, the same style
+// as picker-backend.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const TIMELINE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+
+test("the /models payload's codex section populates its own choice arrays (both surfaces)", () => {
+  for (const src of [RENDER, TIMELINE]) {
+    assert.match(src, /CODEX_MODEL_CHOICES/);
+    assert.match(src, /CODEX_EFFORT_CHOICES/);
+    assert.match(src, /d\.codex && Array\.isArray\(d\.codex\.models\)/);
+    assert.match(src, /d\.codex && Array\.isArray\(d\.codex\.efforts\)/);
+  }
+});
+
+test("menu construction picks the choice list by the session's backend", () => {
+  assert.match(RENDER, /function metaChoices\(kind: MetaKind, st: Status\)/);
+  assert.match(RENDER, /st\.backend === "codex"/);
+  assert.match(RENDER, /for \(const c of metaChoices\(kind, s\.status\)\.filter\(/);
+  assert.match(TIMELINE, /s\.backend === 'codex'/);
+  assert.match(TIMELINE, /\? \(kind === 'model' \? CODEX_MODEL_CHOICES : CODEX_EFFORT_CHOICES\)/);
+});
+
+test("a codex session's fixed mode is informational: no permission-cycle menu, a Sandboxed label", () => {
+  assert.match(RENDER, /if \(kind === "mode" && s\.status\.backend === "codex"\) return;/);
+  assert.match(RENDER, /case "sandboxed": return "Sandboxed";/);
+});

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -66,9 +66,9 @@ var GEAR_HTML =
   "<button id=rs-defaultdir-browse type=button style='flex:0 0 auto;cursor:pointer;background:var(--btn-bg, #2a2a2a);color:var(--fg, #ccc);border:1px solid var(--hairline, #3a3a3a);border-radius:5px;padding:3px 8px'>Browse…</button>" +
   '</div></span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
-  '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK. Both kinds run side by side; this only sets the default.</span>' +
+  '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK; Codex runs an OpenAI Codex agent (docs/codex.md). All kinds run side by side; this only sets the default.</span>' +
   "<select id=rs-backend style='display:none'>" +
-  '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option>' +
+  '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option><option value=codex>Codex</option>' +
   '</select></span></div>' +
   "<label class='rs-row rs-sep'><input type=checkbox id=rs-autonudge>" +
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +

--- a/ui/webview/picker-backend.test.ts
+++ b/ui/webview/picker-backend.test.ts
@@ -8,10 +8,11 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("the + dialog builds a tmux | SDK backend toggle, hidden in pick-mode", () => {
+test("the + dialog builds a SDK | tmux | Codex backend toggle, hidden in pick-mode", () => {
   assert.match(RENDER, /const beWrap = el\("div", "picker-backend"\)/);
   assert.match(RENDER, /mkBe\("tmux", "tmux"/);
   assert.match(RENDER, /mkBe\("sdk", "SDK"/);
+  assert.match(RENDER, /mkBe\("codex", "Codex"/);
   assert.match(RENDER, /box\.appendChild\(beWrap\)/);
   // hidden + reset to the gear default each open (overridable for this session)
   assert.match(RENDER, /beWrapEl\.style\.display = pick \? "none" : ""/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4272,7 +4272,7 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   if (s.status.effort) rows.push(["Effort", s.status.effort]);
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
-  if (be === "sdk" || be === "tmux") rows.push(["Backend", be === "sdk" ? "SDK" : "tmux"]);
+  if (be === "sdk" || be === "tmux" || be === "codex") rows.push(["Backend", be === "sdk" ? "SDK" : be === "codex" ? "Codex" : "tmux"]);
   // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
   // user 2026-08-09: shown whenever the backend reports it, one-auth machines included; only a tmux
   // session, whose CLI env romp does not control, reports nothing). No key material, ever.
@@ -6015,7 +6015,8 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       return b;
     };
     beWrap.append(beLabel, mkBe("sdk", "SDK", "Runs via the Claude Agent SDK."),   // not "headless" — same full chat UI (the user 2026-07-12)
-                  mkBe("tmux", "tmux", "Drives a real terminal pane (tmux)."));   // SDK first — the de-facto default (the user 2026-07-02)
+                  mkBe("tmux", "tmux", "Drives a real terminal pane (tmux)."),   // SDK first — the de-facto default (the user 2026-07-02)
+                  mkBe("codex", "Codex", "Runs an OpenAI Codex agent (the host needs romp-codex-setup + codex login)."));
     // the billing row exists only for SDK sessions — re-decide on every backend toggle
     beWrap.addEventListener("click", () => syncPickerAuth());
     // per-session BILLING row (the user 2026-08-08): Login | API key buttons when the selected host
@@ -10013,9 +10014,16 @@ interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boo
 // keeps its reference; the session picker appends its own "Default" (use-the-CLI-default) sentinel — not a model.
 const MODEL_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
 const EFFORT_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
+// A CODEX session's pickers speak Codex's vocabulary (the payload's codex section — models from
+// the app-server's own list, efforts the four Codex accepts). Empty until the codex backend has
+// run: an empty model menu beats offering another vendor's models (docs/codex.md).
+const CODEX_MODEL_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
+const CODEX_EFFORT_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
 fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
   if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models, { label: "Default", value: "default" }); }
   if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; EFFORT_CHOICES.push(...d.efforts); }
+  if (d.codex && Array.isArray(d.codex.models)) { CODEX_MODEL_CHOICES.length = 0; CODEX_MODEL_CHOICES.push(...d.codex.models); }
+  if (d.codex && Array.isArray(d.codex.efforts)) { CODEX_EFFORT_CHOICES.length = 0; CODEX_EFFORT_CHOICES.push(...d.codex.efforts); }
   if (d.commentDefaults) adoptCommentDefaults(d.commentDefaults);
 }).catch(() => { /* picker stays empty until it lands */ });
 // The kernel's default-comment settings, RAW ("session" = same as the session — the user 2026-08-29):
@@ -10131,12 +10139,24 @@ function prettyMode(m: string | undefined): string {
     case "auto": return "Auto";
     case "dontask": return "Don’t ask";
     case "bypasspermissions": return "Bypass";
+    case "sandboxed": return "Sandboxed";   // a Codex session's fixed posture (workspace-write)
     default: return "Normal";   // default / normal / unknown
   }
 }
 const META_CHOICES: Record<MetaKind, MetaChoice[]> = {
   mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,
 };
+// The choices a menu offers depend on the session's BACKEND: a Codex session speaks Codex's
+// vocabulary (its own model list, the four efforts it accepts) — never Claude's, whose aliases
+// the codex backend refuses (docs/codex.md). Mode/fast never reach here for codex (see the
+// toggleMetaMenu guard / the fast badge's report gate).
+function metaChoices(kind: MetaKind, st: Status): MetaChoice[] {
+  if (st.backend === "codex") {
+    if (kind === "model") return CODEX_MODEL_CHOICES;
+    if (kind === "effort") return CODEX_EFFORT_CHOICES;
+  }
+  return META_CHOICES[kind];
+}
 // the live value of a meta kind for the active session
 function metaCurrent(kind: MetaKind, st: Status): string {
   return (kind === "model" ? st.model : kind === "effort" ? st.effort : kind === "fast" ? st.fast
@@ -10293,6 +10313,9 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
   // slash command there would answer the prompt instead (host guards this too)
   if (status.state === "needsInput" || status.state === "awaiting") return;
   const s = { status };
+  // a Codex session's mode is fixed (sandboxed, plans/codex-backend.md phase 1) — the badge is
+  // informational, and opening Claude's permission-mode cycle under it would offer four no-ops
+  if (kind === "mode" && s.status.backend === "codex") return;
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
   const pickValue = (value: string) => {
@@ -10306,9 +10329,10 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
   };
   let subEl: HTMLElement | null = null;
   const closeSub = () => { subEl?.remove(); subEl = null; };
-  // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it, and
-  // a menu that lists a mode you can't have is worse than one that doesn't.
-  for (const c of META_CHOICES[kind].filter((c) => !c.sdkOnly || s.status.backend === "sdk")) {
+  // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it,
+  // and a menu that lists a mode you can't have is worse than one that doesn't. Codex sessions read
+  // their own vocabulary via metaChoices (docs/codex.md) before the same filter.
+  for (const c of metaChoices(kind, s.status).filter((c) => !c.sdkOnly || s.status.backend === "sdk")) {
     const item = el("div", "meta-item" + (isCurrentMeta(kind, s.status, c.value) ? " current" : ""));
     item.tabIndex = 0;
     const rowIco = kind === "mode" ? el("span", "meta-ico mode-ico") : null;

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -13,7 +13,7 @@ export interface RompSettings {
   showIndexJudges: boolean;
   showTriageJudges: boolean;
   debug?: boolean;    // LEGACY (the user 2026-06-17): the old single judging-band toggle; read as the migration fallback for the two judge-set toggles when those are unset. The ↻ restart button is always-visible (decoupled).
-  backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
+  backend: "tmux" | "sdk" | "codex";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal), "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -22,8 +22,8 @@ test("the tab tooltip is a custom DOM tooltip shown on hover, not a native title
 });
 
 test("backend is a plain labelled FIELD ROW under the others — no coloured top badge (the user 2026-07-08)", () => {
-  // it's just another "Backend: SDK|tmux" row alongside Branch/Mode/Model/Effort, not a bold coloured badge
-  assert.match(RENDER, /rows\.push\(\["Backend", be === "sdk" \? "SDK" : "tmux"\]\)/);
+  // it's just another "Backend: SDK|tmux|Codex" row alongside Branch/Mode/Model/Effort, not a bold coloured badge
+  assert.match(RENDER, /rows\.push\(\["Backend", be === "sdk" \? "SDK" : be === "codex" \? "Codex" : "tmux"\]\)/);
   assert.doesNotMatch(RENDER, /"tab-tip-be"/, "no dedicated backend-badge element");
   assert.doesNotMatch(RENDER, /be === "tmux" \? "#54B204" : "#1EA1EB"/, "no per-backend colour on the tooltip");
   assert.doesNotMatch(CSS, /\.tab-tip-be \b/, "the badge's CSS rule is gone");


### PR DESCRIPTION
## Codex session backend

Adds **OpenAI Codex** as a third session backend beside tmux and the Claude Agent SDK, so a romp install can run Codex agents alongside — or instead of — Claude Code sessions, with the same dashboard, feed, timeline, judges and postal service.

### What's in it
- **`kernel/codex_backend.py`** — a `SessionBackend` that drives Codex threads through `codex app-server`, materializes Claude-shaped transcripts under `STATE/codex/projects/` (so every existing reader — the event model, judges, feed — works unchanged), keeps a registry of stable session ids, and supports spawn / resume / rename / model & effort pickers.
- **`kernel/codex_events.py`** — translation of app-server events into the transcript event model.
- **Kernel wiring** (`kernel/kernel.py`): backend selection (`POST /new` and the WS `create` op accept `backend: "codex"`, honoring a machine default), `Sessions.backend_for` / `live()` / revive / rename aware of the third backend, and a `codex` section on `GET /models` (the models the app-server actually offers, the four efforts Codex accepts) so a Codex session's pickers never show another vendor's vocabulary.
- **Judges on Codex** (`kernel/judge.py`): `STATE/judge-engine` = `codex` runs every judge as a one-shot `codex exec` with an invocation-local read-only permission profile; Codex sessions join `discover()` through the registry.
- **CLI**: `romp new --codex <name>`, and `romp engine claude|codex|status` — one switch for both knobs (which vendor runs the judges, what new sessions default to).
- **UI**: the create picker and the gear's default-backend select offer Codex; tab tooltips and timeline lanes label it; a Codex session's model/effort menus use Codex's lists.
- **Setup**: `bin/romp-codex-setup` builds an isolated venv with the Codex CLI; `docs/codex.md` documents the flow (`codex login`, engine switch, limitations).
- **Tests**: backend unit tests with a fake app-server client, event-translation goldens, discovery, judge-engine, revive, and a bats file for `romp engine` / `romp new --codex`.

### Scope and known limitations
- Purely additive: 22 files, ~5.1k lines added, 30 removed; no behavior change for tmux/SDK sessions.
- When both a Claude login and a Codex login exist and Claude's usage window is exhausted, judge calls on the Codex engine still respect the Claude usage pause (the gate reads `usage.json` before the engine branch). A machine with no Claude login is unaffected. Follow-up candidate.
- Codex reports no token usage for `codex exec`, so judge usage rows carry duration only.

### Verification
- Python: full suite green on this branch; UI/extension: 2677 pass, 0 fail; bats: 368 ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
