### PR TITLE
Theme feedback round three: links, the file viewer, the bells, mobile — plus the recovered sienna round

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10393,6 +10393,8 @@ class Sessions:
                                 "connected": bool(st.get("connected")),   # SDK handshake up → the opening-chip override stands down (fresh sessions have no transcript yet)
                                 "spawning": bool(st.get("spawning")),   # spawn/handshake in flight NOW — the ONLY window the opening chip covers (a dormant created session must read ready, the user 2026-08-13)
                                 "context": ctx if isinstance(ctx, (int, float)) else None, "compactPct": None,
+                                "ctxOver": bool(st.get("ctxOver")),   # context% is CLAMPED at 100 — this says the CLI
+                                #   reported 100+ (tokens exceed the CURRENT model's window, e.g. after a 1M→200k switch)
                                 "ctxTokens": st.get("ctxTokens"),   # raw totalTokens (SDK only) — the
                                 #   compaction-suggestion thresholds key on true tokens (2026-08-30)
                                 "fast": st.get("fast", ""),   # fast-mode state from the CLI's init ("on"/"off"/"cooldown"; "" = unknown → no badge)
@@ -20236,6 +20238,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   "modelPending": _model_pending_now(sid, tm),   # switching-dots on the model badge until the pick lands, from EITHER surface (the user 2026-07-03)
                   "effortPending": bool(tm.get("effortPending")),   # switching-dots on the effort badge while the /effort reconnect applies (SDK-only; the user 2026-07-06)
                   "ctx": str(tm["context"]) if tm["context"] is not None else "",
+                  # the % above is clamped at 100 — ctxOver says the CLI reported 100+ (tokens exceed
+                  # the CURRENT model's window, e.g. right after a 1M→200k model switch), so the
+                  # battery can say "over this model's window" instead of a silent 100% (2026-09-02)
+                  "ctxOver": bool(tm.get("ctxOver")),
                   # model name + effort tinted on the GLOBAL colormap by capability/effort rank (the user
                   # 2026-07-02): the statusline meta buttons just apply these (mirrors ctxColor). None = default.
                   "modelColor": _model_color(tm["model"], cm.stops_for(_colormap())),
@@ -27384,12 +27390,16 @@ _CHAT_MOBILE_CSS = (
     "#tabbar #tabs{display:none}"                       # the wrapping multi-row tab strip
     "#tabbar-resize{display:none}"                      # nothing to resize under the mobile header
     "#mhdr{display:flex;align-items:stretch;gap:6px;width:100%}"
+    # the chip's surfaces read the chrome tokens where the dark value is byte-identical
+    # (--btn-bg → #2a2a2a, --hairline → #3a3a3a — the #mlist pattern below), so the light theme
+    # re-skins them for free; the text colors have no byte-identical token and take light-block
+    # overrides instead (the user 2026-09-02: the chip stayed a dark slab on the light chat page)
     "#mcur{flex:1 1 auto;min-width:0;display:flex;align-items:center;gap:8px;cursor:pointer;"
-    "background:#2a2a2a;color:#dddddd;border:1px solid #3a3a3a;border-radius:6px;padding:7px 10px;"
+    "background:var(--btn-bg,#2a2a2a);color:#dddddd;border:1px solid var(--hairline,#3a3a3a);border-radius:6px;padding:7px 10px;"
     "font:600 13px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     # colored session: the identity color reads as the NAME (bold) on the same grey chip as the +/madd
     # button, with a hairline color border, not the color as a fill (the user 2026-07-22).
-    "#mcur.colored{background:#2a2a2a;color:var(--cbg);border-color:var(--cbg)}"
+    "#mcur.colored{background:var(--btn-bg,#2a2a2a);color:var(--cbg);border-color:var(--cbg)}"
     "#mcur .nm{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700}"
     # the working cue is the SAME gold status dot desktop uses (the tab's .tab-dot), not a text bullet
     "#mcur .wd{flex:0 0 auto;width:7px;height:7px;border-radius:50%;background:var(--st-working-bg,#e0b020)}"
@@ -27397,7 +27407,7 @@ _CHAT_MOBILE_CSS = (
     "#mcur .cv{flex:0 0 auto;opacity:.6;font-size:11px}"
     "#mtag-slot{flex:0 0 auto;display:flex;align-items:center;gap:5px}"   # T161: the tag control's slot, sized by the shared button's own inline metrics
     "#madd{flex:0 0 auto;width:36px;display:flex;align-items:center;justify-content:center;cursor:pointer;"
-    "background:#2a2a2a;color:#bbbbbb;border:1px solid #3a3a3a;border-radius:6px;font-size:16px;line-height:1}"
+    "background:var(--btn-bg,#2a2a2a);color:#bbbbbb;border:1px solid var(--hairline,#3a3a3a);border-radius:6px;font-size:16px;line-height:1}"
     # the mobile session picker IS a dropdown (T226 review): its card + hairline read the menu tokens
     # (dark: --menu-bg → #252526 and --hairline → #3a3a3a, byte-identical to the literals they replace)
     "#mlist{display:none;position:absolute;left:8px;right:8px;top:100%;margin-top:4px;z-index:200;"
@@ -27411,6 +27421,11 @@ _CHAT_MOBILE_CSS = (
     "body.theme-light .mrow .nm{color:var(--menu-fg)}"
     "body.theme-light .mrow .mclose{color:var(--text-muted)}"
     "body.theme-light .mrow.active{background:var(--accent-wash)}"
+    # the trigger chip's text tiers (its surfaces already re-skin through --btn-bg/--hairline above);
+    # the .colored restatement outweighs the plain override so the identity color keeps the name
+    "body.theme-light #mcur{color:var(--menu-fg)}"
+    "body.theme-light #mcur.colored{color:var(--cbg)}"
+    "body.theme-light #madd{color:var(--text-muted)}"
     ".mrow{display:flex;align-items:center;gap:9px;padding:10px 12px;cursor:pointer;"
     "border-bottom:1px solid #ffffff12;font:600 13px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}"
     ".mrow:last-child{border-bottom:0}"
@@ -29238,7 +29253,11 @@ _LANDING_MOBILE_JS = """
 function fit(){try{var vv=window.visualViewport;
 var coarse=window.matchMedia&&matchMedia('(pointer: coarse)').matches;
 var h=(!coarse||!vv)?window.innerHeight:Math.round(vv.height*(vv.scale||1));
-if(h)document.documentElement.style.setProperty('--app-h',h+'px');}catch(e){}}
+if(h)document.documentElement.style.setProperty('--app-h',h+'px');
+// iOS ignores interactive-widget and reveals a focused input by SCROLLING this overflow:hidden page
+// (a UA scroll bypasses the clamp) — the shell then sits a keyboard-height up until dragged back
+// (the user 2026-09-02). The layout must never scroll: undo any stray offset on the same events.
+if(window.scrollY||document.documentElement.scrollTop)window.scrollTo(0,0);}catch(e){}}
 fit();window.addEventListener('resize',fit);window.addEventListener('orientationchange',fit);
 // iOS Safari collapses/expands its toolbars AS YOU SCROLL, and the visible height changes with them
 // without a window resize; the visual viewport's own scroll event is where that settles. pageshow covers
@@ -29773,7 +29792,17 @@ def _landing():
             # safe-area padding-bottom became a dead slab below the Chat/Feed/Timeline labels; cover also drew
             # the top edge under the status bar with no top inset (clipped chat tab bar). The default viewport
             # auto-insets clear of the status bar AND the nav bar and zeroes every env() inset.
-            "<meta name=viewport content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no'>"
+            # interactive-widget=resizes-content (the user 2026-09-02, whose composer tap scrolled the
+            # whole page up behind the keyboard): without it browsers default to resizes-visual — the
+            # soft keyboard PANS the visual viewport while innerHeight stands still, so the UA slides
+            # the shell up to reveal the input and fit() (below) re-lays the shrunken --app-h into a
+            # window whose visible band now starts a keyboard-height down; the composer ends up
+            # off-screen until the user drags it back. With resizes-content the LAYOUT viewport
+            # shrinks (innerHeight, 100dvh and vv.height agree, offsetTop stays 0), the iframes
+            # shrink with --app-h, and the flex-footer composer lands right above the keyboard.
+            # Android Chrome 108+ honors it; engines that don't (iOS Safari) ignore the token and
+            # keep today's behavior plus fit()'s stray-scroll reset.
+            "<meta name=viewport content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,interactive-widget=resizes-content'>"
             # …EXCEPT installed on an iOS home screen (plans/ios-app.md; the user 2026-08-07): standalone
             # mode has no browser chrome keeping #mtabs off the home indicator, and iOS only populates
             # env(safe-area-inset-*) under cover. navigator.standalone is iOS-only and standalone-only,
@@ -29895,6 +29924,12 @@ def _landing():
             # the rail's network (⧉) action opens a shell-native popover anchored by the rail to manage
             # federated remote kernels (attach a host from ~/.ssh/config, see status, detach).
             ".rail-act.on{color:var(--accent)}"   # the network icon glows accent-blue while a remote is connected
+            # the master bell says OFF the way every other bell in the app does — a slash through
+            # the glyph (the feed card bell, the timeline lane bell) — never color alone: the light
+            # theme's rail recolor happened to equalize the two colors and on/off rendered
+            # pixel-identical (the user 2026-09-02)
+            ".bell-slash{display:none}"
+            "#rail-bell:not(.on) .bell-slash,#mbell:not(.on) .bell-slash{display:block}"
             # Per-node fleet colour on the network glyph (the user 2026-07-29). The nodes carry their own
             # fill, so they override the icon's currentColor: accent = connected and on this build,
             # grey = attached but not answering (romp is dialing), red = needs you (drift, no kernel, or
@@ -30344,9 +30379,13 @@ def _landing():
             "body.theme-light .pane-rail{background:#E7DED2;border-top-color:#DCD2C4}"
             "body.theme-light .rail-btn{color:#5D574E}"
             "body.theme-light .rail-btn:hover{color:#C2410C;background:rgba(0,0,0,0.05)}"
-            "body.theme-light .rail-btn.on{background:rgba(194,65,12,0.10);border-color:rgba(194,65,12,0.35)}"
+            "body.theme-light .rail-btn.on{color:var(--accent);background:rgba(194,65,12,0.10);border-color:rgba(194,65,12,0.35)}"
             "body.theme-light .rail-act{color:#5D574E}"
             "body.theme-light .rail-act:hover{color:#1F1E1D;background:rgba(0,0,0,0.06)}"
+            # the light rail recolors above outspecify the bare `.on` rules ((0,2,1) beats (0,2,0)),
+            # which silenced the bell's and the network glyph's on-state entirely in the light theme
+            # (the user 2026-09-02) — restate `.on` at the winning specificity
+            "body.theme-light .rail-act.on{color:var(--accent)}"
             "body.theme-light .gv{background:linear-gradient(90deg,transparent 3px,rgba(0,0,0,0.14) 3px,rgba(0,0,0,0.14) 4px,transparent 4px)}"
             "body.theme-light .gh{background:linear-gradient(180deg,transparent 3px,rgba(0,0,0,0.14) 3px,rgba(0,0,0,0.14) 4px,transparent 4px)}"
             "body.theme-light .gv::after,body.theme-light .gh::after{background:rgba(0,0,0,0.22)}"
@@ -30459,7 +30498,8 @@ def _landing():
             "<svg viewBox='0 0 16 16' width='18' height='18'>"
             "<path d='M8 2 C5.7 2 4.3 3.8 4.3 6.2 L4.3 9 L3 11.2 L13 11.2 L11.7 9 L11.7 6.2 C11.7 3.8 10.3 2 8 2 Z'"
             " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
-            "<path d='M6.5 13 A1.7 1.7 0 0 0 9.5 13' fill='none' stroke='currentColor' stroke-width='1.2'/></svg></div>"
+            "<path d='M6.5 13 A1.7 1.7 0 0 0 9.5 13' fill='none' stroke='currentColor' stroke-width='1.2'/>"
+            "<line class='bell-slash' x1='2.8' y1='2.2' x2='13.2' y2='13.8' stroke='currentColor' stroke-width='1.2' stroke-linecap='round'/></svg></div>"
             "<div class=rail-act id=rail-gear data-keycmd=settings.open title=Settings aria-label=Settings>⛭</div>"   # ⛭ (gear-without-hub): the bigger, bolder gear the user prefers (restored 2026-06-29)
             "</div>"   # /.rail-acts
             "</div>"   # /.pane-rail (bottom bar)
@@ -30501,7 +30541,8 @@ def _landing():
             "<svg viewBox='0 0 16 16' width='18' height='18'>"
             "<path d='M8 2 C5.7 2 4.3 3.8 4.3 6.2 L4.3 9 L3 11.2 L13 11.2 L11.7 9 L11.7 6.2 C11.7 3.8 10.3 2 8 2 Z'"
             " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
-            "<path d='M6.5 13 A1.7 1.7 0 0 0 9.5 13' fill='none' stroke='currentColor' stroke-width='1.2'/></svg></button>"
+            "<path d='M6.5 13 A1.7 1.7 0 0 0 9.5 13' fill='none' stroke='currentColor' stroke-width='1.2'/>"
+            "<line class='bell-slash' x1='2.8' y1='2.2' x2='13.2' y2='13.8' stroke='currentColor' stroke-width='1.2' stroke-linecap='round'/></svg></button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
             "<button class=mact data-act=settings data-keycmd=settings.open aria-label=Settings title=Settings>⛭</button>"
             "</nav>"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24900,6 +24900,19 @@ def _dedup_sig(msg, s):
     return s
 
 
+def _client_reset_chat_base(client):
+    """Forget every session tail we believe this client holds. Both suppressors must go: the echat
+    entries (their absence is what routes _send_chat down its full-session path) AND the ("chat", sid)
+    dedup slots (_DEDUP_REPOST_S would otherwise eat the re-send as unchanged for 60s). The needFull
+    handler does this per-sid; `ready` does it for the whole client — a renderer that just evaluated
+    holds NOTHING, whatever this socket was sent before its listener existed (the stuck-« opening … »
+    class, the user 2026-09-02)."""
+    client.get("echat", {}).clear()
+    snt = client.get("sent", {})
+    for k in [k for k in snt if isinstance(k, tuple) and k and k[0] == "chat"]:
+        snt.pop(k, None)
+
+
 def _send_client(c, key, msg, pre=None, sig=None):
     """Send a payload to ONE client only if it differs from what that client last received (per-client
     dedup, key = the slot e.g. ("chat", sid)) — so the periodic push re-sends nothing when unchanged.
@@ -32398,6 +32411,16 @@ class Handler(BaseHTTPRequestHandler):
             _mark_views_dirty()
             return
         if msg and msg.get("type") == "ready":
+            # `ready` = the render bundle JUST evaluated, so this renderer holds NOTHING — but this
+            # socket may already have been served: the pusher fires from the moment the WS opens
+            # (the inline shim dials during HTML parse), while the 1.4MB bundle can still be
+            # downloading/evaluating, so the first full session frames can land in a document with
+            # no message listener and vanish. echat then believes the client holds those tails and
+            # every later push is a delta the client drops — the tab stuck on « opening … » until
+            # its socket died (the user 2026-09-02; duplicating the browser tab always recovered
+            # because cached bundles win the race). Same repair as needFull above, client-wide;
+            # ready is posted once per renderer life, so this cannot loop.
+            _client_reset_chat_base(client)
             self._push_one(client)
             # Push the SHARED, STABLE tab order so the UI honors it on connect/reload. Without this
             # the webview only learns the order from a live drag, loses it on every reload, and falls

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1679,7 +1679,11 @@ class SdkSession:
         _lt0 = reg.get("liveCtxTokens")           # raw totalTokens from the same get_context_usage payload —
         self._ctx_tokens: int | None = (int(_lt0) if isinstance(_lt0, (int, float)) else None)   # the kernel's
         #   compaction-suggestion thresholds key on true tokens, window-independent (2026-08-30)
+        self._ctx_over = bool(reg.get("liveCtxOver"))   # the CLI's percentage ran past 100 (tokens exceed the
+        #   CURRENT model's window — a 1M→200k model switch does this instantly); the battery caps at 100 but
+        #   says so instead of presenting a silent full battery (the user 2026-09-02)
         self._ctx_refreshing = False             # one get_context_usage control request in flight at a time
+        self._ctx_refresh_again = False          # a refresh asked for WHILE one was in flight → run once more
         self._usage_refreshing = False           # one get_usage control request in flight at a time
         self.retrying = False                        # an api_retry storm (API rate-limit/overload) is stalling the turn → 'retrying', not 'working'
         self.retry_count = 0                          # api_retry backoff attempts in the CURRENT storm; → the live 'attempt N' + the 'Recovered after N retries' note, reset each turn
@@ -2118,7 +2122,13 @@ class SdkSession:
         window from peak prompt sizes (the user 2026-06-24: the SDK read 14% where tmux read 3% on a 1M-context
         model — a wrong-window guess). Updates the live % + model and persists both (so a dormant / restarted
         session keeps showing them). Cheap; guarded so only one is in flight."""
-        if not self.client or self._ctx_refreshing:
+        if not self.client:
+            return
+        if self._ctx_refreshing:
+            # a model/effort switch can land while the turn-end refresh is mid-flight; DROPPING this
+            # call left the old model's percentage standing until the next turn (the user 2026-09-02,
+            # who watched the battery misreport right after a switch) — queue exactly one rerun
+            self._ctx_refresh_again = True
             return
         self._ctx_refreshing = True
         try:
@@ -2132,6 +2142,14 @@ class SdkSession:
         changed = False
         pct = cu.get("percentage")
         if isinstance(pct, (int, float)):
+            # the CLI documents percentage as "0-100+": past 100 the tokens exceed the CURRENT
+            # model's window (a 1M→200k model switch does this instantly, and the next turn
+            # compacts or refuses). The clamp below is right for every gauge, but the overflow is
+            # NEWS — _ctx_over lets the battery say "over this model's window" instead of a
+            # silent, wrong-looking 100% (the user 2026-09-02).
+            over = round(pct) > 100
+            if over != self._ctx_over:
+                self._ctx_over, changed = over, True
             v = max(0, min(100, round(pct)))
             if v != self._ctx:
                 self._ctx, changed = v, True
@@ -2149,6 +2167,7 @@ class SdkSession:
         upd["modelPending"] = bool(self._model_pending)
         if self._ctx is not None:
             upd["liveCtx"] = self._ctx
+            upd["liveCtxOver"] = self._ctx_over
         if self._ctx_tokens is not None:
             upd["liveCtxTokens"] = self._ctx_tokens
         if upd:
@@ -2162,6 +2181,11 @@ class SdkSession:
         # change waited for the backstop.)
         if changed:
             self.backend._poke()
+        if self._ctx_refresh_again:
+            # someone asked while this refresh was in flight (their answer may predate their event —
+            # e.g. a model switch mid-refresh): run once more so the number reflects the newest world
+            self._ctx_refresh_again = False
+            await self._do_refresh_context()
 
     def _adopt_fast_state(self, d) -> bool:
         """Adopt fast-mode truth from a CLI payload that carries it. The per-turn init message and the
@@ -3732,6 +3756,8 @@ class SdkSession:
                 #   (a key found via apiKeyHelper bills the key while `auth` still reads login)
                 "authPending": bool(self._auth_pending),   # an /auth switch reconnecting → badge dots
                 "mode": self.perm_mode, "ctx": self._ctx_pct(), "ctxTokens": self._ctx_tokens,
+                "ctxOver": self._ctx_over,   # the % above is CLAMPED — true when the CLI reported 100+
+                #   (tokens exceed the current model's window, e.g. right after a 1M→200k switch)
                 "summary": "",
                 "connected": bool(self.client),   # the SDK handshake is up (set at connect, cleared at
                 #   teardown) — the "this session is OPEN" event for a transcript-less fresh session:
@@ -6296,6 +6322,7 @@ class SdkBackend:
                     "fast": reg.get("liveFast", ""),
                     "fastReason": reg.get("liveFastReason", ""),
                     "ctx": lc if isinstance(lc, (int, float)) else "",
+                    "ctxOver": bool(reg.get("liveCtxOver")),   # persisted beside liveCtx — same survival
                     "ctxTokens": (int(reg["liveCtxTokens"])
                                   if isinstance(reg.get("liveCtxTokens"), (int, float)) else None),
                     "summary": ""}

--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -175,3 +175,39 @@ def test_build_sig_still_tracks_the_fsid_states_file(tmp_path):
     before = km._chat_build_sig(sess)
     states.write_text('{"t":1,"state":"working"}\n{"t":2,"state":"waiting"}\n')
     assert before != km._chat_build_sig(sess)
+
+
+# ───────────────────────── the lost-first-frame class (the user 2026-09-02) ─────────────────────────
+
+def test_ready_forgets_the_whole_chat_base_so_the_repush_is_full_frames():
+    """The pusher fires from the moment the socket opens (the shim dials during HTML parse), while the
+    1.4MB render bundle can still be evaluating — so the FIRST full frames can land in a document with
+    no message listener and vanish, with echat then believing the client holds those tails. `ready`
+    (posted once, when the bundle finally evaluated) must therefore reset the client's whole chat base:
+    the renderer provably holds nothing, whatever this socket was sent. The stuck-« opening … » tab;
+    duplicating the browser tab recovered because cached bundles win the race."""
+    import json
+    c = _client()
+    sid = "11111111-2222-3333-4444-555555555555"
+    m = _sess(sid, _evs(5))
+    km._send_chat(c, m, json.dumps(m), 3, False)          # the pre-listener full send — LOST client-side
+    assert sid in c["echat"] and ("chat", sid) in c["sent"], "the kernel now believes the client is based"
+    c["_out"].clear()
+
+    km._client_reset_chat_base(c)                          # what the ready branch does
+    assert not c["echat"], "every believed tail is forgotten"
+    assert not any(isinstance(k, tuple) and k and k[0] == "chat" for k in c["sent"]), \
+        "…and every chat dedup slot, or _DEDUP_REPOST_S eats the re-send for 60s"
+
+    km._send_chat(c, m, json.dumps(m), 3, False)           # the ready-triggered repush
+    got = json.loads(c["_out"][-1])
+    assert got["type"] == "session", "the repush is a FULL frame, never a delta onto a base that was lost"
+
+
+def test_ready_branch_is_wired_to_the_reset():
+    src = inspect.getsource(km)
+    i = src.find('msg.get("type") == "ready"')
+    assert i > 0
+    body = src[i:i + 1600]
+    assert "_client_reset_chat_base(client)" in body, "ready must reset BEFORE its push"
+    assert body.find("_client_reset_chat_base(client)") < body.find("_push_one(client)")

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6182,6 +6182,18 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(st["state"], "needsInput", "permission -> the needs-input chip (renamed 2026-08-15)")
         self.assertEqual(st["model"], "Opus 4.8")
         self.assertEqual(st["ctx"], "20")
+        self.assertFalse(st["ctxOver"], "tmux sessions never report a window overflow")
+
+    def test_chat_status_carries_ctx_overflow(self):
+        """The context % is clamped at 100 kernel-side; ctxOver carries the CLI's '100+' truth (tokens
+        exceed the CURRENT model's window, e.g. right after a 1M→200k model switch) so the battery says
+        'over this model's window' instead of a silent 100% (the user 2026-09-02)."""
+        km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 5, "model": "Haiku 4.5",
+                                           "effort": "max", "context": 100, "compactPct": None,
+                                           "color": None, "ctxOver": True}}
+        st = km.build_session(SID, NOW)["status"]
+        self.assertEqual(st["ctx"], "100")
+        self.assertTrue(st["ctxOver"], "the overflow flag rides beside the clamped %")
 
 
 class CrossPane(unittest.TestCase):

--- a/tests/test_kernel_light_shell.py
+++ b/tests/test_kernel_light_shell.py
@@ -56,9 +56,13 @@ class LightShell(unittest.TestCase):
         self.assertIn("rgba(0,0,0,0.14)", self.html)
 
     def test_rail_toggle_on_goes_clay(self):
+        # color restated too (2026-09-02): the light .rail-btn recolor outspecifies the bare
+        # `.rail-btn.on`, so without it a selected toggle's TEXT stayed the resting grey
         self.assertIn(
-            "body.theme-light .rail-btn.on{background:rgba(194,65,12,0.10);border-color:rgba(194,65,12,0.35)}",
+            "body.theme-light .rail-btn.on{color:var(--accent);background:rgba(194,65,12,0.10);border-color:rgba(194,65,12,0.35)}",
             self.html)
+        # same clash, the icon row: the bell's / network glyph's on-state was silenced entirely
+        self.assertIn("body.theme-light .rail-act.on{color:var(--accent)}", self.html)
 
     def test_banner_css_strings_carry_light_blocks(self):
         for css in (km._STALE_CSS, km._UPD_CSS, km._RDRIFT_CSS):

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -223,12 +223,25 @@ class LandingShell(unittest.TestCase):
         # that branch, so the 2026-06-17 regression cannot recur through it.
         html = km._landing()
         self.assertIn("<meta name=viewport content='width=device-width,initial-scale=1,"
-                      "maximum-scale=1,user-scalable=no'>", html)     # the static meta: no cover
+                      "maximum-scale=1,user-scalable=no,interactive-widget=resizes-content'>", html)   # the static meta: no cover
         self.assertEqual(html.count("viewport-fit=cover"), 1)         # exactly the runtime flip…
         self.assertIn("if(navigator.standalone)", html)               # …behind the iOS-standalone gate
         self.assertLess(html.index("if(navigator.standalone)"), html.index("viewport-fit=cover"))
         self.assertIn("100dvh", html)            # still address-bar-aware
         self.assertIn("user-scalable=no", html)  # pinch-zoom governance preserved alongside the change
+
+    def test_keyboard_shrinks_content_and_never_strands_a_scroll(self):
+        """The composer tap used to scroll the whole shell up behind the soft keyboard (the user
+        2026-09-02): the viewport's default mode is resizes-visual — the keyboard PANS the visual
+        viewport while innerHeight stands still, the UA slides the page up to reveal the input, and
+        fit() re-lays the shrunken --app-h top-anchored into a window whose visible band starts a
+        keyboard-height down; the composer sat off-screen until dragged back. Two halves, both
+        pinned: interactive-widget=resizes-content makes engines that honor it (Android Chrome)
+        SHRINK the layout viewport instead of panning, and fit() undoes the stray page offset iOS
+        still forces (a UA input-reveal scroll bypasses overflow:hidden)."""
+        self.assertIn("interactive-widget=resizes-content", km._landing())
+        self.assertIn("if(window.scrollY||document.documentElement.scrollTop)window.scrollTo(0,0);",
+                      km._LANDING_MOBILE_JS)
 
     def test_bottom_bar_has_no_safe_area_padding(self):
         # The user 2026-06-19 (Firefox/Android): the bar showed a dead slab below the labels in PORTRAIT
@@ -331,11 +344,13 @@ class ChatSessionPicker(unittest.TestCase):
 
     def test_current_session_title_is_bold_color_on_the_grey_chip(self):
         # the user 2026-07-22: the mobile current-session title reads as the identity color in BOLD on the
-        # SAME grey chip as the +/madd button (#2a2a2a), with a hairline color border, not the color as a fill.
+        # SAME grey chip as the +/madd button, with a hairline color border, not the color as a fill.
+        # (The chip grey rides --btn-bg since 2026-09-02 — dark value byte-identical to the old #2a2a2a
+        # literal, and the light theme re-skins it; see test_kernel_mobile_picker's token test.)
         css = km._CHAT_MOBILE_CSS
-        self.assertIn("#mcur.colored{background:#2a2a2a;color:var(--cbg);border-color:var(--cbg)}", css)
+        self.assertIn("#mcur.colored{background:var(--btn-bg,#2a2a2a);color:var(--cbg);border-color:var(--cbg)}", css)
         self.assertIn("#madd{flex:0 0 auto", css)                    # ...and the + button is that same grey
-        self.assertIn("background:#2a2a2a;color:#bbbbbb", css)       # (the shared chip grey)
+        self.assertIn("background:var(--btn-bg,#2a2a2a);color:#bbbbbb", css)   # (the shared chip grey)
         self.assertIn("white-space:nowrap;font-weight:700}", css)   # the .nm name span is bold
 
     def test_no_pane_focus_ring_on_mobile(self):

--- a/tests/test_kernel_mobile_picker.py
+++ b/tests/test_kernel_mobile_picker.py
@@ -56,6 +56,22 @@ class MobilePickerClickSafe(unittest.TestCase):
         self.assertIn(".mrow.ph::after{content:'syncing", km._CHAT_MOBILE_CSS)
         self.assertIn(".mrow.pending::after{content:'opening", km._CHAT_MOBILE_CSS)
 
+    def test_the_trigger_chip_wears_the_chrome_tokens_and_a_light_skin(self):
+        """The #mcur/#madd chip is the one mobile surface that never joined the token migration: raw
+        #2a2a2a/#3a3a3a in this inline sheet outranked everything styles.css could say, so the chip sat
+        as a dark slab on the light chat page (the user 2026-09-02). Surfaces ride tokens whose dark
+        value is byte-identical to the old literals; text tiers take light-block overrides, with the
+        .colored restatement keeping the identity color on the name."""
+        css = km._CHAT_MOBILE_CSS
+        self.assertNotIn("background:#2a2a2a", css, "no raw chip surface left — tokens with dark fallbacks")
+        self.assertNotIn("border:1px solid #3a3a3a", css)
+        self.assertEqual(css.count("background:var(--btn-bg,#2a2a2a)"), 3, "chip, colored chip, and +")
+        self.assertEqual(css.count("border:1px solid var(--hairline,#3a3a3a)"), 3,
+                         "chip + the '+' + the #mlist card share the one hairline")
+        self.assertIn("body.theme-light #mcur{color:var(--menu-fg)}", css)
+        self.assertIn("body.theme-light #mcur.colored{color:var(--cbg)}", css)
+        self.assertIn("body.theme-light #madd{color:var(--text-muted)}", css)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -545,6 +545,15 @@ class RailBell(unittest.TestCase):
         # the rail bell paints its states exactly like the mobile one
         self.assertIn(".rail-acts #rail-bell.on{color:var(--accent)}", page)
         self.assertIn(".rail-acts #rail-bell.busy{opacity:.45}", page)
+        # the on-state must survive the light theme, whose .rail-act recolor outspecifies the bare
+        # `.on` rule — with no light restatement on and off rendered pixel-identical there (the
+        # user 2026-09-02)
+        self.assertIn("body.theme-light .rail-act.on{color:var(--accent)}", page)
+        # …and OFF reads as a slashed bell — the app's one bell-off idiom (feed card bell, timeline
+        # lane bell) — never a color difference alone
+        self.assertEqual(page.count("class='bell-slash'"), 2, "both bells carry the slash glyph")
+        self.assertIn(".bell-slash{display:none}", page)
+        self.assertIn("#rail-bell:not(.on) .bell-slash,#mbell:not(.on) .bell-slash{display:block}", page)
 
     def test_the_bell_is_the_master_switch_not_a_device_toggle(self):
         _, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -806,6 +806,45 @@ class LiveTail(unittest.TestCase):
         s.client = _Client({"percentage": 88, "model": "claude-opus-4-8"})
         asyncio.run(s._do_refresh_context())
         self.assertEqual(s._ctx_pct(), 88, "tracks the live value across turns")
+        self.assertFalse(s._ctx_over, "88% is inside the window — no overflow flag")
+
+        # the CLI documents percentage as "0-100+": past 100 the tokens exceed the CURRENT model's
+        # window (a 1M→200k model switch does this instantly). The battery stays clamped at 100,
+        # but the overflow is surfaced (ctxOver) instead of clamped into a silent, wrong-looking
+        # 100% (the user 2026-09-02, who switched models and read the full battery as a bug).
+        s.client = _Client({"percentage": 147, "model": "claude-haiku-4-5"})
+        asyncio.run(s._do_refresh_context())
+        self.assertEqual(s._ctx_pct(), 100, "the gauge value itself stays clamped")
+        self.assertTrue(s._ctx_over, "…but the overflow is news, not noise")
+        self.assertTrue(s.snapshot()["ctxOver"], "the snapshot ships it to the statusline")
+        self.assertTrue(sb.read_reg(d, sid).get("liveCtxOver"),
+                        "persisted beside liveCtx so a dormant/restarted session keeps saying so")
+        s.client = _Client({"percentage": 61, "model": "claude-haiku-4-5"})
+        asyncio.run(s._do_refresh_context())
+        self.assertFalse(s._ctx_over, "dropping back inside the window clears the flag")
+        self.assertFalse(sb.read_reg(d, sid).get("liveCtxOver"))
+
+    def test_context_refresh_queued_when_one_is_in_flight(self):
+        """A model/effort switch can ask for a context refresh while the turn-end refresh is still in
+        flight. The in-flight guard used to DROP that call silently, leaving the old model's percentage
+        standing until the next turn (the user 2026-09-02) — now it queues exactly one rerun, so the
+        number reflects the newest world."""
+        import asyncio
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        s = sb.SdkSession(be, {"sid": "11111111-2222-3333-4444-555555555555", "name": "n", "cwd": "/tmp"})
+
+        class _Counting:
+            def __init__(self): self.calls = 0
+            async def get_context_usage(self): self.calls += 1; return {"percentage": 40}
+        s.client = _Counting()
+        s._ctx_refreshing = True                       # a refresh is mid-flight
+        asyncio.run(s._do_refresh_context())
+        self.assertEqual(s.client.calls, 0, "the guarded call never races the in-flight one")
+        self.assertTrue(s._ctx_refresh_again, "…but it is REMEMBERED, not dropped")
+        s._ctx_refreshing = False
+        asyncio.run(s._do_refresh_context())           # the in-flight one finishing runs the queued ask
+        self.assertEqual(s.client.calls, 2, "the queued rerun fires after the live refresh lands")
+        self.assertFalse(s._ctx_refresh_again, "the queue holds ONE rerun, not a storm")
 
     def test_assistant_model_sets_badge_but_synthetic_does_not_corrupt_it(self):
         """The model 'doesn't show' mid-conversation (the user 2026-06-24): injected/synthetic assistant turns

--- a/ui/webview/ask-answer.test.ts
+++ b/ui/webview/ask-answer.test.ts
@@ -57,6 +57,6 @@ test("a free-text answer matching no option renders as an 'Other' row with the v
 
 test("the answered box is styled as a blue, right-aligned 'your reply' box", () => {
   assert.match(CSS, /\.turn-ask\.answered \{[^}]*align-items: flex-end/);
-  assert.match(CSS, /\.ask-card\.ask-answered \{[^}]*#2b6cef/);
+  assert.match(CSS, /\.ask-card\.ask-answered \{[^}]*var\(--you\)/);
   assert.match(CSS, /\.ask-answered-tag \{/);
 });

--- a/ui/webview/chat-affordances.test.ts
+++ b/ui/webview/chat-affordances.test.ts
@@ -40,7 +40,7 @@ test("dot colors are decoupled from the session (no ring, absolute hues)", () =>
   assert.match(CSS, /\.dot\.ring \{[^}]*background: var\(--fg\)/, "assistant/thinking = the assistant text color (--fg)");
   assert.match(CSS, /\.dot\.green \{[^}]*background: var\(--check-bg\)/, "tool success = the blue ✓ disc (consistent with the feed)");
   assert.match(CSS, /\.dot\.err \{[^}]*background: var\(--err\)/, "tool error = red");
-  assert.match(CSS, /\.dot\.user \{ background: #2b6cef/, "your prompt = the bubble blue (#2b6cef)");
+  assert.match(CSS, /\.dot\.user \{ background: var\(--you\)/, "your prompt = the bubble blue (#2b6cef)");
 });
 
 test("a hard-blocked (API-error) tab carries a translucent red fill atop its dashed ring (the user 2026-06-18)", () => {

--- a/ui/webview/chat-cmd-gesture.test.ts
+++ b/ui/webview/chat-cmd-gesture.test.ts
@@ -36,6 +36,6 @@ test("no edit/delete/fork affordances — a gesture is not a rewindable message"
 test("the gesture chip's ink is the outgoing-bubble blue on the chat's own ground", () => {
   // the user 2026-08-14: the --code-bg terracotta tint read as a stray red — the chip now borrows
   // .user-bubble's #2b6cef for border + text so the gesture still reads as "yours" without the bubble
-  assert.match(CSS, /\.user-bubble\.cmd-row \.slash-cmd-chip \{ background: var\(--bg\); color: #2b6cef;/);
-  assert.match(CSS, /\.user-bubble\.cmd-row \.slash-cmd-chip \{[^}]*border-color: #2b6cef/);
+  assert.match(CSS, /\.user-bubble\.cmd-row \.slash-cmd-chip \{ background: var\(--bg\); color: var\(--you\);/);
+  assert.match(CSS, /\.user-bubble\.cmd-row \.slash-cmd-chip \{[^}]*border-color: var\(--you\)/);
 });

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -70,3 +70,29 @@ test("the anchor re-query uses the same selectors as the first lookup", () => {
   const both = RENDER.split("data-mids~=").length - 1;
   assert.ok(both >= 2, "data-mids must be in BOTH the initial query and the post-re-render re-query");
 });
+
+test("a delta with NO base at all is a desync too — every delta path asks for the full frame", () => {
+  // the lost-first-frame class (the user 2026-09-02): the full session frame landed before the bundle's
+  // message listener existed, so the pane holds nothing while the kernel volunteers only deltas. Each
+  // delta shape must ask for the base instead of silently returning (the old `if (!s) return;`).
+  const chatTailFn = RENDER.slice(RENDER.indexOf("function chatTail(msg"), RENDER.indexOf("function statusOnly(msg"));
+  assert.match(chatTailFn, /if \(!s\) \{[\s\S]{0,900}?requestFullSession\(msg\.id\);\s*\n\s*return;\s*\n\s*\}/,
+    "chatTail: no base → ask, don't wait forever");
+  const updateFn = RENDER.slice(RENDER.indexOf("function update(msg"), RENDER.indexOf("function chatTail(msg"));
+  assert.match(updateFn, /if \(!s\) \{ requestFullSession\(msg\.id\); return; \}/, "update: same");
+  const statusFn = RENDER.slice(RENDER.indexOf("function statusOnly(msg"), RENDER.indexOf("function statusOnly(msg") + 400);
+  assert.match(statusFn, /if \(!s\) \{ requestFullSession\(msg\.id\); return; \}/, "statusOnly: same");
+});
+
+test("a reconnect clears parked asks — a dead socket's pending needFull can never gag the new one", () => {
+  assert.match(RENDER, /window\.addEventListener\("romp:wsup", \(\) => awaitingFull\.clear\(\)\);/);
+});
+
+test("the kernel's ready branch resets the client's WHOLE chat base before its push", () => {
+  const i = KERNEL.indexOf('msg.get("type") == "ready"');
+  assert.ok(i > 0);
+  const body = KERNEL.slice(i, i + 1600);
+  assert.ok(body.includes("_client_reset_chat_base(client)"), "ready = the renderer holds nothing");
+  assert.ok(body.indexOf("_client_reset_chat_base(client)") < body.indexOf("_push_one(client)"),
+    "…reset first, so the push that follows is full frames");
+});

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -35,8 +35,8 @@ test("the landing highlights with zero DOM surgery, and falls back honestly", ()
   assert.match(fn, /if \(!H \|\| typeof Highlight === "undefined"\) return;/, "no API → today's whole-message landing");
   assert.match(fn, /if \(!m\) return;\s*\/\/ unfindable in the rendered text → no highlight, no guess/);
   assert.match(fn, /scrollIntoView\(\{ block: "center", behavior: "auto" \}\)/, "land ON the sentence, not the message top");
-  assert.match(CSS, /::highlight\(cite-span\) \{ background-color: rgba\(156, 210, 255, 0\.30\);/,
-    "accent-tinted, never a status colour");
+  assert.match(CSS, /::highlight\(cite-span\) \{ background-color: color-mix\(in srgb, var\(--accent\) 30%, transparent\);/,
+    "accent-tinted, never a status colour (via the token, so the light theme re-inks it)");
 });
 
 test("substantive non-prose atoms are citable — the study's convicted classes", () => {

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -282,3 +282,30 @@ test("deselecting in the editor (editorSelectionCleared) drops the editor chip, 
   assert.match(fn, /if \(kept\.length\) composerCitations\.set\(id, kept\); else composerCitations\.delete\(id\);/);
   assert.doesNotMatch(fn, /focusComposer/);
 });
+
+// ── select → TYPE → ⌘⏎ (the user 2026-09-02): typing needs no click into the box ─────────────────
+test("an unclaimed printable keystroke drops the cursor into the composer — natively, never synthesized", () => {
+  const mark = RENDER.indexOf("// SELECT → TYPE → ⌘⏎");
+  assert.ok(mark > 0, "the type-to-focus handler exists");
+  const at = RENDER.indexOf('window.addEventListener("keydown"', mark);   // the CODE, past the design comment
+  assert.ok(at > mark, "the handler follows its design note");
+  const end = RENDER.indexOf("ta.focus({ preventScroll: true })", at);
+  assert.ok(end > at, "the redirect focuses the box without jolting the transcript");
+  const block = RENDER.slice(at, end);
+  // gates, in the order the hazards were mapped: upstream handlers, chords, IME, non-printables,
+  // Space (ask-card toggle / scroll), a missing or read-only box, key repeat, typing targets, the
+  // live-ask card's number keys, open menus/dialogs, and the full-pane surfaces
+  assert.match(block, /if \(e\.defaultPrevented \|\| e\.altKey \|\| e\.ctrlKey \|\| e\.metaKey\) return;/);
+  assert.match(block, /if \(e\.isComposing \|\| e\.keyCode === 229\) return;/);
+  assert.match(block, /if \(e\.key\.length !== 1 \|\| e\.key === " "\) return;/);
+  assert.match(block, /if \(!ta \|\| ta\.disabled \|\| document\.activeElement === ta\) return;/);
+  assert.match(block, /if \(isTypingTarget\(e\.target\) \|\| isTypingTarget\(document\.activeElement\)\) return;/);
+  assert.match(block, /if \(activeId && liveAsks\.has\(activeId\)\) return;/);
+  assert.match(block, /if \(ctxMenuEl \|\| document\.querySelector\("\.picker-overlay"\)\) return;/);
+  assert.match(block, /romp-fileview[\s\S]*romp-filebrowse[\s\S]*romp-lightbox/);
+  // NEVER preventDefault: the point is that the native keystroke inserts into the newly focused
+  // box, so the composer's own input bookkeeping (draft, slash menu) sees ordinary typing
+  assert.doesNotMatch(block, /preventDefault/);
+  // …and the armed quote chip survives the focus (a collapse never clears it), so ⌘⏎ stages
+  // selection+typing exactly as if the user had clicked in: the existing stage pins above cover it
+});

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -300,6 +300,10 @@ test("an unclaimed printable keystroke drops the cursor into the composer — na
   assert.match(block, /if \(e\.key\.length !== 1 \|\| e\.key === " "\) return;/);
   assert.match(block, /if \(!ta \|\| ta\.disabled \|\| document\.activeElement === ta\) return;/);
   assert.match(block, /if \(isTypingTarget\(e\.target\) \|\| isTypingTarget\(document\.activeElement\)\) return;/);
+  // the pane's own modals and meta menus own their keys, and a dropdown's type-ahead is typing: a
+  // letter typed in the settings modal must never land in the hidden draft (review 2026-09-02)
+  assert.match(block, /document\.querySelector\("#rsettings:not\(\[hidden\]\), #ra-back:not\(\[hidden\]\), #rkeys-back, \.meta-menu"\)/);
+  assert.match(RENDER, /elm\.tagName === "SELECT"/, "SELECT is a typing target");
   assert.match(block, /if \(activeId && liveAsks\.has\(activeId\)\) return;/);
   assert.match(block, /if \(ctxMenuEl \|\| document\.querySelector\("\.picker-overlay"\)\) return;/);
   assert.match(block, /romp-fileview[\s\S]*romp-filebrowse[\s\S]*romp-lightbox/);

--- a/ui/webview/composer-ship-gate.test.ts
+++ b/ui/webview/composer-ship-gate.test.ts
@@ -78,6 +78,8 @@ test("the ack attaches to the composer that SHIPPED the file, not whatever tab i
 
 test("a held send is visible on the button and always inspectable", () => {
   assert.match(RENDER, /sendBtn\.classList\.toggle\("send-held", held\);/);
-  assert.match(RENDER, /"sends when the upload finishes"/);
+  // inspectable through the ONE styled tip: a native title beside the button's setTip showed two
+  // stacked tooltip boxes while a hold was armed (2026-09-02)
+  assert.match(RENDER, /setTip\(sendBtn, held \? "Send \(Enter\)\\nsends when the upload finishes" : "Send \(Enter\)"\);/);
   assert.match(CSS, /#composer-send\.send-held \{ opacity: 0\.45; \}/);
 });

--- a/ui/webview/continue-bubble.test.ts
+++ b/ui/webview/continue-bubble.test.ts
@@ -38,7 +38,7 @@ test("the row sheds the bubble, keeps the header when expanded, and the caret fl
   assert.match(CSS, /\.user-bubble\.nudge-collapsible \{ cursor: pointer; \}/);
   // the LIGHT BLUE box (the user 2026-08-18, superseding the bare row): blue = "from you", gray =
   // "from romp" — pale blue says "your gesture, standardized words", never posing as typed prose
-  assert.match(CSS, /\.user-bubble\.cont-row \{\s*\n\s*max-width: 72%;\s*\n\s*background: rgba\(43, 108, 239, 0\.16\); border: 1px solid rgba\(43, 108, 239, 0\.42\);/);
+  assert.match(CSS, /\.user-bubble\.cont-row \{\s*\n\s*max-width: 72%;\s*\n\s*background: color-mix\(in srgb, var\(--you\) 16%, transparent\); border: 1px solid color-mix\(in srgb, var\(--you\) 42%, transparent\);/);
   assert.match(CSS, /\.user-bubble\.cont-row \.cont-tri::before \{ content: "▸"; \}/);
   assert.match(CSS, /\.user-bubble\.cont-row\.expanded \.cont-tri::before \{ content: "▾"; \}/,
     "the same .expanded class the fold delegate flips also turns the caret");

--- a/ui/webview/css-census.test.ts
+++ b/ui/webview/css-census.test.ts
@@ -33,7 +33,7 @@ const rawDims = (css: string) => {
 // EXACT counts, not ceilings (PR #763 item 7: a <= pin with slack lets new raw hexes arrive
 // unnoticed) — a count that moves in EITHER direction is a deliberate change to name here.
 const EXACT: Record<string, number> = {
-  "gear.css": 14,   // T226 review: the colormap/palette dropdowns' two `0 8px 24px #000000aa` shadows moved onto var(--shadow-menu)
+  "gear.css": 13,   // T226's shadows-onto-var(--shadow-menu) (14) plus the .ra-li legend joining --text-soft (2026-08-31)
   "strip.css": 8,
   "fleet-pane.css": 9,
   "timeline-pane.css": 10,

--- a/ui/webview/css-census.test.ts
+++ b/ui/webview/css-census.test.ts
@@ -33,7 +33,8 @@ const rawDims = (css: string) => {
 // EXACT counts, not ceilings (PR #763 item 7: a <= pin with slack lets new raw hexes arrive
 // unnoticed) — a count that moves in EITHER direction is a deliberate change to name here.
 const EXACT: Record<string, number> = {
-  "gear.css": 13,   // T226's shadows-onto-var(--shadow-menu) (14) plus the .ra-li legend joining --text-soft (2026-08-31)
+  "gear.css": 12,   // T226's shadows-onto-var(--shadow-menu), the .ra-li legend joining --text-soft, and the
+                    // .ra-openbtn slab joining --btn-bg (2026-09-02: it sat black with dark text in light)
   "strip.css": 8,
   "fleet-pane.css": 9,
   "timeline-pane.css": 10,

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -209,3 +209,13 @@ test("the px type set is CLOSED: chrome sizes come from the pinned set, like the
     assert.deepEqual(strays, [], name + " px sizes outside the set");
   }
 });
+
+test("the bubble's inner-markdown overrides OUTRANK .md — the doubled-selector guard", () => {
+  // the bubble element itself wears .md, so a plain `.user-bubble X` (0,1,1) ties `.md X` and
+  // loses on source order — links rendered link-ink-on-saturated-fill and the quote tint fell to
+  // var(--dim) grey at ~2:1 (found 2026-09-02). The doubled form (0,2,1) is the guard; a new
+  // inner-markdown override on the bubble must carry it too.
+  assert.match(CHAT, /\.user-bubble a, \.user-bubble\.md a \{ color: #fff;/, "bubble links stay white");
+  assert.match(CHAT, /\.user-bubble blockquote, \.user-bubble\.md blockquote \{ color: rgba\(255, 255, 255, 0\.88\);/,
+    "the quoted-assistant tint actually lands");
+});

--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -222,3 +222,12 @@ test("a new question drops the old verdict, so no answer ever describes another 
   assert.match(RENDER, /if \(out\.type === "dirCompletions"\) out\.host = host;/,
     "federation stamps a remote answer with the machine that gave it");
 });
+
+test("the completion dropdown is a LIST, not the picker's full 900px (the user 2026-09-02)", () => {
+  // width min(520px, calc(100% - 28px)) = the one-column dropdown measure on desktop, and
+  // byte-identical to the old left+right-14px geometry on any picker ≤548px (phones unchanged)
+  assert.match(STYLES, /\.picker-dir-menu \{[\s\S]{0,900}?width: min\(520px, calc\(100% - 28px\)\);/);
+  assert.match(STYLES, /\.picker-dir-menu \{[\s\S]{0,900}?max-height: min\(216px, 40vh\);/);
+  assert.match(STYLES, /\.picker-dir-menu \{[\s\S]{0,900}?border-radius: var\(--radius-menu\); box-shadow: var\(--shadow-menu\);/,
+    "the dropdown wears the shared menu vocabulary");
+});

--- a/ui/webview/editor-chunk.ts
+++ b/ui/webview/editor-chunk.ts
@@ -68,7 +68,7 @@ function langExt(ext: string): Extension[] {
 // not per module: `dark` is a CodeMirror-side branch (its base theme for panels/popups), so it must
 // read the LIVE body class — a module-load constant froze the first theme forever (and was
 // hardcoded { dark: true }, which kept the search panel near-black under body.theme-light — the
-// user 2026-09-02, "the file editor looked black").
+// user 2026-09-02, who saw a near-black file editor).
 function rompTheme(): Extension {
   const light = typeof document !== "undefined" && document.body.classList.contains("theme-light");
   return EditorView.theme({

--- a/ui/webview/editor-chunk.ts
+++ b/ui/webview/editor-chunk.ts
@@ -60,30 +60,40 @@ function langExt(ext: string): Extension[] {
   }
 }
 
-// The dashboard's own look and nothing more: the panel palette from styles.css, the accent
-// (#9cd2ff) only where the app already uses it (selection, matches, focus cues), the mono stack
-// and 13px the viewer's read mode already renders — no new fonts, no new sizes (the font-size
-// rule; and like the timeline, an adopted style must DECLARE font-family, never inherit a host's).
-const rompTheme = EditorView.theme({
-  "&": { height: "100%", fontSize: "13px", backgroundColor: "var(--bg, #1e1e1e)", color: "var(--fg, #d4d4d4)" },
-  ".cm-content": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", caretColor: "var(--fg, #d4d4d4)" },
-  ".cm-scroller": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", overflow: "auto" },
-  "&.cm-focused": { outline: "none" },
-  ".cm-gutters": { backgroundColor: "var(--bg, #1e1e1e)", color: "var(--dim, #8a8f98)", border: "none",
-    borderRight: "1px solid rgba(255, 255, 255, 0.08)" },
-  ".cm-activeLine": { backgroundColor: "rgba(255, 255, 255, 0.04)" },
-  ".cm-activeLineGutter": { backgroundColor: "rgba(255, 255, 255, 0.04)" },
-  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": { backgroundColor: "rgba(156, 210, 255, 0.22)" },
-  ".cm-selectionMatch": { backgroundColor: "rgba(156, 210, 255, 0.14)" },
-  ".cm-matchingBracket": { backgroundColor: "rgba(156, 210, 255, 0.18)", outline: "1px solid rgba(156, 210, 255, 0.4)" },
-  ".cm-cursor": { borderLeftColor: "var(--fg, #d4d4d4)" },
-  // the search panel wears the shared menu vocabulary (one dropdown skin, 2026-08-09)
-  ".cm-panels": { backgroundColor: "#252526", color: "var(--fg, #d4d4d4)",
-    borderTop: "1px solid rgba(255, 255, 255, 0.12)" },
-  ".cm-panel.cm-search input, .cm-panel.cm-search button": {
-    fontFamily: "inherit", fontSize: "12px", background: "var(--bg, #1e1e1e)",
-    color: "var(--fg, #d4d4d4)", border: "1px solid rgba(255, 255, 255, 0.12)", borderRadius: "4px" },
-}, { dark: true });
+// The dashboard's own look and nothing more: the panel palette from styles.css, the accent only
+// where the app already uses it (selection, matches, focus cues — via color-mix over var(--accent),
+// which resolves to the dark literal rgba(156,210,255,…) washes exactly), the mono stack and 13px
+// the viewer's read mode already renders — no new fonts, no new sizes (the font-size rule; and like
+// the timeline, an adopted style must DECLARE font-family, never inherit a host's). Built per mount,
+// not per module: `dark` is a CodeMirror-side branch (its base theme for panels/popups), so it must
+// read the LIVE body class — a module-load constant froze the first theme forever (and was
+// hardcoded { dark: true }, which kept the search panel near-black under body.theme-light — the
+// user 2026-09-02, "the file editor looked black").
+function rompTheme(): Extension {
+  const light = typeof document !== "undefined" && document.body.classList.contains("theme-light");
+  return EditorView.theme({
+    "&": { height: "100%", fontSize: "13px", backgroundColor: "var(--bg, #1e1e1e)", color: "var(--fg, #d4d4d4)" },
+    ".cm-content": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", caretColor: "var(--fg, #d4d4d4)" },
+    ".cm-scroller": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", overflow: "auto" },
+    "&.cm-focused": { outline: "none" },
+    ".cm-gutters": { backgroundColor: "var(--bg, #1e1e1e)", color: "var(--dim, #8a8f98)", border: "none",
+      borderRight: "1px solid var(--hairline, #3a3a3a)" },
+    ".cm-activeLine": { backgroundColor: "var(--overlay-05, rgba(255, 255, 255, 0.06))" },
+    ".cm-activeLineGutter": { backgroundColor: "var(--overlay-05, rgba(255, 255, 255, 0.06))" },
+    ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+      backgroundColor: "color-mix(in srgb, var(--accent, #9cd2ff) 22%, transparent)" },
+    ".cm-selectionMatch": { backgroundColor: "color-mix(in srgb, var(--accent, #9cd2ff) 14%, transparent)" },
+    ".cm-matchingBracket": { backgroundColor: "color-mix(in srgb, var(--accent, #9cd2ff) 18%, transparent)",
+      outline: "1px solid color-mix(in srgb, var(--accent, #9cd2ff) 40%, transparent)" },
+    ".cm-cursor": { borderLeftColor: "var(--fg, #d4d4d4)" },
+    // the search panel wears the shared menu vocabulary (one dropdown skin, 2026-08-09)
+    ".cm-panels": { backgroundColor: "var(--surface-raised, #252526)", color: "var(--fg, #d4d4d4)",
+      borderTop: "1px solid var(--box-border, rgba(255, 255, 255, 0.12))" },
+    ".cm-panel.cm-search input, .cm-panel.cm-search button": {
+      fontFamily: "inherit", fontSize: "12px", background: "var(--bg, #1e1e1e)",
+      color: "var(--fg, #d4d4d4)", border: "1px solid var(--box-border, rgba(255, 255, 255, 0.12))", borderRadius: "4px" },
+  }, { dark: !light });
+}
 
 export interface EditorHandle {
   value(): string;
@@ -112,7 +122,7 @@ export function mount(host: HTMLElement, opts: MountOpts): EditorHandle {
         highlightSelectionMatches(),
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         ...langExt(opts.ext),
-        rompTheme,
+        rompTheme(),
         keymap.of([
           { key: "Mod-s", run: () => { opts.onSave(); return true; } },
           ...closeBracketsKeymap, ...defaultKeymap, ...searchKeymap,

--- a/ui/webview/editor-lazy.test.ts
+++ b/ui/webview/editor-lazy.test.ts
@@ -103,5 +103,11 @@ test("edit arming stays the kernel's verdict: UTF-8-only and the ns mtime anchor
 test("the editor declares its font and reuses the panel palette — no new fonts or sizes", () => {
   assert.match(CHUNK, /fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace"/);
   assert.match(CHUNK, /fontSize: "13px"/);
-  assert.match(CHUNK, /rgba\(156, 210, 255, 0\.22\)/, "selection wears the romp accent, nothing new");
+  assert.match(CHUNK, /color-mix\(in srgb, var\(--accent, #9cd2ff\) 22%, transparent\)/,
+    "selection wears the romp accent, nothing new (via the token, so the light theme re-inks it)");
+  // and the CodeMirror-side dark branch (its base theme for panels/popups) reads the LIVE body
+  // class per mount — hardcoded { dark: true } kept the search panel near-black under
+  // body.theme-light (the user 2026-09-02)
+  assert.match(CHUNK, /document\.body\.classList\.contains\("theme-light"\)/);
+  assert.match(CHUNK, /\{ dark: !light \}/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -78,6 +78,10 @@
      light text on dark; a LIGHT glow under the dark text on light — a dark halo around dark
      glyphs read as blur (the user 2026-08-31, off the live preview) */
   --text-halo: rgba(0, 0, 0, 0.75);
+  /* YOUR voice (the outgoing bubble, the rail's user dot, the comment marker): royal blue on
+     dark; the light theme wears a warm sienna from the page's own family instead (the user
+     2026-08-31: 'in family of the background colour, but darker/saturated' — not blue) */
+  --you: #2b6cef;
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
                        in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
@@ -182,6 +186,7 @@ body.theme-light {
   --kbd-border: #D3C7B6;
   --overlay-05: rgba(0, 0, 0, 0.045);
   --overlay-10: rgba(0, 0, 0, 0.08);
+  --you: #A55A2A;   /* warm sienna — white text clears 5:1 */
   --text-halo: rgba(252, 249, 244, 0.85);
   --mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   --sans: "Space Grotesk", "Inter", var(--vscode-chat-font-family, var(--vscode-font-family, system-ui, -apple-system, "Segoe UI", sans-serif));

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1638,7 +1638,10 @@ body.filebrowse-open { overflow: hidden; }
 .fb-crumb:hover { color: var(--accent); text-decoration: underline; }
 .fb-crumb:last-child { color: var(--fg); }
 .fb-crumb-sep { margin: 0 3px; opacity: 0.6; }
-.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
+/* the overlay still takes the whole pane (the user 2026-08-24 ruling) — but the LISTING reads at a
+   centered 720px measure on a wide pane (the user 2026-09-02: full-width rows put a file's size
+   ~800px from its name); 100% wins on narrow panes/phones, pixel-identical to before */
+.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; width: min(720px, 100%); margin-inline: auto; }
 /* compact one-line rows (progressive disclosure): marker + name, size right-aligned on files; mtime
    and the full path live in the row's hover title */
 .fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -34,6 +34,12 @@
                        the await-paused outline rendered with NO border at all (the user 2026-07-02) */
   --accent: #9cd2ff;  /* the romp accent (CLAUDE.md Design) — feed.css has its OWN :root, so selected-state
                        chrome here needs it defined locally or var(--accent) silently falls back */
+  --link: var(--vscode-textLink-foreground, #4daafc);  /* hyperlink ink — mirrors styles.css (one token
+                       for every rendered link; the light block re-inks it) */
+  /* the hljs syntax palette, as tokens — mirrors styles.css byte-for-byte (one treatment, two
+     sheets; file-view.test.ts pins the two identical). Raw hexes here were dark-only. */
+  --hl-fg: #d8c6a8; --hl-kw: #c98a6a; --hl-str: #9fb878; --hl-num: #d4a36a;
+  --hl-cmt: #6f6a5f; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;
   --accent-fg: #0c1a2e;  /* dark text ON the accent (CLAUDE.md) — for the reverse-highlight on a selected toggle */
   --accent-wash: rgba(156, 210, 255, 0.12);  /* THE faint accent wash — mirrors styles.css; one alpha
                        behind every selected/hovered accent chrome */
@@ -132,6 +138,9 @@ body.theme-light {
                             its clay accent (what the timeline's PAL_LIGHT already drew) */
   --code-fg: #8C4A00;
   --code-bg: rgba(180, 83, 9, 0.08);
+  --link: #1D63A8;   /* inked cobalt — clearly clickable, clearly not the error red (5.2:1 on the page) */
+  --hl-fg: #3E3A35; --hl-kw: #A03509; --hl-str: #47720F; --hl-num: #915C0B;
+  --hl-cmt: #6E675C; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
   --err: #B02A1C;
@@ -196,7 +205,7 @@ body.theme-light {
   --vscode-menu-selectionBackground: #F3E0D5;
   --vscode-menu-selectionForeground: #1F1E1D;
   --vscode-scrollbarSlider-background: rgba(90, 84, 74, 0.35);
-  --vscode-textLink-foreground: #B24A28;
+  --vscode-textLink-foreground: #1D63A8;
   --vscode-button-background: #C2410C;
   --vscode-button-foreground: #FFF8F2;
   --vscode-button-hoverBackground: #A93A0B;
@@ -1361,7 +1370,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #romp-fileview { position: fixed; inset: 0; z-index: 1200; background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; }
 .fileview { width: 95%; height: 95%; display: flex; flex-direction: column; overflow: hidden;
-  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: var(--radius-modal);
+  background: var(--bg, #1e1e1e); border: 1px solid var(--box-border); border-radius: var(--radius-modal);
   box-shadow: var(--shadow-modal); }
 body.fileview-open { overflow: hidden; }
 .fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
@@ -1401,7 +1410,7 @@ a.fileview-btn[hidden] { display: none; }
 .fileview-pre code { background: none; padding: 0; font: inherit; }
 /* a refusal explains itself in place, in the kernel's own words (too large — with the size and the
    cap; not a text file; not found) over the path it was asked for. Never a blank pane. */
-.fileview-err { padding: 18px 14px; font-size: 0.86em; color: #e0a030; }
+.fileview-err { padding: 18px 14px; font-size: 0.86em; color: var(--warn); }
 .fileview-err-hint { margin-top: 6px; color: var(--dim); font-size: 0.92em;
   font-family: var(--mono, ui-monospace, monospace); word-break: break-all; }
 /* the way out of a refusal: when the file exists but cannot render (413/415), the kernel's words are
@@ -1457,7 +1466,7 @@ a.fileview-btn[hidden] { display: none; }
 .fileview-md li { margin: 0.2em 0; }
 .fileview-md strong { color: var(--fg); font-weight: 600; }
 .fileview-md em { font-style: italic; }
-.fileview-md a { color: var(--vscode-textLink-foreground, #4daafc); text-decoration: none; }
+.fileview-md a { color: var(--link); text-decoration: none; }
 .fileview-md a:hover { text-decoration: underline; }
 .fileview-md blockquote { margin: 0.5em 0; padding-left: 12px;
   border-left: 2px solid var(--box-border); color: var(--dim); }
@@ -1478,7 +1487,7 @@ a.fileview-btn[hidden] { display: none; }
 }
 .fileview-md table { border-collapse: collapse; margin: 0.6em 0; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
-.fileview-md th { background: rgba(255, 255, 255, 0.03); }
+.fileview-md th { background: var(--box-bg, rgba(255, 255, 255, 0.03)); }
 .fileview-md img { max-width: 100%; }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
@@ -1496,17 +1505,17 @@ a.fileview-btn[hidden] { display: none; }
    The hljs token palette, mirrored from styles.css (one treatment, two sheets — the .romp-acted
    precedent: each page loads only its own sheet). The viewer wraps every token in .hljs-* spans, and
    until this block landed the feed sheet had NO rules for them, so highlighting rendered colorless. */
-.hljs { color: #d8c6a8; background: transparent; }
-.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type { color: #c98a6a; }
-.hljs-string, .hljs-attr, .hljs-regexp { color: #9fb878; }
-.hljs-number { color: #d4a36a; }
-.hljs-comment, .hljs-quote { color: #6f6a5f; font-style: italic; }
-.hljs-title, .hljs-title.function_, .hljs-section { color: #e1c08d; }
-.hljs-name, .hljs-tag { color: #c98a6a; }
-.hljs-params, .hljs-variable, .hljs-property { color: #d8c6a8; }
-.hljs-meta { color: #9a8f7a; }
-.hljs-attribute { color: #cdaf7e; }
-.hljs-addition { color: #9fb878; }
+.hljs { color: var(--hl-fg); background: transparent; }
+.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type { color: var(--hl-kw); }
+.hljs-string, .hljs-attr, .hljs-regexp { color: var(--hl-str); }
+.hljs-number { color: var(--hl-num); }
+.hljs-comment, .hljs-quote { color: var(--hl-cmt); font-style: italic; }
+.hljs-title, .hljs-title.function_, .hljs-section { color: var(--hl-title); }
+.hljs-name, .hljs-tag { color: var(--hl-kw); }
+.hljs-params, .hljs-variable, .hljs-property { color: var(--hl-fg); }
+.hljs-meta { color: var(--hl-meta); }
+.hljs-attribute { color: var(--hl-attr); }
+.hljs-addition { color: var(--hl-str); }
 .hljs-deletion { color: var(--err); }
 
 /* the "host:" prefix on a federated session's name — see styles.css (one treatment, two sheets) */
@@ -1629,8 +1638,8 @@ body.filebrowse-open { overflow: hidden; }
    and the full path live in the row's hover title */
 .fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;
   font-size: 0.86em; }
-.fb-row:hover, .fb-row.active { background: rgba(255, 255, 255, 0.07); }
-.fb-row.active { outline: 1px solid rgba(156, 210, 255, 0.35); outline-offset: -1px; }
+.fb-row:hover, .fb-row.active { background: var(--menu-hover); }
+.fb-row.active { outline: 1px solid color-mix(in srgb, var(--accent) 35%, transparent); outline-offset: -1px; }
 .fb-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; font-family: var(--mono, ui-monospace, monospace); }
 .fb-dir .fb-name { color: var(--accent); }
@@ -1662,7 +1671,7 @@ body.filebrowse-open { overflow: hidden; }
   background: var(--bg, #1e1e1e); color: var(--fg);
   font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
   white-space: pre; tab-size: 4; }
-.fileview-editor:focus { box-shadow: inset 0 0 0 1px rgba(156, 210, 255, 0.35); }
+.fileview-editor:focus { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent); }
 
 /* usage-limit banner (2026-08-18): analysis paused on a usage limit says so above the columns —
    loud but compact, one line + (Fable only) the switch-to-Opus action. Neutral card chrome, never

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -80,7 +80,7 @@
   --text-halo: rgba(0, 0, 0, 0.75);
   /* YOUR voice (the outgoing bubble, the rail's user dot, the comment marker): royal blue on
      dark; the light theme wears a warm sienna from the page's own family instead (the user
-     2026-08-31: 'in family of the background colour, but darker/saturated' — not blue) */
+     2026-08-31, who wanted a darker, more saturated color from the page's own family, not blue) */
   --you: #2b6cef;
   --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
                        as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -160,19 +160,25 @@ test("langFor maps known extensions and returns null rather than guessing", () =
 // two sheets — the .romp-acted precedent). This pins every rule in both and catches drift.
 test("the hljs token palette lives in feed.css too, identical to the chat's", () => {
   const STYLES = CHAT_CSS;
+  // tokenized 2026-09-02 (the light theme re-inks the same names; theme-parity.test.ts holds the
+  // token set + its contrast in both themes) — the dark :root values are the exact hexes these
+  // rules always carried: fg #d8c6a8, kw #c98a6a, str #9fb878, num #d4a36a, cmt #6f6a5f,
+  // title #e1c08d, meta #9a8f7a, attr #cdaf7e
   const rules = [
-    /\.hljs \{ color: #d8c6a8; background: transparent; \}/,
-    /\.hljs-keyword, \.hljs-built_in, \.hljs-literal, \.hljs-type \{ color: #c98a6a; \}/,
-    /\.hljs-string, \.hljs-attr, \.hljs-regexp \{ color: #9fb878; \}/,
-    /\.hljs-number \{ color: #d4a36a; \}/,
-    /\.hljs-comment, \.hljs-quote \{ color: #6f6a5f; font-style: italic; \}/,
-    /\.hljs-title, \.hljs-title\.function_, \.hljs-section \{ color: #e1c08d; \}/,
-    /\.hljs-name, \.hljs-tag \{ color: #c98a6a; \}/,
-    /\.hljs-params, \.hljs-variable, \.hljs-property \{ color: #d8c6a8; \}/,
-    /\.hljs-meta \{ color: #9a8f7a; \}/,
-    /\.hljs-attribute \{ color: #cdaf7e; \}/,
-    /\.hljs-addition \{ color: #9fb878; \}/,
+    /\.hljs \{ color: var\(--hl-fg\); background: transparent; \}/,
+    /\.hljs-keyword, \.hljs-built_in, \.hljs-literal, \.hljs-type \{ color: var\(--hl-kw\); \}/,
+    /\.hljs-string, \.hljs-attr, \.hljs-regexp \{ color: var\(--hl-str\); \}/,
+    /\.hljs-number \{ color: var\(--hl-num\); \}/,
+    /\.hljs-comment, \.hljs-quote \{ color: var\(--hl-cmt\); font-style: italic; \}/,
+    /\.hljs-title, \.hljs-title\.function_, \.hljs-section \{ color: var\(--hl-title\); \}/,
+    /\.hljs-name, \.hljs-tag \{ color: var\(--hl-kw\); \}/,
+    /\.hljs-params, \.hljs-variable, \.hljs-property \{ color: var\(--hl-fg\); \}/,
+    /\.hljs-meta \{ color: var\(--hl-meta\); \}/,
+    /\.hljs-attribute \{ color: var\(--hl-attr\); \}/,
+    /\.hljs-addition \{ color: var\(--hl-str\); \}/,
     /\.hljs-deletion \{ color: var\(--err\); \}/,
+    /--hl-fg: #d8c6a8; --hl-kw: #c98a6a; --hl-str: #9fb878; --hl-num: #d4a36a;/,
+    /--hl-cmt: #6f6a5f; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;/,
   ];
   for (const r of rules) {
     assert.match(FEED_CSS, r, "feed.css is missing a palette rule: " + r.source);

--- a/ui/webview/filebrowse-chat-overlay.test.ts
+++ b/ui/webview/filebrowse-chat-overlay.test.ts
@@ -39,3 +39,10 @@ test("the overlay geometry: pane-filling, viewer stays one layer above, scroll l
   const vz = Number((CHAT.match(/#romp-fileview \{[^}]*z-index: (\d+)/s) || [])[1]);
   assert.ok(vz > 890, "the viewer's backdrop sits above the browser (got " + vz + ")");
 });
+
+test("the overlay stays GIANT; the LISTING reads at a centered measure on wide panes", () => {
+  // the 2026-08-24 ruling stands (fixed inset-0 over the whole chat area) — the 2026-09-02 fix caps
+  // only the rows' measure: full-width rows put a file's size ~800px from its name on desktop.
+  // min(720px, 100%) keeps narrow panes and phones pixel-identical.
+  assert.match(CHAT, /\.fb-list \{[^}]*width: min\(720px, 100%\); margin-inline: auto; \}/);
+});

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -59,6 +59,16 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
   margin-top: 2px; color: var(--text-soft, #cdd3da); font-size: 0.92em; line-height: 1.35; background: var(--input-bg, #1b1b1c); border: 1px solid var(--hairline, #3a3a3a);
   border-radius: 6px; padding: 6px 9px; box-shadow: 0 4px 14px #000000aa; pointer-events: none; }
 #rsettings .rs-sub code { background: #0d0d0d; border-radius: 3px; padding: 0 3px; }
+/* an inline live status beside a control (the login flow's "starting…") — visible when non-empty,
+   never a popover (as an rs-sub it doubled the Account row's tooltip, 2026-09-02) */
+#rsettings .rs-note { color: var(--text-muted, #9aa0a6); font-size: 0.92em; }
+#rsettings .rs-note:empty { display: none; }
+/* ONE tooltip at a time: while a picker dropdown is open, or the pointer is on the tri-state
+   'mixed' mark (whose own title names the differing hosts), the row's description stands down —
+   otherwise the native tooltip and the description popover stack (2026-09-02) */
+#rsettings .rs-row:has(#rs-cmap-list:not([hidden])) .rs-sub,
+#rsettings .rs-row:has(#rs-pal-list:not([hidden])) .rs-sub,
+#rsettings .rs-row:has(.rs-mixed:hover) .rs-sub { display: none; }
 /* A setting whose value differs between the connected machines: the checkbox goes tri-state, and this
    says so in words beside the label, because an indeterminate box alone is easy to read straight past.
    Label size, section grey — the hover line names which machines. */
@@ -109,7 +119,7 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #rsettings kbd { display: inline-block; background: var(--kbd-bg, #1c1c1f); border: 1px solid var(--kbd-border, #3d3d42); border-bottom-width: 2px;
   border-radius: 4px; padding: 1px 6px; font: 600 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; color: #e6e6e6; }
 /* token-usage analytics: a button in the gear panel opens a centered modal with the chart. */
-.ra-openbtn { margin-top: 8px; width: 100%; background: #2d2d2f; border: 1px solid var(--hairline, #3a3a3a); border-radius: 6px;
+.ra-openbtn { margin-top: 8px; width: 100%; background: var(--btn-bg, #2d2d2f); border: 1px solid var(--hairline, #3a3a3a); border-radius: 6px;
   color: var(--text-soft, #cdd3da); font: 600 12px/1.4 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif; padding: 7px; cursor: pointer;
   transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease, transform 0.08s ease; }
 .ra-openbtn:active { transform: scale(0.96); }

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -138,7 +138,7 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 .ra-chart { margin: 6px 0 10px; min-height: 120px; }
 .ra-empty { color: var(--text-muted, #9aa0a6); text-align: center; padding: 40px 0; }
 .ra-legend { display: flex; flex-wrap: wrap; gap: 6px 12px; margin-bottom: 8px; }
-.ra-li { display: inline-flex; align-items: center; gap: 5px; color: #bcc1c7; font-size: 11px; }
+.ra-li { display: inline-flex; align-items: center; gap: 5px; color: var(--text-soft, #bcc1c7); font-size: 11px; }
 .ra-li b { color: var(--text-bright, #e8eaed); font-weight: 600; }
 .ra-sw { width: 10px; height: 10px; border-radius: 2px; display: inline-block; flex: 0 0 auto; }
 .ra-note { color: var(--text-muted, #9aa0a6); font-size: 11px; border-top: 1px solid var(--hairline, #3a3a3a); padding-top: 7px; }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -55,7 +55,10 @@ var GEAR_HTML =
   '<span class=rs-sub id=rs-login-acct>…</span>' +
   "<div id=rs-login-flow style='margin-top:6px'>" +
   "<button id=rs-login-btn type=button style='cursor:pointer;background:var(--btn-bg, #2a2a2a);color:var(--fg, #ccc);border:1px solid var(--hairline, #3a3a3a);border-radius:5px;padding:3px 10px'>Log in to Claude Code</button>" +
-  "<span id=rs-login-state class=rs-sub style='margin-left:8px'></span>" +
+  // rs-note, NOT rs-sub: this is a live inline status ("starting the login flow…"), not the row's
+  // description — as an rs-sub it floated a SECOND hover popover under the Account row, stacked on
+  // rs-login-acct's (the user 2026-09-02, "weird double tooltip"; even empty it painted a box)
+  "<span id=rs-login-state class=rs-note style='margin-left:8px'></span>" +
   '</div></span></div>' +
   '<div class=rs-sec>Sessions</div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Default directory</b>" +
@@ -133,11 +136,11 @@ var GEAR_HTML =
   '</span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Colormap</b>" +
   '<span class=rs-sub>One ramp for the whole dashboard — feed recency, usage, and context bars. Brightest = newest / highest.</span>' +
-  "<div id=rs-cmap><button id=rs-cmap-btn type=button title='Pick the recency colormap'></button>" +
+  "<div id=rs-cmap><button id=rs-cmap-btn type=button aria-label='Pick the recency colormap'></button>" +
   '<div id=rs-cmap-list hidden></div></div></span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Session colors</b>" +
   '<span class=rs-sub>The palette sessions draw their identity color from — tabs, cards, lanes. Switching recolors every session to the same slot in the new set.</span>' +
-  "<div id=rs-pal><button id=rs-pal-btn type=button title='Pick the session palette'></button>" +
+  "<div id=rs-pal><button id=rs-pal-btn type=button aria-label='Pick the session palette'></button>" +
   '<div id=rs-pal-list hidden></div></div></span></div>' +
   '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
   '<div class=rs-sec>Judges</div>' +

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -936,17 +936,17 @@ function initGear(post) {
     var segs = raSegments(), judgeTot = segs.reduce(function (a, s) { return a + raVal(s); }, 0);
     var maxV = Math.max(sessTot, judgeTot, 1);
     var W = 480, H = 250, top = 24, bot = 30, chartH = H - top - bot, baseY = top + chartH, barW = 92, cx1 = W * 0.30, cx2 = W * 0.70;
-    function rect(x, y, w, h, fill, title) { return '<rect x="' + x + '" y="' + y + '" width="' + w + '" height="' + Math.max(h, 0) + '" fill="' + fill + '" rx="2"><title>' + raEsc(title) + '</title></rect>'; }
+    function rect(x, y, w, h, fill, title) { return '<rect x="' + x + '" y="' + y + '" width="' + w + '" height="' + Math.max(h, 0) + '" style="fill:' + fill + '" rx="2"><title>' + raEsc(title) + '</title></rect>'; }
     var svg = '<svg viewBox="0 0 ' + W + ' ' + H + '" width="100%" preserveAspectRatio="xMidYMid meet">';
-    svg += '<line x1="6" y1="' + baseY + '" x2="' + (W - 6) + '" y2="' + baseY + '" stroke="#3a3a3a"/>';
+    svg += '<line x1="6" y1="' + baseY + '" x2="' + (W - 6) + '" y2="' + baseY + '" style="stroke:var(--hairline, #3a3a3a)"/>';
     var sh = sessTot / maxV * chartH;
-    svg += rect(cx1 - barW / 2, baseY - sh, barW, sh, '#7d8590', 'sessions · ' + fmtTok(sess.in) + ' in / ' + fmtTok(sess.out || 0) + ' out · ' + fmtUsd(sess.cost || 0));
-    svg += '<text x="' + cx1 + '" y="' + (baseY - sh - 6) + '" text-anchor="middle" fill="#ddd" font-size="12">' + raFmt(sessTot) + '</text>';
-    svg += '<text x="' + cx1 + '" y="' + (baseY + 18) + '" text-anchor="middle" fill="#9aa0a6" font-size="12">Sessions</text>';
+    svg += rect(cx1 - barW / 2, baseY - sh, barW, sh, 'var(--text-faint, #7d8590)', 'sessions · ' + fmtTok(sess.in) + ' in / ' + fmtTok(sess.out || 0) + ' out · ' + fmtUsd(sess.cost || 0));
+    svg += '<text x="' + cx1 + '" y="' + (baseY - sh - 6) + '" text-anchor="middle" style="fill:var(--text-bright, #ddd)" font-size="12">' + raFmt(sessTot) + '</text>';
+    svg += '<text x="' + cx1 + '" y="' + (baseY + 18) + '" text-anchor="middle" style="fill:var(--text-muted, #9aa0a6)" font-size="12">Sessions</text>';
     var cum = 0; segs.forEach(function (s) { var st = raVal(s), h = st / maxV * chartH, y = baseY - cum - h; cum += h;
       svg += rect(cx2 - barW / 2, y, barW, h, s.color, s.label + ' · ' + fmtTok(s.in) + ' in / ' + fmtTok(s.out) + ' out · ' + s.calls + ' calls · ' + fmtUsd(s.cost || 0)); });
-    svg += '<text x="' + cx2 + '" y="' + (baseY - cum - 6) + '" text-anchor="middle" fill="#ddd" font-size="12">' + raFmt(judgeTot) + '</text>';
-    svg += '<text x="' + cx2 + '" y="' + (baseY + 18) + '" text-anchor="middle" fill="#9aa0a6" font-size="12">Judges</text>';
+    svg += '<text x="' + cx2 + '" y="' + (baseY - cum - 6) + '" text-anchor="middle" style="fill:var(--text-bright, #ddd)" font-size="12">' + raFmt(judgeTot) + '</text>';
+    svg += '<text x="' + cx2 + '" y="' + (baseY + 18) + '" text-anchor="middle" style="fill:var(--text-muted, #9aa0a6)" font-size="12">Judges</text>';
     svg += '</svg>'; raChart.innerHTML = svg;
     var lg = segs.map(function (s) { return '<span class=ra-li><span class=ra-sw style="background:' + s.color + '"></span>' + raEsc(s.label) + ' <b>' + raFmt(raVal(s)) + '</b></span>'; }).join('');
     raLegend.innerHTML = '<span class=ra-li><span class="ra-sw" style="background:#7d8590"></span>sessions <b>' + raFmt(sessTot) + '</b></span>' + lg;

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -57,7 +57,7 @@ var GEAR_HTML =
   "<button id=rs-login-btn type=button style='cursor:pointer;background:var(--btn-bg, #2a2a2a);color:var(--fg, #ccc);border:1px solid var(--hairline, #3a3a3a);border-radius:5px;padding:3px 10px'>Log in to Claude Code</button>" +
   // rs-note, NOT rs-sub: this is a live inline status ("starting the login flow…"), not the row's
   // description — as an rs-sub it floated a SECOND hover popover under the Account row, stacked on
-  // rs-login-acct's (the user 2026-09-02, "weird double tooltip"; even empty it painted a box)
+  // rs-login-acct's (the user 2026-09-02, who saw two tooltips stacked; even empty it painted a box)
   "<span id=rs-login-state class=rs-note style='margin-left:8px'></span>" +
   '</div></span></div>' +
   '<div class=rs-sec>Sessions</div>' +

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -167,7 +167,7 @@ test("gear.css carries the modal styling for every pane that hosts it", () => {
 
 test("one tooltip per settings row: the Account row's live status is NOT a second rs-sub", () => {
   // the rs-sub CSS floats EVERY rs-sub in a hovered row at the same top:100% box, so a second one
-  // stacks a second bordered popover — the 2026-09-02 "weird double tooltip" (even empty it painted
+  // stacks a second bordered popover — the 2026-09-02 stacked double tooltip (even empty it painted
   // a box). #rs-login-state is a live inline status, not a description: it wears rs-note.
   assert.ok(GEAR.includes("id=rs-login-state class=rs-note"), "the login status line is an inline note");
   const billing = GEAR.slice(GEAR.indexOf("id=rs-billing"), GEAR.indexOf(">Sessions<"));

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -164,3 +164,21 @@ test("gear.css carries the modal styling for every pane that hosts it", () => {
     assert.ok(GEAR_CSS.includes(sel), `gear.css must style ${sel}`);
   assert.ok(KERNEL.includes("/dist/gear.css"), "the kernel feed page must link the extracted stylesheet");
 });
+
+test("one tooltip per settings row: the Account row's live status is NOT a second rs-sub", () => {
+  // the rs-sub CSS floats EVERY rs-sub in a hovered row at the same top:100% box, so a second one
+  // stacks a second bordered popover — the 2026-09-02 "weird double tooltip" (even empty it painted
+  // a box). #rs-login-state is a live inline status, not a description: it wears rs-note.
+  assert.ok(GEAR.includes("id=rs-login-state class=rs-note"), "the login status line is an inline note");
+  const billing = GEAR.slice(GEAR.indexOf("id=rs-billing"), GEAR.indexOf(">Sessions<"));
+  assert.equal((billing.match(/class=rs-sub/g) || []).length, 1, "the Account row keeps ONE description popover");
+  assert.ok(GEAR_CSS.includes("#rsettings .rs-note {") && GEAR_CSS.includes("#rsettings .rs-note:empty { display: none; }"),
+    "rs-note is inline, hidden while it has nothing to say");
+  // native titles never stack on the row popover: the picker buttons speak through aria-label, and
+  // the description stands down while a picker dropdown is open or the 'mixed' mark is hovered
+  assert.doesNotMatch(GEAR, /id=rs-cmap-btn type=button title=/);
+  assert.doesNotMatch(GEAR, /id=rs-pal-btn type=button title=/);
+  assert.ok(GEAR.includes("aria-label='Pick the recency colormap'") && GEAR.includes("aria-label='Pick the session palette'"));
+  assert.ok(GEAR_CSS.includes("#rsettings .rs-row:has(#rs-cmap-list:not([hidden])) .rs-sub"), "open cmap menu owns the row");
+  assert.ok(GEAR_CSS.includes("#rsettings .rs-row:has(.rs-mixed:hover) .rs-sub { display: none; }"), "the mixed mark's title stands alone");
+});

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -22,8 +22,21 @@ test("upsert tells append from fork by transcript OVERLAP, not the first uuid (s
 test("a content refresh appends (preserves scroll); only a fork drops the DOM", () => {
   assert.match(RENDER, /if \(forked\) \{[\s\S]{0,120}?v\.el\.remove\(\)/,
     "the cached DOM is dropped only on a fork, not on every push");
-  assert.match(RENDER, /if \(existed && !forked\) \{\s*appendActive\(\);/,
+  assert.match(RENDER, /if \(existed && !forked && !firstBuild\) \{\s*appendActive\(\);/,
     "a refresh of the active tab appends instead of snapping to the bottom");
+});
+
+test("a placeholder's first content-bearing build LANDS (bottom), it does not append (top)", () => {
+  // A fork's provisional tab and a revive's stub hold zero events; the payload that fills them used
+  // to route down the append path, whose overflow gate read the one-line placeholder as "not at
+  // bottom" and left the whole arriving history at scrollTop 0 — with the never-yank rule then
+  // holding the top forever (the user 2026-09-02: an opened/forked session sat at the top after its
+  // context loaded). First build = prev had NO events and the payload brings some → showActive →
+  // landActive pins the bottom exactly like a brand-new tab.
+  assert.match(RENDER, /const firstBuild = !!\(existed && prev && !prev\.events\.length && msg\.events && msg\.events\.length\);/,
+    "first build = the view's zero-event placeholder filling with its first real events");
+  assert.match(RENDER, /if \(msg\.id === activeId && !\(existed && !forked && !firstBuild\)\) \{/,
+    "the land branch's scroll capture covers the first build too");
 });
 
 test("a rebuild NEVER snaps a scrolled-up reader to the bottom — it captures + restores their anchor", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5373,6 +5373,28 @@ window.addEventListener("keydown", (e) => {
     if (focusComposerOrAsk()) e.preventDefault();   // the picker card if one's up, else the message box
   }
 });
+// SELECT → TYPE → ⌘⏎ (the user 2026-09-02): a transcript selection already seeded the reply chip
+// (selectionchange), so the natural next act is just TYPING — the first printable keystroke drops
+// the cursor into the message box with the chip attached, no mouse round-trip, and ⌘⏎ stages as
+// ever. (Not selection-gated: a printable keystroke nobody claimed means "type" from anywhere —
+// the same two-state default as bare-area Enter above.) Bubble phase on window = every capture
+// handler (shell chords, overlays) and element handler (live-ask card, focused tab, slash menu)
+// has already spoken; we take only keystrokes nobody claimed. NEVER preventDefault: focusing
+// during keydown lets the NATIVE keystroke insert into the newly focused box, so the composer's
+// own input bookkeeping (draft, slash menu) sees ordinary typing.
+window.addEventListener("keydown", (e) => {
+  if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;   // chords are not typing (shift stays: capitals)
+  if (e.isComposing || e.keyCode === 229) return;   // IME mid-composition — a focus steal aborts the composition
+  if (e.key.length !== 1 || e.key === " ") return;  // printable only; Space stays a toggle/scroll key
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!ta || ta.disabled || document.activeElement === ta) return;   // no box / read-only session / already typing (covers key repeat)
+  if (isTypingTarget(e.target) || isTypingTarget(document.activeElement)) return;
+  if (activeId && liveAsks.has(activeId)) return;   // digits belong to the live-ask card's number keys
+  if (ctxMenuEl || document.querySelector(".picker-overlay")) return;   // an open menu / #picker / #confirm owns the keys
+  if (document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse")
+      || document.getElementById("romp-lightbox")) return;   // full-pane surfaces own their keys
+  ta.focus({ preventScroll: true });   // the native keystroke lands in the box; the chip survives (a collapse never clears it)
+});
 // Cmd/Ctrl+O and Cmd/Ctrl+Shift+O — the in-PAGE fallback, from anywhere including the composer, the
 // way Obsidian's quick switcher opens over the editor (the user 2026-08-08). Inside the romp shell
 // this handler STANDS DOWN: the shell owns both combos (palette-main.ts — plain O is the session jump
@@ -11676,7 +11698,7 @@ function upsert(msg: any) {
 function update(msg: any) {
   retryCmtCreates(String(msg.id || ""));   // ditto for the delta path (T106)
   const s = sessions.get(msg.id);
-  if (!s) return;
+  if (!s) { requestFullSession(msg.id); return; }   // a delta with no base is PROOF of desync (see chatTail)
   s.events = msg.events || s.events;
   const before = awaitKey(s.status);
   s.status = msg.status || s.status;
@@ -11715,10 +11737,23 @@ function requestFullSession(id: string): void {
   awaitingFull.add(id);
   vscodeApi?.postMessage({ type: "needFull", id });
 }
+// A reconnect mints a FRESH kernel-side client (its echat starts empty, so full frames are already
+// guaranteed) — but an ask parked against the dead socket would gag the new socket's repair path
+// forever (awaitingFull only clears when the reply lands, and the dead socket's never will).
+window.addEventListener("romp:wsup", () => awaitingFull.clear());
 
 function chatTail(msg: any) {
   const s = sessions.get(msg.id);
-  if (!s) return;                                  // no base yet → ignore; a full session must arrive first
+  if (!s) {
+    // A delta for a session we hold NO base for is PROOF of desync, not noise to ignore: the full
+    // frame was sent while this document had no message listener yet (the pusher fires from the
+    // moment the socket opens; the 1.4MB bundle can still be evaluating), and the kernel's echat
+    // advances on SEND — so deltas are all it will ever volunteer, and the tab sat on the
+    // « opening … » placeholder forever (the user 2026-09-02; a duplicated browser tab won the
+    // race via cached bundles, a reload only sometimes). Ask for the base instead of waiting.
+    requestFullSession(msg.id);
+    return;
+  }
   // msg.from is a GLOBAL transcript index; the resident events are the tail [headFrom, …) → map to local.
   const from = (msg.from | 0) - (s.headFrom || 0);
   // The kernel's coordinate space ends at ITS OWN events — our injected optimistic tail is not in it.
@@ -11875,7 +11910,7 @@ function awaitKey(st: Status | undefined): string {
 
 function statusOnly(msg: any) {
   const s = sessions.get(msg.id);
-  if (!s) return;
+  if (!s) { requestFullSession(msg.id); return; }   // a delta with no base is PROOF of desync (see chatTail)
   const before = awaitKey(s.status);
   s.status = msg.status || s.status;
   renderTabs();                          // status-only push → repaint the chip; order is untouched

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11092,8 +11092,9 @@ function renderComposerFiles(id: string | null): void {
   if (sendBtn) {
     const held = !!id && sendOnShip.has(id);
     sendBtn.classList.toggle("send-held", held);
-    if (held) sendBtn.setAttribute("title", "sends when the upload finishes");
-    else if (sendBtn.getAttribute("title") === "sends when the upload finishes") sendBtn.removeAttribute("title");
+    // through the styled tip, not a native title: the button already wears setTip("Send (Enter)"),
+    // and a native title beside it showed BOTH boxes while a hold was armed (2026-09-02)
+    setTip(sendBtn, held ? "Send (Enter)\nsends when the upload finishes" : "Send (Enter)");
   }
   strip.replaceChildren();
   const paths = (id ? composerFiles.get(id) : undefined) || [];

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5328,7 +5328,7 @@ const NAV_SCROLL_STEP = 60;
 function isTypingTarget(t: EventTarget | null): boolean {
   const elm = t as HTMLElement | null;
   if (!elm || typeof elm.tagName !== "string") return false;
-  return elm.tagName === "TEXTAREA" || elm.tagName === "INPUT" || elm.isContentEditable === true;
+  return elm.tagName === "TEXTAREA" || elm.tagName === "INPUT" || elm.tagName === "SELECT" || elm.isContentEditable === true;   // SELECT: type-ahead in a dropdown is typing too
 }
 window.addEventListener("keydown", (e) => {
   if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
@@ -5393,6 +5393,7 @@ window.addEventListener("keydown", (e) => {
   if (ctxMenuEl || document.querySelector(".picker-overlay")) return;   // an open menu / #picker / #confirm owns the keys
   if (document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse")
       || document.getElementById("romp-lightbox")) return;   // full-pane surfaces own their keys
+  if (document.querySelector("#rsettings:not([hidden]), #ra-back:not([hidden]), #rkeys-back, .meta-menu")) return;   // the pane's own modals + meta menus own their keys (a letter typed there must never land in the draft)
   ta.focus({ preventScroll: true });   // the native keystroke lands in the box; the chip survives (a collapse never clears it)
 });
 // Cmd/Ctrl+O and Cmd/Ctrl+Shift+O — the in-PAGE fallback, from anywhere including the composer, the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10064,6 +10064,13 @@ const MODE_ICONS: Record<string, string> = {
   bypasspermissions: '<path d="M8 2 L13 4 V8 C13 11.4 10.8 13.2 8 14 C5.2 13.2 3 11.4 3 8 V4 Z"/><path d="M3.2 13 L12.8 3"/>',
   dontask: '<path d="M3 3.5 H13 V10 H8.5 L5.5 12.8 V10 H3 Z"/><path d="M3.2 12.6 L12.8 2.6"/>',
 };
+// the modes that REMOVE the gate rather than move it read in a red hue on the yatharth themes
+// (the user 2026-08-31) — CSS-scoped to .chat-theme-yatharth so classic renders untouched
+function riskyMode(mode: string | undefined): boolean {
+  const k = (mode || "").toLowerCase().replace(/[\u2019' -]/g, "");
+  return k === "bypasspermissions" || k === "bypass" || k === "dontask";
+}
+
 function modeIconSvg(mode: string | undefined): string {
   // accepts wire values AND display labels (metaButton receives prettyMode's text)
   const raw = (mode || "default").toLowerCase().replace(/[\u2019' -]/g, "");
@@ -10187,6 +10194,7 @@ function metaButton(kind: MetaKind, text: string, forSid?: string | null): HTMLE
     const ico = el("span", "meta-ico mode-ico");
     ico.innerHTML = modeIconSvg(text);   // refreshed by the sync loop below from st.mode
     btn.appendChild(ico);
+    btn.classList.toggle("mode-risky", riskyMode(text));   // kept live by the sync loop
   }
   const label = el("span", "meta-label");
   label.textContent = text;
@@ -10247,6 +10255,7 @@ function syncMetaControls(meta: HTMLElement, st: Status, forSid?: string | null)
     if (kind === "mode") {
       const ico = b.querySelector(".mode-ico") as HTMLElement | null;
       if (ico) ico.innerHTML = modeIconSvg(st.mode);
+      b.classList.toggle("mode-risky", riskyMode(st.mode));
     }
     // A switching MODEL shows animated dots, not the stale/premature name (the user 2026-07-03): the
     // server drives it (st.modelPending) — event-based, cleared the instant the new model actually lands —
@@ -10313,6 +10322,7 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
     item.tabIndex = 0;
     const rowIco = kind === "mode" ? el("span", "meta-ico mode-ico") : null;
     if (rowIco) rowIco.innerHTML = modeIconSvg(c.value);
+    if (kind === "mode" && riskyMode(c.value)) item.classList.add("mode-risky");
     // model/effort rows wear THEIR OWN rank color (the user 2026-08-31: a picker whose rows are
     // all default-gray codes nothing) — the same /models-fed color+tone the badges use
     if (kind === "model" || kind === "effort") {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -229,7 +229,7 @@ interface TodoTask { id: string; subject: string; activeForm?: string; status: s
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
 type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -4301,7 +4301,7 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   if (s.status.ctx) {
     const cr = el("div", "tab-tip-row tab-tip-ctx");          // extra vertical room — the battery bar is tall
     const ck = el("span", "tab-tip-k"); ck.textContent = "Context"; cr.appendChild(ck);
-    const bar = ctxBar(); setCtxBar(bar, s.status.ctx, s.status.state === "compacting", pickTone(s.status.ctxColor, s.status.ctxTone));
+    const bar = ctxBar(); setCtxBar(bar, s.status.ctx, s.status.state === "compacting", pickTone(s.status.ctxColor, s.status.ctxTone), s.status.ctxOver);
     cr.appendChild(bar); tip.appendChild(cr);
   }
   // ledger rows, LABELLED + aligned with the rows above (the user 2026-06-23 v3): the summary, then Recent.
@@ -10419,7 +10419,7 @@ function ctxBar(): HTMLElement {
   });
   return bar;
 }
-function setCtxBar(bar: HTMLElement, ctxStr: string | undefined, compacting = false, ctxColor?: number[]) {
+function setCtxBar(bar: HTMLElement, ctxStr: string | undefined, compacting = false, ctxColor?: number[], ctxOver = false) {
   // Compacting: hide the fill/% (the number is about to be wrong anyway) and run
   // the scanning bar instead, mirroring the timeline's battery. No ctx% needed.
   bar.classList.toggle("ctx-compacting", compacting);
@@ -10453,8 +10453,13 @@ function setCtxBar(bar: HTMLElement, ctxStr: string | undefined, compacting = fa
   const fillBg = (ctxColor && ctxColor.length === 3) ? `rgb(${ctxColor.join(",")})`
     : ctxFallbackColor(pct);   // theme-aware pair; fills stay un-re-encoded (see tabCtxGauge's note)
   if (fill) { fill.style.width = pct + "%"; fill.style.background = fillBg; }
-  if (txt) txt.textContent = pct + "%";
-  bar.title = `context ${pct}% used — click to /compact`;
+  // ctxOver: the kernel clamps the CLI's "0-100+" percentage at 100 — past it the tokens exceed the
+  // CURRENT model's window (a 1M→200k model switch does this instantly). Say so: a silent 100% right
+  // after picking a smaller model reads as a broken gauge (the user 2026-09-02).
+  if (txt) txt.textContent = ctxOver ? "100%+" : pct + "%";
+  bar.title = ctxOver
+    ? "context exceeds this model's window — the next turn compacts or trims; click to /compact now"
+    : `context ${pct}% used — click to /compact`;
 }
 
 const CHIP_LABEL: Record<ChipState, string> = {
@@ -10631,7 +10636,7 @@ function updateStatusline() {
   syncMetaControls(meta, s.status);
   right.appendChild(meta);
   const bar = ctxBar();
-  setCtxBar(bar, s.status.ctx, s.status.state === "compacting", pickTone(s.status.ctxColor, s.status.ctxTone));
+  setCtxBar(bar, s.status.ctx, s.status.state === "compacting", pickTone(s.status.ctxColor, s.status.ctxTone), s.status.ctxOver);
   right.appendChild(bar);
   // stop/interrupt button — at the FAR RIGHT of the statusline (the user 2026-08-28; it sat
   // beside the state chip on the left before), riding inside the right cluster so a wrapped
@@ -11604,11 +11609,19 @@ function upsert(msg: any) {
   // fork by the ABSENCE of any shared event uuid instead.
   const forked = !!(existed && msg.events && msg.events.length && prev && prev.events.length
                     && !sharesAnyUuid(msg.events, prev.events));
+  // A view that never held an event is a PLACEHOLDER (a fork's provisional tab, a revive's stub):
+  // the payload that fills it is the tab's FIRST content-bearing build, not an append onto a
+  // transcript someone is reading. The append path measured "was the reader at the bottom?"
+  // against a one-line placeholder that cannot overflow, landed the whole arriving history at
+  // scrollTop 0, and the never-yank rule then held the top forever (the user 2026-09-02: an
+  // opened or forked session sat at the top after its context loaded). A first build takes the
+  // showActive branch below, where landActive pins the bottom exactly like a brand-new tab.
+  const firstBuild = !!(existed && prev && !prev.events.length && msg.events && msg.events.length);
   // Preserve the reader's position across ANY active-tab rebuild (fork OR slid tail-window): capture whether
   // they were at the bottom + their anchor turn BEFORE we drop/rebuild the DOM, so a push never SNAPS a
   // scrolled-up reader down (the user 2026-07-06). Only a genuinely-at-bottom reader follows new content.
   let _scrollContent: HTMLElement | null = null, _scrollAnchor: { uuid: string; y: number } | null = null, _wasNear = true;
-  if (msg.id === activeId && !(existed && !forked)) {   // only the rebuild branch (appendActive preserves on its own)
+  if (msg.id === activeId && !(existed && !forked && !firstBuild)) {   // only the rebuild branch (appendActive preserves on its own)
     _scrollContent = document.getElementById("content");
     const _v0 = views.get(msg.id);
     _wasNear = !_scrollContent || !_v0 || !_v0.shown || nearBottom(_scrollContent);
@@ -11626,7 +11639,7 @@ function upsert(msg: any) {
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork
   // lands at the bottom/anchor (showActive). This is what keeps new pushes from snapping to bottom.
   if (msg.id === activeId) {
-    if (existed && !forked) {
+    if (existed && !forked && !firstBuild) {
       appendActive();
     } else {
       showActive();
@@ -12354,7 +12367,7 @@ setInterval(() => {
   const meta = document.getElementById("spinner-meta");
   if (meta) syncMetaControls(meta, s.status);
   const bar = document.getElementById("ctx-bar");
-  if (bar) setCtxBar(bar, s.status.ctx, s.status.state === "compacting", pickTone(s.status.ctxColor, s.status.ctxTone));
+  if (bar) setCtxBar(bar, s.status.ctx, s.status.state === "compacting", pickTone(s.status.ctxColor, s.status.ctxTone), s.status.ctxOver);
 }, 1000);
 
 // the last message we delivered per session — so a Ctrl+C interrupt can put it back

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -59,7 +59,7 @@ test("positions are proportional and pure scrolls do no DOM work", () => {
 
 test("passive chrome in the user's own blue", () => {
   assert.match(CSS, /\.scroll-marks \{ position: fixed; z-index: 3; pointer-events: none; width: 12px; \}/);
-  assert.match(CSS, /background: #2b6cef; opacity: 0\.65;/, "the outgoing-bubble blue, never the romp accent");
+  assert.match(CSS, /background: var\(--you\); opacity: 0\.65;/, "the outgoing-bubble blue, never the romp accent");
 });
 
 test("marks translate EVENT indices to DISPLAY UNITS before asking the frame", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -71,6 +71,17 @@ body.scheme-solarized-dark {
   --check-bg: #1EA1EB;
   --code-fg: #e1c08d;
   --code-bg: rgba(217, 119, 87, 0.10);
+  /* hyperlink ink — ONE token for every rendered link (.md a, .fileview-md a, .tool-file).
+     Dark follows the editor's own link color, as those rules always did; the light block re-inks
+     it (its textLink stand-in #B24A28 sat a hair off --err #B02A1C, so links read as errors —
+     the user 2026-09-02). Mirrored in feed.css (own :root). */
+  --link: var(--vscode-textLink-foreground, #4daafc);
+  /* the hljs syntax palette, as tokens (2026-09-02): dark values are the exact warm-dark set the
+     viewer always had, byte-for-byte; the light block re-inks the same names for the cream ground
+     (as raw hexes the palette was dark-only — pale tan on #F1EAE2). Mirrored in feed.css (own
+     :root) — the viewer mounts in both documents, and file-view.test.ts pins the two identical. */
+  --hl-fg: #d8c6a8; --hl-kw: #c98a6a; --hl-str: #9fb878; --hl-num: #d4a36a;
+  --hl-cmt: #6f6a5f; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;
   --box-bg: rgba(255, 255, 255, 0.03);
   --box-border: var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.12));
   /* the feed's button hairline, MIRRORED byte-equal from feed.css --card-border (T141: the chat's
@@ -193,6 +204,9 @@ body.theme-light {
                             its clay accent (what the timeline's PAL_LIGHT already drew) */
   --code-fg: #8C4A00;
   --code-bg: rgba(180, 83, 9, 0.08);
+  --link: #1D63A8;   /* inked cobalt — clearly clickable, clearly not the error red (5.2:1 on the page) */
+  --hl-fg: #3E3A35; --hl-kw: #A03509; --hl-str: #47720F; --hl-num: #915C0B;
+  --hl-cmt: #6E675C; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
   --err: #B02A1C;
@@ -257,7 +271,7 @@ body.theme-light {
   --vscode-menu-selectionBackground: #F3E0D5;
   --vscode-menu-selectionForeground: #1F1E1D;
   --vscode-scrollbarSlider-background: rgba(90, 84, 74, 0.35);
-  --vscode-textLink-foreground: #B24A28;
+  --vscode-textLink-foreground: #1D63A8;
   --vscode-button-background: #C2410C;
   --vscode-button-foreground: #FFF8F2;
   --vscode-button-hoverBackground: #A93A0B;
@@ -1629,8 +1643,10 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* pending-rewind overlay: turns after an edited message belong to the branch being abandoned — they
    dim until the kernel's rewound payload replaces them (reconcileRewind retires the flag then). */
 .turn.rewound { opacity: 0.35; transition: opacity 0.2s ease; }
-/* white-on-blue legibility for inner markdown */
-.user-bubble a { color: #fff; text-decoration: underline; text-underline-offset: 2px; }
+/* white-on-blue legibility for inner markdown. The bubble ELEMENT also wears .md, and `.md a`
+   ties this selector's specificity later in the sheet — the doubled form outranks it, so bubble
+   links actually stay white instead of link-ink-on-saturated-fill (found 2026-09-02). */
+.user-bubble a, .user-bubble.md a { color: #fff; text-decoration: underline; text-underline-offset: 2px; }
 .user-bubble :not(pre) > code { background: rgba(255, 255, 255, 0.2); color: #fff; }
 /* a slash COMMAND you sent (the user 2026-06-29): the "/cmd" token renders as a monospace KEYWORD chip inside
    the blue bubble — a darkened, outlined pill so it reads as a command, not prose. Args sit after it as text. */
@@ -2087,7 +2103,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* clickable file name → opens the real file in the editor */
 .tool-file {
   font-family: var(--mono); font-size: 0.92em;
-  color: var(--vscode-textLink-foreground, #4daafc); cursor: pointer;
+  color: var(--link); cursor: pointer;
   text-decoration: underline dotted; text-underline-offset: 2px;   /* persistent link affordance */
 }
 .tool-file:hover { text-decoration: underline; }
@@ -2281,7 +2297,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .md li { margin: 0.2em 0; }
 .md strong { color: var(--vscode-foreground, #fff); font-weight: 600; }
 .md em { font-style: italic; }
-.md a { color: var(--vscode-textLink-foreground, #4daafc); text-decoration: none; }
+.md a { color: var(--link); text-decoration: none; }
 .md a:hover { text-decoration: underline; }
 .md blockquote { margin: 0.5em 0; padding-left: 12px; border-left: 2px solid var(--box-border); color: var(--dim); }
 .md hr { border: none; border-top: 1px solid var(--box-border); margin: 1em 0; }
@@ -2324,20 +2340,20 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
 @media (hover: none) { .code-copy { opacity: 0.8; } }   /* touch: no hover state, so keep it visible */
 .md table { border-collapse: collapse; margin: 0.6em 0; }
 .md th, .md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
-.md th { background: rgba(255, 255, 255, 0.03); }
+.md th { background: var(--box-bg); }
 
-/* ---------- syntax highlighting (warm, restrained) ---------- */
-.hljs { color: #d8c6a8; background: transparent; }
-.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type { color: #c98a6a; }
-.hljs-string, .hljs-attr, .hljs-regexp { color: #9fb878; }
-.hljs-number { color: #d4a36a; }
-.hljs-comment, .hljs-quote { color: #6f6a5f; font-style: italic; }
-.hljs-title, .hljs-title.function_, .hljs-section { color: #e1c08d; }
-.hljs-name, .hljs-tag { color: #c98a6a; }
-.hljs-params, .hljs-variable, .hljs-property { color: #d8c6a8; }
-.hljs-meta { color: #9a8f7a; }
-.hljs-attribute { color: #cdaf7e; }
-.hljs-addition { color: #9fb878; }
+/* ---------- syntax highlighting (warm, restrained; values are the --hl-* tokens) ---------- */
+.hljs { color: var(--hl-fg); background: transparent; }
+.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type { color: var(--hl-kw); }
+.hljs-string, .hljs-attr, .hljs-regexp { color: var(--hl-str); }
+.hljs-number { color: var(--hl-num); }
+.hljs-comment, .hljs-quote { color: var(--hl-cmt); font-style: italic; }
+.hljs-title, .hljs-title.function_, .hljs-section { color: var(--hl-title); }
+.hljs-name, .hljs-tag { color: var(--hl-kw); }
+.hljs-params, .hljs-variable, .hljs-property { color: var(--hl-fg); }
+.hljs-meta { color: var(--hl-meta); }
+.hljs-attribute { color: var(--hl-attr); }
+.hljs-addition { color: var(--hl-str); }
 .hljs-deletion { color: var(--err); }
 
 /* scrollbars */
@@ -3216,7 +3232,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 #romp-fileview { position: fixed; inset: 0; z-index: 1200; background: var(--overlay-dim);
   display: flex; align-items: center; justify-content: center; }
 .fileview { width: 95%; height: 95%; display: flex; flex-direction: column; overflow: hidden;
-  background: var(--bg, #1e1e1e); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: var(--radius-modal);
+  background: var(--bg, #1e1e1e); border: 1px solid var(--box-border); border-radius: var(--radius-modal);
   box-shadow: var(--shadow-modal); }
 body.fileview-open { overflow: hidden; }
 .fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
@@ -3256,7 +3272,7 @@ a.fileview-btn[hidden] { display: none; }
   background: var(--bg, #1e1e1e); color: var(--fg);
   font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
   white-space: pre; tab-size: 4; }
-.fileview-editor:focus { box-shadow: inset 0 0 0 1px rgba(156, 210, 255, 0.35); }
+.fileview-editor:focus { box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent); }
 /* the directory half of the title is the click into the file BROWSER (feed pane) — mirrored in
    feed.css so the viewer behaves identically wherever it mounts */
 .fileview-dir-link { cursor: pointer; }
@@ -3285,8 +3301,8 @@ body.filebrowse-open { overflow: hidden; }
 .fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
 .fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;
   font-size: 0.86em; }
-.fb-row:hover, .fb-row.active { background: rgba(255, 255, 255, 0.07); }
-.fb-row.active { outline: 1px solid rgba(156, 210, 255, 0.35); outline-offset: -1px; }
+.fb-row:hover, .fb-row.active { background: var(--menu-hover); }
+.fb-row.active { outline: 1px solid color-mix(in srgb, var(--accent) 35%, transparent); outline-offset: -1px; }
 .fb-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; font-family: var(--mono, ui-monospace, monospace); }
 .fb-dir .fb-name { color: var(--accent); }
@@ -3309,7 +3325,7 @@ body.filebrowse-open { overflow: hidden; }
 .fileview-pre code { background: none; padding: 0; font: inherit; }
 /* a refusal explains itself in place, in the kernel's own words (too large — with the size and the
    cap; not a text file; not found) over the path it was asked for. Never a blank pane. */
-.fileview-err { padding: 18px 14px; font-size: 0.86em; color: #e0a030; }
+.fileview-err { padding: 18px 14px; font-size: 0.86em; color: var(--warn); }
 .fileview-err-hint { margin-top: 6px; color: var(--dim); font-size: 0.92em;
   font-family: var(--mono, ui-monospace, monospace); word-break: break-all; }
 /* the way out of a refusal: when the file exists but cannot render (413/415), the kernel's words are
@@ -3365,7 +3381,7 @@ body.filebrowse-open { overflow: hidden; }
 .fileview-md li { margin: 0.2em 0; }
 .fileview-md strong { color: var(--fg); font-weight: 600; }
 .fileview-md em { font-style: italic; }
-.fileview-md a { color: var(--vscode-textLink-foreground, #4daafc); text-decoration: none; }
+.fileview-md a { color: var(--link); text-decoration: none; }
 .fileview-md a:hover { text-decoration: underline; }
 .fileview-md blockquote { margin: 0.5em 0; padding-left: 12px;
   border-left: 2px solid var(--box-border); color: var(--dim); }
@@ -3386,7 +3402,7 @@ body.filebrowse-open { overflow: hidden; }
 }
 .fileview-md table { border-collapse: collapse; margin: 0.6em 0; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
-.fileview-md th { background: rgba(255, 255, 255, 0.03); }
+.fileview-md th { background: var(--box-bg); }
 .fileview-md img { max-width: 100%; }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
@@ -3409,4 +3425,4 @@ body.filebrowse-open { overflow: hidden; }
 /* the supporting-span highlight (T218): the sentence the summary rests on, painted via the CSS
    Custom Highlight API (no DOM surgery — the turn list re-renders constantly). Accent-tinted like
    the focus family, never a status colour. */
-::highlight(cite-span) { background-color: rgba(156, 210, 255, 0.30); color: #ffffff; }
+::highlight(cite-span) { background-color: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--text-bright); }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1659,8 +1659,9 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .user-bubble a, .user-bubble.md a { color: #fff; text-decoration: underline; text-underline-offset: 2px; }
 /* a quoted passage in YOUR bubble is the ASSISTANT's words (select-to-quote): the prose face
    (mono in light), and a light tint readable on the saturated fill — var(--dim) grey sat at
-   ~2:1 there (the user 2026-08-31, on the light preview) */
-.user-bubble blockquote { color: rgba(255, 255, 255, 0.88); border-left-color: rgba(255, 255, 255, 0.40);
+   ~2:1 there (the user 2026-08-31, on the light preview). Doubled selector for the same reason
+   as the links above: `.md blockquote` ties it later in the sheet and was silently winning. */
+.user-bubble blockquote, .user-bubble.md blockquote { color: rgba(255, 255, 255, 0.88); border-left-color: rgba(255, 255, 255, 0.40);
   font-family: var(--font-prose); }
 .user-bubble :not(pre) > code { background: rgba(255, 255, 255, 0.2); color: #fff; }
 /* a slash COMMAND you sent (the user 2026-06-29): the "/cmd" token renders as a monospace KEYWORD chip inside

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -152,6 +152,10 @@ body.scheme-solarized-dark {
      light text on dark; a LIGHT glow under the dark text on light — a dark halo around dark
      glyphs read as blur (the user 2026-08-31, off the live preview) */
   --text-halo: rgba(0, 0, 0, 0.75);
+  /* YOUR voice (the outgoing bubble, the rail's user dot, the comment marker): royal blue on
+     dark; the light theme wears a warm sienna from the page's own family instead (the user
+     2026-08-31: 'in family of the background colour, but darker/saturated' — not blue) */
+  --you: #2b6cef;
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
@@ -248,6 +252,7 @@ body.theme-light {
   --kbd-border: #D3C7B6;
   --overlay-05: rgba(0, 0, 0, 0.045);
   --overlay-10: rgba(0, 0, 0, 0.08);
+  --you: #A55A2A;   /* warm sienna — white text clears 5:1 */
   --text-halo: rgba(252, 249, 244, 0.85);
   --mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   --sans: "Space Grotesk", "Inter", var(--vscode-chat-font-family, var(--vscode-font-family, system-ui, -apple-system, "Segoe UI", sans-serif));
@@ -1253,6 +1258,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   padding: 4px; box-shadow: var(--shadow-menu);
   font-family: var(--sans); font-size: 0.92em;
 }
+/* the gate-REMOVING modes (Bypass, Don't ask) read in the err red on the yatharth themes — the
+   glyph rides currentColor. Scoped to the yatharth class so classic renders untouched; ONE rule,
+   the sanctioned theme-scoped exception (the user 2026-08-31). */
+body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-item.mode-risky { color: var(--err); }
+
 /* the permission glyph beside its text (mode badge + mode picker rows, 2026-08-28) */
 .meta-ico { display: inline-flex; align-items: center; margin-right: 4px; vertical-align: -2px; }
 .meta-ico svg { display: block; }
@@ -1502,7 +1512,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    The blue is the OUTGOING-BUBBLE blue (#2b6cef, "yours"), deliberately not the romp accent. */
 .scroll-marks { position: fixed; z-index: 3; pointer-events: none; width: 12px; }
 .scroll-marks .scroll-mark { position: absolute; right: 1px; width: 8px; height: 2px;
-  border-radius: 1px; background: #2b6cef; opacity: 0.65;
+  border-radius: 1px; background: var(--you); opacity: 0.65;
   transition: top 180ms ease; }   /* history streaming in rescales the map — carried, not teleported */
 @media (prefers-reduced-motion: reduce) { .scroll-marks .scroll-mark { transition: none; } }
 .rail-day {
@@ -1552,7 +1562,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .dot.ring { background: var(--fg); border: none; }
 /* your prompt — the SAME royal/indigo blue as your message bubble (#2b6cef), so the dot matches your
    chat box (the user 2026-06-15). Distinct from the cyan ✓ success disc (--check-bg #1EA1EB). */
-.dot.user { background: #2b6cef; border: none; }
+.dot.user { background: var(--you); border: none; }
 /* a TAGGED (machine-sent under a label) prompt: the gray of its tag-bubble family, so the rail agrees
    with the bubble — it used to wear the blue "you typed this" dot (the identity-channel gap, 2026-08-18) */
 .dot.tag { background: #8a8f98; border: none; }
@@ -1591,7 +1601,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .turn-user:not(.injected) { display: flex; flex-direction: column; align-items: flex-end; }
 .user-bubble {
   max-width: 72%;
-  background: #2b6cef; border: 1px solid #2b6cef;
+  background: var(--you); border: 1px solid var(--you);
   border-radius: 14px; padding: 7px 12px; color: #ffffff;
   display: flow-root;   /* contain inner floats (e.g. image captions) */
 }
@@ -1647,6 +1657,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    ties this selector's specificity later in the sheet — the doubled form outranks it, so bubble
    links actually stay white instead of link-ink-on-saturated-fill (found 2026-09-02). */
 .user-bubble a, .user-bubble.md a { color: #fff; text-decoration: underline; text-underline-offset: 2px; }
+/* a quoted passage in YOUR bubble is the ASSISTANT's words (select-to-quote): the prose face
+   (mono in light), and a light tint readable on the saturated fill — var(--dim) grey sat at
+   ~2:1 there (the user 2026-08-31, on the light preview) */
+.user-bubble blockquote { color: rgba(255, 255, 255, 0.88); border-left-color: rgba(255, 255, 255, 0.40);
+  font-family: var(--font-prose); }
 .user-bubble :not(pre) > code { background: rgba(255, 255, 255, 0.2); color: #fff; }
 /* a slash COMMAND you sent (the user 2026-06-29): the "/cmd" token renders as a monospace KEYWORD chip inside
    the blue bubble — a darkened, outlined pill so it reads as a command, not prose. Args sit after it as text. */
@@ -1668,8 +1683,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* The chip's ink is the OUTGOING-BUBBLE blue on the chat's own ground (the user 2026-08-14: the --code-bg
    terracotta tint read as a stray red here) — the same #2b6cef as .user-bubble, so the gesture still reads
    as "yours" without the said-thing bubble. */
-.user-bubble.cmd-row .slash-cmd-chip { background: var(--bg); color: #2b6cef;
-  border-color: #2b6cef; }
+.user-bubble.cmd-row .slash-cmd-chip { background: var(--bg); color: var(--you);
+  border-color: var(--you); }
 .user-bubble.cmd-row .slash-cmd-args { color: var(--dim); }
 .user-bubble.cmd-row .nudge-gist, .user-bubble.cmd-row .nudge-caret { color: var(--dim); }
 .user-bubble.cmd-row .nudge-gist { margin-left: 8px; }
@@ -1682,7 +1697,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    spot and width cap as the bubbles it sits among; the ↩ Follow-up header itself is unchanged. */
 .user-bubble.cont-row {
   max-width: 72%;
-  background: rgba(43, 108, 239, 0.16); border: 1px solid rgba(43, 108, 239, 0.42);
+  background: color-mix(in srgb, var(--you) 16%, transparent); border: 1px solid color-mix(in srgb, var(--you) 42%, transparent);
   border-radius: 14px; padding: 7px 12px;
 }
 .user-bubble.cont-row .followup-tag { max-width: none; }
@@ -1733,7 +1748,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .queued-head .queued-icon { color: var(--accent); display: flex; }   /* wireframe hourglass in the accent blue */
 .queued-bubble {
   max-width: 72%; overflow-wrap: anywhere; display: flow-root;
-  background: rgba(43, 108, 239, 0.10); border: 1px dashed rgba(43, 108, 239, 0.65);
+  background: color-mix(in srgb, var(--you) 10%, transparent); border: 1px dashed color-mix(in srgb, var(--you) 65%, transparent);
   border-radius: 14px; padding: 7px 12px; color: var(--fg); opacity: 0.85;
 }
 /* A CANCELABLE queued bubble carries an explicit ✕ (the user 2026-07-08 — the old whole-bubble click was
@@ -1754,7 +1769,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    (the user 2026-07-29). Dashed like the queued family (a send that never became a turn), red-edged like
    every "something went wrong" cue. The note + actions sit under the right-aligned bubble and are always
    visible — a loss notice is not a hover secret. Button sizes wear .msg-edit's clothes (one size). */
-.user-bubble.undelivered-bubble { background: rgba(43, 108, 239, 0.10); }
+.user-bubble.undelivered-bubble { background: color-mix(in srgb, var(--you) 10%, transparent); }
 .user-bubble.undelivered-bubble, .romp-bubble.undelivered-bubble {
   border: 1px dashed rgba(244, 135, 113, 0.65); opacity: 0.85;
 }
@@ -1882,9 +1897,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .turn-ask.answered { display: flex; flex-direction: column; align-items: flex-end; }
 .ask-card.ask-answered {
   max-width: 88%;
-  background: rgba(43, 108, 239, 0.10);
-  border-color: #2b6cef;
-  box-shadow: inset 3px 0 0 #2b6cef;
+  background: color-mix(in srgb, var(--you) 10%, transparent);
+  border-color: var(--you);
+  box-shadow: inset 3px 0 0 var(--you);
 }
 /* the "↳ You answered Claude's question" marker line atop the box */
 .ask-answered-tag { font-size: 0.72em; letter-spacing: 0.04em; font-weight: 700; color: #6da0ff; margin-bottom: 6px; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -154,7 +154,7 @@ body.scheme-solarized-dark {
   --text-halo: rgba(0, 0, 0, 0.75);
   /* YOUR voice (the outgoing bubble, the rail's user dot, the comment marker): royal blue on
      dark; the light theme wears a warm sienna from the page's own family instead (the user
-     2026-08-31: 'in family of the background colour, but darker/saturated' — not blue) */
+     2026-08-31, who wanted a darker, more saturated color from the page's own family, not blue) */
   --you: #2b6cef;
   /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
@@ -2540,7 +2540,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* folder completions: Tab walks into one, so a path is assembled without a modal or a native dialog */
 .picker-dir-menu {
   /* a completion LIST, not a table: capped to the one-column dropdown measure instead of the full
-     900px picker (the user 2026-09-02, "ridiculously large on desktop"). calc(100% - 28px) is
+     900px picker (the user 2026-09-02, who found it far too large on desktop). calc(100% - 28px) is
      byte-identical to the old left+right-14px geometry on any picker ≤548px — a phone keeps
      today's layout exactly; the dropdown wears the shared menu vocabulary while here. */
   position: absolute; left: 14px; width: min(520px, calc(100% - 28px)); top: calc(100% - 4px); z-index: 6;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2539,10 +2539,14 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-dir-hint.bad { color: #e5484d; }
 /* folder completions: Tab walks into one, so a path is assembled without a modal or a native dialog */
 .picker-dir-menu {
-  position: absolute; left: 14px; right: 14px; top: calc(100% - 4px); z-index: 6;
-  max-height: 216px; overflow-y: auto;
+  /* a completion LIST, not a table: capped to the one-column dropdown measure instead of the full
+     900px picker (the user 2026-09-02, "ridiculously large on desktop"). calc(100% - 28px) is
+     byte-identical to the old left+right-14px geometry on any picker ≤548px — a phone keeps
+     today's layout exactly; the dropdown wears the shared menu vocabulary while here. */
+  position: absolute; left: 14px; width: min(520px, calc(100% - 28px)); top: calc(100% - 4px); z-index: 6;
+  max-height: min(216px, 40vh); overflow-y: auto;
   background: var(--vscode-editorWidget-background, #252526);
-  border: 1px solid var(--box-border); border-radius: 6px; box-shadow: 0 8px 24px #000000aa;
+  border: 1px solid var(--box-border); border-radius: var(--radius-menu); box-shadow: var(--shadow-menu);
 }
 .picker-dir-row {
   padding: 4px 10px; cursor: pointer;
@@ -3314,7 +3318,10 @@ body.filebrowse-open { overflow: hidden; }
 .fb-crumb:hover { color: var(--accent); text-decoration: underline; }
 .fb-crumb:last-child { color: var(--fg); }
 .fb-crumb-sep { margin: 0 3px; opacity: 0.6; }
-.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
+/* the overlay still takes the whole pane (the user 2026-08-24 ruling) — but the LISTING reads at a
+   centered 720px measure on a wide pane (the user 2026-09-02: full-width rows put a file's size
+   ~800px from its name); 100% wins on narrow panes/phones, pixel-identical to before */
+.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; width: min(720px, 100%); margin-inline: auto; }
 .fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;
   font-size: 0.86em; }
 .fb-row:hover, .fb-row.active { background: var(--menu-hover); }

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -63,6 +63,15 @@ const PAIRS: Array<[string, string, number]> = [
   ["--st-working-fg", "--st-working-bg", 3],
   ["--st-ready-fg", "--st-ready-bg", 3],
   ["--st-blocked-fg", "--st-blocked-bg", 3],
+  ["--link", "--bg", 4.5],          // hyperlink ink (2026-09-02: the light theme's first link ink sat on --err)
+  ["--hl-fg", "--bg", 4.5],         // the hljs syntax palette (tokenized 2026-09-02; was dark-only raw hex)
+  ["--hl-kw", "--bg", 4.5],
+  ["--hl-str", "--bg", 4.5],
+  ["--hl-num", "--bg", 4.5],
+  ["--hl-cmt", "--bg", 3],          // comments are deliberately quiet — the dark set sits just above 3
+  ["--hl-title", "--bg", 4.5],
+  ["--hl-meta", "--bg", 4.5],
+  ["--hl-attr", "--bg", 4.5],
 ];
 
 for (const sheet of ["styles.css", "feed.css"]) {
@@ -95,7 +104,7 @@ for (const sheet of ["styles.css", "feed.css"]) {
       }
       // a skip must be loud (PR #763 item 6): pin how many pairs actually ran per sheet/theme —
       // grow these numbers when PAIRS grows, never let them silently shrink
-      const expected = sheet === "styles.css" ? PAIRS.length : 10;   // feed's :root holds a deliberate subset
+      const expected = sheet === "styles.css" ? PAIRS.length : 19;   // feed's :root holds a deliberate subset
       assert.ok(evaluated >= expected,
         `${sheet} ${name}: only ${evaluated}/${expected} contrast pairs evaluated — silent skip`);
     }

--- a/ui/webview/tip.ts
+++ b/ui/webview/tip.ts
@@ -98,6 +98,9 @@ function wireDismiss(): void {
 export function wireTip(anchor: HTMLElement, render: (el: HTMLElement) => void, opts?: TipOpts): void {
   wireDismiss();
   const a = anchor as any;
+  // a styled tip REPLACES the native one — never both. Stripped here (not just in setTip) so every
+  // rich tip gets it, and on every re-wire, since surfaces re-title anchors on each push (2026-09-02).
+  anchor.removeAttribute("title");
   a._rompTipRender = render; a._rompTipOpts = opts;
   if (a._rompTipWired) return;
   a._rompTipWired = true;

--- a/vscode-extension/src/context-colormap.test.ts
+++ b/vscode-extension/src/context-colormap.test.ts
@@ -12,13 +12,13 @@ const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timelin
 
 test("the chat battery applies the server ctxColor, falling back to the traffic-light", () => {
   assert.match(RENDER, /ctxColor\?: number\[\];/);   // on the Status interface
-  assert.match(RENDER, /function setCtxBar\(bar: HTMLElement, ctxStr: string \| undefined, compacting = false, ctxColor\?: number\[\]\)/);
+  assert.match(RENDER, /function setCtxBar\(bar: HTMLElement, ctxStr: string \| undefined, compacting = false, ctxColor\?: number\[\], ctxOver = false\)/);
   assert.match(RENDER, /\(ctxColor && ctxColor\.length === 3\) \? `rgb\(\$\{ctxColor\.join\(","\)\}\)`/);   // the fill wears the tone as-is (readableRgb is for TEXT — 2026-08-31)
   assert.match(RENDER, /: ctxFallbackColor\(pct\)/);  // fallback intact, via the ONE shared pair (ctx-color.ts)
 });
 
 test("every setCtxBar caller threads s.status.ctxColor (statusline, tick, tab tooltip)", () => {
-  const calls = RENDER.match(/setCtxBar\(bar, s\.status\.ctx, s\.status\.state === "compacting", pickTone\(s\.status\.ctxColor, s\.status\.ctxTone\)\)/g) || [];   // dual palette (PR #763): every caller picks by theme
+  const calls = RENDER.match(/setCtxBar\(bar, s\.status\.ctx, s\.status\.state === "compacting", pickTone\(s\.status\.ctxColor, s\.status\.ctxTone\), s\.status\.ctxOver\)/g) || [];   // dual palette (PR #763): every caller picks by theme; ctxOver = the clamped 100 is really 100+ (2026-09-02)
   assert.equal(calls.length, 3, "all three callers pass the color through");
 });
 


### PR DESCRIPTION
Seven fixes off the live yatharth-light board, plus a recovery: the "round two" commit (your voice goes sienna, quotes read mono, risky modes red, the gear's last dark corners) was committed sixteen minutes **after** PR #763 auto-merged and died with the branch — it survived only in the reflog. It is cherry-picked here, reconciled with main's newer T226 menu tokens, and its quote-tint rule — which a specificity tie had silently disabled — actually works now.

## Light-theme fixes
- **Links**: one `--link` token in both sheets. The light stand-in was `#B24A28` — a hair off `--err #B02A1C`, so every rendered link read as an error. Now an inked cobalt `#1D63A8` (5.2:1 on the page); dark unchanged (follows the editor's link color). Bubble links stay white — `.md a` was outranking `.user-bubble a` by source order.
- **File viewer / editor**: the hljs palette is `--hl-*` tokens (dark byte-identical, light re-inked for cream — the old raw palette was pale tan on `#F1EAE2`); the CodeMirror theme builds per mount reading the live body class (`{ dark: true }` was frozen at module load — the near-black search panel), chrome on shared tokens; viewer/browser raws (modal edge, row hover, focus ring, cite highlight, `th` washes) resolve through tokens / `color-mix` of the accent.
- **The master bell**: the light rail recolor outspecified the bare `.on` rules — on/off rendered pixel-identical (the network glyph's connected cue died with it). The light block restates `.on`, and OFF now reads as a slashed bell, the app's one bell-off idiom.
- **Mobile session chip** (`#mcur`/`#madd`): joins the token migration (`--btn-bg`/`--hairline`, old literals as fallbacks, light text overrides) — it sat as a raw `#2a2a2a` slab on the light chat page.

## Cross-theme fixes
- **Transcript opens at the top** (open/fork): a provisional/revive tab holds zero events, so its first real payload routed down the APPEND path, measured "at bottom?" against a one-line placeholder, landed the history at `scrollTop 0`, and the never-yank rule held it there. A first content-bearing build now lands like a brand-new tab (bottom).
- **Context battery reads 100% after a model switch**: the CLI's percentage is documented "0–100+" — a 1M→200k switch legitimately overflows and the kernel clamp presented a silent full battery. `ctxOver` now rides snapshot → merge → chat status, and the battery says **100%+**, "over this model's window". The in-flight refresh guard also queues one rerun instead of dropping a switch-time ask.
- **Mobile keyboard scrolls the page away**: `interactive-widget=resizes-content` on the shell viewport (layout shrinks instead of panning; Android Chrome), plus `fit()` undoing the stray page offset iOS still forces. The composer stays visible above the keyboard.

## Guardrails
Key-parity + WCAG contrast pairs now cover `--link` and all eight `--hl-*` tokens in both themes; the hljs pin moved to the tokenized form (dark hexes still pinned verbatim in `:root`); css-vocab pins the doubled bubble-override selectors; new pinned tests for the first-build scroll land, the bell's light on-state + slash, the chip tokens, the viewport meta + scroll reset, `ctxOver` end-to-end, and the queued context refresh.

Verified: typecheck, 2676 webview tests, full pytest (6542), build; both-theme fixture screenshots for links/hljs/bubbles/browser/queued/quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)