### PR TITLE
Three queue-delivery fixes: a recovered send reaches the live queue, the rename ping's gate is atomic, and its feed-hold counts as a hold

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2017,8 +2017,13 @@ class SdkSession:
           after our receive loop was cancelled — repeats a kickoff message, which beats silently losing
           it.)
         - A RESUMABLE conversation: the atom may genuinely have landed, so re-feeding risks a real
-          duplicate. Surface the loss instead: the drop-mark flips the echo to "never delivered" NOW,
-          rather than hours later at the next thread spawn."""
+          duplicate. Surface the loss instead, FLAG-ONLY (refeed=False, 2026-08-26): the drop-mark flips
+          the echo to "never delivered" NOW, rather than hours later at the next thread spawn.
+          _mark_dropped_echoes' redeliver arm must not run here: its _text_landed scan is a bounded
+          transcript-tail read whose miss would land the message TWICE in the resumed conversation, the
+          exact duplicate this branch is documented to refuse. The re-feed lives only where the
+          conversation is NOT resumable — the re-head above, and the boot/dead-spawn callers
+          (_reseed_echoes, _run), where no client survives to have landed it."""
         if not self.inflight:
             return
         stranded = list(self._inflight_texts)      # fed to the abandoned client, never resulted
@@ -2035,7 +2040,7 @@ class SdkSession:
                 self._pending[0:0] = stranded
             self._persist_queue()                  # the fresh inputs() drains _pending on its first pass
         elif stranded:
-            self.backend._mark_dropped_echoes(self.sid, self.pending())
+            self.backend._mark_dropped_echoes(self.sid, self.pending(), refeed=False)
         self.backend._poke()
 
     # ---- async internals (run inside the quarantined loop) ----
@@ -5323,7 +5328,7 @@ class SdkBackend:
             if self._live.get(reg["sid"]):
                 self._mark_dropped_echoes(reg["sid"], reg.get("queue") or [])
 
-    def _mark_dropped_echoes(self, sid: str, queued_texts) -> None:
+    def _mark_dropped_echoes(self, sid: str, queued_texts, refeed: bool = True) -> None:
         """A fresh CLI is spawning for this sid, or the kernel just booted: whatever process held any
         earlier send is gone. An input echo whose text is neither in the surviving queue (about to be
         delivered to the new CLI) nor landed in the transcript has no holder left — its send is provably
@@ -5333,7 +5338,14 @@ class SdkBackend:
         history). Event-based — keyed on the spawn/boot that orphaned the send, never on age — and
         self-correcting: an echo whose text actually LANDED still prunes by text on the next build, so a
         premature flag can never stick to a delivered message. The flag rides the registry mirror
-        (_persist_echoes), so it survives further restarts."""
+        (_persist_echoes), so it survives further restarts.
+
+        `refeed=False` (2026-08-26, honoring _reconcile_stranded's documented policy): the RESUMABLE-
+        reconnect caller takes the flag path ONLY — the redeliver arm's _text_landed scan is a bounded
+        tail read whose miss would land the message a second time in a conversation that genuinely
+        kept the first, exactly the duplicate that branch refuses by design. The loss still surfaces in
+        full (the dropped flag); only the queue re-add is withheld. Boot and dead-spawn callers keep the
+        default: no client survived there to have landed anything."""
         d = self._live.get(sid)
         if not d:
             return
@@ -5348,26 +5360,54 @@ class SdkBackend:
         # prompt queued at 11:20 was silently discarded by the 11:25 restart). A HUMAN send whose
         # loss is proven — and whose text a direct transcript scan confirms never landed as a user
         # record (the flag path self-corrects on a wrong guess; a re-delivery would DUPLICATE, so it
-        # verifies first) — goes back into the persisted queue in send order: the next spawn feeds
-        # it to the fresh CLI exactly like the surviving queue, recreating the pre-restart state.
+        # verifies first) — goes back into the queue in send order, exactly like the surviving
+        # queue, recreating the pre-restart state: the LIVE session's _pending when one is running
+        # (its mirror rewrites reg['queue'] on every mutation, so only _pending sticks), else the
+        # persisted reg queue the next spawn's seed reads.
         # romp-authored echoes (nudges) keep the flag path: re-delivering one could double-nudge,
-        # and its content is regenerable machinery, not the user's words.
+        # and its content is regenerable machinery, not the user's words. A refeed=False caller
+        # (the resumable reconnect — docstring above) keeps EVERY echo on the flag path.
         redeliver = []
-        for a in sorted(newly, key=lambda x: x.get("t") or 0):
-            if a.get("author") == "human" and not self._text_landed(sid, a["_echo_text"]):
-                redeliver.append(a)
+        if refeed:
+            for a in sorted(newly, key=lambda x: x.get("t") or 0):
+                if a.get("author") == "human" and not self._text_landed(sid, a["_echo_text"]):
+                    redeliver.append(a)
         if redeliver:
-            with self._reg_lock:
-                reg = read_reg(self.state_dir, sid)
-                if reg is not None:
-                    have = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
-                    add = [a["_echo_text"] for a in redeliver if a["_echo_text"] not in have]
-                    if add:
-                        reg["queue"] = have + add          # behind the surviving queue: original send order
-                        write_reg(self.state_dir, sid, reg)
-                        for a in redeliver:
-                            self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
-                                      % (sid[:8], a["_echo_text"]))
+            # The LIVE-session caller (a fresh spawn's _run) must deliver through the session's
+            # own queue: there the in-memory _pending is authoritative and its very next
+            # _persist_queue snapshot rewrites reg['queue'] — a reg-only write sat in limbo (echo
+            # unmarked, nothing fed) until a future kernel boot re-read the reg (found 2026-08-26).
+            # The boot caller (_reseed_echoes) runs before any session spawns, so the reg IS the
+            # queue there.
+            sess_map = getattr(self, "sessions", None)   # getattr: bound-method test doubles skip __init__
+            s = None
+            if sess_map is not None:
+                with self._lock:
+                    s = sess_map.get(sid)
+            if s is not None:
+                have = set(s.pending())
+                for a in redeliver:                        # already in send order (sorted above)
+                    if a["_echo_text"] in have:
+                        continue                           # already back in the queue — never duplicate
+                    if _is_compact_cmd(a["_echo_text"]):
+                        s._compacting = True               # same enqueue-time semantics as send()
+                    if _is_clear_cmd(a["_echo_text"]):
+                        s._clearing = True
+                    s.enqueue(a["_echo_text"])
+                    self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
+                              % (sid[:8], a["_echo_text"]))
+            else:
+                with self._reg_lock:
+                    reg = read_reg(self.state_dir, sid)
+                    if reg is not None:
+                        have = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+                        add = [a["_echo_text"] for a in redeliver if a["_echo_text"] not in have]
+                        if add:
+                            reg["queue"] = have + add      # behind the surviving queue: original send order
+                            write_reg(self.state_dir, sid, reg)
+                            for a in redeliver:
+                                self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
+                                          % (sid[:8], a["_echo_text"]))
         rekeyed = {a["_echo_text"] for a in redeliver}
         for a in newly:
             if a["_echo_text"] in rekeyed:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5249,7 +5249,8 @@ class SdkBackend:
         """Can a ✕ on this session's queued bubble still win? False while a turn is running UN-HELD:
         there the input generator forwards a queued send to the CLI within milliseconds, and once it's
         inside the CLI no recall exists — so offering a cancel would be a lie that ends in "too late".
-        True when the queue is genuinely romp-held — the interrupt hold, the rewind hold — or when no
+        True when the queue is genuinely romp-held — the interrupt hold, the rewind hold, the rename
+        ping's feed-hold (while the ping's turn is in flight the drain releases nothing) — or when no
         turn is in flight (idle/connecting: entries sit in _pending until the client drains them).
         The kernel reads this to decide whether the queued bubble gets its ✕ at all; the loud
         unqueue-miss toast covers the races this gate can't (a click on a just-stale push)."""
@@ -5260,7 +5261,9 @@ class SdkBackend:
         with s._lock:
             if s.inflight <= 0:
                 return True
-            return bool(s._interrupted or (s._rewind_to and not getattr(s, "_rewind_armed", False)))
+            return bool(s._interrupted
+                        or getattr(s, "_ping_feeding", False)   # getattr: test doubles skip __init__
+                        or (s._rewind_to and not getattr(s, "_rewind_armed", False)))
 
     def send(self, sid: str, text: str) -> bool:
         s = self._ensure(sid)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1848,6 +1848,23 @@ class SdkSession:
         if loop is not None and wake is not None:
             loop.call_soon_threadsafe(wake.set)
 
+    def enqueue_if_empty(self, text: str) -> bool:
+        """Enqueue `text` only when NOTHING is queued — the emptiness check and the append share
+        ONE lock hold. The rename ping's gate (found 2026-08-26): with the check and the enqueue
+        in separate holds, a send racing the gap between them queued AHEAD of the ping, and the
+        CLI's pre-turn batching folded the user's words into the ping's machine record — the
+        exact 2026-08-25 fold the empty-queue gate exists to prevent. Returns whether the text
+        was queued; False leaves the queue untouched."""
+        with self._lock:
+            if self._pending:
+                return False
+            self._pending.append(text)
+            loop, wake = self.loop, self._input_wake
+        self._persist_queue()
+        if loop is not None and wake is not None:
+            loop.call_soon_threadsafe(wake.set)
+        return True
+
     def pending(self) -> list[str]:
         """The queued user turns not yet started (oldest first); thread-safe. The kernel
         renders these as the chat's 'queued' indicator for this SDK session."""
@@ -6582,11 +6599,15 @@ class SdkBackend:
         note = reg.get("renameNote")
         if not note:
             return False
-        with s._lock:
-            if s._pending:
-                return False               # a queued turn would share the pre-turn window — hold the note
+        # ONE lock hold for the emptiness check AND the enqueue (enqueue_if_empty, found
+        # 2026-08-26): checking under the lock, then enqueueing after the reg write, left a
+        # window where a racing send queued AHEAD of the ping — folding the user's words into
+        # its pre-turn record, the very fold this gate guards. The note is spent only AFTER the
+        # ping is provably queued; a kernel death between the two re-pings at a later settle
+        # (a repeat of a true fact) instead of losing the note.
+        if not s.enqueue_if_empty("<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % note):
+            return False                   # a queued turn would share the pre-turn window — hold the note
         self._update_reg(s.sid, renameNote=None)
-        s.enqueue("<!-- romp-injected --><!-- romp-system -->" + RENAME_NUDGE % note)
         return True
 
     def _update_reg(self, sid: str, **fields):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2473,6 +2473,18 @@ class PendingQueue(unittest.TestCase):
         self.assertFalse(self.be.queue_recallable("qr1"), "armed rewind releases the hold")
         self.assertTrue(self.be.queue_recallable("no-such-sid"), "unknown session fails toward the ✕")
 
+    def test_queue_recallable_during_the_ping_feed_hold(self):
+        # the rename ping's feed-hold (2026-08-25) is a romp-side hold exactly like the interrupt
+        # and rewind ones: while the ping's turn is in flight the drain releases nothing, so a
+        # recall can still win — withholding the ✕ there denies a cancel that would succeed
+        # (found 2026-08-26).
+        s = self._sess("qr2")
+        s.inflight = 1
+        s._ping_feeding = True
+        self.assertTrue(self.be.queue_recallable("qr2"), "ping feed-hold → the queue is romp-held")
+        s._ping_feeding = False
+        self.assertFalse(self.be.queue_recallable("qr2"), "hold cleared → forwards instantly again")
+
 
 @unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")
 class PendingQueueLoop(unittest.TestCase):

--- a/tests/test_sdk_echo_durability.py
+++ b/tests/test_sdk_echo_durability.py
@@ -252,5 +252,144 @@ class DroppedSendsAnnounceThemselves(unittest.TestCase):
         self.assertIn(k, be._live[SID])
 
 
+class RedeliveryFeedsTheAuthoritativeQueue(unittest.TestCase):
+    """The redeliver arm of _mark_dropped_echoes (2026-08-23: a proven-lost HUMAN send goes back
+    into the queue instead of just flagging) must write the queue that is AUTHORITATIVE for its
+    caller (found 2026-08-26): on the LIVE-session caller (a fresh spawn's _run; the resumable
+    reconnect is flag-only — ReconnectStrandIsFlagOnly below) the in-memory _pending is
+    authoritative — a reg-only write is clobbered by the very next _persist_queue snapshot,
+    leaving the recovered send in limbo until a future kernel boot. SYNTHETIC fixtures only."""
+
+    def setUp(self):
+        self.state = tempfile.mkdtemp()
+        # an EMPTY reg listing, not a MISSING one: list_regs treats an absent sdk/ dir as a scan
+        # fault and serves every cached row — earlier tests' regs would reseed into this boot
+        os.makedirs(os.path.join(self.state, "sdk"))
+        # a real (empty) transcript, so _text_landed answers False (readable, nothing landed)
+        # and the redeliver arm actually runs — unreadable fails safe toward the flag path
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.state, "claude")
+        self.cwd = os.path.join(self.state, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        open(tp, "w").close()
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None)
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def _reg(self, **extra):
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits",
+               "alive": True, "cwd": self.cwd, "lastSid": SID}
+        reg.update(extra)
+        sb.write_reg(self.be.state_dir, SID, reg)
+        return reg
+
+    def _sess(self, reg):
+        s = sb.SdkSession(self.be, dict(reg))
+        self.be.sessions[SID] = s          # register WITHOUT starting the thread (no loop)
+        return s
+
+    def _stash_echo(self, text, t=100):
+        e = {"type": "user", "uuid": "echo:" + text[:10], "session_id": SID, "t": t,
+             "parentUuid": None, "author": "human", "_echo_text": text,
+             "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+        self.be._live.setdefault(SID, {})[e["uuid"]] = e
+        return e
+
+    def _queue(self):
+        return (sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or []
+
+    def test_live_session_redelivery_reaches_pending_and_survives_the_next_persist(self):
+        reg = self._reg(queue=[])
+        s = self._sess(reg)
+        e = self._stash_echo("typed while the old client was dying", t=300)
+        self.be._mark_dropped_echoes(SID, s.pending())     # the fresh-spawn (_run) call shape
+        self.assertEqual(s.pending(), ["typed while the old client was dying"],
+                         "a live session's recovered send must enter _pending — a reg-only write "
+                         "is overwritten by the very next queue mirror")
+        s._persist_queue()          # the mirror snapshot a reg-only write could not survive
+        self.assertEqual(self._queue(), ["typed while the old client was dying"])
+        self.assertFalse(e.get("dropped"), "re-delivered → renders as queued, not never-delivered")
+
+    def test_live_session_redelivery_never_duplicates_a_pending_text(self):
+        reg = self._reg(queue=[])
+        s = self._sess(reg)
+        s.enqueue("already back in the queue")
+        self._stash_echo("already back in the queue")
+        # a caller's queued snapshot can predate the enqueue — the write-moment check must dedupe
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(s.pending(), ["already back in the queue"], "one copy, not two")
+
+
+class ReconnectStrandIsFlagOnly(unittest.TestCase):
+    """_reconcile_stranded's RESUMABLE branch is documented flag-only — the fed atom may genuinely
+    have landed, so re-feeding risks a REAL duplicate the user sees twice. The redeliver arm of
+    _mark_dropped_echoes silently flipped that policy (found 2026-08-26): a missed _text_landed
+    scan (a tail-window miss, an unusual content shape) re-fed the message into the resumed
+    conversation. On the resumable branch the loss is SURFACED (the dropped flag) and never
+    re-fed; the re-feed belongs only where the conversation is NOT resumable (the no-init re-head,
+    the boot/spawn dead paths). SYNTHETIC fixtures only."""
+
+    TEXT = "typed while the reconnect tore the client down"
+
+    def setUp(self):
+        self.state = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.state, "sdk"))   # an empty listing, not a missing one (see above)
+        # a real (empty) transcript: _text_landed answers False — the exact "missed scan" shape,
+        # since the resumable branch must not trust that answer with a re-feed
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.state, "claude")
+        self.cwd = os.path.join(self.state, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        open(tp, "w").close()
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None)
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def _sess(self, **extra):
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits",
+               "alive": True, "cwd": self.cwd, "lastSid": SID}
+        reg.update(extra)
+        sb.write_reg(self.be.state_dir, SID, reg)
+        s = sb.SdkSession(self.be, dict(reg))
+        self.be.sessions[SID] = s          # register WITHOUT starting the thread (no loop)
+        return s
+
+    def _stash_echo(self, text, t=100):
+        e = {"type": "user", "uuid": "echo:" + text[:10], "session_id": SID, "t": t,
+             "parentUuid": None, "author": "human", "_echo_text": text,
+             "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+        self.be._live.setdefault(SID, {})[e["uuid"]] = e
+        return e
+
+    def test_a_resumable_reconnect_flags_and_never_refeeds(self):
+        s = self._sess()                                # lastSid set → the conversation is resumable
+        self.assertEqual(s.resume_sid, SID)
+        s.inflight = 1
+        s._inflight_texts.append(self.TEXT)
+        e = self._stash_echo(self.TEXT, t=300)
+        s._reconcile_stranded()
+        self.assertEqual(s.pending(), [],
+                         "flag-only: a fed turn on a resumable conversation is never re-fed — "
+                         "re-feeding risks a real duplicate")
+        self.assertEqual((sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or [], [],
+                         "…and no reg-queue back door either")
+        self.assertTrue(e.get("dropped"), "the loss surfaces NOW as never-delivered")
+
+    def test_a_fresh_conversation_reconnect_still_reheads(self):
+        # the documented other branch: no init ever streamed → nothing the user can see exists,
+        # so re-feeding cannot duplicate — the queue re-head is the loss-proof path here
+        s = self._sess(lastSid="")                      # never resumed → resume_sid None
+        self.assertIsNone(s.resume_sid)
+        s.inflight = 1
+        s._inflight_texts.append(self.TEXT)
+        s._reconcile_stranded()
+        self.assertEqual(s.pending(), [self.TEXT],
+                         "the not-yet-materialized conversation re-heads the queue, as documented")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sdk_rename_ping.py
+++ b/tests/test_sdk_rename_ping.py
@@ -80,6 +80,14 @@ class RenamePing(unittest.TestCase):
         def enqueue(self, text):
             self.sent.append(text)
 
+        def enqueue_if_empty(self, text):
+            # the real session's atomic gate: emptiness check + append under ONE lock hold
+            with self._lock:
+                if self._pending:
+                    return False
+                self.enqueue(text)
+                return True
+
     def test_settle_delivery_ships_the_dressed_ping_alone_and_once(self):
         self._write_history()
         self.be.rename(SID, "tests")
@@ -101,6 +109,40 @@ class RenamePing(unittest.TestCase):
         self.assertEqual(s.sent, [], "nothing fed beside a queued turn")
         self.assertEqual(sb.read_reg(Path(self.td.name), SID).get("renameNote"), "tests",
                          "the note survives for a later, empty-queue settle")
+
+    def test_a_send_racing_the_gate_cannot_queue_ahead_of_the_ping(self):
+        # the gate's TOCTOU (found 2026-08-26): the empty-queue check and the ping's enqueue held
+        # the session lock SEPARATELY, with the renameNote reg write between them — a send landing
+        # in that window queued AHEAD of the ping, and the CLI's pre-turn batching folded the
+        # user's words into the ping's machine record (the exact 2026-08-25 fold the gate exists
+        # to prevent). Deterministic interleave: the reg write IS the window, so a hook there
+        # plays the racing send. A real (unstarted) session — the race is in its lock discipline.
+        self._write_history()
+        self.be.rename(SID, "tests")
+        s = sb.SdkSession(self.be, {"sid": SID, "name": "web", "cwd": self.cwd,
+                                    "mode": "acceptEdits"})
+        orig, raced = self.be._update_reg, []
+
+        def racing_update(sid, **fields):
+            if "renameNote" in fields and not raced:
+                raced.append(True)
+                s.enqueue("the user's own racing words")   # a concurrent send() in the window
+            orig(sid, **fields)
+
+        self.be._update_reg = racing_update
+        try:
+            delivered = self.be._deliver_rename_ping(s)
+        finally:
+            self.be._update_reg = orig
+        pending = s.pending()
+        if delivered:
+            self.assertTrue(pending and pending[0].startswith(sb.RENAME_PING_HEAD),
+                            "a racing send must never queue AHEAD of the ping — that is the fold")
+            self.assertIn("the user's own racing words", pending,
+                          "…and the racing send itself is queued behind it, not lost")
+        else:
+            self.assertEqual(sb.read_reg(Path(self.td.name), SID).get("renameNote"), "tests",
+                             "an undelivered ping keeps its note for a later settle")
 
     def test_the_fold_gates_are_pinned_at_source(self):
         # the fold's mechanics live in async plumbing a unit test can't drive — pin the three gates

--- a/tests/test_sdk_spawn_pin_send.py
+++ b/tests/test_sdk_spawn_pin_send.py
@@ -45,7 +45,8 @@ class _FakeBackend:
     def _poke(self): pass
     def _deliver_rename_ping(self, s): return False   # settle hook (2026-08-25); no ping in these worlds
     def _update_reg(self, *a, **k): pass
-    def _mark_dropped_echoes(self, sid, surviving): self.dropped_calls.append((sid, list(surviving)))
+    def _mark_dropped_echoes(self, sid, surviving, refeed=True):
+        self.dropped_calls.append((sid, list(surviving), refeed))
     # the ResultMessage settle's other hooks (mirrors test_sdk_compacting_signal's fake)
     def _turn_completed(self, sid): pass
     def _record_spend(self, *a, **k): pass
@@ -89,6 +90,9 @@ class ReconcileStranded(unittest.TestCase):
         s._reconcile_stranded()
         self.assertEqual(s._pending, [], "never re-fed into a resumable conversation")
         self.assertEqual(len(be.dropped_calls), 1, "the loss is surfaced immediately")
+        self.assertIs(be.dropped_calls[0][2], False,
+                      "…and FLAG-ONLY (2026-08-26): the redeliver arm's missed _text_landed scan "
+                      "must never land the message twice here")
 
     def test_clean_reconnect_is_a_no_op(self):
         s, be = _session()


### PR DESCRIPTION
Three fixes in the SDK backend's queue delivery, one commit each, all in `kernel/sdk_backend.py`. Each commit carries its own tests, and each test failed against the tree before its change.

## 1. A recovered send enters the live session's queue; a resumable reconnect only flags

**What breaks.** `_mark_dropped_echoes`' redeliver arm (a provably lost human send, verified unlanded by `_text_landed`, goes back into the queue) always writes `reg['queue']` on disk. Two of its three callers run with a live `SdkSession` already registered: `SdkSession._run` (the fresh-spawn call; `_ensure` registers the session before `start()`) and `_reconcile_stranded`'s resumable branch. There the in-memory `_pending` is authoritative, and its next `_persist_queue` snapshot (any enqueue, unqueue, or feed) overwrites the reg. The recovered text sits on disk unfed, its echo un-flagged, until a future kernel boot happens to re-read the reg.

**Trace.** A session restart inside a live kernel: `_ensure` builds the `SdkSession` (seeding `_pending` from the reg's queue) and registers it; `_run` calls `_mark_dropped_echoes(sid, self.pending())`; the redeliver arm writes `reg['queue'] = have + add`; the CLI connects and the drain pops, or the user enqueues; `_persist_queue` writes `reg['queue'] = list(self._pending)`, which never held the recovered text.

**Fix.** When a live session is registered for the sid, deliver through `SdkSession.enqueue`: dedupe against `pending()` at the write moment and set `send()`'s `/compact` and `/clear` enqueue-time flags. The boot caller (`_reseed_echoes`, before any session exists) keeps the reg write unchanged.

The same commit fixes the resumable-reconnect caller. `_reconcile_stranded`'s resumable branch is documented flag-only (the fed atom may have landed, so re-feeding risks a real duplicate), but the redeliver arm re-fed there whenever the bounded transcript-tail scan missed. `_mark_dropped_echoes` gains `refeed: bool = True`, and that caller passes `refeed=False`: the loss surfaces as the dropped flag and is never re-fed. One behavior change to review: a human send lost across a resumable reconnect now shows as never-delivered instead of being re-queued. It is what the branch's docstring already promised; if you prefer the re-feed there, reverting is one argument.

**Tests.** `tests/test_sdk_echo_durability.py`: `RedeliveryFeedsTheAuthoritativeQueue` (the live path reaches `_pending` and survives the next mirror; a text already pending is not duplicated) and `ReconnectStrandIsFlagOnly` (the resumable reconnect flags, leaves `reg['queue']` empty, and never re-feeds; the fresh-conversation branch still re-heads). `tests/test_sdk_spawn_pin_send.py`'s fake backend accepts the new keyword (required: without it the existing resumable-reconnect test raises `TypeError`) and asserts `refeed=False` there. `tests/test_restart_redelivery.py` is untouched and stays green: its stub has no `sessions` attribute, so it exercises the reg path by construction.

Relation to #878: independent and complementary. The boot path is unchanged here, so #878's fresh re-read in `_boot_reconcile` still addresses the boot-listing staleness, and its `BootDeliversARefedSend` test builds a real backend whose `sessions` is empty at boot, which is the reg path this PR keeps. No textual overlap.

## 2. The rename ping's empty-queue check and its enqueue share one lock hold

**What breaks.** `_deliver_rename_ping` checks emptiness under `s._lock`, releases, writes `renameNote=None`, then enqueues in a second hold. A send landing between the two holds queues ahead of the ping, and the CLI batches every message that arrives before a turn starts into one user record: the user's words render inside the ping's machine bubble, the fold the 2026-08-25 settle-delivery redesign exists to prevent.

**Fix.** `SdkSession.enqueue_if_empty(text) -> bool` does the check and the append in one hold. The gate uses it and spends the note only after the ping is queued, so a kernel death between the two steps re-pings a true fact at a later settle instead of losing the note.

**Tests.** `tests/test_sdk_rename_ping.py::test_a_send_racing_the_gate_cannot_queue_ahead_of_the_ping`: a deterministic interleave on a real, unstarted session. The reg write is the window, so a hook on `_update_reg` plays the racing send there; before the change the racing text landed at the head of the queue. The file's stub session gains the same atomic gate so the two existing delivery tests keep driving the real `_deliver_rename_ping`.

## 3. `queue_recallable` treats the rename ping's feed-hold as a hold

**What breaks.** `queue_recallable` returns False while a turn is in flight unless a hold is on. The ping's feed-hold (`_ping_feeding`: set when the drain feeds a `RENAME_PING_HEAD` item, cleared by that turn's first streamed message) holds every feed but was not counted, so the queued bubble lost its cancel affordance for the window in which a recall would still win.

**Fix.** Add the flag to the hold set beside the interrupt and rewind holds.

**Tests.** `tests/test_sdk_backend.py::PendingQueue::test_queue_recallable_during_the_ping_feed_hold`: a real session with `inflight=1`, toggling `_ping_feeding`. Before the change the gate returned False under the hold.

## Tests

All fixtures are synthetic (placeholder uuids, invented texts) and SDK-free (a `/bin/true` backend; unstarted real sessions or the files' existing stubs).

- Targeted: `python -m pytest -q tests/test_sdk_backend.py tests/test_sdk_echo_durability.py tests/test_sdk_rename_ping.py tests/test_sdk_spawn_pin_send.py tests/test_restart_redelivery.py tests/test_sdk_compacting_signal.py tests/test_sdk_api_retry_detail.py tests/test_model_fallback_card.py tests/test_sdk_lifecycle_hardening.py tests/test_sdk_boot_stagger.py tests/test_injected_voice.py`: 300 passed, 30 skipped.
- Full suite (`python -m pytest -q tests/`, run with pytest-xdist `-n 8`): 6533 passed, 44 skipped, 1 failed. The failure, `tests/test_postal_relay_honesty.py::PresenceBlinkHonesty::test_disk_twin_carries_the_cache_across_a_bus_restart`, fails the same way on the base commit 31d8731b (alone and under xdist; it passes when its file runs in order), and its module loads only `bin/romp-postal-service`. Pre-existing and unrelated.
- No shell or UI surface changed, so bats and the extension's tests were not run.
- No injected copy changed; `test_injected_voice` is green.

One test-setup detail: the two new echo-durability classes create the state dir's `sdk/` listing dir before constructing the backend. `list_regs` treats a missing dir as a scan fault and serves every cached row, so a fresh state dir without that dir reseeded earlier tests' regs into the new backend's boot. That looks like a separate finding in `list_regs` (its comment says a missing dir enumerates fine, but `os.scandir` raises on one) and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)