### PR TITLE
Move a live session's working directory: SdkBackend.move over the CLI's set_cwd control request, with a tab-menu row, POST /move and `romp move`

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -657,6 +657,7 @@ EOF
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
+    _romp_cmd "romp move <session> <dir>"   -           "Move an SDK session's working directory (its conversation follows; mid-turn it waits for the turn to end)"
     _romp_cmd "romp color <session> [<#hex|slot>]" -    "Recolor a session's identity swatch (palette hex or slot number; no color arg reads bg/fg)"
     _romp_cmd "romp tag [<name>] [--add ...]" -         "Session tags: bare lists them; <name> with --add/--remove/--color/--delete merges one (a tagged session leaves the no-tags view); --host <kernel> edits an attached kernel's tag; --rename renames"
     _romp_cmd "romp watch-pr <n> [--repo o/r]" -        "One mail here when the PR lands or fails — the kernel owns the watch, so it survives restarts (replaces the mortal shell loop)"
@@ -865,6 +866,44 @@ if [[ "${1:-}" == "rename" ]]; then
     fi
     _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
     echo "romp rename: refused — $_err" >&2
+    exit 1
+fi
+
+# Move a session's working directory (the user 2026-09-01: a subproject promoted to its own repo, and
+# the session should follow it): the kernel's POST /move, the sibling of `romp rename`. The session
+# keeps its conversation, name, mailbox and history; Claude's tools, CLAUDE.md and project settings
+# come from the new folder from the next turn on. SDK sessions only — a terminal (tmux) session has
+# no relocation primitive and the kernel says so. A relative dir is resolved against THIS shell's
+# cwd here (the kernel would otherwise resolve it against its own default directory, which is not
+# where the caller stands); `~` is the shell's to expand, and the kernel canonicalises the rest.
+if [[ "${1:-}" == "move" ]]; then
+    shift
+    _mv_usage="usage: romp move <session> <dir>"
+    if [[ $# -ne 2 || "$1" == -* || "$2" == -* || -z "$2" ]]; then echo "$_mv_usage" >&2; exit 2; fi
+    _mv_dir="$2"
+    [[ "$_mv_dir" != /* && "$_mv_dir" != "~"* && "$_mv_dir" != '$'* ]] && _mv_dir="$PWD/$_mv_dir"
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp move: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
+        exit 1
+    fi
+    _payload="$(python3 -c 'import json,sys; print(json.dumps({"target": sys.argv[1], "dir": sys.argv[2]}))' "$1" "$_mv_dir")"
+    # -m 90: a quiet session's move answers in a second or two, but a DORMANT one is revived first and
+    # its CLI has to come up before the request can go out (the kernel waits up to 60s for that)
+    _resp="$(_romp_token_cfg | curl -sf -m 90 --config - -X POST "http://127.0.0.1:$_kport/move" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp move: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        if [[ "$_resp" == *'"queued": true'* || "$_resp" == *'"queued":true'* ]]; then
+            echo "romp move: \"$1\" is mid-turn — the move is queued and fires when the turn ends (watch: romp sessions)"
+        else
+            echo "romp move: \"$1\" now works in $_mv_dir"
+        fi
+        exit 0
+    fi
+    _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
+    echo "romp move: refused — $_err" >&2
     exit 1
 fi
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -155,6 +155,12 @@ to open it read-only. Revival works by picking the session, not by its name, so
 a new session that reuses an old name is a new session rather than the old one
 resumed.
 
+A session can also move to another folder. When the code it works on moves, say
+a subproject that became its own repository, right-click its tab and choose
+**Move to folder…** (or run `romp move <session> <dir>`): the conversation,
+name, mail and history stay with the session, and from the next turn on the
+agent works in the new folder and reads its `CLAUDE.md`.
+
 Search reaches inside sessions, not just across their names. As sessions run, a
 lightweight index judge writes each one a headline and an abstract of what it
 did, so searching for the work finds the session that did it, months later.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -37,6 +37,7 @@ These are for scripting and for agents rather than daily use:
 | `romp interrupt <session>` | Interrupt whatever turn a session is taking |
 | `romp compact <session> [--wait] [--timeout <s>]` | Compact a session's context in place (Claude's `/compact`: summarize the history, keep the session's name, id, mailbox, and watches) — the alternative to ending and recreating a long-lived session, and the external hand a session needs since it cannot `/compact` itself mid-turn. Quiet session → compacts now; open turn → queued, fires alone the moment the turn ends (the same safe path the chat's compact button uses). `--wait` blocks until the compaction has started and cleared, polling the kernel's own `compacting` signal on the `/sessions` rows (also the field to point a `romp watch` predicate at for scripted recycling); exits 1 honestly on timeout. A remote session's compaction is requested on its own kernel — `--wait` can't follow it from here and says so |
 | `romp end <session>` | End a session |
+| `romp move <session> <dir>` | Move an SDK session's working directory to `<dir>` (the folder must already exist); the conversation, name, mail and history stay with the session. Quiet session → moves now; open turn → queued, fires when the turn ends. See [Moving a session to another folder](#moving-a-session-to-another-folder) |
 | `romp checkin <host>` / `romp checkout <host>` | Publish this machine to an attached hub, or withdraw it |
 | `romp default-dir [PATH]` | The default working directory for new sessions; no argument prints it, `""` clears it |
 | `romp debug [on\|off\|status]` | Judge debug mode, where rejection rows carry the full input and reply |
@@ -59,6 +60,52 @@ the text under `caption`. A record's own `id` field is not the session's: it
 identifies the turn within it. There is no `summaries/` directory; an older
 layout had one, and reading it fails silently, since a missing directory just
 yields nothing rather than an error.
+
+### Moving a session to another folder
+
+A session's working directory can change after it starts, so when a subproject
+moves to its own repository, the session working on it can follow. Right-click
+the session's tab and choose **Move to folder…**, or run `romp move <session>
+<dir>`. The folder must already exist. Terminal (tmux) sessions cannot be
+moved; start a new one in the folder instead.
+
+What moves with the session:
+
+- The conversation. Claude Code moves the transcript, with the tool-results,
+  subagent and workflow files beside it, into the new folder's project
+  directory under `~/.claude/projects/`; Romp moves the session's earlier
+  transcripts (its `/clear` episodes and resume forks) the same way, so history
+  and search keep working.
+- The session's name, colour, mailbox, goals, cards and captions, all keyed by
+  the session id rather than the folder.
+- What the agent sees. Claude Code tells the model where it now is and loads
+  the new folder's `CLAUDE.md`; from the next turn on, permission rules, hooks,
+  skills and project MCP servers come from the new folder.
+
+What does not move, because Claude Code keys it by folder rather than by
+session: the old project's auto-memory (`~/.claude/projects/<old
+folder>/memory/`), the old folder's entry in `~/.claude.json` (its allowed
+tools, MCP approvals and trust), and the old repository's
+`.claude/settings.local.json`. A comment thread opened on the session also
+keeps its own folder. What Claude Code keys by session id (its debug log, task
+store and file-history checkpoints) needs no move.
+
+A move never interrupts a turn: on a session mid-turn it is queued as a chip in
+the chat and fires the moment the turn ends, like a queued `/compact`. If Claude
+Code reports a turn Romp could not see (one it started itself), the chip waits
+for that turn to end too; the chip can be cancelled like any queued item. A
+closed session is revived first, in its old folder, then moved. Only one move
+per session is in flight at a time; a second request while one is pending is
+refused. Every refusal (a folder that does not exist, a path that is a file, a
+move already pending) is reported where you asked. If Claude Code's reply to
+the move is lost, Romp settles the outcome by where the transcript is, the same
+check it runs after a restart that interrupted a move; a move it cannot settle
+is reported and left for the next kernel start, with nothing changed.
+
+The move is Claude Code's own relocation (the `set_cwd` control behind the
+interactive `/cd`), with Romp moving its own records alongside. It fires Claude
+Code's `CwdChanged` hook, not `SessionStart`; Romp registers no `CwdChanged`
+hook, so nothing on Romp's side re-runs.
 
 ## The Romp Postal Service
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1234,7 +1234,8 @@ def _name_of(sid):
 def _cwd_of(sid):
     """The session's working directory from the names registry (2nd tab field: name\\tcwd\\tbg\\tfg), or "".
     Written at launch for BOTH backends (tmux romp launcher + SDK write_name), so it's available before any
-    transcript exists. The directory is fixed at creation — there's no SDK call to relocate a session."""
+    transcript exists — and REWRITTEN by a move (SdkBackend.move, the CLI's set_cwd control request), so
+    this is the current directory, not the launch one; every transcript path derives from it."""
     parts = _names_parts(sid)
     return parts[1] if parts and len(parts) > 1 else ""
 
@@ -7063,8 +7064,9 @@ def _expand_dir(raw):
 
 
 def _resolve_create_dir(raw, create=False):
-    """Resolve a UI-supplied new-session directory → (path, error). ~ and $VAR are expanded; the path must
-    be an existing directory (the session's cwd is fixed at creation, so a bad path can't be fixed later —
+    """Resolve a UI-supplied session directory → (path, error) — for a NEW session and for a move
+    (moveSession / POST /move, the one later fix for a wrong pick). ~ and $VAR are expanded; the path must
+    be an existing directory (a session launched into a bad path is a real session nothing can find —
     reject it up front), and it is canonicalized — symlinks and trailing slash via realpath, on-disk
     casing via _true_case — because the string, not just the directory, is load-bearing (see
     _true_case). Empty/None → the kernel default, no error.
@@ -9173,7 +9175,8 @@ def _kernel_knows(sid):
 _FOREIGN_OP_VERB = {"sendMessage": "message", "askFollowUp": "reply", "askText": "answer",
                     "addCustomAsk": "answer", "answerAsk": "answer", "submitAsk": "answer",
                     "rewindSend": "edited message", "sendCommand": "command", "renameSession": "rename",
-                    "endSession": "end", "interrupt": "interrupt", "compactSession": "compact"}
+                    "endSession": "end", "interrupt": "interrupt", "compactSession": "compact",
+                    "moveSession": "move"}
 
 
 def _refuse_drive(client, op, sid, msg):
@@ -9223,7 +9226,7 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
-              "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction", "forkSession",
+              "setAuth", "endSession", "renameSession", "moveSession", "stopTask", "rewindFiles", "mcpAction", "forkSession",
               "commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote",
               "commentMerge")
     if t in ID_OPS and msg.get("id"):
@@ -9592,6 +9595,18 @@ def _drive(msg, client):
             client["send"](json.dumps({"type": "warn", "text": _thread_name_refusal(new, _thread_names())}))
         elif be.rename(sid, new):                         # live → tmux rename hook / SDK reg; dead → names file
             client["send"](json.dumps({"type": "renamed", "id": sid, "name": new}))
+    elif t == "moveSession" and msg.get("dir"):
+        # Move the session's working directory (the user 2026-09-01: a subproject was promoted to its own
+        # repo and the session should follow it). The dir is resolved and canonicalised HERE like a
+        # new-session dir (~ / $VAR, must exist, realpath + true case — the string is load-bearing), then
+        # the op goes through the same park-or-fire gate as every drive op: mid-turn it waits as a queued
+        # chip for the turn's end, idle it fires now. Every refusal is a typed moveFailed to the asker.
+        raw = str(msg["dir"]).strip()
+        path, derr = _resolve_create_dir(raw) if raw else (None, "pick a folder to move the session to")
+        if derr:
+            client["send"](json.dumps({"type": "moveFailed", "id": sid, "name": _name_of(sid) or sid, "text": derr}))
+        else:
+            _move_or_park(be, sid, path, client)
     else:
         return False    # recognized type but a required field is missing (e.g. sendMessage w/o text) → no-op
     return True
@@ -10068,6 +10083,13 @@ class TmuxBackend(sb.SessionBackend):
 
     def rename(self, sid, new_name):
         return _rename_session(str(sid), new_name) is not None   # live → tmux rename hook; dead → names file
+
+    def move(self, sid, cwd):
+        # No relocation primitive exists for a TUI session: /cd is interactive and romp would have to
+        # type it blind, with no answer to read and no transcript move to verify. The ABC default's
+        # honest refusal, worded for the terminal case so the user learns what to do instead.
+        return ("this session runs in a terminal (tmux), which has no way to move a running session — "
+                "start a new session in that folder instead")
 
     # chat tail — the kernel-side input echo store (_tmux_echo) is tmux's live_atoms; queued msgs are folded
     # event-based from the transcript's queue-operation records.
@@ -18186,7 +18208,7 @@ def _save_pending_ops():
         sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
 
 
-_pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("compact",), …] in park order
+_pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("cwd", path, busy_retries) | ("compact",), …] in park order
 
 
 _PATH_UNRESOLVED = object()   # _compacting_now's "no path was passed" sentinel — None is a real value (no transcript)
@@ -18316,7 +18338,7 @@ def _ops_gate(sid):
     escape hatch), and it is what a user reaches for when they want the storm to stop, not the queue."""
     sid = str(sid)
     return (_compacting_now(sid) or _working_now(sid) or bool(_pending_ops.get(sid))
-            or _limit_hold(sid) is not None)
+            or sid in _moving or _limit_hold(sid) is not None)   # a move in flight holds the queue too
 
 
 def _park_op(sid, op):
@@ -18325,7 +18347,7 @@ def _park_op(sid, op):
     earlier parked op of the same kind IN PLACE — its queue position stands, its value updates — so the
     chat shows one "/model …" chip carrying the latest pick. Messages always append."""
     q = _pending_ops.setdefault(str(sid), [])
-    if op[0] in ("model", "effort", "fast"):
+    if op[0] in ("model", "effort", "fast", "cwd"):
         for i, o in enumerate(q):
             if o[0] == op[0]:
                 q[i] = op
@@ -18348,7 +18370,94 @@ def _parked_md(op):
         return op[1]                     # the typed slash command IS the bubble (so the running-/compact fold matches it too)
     if op[0] == "compact":
         return "/compact"
+    if op[0] == "cwd":
+        # a parked MOVE (moveSession): plain words, not a slash command — nothing the user could type
+        # does this, so a "/cd" chip would advertise a command the composer does not have
+        return "move to " + _tilde(op[1])
     return "/%s %s" % (op[0], op[1])
+
+
+# ── moving a session's working directory (the user 2026-09-01) ─────────────────────────────────
+# A move rides the drive-op FIFO like /compact: parked as ("cwd", <canonical path>, <busy retries>)
+# while the session is not quiet, fired when it is. The backend's move() is a BLOCKING round trip
+# (set_cwd's control response) — it runs on its own thread so neither the WS handler nor the producer
+# tick waits on it, and `_moving` holds the session's queue for the duration: _ops_gate parks anything
+# pressed meanwhile and _apply_pending_ops skips the sid, so nothing else reaches the CLI mid-move.
+_moving: set = set()
+_move_askers: dict = {}          # sid -> wid of the dashboard that asked for a PARKED move (failure lands there)
+_MOVE_BUSY_RETRIES = 3           # CLI-side `busy` answers retried on the next pass without waiting for a turn end
+                                 # (the CLI's post-result window); after these, the op waits on turn_seq (_move_now)
+
+
+def _move_or_park(be, sid, path, client=None):
+    """Park-or-fire for a move, the same gate every drive op takes (_ops_gate): mid-turn, compacting,
+    behind an existing queue, or under an account hold it parks as a visible "move to …" chip and
+    fires at the turn's end (_apply_pending_ops); quiet, it fires now."""
+    sid = str(sid)
+    wid = (client or {}).get("wid") or ""
+    if _ops_gate(sid):
+        _park_op(sid, ("cwd", path, 0))
+        _move_askers[sid] = wid
+        return None
+    return _fire_move(be, sid, path, 0, wid)
+
+
+def _fire_move(be, sid, path, tries, wid):
+    """Run the backend's blocking move on its own thread (returned, so a test can join it). `_moving`
+    is claimed synchronously, before the thread starts, so a producer tick landing in between cannot
+    fire the op behind this one."""
+    sid = str(sid)
+    _moving.add(sid)
+    th = threading.Thread(target=_move_now, args=(be, sid, path, tries, wid), name="romp-move", daemon=True)
+    th.start()
+    return th
+
+
+def _move_now(be, sid, path, tries, wid):
+    """The move itself, on whatever thread called it: ask the backend, then report. "" → the session
+    broadcast carries the new cwd (build_session reads _cwd_of) and the asker gets a typed `moved`;
+    "busy" → the CLI has a turn in flight that romp's own idle check did not see, and the op goes BACK
+    to the head of the queue. Two shapes hide behind that answer, and the retry keys on the event each
+    one has:
+      * a turn the CLI started itself (a hook, a background task's notification): romp's inflight never
+        counted it, but it ENDS with a ResultMessage like any other, and that end is the cue — the parked
+        op carries the backend's turn_seq, and the producer pass fires it once that counter has moved;
+      * the CLI's own post-result bookkeeping window (sub-second, after a turn romp DID see end): no
+        further ResultMessage is coming, so the counter never moves — the first _MOVE_BUSY_RETRIES passes
+        therefore fire without waiting on it. Past those, the op waits for the event only, as a visible,
+        cancellable chip, instead of failing loudly while the CLI's turn is still running.
+    Anything else → a typed moveFailed with the backend's reason verbatim. Returns the backend's answer,
+    for the synchronous callers (POST /move)."""
+    sid = str(sid)
+    nm = _name_of(sid) or sid
+    try:
+        try:
+            res = be.move(sid, path) if hasattr(be, "move") else \
+                "this session's backend has no way to move a running session"
+        except Exception as e:
+            res = "%s: %s" % (type(e).__name__, str(e)[:200])
+    finally:
+        _moving.discard(sid)
+    if res == "busy":
+        seq = be.turn_seq(sid) if hasattr(be, "turn_seq") else None      # the turn end this retry waits on
+        _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
+        _move_askers[sid] = wid
+        _save_pending_ops()
+        _mark_views_dirty()
+        return res
+    if res:
+        _move_failed(sid, nm, wid, res)
+        return res
+    _commands_for_cwd(_cwd_of(sid))          # the new folder's slash commands warm before the next "/"
+    _mark_views_dirty()                       # the cwd lives in names/ — no sig sees it; rebuild past the sig
+    _push_soon()
+    _send_to_view("chat", {"type": "moved", "id": sid, "name": nm, "cwd": _tilde(_cwd_of(sid))}, wid)
+    return res
+
+
+def _move_failed(sid, nm, wid, text):
+    sys.stderr.write("move '%s' (%s): %s\n" % (nm, sid, text))
+    _send_to_view("chat", {"type": "moveFailed", "id": sid, "name": nm, "text": text}, wid)
 
 
 def _cancel_miss_text(md):
@@ -18605,12 +18714,26 @@ def _apply_pending_ops():
         if not ops:
             _pending_ops.pop(sid, None)
             continue
+        if sid in _moving:
+            continue                                  # a move is mid-flight: its relocation must finish first
         if _compacting_now(sid) or _working_now(sid) or _limit_hold(sid):
             continue                                  # …or the account can't serve a request yet
         try:
             be = Sessions.backend_for(sid)
             while ops:
                 op = ops[0]
+                if op[0] == "cwd":
+                    # a parked move: fires on its own thread and CLAIMS _moving before this pass ends, so
+                    # the ops behind it wait for the relocation to finish (the next pass skips the sid
+                    # until then) — a send fed mid-move could make the CLI reject the move as busy
+                    tries = int(op[2]) if len(op) > 2 else 0
+                    seq = op[3] if len(op) > 3 else None
+                    if (seq is not None and tries >= _MOVE_BUSY_RETRIES and hasattr(be, "turn_seq")
+                            and be.turn_seq(sid) == seq):
+                        break      # the CLI still owns a turn romp cannot see: its ResultMessage is the cue (_move_now)
+                    ops.pop(0)
+                    _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
+                    break
                 if op[0] == "send":
                     run = []                          # coalesce the leading run of sends → deliver them AT ONCE
                     while ops and ops[0][0] == "send":
@@ -20258,8 +20381,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # effect + this session's model / cwd / branch / permission-mode / version (NOT the harness prompt —
     # see _claudemd_docs). Only when there's a real transcript to describe AND something to show.
     meta = _session_meta(sess["path"])
-    scwd = _cwd_of(sid) or meta.get("cwd") or ""    # the session's fixed dir — known even before the first turn
-    docs = _claudemd_docs(meta.get("cwd") or scwd)
+    # The registry's dir FIRST (known before the first turn), the transcript's stamp only as a fallback:
+    # a move (SdkBackend.move) rewrites the registry at once, while the transcript keeps stamping the old
+    # cwd until the model's next turn — so the card would name the old folder for as long as the session
+    # sat idle after the move. And the per-record `cwd` stamp is the CLI's TRACKED cwd, which a shell
+    # `cd` inside a Bash tool call also moves (with no transcript move behind it), so it never was the
+    # session's project directory — only the registry (and the CLI's own `relocated` record) is.
+    scwd = _cwd_of(sid) or meta.get("cwd") or ""
+    docs = _claudemd_docs(scwd)
     # The WORKTREE the session actually works in (the user 2026-08-13): the repo convention here puts real
     # work on per-session worktrees beside the registered clone, so the registered dir's branch read 'main'
     # forever and the real location showed nowhere. The newest write-tool file_path names the tree — the
@@ -20271,7 +20400,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     work_tree = ({"dir": _tilde(_wt_top), "branch": _wt_br}
                  if _wt_top and os.path.realpath(_wt_top) != os.path.realpath(_reg_top or "/nonexistent")
                  else None)
-    sysinfo = {"kind": "system", "model": last_model, "cwd": _tilde(meta.get("cwd") or scwd),
+    sysinfo = {"kind": "system", "model": last_model, "cwd": _tilde(scwd),
                # branch from the transcript if present (normalized: a detached stamp says 'HEAD', not a
                # branch), else derived straight from the folder so it shows on open (the user 2026-06-24) —
                # works for a never-run session of EITHER backend.
@@ -20321,7 +20450,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     _kids = (_be_fk.fork_children().get(sid) if _be_fk and hasattr(_be_fk, "fork_children") else None) or None
     return {"type": "session", "id": sid, "name": sess["name"], "color": _name_color(sid),
             "branch": branch, "branches": _kids,
-            "cwd": _tilde(_cwd_of(sid) or meta.get("cwd") or ""),   # fixed-at-creation dir; lane tab shows it (the user 2026-06-22)
+            "cwd": _tilde(_cwd_of(sid) or meta.get("cwd") or ""),   # the CURRENT dir (a move rewrites it); lane tab shows it (the user 2026-06-22)
             # git branch as a TOP-LEVEL session field, NOT just inside the head system event: the status-bar
             # branch + tab tooltip must show for EVERY session, but the system event lives at events[0] and the
             # WIRE_TAIL window ships only the last 250 events — so on any session with >250 events the head
@@ -31752,6 +31881,46 @@ class Handler(BaseHTTPRequestHandler):
                 _mark_views_dirty()
                 return self._send(200, json.dumps({"ok": True, "id": tsid, "name": nm}),
                                   "application/json")
+            if u.path == "/move":
+                # Headless move (`romp move`, the user 2026-09-01): the moveSession WS op as a one-shot
+                # POST, sibling of /rename. Body: {"target": <live name or sid>, "dir": <folder>}. The dir
+                # is resolved like a new-session dir (must exist; canonicalised). A quiet session moves
+                # NOW and the reply carries the outcome; a busy one parks the move behind its turn and
+                # the reply says so (queued: true) — the CLI cannot tell whether that later fires, so it
+                # reports the park honestly rather than waiting on a turn of unknown length. Loud errors.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                target = str((b or {}).get("target") or "").strip()
+                raw_dir = str((b or {}).get("dir") or "").strip()
+                if not target or not raw_dir:
+                    return self._send(400, json.dumps({"ok": False, "error": "target and dir required"}),
+                                      "application/json")
+                path, derr = _resolve_create_dir(raw_dir)
+                if derr:
+                    return self._send(200, json.dumps({"ok": False, "error": derr}), "application/json")
+                live = _live_names(_tmux_sessions())
+                tsid = live.get(target) or ""
+                if not tsid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", target):
+                    tsid = target
+                if not tsid or not _kernel_knows(tsid):
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        'no live session named "%s" (a dormant one can be moved by sid)' % target}),
+                                      "application/json")
+                be = Sessions.backend_for(tsid)
+                if _ops_gate(tsid):
+                    _park_op(tsid, ("cwd", path, 0))
+                    return self._send(200, json.dumps({"ok": True, "id": tsid, "queued": True, "dir": path}),
+                                      "application/json")
+                _moving.add(tsid)
+                res = _move_now(be, tsid, path, 0, "")   # synchronous here: the reply IS the outcome
+                if res == "busy":
+                    return self._send(200, json.dumps({"ok": True, "id": tsid, "queued": True, "dir": path}),
+                                      "application/json")
+                if res:
+                    return self._send(200, json.dumps({"ok": False, "error": res}), "application/json")
+                return self._send(200, json.dumps({"ok": True, "id": tsid, "dir": path}), "application/json")
             if u.path == "/color":
                 # Headless recolor (`romp color`, the user 2026-08-23 via the manager/worker workflow:
                 # a manager keeps its whole worker group one identity color): the setSessionColor WS op

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -170,6 +170,121 @@ def transcript_path(cwd: str, fsid: str) -> str:
                     "projects", proj, fsid + ".jsonl")   # per-kernel Claude root (plans/multi-kernel.md phase 2)
 
 
+# ── moving a live session's working directory (the user 2026-09-01, who wanted a session to follow a
+# subproject promoted to its own repo) ────────────────────────────────────────────────────────────
+# Claude Code 2.1.257 has a `set_cwd` control request — the headless twin of the interactive /cd. On
+# `ok` the CLI itself chdirs, MOVES the current transcript (`<lastSid>.jsonl` + its `<lastSid>/`
+# sidecar folder) to the new cwd's project slug (a file already at the destination is set aside as
+# `.superseded-<ts>` first, never overwritten), appends a `{type: relocated, sessionId, relocatedCwd}`
+# record (forks strip it; a later non-fork resume restores it) plus an isMeta notice that tells the
+# model its environment block is stale, re-resolves project settings/hooks/skills/MCP, fires the
+# CwdChanged hook (NOT SessionStart — romp registers no CwdChanged hook, so nothing romp-side re-runs),
+# and emits (with no query sent) an init SystemMessage, a turn-less ResultMessage (num_turns 0) and two
+# commands_changed SystemMessages. Verified 2026-09-02 on SDK 0.2.132 + CLI 2.1.257 (hermetic
+# CLAUDE_CONFIG_DIR) and against the CLI binary: `ok {cwd, changed, transcript_relocated}` (a same-dir
+# request is `ok, changed: false` and emits nothing); `needs_trust {directory, trust_root?}` → re-send
+# with trust_accepted + trusted_directory (trust is recorded per git root in the CLI's config);
+# `rejected {reason, message}` with reason ∈ not_found / not_a_directory / unsafe_path /
+# blocked_by_rule (a `Cd(...)` permission rule) / busy ("A turn is in progress — the working directory
+# can only change while the session is idle…"); a relocation failure comes back as a control error and
+# the CLI rolls its chdir back. Nothing here ever COPIES a transcript: the same fsid under two project
+# slugs makes every future --resume fail ("No conversation found" — the CLI's id-scan fallback refuses
+# ambiguity), so the CLI moves the current file and romp moves the rest, both by rename.
+MOVE_CONTROL_TIMEOUT = 30.0   # the set_cwd round trip (a rename + a settings re-resolve; seconds at most)
+MOVE_CONNECT_WAIT = 60.0      # a dormant session's CLI coming up for the move (resume + handshake)
+_NO_CONTROL_SENDER = ("this Claude Agent SDK exposes no _send_control_request on its client — romp needs it "
+                      "to send set_cwd; nothing was changed")
+
+
+def true_case(path: str) -> str:
+    """`path` (absolute) with every component in its true on-disk casing — the kernel's _true_case,
+    duplicated tiny so the backend can canonicalise a move target without a kernel import. The cwd
+    STRING is load-bearing: the CLI encodes its projects dir from its own getcwd (true case) while
+    romp derives transcript paths from the stored string, so a case variant would point every consumer
+    at a slug that does not exist (the silent wrong-case launch, the user 2026-07-17)."""
+    out = "/"
+    for comp in [c for c in path.split("/") if c]:
+        try:
+            names = os.listdir(out)
+        except OSError:
+            names = []
+        if comp not in names:
+            m = [e for e in names if e.lower() == comp.lower()]
+            if len(m) == 1:
+                comp = m[0]
+        out = os.path.join(out, comp)
+    return out
+
+
+def canon_dir(raw: str) -> tuple[str, str]:
+    """(canonical path, "") for an EXISTING directory — ~ expanded, symlinks and trailing slash via
+    realpath, casing via true_case — or ("", why not). Never creates: a move goes to a folder the user
+    already has (the create-session picker owns the "make it" offer)."""
+    p = os.path.expanduser(str(raw or "").strip())
+    if not p:
+        return "", "no folder given"
+    if not os.path.isabs(p):
+        return "", "the folder must be an absolute path: %s" % p
+    if not os.path.isdir(p):
+        return "", ("not a directory: %s" if os.path.exists(p) else "directory not found: %s") % p
+    return true_case(os.path.realpath(p)), ""
+
+
+def known_fsids(state_dir: Path, sid: str, reg: dict | None = None) -> set[str]:
+    """Every transcript fsid romp has on record for `sid`: the sid itself, the reg's lastSid, each
+    /clear episode head (episodes/<sid>.jsonl, fsid per row) and both ends of every resume fork
+    (states/<sid>.jsonl resumeFork rows). These are the files that share the session's project slug and
+    that romp's episode/lineage readers derive from the stored cwd — the set a move has to carry."""
+    out = {str(sid)}
+    reg = reg if reg is not None else (read_reg(state_dir, sid) or {})
+    if reg.get("lastSid"):
+        out.add(str(reg["lastSid"]))
+    for sub, pick in (("episodes", lambda r: [r.get("fsid")]),
+                      ("states", lambda r: [(r.get("resumeFork") or {}).get(k) for k in ("from", "to")])):
+        try:
+            lines = (Path(state_dir) / sub / (str(sid) + ".jsonl")).read_text().splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(r, dict):
+                out.update(str(v) for v in pick(r) if v)
+    return out
+
+
+def relocate_transcripts(old_cwd: str, new_cwd: str, fsids, log=None) -> list[str]:
+    """Move the transcripts of `fsids` (each `.jsonl` and its `<fsid>/` sidecar folder) from
+    `old_cwd`'s project slug to `new_cwd`'s, by RENAME within the projects tree. A source that is not
+    there is skipped silently (the CLI already moved the current one; a fsid may never have written a
+    sidecar); an existing TARGET is never overwritten — logged and left, since two candidates mean a
+    collision only a person should resolve. Returns the fsids whose file moved."""
+    moved = []
+    if not old_cwd or not new_cwd or os.path.realpath(old_cwd) == os.path.realpath(new_cwd):
+        return moved
+    for fsid in sorted(fsids):
+        src = transcript_path(old_cwd, fsid)
+        dst = transcript_path(new_cwd, fsid)
+        for a, b in ((src, dst), (src[:-len(".jsonl")], dst[:-len(".jsonl")])):
+            if not os.path.exists(a):
+                continue
+            if os.path.exists(b):
+                if log:
+                    log("move: %s already exists — leaving %s where it is" % (b, a), problem=True)
+                continue
+            try:
+                os.makedirs(os.path.dirname(b), exist_ok=True)
+                os.rename(a, b)
+                if a == src:
+                    moved.append(fsid)
+            except OSError as e:
+                if log:
+                    log("move: could not relocate %s -> %s: %s" % (a, b, e), problem=True)
+    return moved
+
+
 def last_record_uuid(path, tail_bytes: int = 262144) -> str:
     """The uuid of the LAST uuid-bearing record in a transcript — the conversation's current
     leaf. Reads only the file's tail (a transcript can be tens of MB; the leaf is always within
@@ -1785,6 +1900,14 @@ class SdkSession:
         self._wake: asyncio.Event | None = None
         self._reconnect = False                 # the current break is a reconnect (not a shutdown)
         self._reconnect_when_idle = False        # a reconnect was requested mid-turn → apply at turn end
+        # The handshake as a cross-thread EVENT: set the moment a ClaudeSDKClient is up, cleared when
+        # it goes down — what a kernel-thread caller that needs the control channel (SdkBackend.move on
+        # a just-revived session) waits on, instead of polling for self.client.
+        self._connected = threading.Event()
+        # A set_cwd the CLI accepted emits a turn-less ResultMessage (num_turns 0) with no query behind
+        # it; this flag, armed by move() before the request and spent by that result, keeps the settle
+        # side effects (turn-completed, waiting, refreshes, the rename ping) off a turn that never was.
+        self._move_settle_expected = False
         self.ended = False
         # input + ask bridging
         # Queued user turns are held in a VISIBLE list (not flushed into the SDK) until the
@@ -2433,6 +2556,7 @@ class SdkSession:
                     # ready to take a message (measured live 2026-08-10: connect done ~1.5s after
                     # create, the ready chip landing at 5-12s with the cycle).
                     self.backend._push_session(self.sid)
+                    self._connected.set()   # the control channel exists from here (move() waits on this)
                     self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
                     self._last_usage_totals = {}  # …and its cumulative token counters
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
@@ -2497,6 +2621,7 @@ class SdkSession:
                             except Exception as e:                 # a genuine stream/transport error — surface it
                                 self.backend._log(f"sdk session {self.name}: {type(e).__name__}: {e}")
                         self.client = None
+                        self._connected.clear()
             except Exception as e:
                 # A REWIND-armed connect the CLI refused (a bad --resume-session-at target exits 1 with
                 # "No message found" BEFORE the handshake) must not crash-loop: the flag would re-apply on
@@ -2844,6 +2969,8 @@ class SdkSession:
             # "claude" (claude-opus-4-8, us.anthropic.claude-…); keep the last good one otherwise.
             if m and "claude" in m.lower():
                 self._learn_model(pretty_model(m))
+        elif isinstance(msg, ResultMessage) and self._consume_move_settle(msg):
+            pass   # the accepted move's turn-less result — nothing ended, so nothing settles (see the def)
         elif isinstance(msg, ResultMessage):
             # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
             # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole
@@ -2949,6 +3076,23 @@ class SdkSession:
                 self.backend._record_rate_limit(msg.rate_limit_info)
         # Forward the raw message to the kernel for live chat/event use.
         self.backend._forward(self, msg)
+
+    def _consume_move_settle(self, msg) -> bool:
+        """Is this ResultMessage the turn-less one an accepted set_cwd emits (verified 2026-09-02:
+        `ResultMessage(result='', num_turns=0)` right after the init, with no query sent)? Two facts
+        must agree: move() ARMED _move_settle_expected before its request (the response and the result
+        race on two threads, so arming after `ok` could lose), and the result says num_turns == 0 — a
+        real turn, even an interrupted one, reports its API round trips. Spent on the match, so the
+        NEXT zero-turn result (there is none in normal traffic) settles as before. Without this guard
+        the settle path ran on a turn that never was: a false _turn_completed, a redundant 'waiting'
+        write, the rename ping fired as its own turn, and a parked effort reconnect consumed early."""
+        if not getattr(self, "_move_settle_expected", False):   # getattr: __new__-built test doubles
+            return False
+        if getattr(msg, "num_turns", None) != 0:
+            return False
+        self._move_settle_expected = False
+        self.backend._log("sdk %s: the move's turn-less result arrived — not a turn end" % self.sid[:8])
+        return True
 
     # ---- the permission/AskUserQuestion callback (the headless-parity piece) ----
 
@@ -3825,6 +3969,7 @@ class SdkBackend:
         self._log_cb = log
         self.sessions: dict[str, SdkSession] = {}
         self._lock = threading.Lock()
+        self._turn_seq: dict = {}                 # sid -> turns ended this kernel life (turn_seq; under _lock)
         self._reg_lock = threading.Lock()         # serializes _update_reg read-modify-writes (queue mirror
         #                                           writes come from kernel AND loop threads)
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
@@ -3935,6 +4080,13 @@ class SdkBackend:
           * A session with a persisted queue (reg['queue'], the _persist_queue mirror): resume it so the
             queue delivers via the __init__ seed.
         Everything else stays lazy/dormant. Loud one-line summary whenever anything was recovered."""
+        for r in regs:
+            if r.get("cwdPending"):   # a move cut by the kernel's death — settle it before anything resumes
+                try:
+                    self._heal_cwd_pending(r)
+                except Exception:
+                    self._log("boot reconcile: cwdPending heal for %s failed: %s"
+                              % (r.get("sid"), traceback.format_exc()))
         try:
             alive = [r for r in regs if r.get("alive") and r.get("sid")]
             reaped = 0
@@ -5859,6 +6011,222 @@ class SdkBackend:
             s.name = new_name
         return True
 
+    def move(self, sid: str, new_cwd: str) -> str:
+        """Move a session's working directory to `new_cwd` by wrapping the CLI's own `set_cwd` control
+        request (the user 2026-09-01, who wanted a session to follow a subproject promoted to its own
+        repo; the mechanism notes sit above `true_case`). "" on success; "busy" when a turn is in
+        flight — the kernel parks the op and retries at turn end; any other string is the reason the
+        move did not happen, verbatim for the user's error card (fail loudly, never quietly stay put).
+
+        Order of operations, and why:
+          * canonicalise first (realpath + true case; an existing directory, never created) — the
+            stored string is what every transcript path is derived from;
+          * a DORMANT session is revived first, in the OLD cwd, where its transcript is — never resumed
+            in the new dir "to save a step": `--resume` from another cwd finds the file by scan and then
+            keeps WRITING where it found it (the CLI adopts the found project dir), which would leave the
+            transcript behind under the old slug with romp pointing at the new one;
+          * `busy` is answered BEFORE anything is written (the kernel's park is the retry);
+          * TWO-PHASE write: `cwdPending: <new>` lands in the reg before the request, so a kernel that
+            dies between the CLI's `ok` (transcript already moved) and the reg write leaves a flag the
+            boot reconcile settles by checking which slug actually holds the transcript
+            (_heal_cwd_pending); a rejection drops the flag and changes nothing else;
+          * `needs_trust` is answered by re-sending with trust accepted: the user picked this folder for
+            the session — that pick IS the trust decision, and the CLI latches it durably in its config
+            (the same latch an interactive /cd's prompt would set), so a later resume there never asks;
+          * on `ok`: the live cwd, the reg (cwd + a durable movedFrom), the names/ discovery file (name
+            and colours preserved) and the PRIOR-EPISODE transcripts (the CLI moves only the current
+            <lastSid>.jsonl + folder; the older fsids of this sid — /clear episodes, resume forks — have
+            no writer, so romp renames them) all follow. Comment threads (threadOf regs) keep their own
+            reg.cwd and stay where they are in v1 — their transcripts stay consistent with their own reg.
+
+        Nothing is injected into the session: the CLI's own isMeta notice already tells the model where
+        it is now and loads the new folder's CLAUDE.md. No SessionStart hook fires. Not moved by anyone:
+        the old project's auto-memory, per-project allowedTools/MCP in the CLI's config, and the old
+        repo's .claude/settings.local.json — they are keyed on the folder, not the session."""
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
+            return "romp has no record of this session"
+        if reg.get("threadOf"):
+            return "a comment thread keeps its own folder — move the session it belongs to"
+        target, err = canon_dir(new_cwd)
+        if err:
+            return err
+        old = str(reg.get("cwd") or "")
+        if target == old:
+            # already there: nothing to ask the CLI and nothing to record. A flag written here would equal
+            # `cwd`, and the boot heal's location test cannot tell "pending == current" from "under BOTH
+            # slugs" — a kernel death inside that round trip left a flag it reported as a problem forever.
+            return ""
+        if not reg.get("alive"):
+            # dormant → revive in the OLD cwd (that is where the transcript is), then move like any live one
+            self.resume(str(reg.get("name") or sid), sid)
+        s = self._ensure(sid)
+        if s is None:
+            return "the session could not be started (see the kernel log)"
+        deadline = time.time() + MOVE_CONNECT_WAIT
+        while not s._connected.wait(0.5):   # event-based; the loop only re-checks the two exits
+            if not s.thread.is_alive():
+                le = self.launch_error(sid) or {}
+                return "the session's CLI did not start: %s" % (le.get("text") or "see the kernel log")
+            if time.time() > deadline:
+                return "the session's CLI did not come up within %ds" % int(MOVE_CONNECT_WAIT)
+        if self.busy(sid):
+            return "busy"
+        claim = self._claim_cwd_pending(sid, target)
+        if claim:
+            return claim
+        s._move_settle_expected = True   # armed BEFORE the request — see _consume_move_settle
+        r, err = self._set_cwd_request(s, target)
+        if not err and isinstance(r, dict) and r.get("status") == "needs_trust":
+            r, err = self._set_cwd_request(s, target, trust=str(r.get("directory") or target))
+        ok = not err and isinstance(r, dict) and r.get("status") == "ok"
+        if not ok:
+            if err == _NO_CONTROL_SENDER:
+                s._move_settle_expected = False                 # nothing was sent
+                self._update_reg_dropping(sid, ("cwdPending",))
+                return err
+            if isinstance(r, dict) and r.get("status") == "rejected":
+                s._move_settle_expected = False                 # the CLI answered: it did nothing
+                self._update_reg_dropping(sid, ("cwdPending",))
+                if r.get("reason") == "busy":
+                    return "busy"
+                return str(r.get("message") or r.get("reason") or "the CLI rejected the move")
+            # No usable answer — a control error, a timeout, an unknown shape. The CLI relocates FIRST
+            # and replies after, so a lost reply can mean a move that happened: dropping the flag here
+            # would leave romp deriving the transcript path from the old folder while the file sits
+            # under the new one (a blind feed, and the next --resume writes to the wrong place). The
+            # transcript's location decides, exactly as the boot heal decides a kernel death mid-move.
+            why = err or ("unexpected reply to set_cwd: %r" % (r,))
+            self._heal_cwd_pending(read_reg(self.state_dir, sid) or {"sid": sid, "cwdPending": target, "cwd": old})
+            after = read_reg(self.state_dir, sid) or {}
+            if after.get("cwd") == target and not after.get("cwdPending"):
+                # it moved (and the CLI's turn-less result is still expected — the arm stands)
+                self._log("sdk %s: set_cwd's reply was lost (%s) but the transcript is under %s — the move stands"
+                          % (sid[:8], why, target))
+                return ""
+            s._move_settle_expected = False
+            if after.get("cwdPending"):
+                return ("the move's outcome is uncertain: %s — the transcript was not found under exactly one of "
+                        "%s and %s, so nothing was changed; the next kernel start re-checks (see the kernel log)"
+                        % (why, old or "its folder", target))
+            return "the move failed: %s — the session stays in %s" % (why, old or "its folder")
+        new = r.get("cwd") if isinstance(r.get("cwd"), str) and r.get("cwd") else target
+        if r.get("changed") is False or new == old:
+            s._move_settle_expected = False                     # no relocation → no turn-less result is coming
+            self._update_reg_dropping(sid, ("cwdPending",))     # already there — nothing to record
+            return ""
+        self._finish_move(s, sid, old, new)
+        return ""
+
+    def _claim_cwd_pending(self, sid: str, target: str) -> str:
+        """Set the two-phase flag ONLY when no move is pending. Two concurrent move() calls for one sid (a
+        dashboard and `romp move`, or a double click) must not both send set_cwd — the second would race
+        the first's rename and reg write. The check and the write are one step under _reg_lock. "" when
+        claimed; otherwise the reason, verbatim for the user's error card. A flag an earlier kernel left
+        unsettled (the boot heal's BOTH/NEITHER case) refuses too, and says where to look."""
+        with self._reg_lock:
+            reg = read_reg(self.state_dir, sid)
+            if reg is None:
+                return "romp has no record of this session"
+            pend = reg.get("cwdPending")
+            if pend:
+                return ("a move to %s is already pending for this session — in flight, or left unsettled by an "
+                        "earlier kernel (see the kernel log)" % pend)
+            reg["cwdPending"] = target
+            write_reg(self.state_dir, sid, reg)
+            return ""
+
+    @staticmethod
+    def _set_cwd_request(s, path: str, trust: str | None = None):
+        """The ONE place romp speaks the SDK's PRIVATE control-request sender. Python SDK 0.2.132 has no
+        public wrapper for set_cwd (the TypeScript SDK already ships `setCwd(path, {trustAccepted,
+        trustedDirectory})`); when the Python SDK grows one, swap this body for it and nothing else
+        changes. `trust` is the directory a `needs_trust` answer named — the re-send accepts it.
+        Returns _call_on_loop's (response, error) pair; a client without the sender is the named
+        _NO_CONTROL_SENDER error, never a guess at another route."""
+        q = getattr(s.client, "_query", None)
+        send = getattr(q, "_send_control_request", None)
+        if not callable(send):
+            return None, _NO_CONTROL_SENDER
+        req = {"subtype": "set_cwd", "path": path}
+        if trust:
+            req.update(trust_accepted=True, trusted_directory=trust)
+        return s._call_on_loop(lambda: send(req), "move (trust)" if trust else "move", timeout=MOVE_CONTROL_TIMEOUT)
+
+    def _finish_move(self, s, sid: str, old: str, new: str) -> None:
+        """Everything romp records about a session's cwd follows the CLI's `ok` — the live object (the
+        next reconnect's --resume must look where the transcript now is), the reg (cwd, a durable
+        movedFrom; cwdPending spent), the names/ file (discovery re-scans on its mtime), and the
+        prior-episode transcripts the CLI did not move. Also the boot heal's finishing half."""
+        if s is not None:
+            s.cwd = new
+        self._update_reg_dropping(sid, ("cwdPending",), cwd=new,
+                                  movedFrom={"cwd": old, "t": int(time.time())})
+        reg = read_reg(self.state_dir, sid) or {}
+        try:
+            parts = (Path(self.state_dir) / "names" / sid).read_text().rstrip("\n").split("\t")
+        except OSError:
+            parts = [str(reg.get("name") or sid), old]
+        parts += ["", "", ""]
+        write_name(self.state_dir, sid, parts[0] or str(reg.get("name") or sid), new, parts[2], parts[3])
+        moved = relocate_transcripts(old, new, known_fsids(self.state_dir, sid, reg), log=self._log)
+        self._log("sdk %s: moved %r -> %r (%d prior transcript file(s) followed)"
+                  % (sid[:8], old, new, len(moved)))
+        self._poke()
+
+    def _update_reg_dropping(self, sid: str, drop=(), **fields) -> None:
+        """_update_reg that also REMOVES keys — a spent two-phase flag (cwdPending) must leave the reg,
+        not linger as a null every reader has to know about. Same lock, same unreadable-reg guard."""
+        with self._reg_lock:
+            reg = read_reg(self.state_dir, sid)
+            if reg is None:
+                if _reg_path(self.state_dir, sid).exists():
+                    sys.stderr.write("update_reg: %s unreadable — skipping a %s write rather than "
+                                     "gutting the reg\n" % (sid[:8], "/".join(sorted(fields) + list(drop))))
+                    return
+                reg = {"sid": sid}
+            for k in drop:
+                reg.pop(k, None)
+            reg.update(fields)
+            write_reg(self.state_dir, sid, reg)
+
+    def _heal_cwd_pending(self, reg: dict) -> None:
+        """Settle a reg the previous kernel left mid-move (cwdPending set: the request went out, the reg
+        never learned the answer). The transcript's location is the fact that decides it — exactly ONE
+        of the two project slugs should hold `<lastSid>.jsonl`: under the pending cwd the CLI said `ok`
+        and only romp's half is missing (finish it); still under the old cwd the move never happened
+        (drop the flag). Neither or both is a state this code must not guess at: say so loudly and
+        leave the flag for a person."""
+        sid = str(reg.get("sid") or "")
+        pend = str(reg.get("cwdPending") or "")
+        cur = str(reg.get("cwd") or "")
+        fsid = str(reg.get("lastSid") or sid)
+        if not sid or not pend:
+            return
+        if pend == cur:
+            # a move to the folder the session was already in, cut mid-flight (a reg from before move()
+            # short-circuited that case): nothing moved and nothing can be learned from the location
+            # test below — both slugs are ONE slug, so it would read "under BOTH" and file a problem
+            # on every boot for as long as the flag lived
+            self._log("boot reconcile: %s had a move to its own folder pending — nothing to settle; cleared" % sid[:8])
+            self._update_reg_dropping(sid, ("cwdPending",))
+            return
+        at_new = os.path.exists(transcript_path(pend, fsid))
+        at_old = bool(cur) and os.path.exists(transcript_path(cur, fsid))
+        if at_new and not at_old:
+            self._log("boot reconcile: %s was mid-move to %s — the transcript is there; finishing romp's half"
+                      % (sid[:8], pend))
+            self._finish_move(self.sessions.get(sid), sid, cur, pend)
+        elif at_old and not at_new:
+            self._log("boot reconcile: %s had a move to %s pending that never happened — cleared" % (sid[:8], pend))
+            self._update_reg_dropping(sid, ("cwdPending",))
+        else:
+            self._log("boot reconcile: %s has cwdPending=%s but its transcript %s is %s — leaving the flag; "
+                      "check %s and %s by hand"
+                      % (sid[:8], pend, fsid, "under BOTH slugs" if at_new else "under NEITHER slug",
+                         transcript_path(cur, fsid) if cur else "(no cwd)", transcript_path(pend, fsid)),
+                      problem=True)
+
     def set_model(self, sid: str, value: str) -> bool:
         """Change the session's model. Persisted in the registry (so a reconnect keeps it) and applied
         LIVE on a connected session via the SDK control channel — NOT a /model slash injection, which the
@@ -6729,6 +7097,16 @@ class SdkBackend:
 
     def _turn_completed(self, sid: str):
         """A turn's ResultMessage landed — the session is demonstrably able to finish turns again, so
-        re-arm the crash-resume budget (_heal_cut_session's one-resume-per-cut bound)."""
+        re-arm the crash-resume budget (_heal_cut_session's one-resume-per-cut bound), and count the
+        turn end (turn_seq — the event a parked move waits on after the CLI answered `busy`)."""
         with self._lock:
             self._heal_attempts.pop(sid, None)
+            self._turn_seq[sid] = self._turn_seq.get(sid, 0) + 1
+
+    def turn_seq(self, sid: str) -> int:
+        """How many of this session's turns have ENDED (ResultMessages seen) this kernel life. The kernel's
+        parked move keys its retry on this after the CLI answered `busy`: a turn the CLI knows about that
+        romp's inflight does not (one the CLI started itself — a hook, a background task's notification)
+        still ends with a ResultMessage, and that end is the event, not a timer."""
+        with self._lock:
+            return self._turn_seq.get(sid, 0)

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -16,7 +16,7 @@ A conformance test asserts SdkBackend implements every abstract method, so the d
 Method groups:
   liveness/identity — owns, live_sessions
   control           — send, interrupt, set_model, set_mode, set_effort, set_fast
-  lifecycle         — spawn, resume, connect, kill, rename
+  lifecycle         — spawn, resume, move, connect, kill, rename
   coordination      — working_note, set_working_note, wake   (backend-agnostic; tmux used @romp-working +
                       send-keys, the SDK now gets a store + an enqueue-wake so it has both too)
   chat tail         — pending_queued, live_atoms, prune_live
@@ -163,6 +163,17 @@ class SessionBackend(ABC):
     @abstractmethod
     def resume(self, name: str, sid: str, cwd: str | None = None) -> bool:
         """Revive a DEAD session by sid (resumes its conversation)."""
+
+    def move(self, sid: str, cwd: str) -> str:
+        """Move a session's working directory to `cwd` — its conversation, transcript and identity
+        follow it (the user 2026-09-01, who wanted a session to follow a subproject promoted to its own
+        repo). "" on success; "busy" when a turn is in flight (the kernel parks the op and retries at
+        turn end); any other string is the reason it did not happen, shown to the user verbatim. SDK-only
+        control (the CLI's `set_cwd` control request — see SdkBackend.move): a backend with no relocation
+        primitive romp can drive inherits this refusal, worded for no backend in particular, so a new
+        backend never reads as movable by omission (TmuxBackend.move spells out the terminal case)."""
+        return ("this session's backend has no way to move a running session — "
+                "start a new session in that folder instead")
 
     @abstractmethod
     def kill(self, sid: str) -> bool: ...

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -226,6 +226,47 @@ MOCK
     [[ "$output" == *"kernel isn't running"* ]]
 }
 
+@test "move: POST /move with target and dir; a relative dir is resolved against the caller's cwd; usage, queued and no-token are loud" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp move exp-web /srv/notes-api/web
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"exp-web" now works in /srv/notes-api/web'* ]]
+    grep '/move' "$MOCK_LOG" | grep -q '"target": *"exp-web"'
+    grep '/move' "$MOCK_LOG" | grep -q '"dir": *"/srv/notes-api/web"'
+    # a relative folder means relative to where the caller stands, not to the kernel's default dir
+    run run_romp move exp-web sub/dir
+    [ "$status" -eq 0 ]
+    grep '/move' "$MOCK_LOG" | grep -q "\"dir\": *\"$WORK_DIR/sub/dir\""
+    # a mid-turn session parks the move: the CLI says so instead of claiming it happened
+    cat > "$MOCK_DIR/curl" << 'MOCK'
+#!/usr/bin/env bash
+echo "curl $*" >> "$MOCK_LOG"
+echo '{"ok": true, "id": "11111111-2222-3333-4444-555555555555", "queued": true, "dir": "/srv/notes-api/web"}'
+MOCK
+    chmod +x "$MOCK_DIR/curl"
+    run run_romp move exp-web /srv/notes-api/web
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"queued"* ]]
+    # a refusal rides the kernel's own words
+    cat > "$MOCK_DIR/curl" << 'MOCK'
+#!/usr/bin/env bash
+echo '{"ok": false, "error": "directory not found: /nowhere"}'
+MOCK
+    chmod +x "$MOCK_DIR/curl"
+    run run_romp move exp-web /nowhere
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused — directory not found: /nowhere"* ]]
+    run run_romp move only-one-arg
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp move"* ]]
+    unset ROMP_SERVE_TOKEN
+    run run_romp move exp-web /srv/notes-api/web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel isn't running"* ]]
+}
+
 @test "color: POST /color with target and a literal hex; prints the new color" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_event_model_relocated.py
+++ b/tests/test_event_model_relocated.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""The two records a session move leaves in its transcript (the user 2026-09-01; Claude Code 2.1.257's
+`set_cwd`): a uuid-less `{type: relocated, sessionId, relocatedCwd}` marker and an isMeta user record
+carrying the CLI's own "your working directory has changed" notice to the model. Neither is a message:
+the event model must yield no atom for either, and the conversation's parent chain — which the next
+turn hangs off the isMeta record — must still stitch across them. SYNTHETIC transcript only."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+em = SourceFileLoader("romp_event_model_reloc", os.path.join(BIN, "romp-event-model")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+OLD, NEW = "/srv/notes-api", "/srv/notes-api/web"
+
+MOVE_NOTICE = ("<system-reminder>\nThe session's working directory has changed to %s (by the user). The "
+               "environment block at the start of this conversation still names the previous directory — "
+               "that information is stale. All tool calls and relative paths now resolve from %s.\n"
+               "</system-reminder>\n\nCodebase and user instructions are shown below.\n# web\nA tiny synthetic "
+               "CLAUDE.md for the promoted subproject." % (NEW, NEW))
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, cwd=OLD):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "cwd": cwd,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, cwd=OLD):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "cwd": cwd,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def records():
+    return [
+        uline(T0, "rename the web module's config loader", "u1"),
+        aline(T0 + 5, "Done — the loader is renamed.", "a1", parent="u1"),
+        # the move: the CLI's marker (no uuid, no timestamp) and its notice to the model
+        {"type": "relocated", "sessionId": SID, "relocatedCwd": NEW},
+        {"type": "user", "timestamp": iso(T0 + 10), "uuid": "m1", "parentUuid": "a1", "isMeta": True,
+         "cwd": NEW, "message": {"role": "user", "content": MOVE_NOTICE}},
+        uline(T0 + 20, "now run the web tests here", "u2", parent="m1", cwd=NEW),
+        aline(T0 + 25, "All 12 tests pass in the new folder.", "a2", parent="u2", cwd=NEW),
+    ]
+
+
+def parse(recs):
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / (SID + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        return em.parse_session(str(p), rompuuid=SID, name="web", dir="/TESTDIR",
+                                candidate_files=[str(p)], states=None, postal_log=[], now=NOW)
+
+
+class RelocationRecords(unittest.TestCase):
+    def test_neither_record_becomes_an_atom_and_the_chain_still_stitches(self):
+        out = parse(records())
+        atoms = [a for t in out["turns"] for a in t["atoms"]]
+        self.assertEqual([a["uuid"] for a in atoms], ["u1", "a1", "u2", "a2"],
+                         "the marker and the isMeta notice are bookkeeping, not conversation")
+        texts = json.dumps(atoms)
+        self.assertNotIn("working directory has changed", texts)
+        self.assertNotIn("relocatedCwd", texts)
+        self.assertEqual(len(out["turns"]), 2)
+        self.assertTrue(all(t["ended"] for t in out["turns"]), "both turns close normally across the move")
+
+    def test_the_move_notice_never_opens_a_turn(self):
+        # a session that moved and then sat idle: the isMeta record is the newest thing on disk and
+        # must not read as a pending human ask
+        out = parse(records()[:4])
+        self.assertEqual(len(out["turns"]), 1)
+        self.assertTrue(out["turns"][0]["ended"])
+        self.assertEqual([a["uuid"] for a in out["turns"][0]["atoms"]], ["u1", "a1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -46,6 +46,22 @@ class AbcContract(unittest.TestCase):
         m = re.search(r"def forwards_sends\(self\)[\s\S]*?\n        return (\w+)", src)
         self.assertTrue(m and m.group(1) == "True", "SdkBackend.forwards_sends returns True")
 
+    def test_move_is_a_concrete_default_that_refuses_and_the_sdk_implements_it(self):
+        # move (the user 2026-09-01: a session follows a subproject promoted to its own repo) is a
+        # CONCRETE default on the ABC — a backend with no relocation primitive answers with the reason,
+        # never "" (which would read as success), never "busy" (which would park a retry forever) and
+        # never a raise. The SDK backend implements it over the CLI's set_cwd control request; asserted
+        # at the source level like the abstract set.
+        self.assertNotIn("move", ABSTRACT, "move is a concrete default (a backend without one inherits the refusal)")
+        why = sb.SessionBackend.move(object(), "sid", "/tmp")
+        self.assertIsInstance(why, str)
+        self.assertTrue(why, "the default is a REASON, not an empty success")
+        self.assertNotEqual(why, "busy")
+        self.assertIn("no way to move", why)
+        src = open(os.path.join(BIN, "romp_sdk_backend.py"), encoding="utf-8").read()
+        self.assertIn("\n    def move(self, sid: str, new_cwd: str) -> str:", src,
+                      "SdkBackend implements move")
+
     def test_sdk_backend_honors_every_abstract_method(self):
         # SdkBackend is SDK-gated so it can't import the ABC when the dep is absent; it conforms by
         # duck-typing. Assert at the SOURCE level (no SDK dep needed) that it DEFINES each abstract method,

--- a/tests/test_session_move.py
+++ b/tests/test_session_move.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Moving a live session's working directory (the user 2026-09-01, who wanted a session to follow a
+subproject promoted to its own repo): SdkBackend.move as a thin wrapper over the CLI's `set_cwd`
+control request, driven here through a SCRIPTED fake control channel — every response arm the CLI
+has (ok / needs_trust→ok / rejected busy / rejected not_found / a control error / a missing sender),
+the two-phase `cwdPending` reg write, the names-file rewrite, the prior-episode transcript relocation,
+the boot-reconcile heal, and the guard that keeps the move's turn-less ResultMessage from settling a
+turn that never was. All fixtures SYNTHETIC: placeholder uuids, temp dirs, hostname TESTHOST."""
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import threading
+import time
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_move", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"        # the session's stable romp uuid (= its first fsid)
+EPISODE_FSID = "22222222-3333-4444-5555-666666666666"   # an earlier /clear episode of the same session
+FORK_FSID = "33333333-4444-5555-6666-777777777777"      # a resume-fork transcript of the same session
+THREAD = "99999999-8888-7777-6666-555555555555"
+
+
+def _ok(cwd, changed=True):
+    return {"status": "ok", "cwd": cwd, "changed": changed, "transcript_relocated": True}
+
+
+class _Query:
+    """The SDK client's private control-request sender, scripted: each call records the request and
+    pops the next arm — a dict is the CLI's response, an exception is a control error."""
+    def __init__(self, arms):
+        self.arms = list(arms)
+        self.requests = []
+
+    async def _send_control_request(self, req):
+        self.requests.append(dict(req))
+        arm = self.arms.pop(0)
+        if isinstance(arm, BaseException):
+            raise arm
+        return arm
+
+
+class _Client:
+    def __init__(self, query):
+        self._query = query
+
+
+class MoveBase(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.claude = tempfile.mkdtemp()
+        os.environ["CLAUDE_CONFIG_DIR"] = self.claude   # transcript_path resolves through this
+        self.logs = []
+        self.be = sb.SdkBackend(Path(self.td), "/bin/true", lambda *a, **k: None)
+        self.be._log = lambda m, problem=None: self.logs.append((m, bool(problem)))
+        self.old = os.path.realpath(tempfile.mkdtemp())
+        self.new = os.path.realpath(tempfile.mkdtemp())
+        self.be.spawn("web", self.old, bg="#123456", fg="#ffffff", sid=SID)
+        self.loops = []
+
+    def tearDown(self):
+        for loop in self.loops:
+            loop.call_soon_threadsafe(loop.stop)
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        for d in (self.td, self.claude, self.old, self.new):
+            shutil.rmtree(d, ignore_errors=True)
+
+    # -- fixtures --
+    def _reg(self):
+        return json.loads((Path(self.td) / "sdk" / (SID + ".json")).read_text())
+
+    def _names(self):
+        return (Path(self.td) / "names" / SID).read_text().rstrip("\n").split("\t")
+
+    def _wire(self, arms):
+        """A session the backend believes is running: a real SdkSession (never started), its loop a live
+        asyncio loop on a helper thread (so _call_on_loop's run_coroutine_threadsafe works), its client
+        the scripted fake, its thread reporting alive so _ensure hands it back instead of spawning."""
+        s = sb.SdkSession(self.be, dict(sb.read_reg(self.be.state_dir, SID) or {}, sid=SID))
+        loop = asyncio.new_event_loop()
+        threading.Thread(target=loop.run_forever, daemon=True).start()
+        self.loops.append(loop)
+        s.loop = loop
+        s.client = _Client(_Query(arms))
+        s._connected.set()
+        s.thread = types.SimpleNamespace(is_alive=lambda: True)
+        self.be.sessions[SID] = s
+        return s
+
+    def _place(self, cwd, fsid, sidecar=False, text="x"):
+        p = Path(sb.transcript_path(cwd, fsid))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"type": "user", "uuid": "u1", "cwd": cwd, "text": text}) + "\n")
+        if sidecar:
+            (p.parent / fsid / "subagents").mkdir(parents=True, exist_ok=True)
+            (p.parent / fsid / "subagents" / "agent-1.jsonl").write_text("{}\n")
+        return p
+
+    def _record_history(self):
+        """The session's earlier transcripts as romp knows them: an episode row (a /clear) and a
+        resume-fork row (a cut turn resumed onto a fresh head), each with files under the OLD slug."""
+        (Path(self.td) / "episodes").mkdir(exist_ok=True)
+        (Path(self.td) / "episodes" / (SID + ".jsonl")).write_text(
+            json.dumps({"head": "h1", "fsid": EPISODE_FSID, "t": 1}) + "\n"
+            + json.dumps({"head": "h2", "fsid": SID, "t": 2}) + "\n")
+        (Path(self.td) / "states").mkdir(exist_ok=True)
+        with (Path(self.td) / "states" / (SID + ".jsonl")).open("a") as fh:
+            fh.write(json.dumps({"t": 3, "resumeFork": {"from": FORK_FSID, "to": SID}}) + "\n")
+        self._place(self.old, EPISODE_FSID, sidecar=True)
+        self._place(self.old, FORK_FSID)
+
+
+class MoveOk(MoveBase):
+    def test_ok_moves_every_record_romp_keeps(self):
+        self._record_history()
+        s = self._wire([_ok(self.new)])
+        res = self.be.move(SID, self.new + "/")   # trailing slash: canonicalised before the request
+        self.assertEqual(res, "")
+        self.assertEqual(s.client._query.requests, [{"subtype": "set_cwd", "path": self.new}])
+        reg = self._reg()
+        self.assertEqual(reg["cwd"], self.new)
+        self.assertEqual(reg["movedFrom"]["cwd"], self.old)
+        self.assertIsInstance(reg["movedFrom"]["t"], int)
+        self.assertNotIn("cwdPending", reg, "the two-phase flag is SPENT, not left as a null")
+        self.assertEqual(self._names(), ["web", self.new, "#123456", "#ffffff"],
+                         "the names file follows, name and colours preserved")
+        self.assertEqual(s.cwd, self.new, "the next reconnect resumes where the transcript now is")
+        self.assertTrue(s._move_settle_expected, "the turn-less result the CLI emits next is expected")
+        # the CLI moved the current transcript; romp moved the session's OLDER files the same way
+        for fsid in (EPISODE_FSID, FORK_FSID):
+            self.assertFalse(os.path.exists(sb.transcript_path(self.old, fsid)), fsid + " left the old slug")
+            self.assertTrue(os.path.exists(sb.transcript_path(self.new, fsid)), fsid + " is under the new slug")
+        side = Path(sb.transcript_path(self.new, EPISODE_FSID)).parent / EPISODE_FSID / "subagents" / "agent-1.jsonl"
+        self.assertTrue(side.exists(), "the <fsid>/ sidecar folder followed its transcript")
+
+    def test_needs_trust_is_answered_with_the_users_own_pick(self):
+        s = self._wire([{"status": "needs_trust", "directory": self.new}, _ok(self.new)])
+        self.assertEqual(self.be.move(SID, self.new), "")
+        reqs = s.client._query.requests
+        self.assertEqual(len(reqs), 2)
+        self.assertEqual(reqs[1]["subtype"], "set_cwd")
+        self.assertIs(reqs[1]["trust_accepted"], True)
+        self.assertEqual(reqs[1]["trusted_directory"], self.new)
+        self.assertEqual(self._reg()["cwd"], self.new)
+
+    def test_the_clis_reported_cwd_is_the_stored_string(self):
+        # the CLI answers with its own getcwd (true on-disk casing); that string is what every transcript
+        # path derives from, so it wins over the one romp sent
+        s = self._wire([_ok(self.new)])
+        self.be.move(SID, self.new)
+        self.assertEqual(self._reg()["cwd"], self.new)
+        self.assertEqual(s.cwd, self.new)
+
+    def test_same_folder_is_a_quiet_no_op(self):
+        # never a request and never the flag: a cwdPending EQUAL to cwd is a state the boot heal cannot
+        # read (both slugs are one slug → "under BOTH", a problem filed on every boot forever)
+        s = self._wire([_ok(self.old, changed=False)])
+        claims = []
+        real = self.be._claim_cwd_pending
+        self.be._claim_cwd_pending = lambda *a: (claims.append(a), real(*a))[1]
+        self.assertEqual(self.be.move(SID, self.old), "")
+        self.assertEqual(s.client._query.requests, [], "nothing to ask the CLI")
+        self.assertEqual(claims, [], "the two-phase flag is never written for a same-folder move")
+        reg = self._reg()
+        self.assertEqual(reg["cwd"], self.old)
+        self.assertNotIn("movedFrom", reg)
+        self.assertNotIn("cwdPending", reg)
+        self.assertFalse(s._move_settle_expected, "no request → nothing armed")
+
+    def test_the_clis_changed_false_disarms_and_drops_the_flag(self):
+        # the CLI resolved the target to where the session already is (a symlink, a case difference the
+        # canonicaliser missed): no relocation → no turn-less result, and nothing to record
+        s = self._wire([_ok(self.old, changed=False)])
+        self.assertEqual(self.be.move(SID, self.new), "")
+        reg = self._reg()
+        self.assertEqual(reg["cwd"], self.old)
+        self.assertNotIn("movedFrom", reg)
+        self.assertNotIn("cwdPending", reg)
+        self.assertFalse(s._move_settle_expected, "changed:false emits no turn-less result — disarmed")
+
+    def test_two_concurrent_moves_send_one_request(self):
+        # the second asker (a dashboard and `romp move`, or a double click) must not race the first's
+        # rename and reg write: the two-phase flag is CLAIMED under the reg lock, and a claimed flag
+        # refuses the second call before any request goes out
+        gate = threading.Event()
+
+        class _Gated(_Query):
+            async def _send_control_request(self, req):
+                self.requests.append(dict(req))
+                await asyncio.get_running_loop().run_in_executor(None, gate.wait)
+                return _ok(req["path"])
+        s = self._wire([])
+        s.client = _Client(_Gated([]))
+        out = {}
+        ta = threading.Thread(target=lambda: out.__setitem__("a", self.be.move(SID, self.new)))
+        ta.start()
+        for _ in range(500):                         # until the first call has claimed the flag
+            if self._reg().get("cwdPending"):
+                break
+            time.sleep(0.01)
+        out["b"] = self.be.move(SID, self.new)       # the second asker, while the first is in flight
+        gate.set()
+        ta.join(10)
+        self.assertEqual(out.get("a"), "")
+        self.assertIn("already pending", out["b"])
+        self.assertEqual(len(s.client._query.requests), 1, "one set_cwd, not two")
+        self.assertEqual(self._reg()["cwd"], self.new)
+        self.assertNotIn("cwdPending", self._reg())
+
+    def test_dormant_session_is_revived_first_then_moved(self):
+        reg = self._reg()
+        reg["alive"] = False
+        (Path(self.td) / "sdk" / (SID + ".json")).write_text(json.dumps(reg))
+        self._wire([_ok(self.new)])   # _ensure hands this back (alive thread) once resume flipped the reg
+        self.assertEqual(self.be.move(SID, self.new), "")
+        self.assertTrue(self._reg()["alive"], "resume() ran before the move")
+        self.assertEqual(self._reg()["cwd"], self.new)
+
+
+class MoveRefusals(MoveBase):
+    def _unchanged(self, s=None):
+        reg = self._reg()
+        self.assertEqual(reg["cwd"], self.old)
+        self.assertNotIn("cwdPending", reg)
+        self.assertNotIn("movedFrom", reg)
+        self.assertEqual(self._names()[1], self.old)
+        if s is not None:
+            self.assertEqual(s.cwd, self.old)
+            self.assertFalse(s._move_settle_expected)
+
+    def test_rejected_busy_is_the_parking_signal(self):
+        s = self._wire([{"status": "rejected", "reason": "busy"}])
+        self.assertEqual(self.be.move(SID, self.new), "busy")
+        self._unchanged(s)
+
+    def test_a_turn_in_flight_is_busy_before_any_request(self):
+        s = self._wire([_ok(self.new)])
+        s.inflight = 1
+        self.assertEqual(self.be.move(SID, self.new), "busy")
+        self.assertEqual(s.client._query.requests, [])
+        self._unchanged(s)
+
+    def test_rejected_carries_the_clis_own_words(self):
+        s = self._wire([{"status": "rejected", "reason": "not_found",
+                         "message": "Couldn't find a directory at /srv/notes-api/web."}])
+        self.assertEqual(self.be.move(SID, self.new), "Couldn't find a directory at /srv/notes-api/web.")
+        self._unchanged(s)
+
+    def test_a_control_error_leaves_the_session_where_it_was(self):
+        # the CLI rolls its chdir back on a relocation failure — the transcript is still under the OLD
+        # slug, which is how romp knows nothing moved; it drops the flag and says why
+        s = self._wire([RuntimeError("relocation failed: EXDEV")])
+        self._place(self.old, SID)
+        res = self.be.move(SID, self.new)
+        self.assertTrue(res.startswith("the move failed:"), res)
+        self.assertIn("EXDEV", res)
+        self.assertIn(self.old, res)
+        self._unchanged(s)
+
+    def test_a_missing_sender_is_named_not_worked_around(self):
+        s = self._wire([])
+        s.client = types.SimpleNamespace(_query=object())   # an SDK without the private sender
+        res = self.be.move(SID, self.new)
+        self.assertIn("_send_control_request", res)
+        self.assertIn("set_cwd", res)
+        self._unchanged(s)
+
+    def test_a_bad_target_is_refused_before_any_request(self):
+        s = self._wire([_ok(self.new)])
+        f = os.path.join(self.new, "notes.txt")
+        Path(f).write_text("not a folder")
+        self.assertTrue(self.be.move(SID, f).startswith("not a directory: "))
+        self.assertTrue(self.be.move(SID, os.path.join(self.new, "nope")).startswith("directory not found: "))
+        self.assertEqual(self.be.move(SID, "relative/path"), "the folder must be an absolute path: relative/path")
+        self.assertEqual(self.be.move(SID, ""), "no folder given")
+        self.assertEqual(s.client._query.requests, [])
+        self._unchanged(s)
+
+    def test_a_comment_thread_keeps_its_own_folder(self):
+        self.be.fork("thread-x", SID, "a1", sid=THREAD, thread_of=SID)
+        res = self.be.move(THREAD, self.new)
+        self.assertIn("comment thread", res)
+
+    def test_an_unknown_sid_is_refused(self):
+        self.assertIn("no record", self.be.move("44444444-5555-6666-7777-888888888888", self.new))
+
+    def test_an_existing_target_file_is_never_overwritten(self):
+        self._record_history()
+        self._place(self.new, EPISODE_FSID, text="already here")   # a collision only a person should resolve
+        self._wire([_ok(self.new)])
+        self.assertEqual(self.be.move(SID, self.new), "")
+        self.assertTrue(os.path.exists(sb.transcript_path(self.old, EPISODE_FSID)), "left where it was")
+        self.assertIn("already here", Path(sb.transcript_path(self.new, EPISODE_FSID)).read_text())
+        self.assertTrue(any("already exists" in m and p for m, p in self.logs), "logged as a problem")
+        self.assertFalse(os.path.exists(sb.transcript_path(self.old, FORK_FSID)), "the others still moved")
+
+
+class LostReply(MoveBase):
+    """set_cwd's reply can be lost (a control error, a timeout) AFTER the CLI relocated — it moves first
+    and replies after. The transcript's location decides, exactly as the boot heal decides a kernel death
+    mid-move; dropping the flag blindly would leave romp deriving paths from the old folder."""
+
+    def test_a_lost_reply_after_the_cli_moved_stands(self):
+        self._record_history()
+        s = self._wire([RuntimeError("control request timed out")])
+        self._place(self.new, SID)                  # the CLI's half happened; only its reply was lost
+        self.assertEqual(self.be.move(SID, self.new), "")
+        reg = self._reg()
+        self.assertEqual(reg["cwd"], self.new)
+        self.assertEqual(reg["movedFrom"]["cwd"], self.old)
+        self.assertNotIn("cwdPending", reg)
+        self.assertEqual(self._names()[1], self.new)
+        self.assertEqual(s.cwd, self.new)
+        self.assertTrue(s._move_settle_expected, "the CLI's turn-less result is still coming — the arm stands")
+        self.assertTrue(os.path.exists(sb.transcript_path(self.new, EPISODE_FSID)), "prior episodes follow")
+        self.assertTrue(any("reply was lost" in m for m, p in self.logs))
+
+    def test_a_lost_reply_with_the_transcript_nowhere_is_uncertain_and_keeps_the_flag(self):
+        s = self._wire([RuntimeError("control request timed out")])
+        res = self.be.move(SID, self.new)
+        self.assertIn("uncertain", res)
+        self.assertIn("timed out", res)
+        reg = self._reg()
+        self.assertEqual(reg["cwd"], self.old, "nothing changed")
+        self.assertEqual(reg["cwdPending"], self.new, "the flag stays for the next boot's heal")
+        self.assertNotIn("movedFrom", reg)
+        self.assertFalse(s._move_settle_expected)
+        self.assertTrue(any("NEITHER" in m and p for m, p in self.logs), "said loudly")
+        # …and a second move is refused until it is settled, rather than racing a state nobody can read
+        s2 = self._wire([_ok(self.new)])
+        self.assertIn("already pending", self.be.move(SID, self.new))
+        self.assertEqual(s2.client._query.requests, [])
+
+
+class BootHeal(MoveBase):
+    """A kernel that died between the CLI's `ok` and romp's reg write leaves cwdPending; the transcript's
+    location settles it."""
+
+    def test_a_pending_move_to_the_same_folder_is_simply_cleared(self):
+        # a flag from before move() short-circuited the same-folder case: nothing moved, nothing to
+        # settle, and the location test would otherwise read "under BOTH" on every boot forever
+        reg = self._reg()
+        reg["cwdPending"] = self.old
+        reg["lastSid"] = SID
+        (Path(self.td) / "sdk" / (SID + ".json")).write_text(json.dumps(reg))
+        self._place(self.old, SID)
+        self.be._heal_cwd_pending(reg)
+        got = self._reg()
+        self.assertNotIn("cwdPending", got)
+        self.assertEqual(got["cwd"], self.old)
+        self.assertFalse(any(p for m, p in self.logs), "no problem filed — there was nothing to settle")
+        self.assertTrue(any("own folder" in m for m, p in self.logs))
+
+    def _pending_reg(self):
+        reg = self._reg()
+        reg["cwdPending"] = self.new
+        reg["lastSid"] = SID
+        (Path(self.td) / "sdk" / (SID + ".json")).write_text(json.dumps(reg))
+        return reg
+
+    def test_transcript_under_the_new_slug_finishes_romps_half(self):
+        self._record_history()
+        reg = self._pending_reg()
+        self._place(self.new, SID)          # the CLI's move happened
+        self.be._boot_reconcile([reg])     # the wiring: the heal runs for EVERY reg, dormant included
+        got = self._reg()
+        self.assertEqual(got["cwd"], self.new)
+        self.assertEqual(got["movedFrom"]["cwd"], self.old)
+        self.assertNotIn("cwdPending", got)
+        self.assertEqual(self._names()[1], self.new)
+        self.assertTrue(os.path.exists(sb.transcript_path(self.new, EPISODE_FSID)), "prior episodes follow too")
+
+    def test_transcript_still_under_the_old_slug_clears_the_flag(self):
+        reg = self._pending_reg()
+        self._place(self.old, SID)          # the move never happened
+        self.be._heal_cwd_pending(reg)
+        got = self._reg()
+        self.assertEqual(got["cwd"], self.old)
+        self.assertNotIn("cwdPending", got)
+        self.assertNotIn("movedFrom", got)
+
+    def test_both_or_neither_is_left_for_a_person_loudly(self):
+        reg = self._pending_reg()
+        self._place(self.old, SID)
+        self._place(self.new, SID)
+        self.be._heal_cwd_pending(reg)
+        self.assertEqual(self._reg()["cwdPending"], self.new, "ambiguous → the flag stays")
+        self.assertTrue(any("BOTH" in m and p for m, p in self.logs))
+        os.remove(sb.transcript_path(self.old, SID))
+        os.remove(sb.transcript_path(self.new, SID))
+        self.be._heal_cwd_pending(reg)
+        self.assertEqual(self._reg()["cwdPending"], self.new)
+        self.assertTrue(any("NEITHER" in m and p for m, p in self.logs))
+
+
+class Helpers(MoveBase):
+    def test_known_fsids_reads_every_lineage_record(self):
+        self._record_history()
+        reg = self._reg()
+        reg["lastSid"] = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        got = sb.known_fsids(Path(self.td), SID, reg)
+        self.assertEqual(got, {SID, EPISODE_FSID, FORK_FSID, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"})
+
+    def test_canon_dir_realpaths_and_requires_an_existing_directory(self):
+        link = os.path.join(self.td, "link")
+        os.symlink(self.new, link)
+        self.assertEqual(sb.canon_dir(link + "/"), (self.new, ""))
+        self.assertEqual(sb.canon_dir("~")[0], os.path.realpath(os.path.expanduser("~")))
+        self.assertEqual(sb.canon_dir("rel")[1], "the folder must be an absolute path: rel")
+        self.assertEqual(sb.canon_dir("  ")[1], "no folder given")
+        self.assertTrue(sb.canon_dir(os.path.join(self.new, "gone"))[1].startswith("directory not found"))
+
+    def test_relocate_skips_absent_sources_and_a_same_slug_move(self):
+        self.assertEqual(sb.relocate_transcripts(self.old, self.new, {SID}), [])
+        self._place(self.old, SID)
+        self.assertEqual(sb.relocate_transcripts(self.old, self.old + "/", {SID}), [], "same slug → nothing to do")
+        self.assertTrue(os.path.exists(sb.transcript_path(self.old, SID)))
+
+
+class FakeResultMessage:
+    def __init__(self, num_turns):
+        self.num_turns = num_turns
+        self.result = ""
+
+
+class FakeAssistantMessage:
+    pass
+
+
+class FakeSystemMessage:
+    pass
+
+
+class SpuriousSettle(unittest.TestCase):
+    """The accepted move's turn-less ResultMessage(num_turns=0) must not run the turn-settle side effects."""
+
+    def _session(self, be, armed):
+        s = object.__new__(sb.SdkSession)
+        s.backend = be
+        s.sid = SID
+        s.name = "web"
+        s.resume_sid = None
+        s._skill_tool_ids = set()
+        s._move_settle_expected = armed
+        s.marks = []
+        s._mark = lambda st: s.marks.append(st)
+        return s
+
+    def test_armed_and_zero_turns_is_consumed_without_settling(self):
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        completed = []
+        be._turn_completed = lambda sid: completed.append(sid)
+        s = self._session(be, armed=True)
+        s._on_message(FakeResultMessage(0), FakeAssistantMessage, FakeResultMessage, FakeSystemMessage)
+        self.assertEqual(completed, [], "no turn ended — nothing re-arms the crash-resume budget")
+        self.assertEqual(s.marks, [], "no 'waiting' write for a turn that never was")
+        self.assertFalse(s._move_settle_expected, "spent on the match")
+
+    def test_the_guard_only_fires_on_an_armed_zero_turn_result(self):
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        s = self._session(be, armed=False)
+        self.assertFalse(s._consume_move_settle(FakeResultMessage(0)), "unarmed: a real result settles as before")
+        s._move_settle_expected = True
+        self.assertFalse(s._consume_move_settle(FakeResultMessage(1)), "a real turn reports its round trips")
+        self.assertTrue(s._move_settle_expected, "…and leaves the arm for the move's own result")
+        self.assertTrue(s._consume_move_settle(FakeResultMessage(0)))
+        self.assertFalse(s._move_settle_expected)
+
+    def test_the_guard_precedes_the_settle_branch(self):
+        src = open(os.path.join(BIN, "romp_sdk_backend.py"), encoding="utf-8").read()
+        i = src.index("def _on_message(self, msg, AssistantMessage, ResultMessage, SystemMessage):")
+        g = src.index("elif isinstance(msg, ResultMessage) and self._consume_move_settle(msg):", i)
+        b = src.index("elif isinstance(msg, ResultMessage):", i)
+        self.assertLess(g, b, "the move guard is checked before the ordinary ResultMessage settle")
+        # armed BEFORE the request goes out — the response and the result race on two threads
+        m = src.index("def move(self, sid: str, new_cwd: str) -> str:")
+        arm = src.index("s._move_settle_expected = True", m)
+        req = src.index("r, err = self._set_cwd_request(s, target)", m)
+        self.assertLess(arm, req)
+
+    def test_the_private_sender_is_spoken_in_one_place(self):
+        # the SDK has no public set_cwd wrapper yet; the private call is isolated so the swap is one edit
+        src = open(os.path.join(BIN, "romp_sdk_backend.py"), encoding="utf-8").read()
+        body = src[src.index("def _set_cwd_request(s, path: str, trust: str | None = None):"):]
+        body = body[:body.index("\n    def _finish_move(")]
+        self.assertIn('"_send_control_request"', body)
+        elsewhere = src.replace(body, "")
+        m = elsewhere.index("def move(self, sid: str, new_cwd: str) -> str:")
+        self.assertNotIn("_send_control_request", elsewhere[m:m + 6000],
+                         "move() speaks set_cwd only through _set_cwd_request")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_move_kernel.py
+++ b/tests/test_session_move_kernel.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""The kernel half of moving a session's working directory (the user 2026-09-01): the moveSession WS
+op and POST /move resolve + canonicalise the folder like a new-session dir, go through the drive-op
+park-or-fire gate (a busy session parks a visible "move to …" chip; a quiet one fires now), hold the
+FIFO while the backend's blocking move runs (`_moving`), re-park a CLI-side `busy` a bounded number of
+times, and report every outcome as a typed event (moved / moveFailed) to the asker. The tmux backend
+refuses with a reason. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_move", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The ACCOUNT gate (_limit_hold) is a separate axis, tested in tests/test_kernel_limit_queue.py.
+km._limit_hold = lambda sid: None
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class _FakeBackend:
+    def __init__(self, answers=()):
+        self.answers = list(answers)
+        self.calls = []
+        self.models = []
+
+    def move(self, sid, path):
+        self.calls.append((sid, path))
+        return self.answers.pop(0) if self.answers else ""
+
+    def set_model(self, sid, value):
+        self.models.append((sid, value))
+        return True
+
+    def busy(self, sid):
+        return None
+
+    def turn_seq(self, sid):
+        return getattr(self, "seq", 0)
+
+
+def _sync_fire(be, sid, path, tries, wid):
+    """_fire_move without the thread: the test wants the outcome on this thread."""
+    km._moving.add(sid)
+    km._move_now(be, sid, path, tries, wid)
+
+
+class MoveOps(unittest.TestCase):
+    def setUp(self):
+        self.dir = os.path.realpath(tempfile.mkdtemp())
+        self.be = _FakeBackend()
+        self.sent = []          # client["send"] payloads (the WS asker)
+        self.views = []         # _send_to_view(app, msg, wid)
+        self.client = {"send": lambda s: self.sent.append(json.loads(s)), "wid": "w1"}
+        self._patches = [
+            mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: self.be)),
+            mock.patch.object(km, "_kernel_knows", lambda sid: True),
+            mock.patch.object(km, "_compacting_now", lambda sid: False),
+            mock.patch.object(km, "_working_now", lambda sid: False),
+            mock.patch.object(km, "_commands_for_cwd", lambda cwd: ([], False)),
+            mock.patch.object(km, "_push_soon", lambda: None),
+            mock.patch.object(km, "_name_of", lambda sid: "web"),
+            mock.patch.object(km, "_cwd_of", lambda sid: self.dir),
+            mock.patch.object(km, "_send_to_view", lambda app, msg, wid: self.views.append((app, msg, wid))),
+            mock.patch.object(km, "_fire_move", _sync_fire),
+        ]
+        for p in self._patches:
+            p.start()
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._move_askers.clear()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._move_askers.clear()
+
+    def test_idle_session_moves_now_and_the_asker_hears_moved(self):
+        handled = km._drive({"type": "moveSession", "id": SID, "dir": self.dir + "/"}, self.client)
+        self.assertTrue(handled)
+        self.assertEqual(self.be.calls, [(SID, self.dir)], "canonicalised (trailing slash gone) before the backend")
+        self.assertEqual(self.views, [("chat", {"type": "moved", "id": SID, "name": "web",
+                                                "cwd": km._tilde(self.dir)}, "w1")])
+        self.assertEqual(self.sent, [])
+        self.assertNotIn(SID, km._moving, "the hold is released with the outcome")
+
+    def test_a_missing_folder_is_refused_at_the_door(self):
+        km._drive({"type": "moveSession", "id": SID, "dir": os.path.join(self.dir, "nope")}, self.client)
+        self.assertEqual(self.be.calls, [])
+        self.assertEqual(self.sent[0]["type"], "moveFailed")
+        self.assertEqual(self.sent[0]["id"], SID)
+        self.assertIn("directory not found", self.sent[0]["text"])
+        self.sent.clear()
+        km._drive({"type": "moveSession", "id": SID, "dir": "   "}, self.client)
+        self.assertEqual(self.sent[0]["type"], "moveFailed")
+        self.assertIn("pick a folder", self.sent[0]["text"])
+
+    def test_a_busy_session_parks_a_visible_chip_and_fires_at_turn_end(self):
+        with mock.patch.object(km, "_working_now", lambda sid: True):
+            km._drive({"type": "moveSession", "id": SID, "dir": self.dir}, self.client)
+        self.assertEqual(self.be.calls, [], "mid-turn the backend is not touched")
+        self.assertEqual(km._pending_ops.get(SID), [("cwd", self.dir, 0)])
+        self.assertEqual(km._move_askers.get(SID), "w1")
+        self.assertEqual(km._parked_md(("cwd", self.dir, 0)), "move to " + km._tilde(self.dir),
+                         "plain words, not a slash command nobody can type")
+        # the turn ends → the producer pass fires the move and ENDS the pass: the op behind it waits
+        km._pending_ops[SID].append(("model", "opus"))
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [(SID, self.dir)])
+        self.assertEqual(self.be.models, [], "the model pick waits for the relocation to finish")
+        self.assertEqual(km._pending_ops.get(SID), [("model", "opus")])
+        self.assertEqual(self.views[-1][1]["type"], "moved")
+        self.assertEqual(self.views[-1][2], "w1", "a parked move still reports to the dashboard that asked")
+        km._apply_pending_ops()
+        self.assertEqual(self.be.models, [(SID, "opus")])
+
+    def test_a_repeat_pick_while_parked_replaces_in_place(self):
+        other = os.path.realpath(tempfile.mkdtemp())
+        with mock.patch.object(km, "_working_now", lambda sid: True):
+            km._drive({"type": "moveSession", "id": SID, "dir": self.dir}, self.client)
+            km._drive({"type": "moveSession", "id": SID, "dir": other}, self.client)
+        self.assertEqual(km._pending_ops.get(SID), [("cwd", other, 0)], "one chip, the latest folder")
+
+    def test_a_move_in_flight_holds_the_queue(self):
+        km._moving.add(SID)
+        self.assertTrue(km._ops_gate(SID), "anything pressed mid-move parks")
+        km._pending_ops[SID] = [("model", "opus")]
+        km._apply_pending_ops()
+        self.assertEqual(self.be.models, [], "the pass skips a sid whose move is still running")
+        km._moving.discard(SID)
+        km._apply_pending_ops()
+        self.assertEqual(self.be.models, [(SID, "opus")])
+
+    def test_a_cli_side_busy_retries_then_waits_for_the_turn_end(self):
+        # the CLI has a turn romp cannot see. A few passes retry blind (the CLI's post-result window has
+        # no further event); past those, the cue is the turn's END — the backend's turn_seq moving —
+        # never a timer, and never a loud failure while the CLI's turn is still running
+        self.be.answers = ["busy", "busy", "busy", "busy"]
+        km._pending_ops[SID] = [("cwd", self.dir, 0), ("send", "hello", "human")]
+        km._apply_pending_ops()
+        self.assertEqual(km._pending_ops[SID][0], ("cwd", self.dir, 1, 0), "back at the head, carrying the turn count")
+        km._apply_pending_ops()
+        km._apply_pending_ops()
+        self.assertEqual(len(self.be.calls), 3, "three passes retry without a cue")
+        self.assertEqual(km._pending_ops[SID][0], ("cwd", self.dir, 3, 0))
+        km._apply_pending_ops()
+        km._apply_pending_ops()
+        self.assertEqual(len(self.be.calls), 3, "no turn has ended (turn_seq unchanged) → it waits")
+        self.assertEqual(km._pending_ops[SID], [("cwd", self.dir, 3, 0), ("send", "hello", "human")],
+                         "a visible chip, the send still behind it")
+        self.assertEqual([m for a, m, w in self.views if m["type"] == "moveFailed"], [],
+                         "no loud failure while the CLI's turn runs")
+        self.be.seq = 1                              # the CLI's own turn ended: a ResultMessage was seen
+        km._apply_pending_ops()
+        self.assertEqual(len(self.be.calls), 4, "the turn end is the cue")
+        self.assertEqual(km._pending_ops[SID][0], ("cwd", self.dir, 4, 1), "busy again → waits on the NEXT turn end")
+        km._apply_pending_ops()
+        self.assertEqual(len(self.be.calls), 4)
+        self.be.seq = 2
+        km._apply_pending_ops()                      # answers exhausted → "" → moved
+        self.assertEqual(len(self.be.calls), 5)
+        self.assertEqual(km._pending_ops[SID], [("send", "hello", "human")])
+        self.assertEqual(self.views[-1][1]["type"], "moved")
+
+    def test_a_parked_retry_survives_a_kernel_restart_and_fires(self):
+        # a restart resets turn_seq to 0 and ends whatever turn the CLI owned: an op that waited on a
+        # higher count fires on the first pass
+        km._pending_ops[SID] = [("cwd", self.dir, 3, 7)]
+        km._apply_pending_ops()
+        self.assertEqual(len(self.be.calls), 1)
+        self.assertEqual(self.views[-1][1]["type"], "moved")
+
+    def test_a_foreign_move_is_refused_by_name(self):
+        self.assertEqual(km._FOREIGN_OP_VERB.get("moveSession"), "move",
+                         "a federated-board refusal names the move, not a generic action")
+
+    def test_a_backend_refusal_is_a_typed_failure_with_its_words(self):
+        self.be.answers = ["Couldn't find a directory at /srv/notes-api/web."]
+        km._drive({"type": "moveSession", "id": SID, "dir": self.dir}, self.client)
+        self.assertEqual(self.views, [("chat", {"type": "moveFailed", "id": SID, "name": "web",
+                                                "text": "Couldn't find a directory at /srv/notes-api/web."}, "w1")])
+
+    def test_a_backend_without_move_fails_loudly(self):
+        class _NoMove:
+            def busy(self, sid):
+                return None
+        with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: _NoMove())):
+            km._drive({"type": "moveSession", "id": SID, "dir": self.dir}, self.client)
+        self.assertEqual(self.views[-1][1]["type"], "moveFailed")
+        self.assertIn("no way to move", self.views[-1][1]["text"])
+
+    def test_tmux_backend_refuses_with_a_reason(self):
+        why = km._TMUX.move(SID, self.dir)
+        self.assertIsInstance(why, str)
+        self.assertIn("tmux", why)
+        self.assertIn("new session", why)
+
+    def test_move_session_is_a_drive_op_beside_rename(self):
+        import inspect
+        src = inspect.getsource(km._drive)
+        ops = [c for c in km._drive.__code__.co_consts if isinstance(c, tuple) and "renameSession" in c]
+        self.assertTrue(ops and "moveSession" in ops[0], "moveSession rides the same sid-keyed gate as renameSession")
+        self.assertIn('t == "moveSession" and msg.get("dir")', src)
+
+
+class MoveRoute(unittest.TestCase):
+    """POST /move over the REAL handler on loopback (the HeadlessRoutes pattern)."""
+
+    @classmethod
+    def setUpClass(cls):
+        import threading
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.dir = os.path.realpath(tempfile.mkdtemp())
+        self.be = _FakeBackend()
+        self._patches = [
+            mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: self.be)),
+            mock.patch.object(km, "_kernel_knows", lambda sid: True),
+            mock.patch.object(km, "_live_names", lambda tmux: {"web": SID}),
+            mock.patch.object(km, "_tmux_sessions", lambda: {}),
+            mock.patch.object(km, "_compacting_now", lambda sid: False),
+            mock.patch.object(km, "_working_now", lambda sid: False),
+            mock.patch.object(km, "_commands_for_cwd", lambda cwd: ([], False)),
+            mock.patch.object(km, "_push_soon", lambda: None),
+            mock.patch.object(km, "_name_of", lambda sid: "web"),
+            mock.patch.object(km, "_cwd_of", lambda sid: self.dir),
+            mock.patch.object(km, "_send_to_view", lambda app, msg, wid: None),
+        ]
+        for p in self._patches:
+            p.start()
+        km._pending_ops.clear()
+        km._moving.clear()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        km._pending_ops.clear()
+        km._moving.clear()
+
+    def _post(self, body):
+        import urllib.request, urllib.error
+        req = urllib.request.Request("http://127.0.0.1:%d/move" % self.port, method="POST",
+                                     data=json.dumps(body).encode(),
+                                     headers={"Content-Type": "application/json", "X-Romp-Token": km.TOKEN})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_quiet_session_moves_now_and_the_reply_is_the_outcome(self):
+        code, resp = self._post({"target": "web", "dir": self.dir + "/"})
+        self.assertEqual((code, resp), (200, {"ok": True, "id": SID, "dir": self.dir}))
+        self.assertEqual(self.be.calls, [(SID, self.dir)])
+
+    def test_busy_session_parks_and_says_queued(self):
+        with mock.patch.object(km, "_working_now", lambda sid: True):
+            code, resp = self._post({"target": "web", "dir": self.dir})
+        self.assertEqual((code, resp), (200, {"ok": True, "id": SID, "queued": True, "dir": self.dir}))
+        self.assertEqual(km._pending_ops.get(SID), [("cwd", self.dir, 0)])
+        self.assertEqual(self.be.calls, [])
+
+    def test_a_cli_side_busy_also_reads_as_queued(self):
+        self.be.answers = ["busy"]
+        code, resp = self._post({"target": "web", "dir": self.dir})
+        self.assertEqual((code, resp), (200, {"ok": True, "id": SID, "queued": True, "dir": self.dir}))
+        self.assertEqual(km._pending_ops[SID][0], ("cwd", self.dir, 1, 0), "re-parked, carrying the turn count it waits on")
+
+    def test_refusals_are_loud(self):
+        code, resp = self._post({"target": "web"})
+        self.assertEqual(code, 400)
+        code, resp = self._post({"target": "web", "dir": os.path.join(self.dir, "nope")})
+        self.assertEqual(code, 200)
+        self.assertFalse(resp["ok"])
+        self.assertIn("directory not found", resp["error"])
+        code, resp = self._post({"target": "nobody", "dir": self.dir})
+        self.assertFalse(resp["ok"])
+        self.assertIn('no live session named "nobody"', resp["error"])
+        why = "this session runs in a terminal (tmux), which has no way to move a running session"
+        self.be.answers = [why]
+        code, resp = self._post({"target": "web", "dir": self.dir})
+        self.assertEqual(resp, {"ok": False, "error": why}, "the backend's own words ride back")
+
+    def test_a_dormant_session_is_addressed_by_sid(self):
+        with mock.patch.object(km, "_live_names", lambda tmux: {}):
+            code, resp = self._post({"target": SID, "dir": self.dir})
+        self.assertEqual(resp.get("ok"), True)
+        self.assertEqual(self.be.calls, [(SID, self.dir)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_move_live.py
+++ b/tests/test_session_move_live.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""LIVE integration test for the session move (the user 2026-09-01): the CLI's `set_cwd` control
+request, driven through the real Claude Agent SDK against a real `claude`, in a HERMETIC config dir
+(CLAUDE_CONFIG_DIR under a temp path — the recipe the 2026-09-02 investigation verified the response
+shape with). It proves the facts SdkBackend.move is built on: the `ok {cwd, changed,
+transcript_relocated}` arm, the messages that follow with no query sent (init with the new cwd, the
+turn-less ResultMessage), `changed: false` on a same-dir request, `rejected not_found`, and that the
+transcript ends up under the NEW project slug ONLY — never copied — while the conversation (a codeword
+planted before the move) is still remembered after it.
+
+OPT-IN, and skipped otherwise: it bills two short model turns and reaches a real CLI, which the test
+suite's floors (conftest's ROMP_CLAUDE_BIN=/bin/false) exist to prevent by default. Runs only when
+  * ROMP_MOVE_LIVE=1,
+  * an interpreter with claude_agent_sdk is available — this one, $ROMP_SDK_PYTHON, or the kernel's own
+    SDK venv (~/.local/state/romp/sdkvenv, what bin/romp-sdk-setup builds) — the child runs there, so the
+    suite's interpreter needs no SDK,
+  * a `claude` binary ($ROMP_MOVE_LIVE_CLAUDE, else PATH), and
+  * Claude Code auth the hermetic config dir can use: ANTHROPIC_API_KEY in the environment, or
+    $ROMP_MOVE_LIVE_API_KEY_HELPER — a shell command that prints a key, written into the hermetic
+    settings as their apiKeyHelper (the hermetic dir sees none of the operator's own settings).
+CI has none of these and skips cleanly. Synthetic content throughout (an invented sid, an invented
+codeword, temp folders)."""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SID = "aaaaaaaa-1111-4222-8333-444444444444"
+CODEWORD = "PLUM-FORTY-TWO"
+
+CHILD = r'''
+import asyncio, glob, json, os, sys
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+CFG, A, B, CLI, SID, CODEWORD, SETTINGS = sys.argv[1:8]
+
+def desc(m):
+    t = type(m).__name__
+    if t == "ResultMessage":
+        return {"type": t, "num_turns": m.num_turns, "result": (m.result or "")[:400], "is_error": m.is_error}
+    if t == "SystemMessage":
+        return {"type": t, "subtype": m.subtype, "cwd": (m.data or {}).get("cwd")}
+    if t == "AssistantMessage":
+        return {"type": t, "text": " ".join(getattr(b, "text", "") for b in m.content)[:400]}
+    return {"type": t}
+
+async def drain(c, secs):
+    out = []
+    async def rd():
+        async for m in c.receive_messages():
+            out.append(desc(m))
+    try:
+        await asyncio.wait_for(rd(), timeout=secs)
+    except asyncio.TimeoutError:
+        pass
+    return out
+
+async def main():
+    res = {}
+    opts = ClaudeAgentOptions(cwd=A, cli_path=CLI, settings=SETTINGS, env={"CLAUDE_CONFIG_DIR": CFG},
+                              setting_sources=["user", "project"],
+                              system_prompt={"type": "preset", "preset": "claude_code"},
+                              extra_args={"session-id": SID})
+    async with ClaudeSDKClient(opts) as c:
+        q = c._query
+        res["has_sender"] = callable(getattr(q, "_send_control_request", None))
+        await c.query("The codeword for this project is %s. Reply with just OK." % CODEWORD)
+        async for m in c.receive_response():
+            pass
+        r = await q._send_control_request({"subtype": "set_cwd", "path": B})
+        if r.get("status") == "needs_trust":
+            res["needs_trust"] = r
+            r = await q._send_control_request({"subtype": "set_cwd", "path": B, "trust_accepted": True,
+                                               "trusted_directory": r.get("directory") or B})
+        res["move"] = r
+        res["after_move"] = await drain(c, 6)
+        res["same_dir"] = await q._send_control_request({"subtype": "set_cwd", "path": B})
+        res["missing"] = await q._send_control_request({"subtype": "set_cwd", "path": B + "/does-not-exist"})
+        await c.query("Without running any tools, answer in one line: what is the codeword?")
+        reply = ""
+        async for m in c.receive_response():
+            d = desc(m)
+            if d["type"] == "ResultMessage":
+                reply = d["result"]
+        res["reply"] = reply
+    res["files"] = sorted(os.path.relpath(p, os.path.join(CFG, "projects"))
+                          for p in glob.glob(os.path.join(CFG, "projects", "*", "*.jsonl")))
+    print(json.dumps(res))
+
+asyncio.run(main())
+'''
+
+
+def _sdk_python():
+    for cand in (sys.executable, os.environ.get("ROMP_SDK_PYTHON") or "",
+                 os.path.expanduser("~/.local/state/romp/sdkvenv/bin/python")):
+        if cand and os.path.exists(cand):
+            r = subprocess.run([cand, "-c", "import claude_agent_sdk"], capture_output=True)
+            if r.returncode == 0:
+                return cand
+    return ""
+
+
+def _skip_reason():
+    if os.environ.get("ROMP_MOVE_LIVE") != "1":
+        return "live move test is opt-in (ROMP_MOVE_LIVE=1): it bills two model turns against a real CLI"
+    if not _sdk_python():
+        return "no interpreter with claude_agent_sdk (this one, $ROMP_SDK_PYTHON, or ~/.local/state/romp/sdkvenv)"
+    if not (os.environ.get("ROMP_MOVE_LIVE_CLAUDE") or shutil.which("claude")):
+        return "no `claude` binary ($ROMP_MOVE_LIVE_CLAUDE or PATH)"
+    if not (os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ROMP_MOVE_LIVE_API_KEY_HELPER")):
+        return "no Claude Code auth for a hermetic config dir (ANTHROPIC_API_KEY or ROMP_MOVE_LIVE_API_KEY_HELPER)"
+    return ""
+
+
+@unittest.skipIf(_skip_reason(), _skip_reason())
+class LiveSetCwd(unittest.TestCase):
+    def test_set_cwd_relocates_and_the_conversation_survives(self):
+        td = tempfile.mkdtemp(prefix="romp-move-live-")
+        try:
+            cfg, a, b = (os.path.join(td, d) for d in ("cfg", "a", "b"))
+            for d in (cfg, a, b):
+                os.makedirs(d)
+            settings = {"permissions": {"defaultMode": "default"}}
+            env = dict(os.environ)
+            env.pop("ROMP_CLAUDE_BIN", None)
+            if not env.get("ANTHROPIC_API_KEY"):
+                settings["apiKeyHelper"] = os.environ["ROMP_MOVE_LIVE_API_KEY_HELPER"]
+            spath = os.path.join(cfg, "settings.json")
+            with open(spath, "w") as f:
+                json.dump(settings, f)
+            cli = os.environ.get("ROMP_MOVE_LIVE_CLAUDE") or shutil.which("claude")
+            child = os.path.join(td, "child.py")
+            with open(child, "w") as f:
+                f.write(CHILD)
+            r = subprocess.run([_sdk_python(), child, cfg, a, b, cli, SID, CODEWORD, spath],
+                               capture_output=True, text=True, timeout=300, env=env, cwd=td)
+            self.assertEqual(r.returncode, 0, "child failed:\n%s\n%s" % (r.stdout[-2000:], r.stderr[-4000:]))
+            res = json.loads(r.stdout.strip().splitlines()[-1])
+            self.assertTrue(res["has_sender"], "the SDK still exposes _send_control_request")
+            mv = res["move"]
+            self.assertEqual(mv.get("status"), "ok", mv)
+            self.assertEqual(mv.get("cwd"), os.path.realpath(b))
+            self.assertIs(mv.get("changed"), True)
+            self.assertIs(mv.get("transcript_relocated"), True)
+            kinds = [(m["type"], m.get("subtype"), m.get("cwd"), m.get("num_turns")) for m in res["after_move"]]
+            self.assertIn(("SystemMessage", "init", os.path.realpath(b), None), kinds,
+                          "the CLI announces the new cwd with no query sent")
+            self.assertIn(("ResultMessage", None, None, 0), kinds, "…followed by the turn-less result")
+            self.assertEqual(res["same_dir"].get("status"), "ok")
+            self.assertIs(res["same_dir"].get("changed"), False)
+            self.assertEqual((res["missing"].get("status"), res["missing"].get("reason")), ("rejected", "not_found"))
+            self.assertIn(CODEWORD, res["reply"], "the conversation is remembered after the move")
+            slug_b = "-".join(part for part in os.path.realpath(b).split("/") if part)
+            self.assertEqual(res["files"], [os.path.join("-" + slug_b, SID + ".jsonl")],
+                             "the transcript lives under the NEW slug only — moved, never copied")
+        finally:
+            shutil.rmtree(td, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -70,6 +70,6 @@ test("a refusal answering the user's ask is loud — warn toast, ask cleared, ba
 test("setFast is a drive op that parks like /model and /effort", () => {
   assert.match(KERNEL, /"setModel", "setEffort", "setMode", "setFast",/);    // in the drive-op allowlist
   assert.match(KERNEL, /def _set_fast_or_park\(be, sid, value\)/);
-  assert.match(KERNEL, /op\[0\] in \("model", "effort", "fast"\)/);          // repeat pick replaces in place
+  assert.match(KERNEL, /op\[0\] in \("model", "effort", "fast", "cwd"\)/);   // repeat pick replaces in place (cwd joined 2026-09-01)
   assert.match(KERNEL, /elif op\[0\] == "fast":/);                           // parked delivery branch
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4893,6 +4893,25 @@ function showTabMenu(e: MouseEvent, id: string) {
     rename.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); startTabRename(id); });
     menu.appendChild(rename);
   }
+  // Move to folder… sits with Rename (the user 2026-09-01: a subproject became its own repo and the
+  // session should follow it) — the same dress, the sub-line saying what a move KEEPS. The dialog does
+  // the rest (showMovePrompt); the kernel wraps the CLI's own relocation. SDK sessions only: a terminal
+  // session has no relocation primitive, so its row says so rather than failing after a click.
+  {
+    const sTm = sessions.get(id);
+    const isTmux = !!(sTm && sTm.status && sTm.status.backend === "tmux");
+    const mv = el("div", "ctx-item ctx-item-toggle" + (isTmux ? " ctx-item-off" : ""));
+    mv.appendChild(ctxIcon("folder", isTmux));
+    const bodyEl = el("span", "ctx-item-body");
+    const l = el("span", "ctx-item-label"); l.textContent = "Move to folder…"; bodyEl.appendChild(l);
+    const sb = el("span", "ctx-item-sub");
+    sb.textContent = isTmux ? "terminal sessions can't move — start a new one in that folder"
+                            : "the conversation, mail, goals and history stay with the session";
+    bodyEl.appendChild(sb);
+    mv.appendChild(bodyEl);
+    if (!isTmux) mv.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); showMovePrompt(id); });
+    menu.appendChild(mv);
+  }
   // Colors join Rename in the AESTHETIC section (the user 2026-08-24, the final by-kind grouping:
   // [Rename + colors] / [feed, mail, bell, billing, Tags] / [Browse]). The swatch row itself is
   // unchanged (the user 2026-06-29): the identity palette as circles, the current one ringed,
@@ -6334,6 +6353,110 @@ function showConfirm(title: string, detail: string, buttons: Array<{ label: stri
   document.addEventListener("keydown", onKey, true);
   (actions.firstElementChild as HTMLElement | null)?.focus();
 }
+// ---- move session (the user 2026-09-01) ----
+// "Move to folder…" on the tab menu: the session's working directory follows a subproject that became
+// its own repo. The kernel wraps the CLI's own relocation (its set_cwd control request): conversation,
+// name, mailbox and history stay with the session; its tools, CLAUDE.md and project settings come from
+// the new folder from the next turn on. One small dialog on the confirm chrome: the path box prefilled
+// with the current folder, the owning kernel's verdict for what is typed (the create picker's dirComplete
+// op, asked with NEGATIVE reqIds so the picker's own completer never claims these answers), Move/Cancel.
+// Acknowledged at once (the button reads "Moving…"), CLOSED by the kernel's typed `moved`, and on a typed
+// `moveFailed` left open with the reason where the path is — never a silent nothing. A 90s backstop covers
+// a dormant session, which the kernel revives first (it waits up to 60s for that CLI to come up).
+let movePrompt: { sid: string; overlay: HTMLElement; input: HTMLInputElement; hint: HTMLElement;
+                  go: HTMLButtonElement; close: () => void; backstop?: number } | null = null;
+let moveDirReq = 0;
+
+function closeMovePrompt(): void {
+  if (!movePrompt) return;
+  if (movePrompt.backstop !== undefined) clearTimeout(movePrompt.backstop);
+  const p = movePrompt; movePrompt = null;
+  p.close();
+}
+
+function showMovePrompt(sid: string): void {
+  closeMovePrompt();
+  const sess = sessions.get(sid);
+  const overlay = el("div", "picker-overlay confirm-overlay"); overlay.id = "move-prompt";
+  const box = el("div", "picker-box confirm-box");
+  const h = el("div", "confirm-title"); h.textContent = `Move “${sess?.name || "session"}” to a folder`;
+  const d = el("div", "confirm-detail");
+  d.textContent = "The conversation, name, mail and history stay with the session. From its next turn on, its tools, CLAUDE.md and project settings come from the new folder.";
+  const input = document.createElement("input");
+  input.type = "text"; input.className = "fork-name move-dir"; input.value = sess?.cwd || "";
+  input.placeholder = "folder path (~ and $VARs expand)";
+  input.setAttribute("autocapitalize", "off"); input.setAttribute("autocomplete", "off");
+  input.setAttribute("autocorrect", "off"); input.setAttribute("spellcheck", "false");
+  const hint = el("div", "move-dir-hint");   // the kernel's one-line verdict for the typed path
+  const actions = el("div", "confirm-actions");
+  const cancel = el("button", "picker-action confirm-btn"); cancel.textContent = "Cancel";
+  const go = el("button", "picker-action confirm-btn") as HTMLButtonElement; go.textContent = "Move";
+  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); closeMovePrompt(); } };
+  const close = () => { overlay.remove(); document.removeEventListener("keydown", onKey, true); };
+  movePrompt = { sid, overlay, input, hint, go, close };
+  const ask = () => {
+    if (!vscodeApi) return;
+    vscodeApi.postMessage({ type: "dirComplete", value: input.value.trim(), reqId: -(++moveDirReq), host: hostOf(sid) });
+  };
+  const start = () => {
+    const dir = input.value.trim();
+    if (!dir) { input.classList.add("bad"); input.focus(); return; }
+    // acknowledge the click before the round trip (the repo's button rule); the kernel's typed reply
+    // — moved / moveFailed — is what changes this dialog next
+    go.disabled = true; go.textContent = "Moving…"; input.disabled = true;
+    vscodeApi?.postMessage({ type: "moveSession", id: sid, dir });
+    if (movePrompt) movePrompt.backstop = window.setTimeout(
+      () => moveFailedLocal(sid, sess?.name || sid, "still waiting — the kernel has not answered; check the kernel log"), 90000);
+  };
+  cancel.addEventListener("click", closeMovePrompt);
+  go.addEventListener("click", start);
+  input.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); start(); } });
+  input.addEventListener("input", () => { input.classList.remove("bad"); ask(); });
+  overlay.addEventListener("click", (e) => { if (e.target === overlay) closeMovePrompt(); });
+  actions.appendChild(cancel); actions.appendChild(go);
+  box.appendChild(h); box.appendChild(d); box.appendChild(input); box.appendChild(hint); box.appendChild(actions);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+  document.addEventListener("keydown", onKey, true);
+  input.focus(); input.select();
+  ask();   // vet the prefilled path straight away, like the picker does
+}
+
+// the owning kernel's verdict for the move dialog's path (a dirCompletions reply with our negative reqId)
+function onMoveDirCompletions(m: any): void {
+  if (!movePrompt || m.reqId !== -moveDirReq) return;   // a newer keystroke owns the field, or no dialog
+  const s = m.status || null;
+  // dirStatusHint's "can be created" verdict is the picker's offer; a move never creates, so a missing
+  // folder is simply not there
+  const said = s && !s.isDir && s.canCreate ? { text: "not found", cls: "bad", title: "A move goes to a folder that already exists." }
+                                             : dirStatusHint(s);
+  movePrompt.hint.textContent = said.text;
+  movePrompt.hint.title = said.title;
+  movePrompt.hint.className = "move-dir-hint" + (said.cls ? " " + said.cls : "");
+  movePrompt.input.classList.toggle("bad", said.cls === "bad");
+}
+
+// the kernel's typed outcome: `moved` closes the dialog (a parked move that lands later says so in a
+// toast, since the dialog may be long gone); `moveFailed` puts the reason where the path is
+function moveLanded(sid: string, name: string, cwd: string): void {
+  const s = sessions.get(sid);
+  if (s && cwd) s.cwd = cwd;   // the kernel's push carries the same; this keeps the statusline honest meanwhile
+  if (movePrompt && movePrompt.sid === sid) { closeMovePrompt(); return; }
+  warnToast(`“${name}” now works in ${cwd || "its new folder"}`);
+}
+
+function moveFailedLocal(sid: string, name: string, text: string): void {
+  const p = movePrompt;
+  if (p && p.sid === sid) {
+    if (p.backstop !== undefined) { clearTimeout(p.backstop); p.backstop = undefined; }
+    p.go.disabled = false; p.go.textContent = "Move"; p.input.disabled = false;
+    p.hint.textContent = text; p.hint.title = text; p.hint.className = "move-dir-hint bad";
+    p.input.classList.add("bad"); p.input.focus();
+    return;
+  }
+  warnToast(`Couldn’t move “${name}”: ${text}`);
+}
+
 // THE FORK MODAL (the user 2026-08-13): fork this conversation into a NEW parallel session — from just
 // before a given user message (the bubble's fork button) or from the tip (the palette command, uuid "").
 // One small dialog on the confirm chrome: a name box prefilled "<session>-fork" (editable), Fork/Cancel.
@@ -10600,9 +10723,9 @@ function updateStatusline() {
   // at the LEFT edge (justify only reaches the row holding the auto margin) — the user 2026-08-10, on a
   // phone, wanted the wrapped controls to stay clustered on the right.
   const right = el("span", "sl-right");
-  // The session's working directory (fixed at creation), leading the right-side cluster — just left of the
-  // mode/model/effort controls (the user 2026-06-23). Basename only; full path on hover. Empty (rare, no
-  // cwd) it's a zero-width spacer.
+  // The session's working directory (the current one — a tab-menu move changes it), leading the right-side
+  // cluster — just left of the mode/model/effort controls (the user 2026-06-23). Basename only; full path
+  // on hover. Empty (rare, no cwd) it's a zero-width spacer.
   const dir = el("span", "status-dir");
   if (s.cwd) {
     dir.appendChild(folderIcon());
@@ -12049,7 +12172,11 @@ window.addEventListener("message", (e: MessageEvent) => {
                      : [{ label: "Dismiss", value: "ok" }],
                 (v) => { if (v === "copy") navigator.clipboard?.writeText(copy); });
   }
-  else if (m.type === "dirCompletions") onDirCompletions(m);        // the owning kernel's path completions
+  else if (m.type === "dirCompletions") {                            // the owning kernel's path completions
+    // a NEGATIVE reqId is the move dialog's ask (showMovePrompt) — routed before the picker's handler,
+    // whose in-flight bookkeeping must not be flipped by an answer it never asked for
+    if (typeof m.reqId === "number" && m.reqId < 0) onMoveDirCompletions(m); else onDirCompletions(m);
+  }
   else if (m.type === "createDirMissing" && m.name) onCreateDirMissing(m);   // create it, or edit the path
   // The AUTHORITATIVE answer to a ✕ on a queued bubble (the user 2026-07-20). ok:false = the message
   // had already left romp's queue (handed to the CLI — no recall exists): toast the kernel's 'too late'
@@ -12171,6 +12298,11 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "reviveFailed" && m.id) {
     // the kernel's loud revive failure → named, in that session's own pane + the dismissible toast
     reviveFailedLocal(String(m.id), String(m.name || m.id), String(m.text || "unknown error"));
+  }
+  else if (m.type === "moved" && m.id) moveLanded(String(m.id), String(m.name || m.id), String(m.cwd || ""));
+  else if (m.type === "moveFailed" && m.id) {
+    // the kernel's typed move refusal → the reason where the path was typed, or a toast if the dialog is gone
+    moveFailedLocal(String(m.id), String(m.name || m.id), String(m.text || "unknown error"));
   }
   else if (m.type === "focusComposer") { const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null; ta?.focus(); }
   else if (m.type === "glowTurns") applyGlow(Array.isArray(m.groups) ? m.groups : [], Array.isArray(m.mids) ? m.mids : []);

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -14,7 +14,7 @@ export interface RompSettings {
   showTriageJudges: boolean;
   debug?: boolean;    // LEGACY (the user 2026-06-17): the old single judging-band toggle; read as the migration fallback for the two judge-set toggles when those are unset. The ↻ restart button is always-visible (decoupled).
   backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
-  defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
+  defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session starts there; the tab menu's "Move to folder…" can change it later. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1626,6 +1626,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   border: 1px solid var(--box-border); border-radius: 6px; outline: none; }
 .fork-name:focus { border-color: var(--accent); }
 .fork-name.bad { border-color: #ff6a6a; }
+/* the move dialog's one-line verdict under its path box (the user 2026-09-01): the picker's dir-hint
+   tones, as a line of its own — dim by default, amber warn, red bad; empty until the kernel answers */
+.move-dir-hint { min-height: 1.2em; font-family: var(--sans); font-size: 0.82em; color: var(--dim); }
+.move-dir-hint.warn { color: #e0a030; }
+.move-dir-hint.bad { color: #e5484d; }
 /* pending-rewind overlay: turns after an edited message belong to the branch being abandoned — they
    dim until the kernel's rewound payload replaces them (reconcileRewind retires the flag then). */
 .turn.rewound { opacity: 0.35; transition: opacity 0.2s ease; }

--- a/ui/webview/tab-move.test.ts
+++ b/ui/webview/tab-move.test.ts
@@ -1,0 +1,67 @@
+// Right-click a tab → "Move to folder…" (the user 2026-09-01: a subproject became its own repo and the
+// session should follow it). Source pins against render.ts, kernel.py and styles.css — the menu and the
+// dialog build DOM at click time, so a behavioral jsdom run isn't needed to lock the shape; what matters
+// is that the op, the typed replies and the acknowledgement rules hold together across the three files.
+import { test } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the tab menu carries a Move to folder… row beside Rename that opens the move dialog", () => {
+  const i = RENDER.indexOf("function showTabMenu(");
+  const menu = RENDER.slice(i, RENDER.indexOf("menu.appendChild(el(\"div\", \"ctx-sep\"));", i));
+  assert.match(menu, /l\.textContent = "Rename"/);
+  assert.match(menu, /l\.textContent = "Move to folder…"/);
+  assert.match(menu, /dismissTabMenu\(\); showMovePrompt\(id\);/);
+  // a terminal session has no relocation primitive: the row says so and takes no click
+  assert.match(menu, /const isTmux = !!\(sTm && sTm\.status && sTm\.status\.backend === "tmux"\);/);
+  assert.match(menu, /if \(!isTmux\) mv\.addEventListener\("click"/);
+  assert.match(menu, /terminal sessions can't move/);
+});
+
+test("the dialog posts moveSession with the typed folder and acknowledges before the round trip", () => {
+  const i = RENDER.indexOf("function showMovePrompt(");
+  const body = RENDER.slice(i, RENDER.indexOf("function onMoveDirCompletions(", i));
+  const ack = body.indexOf('go.textContent = "Moving…"');
+  const post = body.indexOf('postMessage({ type: "moveSession", id: sid, dir })');
+  assert.ok(ack > 0 && post > ack, "the button changes its label BEFORE the op is posted");
+  assert.match(body, /input\.value = sess\?\.cwd \|\| ""/);   // prefilled with the current folder
+  assert.match(body, /90000\)/);                              // the backstop covers a revive-then-move
+});
+
+test("the path is vetted through the picker's dirComplete op, with reqIds the picker can never claim", () => {
+  assert.match(RENDER, /type: "dirComplete", value: input\.value\.trim\(\), reqId: -\(\+\+moveDirReq\), host: hostOf\(sid\)/);
+  // routed BEFORE the picker's handler, whose in-flight bookkeeping must not flip on a stranger's answer
+  assert.match(RENDER, /if \(typeof m\.reqId === "number" && m\.reqId < 0\) onMoveDirCompletions\(m\); else onDirCompletions\(m\);/);
+  // a move never creates a folder, so the picker's "will be created" offer is not shown
+  assert.match(RENDER, /A move goes to a folder that already exists\./);
+  assert.match(RENDER, /import \{ dirStatusHint, /);
+});
+
+test("the kernel's typed outcomes drive the dialog: moved closes it, moveFailed puts the reason where the path is", () => {
+  assert.match(RENDER, /else if \(m\.type === "moved" && m\.id\) moveLanded\(/);
+  assert.match(RENDER, /else if \(m\.type === "moveFailed" && m\.id\) \{/);
+  const i = RENDER.indexOf("function moveFailedLocal(");
+  const body = RENDER.slice(i, RENDER.indexOf("// THE FORK MODAL", i));
+  assert.match(body, /p\.go\.disabled = false; p\.go\.textContent = "Move"; p\.input\.disabled = false;/);
+  assert.match(body, /p\.hint\.className = "move-dir-hint bad"/);
+  assert.match(body, /warnToast\(`Couldn’t move “\$\{name\}”: \$\{text\}`\)/);   // the dialog may be gone (a parked move)
+});
+
+test("the kernel side: moveSession is a drive op, parks as a plain-words chip, and answers with typed events", () => {
+  assert.match(KERNEL, /"renameSession", "moveSession", "stopTask"/);
+  assert.match(KERNEL, /elif t == "moveSession" and msg\.get\("dir"\):/);
+  assert.match(KERNEL, /return "move to " \+ _tilde\(op\[1\]\)/);
+  assert.match(KERNEL, /\{"type": "moved", "id": sid, "name": nm, "cwd": _tilde\(_cwd_of\(sid\)\)\}/);
+  assert.match(KERNEL, /\{"type": "moveFailed", "id": sid, "name": nm, "text": text\}/);
+  assert.match(KERNEL, /if u\.path == "\/move":/);
+});
+
+test("the verdict line wears the picker's dir-hint tones", () => {
+  assert.match(CSS, /\.move-dir-hint\.warn \{ color: #e0a030; \}/);
+  assert.match(CSS, /\.move-dir-hint\.bad \{ color: #e5484d; \}/);
+});

--- a/vscode-extension/src/pipe-intent.test.ts
+++ b/vscode-extension/src/pipe-intent.test.ts
@@ -13,7 +13,7 @@ test("typed-text ops are intent — losing them loses the user's words", () => {
 
 test("explicit state-changing picks are intent", () => {
   for (const t of ["setModel", "setEffort", "setMode", "setFast", "interrupt", "endSession",
-    "nodeOverride", "askClear", "answerAsk", "submitAsk", "renameSession"]) {
+    "nodeOverride", "askClear", "answerAsk", "submitAsk", "renameSession", "moveSession"]) {
     assert.ok(intentOp(t), `${t} must survive a reconnect`);
   }
 });

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -11,7 +11,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   // explicit clicks that mutate kernel/session state
   "interrupt", "apiRetry", "rewindDelete",
   "setModel", "setEffort", "setMode", "setFast", "setAuth",
-  "renameSession", "endSession", "reviveSession",
+  "renameSession", "moveSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
   "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "openTagsDialog",


### PR DESCRIPTION
## Summary

A live session's working directory can now be changed. Right-click a tab and choose **Move to folder…**, or run `romp move <session> <dir>` (`POST /move`). The conversation, name, mailbox, goals and history stay with the session; from its next turn on, the agent works in the new folder and reads its `CLAUDE.md`. Terminal (tmux) sessions refuse with a reason, since there is no relocation primitive to drive. The case that motivated it: a subproject becomes its own repository and the session working on it should move with it.

Until now the directory was fixed at creation, and `_cwd_of`'s docstring said there was no SDK call to relocate a session. There is one: Claude Code's `set_cwd` control request, the headless twin of the interactive `/cd`. This PR wraps it and corrects the docstring.

## Two dependencies to know about

**A private SDK sender.** The Python `claude-agent-sdk` has no public wrapper for `set_cwd`: none in 0.2.132 (the version a `bin/romp-sdk-setup` venv had installed when this was built) through 0.2.151 (PyPI's newest as of 2026-09-02). The request goes through `client._query._send_control_request(request)`, whose signature `(request: dict, timeout=60.0)` is unchanged across those versions. The call is isolated in one helper, `SdkBackend._set_cwd_request`, with a note to swap in the public wrapper when one lands; a client without the sender fails with a named reason and changes nothing. For the shape to expect: the TypeScript SDK's `Query` implements `setCwd(path, {trustAccepted, trustedDirectory})` and sends exactly this request (`sdk.mjs` in `@anthropic-ai/claude-agent-sdk` 0.3.259), but `sdk.d.ts` does not declare it, so it is not a public API there yet either.

**The CLI's protocol.** Verified against Claude Code 2.1.257 in a hermetic `CLAUDE_CONFIG_DIR`; the protocol strings are also present in 2.1.258. Response arms: `ok {cwd, changed, transcript_relocated}` (a same-dir request is `ok, changed: false` and emits nothing); `needs_trust {directory, trust_root?}`; `rejected {reason, message}` with reason one of `not_found`, `not_a_directory`, `unsafe_path`, `blocked_by_rule` (a `Cd(...)` permission rule), `busy`; a relocation failure comes back as a control error with the CLI's chdir rolled back. On `ok` the CLI moves the current `<lastSid>.jsonl` and its `<lastSid>/` folder into the new cwd's project slug (a file already at the destination is set aside as `.superseded-<ts>`), appends a `{type: relocated, sessionId, relocatedCwd}` record plus an isMeta notice telling the model its environment block is stale, re-resolves project settings, hooks, skills and MCP servers, fires the `CwdChanged` hook (not `SessionStart`; Romp registers no `CwdChanged` hook, so nothing Romp-side re-runs), and emits, with no query sent, an init `SystemMessage`, a turn-less `ResultMessage(num_turns=0)` and two `commands_changed` messages. A `set_cwd` sent right after a `ResultMessage` was accepted in testing, so the bounded busy retry described below is a backstop for a case that did not reproduce.

## The backend: `SdkBackend.move`

In order:

1. Canonicalise the target: realpath plus true on-disk casing, an existing directory only, never created. The stored string is what every transcript path derives from.
2. Revive a dormant session first, in its old folder. A `--resume` from another cwd adopts the project directory it finds the transcript in and keeps writing there.
3. Answer `"busy"` before writing anything when a turn is in flight; the kernel parks the op and retries.
4. Write a two-phase `cwdPending` flag into the registry, then send the request. Answer `needs_trust` by re-sending with trust accepted: the user's folder pick is the trust decision, and the CLI records it per git root.
5. On `ok`: update the live object, the registry (`cwd` plus a durable `movedFrom`), the `names/` discovery file, and rename the session's earlier transcripts (`/clear` episodes, resume forks) into the new slug, since the CLI moves only the current file. Nothing is copied: the same fsid under two slugs makes every future `--resume` fail with "No conversation found".

A lost reply (control error, timeout) and a kernel death between the CLI's `ok` and the registry write are settled the same way: the transcript's location under exactly one slug decides. Both or neither is logged as a problem and left for a person, and a second move is refused until it is cleared.

`SessionBackend.move` is a concrete ABC default that refuses with a backend-neutral reason, so a backend without a relocation primitive never reads as movable by omission; `TmuxBackend.move` spells out the terminal case.

## The kernel around it

- A guard keeps the move's turn-less `ResultMessage` from running the turn-settle side effects (armed before the request, spent on `num_turns == 0`). Without it, a false turn-completed, a redundant `waiting` write and an early parked reconnect all fired on a turn that never was.
- Boot reconcile heals registries left with `cwdPending`.
- The drive-op FIFO gets a `("cwd", path, retries)` kind. A mid-turn move parks as a plain-words "move to …" chip and fires at turn end. `_moving` holds the queue while the blocking round trip runs on its own thread. A CLI-side `busy` retries a few passes, then waits on the backend's turn counter, because a turn the CLI started itself still ends with a `ResultMessage`.
- One move per session at a time (the flag is claimed under the registry lock). Comment threads keep their own folder in this version.
- The system card and lane read the registry's cwd first. The per-record `cwd` stamp is the CLI's tracked cwd (a shell `cd` inside a Bash call moves it too) and lags a move until the next turn.
- `POST /move` runs the move synchronously on the handler thread. A dormant session is revived first, so the handler can block up to 60 s (connect) plus 30 s (control); `romp move` uses `curl -m 90` for that reason.

Claude Code keys three things by folder, so they stay behind: the old project's auto-memory, its entry in `~/.claude.json` (allowed tools, MCP approvals, trust), and the old repository's `.claude/settings.local.json`. The reference docs list them.

## Before and after

Before: the only way to put a session in another folder is to end it and start a new one there, losing the conversation. After: `romp move web /srv/notes-api/web` on an idle SDK session prints `romp move: "web" now works in /srv/notes-api/web`; the transcript sits under `~/.claude/projects/-srv-notes-api-web/` only; the next turn's environment names the new folder. On a session mid-turn the CLI prints that the move is queued, and the chip in the chat fires when the turn ends.

## Tests

- `tests/test_session_move.py` (backend, against a scripted fake control channel): every response arm, the two-phase flag, the names rewrite, prior-transcript relocation, boot heal, lost reply, a concurrent claim, the `num_turns=0` guard, and a source pin that the private sender is spoken in one place.
- `tests/test_session_move_kernel.py`: park, fire, hold and retry, plus `POST /move` over the real handler on loopback.
- `tests/test_event_model_relocated.py`: the `relocated` and isMeta records yield no atoms, the parent chain stitches across them, and no turn is left open.
- `tests/romp.bats`: `romp move` argv plumbing, relative-dir resolution against the caller's cwd, queued and refused replies, usage and no-token exits.
- `ui/webview/tab-move.test.ts`, `fast-toggle.test.ts`, `vscode-extension/src/pipe-intent.test.ts`: source pins for the row, the dialog and the typed replies; `moveSession` is an intent op.
- `tests/test_session_move_live.py`: one live integration test, opt-in (`ROMP_MOVE_LIVE=1` plus an SDK interpreter, a `claude` binary, and `ANTHROPIC_API_KEY` or a helper command in `ROMP_MOVE_LIVE_API_KEY_HELPER`). It skips in CI. It bills two short turns and checks the response shapes, that the conversation survives the move, and that the transcript lives under the new slug only.

The full Python suite, `tests/romp.bats`, and the extension's typecheck, tests and build pass.

## Adjacent open PRs

This touches `_boot_reconcile` (where #878 edits the docstring tail) and the gap between `rename` and `set_model` plus `SdkBackend.__init__` (where #882 adds lines). Whichever lands second needs a mechanical rebase at those spots; nothing semantic overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)