### PR TITLE
Per-session env vars: `romp new --env NAME=VALUE` rides POST /new into the per-session flag-settings payload

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -635,6 +635,8 @@ EOF
     _romp_cmd "romp new -m <text> <name>"  -            "Start it AND deliver <text> as its first prompt (one command, idea to working)"
     _romp_cmd "romp new --model <id> <name>" -          "Model for the SDK session, as a FULL id (e.g. claude-fable-5); re-asserted if <name> already runs"
     _romp_cmd "romp new --effort <level> <name>" -      "Reasoning effort for the SDK session (e.g. high, ultracode); re-asserted if <name> already runs"
+    _romp_cmd "romp new --env NAME=VALUE <name>" -      "Per-session env var for the SDK session (repeatable; toggles, never secrets); a re-run on a running <name> replaces the whole set"
+    _romp_cmd "romp new --no-env <name>"   -            "Clear a running SDK session's per-session env (declares the empty set)"
     _romp_cmd "romp resume [<id>]"         -            "Resume a past conversation (full-screen picker; or an exact UUID)"
     _romp_cmd "romp status"                romp-manager "Show manager + kernel status"
     _romp_cmd "romp refresh"               romp-manager "Restart the postal bus + all romp kernels (picks up new code — run after an update)"
@@ -1647,6 +1649,8 @@ detach=false
 dir_arg=""
 model_arg=""
 effort_arg=""
+env_args=()
+no_env=false
 use_tmux=false
 msg_arg=""
 tag_arg=""
@@ -1660,7 +1664,7 @@ case "${1:-}" in
                 --detach)  detach=true; shift ;;
                 -d)        shift
                            if [[ $# -eq 0 || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
                            fi
                            dir_arg="$1"; shift ;;
                 -m|--message) shift
@@ -1669,7 +1673,7 @@ case "${1:-}" in
                            # last two-step on the idea-to-working path). Empty text is a usage
                            # error, not a silent no-op.
                            if [[ $# -eq 0 || -z "$1" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
                            fi
                            msg_arg="$1"; shift ;;
                 --tag)     shift
@@ -1679,7 +1683,7 @@ case "${1:-}" in
                            # as the user's typed words. Rides POST /send's "tag" field — the
                            # kernel validates and appends the render-hint marker itself.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
                            fi
                            tag_arg="$1"; shift ;;
                 --model)   shift
@@ -1688,25 +1692,51 @@ case "${1:-}" in
                            # FULL id as the picker sends it (claude-fable-5) — the alias table
                            # stops at opus/sonnet/haiku and quietly resolved "fable" to Opus 5.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
                            fi
                            model_arg="$1"; shift ;;
                 --effort)  shift
                            # per-spawn effort (e.g. high, ultracode) — ultracode is per-session
                            # by design, never a machine default, so /new is its sanctioned door.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
                            fi
                            effort_arg="$1"; shift ;;
+                --env)     shift
+                           # per-session env var, repeatable — rides POST /new into the kernel's
+                           # per-sid flag-settings payload, so two sessions in the SAME directory
+                           # can run with different environments (the user 2026-08-17; before this,
+                           # env came only from directory settings, which hit every session there).
+                           # NAME=VALUE, split on the FIRST '=' (values may carry '='); an empty
+                           # VALUE is meaningful (explicitly setting empty), but a missing '=' or a
+                           # NAME outside [A-Za-z_][A-Za-z0-9_]* is a usage error, never a silent
+                           # skip. Toggles only (FEATURE_FLAG=1, CLAUDE_CODE_*) — real secrets stay
+                           # in service.env / the apiKeyHelper, since this payload is copied into
+                           # per-sid files and the session registry.
+                           if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
+                           fi
+                           if [[ "$1" != *=* || ! "${1%%=*}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+                               echo "romp new: --env expects NAME=VALUE with NAME matching [A-Za-z_][A-Za-z0-9_]* (got: $1)" >&2; exit 2
+                           fi
+                           env_args+=("$1"); shift ;;
+                --no-env)  shift
+                           # the explicit EMPTY declaration: set_env is replace-not-merge (a re-run
+                           # declares the full env the session should have), and this is that
+                           # contract's limiting case — without it a debugging var set at spawn
+                           # could never be removed from a running session (only overwritten, which
+                           # presence-checked consumers still see). Sends "env": {}; any --env
+                           # entries alongside simply fill the declaration.
+                           no_env=true ;;
                 -*)        echo "romp new: unknown option: $1" >&2; exit 2 ;;
                 *)         if [[ -n "$session_arg" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
                            fi
                            session_arg="$1"; shift ;;
             esac
         done
         if [[ -z "$session_arg" ]]; then
-            echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+            echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2
         fi
         if [[ -n "$tag_arg" && -z "$msg_arg" ]]; then
             # a tag labels the -m text; without -m there is nothing to label
@@ -1720,10 +1750,11 @@ case "${1:-}" in
             # prompt is the SDK path's job. Refuse loudly rather than dropping the text.
             echo "romp new: -m needs the default (SDK) session — with -t you type into the terminal yourself" >&2; exit 2
         fi
-        if [[ -n "$model_arg$effort_arg" ]] && $use_tmux; then
-            # per-spawn model/effort ride the kernel's /new (SDK); a terminal session picks them
-            # inside Claude itself. Refuse loudly rather than dropping the flags (no silent divergence).
-            echo "romp new: --model/--effort need the default (SDK) session — with -t, pick them inside Claude itself" >&2; exit 2
+        if [[ -n "$model_arg$effort_arg" || ${#env_args[@]} -gt 0 ]] || $no_env && $use_tmux; then
+            # per-spawn model/effort/env ride the kernel's /new (SDK); a terminal session picks
+            # model/effort inside Claude itself and takes env from the tmux server's environment.
+            # Refuse loudly rather than dropping the flags (no silent divergence).
+            echo "romp new: --model/--effort/--env need the default (SDK) session — with -t, pick model/effort inside Claude itself (env comes from the tmux environment)" >&2; exit 2
         fi
         ;;
     resume|--resume)
@@ -1802,8 +1833,19 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         echo "romp new: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`), or use \`romp new -t $session_arg\` for a terminal session." >&2
         exit 1
     fi
-    _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}; sys.argv[3] and d.update(model=sys.argv[3]); sys.argv[4] and d.update(effort=sys.argv[4]); print(json.dumps(d))' "$session_arg" "$_dir" "$model_arg" "$effort_arg")"
-    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/new" \
+    # env pairs ride as trailing argv (argv[6:]) — the builder splits each on the FIRST '=' only, so
+    # values carrying '=' survive; a repeated NAME keeps the LAST value, like re-exporting in a shell.
+    # argv[5] is the --no-env flag: it sends the EXPLICIT empty declaration ("env": {}) — absent still
+    # means "don't touch", so a plain `romp new` never carries an env key at all.
+    _noenv=""; if $no_env; then _noenv=1; fi
+    _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}; sys.argv[3] and d.update(model=sys.argv[3]); sys.argv[4] and d.update(effort=sys.argv[4]); env=dict(kv.split("=",1) for kv in sys.argv[6:]); (env or sys.argv[5]) and d.update(env=env); print(json.dumps(d))' "$session_arg" "$_dir" "$model_arg" "$effort_arg" "$_noenv" ${env_args[@]+"${env_args[@]}"})"
+    # No -f here: the kernel answers a bad /new payload with a 400 whose JSON body NAMES the
+    # problem (reserved env names, bad session names — every validation refusal), and -f discards
+    # exactly that body (exit 22), masking it as the connection-failure message below. Without -f
+    # curl still exits nonzero on a real connection failure, so the || branch keeps meaning
+    # "not reachable", and a 4xx body falls through to the same ok-check + refusal print the
+    # kernel's 200 ok:false replies take.
+    _resp="$(_romp_token_cfg | curl -s -m 15 --config - -X POST "http://127.0.0.1:$_kport/new" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp new: kernel not reachable on :$_kport (is romp running?). \`romp new -t $session_arg\` starts a terminal session without it." >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
@@ -1817,16 +1859,22 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
             echo "romp new: started \"$session_arg\" (SDK session, working in $_dir)"
             echo "romp new: watch it on the dashboard: romp"
         fi
-        # --model/--effort: report what the kernel APPLIED — it echoes them back (the same park-aware
-        # setters as the dashboard pickers, re-asserted even on an already-running session). An ack
-        # WITHOUT the echo means an older kernel dropped the ask — say so loudly instead of letting
-        # this machine and the session quietly diverge.
-        if [[ -n "$model_arg$effort_arg" ]]; then
-            _applied="$(python3 -c 'import json,sys; r=json.loads(sys.argv[1]); print(", ".join("%s %s" % (k, r[k]) for k in ("model","effort") if r.get(k)))' "$_resp" 2>/dev/null || true)"
-            if [[ -n "$_applied" ]]; then
-                echo "romp new: applied $_applied"
-            else
-                echo "romp new: WARNING — the kernel did not acknowledge --model/--effort (older kernel?); set them from the dashboard" >&2
+        # --model/--effort/--env: report what the kernel APPLIED — it echoes them back (the same
+        # park-aware setters as the dashboard pickers, re-asserted even on an already-running
+        # session; env is born into the spawn and re-asserted through set_env). An ack missing an
+        # asked key's echo means an older kernel dropped THAT ask — say so loudly instead of letting
+        # this machine and the session quietly diverge. Per-asked-key, not all-or-nothing: a kernel
+        # can echo model/effort while dropping env (the self-hosting window between merging this
+        # code and `romp refresh`), and the aggregate check read that partial ack as full success.
+        # An env echo of {} is the clear-all ack ("env cleared"), so the dropped check keys on the
+        # echo's PRESENCE (is None), never its truthiness.
+        if [[ -n "$model_arg$effort_arg$_noenv" || ${#env_args[@]} -gt 0 ]]; then
+            _applied="$(python3 -c 'import json,sys; r=json.loads(sys.argv[1]); parts=["%s %s" % (k, r[k]) for k in ("model","effort") if r.get(k)]; e=r.get("env"); e is None or parts.append("env " + (",".join("%s=%s" % kv for kv in sorted(e.items())) or "cleared")); print(", ".join(parts))' "$_resp" 2>/dev/null || true)"
+            [[ -n "$_applied" ]] && echo "romp new: applied $_applied"
+            _envask="${env_args[*]-}$_noenv"
+            _dropped="$(python3 -c 'import json,sys; r=json.loads(sys.argv[1]); print("/".join("--"+k for k,a in (("model",sys.argv[2]),("effort",sys.argv[3]),("env",sys.argv[4])) if a and r.get(k) is None))' "$_resp" "$model_arg" "$effort_arg" "$_envask" 2>/dev/null || echo "--model/--effort/--env")"
+            if [[ -n "$_dropped" ]]; then
+                echo "romp new: WARNING — the kernel did not acknowledge $_dropped (older kernel?); model/effort can be set from the dashboard" >&2
             fi
         fi
         # -m: deliver the first prompt through the same kernel route `romp send` uses, so one

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -34,6 +34,8 @@ These are for scripting and for agents rather than daily use:
 | `romp sessions [--json]` | The fleet with each session's state, identity colours, directory and backend |
 | `romp mail …` | The postal service from the shell (below) |
 | `romp send <session> [--tag <label>] <text>` | Hand a session a message, on either backend. Anything a script, cron job, or launcher composes SHOULD carry a tag (one word, letters/digits/dashes, up to 24 chars): the chat then renders it as machine-sent under that label instead of as the user's typed words. Raw POST /send callers pass it as the JSON `tag` field (`{name, text, tag}` — a malformed tag fails the whole send, loudly); `--tag` is the CLI's equivalent. Both resolve to the `<!-- romp-tag: <label> -->` marker in the delivered text |
+| `romp new --env NAME=VALUE <name>` | A per-session env var for the SDK session, repeatable; a re-run against a running `<name>` replaces the whole set — vars not re-named are dropped |
+| `romp new --no-env <name>` | Clear a running SDK session's per-session env (declares the empty set) |
 | `romp interrupt <session>` | Interrupt whatever turn a session is taking |
 | `romp compact <session> [--wait] [--timeout <s>]` | Compact a session's context in place (Claude's `/compact`: summarize the history, keep the session's name, id, mailbox, and watches) — the alternative to ending and recreating a long-lived session, and the external hand a session needs since it cannot `/compact` itself mid-turn. Quiet session → compacts now; open turn → queued, fires alone the moment the turn ends (the same safe path the chat's compact button uses). `--wait` blocks until the compaction has started and cleared, polling the kernel's own `compacting` signal on the `/sessions` rows (also the field to point a `romp watch` predicate at for scripted recycling); exits 1 honestly on timeout. A remote session's compaction is requested on its own kernel — `--wait` can't follow it from here and says so |
 | `romp end <session>` | End a session |
@@ -42,6 +44,16 @@ These are for scripting and for agents rather than daily use:
 | `romp debug [on\|off\|status]` | Judge debug mode, where rejection rows carry the full input and reply |
 | `romp resume <id> [--name <n>] [--detach]` | Resume one exact conversation by UUID |
 | `romp refresh --quiet` | Refresh at the next quiet window instead — waits for sessions to finish their turns (15-min backstop) |
+
+`--env` gives one session its own environment, so two sessions in the same
+directory can run with different toggles (a `FEATURE_FLAG=1`, a `CLAUDE_CODE_*`
+switch) without editing the directory's `.claude/settings*.json`, which reaches
+every session there and outlives them all. Re-running `romp new --env` against
+a running session declares its full per-session env: any var you don't name
+again is dropped, and `romp new --no-env <name>` declares the empty set — it
+clears them all. Keep real secrets out of it: each value is copied into
+per-session files and the session registry under `~/.local/state/romp/`. Keys
+and credentials stay in `service.env` or the `apiKeyHelper`.
 
 Two things to know before building on `romp sessions --json`. **`waiting` means
 at rest**, the ordinary state of a session that has finished its turn, so

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7320,19 +7320,65 @@ def _pick_identity_color(now=None):
     return bgs[i], fgs[i]
 
 
+_ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")   # the shell-identifier alphabet
+
+# sdk_backend.ENV_RESERVED_NAMES' kernel-side mirror: the identity env the SDK spawn owns
+# (options.env — `romp end self` resolves through ROMP_SID), which a same-named user var would
+# silently shadow or be shadowed by. Same lockstep contract as the validator below.
+_ENV_RESERVED_NAMES = ("ROMP_SID", "ROMP_SESSION_NAME")
+
+
+def _env_error(env):
+    """Why POST /new's "env" is not a valid per-session env payload — "" when it is. The kernel-side
+    mirror of sdk_backend.env_request_error (that module loads lazily inside _sdk(), so the handler
+    can't import it at the door): a dict of NAME → string-value pairs, names in the shell-identifier
+    alphabet — the payload lands in the per-sid flag-settings file the CLI reads at launch, where a
+    name outside it would be written silently and exported never. The first offender is NAMED and the
+    whole request refused (fail-loudly, the user 2026-07-03): a skipped var is a session quietly
+    running without the env it was asked to have. The backend validates AGAIN: spawn backs this
+    door with its loud ValueError, but set_env re-checks and refuses with a silent False its
+    callers discard — so on the existing:true path drift between the two copies would be a 200
+    with an env echo and nothing applied. This copy MUST stay in lockstep with
+    sdk_backend.env_request_error, pinned by test_session_env's ValidatorLockstep."""
+    if not isinstance(env, dict):
+        return "env must be an object of NAME: value pairs"
+    for k, v in env.items():
+        if not isinstance(k, str) or not _ENV_NAME_RE.match(k):
+            return "env: bad name %r — names match [A-Za-z_][A-Za-z0-9_]*" % (k,)
+        if k in _ENV_RESERVED_NAMES:
+            return ("env: %s is reserved — romp sets the session's identity env "
+                    "(ROMP_SID, ROMP_SESSION_NAME) itself" % k)
+        if not isinstance(v, str):
+            return "env: the value for %r must be a string" % (k,)
+        if "\x00" in v:
+            # NUL only — newlines and other control bytes are legitimate env content. An execve
+            # envp entry is a NUL-terminated C string, so this value is unfulfillable BY DEFINITION:
+            # accepted, it bakes into the reg a var the CLI can only truncate or throw on, either
+            # way diverging from what /new echoed as applied.
+            return "env: the value for %r contains a NUL byte — no process environment can carry one" % (k,)
+    return ""
+
+
 def _apply_new_session_prefs(sid, body):
-    """POST /new's optional per-spawn "model"/"effort" (the user 2026-08-14): applied through the SAME
+    """POST /new's optional per-spawn "model"/"effort" (the user 2026-08-14) and "env": applied through the SAME
     park-aware setters as the dashboard's setModel/setEffort ops, and echoed back so the caller can be
     loud when a kernel ignores them. Values pass through VERBATIM — full model ids as the picker sends
     them (claude-fable-5), never a short alias: the CLI alias table stops at opus/sonnet/haiku and
     quietly resolved "fable" to Opus 5 (observed live 2026-08-14). Runs on the idempotent existing:true
     open too, so a nightly re-brief re-asserts them on the standing session — ultracode is per-session
     by design (never a write_sdk_default seed), and a headless script has no WS, so this is the
-    sanctioned door."""
+    sanctioned door. On a FRESH spawn the env was already born into the reg (_create_sdk_session), so
+    the env leg here is the unchanged re-assert set_env skips the reconnect for — the echo still comes
+    back. The handler validated env at the door and refused non-SDK targets, so the hasattr guard is only
+    the backstop for direct callers."""
     out = {}
     m = str((body or {}).get("model") or "").strip()
     e = str((body or {}).get("effort") or "").strip()
-    if not (m or e):
+    ev = (body or {}).get("env")
+    ev = ev if isinstance(ev, dict) else None
+    # an EXPLICIT {} is asked (the clear-all declaration — set_env replaces, so {} clears);
+    # only an absent/non-dict env is "not asked".
+    if not (m or e) and ev is None:
         return out
     try:
         be = Sessions.backend_for(str(sid))
@@ -7346,11 +7392,14 @@ def _apply_new_session_prefs(sid, body):
     if e:
         _set_effort_or_park(be, str(sid), e)
         out["effort"] = e
+    if ev is not None and hasattr(be, "set_env"):
+        _set_env_or_park(be, str(sid), dict(ev))
+        out["env"] = dict(ev)
     _push_soon()
     return out
 
 
-def _create_sdk_session(nm, cwd, auth="", prefs=None, client=None):
+def _create_sdk_session(nm, cwd, auth="", prefs=None, client=None, env=None):
     """Create + open a new SDK-backed session, ACK-FAST (the user 2026-07-14, who asked why it took so long
     to open a new SDK session). spawn() is file writes and connect() is threaded (~0.4s to a booting
     CLI) — the 7-10s the user waited was the handler's inline _push_all(): a new session invalidates the
@@ -7379,7 +7428,10 @@ def _create_sdk_session(nm, cwd, auth="", prefs=None, client=None):
     push."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
     _commands_for_cwd(cwd)   # pre-warm the slash-command list — a new session predicts a composer (the user 2026-08-13)
-    sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
+    # env rides the SPAWN (the reg is born with it), not the prefs pass behind it: the prefs pass
+    # runs pre-connect (pure reg writes), so its env leg sees the reg already carrying this env and
+    # skips the set — the echo still comes back through `extra`.
+    sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth, env=env)
     extra = _apply_new_session_prefs(sid, prefs or {})
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
     if client is not None:
@@ -18186,7 +18238,7 @@ def _save_pending_ops():
         sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
 
 
-_pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("compact",), …] in park order
+_pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("env", {…}) | ("compact",), …] in park order
 
 
 _PATH_UNRESOLVED = object()   # _compacting_now's "no path was passed" sentinel — None is a real value (no transcript)
@@ -18325,7 +18377,7 @@ def _park_op(sid, op):
     earlier parked op of the same kind IN PLACE — its queue position stands, its value updates — so the
     chat shows one "/model …" chip carrying the latest pick. Messages always append."""
     q = _pending_ops.setdefault(str(sid), [])
-    if op[0] in ("model", "effort", "fast"):
+    if op[0] in ("model", "effort", "fast", "env"):
         for i, o in enumerate(q):
             if o[0] == op[0]:
                 q[i] = op
@@ -18348,6 +18400,10 @@ def _parked_md(op):
         return op[1]                     # the typed slash command IS the bubble (so the running-/compact fold matches it too)
     if op[0] == "compact":
         return "/compact"
+    if op[0] == "env":
+        # a dict payload, rendered as the NAME=VALUE list it was asked as (sorted: the bubble and the
+        # ✕ handshake must agree byte-for-byte across the park's disk round-trip)
+        return "/env " + " ".join("%s=%s" % kv for kv in sorted(op[1].items()))
     return "/%s %s" % (op[0], op[1])
 
 
@@ -18543,6 +18599,17 @@ def _set_effort_or_park(be, sid, value):
         be.set_effort(sid, value)
 
 
+def _set_env_or_park(be, sid, value):
+    """Apply a per-session env change (POST /new's "env", the spawn-time slice) now — or park it while
+    the session compacts, in the same FIFO as /model and /effort: a CHANGE applies by reconnecting
+    (env is connect-time, like effort), which mid-compaction would derail the compaction exactly the
+    way an effort switch would. An unchanged re-assert is a no-op inside set_env either way."""
+    if _ops_gate(sid):
+        _park_op(sid, ("env", value))
+    else:
+        be.set_env(sid, value)
+
+
 def _set_auth_or_park(be, sid, value):
     """Apply a billing-account change now — or park it while the session compacts, in the same FIFO as
     /model and /effort (it reconnects the session, which mid-compaction would derail the compaction
@@ -18645,6 +18712,9 @@ def _apply_pending_ops():
                     ops.pop(0)
                 elif op[0] == "auth":
                     be.set_auth(sid, op[1])
+                    ops.pop(0)
+                elif op[0] == "env":
+                    be.set_env(sid, op[1])
                     ops.pop(0)
                 else:
                     ops.pop(0)                        # unknown op kind → drop, never wedge the queue
@@ -31620,7 +31690,8 @@ class Handler(BaseHTTPRequestHandler):
                 # backend — without a browser. Body: {"name": ..., "dir": ..., "backend": "sdk"|"tmux"},
                 # plus optional "model"/"effort" (full ids/levels, applied park-aware and echoed back;
                 # also applied on the existing:true open, so a re-brief re-asserts them — see
-                # _apply_new_session_prefs).
+                # _apply_new_session_prefs) and optional "env" (a NAME→value map of per-session env
+                # vars, the user 2026-08-17: born into the SDK spawn, re-asserted the same way).
                 # Same validation and the same no-silent-fallback rule as the WS op: when the SDK
                 # backend is unavailable, say so (ok:false + reason), never hand back a mystery tmux
                 # session. An already-live name is a success (idempotent open), not an error.
@@ -31632,6 +31703,20 @@ class Handler(BaseHTTPRequestHandler):
                 if not nm or not NAME_RE.match(nm):
                     return self._send(400, json.dumps({"ok": False, "error":
                         "session names use letters, digits, . _ - only"}), "application/json")
+                # env is validated HERE, before anything is created: a bad payload refuses the WHOLE
+                # request (fail-loudly) — never a session spawned quietly missing the env it asked for.
+                # Absent and null mean "not asked" (the model/effort empty-skip contract). An EXPLICIT
+                # {} is the clear-all declaration: set_env is replace-not-merge (a re-run declares the
+                # full env the session should have), and {} is that contract's limiting case — the only
+                # way to remove a spawn-time var from a running session. Every OTHER value goes through
+                # the validator, so falsy junk (false, 0, "", []) 400s instead of being silently
+                # swallowed as "not asked" while the caller reads ok:true as the env applying.
+                env_req = (b or {}).get("env")
+                if env_req is not None:
+                    eerr = _env_error(env_req)
+                    if eerr:
+                        return self._send(400, json.dumps({"ok": False, "error": eerr}),
+                                          "application/json")
                 # mkdir:true makes a missing dir (the WS op's "create it" answer, available headlessly too)
                 cwd, derr = _resolve_create_dir(b.get("dir"), create=bool(b.get("mkdir")))
                 if derr:
@@ -31640,6 +31725,18 @@ class Handler(BaseHTTPRequestHandler):
                                       "application/json")
                 live = _live_names(_tmux_sessions())
                 if nm in live:
+                    if env_req is not None:
+                        # env rides the per-sid flag-settings file, which only the SDK backend hands
+                        # its CLI — a live tmux session can't take it, and dropping it silently would
+                        # leave this machine believing an env the session never saw.
+                        try:
+                            _envbe = Sessions.backend_for(live[nm])
+                        except Exception:
+                            _envbe = None
+                        if not hasattr(_envbe, "set_env"):
+                            return self._send(200, json.dumps({"ok": False, "error":
+                                'per-session env needs an SDK session — "%s" runs on tmux, whose CLI '
+                                "reads the tmux server's environment" % nm}), "application/json")
                     extra = _apply_new_session_prefs(live[nm], b)
                     return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True, **extra}),
                                       "application/json")
@@ -31661,9 +31758,14 @@ class Handler(BaseHTTPRequestHandler):
                                           "application/json")
                     a = (b or {}).get("auth")
                     sid, extra = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""),
-                                                     prefs=b)   # pins ride the FIRST connect — see the def
+                                                     prefs=b,   # pins ride the FIRST connect — see the def
+                                                     env=env_req)   # env is born into the spawn's reg
                     return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd, **extra}),
                                       "application/json")
+                if env_req is not None:
+                    return self._send(200, json.dumps({"ok": False, "error":
+                        "per-session env needs the SDK backend — a tmux session's CLI reads the "
+                        "tmux server's environment"}), "application/json")
                 threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
                 return self._send(200, json.dumps({"ok": True, "pending": True, "dir": cwd}),
                                   "application/json")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18401,9 +18401,10 @@ def _parked_md(op):
     if op[0] == "compact":
         return "/compact"
     if op[0] == "env":
-        # a dict payload, rendered as the NAME=VALUE list it was asked as (sorted: the bubble and the
-        # ✕ handshake must agree byte-for-byte across the park's disk round-trip)
-        return "/env " + " ".join("%s=%s" % kv for kv in sorted(op[1].items()))
+        # a dict payload, rendered as the sorted NAME list it was asked as — NAMES ONLY: env values can
+        # be secrets, and this string is the visible chat chip (PR #889 review). Sorted so the bubble
+        # and the ✕ handshake agree byte-for-byte across the park's disk round-trip.
+        return "/env " + " ".join(sorted(op[1])) if op[1] else "/env (cleared)"
     return "/%s %s" % (op[0], op[1])
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1458,8 +1458,12 @@ def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bo
     p = os.path.join(d, "%s.json" % sid)
     try:
         os.makedirs(d, exist_ok=True)
-        with open(p, "w") as f:
+        # 0600, the serve-token treatment: the env block can carry secrets, and a default-umask file is
+        # world-readable on a shared host (PR #889 review). Created private, then written.
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
             f.write(json.dumps(keys) + "\n")
+        os.chmod(p, 0o600)   # a pre-existing file keeps its old mode through O_CREAT — tighten it too
     except OSError as e:
         # no settings file → the session still launches, just without these keys — and the Log says
         # so (fail-loudly, the user 2026-07-03): for env especially, a silent drop here leaves the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1377,12 +1377,50 @@ _FAST_REFUSALS = {
 }
 
 
-def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bool = False) -> str:
+ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")   # the shell-identifier alphabet
+
+# The identity env _options owns (its options.env overlay): ROMP_SID is how `romp end self`
+# resolves itself to the kernel. A user var of either name rides the OTHER layer (the per-sid
+# flag-settings file), whose rank against options.env is unverified — so it would silently shadow
+# or be shadowed, and the break surfaces nowhere. Reserved at the door instead.
+ENV_RESERVED_NAMES = ("ROMP_SID", "ROMP_SESSION_NAME")
+
+
+def env_request_error(env) -> str:
+    """Why `env` is NOT a valid per-session env payload — "" when it is (an empty dict is a valid,
+    vacuous one). A payload is a dict of NAME → string-value pairs, names in the shell-identifier
+    alphabet and outside the reserved identity names (ENV_RESERVED_NAMES): it lands in the per-sid
+    flag-settings file the CLI reads at launch, where a name outside that alphabet would be written
+    silently and exported never. One validator for every door (the /new handler mirrors it
+    client-side of the backend seam; spawn and set_env enforce it here), loud and specific by rule —
+    the first offender is NAMED and the whole payload refused, never skipped (fail-loudly, the user
+    2026-07-03)."""
+    if not isinstance(env, dict):
+        return "env must be an object of NAME: value pairs"
+    for k, v in env.items():
+        if not isinstance(k, str) or not ENV_NAME_RE.match(k):
+            return "env: bad name %r — names match [A-Za-z_][A-Za-z0-9_]*" % (k,)
+        if k in ENV_RESERVED_NAMES:
+            return ("env: %s is reserved — romp sets the session's identity env "
+                    "(ROMP_SID, ROMP_SESSION_NAME) itself" % k)
+        if not isinstance(v, str):
+            return "env: the value for %r must be a string" % (k,)
+        if "\x00" in v:
+            # NUL only — newlines and other control bytes are legitimate env content. An execve
+            # envp entry is a NUL-terminated C string, so this value is unfulfillable BY DEFINITION:
+            # accepted, it bakes into the reg a var the CLI can only truncate or throw on, either
+            # way diverging from what /new echoed as applied.
+            return "env: the value for %r contains a NUL byte — no process environment can carry one" % (k,)
+    return ""
+
+
+def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bool = False,
+                       env: dict | None = None, log=None) -> str:
     """The settings file handed to the CLI (options.settings — the flag-settings layer, the CLI's
     documented per-session hook for keys the SDK has no typed field for). Returns "" when a session
     needs none, which is the common case.
 
-    Two keys ride here, both per-session:
+    Three keys ride here, all per-session:
     - `ultracode`: the SDK's typed EffortLevel has no such value — ultracode IS xhigh plus standing
       dynamic-workflow orchestration, so the typed field carries "xhigh" and this key switches the
       orchestration on.
@@ -1391,15 +1429,29 @@ def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bo
       host's designed opt-in, not a loophole (verified against claude 2.1.224 on 2026-08-07: with the
       key, a headless run reports fast_mode_state "on"; without it, "off" with the disabled reason
       "sdk_opt_in_required").
+    - `env` (the user 2026-08-17): per-session env vars, so two SDK sessions in the SAME directory can
+      run with different environments — before this, env came only from directory-scoped
+      .claude/settings*.json, which hits every session in the repo and outlives the session. Settings
+      files accept an `env` block, and this one is per-sid, handed to exactly one CLI. Callers
+      validate (env_request_error) before the dict gets here. PRECEDENCE, verified vs not: what this
+      repo has verified about the flag-settings layer is that the CLI honors keys riding
+      options.settings (the fastMode opt-in above, confirmed live against claude 2.1.224) — how this
+      layer's `env` block RANKS against a directory .claude/settings*.json `env` naming the same var
+      is NOT verified here; nothing in this repo's recorded behavior pins it, so don't rely on
+      per-session values overriding a directory-set var of the same name until someone verifies it
+      live. Distinct names — the toggle case this slice exists for — need no ranking at all.
 
     One file PER SESSION (not the single shared file the ultracode key used to get): the content now
     varies by session, so a shared file would hand one session's fast mode to every other one. Rewritten
-    on every use — a couple of boolean keys, atomic enough."""
+    on every use — that is what makes reconnects RE-ASSERT the reg's env by construction (pinned in
+    tests/test_session_env.py), and why a change to any of these keys applies by reconnecting."""
     keys = {}
     if ultracode:
         keys["ultracode"] = True
     if fast:
         keys["fastMode"] = True
+    if env:
+        keys["env"] = dict(env)
     if not keys:
         return ""
     d = os.path.join(str(state_dir), FLAG_SETTINGS_DIR)
@@ -1408,8 +1460,15 @@ def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bo
         os.makedirs(d, exist_ok=True)
         with open(p, "w") as f:
             f.write(json.dumps(keys) + "\n")
-    except OSError:
-        return ""     # no settings file → the session still launches, just without these keys
+    except OSError as e:
+        # no settings file → the session still launches, just without these keys — and the Log says
+        # so (fail-loudly, the user 2026-07-03): for env especially, a silent drop here leaves the
+        # reg, the /new echo, and every future surface claiming an env the session never saw, with
+        # no readback channel to catch it (fastMode has _adopt_fast_state; env has nothing).
+        if log:
+            log("flag settings (%s): %s unwritable (%s) — launching WITHOUT %s"
+                % (sid, p, e, ", ".join(sorted(keys))), problem=True)
+        return ""
     return p
 
 
@@ -1702,6 +1761,11 @@ class SdkSession:
         #   chosen alias but left liveModel stale, and model_label PREFERS liveModel → the badge kept the OLD name).
         #   Cleared the instant _learn_model / _do_refresh_context reports a model matching the alias (event-based).
         self.effort = reg.get("effort") or DEFAULT_EFFORT   # connect-time --effort; tracked since the init msg doesn't echo it
+        self.env_vars = dict(reg.get("env") or {})   # per-session env vars (the reg's `env`, the user 2026-08-17):
+        #   _options folds them into the per-sid flag-settings file at EVERY connect, so two sessions in the
+        #   same directory can run with different environments. Connect-time like effort (the CLI reads
+        #   settings at launch); spawn seeds it, set_env replaces it. Named env_VARS because `env` at this
+        #   layer already means the CLI child's process environment (_options' options.env).
         self._effort_pending = ""                    # target LEVEL while an /effort switch RECONNECTS to apply (--effort is
         #   a connect-time flag, no runtime control): the effort badge shows the switching-dots + the chat shows a
         #   "Reloading session…" notice until the reconnect completes (the user 2026-07-06). Cleared the instant the
@@ -4914,10 +4978,27 @@ class SdkBackend:
             self._rewind_resolved(sess.sid, "spent")
         if self.mcp_config:
             kw["mcp_servers"] = self.mcp_config
-        # The flag-settings layer carries the two keys the SDK has no typed field for — ultracode
-        # (effort) and fastMode. Both are connect-time, which is why changing either reconnects.
+        # The flag-settings layer carries the keys the SDK has no typed field for — ultracode
+        # (effort), fastMode and the per-session env vars. All are connect-time, which is why
+        # changing any of them reconnects; the file is rewritten from the session here on EVERY
+        # connect, so a reconnect re-asserts them by construction.
+        # The reserved identity names are skipped at THIS seam, not only refused at the doors:
+        # a reg written before ENV_RESERVED_NAMES existed can still carry them, and every connect
+        # replays the stored env verbatim — applied, either name shadow-races the options.env
+        # identity above (`romp end self` resolving to a forged sid); refused, a reconnect bricks
+        # a long-running session over a var accepted under older rules. Skip the var, keep the
+        # rest, launch the session — and say so (fail-loudly: the line lands on stderr via the
+        # kernel's log wire and in the problem ring the dashboard's error center reads).
+        env_vars = sess.env_vars
+        legacy = [k for k in ENV_RESERVED_NAMES if k in env_vars]
+        if legacy:
+            env_vars = {k: v for k, v in env_vars.items() if k not in ENV_RESERVED_NAMES}
+            self._log("env (%s): ignoring reserved %s from the stored session env — romp sets the "
+                      "identity env itself (a reg from before the names were reserved)"
+                      % (sess.name, ", ".join(legacy)), problem=True)
         fs = flag_settings_path(self.state_dir, sess.sid,
-                                ultracode=(sess.effort or "") == "ultracode", fast=sess.fast_opt)
+                                ultracode=(sess.effort or "") == "ultracode", fast=sess.fast_opt,
+                                env=env_vars, log=self._log)
         if fs:
             kw["settings"] = fs
         # Per-session auth (the user 2026-08-08): the work key was claimed OUT of this process's env at
@@ -4939,7 +5020,15 @@ class SdkBackend:
 
     # ---- lifecycle (kernel-thread API) ----
     def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None,
-              auth: str = "") -> str:
+              auth: str = "", env: dict | None = None) -> str:
+        if env:
+            # per-session env vars (the user 2026-08-17), validated at the door: a bad payload is
+            # refused OUTRIGHT rather than written into a reg every future connect would launch
+            # with. The /new handler validates before calling; this raise is the backend's own
+            # fail-loudly backstop for any other caller.
+            err = env_request_error(env)
+            if err:
+                raise ValueError(err)
         sid = sid or str(uuid.uuid4())
         cwd = os.path.realpath(cwd) if os.path.exists(cwd) else cwd
         if not bg:                                   # give the session a stable identity colour like tmux sessions get
@@ -4963,6 +5052,11 @@ class SdkBackend:
         a = auth if auth in ("login", "key") else (d.get("auth") if d.get("auth") in ("login", "key") else "")
         if a:
             reg["auth"] = a
+        # Per-session env is a per-spawn ask, never a remembered default (a var one session needed is
+        # the last thing the NEXT session should silently inherit) — recorded only when asked for, so
+        # the common env-less session carries no key and _options writes no settings file for it.
+        if env:
+            reg["env"] = dict(env)
         self._write_reg_locked(sid, reg)
         append_state(self.state_dir, sid, "waiting")
         self._poke()
@@ -4977,8 +5071,8 @@ class SdkBackend:
         with the parent's title would be discovered as a fork LANE of the parent and hidden. Mechanism:
         the reg is born with lastSid = the parent's newest fsid plus forkOf/forkAt, which _options turns
         into resume + fork_session + session_id (+ resume-session-at) on first connect; the init's
-        lastSid flip to this sid spends the flags. Model / effort / mode / auth inherit from the parent —
-        it is that conversation, continued elsewhere. Resumable by construction: a fork whose CLI dies
+        lastSid flip to this sid spends the flags. Model / effort / mode / auth / env inherit from the
+        parent — it is that conversation, continued elsewhere. Resumable by construction: a fork whose CLI dies
         before init still carries the flags and retries on the next connect.
 
         `thread_of` (the user 2026-08-13, who asked to comment on a highlighted passage and keep a side
@@ -5053,6 +5147,19 @@ class SdkBackend:
             reg["effort"] = effort
         if parent.get("auth") in ("login", "key"):
             reg["auth"] = parent["auth"]
+        if parent.get("env"):
+            # the reserved identity names never cross the copy: a parent reg from before
+            # ENV_RESERVED_NAMES existed carries them (the _options apply seam skips them there),
+            # and the copy is where that legacy poison stops propagating into fresh regs
+            env = {k: v for k, v in parent["env"].items() if k not in ENV_RESERVED_NAMES}
+            dropped = [k for k in parent["env"] if k in ENV_RESERVED_NAMES]
+            if dropped:
+                self._log("env (%s): dropping reserved %s from the inherited env — romp sets the "
+                          "identity env itself (the parent reg predates the reserved names)"
+                          % (name, ", ".join(dropped)), problem=True)
+            if env:
+                reg["env"] = env   # per-session env inherits like model/auth — it is that
+                #   conversation, continued elsewhere (a copy: the two regs diverge independently)
         self._write_reg_locked(sid, reg)
         # the names/ entry LAST — it is the discoverability trigger (discover() iterates names/), and
         # everything above must exist before any judge pass can see the session. A comment thread never
@@ -6041,6 +6148,40 @@ class SdkBackend:
                 "t": t, "author": "human", "command": "/effort", "_echo_text": disp,
                 "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
             append_cmd_gesture(self.state_dir, sid, disp, t=t)   # durable twin — see set_model
+            self._wake_push()
+        return True
+
+    def set_env(self, sid: str, env: dict) -> bool:
+        """REPLACE this session's per-session env vars (the reg's `env`) — the dict flag_settings_path
+        folds into the per-sid settings payload at every connect. Replace, not merge: the payload IS
+        the session's per-session env, so a re-assert naming fewer vars drops the missing ones (the
+        one coherent reading of `romp new --env` re-run on a standing session, which declares the
+        full env it wants). Env is connect-time exactly like --effort (the CLI reads settings at
+        launch, no runtime control), so a CHANGE persists and RECONNECTS to apply — idle → now, busy
+        → at turn end — set_effort's shape, via the same locked _update_reg (an unserialized RMW
+        could drop the field, the 2026-08-14 downgrade bug). An UNCHANGED re-assert (the fresh-spawn
+        echo from /new's prefs pass, a nightly re-brief repeating the same --env) is already the
+        world the reg describes — reg and live connection can only diverge while an applying
+        reconnect is in flight, and then one is already queued — so it persists nothing and skips
+        the reconnect rather than churning the CLI process on no new information. Never a remembered
+        default (write_sdk_default): a var one session needed is not a seed for the next. No pending
+        badge or chat chip yet — that surface ships with the env UI slice; the Log records the
+        change (spawn-time slice, the user 2026-08-17)."""
+        if env_request_error(env):
+            return False
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
+            return False
+        env = dict(env)
+        if (reg.get("env") or {}) == env:
+            return True
+        self._update_reg(sid, env=env)
+        s = self.sessions.get(sid)
+        if s:
+            s.env_vars = dict(env)
+            s.request_reconnect()
+            self._log("env (%s): per-session env set (%s) — reconnecting to apply"
+                      % (s.name, ", ".join(sorted(env)) or "cleared"))
             self._wake_push()
         return True
 

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -113,6 +113,11 @@ STUB
 # Helper — a fake `curl` for the kernel-API paths (`romp new` SDK spawn + `-m` send).
 # Logs every call to MOCK_LOG and answers {"ok": true}; MOCK_CURL_FAIL_SEND=1 makes
 # the /send leg fail the way curl -f does, so per-leg error reporting is testable.
+# MOCK_CURL_FAIL_NEW=1 makes the /new leg a connection failure (exit 7, no body);
+# MOCK_CURL_NEW_400=1 makes the kernel answer /new with a 400 whose JSON body names
+# the problem — honoring the FLAGS romp passes, the way real curl splits on a 4xx:
+# a short-flag cluster carrying -f discards the body and exits 22; plain -s prints
+# the body and exits 0. So the test proves the flags, not just the message.
 _stub_curl() {
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
@@ -120,6 +125,14 @@ echo "curl $*" >> "$MOCK_LOG"
 url=""
 for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ -n "${MOCK_CURL_FAIL_SEND:-}" && "$url" == */send ]]; then exit 22; fi
+if [[ -n "${MOCK_CURL_FAIL_NEW:-}" && "$url" == */new ]]; then exit 7; fi
+if [[ -n "${MOCK_CURL_NEW_400:-}" && "$url" == */new ]]; then
+  for a in "$@"; do
+    if [[ "$a" == "-f" || "$a" == -[!-]*f* ]]; then exit 22; fi
+  done
+  echo '{"ok": false, "error": "env: ROMP_SID is reserved — romp sets the session identity env itself"}'
+  exit 0
+fi
 echo '{"ok": true}'
 MOCK
     chmod +x "$MOCK_DIR/curl"
@@ -405,6 +418,29 @@ MOCK
     [ "$status" -eq 1 ]
     [[ "$output" == *"did NOT land"* ]]
     [[ "$output" == *"romp send ideabox"* ]]
+}
+
+@test "new: a kernel 400 surfaces the kernel's own refusal, never 'not reachable'" {
+    # every /new validation error (reserved env names, bad names, bad values) is a 400 whose
+    # body names the problem — masked as a connection failure, the user retypes forever
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    export MOCK_CURL_NEW_400=1
+    run run_romp new --env ROMP_SID=x web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ROMP_SID is reserved"* ]]
+    [[ "$output" != *"not reachable"* ]]
+}
+
+@test "new: a real connection failure still says 'not reachable'" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    export MOCK_CURL_FAIL_NEW=1
+    run run_romp new web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not reachable"* ]]
 }
 
 @test "help lists new -m" {
@@ -1337,14 +1373,50 @@ PY
     ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --model claude-fable-5 opt
     kill "$srv" 2>/dev/null || true
     [ "$status" -eq 0 ]
-    [[ "$output" == *"did not acknowledge --model/--effort"* ]]
+    # per-asked-key: only --model was asked, so only --model is named as dropped
+    [[ "$output" == *"did not acknowledge --model (older kernel?)"* ]]
+}
+
+@test "new --model + --env: a kernel that acks model but drops env warns about --env specifically" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'tok-test' > "$XDG_STATE_HOME/romp/serve-token"
+    # fake OLDER kernel mid-window: echoes model (a key it knows) but silently ignores env — the
+    # guaranteed self-hosting shape between merging env support and `romp refresh`. The old
+    # all-or-nothing check read this partial ack as full success and the env drop went unsaid.
+    python3 - "$TEST_DIR/port" <<'PY' &
+import sys, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+portfile = sys.argv[1]
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+        out = json.dumps({"ok": True, "id": "11111111-2222-3333-4444-555555555555",
+                          "model": body.get("model")}).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+    def log_message(self, *a): pass
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(portfile, "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.handle_request()
+PY
+    local srv=$!
+    until [ -s "$TEST_DIR/port" ]; do sleep 0.05; done
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --model claude-fable-5 --env FEATURE_FLAG=1 envy
+    kill "$srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"applied model claude-fable-5"* ]]
+    [[ "$output" == *"did not acknowledge --env (older kernel?)"* ]]
 }
 
 @test "new --model with -t refuses loudly (SDK-only flags), and starts nothing" {
     touch "$MOCK_LOG"
     run run_romp new -t --model claude-fable-5 x
     [ "$status" -eq 2 ]
-    [[ "$output" == *"--model/--effort need the default (SDK) session"* ]]
+    [[ "$output" == *"--model/--effort/--env need the default (SDK) session"* ]]
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
@@ -1353,4 +1425,114 @@ PY
     [ "$status" -eq 0 ]
     [[ "$output" == *"--model <id>"* ]]
     [[ "$output" == *"--effort <level>"* ]]
+}
+
+# Helper — a one-shot fake kernel for the --env tests: records the /new body and echoes the env
+# back, the applied-ack contract of the real handler (the same shape the --model/--effort fake uses).
+_env_fake_kernel() {
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'tok-test' > "$XDG_STATE_HOME/romp/serve-token"
+    python3 - "$TEST_DIR/port" "$TEST_DIR/req.log" <<'PY' &
+import sys, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+portfile, log = sys.argv[1], sys.argv[2]
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+        with open(log, "w") as f:
+            json.dump({"path": self.path, "body": body}, f)
+        out = {"ok": True, "id": "11111111-2222-3333-4444-555555555555"}
+        if "env" in body:              # echo whenever ASKED — {} (the clear declaration) included
+            out["env"] = body["env"]
+        out = json.dumps(out).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+    def log_message(self, *a): pass
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(portfile, "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.handle_request()
+PY
+    _env_srv=$!
+    until [ -s "$TEST_DIR/port" ]; do sleep 0.05; done
+}
+
+@test "new --env: repeatable flags accumulate into ONE env object on /new, echoed as applied" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _env_fake_kernel
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --env FEATURE_FLAG=1 --env UI_THEME=dark envy
+    kill "$_env_srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    grep -q '"FEATURE_FLAG": "1"' "$TEST_DIR/req.log"
+    grep -q '"UI_THEME": "dark"' "$TEST_DIR/req.log"
+    [[ "$output" == *"applied env FEATURE_FLAG=1,UI_THEME=dark"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new --env: the value splits on the FIRST '=' and an empty value is meaningful" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _env_fake_kernel
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --env TOGGLE=a=b --env EMPTY= envy
+    kill "$_env_srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    grep -q '"TOGGLE": "a=b"' "$TEST_DIR/req.log"
+    grep -q '"EMPTY": ""' "$TEST_DIR/req.log"
+}
+
+@test "new without --env sends NO env key (absent means don't touch, never an empty object)" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _env_fake_kernel
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new envy
+    kill "$_env_srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    run grep '"env"' "$TEST_DIR/req.log"
+    [ "$status" -ne 0 ]
+}
+
+@test "new --env: a malformed or empty NAME is a usage error, never a silent skip" {
+    touch "$MOCK_LOG"
+    run run_romp new --env 9BAD=1 x
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"[A-Za-z_][A-Za-z0-9_]*"* ]]
+    run run_romp new --env =x x
+    [ "$status" -eq 2 ]
+    run run_romp new --env NOEQUALS x
+    [ "$status" -eq 2 ]
+    run run_romp new --env
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp new"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new --no-env sends the explicit empty declaration and reports the clear as applied" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _env_fake_kernel
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --no-env envy
+    kill "$_env_srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    grep -q '"env": {}' "$TEST_DIR/req.log"
+    [[ "$output" == *"applied env cleared"* ]]
+    [[ "$output" != *"WARNING"* ]]
+}
+
+@test "new --env with -t refuses loudly (SDK-only flags), and starts nothing" {
+    touch "$MOCK_LOG"
+    run run_romp new -t --env FEATURE_FLAG=1 x
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"need the default (SDK) session"* ]]
+    run run_romp new -t --no-env x
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"need the default (SDK) session"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new: help names --env (the same presence guard as --model/--effort)" {
+    run run_romp -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--env NAME=VALUE"* ]]
 }

--- a/tests/test_kernel_color_pick.py
+++ b/tests/test_kernel_color_pick.py
@@ -91,7 +91,7 @@ class PickColor(unittest.TestCase):
         got = {}
 
         class _FakeSdk:
-            def spawn(self, nm, cwd, bg="", fg="", sid=None, auth=""):
+            def spawn(self, nm, cwd, bg="", fg="", sid=None, auth="", env=None):
                 got.update(bg=bg, fg=fg)
                 return SID % 9
             def connect(self, sid):

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -30,7 +30,7 @@ class _FakeSdk:
 
     # mirrors the real SdkBackend.spawn: the kernel now picks a fleet-aware identity colour and hands it
     # down (test_kernel_color_pick.py), so the fake must accept it exactly like the real one does
-    def spawn(self, nm, cwd, bg="", fg="", sid=None, auth=""):
+    def spawn(self, nm, cwd, bg="", fg="", sid=None, auth="", env=None):
         self.calls.append(("spawn", nm, cwd))
         return "11111111-2222-3333-4444-555555555555"
 

--- a/tests/test_new_route_prefs.py
+++ b/tests/test_new_route_prefs.py
@@ -10,6 +10,7 @@ import json
 import os
 import tempfile
 import threading
+import time
 import unittest
 import urllib.request
 from http.server import ThreadingHTTPServer
@@ -92,7 +93,7 @@ class NewRoutePrefs(unittest.TestCase):
         km._sdk_ready = lambda: True
         # the create path owns the prefs now — applied between spawn and connect, so the FIRST
         # connect carries them (the 2026-08-16 -m drop); the stub mirrors that seam
-        km._create_sdk_session = (lambda nm, cwd, auth="", prefs=None:
+        km._create_sdk_session = (lambda nm, cwd, auth="", prefs=None, client=None, env=None:
                                   (SID2, km._apply_new_session_prefs(SID2, prefs or {})))
         r = self._post({"name": "opt", "dir": self.dir,
                         "model": "claude-fable-5", "effort": "ultracode"})
@@ -109,6 +110,177 @@ class NewRoutePrefs(unittest.TestCase):
         self.assertEqual(r.get("model"), "claude-fable-5")
         self.assertNotIn("effort", r)
         self.assertEqual(self.calls, [("model", SID, "claude-fable-5")])
+
+
+class NewRouteEnv(unittest.TestCase):
+    """POST /new's per-spawn "env" (the user 2026-08-17), the spawn-time slice: validated server-side
+    (a bad name refuses the WHOLE request with a 400 — fail-loudly, never a silent skip), born into
+    the SDK spawn so the eager connect already carries it, re-asserted through the park-aware
+    set_env on the idempotent existing:true open, and echoed back like model/effort. SDK-only: the
+    payload rides the per-sid flag-settings file, which a tmux session's CLI never reads — asked of
+    a tmux session or the tmux backend, /new says so instead of pretending. Synthetic values only
+    (FEATURE_FLAG=1 shapes, never anything credential-shaped — gitleaks reads this repo too)."""
+
+    class _SdkBe:
+        """A backend double WITH the set_env capability (the SDK shape)."""
+
+        def set_env(self, sid, env):
+            return True
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+        cls.dir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.calls = []
+        self.created = []
+        self.spawns = []
+        self._saved = (km._live_names, km._tmux_sessions, km._set_env_or_park,
+                       km.Sessions.backend_for, km._sdk_ready, km._create_sdk_session,
+                       km._push_soon, km._spawn_session)
+        km._tmux_sessions = lambda: []
+        km._live_names = lambda *_: {}
+        km._set_env_or_park = lambda be, sid, v: self.calls.append(("env", sid, v))
+        km.Sessions.backend_for = staticmethod(lambda sid: self._SdkBe())
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = (lambda nm, cwd, auth="", prefs=None, client=None, env=None:
+                                  (self.created.append((nm, auth, env)),
+                                   (SID2, km._apply_new_session_prefs(SID2, prefs or {})))[1])
+        km._push_soon = lambda: None
+        km._spawn_session = lambda nm, cwd=None: self.spawns.append(nm)
+
+    def tearDown(self):
+        (km._live_names, km._tmux_sessions, km._set_env_or_park,
+         km.Sessions.backend_for, km._sdk_ready, km._create_sdk_session,
+         km._push_soon, km._spawn_session) = self._saved
+
+    def _post(self, body):
+        req = urllib.request.Request("http://127.0.0.1:%d/new" % self.port,
+                                     data=json.dumps(body).encode(),
+                                     headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"],
+                                              "Content-Type": "application/json"}, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read() or b"{}")
+
+    def test_a_bad_name_refuses_the_whole_request(self):
+        for env in ({"9BAD": "1"}, {"BAD-NAME": "1"}, {"": "1"}):
+            code, body = self._post({"name": "opt", "dir": self.dir, "env": env})
+            self.assertEqual(code, 400, "bad env name %r must 400, not spawn" % env)
+            self.assertFalse(body["ok"])
+            self.assertIn("[A-Za-z_][A-Za-z0-9_]*", body["error"],
+                          "the error teaches the alphabet, not just refuses")
+        self.assertEqual(self.created, [], "nothing may be created on a refused request")
+        self.assertEqual(self.calls, [])
+
+    def test_a_non_object_or_non_string_value_refuses(self):
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": "FEATURE_FLAG=1"})
+        self.assertEqual(code, 400)
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {"FEATURE_FLAG": 1}})
+        self.assertEqual(code, 400)
+        self.assertIn("FEATURE_FLAG", body["error"], "the offender is named — fail loudly")
+
+    def test_falsy_junk_env_refuses_not_swallowed(self):
+        # `or None` used to collapse ALL falsy values to "not asked": a script serializing env as
+        # false/0/"" got an acked spawn silently missing its env — 0 skipped while 1 400'd
+        for junk in (False, 0, "", []):
+            code, body = self._post({"name": "opt", "dir": self.dir, "env": junk})
+            self.assertEqual(code, 400, "falsy junk %r must 400, not spawn env-less" % (junk,))
+            self.assertFalse(body["ok"])
+            self.assertIn("env", body["error"], "the refusal names the offending key")
+        self.assertEqual(self.created, [], "nothing may be created on a refused request")
+        self.assertEqual(self.calls, [])
+
+    def test_null_env_still_means_not_asked(self):
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": None})
+        self.assertEqual(code, 200)
+        self.assertTrue(body["ok"])
+        self.assertEqual(self.created, [("opt", "", None)], "null = absent, the don't-touch contract")
+        self.assertNotIn("env", body)
+        self.assertEqual(self.calls, [])
+
+    def test_a_nul_byte_in_a_value_refuses(self):
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {"X": "a\x00b"}})
+        self.assertEqual(code, 400, "a NUL value is unfulfillable by any process environment")
+        self.assertFalse(body["ok"])
+        self.assertIn("X", body["error"], "the offender is named — fail loudly")
+        self.assertIn("NUL", body["error"])
+        self.assertEqual(self.created, [])
+        self.assertEqual(self.calls, [])
+
+    def test_env_is_born_into_the_spawn_and_echoed(self):
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {"FEATURE_FLAG": "1"}})
+        self.assertEqual(code, 200)
+        self.assertTrue(body["ok"])
+        self.assertEqual(self.created, [("opt", "", {"FEATURE_FLAG": "1"})],
+                         "the reg must be born with the env — BEFORE the eager connect, "
+                         "not patched in behind it")
+        self.assertEqual(body.get("env"), {"FEATURE_FLAG": "1"},
+                         "the echo is the ack the CLI is loud about missing")
+        self.assertIn(("env", SID2, {"FEATURE_FLAG": "1"}), self.calls,
+                      "the prefs pass re-asserts (set_env's unchanged-skip makes it free)")
+
+    def test_no_env_asked_none_threaded(self):
+        code, body = self._post({"name": "opt", "dir": self.dir})
+        self.assertEqual(code, 200)
+        self.assertEqual(self.created, [("opt", "", None)])
+        self.assertNotIn("env", body)
+        self.assertEqual(self.calls, [], "nothing asked, nothing re-asserted")
+
+    def test_existing_session_reasserts_through_set_env(self):
+        km._live_names = lambda *_: {"opt": SID}
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {"FEATURE_FLAG": "1"}})
+        self.assertEqual(code, 200)
+        self.assertTrue(body["ok"] and body["existing"])
+        self.assertEqual(self.calls, [("env", SID, {"FEATURE_FLAG": "1"})],
+                         "re-asserted if <name> already runs — the model/effort contract")
+        self.assertEqual(body.get("env"), {"FEATURE_FLAG": "1"})
+
+    def test_an_explicit_empty_env_clears_a_running_session(self):
+        # the clear-all door: {} is the replace-not-merge contract's limiting case (a re-run
+        # declares the FULL env, and the empty declaration is "none") — before this, a spawn-time
+        # debugging var could never be removed from a running session, only overwritten
+        km._live_names = lambda *_: {"opt": SID}
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {}})
+        self.assertEqual(code, 200)
+        self.assertTrue(body["ok"] and body["existing"])
+        self.assertEqual(self.calls, [("env", SID, {})],
+                         "an explicit {} must reach set_env, which clears by replacing")
+        self.assertEqual(body.get("env"), {}, "the clear ask is echoed like any other env ask")
+
+    def test_an_explicit_empty_env_on_a_fresh_spawn_is_vacuous_but_echoed(self):
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {}})
+        self.assertEqual(code, 200)
+        self.assertTrue(body["ok"])
+        self.assertEqual(self.created, [("opt", "", {})],
+                         "spawn's own `if env:` makes the empty declaration naturally vacuous")
+        self.assertEqual(body.get("env"), {})
+
+    def test_an_existing_tmux_session_refuses_loudly(self):
+        km._live_names = lambda *_: {"opt": SID}
+        km.Sessions.backend_for = staticmethod(lambda sid: object())   # no set_env — the tmux shape
+        code, body = self._post({"name": "opt", "dir": self.dir, "env": {"FEATURE_FLAG": "1"}})
+        self.assertEqual(code, 200)
+        self.assertFalse(body["ok"], "a session that can't take the env must say so, not drop it")
+        self.assertIn("SDK", body["error"])
+
+    def test_the_tmux_backend_refuses_env_outright(self):
+        code, body = self._post({"name": "term1", "dir": self.dir,
+                                 "backend": "tmux", "env": {"FEATURE_FLAG": "1"}})
+        self.assertEqual(code, 200)
+        self.assertFalse(body["ok"], "no tmux spawn, no env silently dropped")
+        self.assertIn("SDK", body["error"])
+        time.sleep(0.2)                       # the tmux spawn is threaded — give a regression a beat
+        self.assertEqual(self.spawns, [], "the refusal must come BEFORE the spawn thread starts")
 
 
 if __name__ == "__main__":

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -160,7 +160,7 @@ class CreateOpenReviveAreAimedToo(unittest.TestCase):
 
     def test_a_create_with_no_asking_dashboard_moves_nobody(self):
         class _BE:
-            def spawn(self, nm, cwd, bg, fg, auth=""):
+            def spawn(self, nm, cwd, bg, fg, auth="", env=None):
                 return "sid-new"
 
             def connect(self, sid):
@@ -185,8 +185,13 @@ class CreateOpenReviveAreAimedToo(unittest.TestCase):
         self.assertIn('_create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""), client=client)',
                       src, "the picker's createSession follows on the asking window")
         flat = re.sub(r"\s+", "", src)   # the POST /new call wraps; pin it whitespace-blind
-        self.assertIn('sid,extra=_create_sdk_session(nm,cwd,auth=(aifain("login","key")else""),prefs=b)', flat,
+        # POST /new threads env=env_req through the same call (its args carry inline comments, so the
+        # pin walks the span rather than matching one literal); the PROPERTY is unchanged: no client
+        self.assertIn('sid,extra=_create_sdk_session(nm,cwd,auth=(aifain("login","key")else""),prefs=b,', flat,
                       "POST /new (the CLI) has no dashboard in hand, and so names none")
+        start = flat.index('sid,extra=_create_sdk_session(')
+        call = flat[start:flat.index('env=env_req)', start) + len('env=env_req)')]
+        self.assertNotIn('client', call, "POST /new (the CLI) has no dashboard in hand, and so names none")
         self.assertIn('threading.Thread(target=_revive_session, args=(msg["id"], client), daemon=True)', src,
                       "the revive thread carries its asker across to the focus that clears the loader")
         self.assertIn('_fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]), client=client)',

--- a/tests/test_sdk_spawn_pin_send.py
+++ b/tests/test_sdk_spawn_pin_send.py
@@ -132,7 +132,8 @@ class SpawnPinsRideTheFirstConnect(unittest.TestCase):
                         "pins land in the reg after spawn and BEFORE connect — connect-time, race-free")
 
     def test_the_new_route_threads_the_body_through(self):
-        self.assertTrue(re.search(r"_create_sdk_session\(nm, cwd, auth=\(a if a in \(\"login\", \"key\"\) else \"\"\),\s*\n\s*prefs=b\)", self.KERNEL),
+        # the env request rides the same call, after prefs (inline comments tolerated)
+        self.assertTrue(re.search(r"_create_sdk_session\(nm, cwd, auth=\(a if a in \(\"login\", \"key\"\) else \"\"\),\s*\n\s*prefs=b,[^\n]*\n\s*env=env_req\)", self.KERNEL),
                         "/new hands its body to the create path instead of applying pins after connect")
 
 

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -557,7 +557,7 @@ class DrivePlumbing(unittest.TestCase):
 
     def test_create_paths_pass_the_pick_through(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\", prefs=None, client=None):", src)
+        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\", prefs=None, client=None, env=None):", src)
         self.assertEqual(src.count('auth=(a if a in ("login", "key") else "")'), 2,
                          "the WS op and POST /new both pass it")
 

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -517,3 +517,26 @@ class SessionIdentityEnv(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class EnvSecretsStayPrivate(unittest.TestCase):
+    """Env values can be secrets (PR #889 review): the per-sid flag-settings file is created 0600
+    like the serve token, and the parked chat chip renders NAMES only — never a value."""
+
+    def test_the_flag_settings_file_is_private(self):
+        import stat
+        d = tempfile.mkdtemp()
+        p = sb.flag_settings_path(d, "11111111-2222-3333-4444-555555555555", env={"TOKEN": "s3cret"})
+        self.assertTrue(p, "an env writes the file")
+        self.assertEqual(stat.S_IMODE(os.stat(p).st_mode), 0o600, "0600, the serve-token treatment")
+        self.assertIn("s3cret", open(p).read(), "…and the value is in it (the CLI reads it), private")
+        p2 = sb.flag_settings_path(d, "11111111-2222-3333-4444-555555555555", env={"TOKEN": "other"})
+        self.assertEqual(stat.S_IMODE(os.stat(p2).st_mode), 0o600, "a rewrite keeps it private")
+
+    def test_the_parked_chip_names_the_vars_but_never_their_values(self):
+        km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+        md = km._parked_md(("env", {"B_TOKEN": "s3cret", "A_FLAG": "1"}))
+        self.assertEqual(md, "/env A_FLAG B_TOKEN", "sorted names, no values")
+        self.assertNotIn("s3cret", md)
+        self.assertEqual(km._parked_md(("env", {})), "/env (cleared)")
+

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -1,17 +1,492 @@
-"""The session-identity environment surface (the user 2026-08-15 sid, 2026-08-16 name).
+#!/usr/bin/env python3
+"""Per-session env vars, spawn-time slice (the user 2026-08-17): two SDK sessions in the SAME
+directory can run with different environments. Before this, env came only from directory-scoped
+.claude/settings*.json — every session in the repo got it, and it outlived the session.
 
-Every SDK session's CLI process — and every Bash it runs — carries its romp identity in env:
-ROMP_SID (the stable uuid; what `romp end self` resolves through) and ROMP_SESSION_NAME (the
-human name at spawn). The name is a GENERIC capability for child processes that need to know
-which session they belong to (attribution, logging), deliberately coupled to no consumer.
-Env is spawn-frozen, so a post-spawn rename is not reflected — the sid is the address, the
-name a label. Source pins over _options' env line (the SDK merges options.env OVER the
-inherited environment, so both ride the same additive overlay as the bin PATH)."""
+The mechanics under test:
+  * `env_request_error` is the ONE validator both doors share (the /new handler mirrors it): a
+    payload is a dict of NAME→string-value pairs, names matching [A-Za-z_][A-Za-z0-9_]*; anything
+    else is named loudly, never skipped.
+  * spawn() persists the dict in the session's reg (`env`) — the same home model/effort live in —
+    and refuses a bad payload outright rather than writing a poisoned reg.
+  * flag_settings_path folds a non-empty env into the per-sid settings payload beside ultracode /
+    fastMode, and the return-""-when-no-keys contract stands.
+  * _options threads the session's env into that file at EVERY connect — the file is rewritten on
+    each use, so reconnects re-assert the reg's env by construction (pinned by tampering the file
+    between two _options calls).
+  * set_env mirrors set_effort's shape (persist + reconnect to apply; env is connect-time), minus
+    the badge/chip machinery that belongs to the not-yet-built UI slice; an UNCHANGED re-assert
+    (the `romp new --env` re-brief on a standing session, or the fresh-spawn echo) skips the
+    reconnect — the asked-for env is already in force or already queued.
+  * fork() inherits the parent's env like model/auth — it is that conversation, continued elsewhere.
+
+Synthetic fixtures only: FEATURE_FLAG=1 shapes, placeholder sids — never credential-shaped values
+(the gitleaks scanner reads this repo too).
+"""
+import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
+from importlib.machinery import SourceFileLoader
 
-HERE = os.path.dirname(os.path.abspath(__file__))
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_env", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+CHILD = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+ENV = {"FEATURE_FLAG": "1", "UI_THEME": "dark"}
+
+
+class _Backend(unittest.TestCase):
+    """Base: a backend on a temp state dir, no real CLI, no real key claim."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self._stash_before = sb._WORK_KEY
+        sb._WORK_KEY = ""                          # never claim a real key from this process's env
+        self._fetch_before = sb._fetch_key_fast_org
+        sb._fetch_key_fast_org = lambda key: None  # the fast-org probe is a real HTTPS GET — never from a test
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+
+    def tearDown(self):
+        sb._WORK_KEY = self._stash_before
+        sb._fetch_key_fast_org = self._fetch_before
+
+    def _reg(self, sid):
+        return sb.read_reg(self.be.state_dir, sid)
+
+    def _sess(self, sid):
+        return sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, sid))
+
+
+class EnvRequestError(unittest.TestCase):
+    """The shared validator: loud and specific, never a silent skip."""
+
+    def test_valid_payloads_pass(self):
+        self.assertEqual(sb.env_request_error({"FEATURE_FLAG": "1"}), "")
+        self.assertEqual(sb.env_request_error({"_UNDER": "x", "A9": ""}), "",
+                         "an empty VALUE is meaningful — explicitly setting empty")
+        self.assertEqual(sb.env_request_error({}), "", "an empty dict is a valid (vacuous) payload")
+
+    def test_a_non_dict_is_named(self):
+        for bad in ("FEATURE_FLAG=1", ["FEATURE_FLAG"], 7, None):
+            err = sb.env_request_error(bad)
+            self.assertIn("env", err)
+            self.assertTrue(err, "a non-object payload must be refused, not coerced")
+
+    def test_a_bad_name_is_named(self):
+        for bad in ("9BAD", "", "BAD-NAME", "BAD NAME", "über"):
+            err = sb.env_request_error({bad: "1"})
+            self.assertIn("[A-Za-z_][A-Za-z0-9_]*", err,
+                          "the error must teach the alphabet, not just refuse: %r" % bad)
+
+    def test_a_non_string_value_is_named(self):
+        for bad in (1, None, True, {"nested": "no"}):
+            err = sb.env_request_error({"FEATURE_FLAG": bad})
+            self.assertIn("FEATURE_FLAG", err,
+                          "the offending NAME must be in the error (fail loudly): %r" % (bad,))
+
+    def test_a_nul_byte_in_a_value_is_named(self):
+        # an execve envp entry is a NUL-terminated C string, so a NUL value is unfulfillable by
+        # definition — accepted, it bakes an env the CLI can only truncate or throw on into the reg
+        err = sb.env_request_error({"FEATURE_FLAG": "1\x00x"})
+        self.assertIn("FEATURE_FLAG", err, "the offending NAME must be in the error")
+        self.assertIn("NUL", err, "the error names the actual problem")
+
+    def test_other_control_bytes_stay_legitimate(self):
+        self.assertEqual(sb.env_request_error({"FEATURE_FLAG": "line1\nline2\ttabbed"}), "",
+                         "NUL only — newlines and tabs are legitimate env content")
+
+    def test_the_identity_names_are_refused(self):
+        # options.env owns ROMP_SID / ROMP_SESSION_NAME (the identity overlay below): a user var of
+        # either name would silently shadow or be shadowed by the identity, breaking `romp end self`
+        # with nothing pointing at the cause — refused at the door instead, like every bad payload
+        for name in ("ROMP_SID", "ROMP_SESSION_NAME"):
+            err = sb.env_request_error({name: "x"})
+            self.assertIn(name, err, "the reserved NAME must be in the error")
+            self.assertIn("romp sets", err, "the error teaches WHO owns the name, not just 'no'")
+        self.assertTrue(sb.env_request_error({"FEATURE_FLAG": "1", "ROMP_SID": "x"}),
+                        "a reserved name refuses the WHOLE payload, never a silent skip")
+
+
+class FlagSettingsEnv(unittest.TestCase):
+    """flag_settings_path folds env in beside ultracode/fastMode; the ""-when-empty contract stands."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def _read(self, p):
+        return json.loads(Path(p).read_text())
+
+    def test_env_alone_writes_the_file(self):
+        p = sb.flag_settings_path(self.d, PARENT, env=ENV)
+        self.assertTrue(p)
+        self.assertEqual(self._read(p), {"env": ENV})
+
+    def test_env_rides_beside_the_boolean_keys(self):
+        p = sb.flag_settings_path(self.d, PARENT, ultracode=True, fast=True, env=ENV)
+        got = self._read(p)
+        self.assertEqual(got["env"], ENV)
+        self.assertTrue(got["ultracode"] and got["fastMode"],
+                        "env must merge INTO the payload, not replace the keys already riding it")
+
+    def test_no_keys_still_returns_empty(self):
+        self.assertEqual(sb.flag_settings_path(self.d, PARENT), "")
+        self.assertEqual(sb.flag_settings_path(self.d, PARENT, env=None), "")
+        self.assertEqual(sb.flag_settings_path(self.d, PARENT, env={}), "",
+                         "an empty env adds no key — the no-keys contract is the common case")
+
+    def test_an_unwritable_dir_degrades_loudly(self):
+        # a plain FILE where the flag-settings dir goes forces the OSError (os.makedirs raises)
+        Path(self.d, sb.FLAG_SETTINGS_DIR).write_text("not a directory")
+        logged = []
+        p = sb.flag_settings_path(self.d, PARENT, env=ENV,
+                                  log=lambda msg, problem=False: logged.append((msg, problem)))
+        self.assertEqual(p, "", "degrade to launch — a session without its env still beats none")
+        self.assertEqual(len(logged), 1)
+        msg, problem = logged[0]
+        self.assertTrue(problem, "the drop is a problem row, not a quiet info line")
+        self.assertIn("env", msg, "the log names the dropped keys")
+        self.assertIn(PARENT, msg, "the log names whose launch went without them")
+
+    def test_the_oserror_path_stays_quiet_without_a_logger(self):
+        Path(self.d, sb.FLAG_SETTINGS_DIR).write_text("not a directory")
+        self.assertEqual(sb.flag_settings_path(self.d, PARENT, env=ENV), "",
+                         "log=None (direct callers) must neither raise nor change the '' contract")
+
+    def test_no_keys_asked_means_no_log_even_on_a_bad_dir(self):
+        Path(self.d, sb.FLAG_SETTINGS_DIR).write_text("not a directory")
+        logged = []
+        self.assertEqual(
+            sb.flag_settings_path(self.d, PARENT, log=lambda *a, **k: logged.append(a)), "")
+        self.assertEqual(logged, [], "nothing requested, nothing dropped — nothing to report")
+
+
+class SpawnEnv(_Backend):
+    def test_spawn_persists_the_env_in_the_reg(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        self.assertEqual(self._reg(sid).get("env"), ENV)
+
+    def test_spawn_without_env_writes_no_key(self):
+        sid = self.be.spawn("web", "/tmp")
+        self.assertNotIn("env", self._reg(sid))
+
+    def test_spawn_refuses_a_bad_payload_loudly(self):
+        with self.assertRaises(ValueError):
+            self.be.spawn("web", "/tmp", env={"9BAD": "1"})
+        with self.assertRaises(ValueError):
+            self.be.spawn("web", "/tmp", env={"FEATURE_FLAG": 1})
+
+    def test_spawn_refuses_the_identity_names(self):
+        # a reg born with ROMP_SID in its user env would shadow-race the identity at every connect
+        with self.assertRaises(ValueError):
+            self.be.spawn("web", "/tmp", env={"ROMP_SID": PARENT})
+        with self.assertRaises(ValueError):
+            self.be.spawn("web", "/tmp", env={"ROMP_SESSION_NAME": "impostor"})
+
+
+class _OptionsBackend(_Backend):
+    """_Backend plus the _options seam: ClaudeAgentOptions is a parameter (a dict stands in) and
+    the in-function import only needs HookMatcher — stub the module when the real dependency is
+    absent (CI without the venv)."""
+
+    def setUp(self):
+        super().setUp()
+        import sys
+        import types
+        self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
+        if self._fake_sdk:
+            fake = types.ModuleType("claude_agent_sdk")
+            fake.HookMatcher = lambda **kw: kw
+            sys.modules["claude_agent_sdk"] = fake
+
+    def tearDown(self):
+        import sys
+        if self._fake_sdk:
+            sys.modules.pop("claude_agent_sdk", None)
+        super().tearDown()
+
+    def _options_kw(self, sess):
+        return self.be._options(sess, dict)
+
+
+class OptionsThreadsEnv(_OptionsBackend):
+    """_options → flag_settings_path(env=…): the file the CLI launches with carries the reg's env."""
+
+    def test_the_settings_file_carries_the_regs_env(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        kw = self._options_kw(self._sess(sid))
+        self.assertIn("settings", kw)
+        self.assertEqual(json.loads(Path(kw["settings"]).read_text())["env"], ENV)
+
+    def test_no_env_and_no_flags_means_no_settings_file(self):
+        sid = self.be.spawn("web", "/tmp")
+        kw = self._options_kw(self._sess(sid))
+        self.assertNotIn("settings", kw,
+                         "the return-\"\"-when-no-keys contract: a plain session launches without "
+                         "a flag-settings file at all")
+
+    def test_every_connect_rewrites_the_file_so_reconnects_reassert(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        s = self._sess(sid)
+        p = self._options_kw(s)["settings"]
+        Path(p).write_text('{"env": {"TAMPERED": "yes"}}')   # drift the file behind romp's back
+        p2 = self._options_kw(s)["settings"]
+        self.assertEqual(p2, p)
+        self.assertEqual(json.loads(Path(p2).read_text())["env"], ENV,
+                         "the file is rewritten from the session on EVERY use — a reconnect "
+                         "re-asserts the env by construction, never trusts what's on disk")
+
+    def test_a_failed_flag_write_degrades_loudly_through_options(self):
+        # the connect-time seam: /new already echoed the env as applied, so a write failure here
+        # must reach the Log as a problem — the session launching without its env is otherwise
+        # invisible to every surface (no readback channel)
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        Path(self.be.state_dir, sb.FLAG_SETTINGS_DIR).write_text("not a directory")
+        logged = []
+        self.be._log = lambda msg, problem=False: logged.append((msg, problem))
+        kw = self._options_kw(self._sess(sid))
+        self.assertNotIn("settings", kw, "degrade to launch, never abort the connect")
+        self.assertTrue(any(problem and "env" in msg for msg, problem in logged),
+                        "the drop must land in the Log as a problem naming env: %r" % (logged,))
+
+
+class SetEnv(_Backend):
+    """set_env: set_effort's persist+reconnect shape, minus the UI slice's badge/chip machinery."""
+
+    def _live(self, sid):
+        s = self._sess(sid)
+        s.request_reconnect = lambda: self.reconnects.append(1)
+        self.reconnects = []
+        self.be.sessions[sid] = s
+        return s
+
+    def test_a_change_persists_and_reconnects(self):
+        sid = self.be.spawn("web", "/tmp")
+        s = self._live(sid)
+        self.assertTrue(self.be.set_env(sid, ENV))
+        self.assertEqual(self._reg(sid)["env"], ENV)
+        self.assertEqual(s.env_vars, ENV)
+        self.assertTrue(self.reconnects, "env is connect-time — the reconnect is what applies it")
+
+    def test_an_unchanged_reassert_skips_the_reconnect(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        self._live(sid)
+        self.assertTrue(self.be.set_env(sid, dict(ENV)))
+        self.assertFalse(self.reconnects,
+                         "same env = nothing to apply: the fresh-spawn echo and the nightly "
+                         "re-brief must not churn the CLI process")
+
+    def test_replace_not_merge(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        self._live(sid)
+        self.assertTrue(self.be.set_env(sid, {"FEATURE_FLAG": "0"}))
+        self.assertEqual(self._reg(sid)["env"], {"FEATURE_FLAG": "0"},
+                         "the payload IS the session's per-session env — names not re-asserted drop")
+
+    def test_refuses_junk_and_unknown_sids(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        self.assertFalse(self.be.set_env(sid, {"9BAD": "1"}))
+        self.assertEqual(self._reg(sid)["env"], ENV, "a refused payload must not half-apply")
+        self.assertFalse(self.be.set_env(CHILD, ENV), "no reg, no session — refuse, don't mint")
+
+    def test_refuses_a_nul_value(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        self.assertFalse(self.be.set_env(sid, {"FEATURE_FLAG": "1\x00x"}),
+                         "a NUL value is unfulfillable — refuse, never persist it into the reg")
+        self.assertEqual(self._reg(sid)["env"], ENV, "the poisoned payload must not half-apply")
+
+    def test_refuses_the_identity_names(self):
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        self.assertFalse(self.be.set_env(sid, {"ROMP_SESSION_NAME": "impostor"}),
+                         "the identity env is romp's own — never a per-session override")
+        self.assertEqual(self._reg(sid)["env"], ENV, "the refused payload must not half-apply")
+
+    def test_an_explicit_empty_dict_clears_and_reconnects(self):
+        # the replace-not-merge contract's limiting case: {} DECLARES "no per-session env" —
+        # the only way to remove a spawn-time debugging var from a running session
+        sid = self.be.spawn("web", "/tmp", env=ENV)
+        s = self._live(sid)
+        self.assertTrue(self.be.set_env(sid, {}))
+        self.assertEqual(self._reg(sid)["env"], {}, "the empty declaration replaces the whole set")
+        self.assertEqual(s.env_vars, {})
+        self.assertTrue(self.reconnects, "clearing is a CHANGE — it applies by reconnecting")
+        self.assertEqual(sb.flag_settings_path(self.be.state_dir, sid, env=s.env_vars), "",
+                         "cleared env adds no key — the next connect launches without a flag file")
+        self.reconnects.clear()
+        self.assertTrue(self.be.set_env(sid, {}), "re-clearing is the unchanged re-assert")
+        self.assertFalse(self.reconnects, "already clear = nothing to apply, no CLI churn")
+
+    def test_a_dormant_session_persists_without_a_live_object(self):
+        sid = self.be.spawn("web", "/tmp")
+        self.assertTrue(self.be.set_env(sid, ENV))
+        self.assertEqual(self._reg(sid)["env"], ENV,
+                         "the next connect reads the reg — persistence alone is a full apply "
+                         "for a session with no live client")
+
+
+class ForkInheritsEnv(_Backend):
+    def test_a_fork_carries_the_parents_env(self):
+        os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp()   # transcript_path resolves through this
+        try:
+            self.be.spawn("parent", self.d, sid=PARENT, env=ENV)
+            self.be.fork("child", PARENT, "a1", sid=CHILD)
+            self.assertEqual(self._reg(CHILD).get("env"), ENV,
+                             "it is that conversation, continued elsewhere — env inherits like "
+                             "model/auth do")
+        finally:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def test_a_fork_of_an_env_less_parent_stays_env_less(self):
+        os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp()
+        try:
+            self.be.spawn("parent", self.d, sid=PARENT)
+            self.be.fork("child", PARENT, "a1", sid=CHILD)
+            self.assertNotIn("env", self._reg(CHILD))
+        finally:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+
+class LegacyReservedEnv(_OptionsBackend):
+    """Regs written before ENV_RESERVED_NAMES existed can carry ROMP_SID / ROMP_SESSION_NAME in
+    their stored env. Spawn and set_env refuse them at the door now — but a standing reg is
+    replayed verbatim at every connect, and fork() copies the parent's. Three obligations at the
+    apply seam: the session still LAUNCHES (a reconnect refusal would brick a long-running session
+    over a var accepted under older rules), the reserved name never reaches the applied env (it
+    would shadow-race the options.env identity — `romp end self` resolving to a forged sid), and
+    the skip is LOUD, naming the session and the ignored var (never silently)."""
+
+    def _poisoned(self, env):
+        """A reg whose stored env predates the reserved-name rule — written behind the validator,
+        the way those regs actually exist on disk."""
+        sid = self.be.spawn("web", "/tmp")
+        reg = self._reg(sid)
+        reg["env"] = dict(env)
+        sb.write_reg(self.be.state_dir, sid, reg)
+        return sid
+
+    def test_a_pre_rule_reg_launches_with_the_reserved_name_skipped(self):
+        sid = self._poisoned({"FEATURE_FLAG": "1", "ROMP_SID": PARENT})
+        logged = []
+        self.be._log = lambda msg, problem=False: logged.append((msg, problem))
+        kw = self._options_kw(self._sess(sid))
+        applied = json.loads(Path(kw["settings"]).read_text())["env"]
+        self.assertEqual(applied, {"FEATURE_FLAG": "1"},
+                         "the rest of the stored env still applies — skip the var, not the session")
+        self.assertEqual(kw["env"]["ROMP_SID"], sid,
+                         "the identity overlay stands untouched — the forged sid never shadows it")
+        self.assertTrue(any(problem and "ROMP_SID" in msg and "web" in msg
+                            for msg, problem in logged),
+                        "the skip must be loud, naming the session and the ignored var: %r"
+                        % (logged,))
+
+    def test_a_reg_carrying_only_reserved_names_still_launches(self):
+        sid = self._poisoned({"ROMP_SESSION_NAME": "impostor"})
+        logged = []
+        self.be._log = lambda msg, problem=False: logged.append((msg, problem))
+        kw = self._options_kw(self._sess(sid))
+        self.assertNotIn("settings", kw,
+                         "nothing left after the skip = the no-keys contract, not an empty env")
+        self.assertEqual(kw["env"]["ROMP_SESSION_NAME"], "web")
+        self.assertTrue(any(problem and "ROMP_SESSION_NAME" in msg for msg, problem in logged))
+
+    def test_a_fork_drops_the_reserved_names_from_the_inherited_env(self):
+        os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp()   # transcript_path resolves through this
+        try:
+            self.be.spawn("parent", self.d, sid=PARENT)
+            reg = self._reg(PARENT)
+            reg["env"] = {"FEATURE_FLAG": "1", "ROMP_SID": PARENT}
+            sb.write_reg(self.be.state_dir, PARENT, reg)
+            logged = []
+            self.be._log = lambda msg, problem=False: logged.append((msg, problem))
+            self.be.fork("child", PARENT, "a1", sid=CHILD)
+            self.assertEqual(self._reg(CHILD).get("env"), {"FEATURE_FLAG": "1"},
+                             "the copy is where a legacy reg's poison stops propagating")
+            self.assertTrue(any(problem and "ROMP_SID" in msg and "child" in msg
+                                for msg, problem in logged),
+                            "the drop must be loud, naming the session and the var: %r" % (logged,))
+        finally:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+
+class ValidatorLockstep(unittest.TestCase):
+    """_env_error (the /new door's kernel-side mirror) and env_request_error are hand-kept copies.
+    Spawn backs the door with a loud ValueError, but set_env refuses with a silent False its callers
+    discard — so drift between the copies on the existing:true path would be a 200 with an env echo
+    and NOTHING applied. This pin is the backstop the door docstring cites: identical verdicts
+    (messages included) across the whole good/bad payload table, so loosening one copy fails here
+    instead of going silent."""
+
+    PAYLOADS = (
+        # valid: plain, underscore/empty-value, the vacuous empty declaration
+        {"FEATURE_FLAG": "1"}, {"_UNDER": "x", "A9": ""}, {},
+        # non-dicts, truthy and falsy alike (the door 400s all of them)
+        "FEATURE_FLAG=1", ["FEATURE_FLAG"], 7, None, False, 0, "", [],
+        # bad names
+        {"9BAD": "1"}, {"": "1"}, {"BAD-NAME": "1"}, {"BAD NAME": "1"}, {"über": "1"},
+        # the reserved identity names (options.env owns them), alone and riding a valid payload
+        {"ROMP_SID": "x"}, {"ROMP_SESSION_NAME": "web"}, {"FEATURE_FLAG": "1", "ROMP_SID": "x"},
+        # bad values, the NUL hole included
+        {"FEATURE_FLAG": 1}, {"FEATURE_FLAG": None}, {"FEATURE_FLAG": True},
+        {"FEATURE_FLAG": {"nested": "no"}}, {"FEATURE_FLAG": "1\x00x"},
+    )
+
+    @staticmethod
+    def _kernel():
+        import sys
+        if "romp_kernel" in sys.modules:
+            return sys.modules["romp_kernel"]
+        # the kernel imports its deps by these exact module names (the test_new_route_prefs pattern)
+        for name, fn in (("romp_event_model", "romp-event-model"), ("romp_judge", "romp-judge")):
+            if name not in sys.modules:
+                SourceFileLoader(name, os.path.join(BIN, fn)).load_module()
+        return SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+    def test_the_two_validator_copies_agree_verdict_for_verdict(self):
+        km = self._kernel()
+        for payload in self.PAYLOADS:
+            self.assertEqual(km._env_error(payload), sb.env_request_error(payload),
+                             "the copies must stay in lockstep — payload %r" % (payload,))
+
+
+class DrivePlumbing(unittest.TestCase):
+    """The /new door rides the same park/drain path as the other per-session switches (source pins,
+    the test_session_auth.DrivePlumbing pattern)."""
+
+    def test_the_op_is_routed_parked_and_replayed(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("def _set_env_or_park(be, sid, value):", src)
+        self.assertIn('_park_op(sid, ("env", value))', src)
+        self.assertIn('elif op[0] == "env":', src)
+        self.assertIn("be.set_env(sid, op[1])", src)
+        self.assertIn('("model", "effort", "fast", "env")', src,
+                      "a repeat env pick REPLACES the earlier parked one in place, like model/effort")
+
+    def test_the_create_path_passes_env_through(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('def _create_sdk_session(nm, cwd, auth="", prefs=None, client=None, env=None):', src)
+        self.assertIn("sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth, env=env)", src,
+                      "env rides the SPAWN — the reg is born with it, ahead of the prefs pass")
+
+
+# ── The session-identity environment surface (the user 2026-08-15 sid, 2026-08-16 name).
+# Every SDK session's CLI process — and every Bash it runs — carries its romp identity in env:
+# ROMP_SID (the stable uuid; what `romp end self` resolves through) and ROMP_SESSION_NAME (the
+# human name at spawn). The name is a GENERIC capability for child processes that need to know
+# which session they belong to (attribution, logging), deliberately coupled to no consumer.
+# Env is spawn-frozen, so a post-spawn rename is not reflected — the sid is the address, the
+# name a label. Source pins over _options' env line (the SDK merges options.env OVER the
+# inherited environment, so both ride the same additive overlay as the bin PATH). Distinct layer
+# from the per-session user env above: identity rides options.env (the transport), user env the
+# per-sid flag-settings file — neither writes the other's layer.
 SDK = Path(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read_text()
 
 

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -70,6 +70,6 @@ test("a refusal answering the user's ask is loud — warn toast, ask cleared, ba
 test("setFast is a drive op that parks like /model and /effort", () => {
   assert.match(KERNEL, /"setModel", "setEffort", "setMode", "setFast",/);    // in the drive-op allowlist
   assert.match(KERNEL, /def _set_fast_or_park\(be, sid, value\)/);
-  assert.match(KERNEL, /op\[0\] in \("model", "effort", "fast"\)/);          // repeat pick replaces in place
+  assert.match(KERNEL, /op\[0\] in \("model", "effort", "fast", "env"\)/);   // repeat pick replaces in place (env joined too)
   assert.match(KERNEL, /elif op\[0\] == "fast":/);                           // parked delivery branch
 });


### PR DESCRIPTION
## Problem

Two SDK sessions in the same directory cannot run with different environments. Env reaches a session only through the directory-scoped `.claude/settings*.json`, which applies to every session in that repo and outlives all of them. The per-session mechanism already exists: `flag_settings_path` hands each CLI a per-sid settings file (the `ultracode`/`fastMode` carrier), and settings files accept an `env` block.

Reproduce today: start two SDK sessions in one repo and try to give only one of them `FEATURE_FLAG=1`. There is no door — `romp new` has no env flag, POST /new ignores an `env` key, and the settings-file route reaches both sessions.

## What ships

Spawn-time slice: no dashboard surface, no separate live-mutation op.

- **CLI.** `romp new --env NAME=VALUE <name>`, repeatable, split on the first `=` (values may contain `=`; an empty value is meaningful). A missing `=` or a NAME outside `[A-Za-z_][A-Za-z0-9_]*` is a usage error (exit 2). `romp new --no-env <name>` sends the explicit empty declaration and clears a running session's per-session env. Both refuse loudly with `-t` (a tmux session's CLI reads the tmux server's environment). The `/new` leg now calls curl without `-f`, so the kernel's 400 body reaches the user instead of reading as "kernel not reachable"; a real connection failure still says so. The older-kernel warning is per asked key: a kernel that echoes model but not env warns about `--env` specifically.
- **POST /new** takes `"env": {NAME: value}`. It is validated before anything is created: non-object payloads, bad names, non-string values, NUL bytes, and falsy junk (`false`/`0`/`""`/`[]`) all answer 400 naming the offender; only absent/`null` means "not asked". On a fresh SDK spawn the reg is born with the env, so the eager first connect already carries it. On the idempotent `existing:true` open it re-asserts through the park-aware `_set_env_or_park` (same FIFO as `/model` and `/effort`, replace-in-place on repeat). Echoed back like model/effort. A live tmux target, or `backend: tmux`, refuses with `ok:false` rather than dropping the env.
- **Backend.** Reg key `env` beside model/effort. `flag_settings_path(..., env=, log=)` folds it in beside `ultracode`/`fastMode`; the return-`""`-when-no-keys contract stands, and an unwritable file now logs a problem row naming the dropped keys (the session still launches). `_options` rewrites the file from the session at every connect, so reconnects re-assert the env by construction. `set_env` mirrors `set_effort`: validate, locked persist via `_update_reg`, reconnect to apply; an unchanged re-assert skips the reconnect; never a remembered default (`write_sdk_default` is not touched). Forks inherit env like model/auth.
- **Replace, not merge.** A re-run declares the session's full env; vars not re-named drop. `{}` is that contract's limiting case and is how a spawn-time var is removed from a running session.
- **Reserved names.** `ROMP_SID` and `ROMP_SESSION_NAME` are refused in both validator copies: `options.env` owns them, and a user var of either name would shadow or be shadowed with nothing pointing at the cause. A reg written before the rule still launches, with just those names skipped (loudly, in the Log); a fork drops them from the inherited copy, also loudly.

## Documented boundaries

- The rank of this layer's `env` against a same-named directory `.claude/settings*.json` var is **not verified** live; the docstring and `docs/reference.md` say so. Distinct names, the toggle case this is for, need no ranking.
- Values are copied into per-sid files and the session registry, so this is for toggles (`FEATURE_FLAG=1`, `CLAUDE_CODE_*`), not secrets; the docs say where credentials go instead.
- Two validator copies exist by necessity (`kernel._env_error` at the /new door, `sdk_backend.env_request_error` behind the lazy `_sdk()` import). `ValidatorLockstep` pins them verdict-for-verdict, messages included.

## Tests

- `tests/test_session_env.py` grows from the existing identity-env pins (kept unchanged at its end) to: the validator table (`EnvRequestError`), the flag-settings merge and loud OSError path (`FlagSettingsEnv`), spawn persistence and refusals (`SpawnEnv`), the per-connect rewrite that makes reconnects re-assert (`OptionsThreadsEnv`), `set_env` (change/unchanged/replace/clear/dormant), fork inheritance, the legacy reserved-name skip at `_options` and `fork` (`LegacyReservedEnv`), the lockstep pin, and source pins on the park/drain plumbing.
- `NewRouteEnv` in `tests/test_new_route_prefs.py`: the 400s, null-means-not-asked, born-into-spawn with echo, existing-session re-assert, `{}` clears, both tmux refusals (including that no spawn thread starts).
- `tests/romp.bats`: the seven `--env`/`--no-env`/help cases, the per-key ack warning, and the 400-body-vs-not-reachable pair (the curl stub honours `-f` the way real curl does, so the test proves the flag, not just the message).
- `ui/webview/fast-toggle.test.ts`: the kernel park-tuple pin gains `"env"`.
- Fake `spawn()` doubles and the `_create_sdk_session` source pins in three other test files take the `env=` parameter.

Red-first: with the code hunks reverted, 46 pytest cases, 7 bats cases and the webview pin fail; all green with them. Full suite: pytest 6581 passed / 40 skipped, bats 102/102, vscode-extension 2674/2674, typecheck clean. Fixtures are synthetic (`FEATURE_FLAG`/`UI_THEME`, placeholder sids).

## Note on #882

#882 (model pickers) edits the docstring of `_apply_new_session_prefs` and the `--model` help/comment lines in `bin/romp`; this PR adds adjacent lines (a first-line clause and appended sentences in that docstring; `--env` lines after the `--effort` ones). Whichever lands second may need a trivial docstring merge; the rest auto-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)