### PR TITLE
VS Code self-update: the dead-end error offers the copy action and shares the toast's wording

### DIFF
--- a/vscode-extension/src/build-drift.test.ts
+++ b/vscode-extension/src/build-drift.test.ts
@@ -50,8 +50,8 @@ test("the drift prompt's buttons are resolved LOCALLY and never dead-end in an e
     "shows driftNotice's message and its actions, in order");
   assert.ok(notice.includes("choice === UPDATE_ACTION") && notice.includes("void updateExtension()"),
     "the Update action runs the self-update");
-  assert.ok(notice.includes("choice === COPY_ACTION") && notice.includes("clipboard.writeText(INSTALL_COMMAND)"),
-    "the Copy action puts the install command on the clipboard — a client-side action that cannot fail");
+  assert.ok(notice.includes("choice === COPY_ACTION") && notice.includes("void copyInstallCommand()"),
+    "the Copy action goes through the one client-side copy helper");
   // The notice itself must NOT reload — the drift toast never auto-anything (the reload is gated later).
   assert.ok(!notice.includes("reloadWindow"), "maybeBuildNotice must not reload the window");
 });
@@ -73,14 +73,42 @@ test("updateExtension rebuilds+reinstalls the VSIX, then offers a USER-gated rel
   assert.ok(upd.includes('"Reload window"') && upd.includes('choice === "Reload window"') &&
     upd.includes('executeCommand("workbench.action.reloadWindow")'),
     "reload only fires when the user clicks Reload window");
-  assert.ok(upd.includes("showErrorMessage") && upd.includes("install.sh in a terminal"),
+  assert.ok(upd.includes("showErrorMessage") && upd.includes("MANUAL_REMEDY"),
     "a failed/skipped update fails loudly with the manual remedy");
+  // A copy that can't rebuild itself (installed from a .vsix, no ROMP_DIR) says so and stops — never
+  // some other directory's install.sh. Same words as the toast (the constants update-target.ts already
+  // exports) and the same clipboard action, so the palette command, the menu's Update row and the
+  // toast read as one message with one remedy.
+  assert.ok(upd.includes("if (!target)") && upd.includes("CANT_REBUILD") && upd.includes("MANUAL_REMEDY"),
+    "no resolvable checkout → the toast's own wording, not a second one");
+  assert.ok(upd.includes("COPY_ACTION") && upd.includes("void copyInstallCommand()"),
+    "both dead ends hand over the command to run");
+  assert.ok(!upd.includes("packaged VSIX") && !upd.includes("install.sh in a terminal"),
+    "no hand-written remedy text survives in updateExtension");
 });
 
 test("runInstall shells out with the host's resolved env so node/npm/code resolve", () => {
   const run = slice("function runInstall", "function updateHint");
   assert.ok(run.includes('execFile("bash"') && run.includes("env: process.env"),
     "install.sh runs under bash with the extension host's PATH");
+});
+
+test("copying the install command is client-side, so the offered action cannot fail", () => {
+  const copy = slice("function copyInstallCommand", "// Ports are CONFIGURABLE");
+  assert.ok(copy.includes("vscode.env.clipboard.writeText(INSTALL_COMMAND)"), "the clipboard, not a shell-out");
+  assert.ok(!/execFile|runInstall/.test(copy), "nothing is executed on this path");
+  assert.ok(copy.includes("setStatusBarMessage"), "the click is acknowledged");
+  assert.ok(copy.includes("MANUAL_REMEDY"), "a clipboard failure still states the remedy");
+});
+
+test("every copy entry point is the one helper", () => {
+  // The drift toast's Copy button, the status-bar item's command and both error toasts copy the same
+  // command; routing them through one helper is what makes the acknowledgment and the failure warning
+  // hold everywhere — so the clipboard write itself appears exactly once.
+  assert.ok(EXT.includes('registerCommand("rompChat.copyInstallCommand", copyInstallCommand)'),
+    "the status-bar item's command copies through the helper, acknowledged like the toast's button");
+  assert.equal((EXT.match(/clipboard\.writeText\(INSTALL_COMMAND\)/g) || []).length, 1,
+    "one clipboard write, inside the helper");
 });
 
 test("a palette command exposes the update anytime a faded toast can't be clicked", () => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -29,7 +29,9 @@ import { deriveStatus, freshNeedsYou, renderStatusBar, statusTooltipLines, Fleet
 import { citeText, sessionsForWorkspace, SessionInfo } from "./workspace-sessions";
 import { parsePorcelain } from "./session-diff";
 import { buildMenu, usageSummary } from "./romp-menu";
-import { resolveInstallScript, driftNotice, UPDATE_ACTION, COPY_ACTION, INSTALL_COMMAND } from "./update-target";
+import {
+  resolveInstallScript, driftNotice, UPDATE_ACTION, COPY_ACTION, INSTALL_COMMAND, CANT_REBUILD, MANUAL_REMEDY,
+} from "./update-target";
 
 const HOST = "127.0.0.1";
 
@@ -96,7 +98,7 @@ function maybeBuildNotice(dv: unknown): void {
   showDriftStatusItem(!!target);
   void vscode.window.showInformationMessage(notice.message, ...notice.actions).then((choice) => {
     if (choice === UPDATE_ACTION) void updateExtension();
-    else if (choice === COPY_ACTION) void vscode.env.clipboard.writeText(INSTALL_COMMAND);
+    else if (choice === COPY_ACTION) void copyInstallCommand();
   });
 }
 
@@ -118,9 +120,9 @@ async function updateExtension(): Promise<void> {
   if (updating) return;                                    // one run per host (double-click, or toast + palette)
   const target = resolveInstallScript(ctx?.extensionPath || "", process.env.ROMP_DIR, (p) => fs.existsSync(p));
   if (!target) {
-    void vscode.window.showErrorMessage(
-      "romp: this copy of the extension can't rebuild itself — it runs from a packaged VSIX, not a romp checkout. " +
-      "Run vscode-extension/install.sh in your romp checkout from a terminal, then reload this window.");
+    // Same wording and the same always-works action as the toast — one voice, one remedy.
+    void vscode.window.showErrorMessage(`romp: ${CANT_REBUILD} ${MANUAL_REMEDY}`, COPY_ACTION)
+      .then((choice) => { if (choice === COPY_ACTION) void copyInstallCommand(); });
     return;
   }
   const extDir = target.dir;
@@ -145,8 +147,8 @@ async function updateExtension(): Promise<void> {
         });
     } else {
       void vscode.window.showErrorMessage(
-        "romp: the extension update didn't complete — " + updateHint(out) +
-        " You can run vscode-extension/install.sh in a terminal.");
+        "romp: the extension update didn't complete — " + updateHint(out) + " " + MANUAL_REMEDY,
+        COPY_ACTION).then((choice) => { if (choice === COPY_ACTION) void copyInstallCommand(); });
     }
   } finally {
     updating = false;
@@ -175,6 +177,17 @@ function updateHint(out: { code: number; text: string }): string {
   if (/No VS Code-family editor CLI found/.test(t)) return "no editor CLI was found to install into.";
   const last = t.trim().split(/\r?\n/).filter((l) => l.trim()).slice(-1)[0] || "";
   return last ? "the build reported: " + last.slice(0, 200) : "see the terminal for details.";
+}
+
+// The action a copy that can't rebuild itself gets instead of a doomed Update button: the exact
+// command on the clipboard, so the remedy is a paste rather than something to retype from a toast
+// that has already faded. Purely client-side (the clipboard is one of the few capabilities this host
+// owns outright), so unlike the update it cannot fail — and it acknowledges immediately. Every copy
+// entry point (the drift toast, the status-bar item's command, the two error toasts) goes through here.
+function copyInstallCommand(): void {
+  void vscode.env.clipboard.writeText(INSTALL_COMMAND).then(
+    () => vscode.window.setStatusBarMessage(`romp: copied "${INSTALL_COMMAND}" — run it in your romp checkout.`, 6000),
+    () => vscode.window.showWarningMessage(`romp: couldn't reach the clipboard. ${MANUAL_REMEDY}`));
 }
 
 // Ports are CONFIGURABLE so different VS Code windows can attach to different kernels (each kernel
@@ -247,8 +260,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Rebuild + reinstall the VSIX from source, then offer a reload — the clickable form of the
     // drift toast's remedy, always reachable (a faded toast leaves nothing to click). See updateExtension.
     vscode.commands.registerCommand("rompChat.updateExtension", updateExtension),
-    vscode.commands.registerCommand("rompChat.copyInstallCommand",
-      () => vscode.env.clipboard.writeText(INSTALL_COMMAND)),
+    vscode.commands.registerCommand("rompChat.copyInstallCommand", copyInstallCommand),
     // The webviews scale to the editor font (uiZoom) — re-render them when it changes.
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("editor.fontSize")) refreshWebviewHtml();


### PR DESCRIPTION
## What breaks

On an installed VSIX (the ordinary case after `bash vscode-extension/install.sh`), `updateExtension()` resolves no checkout and shows an error with no button. The drift toast has offered "Copy install command" a moment earlier, but the palette command "romp: Update Extension", the romp menu's Update Extension row, and a status-bar click after the checkout has moved all land on a toast the user can only read.

The same remedy is also written three ways: `driftNotice` composes the exported `CANT_REBUILD`/`MANUAL_REMEDY` constants (from #352), the dead-end error hand-writes its own two sentences, and the "update didn't complete" toast hand-writes a third ("You can run vscode-extension/install.sh in a terminal."). Since #617 there are two inline `clipboard.writeText(INSTALL_COMMAND)` calls (the toast's Copy button and `rompChat.copyInstallCommand`), neither of which confirms the copy or reports a clipboard failure.

## Reproduction

1. Install the extension from the packaged VSIX (`bash vscode-extension/install.sh`) with no `ROMP_DIR` in the extension host's environment.
2. Run "romp: Update Extension" from the command palette (or the romp menu's Update Extension row).
3. An error toast appears with no action. Its wording differs from the drift toast's, which offered a Copy button for the same situation.

## The fix (one commit; `vscode-extension/src/extension.ts` and its test)

- One `copyInstallCommand()` helper: writes `INSTALL_COMMAND` to the clipboard, acknowledges in the status bar (`setStatusBarMessage`, the file's existing pattern), and on a clipboard failure shows a warning that still states `MANUAL_REMEDY`. Client-side only; nothing executes on this path.
- The no-checkout error becomes `romp: ${CANT_REBUILD} ${MANUAL_REMEDY}` with the `COPY_ACTION` button, so toast and palette read as one message with one remedy.
- The "didn't complete" toast ends with `MANUAL_REMEDY` and offers `COPY_ACTION` too.
- The toast's Copy button and `rompChat.copyInstallCommand` route through the helper; `clipboard.writeText(INSTALL_COMMAND)` now appears once in the file.
- No change to `update-target.ts` (the constants were already exported), `package.json` (`rompChat.copyInstallCommand` stays palette-hidden), the status-bar item's tooltip, or the resolution logic (both `resolveInstallScript` calls are untouched).

## Tests (`vscode-extension/src/build-drift.test.ts`, source pins like the rest of the file)

- Toast test: the Copy action calls the helper (was: inline `writeText`).
- updateExtension test: the dead end uses `CANT_REBUILD`/`MANUAL_REMEDY` + `COPY_ACTION`, and no hand-written remedy text remains in the function.
- New: the helper is client-side (`writeText`, no `execFile`/`runInstall`), acknowledges, and names the remedy on failure.
- New: the `rompChat.copyInstallCommand` registration uses the helper; exactly one `clipboard.writeText(INSTALL_COMMAND)` in the file.

All four fail on the base commit and pass with the change. `npm run typecheck`, `npm test` (2676 passing) and `npm run build` are green. The Python suite is unaffected (no kernel change) and no shell surface is touched. No manual VS Code smoke was possible on a headless machine; the change is source-pinned like every prior change in this file, and the constants it reuses are already covered by `update-target.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)