### PR TITLE
Ask-unit follow-through: a fanned ask keeps its card, the recipient mint keys on card visibility, and undo spares a restored container

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7188,6 +7188,49 @@ def _mirror_mint_ctx(session, store, fsid, path, latest_seg, now):
     return ctx
 
 
+def _latch_ask_anchors(fsid, session, store):
+    """LATCH the ask-unit exemption's anchor verdict durably on the node. The kernel's
+    _pure_delegation_top must decide "is this promptUuid-anchored top the dictated ask?" by
+    resolving the anchor RECORD — but it reads the CACHED parse only (build_feed's cold-start
+    contract) and fails open on doubt, so a machine-anchored coordination card would flap
+    shown→hidden on every restart/cache-cold beat: cache temperature, not new information (the
+    cards-move-on-new-information rule). The verdict is a fact about a record that never changes
+    once readable, so resolve it ONCE from the judge's own WARM parse and stamp `askAnchor` on the
+    node: 'human' (the dictated ask), 'machine' (a peer mail, the agent's own atom, romp
+    bookkeeping — _human_prompt_record, the one definition of 'dictated'), or 'absent' (the
+    stitched chain no longer holds the uuid: rewound/compacted/pre-/clear — durable doubt, which
+    keeps failing open exactly as the per-beat read did, just stably). The write rides the planner
+    apply path (_plan_session's end-of-pass rollup+save) — judge-side, the goal store's normal
+    writer; build_feed stays read-only. Only the tops the exemption actually consults are latched:
+    parentless, promptUuid-bearing, no origin (a courier top's evidence is T105's userAsk, never
+    its mail anchor), not itself a tracker. A parse with NO atoms at all latches nothing — a
+    missing/unreadable transcript is no evidence of absence, and 'absent' must never be minted
+    from one. Returns the number latched; the caller's unconditional save persists them."""
+    cands = [nd for nd in store.get("nodes", {}).values()
+             if isinstance(nd, dict) and nd.get("parentId") is None and nd.get("promptUuid")
+             and not isinstance(nd.get("origin"), dict)
+             and not isinstance(nd.get("handoff"), dict)
+             and not nd.get("askAnchor")]
+    if not cands:
+        return 0
+    by_uuid = {}
+    for turn in session.get("turns") or []:
+        for a in turn.get("atoms") or []:
+            if a.get("uuid"):
+                by_uuid[a["uuid"]] = a
+    if not by_uuid:
+        return 0
+    n = 0
+    for nd in cands:
+        a = by_uuid.get(nd["promptUuid"])
+        if a is None:
+            nd["askAnchor"] = "absent"
+        else:
+            nd["askAnchor"] = "human" if _human_prompt_record(a, fsid) else "machine"
+        n += 1
+    return n
+
+
 def _plan_session(fsid, path, now):
     """Advance ONE session's goal tree: place its un-placed planner UNITS oldest-first (each sees the prior
     tree's open menu) and GROUP after every placement (the user 2026-06-17: planner + grouper are both
@@ -7675,6 +7718,9 @@ def _plan_session(fsid, path, now):
         #   segment's chain liveness, not about anchor suitability.
         _group_store(store, fsid, now)
         save_goals(fsid, store)
+    _latch_ask_anchors(fsid, session, store)          # durable ask-unit anchor verdicts — no LLM,
+    #                                                   idempotent (latched nodes skip), persisted
+    #                                                   by the save just below
     rollup_status(store, _session_settled(fsid, path, session, store))
     save_goals(fsid, store)
     return placed
@@ -12047,13 +12093,34 @@ def _lift_handoff_children(store, hid):
     return moved
 
 
+def _human_prompt_record(a, sender):
+    """The {"text","sid"} record when atom `a` IS a human-dictated prompt record, else None. The
+    ONE definition of 'dictated' (factored out of _session_user_prompt_record so the kernel's
+    ask-unit exemption reads the SAME rule against its own cached parse instead of growing a
+    second one): author 'human' minus the CLI's interrupt artifacts — the board audit's rule — and
+    an attachment record (a queued_command wrapping what the user dictated mid-turn) exactly when
+    it carries no postal or romp-injected marker. Everything else — mail, romp's own lines, the
+    agent's assistant atoms, machine input — is None."""
+    if a.get("author") == "human":
+        if em.is_interrupt_record(a):
+            return None
+        c = (a.get("message") or {}).get("content")
+        # human prompt records carry content as a plain string; block lists ride _atom_text
+        txt = c if isinstance(c, str) else (_atom_text(a) or str(a.get("text") or ""))
+        return {"text": txt, "sid": sender}
+    if a.get("type") == "attachment":
+        txt = _atom_text(a) or str(a.get("text") or "")
+        if em.postal_pairs(txt) or NUDGE_MARKER_RE.search(txt):
+            return None
+        return {"text": txt, "sid": sender} if txt.strip() else None
+    return None
+
+
 def _session_user_prompt_record(sender, path, uuid, now):
     """The HUMAN prompt record behind `uuid` in the sender's session — {"text","sid"}, always
     truthy — or None. Read from the CACHED stitched parse (parsed_session: fork-aware,
-    author-stamped with the SDK-human channel applied), so the courier pays no extra parse. author
-    'human' minus the CLI's interrupt artifacts is the rule the board audit used; an attachment
-    record (a queued_command wrapping what the user dictated mid-turn) counts as human exactly when
-    it carries no postal or romp-injected marker. Everything else — mail, romp's own lines, machine
+    author-stamped with the SDK-human channel applied), so the courier pays no extra parse. The
+    record rule is _human_prompt_record above; everything else — mail, romp's own lines, machine
     input, a record the stitched chain no longer holds — is None. The record carries the atom's RAW
     text (markers and all; shape it with _ask_head at the point of use): returning the record
     instead of True is T105 — the prose writers anchor at the ROOT ask, so the trace must carry the
@@ -12066,19 +12133,7 @@ def _session_user_prompt_record(sender, path, uuid, now):
         for a in turn.get("atoms") or []:
             if a.get("uuid") != uuid:
                 continue
-            if a.get("author") == "human":
-                if em.is_interrupt_record(a):
-                    return None
-                c = (a.get("message") or {}).get("content")
-                # human prompt records carry content as a plain string; block lists ride _atom_text
-                txt = c if isinstance(c, str) else (_atom_text(a) or str(a.get("text") or ""))
-                return {"text": txt, "sid": sender}
-            if a.get("type") == "attachment":
-                txt = _atom_text(a) or str(a.get("text") or "")
-                if em.postal_pairs(txt) or NUDGE_MARKER_RE.search(txt):
-                    return None
-                return {"text": txt, "sid": sender} if txt.strip() else None
-            return None
+            return _human_prompt_record(a, sender)
     return None
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4308,11 +4308,34 @@ def rollup_status(store, session_closed, now=None):
     # TOP-LEVEL with their own provenance intact, and the empty container leaves the store. This is
     # what un-strands the asks the provenance audit measured (every dead chain ended at a promptless
     # container): once the child is a top again, its promptUuid/origin evidence is reachable by the
-    # mint-time trace and the closer's nominations. Idempotent by construction (no umbrellas remain
-    # after one pass) and self-healing like the lift above: a save-rebase republishing a stale
-    # parentId is re-dissolved on the very next rollup. Diary-less container removal follows the
-    # born-done backlog self-heal precedent — an umbrella has no verdicts of its own to preserve.
-    _umbrellas = {k for k, v in nodes.items() if isinstance(v, dict) and v.get("umbrella")}
+    # mint-time trace and the closer's nominations. Idempotent by construction (no undissolved
+    # umbrellas remain after one pass) and self-healing like the lift above: a save-rebase
+    # republishing a stale parentId is re-dissolved on the very next rollup. Diary-less container
+    # removal follows the born-done backlog self-heal precedent — an umbrella has no verdicts of
+    # its own to preserve.
+    #
+    # THE SWEEP YIELDS TO THE USER'S UNDO: archives keep their containers, so UndoClear can pull a
+    # pre-T101 umbrella back into the live store — and the sweep was eating the card the user had
+    # JUST restored, promoting its children in its place. The un-clear is NEWER information than
+    # the standing purge (a writer whose evidence predates the diary stands down): a container
+    # whose latest clear-family diary row is the user's undo-restore (the reopen/undo=True row
+    # _mark_nodes_cleared's dual-write and the unclear override replay both record) is SPARED — it
+    # stays the card the user asked back for, until they clear it again. A flag-CLEARED container
+    # is spared too: it is already off the board and the compactor archives it whole; dissolving
+    # it in that window would promote its children out of the user's seal. Peer-adopted and
+    # legacy copies carry neither mark and dissolve as before.
+    def _undo_restored(v):
+        latest = ""
+        latest_t = -1
+        for e in (v.get("log") or []):
+            k = e.get("kind")
+            if k == "clear" or (k == "reopen" and e.get("undo")):
+                et = int(e.get("ev_t") or 0)
+                if et >= latest_t:                      # ties go to the later row (append order):
+                    latest_t, latest = et, k            # the restore that popped a same-second clear wins
+        return latest == "reopen"
+    _umbrellas = {k for k, v in nodes.items() if isinstance(v, dict) and v.get("umbrella")
+                  and not v.get("cleared") and not _undo_restored(v)}
     if _umbrellas:
         _uparent = {k: nodes[k].get("parentId") for k in _umbrellas}
         def _solid_parent(uid):

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8201,6 +8201,29 @@ def _merge_nodes(store, dupe_id, surv_id, t, why):
         surv["promptUuid"] = dupe["promptUuid"]
     if not surv.get("userAsk") and dupe.get("userAsk"):
         surv["userAsk"] = dupe["userAsk"]
+    # THE DELEGATION IDENTITY RIDES THE MERGE: origin, links, askRef. A dispatch's msgId must stay
+    # JOINABLE on the surviving node — apply_courier's idempotency scan, run_propagate's back-link,
+    # and its dismissal arm all key on origin/links — so dropping them stranded the sender's
+    # non-quiet tracker FOREVER (no recipient node carried the msgId, and the reply sweep defers to
+    # a back-link that could no longer fire); a dropped askRef reopened duplicate minting for the
+    # next dispatch of the same ask. The survivor keeps its own birth when it has one — origin
+    # means "BORN from that delegation" and stays truthful — and the dupe's origin then rides
+    # links[], the same additional-dispatch shape the ask dedupe writes; links union by msgId;
+    # askRef fills only a lack, like quote/promptUuid above.
+    do = dupe.get("origin")
+    if isinstance(do, dict):
+        if not isinstance(surv.get("origin"), dict):
+            surv["origin"] = do
+        elif do.get("msgId") and all(not (isinstance(l, dict) and l.get("msgId") == do["msgId"])
+                                     for l in surv.get("links") or []):
+            surv.setdefault("links", []).append(
+                {k: do[k] for k in ("peer", "goalId", "msgId", "peerHost") if k in do})
+    for l in dupe.get("links") or []:
+        if isinstance(l, dict) and all(not (isinstance(s, dict) and s.get("msgId") == l.get("msgId"))
+                                       for s in surv.get("links") or []):
+            surv.setdefault("links", []).append(l)
+    if not isinstance(surv.get("askRef"), dict) and isinstance(dupe.get("askRef"), dict):
+        surv["askRef"] = dupe["askRef"]
     surv["t"] = min(surv.get("t") or t, dupe.get("t") or t)
     surv["mt"] = t
     # chained merges keep every tombstone: the dupe's own mergedFrom rides along, so an id merged
@@ -11903,6 +11926,18 @@ def _postal_from(mid):
     return _postal_row(mid)[:2]
 
 
+def _ask_stamp_text(user_ask):
+    """The `userAsk` text as STAMPED on a minted top: the chain-proven record's raw text shaped by
+    _ask_head — or, when that leaves NOTHING (an image-only / attachment-only dictated prompt whose
+    record carries no text), the '(user message)' placeholder _seg_label already uses for a
+    titleless prompt. Always non-empty for a dict record: skipping the stamp on empty text leaves
+    an askRef-bearing top with NO dictation evidence the ask-unit exemption accepts, so a
+    fully-fanned image ask renders NOWHERE while the dedupe keeps linking later dispatches into
+    that invisible top. ONE definition shared by the stamp and the dedupe's identity cross-check —
+    the compare only holds if both sides shape alike."""
+    return _ask_head(str(user_ask.get("text") or "")) or "(user message)"
+
+
 def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None, frame=None, user_ask=None):
     """Plant a top-level goal in the recipient's tree for a delegating message, with origin
     provenance. Idempotent by seg_id and origin.msgId (one planted goal per message). Returns nid.
@@ -11915,12 +11950,44 @@ def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None, frame=No
     `user_ask` (the user 2026-08-26, T105): the ROOT human prompt record the chain trace proved
     ({"text","sid"}) — the frame is an INTERMEDIARY's restatement one hop up, and a manager's
     dispatch speaks implementation nouns, so the writers also need the root. Stored shaped
-    (_ask_head). A non-dict truthy (tests stub the trace with literal True) stores nothing."""
+    (_ask_head). A non-dict truthy (tests stub the trace with literal True) stores nothing.
+
+    ASK-IDENTITY DEDUPE: msgId idempotency alone lets one ask fanned N times to the SAME recipient
+    mint N near-duplicate tops — every dispatch carries a fresh msgId. The trace's `askRef` (the
+    proof node's (sender sid, goal id), riding user_ask) is the ask's stable identity: it is
+    STAMPED on the minted top, and a later dispatch of the same ask finds the standing VISIBLE top
+    (_node_carded) and LINKS instead — placements point at it, and a links[] backref carries the
+    new msgId so run_propagate still ends that dispatch's sender-side tracker off the one card.
+    Stub-True traces carry no askRef and mint exactly as before (the stubbed suites' contract);
+    each recipient session still gets its own card — the dedupe never reaches across stores. Two
+    hardenings on the dedupe: goal ids RECYCLE after a sender store reset (sid:gN, per-store seq),
+    so it also cross-checks the standing top's own userAsk text against the incoming record (one
+    shaping, _ask_stamp_text) — the same ask still links, a recycled id over different dictation
+    mints its own card (a mismatch fails toward the mint, the recoverable side); and the
+    standing-card test honors the rollup's done-confirming window: a done-verdict-filed top whose
+    settle is pending still renders in Working, so the dispatch links into it rather than minting
+    a twin beside the doneConfirming cue."""
     nodes, placements = store["nodes"], store["placements"]
     mid = origin.get("msgId")
     if mid:
         for nid, nd in nodes.items():
             if isinstance(nd.get("origin"), dict) and nd["origin"].get("msgId") == mid:
+                placements[seg_id] = nid
+                return nid
+            if any(isinstance(l, dict) and l.get("msgId") == mid for l in (nd.get("links") or [])):
+                placements[seg_id] = nid               # an ask-dedupe link already carries this message
+                return nid
+    ref = user_ask.get("askRef") if isinstance(user_ask, dict) else None
+    if isinstance(ref, dict) and ref.get("peer") and ref.get("goalId"):
+        conf = frozenset(store.get("confirming") or ())
+        for nid, nd in nodes.items():
+            r = nd.get("askRef")
+            if (isinstance(r, dict) and r.get("peer") == ref["peer"]
+                    and r.get("goalId") == ref["goalId"] and _node_carded(nodes, nid, conf)
+                    and (nd.get("userAsk") or {}).get("text") == _ask_stamp_text(user_ask)):
+                if mid and origin.get("peer") and origin.get("goalId"):
+                    nd.setdefault("links", []).append(
+                        {"peer": origin["peer"], "goalId": origin["goalId"], "msgId": mid})
                 placements[seg_id] = nid
                 return nid
     store["seq"] = store.get("seq", 0) + 1
@@ -11930,9 +11997,11 @@ def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None, frame=No
                "trail": [seg_id], "t": seg_t, "origin": origin, "promptUuid": prompt_uuid, "log": []}
     if frame:
         payload["frame"] = frame
-    if isinstance(user_ask, dict) and str(user_ask.get("text") or "").strip():
-        payload["userAsk"] = {"text": _ask_head(str(user_ask["text"])), "sid": user_ask.get("sid"),
+    if isinstance(user_ask, dict):
+        payload["userAsk"] = {"text": _ask_stamp_text(user_ask), "sid": user_ask.get("sid"),
                               **({"host": str(user_ask["host"])} if user_ask.get("host") else {})}
+    if isinstance(ref, dict) and ref.get("peer") and ref.get("goalId"):
+        payload["askRef"] = {"peer": ref["peer"], "goalId": ref["goalId"]}
     nodes[nid] = GuardedNode(payload)
     placements[seg_id] = nid
     store["lastNode"] = nid                            # the delegation is now the active focus
@@ -12052,10 +12121,19 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
         _xh = _xnd.get("handoff") if isinstance(_xnd, dict) else None
         if (isinstance(_xh, dict) and _xh.get("peer") == peer_sid and not _xnd.get("nodeComplete")
                 and not _xnd.get("cleared") and _xnd.get("text") == label[:120]
-                and _xnd.get("parentId") == parent_id):
+                and _xnd.get("parentId") == parent_id
+                and _postal_row(_xh.get("msgId"))[3] == _postal_row(mid)[3]):
             return _xnid                               # byte-identical OPEN twin (2026-08-28: an ext
             #                                            mailer double-minted the same delegation in one
-            #                                            minute under two mids) — reuse, never duplicate
+            #                                            minute under two mids) — reuse, never duplicate.
+            #                                            The label is the judge's RENDERING, which can
+            #                                            collapse two real dispatches into one string —
+            #                                            so sameness is confirmed against the messages'
+            #                                            RECORDED bodies (the authoritative postal rows):
+            #                                            equal or both-unrecorded reads as the
+            #                                            double-mint; differing bodies are two real
+            #                                            dispatches, each keeping its own tracker (the
+            #                                            fan-out contract, test_chain_rooted_minting)
     if tracked:
         handoff["tracked"] = True
     nodes[nid] = GuardedNode({"id": nid, "text": label[:120], "parentId": parent_id,
@@ -12137,7 +12215,38 @@ def _session_user_prompt_record(sender, path, uuid, now):
     return None
 
 
-def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
+def _node_carded(live, nid, confirming=()):
+    """Does `nid` currently RENDER on a visible card in its session's LIVE store? The trace's
+    `carded` and the mint's ask-identity dedupe both key on this: bare live-membership says True
+    for a user-CLEARED ask still awaiting the compactor, for a node sealed under a complete/cleared
+    ancestor (the fold displays that subtree done — the sealed-open leak), and for a DANGLING node
+    whose parent a rewind swept (the feed walks top subtrees, so it renders on none) — and the
+    courier would then link the fan-out into a card that renders nowhere, the exact no-card hole
+    T101's fallback exists to close. Visibility here reuses the store's own seal/reach rules: in
+    the live store, not itself cleared/complete (open_menu's self-seal), no complete/cleared
+    ancestor (_sealed_above, the closer channels' shared seal), and the parent chain lands on a
+    LIVE top (_top_of, cycle-safe) — a walk that dead-ends at a missing node or a cycle renders
+    nowhere. Pure over the passed nodes dict: the cleared flag is the store's own dual-written
+    record, so no journal read here.
+
+    `confirming`: the rollup's done-confirming export — tops whose done verdict is filed with only
+    the settle pending. Their column still reads Working (the steady doneConfirming cue), so bare
+    nodeComplete would call a VISIBLY RENDERING card dead and a same-ask dispatch would mint a
+    twin beside it. A top in the window stays carded; a genuinely SETTLED completion (out of the
+    export) stays uncarded — the sealed-open trade holds. Callers thread their store's own export;
+    the default () keeps pure-dict callers exact."""
+    nd = live.get(nid)
+    if not isinstance(nd, dict) or nd.get("cleared"):
+        return False
+    if nd.get("nodeComplete") and nid not in confirming:
+        return False
+    if _sealed_above(live, nid):
+        return False
+    top = _top_of(live, nid)
+    return top in live and live[top].get("parentId") is None
+
+
+def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None, _fb=None):
     """MINT-TIME chain trace (the user 2026-08-25 ~19:4x, who wants team-internal cards not
     CREATED rather than foldable behind a lens): the ROOT HUMAN PROMPT RECORD ({"text","sid"},
     always truthy; record-not-boolean is T105) when the SENDER's linked goal traces
@@ -12153,39 +12262,127 @@ def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
     recipient — is bounded by what surfaces regardless of this trace: the SENDER-side tracking
     node (planted either way, with the parked cue and the report-back closure), and every
     needs-you state (the hard-block floor + placeholder synthesize a board card from the live
-    prompt with zero goal nodes; interrupt only when the human is the bottleneck)."""
+    prompt with zero goal nodes; interrupt only when the human is the bottleneck).
+
+    `carded`: the record also says whether the ask still RENDERS ON A VISIBLE CARD a tracking
+    node can plant under — _node_carded, not bare live-membership, which reads True for a
+    user-cleared ask awaiting the compactor, an ask sealed under a done/cleared ancestor, and a
+    dangling node whose parent a rewind swept (all three link into a card that renders nowhere:
+    the no-card hole). Uncarded — archive-only proof, or any of those live-but-invisible shapes —
+    is where T101's mint fallback fires, because "the recipient card IS the ask's card"; the
+    answer is deliberately identical on both sides of the compaction boundary (a cleared card
+    mints alike live and archived — the compactor is bookkeeping, never a mint event). Rides up
+    origin hops unchanged: it reports on the ask node itself, wherever in the local chain it lives.
+
+    THE HOP STAND-DOWN + `askRef`: a climb that passes a LIVE, VISIBLE userAsk-bearing top
+    short-circuits carded:True — that top IS the ask's card at this hop, so re-dispatching onward
+    must file under it, never re-mint at every origin-hop level. And the record carries `askRef`,
+    the proof node's (sender sid, goal id) — the ask's stable identity across dispatches and hops
+    — which apply_courier stamps on the minted top and dedupes on, so one ask fanned N times to
+    one recipient stays ONE card there."""
+    # THE SHARED FALLBACK SLOT `fb`: EVERY carded:False record — T126's stored userAsk-on-node
+    # proof AND an uncarded human prompt record — is captured into a one-slot holder THREADED
+    # ACROSS THE RECURSION, never returned mid-climb, so it wins only when the WHOLE climb — every
+    # origin hop and container-sibling included — exhausts. Returning it inline from an origin-hop
+    # callsite (`rec = _delegate_user_rooted(...); if rec: return rec`) takes an INNER frame's
+    # uncarded record as a final answer and preempts carded evidence the OUTER climb would still
+    # reach above the origin-hop node — minting a standalone recipient top for an ask that STILL
+    # renders on a visible card (the pre-T101 duplicate-card hole) and skewing askRef with the hop
+    # level the walk happened to stop at (_walk_root_record's dedupe key). The TRUE-ORIGIN shape
+    # (the origin kernel's own ask node carries promptUuid; stored userAsk lives only on
+    # courier-planted mid-chain nodes) is the MORE common flavor, so the prompt-record arm is
+    # demoted alongside the stored-proof arm. This is a deliberate contract change from T126,
+    # which treated every prompt record as decisive: now ONLY a CARDED record is decisive
+    # mid-climb — a carded-hop stand-down or a carded human record — everything carded:False rides
+    # `fb` and returns at exhaustion, so the exhausted-climb mint keeps firing with the same record
+    # it always returned.
+    #
+    # PRECEDENCE INSIDE THE SLOT: a two-rank ladder, not bare first-seen across arms — an UNCARDED
+    # HUMAN PROMPT RECORD (rank 1) REPLACES a held STORED PROOF (rank 0); within a rank the slot
+    # stays first-seen. Why: the prompt record is the chain's ROOT evidence read from the
+    # authoritative source (the session transcript), while a stored proof is the courier-written
+    # COPY of a walk — the copy must not shadow the original just because a hop visited it first.
+    # And the root node's identity is hop-invariant, so preferring it keeps askRef
+    # (apply_courier's dedupe key) stable across fan children whose climbs stop at different
+    # copies. RESIDUAL, documented not fixed: an ALL-stored-proof climb (no prompt record, nothing
+    # carded — the ask cleared everywhere) can still hand two fan children different first-seen
+    # askRef keys when their hops traverse DIFFERENT proof nodes with divergent askRef stamps; no
+    # rank choice unifies that (the candidate keys live in different stores), and askRef
+    # propagation makes the shape rare — a courier-planted proof carries the root's own key.
     if not link_id or _depth >= 8:
-        return None
+        return _fb[0][1] if (_depth == 0 and _fb) else None
     seen = _seen if _seen is not None else set()
+    fb = _fb if _fb is not None else []               # the top frame owns the slot; inner frames share it
+
+    def _fb_offer(rank, rec):                         # the two-rank ladder above: replace weaker, keep first-seen peers
+        if not fb:
+            fb.append((rank, rec))
+        elif fb[0][0] < rank:
+            fb[0] = (rank, rec)
+
+    sstore = load_goals(sender)
+    live = sstore.get("nodes") or {}
+    conf = frozenset(sstore.get("confirming") or ())  # the rollup's done-confirming window: a
+    #                                                   settle-pending top still renders in Working,
+    #                                                   so it still counts as carded
     nodes = dict(load_goal_archive(sender).get("nodes") or {})
-    nodes.update(load_goals(sender).get("nodes") or {})
+    nodes.update(live)
     x, last = link_id, None
     while x is not None and (sender, x) not in seen:
         seen.add((sender, x))
         nd = nodes.get(x)
         if not isinstance(nd, dict):
-            return None
+            return fb[0][1] if (_depth == 0 and fb) else None
         ua = nd.get("userAsk")
         if isinstance(ua, dict) and str(ua.get("text") or "").strip():
-            # KERNEL-PROVED ROOT ON THE NODE (the user 2026-08-27, T126): only apply_courier writes
-            # userAsk, from a record either walked locally at mint or walked at RELAY time by the
-            # kernel that held the evidence — so a chain reaching such a node is resolved. This is
-            # the arm that lets a walked-remote chain RE-DELEGATE onward: the planted top's own
-            # promptUuid is the mail segment (refused as a human record) and its origin hop is
-            # cross-host (refused as a foreign read); the stored proof is the surviving evidence.
-            return {"text": ua["text"], "sid": ua.get("sid"),
-                    **({"host": ua["host"]} if ua.get("host") else {})}
+            if _node_carded(live, x, conf):
+                # the hop stand-down (docstring above): a visible chain-proven ask top at THIS hop
+                # is the ask's card — carded, whatever the root's own node has become upstream
+                rec = {"text": str(ua["text"]), "sid": ua.get("sid"), "carded": True,
+                       **({"host": ua["host"]} if ua.get("host") else {})}
+                if isinstance(nd.get("askRef"), dict):
+                    rec["askRef"] = dict(nd["askRef"])
+                return rec
+            if not fb:
+                # KERNEL-PROVED ROOT ON THE NODE (the user 2026-08-27, T126): only apply_courier
+                # writes userAsk, from a record either walked locally at mint or walked at RELAY
+                # time by the kernel that held the evidence — so a chain reaching such a node is
+                # resolved even when its card is gone. This is the arm that lets a walked-remote
+                # chain RE-DELEGATE onward: the planted top's own promptUuid is the mail segment
+                # (refused as a human record) and its origin hop is cross-host (refused as a
+                # foreign read); the stored proof is the surviving evidence. UNCARDED at this hop,
+                # so it yields to any deeper walkable evidence (the carded/askRef discipline
+                # above) and returns only when the climb exhausts — carded:False, exactly where
+                # T101's mint fallback fires. CAPTURED into the shared `fb` slot at STORED rank
+                # (rank 0 — a later prompt record replaces it, a later stored proof does not),
+                # never returned inline: a carded record ANYWHERE — this frame or any OUTER one
+                # still to climb — must still win over it.
+                proof = {"text": str(ua["text"]), "sid": ua.get("sid"), "carded": False,
+                         **({"host": ua["host"]} if ua.get("host") else {})}
+                if isinstance(nd.get("askRef"), dict):
+                    proof["askRef"] = dict(nd["askRef"])
+                _fb_offer(0, proof)
         o = nd.get("origin")
         if (isinstance(o, dict) and o.get("peer") and o.get("goalId")
                 and not o.get("peerHost") and o["peer"] in paths):
-            rec = _delegate_user_rooted(o["peer"], o["goalId"], paths, now, _depth + 1, seen)
-            if rec:
-                return rec
+            rec = _delegate_user_rooted(o["peer"], o["goalId"], paths, now, _depth + 1, seen, fb)
+            if rec:                                    # ONLY a decisive inner record short-circuits;
+                return rec                             # a demoted inner fallback rides `fb` instead
         pu = nd.get("promptUuid")
         if pu and sender in paths:
             rec = _session_user_prompt_record(sender, paths[sender], pu, now)
             if rec:
-                return rec
+                rec["askRef"] = {"peer": sender, "goalId": x}
+                if _node_carded(live, x, conf):
+                    rec["carded"] = True                # a carded human record is decisive — the
+                    return rec                          # ask's own node still renders its card
+                # UNCARDED: the record is root evidence but its card is gone — the TRUE-ORIGIN
+                # twin of the stored-proof demotion above. Returning it here would preempt carded
+                # evidence the OUTER climb still reaches (the duplicate-mint hole in its most
+                # common shape); it rides `fb` at PROMPT rank instead, replacing any stored copy,
+                # and the climb keeps walking toward a card that still renders.
+                rec["carded"] = False
+                _fb_offer(1, rec)
         last = nd
         x = nd.get("parentId")
     # CONTAINER-SIBLING RESCUE (the user 2026-08-26, T101): live umbrellas dissolve now, but
@@ -12208,14 +12405,19 @@ def _delegate_user_rooted(sender, link_id, paths, now, _depth=0, _seen=None):
             if pu and sender in paths:
                 rec = _session_user_prompt_record(sender, paths[sender], pu, now)
                 if rec:
-                    return rec
+                    rec["askRef"] = {"peer": sender, "goalId": cid}
+                    if _node_carded(live, cid, conf):   # the rescue reads archived history — almost never carded
+                        rec["carded"] = True
+                        return rec
+                    rec["carded"] = False               # rescue twin of the prompt-record demotion:
+                    _fb_offer(1, rec)                   # uncarded rides fb, a later sibling may still be carded
             o = cd.get("origin")
             if (isinstance(o, dict) and o.get("peer") and o.get("goalId")
                     and not o.get("peerHost") and o["peer"] in paths):
-                rec = _delegate_user_rooted(o["peer"], o["goalId"], paths, now, _depth + 1, seen)
-                if rec:
-                    return rec
-    return None
+                rec = _delegate_user_rooted(o["peer"], o["goalId"], paths, now, _depth + 1, seen, fb)
+                if rec:                                # container twin of the fix: same discipline —
+                    return rec                         # only a decisive record returns, the proof rides `fb`
+    return fb[0][1] if (_depth == 0 and fb) else None
 
 
 def _presumed_closed(sid, now):
@@ -12630,15 +12832,34 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # by the kernel that held its evidence, not the uncertainty T101 quiets on.
             wired = None if rooted else _postal_row(mid)[4]
             # THE ASK IS THE CARD UNIT (the user 2026-08-26, T101): a dispatch whose chain roots to
-            # an ask that ALREADY HAS A CARD — link_id resolved to the sender's ask node — LINKS
-            # instead of minting: the tracking node below plants under that ask (fan-out lives
-            # INSIDE the ask card, per-dispatch progress one click down), and the recipient gets NO
-            # standalone top (one ask fanned to three workers used to mint three near-duplicate
-            # cards). Only a rooted dispatch with NO resolvable ask node still mints the recipient
-            # top — there the recipient card IS the ask's card, the fallback that keeps every user
-            # ask carded somewhere. Linking alone never moves the ask card's column: planting a
-            # tracking child writes no verdict on the ask.
-            mint_recipient = (rooted or wired) and not link_id
+            # an ask that ALREADY HAS A CARD LINKS instead of minting: the tracking node below
+            # plants under the linked goal (fan-out lives INSIDE the ask card, per-dispatch
+            # progress one click down), and the recipient gets NO standalone top (one ask fanned to
+            # three workers used to mint three near-duplicate cards). Only a rooted dispatch with
+            # NO resolvable ask node still mints the recipient top — there the recipient card IS
+            # the ask's card, the fallback that keeps every user ask carded somewhere. Linking
+            # alone never moves the ask card's column: planting a tracking child writes no verdict
+            # on the ask.
+            #
+            # "Has a card" is the TRACE's answer, not the link's: as `rooted and not link_id` this
+            # could never be true — the trace returns None without a link (its own no-link pin), so
+            # `rooted` implied `link_id` and the local-walk leg of the mint below was dead code
+            # (only the relay-walked record ever reached it). The record's `carded` says whether
+            # the ask still RENDERS ON A VISIBLE CARD (_node_carded — live, uncleared/unsealed,
+            # reachable from a live top; bare live-membership would link into cleared/dangling
+            # cards that render nowhere): visible proof links; uncarded proof — archived, cleared,
+            # sealed, or dangling alike — mints. A truthy NON-dict (tests stub the trace with
+            # literal True, the same shape apply_courier tolerates) carries no node evidence, so it
+            # falls back to the link itself — the stubbed suites' contract. A genuinely link-less
+            # dispatch stays quiet either way: no link, no chain, no proof (uncertainty quiets,
+            # the 2026-08-25 verdict).
+            #
+            # The WIRED arm (T126, the walked-at-relay root above) answers only when the local
+            # walk resolves nothing: the origin kernel's stamped proof licenses the mint exactly
+            # like a local root, and a local link still wins — with a link the tracker plants
+            # under it and the recipient stays quiet, the same link-over-mint rule as ever.
+            carded = rooted.get("carded") if isinstance(rooted, dict) else bool(link_id)
+            mint_recipient = (bool(rooted) and not carded) or (not rooted and bool(wired) and not link_id)
             # Mint the sender's precise '↪ delegated to <recipient>' tracking node (the user 2026-06-22) and
             # point B's goal at IT — so run_propagate checks off only the handed-off piece, never the sender's
             # broader linked goal. Saved to the sender's tree before planting G on the recipient's.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4534,13 +4534,74 @@ def _open_leaves_for_nudge(nodes, top_id):
             if nid != top_id and not isinstance(nodes.get(nid, {}).get("handoff"), dict)]
 
 
-def _pure_delegation_top(nodes, top_id):
+def _dictated_prompt_uuid(sid, path, pu):
+    """Does a node's stored promptUuid name a HUMAN-DICTATED prompt record in the session's own
+    transcript? True / False / None(unknown) — the ask-unit exemption's discriminator. promptUuid
+    alone proves nothing: it is the g200 LANDABLE-ANCHOR field, stamped on essentially every minted
+    top (_seg_anchor hands a peer/system/AUTONOMOUS segment's mint the segment head — often the
+    agent's own assistant atom — and apply_courier stamps the delegate MAIL's anchor), so only the
+    RECORD it names can say whether the top is the dictated ask. The rule is
+    jd._human_prompt_record — the same author-'human'-minus-interrupts / unmarked-attachment
+    classification the T101/T105 trace uses (_session_user_prompt_record, _user_ask_text's quote
+    gate) — read against the CACHED parse only (_parse_cached never parses, preserving build_feed's
+    cold-start contract; the anchors fill in a beat later the same way the dots do). None when the
+    verdict cannot be reached: no path threaded, no cached parse yet, or the uuid absent from the
+    stitched chain (a rewound/compacted record) — the caller decides what doubt means."""
+    if not (pu and path):
+        return None
+    ps = _parse_cached(str(path))
+    if not ps:
+        return None
+    for turn in ps.get("turns") or []:
+        for a in turn.get("atoms") or []:
+            if a.get("uuid") == pu:
+                return jd._human_prompt_record(a, str(sid or "")) is not None
+    return None
+
+
+def _pure_delegation_top(nodes, top_id, sid=None, path=None):
     """True if EVERY leaf in top_id's subtree is a courier handoff-tracking node — the whole top is just work
     handed to PEERS, nothing this session does itself. Such a top is pure peer-coordination and is NOT an
     inbox card (the user 2026-06-23): consistent with _all_outstanding_delegated already treating
     delegated-only work as not-needs-you. Unlike that (which weighs only OPEN leaves for the nudge gate), this
     weighs ALL leaves — a delegation stays coordination even after it completes — so the card is suppressed in
-    every column. A top with ANY own-work leaf still shows."""
+    every column. A top with ANY own-work leaf still shows.
+
+    THE ASK-UNIT EXEMPTION: T101 made the dictated ask itself host the fan-out — the courier plants
+    its tracking nodes UNDER the ask and mints NO recipient tops — so an ask fully fanned to
+    workers is exactly this all-leaves-are-handoffs shape, and suppressing it left the user's ask
+    with no card ANYWHERE (T101's own rule: one ask fanned to two workers = ONE card with two
+    handoff children). A top IS the ask only on real dictation evidence:
+      - T105's chain-proven `userAsk` record — the ONLY evidence a courier-planted top (`origin`)
+        can carry: its promptUuid is the delegate MAIL's anchor by construction (g200), never the
+        dictated prompt, so a bare anchor there would re-show every mid-chain coordination top;
+      - a promptUuid that PROVABLY resolves to a human-dictated record (_dictated_prompt_uuid
+        above; callers thread sid+path). A resolved machine anchor — an autonomous segment's head,
+        a peer mail — is not the ask and the suppression stands. An UNRESOLVABLE anchor fails OPEN
+        (exempt): suppressing on doubt re-opens the no-card-anywhere hole this exemption closes,
+        and a shown coordination card is recoverable noise where a hidden ask is not.
+    A top that is ITSELF a handoff tracker never qualifies: the parentless '↪ delegated' record
+    stays suppressed as before.
+
+    THE LATCH OUTRANKS THE CACHE: `askAnchor` is the judge's durable verdict on this exact
+    question, filed from a WARM parse by the planner pass (jd._latch_ask_anchors) —
+    'human'/'absent' exempt, 'machine' suppresses, and NEITHER is ever re-derived here: re-deriving
+    per build from _parse_cached would make the verdict flap with cache temperature (a
+    machine-anchored coordination card re-shown on every restart/cold beat with no new
+    information — the cards-move-on-new-information rule). Only an UNLATCHED node still reads the
+    cached parse below — the fail-open on doubt — and the judge latches it on its next pass, so
+    that flap happens at most once per node ever, not per beat."""
+    root = nodes.get(top_id) or {}
+    if not isinstance(root.get("handoff"), dict):
+        if isinstance(root.get("userAsk"), dict):
+            return False
+        pu = root.get("promptUuid")
+        if pu and not isinstance(root.get("origin"), dict):
+            latch = root.get("askAnchor")
+            if latch in ("human", "absent"):
+                return False                          # the dictated ask (or durable doubt) — stable
+            if latch != "machine" and _dictated_prompt_uuid(sid, path, pu) is not False:
+                return False                          # unlatched → the cached-parse read, fail-open
     children = {}
     for nid, nd in nodes.items():
         children.setdefault(nd.get("parentId"), []).append(nid)
@@ -15172,7 +15233,24 @@ def _session_stamp_read(sid):
         mkey = (mst.st_mtime_ns, mst.st_size)
     except OSError:
         mkey = None                                    # no postal log yet is normal
-    key = (gkey, okey, mkey)
+    # The ask-unit discriminator reads the SAME transcript the feed does: discover hands build_feed
+    # the registry's lastSid file for a /cleared or resume-forked SDK session, while
+    # _sdk_transcript_path names the ANCHOR file — dead after a fork — so the chip's suppression
+    # call would answer from a transcript the feed no longer reads (the feed suppresses a
+    # machine-anchored top; the chip lights 'waiting on peers' for it — one fact, two answers).
+    # Same project dir, lastSid stem — the exact resolution discover applies.
+    _stamp_path = _sdk_transcript_path(sid)
+    _last = jd._sdk_last_sid(sid)
+    if _last:
+        _stamp_path = _stamp_path.with_name(_last + ".jsonl")
+    _stamp_path = str(_stamp_path)
+    # …and the discriminator's remaining cache-temperature input joins the KEY. A LATCHED verdict
+    # (askAnchor) rides the goal store, so the goals mtime/size above already re-reads on every
+    # latch write — that part is store-keyed and temperature-blind by design. Only a NOT-YET-
+    # LATCHED node still derives from _parse_cached, so the resolved path + its warmth are keyed
+    # too: without them the chip serves a cold-beat fail-open long after the feed's fresh per-build
+    # read has warmed, and holds it until an unrelated store/postal write.
+    key = (gkey, okey, mkey, _stamp_path, _parse_cached(_stamp_path) is not None)
     hit = _SESSION_STAMP_CACHE.get(sid)
     if hit and hit[0] == key:
         return hit[1]
@@ -15224,7 +15302,8 @@ def _session_stamp_read(sid):
         for tid, td_ in nodes.items():
             if td_.get("parentId") is not None or td_.get("nodeComplete") or td_.get("cleared"):
                 continue
-            if not _all_outstanding_delegated(nodes, tid) or _pure_delegation_top(nodes, tid):
+            if not _all_outstanding_delegated(nodes, tid) \
+                    or _pure_delegation_top(nodes, tid, sid=sid, path=_stamp_path):
                 continue
             for x in _open_leaves(nodes, tid):
                 h = nodes.get(x, {}).get("handoff")
@@ -21773,8 +21852,8 @@ def build_feed(now, tmux=None):
             col = status.get(nid, "working")
             if col == "cleared" or nid in cleared:
                 continue
-            if _pure_delegation_top(nodes, nid):         # whole top is just peer handoffs → coordination, not an inbox card
-                continue
+            if _pure_delegation_top(nodes, nid, sid=fsid, path=s["path"]):   # whole top is just peer
+                continue                                 # handoffs → coordination, not an inbox card
             # AWAITING floor (event-based, the user 2026-06-22): a session paused on dispatched/delegated
             # work is a WORKING flavor, never needs-input. Floor a working OR stale-blocked top to awaiting
             # from (a) the session-level awaiting signal (live subagents / SDK states overlay),

--- a/tests/test_ask_unit_cards.py
+++ b/tests/test_ask_unit_cards.py
@@ -30,6 +30,7 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_askunit", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_askunit", os.path.join(BIN, "romp-kernel")).load_module()
 
 NOW = 1_787_500_000
 T0 = NOW - 3600
@@ -183,6 +184,31 @@ class CourierWorld(unittest.TestCase):
         planted = [nd for nd in w1["nodes"].values() if isinstance(nd.get("origin"), dict)]
         self.assertEqual(len(planted), 1, "no ask node resolved → the recipient card IS the ask's card")
         self.assertTrue(planted[0].get("frame"), "the fallback mint keeps the frame enrichment")
+
+    def test_the_fanned_ask_keeps_one_visible_card_through_completion(self):
+        # THE BOARD CONSEQUENCE of the link path: the kernel's _pure_delegation_top suppressed any
+        # top whose every leaf is a handoff dict — exactly the shape T101's own link path builds
+        # for a fully-fanned ask — so one dictated ask fanned to two workers had NO card anywhere
+        # (no recipient tops by design, the ask top suppressed). The suppression exempts the
+        # ask-unit now: ONE card, visible in Working with its two tracker children, and still
+        # visible when it lands in Completed.
+        self._mgr()
+        jd.run_courier(now=NOW)
+        m = jd.load_goals(MGR)
+        ask = MGR + ":g1"
+        self.assertEqual(len(self._trackers_under(ask)), 2)
+        self.assertFalse(km._pure_delegation_top(m["nodes"], ask),
+                         "the dictated ask keeps its card — fan-out lives INSIDE it")
+        jd.rollup_status(m, False)
+        self.assertEqual(m["status"].get(ask, "working"), "working", "…in Working while open")
+        for nid, nd in m["nodes"].items():
+            if isinstance(nd.get("handoff"), dict):
+                jd.record_verdict(m, nd, "romp", "done", NOW + 10, why="the peer reported back")
+        jd.record_verdict(m, m["nodes"][ask], "closer", "done", NOW + 20, why="both halves landed")
+        jd.rollup_status(m, True)
+        self.assertEqual(m["status"].get(ask), "completed", "…and lands in Completed")
+        self.assertFalse(km._pure_delegation_top(m["nodes"], ask),
+                         "a finished ask is still the ask — never re-read as pure coordination")
 
     def test_linking_never_moves_the_ask_cards_column(self):
         self._mgr()

--- a/tests/test_ask_unit_cards.py
+++ b/tests/test_ask_unit_cards.py
@@ -337,5 +337,142 @@ class UmbrellaDissolution(unittest.TestCase):
                          "the un-stranded ask carries its own evidence — the trace can reach it now")
 
 
+MID3 = "1787499000.000003_1.TESTHOST"
+MID4 = "1787499000.000004_1.TESTHOST"
+
+
+class ImageOnlyAsk(unittest.TestCase):
+    """_human_prompt_record returns an EMPTY-TEXT record for an image-only dictated prompt (a human
+    record with no text blocks), and a fallback that gated the userAsk stamp on text.strip()
+    minted with askRef but NO userAsk — a top with no dictation evidence the ask-unit exemption
+    accepts, so a fully-fanned image ask rendered NOWHERE and the dedupe linked later dispatches
+    into that invisible top. The stamp falls back to the '(user message)' placeholder
+    (_seg_label's own titleless-prompt presentation), so the exemption's userAsk check holds for
+    image asks."""
+
+    def test_an_image_only_human_record_is_still_a_record(self):
+        rec = jd._human_prompt_record({"uuid": "hu", "type": "user", "author": "human",
+                                       "message": {"role": "user", "content": [
+                                           {"type": "image",
+                                            "source": {"media_type": "image/png",
+                                                       "data": "Zm9v"}}]}}, MGR)
+        self.assertIsInstance(rec, dict, "an image-only prompt is dictation — the chain roots")
+        self.assertEqual(rec.get("text"), "")
+
+    def _mint(self, st, seg, mid):
+        rec = {"text": "", "sid": MGR, "carded": False,
+               "askRef": {"peer": MGR, "goalId": MGR + ":g1"}}
+        return jd.apply_courier(st, seg, T0, "review the screenshot",
+                                {"peer": MGR, "goalId": MGR + ":t1", "msgId": mid},
+                                prompt_uuid="anchor", frame="review the screenshot",
+                                user_ask=rec)
+
+    def test_the_fallback_mint_stamps_a_userask_for_an_image_only_ask(self):
+        st = {"rompUuid": WK1, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        nid = self._mint(st, "seg1", MID1)
+        ua = st["nodes"][nid].get("userAsk")
+        self.assertIsInstance(ua, dict, "askRef never rides without the dictation stamp")
+        self.assertTrue(str(ua.get("text") or "").strip(),
+                        "empty dictation stamps the placeholder, never nothing")
+        # …and the exemption accepts it: fanned onward, the ask keeps its card
+        st["nodes"]["h1"] = _node("h1", "↪ delegated to tests: the screenshot", nid,
+                                  handoff={"peer": WK2, "msgId": MID2})
+        self.assertFalse(km._pure_delegation_top(st["nodes"], nid),
+                         "a fully-fanned image ask renders SOMEWHERE")
+
+    def test_a_second_dispatch_of_the_image_ask_links_into_the_visible_top(self):
+        st = {"rompUuid": WK1, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        nid = self._mint(st, "seg1", MID1)
+        nid2 = self._mint(st, "seg2", MID3)
+        self.assertEqual(nid2, nid, "one image ask, one card — the placeholder is its identity")
+        self.assertIn(MID3, [l.get("msgId") for l in (st["nodes"][nid].get("links") or [])])
+
+
+class MergeCarriesDelegationIdentity(unittest.TestCase):
+    """_merge_nodes dropped origin, links, and askRef when the grouper folded a courier-minted top
+    into a planner twin — a lost askRef reopened duplicate minting for the next dispatch of the
+    same ask, and a lost origin/links stranded the sender's non-quiet tracker FOREVER
+    (run_propagate's back-link and its dismissal arm both join on the msgId)."""
+
+    def _world(self):
+        surv = _node(WK1 + ":g1", "Drag-range selection over run rows", None)
+        dupe = _node(WK1 + ":g2", "Drag-range selection (delegated)", None,
+                     origin={"peer": MGR, "goalId": MGR + ":t1", "msgId": MID1},
+                     userAsk={"text": "drag-range selection over run rows", "sid": MGR},
+                     askRef={"peer": MGR, "goalId": MGR + ":a1"},
+                     links=[{"peer": MGR, "goalId": MGR + ":t2", "msgId": MID2}])
+        return {"rompUuid": WK1, "seq": 2, "nodes": {surv["id"]: surv, dupe["id"]: dupe},
+                "placements": {}, "status": {}}
+
+    def test_the_merge_carries_origin_links_and_askref(self):
+        st = self._world()
+        self.assertEqual(jd._merge_nodes(st, WK1 + ":g2", WK1 + ":g1", T0 + 10, "twin"), 1)
+        surv = st["nodes"][WK1 + ":g1"]
+        self.assertEqual((surv.get("origin") or {}).get("msgId"), MID1)
+        self.assertEqual(surv.get("askRef"), {"peer": MGR, "goalId": MGR + ":a1"})
+        self.assertIn(MID2, [l.get("msgId") for l in (surv.get("links") or [])])
+        self.assertEqual((surv.get("userAsk") or {}).get("sid"), MGR)
+
+    def test_a_survivor_with_its_own_origin_keeps_the_dupes_msgid_as_a_link(self):
+        st = self._world()
+        st["nodes"][WK1 + ":g1"]["origin"] = {"peer": MGR, "goalId": MGR + ":t0", "msgId": MID4}
+        jd._merge_nodes(st, WK1 + ":g2", WK1 + ":g1", T0 + 10, "twin")
+        surv = st["nodes"][WK1 + ":g1"]
+        self.assertEqual((surv.get("origin") or {}).get("msgId"), MID4,
+                         "the survivor's own birth stands — origin stays truthful")
+        self.assertIn(MID1, [l.get("msgId") for l in (surv.get("links") or [])],
+                      "…and the dupe's delegation stays joinable by msgId")
+
+    def test_merge_then_second_dispatch_links_not_mints(self):
+        st = self._world()
+        jd._merge_nodes(st, WK1 + ":g2", WK1 + ":g1", T0 + 10, "twin")
+        rec = {"text": "drag-range selection over run rows", "sid": MGR, "carded": False,
+               "askRef": {"peer": MGR, "goalId": MGR + ":a1"}}
+        before = set(st["nodes"])
+        nid = jd.apply_courier(st, "segN", T0 + 20, "drag-range, second pass",
+                               {"peer": MGR, "goalId": MGR + ":t3", "msgId": MID3},
+                               prompt_uuid="anc", frame="second pass", user_ask=rec)
+        self.assertEqual(nid, WK1 + ":g1", "the ask identity survived the merge — link")
+        self.assertEqual(set(st["nodes"]), before, "no duplicate mint")
+        self.assertIn(MID3, [l.get("msgId") for l in (st["nodes"][nid].get("links") or [])])
+
+    def test_merge_then_ending_completes_the_senders_trackers(self):
+        # end-to-end: the recipient's merged card completes → run_propagate ends BOTH the
+        # origin's tracker and the linked dispatch's tracker off the one surviving card
+        td = tempfile.TemporaryDirectory()
+        _msgs, _disc = jd.MESSAGES, jd.discover
+        jd.MESSAGES = Path(td.name) / "messages.jsonl"
+        jd.MESSAGES.write_text("")
+        jd.discover = lambda now, window=None, forks=True: [
+            (WK1, "/dev/null", None, "api"), (MGR, "/dev/null", None, "web")]
+        try:
+            st = self._world()
+            jd._merge_nodes(st, WK1 + ":g2", WK1 + ":g1", T0 + 10, "twin")
+            jd.record_verdict(st, st["nodes"][WK1 + ":g1"], "closer", "done", NOW - 100,
+                              why="both halves landed")
+            jd.save_goals(WK1, st)
+            jd.save_goals(MGR, {"rompUuid": MGR, "seq": 2, "nodes": {
+                MGR + ":t1": _node(MGR + ":t1", "↪ delegated to api: drag-range", None,
+                                   handoff={"peer": WK1, "msgId": MID1}),
+                MGR + ":t2": _node(MGR + ":t2", "↪ delegated to api: drag-range, again", None,
+                                   handoff={"peer": WK1, "msgId": MID2})},
+                "placements": {}, "status": {}})
+            jd.run_propagate(now=NOW)
+            m = jd.load_goals(MGR)
+            self.assertTrue(m["nodes"][MGR + ":t1"].get("nodeComplete"),
+                            "the origin back-link ends t1")
+            self.assertTrue(m["nodes"][MGR + ":t2"].get("nodeComplete"),
+                            "the carried link ends t2")
+        finally:
+            jd.MESSAGES, jd.discover = _msgs, _disc
+            for sid in (MGR, WK1):
+                for dd in (jd.GOALDIR, jd.GOALARCHDIR):
+                    try:
+                        (dd / (sid + ".json")).unlink()
+                    except OSError:
+                        pass
+            td.cleanup()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ask_unit_cards.py
+++ b/tests/test_ask_unit_cards.py
@@ -336,6 +336,52 @@ class UmbrellaDissolution(unittest.TestCase):
         self.assertEqual(st["nodes"][MGR + ":a1"].get("promptUuid"), "hu",
                          "the un-stranded ask carries its own evidence — the trace can reach it now")
 
+    def test_an_undo_restored_container_survives_the_dissolution(self):
+        # THE SWEEP YIELDS TO THE USER'S UNDO: UndoClear pulls an archived pre-T101 container back
+        # into the live store (archives keep their containers), and the very next rollup dissolved
+        # it — the card the user just restored vanished into its promoted children. The un-clear
+        # IS newer information than the standing purge: it is recorded on the node by the real
+        # writers (_mark_nodes_cleared's dual-write and the unclear override replay both file the
+        # user reopen row with undo=True), and a container whose latest clear-family event is that
+        # restore is SPARED. Everything without that fresh restore — legacy leftovers, peer-adopted
+        # copies — dissolves exactly as before.
+        st = self._legacy()
+        u1 = st["nodes"][MGR + ":u1"]
+        self.assertTrue(jd.record_verdict(st, u1, "user", "clear", NOW - 100,
+                                          why="cleared from the feed"))
+        self.assertTrue(jd.record_verdict(st, u1, "user", "reopen", NOW - 50,
+                                          why="undo clear", undo=True))
+        u1["cleared"] = False
+        jd.rollup_status(st, False)
+        self.assertIn(MGR + ":u1", st["nodes"], "the card the user restored survives the sweep")
+        self.assertEqual(st["nodes"][MGR + ":a1"].get("parentId"), MGR + ":u1",
+                         "…with its children where the user left them")
+        self.assertEqual(st["placements"].get("segX"), MGR + ":u1", "…and its placement intact")
+        self.assertNotIn(MGR + ":u2", st["nodes"],
+                         "the spare is exact: a nested container with no restore still dissolves")
+        self.assertEqual(st["nodes"][MGR + ":a2"].get("parentId"), MGR + ":u1",
+                         "…its child re-parents to the first surviving non-dissolved ancestor")
+        snap = json.dumps(st["nodes"], sort_keys=True, default=dict)
+        jd.rollup_status(st, False)
+        self.assertEqual(json.dumps(st["nodes"], sort_keys=True, default=dict), snap, "idempotent")
+
+    def test_a_re_cleared_spared_container_waits_for_the_compactor(self):
+        # the round trip's other half: after the restore the user clears the card AGAIN. Between
+        # that clear and the archive compaction the container sits flag-cleared in the live store —
+        # the sweep must stand down there too, or it pops the container and promotes its children
+        # OUT of the user's seal as fresh live tops. The compactor owns a cleared card's exit.
+        st = self._legacy()
+        u1 = st["nodes"][MGR + ":u1"]
+        jd.record_verdict(st, u1, "user", "clear", NOW - 100, why="cleared from the feed")
+        jd.record_verdict(st, u1, "user", "reopen", NOW - 50, why="undo clear", undo=True)
+        jd.record_verdict(st, u1, "user", "clear", NOW - 10, why="cleared from the feed")
+        u1["cleared"] = True
+        jd.rollup_status(st, False)
+        self.assertIn(MGR + ":u1", st["nodes"],
+                      "flag-cleared: the compactor archives it whole — the sweep never dissolves it")
+        self.assertEqual(st["nodes"][MGR + ":a1"].get("parentId"), MGR + ":u1",
+                         "…so its children never escape the user's clear")
+
 
 MID3 = "1787499000.000003_1.TESTHOST"
 MID4 = "1787499000.000004_1.TESTHOST"

--- a/tests/test_chain_rooted_minting.py
+++ b/tests/test_chain_rooted_minting.py
@@ -186,6 +186,309 @@ class TraceRule(unittest.TestCase):
         self._store(MGR, {"a": _node("a", "x", "b"), "b": _node("b", "y", "a")})
         self.assertFalse(jd._delegate_user_rooted(MGR, "a", self.paths, NOW))
 
+    def test_the_record_reports_whether_the_asks_card_is_live(self):
+        # the T101 mint fallback's discriminator: proof found at a LIVE ask node means the ask
+        # still has a card the tracker can link under; the record says so (`carded`), and the
+        # courier links instead of minting.
+        self._store(MGR, {"g1": _node("g1", "Ship the demo", None, promptUuid="hu")})
+        self._human(MGR)
+        self.assertTrue(jd._delegate_user_rooted(MGR, "g1", self.paths, NOW).get("carded"))
+
+    def test_archive_only_evidence_reads_uncarded(self):
+        # …while proof recovered from ARCHIVED history alone means the ask's own card is gone —
+        # the shape where T101's "the recipient card IS the ask's card" fallback mints.
+        self._store(MGR, {"g2": _node("g2", "follow-up work", "g1")})
+        self._store(MGR, {"g1": _node("g1", "the original ask", None, promptUuid="hu")},
+                    archive=True)
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "g2", self.paths, NOW)
+        self.assertTrue(rec, "the chain still proves the human root")
+        self.assertFalse(rec.get("carded"), "…but no live ask node carries it")
+
+    def test_a_cleared_live_ask_reads_uncarded(self):
+        # `carded` answers "does this node currently RENDER on a visible card", not "is it in the
+        # live store" — a user-cleared ask sits live until the compactor takes it, but its card is
+        # off every column, so linking into it hides the fan-out completely. Uncarded → the
+        # fallback mints.
+        self._store(MGR, {"g1": _node("g1", "Ship the demo", None, promptUuid="hu", cleared=True)})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self.assertTrue(rec, "the human proof stands — clearing a card does not erase the chain")
+        self.assertFalse(rec.get("carded"), "…but a cleared card renders nowhere")
+
+    def test_a_sealed_ask_reads_uncarded(self):
+        # the sealed flavor: a complete/cleared ANCESTOR folds the subtree into done-display —
+        # nothing planted under the ask would render as live fan-out (the sealed-open leak).
+        self._store(MGR, {"top": _node("top", "done umbrella", None, nodeComplete=True),
+                          "g1": _node("g1", "the ask", "top", promptUuid="hu")})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self.assertTrue(rec)
+        self.assertFalse(rec.get("carded"))
+
+    def test_a_dangling_ask_reads_uncarded(self):
+        # a rewind-swept parent leaves the ask node live but reachable from NO live top — the feed
+        # walks top subtrees, so the node renders nowhere.
+        self._store(MGR, {"g1": _node("g1", "the ask", "swept-away", promptUuid="hu")})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self.assertTrue(rec)
+        self.assertFalse(rec.get("carded"), "a dangling node has no card to link into")
+
+    def test_carded_never_flips_across_the_compaction_boundary(self):
+        # THE BOUNDARY PIN: a cleared ask answers the same before and after the compactor moves it
+        # to the archive — both uncarded, both mint. With bare live-membership the same cleared
+        # card read carded=True live and carded=False archived, so the mint decision flipped on a
+        # compaction pass that carried no new information.
+        self._store(MGR, {"g1": _node("g1", "the ask", None, promptUuid="hu", cleared=True)})
+        self._human(MGR)
+        live_rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self._store(MGR, {})
+        self._store(MGR, {"g1": _node("g1", "the ask", None, promptUuid="hu", cleared=True)},
+                    archive=True)
+        arch_rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self.assertTrue(live_rec and arch_rec)
+        self.assertEqual(bool(live_rec.get("carded")), bool(arch_rec.get("carded")),
+                         "compaction is bookkeeping, never a mint-decision event")
+        self.assertFalse(arch_rec.get("carded"))
+
+    def test_a_visible_intermediate_userask_top_reads_carded(self):
+        # HOP STAND-DOWN, trace side: the climb passes a LIVE, VISIBLE userAsk-bearing top — the
+        # ask already has a card on the intermediate's board, so the record reads carded even when
+        # the ROOT ask node is archive-only (which would otherwise ride the origin hop up as
+        # carded=False and re-mint at every hop level).
+        self._store(MGR, {"gM": _node("gM", "mid-chain ask", None,
+                                      origin={"peer": GRAND, "goalId": "t1", "msgId": "m0"},
+                                      userAsk={"text": "the user's ask", "sid": GRAND})})
+        self._store(GRAND, {"g9": _node("g9", "the original ask", None, promptUuid="hu"),
+                            "t1": _node("t1", "↪ delegated", "g9")}, archive=True)
+        self._human(GRAND)
+        rec = jd._delegate_user_rooted(MGR, "gM", self.paths, NOW)
+        self.assertTrue(rec)
+        self.assertTrue(rec.get("carded"),
+                        "the intermediate top IS the ask's card — no re-mint below it")
+        self.assertEqual(rec.get("sid"), GRAND, "…and it still speaks for the root ask")
+
+    def test_a_cleared_intermediate_userask_top_does_not_stand_down(self):
+        # …but a cleared intermediate renders nowhere, so it cannot claim the card: the climb
+        # falls through to the origin hop and the root's own (archive-only → uncarded) answer.
+        self._store(MGR, {"gM": _node("gM", "mid-chain ask", None, cleared=True,
+                                      origin={"peer": GRAND, "goalId": "t1", "msgId": "m0"},
+                                      userAsk={"text": "the user's ask", "sid": GRAND})})
+        self._store(GRAND, {"g9": _node("g9", "the original ask", None, promptUuid="hu"),
+                            "t1": _node("t1", "↪ delegated", "g9")}, archive=True)
+        self._human(GRAND)
+        rec = jd._delegate_user_rooted(MGR, "gM", self.paths, NOW)
+        self.assertTrue(rec, "the chain still proves the root")
+        self.assertFalse(rec.get("carded"), "a cleared intermediate is no card — the fallback mints")
+
+    def test_inner_uncarded_fallback_yields_to_outer_carded_top(self):
+        # THE MAIN-LOOP RECURSION RULE: sender M holds a VISIBLE carded ask top `p` with a child
+        # `x` whose origin hops to a local grand-sender G whose ask node `ga` is CLEARED — an
+        # uncarded stored-proof (T126's demoted fallback). An origin-hop callsite that did
+        # `rec = _delegate_user_rooted(...); if rec: return rec` took that INNER frame's
+        # carded:False fallback as a final answer and stopped the walk at G/ga — instead of
+        # climbing the one hop to `p`, the ask's own live card. A carded:False answer here would
+        # mint a standalone recipient top for an ask that STILL renders on a visible card (the
+        # pre-T101 duplicate-card hole). The climb must reach `p`.
+        self._store(MGR, {
+            "p": _node("p", "Ship the demo", None,
+                       userAsk={"text": "the user's ask", "sid": MGR},
+                       askRef={"peer": MGR, "goalId": "p"}),
+            "x": _node("x", "a fanned step", "p",
+                       origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"})})
+        self._store(GRAND, {"ga": _node("ga", "the original ask", None, cleared=True,
+                                        userAsk={"text": "the user's ask", "sid": GRAND},
+                                        askRef={"peer": GRAND, "goalId": "ga"})})
+        rec = jd._delegate_user_rooted(MGR, "x", self.paths, NOW)
+        self.assertTrue(rec.get("carded"),
+                        "the outer climb reaches p, the ask's live card — no standalone re-mint below it")
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "p"},
+                         "…and the dedupe key is the carded top, not the inner cleared proof")
+        self.assertEqual(rec.get("sid"), MGR)
+
+    def test_container_rescue_inner_fallback_yields_to_sibling_evidence(self):
+        # THE CONTAINER-RESCUE TWIN of that rule: the main climb dead-ends at an evidence-free
+        # umbrella, so the sibling rescue runs. childA's origin hop resolves only an uncarded
+        # stored-proof (the demoted fallback); childB carries a live human prompt record. A rescue
+        # callsite with the same `if rec: return rec` returned childA's inner fallback and never
+        # reached childB. The rescue must pass over the demoted fallback and take childB's
+        # decisive record.
+        self._store(MGR, {
+            "U": _node("U", "the dictated round", None, umbrella=True),
+            "childA": _node("childA", "a fanned step", "U",
+                            origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"}),
+            "childB": _node("childB", "the original ask", "U", promptUuid="hu")})
+        self._store(GRAND, {"ga": _node("ga", "an aside", None, cleared=True,
+                                        userAsk={"text": "an aside", "sid": GRAND},
+                                        askRef={"peer": GRAND, "goalId": "ga"})})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "U", self.paths, NOW)
+        self.assertTrue(rec, "the sibling human record proves the round")
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "childB"},
+                         "the rescue takes the sibling's decisive record, not childA's demoted proof")
+        self.assertTrue(rec.get("carded"), "childB renders under the live umbrella")
+
+    def test_askref_consistent_across_a_cross_host_fan(self):
+        # THE DEDUPE-KEY SKEW (_walk_root_record, kernel/kernel.py): one ask fanned to two workers
+        # plants two sibling children under the same carded top `p`, each hopping to a DIFFERENT
+        # local grand-sender's uncarded proof. The record's askRef is the ask's stable identity —
+        # apply_courier dedupes minted tops on it — so both walks must yield the SAME key (p's).
+        # An inline short-circuit stops each walk at its own grand-sender's node, so the two
+        # dispatches carry DIFFERENT askRefs and the dedupe mints a twin card where both parents
+        # reused one.
+        self._store(MGR, {
+            "p": _node("p", "Ship the demo", None,
+                       userAsk={"text": "the user's ask", "sid": MGR},
+                       askRef={"peer": MGR, "goalId": "p"}),
+            "x1": _node("x1", "fan to worker one", "p",
+                        origin={"peer": GRAND, "goalId": "ga", "msgId": "m1"}),
+            "x2": _node("x2", "fan to worker two", "p",
+                        origin={"peer": WKR, "goalId": "gb", "msgId": "m2"})})
+        self._store(GRAND, {"ga": _node("ga", "the original ask", None, cleared=True,
+                                        userAsk={"text": "the user's ask", "sid": GRAND},
+                                        askRef={"peer": GRAND, "goalId": "ga"})})
+        self._store(WKR, {"gb": _node("gb", "the original ask", None, cleared=True,
+                                      userAsk={"text": "the user's ask", "sid": WKR},
+                                      askRef={"peer": WKR, "goalId": "gb"})})
+        r1 = jd._delegate_user_rooted(MGR, "x1", self.paths, NOW)
+        r2 = jd._delegate_user_rooted(MGR, "x2", self.paths, NOW)
+        self.assertEqual(r1.get("askRef"), r2.get("askRef"),
+                         "one ask fanned twice must carry ONE dedupe key, not skew with the hop level")
+        self.assertEqual(r1.get("askRef"), {"peer": MGR, "goalId": "p"},
+                         "…the carded ask top, the identity apply_courier dedupes on")
+
+    def test_inner_uncarded_prompt_record_yields_to_outer_carded_top(self):
+        # THE PROMPT-RECORD TWIN of the main-loop recursion rule: demoting only the STORED-PROOF
+        # arm through the shared fallback slot leaves the HUMAN PROMPT RECORD arm returning an
+        # uncarded record DECISIVELY from the inner frame. This is the TRUE-ORIGIN shape (the
+        # origin kernel's own ask node carries promptUuid; stored userAsk exists only on
+        # courier-planted mid-chain nodes), so it is the MORE common flavor of the same hole:
+        # sender M holds a VISIBLE carded ask top `p` with a fanned child `x` whose origin hops to
+        # local grand-sender G, whose CLEARED ask node `ga` resolves a live human record. A
+        # carded:False answer here re-mints below `p`, the ask's own live card.
+        self._store(MGR, {
+            "p": _node("p", "Ship the demo", None,
+                       userAsk={"text": "the user's ask", "sid": MGR},
+                       askRef={"peer": MGR, "goalId": "p"}),
+            "x": _node("x", "a fanned step", "p",
+                       origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"})})
+        self._store(GRAND, {"ga": _node("ga", "the original ask", None, cleared=True,
+                                        promptUuid="hu")})
+        self._human(GRAND)
+        rec = jd._delegate_user_rooted(MGR, "x", self.paths, NOW)
+        self.assertTrue(rec.get("carded"),
+                        "the outer climb reaches p, the ask's live card — no standalone re-mint below it")
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "p"},
+                         "…and the dedupe key is the carded top, not the inner cleared origin node")
+        self.assertEqual(rec.get("sid"), MGR)
+
+    def test_container_rescue_inner_prompt_record_yields_to_sibling_evidence(self):
+        # THE CONTAINER-RESCUE TWIN of that arm: the main climb dead-ends at an evidence-free
+        # umbrella, childA's origin hop resolves only an UNCARDED human record (the grand-sender's
+        # cleared origin node), childB renders live under the umbrella with its own record. The
+        # rescue's `if rec: return rec` took childA's inner uncarded record and never reached
+        # childB; it must ride the fallback slot instead and yield to childB's carded evidence.
+        self._store(MGR, {
+            "U": _node("U", "the dictated round", None, umbrella=True),
+            "childA": _node("childA", "a fanned step", "U",
+                            origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"}),
+            "childB": _node("childB", "the original ask", "U", promptUuid="hu")})
+        self._store(GRAND, {"ga": _node("ga", "an aside", None, cleared=True, promptUuid="hu")})
+        self._human(GRAND)
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "U", self.paths, NOW)
+        self.assertTrue(rec, "the sibling human record proves the round")
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "childB"},
+                         "the rescue takes the sibling's carded record, not childA's uncarded inner one")
+        self.assertTrue(rec.get("carded"), "childB renders under the live umbrella")
+
+    def test_an_exhausted_origin_hop_climb_still_mints_from_the_prompt_record(self):
+        # T126 PRESERVED (the guard the demotion must not break): when NOTHING anywhere is carded,
+        # the inner uncarded human record is still the climb's answer — promoted from the fallback
+        # slot at exhaustion, carded:False, exactly where the mint fallback fires. Pins that
+        # demoting the arm never lost the exhausted-climb mint.
+        self._store(MGR, {"x": _node("x", "a fanned step", None,
+                                     origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"})})
+        self._store(GRAND, {"ga": _node("ga", "the original ask", None, cleared=True,
+                                        promptUuid="hu")})
+        self._human(GRAND)
+        rec = jd._delegate_user_rooted(MGR, "x", self.paths, NOW)
+        self.assertTrue(rec, "the human proof stands — the exhausted climb still mints")
+        self.assertFalse(rec.get("carded"))
+        self.assertEqual(rec.get("askRef"), {"peer": GRAND, "goalId": "ga"},
+                         "the record keeps the true origin's identity")
+
+    def test_a_prompt_record_outranks_a_stored_proof_when_both_ride_the_fallback(self):
+        # THE PRECEDENCE PIN: with BOTH demoted arms riding the shared fallback slot, bare
+        # first-seen across arms of DIFFERENT strength would let a courier-written stored proof
+        # (seen first, at the origin hop) shadow the human's own prompt record found later in the
+        # same climb. The rule is a two-rank ladder — a prompt record REPLACES a held stored proof;
+        # within a rank the slot stays first-seen. Red against a naive first-seen-across-arms
+        # demotion, which is the regression this pins out.
+        self._store(MGR, {
+            "q": _node("q", "the dictated ask", None, cleared=True, promptUuid="hu"),
+            "x": _node("x", "a fanned step", "q",
+                       origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"})})
+        self._store(GRAND, {"ga": _node("ga", "the original ask", None, cleared=True,
+                                        userAsk={"text": "the user's ask", "sid": GRAND},
+                                        askRef={"peer": GRAND, "goalId": "ga"})})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "x", self.paths, NOW)
+        self.assertTrue(rec)
+        self.assertFalse(rec.get("carded"), "nothing renders — still the mint shape")
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "q"},
+                         "the human's own record outranks the courier-written copy seen first")
+        self.assertEqual(rec.get("sid"), MGR)
+
+    def test_an_origin_hop_to_a_live_carded_grand_ask_is_decisive_with_its_askref(self):
+        # THE DECISIVE ARM'S PIN: the contract keeps exactly TWO decisive mid-climb answers, and
+        # the carded hop stand-down has its own test. The other — a CARDED human prompt record
+        # resolved in an INNER origin-hop frame, returned through the hop callsite — needs one
+        # too: every other origin-hop test uses an archived or cleared grand node (the
+        # fallback-slot path) or asserts bare truthiness. A refactor that lost the inner return
+        # (demoting EVERY prompt record to the fallback slot, say) would still answer truthy here
+        # — but carded:False, and the courier would mint a twin beside the grand-sender's own live
+        # card. Pin the whole record.
+        self._store(MGR, {"g1": _node("g1", "mid-chain ask", None,
+                                      origin={"peer": GRAND, "goalId": "ga", "msgId": "m0"})})
+        self._store(GRAND, {"ga": _node("ga", "the original ask", None, promptUuid="hu")})
+        self._human(GRAND)
+        rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self.assertTrue(rec, "the hop reaches the grand-sender's live human root")
+        self.assertTrue(rec.get("carded"),
+                        "the grand node still renders its card — decisive, never demoted to the slot")
+        self.assertEqual(rec.get("askRef"), {"peer": GRAND, "goalId": "ga"},
+                         "the record carries the grand node's identity, apply_courier's dedupe key")
+        self.assertEqual(rec.get("sid"), GRAND)
+
+    def test_a_cycle_exit_still_promotes_the_held_fallback(self):
+        # PROMOTION-PATH PIN: the seen-guard loop exit is one of the places the climb exhausts,
+        # and a record already riding the fallback slot must survive it —
+        # test_cycles_terminate_quiet holds only the no-evidence half. A cleared ask inside the
+        # cycle offers its uncarded record to the slot; the walk then bites its own tail and must
+        # still promote that record at the top frame, never fall out None.
+        self._store(MGR, {"a": _node("a", "the dictated ask", "b", cleared=True, promptUuid="hu"),
+                          "b": _node("b", "a step", "a")})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "a", self.paths, NOW)
+        self.assertTrue(rec, "the cycle terminates, but the held evidence still answers")
+        self.assertFalse(rec.get("carded"), "a cleared ask renders nowhere — the mint shape")
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "a"})
+
+    def test_a_missing_parent_exit_still_promotes_the_held_fallback(self):
+        # PROMOTION-PATH PIN, the missing-node twin: a chain whose parent pointer dangles exits
+        # through the not-a-dict guard, which must return the held slot at the top frame — the
+        # identity half test_a_dangling_ask_reads_uncarded leaves unpinned (it asserts truthiness
+        # and carded only).
+        self._store(MGR, {"g1": _node("g1", "the dictated ask", "swept-away",
+                                      cleared=True, promptUuid="hu")})
+        self._human(MGR)
+        rec = jd._delegate_user_rooted(MGR, "g1", self.paths, NOW)
+        self.assertTrue(rec)
+        self.assertFalse(rec.get("carded"))
+        self.assertEqual(rec.get("askRef"), {"peer": MGR, "goalId": "g1"})
+
 
 BODY = ("Verify the staged run references and report drift.\n"
         "<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID)
@@ -221,7 +524,7 @@ class CourierMintMatrix(unittest.TestCase):
         jd.MESSAGES = self._msgs
         jd.discover = self._disc
         jd.courier_llm = self._llm
-        for sid in (MGR, WKR):
+        for sid in (MGR, WKR, GRAND):
             for d in (jd.GOALDIR, jd.GOALARCHDIR):
                 try:
                     (d / (sid + ".json")).unlink()
@@ -259,6 +562,142 @@ class CourierMintMatrix(unittest.TestCase):
         self.assertTrue(trackers[0]["handoff"].get("quiet"),
                         "no recipient goal will carry this msgId — the reply-sweep owns the ending")
 
+    def test_a_rooted_dispatch_whose_ask_card_is_gone_mints_the_fallback_top(self):
+        # T101's FALLBACK, MADE SATISFIABLE: as `mint_recipient = rooted and not link_id` this
+        # could never fire — the trace returns None without a link (test_no_link_quiets is the
+        # pin), so `rooted` implied `link_id` and the apply_courier mint below it was dead code.
+        # The condition keys on the trace's OWN answer now: the root record says whether the
+        # chain's proof still sits on a live ask node (`carded`). Here the courier links the
+        # sender's live follow-up node, but the human proof lives only in the ARCHIVE — the ask's
+        # own card is gone, so the recipient card IS the ask's card: minted, origin-stamped, frame
+        # + userAsk intact, tracker un-quiet (the origin back-link owns its ending, exactly the
+        # pre-T101 rooted-mint wiring).
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 2, "nodes": {
+            MGR + ":g2": _node(MGR + ":g2", "Verification follow-up", MGR + ":g1")},
+            "placements": {}, "status": {}})
+        jd.save_goal_archive(MGR, {"rompUuid": MGR, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "Ship the staged-run verification", None,
+                               promptUuid="hu")},
+            "placements": {}, "status": {}})
+        self.mpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 - 600, "please verify the staged run references", "hu"),
+            aline(T0 - 540, "Dispatching.", "ha", "hu")]) + "\n")
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(len(planted), 1,
+                         "no live ask card anywhere → the recipient card IS the ask's card")
+        self.assertTrue(planted[0].get("frame"), "the fallback keeps the frame enrichment")
+        self.assertEqual((planted[0].get("userAsk") or {}).get("sid"), MGR,
+                         "…and stores the chain-proven root record (T105)")
+        m = jd.load_goals(MGR)
+        trackers = [nd for nd in m["nodes"].values()
+                    if isinstance(nd.get("handoff"), dict) and nd["handoff"].get("msgId") == MID]
+        self.assertEqual(len(trackers), 1)
+        self.assertFalse(trackers[0]["handoff"].get("quiet"),
+                         "a recipient goal carries the msgId — the origin back-link owns the ending")
+
+    def test_a_dispatch_linked_to_a_dangling_ask_mints(self):
+        # END TO END: the courier's link resolves to a live ask whose parent was rewind-swept —
+        # the node pierces the menu (a missing ancestor never seals) but renders on NO card (the
+        # feed walks top subtrees). Reading it "carded" would link the fan-out into a card that
+        # renders nowhere; it must take the fallback mint instead.
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 1, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "Ship the staged-run verification", "swept-away",
+                               promptUuid="hu")},
+            "placements": {}, "status": {}})
+        self.mpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 - 600, "please verify the staged run references", "hu"),
+            aline(T0 - 540, "Dispatching.", "ha", "hu")]) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(len(planted), 1,
+                         "a dangling ask has no visible card — the recipient card IS the ask's card")
+
+    def test_a_cleared_live_ask_mints_like_an_archived_one(self):
+        # END TO END + the compaction-boundary pin: the root ask is CLEARED but still live (the
+        # compactor hasn't run). The chain reaches it through the origin hop of a courier-planted
+        # mid-chain top (pre-T105: no userAsk on it). With bare live membership this read
+        # carded=True and the courier filed quiet — the same world a compaction pass later minted,
+        # so the decision flipped on bookkeeping. A cleared card renders nowhere: mint now, exactly
+        # as the archived twin does.
+        gpath = Path(self.td.name) / (GRAND + ".jsonl")
+        gpath.write_text(json.dumps(uline(T0 - 900, "the dictated round", "hu")) + "\n")
+        jd.discover = lambda now, window=None, forks=True: [
+            (WKR, str(self.wpath), None, "api"), (MGR, str(self.mpath), None, "web"),
+            (GRAND, str(gpath), None, "tests")]
+        jd.save_goals(GRAND, {"rompUuid": GRAND, "seq": 2, "nodes": {
+            GRAND + ":g9": _node(GRAND + ":g9", "the original ask", None, promptUuid="hu",
+                                 cleared=True),
+            GRAND + ":t1": _node(GRAND + ":t1", "↪ delegated", GRAND + ":g9")},
+            "placements": {}, "status": {}})
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 1, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "mid-chain ask", None,
+                               origin={"peer": GRAND, "goalId": GRAND + ":t1", "msgId": "m0"})},
+            "placements": {}, "status": {}})
+        self.mpath.write_text(json.dumps(aline(T0 - 540, "Working the round.", "ha")) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(len(planted), 1,
+                         "a cleared-live ask is exactly as card-less as its archived twin — mint")
+
+    def test_an_origin_hop_to_a_live_carded_ask_links_instead_of_minting(self):
+        # THE DECISIVE ARM END TO END: the cleared-live twin above mints; this is the same hop
+        # shape with the grand-sender's ask node LIVE and VISIBLE, the half that must NOT mint. The
+        # chain reaches the carded human root through the origin hop, so the recipient gets no
+        # standalone top — the ask's own card carries the fan-out — and the tracker files quiet.
+        gpath = Path(self.td.name) / (GRAND + ".jsonl")
+        gpath.write_text(json.dumps(uline(T0 - 900, "the dictated round", "hu")) + "\n")
+        jd.discover = lambda now, window=None, forks=True: [
+            (WKR, str(self.wpath), None, "api"), (MGR, str(self.mpath), None, "web"),
+            (GRAND, str(gpath), None, "tests")]
+        jd.save_goals(GRAND, {"rompUuid": GRAND, "seq": 2, "nodes": {
+            GRAND + ":g9": _node(GRAND + ":g9", "the original ask", None, promptUuid="hu"),
+            GRAND + ":t1": _node(GRAND + ":t1", "↪ delegated", GRAND + ":g9")},
+            "placements": {}, "status": {}})
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 1, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "mid-chain ask", None,
+                               origin={"peer": GRAND, "goalId": GRAND + ":t1", "msgId": "m0"})},
+            "placements": {}, "status": {}})
+        self.mpath.write_text(json.dumps(aline(T0 - 540, "Working the round.", "ha")) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(planted, [],
+                         "the ask still renders on the grand-sender's live card — link, never a twin")
+        m = jd.load_goals(MGR)
+        trackers = [nd for nd in m["nodes"].values()
+                    if isinstance(nd.get("handoff"), dict) and nd["handoff"].get("msgId") == MID]
+        self.assertEqual(len(trackers), 1, "the sender tracker still plants")
+        self.assertTrue(trackers[0]["handoff"].get("quiet"),
+                        "no recipient goal will carry this msgId — the reply-sweep owns the ending")
+
+    def test_a_genuinely_unlinked_delegate_still_files_quiet(self):
+        # THE FALLBACK DECISION'S OTHER HALF, pinned: with no link there is no chain to trace, so a
+        # linkless dispatch is never PROVABLY rooted — and at mint time uncertainty files quiet
+        # (the 2026-08-25 verdict; test_no_link_quiets is the trace-side pin). The mint keys on
+        # proof-without-a-live-card, never on linklessness alone.
+        self._mgr_store("hu", [uline(T0 - 600, "please verify the staged run references", "hu"),
+                               aline(T0 - 540, "Dispatching.", "ha", "hu")])
+        jd.courier_llm = lambda text, menu, declared=None: \
+            '{"verdict": "delegating", "goal": 0, "text": "verify staged run references"}'
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        self.assertEqual([nd for nd in w["nodes"].values()
+                          if isinstance(nd.get("origin"), dict)], [],
+                         "no recipient top on an unprovable chain")
+        m = jd.load_goals(MGR)
+        trackers = [nd for nd in m["nodes"].values()
+                    if isinstance(nd.get("handoff"), dict) and nd["handoff"].get("msgId") == MID]
+        self.assertEqual(len(trackers), 1, "the sender tracker still plants")
+        self.assertTrue(trackers[0]["handoff"].get("quiet"),
+                        "…quiet: the reply-sweep owns its ending")
+
     def test_an_untraceable_delegate_files_quiet(self):
         # the sender's linked goal roots at a COORDINATE mail record — team-internal, not the user
         self._mgr_store("cm", [uline(T0 - 600, "heads-up: refs regenerated\n"
@@ -279,6 +718,245 @@ class CourierMintMatrix(unittest.TestCase):
                          "the delegation still lives one glance away on the SENDER's board")
         self.assertTrue(trackers[0]["handoff"].get("quiet"),
                         "marked for report-back completion: no recipient goal will carry this msgId")
+
+
+MID_B = "1787099000.000002_1.TESTHOST"
+BODY_B = ("Verify the staged run references, second pass.\n"
+          "<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID_B)
+
+
+class FanOutDedupe(unittest.TestCase):
+    """The fallback mint was idempotent per msgId ONLY, so one ask fanned N times with archive-only
+    proof minted N origin-stamped tops on the same recipient, and every origin-hop level could
+    re-mint. The mint dedupes by ASK IDENTITY — the proof node's (sender sid, goal id), carried up
+    the trace as askRef and stamped on the minted top — and an intermediate userAsk-bearing top
+    that already shows stands the whole re-mint down (the trace's carded short-circuit). Each
+    RECIPIENT session still gets its one card: the dedupe is per (recipient store, ask identity),
+    never global."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        d = Path(self.td.name)
+        self.wpath = d / (WKR + ".jsonl")
+        self.mpath = d / (MGR + ".jsonl")
+        self.gpath = d / (GRAND + ".jsonl")
+        self._msgs = jd.MESSAGES
+        jd.MESSAGES = d / "messages.jsonl"
+        self._disc = jd.discover
+        roster = [(WKR, str(self.wpath), None, "api"), (MGR, str(self.mpath), None, "web"),
+                  (GRAND, str(self.gpath), None, "tests")]
+        jd.discover = lambda now, window=None, forks=True: roster
+        self._llm = jd.courier_llm
+        jd.courier_llm = lambda text, menu, declared=None: LINK_REPLY
+        self.gpath.write_text(json.dumps(aline(T0 - 1000, "quiet.", "gz")) + "\n")
+        jd._PARSE_CACHE.clear()
+
+    def tearDown(self):
+        jd.MESSAGES = self._msgs
+        jd.discover = self._disc
+        jd.courier_llm = self._llm
+        for sid in (MGR, WKR, GRAND):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+        self.td.cleanup()
+
+    def test_one_ask_fanned_twice_to_one_recipient_mints_once(self):
+        # the archive-only fallback shape, dispatched TWICE to the same worker: msgId idempotency
+        # alone minted two near-duplicate tops (the exact card T101 exists to prevent)
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 2, "nodes": {
+            MGR + ":g2": _node(MGR + ":g2", "Verification follow-up", MGR + ":g1")},
+            "placements": {}, "status": {}})
+        jd.save_goal_archive(MGR, {"rompUuid": MGR, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "Ship the staged-run verification", None,
+                               promptUuid="hu")},
+            "placements": {}, "status": {}})
+        self.mpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 - 600, "please verify the staged run references", "hu"),
+            aline(T0 - 540, "Dispatching.", "ha", "hu")]) + "\n")
+        self.wpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, BODY, "m1", ps="sdk"), aline(T0 + 60, "On it.", "a1", "m1"),
+            uline(T0 + 120, BODY_B, "m2", "a1", ps="sdk"),
+            aline(T0 + 180, "And the second pass.", "a2", "m2")]) + "\n")
+        jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in [
+            {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate", "body": BODY.split("\n")[0]},
+            {"t": T0 + 120, "ev": "sent", "id": MID_B, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate", "body": BODY_B.split("\n")[0]}]) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(len(planted), 1, "one ask, one recipient card — however many dispatches")
+        top = planted[0]
+        self.assertEqual(top.get("askRef"), {"peer": MGR, "goalId": MGR + ":g1"},
+                         "the mint carries the ask identity the dedupe keys on")
+        self.assertIn(MID_B, [l.get("msgId") for l in (top.get("links") or [])],
+                      "the second dispatch LINKS into the standing card, so its tracker still ends")
+        m = jd.load_goals(MGR)
+        trackers = [nd for nd in m["nodes"].values() if isinstance(nd.get("handoff"), dict)]
+        self.assertEqual(len(trackers), 2, "each dispatch keeps its sender-side tracker")
+        self.assertFalse(any(t["handoff"].get("quiet") for t in trackers),
+                         "both trackers have a completion event on the one recipient card")
+
+    def test_a_hop_re_mint_stands_down_when_the_intermediate_ask_top_shows(self):
+        # the hop shape: the root ask is archive-only on GRAND, but MGR's own courier-planted top
+        # (userAsk-bearing, live, visible) IS the ask's card — dispatching onward must file quiet
+        # under it, not re-mint an origin-stamped top on the worker at every hop level
+        jd.save_goals(MGR, {"rompUuid": MGR, "seq": 1, "nodes": {
+            MGR + ":gM": _node(MGR + ":gM", "mid-chain ask", None,
+                               origin={"peer": GRAND, "goalId": GRAND + ":t1", "msgId": "m0"},
+                               userAsk={"text": "the dictated round", "sid": GRAND})},
+            "placements": {}, "status": {}})
+        jd.save_goal_archive(GRAND, {"rompUuid": GRAND, "nodes": {
+            GRAND + ":g9": _node(GRAND + ":g9", "the original ask", None, promptUuid="hu"),
+            GRAND + ":t1": _node(GRAND + ":t1", "↪ delegated", GRAND + ":g9")},
+            "placements": {}, "status": {}})
+        self.gpath.write_text(json.dumps(uline(T0 - 900, "the dictated round", "hu")) + "\n")
+        self.mpath.write_text(json.dumps(aline(T0 - 540, "Fanning the round out.", "ha")) + "\n")
+        self.wpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, BODY, "m1", ps="sdk"), aline(T0 + 60, "On it.", "a1", "m1")]) + "\n")
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
+             "to_id": WKR, "kind": "delegate", "body": BODY.split("\n")[0]}) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd.run_courier(now=NOW)
+        w = jd.load_goals(WKR)
+        self.assertEqual([nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)],
+                         [], "the ask already shows on the intermediate's board — no re-mint")
+        self.assertIn("fyi", set(w["placements"].values()), "the recipient files quietly")
+        m = jd.load_goals(MGR)
+        trackers = [nd for nd in m["nodes"].values() if isinstance(nd.get("handoff"), dict)]
+        self.assertEqual(len(trackers), 1)
+        self.assertEqual(trackers[0].get("parentId"), MGR + ":gM",
+                         "the fan-out lives INSIDE the intermediate's ask card")
+        self.assertTrue(trackers[0]["handoff"].get("quiet"),
+                        "no recipient goal will carry this msgId — the reply-sweep owns the ending")
+
+
+class ConfirmingWindowDispatch(unittest.TestCase):
+    """A done-verdict-filed top whose settle is pending — the rollup's `confirming` export — still
+    renders visibly in Working (the steady doneConfirming cue), so a same-ask dispatch must LINK
+    into it, not mint beside it. Bare nodeComplete would call the confirming window dead. Only a
+    genuinely SETTLED completion stays uncarded — the sealed-open trade holds."""
+
+    def setUp(self):
+        self._saved = jd.parsed_session
+        jd.parsed_session = lambda sid, files, now: _fake_session([
+            {"uuid": "hu", "type": "user", "author": "human",
+             "message": {"role": "user", "content": "verify the staged run references"}}])
+
+    def tearDown(self):
+        jd.parsed_session = self._saved
+        for sid in (MGR, WKR):
+            for d in (jd.GOALDIR, jd.GOALARCHDIR):
+                try:
+                    (d / (sid + ".json")).unlink()
+                except OSError:
+                    pass
+
+    def _confirming_store(self):
+        st = {"rompUuid": MGR, "seq": 1, "nodes": {
+            MGR + ":g1": _node(MGR + ":g1", "Ship the staged-run verification", None,
+                               promptUuid="hu")},
+            "placements": {}, "status": {}, "lastNode": MGR + ":g1"}
+        jd.record_verdict(st, st["nodes"][MGR + ":g1"], "closer", "done", T0 + 100,
+                          why="both halves landed")
+        jd.rollup_status(st, False)                    # focus held → the settle is still pending
+        return st
+
+    def test_a_confirming_ask_reads_carded_so_the_dispatch_links(self):
+        st = self._confirming_store()
+        self.assertIn(MGR + ":g1", st.get("confirming") or (),
+                      "fixture: the rollup exports the done-confirming window")
+        self.assertEqual(st["status"].get(MGR + ":g1", "working"), "working",
+                         "fixture: the card still renders in Working")
+        jd.save_goals(MGR, st)
+        rec = jd._delegate_user_rooted(MGR, MGR + ":g1", {MGR: "/dev/null"}, NOW)
+        self.assertTrue(rec)
+        self.assertTrue(rec.get("carded"),
+                        "the confirming card is visible — link into it, never mint beside it")
+
+    def test_a_settled_completion_stays_uncarded(self):
+        st = self._confirming_store()
+        jd.rollup_status(st, True)                     # the session hands back the floor → settle
+        self.assertEqual(st["status"].get(MGR + ":g1"), "completed")
+        jd.save_goals(MGR, st)
+        rec = jd._delegate_user_rooted(MGR, MGR + ":g1", {MGR: "/dev/null"}, NOW)
+        self.assertTrue(rec, "the chain still proves the human root")
+        self.assertFalse(rec.get("carded"),
+                         "a settled completion renders in Completed, not Working — mint")
+
+    def test_a_second_dispatch_links_into_the_confirming_recipient_top(self):
+        # recipient side: the standing origin-stamped top is done-confirming — the ask dedupe
+        # must accept it as the standing card rather than minting a twin beside the cue
+        wtop = WKR + ":g1"
+        wstore = {"rompUuid": WKR, "seq": 1, "nodes": {
+            wtop: _node(wtop, "Verify the staged run references", None,
+                        origin={"peer": MGR, "goalId": MGR + ":t1", "msgId": MID},
+                        userAsk={"text": "verify the staged run references", "sid": MGR},
+                        askRef={"peer": MGR, "goalId": MGR + ":g1"})},
+            "placements": {}, "status": {}, "lastNode": wtop}
+        jd.record_verdict(wstore, wstore["nodes"][wtop], "closer", "done", T0 + 100, why="landed")
+        jd.rollup_status(wstore, False)
+        self.assertIn(wtop, wstore.get("confirming") or ())
+        rec = {"text": "verify the staged run references", "sid": MGR, "carded": False,
+               "askRef": {"peer": MGR, "goalId": MGR + ":g1"}}
+        before = set(wstore["nodes"])
+        nid = jd.apply_courier(wstore, "seg2", NOW, "verify the refs, second pass",
+                               {"peer": MGR, "goalId": MGR + ":t2", "msgId": MID_B},
+                               prompt_uuid="anchor2", frame="second pass", user_ask=rec)
+        self.assertEqual(nid, wtop, "the dispatch LINKS into the confirming card")
+        self.assertEqual(set(wstore["nodes"]), before, "…and mints nothing beside it")
+        self.assertIn(MID_B, [l.get("msgId") for l in (wstore["nodes"][wtop].get("links") or [])],
+                      "the new dispatch's tracker still gets its completion event")
+
+
+class AskRefRecycling(unittest.TestCase):
+    """Goal ids are sid:gN with a per-store seq that RESETS when the sender's store file is lost,
+    so a NEW ask can recycle an OLD ask's exact goal id — and a dedupe keyed on (sender sid, goal
+    id) alone links the new ask's dispatch into the OLD ask's standing card: no card for the new
+    ask, and the old card's completion would end the new dispatch's tracker. The standing top's
+    own userAsk text is the identity cross-check — the stamp and the dedupe share one shaping
+    (_ask_stamp_text) — so the same ask still links while a recycled id over DIFFERENT dictation
+    mints its own card."""
+
+    def _standing(self):
+        wtop = WKR + ":g1"
+        return wtop, {"rompUuid": WKR, "seq": 1, "nodes": {
+            wtop: _node(wtop, "Ship the demo build", None,
+                        origin={"peer": MGR, "goalId": MGR + ":t1", "msgId": "m1"},
+                        userAsk={"text": "ship the demo build", "sid": MGR},
+                        askRef={"peer": MGR, "goalId": MGR + ":g1"})},
+            "placements": {}, "status": {}}
+
+    def test_a_recycled_askref_over_different_dictation_mints_fresh(self):
+        wtop, wstore = self._standing()
+        rec = {"text": "audit the release checklist", "sid": MGR, "carded": False,
+               "askRef": {"peer": MGR, "goalId": MGR + ":g1"}}   # the RECYCLED identity
+        nid = jd.apply_courier(wstore, "seg2", NOW, "audit the release checklist",
+                               {"peer": MGR, "goalId": MGR + ":t9", "msgId": "m2"},
+                               prompt_uuid="anchor2", frame="audit the release checklist",
+                               user_ask=rec)
+        self.assertNotEqual(nid, wtop,
+                            "different dictation behind the same goal id is a NEW ask — mint")
+        self.assertEqual((wstore["nodes"][nid].get("userAsk") or {}).get("text"),
+                         "audit the release checklist", "…carrying its own dictation evidence")
+        self.assertEqual(wstore["nodes"][wtop].get("links") or [], [],
+                         "…and the old ask's card is untouched — its completion ends nothing new")
+
+    def test_the_same_dictation_still_links(self):
+        wtop, wstore = self._standing()
+        rec = {"text": "ship the demo build", "sid": MGR, "carded": False,
+               "askRef": {"peer": MGR, "goalId": MGR + ":g1"}}
+        nid = jd.apply_courier(wstore, "seg3", NOW, "ship the demo build",
+                               {"peer": MGR, "goalId": MGR + ":t2", "msgId": "m3"},
+                               prompt_uuid="anchor3", frame="ship it", user_ask=rec)
+        self.assertEqual(nid, wtop, "the ask's identity holds — one card")
+        self.assertIn("m3", [l.get("msgId")
+                             for l in (wstore["nodes"][wtop].get("links") or [])])
 
 
 class QuietReportBack(unittest.TestCase):

--- a/tests/test_dead_session_staleness.py
+++ b/tests/test_dead_session_staleness.py
@@ -172,6 +172,28 @@ class PlantDedupe(unittest.TestCase):
                                     "1788299060.000003_3.TESTHOST")
         self.assertNotEqual(a, c, "different work still plants its own mirror")
 
+    def test_twins_with_differing_recorded_bodies_stay_apart(self):
+        # The label is the judge's RENDERING, which can collapse two REAL dispatches into one
+        # string — so the reuse also checks the messages' recorded bodies (the authoritative
+        # postal rows). Differing bodies are two dispatches, each keeping its own tracker (the
+        # fan-out contract, test_chain_rooted_minting); the ext mailer's same-minute twins carry
+        # the SAME body and still fold.
+        msgs, mid2 = jd.MESSAGES, "1788299030.000002_2.TESTHOST"
+        with tempfile.TemporaryDirectory() as td:
+            jd.MESSAGES = Path(td) / "messages.jsonl"
+            jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in [
+                {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": DEAD,
+                 "to_id": RCP, "kind": "delegate", "body": "check the vault warning in the deploy log"},
+                {"t": T0 + 30, "ev": "sent", "id": mid2, "from": "web", "from_id": DEAD,
+                 "to_id": RCP, "kind": "delegate", "body": "check the vault warning in the backup job"}]) + "\n")
+            try:
+                st = {"rompUuid": DEAD, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+                a = jd._plant_handoff_track(st, None, "check the vault warning", RCP, "api", T0, MID)
+                b = jd._plant_handoff_track(st, None, "check the vault warning", RCP, "api", T0 + 30, mid2)
+                self.assertNotEqual(a, b, "one judged label over two recorded bodies is two dispatches")
+            finally:
+                jd.MESSAGES = msgs
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -831,3 +831,82 @@ class SupersedeKeysOnWriteTime(unittest.TestCase):
     def test_job_stamps_never_yield_to_mail(self):
         got = km._goal_awaiting_stamp_full(self._nodes(100, 120, kind="job"), "g1", answered_at=150)
         self.assertIsNotNone(got, "peer-scoped: a slurm wait keeps standing through unrelated mail")
+
+
+class ForkedSessionChipMatchesFeed(unittest.TestCase):
+    """The chip and the card read the SAME fact. build_feed resolves a session's transcript via
+    discover — the registry's lastSid file for a /cleared or resume-forked SDK session — while
+    _session_stamp_read resolved _sdk_transcript_path, the DEAD anchor file, so the chip's
+    ask-unit discriminator (_pure_delegation_top's anchor resolve) answered from a transcript the
+    feed no longer reads: the feed suppressed a machine-anchored coordination top while the chip
+    lit 'waiting on peers' for it. One fact, two answers. The stamp cache also keys on the
+    resolved path + parse warmth: a not-yet-latched node's verdict is the only
+    cache-temperature-dependent input left (a LATCHED askAnchor rides the goal store, whose mtime
+    is already in the key), and without the temperature key the chip served a cold-beat fail-open
+    long after the feed's fresh read had warmed."""
+
+    FSID = "aa110001-2222-4333-8444-000000000001"
+    FORK = "aa110001-2222-4333-8444-000000000002"
+    PEER = "aa110001-2222-4333-8444-000000000003"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km.jd.SDKDIR, km.NAMES, km._tmux_sessions,
+                       km._states_awaiting_overlay, km._name_of, km._parse_cached)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        km.jd.SDKDIR = td / "sdk"
+        km.jd.SDKDIR.mkdir()
+        km.NAMES = td / "names"
+        km.NAMES.mkdir()
+        cwd = str(td / "proj")
+        (km.NAMES / self.FSID).write_text("web\t%s\n" % cwd)
+        (km.jd.SDKDIR / (self.FSID + ".json")).write_text(json.dumps({"lastSid": self.FORK}))
+        self.fork_path = str(km.jd._proj_dir(cwd) / (self.FORK + ".jsonl"))
+        km.jd._lastsid_memo.clear()
+        km._SESSION_STAMP_CACHE.clear()
+        km._states_awaiting_overlay = lambda sid: None
+        km._name_of = lambda s: "probe" if s == self.PEER else None
+        km._tmux_sessions = lambda: {self.FSID: {"state": "", "since": None,
+                                                 "subagents": [], "bgTasks": []}}
+        # the WARM parse lives at the lastSid file — the anchor file is dead (no parse, ever)
+        self._machine = {"turns": [{"atoms": [
+            {"uuid": "a9", "type": "assistant",
+             "message": {"role": "assistant",
+                         "content": [{"type": "text", "text": "wrapping up the sweep"}]}}]}]}
+        km._parse_cached = lambda p: self._machine if str(p) == self.fork_path else None
+
+    def tearDown(self):
+        (km.jd.STATE, km.jd.GOALDIR, km.jd.SDKDIR, km.NAMES, km._tmux_sessions,
+         km._states_awaiting_overlay, km._name_of, km._parse_cached) = self._saved
+        km._SESSION_STAMP_CACHE.clear()
+        km.jd._lastsid_memo.clear()
+        self.td.cleanup()
+
+    def _seed(self):
+        top = _node("g1")
+        top["promptUuid"] = "a9"                       # machine-anchored coordination top, unlatched
+        h = _node("h1", parent="g1")
+        h["handoff"] = {"peer": self.PEER, "msgId": "1787000000.00001_00001.TESTHOST"}
+        nodes = {"g1": top, "h1": h}
+        (km.jd.GOALDIR / (self.FSID + ".json")).write_text(json.dumps({
+            "rompUuid": self.FSID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
+        return nodes
+
+    def test_the_chip_reads_the_forked_transcript_like_the_feed(self):
+        nodes = self._seed()
+        self.assertTrue(km._pure_delegation_top(nodes, "g1", sid=self.FSID, path=self.fork_path),
+                        "feed side: the warm lastSid parse proves a machine anchor — suppressed")
+        self.assertEqual(km._session_stamp_read(self.FSID)[2], (),
+                         "chip side answers identically: no peers lit for a suppressed card")
+
+    def test_the_stamp_cache_re_reads_when_the_parse_warms(self):
+        self._seed()
+        km._parse_cached = lambda p: None              # cold beat: both surfaces fail open (shown)
+        self.assertEqual(km._session_stamp_read(self.FSID)[2], (self.PEER,),
+                         "cold: unlatched fail-open, the same answer the feed's cold read gives")
+        km._parse_cached = lambda p: self._machine if str(p) == self.fork_path else None
+        self.assertEqual(km._session_stamp_read(self.FSID)[2], (),
+                         "the warm parse is new information — the cached chip must not outlive it")

--- a/tests/test_kernel_runspans.py
+++ b/tests/test_kernel_runspans.py
@@ -140,6 +140,206 @@ class PureDelegationTop(unittest.TestCase):
     def test_plain_top_is_not_pure(self):
         self.assertFalse(km._pure_delegation_top({"t": {"id": "t", "parentId": None}}, "t"))
 
+    def test_a_dictated_ask_top_hosting_only_trackers_still_shows(self):
+        # T101 (the user 2026-08-26): the ask is the card unit — one ask fanned to two workers is
+        # ONE card with two handoff children, and the courier plants the trackers UNDER the ask
+        # instead of minting recipient tops. A top that IS the dictated ask (its promptUuid root)
+        # is therefore never "pure coordination", even when every leaf is a tracker: suppressing
+        # it left the fully-delegated ask with no card anywhere.
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "hu"},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}},
+                 "b": {"id": "b", "parentId": "t", "handoff": {"peer": "q", "msgId": "2"}}}
+        self.assertFalse(km._pure_delegation_top(nodes, "t"))
+
+    def test_a_mint_proven_user_ask_top_shows_too(self):
+        # the courier-minted shape: T105's userAsk (the chain-proven root record) marks the
+        # ask-unit even when the mint carried no prompt anchor
+        nodes = {"t": {"id": "t", "parentId": None, "userAsk": {"text": "the ask", "sid": "s"}},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}}}
+        self.assertFalse(km._pure_delegation_top(nodes, "t"))
+
+    def test_a_prompt_stamped_tracker_top_stays_pure(self):
+        # the exemption never reaches a top that is ITSELF a handoff tracker — a '↪ delegated'
+        # record wearing a stray prompt anchor is still coordination, not the ask
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "hu",
+                       "handoff": {"peer": "p", "msgId": "m"}}}
+        self.assertTrue(km._pure_delegation_top(nodes, "t"))
+
+    def test_a_courier_planted_top_without_userask_stays_pure(self):
+        # promptUuid is the g200 LANDABLE-ANCHOR field — apply_courier stamps the delegate MAIL's
+        # anchor on every planted top — so bare-promptUuid truthiness would read every
+        # courier-planted mid-chain top as "the dictated ask" and re-show the exact coordination
+        # card the 2026-06-23 rule suppresses. A courier top's dictated-ask evidence is T105's
+        # chain-proven userAsk, never its own anchor: without one it stays pure coordination.
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "mail-anchor-uuid",
+                       "origin": {"peer": "p0", "goalId": "g0", "msgId": "m0"}},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}},
+                 "b": {"id": "b", "parentId": "t", "handoff": {"peer": "q", "msgId": "2"}}}
+        self.assertTrue(km._pure_delegation_top(nodes, "t"),
+                        "a mail anchor is not the dictated ask — the courier top stays suppressed")
+
+    def test_a_courier_top_with_the_chain_proven_userask_still_shows(self):
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "mail-anchor-uuid",
+                       "origin": {"peer": "p0", "goalId": "g0", "msgId": "m0"},
+                       "userAsk": {"text": "the ask", "sid": "s"}},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}}}
+        self.assertFalse(km._pure_delegation_top(nodes, "t"),
+                         "T105's userAsk IS the courier top's dictated-ask evidence")
+
+    def test_a_segment_anchored_top_resolving_machine_stays_pure(self):
+        # _seg_anchor gives an AUTONOMOUS segment's mint the segment HEAD — an assistant atom's
+        # uuid ("a minted node always gets an anchor"). When the caller can resolve the anchor
+        # against the session's cached parse and it is provably NOT a human-dictated prompt
+        # record, the exemption must not fire.
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "a9"},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}}}
+        saved = km._parse_cached
+        km._parse_cached = lambda p: {"turns": [{"atoms": [
+            {"uuid": "a9", "type": "assistant",
+             "message": {"role": "assistant",
+                         "content": [{"type": "text", "text": "wrapping up the sweep"}]}}]}]}
+        try:
+            self.assertTrue(km._pure_delegation_top(nodes, "t", sid=SID, path="/dev/null"),
+                            "a segment-head anchor resolving to the agent's own atom is not the ask")
+        finally:
+            km._parse_cached = saved
+
+    def test_a_mail_record_anchor_resolving_peer_stays_pure(self):
+        # the same resolution refuses a peer-mail anchor (mail rides user-type atoms)
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "pm"},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}}}
+        saved = km._parse_cached
+        km._parse_cached = lambda p: {"turns": [{"atoms": [
+            {"uuid": "pm", "type": "user", "author": {"peer": "p0", "kind": "delegate"},
+             "message": {"role": "user", "content": "DELEGATE: the fanned piece"}}]}]}
+        try:
+            self.assertTrue(km._pure_delegation_top(nodes, "t", sid=SID, path="/dev/null"))
+        finally:
+            km._parse_cached = saved
+
+    def test_a_dictated_prompt_resolution_keeps_the_card(self):
+        # the positive control: the anchor resolves to a HUMAN record → the ask keeps its card
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "hu"},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}}}
+        saved = km._parse_cached
+        km._parse_cached = lambda p: {"turns": [{"atoms": [
+            {"uuid": "hu", "type": "user", "author": "human",
+             "message": {"role": "user", "content": "please ship the drag-range round"}}]}]}
+        try:
+            self.assertFalse(km._pure_delegation_top(nodes, "t", sid=SID, path="/dev/null"))
+        finally:
+            km._parse_cached = saved
+
+    def test_an_unresolvable_anchor_fails_open_to_the_card(self):
+        # UNKNOWN is not FALSE: with no cached parse (cold kernel, no path threaded, a rewound-away
+        # record) the anchor is unresolvable — suppressing on doubt would hide a real dictated ask,
+        # the exact no-card-anywhere hole T101's exemption exists to close. Uncertainty shows.
+        nodes = {"t": {"id": "t", "parentId": None, "promptUuid": "hu"},
+                 "a": {"id": "a", "parentId": "t", "handoff": {"peer": "p", "msgId": "1"}}}
+        saved = km._parse_cached
+        km._parse_cached = lambda p: None
+        try:
+            self.assertFalse(km._pure_delegation_top(nodes, "t", sid=SID, path="/dev/null"))
+        finally:
+            km._parse_cached = saved
+
+
+class AskAnchorLatch(unittest.TestCase):
+    """The ask-unit exemption's anchor verdict LATCHES on the node. _dictated_prompt_uuid answers
+    None both for durable doubt AND for 'the parse is not warm this beat', and the exemption fails
+    open on None — so a machine-anchored coordination card would flap shown→hidden on every
+    restart/cache-cold beat with NO new information (the cards-move-on-new-information rule). Once
+    a WARM parse answers, the judge stamps the verdict durably (askAnchor: human/machine/absent)
+    through the planner apply path — the store's normal judge-side writer, never build_feed, which
+    stays read-only — and the kernel reads the latch before ever consulting cache temperature.
+    Cache-cold with NO latch keeps the fail-open, so the flap happens at most once per node ever,
+    not per beat."""
+
+    MACHINE = {"turns": [{"atoms": [
+        {"uuid": "a9", "type": "assistant",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "wrapping up the sweep"}]}},
+        {"uuid": "hu", "type": "user", "author": "human",
+         "message": {"role": "user", "content": "please ship the drag-range round"}}]}]}
+
+    def _fanned(self, **top_kw):
+        top = {"id": "t", "parentId": None, "promptUuid": "a9"}
+        top.update(top_kw)
+        return {"t": top, "a": {"id": "a", "parentId": "t",
+                                "handoff": {"peer": "p", "msgId": "1"}}}
+
+    def test_the_latch_stamps_all_three_verdicts_and_only_where_the_exemption_reads(self):
+        store = {"rompUuid": SID, "nodes": {
+            "th": {"id": "th", "parentId": None, "promptUuid": "hu"},
+            "tm": {"id": "tm", "parentId": None, "promptUuid": "a9"},
+            "tg": {"id": "tg", "parentId": None, "promptUuid": "gone-uuid"},
+            "tc": {"id": "tc", "parentId": None, "promptUuid": "a9",       # courier top: origin —
+                   "origin": {"peer": "p0", "goalId": "g0", "msgId": "m0"}},  # the exemption reads
+            "tk": {"id": "tk", "parentId": None, "promptUuid": "a9",       # userAsk there, no anchor
+                   "handoff": {"peer": "p", "msgId": "2"}},                # tracker top: never asks
+            "kid": {"id": "kid", "parentId": "th", "promptUuid": "a9"},    # not a top
+            "tl": {"id": "tl", "parentId": None, "promptUuid": "a9",
+                   "askAnchor": "human"}},                                 # already latched: kept
+            "placements": {}, "status": {}}
+        n = jd._latch_ask_anchors(SID, self.MACHINE, store)
+        self.assertEqual(n, 3, "exactly the exemption-relevant unlatched tops latch")
+        self.assertEqual(store["nodes"]["th"].get("askAnchor"), "human")
+        self.assertEqual(store["nodes"]["tm"].get("askAnchor"), "machine")
+        self.assertEqual(store["nodes"]["tg"].get("askAnchor"), "absent")
+        for nid in ("tc", "tk", "kid"):
+            self.assertNotIn("askAnchor", store["nodes"][nid], nid)
+        self.assertEqual(store["nodes"]["tl"].get("askAnchor"), "human",
+                         "a latched verdict is never re-derived")
+
+    def test_an_atomless_parse_latches_nothing(self):
+        # a missing/unreadable transcript is NO EVIDENCE of absence — 'absent' latched off one
+        # would freeze a fail-open verdict a later warm parse could have resolved machine
+        store = {"rompUuid": SID, "nodes": {
+            "t": {"id": "t", "parentId": None, "promptUuid": "hu"}},
+            "placements": {}, "status": {}}
+        self.assertEqual(jd._latch_ask_anchors(SID, {"turns": []}, store), 0)
+        self.assertNotIn("askAnchor", store["nodes"]["t"])
+
+    def test_a_latched_machine_verdict_is_stable_across_cache_temperature(self):
+        # warm → cold → warm: the judge latched from its warm parse; the kernel's cold beat must
+        # answer from the latch, not re-derive from the (cold) cache and fail open into a flap
+        store = {"rompUuid": SID, "nodes": self._fanned(), "placements": {}, "status": {}}
+        jd._latch_ask_anchors(SID, self.MACHINE, store)
+        self.assertEqual(store["nodes"]["t"]["askAnchor"], "machine")
+        saved = km._parse_cached
+        try:
+            for temp in (None,                                            # restart / cache-cold beat
+                         lambda: self.MACHINE):                           # …and warm again
+                km._parse_cached = (lambda p: None) if temp is None else (lambda p: temp())
+                self.assertTrue(
+                    km._pure_delegation_top(store["nodes"], "t", sid=SID, path="/dev/null"),
+                    "the latched machine anchor holds — no shown→hidden flap on temperature")
+        finally:
+            km._parse_cached = saved
+
+    def test_latched_human_and_absent_keep_the_card_cold_or_warm(self):
+        saved = km._parse_cached
+        try:
+            km._parse_cached = lambda p: None
+            for verdict in ("human", "absent"):
+                nodes = self._fanned(askAnchor=verdict)
+                self.assertFalse(km._pure_delegation_top(nodes, "t", sid=SID, path="/dev/null"),
+                                 verdict)
+            # the latch outranks a later contradicting cache read: it was filed from a warm parse,
+            # and re-deriving per build is exactly the flapping input the latch retires
+            km._parse_cached = lambda p: self.MACHINE
+            nodes = self._fanned(askAnchor="human")
+            self.assertFalse(km._pure_delegation_top(nodes, "t", sid=SID, path="/dev/null"))
+        finally:
+            km._parse_cached = saved
+
+    def test_the_planner_pass_is_the_latch_writer(self):
+        # the write rides an existing legitimate judge-side writer (_plan_session's end-of-pass
+        # save) — never a build_feed-side write; build_feed stays read-only
+        from inspect import getsource
+        self.assertIn("_latch_ask_anchors", getsource(jd._plan_session))
+        self.assertNotIn("_latch_ask_anchors", getsource(km.build_feed))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three defects inherited from the T101/T105 ask-unit change, each reproduced red-first with synthetic stores (sids like `11111111-2222-…`, host `TESTHOST`, the notes-api world). One commit per defect; each stands alone.

## 1. A dictated ask fully fanned to workers renders nowhere

**What breaks.** T101 plants the courier's tracking nodes under the ask and mints no recipient top. An ask whose every leaf is a handoff is therefore the shape `_pure_delegation_top` suppresses in every column, so the design's "one ask, two handoff children, one card" produced zero cards.

**Reproduction.** `tests/test_ask_unit_cards.py::CourierWorld::test_the_fanned_ask_keeps_one_visible_card_through_completion`: a dictated ask `g1` with two linked delegate mails; after `run_courier`, `_pure_delegation_top(nodes, g1)` was True, so no card in Working and none in Completed.

**Fix** (`kernel/kernel.py`, `kernel/judge.py`). The suppression exempts a top that is the ask, on dictation evidence only:

- the chain-proven `userAsk` record (the only evidence a courier-planted `origin` top can carry; its promptUuid is the mail anchor by construction), or
- a promptUuid that resolves to a human-dictated record in the session's own transcript, through `_human_prompt_record`. That helper is factored out of `_session_user_prompt_record` with no behavior change, so the kernel and the trace share one definition of "dictated".

Bare promptUuid truthiness is not enough on purpose: it is the landable-anchor field stamped on nearly every minted top (`_seg_anchor`, `apply_courier`), and keying on it re-shows every coordination top. A tracker top never qualifies.

The kernel reads only the cached parse (build_feed's cold-start contract), so an unresolvable anchor fails open to the card, and the planner pass latches the verdict on the node as `askAnchor` (human, machine, or absent) from a warm parse (`_latch_ask_anchors`, called at the end of `_plan_session`). A machine-anchored coordination card cannot flap with cache temperature; an unlatched node fails open at most once per node. `_session_stamp_read` resolves the same lastSid transcript the feed reads and keys its cache on the parse's warmth, so the session chip and the card give one answer for a forked session.

## 2. The fallback recipient mint is unreachable through the local walk

**What breaks.** `mint_recipient = (rooted or wired) and not link_id`. `_delegate_user_rooted` returns None without a link, so `rooted` implies `link_id` and the `rooted` leg can never fire; only the T126 relay-walked record on a link-less cross-host dispatch reaches the mint. The T105 `userAsk` stamp on a locally-proved dispatch never ran (its test passed through a stubbed trace). Making the mint live follows the T101 design as written: its own fallback ("a rooted dispatch with no resolvable ask node still mints the recipient top; the recipient card is the ask's card") and T105's `userAsk` investment both treat it as reachable.

**Reproduction.** `tests/test_chain_rooted_minting.py::CourierMintMatrix::test_a_rooted_dispatch_whose_ask_card_is_gone_mints_the_fallback_top`: the courier links the sender's live follow-up node while the human proof lives only in the archive. Expected one origin-stamped recipient top with `userAsk`; got none. Reverting the condition reddens this test and the dangling and cleared-live variants while `test_no_link_quiets` stays green.

**Fix** (`kernel/judge.py`). The mint keys on the trace's answer instead of the link. The record carries `carded`, whether the proving ask node still renders on a visible card (`_node_carded`: live, not cleared, not complete outside the done-confirming window, not sealed under a done or cleared ancestor, reachable from a live top), and `askRef`, the proof node's (sender sid, goal id). Visible proof links; uncarded proof (archived, cleared, sealed, or dangling) mints, identically on both sides of the compaction boundary. The relay leg is unchanged: `not rooted and wired and not link_id`. A stub-True trace falls back to the link; a link-less dispatch still files quiet.

`apply_courier` dedupes by `askRef` per recipient store, cross-checking the dictation text so a recycled goal id after a store reset mints fresh. Later dispatches of the same ask are recorded as `links[]` backrefs so `run_propagate` still ends their trackers. An image-only ask stamps the `(user message)` placeholder so a fanned image ask cannot render nowhere. `_merge_nodes` carries origin, links, and askRef so a merged courier top's trackers still complete.

One deliberate contract change in `_delegate_user_rooted`: T126 treated every stored-proof or prompt record as decisive; now only a carded record is decisive mid-climb. Every uncarded record rides a shared fallback slot threaded through the recursion and returns when the whole climb exhausts, with prompt records outranking stored copies. Without this, an inner origin-hop frame's uncarded record preempted a visible card the outer climb would still reach and minted a twin beside it, and fan children carried different askRef keys. `test_root_ask_anchor`, `test_walk_root_endpoint`, `test_postal_walked_ask`, and `test_serving_mirror` pass unmodified. Documented residual: an all-stored-proof climb whose hops traverse proof nodes with divergent askRef stamps can still hand two fan children different keys.

`_plant_handoff_track`'s same-label twin reuse (8e8d143d) now also compares the messages' recorded postal bodies. The label is the judge's rendering and can collapse two real dispatches of one ask into one string, which folded the second dispatch's tracker into the first (`tests/test_dead_session_staleness.py::PlantDedupe::test_twins_with_differing_recorded_bodies_stay_apart`).

Not claimed: cross-host dedupe. The wire copy of `userAsk` stays whitelisted to text, sid, and host, so `carded` and `askRef` never leave the kernel, and a relay-walked record dedupes only when the local walk resolves.

## 3. The dissolution sweep eats a container the user just restored

**What breaks.** UndoClear pulls a pre-T101 container back into the live store (archives keep their containers); the next `rollup_status` dissolves it, promoting its children in place of the card the user asked back for.

**Reproduction.** `tests/test_ask_unit_cards.py::UmbrellaDissolution::test_an_undo_restored_container_survives_the_dissolution`.

**Fix** (`kernel/judge.py`). A container whose latest clear-family diary row is the user's undo-restore (`reopen` with `undo=True`) is spared until the user clears it again. A flag-cleared container is spared too: it is already off the board and the compactor archives it whole. Legacy and peer-adopted copies dissolve as before.

## Tests

- `tests/test_kernel_runspans.py`: PureDelegationTop +9, AskAnchorLatch (5)
- `tests/test_kernel_awaiting_stamp.py`: ForkedSessionChipMatchesFeed (2)
- `tests/test_chain_rooted_minting.py`: TraceRule +18, CourierMintMatrix +5, FanOutDedupe (2), ConfirmingWindowDispatch (3), AskRefRecycling (2)
- `tests/test_ask_unit_cards.py`: CourierWorld +1, UmbrellaDissolution +2, ImageOnlyAsk (3), MergeCarriesDelegationIdentity (4)
- `tests/test_dead_session_staleness.py`: PlantDedupe +1

Red-first per commit: 15 of the commit-1 tests, 26 of the commit-2 tests, and both commit-3 tests fail on the pre-fix code; the rest are pins that hold either way. Every pre-existing test in the touched files passes unmodified. Under `pytest -n 8` the full suite shows the same parallel-run flakes the base does (`test_kernel_trust` PairsSnapshot, `test_model_fallback_card` FallbackCard); all pass serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)