### PR TITLE
PairsSnapshot starts from an empty remotes map: a peer test file's leftover row fails all three tests under pytest-xdist

### DIFF
--- a/tests/test_kernel_remotes_perms.py
+++ b/tests/test_kernel_remotes_perms.py
@@ -33,6 +33,11 @@ def _mode(p):
 
 class RemotesFilePermissions(unittest.TestCase):
     def setUp(self):
+        # the kernel module is ONE object per process for every test file that loads it under this
+        # name (a peer file's km IS this km), so the row planted here leaves with the test: under
+        # xdist a whole-map reader elsewhere (test_kernel_trust's PairsSnapshot) found it (2026-09-02)
+        saved = dict(km._remotes)
+        self.addCleanup(lambda: (km._remotes.clear(), km._remotes.update(saved)))
         km._remotes.clear()
         km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801,
                                    "bus_port": 8802, "token": "REMOTE-SECRET-TOKEN", "proc": None,

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -354,10 +354,19 @@ class PairsSnapshot(unittest.TestCase):
     origin as directed); None + a named per-host error = that machine was unreadable this pass —
     surfaced, never silently dropped (fail loudly)."""
 
+    def setUp(self):
+        # these tests assert the WHOLE hosts map, and the kernel module is ONE object per process for
+        # every test file that loads it under this name — so start from an empty map and put back
+        # exactly what was there (under xdist another file's leftover row landed in the snapshot,
+        # 2026-09-02); popping only this class's own hosts left any other file's row in place
+        with km._remotes_lock:
+            self._saved = dict(km._remotes)
+            km._remotes.clear()
+
     def tearDown(self):
         with km._remotes_lock:
-            for h in ("boxa", "boxb"):
-                km._remotes.pop(h, None)
+            km._remotes.clear()
+            km._remotes.update(self._saved)
 
     def test_pairs_read_both_directions_from_each_machines_own_table(self):
         # boxa holds boxb via an attached-tunnel row; boxb holds boxa via a relay (viaReach) row —

--- a/tests/test_tunnel_demand_redial.py
+++ b/tests/test_tunnel_demand_redial.py
@@ -43,8 +43,18 @@ class _FakeProc:
         self.terminated += 1
 
 
+def _keep_remotes(case):
+    """Restore the kernel's `_remotes` map after `case`: the module is ONE object per process for every
+    test file that loads it under this name, so a TESTHOST row planted here otherwise outlives the
+    test — under xdist a whole-map reader in another file (test_kernel_trust's PairsSnapshot) found
+    it (2026-09-02)."""
+    saved = dict(km._remotes)
+    case.addCleanup(lambda: (km._remotes.clear(), km._remotes.update(saved)))
+
+
 class DemandRedial(unittest.TestCase):
     def setUp(self):
+        _keep_remotes(self)
         km._remotes.clear()
         km._tunnel_wake.clear()
 
@@ -102,6 +112,7 @@ class DemandDoors(unittest.TestCase):
         cls.srv.shutdown()
 
     def setUp(self):
+        _keep_remotes(self)
         km._remotes.clear()
         km._tunnel_wake.clear()
         km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 1,


### PR DESCRIPTION
Test-only; three files under `tests/`, no behavior change. Follow-through on the `PairsSnapshot` xdist failures that #881's Tests section noted as out of scope.

## What breaks

`tests/test_kernel_trust.py::PairsSnapshot` asserts the whole `hosts` map and the full `pairs` list returned by `km.pairs_snapshot()`, and its `tearDown` pops only the `boxa`/`boxb` rows it added. `pairs_snapshot()` (`kernel/kernel.py`) copies every row of `_remotes` and pairs every host, so a single foreign row adds a `hosts` key (`{"ok": False, "error": "not connected"}` for a row whose status is not `"up"`; the dial error for one that is) and two extra pairs. All three tests fail.

Two such planters are `RemotesFilePermissions.setUp` (`tests/test_kernel_remotes_perms.py`) and `DemandDoors.setUp` / `DemandRedial._row` (`tests/test_tunnel_demand_redial.py`): each writes a `TESTHOST` row into `km._remotes` and leaves it there.

## Why a row in one file reaches a test in another

Every kernel test file loads `bin/romp-kernel` with `SourceFileLoader("romp_kernel", ...).load_module()`. Once `romp_kernel` is in `sys.modules`, `load_module()` re-executes the source into that same module object (`importlib._bootstrap._load_module_shim`), so every file's `km` is one object per process and `km._remotes` is one dict. This is the mechanism #881 describes for `romp_judge`.

## Why CI is green today

CI runs `python -m pytest -q`, serially, and the order happens to work out. `test_kernel_remotes_perms.py` sorts before `test_kernel_trust.py`. Inside the trust file, `SetTrust` and `TrustRoute` clear the map on the way in; the alphabetically last `TrustRoute` method (`test_route_unattached_host_sets_origin_trust`) clears without replanting; and the classes after it either never touch the map (`QuarantineCards`) or pop exactly the row they add (`MirrorTrust`, `RemoteTrust`). So `PairsSnapshot` starts on an empty map. `test_tunnel_demand_redial.py` sorts after the trust file. Under `pytest -n N` a file's items are spread across workers, and `PairsSnapshot` can land on one that ran a planter and never ran those clears. Observed locally on a downstream tree at 70a36077: one `-n 8` run failed exactly the three `PairsSnapshot` tests, the next run passed.

## Reproduction

Deterministic, serial, no xdist needed. pytest runs command-line arguments in the order given, so the planter runs and the trust file's clears do not:

```
python -m pytest -q tests/test_kernel_remotes_perms.py "tests/test_kernel_trust.py::PairsSnapshot"
```

Unfixed: 3 failed, 6 passed. All three `PairsSnapshot` tests fail; `hosts` carries a `TESTHOST` entry with a connection-refused error, since that row is planted `"up"`. Fixed: 9 passed.

```
python -m pytest -q tests/test_tunnel_demand_redial.py::DemandDoors "tests/test_kernel_trust.py::PairsSnapshot"
```

Unfixed: 3 failed, 3 passed (`TESTHOST` with `"not connected"`). Fixed: 6 passed.

The shape it was found in, scheduling-dependent:

```
python -m pytest -q -n 2 tests/test_kernel_remotes_perms.py tests/test_kernel_trust.py tests/test_tunnel_demand_redial.py
```

Unfixed: 5 runs out of 5 failed (3, 3, 2, 2, 2 of the `PairsSnapshot` tests). Fixed: 3 runs out of 3 passed (42 passed each). A single try may not reproduce it; the serial recipe above always does. The trust file alone passes unfixed (28 passed), which is why nothing has flagged this before.

## The fix

1. `PairsSnapshot.setUp` snapshots `km._remotes` under `_remotes_lock` and clears it; `tearDown` clears and restores the snapshot. This alone makes the class independent of whatever any other file leaves behind.
2. The two planters restore the pre-test map through `addCleanup`: `RemotesFilePermissions.setUp` directly, and a module-level `_keep_remotes(case)` helper called first in `DemandRedial.setUp` and `DemandDoors.setUp`.

No production code changes.

## Tests

- The two serial recipes above: red on base, green with the fix.
- `-n 2` over the three files: 5/5 red on base, 3/3 green with the fix.
- `python -m pytest -q tests/test_kernel_trust.py tests/test_kernel_remotes_perms.py tests/test_tunnel_demand_redial.py`: 42 passed.
- Full suite serial (CI's shape), `python -m pytest -q`: 6528 passed, 44 skipped locally; 6534 passed, 38 skipped on each of CI's four Python cells. Same 6572 items; the skips are environment-dependent.
- Full suite `python -m pytest -q -n 8`, three runs: `PairsSnapshot` in no failure list. One run was fully green (6532 passed, 40 skipped). The other two each had xdist-only failures in files this PR does not touch: `tests/test_model_fallback_card.py::FallbackCard::test_mints_a_completed_top_naming_the_swap` (the test #881 fixes) and two `tests/test_judge.py::AwaitingVerdict` tests (the other leak #881's description mentions).
- `bats tests/*.bats`: 364 passed. `node --test tests/manager-*.test.js`: 40 passed. `vscode-extension` typecheck, test (2674 passed) and build: green. None of these read the changed files; listed for completeness.

## Not in this PR

Other files that load the kernel as `romp_kernel` also write `_remotes` rows, and this PR leaves them alone; `PairsSnapshot`'s own clear protects it from all of them. Most of those files restore the map afterwards or remove the rows they added. Two leave rows behind: `KnownHostMemory` (`tests/test_kernel_known_hosts.py`) clears the map in `setUp` and has no `tearDown`, so the `A` row one of its tests plants stays; `UpdateRemote` (`tests/test_kernel_remote_update.py`) rebinds `km._remotes` to a one-row dict and never restores it. A suite-wide autouse fixture in `tests/conftest.py` that snapshots and restores `_remotes` per test would remove the whole class of problem; happy to send that as a follow-up if wanted. The `tests/test_judge.py` xdist-only failures are a different leak and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
