### PR TITLE
Working-note expiry keeps the note of a session blocked on the user

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4461,9 +4461,12 @@ def _log_nudge_event(sid, gid, t, count, verdict="fired", ev_t=None, parked_s=No
         pass
 
 
-def _working_top_goal(sid):
-    """A TOP-level goal of `sid` whose rolled-up status is 'working' (not blocked/completed/cleared), or
-    None — the 'orphaned' goal Auto Nudge follows up on."""
+def _open_top_goal(sid):
+    """A TOP-level goal of `sid` that is still OPEN — rolled-up status 'working' OR 'blocked' (parked on the
+    user) — or None. The working-note expiry keys on this: a session waiting on the user has not finished,
+    and the worktree, branch and files it published still belong to it (parked sessions were observed with
+    their notes lifted while they still held exactly those). Was _working_top_goal ('working' only), whose
+    sole caller was that expiry."""
     try:
         store = jd.load_goals(sid)
     except Exception:
@@ -4475,7 +4478,7 @@ def _working_top_goal(sid):
             continue
         if nd.get("cleared") or nid in cleared:
             continue
-        if status.get(nid, "working") == "working":
+        if status.get(nid, "working") in ("working", "blocked"):
             return nid
     return None
 
@@ -6841,14 +6844,16 @@ def _set_working_note(sid, text):
 
 def _clear_done_working_notes(now, tmux):
     """Event-based expiry of the set_working ownership note (the user 2026-06-24): once a session is IDLE
-    with NO working top goal left — its work is done (only done / blocked-on-you / cleared remains) — its
-    @romp-working claim is moot, so clear it. Peers reading list_agents then stop coordinating against a
-    finished session instead of waking it to ask "do you still own this?". Keyed on the completion EVENT
-    (idle + no working top goal), NOT a time heuristic. A session still WORKING — or idle with a goal still
-    WORKING (orphaned/stalled, the auto-nudge case) — keeps its note; it still owns that in-flight work.
-    (A session parked blocked-on-YOU also has its note lifted: it isn't actively editing, and it re-publishes
-    on resume — consistent with Part 1 flagging idle notes stale.) Runs every pusher tick, independent of the
-    auto-nudge toggle; a no-op (one tmux read) unless some session has published a note."""
+    with NO open top goal left — its work is done (only done / cleared remains) — its @romp-working claim
+    is moot, so clear it. Peers reading list_agents then stop coordinating against a finished session
+    instead of waking it to ask "do you still own this?". Keyed on the completion EVENT (idle + no open top
+    goal), NOT a time heuristic. A session still WORKING — or idle with a goal still WORKING (orphaned/
+    stalled, the auto-nudge case) — keeps its note; it still owns that in-flight work. So does a session
+    parked BLOCKED on the user: it has not finished, and the worktree, branch and files its note names are
+    still its own — the first cut lifted those notes too, and parked sessions were then observed with their
+    claims gone from list_agents while they still held them, which is the interference the contract "a peer
+    with no note holds nothing" exists to prevent. Runs every pusher tick, independent of the auto-nudge
+    toggle; a no-op (one tmux read) unless some session has published a note."""
     notes = _working_notes()
     if not notes:
         return
@@ -6864,9 +6869,9 @@ def _clear_done_working_notes(now, tmux):
             continue
         if not turns or _session_working(turns):         # still working per the event model → keep its claim
             continue
-        if _working_top_goal(sid):                        # an OPEN working top goal remains → still its work
+        if _open_top_goal(sid):                           # working OR blocked top remains → still its work
             continue
-        _set_working_note(sid, "")                        # idle + nothing working → lift the stale claim
+        _set_working_note(sid, "")                        # idle + nothing open → lift the stale claim
 
 
 def _chat_tab_sessions(now, tmux):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2469,40 +2469,59 @@ class ViewBuilder(unittest.TestCase):
             km._tmux_send, jd.optimistic_followup = saved_send, saved_fu
         return sent, restore
 
-    def test_working_top_goal_picks_only_a_working_top(self):
-        g1, g2, g3, sub = SID + ":g1", SID + ":g2", SID + ":g3", SID + ":s1"
+    def test_open_top_goal_picks_a_working_top(self):
+        g1, g2, sub = SID + ":g1", SID + ":g2", SID + ":s1"
+        def n(nid, parent, done, blocked, cleared):
+            return {"id": nid, "text": nid, "parentId": parent, "nodeComplete": done,
+                    "blocked": blocked, "cleared": cleared, "trail": [], "t": T0}
+        self._goal_store({g1: n(g1, None, True, False, False), g2: n(g2, None, False, False, False),
+                          sub: n(sub, g2, False, False, False)},
+                         {g1: "completed", g2: "working"})
+        self.assertEqual(km._open_top_goal(SID), g2, "a working TOP goal qualifies, not done tops or subs")
+
+    def test_open_top_goal_counts_a_blocked_top_as_open(self):
+        # the working-note expiry's predicate: a top goal parked on the user is OPEN (the session has not
+        # finished), while done and cleared tops are not
+        g1, g2, sub = SID + ":g1", SID + ":g2", SID + ":s1"
         def n(nid, parent, done, blocked, cleared):
             return {"id": nid, "text": nid, "parentId": parent, "nodeComplete": done,
                     "blocked": blocked, "cleared": cleared, "trail": [], "t": T0}
         self._goal_store({g1: n(g1, None, True, False, False), g2: n(g2, None, False, True, False),
-                          g3: n(g3, None, False, False, False), sub: n(sub, g3, False, False, False)},
-                         {g1: "completed", g2: "blocked", g3: "working"})
-        self.assertEqual(km._working_top_goal(SID), g3, "only a working TOP goal (not done/blocked/sub) qualifies")
+                          sub: n(sub, g2, False, False, False)},
+                         {g1: "completed", g2: "blocked", sub: "working"})
+        self.assertEqual(km._open_top_goal(SID), g2, "a blocked top is still open work (done/sub skipped)")
+        self._goal_store({g1: n(g1, None, True, False, False), g2: n(g2, None, False, False, True)},
+                         {g1: "completed", g2: "working"})
+        self.assertIsNone(km._open_top_goal(SID), "done + cleared → nothing open")
 
-    def test_working_top_goal_none_when_cleared(self):
+    def test_open_top_goal_none_when_cleared(self):
         g = SID + ":g1"
         self._goal_store({g: {"id": g, "text": "x", "parentId": None, "nodeComplete": False,
                               "blocked": False, "cleared": True, "trail": [], "t": T0}}, {g: "working"})
-        self.assertIsNone(km._working_top_goal(SID), "a cleared goal is not nudge-worthy")
+        self.assertIsNone(km._open_top_goal(SID), "a cleared goal is not open work")
 
     # ── working-note auto-expire (the user 2026-06-24): lift a stale set_working claim once a session goes
-    #    idle with no working top goal, so peers stop coordinating against a finished session ──
+    #    idle with no open top goal, so peers stop coordinating against a finished session ──
+    STORE = object()                                     # _stub_expire top_goal: keep the real predicate
+
     def _stub_expire(self, notes, working, top_goal):
         # stub the deps of _clear_done_working_notes; returns (cleared_calls, restore_fn). cleared_calls
-        # records every _set_working_note(sid, text) the pass makes.
+        # records every _set_working_note(sid, text) the pass makes. top_goal=self.STORE leaves
+        # _open_top_goal unstubbed, reading the goal store the test wrote with _goal_store.
         cleared = []
         saved = (km._working_notes, km._alive_sessions, km._set_working_note,
-                 km._session_working, km._working_top_goal, jd.parsed_session)
+                 km._session_working, km._open_top_goal, jd.parsed_session)
         km._working_notes = lambda: dict(notes)
         km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": str(self.tpath)}]
         km._set_working_note = lambda sid, text: cleared.append((sid, text))
         km._session_working = lambda turns: working
-        km._working_top_goal = lambda sid: top_goal
+        if top_goal is not self.STORE:
+            km._open_top_goal = lambda sid: top_goal
         jd.parsed_session = lambda sid, paths, now: {"turns": [{"atoms": [], "ended": True}]}
 
         def restore():
             (km._working_notes, km._alive_sessions, km._set_working_note,
-             km._session_working, km._working_top_goal, jd.parsed_session) = saved
+             km._session_working, km._open_top_goal, jd.parsed_session) = saved
         return cleared, restore
 
     def test_working_note_cleared_when_idle_and_done(self):
@@ -2526,6 +2545,30 @@ class ViewBuilder(unittest.TestCase):
         try:
             km._clear_done_working_notes(NOW, {SID: {"state": "idle"}})
             self.assertEqual(cleared, [], "idle but a working top goal remains (orphaned/stalled) → still its work")
+        finally:
+            restore()
+
+    def test_working_note_kept_while_a_top_goal_is_blocked_on_the_user(self):
+        # a BLOCKED (parked-on-you) top goal is open work: the session has not finished and the worktree its
+        # note names is still its own. Runs the real _open_top_goal over the store, so this fails if a blocked
+        # top ever stops counting as open (the previous, working-only predicate lifted this note).
+        g1, g2 = SID + ":g1", SID + ":g2"
+        def n(nid, done, blocked):
+            return {"id": nid, "text": nid, "parentId": None, "nodeComplete": done, "blocked": blocked,
+                    "cleared": False, "trail": [], "t": T0}
+        self._goal_store({g1: n(g1, True, False), g2: n(g2, False, True)}, {g1: "completed", g2: "blocked"})
+        cleared, restore = self._stub_expire({SID: "feed.ts"}, working=False, top_goal=self.STORE)
+        try:
+            km._clear_done_working_notes(NOW, {SID: {"state": "idle"}})
+            self.assertEqual(cleared, [], "parked on the user is not done → the claim stands")
+        finally:
+            restore()
+        # …and the same session, once the answer lands and that goal completes, does have its note lifted
+        self._goal_store({g1: n(g1, True, False), g2: n(g2, True, False)}, {g1: "completed", g2: "completed"})
+        cleared, restore = self._stub_expire({SID: "feed.ts"}, working=False, top_goal=self.STORE)
+        try:
+            km._clear_done_working_notes(NOW, {SID: {"state": "idle"}})
+            self.assertEqual(cleared, [(SID, "")], "all top goals done → the claim is lifted")
         finally:
             restore()
 


### PR DESCRIPTION
## What breaks

`_clear_done_working_notes` (`kernel/kernel.py`) lifts a session's `set_working` note once the session is idle with no *working* top goal. The predicate it used, `_working_top_goal`, treats a top goal whose rolled-up status is `blocked` — the session asked the user something and is parked on the answer — as not working, so a session blocked on the user had its note cleared.

Such a session has not finished: the worktree, branch and files its note names are still its own. The postal contract tells peers that "a peer with no note holds nothing" (server instructions in `postal/postal_service.py`; `claude/skills/romp-postal/SKILL.md`), so clearing the note told every peer the surface was free while it was still held. Parked sessions were observed with their claims gone from `list_agents` while they still held the worktree the note named.

## Reproduction (synthetic)

On a `notes-api` repo, session `web` publishes the note "own ui/feed.ts, branch web", asks the user which layout to keep, and goes idle blocked on that answer. On the next pusher tick `_working_top_goal(sid)` is `None` (its only top goal rolls up as `blocked`), so the expiry calls `_set_working_note(sid, "")`. Session `api` runs `list_agents`, sees no note on `web`, and starts editing `ui/feed.ts` on the same branch.

In test form: `tests/test_kernel.py::ViewBuilder::test_working_note_kept_while_a_top_goal_is_blocked_on_the_user` — an idle session with a published note and a blocked top goal. Against the previous expiry it fails with `[(SID, '')] != []`: the note was lifted.

## The fix

- `_working_top_goal(sid)` is renamed and widened in place to `_open_top_goal(sid)`: a top goal counts as open when its rolled-up status is `working` **or** `blocked`. The rolled-up statuses (`kernel/judge.py`) are exactly `cleared` / `blocked` / `completed` / `working`, so that pair is the whole open set. The expiry was the helper's only remaining caller — Auto Nudge dropped its own call in c48dd598 (2026-06-28), after 094245cb (2026-06-24) added the expiry call — so there is no second helper and no dead code; the docstring records the former name.
- `_clear_done_working_notes` keys on `_open_top_goal`. A note is now lifted only when every top goal is completed or cleared.

This reverses the deliberate choice in 094245cb (Part 2 of the over-coordination fix) to lift blocked-on-you notes too, on the reasoning that a parked session "re-publishes on resume". It does not re-publish until it is resumed, and in the meantime peers read the missing note as a free surface — the interference the contract exists to prevent. Part 1 (b9a53760) already renders an idle session's note as "(idle now — claim may be stale)" in `list_agents`, so a parked session keeping its note does not send peers back to waking it: they see a live, idle, flagged claim and steer clear. The docstring records the reversal and the reason.

Trade-off to weigh: a session parked on the user now keeps its note for as long as it stays parked (until the goal is resolved or cleared, or the session dies and leaves `_alive_sessions`). The cost is a longer-lived, flagged claim, not a wake-up.

No documentation change: the `set_working` tool description ("auto-clears once your work is done and the session idles") and SKILL.md already describe the expiry as work-done, which the code now matches.

## Tests

`tests/test_kernel.py`:
- `test_open_top_goal_picks_a_working_top` and `test_open_top_goal_none_when_cleared` — the former `_working_top_goal` pins, renamed with the helper (the first fixture drops its blocked top, which now also qualifies).
- `test_open_top_goal_counts_a_blocked_top_as_open` — a completed top plus a blocked top with a working sub-goal returns the blocked top; with the second top cleared instead, `None`.
- `test_working_note_kept_while_a_top_goal_is_blocked_on_the_user` — drives the real `_open_top_goal` over a goal store: an idle session with a published note and a blocked top goal keeps its note; completing that goal then lifts it, so the test cannot pass vacuously.
- `_stub_expire` gains a sentinel that leaves the predicate unstubbed; the five existing working-note tests are unchanged and pass.

Red-first: narrowing the predicate back to `== "working"` (helper present under the new name) fails exactly the two new tests — the predicate test, and the expiry test behaviorally with `[(SID, '')] != []` — and passes the other seven. Full suite: `pytest -q -n 8 tests/` 6534 passed, 40 skipped (base commit: 6528 passed, 44 skipped; net +2 tests); bats 364/364; `node --test tests/manager-*.test.js` 40/40; vscode-extension `npm test` 2674/2674 and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)