### PR TITLE
Reminted forward ports are fresh by construction, never by luck

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11384,6 +11384,40 @@ def _free_port():
         s.close()
 
 
+def _fresh_ports(n, avoid, host, attempts=32):
+    """`n` DISTINCT free ports, none of them in `avoid` — the enforced version of "the next dial is not
+    the same doomed argv" (T230a). A bare _free_port() per slot only made that LIKELY: Linux bind(0)
+    draws from ~14k ephemeral ports, so the collided number came back verbatim about 1 draw in 14,000
+    (CI run 33696143887: the reminted rk_port equalled the one that failed to bind) and the supervisor
+    re-dialed the identical argv with its backoff thrown away. `attempts` is a DRAW COUNT, never a
+    clock: an OS allocator spreads bind(0) across ~14k ephemeral ports (a released port recurred once
+    in ~60k draws when measured), so 32 draws exhaust only when the allocator keeps returning avoided
+    or duplicate ports — a degenerate one, or a stubbed one — and never because time passed. Do not
+    add a sleep here. Exhausting it (or an OSError from the allocator) logs ports-remint-failed for
+    `host` and raises RuntimeError; the caller leaves its old ports in place."""
+    avoid = set(avoid)
+    drew, out = [], []
+    for _ in range(attempts):
+        try:
+            p = _free_port()
+        except OSError as e:
+            # EMFILE / EADDRNOTAVAIL: the allocator itself failed. Same contract as exhaustion —
+            # a dial-log record and ONE exception class for the caller's failure arm (review find:
+            # a bare OSError escaped that arm, aborted the rest of the supervisor pass, and left
+            # no trace of the failed remint)
+            _tunnel_log(host, "ports-remint-failed", avoid=sorted(avoid), drew=drew, error=str(e))
+            raise RuntimeError("could not draw fresh ports for %s: %s" % (host, e)) from e
+        drew.append(p)
+        if p in avoid or p in out:
+            continue
+        out.append(p)
+        if len(out) == n:
+            return out
+    _tunnel_log(host, "ports-remint-failed", avoid=sorted(avoid), drew=drew, attempts=attempts)
+    raise RuntimeError("could not draw %d fresh ports for %s in %d attempts (avoiding %s)"
+                       % (n, host, attempts, sorted(avoid)))
+
+
 def _port_open(port):
     import socket
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -12210,12 +12244,28 @@ def _remint_forward_ports(r):
     """Give this row fresh local/reverse forward ports after a bind failure, so the next dial is not the
     same doomed argv (the user 2026-07-29). The ports were minted ONCE by _free_port and then persisted,
     so a collision — a corpse of ours, another kernel, or an unrelated process that grabbed the number out
-    of the ephemeral range — wedged every future dial identically and forever. Caller holds _remotes_lock."""
+    of the ephemeral range — wedged every future dial identically and forever. Caller holds _remotes_lock.
+
+    ENFORCED, not probable (T230a): no new port equals ANY old one — the whole old set, not just the
+    same slot (rk/rb are -R listeners bound on the hub, so the collided number is as likely as any other
+    to come back in a different slot), plus every other attached row's persisted ports. The old set
+    deliberately keeps STALE rk/rb on a row whose sharing was turned off (checkin_set never pops them):
+    a harmless over-constraint — do not trim it. The new ports are mutually distinct (two -L forwards on
+    one port are a doomed argv too; per remint about 1 in 2,400 — 6/14,116 — that two of four bare draws
+    coincide). The draw bound is a loop count, reachable only with a degenerate allocator. All ports are
+    drawn BEFORE the row is touched: a RuntimeError from _fresh_ports leaves the old ports in place."""
     old = {k: r.get(k) for k in ("local_port", "bus_port", "rk_port", "rb_port") if r.get(k)}
-    r["local_port"] = _free_port()
-    r["bus_port"] = _free_port()
+    # every OTHER attached row's persisted ports join the avoid set: a peer waiting out its backoff
+    # has its -L port UNBOUND, so a bare draw could hand it to this row and doom the peer's next dial
+    # (review find; the caller holds _remotes_lock, so the walk is consistent)
+    taken = set(old.values())
+    for other in _remotes.values():
+        if other is not r:
+            taken |= {other.get(k) for k in ("local_port", "bus_port", "rk_port", "rb_port") if other.get(k)}
+    fresh = _fresh_ports(4 if r.get("checkin") else 2, taken, r["host"])
+    r["local_port"], r["bus_port"] = fresh[0], fresh[1]
     if r.get("checkin"):
-        r["rk_port"], r["rb_port"] = _free_port(), _free_port()
+        r["rk_port"], r["rb_port"] = fresh[2], fresh[3]
         r.pop("_handshook", None)        # the hub must be re-told the new ports
     r["_peer_notified"] = None           # bus_port moved: the local bus is holding a stale endpoint
     new = {k: r.get(k) for k in ("local_port", "bus_port", "rk_port", "rb_port") if r.get(k)}
@@ -14386,11 +14436,24 @@ def _tunnel_supervisor():
                                         fails=r.get("fails", 0))
                             probe_ssh = err      # the ssh probe runs below, OUTSIDE this lock
                             if _forward_bind_failed(err):
-                                r["detail"] = ("a forwarded port was already taken, so the tunnel could "
-                                               "not open — romp is retrying on fresh ports")
-                                _remint_forward_ports(r)
-                                r["fails"], r["next_try"] = 0, 0   # a NEW argv deserves a fresh ladder
                                 probe_ssh = None                   # cause already known; don't ask twice
+                                try:
+                                    _remint_forward_ports(r)
+                                except RuntimeError:
+                                    # the ports could not be moved (a degenerate allocator, or the
+                                    # allocator erred — see _fresh_ports): say so, mark the row, and
+                                    # keep the backoff ladder — the next dial IS the same argv, so it
+                                    # must not be hammered; CONTAINED here so one row's failure never
+                                    # aborts the pass tail for every other row (T230a review)
+                                    r["status"] = "error"
+                                    r["detail"] = ("a forwarded port was already taken and "
+                                                   "fresh ports could not be found — the same ports retry "
+                                                   "under backoff; see tunnel-dials.jsonl")
+                                else:
+                                    # the detail claims fresh ports only once the row HOLDS them
+                                    r["detail"] = ("a forwarded port was already taken, so the tunnel could "
+                                                   "not open — romp is retrying on fresh ports")
+                                    r["fails"], r["next_try"] = 0, 0   # a NEW argv deserves a fresh ladder
                         # BACK OFF re-spawns (exponential — see _tunnel_backoff) so an unreachable host
                         # isn't hammered every tick: repeated ssh attempts can trip the remote sshd's
                         # rate-limit (the user 2026-06-30). It never stops dialing (the user 2026-07-29);

--- a/tests/test_tunnel_stale_and_logging.py
+++ b/tests/test_tunnel_stale_and_logging.py
@@ -143,6 +143,93 @@ class ForwardBindFailure(unittest.TestCase):
         self.assertNotIn("_handshook", r, "the hub must be told the new ports")
 
 
+    # ── T230a: the remint must ENFORCE "not the same doomed argv", never just make it likely ──
+    # Linux bind(0) draws from ~14k ephemeral ports, so a bare _free_port() per slot hands the collided
+    # number straight back about 1/14,000 draws (CI run 33696143887: `52025 == 52025`), and the live
+    # supervisor then re-dials the identical argv with its backoff ladder thrown away. Both pins are
+    # deterministic — a stubbed allocator, no OS draw — and restore the stub via addCleanup: this
+    # module object (romp_kernel_stale) is shared with two sibling test files.
+
+    def _stub_ports(self, seq):
+        it = iter(seq)
+        saved = km._free_port
+        km._free_port = lambda: next(it)
+        self.addCleanup(setattr, km, "_free_port", saved)
+
+    def test_reminting_never_hands_back_any_old_port_and_keeps_the_new_ones_distinct(self):
+        # the allocator returns the four OLD ports first, scrambled across slots, then fresh ones:
+        # every slot must land on a fresh port — avoiding the whole old set, not just its own slot
+        self._stub_ports([52025, 51001, 51000, 52026, 61001, 61002, 61003, 61004, 61005, 61006])
+        r = {"host": "TESTHOST", "local_port": 51000, "bus_port": 51001, "checkin": True,
+             "rk_port": 52025, "rb_port": 52026, "_handshook": 999, "_peer_notified": (True, "trusted")}
+        km._remint_forward_ports(r)
+        new = [r["local_port"], r["bus_port"], r["rk_port"], r["rb_port"]]
+        self.assertFalse(set(new) & {51000, 51001, 52025, 52026}, "an old port came back: %r" % new)
+        self.assertEqual(len(set(new)), 4, "two forwards on one port are a doomed argv too: %r" % new)
+        self.assertNotIn("_handshook", r)
+        self.assertIsNone(r["_peer_notified"])
+
+    def test_an_allocator_that_cannot_move_the_ports_fails_loudly_and_leaves_the_row_intact(self):
+        # a degenerate allocator (the same port forever) exhausts the DRAW bound: RuntimeError, the
+        # old ports untouched (atomic), and a ports-remint-failed record appended to the dial log
+        self._stub_ports([52025] * 200)
+        before = len(km.TUNNEL_LOG.read_text().splitlines()) if km.TUNNEL_LOG.exists() else 0
+        r = {"host": "TESTHOST", "local_port": 51000, "bus_port": 51001, "checkin": True,
+             "rk_port": 52025, "rb_port": 52026, "_handshook": 999}
+        with self.assertRaises(RuntimeError):
+            km._remint_forward_ports(r)
+        self.assertEqual((r["local_port"], r["bus_port"], r["rk_port"], r["rb_port"]),
+                         (51000, 51001, 52025, 52026), "a failed remint changes nothing")
+        self.assertEqual(r.get("_handshook"), 999, "no re-handshake was armed for ports that never moved")
+        appended = [json.loads(x) for x in km.TUNNEL_LOG.read_text().splitlines()[before:] if x.strip()]
+        self.assertTrue(any(x.get("event") == "ports-remint-failed" and x.get("host") == "TESTHOST"
+                            for x in appended), appended)
+
+
+    def test_an_allocator_error_is_a_failed_remint_too_logged_and_in_one_exception_class(self):
+        # EMFILE/EADDRNOTAVAIL from bind(0) used to escape the supervisor's failure arm (RuntimeError
+        # only), abort the rest of the pass and leave no dial-log trace of the failed remint
+        def boom():
+            raise OSError(24, "Too many open files")
+        saved = km._free_port
+        km._free_port = boom
+        self.addCleanup(setattr, km, "_free_port", saved)
+        before = len(km.TUNNEL_LOG.read_text().splitlines()) if km.TUNNEL_LOG.exists() else 0
+        r = {"host": "TESTHOST", "local_port": 51000, "bus_port": 51001}
+        with self.assertRaises(RuntimeError):
+            km._remint_forward_ports(r)
+        self.assertEqual((r["local_port"], r["bus_port"]), (51000, 51001))
+        appended = [json.loads(x) for x in km.TUNNEL_LOG.read_text().splitlines()[before:] if x.strip()]
+        self.assertTrue(any(x.get("event") == "ports-remint-failed" and "open files" in str(x.get("error"))
+                            for x in appended), appended)
+
+    def test_reminting_avoids_every_other_attached_rows_ports(self):
+        # a peer waiting out its backoff has its -L port unbound — a bare draw could hand it over
+        self._stub_ports([61001, 61002, 61003, 61004, 61005])
+        peer = {"host": "PEERHOST", "local_port": 61001, "bus_port": 61003}
+        km._remotes["PEERHOST"] = peer
+        self.addCleanup(km._remotes.pop, "PEERHOST", None)
+        r = {"host": "TESTHOST", "local_port": 51000, "bus_port": 51001}
+        km._remint_forward_ports(r)
+        self.assertEqual((r["local_port"], r["bus_port"]), (61002, 61004))
+
+    def test_the_supervisor_claims_fresh_ports_only_after_it_holds_them(self):
+        # the row's detail said "retrying on fresh ports" BEFORE the remint ran, so on the loud path
+        # it claimed fresh ports while re-dialing old ones (T230a review); a failed remint must also
+        # keep the backoff ladder — the next dial IS the same argv
+        import inspect
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertLess(src.index("_remint_forward_ports(r)"), src.index("retrying on fresh ports"))
+        self.assertIn("except RuntimeError", src, "the loud path is CONTAINED — one row never aborts the pass")
+        self.assertIn("fresh ports could not be found", src)
+        self.assertIn('r["status"] = "error"', src, "the row is marked, not left claiming a retry on fresh ports")
+        detail = src.index("retrying on fresh ports")
+        reset = src.index('r["fails"], r["next_try"] = 0, 0', detail)   # the reset that FOLLOWS the detail
+        self.assertLess(reset - detail, 400, "the ladder reset sits in the success arm, right after the detail")
+        self.assertNotIn('r["fails"], r["next_try"] = 0, 0',
+                         src[src.index("except RuntimeError"):detail], "the failure arm keeps the ladder")
+
+
 class DialLog(unittest.TestCase):
     def test_every_dial_and_death_is_appended_with_its_reason(self):
         km._tunnel_log("TESTHOST", "dial", pid=4242, fails=0, argv=["ssh", "-N", "--", "TESTHOST"])


### PR DESCRIPTION
## What (T230a)

`_remint_forward_ports` filled each slot with a bare `_free_port()` and never compared the draws against the old map, so its contract — *the next dial is not the same doomed argv* — was probabilistic. Linux `bind(0)` draws from ~14k ephemeral ports, so the collided number came back verbatim about one draw in 14,000 (CI run 33696143887: `AssertionError: 52025 == 52025`). Live, the supervisor then reset `fails`/`next_try` and re-dialed the identical doomed argv at once with its backoff ladder thrown away.

**Fix**: `_fresh_ports(n, avoid, host, attempts=32)` draws `n` *distinct* ports outside the avoid set — the row's *whole* old set (rk/rb are `-R` listeners bound on the hub, so the collided number is as likely to return in another slot; stale rk/rb on a row whose sharing was turned off stay in it as a harmless over-constraint, stated so nobody trims it) **plus every other attached row's persisted ports** (a peer waiting out its backoff has its `-L` port unbound). Mutually distinct because two `-L` forwards on one port are a doomed argv too (about 1 in 2,400 per remint that two of four bare draws coincide). The bound is a loop count, never a clock — reachable only with a degenerate allocator — and exhausting it, or an `OSError` from the allocator, logs `ports-remint-failed` and raises one exception class. The remint draws everything *before* touching the row, so a raise leaves the old ports in place.

**Containment**: the supervisor's death branch catches that raise — the row is marked status `error` (a status the panel already renders as warn) with a plain detail naming `tunnel-dials.jsonl`, its backoff ladder is kept (the next dial *is* the same argv), and the pass continues to the other rows; an escape would have skipped the whole pass tail (trust pushes, PR/predicate watches, conserve sweep, periodic save). The row claims "retrying on fresh ports" only once it holds them.

**Pins, red-first and deterministic** (stubbed allocator, no OS draw), in `ForwardBindFailure`: the four old ports handed back scrambled across slots are all refused and the new four are distinct (red on main: `[52025, 51001, 51000, 52026]` came straight back); a degenerate allocator raises `RuntimeError`, leaves the row intact and appends a `ports-remint-failed` record (red on main: no raise); an allocator `OSError` is converted and logged the same way; another row's persisted ports are avoided; the supervisor's containment (`except RuntimeError`, `status = "error"`) and ordering pinned by source. The existing two tests and their fixture ports are untouched; the sibling source pins survive. The stub restores via `addCleanup` — the module object is shared across three test files.

**Review** (2 lenses, 8 findings, 4 real, all folded): the `OSError` bypass, the row-scoped avoid set, the allocator claim in the docstring corrected to measured behavior, the failure detail de-duplicated. Manager's second pass: containment with status `error`, the over-constraint note, the per-remint probability.

**Follow-up, out of scope here**: the initial mint paths (`attach_remote`, boot) share the same collision class with no distinctness check.

No ui/ pin references either function (confirmed). Suites green on the shipped head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)