### PR TITLE
The workflow-progress parser says so, once, when the CLI's list is a shape it cannot read

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1863,9 +1863,10 @@ class SdkSession:
         self._sub_lock = threading.Lock()            #   hooks mutate on the loop thread; snapshot() reads from the kernel thread
         #                                                (guards _subagents AND _bg_tasks)
         self._wf_agents: dict[str, set] = {}         # LIVE Workflow runs: task_id -> the agent ids its progress
-        #   lists have named (the roster). The CLI fires SubagentStart for every workflow agent but SubagentStop
-        #   ONLY for the ones that finish cleanly (probe-verified on CLI 2.1.257, 2026-09-02: a failed agent
-        #   leaves no stop hook), so a run's own per-agent list is what retires the rest — _reconcile_workflow_agents.
+        #   lists have named (the roster). The CLI fires SubagentStart for every workflow agent but NOT
+        #   SubagentStop for every one of them (probe-verified on CLI 2.1.257, 2026-09-02: a workflow agent whose
+        #   model did not exist got a start hook and no stop hook), so a run's own per-agent list is what retires
+        #   the rest — _reconcile_workflow_agents.
         self._wf_slots: dict[str, dict] = {}         # task_id -> {slot index: the agent id it last held}: a retried
         #   slot is re-minted with a NEW id, and the displaced id is over the moment the slot changes hands
         self.chosen_model = reg.get("model") or ""   # the alias the user picked (opus/sonnet/…); self.model is the display name
@@ -3944,11 +3945,11 @@ class SdkSession:
         return {}
 
     async def _subagent_stop_hook(self, inp, tool_use_id, context):
-        """A subagent FINISHED CLEANLY — drop it from the live set (SubagentStop carries the same agent_id).
-        The CLI fires this only for clean finishes; a failed agent's end arrives through its run's progress
-        list or its own task end instead (see _reconcile_workflow_agents / _on_task_event). When the last
-        one clears, the session falls back to its real state (working if the main turn is still in flight,
-        else idle)."""
+        """A subagent FINISHED — drop it from the live set (SubagentStop carries the same agent_id). Not every
+        agent gets one: probe-verified on 2.1.257, a workflow agent that failed (its model did not exist) got
+        no stop hook, so a failed agent's end arrives through its run's progress list or its own task end
+        instead (see _reconcile_workflow_agents / _on_task_event). When the last one clears, the session
+        falls back to its real state (working if the main turn is still in flight, else idle)."""
         aid = inp.get("agent_id") if isinstance(inp, dict) else None
         if aid:
             with self._sub_lock:
@@ -3999,6 +4000,60 @@ class SdkSession:
     #   rollbacks) is named truthfully — the loop cannot tell them apart here, so the notice names the family
 
     _WF_AGENT_ENDED = frozenset(("done", "error"))
+    _WF_AGENT_STATES = frozenset(("start", "progress", "done", "error"))   # the vocabulary the probe recorded
+    _WF_ENTRY_TYPES = frozenset(("workflow_agent", "workflow_phase", "workflow_log"))   # the entry types it recorded
+    _wf_shape_warned = False   # once per process, like _retry_shape_warned
+
+    @classmethod
+    def _wf_shape_problem(cls, progress) -> str | None:
+        """Why this `workflow_progress` list cannot be read by this build, or None when it can — or when there
+        is nothing to read yet. Only the fields the parser keys on: an entry typed `workflow_agent`, its
+        `index`, its `state` from the known vocabulary, and an `agentId` on every slot that has STARTED. Two
+        recorded shapes that are NOT renames: a list of only phase/log entries (a run announces its phases
+        before any agent is queued), and an error slot with no `agentId` or `startedAt` at all (an agent
+        blocked, or thrown before its id was minted) — a queued slot has none yet either. Only an entry of
+        a type this build has never seen counts as a rename when no agent entry is present."""
+        if not isinstance(progress, list) or not progress:
+            return None
+        rows = [e for e in progress if isinstance(e, dict)]
+        if not rows:
+            return "no entry is an object"
+        agents = [e for e in rows if e.get("type") == "workflow_agent"]
+        if not agents:
+            unknown = sorted({str(e.get("type")) for e in rows} - cls._WF_ENTRY_TYPES)
+            if not unknown:
+                return None                       # phases/logs only — nothing to read yet, not a rename
+            return "no entry is typed 'workflow_agent' (unknown types seen: %r)" % unknown[:6]
+        if not any("state" in e for e in agents):
+            return "no 'workflow_agent' entry carries a 'state'"
+        if not any("index" in e for e in agents):
+            return "no 'workflow_agent' entry carries an 'index'"
+        started = [e for e in agents if e.get("startedAt") is not None or e.get("state") in ("progress", "done")]
+        if started and not any(e.get("agentId") for e in started):
+            return "no started 'workflow_agent' entry carries an 'agentId'"
+        odd = sorted({str(e.get("state")) for e in agents if "state" in e and e.get("state") not in cls._WF_AGENT_STATES})
+        if odd:
+            return "unknown state word%s %r (this build ends an agent on %r)" % (
+                "" if len(odd) == 1 else "s", odd, sorted(cls._WF_AGENT_ENDED))
+        return None
+
+    def _warn_wf_shape(self, progress):
+        """Fail LOUDLY, once per process, when a run's per-agent list has a shape this build cannot read —
+        otherwise a renamed field silently brings back the ever-growing live count this parser exists to
+        prevent (CLAUDE.md: a visible error beats data that looks fine and misleads). Covers renames INSIDE
+        the list; the `workflow_progress` key itself is not checked (a payload without the list is a
+        throttled tick, indistinguishable from a renamed key)."""
+        if SdkSession._wf_shape_warned:
+            return
+        why = self._wf_shape_problem(progress)
+        if not why:
+            return
+        SdkSession._wf_shape_warned = True
+        keys = sorted({k for e in progress if isinstance(e, dict) for k in e})[:20]
+        sys.stderr.write(
+            "romp: workflow_progress payload has a shape this build cannot read — %s; keys seen=%r. Failed "
+            "workflow agents will stay in the live subagent count until the session reconnects (a run's end "
+            "can only retire agents this build managed to read), until these are mapped.\n" % (why, keys))
 
     def _reconcile_workflow_agents(self, tid: str, progress, terminal: bool):
         """Retire the live workflow-subagent entries the Workflow run `tid` has finished with, from the run's
@@ -4007,12 +4062,19 @@ class SdkSession:
         done/error and never capped (only the run's log lines are trimmed), the full list re-sent on every
         state change. Called on the run's task-stream events, never a timer.
 
-        Why not the stop hook alone: the CLI fires SubagentStart for every workflow agent but SubagentStop
-        only for the ones that finish CLEANLY (probe-verified on 2.1.257, 2026-09-02: a run with one agent
-        on a nonexistent model got one stop hook; the failed agent's slot read state "error" and nothing
-        else). Left to the hooks the live set only grows — three sessions carried 192, 37 and 10 stale
-        entries, each EXACTLY the number of agents its runs recorded as failed, and read Working with
-        "37 subagents" for hours (the user 2026-09-02).
+        Why not the stop hook alone: the CLI fires SubagentStart for every workflow agent but not SubagentStop
+        for every one of them. What was observed (probe-verified on 2.1.257, 2026-09-02): a run with one
+        agent on a nonexistent model got one stop hook; the failed agent's slot read state "error" and
+        nothing else. (The bundle does attempt the stop hook on an interrupted query, so the gap seen is
+        failures, not interrupts; what other endings skip it is not known.) Left to the hooks the live set
+        only grows — three sessions carried 192, 37 and 10 stale entries, each EXACTLY the number of agents
+        its runs recorded as failed, and read Working with "37 subagents" for hours (the user 2026-09-02).
+
+        The parser keys on the field names the probe recorded (`workflow_agent`, `agentId`, `index`,
+        `state`, and the four state words). A CLI rename inside the list would bring the growth back
+        SILENTLY, so a list whose entries carry none of them is reported once per process — the api_retry
+        shape warning's pattern (_retry_shape_warned): a visible line naming what arrived beats a count
+        that quietly drifts. The key itself is not checked; see _warn_wf_shape.
 
         Three exact ends: a slot's done/error state; a slot re-minted with a NEW agent id (a retried
         attempt — the displaced id is over the moment the slot changes hands); and the run's END, which
@@ -4021,6 +4083,7 @@ class SdkSession:
         absence of something else rather than from an event about the agent, and every retirement here
         keys on an exact event (an earlier draft had that inference; review 2026-09-02). Such an agent
         ends on its own stop hook, its task's end, or the client teardown."""
+        self._warn_wf_shape(progress)
         ended = set()
         with self._sub_lock:
             seen = self._wf_agents.setdefault(tid, set())
@@ -4061,7 +4124,7 @@ class SdkSession:
         Pokes a push only when the set actually changed, so progress chatter stays cheap.
 
         Two live-subagent retirements ride the same stream (2026-09-02), for the agents whose
-        SubagentStop never comes (a failed agent leaves none — see _reconcile_workflow_agents): a
+        SubagentStop never comes (a failed agent got none in the probe — see _reconcile_workflow_agents): a
         Task/Agent subagent's lifecycle task carries the AGENT ID as its task_id (probe-verified on
         2.1.257), so the task's end is the agent's end; and a Workflow run's progress events carry its
         per-agent list, its end the roster's end."""

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -12,12 +12,14 @@ Two layers:
 """
 import asyncio
 import inspect
+import io
 import os
 import json
 import threading
 import time
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from unittest import mock
 from importlib.machinery import SourceFileLoader
@@ -4126,10 +4128,10 @@ class PushSessionCallback(unittest.TestCase):
 
 class LiveSubagentsRetire(unittest.TestCase):
     """The lane's live subagent count only ever GREW (the user 2026-09-02, whose session read Working with
-    37 subagents for hours). The CLI fires SubagentStart for every workflow agent but SubagentStop only
-    for the ones that finish cleanly (probe-verified on CLI 2.1.257: a run with one agent on a nonexistent
-    model got one stop hook; the failed agent's slot in the run's `workflow_progress` list read state
-    "error" and nothing else), so the set is retired on the events that DO arrive: a run's per-agent
+    37 subagents for hours). The CLI fires SubagentStart for every workflow agent but not SubagentStop for
+    every one of them (probe-verified on CLI 2.1.257: a run with one agent on a nonexistent model got one
+    stop hook; the failed agent's slot in the run's `workflow_progress` list read state "error" and
+    nothing else), so the set is retired on the events that DO arrive: a run's per-agent
     progress list (an end state, or a slot re-minted for a retry), the run's end, a Task agent's own
     task end (its task_id IS the agent id), and the client teardown. Every id and uuid here is synthetic."""
 
@@ -4223,7 +4225,9 @@ class LiveSubagentsRetire(unittest.TestCase):
 
     def test_d_a_task_agents_own_task_end_retires_it(self):
         """A Task/Agent subagent's lifecycle task carries the agent id as its task_id (probe-verified), so
-        the task ending — here as a failure, which leaves no SubagentStop — retires the agent."""
+        the task ending retires the agent — here as a failure. Whether a failed Task agent gets a
+        SubagentStop is unverified (the probe saw a failed WORKFLOW agent get none); its task end retires
+        it either way."""
         s = self._sess()
         self._start(s, "t1", "general-purpose")
         s._on_task_event("task_started", {"task_id": "t1", "task_type": "local_agent", "subagent_type": "general-purpose"})
@@ -4316,6 +4320,90 @@ class LiveSubagentsRetire(unittest.TestCase):
         s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": [
             self._wf(1, "a1", "done"), self._wf(2, "a2", "progress")]})
         self.assertEqual(set(s._subagents), {"a2"})
+
+
+class WorkflowProgressShapeIsLoud(unittest.TestCase):
+    """The retirement parser keys on the field names the probe recorded. If the CLI renames them, the
+    ever-growing live count comes back — and would come back SILENTLY, so a list this build cannot read is
+    reported once per process, naming what arrived (the api_retry shape warning's pattern)."""
+
+    SID = "11111111-2222-3333-4444-888888888888"
+
+    def setUp(self):
+        sb.SdkSession._wf_shape_warned = False
+
+    def tearDown(self):
+        sb.SdkSession._wf_shape_warned = False
+
+    def _sess(self):
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=lambda m, problem=None: None)
+        s = sb.SdkSession(be, {"sid": self.SID, "name": "web", "cwd": "/tmp"})
+        s.inflight = 0
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow"})
+        return s
+
+    def _feed(self, s, progress):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": progress})
+        return buf.getvalue()
+
+    def test_a_renamed_list_says_so_once_and_names_what_arrived(self):
+        s = self._sess()
+        out = self._feed(s, [{"type": "wf_agent", "agent_ref": "a1", "phase": "done"}])
+        self.assertIn("workflow_progress payload", out)
+        self.assertIn("workflow_agent", out, "the diagnostic names the type it expected")
+        self.assertIn("agent_ref", out, "…and the keys it actually got")
+        self.assertIn("live subagent count", out, "…and what the user will see go wrong")
+        self.assertIn("until the session reconnects", out, "…stated for the worst case: a type/agentId rename "
+                                                          "leaves the roster empty, so a run's end retires nothing")
+        self.assertEqual(self._feed(s, [{"type": "wf_agent", "agent_ref": "a2"}]), "", "once per process, not per event")
+
+    def test_b_the_probe_recorded_shapes_are_silent(self):
+        """Every shape CLI 2.1.257 was seen to ship on an ordinary run must stay silent, or the latch is spent
+        on a false alarm and a real rename later in the process goes unreported (review 2026-09-03)."""
+        s = self._sess()
+        cases = {
+            "phases only, before any agent is queued": [
+                {"type": "workflow_phase", "index": 0, "title": "Review", "kind": "review"},
+                {"type": "workflow_phase", "index": 1, "title": "Verify"}],
+            "a log line beside the phases": [
+                {"type": "workflow_log", "message": "scanning"}, {"type": "workflow_phase", "index": 0, "title": "Review"}],
+            "a queued slot has no agentId yet": [
+                {"type": "workflow_agent", "index": 1, "label": "a", "agentId": "a1", "state": "done", "queuedAt": 1, "startedAt": 2},
+                {"type": "workflow_agent", "index": 2, "label": "b", "state": "start", "queuedAt": 1},
+                {"type": "workflow_phase", "index": 0, "title": "Review"}],
+            "a slot blocked before spawn: error, no agentId, no startedAt": [
+                {"type": "workflow_agent", "index": 1, "label": "a", "state": "error", "blocked": True,
+                 "error": "blocked", "queuedAt": 1, "lastProgressAt": 2}],
+            "a slot whose spawn threw: error, no agentId, no startedAt": [
+                {"type": "workflow_agent", "index": 1, "label": "a", "state": "error", "error": "spawn failed", "queuedAt": 1}],
+        }
+        for name, shape in cases.items():
+            self.assertEqual(self._feed(s, shape), "", name)
+        self.assertFalse(sb.SdkSession._wf_shape_warned)
+
+    def test_c_a_missing_field_is_named(self):
+        for entry, word in (({"type": "workflow_agent", "index": 1, "agentId": "a1", "startedAt": 2}, "'state'"),
+                            ({"type": "workflow_agent", "agentId": "a1", "state": "done"}, "'index'"),
+                            ({"type": "workflow_agent", "index": 1, "state": "done", "startedAt": 2}, "'agentId'"),
+                            ({"type": "workflow_step", "index": 1, "agentId": "a1", "state": "done"}, "'workflow_agent'")):
+            sb.SdkSession._wf_shape_warned = False
+            out = self._feed(self._sess(), [entry])
+            self.assertIn(word, out, "the diagnostic names the missing field: %r → %r" % (entry, out))
+
+    def test_d_an_unknown_state_word_is_named(self):
+        out = self._feed(self._sess(), [{"type": "workflow_agent", "index": 1, "agentId": "a1", "state": "failed", "startedAt": 2}])
+        self.assertIn("failed", out)
+        self.assertIn("unknown state word", out)
+
+    def test_e_a_throttled_tick_without_the_list_is_not_a_shape(self):
+        s = self._sess()
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            s._on_task_event("task_progress", {"task_id": "w1"})
+            s._on_task_event("task_progress", {"task_id": "w1", "workflow_progress": []})
+        self.assertEqual(buf.getvalue(), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #884, covering the two suggestions from its merge note.

## Shape diagnostic

The retirement parser keys on the field names a probe of CLI 2.1.257 recorded: an entry typed `workflow_agent`, its `index`, its `state` from `start`/`progress`/`done`/`error`, and an `agentId` on every started slot. A rename inside that list would bring the ever-growing live count back silently. So a list this build cannot read is now reported once per process on stderr, naming what arrived and what the user will see go wrong, on the same pattern the api_retry payload already uses (`_retry_shape_warned`).

The shapes the CLI ships on an ordinary run stay silent, so the latch is never spent on a false alarm:

- a list of only phase (and log) entries, which a run announces before any agent is queued;
- a queued slot with no `agentId` yet;
- an error slot with neither `agentId` nor `startedAt`, written for an agent blocked or thrown before its id was minted.

Only an entry of a type this build has never seen counts as a rename when no agent entry is present, and "started" means `startedAt` or a `progress`/`done` state, never an error state. The consequence line states the worst case truthfully: under a type or id rename the run's roster stays empty, so a run's end retires nothing and the agents stay until the session reconnects. The `workflow_progress` key itself is not checked, since a payload without the list is indistinguishable from a throttled tick; the docstring says so.

## Wording

The docstrings no longer claim the CLI fires `SubagentStop` only for clean finishes. What the probe showed is narrower: a workflow agent whose model did not exist got a start hook and no stop hook. The bundle does attempt the stop hook on an interrupted query, so the observed gap is failures, and the comments now say exactly that.

## Tests and verification

- `WorkflowProgressShapeIsLoud` in `tests/test_sdk_backend.py`: a renamed list is named once with the worst-case consequence; every recorded ordinary shape is silent; each missing field and an unknown entry type is named; an unknown state word is named; a throttled tick is not a shape.
- Full Python suite and node suite green on the branch.
- A two-lens adversarial review with one refuter per finding confirmed three defects in the first draft (the phase-only list, the id-less error slot, the consequence line); all three are fixed here, and the refuter for the phase-only case reproduced the shape against the installed CLI before the fix.

Unrelated observation while running the suites: `tests/test_kernel_update.py::CheckLoop::test_two_cadences_one_loop_and_a_crash_never_kills_the_thread` fails about one run in three on pristine `main` as well as on this branch, always with the drift probe never having run, so the loop is exiting on the two mocked naps before reaching it. Likely the unmocked converge check between them. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)