### PR TITLE
Let SDK sessions request thinking summaries, and render a summary instead of the "Thinking…" placeholder

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20597,8 +20597,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                     if not isinstance(b, dict):
                         continue
                     if b.get("type") == "thinking":
+                        # `encrypted` means OPAQUE — nothing to show but the placeholder: a signature and
+                        # no text. A block with a signature AND text is a summary (the SDK's display
+                        # "summarized", requested when the thinking-summaries toggle is on) and renders
+                        # its text; the old signature-only rule hid every summary (2026-09-01).
                         events.append({"kind": "thinking", "text": b.get("thinking", ""),
-                                       "encrypted": bool(b.get("signature")), "uuid": a.get("uuid"), "ts": ts})
+                                       "encrypted": bool(b.get("signature")) and not (b.get("thinking") or "").strip(),
+                                       "uuid": a.get("uuid"), "ts": ts})
                     elif b.get("type") == "text" and b.get("text", "").strip():
                         txt = b["text"]
                         if a.get("command"):             # a slash command's OUTPUT (command:True on the synthetic

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -573,6 +573,9 @@ def _version_info():
             "login": _login_state(),         # the in-dashboard login flow's state/url/err (T157) — never a secret
             "acctLabel": _claude_account_label(),   # which login this box holds ("" = none) — the gear's Billing row
             "fileEditing": _file_editing_on(),   # dashboard raw-mode editing opt-in → gates the viewer's Edit
+            # per-install: SDK sessions ask for reasoning summaries (gear checkbox). Top-level only — not
+            # in the "settings" sub-dict below, whose mixed marks promise a cross-machine write this never makes
+            "thinkingSummaries": _thinking_summaries_on(),
             "updateMode": _update_mode(),    # ask|auto|off (the boot release check) → the gear dropdown
             "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
@@ -3511,6 +3514,65 @@ def _set_file_editing(enabled, gt=None):
             _atomic_write(jd.STATE / "file-editing.json", json.dumps({"enabled": bool(enabled), "gt": stamp}))
         except OSError as e:
             sys.stderr.write("setting file-editing: write failed (%s) — nothing applied\n" % e)
+            return None
+        return stamp
+
+
+# ── thinking summaries for SDK sessions (2026-09-01) ──────────────────────────────────────────────
+# On the SDK's stream-json path the CLI requests NO thinking display — it uses an explicit
+# --thinking-display when given, consults settings.json showThinkingSummaries only when interactive,
+# and forces "omitted" only for --print text/json output (verified in the 2.1.257 binary, re-read at
+# 2.1.258) — so the API default applies, which for current models is signature-only: every SDK
+# session returned textless thinking blocks and the chat showed "Thinking…" for each. This toggle
+# asks for summaries: the SDK backend reads the same file at every connect
+# (sdk_backend.thinking_summaries_on → _options passes the SDK's typed
+# thinking={"type": "adaptive", "display": "summarized"}). PER-INSTALL and off by default: it is not
+# in federation's KERNEL_SETTING set, so it never propagates — whoever reads the summaries turns it
+# on where they read them. A running session is NOT switched live (the python SDK exposes no runtime
+# thinking-display control; the CLI's set_max_thinking_tokens control does carry one, unwrapped) —
+# it picks the setting up at its next reconnect. What reconnects a session: an effort, billing,
+# per-session-env or bypass-mode switch, the first fast-mode opt-in, a file rewind, a kernel restart
+# (sdk_backend: every request_reconnect caller). A MODEL switch does NOT — set_model applies live
+# over the SDK control channel — so the gear's sub-copy names the real triggers and says a model
+# switch is not one. And the CLI resolves `--thinking adaptive` ahead of a MAX_THINKING_TOKENS in
+# its environment and of `alwaysThinkingEnabled: false` in settings, so on an install that had
+# thinking OFF this toggle also turns adaptive thinking on (the SDK has no display-only field); the
+# sub-copy says that too, and sdk_backend logs it when a cap is present.
+THINKING_SUMMARIES_FILE = "thinking-summaries.json"   # same name sdk_backend.THINKING_SUMMARIES_FILE reads
+
+
+def _thinking_summaries_on():
+    """OFF unless this install's file says yes: absent, unreadable or malformed all read False — the
+    opt-in must be provable, and reading never creates the file (shipping never turns it on)."""
+    try:
+        return bool(json.loads((jd.STATE / THINKING_SUMMARIES_FILE).read_text()).get("enabled"))
+    except Exception:
+        return False
+
+
+def _set_thinking_summaries(enabled, gt=None):
+    """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down — the
+    gesture-time ordering block above _NUDGE_LOCK; per-install or not, two dashboards on ONE kernel
+    still race — or an equal stamp carried the stored value (the gesture's own echo: nothing to apply,
+    nothing to say), or the store write failed (OSError: loud on stderr, nothing applied; caught HERE
+    like _set_file_editing's, because a raised OSError reads as a socket failure to the WS reader
+    loop and silently tears the connection down). A file without the field reads as gt 0, so any
+    stamped gesture applies over it. Read-check-write under _SETTINGS_LOCK, like its siblings."""
+    with _SETTINGS_LOCK:
+        try:
+            prev = json.loads((jd.STATE / THINKING_SUMMARIES_FILE).read_text())
+        except Exception:
+            prev = None
+        prev_gt = _gt_int(prev.get("gt")) if isinstance(prev, dict) else 0
+        if _gesture_echo(gt, prev_gt, isinstance(prev, dict) and bool(prev.get("enabled")) == bool(enabled)):
+            return None
+        if _setting_stale("thinking-summaries", gt, prev_gt):
+            return None
+        stamp = gt if gt is not None else int(time.time() * 1000)
+        try:
+            _atomic_write(jd.STATE / THINKING_SUMMARIES_FILE, json.dumps({"enabled": bool(enabled), "gt": stamp}))
+        except OSError as e:
+            sys.stderr.write("setting thinking-summaries: write failed (%s) — nothing applied\n" % e)
             return None
         return stamp
 
@@ -26186,6 +26248,8 @@ def _setting_kept_value(name):
         return _file_editing_on()
     if name == "update-mode":
         return _update_mode()
+    if name == "thinking-summaries":
+        return _thinking_summaries_on()
     return jd._state_str(name, "")   # the judge-tier stores are bare value files
 
 
@@ -33603,6 +33667,12 @@ class Handler(BaseHTTPRequestHandler):
             # setAutoNudge, broadcast by federation.ts KERNEL_SETTING so one yes answers the mesh.
             # A stale gesture stamp stands down (a queued flush must not undo a newer choice).
             if _set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
+                _tell_stale_gesture(client)
+        elif msg and msg.get("type") == "setThinkingSummaries" and msg.get("enabled") is not None:
+            # The gear's Thinking summaries checkbox (2026-09-01) — kernel-side like setFileEditing but
+            # PER-INSTALL (not a KERNEL_SETTING: nothing to propagate), gt-gated all the same; the SDK
+            # backend reads the store at each session's next connect, so nothing else to do here.
+            if _set_thinking_summaries(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
                 _tell_stale_gesture(client)
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
             # a cleared card drops any composer citation chip pointing INTO it (the user 2026-07-01) — the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1609,6 +1609,49 @@ def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bo
     return p
 
 
+THINKING_SUMMARIES_FILE = "thinking-summaries.json"   # written by the kernel's gear toggle (_set_thinking_summaries)
+
+
+def thinking_summaries_on(state_dir: Path) -> bool:
+    """The kernel's per-install thinking-summaries toggle (2026-09-01), read at every connect by _options
+    — a connect-time knob like flag_settings_path's above. Absent, unreadable or malformed all read False:
+    OFF is the shipped default and the opt-in must be provable. Same file the kernel writes
+    ({"enabled": bool, "gt": ms}); reading never creates it."""
+    try:
+        d = json.loads((Path(state_dir) / THINKING_SUMMARIES_FILE).read_text())
+        return bool(isinstance(d, dict) and d.get("enabled"))
+    except (OSError, ValueError):
+        return False
+
+
+THINKING_SUMMARIES_KW = {"type": "adaptive", "display": "summarized"}   # the SDK's typed ThinkingConfigAdaptive
+
+
+def thinking_kw(state_dir: Path):
+    """What _options hands ClaudeAgentOptions as `thinking=`: the SDK's typed ThinkingConfigAdaptive with
+    display "summarized" when the per-install toggle is on, None when it is off (nothing passed, so the
+    CLI's own default stands). Pure and SDK-free on purpose (2026-09-01, round 2): the standard test
+    runner has no claude_agent_sdk and skips every _options pin, so the decision lives where it runs."""
+    return dict(THINKING_SUMMARIES_KW) if thinking_summaries_on(state_dir) else None
+
+
+def thinking_override_note(thinking, cli_env) -> str:
+    """The one log line owed when `thinking` (thinking_kw's answer) will override a thinking cap the CLI
+    would otherwise honor. The CLI resolves `--thinking adaptive` FIRST — ahead of a MAX_THINKING_TOKENS
+    in its environment and of `alwaysThinkingEnabled: false` in settings (verified in the 2.1.257 binary,
+    re-read at 2.1.258) — so on an install that had thinking off, asking for summaries turns adaptive
+    thinking ON, at full thinking cost. The SDK has no display-only field, so the override is inherent;
+    what romp owes is to say so. `cli_env` is the environment the CLI child will see (the SDK transport
+    merges options.env over the process's). "" when there is nothing to say: toggle off, or no cap
+    present — the settings layer is not readable from here, so that half is carried by the gear's
+    sub-copy alone."""
+    if not thinking or "MAX_THINKING_TOKENS" not in cli_env:
+        return ""
+    return ("thinking summaries: MAX_THINKING_TOKENS=%s is set in the CLI's environment, but the toggle's "
+            "--thinking adaptive takes precedence: sessions run adaptive thinking (billed as such) where the "
+            "cap had it off" % cli_env["MAX_THINKING_TOKENS"])
+
+
 def _defaults_path(state_dir: Path) -> Path:
     return Path(state_dir) / "sdk-defaults.json"
 
@@ -4469,6 +4512,7 @@ class SdkBackend:
         self.mcp_config = mcp_config
         self.append_prompt_path = append_prompt_path
         self._log_cb = log
+        self._thinking_override_logged = False   # thinking_override_note said once per backend (see _options)
         self.sessions: dict[str, SdkSession] = {}
         self._lock = threading.Lock()
         self._turn_seq: dict = {}                 # sid -> turns ended this kernel life (turn_seq; under _lock)
@@ -5527,6 +5571,32 @@ class SdkBackend:
             effort=("xhigh" if (sess.effort or DEFAULT_EFFORT) == "ultracode" else (sess.effort or DEFAULT_EFFORT)),
             max_buffer_size=SDK_MAX_BUFFER,   # a >1MB stdout message would crash the receive loop → kill any live picker
         )
+        # Thinking summaries (the kernel's per-install gear toggle, 2026-09-01). On the SDK's stream-json
+        # path the CLI requests NO thinking display: it uses an explicit --thinking-display when given,
+        # consults the showThinkingSummaries settings key only when interactive, and forces "omitted" only
+        # for --print text/json output (verified in the 2.1.257 binary, re-read at 2.1.258). So the API
+        # default applies, and for current models that is signature-only (the SDK's types.py says so):
+        # every SDK session returned thinking blocks with no text. When the toggle is on, pass the SDK's
+        # TYPED field — types.py ThinkingConfigAdaptive, display "summarized" | "omitted"; the transport
+        # turns it into `--thinking adaptive --thinking-display summarized` — never extra_args, which is
+        # for flags with no field. The flag is NOT display-only: the CLI resolves `--thinking adaptive`
+        # FIRST, ahead of a MAX_THINKING_TOKENS in its environment and of `alwaysThinkingEnabled: false`
+        # in settings, so on an install that had thinking OFF this turns adaptive thinking ON, at full
+        # thinking cost. The SDK has no display-only field, so the override is inherent to asking for
+        # summaries; what romp owes is to say so — the gear's sub-copy does, and thinking_override_note
+        # logs the one case visible from here (a cap in the CLI's environment, fixed for this process's
+        # lifetime, hence once per backend). Connect-time like effort: re-read on EVERY connect, so a
+        # reconnect re-asserts the current answer, and a running session picks a flip up at its next
+        # reconnect — an effort/billing/env/bypass switch, the first fast-mode opt-in, a rewind, a kernel
+        # restart; NOT a model switch, which set_model applies live over the control channel. Off → no
+        # `thinking` at all: the CLI's own default stands, exactly as before.
+        tk = thinking_kw(self.state_dir)
+        if tk:
+            kw["thinking"] = tk
+            note = thinking_override_note(tk, {**os.environ, **kw["env"]})
+            if note and not self._thinking_override_logged:
+                self._thinking_override_logged = True
+                self._log(note)
         # romp's harness prompt is APPENDED via the SDK's DESIGNED system_prompt field — the Claude Code preset
         # plus an `append` (types.py SystemPromptPreset) — NOT extra_args={"append-system-prompt"}. Same effect
         # (append to the default Claude Code system prompt) but it's the typed, documented option; extra_args is

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,12 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
   (through the stable `bin/` names) and isolate state with `XDG_STATE_HOME`.
   Golden transcript fixtures: `test_romp_events_golden.py` + `fixtures/`.
   Run: `python3 -m pytest tests/ -q` (~20s; a stalled run is a hang, not slow).
+  The `_HAVE_SDK`-gated classes in `test_sdk_backend.py` (OptionsAssembly, the
+  runner and can_use_tool bridge suites) SKIP unless `claude_agent_sdk` imports,
+  and a skip reads as green — to execute them, put romp's SDK venv on the path:
+  `PYTHONPATH=~/.local/state/romp/sdkvenv/lib/python3.12/site-packages python3 -m
+  pytest tests/test_sdk_backend.py -q` (the venv `bin/romp-sdk-setup` creates;
+  match the python version to it).
 - **`*.bats`** — the shell surfaces: `bin/romp`, the launch chain, hooks,
   postal CLI. Keep them GNU/BSD-portable (CI runs bats on ubuntu).
   Run: `bats tests/*.bats`.

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -43,7 +43,7 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertTrue(h.index(">Account<") < h.index("id=rs-login-btn") < h.index(">Sessions<"))
         # Sessions (lifecycle): dir, backend, nudge, conserve, file editing — before Chat
         for rid in ("id=rs-defaultdir", "id=rs-backend", "id=rs-autonudge", "id=rs-suggestcompact",
-                    "id=rs-conserve", "id=rs-fileedit"):
+                    "id=rs-conserve", "id=rs-thinksum", "id=rs-fileedit"):
             self.assertTrue(h.index(">Sessions<") < h.index(rid) < h.index(">Chat<"), rid)
         # Chat: transcript prefs AND the comment defaults (comments are part of the chat)
         for rid in ("id=rs-compact", "id=rs-branch", "id=rs-cmtmodel", "id=rs-cmtfast"):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2267,6 +2267,49 @@ class OverlappingAsksAnswerInTurn(unittest.TestCase):
         self.assertIsNone(sess._cur_ask_fut)
 
 
+class ThinkingKw(unittest.TestCase):
+    """The thinking-summaries decision WITHOUT the SDK (2026-09-01, round 2): `thinking_kw` is what
+    _options hands ClaudeAgentOptions as `thinking=`, and `thinking_override_note` the one log line owed
+    when that flag will override a thinking cap. Both are pure, so the standard runner — which has no
+    claude_agent_sdk and therefore SKIPS every OptionsAssembly pin — still exercises the rule.
+    OptionsAssembly keeps the composition and the transport's `--thinking adaptive --thinking-display
+    summarized` pin; run it with the SDK venv on PYTHONPATH (tests/README.md)."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def _write(self, obj):
+        with open(os.path.join(self.d, sb.THINKING_SUMMARIES_FILE), "w") as f:
+            f.write(obj if isinstance(obj, str) else json.dumps(obj))
+
+    def test_off_is_none_whether_absent_explicit_or_unreadable(self):
+        self.assertIsNone(sb.thinking_kw(self.d), "absent file → pass nothing; the CLI's own default stands")
+        self._write({"enabled": False, "gt": 2})
+        self.assertIsNone(sb.thinking_kw(self.d), "an explicit off is the same as absent")
+        self._write("not json")
+        self.assertIsNone(sb.thinking_kw(self.d), "unreadable refuses — the opt-in must be provable")
+
+    def test_on_is_the_typed_adaptive_summarized_field(self):
+        self._write({"enabled": True, "gt": 1})
+        self.assertEqual(sb.thinking_kw(self.d), {"type": "adaptive", "display": "summarized"},
+                         "the SDK's ThinkingConfigAdaptive shape, display summarized")
+        self.assertIsNot(sb.thinking_kw(self.d), sb.THINKING_SUMMARIES_KW, "a copy per call, never the shared literal")
+
+    def test_the_override_note_fires_only_for_a_cap_in_the_cli_environment(self):
+        # The CLI resolves --thinking adaptive ahead of MAX_THINKING_TOKENS (verified in the 2.1.257
+        # binary, re-read at 2.1.258): with a cap in the environment the toggle turns thinking ON where
+        # the cap had it off. Real, so never silent — but only when it is real.
+        on = {"type": "adaptive", "display": "summarized"}
+        self.assertEqual(sb.thinking_override_note(None, {"MAX_THINKING_TOKENS": "0"}), "",
+                         "toggle off → the flag is not sent, so nothing is overridden")
+        self.assertEqual(sb.thinking_override_note(on, {"PATH": "/bin"}), "",
+                         "no cap in the environment → the flag changes only the display; nothing to say")
+        note = sb.thinking_override_note(on, {"MAX_THINKING_TOKENS": "0", "PATH": "/bin"})
+        self.assertIn("MAX_THINKING_TOKENS=0", note, "names the cap it overrides, with its value")
+        self.assertIn("--thinking adaptive", note, "…and the flag that wins")
+        self.assertIn("adaptive thinking", note, "…and what the sessions will actually run")
+
+
 # --- Runner + can_use_tool bridge (needs the SDK message classes) ---
 try:
     import claude_agent_sdk as _sdk
@@ -3086,6 +3129,88 @@ class OptionsAssembly(unittest.TestCase):
         self.assertEqual(opts.max_buffer_size, sb.SDK_MAX_BUFFER, "romp sets the buffer cap explicitly")
         self.assertGreaterEqual(opts.max_buffer_size, 32 * 1024 * 1024,
                                 "well past any realistic single message, so a picker never dies on overflow")
+
+    # Thinking summaries (2026-09-01). On the SDK's stream-json path the CLI requests NO thinking display
+    # (it uses an explicit --thinking-display when given, consults the showThinkingSummaries settings key
+    # only when interactive, and forces "omitted" only for --print text/json output — verified in the
+    # 2.1.257 binary, re-read at 2.1.258), so the API default applies and current models return
+    # signature-only thinking blocks. The kernel's per-install gear toggle writes
+    # STATE/thinking-summaries.json; _options reads it at every connect and, when on, passes the SDK's
+    # TYPED ThinkingConfigAdaptive field (types.py: display "summarized" | "omitted") — never the
+    # extra_args escape hatch, which this option has a field for.
+    def test_thinking_summaries_off_by_default_requests_no_display(self):
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        self.assertFalse(sb.thinking_summaries_on(be.state_dir), "absent file reads OFF")
+        opts = be._options(self._sess(be), _sdk.ClaudeAgentOptions)
+        self.assertIsNone(opts.thinking, "off → no thinking option at all (the CLI's own default stands)")
+        self.assertNotIn("thinking-display", opts.extra_args or {})
+
+    def test_thinking_summaries_on_passes_the_typed_adaptive_summarized_field(self):
+        with open(os.path.join(self.d, sb.THINKING_SUMMARIES_FILE), "w") as f:
+            json.dump({"enabled": True, "gt": 1}, f)
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        self.assertTrue(sb.thinking_summaries_on(be.state_dir))
+        opts = be._options(self._sess(be), _sdk.ClaudeAgentOptions)
+        self.assertEqual(opts.thinking, {"type": "adaptive", "display": "summarized"},
+                         "the designed field, in the shape the SDK types")
+        self.assertNotIn("thinking-display", opts.extra_args or {},
+                         "must NOT route the display through the extra_args CLI-flag escape hatch")
+        # …and the installed SDK's transport turns that field into the CLI flags the binary honors
+        # (--thinking adaptive --thinking-display summarized) — verified against the SDK romp runs, not
+        # assumed from its docs.
+        from claude_agent_sdk._internal.transport.subprocess_cli import SubprocessCLITransport
+        cmd = SubprocessCLITransport("", opts)._build_command()
+        self.assertIn("--thinking-display", cmd)
+        self.assertEqual(cmd[cmd.index("--thinking-display") + 1], "summarized")
+        self.assertEqual(cmd[cmd.index("--thinking") + 1], "adaptive")
+
+    def test_thinking_summaries_explicit_off_requests_no_display(self):
+        # OFF written as a value (the user turned it on, then off again) is the same as absent
+        with open(os.path.join(self.d, sb.THINKING_SUMMARIES_FILE), "w") as f:
+            json.dump({"enabled": False, "gt": 2}, f)
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        self.assertIsNone(be._options(self._sess(be), _sdk.ClaudeAgentOptions).thinking)
+        with open(os.path.join(self.d, sb.THINKING_SUMMARIES_FILE), "w") as f:
+            f.write("not json")
+        self.assertFalse(sb.thinking_summaries_on(be.state_dir), "an unreadable file refuses — the opt-in must be provable")
+
+    def test_thinking_summaries_on_over_a_thinking_cap_logs_the_override_once(self):
+        # The CLI resolves --thinking adaptive ahead of MAX_THINKING_TOKENS (verified in the 2.1.257
+        # binary), so with a cap in the manager's environment the toggle turns thinking ON where the cap
+        # had it off — real, and never silent: one kernel-log line per backend (the environment is fixed
+        # for the process's lifetime), not one per connect.
+        with open(os.path.join(self.d, sb.THINKING_SUMMARIES_FILE), "w") as f:
+            json.dump({"enabled": True, "gt": 1}, f)
+        lines = []
+        had = os.environ.get("MAX_THINKING_TOKENS")
+        os.environ["MAX_THINKING_TOKENS"] = "0"
+        try:
+            be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=lines.append)
+            opts = be._options(self._sess(be), _sdk.ClaudeAgentOptions)
+            self.assertEqual(opts.thinking, {"type": "adaptive", "display": "summarized"}, "the flag still goes")
+            be._options(self._sess(be), _sdk.ClaudeAgentOptions)   # a second connect: no second line
+        finally:
+            if had is None:
+                os.environ.pop("MAX_THINKING_TOKENS", None)
+            else:
+                os.environ["MAX_THINKING_TOKENS"] = had
+        hits = [l for l in lines if "MAX_THINKING_TOKENS=0" in l]
+        self.assertEqual(len(hits), 1, "one line though two sessions connected: %r" % lines)
+        self.assertIn("--thinking adaptive", hits[0], "names the flag that wins")
+
+    def test_thinking_summaries_on_without_a_cap_logs_nothing(self):
+        with open(os.path.join(self.d, sb.THINKING_SUMMARIES_FILE), "w") as f:
+            json.dump({"enabled": True, "gt": 1}, f)
+        lines = []
+        had = os.environ.pop("MAX_THINKING_TOKENS", None)
+        try:
+            be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=lines.append)
+            be._options(self._sess(be), _sdk.ClaudeAgentOptions)
+        finally:
+            if had is not None:
+                os.environ["MAX_THINKING_TOKENS"] = had
+        self.assertEqual([l for l in lines if "thinking" in l.lower()], [],
+                         "no cap → the flag changes only the display; nothing to announce")
 
 
 @unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -640,6 +640,10 @@ class StaleGestureAnswersTheDeliveringSocket(_Base):
                   "file-editing", True),
                  ({"type": "setUpdateMode", "mode": "auto"}, {"type": "setUpdateMode", "mode": "off"},
                   "update-mode", "auto"),
+                 # per-install (never propagated), but two dashboards on ONE kernel still race, so it
+                 # gt-gates and answers like the rest (2026-09-01)
+                 ({"type": "setThinkingSummaries", "enabled": True}, {"type": "setThinkingSummaries", "enabled": False},
+                  "thinking-summaries", True),
                  ({"type": "setIndexEffort", "effort": "high"}, {"type": "setIndexEffort", "effort": "low"},
                   "index-effort", "high"),
                  ({"type": "setDistillModel", "model": "haiku"}, {"type": "setDistillModel", "model": "triage"},
@@ -694,8 +698,8 @@ class WiringPins(unittest.TestCase):
         self.assertIn('_set_update_mode(str(msg["mode"]), gt=_gesture_ms(msg))', self.src)
 
     def test_every_stood_down_branch_tells_the_delivering_socket(self):
-        self.assertGreaterEqual(self.src.count("_tell_stale_gesture(client)"), 13,
-                                "all thirteen gt-gated branches (four toggles + nine judge tiers) "
+        self.assertGreaterEqual(self.src.count("_tell_stale_gesture(client)"), 14,
+                                "all fourteen gt-gated branches (five toggles + nine judge tiers) "
                                 "answer the delivering socket on a stand-down")
 
     def test_the_docstring_names_all_three_none_causes(self):
@@ -707,7 +711,8 @@ class WiringPins(unittest.TestCase):
     def test_the_toggle_docstrings_name_the_write_failure_stand_down(self):
         # the same contract _set_judge_state documents: None's write-failure cause is named, so a
         # caller reading the docstring knows a full disk stands the gesture down rather than raising
-        for fn in (km._set_auto_nudge, km._set_compact_suggest, km._set_file_editing):
+        for fn in (km._set_auto_nudge, km._set_compact_suggest, km._set_file_editing,
+                   km._set_thinking_summaries):
             self.assertIn("OSError", fn.__doc__ or "",
                           "%s documents the write-failure cause of None" % fn.__name__)
 
@@ -719,6 +724,109 @@ class WiringPins(unittest.TestCase):
         self.assertNotIn(".write_text(", src, "no raw write_text — a torn write must not tear the store")
         self.assertLess(src.index('fname + ".gt"'), src.index("_atomic_write(jd.STATE / fname,"),
                         "the sidecar publishes FIRST — a crash between the two errs toward stand-down")
+
+
+class ThinkingSummariesSetting(_Base):
+    """The thinking-summaries toggle (2026-09-01): a PER-INSTALL kernel setting — its own json under
+    STATE, off until this install says yes, never propagated (not in federation's KERNEL_SETTING
+    set) — that still rides the gesture-ordered door: two dashboards on one kernel can race, so a
+    stale stamp stands down loudly and the delivering socket hears settingStale, exactly like
+    _set_file_editing. The SDK backend reads the same file at every connect (_options), so the
+    store here IS the switch the sessions see."""
+
+    FILE = "thinking-summaries.json"
+
+    def test_absent_file_reads_off_and_never_writes(self):
+        self.assertFalse(km._thinking_summaries_on(), "a fresh install is OFF — shipping never turns it on")
+        self.assertFalse((km.jd.STATE / self.FILE).exists(), "reading must not create the file")
+
+    def test_set_persists_value_and_stamp_in_its_own_file(self):
+        self.assertEqual(km._set_thinking_summaries(True, gt=T_NEW), T_NEW)
+        d = json.loads((km.jd.STATE / self.FILE).read_text())
+        self.assertEqual((d["enabled"], d["gt"]), (True, T_NEW))
+        self.assertTrue(km._thinking_summaries_on())
+        self.assertEqual(km._set_thinking_summaries(False, gt=T_NEW + 1), T_NEW + 1)
+        self.assertFalse(km._thinking_summaries_on(), "OFF is a real value, not the absent default")
+
+    def test_a_stale_gesture_stands_down_loudly(self):
+        self.assertEqual(km._set_thinking_summaries(True, gt=T_NEW), T_NEW)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_thinking_summaries(False, gt=T_OLD), "older stamp must not apply")
+        self.assertTrue(km._thinking_summaries_on(), "the newer ON survives the stale OFF")
+        for needle in ("thinking-summaries", str(T_OLD), str(T_NEW), "stood down"):
+            self.assertIn(needle, err.getvalue(), "the stand-down names the setting and both stamps")
+
+    def test_an_equal_stamp_with_the_same_value_is_a_silent_echo(self):
+        # the same rule the other gt-gated setters follow: one gesture delivered twice with one stamp
+        # (a re-dialed socket flushing what already landed) applies nothing and says nothing — no
+        # stand-down line, no settingStale notice — while an equal stamp carrying a DIFFERENT value
+        # still stands down loudly
+        self.assertEqual(km._set_thinking_summaries(True, gt=T_NEW), T_NEW)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_thinking_summaries(True, gt=T_NEW), "nothing to apply")
+        self.assertEqual(err.getvalue(), "", "the echo is silent")
+        self.assertIsNone(km._pop_stale_notice(), "…and leaves no settingStale notice for the socket")
+        self.assertTrue(km._thinking_summaries_on())
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._set_thinking_summaries(False, gt=T_NEW))
+        self.assertIn("stale gesture stood down", err.getvalue(), "a differing equal-stamp gesture is still loud")
+        self.assertIsNotNone(km._pop_stale_notice())
+        self.assertTrue(km._thinking_summaries_on(), "the stored ON survives the equal-stamp OFF")
+
+    def test_a_file_without_the_field_reads_as_zero(self):
+        (km.jd.STATE / self.FILE).write_text(json.dumps({"enabled": True}))
+        self.assertEqual(km._set_thinking_summaries(False, gt=1), 1, "gt 1 beats the absent field's 0")
+        self.assertFalse(km._thinking_summaries_on())
+
+    def test_the_dispatch_branch_hands_the_stamp_over_and_answers_the_socket(self):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "setThinkingSummaries", "enabled": True,
+                                                              "gt": T_NEW}, client)
+            self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [], "an applied gesture: no frame")
+            km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "setThinkingSummaries", "enabled": False,
+                                                              "gt": T_OLD}, client)
+        self.assertTrue(km._thinking_summaries_on(), "the store keeps the newer pick")
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(len(frames), 1)
+        self.assertEqual((frames[0]["setting"], frames[0]["storedGt"], frames[0]["kept"]),
+                         ("thinking-summaries", T_NEW, True))
+        self.assertEqual(self.propagated, [], "per-install: a thinking-summaries pick never fans out")
+
+    def test_write_failure_is_loud_none_and_applies_nothing(self):
+        self.assertEqual(km._set_thinking_summaries(True, gt=T_OLD), T_OLD)
+        import pathlib
+        orig = pathlib.Path.write_text
+
+        def failing(p, *a, **k):
+            raise OSError("simulated full disk")
+
+        pathlib.Path.write_text = failing
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._set_thinking_summaries(False, gt=T_NEW), "a failed write never raises")
+        finally:
+            pathlib.Path.write_text = orig
+        self.assertIn("thinking-summaries", err.getvalue(), "the refusal names the setting on stderr")
+        self.assertTrue(km._thinking_summaries_on(), "nothing applied — the store keeps the old value")
+        self.assertIn("OSError", km._set_thinking_summaries.__doc__ or "",
+                      "the docstring names the write-failure cause of None, like its siblings")
+
+    def test_the_setting_is_reported_but_not_broadcast(self):
+        import inspect
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        self.assertIn('_set_thinking_summaries(bool(msg["enabled"]), gt=_gesture_ms(msg))', src,
+                      "the WS branch hands the gesture stamp to the store")
+        fed = Path(BIN).parent / "ui" / "webview" / "federation.ts"
+        self.assertNotIn("setThinkingSummaries", fed.read_text(),
+                         "per-install: NOT a KERNEL_SETTING — it must never queue for or reach another kernel")
+        km._set_thinking_summaries(True, gt=T_NEW)
+        self.assertIs(km._version_info()["thinkingSummaries"], True, "/version reports it so the gear fills")
 
 
 if __name__ == "__main__":

--- a/tests/test_thinking_summary_events.py
+++ b/tests/test_thinking_summary_events.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""A thinking block that carries TEXT renders its text; only a signature-only block is opaque (2026-09-01).
+
+build_session marked every signed thinking block `encrypted` (kernel.py, the ChatEvent builder), and
+render.ts shows "Thinking…" for an encrypted block. That was right while every block the CLI wrote was
+signature-only. With thinking summaries requested (sdk_backend._options passes the SDK's typed
+`thinking={"type": "adaptive", "display": "summarized"}` when the per-install gear toggle is on), a
+block carries BOTH a signature and the summary text — and the old rule would have hidden every summary
+behind the placeholder. The rule is now: opaque only when the block has a signature AND no text.
+
+The judges stay blind to thinking text on purpose: their readers key on type == "text" (event_model
+_text_of, kernel _atom_md), and this file pins that they still do. Synthetic data only.
+"""
+import inspect
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_thinksum", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+em = SourceFileLoader("romp_event_model_thinksum",
+                      os.path.join(os.path.dirname(HERE), "kernel", "event_model.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1750000000
+SIG = "c2lnbmF0dXJlLWJ5dGVzLXN5bnRoZXRpYw=="   # a synthetic opaque signature, never a real one
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _urec(t, uuid, text, parent=None):
+    return {"type": "user", "uuid": uuid, "parentUuid": parent, "timestamp": iso(t),
+            "sessionId": SID, "cwd": "/tmp/notes-api", "version": "2.0.0", "gitBranch": "main",
+            "message": {"role": "user", "content": text}}
+
+
+def _arec(t, uuid, blocks, parent):
+    return {"type": "assistant", "uuid": uuid, "parentUuid": parent, "timestamp": iso(t),
+            "sessionId": SID, "cwd": "/tmp/notes-api", "version": "2.0.0", "gitBranch": "main",
+            "message": {"role": "assistant", "model": "claude-fable-5-1", "content": blocks}}
+
+
+class ThinkingBlockOpacity(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        self._saved_state = jd.STATE
+        jd._rebind_state(Path(self._td))
+        self.path = Path(self._td) / "transcript.jsonl"
+        self.path.write_text("".join(json.dumps(r) + "\n" for r in [
+            _urec(NOW - 100, "u1", "wire the notes-api health route"),
+            # 1) summarized: a signature AND text — the shape the SDK returns with display "summarized"
+            _arec(NOW - 90, "a1", [{"type": "thinking", "thinking": "Checking the router for an existing "
+                                                                     "health handler before adding one.",
+                                    "signature": SIG},
+                                   {"type": "text", "text": "Adding the route now."}], "u1"),
+            # 2) omitted: a signature and EMPTY text — every block the CLI wrote before this change
+            _arec(NOW - 80, "a2", [{"type": "thinking", "thinking": "", "signature": SIG},
+                                   {"type": "text", "text": "Route added."}], "a1"),
+            # 3) unsigned text (older transcripts) — was never opaque and still is not
+            _arec(NOW - 70, "a3", [{"type": "thinking", "thinking": "Now the tests."},
+                                   {"type": "text", "text": "Tests pass."}], "a2"),
+        ]))
+
+    def tearDown(self):
+        jd._rebind_state(self._saved_state)
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _thinking_events(self):
+        # path_override is the read-only render of exactly this transcript; the tmux stub makes the
+        # sid resolvable without a registry (the same synthesized entry a brand-new pane gets)
+        m = km.build_session(SID, NOW, tmux={SID: {}}, path_override=str(self.path))
+        self.assertIsNotNone(m)
+        return [e for e in m["events"] if e.get("kind") == "thinking"]
+
+    def test_a_signed_block_with_text_is_not_opaque_and_keeps_its_text(self):
+        evs = self._thinking_events()
+        self.assertEqual(len(evs), 3, "one thinking event per block")
+        summarized, omitted, unsigned = evs
+        self.assertFalse(summarized["encrypted"], "signature + text = a summary to SHOW, not a placeholder")
+        self.assertIn("health handler", summarized["text"])
+        self.assertTrue(omitted["encrypted"], "signature + no text = opaque, exactly as before")
+        self.assertEqual(omitted["text"], "")
+        self.assertFalse(unsigned["encrypted"])
+        self.assertEqual(unsigned["text"], "Now the tests.")
+
+    def test_whitespace_only_text_still_reads_as_opaque(self):
+        self.path.write_text(json.dumps(_urec(NOW - 10, "u1", "hi")) + "\n"
+                             + json.dumps(_arec(NOW - 5, "a1", [{"type": "thinking", "thinking": "  \n",
+                                                                 "signature": SIG},
+                                                                {"type": "text", "text": "hello"}], "u1")) + "\n")
+        evs = self._thinking_events()
+        self.assertEqual(len(evs), 1)
+        self.assertTrue(evs[0]["encrypted"], "blank text is no summary — the placeholder is honest here")
+
+    def test_the_seam_states_the_rule(self):
+        src = inspect.getsource(km.build_session)
+        self.assertIn('"encrypted": bool(b.get("signature")) and not (b.get("thinking") or "").strip()', src,
+                      "opaque = signature AND no text, in one expression at the builder")
+
+
+class JudgesStayBlindToThinking(unittest.TestCase):
+    """Summaries are for the human reading the chat. The planner/closer/distiller read text blocks
+    only — a summary must not start leaking into verdicts or briefs by accident."""
+
+    ATOM = {"type": "assistant", "message": {"content": [
+        {"type": "thinking", "thinking": "a reasoning summary the judges must not read", "signature": SIG},
+        {"type": "text", "text": "the reply "},
+        {"type": "text", "text": "the judges do read"}]}}
+
+    def test_kernel_atom_md_joins_text_blocks_only(self):
+        self.assertEqual(km._atom_md(self.ATOM), "the reply the judges do read")
+
+    def test_event_model_text_reader_skips_thinking(self):
+        got = em._text_of(self.ATOM["message"]["content"])
+        self.assertNotIn("reasoning summary", got)
+        self.assertIn("the judges do read", got)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -85,6 +85,10 @@ var GEAR_HTML =
   '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Close the claude process of a session that has FADED (idle over an hour) and is on no open tab (each averages ~340MB). Everything persists — it revives on a tab click, a message, or a scheduled wake. An open tab always keeps its process; off = every session keeps its process for as long as it lives.</span>' +
   '</span></label>' +
+  "<label class='rs-row'><input type=checkbox id=rs-thinksum>" +
+  '<span><b>Thinking summaries</b>' +
+  '<span class=rs-sub>For every new SDK session, ask the API for reasoning summaries and show them in the chat, folded to two lines (click to expand). Compact transcript still hides them. If thinking was turned off for this install, this turns adaptive thinking on as well. A running session picks the change up at its next reconnect: an effort or billing switch, the first fast-mode opt-in, or a kernel restart. Switching the model applies live and does not reconnect. Off by default; this kernel keeps its own copy.</span>' +
+  '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-fileedit>" +
   '<span><b>File editing</b><span class=rs-mixed hidden></span>' +
   '<span class=rs-sub>Let the file viewer’s Edit save straight to disk on the file’s machine. Off by default; the viewer asks the first time. A session working in the edited folder is told, and a save always refuses when the file changed underneath you. Applies on every connected machine’s kernel.</span>' +
@@ -226,6 +230,7 @@ function initGear(post) {
     cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
     cmf = document.getElementById('rs-cmtfast'),
     fe = document.getElementById('rs-fileedit'),
+    ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
   function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
@@ -432,6 +437,11 @@ function initGear(post) {
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
   if (ao) ao.addEventListener('change', function () { var s = load(); s.activeOnly = ao.checked; save(s); });
   if (fc) fc.addEventListener('change', function () { var s = load(); s.collapsed = fc.checked; save(s); });
+  // Thinking summaries is kernel-side but PER-INSTALL (2026-09-01): the post goes to the LOCAL kernel
+  // only — it is deliberately not in federation's KERNEL_SETTING set, so it never queues for or
+  // reaches another machine. Stamped with the gesture time all the same (two dashboards on one
+  // kernel still race, and the kernel orders every setting by `gt`; see the block below).
+  if (ths) ths.addEventListener('change', function () { post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: Date.now() }); });
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the
   // change; the controls re-initialize from /version on every open (fill()).
   // Each attached kernel keeps its own copy, so the post goes to all of them
@@ -763,7 +773,7 @@ function initGear(post) {
     'index-model': 'Indexing model', 'index-effort': 'Indexing effort',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
-    'comment-fast': 'Fast comment threads' };
+    'comment-fast': 'Fast comment threads', 'thinking-summaries': 'Thinking summaries' };
   // Dismissal is the warn-toast FAMILY treatment (the user 2026-08-25: a notice with no visible
   // way out gets in the way — worst on touch, and this toast's mint site is a frozen phone tab
   // flushing on recovery): a visible ✕ in the chip-✕ dress, the whole toast still click-dismisses,
@@ -969,6 +979,7 @@ function initGear(post) {
       fillAutoNudge(v.autoNudge, rows);
       fillMixedMarks(v, rows);
     }).catch(function () { fillAutoNudge(v.autoNudge, []); fillMixedMarks(v, []); });
+    if (ths) ths.checked = !!v.thinkingSummaries;   // per-install opt-in: this kernel's persisted answer is authoritative
     if (fe) fe.checked = !!v.fileEditing;   // the kernel's persisted opt-in is authoritative (see the viewer's consent popup)
     if (cvm) cvm.checked = !!v.conserveMemory;   // T148: the kernel's persisted conserve flag is authoritative
     if (csg) csg.checked = !!v.compactSuggest;   // T208+: the kernel's persisted opt-in is authoritative

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2565,9 +2565,15 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
   if (ev.kind === "thinking") {
     const turn = el("div", "turn turn-thinking");
     turn.appendChild(dot("ring"));
-    const t = el("div", "thinking" + (ev.encrypted ? " encrypted" : ""));
-    t.textContent = ev.encrypted ? "Thinking…" : ev.text;
-    if (ev.encrypted) { turn.appendChild(t); return turn; }   // already a one-liner
+    // Opaque = signed AND textless: only then is "Thinking…" all there is to show. A block with a
+    // signature and text is a reasoning SUMMARY (the kernel asks for them when its thinking-summaries
+    // toggle is on) and renders like any thinking text. The kernel's flag means opaque already; the
+    // text is re-checked here so a bundle fed by an older kernel (flag = signed) still shows what it
+    // was handed (2026-09-01 — before this, every summary hid behind the placeholder).
+    const opaque = ev.encrypted && !(ev.text || "").trim();
+    const t = el("div", "thinking" + (opaque ? " encrypted" : ""));
+    t.textContent = opaque ? "Thinking…" : ev.text;
+    if (opaque) { turn.appendChild(t); return turn; }   // already a one-liner
     // condense: clamp to ~2 lines with a fade; click to expand (the user: don't let
     // the interspersed thinking blocks dominate vertically).
     const clamp = el("div", "think-clamp");

--- a/ui/webview/thinking-summaries.test.ts
+++ b/ui/webview/thinking-summaries.test.ts
@@ -1,0 +1,36 @@
+// Thinking summaries (2026-09-01), pinned at the source like the other webview tests (the chat
+// renderer has no jsdom harness):
+//  - the FEED rule: a thinking block is opaque ("Thinking…") only when it has a signature AND no
+//    text. The old `ev.encrypted ? "Thinking…" : ev.text` hid every summary once the kernel asked
+//    the API for them, because a summarized block carries both a signature and its text. The
+//    kernel computes the flag the same way; the renderer re-checks the text so a bundle talking to
+//    an older kernel (flag = signature only) still shows any text it is handed.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const read = (...p: string[]) => fs.readFileSync(path.join(ROOT, ...p), "utf8");
+const RENDER = read("ui", "webview", "render.ts");
+const KERNEL = read("bin", "romp-kernel");
+
+test("a thinking block is opaque only when signed AND textless — a summary renders its text", () => {
+  const at = RENDER.indexOf('if (ev.kind === "thinking") {');
+  assert.ok(at > 0, "the thinking branch exists");
+  const branch = RENDER.slice(at, at + 1400);
+  assert.match(branch, /const opaque = ev\.encrypted && !\(ev\.text \|\| ""\)\.trim\(\);/,
+    "the renderer re-derives opacity from the text it was handed, never from the flag alone");
+  assert.match(branch, /t\.textContent = opaque \? "Thinking…" : ev\.text;/);
+  assert.match(branch, /if \(opaque\) \{ turn\.appendChild\(t\); return turn; \}/,
+    "only the opaque block is the one-liner; a text-bearing block falls through to the clamp");
+  assert.ok(!/ev\.encrypted \? "Thinking…"/.test(branch), "the old flag-only rule is gone");
+  // the text-bearing path keeps progressive disclosure: clamped to ~2 lines, click to expand, state keyed
+  assert.match(branch, /el\("div", "think-clamp"\)/);
+  assert.match(branch, /applyFold\(clamp, "expanded", tkey\)/);
+});
+
+test("the kernel computes the flag by the same rule (signature AND no text)", () => {
+  assert.ok(KERNEL.includes('"encrypted": bool(b.get("signature")) and not (b.get("thinking") or "").strip()'),
+    "the ChatEvent builder's flag means opaque, not merely signed");
+});

--- a/ui/webview/thinking-summaries.test.ts
+++ b/ui/webview/thinking-summaries.test.ts
@@ -5,6 +5,10 @@
 //    the API for them, because a summarized block carries both a signature and its text. The
 //    kernel computes the flag the same way; the renderer re-checks the text so a bundle talking to
 //    an older kernel (flag = signature only) still shows any text it is handed.
+//  - the GEAR toggle: a per-install kernel-side checkbox beside the other kernel toggles, stamped
+//    with its gesture time like every kernel-side setting the gear posts, filled from /version, named
+//    in the stale-gesture toast — and deliberately NOT in federation's KERNEL_SETTING set, so it
+//    never queues for or reaches another machine's kernel.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -13,6 +17,8 @@ import * as path from "node:path";
 const ROOT = path.resolve(process.cwd(), "..");
 const read = (...p: string[]) => fs.readFileSync(path.join(ROOT, ...p), "utf8");
 const RENDER = read("ui", "webview", "render.ts");
+const GEAR = read("ui", "webview", "gear.js");
+const FED = read("ui", "webview", "federation.ts");
 const KERNEL = read("bin", "romp-kernel");
 
 test("a thinking block is opaque only when signed AND textless — a summary renders its text", () => {
@@ -33,4 +39,45 @@ test("a thinking block is opaque only when signed AND textless — a summary ren
 test("the kernel computes the flag by the same rule (signature AND no text)", () => {
   assert.ok(KERNEL.includes('"encrypted": bool(b.get("signature")) and not (b.get("thinking") or "").strip()'),
     "the ChatEvent builder's flag means opaque, not merely signed");
+});
+
+test("the gear has a Thinking summaries checkbox among the kernel-side toggles, gesture-stamped, filled from /version", () => {
+  assert.ok(GEAR.includes("id=rs-thinksum"), "the checkbox exists in the gear markup");
+  const at = GEAR.indexOf("id=rs-thinksum");
+  assert.ok(GEAR.indexOf("id=rs-conserve") < at && at < GEAR.indexOf("id=rs-fileedit"),
+    "…between Conserve memory and File editing, with the other kernel-side toggles");
+  const row = GEAR.slice(at, at + 1200);
+  assert.match(row, /<b>Thinking summaries<\/b>/);
+  assert.ok(/new SDK session/.test(row) && /running session picks the change up at its next reconnect/.test(row),
+    "the sub-copy is honest that a running session is not switched live");
+  // …and names the events that actually reconnect one (sdk_backend's request_reconnect callers), never a
+  // model switch: set_model applies live over the SDK control channel and reconnects nothing, so copy that
+  // named a model switch as a trigger would send the user to switch models and wait forever.
+  assert.ok(/reconnect: an effort or billing switch, the first fast-mode opt-in, or a kernel restart/.test(row),
+    "the real reconnect triggers are named");
+  assert.ok(/Switching the model applies live and does not reconnect/.test(row),
+    "a model switch is called out as NOT one");
+  assert.ok(!/model or effort triggers one/.test(row), "no clause names a model switch as a trigger");
+  // The CLI resolves --thinking adaptive ahead of MAX_THINKING_TOKENS and alwaysThinkingEnabled:false, so
+  // on an install with thinking off the toggle turns adaptive thinking on; the copy owns that.
+  assert.ok(/turns adaptive thinking on/.test(row),
+    "the copy says the toggle also turns adaptive thinking on where it was off");
+  assert.ok(/Compact transcript still hides them/.test(row),
+    "…and that the compact view (default on) keeps hiding thinking, summaries included");
+  assert.ok(GEAR.includes("post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: Date.now() })"),
+    "the click posts the kernel's designed message with the gesture stamp minted in the literal");
+  assert.ok(GEAR.includes("ths.checked = !!v.thinkingSummaries"),
+    "the box always shows the kernel's persisted answer, never a page default");
+  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'thinking-summaries': 'Thinking summaries'/,
+    "a stood-down gesture toasts under the row's own name");
+});
+
+test("Thinking summaries is per-install: not a KERNEL_SETTING, so it never propagates", () => {
+  const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(setSrc, "federation.ts's KERNEL_SETTING set located");
+  assert.ok(!setSrc![1].includes("setThinkingSummaries"),
+    "the set must not carry it — this kernel keeps its own copy (the sub-copy says so)");
+  assert.ok(!FED.includes("setThinkingSummaries"), "…and no other federation path names it either");
+  assert.ok(!KERNEL.includes('"thinkingSummaries", _set_thinking_summaries'),
+    "…nor the /judge-settings propagation table on the kernel side");
 });


### PR DESCRIPTION
## What breaks

Every thinking block an SDK session writes back is signature-only. The chat shows "Thinking…" for each one, and the transcript on disk carries no reasoning summary, so an agent's reasoning cannot be read after the fact.

The cause is in the CLI, read in the 2.1.257 binary and re-read at 2.1.258. Its thinking-display resolver uses an explicit `--thinking-display` when one is passed, consults `settings.json`'s `showThinkingSummaries` only in interactive mode, forces `omitted` only for `--print` text/json output, and on the SDK's `stream-json --verbose` path requests no display at all. The API default then applies, and for current models that is signature-only (claude-agent-sdk's `types.py` says so for Opus 4.7+). romp's `_options` passes `effort=` and no thinking config, so nothing ever asks for summaries.

## Reproduction

On CLI 2.1.257 or 2.1.258, open any SDK session's transcript under `~/.claude/projects/`: every `thinking` block has a `signature` and an empty `thinking` string, and in the chat every thinking turn reads "Thinking…". A counts-only census of local transcripts (no content read out) found zero thinking blocks with both a signature and text on CLI 2.1.221 through 2.1.247 (15,563 signed blocks in total); such blocks appear only on the two versions where the flag below was passed.

## The fix, in three commits

1. **`kernel/sdk_backend.py`**: a connect-time setting read on every connect, like `effort`. When `STATE/thinking-summaries.json` says enabled, `_options` passes the SDK's typed `ThinkingConfigAdaptive` field, `thinking={"type": "adaptive", "display": "summarized"}` (claude-agent-sdk 0.2.132; the transport emits `--thinking adaptive --thinking-display summarized`), never `extra_args`. Off passes nothing, so the CLI's default stands unchanged. The decision is a pure helper (`thinking_kw`), so the standard test runner, which has no `claude_agent_sdk` and skips the `_options` pins, still exercises it; `tests/README.md` says how to run the gated classes with the SDK venv on `PYTHONPATH`.

2. **`kernel/kernel.py` `build_session` and `ui/webview/render.ts`**: `encrypted` now means opaque, a signature AND no text. A signed block with text is a summary and renders through the existing two-line clamp (click to expand). The renderer re-checks the text itself, so a bundle served by an older kernel, whose flag still means "signed", shows what it is handed. Judges do not read thinking text: their readers key on `type == "text"`, and a test pins that.

3. **The setting**: per-install, OFF by default, its own json under `STATE`, a gear checkbox "Thinking summaries" between Conserve memory and File editing, reported by `/version`. It is deliberately not in federation's `KERNEL_SETTING` set: each kernel keeps its own answer and nothing propagates (whoever reads the summaries turns it on where they read them). For the same reason it sits top-level in `/version` and not in the `settings` sub-dict, whose mixed marks promise a cross-machine write. It follows the same gesture ordering as the other kernel-side settings, because two dashboards on one kernel can race: the post carries `gt`, the store applies under `_SETTINGS_LOCK` in gesture order, a stale stamp stands down and answers the delivering socket with `settingStale` (the gear toasts it under the row's name via `STALE_LABELS`), an equal stamp carrying the stored value is a silent echo (the `_gesture_echo` check the other five gt-gated setters have), and a failed write is a loud `None` that applies nothing.

## Two limits, both stated in the gear copy

- A running session is not switched live. The python SDK wraps no runtime thinking-display control (the CLI's `set_max_thinking_tokens` control request carries a `thinking_display`; 0.2.132 does not expose it). The setting applies at the session's next reconnect: an effort, billing, per-session-env or bypass-mode switch, the first fast-mode opt-in, a file rewind, a kernel restart. A model switch applies live over the control channel and does not reconnect; the copy says so.
- The flag is not display-only. The CLI resolves `--thinking adaptive` before a `MAX_THINKING_TOKENS` in its environment and before `alwaysThinkingEnabled: false` in settings (read in the binary), so on an install that had thinking off, asking for summaries also turns adaptive thinking on, at that cost. The SDK has no display-only field. `_options` logs one line per backend when a cap is present in the CLI's environment; the settings half is not readable from the backend, so the gear copy carries it.

## Verified behavior

CLI 2.1.257 and 2.1.258, claude-agent-sdk 0.2.132 (`ThinkingConfigAdaptive.display`): on a running install with the toggle on, new SDK sessions write thinking blocks carrying both a signature and summary text into their transcripts, and the chat shows the clamp. With it off, blocks stay signature-only exactly as before. Counts only, from local transcripts: 10 signed+text blocks on 2.1.257 and 271 on 2.1.258, beside 5,174 and 1,493 signed-only blocks on the same versions; zero on every earlier CLI.

## Default and version floor

Shipped OFF. Default-ON is one boolean in `_thinking_summaries_on`'s fallback plus the fresh-install test.

`bin/romp-sdk-setup` installs `claude-agent-sdk` unpinned; the typed `thinking` field and `ThinkingConfigAdaptive.display` are present in 0.2.132. On a venv that predates the field, turning the toggle on makes `ClaudeAgentOptions(**kw)` raise `TypeError` at connect, a loud failure rather than a silent one; `effort=` has the same exposure today.

## Tests

- `tests/test_sdk_backend.py`: `ThinkingKw` (the SDK-free decision and the override note); `OptionsAssembly` (the typed field, the transport flags, one override log line per backend, none without a cap). Run with the SDK on `PYTHONPATH`, the 5 new tests pass; the one remaining failure in that class (`test_ultracode_…`) is pre-existing at the base and unrelated to this change.
- `tests/test_thinking_summary_events.py`: the opaque rule through `build_session` on a synthetic transcript; the judges' readers skip thinking.
- `tests/test_setting_gesture_order.py`: `ThinkingSummariesSetting` (store, stale stand-down, silent echo, a pre-field file reads as gt 0, the WS branch answers the socket and propagates nothing, write failure, `/version`); the `settingStale` cases-table row; the WiringPins counts now cover five toggles.
- `tests/test_kernel_settings_sections.py`: section placement of the new row.
- `ui/webview/thinking-summaries.test.ts`: the render rule, the kernel's matching expression, the gear row and copy, the stamped post, the `STALE_LABELS` entry, and that it is not a `KERNEL_SETTING`.

Each new test was red against the base before its code landed. Full runs: 6876 Python tests pass (`pytest -n 8`), 2735 node tests pass, `tsc --noEmit` clean, bats 375/375. All fixtures synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)