### PR TITLE
The compaction suggestion claims its latch before it sends, and every nudge-ledger writer holds the lock

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5350,6 +5350,29 @@ def _compact_suggest_tick(sid, tm, now):
     if not _st or now - _st < idle_s:
         return False                                   # not settled long enough — the crossing stays
     #                                                    armed; a later tick re-checks the same gate
+    with _NUDGE_LOCK:                                  # CLAIM BEFORE SEND (the double-send race,
+        # 2026-09-01): the check above releases the lock before the fire-time gates, and this tick
+        # has two concurrent entry points (the pusher's periodic pass and the setCompactSuggest
+        # handler's act-now re-tick) — latching only after the send let two entries pass the same
+        # unlatched check and inject the suggestion twice into one session. The latch write IS
+        # the claim: a fresh read under the lock re-derives what is still due (a concurrent entry
+        # may have claimed it in the gap), the winner latches and sends, the loser stands down
+        # right here. Same direction as the nudge machinery's own bookkeeping (_mark_auto_nudged
+        # records only after its send, so a failed send retries), inverted at this seam because
+        # the send must be single-shot — and the failure arm below rolls the claim back under the
+        # lock, so "never latch a fire that never went out" still holds durably: the next tick
+        # retries the same crossing.
+        d = dict(_auto_nudge_data())                   # fresh read — a concurrent writer's blob is
+        cs = dict(d.get("compactSuggested") or {})     # not clobbered
+        held = [t for t in [int(x) for x in cs.get(sid, [])] if tokens >= t]
+        due = [t for t in due if t not in held]
+        if not due:
+            return False                               # a concurrent entry already claimed this fire
+        cs[sid] = held + due
+        #                                                BOTH thresholds latch when found past both —
+        #                                                one message, never two in a tick
+        d["compactSuggested"] = cs
+        _write_auto_nudge(d)
     try:
         # the marker tail its sibling injectors carry (T207, the user 2026-08-31, who saw the
         # bare send render as their own blue bubble and ruled it must read system-injected):
@@ -5367,15 +5390,13 @@ def _compact_suggest_tick(sid, tm, now):
             "<!-- romp-injected -->")
     except Exception:
         sys.stderr.write("compact-suggest send (%s): %s\n" % (sid, traceback.format_exc()))
+        with _NUDGE_LOCK:                              # the claimed fire never went out — roll the
+            d = dict(_auto_nudge_data())               # claim back so the next tick retries
+            cs = dict(d.get("compactSuggested") or {})
+            cs[sid] = [t for t in [int(x) for x in cs.get(sid, [])] if t not in due]
+            d["compactSuggested"] = cs
+            _write_auto_nudge(d)
         return False
-    with _NUDGE_LOCK:                                  # latch AFTER the send went out, fresh read —
-        d = dict(_auto_nudge_data())                   # a concurrent writer's blob is not clobbered
-        cs = dict(d.get("compactSuggested") or {})
-        cs[sid] = [t for t in [int(x) for x in cs.get(sid, [])] if tokens >= t] + due
-        #                                                BOTH thresholds latch when found past both —
-        #                                                one message, never two in a tick
-        d["compactSuggested"] = cs
-        _write_auto_nudge(d)
     _log_nudge_event(sid, sid, now, 0, verdict="compact-suggested", ev_t=tokens)
     return True
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1863,21 +1863,29 @@ def _debt_reminder_body(asks):
 def _fire_debt_reminder(sid, now, alive_ids):
     """Send the reminder for every not-yet-reminded ask this session owes; True when one went out. The
     per-ask dedup key (asker>debtor:ts) makes this once-per-ask-EVER — escalation past an ignored
-    reminder belongs to the sender's card (the nudge-failed ladder), not to repeat reminders."""
+    reminder belongs to the sender's card (the nudge-failed ladder), not to repeat reminders.
+    Records AFTER the send, so a failed send retries (_mark_auto_nudged's direction) — and the record
+    write RE-READS the blob fresh under _NUDGE_LOCK and mutates only debtNudged, the key this writer
+    owns. The old shape held a pre-send snapshot across the live send and wrote the whole blob back:
+    last-writer-wins over every key, so it erased whatever a concurrent writer landed in the gap —
+    including _compact_suggest_tick's claim-before-send latch, which re-opened the double send the
+    claim exists to close (2026-09-01)."""
     asks = _debt_asks(sid, alive_ids)
     if not asks:
         return False
-    d = _auto_nudge_data()
-    dn = dict(d.get("debtNudged") or {})
+    dn0 = _auto_nudge_data().get("debtNudged") or {}
     due = [(asker, name, ts, kind, head) for asker, name, ts, kind, head in asks
-           if ("%s>%s:%d" % (asker, sid, ts)) not in dn]
+           if ("%s>%s:%d" % (asker, sid, ts)) not in dn0]
     if not due:
         return False
     Sessions.backend_for(sid).send(sid, _debt_reminder_body([(n, t, k, h) for _a, n, t, k, h in due]))
-    for asker, _n, ts, _k, _h in due:
-        dn["%s>%s:%d" % (asker, sid, ts)] = int(now)
-    d["debtNudged"] = dn
-    _write_auto_nudge(d)
+    with _NUDGE_LOCK:
+        d = dict(_auto_nudge_data())
+        dn = dict(d.get("debtNudged") or {})
+        for asker, _n, ts, _k, _h in due:
+            dn["%s>%s:%d" % (asker, sid, ts)] = int(now)
+        d["debtNudged"] = dn
+        _write_auto_nudge(d)
     return True
 
 
@@ -1929,27 +1937,31 @@ def _debt_reminder_outcomes(sid, lt, now):
     its chance and moved on without replying (the reminder's own response turn included: both honest
     exits it offered were postal replies, so a reply-less end IS the failure). A debtor that never turns
     again is the backstop's case (_debt_backstop_tick)."""
-    d = _auto_nudge_data()
-    dn = dict(d.get("debtNudged") or {})
-    if not dn:
+    dn0 = _auto_nudge_data().get("debtNudged") or {}
+    if not dn0:
         return
     last_any, _ask = _postal_wait_maps()
     lt_end = (lt.get("end", lt.get("t", 0)) or 0) if lt else 0
-    changed = False
-    for key, fire_t in list(dn.items()):
+    drop = []
+    for key, fire_t in dn0.items():
         parsed = _debt_key_parse(key)
         if not parsed or parsed[1] != sid:
             continue
         asker, _debtor, ts = parsed
         if last_any.get((sid, asker), 0) >= ts:        # answered → the reminder worked
-            dn.pop(key); changed = True
+            drop.append(key)
             continue
         if isinstance(fire_t, (int, float)) and lt_end > fire_t:
             _debt_escalate(asker, sid, ts, now)        # moved on without replying → the user's turn
-            dn.pop(key); changed = True
-    if changed:
-        d["debtNudged"] = dn
-        _write_auto_nudge(d)
+            drop.append(key)
+    if drop:
+        with _NUDGE_LOCK:                              # retire-only, key-scoped: the goal-store IO
+            d = dict(_auto_nudge_data())               # above stays outside the lock; the fresh
+            dn = dict(d.get("debtNudged") or {})       # re-read means every key another writer
+            for key in drop:                           # landed meanwhile (a compact-suggest claim)
+                dn.pop(key, None)                      # survives this write (2026-09-01)
+            d["debtNudged"] = dn
+            _write_auto_nudge(d)
 
 
 def _debt_backstop_tick(now):
@@ -1957,27 +1969,31 @@ def _debt_backstop_tick(now):
     idling forever on its reminder: past the same backstop the awaiting/deferral machinery uses, an
     unanswered reminder escalates (or, if answered meanwhile, retires) regardless. Mirrors
     AWAITING_DEADMAN_SECS' rationale: a missing event, surfaced rather than waited on forever."""
-    d = _auto_nudge_data()
-    dn = dict(d.get("debtNudged") or {})
-    if not dn:
+    dn0 = _auto_nudge_data().get("debtNudged") or {}
+    if not dn0:
         return
     last_any, _ask = _postal_wait_maps()
-    changed = False
-    for key, fire_t in list(dn.items()):
+    drop = []
+    for key, fire_t in dn0.items():
         parsed = _debt_key_parse(key)
         if not parsed:
-            dn.pop(key); changed = True                # malformed → drop rather than loop on it forever
+            drop.append(key)                           # malformed → drop rather than loop on it forever
             continue
         asker, debtor, ts = parsed
         if last_any.get((debtor, asker), 0) >= ts:
-            dn.pop(key); changed = True
+            drop.append(key)
             continue
         if isinstance(fire_t, (int, float)) and now - fire_t > NUDGE_DEFER_BACKSTOP_SECS:
             _debt_escalate(asker, debtor, ts, now)
-            dn.pop(key); changed = True
-    if changed:
-        d["debtNudged"] = dn
-        _write_auto_nudge(d)
+            drop.append(key)
+    if drop:
+        with _NUDGE_LOCK:                              # _debt_reminder_outcomes' write shape exactly:
+            d = dict(_auto_nudge_data())               # escalation IO outside the lock, then a fresh
+            dn = dict(d.get("debtNudged") or {})       # re-read popping only this writer's own keys,
+            for key in drop:                           # so a concurrent claim on any other key
+                dn.pop(key, None)                      # survives (2026-09-01)
+            d["debtNudged"] = dn
+            _write_auto_nudge(d)
 
 
 def _rgb(color):
@@ -3296,8 +3312,14 @@ _SETTINGS_LOCK = threading.RLock()
 # ONE lock for the nudge ledger's read-modify-write spans (2026-08-19 audit: a live episode
 # record vanished with no state-visible writer — the ledger's writers run on the producer tick,
 # judge callbacks, and WS handlers concurrently, and two overlapping dict(read)…write() spans
-# silently drop whichever landed first). The four EPISODE-record writers hold it across their
-# span; remaining writers (debt, settings) migrate as touched.
+# silently drop whichever landed first). EVERY writer holds it now (the last unlocked ones —
+# debt, deferrals, the interrupt-block marker — migrated 2026-09-01, when a debt writer's
+# pre-send snapshot erased a concurrent compact-suggest claim and re-opened the double send the
+# claim closes), in one of two shapes: a writer whose whole span is cheap dict ops holds the
+# lock across it (_set_auto_nudge's idiom), and a writer with IO between evidence and write (a
+# live send, the goal-store escalations, the sweep's transcript reads) does that IO OUTSIDE the
+# lock, then RE-READS the blob fresh under it and mutates only the keys it owns — never a held
+# snapshot, whose whole-blob write is last-writer-wins over every other key.
 _NUDGE_LOCK = threading.RLock()
 
 
@@ -4842,14 +4864,15 @@ def _intr_blocked(sid=None):
 
 
 def _set_intr_blocked(sid, gid):
-    d = dict(_auto_nudge_data())
-    m = dict(d.get("intrBlocked") or {})
-    if gid:
-        m[str(sid)] = gid
-    else:
-        m.pop(str(sid), None)
-    d["intrBlocked"] = m
-    _write_auto_nudge(d)
+    with _NUDGE_LOCK:                    # every ledger writer serializes here (2026-09-01) — an
+        d = dict(_auto_nudge_data())     # unlocked read→write span, however small, can erase a
+        m = dict(d.get("intrBlocked") or {})   # concurrent writer's keys (whole-blob last-writer-wins)
+        if gid:
+            m[str(sid)] = gid
+        else:
+            m.pop(str(sid), None)
+        d["intrBlocked"] = m
+        _write_auto_nudge(d)
 
 
 def _intr_block_stands(sid, gid):
@@ -5361,7 +5384,12 @@ def _compact_suggest_tick(sid, tm, now):
         # records only after its send, so a failed send retries), inverted at this seam because
         # the send must be single-shot — and the failure arm below rolls the claim back under the
         # lock, so "never latch a fire that never went out" still holds durably: the next tick
-        # retries the same crossing.
+        # retries the same crossing. The claim (and the rollback) is durable against every OTHER
+        # ledger writer too: all of them hold _NUDGE_LOCK across their read-modify-write, and the
+        # ones with IO mid-span re-read fresh under the lock and mutate only their own keys —
+        # before that migration (2026-09-01), a debt reminder's pre-send snapshot written whole
+        # erased a concurrent claim (or resurrected a rolled-back one) and re-opened the double
+        # send through the side door.
         d = dict(_auto_nudge_data())                   # fresh read — a concurrent writer's blob is
         cs = dict(d.get("compactSuggested") or {})     # not clobbered
         held = [t for t in [int(x) for x in cs.get(sid, [])] if tokens >= t]
@@ -6527,27 +6555,30 @@ def _nudge_deferred_ok(gid, reason, now, sid=None, ev_t=None):
     a seen counter or a screen (both retired; a frozen record can no longer hide a stale claim,
     because nothing freezes). `ev_t` rides WHY_TURN_IN_FLIGHT records: the newest diary evidence the
     hold is waiting to see END, which is exactly the event the sweep retires it on."""
-    d = _auto_nudge_data()
-    dd = dict(d.get("deferred") or {})
-    if not reason:
-        if gid in dd:                                    # the reviver ran → forget the deferral
-            dd.pop(gid, None)
+    with _NUDGE_LOCK:                                    # the ledger's one write discipline (2026-09-01):
+        # every read→write span holds the lock — the decisions between are pure dict ops, and an
+        # unlocked span here could erase whatever another writer landed in the gap
+        d = dict(_auto_nudge_data())
+        dd = dict(d.get("deferred") or {})
+        if not reason:
+            if gid in dd:                                # the reviver ran → forget the deferral
+                dd.pop(gid, None)
+                d["deferred"] = dd
+                _write_auto_nudge(d)
+            return True
+        rec = dd.get(gid)
+        first = _deferral_at(rec)
+        if first is None:
+            dd[gid] = {"at": int(now), "why": reason, "sid": sid,
+                       **({"evT": int(ev_t)} if ev_t else {})}
             d["deferred"] = dd
             _write_auto_nudge(d)
-        return True
-    rec = dd.get(gid)
-    first = _deferral_at(rec)
-    if first is None:
-        dd[gid] = {"at": int(now), "why": reason, "sid": sid,
-                   **({"evT": int(ev_t)} if ev_t else {})}
-        d["deferred"] = dd
-        _write_auto_nudge(d)
-        return False
-    if _deferral_why(rec) != reason:                     # the wait moved to a DIFFERENT reviver: keep the clock
-        dd[gid] = {"at": first, "why": reason, "sid": sid,
-                   **({"evT": int(ev_t)} if ev_t else {})}
-        d["deferred"] = dd
-        _write_auto_nudge(d)
+            return False
+        if _deferral_why(rec) != reason:                 # the wait moved to a DIFFERENT reviver: keep the clock
+            dd[gid] = {"at": first, "why": reason, "sid": sid,
+                       **({"evT": int(ev_t)} if ev_t else {})}
+            d["deferred"] = dd
+            _write_auto_nudge(d)
     # WEDGED-REVIVER BOUND ON THE PASS EVENT, not a clock (W2c, the user 2026-08-24): the named
     # reviver is wedged exactly when its OWNING TIER has completed a per-session pass over this fsid
     # SINCE the deferral was minted and the reason still stands — the pass ran and did not retire it.
@@ -6611,8 +6642,7 @@ def _deferral_sweep_tick(now):
     An unknown/future why stands (and presents) until the walk re-runs it — the honest default. The
     sweep only POPS; it never rewrites a why (one writer per duty: rewriting here raced the walk and
     could re-dress a durable hold as in-flight whenever any judge call happened to be running)."""
-    d = _auto_nudge_data()
-    dd = dict(d.get("deferred") or {})
+    dd = dict(_auto_nudge_data().get("deferred") or {})
     if not dd:
         return
     by_sid = {}
@@ -6620,7 +6650,7 @@ def _deferral_sweep_tick(now):
         sid = (rec.get("sid") if isinstance(rec, dict) else None) or str(gid).rsplit(":", 1)[0]
         by_sid.setdefault(sid, []).append((gid, rec))
     active = {r.get("fsid") for r in jd.active_runs()}
-    changed = False
+    drop = []
     for sid, recs in by_sid.items():
         try:
             store = jd.load_goals(sid)
@@ -6669,11 +6699,15 @@ def _deferral_sweep_tick(now):
                 except Exception:
                     pop = False
             if pop:
-                dd.pop(gid, None)
-                changed = True
-    if changed:
-        d["deferred"] = dd
-        _write_auto_nudge(d)
+                drop.append(gid)
+    if drop:
+        with _NUDGE_LOCK:                              # the sweep's evidence-gathering above is heavy
+            d = dict(_auto_nudge_data())               # IO held across a long span — so it writes the
+            dd = dict(d.get("deferred") or {})         # debt writers' way (2026-09-01): a fresh
+            for gid in drop:                           # re-read under the lock, popping only the gids
+                dd.pop(gid, None)                      # it decided, so a concurrent writer's keys
+            d["deferred"] = dd                         # (a compact-suggest claim, a fresh mint)
+            _write_auto_nudge(d)                       # survive the write
 
 
 def _last_assistant_text(path, cap=4000):

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -9,9 +9,12 @@ observed as the authoritative token counter falling back below the latched thres
 silent forever, acted+regrown+idle = one fresh suggestion per threshold (the manager's amendment).
 Workers (their roster tags), comment-thread forks, and mid-turn sessions are excluded at fire
 time. The voice render is pinned in test_injected_voice.py. SYNTHETIC fixtures only."""
+import contextlib
+import io
 import json
 import os
 import tempfile
+import threading
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -33,7 +36,9 @@ IDLE = NOW - 7200          # settled two hours ago — past the hour gate
 FRESH = NOW - 120          # settled two minutes ago — inside it
 
 
-class CompactSuggest(unittest.TestCase):
+class _Fixture(unittest.TestCase):
+    """The shared hermetic world: opted-in install, idle-settled session, captured sends."""
+
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved_state = jd.STATE
@@ -68,6 +73,8 @@ class CompactSuggest(unittest.TestCase):
         km._autonudge_cache.clear()
         return (km._auto_nudge_data().get("compactSuggested") or {}).get(SID, [])
 
+
+class CompactSuggest(_Fixture):
     # ── the crossing latch ──
     def test_a_crossing_fires_once_and_latches(self):
         self.assertTrue(self._tick(450_000))
@@ -223,6 +230,68 @@ class CompactSuggest(unittest.TestCase):
         rows = [json.loads(l) for l in p.read_text().splitlines()]
         self.assertEqual([r["verdict"] for r in rows], ["compact-suggested"])
         self.assertEqual(rows[0]["evT"], 450_000, "the row carries the token count it fired on")
+
+
+class ConcurrentSendRace(_Fixture):
+    """The double-send race (2026-09-01): the tick checked the compactSuggested
+    latch under _NUDGE_LOCK, released it, sent, and latched only after — so two concurrent entries
+    (the pusher's periodic pass racing a settings-WS re-tick) both passed the same unlatched check
+    and injected the suggestion twice into one session. The fire is now CLAIMED under the lock
+    before the send (a fresh re-read re-derives what is still due, so the loser stands down), and
+    a failed send rolls the claim back for the next tick's retry. Deterministic, events only — the
+    first entry is held between its check and its send until the second has fully landed (the
+    TwoFlushRace idiom, test_setting_gesture_order.py)."""
+
+    def test_two_concurrent_entries_inject_once(self):
+        first_at_gate = threading.Event()
+        second_done = threading.Event()
+
+        def gated(sid):
+            # _settle_event_key sits between the latch check and the send on every entry path;
+            # stalling the first entry here holds it in exactly the window the race needs
+            if threading.current_thread().name == "first":
+                first_at_gate.set()
+                second_done.wait(10)
+            return IDLE
+
+        km._settle_event_key = gated
+        got = {}
+        t = threading.Thread(target=lambda: got.__setitem__("first", self._tick(450_000)),
+                             name="first")
+        t.start()
+        try:
+            self.assertTrue(first_at_gate.wait(10), "the first entry passed its latch check")
+            got["second"] = self._tick(450_000)     # the concurrent entry runs to completion
+        finally:
+            second_done.set()
+            t.join(10)
+        self.assertFalse(t.is_alive(), "both entries finished")
+        self.assertEqual(len(self.sent), 1,
+                         "two entries past the same unlatched check must still inject exactly once")
+        self.assertEqual(sorted((got["first"], got["second"])), [False, True],
+                         "exactly one entry claims the fire; the other stands down")
+        self.assertEqual(self._latched(), [400_000], "one claim, latched once")
+
+    def test_a_failed_send_unlatches_so_the_next_tick_retries(self):
+        test = self
+        attempts = []
+
+        class BlinkingBackend:
+            def send(self, sid, body):
+                attempts.append(body)
+                if len(attempts) == 1:
+                    raise RuntimeError("stream blink")
+                test.sent.append(body)
+
+        be = BlinkingBackend()
+        km.Sessions.backend_for = staticmethod(lambda sid: be)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertFalse(self._tick(450_000), "a failed send reports no fire")
+        self.assertEqual(self._latched(), [],
+                         "the claim rolls back — no durable latch for a send that never went out")
+        self.assertTrue(self._tick(450_000), "the next tick retries the same crossing")
+        self.assertEqual(len(self.sent), 1)
+        self.assertEqual(len(attempts), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -294,5 +294,134 @@ class ConcurrentSendRace(_Fixture):
         self.assertEqual(len(attempts), 2)
 
 
+class DebtWriterRace(_Fixture):
+    """The claim's SIDE DOOR (2026-09-01): the ledger's debt writers ran an
+    unlocked read→write span — a snapshot of the whole blob held across a LIVE send, written back
+    whole — so a debt reminder straddling a concurrent claim erased the compactSuggested latch
+    (last-writer-wins over every key), and the next tick re-derived the crossing as due and sent
+    the suggestion a SECOND time; the mirror straddle of a failed send's rollback RESURRECTED a
+    latch whose fire never went out, so the retry stood down forever. The writers now hold
+    _NUDGE_LOCK for their record write and RE-READ the blob fresh under it, mutating only the
+    debt keys they own — the claim survives the straddle, the rollback survives it too, and the
+    debt writer's own record still lands (neither writer's output is lost). Deterministic, events
+    only — the debt writer is held inside its send across the other entry's whole claim (the
+    TwoFlushRace idiom). SYNTHETIC sids throughout."""
+
+    YSID = "11111111-2222-3333-4444-ffffffffffff"      # the debtor owing a reply
+    ASKER = "11111111-2222-3333-4444-aaaaaaaaaaaa"     # the peer still waiting on it
+    DEBT_KEY = "%s>%s:1000" % (ASKER, YSID)
+
+    def setUp(self):
+        super().setUp()
+        self._orig_debt_asks = km._debt_asks
+        # one synthetic unanswered ask the debtor owes — the writers' blob read-modify-write is
+        # the thing under test, not the postal wait maps
+        km._debt_asks = lambda sid, alive: [
+            (self.ASKER, "peer", 1000, "question", "where do things stand?")]
+
+    def tearDown(self):
+        km._debt_asks = self._orig_debt_asks
+        super().tearDown()
+
+    def _debt_recorded(self):
+        km._autonudge_cache.clear()
+        return self.DEBT_KEY in (km._auto_nudge_data().get("debtNudged") or {})
+
+    def test_a_debt_writer_straddling_a_claim_never_erases_it(self):
+        b_in_send = threading.Event()
+        claim_done = threading.Event()
+        sent_y, got = [], {}
+        test = self
+
+        class XBackend:                                # the suggestion's recipient
+            def send(self, sid, body):
+                test.sent.append(body)
+
+        class YBackend:                                # the debtor: the reminder send holds the
+            def send(self, sid, body):                 # writer in exactly the straddle window —
+                sent_y.append(body)                    # blob read behind it, record write ahead
+                b_in_send.set()
+                claim_done.wait(10)
+        km.Sessions.backend_for = staticmethod(
+            lambda sid: XBackend() if sid == SID else YBackend())
+
+        tb = threading.Thread(target=lambda: got.__setitem__(
+            "debt", km._fire_debt_reminder(self.YSID, NOW, {self.ASKER})), name="debt")
+        tb.start()
+        try:
+            self.assertTrue(b_in_send.wait(10), "the debt writer reached its send")
+            got["tick"] = self._tick(450_000)          # claim + send, inside the straddle
+            self.assertTrue(got["tick"])
+            self.assertEqual(self._latched(), [400_000], "the claim landed")
+        finally:
+            claim_done.set()
+            tb.join(10)
+        self.assertFalse(tb.is_alive(), "the debt writer finished")
+        self.assertTrue(got["debt"], "the reminder went out")
+        self.assertEqual(self._latched(), [400_000],
+                         "the debt record write must not erase the concurrent claim")
+        self.assertFalse(self._tick(450_000),
+                         "the crossing stays claimed — no re-derived second fire")
+        self.assertEqual(len(self.sent), 1, "one suggestion, never two")
+        self.assertEqual(len(sent_y), 1)
+        self.assertTrue(self._debt_recorded(),
+                        "…and the debt writer's own key lands too — both writers' outputs "
+                        "survive the interleaving")
+
+    def test_a_debt_writer_straddling_a_rollback_never_resurrects_the_latch(self):
+        claim_landed = threading.Event()
+        b_in_send = threading.Event()
+        rollback_done = threading.Event()
+        sent_y, got = [], {}
+        test = self
+
+        class XGatedFail:                              # the claimed fire never goes out — and the
+            def send(self, sid, body):                 # failure is held until the debt writer has
+                claim_landed.set()                     # read the blob WITH the claim in it
+                test.assertTrue(b_in_send.wait(10), "the debt writer read while the claim stood")
+                raise RuntimeError("stream blink")
+
+        class YBackend:
+            def send(self, sid, body):
+                sent_y.append(body)
+                b_in_send.set()
+                rollback_done.wait(10)                 # record write held past the rollback
+        km.Sessions.backend_for = staticmethod(
+            lambda sid: XGatedFail() if sid == SID else YBackend())
+
+        def run_claimer():
+            with contextlib.redirect_stderr(io.StringIO()):
+                got["tick"] = self._tick(450_000)
+
+        ta = threading.Thread(target=run_claimer, name="claimer")
+        ta.start()
+        self.assertTrue(claim_landed.wait(10), "the claim landed before the failing send")
+        tb = threading.Thread(target=lambda: got.__setitem__(
+            "debt", km._fire_debt_reminder(self.YSID, NOW, {self.ASKER})), name="debt")
+        tb.start()
+        try:
+            ta.join(10)                                # the send fails; the rollback lands
+            self.assertFalse(ta.is_alive(), "the claimer finished")
+            self.assertEqual(self._latched(), [], "the rollback landed")
+        finally:
+            rollback_done.set()
+            tb.join(10)
+        self.assertFalse(tb.is_alive(), "the debt writer finished")
+        self.assertFalse(got["tick"], "a failed send reports no fire")
+        self.assertTrue(got["debt"], "the reminder went out")
+        self.assertEqual(self._latched(), [],
+                         "the debt record write must not resurrect a latch whose fire never "
+                         "went out")
+
+        class XBackend:                                # a working backend for the retry
+            def send(self, sid, body):
+                test.sent.append(body)
+        km.Sessions.backend_for = staticmethod(
+            lambda sid: XBackend() if sid == SID else YBackend())
+        self.assertTrue(self._tick(450_000), "the next tick retries the same crossing")
+        self.assertEqual(len(self.sent), 1)
+        self.assertTrue(self._debt_recorded(), "…and the debt key still lands")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What breaks

`_compact_suggest_tick` can inject the `/compact` suggestion twice into one session. It reads the per-session `compactSuggested` latch under `_NUDGE_LOCK`, releases the lock, runs its fire-time gates (roster tag, thread fork, open turn, and the idle gate through `_settle_event_key`), sends, and latches only after the send. The tick rides `_auto_nudge_tick`'s alive walk, which has two concurrent entry points on main: the pusher's periodic pass and the `setCompactSuggest` WS handler's act-now re-tick (`run_dead_wait=False`). Two entries that pass the same unlatched check both send.

The latch is also only as durable as the ledger's other writers. `_fire_debt_reminder` held a snapshot of the whole auto-nudge blob across a live send and wrote it back whole; `_debt_reminder_outcomes`, `_debt_backstop_tick`, `_set_intr_blocked`, `_nudge_deferred_ok`, and `_deferral_sweep_tick` ran unlocked read-then-write spans over the same file. A whole-blob write is last-writer-wins over every key, so any of these straddling a latch write erases it, and the next tick re-derives the crossing as due and sends again.

## Reproduction

Both are deterministic two-thread tests in `tests/test_compact_suggest.py`, gated on events (no sleeps), in the same idiom as `TwoFlushRace` in `tests/test_setting_gesture_order.py`:

- `ConcurrentSendRace.test_two_concurrent_entries_inject_once`: the first entry is held inside `_settle_event_key` (between its latch check and its send) until a second entry runs to completion. On main: two sends (`2 != 1`).
- `DebtWriterRace.test_a_debt_writer_straddling_a_claim_never_erases_it`: a debt reminder is held inside its send while a compact suggestion latches; the reminder's record write then lands. On main: the latch is gone (`[] != [400000]`) and the next tick sends the suggestion a second time.

## The fix, in two commits

**1. The latch write becomes the claim** (`_compact_suggest_tick`). Under `_NUDGE_LOCK`, re-read the blob, re-derive what is still due against the fresh latch, and stand down (`return False`) if a concurrent entry already claimed it; otherwise latch, then send. A failed send rolls the claim back under the lock so the next tick retries the same crossing, which keeps the existing rule that a fire that never went out is never left latched. The post-send latch block is deleted.

**2. Every remaining ledger writer holds `_NUDGE_LOCK` and mutates only its own keys.** The writers take one of two shapes. A span that is pure dict work holds the lock across the whole span (`_set_intr_blocked`, `_nudge_deferred_ok`; the idiom the settings writers use since #879). A writer with IO between evidence and write (`_fire_debt_reminder`'s send, `_debt_escalate`'s goal-store writes in the two debt sweeps, `_deferral_sweep_tick`'s transcript reads) does that IO outside the lock, then re-reads the blob fresh under it and pops or sets only the keys it decided. This finishes the migration the lock's comment deferred "as touched"; the comment now describes the two shapes. No new lock ordering: `_atomic_write` takes only its own short counter lock, and the episode writers already hold `_NUDGE_LOCK` across the same call.

The second commit is in this PR because the first is not durable without it: the debt writers can erase the claim, and can also resurrect a rolled-back claim after a failed send (`DebtWriterRace.test_a_debt_writer_straddling_a_rollback_never_resurrects_the_latch` is red against commit 1 alone, the first point at which there is a claim to resurrect).

## Tests

`tests/test_compact_suggest.py`: the 18 existing tests are unchanged (their class becomes a shared `_Fixture`); 22 total.

- `ConcurrentSendRace` (2): inject once under the race; a failed send unlatches and the next tick retries.
- `DebtWriterRace` (2): the erasure straddle and the resurrection straddle, each also asserting that the debt writer's own `debtNudged` key still lands, so neither writer's output is lost.

Red-first progression: on main, inject-once and erasure fail and the other two pass (the old code never latched a failed send). After commit 1 alone, inject-once passes; erasure and resurrection fail. After commit 2, all four pass. The race tests ran green 10 of 10 in a loop; their waits are 10 s event timeouts, so a starved runner surfaces an assertion rather than a hang.

Also run: `test_kernel_debt_nudge`, `test_kernel_deferral_sweep`, `test_kernel_nudge_last_resort`, `test_kernel_interrupt_blocks`, `test_kernel_stalled_blocks`, `test_nudge_unblock_hold`, `test_auto_nudge_every_kernel`, `test_setting_gesture_order`, `test_injected_voice`, `test_kernel` (these patch the ledger accessors directly and drive every migrated writer): 620 passed. Full suite: 6860 passed, 45 skipped. Synthetic ids only.

## Reviewer notes

- `_set_auto_nudge` and `_set_compact_suggest` are untouched; #879 already put them under `_NUDGE_LOCK`.
- A lock audit (nearest enclosing `with _NUDGE_LOCK:` for every `_write_auto_nudge(` call) reports zero unlocked sites after this change. Main has eight, in the six functions above.
- A send failure now writes the blob twice (claim, then rollback) where the old code wrote nothing. Both are atomic publishes.
- Not claimed fixed: two concurrent `_fire_debt_reminder` calls for one debtor can still both pass the pre-read and both send. That race pre-exists; this change only stops the reminder's record write from erasing other writers' keys.
- The comment inside `_auto_nudge_tick` attributing the `run_dead_wait=False` re-tick to `setAutoNudge` is pre-existing and left alone; on main the re-tick is `setCompactSuggest`'s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)