### PR TITLE
T230b: the update-check loop waits on its own seam — the CI hang's convicted site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,17 @@ jobs:
         # cryptography: the kernel's Web Push soft dependency (plans/ios-app.md). Installed here
         # so tests/test_kernel_webpush.py's crypto layers RUN in CI instead of skipping — the
         # kernel itself still degrades loudly without it (that path has its own test).
-        run: python -m pip install --upgrade pip pytest cryptography
+        run: python -m pip install --upgrade pip pytest pytest-timeout cryptography
       - name: Run pytest
-        run: python -m pytest -q
+        # T230b: a hung test used to be 15 minutes of silence (five jobs since 2026-08-27, a
+        # process-global time.sleep patch consumed by a foreign thread). pytest-timeout turns the
+        # NEXT stall into a named failure with every thread's stack: thread method = guaranteed
+        # termination (the process ends; the test is the bottom MainThread frame) - the signal
+        # method cannot interrupt a C call. 600 s strictly exceeds the slowest legitimate test
+        # (~122 s, leak-scaled) and the 300 s child timeout in test_session_move_live. Its timer
+        # waits on an Event, so it can never itself consume a patched sleep. --durations names the
+        # slowest tests on every run so a creeping one is visible before it stalls.
+        run: python -m pytest -q --durations=10 --timeout=600 --timeout-method=thread
 
   shell:
     name: Shell (bats, ${{ matrix.os }})

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3773,6 +3773,14 @@ _UPDATE_CHECK_EVERY_S = 6 * 3600
 # tree LOUDLY — peers' uncommitted work is never discarded — and the restart rides the manager's
 # quiet window, whose chain is silent-death-proof since the same day's fix).
 _MAIN_CHECK_EVERY_S = 300
+# T230b (the user 2026-09-03): the update-check loop's cadence wait is a loop-PRIVATE seam, never the
+# process-global time.sleep. Event.wait does not route through time.sleep, so nothing a test (or any
+# other thread) does to the shared sleep can touch this loop - and the loop gains a real exit event.
+# Never set by the kernel: zero runtime change. Five CI jobs since 08-27 hung silently because the
+# loop's only exit was a SystemExit raised out of a patched time.sleep on its 2nd call, and a leaked
+# heartbeat thread sleeping in the same window consumed that call; the loop then spun forever on a
+# no-op sleep with pytest printing nothing until the 15-minute cap.
+_CHECK_LOOP_STOP = threading.Event()
 _CONVERGE_COOLDOWN_S = float(os.environ.get("ROMP_CONVERGE_COOLDOWN", "1500"))   # min gap between AUTO converges (25 min → ≤2-3 restarts/hour on a hot main)
 _LAST_AUTO_CONVERGE = [0.0]   # when the last auto converge fired (module state; a restart resets it, which is fine — the restart WAS the converge)              # one ls-remote — cheap enough to notice a merge within minutes
 _MAIN_DRIFT = ["", ""]                 # [origin sha a notice fired for, checkout sha one fired for]
@@ -4233,7 +4241,8 @@ def _update_check_loop():
             _main_drift_check()
         except Exception:
             sys.stderr.write("main drift pass: %s\n" % traceback.format_exc())
-        time.sleep(_MAIN_CHECK_EVERY_S)
+        if _CHECK_LOOP_STOP.wait(_MAIN_CHECK_EVERY_S):
+            return                                    # the loop's own exit event (T230b) - see the seam
 
 
 def _auto_update_remotes_on():

--- a/tests/test_kernel_socket_deliver.py
+++ b/tests/test_kernel_socket_deliver.py
@@ -46,14 +46,17 @@ class _OneShotInbox:
         self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._srv.bind(self.path)
         self._srv.listen(1)
+        self._srv.settimeout(5.0)                      # can-never-trap backstop: a never-connected inbox's
+        #                                                accept() returns instead of parking the thread
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
     def _run(self):
         try:
             conn, _ = self._srv.accept()
-        except OSError:
+        except OSError:                                # includes the timeout (socket.timeout is an OSError)
             return
+        conn.settimeout(5.0)
         buf = b""
         while True:
             chunk = conn.recv(4096)
@@ -68,10 +71,17 @@ class _OneShotInbox:
         return self.got
 
     def close(self):
+        # shutdown BEFORE close wakes a parked accept() (a bare close leaves it blocked until the
+        # listener's timeout), then join so no capture thread outlives its test (T230b hygiene)
+        try:
+            self._srv.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
         try:
             self._srv.close()
         except OSError:
             pass
+        self._thread.join(timeout=1.0)
 
 
 class SocketRegistry(unittest.TestCase):

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -241,12 +241,22 @@ class CheckLoop(Fresh):
         # nor one watcher's crash starve the other.
         releases = []
         drifts = []
+        converges = []
         naps = []
 
-        def nap(s):
-            naps.append(s)
-            if len(naps) == 2:
-                raise SystemExit                       # unhook the forever-loop after two rounds
+        # T230b: the loop is unhooked through ITS OWN seam - the stop event - never by patching the
+        # process-global time.sleep (that patch, a counter raising SystemExit on call #2, was consumed
+        # by leaked heartbeat threads sleeping in the window and hung five CI jobs for 15 silent
+        # minutes each). The stub returns True on the 2nd wait (the event fired) and RAISES on any
+        # later wait: a loop wired to wait but not to return would otherwise hang this very pin.
+        class Stop:
+            def wait(self, s):
+                naps.append(s)
+                if len(naps) == 2:
+                    return True
+                if len(naps) > 2:
+                    raise AssertionError("the loop kept waiting after the stop event fired")
+                return False
 
         def release_pass():
             releases.append(1)
@@ -256,16 +266,76 @@ class CheckLoop(Fresh):
             drifts.append(1)
             if len(drifts) == 1:
                 raise RuntimeError("boom")             # …nor a dying drift probe the NEXT drift probe
+
+        def converge_pass():
+            converges.append(1)                        # stubbed: the real one spawns node + rglobs ui/
+            raise RuntimeError("boom")                 # …nor a dying dist converge any of them
         with mock.patch.object(km, "_update_check", side_effect=release_pass), \
              mock.patch.object(km, "_main_drift_check", side_effect=drift_pass), \
-             mock.patch.object(km.time, "sleep", side_effect=nap), \
-             self.assertRaises(SystemExit):
-            km._update_check_loop()
+             mock.patch.object(km, "_dist_converge_check", side_effect=converge_pass), \
+             mock.patch.object(km, "_CHECK_LOOP_STOP", Stop()):
+            km._update_check_loop()                    # RETURNS on the stop event
         self.assertEqual(len(releases), 1, "the six-hour stride: one release check across two fast rounds")
         self.assertEqual(len(drifts), 2, "the drift probe runs every round, surviving its own crash")
+        self.assertEqual(len(converges), 2, "the dist converge runs every round, surviving its own crash")
         self.assertEqual(naps, [km._MAIN_CHECK_EVERY_S] * 2)
         self.assertEqual(km._UPDATE_CHECK_EVERY_S, 6 * 3600)
         self.assertEqual(km._MAIN_CHECK_EVERY_S, 300)
+
+
+    def test_the_loop_never_sleeps_through_the_shared_time_sleep(self):
+        # T230b (the user 2026-09-03, five hung CI jobs since 08-27): the loop's cadence wait must be a
+        # loop-PRIVATE seam, never the process-global time.sleep. The sibling test above used to
+        # patch km.time.sleep with a counter that raised SystemExit on call #2 — and any OTHER
+        # thread sleeping in the window (test_heartbeat_thread leaks _heartbeat daemons that sleep
+        # every 10s for the rest of the run) consumed a count; when a foreign thread drew #2,
+        # threading swallowed its SystemExit and the loop spun forever on a no-op sleep: a silent
+        # 15-minute job. Deterministic, no timing: a spinning foreign sleeper runs throughout; the
+        # shared sleep is a PLAIN guard (never a recording mock the spinner would fill) that raises
+        # only on the MAIN thread — so a loop reaching time.sleep fails in milliseconds, never hangs.
+        import threading
+        stop = threading.Event()
+        main = threading.get_ident()
+
+        def spinner():
+            while not stop.is_set():
+                time.sleep(0)
+        t = threading.Thread(target=spinner, daemon=True)
+        t.start()
+        releases, drifts, naps = [], [], []
+
+        def guard(s):
+            if threading.get_ident() == main:
+                raise AssertionError("the update-check loop must wait on its own seam, not the shared time.sleep")
+
+        class Stub:
+            def wait(self, s):
+                naps.append(s)
+                if len(naps) == 2:
+                    return True                        # the stop event fires → the loop must RETURN
+                if len(naps) > 2:
+                    raise AssertionError("the loop kept waiting after the stop event fired")
+                return False
+
+        def release_pass():
+            releases.append(1)
+            raise RuntimeError("boom")
+
+        def drift_pass():
+            drifts.append(1)
+        try:
+            with mock.patch.object(km, "_update_check", side_effect=release_pass), \
+                 mock.patch.object(km, "_main_drift_check", side_effect=drift_pass), \
+                 mock.patch.object(km, "_dist_converge_check"), \
+                 mock.patch.object(km.time, "sleep", guard), \
+                 mock.patch.object(km, "_CHECK_LOOP_STOP", Stub(), create=True):
+                km._update_check_loop()               # returns — the stop event is the loop's exit
+        finally:
+            stop.set()
+            t.join(timeout=2)
+        self.assertEqual(naps, [km._MAIN_CHECK_EVERY_S] * 2)
+        self.assertEqual(len(releases), 1)
+        self.assertEqual(len(drifts), 2)
 
 
 class RunUpdate(Fresh):

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -327,6 +327,10 @@ class NativeDialogWire(_Wire):
 
     def test_a_kernel_that_can_show_one_says_nothing_and_opens_it(self):
         opened = []
+        before = set(threading.enumerate())            # join only the threads THIS test starts (T230b):
+        #                                                joining every daemon in the process made this
+        #                                                test's runtime scale with the suite's leaked
+        #                                                threads (~122 s measured, 2 s per leak)
         with mock.patch.object(km, "_native_dialogs", lambda: True), \
              mock.patch.object(km, "_pick_folder", lambda: opened.append("folder") or ""), \
              mock.patch.object(km, "_pick_file", lambda: opened.append("file") or ""):
@@ -336,7 +340,7 @@ class NativeDialogWire(_Wire):
                 self.assertEqual([m for m in self.sent if m.get("type") == "warn"], [],
                                  "an available dialog must not be talked about, only shown")
         for t in threading.enumerate():                      # the dialog runs off the message loop
-            if t is not threading.current_thread() and t.daemon:
+            if t not in before and t is not threading.current_thread() and t.daemon:
                 t.join(timeout=2)
         self.assertEqual(sorted(opened), ["file", "folder"])
 


### PR DESCRIPTION
## Summary
Five Python CI jobs since 2026-08-27 hung silently to the 15-minute cap. The convicted site: `tests/test_kernel_update.py`'s CheckLoop test patched the **process-global** `time.sleep` with a counter raising `SystemExit` on call #2 to unhook `_update_check_loop` — whose only exit was that `SystemExit`. Any other thread sleeping in the window consumed a count (leaked `_heartbeat` daemons from `test_heartbeat_thread` sleep every 10s for the rest of the run); when a foreign thread drew #2, threading swallowed its `SystemExit` and the loop spun forever on a no-op sleep. Since 08-27 the loop also ran an unstubbed `_dist_converge_check` (node esbuild + rglobs on CI), widening the window to ~30–50 ms — ~1% per job. Reproduced locally: the faithful repro hung 3 of 4 runs on main.

- **The seam**: `_CHECK_LOOP_STOP`, a loop-private `threading.Event` beside the cadence constant; the loop waits on it (`Event.wait` never routes through `time.sleep`) and returns when it fires. Never set by the kernel — zero runtime change; the thread-start line is byte-identical (its source pin stands).
- **The tests**: the CheckLoop test patches the seam (a stub returning True on the 2nd wait and raising on any later one — a loop wired to wait but not return would otherwise hang the pin itself), stubs `_dist_converge_check` (no node, no rglob) and pins its crash isolation, and drops the `SystemExit` dance. A **new red-first pin** runs a spinning foreign sleeper throughout and guards the shared `time.sleep` with a plain function raising only on the main thread — red on main in milliseconds (`the update-check loop must wait on its own seam, not the shared time.sleep`), never a hang; green here.
- **The backstop**: CI installs `pytest-timeout` and runs `--timeout=600 --timeout-method=thread --durations=10`, so the next stall is a named failure with every thread's stack (600 strictly exceeds the slowest legitimate test and the 300 s child timeout in `test_session_move_live`; the timer waits on an Event, never a patched sleep). The durations table shows on this PR's own run.
- **Hygiene, same class**: `test_new_session_dir` joins only the daemon threads it started (it joined every daemon in the process, ~122 s leak-scaled); `_OneShotInbox` shuts down before closing, carries socket timeouts as a can-never-trap backstop, and `close()` joins its thread.

**Follow-ups named, not taken here**: `test_heartbeat_thread` leaks `_heartbeat` threads and a wedged `_pusher` for the whole run (needs its own kernel stop seam); `tests/test_kernel_inject.py:66` and `tests/test_kernel.py:5439/:6540` still patch the process-global sleep (harmless no-ops today, same anti-pattern).

## Test plan
- Pin red on main / green on the branch (quoted above). Faithful repro (`ROMP_WS_KEEPALIVE=0.0001 timeout 30 uvx --with cryptography pytest -q tests/test_heartbeat_thread.py tests/test_kernel_update.py::CheckLoop -o faulthandler_timeout=15 -p no:cacheprovider`): 3/4 hangs on main → **10/10 green** on the branch.
- `tests/test_kernel_update.py` 39 pass, `test_kernel_socket_deliver.py` 9 pass, `test_new_session_dir.py` 35 pass; full Python suite and webview node tests running (results in the ship report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)