### PR TITLE
T230b follow-up: the Python job cap exceeds the per-test timeout plus the run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
     # Every job is time-boxed. Without this a test that BLOCKS (waiting on a tmux
     # server, a socket, a prompt that never comes) burns the 6h default before
     # anyone finds out, and a required check that hangs blocks merges silently.
-    timeout-minutes: 15
+    # T230b follow-up (the review's catch): the job cap must EXCEED the pytest phase plus the
+    # 600 s per-test timeout plus setup, or a stall that begins late in the run is killed by
+    # this cap first - the identical silence the per-test timeout exists to end. Measured pytest
+    # phases run 160-300 s, so 15 min left ~100 s of headroom; 25 min = 300 + 600 + setup, with
+    # margin for a slow runner.
+    timeout-minutes: 25
     strategy:
       # One red cell must not hide the others: a 3.10-only break and a
       # macOS-only break look identical if the matrix stops at the first.


### PR DESCRIPTION
## Summary
The T230b review's rules lens caught the arithmetic gap in the new backstop: the Python job kept `timeout-minutes: 15` (900 s) beside `--timeout=600` per test, so a stall beginning later than ~285 s into the job would be killed by the GitHub job cap before pytest-timeout fired — the identical 15-minute silence the backstop exists to end, with no stack and no test name. Measured pytest phases on main run 160–300 s, leaving ~100 s of headroom that shrinks with every test and vanishes on a slow runner.

One line: the Python job cap is now 25 minutes — the pytest phase plus the 600 s per-test timeout plus setup, with margin. The per-test value stays 600 (it must strictly exceed the 300 s child timeout in `test_session_move_live`).

## Test plan
- YAML validated; only the Python job's cap changes (Shell 15 → unchanged, extension unchanged).
- No test code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)