### PR TITLE
T230c: the CheckLoop sibling fails fast under a sleep regression; pin and comment accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
         # T230b: a hung test used to be 15 minutes of silence (five jobs since 2026-08-27, a
         # process-global time.sleep patch consumed by a foreign thread). pytest-timeout turns the
         # NEXT stall into a named failure with every thread's stack: thread method = guaranteed
-        # termination (the process ends; the test is the bottom MainThread frame) - the signal
+        # termination (the process ends; the dump's bottom frame is the blocked primitive, and the
+        # hung test is the lowest tests/ frame above the _pytest/runner frames) - the signal
         # method cannot interrupt a C call. 600 s strictly exceeds the slowest legitimate test
         # (~122 s, leak-scaled) and the 300 s child timeout in test_session_move_live. Its timer
         # waits on an Event, so it can never itself consume a patched sleep. --durations names the

--- a/tests/test_gear_select_matrix.py
+++ b/tests/test_gear_select_matrix.py
@@ -197,7 +197,7 @@ class ServedMatrix(unittest.TestCase):
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)
-        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=600,
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
                            env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
         if p.returncode == 3:
             raise unittest.SkipTest("no playwright browser on this box — the matrix needs one (CI installs none)")

--- a/tests/test_kernel_socket_deliver.py
+++ b/tests/test_kernel_socket_deliver.py
@@ -71,8 +71,10 @@ class _OneShotInbox:
         return self.got
 
     def close(self):
-        # shutdown BEFORE close wakes a parked accept() (a bare close leaves it blocked until the
-        # listener's timeout), then join so no capture thread outlives its test (T230b hygiene)
+        # shutdown THEN close, adjacent and in this order - load-bearing (T230c): on the timed-out
+        # listener, shutdown alone makes poll() report the socket readable but accept4() returns
+        # EAGAIN and CPython's accept loop keeps spinning until the timeout; it is the CLOSE that
+        # ends it. Then join so no capture thread outlives its test (T230b hygiene).
         try:
             self._srv.shutdown(socket.SHUT_RDWR)
         except OSError:

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -270,9 +270,20 @@ class CheckLoop(Fresh):
         def converge_pass():
             converges.append(1)                        # stubbed: the real one spawns node + rglobs ui/
             raise RuntimeError("boom")                 # …nor a dying dist converge any of them
+
+        # T230c: FAST-FAIL if the loop ever regresses to the shared time.sleep. Without this guard the
+        # test blocked in a real 300 s sleep until the 600 s CI backstop, whose os._exit then swallowed
+        # this pin's own named failure (reproduced: `F` + the timeout dump, the message nowhere).
+        # Main-thread-only, a plain function (never a recording mock a foreign sleeper could fill).
+        main = threading.get_ident()
+
+        def guard(s):
+            if threading.get_ident() == main:
+                raise AssertionError("the update-check loop must wait on its own seam, not the shared time.sleep")
         with mock.patch.object(km, "_update_check", side_effect=release_pass), \
              mock.patch.object(km, "_main_drift_check", side_effect=drift_pass), \
              mock.patch.object(km, "_dist_converge_check", side_effect=converge_pass), \
+             mock.patch.object(km.time, "sleep", guard), \
              mock.patch.object(km, "_CHECK_LOOP_STOP", Stop()):
             km._update_check_loop()                    # RETURNS on the stop event
         self.assertEqual(len(releases), 1, "the six-hour stride: one release check across two fast rounds")
@@ -293,6 +304,9 @@ class CheckLoop(Fresh):
         # 15-minute job. Deterministic, no timing: a spinning foreign sleeper runs throughout; the
         # shared sleep is a PLAIN guard (never a recording mock the spinner would fill) that raises
         # only on the MAIN thread — so a loop reaching time.sleep fails in milliseconds, never hangs.
+        # The seam patch deliberately has NO create=True (T230c): an absent or RENAMED seam then
+        # fails as an AttributeError in under a second — still red-first and named — where create=True
+        # would have minted a dead attribute and let the loop wait on the real Event to the backstop.
         import threading
         stop = threading.Event()
         main = threading.get_ident()
@@ -328,7 +342,7 @@ class CheckLoop(Fresh):
                  mock.patch.object(km, "_main_drift_check", side_effect=drift_pass), \
                  mock.patch.object(km, "_dist_converge_check"), \
                  mock.patch.object(km.time, "sleep", guard), \
-                 mock.patch.object(km, "_CHECK_LOOP_STOP", Stub(), create=True):
+                 mock.patch.object(km, "_CHECK_LOOP_STOP", Stub()):
                 km._update_check_loop()               # returns — the stop event is the loop's exit
         finally:
             stop.set()


### PR DESCRIPTION
## Summary
Follow-up from the post-merge review of T230b (3 lenses × 2 skeptics; 4 findings upheld, the job-cap one already landed). All in `tests/` and `ci.yml` comments — no kernel change.

- **REAL**: the sibling CheckLoop test had dropped its sleep patch entirely, so under a regression to `time.sleep` it blocked in a real 300 s sleep until the 600 s backstop, whose `os._exit` swallowed the pin's own named failure. It now carries the same main-thread-only plain-function guard the pin uses.
- **Nit 1**: the pin's seam patch drops `create=True` — an absent or renamed seam now fails as an `AttributeError` in under a second (still red-first and named) instead of minting a dead attribute and waiting on the real Event to the backstop.
- **Nit 2**: the `ci.yml` comment now says where the hung test actually appears in the thread dump (the lowest `tests/` frame above the `_pytest/runner` frames; the bottom frame is the blocked primitive).
- **Nit 3**: the `_OneShotInbox.close()` comment states the real mechanism — on the timed-out listener, `shutdown` alone leaves `accept4()` spinning on EAGAIN; the `close` ends it — and names the shutdown-then-close order as load-bearing.
- **Optional taken**: the gear-matrix node driver's subprocess timeout drops 600 → 300, strictly under the per-test cap, so a stalled driver is ended by `subprocess.run`'s kill + tearDown rather than `os._exit` orphaning node and the hermetic kernel.

## Demonstration (scratch revert of the seam in the working tree only; `kernel.py` restored, never committed)
With `_CHECK_LOOP_STOP.wait(...)` swapped back to `time.sleep(_MAIN_CHECK_EVERY_S)`, `pytest -q tests/test_kernel_update.py::CheckLoop` finished in **2.0 s wall** with both tests failing on the property message — captured output, counted:

```
2 >           raise AssertionError("the update-check loop must wait on its own seam, not the shared time.sleep")
2 E           AssertionError: the update-check loop must wait on its own seam, not the shared time.sleep
```

Unregressed, `tests/test_kernel_update.py` + `tests/test_kernel_socket_deliver.py`: 48 passed in 8.7 s.

## Test plan
- The two modules above green; full Python suite and webview node tests running (results in the ship report). YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)