### PR TITLE
_api_error reads a tail window instead of the whole transcript per append

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17495,7 +17495,7 @@ def _api_error(path):
         # TAIL-FIRST: the pusher calls this per session per push, and the old whole-file read cost
         # O(transcript) on EVERY append — the same unamortized shape the assembly fold retired for the
         # event-model parse, left behind here. Widen 4x until a pass reports it saw the deciding record.
-        win = _API_ERR_TAIL_WINDOW
+        win = max(1, _API_ERR_TAIL_WINDOW)   # a knob of 0 or less would never widen (0*4 stays 0): clamp, don't spin
         while True:
             start = size - win if win < size else 0
             err, decided = _api_error_scan(path, start)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17375,6 +17375,102 @@ def _spend_dialog_showing(pane):
             and ("What do you want to do?" in pane or "Enter to confirm" in pane))
 
 
+# _api_error's scan window. Its answer depends ONLY on the records from the LAST DECIDING one
+# onward, so the scan starts near the TAIL and widens until it provably saw one — a session's whole
+# transcript is re-read only when its tail genuinely carries no verdict. Overridable for tests.
+_API_ERR_TAIL_WINDOW = int(os.environ.get("ROMP_API_ERR_TAIL_WINDOW", "262144"))
+
+
+def _api_error_scan(path, start):
+    """One pass of _api_error's classification from byte `start` to EOF → (err, decided).
+
+    The loop is _api_error's original whole-file scan, UNCHANGED (one dedent) except that each of its
+    three `err = ...` sites now also sets `decided`. That flag is the window's own proof of sufficiency:
+    True iff this pass saw a record that ASSIGNS the verdict (an isApiErrorMessage assistant record,
+    fresh assistant output, or a genuine user prompt) — exactly the record the whole-file scan's result
+    depends on, since everything before it is overwritten. False means the window started too late and
+    the caller must widen; True means this window's answer IS the whole file's answer.
+
+    A non-zero `start` lands mid-line, so the first partial line is dropped. model_refusal_* records
+    land a few records AFTER the error they annotate and only mutate an err already set, so they need no
+    special handling: with their error out of window nothing is assigned, and the caller widens."""
+    err = None
+    decided = False
+    with open(path, errors="replace") as f:
+        if start > 0:
+            f.seek(start)
+            f.readline()                          # the window cut this line in half — drop it
+        for line in f:
+            if '"type"' not in line:
+                continue
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            t = o.get("type")
+            if t == "assistant":
+                msg = o.get("message") or {}
+                c = msg.get("content")
+                if o.get("isApiErrorMessage"):
+                    text = (" ".join(b.get("text", "") for b in c
+                                     if isinstance(b, dict) and b.get("type") == "text").strip()
+                            if isinstance(c, list) else (c.strip() if isinstance(c, str) else ""))
+                    # "prompt is too long" is NOT a transient API error (the user 2026-06-29): it means the
+                    # context needs compacting → it's on YOU. Flag it so it (and only it) blocks; other API
+                    # errors are transient (auto-retry recovers them) and stay in Working.
+                    decided = True
+                    err = {"text": text, "status": o.get("apiErrorStatus"),
+                           "category": o.get("error") or "unknown",
+                           # the error RECORD's identity — a new failed attempt writes a new record,
+                           # so this uuid IS the error episode (one auto-retry per episode, apiRetry)
+                           "uuid": o.get("uuid"),
+                           "tooLong": "too long" in text.lower(),
+                           # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
+                           # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
+                           "spendLimit": _is_spend_limit(text),
+                           # a model's own allowance is spent — on YOU too (switch model / add
+                           # credits), and the auto-retry keeps running only because the window does
+                           # eventually reset; see _is_model_limit
+                           "modelLimit": _is_model_limit(text),
+                           # a dead credential (no login / refused key) — on YOU, never auto-retried;
+                           # see _is_auth_error (per-session auth, the user 2026-08-08)
+                           "authErr": _is_auth_error(text),
+                           # the error's parent = the refused/failed USER message — kept so the
+                           # system model_refusal_* record below can link itself to THIS episode
+                           "parentUuid": o.get("parentUuid"),
+                           # a safeguards refusal is deterministic on the same input — on YOU
+                           # (rewrite the ask or drop the thread), never auto-retried; see
+                           # _is_refusal_text, and the system-record event path below (the user
+                           # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
+                           "refusal": _is_refusal_text(text)}
+                elif (isinstance(c, list) and any(isinstance(b, dict)
+                        and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
+                        or (isinstance(c, str) and c.strip()):
+                    decided = True
+                    err = None                            # fresh assistant output → recovered
+            elif t == "user":
+                c = (o.get("message") or {}).get("content")
+                is_tool_result = isinstance(c, list) and any(
+                    isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
+                if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears it
+                    decided = True
+                    err = None
+            elif t == "system" and o.get("subtype") in ("model_refusal_no_fallback",
+                                                        "model_refusal_fallback"):
+                # The CLI's structured refusal record — the EXACT event behind _is_refusal_text's
+                # wording check (so a future CLI rephrase still classifies). It lands a few records
+                # AFTER the assistant error it explains (queue-operation / file-history-snapshot
+                # lines sit between; none of those clears err), linked by parentUuid: the refusal
+                # record and the error BOTH carry the refused user message's uuid as parentUuid.
+                # Deliberately NOT refusedUserMessageUuid — observed diverging from the episode's
+                # parent in 2 of 13 refusal records of one storm — and deliberately not
+                # record-alone: the CLI also omits this record for some refusal errors, which is
+                # why the text signature above stays co-equal rather than a legacy fallback.
+                if err is not None and o.get("parentUuid") == err.get("parentUuid"):
+                    err["refusal"] = True
+    return err, decided
+
+
 def _api_error(path):
     """If the session is sitting BLOCKED on an API error right now, the error; else None. Claude Code
     writes every API failure to the transcript as an assistant record with top-level
@@ -17387,79 +17483,25 @@ def _api_error(path):
     try:
         st = os.stat(path)
         key = (st.st_mtime, st.st_size)
+        size = st.st_size
     except OSError:
         key = None
+        size = 0
     hit = _api_err_cache.get(path)
     if hit is not None and key is not None and hit[0] == key:
         return hit[1]
     err = None
     try:
-        with open(path, errors="replace") as f:
-            for line in f:
-                if '"type"' not in line:
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                t = o.get("type")
-                if t == "assistant":
-                    msg = o.get("message") or {}
-                    c = msg.get("content")
-                    if o.get("isApiErrorMessage"):
-                        text = (" ".join(b.get("text", "") for b in c
-                                         if isinstance(b, dict) and b.get("type") == "text").strip()
-                                if isinstance(c, list) else (c.strip() if isinstance(c, str) else ""))
-                        # "prompt is too long" is NOT a transient API error (the user 2026-06-29): it means the
-                        # context needs compacting → it's on YOU. Flag it so it (and only it) blocks; other API
-                        # errors are transient (auto-retry recovers them) and stay in Working.
-                        err = {"text": text, "status": o.get("apiErrorStatus"),
-                               "category": o.get("error") or "unknown",
-                               # the error RECORD's identity — a new failed attempt writes a new record,
-                               # so this uuid IS the error episode (one auto-retry per episode, apiRetry)
-                               "uuid": o.get("uuid"),
-                               "tooLong": "too long" in text.lower(),
-                               # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
-                               # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
-                               "spendLimit": _is_spend_limit(text),
-                               # a model's own allowance is spent — on YOU too (switch model / add
-                               # credits), and the auto-retry keeps running only because the window does
-                               # eventually reset; see _is_model_limit
-                               "modelLimit": _is_model_limit(text),
-                               # a dead credential (no login / refused key) — on YOU, never auto-retried;
-                               # see _is_auth_error (per-session auth, the user 2026-08-08)
-                               "authErr": _is_auth_error(text),
-                               # the error's parent = the refused/failed USER message — kept so the
-                               # system model_refusal_* record below can link itself to THIS episode
-                               "parentUuid": o.get("parentUuid"),
-                               # a safeguards refusal is deterministic on the same input — on YOU
-                               # (rewrite the ask or drop the thread), never auto-retried; see
-                               # _is_refusal_text, and the system-record event path below (the user
-                               # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
-                               "refusal": _is_refusal_text(text)}
-                    elif (isinstance(c, list) and any(isinstance(b, dict)
-                            and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
-                            or (isinstance(c, str) and c.strip()):
-                        err = None                            # fresh assistant output → recovered
-                elif t == "user":
-                    c = (o.get("message") or {}).get("content")
-                    is_tool_result = isinstance(c, list) and any(
-                        isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
-                    if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears it
-                        err = None
-                elif t == "system" and o.get("subtype") in ("model_refusal_no_fallback",
-                                                            "model_refusal_fallback"):
-                    # The CLI's structured refusal record — the EXACT event behind _is_refusal_text's
-                    # wording check (so a future CLI rephrase still classifies). It lands a few records
-                    # AFTER the assistant error it explains (queue-operation / file-history-snapshot
-                    # lines sit between; none of those clears err), linked by parentUuid: the refusal
-                    # record and the error BOTH carry the refused user message's uuid as parentUuid.
-                    # Deliberately NOT refusedUserMessageUuid — observed diverging from the episode's
-                    # parent in 2 of 13 refusal records of one storm — and deliberately not
-                    # record-alone: the CLI also omits this record for some refusal errors, which is
-                    # why the text signature above stays co-equal rather than a legacy fallback.
-                    if err is not None and o.get("parentUuid") == err.get("parentUuid"):
-                        err["refusal"] = True
+        # TAIL-FIRST: the pusher calls this per session per push, and the old whole-file read cost
+        # O(transcript) on EVERY append — the same unamortized shape the assembly fold retired for the
+        # event-model parse, left behind here. Widen 4x until a pass reports it saw the deciding record.
+        win = _API_ERR_TAIL_WINDOW
+        while True:
+            start = size - win if win < size else 0
+            err, decided = _api_error_scan(path, start)
+            if decided or start <= 0:
+                break
+            win *= 4
     except OSError:
         return None
     if key is not None:

--- a/tests/test_api_error_tail.py
+++ b/tests/test_api_error_tail.py
@@ -4,7 +4,7 @@ whole transcript on every append.
 
 Why it mattered: the pusher calls _api_error per session per push, and its (mtime,size) cache is busted by
 every append — so a working session's whole transcript was re-read and re-json-decoded per push cycle. On a
-live 11-session fleet with 20-116MB transcripts that was ~two thirds of the kernel's entire CPU (py-spy: 88%
+live 11-session install with 20-116MB transcripts that was ~two thirds of the kernel's entire CPU (py-spy: 88%
 of kernel CPU in Thread-5 (_pusher), 9 of 12 samples inside _api_error / raw_decode / read_text), which
 starved the pusher and left every pane visibly stale. This is the same unamortized whole-file shape the
 assembly fold retired for the event-model parse; _api_error was left behind on the same hot path.
@@ -162,6 +162,67 @@ class ApiErrorTailWindow(unittest.TestCase):
         self.assertTrue(km._api_error_scan(p, 0)[1])
         p2 = self._write([_filler(1)])
         self.assertFalse(km._api_error_scan(p2, 0)[1])
+
+    # ── the READ itself is partial: the property every differential above is blind to ──
+    def _windowed_starts(self, recs, window):
+        """Run _api_error with `window` and return (the byte offset each scan pass started at, the answer,
+        the path). The offsets are the only evidence that the read is partial: every differential assertion
+        above also holds against a scan that always starts at byte 0, i.e. with the speedup silently gone."""
+        p = self._write(recs)
+        starts = []
+        real = km._api_error_scan
+
+        def recording(path, start):
+            starts.append(start)
+            if len(starts) > 64:
+                raise AssertionError("the widen loop is not terminating: %r" % starts[:8])
+            return real(path, start)
+        saved = km._API_ERR_TAIL_WINDOW
+        km._api_error_scan = recording
+        try:
+            km._API_ERR_TAIL_WINDOW = window
+            km._api_err_cache.clear()
+            got = km._api_error(p)
+        finally:
+            km._api_error_scan = real
+            km._API_ERR_TAIL_WINDOW = saved
+        return starts, got, p
+
+    def test_a_decided_tail_is_read_once_from_a_nonzero_offset(self):
+        recs = [_filler(i) for i in range(200)] + [_err_rec()]
+        starts, got, p = self._windowed_starts(recs, window=1024)
+        self.assertEqual(len(starts), 1, "one pass must settle a decided tail: %r" % starts)
+        self.assertGreater(starts[0], 0, "the pass must start inside the file, never at byte 0")
+        self.assertIsNotNone(got)
+        self.assertEqual(got, km._api_error_scan(p, 0)[0])
+
+    def test_widening_reads_strictly_earlier_offsets_until_the_deciding_record(self):
+        recs = [_err_rec()] + [_filler(i) for i in range(400)]
+        starts, got, p = self._windowed_starts(recs, window=64)
+        self.assertGreater(len(starts), 1, "the deciding record sits far from EOF, so the window must widen")
+        self.assertEqual(starts, sorted(set(starts), reverse=True), "each widen must start strictly earlier")
+        self.assertIsNotNone(got)
+        self.assertEqual(got, km._api_error_scan(p, 0)[0])
+
+    def test_a_verdict_from_a_mid_file_window_equals_the_whole_file(self):
+        # the window covers just the last three records: a non-None answer, refusal included, from a start > 0
+        recs = [_prompt_rec() for _ in range(50)] + [_err_rec(), _filler(1), _refusal_rec()]
+        tail = sum(len(json.dumps(r)) + 1 for r in recs[-3:])
+        starts, got, p = self._windowed_starts(recs, window=tail + 8)
+        self.assertEqual(len(starts), 1, starts)
+        self.assertGreater(starts[0], 0)
+        self.assertIsNotNone(got)
+        self.assertTrue(got["refusal"], "the refusal record inside the window still marks the episode")
+        self.assertEqual(got, km._api_error_scan(p, 0)[0])
+
+    def test_a_non_positive_window_knob_still_terminates_and_answers(self):
+        # ROMP_API_ERR_TAIL_WINDOW set to 0 or less must not spin the pusher forever (0*4 is 0): the driver
+        # clamps to one byte and widens from there. The recorder above turns a spin into a failure, not a hang.
+        for bad in (0, -7):
+            starts, got, p = self._windowed_starts([_prompt_rec(), _err_rec()], window=bad)
+            self.assertGreater(len(starts), 1, "window %d must widen, not spin in place" % bad)
+            self.assertIsNotNone(got, "window %d" % bad)
+            self.assertEqual(got, km._api_error_scan(p, 0)[0])
 
     # ── unchanged edges ──
     def test_missing_file_is_none(self):

--- a/tests/test_api_error_tail.py
+++ b/tests/test_api_error_tail.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""_api_error reads a TAIL WINDOW and widens until it saw the deciding record, instead of re-reading the
+whole transcript on every append.
+
+Why it mattered: the pusher calls _api_error per session per push, and its (mtime,size) cache is busted by
+every append — so a working session's whole transcript was re-read and re-json-decoded per push cycle. On a
+live 11-session fleet with 20-116MB transcripts that was ~two thirds of the kernel's entire CPU (py-spy: 88%
+of kernel CPU in Thread-5 (_pusher), 9 of 12 samples inside _api_error / raw_decode / read_text), which
+starved the pusher and left every pane visibly stale. This is the same unamortized whole-file shape the
+assembly fold retired for the event-model parse; _api_error was left behind on the same hot path.
+
+The CLASSIFICATION is unchanged by construction — `git diff -w` on the commit shows no loop-body line
+removed, only relocated scaffolding plus three `decided = True` markers. So these tests pin the part that IS
+new: that the WINDOWED read returns exactly what the whole-file read returns, for every transcript shape,
+including the ones that force a widen. Synthetic only — invented text, placeholder uuids, no real session
+data."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate: importing the kernel must not touch live state
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+km = SourceFileLoader("romp_kernel_apierr_tail", os.path.join(BIN, "romp-kernel")).load_module()
+
+U_PROMPT = "11111111-2222-3333-4444-000000000001"     # the refused/failed user message
+U_OTHER = "11111111-2222-3333-4444-000000000002"
+
+
+def _err_rec(parent=U_PROMPT, text="API Error: 500 server_error"):
+    return {"type": "assistant", "uuid": "aaaaaaaa-0000-0000-0000-000000000001",
+            "parentUuid": parent, "isApiErrorMessage": True, "apiErrorStatus": 500,
+            "error": "server_error", "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+
+
+def _out_rec():
+    return {"type": "assistant", "uuid": "aaaaaaaa-0000-0000-0000-000000000002",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "back on track"}]}}
+
+
+def _prompt_rec():
+    return {"type": "user", "uuid": U_OTHER,
+            "message": {"role": "user", "content": [{"type": "text", "text": "try that again"}]}}
+
+
+def _tool_result_rec(i=0):
+    return {"type": "user", "uuid": "bbbbbbbb-0000-0000-0000-%012d" % i,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_%d" % i,
+                                                     "content": "ok"}]}}
+
+
+def _refusal_rec(parent=U_PROMPT):
+    return {"type": "system", "subtype": "model_refusal_no_fallback", "parentUuid": parent,
+            "uuid": "cccccccc-0000-0000-0000-000000000001"}
+
+
+def _filler(i=0):
+    # a record kind _api_error ignores entirely (neither sets nor clears) — the padding that forces a widen
+    return {"type": "queue-operation", "uuid": "dddddddd-0000-0000-0000-%012d" % i, "op": "noop"}
+
+
+class ApiErrorTailWindow(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.n = 0
+        km._api_err_cache.clear()
+
+    def _write(self, recs):
+        """A fresh path per write, so the (mtime,size) cache can never mask a difference."""
+        self.n += 1
+        p = os.path.join(self.dir, "transcript-%d.jsonl" % self.n)
+        with open(p, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        return p
+
+    def _both(self, recs, window=64):
+        """(windowed answer, whole-file answer) for the same file — the differential this patch must hold."""
+        p = self._write(recs)
+        saved = km._API_ERR_TAIL_WINDOW
+        try:
+            km._API_ERR_TAIL_WINDOW = window
+            km._api_err_cache.clear()
+            windowed = km._api_error(p)
+        finally:
+            km._API_ERR_TAIL_WINDOW = saved
+        whole, decided = km._api_error_scan(p, 0)
+        return windowed, whole
+
+    def _assert_agrees(self, recs, msg, window=64):
+        w, f = self._both(recs, window)
+        self.assertEqual(w, f, "windowed read disagrees with the whole-file read: " + msg)
+        return w
+
+    # ── the verdict itself ──
+    def test_api_error_last_is_reported(self):
+        err = self._assert_agrees([_prompt_rec(), _err_rec()], "error is the last deciding record")
+        self.assertIsNotNone(err)
+        self.assertEqual(err["status"], 500)
+
+    def test_a_genuine_prompt_after_the_error_clears_it(self):
+        self.assertIsNone(self._assert_agrees([_err_rec(), _prompt_rec()], "a retry clears the block"))
+
+    def test_fresh_assistant_output_after_the_error_clears_it(self):
+        self.assertIsNone(self._assert_agrees([_err_rec(), _out_rec()], "output means it recovered"))
+
+    def test_tool_results_after_the_error_do_not_clear_it(self):
+        recs = [_err_rec()] + [_tool_result_rec(i) for i in range(5)]
+        self.assertIsNotNone(self._assert_agrees(recs, "a tool_result is not a genuine prompt"))
+
+    def test_a_matching_refusal_record_marks_the_error(self):
+        err = self._assert_agrees([_err_rec(), _filler(1), _refusal_rec()], "refusal rides the episode")
+        self.assertTrue(err["refusal"], "the model_refusal_* record with the same parentUuid marks it")
+
+    def test_a_nonmatching_refusal_record_does_not_mark_it(self):
+        err = self._assert_agrees([_err_rec(), _refusal_rec(parent=U_OTHER)], "different episode")
+        self.assertFalse(err["refusal"], "a refusal for another episode must not mark this error")
+
+    # ── the widening itself: THE regression this patch is about ──
+    def test_a_window_that_misses_the_error_widens_instead_of_answering_none(self):
+        # the error sits far from EOF behind padding that neither sets nor clears the verdict, so the first
+        # window sees no deciding record and MUST widen. Answering from the short window would report the
+        # session as unblocked while it is blocked.
+        recs = [_err_rec()] + [_filler(i) for i in range(400)]
+        err = self._assert_agrees(recs, "widen past non-deciding padding", window=64)
+        self.assertIsNotNone(err, "the error is still the last deciding record, however far back it sits")
+
+    def test_the_whole_file_pass_runs_when_the_window_reaches_the_start(self):
+        # a transcript with NO deciding record at all: every widen fails until start hits 0, and the
+        # whole-file pass must actually execute (an early version nested the loop inside the seek guard,
+        # so the start==0 pass silently scanned nothing).
+        recs = [_filler(i) for i in range(200)]
+        p = self._write(recs)
+        saved = km._API_ERR_TAIL_WINDOW
+        try:
+            km._API_ERR_TAIL_WINDOW = 64
+            km._api_err_cache.clear()
+            self.assertIsNone(km._api_error(p), "no deciding record anywhere → None")
+        finally:
+            km._API_ERR_TAIL_WINDOW = saved
+        # and the whole-file pass reports it saw nothing, rather than falsely claiming a verdict
+        err, decided = km._api_error_scan(p, 0)
+        self.assertIsNone(err)
+        self.assertFalse(decided, "no assignment happened, so the pass must not claim it decided")
+
+    def test_a_partial_first_line_is_dropped_not_misparsed(self):
+        # a non-zero start lands mid-line; the half line must be discarded without disturbing the verdict
+        recs = [_err_rec(), _filler(1)]
+        p = self._write(recs)
+        size = os.path.getsize(p)
+        err, decided = km._api_error_scan(p, size // 2)   # guaranteed mid-line
+        self.assertFalse(decided, "the deciding record is before this start → nothing assigned")
+        self.assertIsNone(err)
+
+    def test_decided_is_true_exactly_when_a_verdict_was_assigned(self):
+        p = self._write([_err_rec()])
+        self.assertTrue(km._api_error_scan(p, 0)[1])
+        p2 = self._write([_filler(1)])
+        self.assertFalse(km._api_error_scan(p2, 0)[1])
+
+    # ── unchanged edges ──
+    def test_missing_file_is_none(self):
+        self.assertIsNone(km._api_error(os.path.join(self.dir, "nope.jsonl")))
+
+    def test_empty_file_is_none(self):
+        self.assertIsNone(self._assert_agrees([], "empty transcript"))
+
+    def test_the_cache_still_serves_an_unchanged_transcript(self):
+        p = self._write([_err_rec()])
+        first = km._api_error(p)
+        self.assertIsNotNone(first)
+        self.assertIn(p, km._api_err_cache, "an unchanged (mtime,size) must stay cached")
+        self.assertEqual(km._api_error(p), first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -23,7 +23,9 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 class ApiErrorWorking(unittest.TestCase):
     def test_api_error_carries_a_tooLong_flag(self):
-        src = inspect.getsource(km._api_error)
+        # the classification lives in _api_error_scan since the tail-window split — _api_error is now the
+        # widening driver around it, so read the pair rather than pinning which half holds the flag
+        src = inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan)
         self.assertIn('"tooLong": "too long" in text.lower()', src)
 
     def test_only_on_you_errors_floor_the_card_to_needs_input(self):
@@ -41,7 +43,8 @@ class ApiErrorWorking(unittest.TestCase):
     def test_spend_cap_is_classified_and_floors_like_tooLong(self):
         # a monthly spend cap is on you (raise it) AND never auto-retried — classified in _api_error, floored
         # to needs-input, and badged with the raise-your-cap guidance (the user 2026-07-14).
-        self.assertIn('"spendLimit": _is_spend_limit(text)', inspect.getsource(km._api_error))
+        self.assertIn('"spendLimit": _is_spend_limit(text)',
+                      inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan))
         bf = inspect.getsource(km.build_feed)
         self.assertIn('"spendLimit": bool(aerr.get("spendLimit"))', bf)
         self.assertIn("monthly spend limit — raise it at claude.ai/settings/usage", bf)

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -399,7 +399,10 @@ class AuthErrorClass(unittest.TestCase):
 
     def test_it_is_an_on_you_class_end_to_end(self):
         import inspect
-        self.assertIn('"authErr": _is_auth_error(text)', inspect.getsource(km._api_error))
+        # the classification lives in _api_error_scan since the tail-window split; _api_error is the
+        # widening driver around it, so read the pair rather than pinning which half holds the flag
+        self.assertIn('"authErr": _is_auth_error(text)',
+                      inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan))
         self.assertIn('"apiAuthErr": bool(aerr and aerr.get("authErr"))', inspect.getsource(km.build_session))
         feed = inspect.getsource(km.build_feed)
         self.assertIn('aerr.get("authErr") or aerr.get("refusal"))))', feed, "the card floors to needs-you")


### PR DESCRIPTION
## Why

`db479cd3` ("Appends fold through the parse instead of re-emitting the whole session") amortized the event-model parse. `_api_error` sits beside it on the same hot path, with the same `(mtime,size)` cache in front of the same whole-file read — and was left behind. Every append busts that key, so `build_feed`/`build_session` re-read and re-`json.loads`'d the **entire** transcript, per session, per push cycle.

Profiled on a live 11-session install (transcripts 20–116 MB, ~475 MB total):

- `Thread-5 (_pusher)` held **88% of the kernel's CPU** — 7.2M of 8.15M ticks, ≈20 CPU-hours in a 22h uptime.
- 9 of 12 `py-spy` samples of that thread sat in `_api_error` / `raw_decode` / `read_text`.
- `/version` on the same kernel reported `parse: {full: 927, fold: 14213, fallback: 0}` — the fold was working at **93.9%** and buying nothing visible, because this scan was next to it.

Symptoms were a pusher that couldn't finish a cycle: panes minutes stale, and a reconnected pane never receiving the non-keepalive frame that retires the stale-connection banner.

## What

The verdict depends only on the records from the **last deciding one** onward — an `isApiErrorMessage` assistant record, fresh assistant output, or a genuine user prompt — because anything earlier is overwritten. So the scan starts near the tail and widens 4× until a pass reports it actually saw such a record.

`decided` is the window's own proof of sufficiency rather than a heuristic: it's set at the three sites that assign the verdict, so `False` means "started too late, widen" and `True` means this window's answer **is** the whole file's answer. A transcript whose tail genuinely carries no verdict still reads in full, one widen at a time.

`model_refusal_*` records need no special casing — they land after the error they annotate and only mutate an `err` already set, so with their error out of window nothing is assigned and the caller widens.

## Reviewing this

The classification is unchanged **by construction**. `git diff -w` removes no loop-body line — only relocated scaffolding plus the three `decided = True` markers. The loop is the original, dedented one level (it loses the `try:` nesting).

## Tests

`tests/test_api_error_tail.py` (13 tests) pins the part that's new: the windowed read equals the whole-file read for every transcript shape, including the widen cases.

Red first — an earlier draft nested the loop inside the seek guard, so the `start == 0` pass scanned nothing. It compiled clean, and 7 of these 13 tests fail on it.

Also run green: `test_kernel_apiretry`, `test_judge_apierror_no_caption`, `test_judge_apierror_no_fabricated_done`, `test_judge_orphan_replies`, `test_judge_nudge_wedge_moot_retire`, `test_idle_queue_drive`, `test_event_model_{incremental,assembly,golden}`, `test_kernel_{send_park,ops_gate_busy,limit_queue}`.

Unrelated note: `tests/test_judge_auth_billing.py` fails 3 tests on clean `main` on my machine, identically with and without this change (5 runs) — flagging in case it's not already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)