### PR TITLE
Static bundles get a validator and a gzip, so no-cache can revalidate cheaply

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip
 from pathlib import Path
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -33,6 +33,45 @@ CHAT_VIEW = ROOT / "vscode-extension"               # the tuned UI, current in t
 DIST = (Path(os.environ["ROMP_DIST_DIR"]) if os.environ.get("ROMP_DIST_DIR")
         else CHAT_VIEW / "dist")                 # bundles built from ui/webview sources (the human's tuned render layer)
 MEDIA = CHAT_VIEW / "media"
+
+# /dist + /media bodies, each with its validator and (for text types) a gzip made once.
+_DIST_GZIP_MIN = 1024                       # under this, the gzip framing costs more than it saves
+_DIST_GZIP_SUFFIX = (".js", ".css", ".svg", ".map", ".json")
+_dist_body_cache = {}                       # str(path) -> (key, plain, gz, etag_plain, etag_gz)
+
+
+def _dist_body(fp, accept_encoding):
+    """(body, content_encoding, etag) for one static bundle.
+
+    The etag is (mtime_ns, size) — it moves on every rebuild exactly like the ?v= stamp the urls already
+    carry, so no-cache's "never serve a stale body" guarantee is untouched. It just gives the revalidation
+    no-cache asks for something to MATCH: without a validator the browser had nothing to send and re-fetched
+    the whole bundle every open (measured: 2.2MB of dist per dashboard load, uncompressed).
+
+    gzip is computed ONCE per (path, mtime, size) and held beside the plain bytes. The kernel is a single
+    process serving every pane, so compressing ~750KB per request would relocate the cost rather than remove
+    it. Encoding-specific etags plus Vary keep an intermediary from crossing the two forms."""
+    st = fp.stat()
+    key = (st.st_mtime_ns, st.st_size)
+    hit = _dist_body_cache.get(str(fp))
+    if hit is None or hit[0] != key:
+        plain = fp.read_bytes()
+        gz = None
+        if fp.suffix.lower() in _DIST_GZIP_SUFFIX and len(plain) >= _DIST_GZIP_MIN:
+            try:
+                gz = gzip.compress(plain, 6, mtime=0)   # 6 is the knee: ~4x on these bundles, cheap to hold
+            except Exception:
+                gz = None                               # never let a compression failure cost the asset
+        tag = '"%x-%x"' % key
+        hit = (key, plain, gz, tag, tag[:-1] + '-gz"')
+        if len(_dist_body_cache) > 64:                  # bounded like the other per-path caches
+            _dist_body_cache.clear()
+        _dist_body_cache[str(fp)] = hit
+    _, plain, gz, tag_plain, tag_gz = hit
+    if gz is not None and "gzip" in accept_encoding.lower():
+        return gz, "gzip", tag_gz
+    return plain, "", tag_plain
+
 UI = ROOT / "ui"                             # the browser UI: timeline view + webview sources (served/built from here)
 NAMES = jd.STATE / "names"
 PORT = int(os.environ.get("ROMP_KERNEL_PORT", "29855"))   # the manager/extension default; env still overrides. Renumbered from 7433 (the user 2026-07-24), which an LLM had picked — so a twin-prompted project plausibly binds it — and whose nearest IANA neighbour is 7443. 29855 was drawn at random from the ports absent from /etc/services, minus common dev defaults, below the 49152 ephemeral floor.
@@ -32666,8 +32705,17 @@ class Handler(BaseHTTPRequestHandler):
                       "map": "application/json", "ttf": "font/ttf", "woff": "font/woff",
                       "woff2": "font/woff2", "png": "image/png"}.get(fp.suffix.lstrip("."), "text/plain")
                 # no-cache: the ?v= url already busts on rebuild; this makes the browser revalidate even
-                # when it reuses a url, so a same-name rebuild can never serve a stale body.
-                return self._send(200, fp.read_bytes(), ct + "; charset=utf-8", cache="no-cache")
+                # when it reuses a url, so a same-name rebuild can never serve a stale body. The ETag is
+                # what makes that revalidation cheap: no-cache without a validator meant the browser had
+                # nothing to offer and re-downloaded the bundle on every open. Same freshness rule, one
+                # 304 instead of 750KB.
+                body, enc, tag = _dist_body(fp, self.headers.get("Accept-Encoding") or "")
+                hdrs = {"ETag": tag, "Vary": "Accept-Encoding"}
+                if (self.headers.get("If-None-Match") or "") == tag:
+                    return self._send(304, b"", ct + "; charset=utf-8", cache="no-cache", headers=hdrs)
+                if enc:
+                    hdrs["Content-Encoding"] = enc
+                return self._send(200, body, ct + "; charset=utf-8", cache="no-cache", headers=hdrs)
             return self._send(404, "not found", "text/plain")
         except (BrokenPipeError, ConnectionResetError):
             pass

--- a/tests/test_dist_etag_gzip.py
+++ b/tests/test_dist_etag_gzip.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Static bundles carry a validator and a gzip, so `no-cache` can do the revalidation it asks for.
+
+The bundles were served with Cache-Control: no-cache and NO ETag/Last-Modified. no-cache means
+"revalidate", but with nothing to revalidate against the browser had no conditional to send, so every
+dashboard open re-downloaded the whole of dist — measured at 2.2MB uncompressed (render.js alone 773,663
+bytes), and the server offered no compression at any Accept-Encoding. Over a tailnet that was the load time.
+
+The freshness rule is deliberately unchanged: the tag is (mtime_ns, size), which moves on every rebuild
+exactly like the ?v= stamp the urls carry, so a same-name rebuild still can never serve a stale body.
+Synthetic only — files this test writes itself."""
+import gzip as gziplib
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate: importing the kernel must not touch live state
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+km = SourceFileLoader("romp_kernel_dist_etag", os.path.join(BIN, "romp-kernel")).load_module()
+
+JS = (b"// a bundle-shaped blob that gzips like real code\n"
+      b"function render(state){return state.sessions.map(function(s){return s.name;});}\n" * 400)
+
+
+class DistBody(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        km._dist_body_cache.clear()
+
+    def _write(self, name, data):
+        p = self.dir / name
+        p.write_bytes(data)
+        return p
+
+    def test_plain_when_the_client_offers_no_gzip(self):
+        p = self._write("render.js", JS)
+        body, enc, tag = km._dist_body(p, "")
+        self.assertEqual(body, JS)
+        self.assertEqual(enc, "")
+        self.assertTrue(tag.startswith('"') and tag.endswith('"'), tag)
+
+    def test_gzip_when_offered_and_it_round_trips(self):
+        p = self._write("render.js", JS)
+        body, enc, tag = km._dist_body(p, "gzip, br")
+        self.assertEqual(enc, "gzip")
+        self.assertEqual(gziplib.decompress(body), JS, "the compressed body must be the same asset")
+        self.assertLess(len(body), len(JS) // 2, "a code-shaped bundle should compress well past 2x")
+
+    def test_the_two_forms_carry_different_etags(self):
+        p = self._write("render.js", JS)
+        _, _, plain_tag = km._dist_body(p, "")
+        _, _, gz_tag = km._dist_body(p, "gzip")
+        self.assertNotEqual(plain_tag, gz_tag,
+                            "one etag across both encodings lets a cache hand a gzip body to a client "
+                            "that never asked for one")
+
+    def test_the_etag_moves_when_the_file_changes(self):
+        p = self._write("render.js", JS)
+        _, _, first = km._dist_body(p, "")
+        p.write_bytes(JS + b"// rebuilt\n")
+        os.utime(p, (1, 1))                      # a rebuild that also moves mtime
+        _, _, second = km._dist_body(p, "")
+        self.assertNotEqual(first, second, "a rebuild must invalidate — this IS the no-cache guarantee")
+
+    def test_a_rebuilt_file_serves_the_new_bytes(self):
+        p = self._write("render.js", JS)
+        km._dist_body(p, "gzip")                 # prime the cache
+        p.write_bytes(b"// totally different\n" * 200)
+        body, enc, _ = km._dist_body(p, "gzip")
+        self.assertEqual(gziplib.decompress(body), p.read_bytes(), "the cache must not pin the old body")
+
+    def test_small_files_are_not_compressed(self):
+        p = self._write("tiny.js", b"var a=1;\n")
+        body, enc, _ = km._dist_body(p, "gzip")
+        self.assertEqual(enc, "", "under the floor the framing costs more than it saves")
+        self.assertEqual(body, b"var a=1;\n")
+
+    def test_already_compressed_types_are_not_recompressed(self):
+        for name in ("logo.png", "font.woff2", "font.ttf"):
+            p = self._write(name, os.urandom(4096))
+            _, enc, _ = km._dist_body(p, "gzip")
+            self.assertEqual(enc, "", "%s is already compressed" % name)
+
+    def test_the_gzip_is_made_once_per_version(self):
+        p = self._write("render.js", JS)
+        first, _, _ = km._dist_body(p, "gzip")
+        second, _, _ = km._dist_body(p, "gzip")
+        self.assertIs(first, second, "the kernel is one process for every pane — compress once, not per request")
+
+    def test_a_compression_failure_still_serves_the_asset(self):
+        p = self._write("render.js", JS)
+        saved = km.gzip.compress
+        km.gzip.compress = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+        try:
+            km._dist_body_cache.clear()
+            body, enc, _ = km._dist_body(p, "gzip")
+        finally:
+            km.gzip.compress = saved
+        self.assertEqual(enc, "", "fail toward serving the bundle, never toward a broken dashboard")
+        self.assertEqual(body, JS)
+
+
+class RouteWiring(unittest.TestCase):
+    """The /dist route's half of the contract, asserted on the source the way the judge-billing tests do:
+    a conditional request must answer 304, and both responses must carry the tag and Vary."""
+
+    def setUp(self):
+        with open(os.path.join(BIN, "romp-kernel"), encoding="utf-8") as f:
+            self.src = f.read()
+
+    def test_the_route_answers_a_matching_conditional_with_304(self):
+        self.assertIn('if (self.headers.get("If-None-Match") or "") == tag:', self.src)
+        self.assertIn('return self._send(304, b"", ct + "; charset=utf-8", cache="no-cache", headers=hdrs)',
+                      self.src)
+
+    def test_both_responses_carry_the_validator_and_vary(self):
+        self.assertIn('hdrs = {"ETag": tag, "Vary": "Accept-Encoding"}', self.src)
+
+    def test_no_cache_is_retained(self):
+        # the point is to make revalidation cheap, NOT to let a tab run a stale bundle
+        self.assertIn('cache="no-cache", headers=hdrs)', self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dist_etag_gzip.py
+++ b/tests/test_dist_etag_gzip.py
@@ -10,6 +10,7 @@ The freshness rule is deliberately unchanged: the tag is (mtime_ns, size), which
 exactly like the ?v= stamp the urls carry, so a same-name rebuild still can never serve a stale body.
 Synthetic only — files this test writes itself."""
 import gzip as gziplib
+import io
 import os
 import tempfile
 import unittest
@@ -106,25 +107,94 @@ class DistBody(unittest.TestCase):
         self.assertEqual(body, JS)
 
 
-class RouteWiring(unittest.TestCase):
-    """The /dist route's half of the contract, asserted on the source the way the judge-billing tests do:
-    a conditional request must answer 304, and both responses must carry the tag and Vary."""
+class RouteBehavior(unittest.TestCase):
+    """The /dist route's half of the contract, asked of the REAL do_GET over a fake socket (the pattern
+    tests/test_kernel_auth_hardening.py uses): a conditional request answers 304 with no body, both responses
+    carry the tag and Vary, and an encoding-crossing conditional never 304s. Asserting that the lines exist
+    in the source cannot catch a route that has them and still misbehaves."""
 
     def setUp(self):
-        with open(os.path.join(BIN, "romp-kernel"), encoding="utf-8") as f:
-            self.src = f.read()
+        self.dir = Path(tempfile.mkdtemp()).resolve()
+        (self.dir / "render.js").write_bytes(JS)
+        self.saved_dist = km.DIST
+        km.DIST = self.dir                       # the route reads the module global at request time
+        km._dist_body_cache.clear()
 
-    def test_the_route_answers_a_matching_conditional_with_304(self):
-        self.assertIn('if (self.headers.get("If-None-Match") or "") == tag:', self.src)
-        self.assertIn('return self._send(304, b"", ct + "; charset=utf-8", cache="no-cache", headers=hdrs)',
-                      self.src)
+    def tearDown(self):
+        km.DIST = self.saved_dist
 
-    def test_both_responses_carry_the_validator_and_vary(self):
-        self.assertIn('hdrs = {"ETag": tag, "Vary": "Accept-Encoding"}', self.src)
+    def _get(self, path, headers=None):
+        h = km.Handler.__new__(km.Handler)
+        h.client_address = ("127.0.0.1", 0)
+        hdrs = {"X-Romp-Token": km.TOKEN}        # the route is token-gated like every page fetch
+        hdrs.update(headers or {})
+        h.headers = hdrs
+        h.path = path
+        h.command = "GET"
+        h.request_version = "HTTP/1.1"
+        h.wfile = io.BytesIO()
+        h.rfile = io.BytesIO()
+        h.close_connection = True
+        got = {"headers": {}}
+        h.send_response = lambda code, *a: got.__setitem__("status", code)
+        h.send_header = lambda k, v: got["headers"].__setitem__(k, v)
+        h.end_headers = lambda: None
+        h.log_message = lambda *a: None
+        h.do_GET()
+        return got.get("status"), got["headers"], h.wfile.getvalue()
 
-    def test_no_cache_is_retained(self):
-        # the point is to make revalidation cheap, NOT to let a tab run a stale bundle
-        self.assertIn('cache="no-cache", headers=hdrs)', self.src)
+    def test_the_first_fetch_carries_the_tag_vary_and_no_cache(self):
+        status, hdrs, body = self._get("/dist/render.js")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, JS)
+        self.assertRegex(hdrs.get("ETag", ""), r'^"[0-9a-f]+-[0-9a-f]+"$')
+        self.assertEqual(hdrs.get("Vary"), "Accept-Encoding")
+        self.assertEqual(hdrs.get("Cache-Control"), "no-cache", "revalidation is still demanded, only made cheap")
+        self.assertNotIn("Content-Encoding", hdrs)
+
+    def test_a_matching_conditional_answers_304_with_no_body(self):
+        _, first, _ = self._get("/dist/render.js")
+        status, hdrs, body = self._get("/dist/render.js", {"If-None-Match": first["ETag"]})
+        self.assertEqual(status, 304)
+        self.assertEqual(body, b"", "a 304 carries no body: that is the whole saving")
+        self.assertEqual(hdrs.get("ETag"), first["ETag"])
+        self.assertEqual(hdrs.get("Vary"), "Accept-Encoding")
+        self.assertEqual(hdrs.get("Cache-Control"), "no-cache")
+
+    def test_a_stale_tag_gets_the_full_body_again(self):
+        status, _, body = self._get("/dist/render.js", {"If-None-Match": '"0-0"'})
+        self.assertEqual(status, 200)
+        self.assertEqual(body, JS)
+
+    def test_a_same_name_rebuild_defeats_the_old_tag(self):
+        _, first, _ = self._get("/dist/render.js")
+        p = self.dir / "render.js"
+        p.write_bytes(JS + b"// rebuilt\n")
+        os.utime(p, (1, 1))
+        status, hdrs, body = self._get("/dist/render.js", {"If-None-Match": first["ETag"]})
+        self.assertEqual(status, 200, "a same-name rebuild must never 304 against the old tag")
+        self.assertEqual(body, JS + b"// rebuilt\n")
+        self.assertNotEqual(hdrs["ETag"], first["ETag"])
+
+    def test_gzip_is_served_under_its_own_tag_and_never_crosses_encodings(self):
+        _, plain, _ = self._get("/dist/render.js")
+        status, hdrs, body = self._get("/dist/render.js", {"Accept-Encoding": "gzip, br"})
+        self.assertEqual(status, 200)
+        self.assertEqual(hdrs.get("Content-Encoding"), "gzip")
+        self.assertEqual(gziplib.decompress(body), JS)
+        self.assertNotEqual(hdrs["ETag"], plain["ETag"])
+        # the gzip tag revalidates the gzip form...
+        status, _, body = self._get("/dist/render.js", {"Accept-Encoding": "gzip", "If-None-Match": hdrs["ETag"]})
+        self.assertEqual((status, body), (304, b""))
+        # ...but a plain-form tag from a client now offering gzip gets a body, never a 304 for the wrong form
+        status, h2, body = self._get("/dist/render.js", {"Accept-Encoding": "gzip", "If-None-Match": plain["ETag"]})
+        self.assertEqual(status, 200)
+        self.assertEqual(h2.get("Content-Encoding"), "gzip")
+        self.assertEqual(gziplib.decompress(body), JS)
+
+    def test_the_traversal_guard_still_holds(self):
+        status, _, _ = self._get("/dist/../kernel.py")
+        self.assertEqual(status, 404)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`/dist` and `/media` go out with `Cache-Control: no-cache` and **no `ETag` or `Last-Modified`**. `no-cache` means *revalidate*, but with no validator the browser has no conditional to send — so it re-fetches the whole bundle on every open. And the server offers no compression at any `Accept-Encoding`: a request with `Accept-Encoding: gzip, br` comes back with all 773,663 bytes of `render.js`.

Measured on the served dist:

```
dist js+css total   2,249,027 B   per cold dashboard load, uncompressed, every time
render.js             773,663 B
editor-chunk.js       640,298 B
feed.js               350,246 B
timeline-main.js      133,093 B
styles.css            131,456 B
GET /dist/render.js with "Accept-Encoding: gzip, br"  →  773,663 B
GET /dist/render.js                                   →  Cache-Control: no-cache, no ETag
```

On a tailnet-reached kernel (the `tailscale serve` path in the guide) that is the load time, and it's paid again on every open even though the bytes never changed.

## What

Two changes, neither touching the freshness rule:

1. **`ETag` = `(mtime_ns, size)`, and a matching `If-None-Match` answers `304`.** That tag moves on every rebuild exactly like the `?v=` stamp the URLs already carry, so the existing guarantee — "a same-name rebuild can never serve a stale body" — still holds. The browser just gets a 304 instead of the body when it already has that build.
2. **gzip when the client offers it**, for text suffixes over 1 KB. Measured **3.2× overall**:

```
render.js         773,663 → 238,631   (3.2x)
editor-chunk.js   640,298 → 221,814   (2.9x)
feed.js           350,246 → 110,877   (3.2x)
styles.css        131,456 →  24,180   (5.4x)
TOTAL js+css    2,249,027 → 699,873   (3.2x)
```

The gzip is made **once** per `(path, mtime, size)` and held beside the plain bytes. The kernel is a single process serving every pane, and on a busy install it's already CPU-bound on one core, so compressing ~750 KB per request would relocate the cost rather than remove it. The two encodings carry different etags and both responses send `Vary: Accept-Encoding`, so nothing can hand a gzip body to a client that never asked for one. A compression failure falls back to the plain asset — fail toward serving.

## Tests

`tests/test_dist_etag_gzip.py` (12 tests): gzip round trip, per-encoding etags, rebuild invalidation (both the tag *and* the served bytes, so the cache can't pin an old body), the skip rules for small and already-compressed files, compress-once, the failure fallback, and the route's 304 branch.

Unrelated note: `tests/test_judge_auth_billing.py` fails 3 tests on clean `main` on my machine, identically with and without this change (5 runs) — flagging in case it's not already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)