### PR TITLE
Parked ops deliver on the turn's settle, not at the tail of a judge pass

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1526,6 +1526,13 @@ print(json.dumps(d))' "$_who" "$_when")"
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        if [[ "$_verb" == "send" && ( "$_resp" == *'"queued": true'* || "$_resp" == *'"queued":true'* ) ]]; then
+            # the kernel PARKED it (a turn is open / compacting / the account is limit-held) and delivers it
+            # when the session is quiet. Said out loud so a sender inside that very turn — an agent sending
+            # itself a slash command — knows the command has NOT run yet.
+            echo "romp send: queued ($_who) — delivers when the session is quiet"
+            exit 0
+        fi
         echo "romp $_verb: ok ($_who)"
         exit 0
     fi

--- a/bin/romp
+++ b/bin/romp
@@ -2016,7 +2016,12 @@ print(json.dumps(d))' "$session_arg" "$msg_arg" "$tag_arg" "$_resp")"
                           -H 'Content-Type: application/json' -d "$_mpayload")" \
                 || { echo "romp new: session is up but the message did NOT land (kernel send failed). Retry: romp send $session_arg '<text>'" >&2; exit 1; }
             if [[ "$_mresp" == *'"ok": true'* || "$_mresp" == *'"ok":true'* ]]; then
-                echo "romp new: first prompt delivered"
+                if [[ "$_mresp" == *'"queued": true'* || "$_mresp" == *'"queued":true'* ]]; then
+                    # the kernel PARKED it (the fresh session is not quiet yet): it delivers when it is
+                    echo "romp new: first prompt queued — delivers when the session is quiet"
+                else
+                    echo "romp new: first prompt delivered"
+                fi
             else
                 echo "romp new: session is up but the kernel refused the message: $_mresp. Retry: romp send $session_arg '<text>'" >&2
                 exit 1

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -1300,7 +1300,8 @@ class CodexBackend:
                 s.turn_id = None
                 s.state = "waiting"
                 s.since = time.time()
-            self.push_session(s.sid)
+            self.poke()                    # the turn END is the kernel's cue (parked ops deliver on it): every
+            self.push_session(s.sid)       # in-loop poke above fired while turn_id was set, i.e. busy() True
         return True
 
     # ── chat tail ────────────────────────────────────────────────────────────────────────────────

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2067,10 +2067,19 @@ def _sessions(now, window=None, forks=True):
 
 def _path_of(sid, now=None):
     """The transcript path for a sid (discover-cached → cheap), or None. Lets the sid-keyed backend API
-    resolve a session's transcript without the caller threading the path through (e.g. pending_queued)."""
+    resolve a session's transcript without the caller threading the path through (e.g. pending_queued).
+    Inside a pusher cycle the answer is memoized on the cycle's scope (_live_scope.paths, opened by
+    _pusher_cycle, thread-confined like its liveness snapshot): the parked-op drain asks for a held sid's
+    path in up to three gates per cycle, and each ask was a discover fingerprint (review find, #904)."""
+    memo = getattr(_live_scope, "paths", None)
+    if memo is not None and sid in memo:
+        return memo[sid]
     now = int(time.time()) if now is None else now
     s = next((s for s in _sessions(now) if s["sid"] == sid), None)
-    return s["path"] if s else None
+    p = s["path"] if s else None
+    if memo is not None:
+        memo[sid] = p
+    return p
 
 
 def _has_tmux():
@@ -19595,13 +19604,16 @@ def _move_now(be, sid, path, tries, wid):
                 "this session's backend has no way to move a running session"
         except Exception as e:
             res = "%s: %s" % (type(e).__name__, str(e)[:200])
+        if res == "busy":
+            # re-park and hold BEFORE `_moving` releases the queue (review find, #904): a drain cycle landing
+            # between the release and the re-park would fire the op behind the move, or burn a retry
+            seq = be.turn_seq(sid) if hasattr(be, "turn_seq") else None  # the turn end this retry waits on
+            _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
+            _move_askers[sid] = wid
+            _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (_hold_drain)
     finally:
         _moving.discard(sid)
     if res == "busy":
-        seq = be.turn_seq(sid) if hasattr(be, "turn_seq") else None      # the turn end this retry waits on
-        _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
-        _move_askers[sid] = wid
-        _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (see _hold_drain)
         _save_pending_ops()
         _mark_views_dirty()                    # the chip re-renders now; the hold, not the wake, spaces the retry
         return res
@@ -28589,6 +28601,8 @@ def _pusher_cycle():
     #                                       however deep it hides (_bg_live_norm, _compacting_now,
     #                                       build_feed's per-session gates) — see _live_scope
     try:
+        _live_scope.paths = {}                  # …and the cycle's sid→path memo (_path_of): the parked-op drain
+        #                                         otherwise resolves a held sid's path once per gate per cycle
         _live_scope.names = _names_snapshot()   # …and the cycle's NAMES snapshot, same idiom: the name/
         #                                       cwd/color helpers otherwise re-read the registry per path
         #                                       token and per postal card (~38% of pusher wall, py-spy
@@ -28598,6 +28612,7 @@ def _pusher_cycle():
     finally:
         _live_scope.snapshot = None
         _live_scope.names = None
+        _live_scope.paths = None
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):
@@ -33103,6 +33118,8 @@ class Handler(BaseHTTPRequestHandler):
                         return self._send(200, json.dumps({"ok": False, "error":   # pretend it was delivered
                             "the remote kernel for this session (%s) isn't answering — message not delivered"
                             % r.get("host", "?")}), "application/json")
+                    if isinstance(res, dict) and res.get("ok") is False:
+                        return self._send(200, json.dumps(res), "application/json")   # its refusal, verbatim
                     # the far kernel's `queued` rides through (an older remote without the field reads False)
                     return self._send(200, json.dumps({"ok": True, "queued": bool(isinstance(res, dict)
                                                                                   and res.get("queued"))}),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9392,7 +9392,7 @@ def _sdk_locked():
                 sys.stderr.write("model catalog boot: %s\n" % traceback.format_exc())
             _sdk_backend = sbmod.SdkBackend(
                 jd.STATE, _claude_bin(), _send_to_app,
-                poke=_producer_wake.set, push=_pusher_wake.set,
+                poke=_wake_kernel, push=_pusher_wake.set,   # poke = the turn END: judges AND parked-op delivery
                 push_session=_push_session_now,   # targeted one-session push for per-session chip events (connect)
                 mcp_config=(str(_SDK_MCP) if _SDK_MCP.exists() else None),
                 append_prompt_path=(str(_SDK_PROMPT) if _SDK_PROMPT.exists() else None),
@@ -9466,7 +9466,7 @@ def _codex():
                 cxmod = SourceFileLoader("romp_codex_backend", str(HERE / "codex_backend.py")).load_module()
                 _codex_backend = cxmod.CodexBackend(
                     jd.STATE, notify=_send_to_app,
-                    poke=_producer_wake.set, push=_pusher_wake.set,
+                    poke=_wake_kernel, push=_pusher_wake.set,
                     push_session=_push_session_now,
                     codex_bin=shutil.which("codex"),   # None → the SDK's bundled binary resolver
                     log=lambda m: sys.stderr.write("codex-backend: %s\n" % m))
@@ -19334,7 +19334,7 @@ _PATH_UNRESOLVED = object()   # _compacting_now's "no path was passed" sentinel 
 def _compacting_now(sid, tm=None, path=_PATH_UNRESOLVED):
     """Is this session compacting RIGHT NOW — the same corroborated signal the chip uses (_compacting:
     live/optimistic state, disproved by resumed work or a compact_boundary, 180s optimistic cap), read
-    from the CACHED parse only so it's cheap enough for the WS handler and the producer tick. `tm` lets
+    from the CACHED parse only so it's cheap enough for the WS handler and the pusher's drain. `tm` lets
     a caller already holding the session's live() meta pass it in — _session_rows exposes this per row,
     and refetching would pay one full Sessions.live() merge PER ROW on a polled route (review find,
     2026-08-30). `path` is the same hoist for the transcript path: the default _path_of resolves
@@ -19370,7 +19370,7 @@ def _working_now(sid):
     — the CACHED parse below LAGS a just-started turn (transcript-not-yet-written), which raced the drive-op
     gate: a /compact pressed while a turn was truly in flight saw 'not working', skipped the FIFO, and fired
     immediately, out of press-order (the user 2026-07-14). tmux has no such signal (busy→None) → the cached
-    event-model parse, unchanged. Both are cheap enough for the WS handler + producer tick."""
+    event-model parse, unchanged. Both are cheap enough for the WS handler + the pusher's drain."""
     try:
         be = Sessions.backend_for(sid)
         b = be.busy(sid) if be is not None else None
@@ -19397,7 +19397,8 @@ def _limit_hold(sid):
 
     RELEASE is read from the event, never a timer romp invents:
       - a rate window carries the API's own resetsAt, and _usage().limited goes false the moment that
-        stamp passes, so the producer tick drains the queue within one pass of the reset;
+        stamp passes, so the pusher cycle that delivers parked ops drains the queue within one cycle
+      (its 0.5 s backstop) of the reset;
       - a spend cap has no readable reset (it lifts when the user raises it), so the hold rides the
         retry-pause _auto_pause_on_spend_limit engaged and lifts when that lifts: the user resumes it, or
         _auto_resume_retry sees a session serve a request again.
@@ -19502,13 +19503,49 @@ def _parked_md(op):
 # ── moving a session's working directory (the user 2026-09-01) ─────────────────────────────────
 # A move rides the drive-op FIFO like /compact: parked as ("cwd", <canonical path>, <busy retries>)
 # while the session is not quiet, fired when it is. The backend's move() is a BLOCKING round trip
-# (set_cwd's control response) — it runs on its own thread so neither the WS handler nor the producer
-# tick waits on it, and `_moving` holds the session's queue for the duration: _ops_gate parks anything
+# (set_cwd's control response) — it runs on its own thread so neither the WS handler nor the pusher's
+# drain waits on it, and `_moving` holds the session's queue for the duration: _ops_gate parks anything
 # pressed meanwhile and _apply_pending_ops skips the sid, so nothing else reaches the CLI mid-move.
 _moving: set = set()
 _move_askers: dict = {}          # sid -> wid of the dashboard that asked for a PARKED move (failure lands there)
-_MOVE_BUSY_RETRIES = 3           # CLI-side `busy` answers retried on the next pass without waiting for a turn end
-                                 # (the CLI's post-result window); after these, the op waits on turn_seq (_move_now)
+_MOVE_BUSY_RETRIES = 3           # CLI-side `busy` answers retried without waiting for a turn end (the CLI's
+                                 # post-result window); after these, the op waits on turn_seq (_move_now). Each
+                                 # retry first waits out _MOVE_BUSY_RETRY_S (_hold_drain — see there for why).
+_MOVE_BUSY_RETRY_S = 3.0         # the spacing between those retries: the judge producer's pass cadence, which
+                                 # spaced them by accident until the drain moved to the pusher (2026-09-03)
+_TMUX_PROMPT_HOLD_S = 3.0        # after the drain hands a turn-opening op to a backend with NO authoritative
+                                 # busy() (tmux), how long that sid's queue holds before the op behind may fire
+_drain_hold: dict = {}           # sid -> time.monotonic() deadline; _apply_pending_ops skips the sid until then
+
+
+def _hold_drain(sid, seconds):
+    """Hold ONE sid's parked queue for `seconds` — the two places the drain must NOT run again at its own
+    cadence, made explicit (2026-09-03). The drain rides the pusher cycle, which any client push, any SDK
+    stream atom of any session, and the drain's own deliveries wake — so "the next cycle" can be
+    milliseconds away. Two consumers need more than that and have NO event to key on:
+      * a move the CLI answered `busy` (_move_now): the CLI's post-result bookkeeping window is sub-second
+        and emits nothing when it closes; the _MOVE_BUSY_RETRIES exist to outlast it, and back-to-back
+        cycles would burn all three inside it, leaving the op waiting on a turn_seq that never moves;
+      * a send / command / compact just handed to a tmux session (TmuxBackend has no busy(); _working_now
+        falls to the cached transcript parse): the keystrokes have landed but the transcript has not
+        recorded the prompt, so the gate reads idle for a moment and the op behind would fire into the
+        opening turn — the mis-delivery the SEND-ends-the-drain contract exists to prevent.
+    Both are the judge producer's old 3 s cadence made explicit, which spaced them by accident before. An
+    honest clock, named as one: the tmux half retires when TmuxBackend gains an authoritative busy() from
+    the hook-maintained session state; the SDK and Codex backends need neither hold (_after_turn_opening)."""
+    _drain_hold[str(sid)] = time.monotonic() + seconds
+
+
+def _after_turn_opening(be, sid):
+    """The drain just handed `sid` an op that OPENS a turn (a send batch, a typed command, a /compact). A
+    backend with an authoritative busy() (SDK, Codex) closed the working gate synchronously inside send(),
+    so the op behind waits for the turn's end by itself; one without (tmux) gets the hold — _hold_drain."""
+    try:
+        authoritative = be.busy(sid) is not None
+    except Exception:
+        authoritative = False
+    if not authoritative:
+        _hold_drain(sid, _TMUX_PROMPT_HOLD_S)
 
 
 def _move_or_park(be, sid, path, client=None):
@@ -19526,7 +19563,7 @@ def _move_or_park(be, sid, path, client=None):
 
 def _fire_move(be, sid, path, tries, wid):
     """Run the backend's blocking move on its own thread (returned, so a test can join it). `_moving`
-    is claimed synchronously, before the thread starts, so a producer tick landing in between cannot
+    is claimed synchronously, before the thread starts, so a pusher cycle landing in between cannot
     fire the op behind this one."""
     sid = str(sid)
     _moving.add(sid)
@@ -19543,9 +19580,9 @@ def _move_now(be, sid, path, tries, wid):
     one has:
       * a turn the CLI started itself (a hook, a background task's notification): romp's inflight never
         counted it, but it ENDS with a ResultMessage like any other, and that end is the cue — the parked
-        op carries the backend's turn_seq, and the producer pass fires it once that counter has moved;
+        op carries the backend's turn_seq, and the pusher cycle fires it once that counter has moved;
       * the CLI's own post-result bookkeeping window (sub-second, after a turn romp DID see end): no
-        further ResultMessage is coming, so the counter never moves — the first _MOVE_BUSY_RETRIES passes
+        further ResultMessage is coming, so the counter never moves — the first _MOVE_BUSY_RETRIES cycles
         therefore fire without waiting on it. Past those, the op waits for the event only, as a visible,
         cancellable chip, instead of failing loudly while the CLI's turn is still running.
     Anything else → a typed moveFailed with the backend's reason verbatim. Returns the backend's answer,
@@ -19564,8 +19601,9 @@ def _move_now(be, sid, path, tries, wid):
         seq = be.turn_seq(sid) if hasattr(be, "turn_seq") else None      # the turn end this retry waits on
         _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
         _move_askers[sid] = wid
+        _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (see _hold_drain)
         _save_pending_ops()
-        _mark_views_dirty()
+        _mark_views_dirty()                    # the chip re-renders now; the hold, not the wake, spaces the retry
         return res
     if res:
         _move_failed(sid, nm, wid, res)
@@ -19600,13 +19638,16 @@ def _cancel_parked(sid, park, md):
     would remove the WRONG op — re-locate by md. Returns None on success; when the op is GONE (it
     already ran / was delivered) returns the 'too late' text for the caller to toast — a silent miss
     read as a successful cancel while the message got answered anyway (the user 2026-07-20). Persists +
-    wakes the pusher like every queue mutation."""
+    wakes the pusher like every queue mutation. LOGGED — sid and op kind, never the body, which is user
+    text — so an emptied queue can be told apart from one that was never delivered: the 2026-09-03
+    diagnosis of a parked /clear that vanished had to infer this ✕ by elimination."""
     sid = str(sid)
     ops = _pending_ops.get(sid) or []
     if not (0 <= park < len(ops)) or (md and _parked_md(ops[park]) != md):
         park = next((j for j, op in enumerate(ops) if _parked_md(op) == md), -1) if md else -1
         if park < 0:
             return _cancel_miss_text(md)
+    sys.stderr.write("parked-op cancel: %s %s\n" % (sid, ops[park][0]))
     ops.pop(park)
     if not ops:
         _pending_ops.pop(sid, None)
@@ -19692,18 +19733,24 @@ def _send_or_park(be, sid, text, echo=None):
     open, even on a forwards_sends backend (the user 2026-08-13): the CLI only EXECUTES a slash command
     arriving as a fresh top-level prompt — forwarded into a running turn it lands as plain user text, the
     model politely replies to it, and the setting never changes. Parked as a ("command",) op, it fires ALONE
-    at turn end (never folded into a send batch, which would bury it as text the same way)."""
+    at turn end (never folded into a send batch, which would bury it as text the same way).
+
+    Returns True when PARKED, False when handed over now, so a route can tell its caller which: POST
+    /send answers `queued` and `romp send` prints it. An agent sending ITSELF a slash command from inside
+    its own turn otherwise read 'ok' and had no way to know the command was waiting for that turn to end
+    (2026-09-03, a /clear that then never fired)."""
     cmd = _is_slash_command(text)
     op = ("command", text, echo) if cmd else ("send", text, echo)
     if _compacting_now(sid) or _pending_ops.get(sid) or _limit_hold(sid):
         _park_op(sid, op)
-        return
+        return True
     if _working_now(sid) and (cmd or not _forwards_sends(be)):
         _park_op(sid, op)
-        return
+        return True
     be.send(sid, text)
     if echo:
         _optimistic_echo(sid, text, author=echo)
+    return False
 
 
 def _compact_or_park(be, sid):
@@ -19817,7 +19864,7 @@ def _set_fast_or_park(be, sid, value):
     return be.set_fast(sid, value)
 
 
-def _route_meta_command(be, sid, text, client=None, floating=False):
+def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
     """A "/model X", "/effort X" or "/fast on|off" — typed into the chat composer or sent by the timeline
     lane menu — goes through the kernel's OWN setters (_set_*_or_park), never to the CLI as literal text.
     `floating` rides the lane menu's "Latest" row to _set_model_or_park (forget the family's pin).
@@ -19828,7 +19875,9 @@ def _route_meta_command(be, sid, text, client=None, floating=False):
     another slash command, a bare "/model" (the CLI's own picker), plain text that merely contains one
     — is the caller's to send verbatim: the CLI owns what executes. A refused fast toggle is told to
     the client (fail loudly): a dormant SDK session has no live CLI to apply it, and the typed text
-    used to at least draw the CLI's own refusal."""
+    used to at least draw the CLI's own refusal. `state`, when given, receives {"queued": bool} — whether
+    the setter PARKED the change (they park under _ops_gate, read here) — so POST /send answers `queued`
+    for a meta command exactly as for a text send (2026-09-03: a parked /model read as plain 'ok')."""
     head, _, rest = (text or "").strip().partition(" ")
     value = rest.strip()
     # ONE token, and one the kernel can vouch for: the setters PERSIST their value — set_model's lands
@@ -19837,16 +19886,23 @@ def _route_meta_command(be, sid, text, client=None, floating=False):
     # ours to swallow: it stays the CLI's, verbatim, and the user sees the CLI's own error.
     if not value or len(value.split()) != 1:
         return False
+    gate = _ops_gate(sid)                  # the setters park under exactly this gate; read here so `state` can say so
     if head == "/model" and _vouched_model(value):
         _set_model_or_park(be, sid, value, floating=floating)     # mid-compaction → parked as a queued command
+        parked = gate
     elif head == "/effort" and value in _EFFORT_VALUES:
         _set_effort_or_park(be, sid, value)    # mid-compaction → parked as a queued command
+        parked = gate
     elif head == "/fast" and value in ("on", "off"):
-        if not _set_fast_or_park(be, sid, value) and client:   # mid-compaction → parked
+        took = _set_fast_or_park(be, sid, value)                  # mid-compaction → parked
+        parked = bool(took) and gate
+        if not took and client:
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't toggle fast mode — the session isn't connected right now."}))
     else:
         return False
+    if state is not None:
+        state["queued"] = parked
     return True
 
 
@@ -19884,7 +19940,7 @@ def _deliver_send_batch(be, sid, run):
 
 
 def _apply_pending_ops():
-    """Producer tick: FIFO-deliver parked ops once the session is QUIET (neither compacting nor an open
+    """Pusher cycle: FIFO-deliver parked ops once the session is QUIET (neither compacting nor an open
     turn) — in exactly the order they were parked, which is exactly the order the chat rendered their
     queued bubbles (the user 2026-07-02: what you see is what runs). SEQUENTIAL by construction (the user
     2026-07-02, compact-mid-turn): settings ops (model/effort) apply instantly and delivery continues,
@@ -19893,24 +19949,42 @@ def _apply_pending_ops():
     is delivered together, not one turn each (_deliver_send_batch — the user 2026-07-17, who wanted them sent all at
     once; the SDK folds the run into one turn, tmux merges it). Event-gated throughout (_compacting
     + the event-model open-turn signal, both off cached parses refreshed by turn-end pokes, plus
-    _limit_hold's account gate — a queue held by a usage limit drains on the pass after the API's own
+    _limit_hold's account gate — a queue held by a usage limit drains on the cycle after the API's own
     reset stamp passes, so the whole sequence goes in at the reset in the order it was typed); a dead
-    session's queue is dropped (fails once, logged), never retried."""
+    session's queue is dropped (fails once, logged), never retried.
+
+    WHO runs this (2026-09-03): the pusher cycle (_pusher_cycle_jobs), woken by the backends' turn-end poke
+    (_wake_kernel), by /tick, by every park / cancel / move, and by its own 0.5 s backstop — NOT the tail
+    of the judge producer's pass, where it lived before. A judge pass can run for hours (one session's
+    closer sweep, alarm-killed turn after turn, held a pass for 6h22m), and for all that time no parked op
+    in ANY session could fire: a typed /clear parked mid-turn sat as a queued chip until the user cancelled
+    it. Delivery keys on the settle event now; the judges' progress is irrelevant to it. Two proofs the
+    gates hold at this cadence: SdkBackend.send enqueues under the session lock synchronously and busy()
+    reads inflight>0 or the pending queue, so the working gate is closed before a delivered send returns;
+    and _fire_move claims _moving before its thread starts, so the sid is skipped until the relocation
+    ends. Only a REAL mutation saves the mirror and wakes the pusher: a cycle that delivers nothing (a cwd
+    op waiting on its turn_seq) must not re-wake the thread it runs on, or the backstop becomes a hot loop.
+    Two sids are skipped for a while even when quiet — a move the CLI answered busy, and a tmux session
+    just handed a turn-opening op — because their next step has no event to wait for (_hold_drain)."""
     for sid, ops in list(_pending_ops.items()):
         if not ops:
             _pending_ops.pop(sid, None)
             continue
         if sid in _moving:
             continue                                  # a move is mid-flight: its relocation must finish first
+        if _drain_hold.get(sid, 0.0) > time.monotonic():
+            continue                                  # a CLI-side window is still open for this sid (_hold_drain)
+        _drain_hold.pop(sid, None)
         if _compacting_now(sid) or _working_now(sid) or _limit_hold(sid):
             continue                                  # …or the account can't serve a request yet
+        changed = False                               # a real mutation below → save the mirror + wake the pusher
         try:
             be = Sessions.backend_for(sid)
             while ops:
                 op = ops[0]
                 if op[0] == "cwd":
-                    # a parked move: fires on its own thread and CLAIMS _moving before this pass ends, so
-                    # the ops behind it wait for the relocation to finish (the next pass skips the sid
+                    # a parked move: fires on its own thread and CLAIMS _moving before this cycle ends, so
+                    # the ops behind it wait for the relocation to finish (the next cycle skips the sid
                     # until then) — a send fed mid-move could make the CLI reject the move as busy
                     tries = int(op[2]) if len(op) > 2 else 0
                     seq = op[3] if len(op) > 3 else None
@@ -19918,13 +19992,16 @@ def _apply_pending_ops():
                             and be.turn_seq(sid) == seq):
                         break      # the CLI still owns a turn romp cannot see: its ResultMessage is the cue (_move_now)
                     ops.pop(0)
+                    changed = True
                     _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
                     break
+                changed = True                        # every arm below pops at least one op
                 if op[0] == "send":
                     run = []                          # coalesce the leading run of sends → deliver them AT ONCE
                     while ops and ops[0][0] == "send":
                         run.append(ops.pop(0))
                     _deliver_send_batch(be, sid, run)
+                    _after_turn_opening(be, sid)
                     break                             # the delivered turn must END before any op behind it fires
                 elif op[0] == "command":
                     # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
@@ -19937,11 +20014,13 @@ def _apply_pending_ops():
                     if op[1].strip().split()[0] == "/compact":
                         _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
                     ops.pop(0)
+                    _after_turn_opening(be, sid)
                     break                             # its turn must end before anything behind it fires
                 elif op[0] == "compact":
                     be.send(sid, "/compact")
                     _mark_compacting(sid)
                     ops.pop(0)
+                    _after_turn_opening(be, sid)
                     break                             # the compaction must finish first
                 elif op[0] == "model":
                     be.set_model(sid, op[1])
@@ -19963,10 +20042,12 @@ def _apply_pending_ops():
         except Exception:
             sys.stderr.write("pending ops apply: %s\n" % traceback.format_exc())
             _pending_ops.pop(sid, None)               # a dead session's queue is dropped, never retried
+            changed = True
         if not _pending_ops.get(sid):
             _pending_ops.pop(sid, None)
-        _save_pending_ops()               # every delivery/drop shrinks the disk mirror too
-        _mark_views_dirty()               # the queue shrank (in-memory) → rebuild past the sig so chips retire
+        if changed:
+            _save_pending_ops()           # every delivery/drop shrinks the disk mirror too
+            _mark_views_dirty()           # the queue shrank (in-memory) → rebuild past the sig so chips retire
 
 
 # ── the chat's pinned "system context" card (the user 2026-06-19) ──────────────────────────────────
@@ -27849,6 +27930,17 @@ def _mark_views_dirty():
     _pusher_wake.set()
 
 
+def _wake_kernel():
+    """The backends' turn-end POKE: wake BOTH loops. The producer runs a judge pass; the pusher runs the
+    cycle that delivers parked ops (_apply_pending_ops) and pushes what changed. Until 2026-09-03 the poke
+    reached only the producer, and parked-op delivery sat at the tail of the judge pass — so one session's
+    wedged closer sweep held every parked op in every session hostage for hours, and a typed /clear parked
+    mid-turn never fired. The settle is the event a parked op waits for; it must wake the thread that
+    delivers."""
+    _producer_wake.set()
+    _pusher_wake.set()
+
+
 def _producer_sig(browser):
     """A cheap fingerprint that changes iff there's new work to push: each discovered transcript's mtime,
     each session's names-file mtime (so a RENAME — which touches no transcript — still re-pushes the new
@@ -28454,7 +28546,6 @@ def _producer():
             _judge_gen[0] += 1     # a judge pass may have changed goal/caption state WITHOUT touching any
                                    # transcript → bump the generation so the chat-build cache re-builds the
                                    # background tabs once, keeping their Fleet status/ledger fresh (≤ this cadence).
-            _apply_pending_ops()      # FIFO-deliver everything parked during a compaction that has now ended
             try:                      # sessions with ARMED TIMERS need a LIVE CLI (the user 2026-08-28:
                 _sbe = _sdk()         # crons/wakeups never fired on dormant sessions — the CLI's scheduler
                 if _sbe and _sdk_ready():   # is in-process; see SdkBackend.ensure_scheduled)
@@ -28473,6 +28564,8 @@ def _producer():
         # for (e.g. a segment closing mid-turn) and a safety net if a poke is ever missed. A pass is cheap
         # when nothing changed (cached parses, no LLM calls), so a short backstop is harmless and keeps the
         # timeline/feed snappy. (the user 2026-06-19: 20s → 3s.)
+        # Parked-op delivery is NOT here (2026-09-03): it rides the pusher cycle, woken by the settle itself,
+        # so a long pass — a judge stage stuck on one session — can never hold a user's queued input.
         _producer_wake.wait(3)
 
 
@@ -28508,6 +28601,10 @@ def _pusher_cycle():
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):
+    try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
+        _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
+    except Exception:                     # FIRST, so a delivered op's echo / retired chip rides this push;
+        sys.stderr.write("pending-ops: %s\n" % traceback.format_exc())   # never behind a judge pass (2026-09-03)
     if any_client:
         _push_all(tmux=tmux)
     # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
@@ -33006,7 +33103,10 @@ class Handler(BaseHTTPRequestHandler):
                         return self._send(200, json.dumps({"ok": False, "error":   # pretend it was delivered
                             "the remote kernel for this session (%s) isn't answering — message not delivered"
                             % r.get("host", "?")}), "application/json")
-                    return self._send(200, json.dumps({"ok": True}), "application/json")
+                    # the far kernel's `queued` rides through (an older remote without the field reads False)
+                    return self._send(200, json.dumps({"ok": True, "queued": bool(isinstance(res, dict)
+                                                                                  and res.get("queued"))}),
+                                      "application/json")
                 # PARKS like a composer send (the user 2026-07-24), through the same FIFO: a message handed
                 # in by a local tool while the account is rate-limited — or while the session compacts —
                 # waits its turn instead of buying a red API-error card. ok:true still means ACCEPTED,
@@ -33014,9 +33114,15 @@ class Handler(BaseHTTPRequestHandler):
                 # isn't a human composer bubble. A typed /model, /effort or /fast takes the setters,
                 # exactly as the composer's does — same door, same registry.
                 be = Sessions.backend_for(sid)
-                if not _route_meta_command(be, sid, body["text"]):
-                    _send_or_park(be, sid, body["text"])
-                return self._send(200, json.dumps({"ok": True}), "application/json")
+                meta = {}
+                if _route_meta_command(be, sid, body["text"], state=meta):
+                    queued = bool(meta.get("queued"))              # a parked /model, /effort or /fast says so too
+                else:
+                    queued = bool(_send_or_park(be, sid, body["text"]))
+                # `queued` says which arm it took (the /compact route's shape): a sender that IS the
+                # target's open turn — an agent running `romp send <self> /clear` from its own Bash tool —
+                # read 'ok' otherwise and could not know the command waits for that turn to end (2026-09-03).
+                return self._send(200, json.dumps({"ok": True, "queued": queued}), "application/json")
             if u.path in ("/fork-comment", "/fork-promote"):
                 # Parallel review dispatch (the user 2026-08-31, via the Obsidian track-changes
                 # plugin): /fork-comment forks the target as a transcript-comment-style thread and

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2892,6 +2892,12 @@ class SdkSession:
                     blocked = blocked or (self.inflight == 0 and self.backend.drain_holding())
                     item = self._pending.pop(0) if (self._pending and not blocked) else None
                     fresh = item is not None and self.inflight == 0     # starting from idle, not mid-turn
+                    if item is not None:
+                        # under the SAME lock as the pop: busy() reads inflight>0 or _pending, and the kernel's
+                        # parked-op drain re-runs right after a delivery (2026-09-03) — a gap between the pop
+                        # and this increment read as idle and could feed the op behind into this very turn
+                        self.inflight += 1
+                        self._inflight_texts.append(item)   # the fed-turn twin — see its init comment
                 if item is None:
                     await self._input_wake.wait()   # idle, or holding behind a wedged turn → wait for a change
                     continue
@@ -2900,8 +2906,6 @@ class SdkSession:
                     self.since = int(time.time())    # a new turn starts now (mid-turn forwards keep the turn's clock)
                     self._interrupted = False        # a fresh turn → clear any stale interrupt flag
                     self._intr_level = 0             #   ...and its escalation episode (a new stop starts polite)
-                self.inflight += 1
-                self._inflight_texts.append(item)   # the fed-turn twin — see its init comment
                 if item.startswith(RENAME_PING_HEAD):
                     self._ping_feeding = True       # hold feeds until this turn's first streamed message
                 self._mark("working")
@@ -2958,7 +2962,7 @@ class SdkSession:
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
                     # here, at the proof, rather than on a timer. This is what lifts the usage-limit
                     # hold once the window resets: the next _ensure connects, the error record goes, and
-                    # the queue the limit was holding drains on the following producer pass.
+                    # the queue the limit was holding drains on the following pusher cycle.
                     self.backend._clear_launch_error(self.sid)
                     # A pending /effort switch is APPLIED the instant this (re)connect lands (--effort rode _options
                     # above) → clear the switching-dots + "Reloading session…" notice (the user 2026-07-06). Covers
@@ -5576,7 +5580,7 @@ class SdkBackend:
             try:
                 self._poke_cb()
             except Exception as e:
-                self._log("producer wake failed: %s" % e)
+                self._log("kernel wake failed: %s" % e)
 
     # ---- SDK option assembly (mirrors the tmux launch flags) ----
     def _options(self, sess: SdkSession, ClaudeAgentOptions):
@@ -6130,7 +6134,7 @@ class SdkBackend:
             return False
         if _is_compact_cmd(text):
             # Delivering /compact: mark the session compacting NOW (authoritative), covering the gap between
-            # this send and the CLI actually starting the turn — so a drive op the producer tick checks in
+            # this send and the CLI actually starting the turn — so a drive op the pusher's drain checks in
             # that window still parks. Cleared event-based by the boundary / the turn's ResultMessage.
             s._compacting = True
         if _is_clear_cmd(text):

--- a/tests/romp-headless.bats
+++ b/tests/romp-headless.bats
@@ -124,6 +124,23 @@ PY
     [[ "$output" == *"usage: romp send"* ]]
 }
 
+@test "romp send reports queued when the kernel parked it" {
+    # a sender inside the target's own open turn (an agent sending itself a slash command) must learn
+    # the command has not run yet (2026-09-03: a parked /clear read 'ok' and never fired)
+    start_fake_kernel '{"ok": true, "queued": true}'
+    run "$ROMP_SCRIPT" send busy1 "/frobnicate now"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp send: queued (busy1)"* ]]
+    [[ "$output" == *"delivers when the session is quiet"* ]]
+}
+
+@test "romp send still says ok on queued:false and on a bare ok reply" {
+    start_fake_kernel '{"ok": true, "queued": false}'
+    run "$ROMP_SCRIPT" send web "hello"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp send: ok (web)"* ]]
+}
+
 @test "a kernel refusal is loud: non-zero exit + the kernel's answer" {
     start_fake_kernel '{"ok": false, "error": "id or name required"}'
     run "$ROMP_SCRIPT" interrupt ghost

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -126,6 +126,7 @@ url=""
 for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ -n "${MOCK_CURL_FAIL_SEND:-}" && "$url" == */send ]]; then exit 22; fi
 if [[ -n "${MOCK_CURL_FAIL_NEW:-}" && "$url" == */new ]]; then exit 7; fi
+if [[ -n "${MOCK_CURL_SEND_QUEUED:-}" && "$url" == */send ]]; then echo '{"ok": true, "queued": true}'; exit 0; fi
 if [[ -n "${MOCK_CURL_NEW_400:-}" && "$url" == */new ]]; then
   for a in "$@"; do
     if [[ "$a" == "-f" || "$a" == -[!-]*f* ]]; then exit 22; fi
@@ -164,6 +165,18 @@ MOCK
     [ "$status" -eq 2 ]
     [[ "$output" == *"-m needs the default (SDK) session"* ]]
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new -m: a first prompt the kernel PARKED is reported as queued, not delivered" {
+    # the /send route says which arm it took (2026-09-03); a fresh session that is not quiet yet holds the
+    # prompt, and the CLI must not claim a delivery that has not happened
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok MOCK_CURL_SEND_QUEUED=1
+    run run_romp new -m "look into the flaky test" ideabox
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"first prompt queued"* ]]
+    [[ "$output" != *"first prompt delivered"* ]]
 }
 
 @test "new -m: one command spawns AND delivers the first prompt (POST /new, then /send)" {

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -549,6 +549,19 @@ class Lifecycle(unittest.TestCase):
                          "the pending placeholder must become a real Codex thread")
         self.assertFalse(be.pending_queued(sid))
 
+    def test_turn_end_pokes_after_busy_clears(self):
+        # the kernel's parked-op drain wakes on the poke (2026-09-03): every in-loop poke fires while the
+        # turn is still open (turn_id set → busy() True), so the finally must poke once more AFTER it clears,
+        # or a parked op on a Codex session waits out the pusher's backstop instead of firing on the event
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        seen = []
+        real = be.poke
+        be.poke = lambda: (seen.append(be.busy(sid)), real())
+        self.assertTrue(be.send(sid, "one"))
+        self.assertTrue(until(lambda: not be.busy(sid)))
+        self.assertTrue(until(lambda: False in seen), "a poke observed the settled turn (busy() False)")
+
     def test_kill_interrupts_an_active_turn_and_worker_exits(self):
         be, fake, _ = build()
         fake.hold_open = True

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -38,6 +38,11 @@ km = SourceFileLoader("romp_kernel_headless", os.path.join(BIN, "romp-kernel")).
 # limit. Pinning it off keeps them hermetic.
 km._limit_hold = lambda sid: None
 
+# The tmux PROMPT HOLD (_hold_drain: a tmux-shaped delivery holds the sid for a moment, tested in
+# tests/test_kernel_parked_ops_liveness.py) is a separate axis: off here, so back-to-back
+# _apply_pending_ops calls stand for successive cycles.
+km._TMUX_PROMPT_HOLD_S = 0.0
+
 
 class PendingOpsPersistence(unittest.TestCase):
     def setUp(self):
@@ -122,6 +127,67 @@ class HeadlessRoutes(unittest.TestCase):
         self.assertEqual((code, resp), (200, {"ok": True}))
         fake.kill.assert_called_once()
         self.assertIn(("chat", {"type": "closed", "id": fake.kill.call_args[0][0]}), sent)
+
+    def test_send_route_reports_queued_vs_sent(self):
+        # `queued` says which arm the send took (2026-09-03): an agent sending ITSELF a slash command from
+        # inside its own turn read 'ok' and could not know the command was parked until that turn ended
+        fake = mock.Mock()
+        fake.busy.return_value = None
+        km._pending_ops.clear()
+        try:
+            with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)), \
+                 mock.patch.object(km, "_compacting_now", lambda sid, **k: False), \
+                 mock.patch.object(km, "_working_now", lambda sid: True):
+                code, resp = self._post("/send", {"id": "sid-q", "text": "/frobnicate now"})
+            self.assertEqual((code, resp), (200, {"ok": True, "queued": True}))
+            self.assertEqual(list(km._pending_ops.values()), [[("command", "/frobnicate now", None)]])
+            fake.send.assert_not_called()
+            km._pending_ops.clear()
+            with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)), \
+                 mock.patch.object(km, "_compacting_now", lambda sid, **k: False), \
+                 mock.patch.object(km, "_working_now", lambda sid: False):
+                code, resp = self._post("/send", {"id": "sid-q", "text": "/frobnicate now"})
+            self.assertEqual((code, resp), (200, {"ok": True, "queued": False}))
+            fake.send.assert_called_once()
+            self.assertEqual(fake.send.call_args[0][1], "/frobnicate now")
+        finally:
+            km._pending_ops.clear()
+
+    def test_send_route_reports_a_parked_meta_command_as_queued(self):
+        # /model, /effort and /fast take the kernel's own setters (_route_meta_command), which park under
+        # the same gate as a text send — the route must say `queued` for them too (review find, 2026-09-03)
+        fake = mock.Mock()
+        fake.busy.return_value = None
+        km._pending_ops.clear()
+        try:
+            with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)), \
+                 mock.patch.object(km, "_compacting_now", lambda sid, **k: False), \
+                 mock.patch.object(km, "_working_now", lambda sid: True):
+                code, resp = self._post("/send", {"id": "sid-m", "text": "/effort high"})
+            self.assertEqual((code, resp), (200, {"ok": True, "queued": True}))
+            self.assertEqual(list(km._pending_ops.values()), [[("effort", "high")]], "parked as the setter's op")
+            fake.set_effort.assert_not_called()
+            km._pending_ops.clear()
+            with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)), \
+                 mock.patch.object(km, "_compacting_now", lambda sid, **k: False), \
+                 mock.patch.object(km, "_working_now", lambda sid: False):
+                code, resp = self._post("/send", {"id": "sid-m", "text": "/effort high"})
+            self.assertEqual((code, resp), (200, {"ok": True, "queued": False}))
+            fake.set_effort.assert_called_once()
+        finally:
+            km._pending_ops.clear()
+
+    def test_send_route_passes_a_remote_kernels_queued_through(self):
+        # a session living on another kernel: its answer's `queued` rides back to the caller; an older
+        # remote without the field reads as not queued (today's behaviour)
+        with mock.patch.object(km, "_host_for_sid", lambda sid: {"host": "TESTHOST"}), \
+             mock.patch.object(km, "_remote_forward", lambda r, path, body: {"ok": True, "queued": True}):
+            code, resp = self._post("/send", {"id": "sid-r", "text": "/frobnicate now"})
+        self.assertEqual((code, resp), (200, {"ok": True, "queued": True}))
+        with mock.patch.object(km, "_host_for_sid", lambda sid: {"host": "TESTHOST"}), \
+             mock.patch.object(km, "_remote_forward", lambda r, path, body: {"ok": True}):
+            code, resp = self._post("/send", {"id": "sid-r", "text": "hello"})
+        self.assertEqual((code, resp), (200, {"ok": True, "queued": False}))
 
     def test_missing_who_is_a_400(self):
         code, resp = self._post("/interrupt", {})

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -188,6 +188,12 @@ class HeadlessRoutes(unittest.TestCase):
              mock.patch.object(km, "_remote_forward", lambda r, path, body: {"ok": True}):
             code, resp = self._post("/send", {"id": "sid-r", "text": "hello"})
         self.assertEqual((code, resp), (200, {"ok": True, "queued": False}))
+        # …and a far kernel's REFUSAL rides back as itself, never rewritten into an ok (review find, #904)
+        refusal = {"ok": False, "error": "isolation: the target session's mailbox is OFF"}
+        with mock.patch.object(km, "_host_for_sid", lambda sid: {"host": "TESTHOST"}), \
+             mock.patch.object(km, "_remote_forward", lambda r, path, body: dict(refusal)):
+            code, resp = self._post("/send", {"id": "sid-r", "text": "hello"})
+        self.assertEqual((code, resp), (200, refusal))
 
     def test_missing_who_is_a_400(self):
         code, resp = self._post("/interrupt", {})

--- a/tests/test_kernel_limit_queue.py
+++ b/tests/test_kernel_limit_queue.py
@@ -38,6 +38,11 @@ SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_limitqueue", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The tmux PROMPT HOLD (_hold_drain: a tmux-shaped delivery holds the sid for a moment, tested in
+# tests/test_kernel_parked_ops_liveness.py) is a separate axis from the ACCOUNT gate this module covers:
+# off here, so back-to-back _apply_pending_ops calls stand for successive cycles.
+km._TMUX_PROMPT_HOLD_S = 0.0
 jd = km.jd
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_model_queue.py
+++ b/tests/test_kernel_model_queue.py
@@ -28,6 +28,11 @@ km = SourceFileLoader("romp_kernel_modelq", os.path.join(BIN, "romp-kernel")).lo
 # limit. Pinning it off keeps them hermetic.
 km._limit_hold = lambda sid: None
 
+# The tmux PROMPT HOLD (_hold_drain: a tmux-shaped delivery holds the sid for a moment, tested in
+# tests/test_kernel_parked_ops_liveness.py) is a separate axis: off here, so back-to-back
+# _apply_pending_ops calls stand for successive cycles.
+km._TMUX_PROMPT_HOLD_S = 0.0
+
 SID = "11111111-2222-3333-4444-555555555555"
 
 
@@ -95,10 +100,16 @@ class ParkOrApply(unittest.TestCase):
         km._apply_pending_ops()                         # must not raise
         self.assertNotIn(SID, km._pending_ops, "a dead session's park is dropped, never retried forever")
 
-    def test_producer_ticks_the_apply(self):
+    def test_the_pusher_cycle_delivers_the_parked_queue_not_the_producer(self):
+        # 2026-09-03: delivery moved OFF the judge producer's tail — a pass can run for hours (one session's
+        # closer sweep, alarm-killed turn after turn) and held every parked op hostage. It rides the pusher
+        # cycle now, woken by the settle itself, and runs FIRST so the delivered op's echo rides the push.
         import inspect
-        src = inspect.getsource(km._producer)
-        self.assertIn("_apply_pending_ops()", src, "the producer tick fires parked ops")
+        self.assertNotIn("_apply_pending_ops()", inspect.getsource(km._producer),
+                         "the judge pass no longer gates delivery")
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_apply_pending_ops()", src, "the pusher cycle delivers the parked queue")
+        self.assertLess(src.index("_apply_pending_ops()"), src.index("_push_all("), "…ahead of the push")
 
 
 class CompactingNowGate(unittest.TestCase):

--- a/tests/test_kernel_parked_ops_liveness.py
+++ b/tests/test_kernel_parked_ops_liveness.py
@@ -218,6 +218,26 @@ class DeliveryRidesTheSettle(unittest.TestCase):
         self.assertEqual(self.be.calls, [("model", "opus")])
         self.assertTrue(km._pusher_wake.is_set(), "a real delivery wakes the push that retires the chip")
 
+    def test_a_cycle_resolves_a_held_sids_path_once(self):
+        # review find on #904: the drain's gates each resolved a held sid's transcript path (a discover
+        # fingerprint) every cycle; inside a cycle the resolution is memoized on the cycle's scope, and a
+        # caller outside a cycle (a WS handler) still resolves fresh
+        calls = []
+        with mock.patch.object(km, "_sessions", lambda now: (calls.append(1), [])[1]):
+            km._path_of(SID)
+            km._path_of(SID)
+            self.assertEqual(len(calls), 2, "outside a cycle every ask resolves fresh")
+            calls.clear()
+            km._live_scope.paths = {}
+            try:
+                km._path_of(SID)
+                km._path_of(SID)
+            finally:
+                km._live_scope.paths = None
+            self.assertEqual(len(calls), 1, "inside a cycle the second ask is the memo")
+        km._pusher_cycle()
+        self.assertIsNone(getattr(km._live_scope, "paths", None), "the memo ends with the cycle")
+
     def test_cancel_parked_logs_sid_and_kind_only(self):
         km._pending_ops[SID] = [("send", "a private sentence", "human")]
         buf = io.StringIO()

--- a/tests/test_kernel_parked_ops_liveness.py
+++ b/tests/test_kernel_parked_ops_liveness.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Parked ops deliver on the SETTLE event, independent of the judge pass (2026-09-03).
+
+The kernel parks a user's input while its session is busy, compacting, or limit-held, and delivers the
+queue FIFO once the session is quiet (_apply_pending_ops). Until this change the ONLY caller of that
+function was the tail of the judge producer's pass, after an untimed join on the judge tiers — so every
+parked op in every session waited for the judges to finish. A judge pass can run for hours: one session's
+closer sweep, alarm-killed turn after turn, held a pass for 6h22m, and a typed /clear parked mid-turn sat
+as a queued chip the whole time until the user cancelled it. The drain now rides the pusher cycle, woken
+by the backends' turn-end poke (_wake_kernel), by /tick, by every queue mutation, and by its own 0.5 s
+backstop; the producer never touches it.
+
+SYNTHETIC fixtures only: a placeholder uuid, invented texts.
+"""
+import inspect
+import io
+import os
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_parkedlive", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The ACCOUNT gate is a separate axis (tests/test_kernel_limit_queue.py); pinned off so the real
+# machine's usage.json can never make these tests park for a reason none of them is about.
+km._limit_hold = lambda sid: None
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+# Every pusher-cycle job except the drain, quieted so a cycle run here does exactly one thing.
+_OTHER_JOBS = ("_push_all", "_lift_spent_awaiting", "_death_sweep_tick", "_end_on_idle_sweep",
+               "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick", "_auto_pause_on_limit",
+               "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
+               "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+               "_clear_done_working_notes")
+
+
+class _FakeBackend:
+    """A tmux-shaped backend: it cannot forward its own sends, so a send parks while the turn is open."""
+
+    def __init__(self):
+        self.calls = []
+        self.open = True
+
+    def busy(self, sid):
+        return self.open
+
+    def forwards_sends(self):
+        return False
+
+    def send(self, sid, text):
+        self.calls.append(("send", text))
+        return True
+
+    def set_model(self, sid, value):
+        self.calls.append(("model", value))
+        return True
+
+    def turn_seq(self, sid):
+        return 0
+
+
+class DeliveryRidesTheSettle(unittest.TestCase):
+    def setUp(self):
+        self.be = _FakeBackend()
+        self._patches = [
+            mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: self.be)),
+            mock.patch.object(km, "_compacting_now", lambda sid, **k: False),
+            mock.patch.object(km, "_optimistic_echo", lambda *a, **k: None),
+            mock.patch.object(km, "_mark_compacting", lambda sid: None),
+            mock.patch.object(km, "_names_snapshot", lambda: {}),
+            mock.patch.object(km, "_tmux_sessions", lambda: {SID: {"state": "waiting", "backend": "tmux"}}),
+        ] + [mock.patch.object(km, name, lambda *a, **k: None) for name in _OTHER_JOBS]
+        for p in self._patches:
+            p.start()
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._drain_hold.clear()
+        km._pusher_wake.clear()
+        km._producer_wake.clear()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._drain_hold.clear()
+
+    def test_parked_op_delivers_on_settle_while_a_judge_pass_is_stuck(self):
+        gate = threading.Event()             # the judge tiers block here: a closer sweep that never returns
+        ran_on = []                          # the threads that ran the drain
+        real_apply = km._apply_pending_ops
+
+        def counting_apply():
+            ran_on.append(threading.current_thread().name)
+            return real_apply()
+
+        # The stuck pass stays stuck: a real _producer has no exit, and ending its thread by exception
+        # trips pytest's thread-exception hook — so the gate is never set and the three daemon threads
+        # (producer + two tiers) stay parked, touching nothing, until the process ends.
+        with mock.patch.object(km, "_run_tier", lambda fn: gate.wait()), \
+             mock.patch.object(km, "_retry_paused_on", lambda: False), \
+             mock.patch.object(km, "_episode_boundary_tick", lambda now: None), \
+             mock.patch.object(km, "_begin_goals_pass", lambda: None), \
+             mock.patch.object(km, "_end_goals_pass", lambda: None), \
+             mock.patch.object(km, "_compact_goal_stores", lambda: 0), \
+             mock.patch.object(km, "_sdk", lambda: None), \
+             mock.patch.object(km.jd, "begin_pass_frame", lambda: False), \
+             mock.patch.object(km.jd, "end_pass_frame", lambda f: None), \
+             mock.patch.object(km.jd, "consume_judge_recovery", lambda: False), \
+             mock.patch.object(km, "_apply_pending_ops", counting_apply):
+            producer = threading.Thread(target=km._producer, name="producer-under-test", daemon=True)
+            producer.start()
+            deadline = time.time() + 5
+            while time.time() < deadline and not any(t.name == "triage" for t in threading.enumerate()):
+                time.sleep(0.01)
+            self.assertTrue(any(t.name == "triage" for t in threading.enumerate()),
+                            "a judge pass is in flight, stuck on its tiers")
+            # a typed slash command lands while the turn is open → parked (the standing rule)
+            km._send_or_park(self.be, SID, "/frobnicate now")
+            self.assertEqual(km._pending_ops[SID], [("command", "/frobnicate now", None)])
+            self.assertEqual(self.be.calls, [])
+            # the turn SETTLES: the backend pokes the kernel exactly as its ResultMessage path does. (On a
+            # tree without _wake_kernel the poke is what the backends did before — both wakes by hand — so
+            # this test reaches the delivery assertion there and fails on the bug, not on a missing name.)
+            self.be.open = False
+            km._pusher_wake.clear()
+            poke = getattr(km, "_wake_kernel", None) or (lambda: (km._producer_wake.set(), km._pusher_wake.set()))
+            poke()
+            self.assertTrue(km._pusher_wake.is_set(), "the settle wakes the thread that delivers")
+            self.assertTrue(km._producer_wake.is_set(), "…and the judges, as before")
+            km._pusher_cycle()                           # ONE pusher cycle, while the judge pass is still stuck
+            self.assertFalse(gate.is_set())
+            self.assertTrue(producer.is_alive())
+            self.assertEqual(self.be.calls, [("send", "/frobnicate now")], "delivered alone, as a fresh prompt")
+            self.assertNotIn(SID, km._pending_ops)
+            self.assertEqual(ran_on, [threading.current_thread().name],
+                             "the drain ran on this cycle and never on the producer")
+
+    def test_two_parks_drain_one_per_settle_in_park_order(self):
+        self.assertTrue(km._send_or_park(self.be, SID, "one", echo="human"))   # tmux-shaped: a send parks mid-turn
+        self.assertTrue(km._compact_or_park(self.be, SID), "the compact parks behind it (queued)")
+        self.assertEqual([op[0] for op in km._pending_ops[SID]], ["send", "compact"])
+        self.be.open = False                                                    # settle #1
+        km._pusher_cycle()
+        self.assertEqual(self.be.calls, [("send", "one")], "the send fired; the compact waits for ITS turn to end")
+        self.assertEqual([op[0] for op in km._pending_ops[SID]], ["compact"])
+        self.be.open = True                                                     # the delivered send's turn
+        km._pusher_cycle()
+        self.assertEqual(self.be.calls, [("send", "one")], "nothing fires into an open turn")
+        self.be.open = False                                                    # settle #2
+        km._pusher_cycle()
+        self.assertEqual(self.be.calls, [("send", "one"), ("send", "/compact")])
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertNotIn(SID, km._drain_hold, "an authoritative busy() needs no hold between deliveries")
+
+    def test_a_tmux_shaped_delivery_holds_the_sid_until_the_prompt_can_have_landed(self):
+        # TmuxBackend has no busy(): _working_now falls to the cached transcript parse, which reads idle for a
+        # moment after the keystrokes land — and the drain's own delivery wakes the pusher, so without the hold
+        # the op behind would fire into the opening turn (the SEND-ends-the-drain contract, broken). The hold
+        # is the producer's old cadence made explicit; it retires when tmux gains an authoritative busy().
+        class _TmuxShaped(_FakeBackend):
+            def busy(self, sid):
+                return None
+        self.be = _TmuxShaped()
+        with mock.patch.object(km, "_working_now", lambda sid: True):             # the turn is open: both park
+            km._send_or_park(self.be, SID, "one", echo="human")
+            km._compact_or_park(self.be, SID)
+        self.assertEqual([op[0] for op in km._pending_ops[SID]], ["send", "compact"])
+        km._pusher_cycle()                                                        # the cached parse reads idle
+        self.assertEqual(self.be.calls, [("send", "one")], "the send fired")
+        self.assertIn(SID, km._drain_hold, "…and the sid is held while its prompt lands")
+        km._pusher_cycle()                                                        # back-to-back, as a wake would
+        self.assertEqual(self.be.calls, [("send", "one")], "the compact does NOT fire into the opening turn")
+        km._drain_hold.clear()                                                    # the window passed
+        km._pusher_cycle()
+        self.assertEqual(self.be.calls, [("send", "one"), ("send", "/compact")])
+
+    def test_wake_kernel_sets_both_events_and_is_the_backends_poke(self):
+        km._producer_wake.clear()
+        km._pusher_wake.clear()
+        km._wake_kernel()
+        self.assertTrue(km._producer_wake.is_set() and km._pusher_wake.is_set())
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        self.assertEqual(src.count("poke=_wake_kernel"), 2, "both backend constructors (SDK + Codex) poke the kernel")
+        self.assertNotIn("poke=_producer_wake.set", src, "no backend pokes only the judges anymore")
+
+    def test_delivery_moved_from_the_producer_to_the_pusher_cycle(self):
+        self.assertNotIn("_apply_pending_ops()", inspect.getsource(km._producer), "the judge pass no longer gates delivery")
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_apply_pending_ops()", src, "the pusher cycle delivers the parked queue")
+        self.assertLess(src.index("_apply_pending_ops()"), src.index("_push_all("),
+                        "delivery precedes the push, so the delivered op's echo and retired chip ride it")
+
+    def test_drain_does_not_wake_the_pusher_when_nothing_changed(self):
+        self.be.open = False
+        d = tempfile.mkdtemp()
+        km._pending_ops[SID] = [("cwd", d, km._MOVE_BUSY_RETRIES, 0)]    # waits on turn_seq: nothing to do yet
+        km._pusher_wake.clear()
+        km._apply_pending_ops()
+        self.assertEqual(km._pending_ops[SID], [("cwd", d, km._MOVE_BUSY_RETRIES, 0)], "still parked")
+        self.assertFalse(km._pusher_wake.is_set(),
+                         "a cycle that delivered nothing must not re-wake the thread it runs on (a hot loop)")
+        km._pending_ops[SID] = [("model", "opus")]
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("model", "opus")])
+        self.assertTrue(km._pusher_wake.is_set(), "a real delivery wakes the push that retires the chip")
+
+    def test_cancel_parked_logs_sid_and_kind_only(self):
+        km._pending_ops[SID] = [("send", "a private sentence", "human")]
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self.assertIsNone(km._cancel_parked(SID, 0, ""))
+        line = buf.getvalue()
+        self.assertIn(SID, line)
+        self.assertIn("send", line)
+        self.assertNotIn("a private sentence", line, "the body is user text — never logged")
+        self.assertNotIn(SID, km._pending_ops)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -28,6 +28,11 @@ km = SourceFileLoader("romp_kernel_sendpark", os.path.join(BIN, "romp-kernel")).
 # limit. Pinning it off keeps them hermetic.
 km._limit_hold = lambda sid: None
 
+# The tmux PROMPT HOLD (_hold_drain: a tmux-shaped delivery holds the sid for a moment, tested in
+# tests/test_kernel_parked_ops_liveness.py) is a separate axis: off here, so back-to-back
+# _apply_pending_ops calls stand for successive cycles.
+km._TMUX_PROMPT_HOLD_S = 0.0
+
 SID = "11111111-2222-3333-4444-555555555555"
 
 
@@ -201,10 +206,16 @@ class OpQueueParkOrDeliver(unittest.TestCase):
         km._apply_pending_ops()                         # must not raise
         self.assertNotIn(SID, km._pending_ops, "a dead session's queue is dropped, never retried forever")
 
-    def test_producer_ticks_the_apply(self):
+    def test_the_pusher_cycle_delivers_the_parked_queue_not_the_producer(self):
+        # 2026-09-03: delivery moved OFF the judge producer's tail — a pass can run for hours (one session's
+        # closer sweep, alarm-killed turn after turn) and held every parked op hostage. It rides the pusher
+        # cycle now, woken by the settle itself, and runs FIRST so the delivered op's echo rides the push.
         import inspect
-        src = inspect.getsource(km._producer)
-        self.assertIn("_apply_pending_ops()", src, "the producer tick delivers the parked queue")
+        self.assertNotIn("_apply_pending_ops()", inspect.getsource(km._producer),
+                         "the judge pass no longer gates delivery")
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_apply_pending_ops()", src, "the pusher cycle delivers the parked queue")
+        self.assertLess(src.index("_apply_pending_ops()"), src.index("_push_all("), "…ahead of the push")
 
 
 class _FakeForwardBackend:

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -4531,5 +4531,31 @@ class WorkflowProgressShapeIsLoud(unittest.TestCase):
         self.assertEqual(buf.getvalue(), "")
 
 
+class SettleBeforePoke(unittest.TestCase):
+    """The kernel's parked-op drain wakes on the backend's turn-end poke (2026-09-03) and reads busy() to
+    decide whether the session is quiet — so the settle must CLOSE the turn (inflight 0, compaction over)
+    before the poke fires, or the woken cycle reads the session as still working and delivery slips to
+    the pusher's backstop with every test green. Codex got the same pin in tests/test_codex_backend.py."""
+
+    def test_the_result_branch_settles_before_it_pokes(self):
+        import inspect
+        src = inspect.getsource(sb.SdkSession._on_message)
+        i = src.index("elif isinstance(msg, ResultMessage):")
+        zero, comp, poke = (src.index("self.inflight = 0", i), src.index("self._compacting = False", i),
+                            src.index("self.backend._poke()", i))
+        self.assertLess(zero, poke, "inflight is zeroed before the poke")
+        self.assertLess(comp, poke, "…and the compaction cue is cleared before it")
+
+    def test_the_fed_turn_counts_as_in_flight_under_the_pop_lock(self):
+        # busy() is inflight>0 or _pending; the input generator pops _pending and must count the turn in
+        # flight under the SAME lock, or a drain re-running right after a delivery reads the gap as idle
+        src = open(os.path.join(BIN, "romp_sdk_backend.py"), encoding="utf-8").read()
+        body = src[src.index("async def inputs():"):src.index("async def drain(client):")]
+        self.assertLess(body.index("self.inflight += 1"), body.index("if item is None:"),
+                        "the increment sits inside the lock block that popped the item")
+        self.assertLess(body.index("self.inflight += 1"), body.index("self._persist_queue()"),
+                        "…before the registry write that used to separate them")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_move_kernel.py
+++ b/tests/test_session_move_kernel.py
@@ -73,12 +73,18 @@ class MoveOps(unittest.TestCase):
             mock.patch.object(km, "_cwd_of", lambda sid: self.dir),
             mock.patch.object(km, "_send_to_view", lambda app, msg, wid: self.views.append((app, msg, wid))),
             mock.patch.object(km, "_fire_move", _sync_fire),
+            # the retry spacing and the tmux prompt hold are a separate axis (their own tests below and in
+            # tests/test_kernel_parked_ops_liveness.py); off, so back-to-back _apply_pending_ops calls here
+            # stand for successive cycles
+            mock.patch.object(km, "_MOVE_BUSY_RETRY_S", 0.0),
+            mock.patch.object(km, "_TMUX_PROMPT_HOLD_S", 0.0),
         ]
         for p in self._patches:
             p.start()
         km._pending_ops.clear()
         km._moving.clear()
         km._move_askers.clear()
+        km._drain_hold.clear()
 
     def tearDown(self):
         for p in self._patches:
@@ -86,6 +92,7 @@ class MoveOps(unittest.TestCase):
         km._pending_ops.clear()
         km._moving.clear()
         km._move_askers.clear()
+        km._drain_hold.clear()
 
     def test_idle_session_moves_now_and_the_asker_hears_moved(self):
         handled = km._drive({"type": "moveSession", "id": SID, "dir": self.dir + "/"}, self.client)
@@ -173,6 +180,26 @@ class MoveOps(unittest.TestCase):
         self.assertEqual(len(self.be.calls), 5)
         self.assertEqual(km._pending_ops[SID], [("send", "hello", "human")])
         self.assertEqual(self.views[-1][1]["type"], "moved")
+
+    def test_a_cli_side_busy_repark_holds_the_retry_for_the_window(self):
+        # the drain runs on the pusher now (2026-09-03), which any push or stream atom wakes — so cycles can
+        # be milliseconds apart and the three retries would burn inside the sub-second post-result window
+        # they exist to outlast. The re-park holds the sid for _MOVE_BUSY_RETRY_S (the producer's old
+        # cadence, made explicit); the chip still re-renders at once.
+        with mock.patch.object(km, "_MOVE_BUSY_RETRY_S", 3.0):
+            self.be.answers = ["busy", "busy"]
+            km._pending_ops[SID] = [("cwd", self.dir, 0)]
+            before = km._views_dirty[0]
+            km._apply_pending_ops()                                  # fires → busy → re-parked at the head
+            self.assertEqual(km._pending_ops[SID][0], ("cwd", self.dir, 1, 0), "back at the head, carrying the try")
+            self.assertEqual(len(self.be.calls), 1)
+            self.assertGreater(km._views_dirty[0], before, "the chip re-renders now")
+            km._apply_pending_ops()                                  # back-to-back, as a woken cycle would
+            self.assertEqual(len(self.be.calls), 1, "no retry inside the post-result window")
+            self.assertIn(SID, km._drain_hold)
+            km._drain_hold.clear()                                   # the window passed
+            km._apply_pending_ops()
+            self.assertEqual(len(self.be.calls), 2, "…then the retry fires")
 
     def test_a_parked_retry_survives_a_kernel_restart_and_fires(self):
         # a restart resets turn_seq to 0 and ends whatever turn the CLI owned: an op that waited on a

--- a/tests/test_session_move_kernel.py
+++ b/tests/test_session_move_kernel.py
@@ -201,6 +201,14 @@ class MoveOps(unittest.TestCase):
             km._apply_pending_ops()
             self.assertEqual(len(self.be.calls), 2, "…then the retry fires")
 
+    def test_the_busy_repark_lands_before_the_move_hold_is_released(self):
+        # review find on #904: with `_moving` released first, a drain cycle in the gap could fire the op
+        # behind the move or burn a retry; the re-park and its hold come first, the release last
+        import inspect
+        src = inspect.getsource(km._move_now)
+        self.assertLess(src.index('insert(0, ("cwd"'), src.index("_moving.discard(sid)"))
+        self.assertLess(src.index("_hold_drain(sid, _MOVE_BUSY_RETRY_S)"), src.index("_moving.discard(sid)"))
+
     def test_a_parked_retry_survives_a_kernel_restart_and_fires(self):
         # a restart resets turn_seq to 0 and ends whatever turn the CLI owned: an op that waited on a
         # higher count fires on the first pass


### PR DESCRIPTION
## Parked ops deliver on the turn's settle, not at the tail of a judge pass

**The bug.** The kernel parks a user's input while its session is busy, compacting, or limit-held, and delivers the FIFO once the session is quiet (`_apply_pending_ops`). The only caller of that function was the tail of the judge producer's pass, after an untimed join on the judge tiers; a turn-end poke only set `_producer_wake`, which the producer reads between passes. So every parked op in every session waited for the judges to finish.

A judge pass can run for hours. On 2026-09-03 one session's closer sweep was alarm-killed turn after turn (192 calls at 120 s each) and held a pass for 6h22m; no judge ran for any session in that window, and a typed `/clear` parked mid-turn sat as a queued chip until the user cancelled it. Sending to an idle session worked because an idle send never touches the queue. The judge-side cause (the closer's unbounded rider menu and its continue-past-failure sweep) is a separate PR.

**The fix.** Delivery rides the pusher cycle, the kernel's existing event-woken at-settle job runner, as its first job; the producer's tail call is removed (not kept as a backstop: `_apply_pending_ops` is not re-entrant). Both backends poke the kernel through `_wake_kernel`, which sets the producer and the pusher wakes; the Codex backend pokes once more after its `turn_id` clears. A no-op cycle no longer re-saves or re-wakes. Two places that leaned on the producer's 3 s cadence without saying so, a move the CLI answered `busy` and a turn-opening delivery to a tmux session (no authoritative `busy()`), now hold the sid's queue for an explicit 3 s (`_hold_drain`), named as a clock; SDK and Codex need no hold. The SDK input generator counts the fed turn in flight under the same lock that popped it.

**Visibility.** `_send_or_park` returns whether it parked; `POST /send` answers `{"ok": true, "queued": <bool>}` for text sends, parked `/model` `/effort` `/fast`, and remote answers; `romp send` prints `queued` vs `ok`; a cancelled parked op is logged (sid and op kind only).

**Verification.** Full Python suite green (7039 passed, 0 failed on the head; 7048 on the maintainer's scratch merge with #905), bats green (382). The behavioral tests fail on the parent commit; two boundary pins pass there by design, and some of the new tests hit the parent's missing names (`_wake_kernel`, `_drain_hold`) before their behavioral assertion, so the headline liveness test pokes both wakes by hand when `_wake_kernel` is absent and fails at the delivery assertion itself. The first commit went through a four-lens adversarial review with two skeptics per finding; its eight confirmed findings are fixed in it (the move-retry spacing, the tmux self-wake, the parked meta-command answer, the remote `queued`, the SDK pop-to-inflight gap, stale comments, and two test-quality points).

**Review round.** The second commit takes the four nits: the `busy` re-park and its hold now land before `_moving` releases the queue; the pusher cycle memoizes sid-to-path on its thread-confined scope so a held sid's transcript path resolves once per cycle instead of once per gate; a far kernel's `ok: false` rides back verbatim; and `romp new -m` prints "first prompt queued" when the kernel parked it. The follow-up PR you asked for, a `TmuxBackend.busy()` read from the hook-maintained session state that also retires the tmux half of `_hold_drain`, is being prepared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
