### PR TITLE
The closer caps its riders per call and a failed call ends the session's sweep for the pass

### DIFF
--- a/docs/judge-pipeline.md
+++ b/docs/judge-pipeline.md
@@ -171,6 +171,6 @@ cards: one in each tree, linked, and the link checks itself off.
 | why is this card in this state? | the node's `log` in `goals/<sid>.json`: every event has source, kind, reason, time |
 | why was this work filed here? | `placements` in the store, plus the node's `why` and `trail` |
 | why did this mint at top level? | the node's `why`: "declared in the agent's own to-do list" means the plan-sync mirror — a step declared while serving a dispatch carries `serving` and folds into the sender's ask card at render (T137); the grouper may merge a duplicate; anything else is the planner |
-| did a judge fail or get skipped? | `judge-errors.jsonl`: every row carries judge, session, kind (parse, call, give-up, cite-miss, rate-limited, task-store, history-unreadable, drift-skip), and the evidence (reply tail, API message, re-arm event) |
+| did a judge fail or get skipped? | `judge-errors.jsonl`: every row carries judge, session, kind (parse, call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable, drift-skip), and the evidence (reply tail, API message, re-arm event) |
 | what did a judge call cost, and when? | `judge-usage.jsonl`, per judge and session |
 | what happened to a peer message? | `timeline/messages.jsonl` by message id, plus the delivered markers in the transcript |

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -341,6 +341,24 @@ While the account usage window is exhausted, the rate gate skips every call
 across every session and logs one `rate-limited` row per window; gate skips count
 toward nothing.
 
+- **The closer bounds its own call and its own sweep.** Behind a turn's own
+  goals the closer carries *riders*: open work nominated from elsewhere (a goal
+  whose recorded steps are all finished, a starved leaf, a lifted card, and on
+  a status-report turn every open top). One session's closer calls were once
+  killed by the call timer 192 times in a row inside a single per-session
+  sweep, silencing every judge for six hours: the menu carried 24 riders, the
+  reply did not fit under the timer, and a killed call stamps nothing, so the
+  identical menu rode the next turn. Two bounds, neither a fairness cap.
+  `CLOSE_RIDER_CAP` limits the re-nominating riders per call (never the turn's
+  own goals, never the status riders, which are one-shot per status turn),
+  never-looked riders first; a cut rider rides a later landed call, so the
+  backlog drains one landed call at a time. And a FAILED call (a kill, a
+  subprocess error, an API error envelope, on either engine) ends that
+  session's sweep for the pass with one `sweep-cut` row naming the turns left
+  behind and the shape of the menu that died; parse rejects and pause-skips
+  still walk on. A dead session cut this way keeps its marker pending and
+  waits at the back of the death drain, so it cannot starve the others.
+
 ## Billing, and when the credential itself is broken
 
 A judge call bills **the account of the session it judges** — the same pick the

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -426,7 +426,7 @@ permission/API-error floors: one interrupt at a time, the present event first.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
 - Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
-  call, give-up, cite-miss, rate-limited, task-store, history-unreadable,
+  call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable,
   task-key-collision — a duplicated to-do mirror key, reconciled per node
   and surfaced loudly),
   `STATE/judge-auth.json` (the per-session judge-auth-down latch — see

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -403,6 +403,24 @@ CLOSE_HISTORY_CHARS = 2000               # per-goal cap in the closer's turn-end
                                          # touched goals at once (so the total scales with menu size).
 CLOSE_FAIRNESS = None                    # per-session turn-close cap — REMOVED (the user 2026-06-30): close
                                          # EVERY end-known turn each pass. The `did >= cap` guard no-ops on None.
+                                         # That stance stands — successful closes are never capped. Two bounds
+                                         # added 2026-09-03 are NOT fairness caps: CLOSE_RIDER_CAP (below) is a
+                                         # queue drain across LANDED calls, and _close_session ends a session's
+                                         # walk at its first FAILED call (parse rejects and pause-skips walk on).
+CLOSE_RIDER_CAP = 6                      # RIDERS per closer call — the steps-finished / starved / status /
+                                         # lifted nominations that ride BEHIND the turn's own menu (which is
+                                         # never capped). 2026-09-03: one session's closer calls were
+                                         # alarm-killed 192 times in a row inside ONE _close_session walk
+                                         # (6h22m, every judge for every session silent). Not hangs: served
+                                         # closer duration tracks OUTPUT tokens, and the menu set the output —
+                                         # 24 riders on most of the backlog, uncapped, so no reply fit under
+                                         # CALL_ALARM_S; and a killed call stamps no closerLookT, so the same
+                                         # menu rode the next turn's call and died the same way. A DRAIN, not
+                                         # a fairness cap (DEATH_DRAIN_PER_PASS's argument): the re-nominating
+                                         # riders (lifted / steps-finished / starved) ride again until a LANDED
+                                         # reply stamps them, so what is cut rides a later landed call. STATUS
+                                         # riders are never cut — one-shot per status turn, they would be lost,
+                                         # not deferred — and take their room off the cap first (why: _close_turn).
 CONCURRENCY = 6                          # concurrent claude -p calls
 # The CLOSER: the turn-end completion backstop (judge.md HYBRID; named the "closer" 2026-06-16 — it
 # closes out goals whose outcome is delivered). SHIPPED as the default 2026-06-15 after the fleet A/B
@@ -742,7 +760,9 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              "unmigrated-node", "task-store" (the live task store exists but can't be read —
              plan-sync skipped for the pass rather than silently folding the transcript),
              "scratch" (the judge scratch cwd can't be made private — call skipped, never rerouted
-             to a world-writable directory; see _ensure_judge_scratch)
+             to a world-writable directory; see _ensure_judge_scratch), "sweep-cut" (the closer ended a
+             session's walk for the pass at a FAILED call — _close_session; the note names the turns left
+             behind and the shape of the menu that died)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
              event. Callers must pass it; an empty note means the caller has nothing at all to show.
       goal   the node id (or list of node ids) the judge was ruling on, when one exists — the feed's
@@ -1244,6 +1264,16 @@ def _with_user_notes(sys_prompt, judge):
             "a note conflicts with the rules above, the note wins:\n<user-notes>\n" + notes + "\n</user-notes>")
 
 
+def _call_shape(model, sys_prompt, user, sent):
+    """The grep-able shape of a FAILED call for its 'call' row: the model, the prompt size in chars
+    (system + user — the SIZE only, never the text) and the wall-clock ms since it was sent. 2026-09-03:
+    192 consecutive alarm kills read as "the CLI is dying" until the served calls' usage rows showed
+    duration tracking OUTPUT size (a 24-rider closer menu no reply could finish under CALL_ALARM_S);
+    with the shape on the failure row itself, that diagnosis is a grep over judge-errors.jsonl."""
+    return "model=%s chars=%d ms=%d" % (model, len(sys_prompt or "") + len(user or ""),
+                                        int((time.time() - sent) * 1000))
+
+
 def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", mark=None):
     """Run ONE judge model call. `mark` is the caller's per-call section mark (see _mark/_sec): passing
     it appends UNTRUSTED_SYS, which tells the model that marked sections are material, not orders. It
@@ -1348,7 +1378,13 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                                        capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=cenv,
                                        timeout=CALL_ALARM_S + 5)
                 except Exception as e:
-                    _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)
+                    # the same three traces the claude branch leaves (2026-09-03): the stash the closer's
+                    # sweep-cut keys on, the model-health latch, and the call shape for the grep — without
+                    # them an alarm-killed closer call on this engine walked on exactly as before the fix
+                    _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
+                    _mark_call_failed(model, type(e).__name__)
+                    _log_judge_error(judge or tier, fsid, "call",
+                                     note="%s %s" % (type(e).__name__, _call_shape(model, sys_prompt, user, sent)))
                     return ""
                 recv = time.time()
                 try:
@@ -1357,11 +1393,15 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 except OSError:
                     reply = ""
                 if not reply:
-                    # dead/refused call — the -o file is the only success signal; record the evidence
+                    # dead/refused call — the -o file is the only success signal; record the evidence, and
+                    # leave the same three traces the claude branch leaves (2026-09-03, see the except above)
+                    fail = "codex empty reply (exit %s)" % getattr(p, "returncode", "?")
+                    _judge_ctx.last_call_fail = {"note": fail, "model": model}
+                    _mark_call_failed(model, fail)
                     _log_judge_error(judge or tier, fsid, "call",
-                                     note="codex empty reply (exit %s): %s"
-                                          % (getattr(p, "returncode", "?"),
-                                             ((p.stderr or "") + (p.stdout or "")).strip()[-200:] or "no output"))
+                                     note="%s: %s %s"
+                                          % (fail, ((p.stderr or "") + (p.stdout or "")).strip()[-200:] or "no output",
+                                             _call_shape(model, sys_prompt, user, sent)))
                     return ""
                 _judge_ctx.last["reply"] = _mid_elide(reply)
                 _log_judge_usage(judge or tier, tier, (model if str(model).startswith("gpt") else "codex-default"),
@@ -1400,7 +1440,8 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # carry the judge's own name + fsid (pre-07-09 rows said "index"/"triage" with no session).
             _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
             _mark_call_failed(model, type(e).__name__)
-            _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)
+            _log_judge_error(judge or tier, fsid, "call",
+                             note="%s %s" % (type(e).__name__, _call_shape(model, sys_prompt, user, sent)))
             return ""
         recv = time.time()                            # literal wall-clock: the response is back
         out = p.stdout or ""
@@ -1471,9 +1512,10 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 "model": model}
             _mark_call_failed(model, _judge_ctx.last_call_fail["note"])
             _log_judge_error(judge or tier, fsid, "call",
-                             note="empty stdout (exit %s): %s"
+                             note="empty stdout (exit %s): %s %s"
                                   % (getattr(p, "returncode", "?"),
-                                     (getattr(p, "stderr", "") or "").strip()[-200:] or "no stderr"))
+                                     (getattr(p, "stderr", "") or "").strip()[-200:] or "no stderr",
+                                     _call_shape(model, sys_prompt, user, sent)))
             return ""
         _judge_ctx.last["reply"] = _mid_elide(out)
         _mark_call_served(model)                      # a raw reply is still a served call (recovery edge)
@@ -9572,7 +9614,13 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     clear-wrap — a reply that accounts for the session's work as a whole — every open working TOP rides
     the menu too (_status_report_candidates), so one all-shipped reply can settle every card it covers,
     not just the goal it was asked about. Turn-scoped and state-free: closedSig already one-shots the
-    closer per turn."""
+    closer per turn.
+
+    RIDER CAP (2026-09-03): the RE-NOMINATING riders behind the turn's own menu (lifted → steps-finished
+    → starved) are cut to the room CLOSE_RIDER_CAP leaves after the status riders, which always ride
+    (one-shot per status turn: cut, they would be lost, not deferred) — a drain across landed calls, never
+    a bound on the turn's own goals or on successful closes (see the constant and the block below).
+    The menu's SHAPE (counts only) rides _judge_ctx.close_menu for a failed call's sweep-cut row."""
     menu = _turn_menu(turn, store)
     n_touched = len(menu)                              # the TURN's own goals; candidates ride behind them
     seen_ids = {nd["id"] for nd in menu}
@@ -9583,6 +9631,30 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     status = [nd for nd in _status_report_candidates(store, turn) if nd["id"] not in seen_ids]
     seen_ids |= {nd["id"] for nd in status}
     lifted = [(nd, why) for nd, why in _lift_riders(store) if nd["id"] not in seen_ids]
+    # RIDER CAP (2026-09-03, CLOSE_RIDER_CAP): the turn's own menu rides whole, and so do the STATUS
+    # riders — turn-scoped and ONE-SHOT (no watermark: closedSig one-shots the closer per turn,
+    # _status_report_candidates), so a status rider cut here would never be judged from THIS reply, the
+    # one the user's question was answered in (a board with more open tops than the cap would lose the
+    # same tops on every status turn — lost, not deferred). Only the RE-NOMINATING riders — lifted,
+    # steps-finished, starved — are cut, to whatever room the cap leaves after the status riders (none,
+    # on a status turn with more tops than the cap: that call is as large as the board, once per status
+    # turn). They come back until a LANDED reply stamps closerLookT below (_look_stamp gates all three
+    # channels), so what is cut rides a LATER landed call — later, not always the next: a verdict a
+    # landed call files is a newer `at` in that top's subtree, which re-arms its earlier-stamped siblings
+    # (_filed_since), and those, older-minted, re-enter ahead of the cut tail. The backlog still drains
+    # (each landed call stamps its riders; nothing is lost; no successful close is ever capped). Channel
+    # membership (the dedupe order above) and the menu's layout are unchanged: only which riders survive
+    # is decided here.
+    renom = [nd for nd, _ in lifted] + cands + starved
+    n_cut = 0
+    if CLOSE_RIDER_CAP is not None:
+        room = max(0, CLOSE_RIDER_CAP - len(status))
+        if len(renom) > room:
+            keep = {nd["id"] for nd in renom[:room]}
+            n_cut = len(renom) - room
+            cands = [nd for nd in cands if nd["id"] in keep]
+            starved = [nd for nd in starved if nd["id"] in keep]
+            lifted = [(nd, why) for nd, why in lifted if nd["id"] in keep]
     menu = menu + cands + starved + status + [nd for nd, _ in lifted]
     if not menu:
         return []
@@ -9661,6 +9733,10 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                       "leaving it open is a fine answer if the history is not plain." % i)
     lift_text = "\n".join("#%d: %s" % (i, str(why).strip()[:220])
                           for i, why in lflagged if str(why or "").strip())
+    # the menu's SHAPE (counts only, never text) rides the per-thread ctx so that if this call FAILS,
+    # _close_session's sweep-cut row can say what the call carried
+    _judge_ctx.close_menu = {"touched": n_touched, "cands": len(cands), "starved": len(starved),
+                             "status": len(status), "lifted": len(lifted), "cut": n_cut}
     raw = closer_llm(_unit_text(turn["atoms"]), menu_text, hist, lift_text)
     out = _parse_close(raw, len(menu))
     if out is None:
@@ -9797,7 +9873,19 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
     goal sticks blocked on an already-answered question (the user 2026-06-26, via bugs: g47). closedSig
     fingerprints each turn's atom count at close; a LARGER count next pass means the turn grew → re-judge
     it. Legacy turns (closed before this, no sig) are assumed unchanged so we don't re-judge the whole
-    backlog. Returns the node ids newly completed."""
+    backlog.
+
+    A FAILED CALL ends this session's walk for the pass (2026-09-03): every end-known turn is visited each
+    pass UNTIL the first failed call — a parse reject (the model answered THIS turn's prompt) and a
+    pause-skip (no call was made) still walk on. The 192-kill incident was this loop `continue`-ing past
+    each alarm kill to the next turn, whose identical over-full menu died identically: 6h22m of every
+    judge for every session silent, since run_close awaits every session's walk. The discriminator is
+    _judge_ctx.last_call_fail — a dict only when _judge_run recorded a call-level failure (a served reply
+    clears it) — NOT `res is None`, which a parse reject under the cap also returns. The safeguards
+    tombstone keeps its own arm. A loop `break`, never a return: the store still saves below and
+    _death_finalize still runs — told NOT settled, so a dead session's marker is never finalized off a
+    walk that left turns unswept (they are reachable only through the death drain). Returns the node ids
+    newly completed."""
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
     session = parsed_session(fsid, [path], now)
     store = load_goals(fsid)
@@ -9805,8 +9893,8 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
     swept = _closed_turns(store)
     sig = dict(store.get("closedSig") or {})
     turns = session["turns"]
-    newly, did = [], 0
-    for turn in turns:
+    newly, did, cut = [], 0, False
+    for ti, turn in enumerate(turns):
         if _turn_open(turn, turns):
             continue
         tid, fp = turn["id"], len(turn["atoms"])
@@ -9815,6 +9903,7 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
         if cap is not None and did >= cap:             # cap is None by default now (no per-pass close cap);
             break                                      # an explicit caller (a test) can still bound a backfill
         _judge_ctx.last_call_fail = None               # a stale stash must never charge THIS turn (below)
+        _judge_ctx.close_menu = None                   # …nor a stale menu shape describe this turn's call
         res = _close_turn(store, turn, seg_by_id=seg_by_id)
         if res is None:
             # SAFEGUARDS TOMBSTONE (the user 2026-08-18): a safeguards refusal is the filter ruling on
@@ -9828,7 +9917,8 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
             # costs one call, not a give-up.
             if not getattr(_judge_ctx, "paused", False):
                 last = getattr(_judge_ctx, "last_call_fail", None)
-                if isinstance(last, dict) and "safeguards flagged" in str(last.get("note") or ""):
+                fail_note = str(last.get("note") or "") if isinstance(last, dict) else ""
+                if isinstance(last, dict) and "safeguards flagged" in fail_note:
                     fails = dict(store.get("closeFails") or {})
                     rec = fails.get(tid) if isinstance(fails.get(tid), dict) else None
                     k = (rec.get("fails", 0) + 1) if rec and rec.get("fp") == fp else 1
@@ -9841,6 +9931,31 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
                     else:
                         fails[tid] = {"fp": fp, "fails": k}
                     store["closeFails"] = fails
+                elif isinstance(last, dict):
+                    # SWEEP CUT (2026-09-03): the CALL failed — a dead CLI (the alarm kill), a subprocess
+                    # error, an API error envelope — evidence about this session's calls, not about this
+                    # one turn. Every remaining end-known turn would cost a call shaped like the one that
+                    # just died (its riders re-nominate until a LANDED reply stamps them, so the same
+                    # menu rides every turn); one session's 192 consecutive kills held every judge for
+                    # every session silent for 6h22m. End THIS session's walk for the pass, loudly, with
+                    # the shape of what was sent. The turn keeps the retry-next-pass contract (no strike,
+                    # no tombstone). A `break`, never a return: the store must still save and
+                    # _death_finalize must still run below.
+                    remaining = sum(1 for t in turns[ti + 1:]
+                                    if not _turn_open(t, turns)
+                                    and not (t["id"] in swept
+                                             and sig.get(t["id"], len(t["atoms"])) == len(t["atoms"])))
+                    shape = getattr(_judge_ctx, "close_menu", None)
+                    shape_s = ("; menu %d own + %d steps-finished + %d starved + %d status + %d lifted, "
+                               "%d rider(s) cut" % (shape["touched"], shape["cands"], shape["starved"],
+                                                    shape["status"], shape["lifted"], shape["cut"])
+                               if isinstance(shape, dict) else "")
+                    _log_judge_error("closer", fsid, "sweep-cut",
+                                     note="%d end-known turn(s) left unswept behind turn %s: %s (model %s%s)"
+                                          % (remaining, str(tid)[:12], fail_note[:160],
+                                             last.get("model"), shape_s))
+                    cut = True
+                    break
             continue                                   # LLM/parse failed → leave unswept, retry next pass
         newly += res
         if isinstance(store.get("closeFails"), dict):
@@ -9851,7 +9966,10 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
     settled = _session_settled(fsid, path, session, store)
     rollup_status(store, settled)
     save_goals(fsid, store)
-    _death_finalize(fsid, store, settled)             # the death marker's one-shot epilogue (2026-08-13)
+    # A CUT walk left end-known turns unswept, and a dead session is swept ONLY through the death drain
+    # (_death_pending skips finalized markers): finalizing its marker now would strand those turns for
+    # good (review find, 2026-09-03). The one-shot epilogue waits for a pass that walks to the end.
+    _death_finalize(fsid, store, settled and not cut)  # the death marker's one-shot epilogue (2026-08-13)
     return newly
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1407,6 +1407,9 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _log_judge_usage(judge or tier, tier, (model if str(model).startswith("gpt") else "codex-default"),
                                  fsid, {"duration_ms": int((recv - sent) * 1000)}, sent, recv)
                 _auth_down_clear(fsid)                # a successful billed call clears either engine's latch
+                _mark_call_served(model)              # THIS model serves again → the give-up re-arm edge (the
+                _judge_ctx.last_call_fail = None      # claude branch's pair, review find 2026-09-03: without them a
+                                                      # failed codex call stayed 'degraded' for the process's life)
                 return reply
             finally:
                 try:
@@ -9645,7 +9648,14 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     # (each landed call stamps its riders; nothing is lost; no successful close is ever capped). Channel
     # membership (the dedupe order above) and the menu's layout are unchanged: only which riders survive
     # is decided here.
-    renom = [nd for nd, _ in lifted] + cands + starved
+    # NEVER-LOOKED FIRST (review find, 2026-09-03): a landed reply's own filing re-arms the riders an EARLIER
+    # call stamped (_filed_since), and those are older-minted, so under plain mint order they would outrank
+    # riders that have never ridden for as long as the top keeps receiving filings — a backlog past twice
+    # the room never drained while the effort was active. Unstamped riders take the room first; inside each
+    # group the channel order (lifted → steps-finished → starved) and the mint order are unchanged.
+    ranked = [(0, nd) for nd, _ in lifted] + [(1, nd) for nd in cands] + [(2, nd) for nd in starved]
+    ranked.sort(key=lambda p: (bool(p[1].get("closerLookT")), p[0], p[1].get("t", 0)))
+    renom = [nd for _, nd in ranked]
     n_cut = 0
     if CLOSE_RIDER_CAP is not None:
         room = max(0, CLOSE_RIDER_CAP - len(status))
@@ -9970,6 +9980,8 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
     # (_death_pending skips finalized markers): finalizing its marker now would strand those turns for
     # good (review find, 2026-09-03). The one-shot epilogue waits for a pass that walks to the end.
     _death_finalize(fsid, store, settled and not cut)  # the death marker's one-shot epilogue (2026-08-13)
+    if cut:
+        _death_rotate(fsid)                           # …and a cut dead session waits its turn behind the others
     return newly
 
 
@@ -9977,7 +9989,10 @@ DEATH_DRAIN_PER_PASS = CONCURRENCY   # a QUEUE-DRAIN bound on death-pending fina
 #   NOT a fairness cap on live sessions (those were removed 2026-06-30 and stay removed): the pending
 #   set is a finite backlog that strictly shrinks (every drained marker gains endedAt, superseded ones
 #   retire), so the bound only spreads the one-time upgrade backfill over successive passes instead of
-#   letting the first post-upgrade pass submit hundreds of dead stores at once.
+#   letting the first post-upgrade pass submit hundreds of dead stores at once. ONE exception (2026-09-03):
+#   a marker whose walk was sweep-CUT stays pending (its turns are reachable only through this drain),
+#   and _death_rotate moves it to the BACK of the oldest-first queue, so it costs one call per pass
+#   behind every newer marker instead of pinning a slot at the head.
 DEATH_BACKFILL_WINDOW = 365 * 86400  # how far back the drain resolves a dead sid's transcript (cached
 #   per (window, forks) like the picker's wide walk — one filesystem walk, not one per marker)
 
@@ -10043,6 +10058,22 @@ def _death_pending(exclude):
         if len(out) >= DEATH_DRAIN_PER_PASS:
             break
     return out
+
+
+def _death_rotate(fsid):
+    """A sweep-CUT walk left this dead session's marker pending (see _close_session). _death_pending drains
+    the OLDEST marker first, so a marker whose walk is cut every pass — a turn whose call dies the same way
+    each time — would hold the head of the queue for good, and DEATH_DRAIN_PER_PASS such sessions would
+    starve every newer dead session of its sweep and its 'ended' settle (review find, 2026-09-03). Touch the
+    marker so it takes its place at the BACK: one doomed call per pass, behind everyone else, and the
+    drain's bound stays honest. A give-up after repeated cuts is the follow-up the sweep-cut row names."""
+    m = _death_marker(fsid)
+    if not isinstance(m, dict) or "endedAt" in m:
+        return
+    try:
+        os.utime(GONEDIR / (fsid + ".json"), None)
+    except OSError:
+        pass
 
 
 def _death_finalize(fsid, store, settled):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -7309,6 +7309,51 @@ class FailureContract(unittest.TestCase):
         for word in ("exit -14", "model=gpt-5-test", "chars=2", "ms="):
             self.assertIn(word, row["note"], "the row carries the evidence and the call shape")
 
+    def test_codex_engine_served_call_clears_the_latch_and_the_stash(self):
+        # review find 2026-09-03: the codex exits above arm the model-health latch and the sweep-cut stash,
+        # but the codex SERVED path never called _mark_call_served nor cleared last_call_fail (the claude
+        # branch does both) — one failed call left the model 'degraded' for the process's life, three spread
+        # over any span read as "N in a row", and a stale stash outlived served replies. The served exit
+        # now leaves the same recovery edge on both engines.
+        import types
+        from pathlib import Path
+        saved = (jd.subprocess, getattr(jd._judge_ctx, "fsid", None), jd._judge_cmd_codex, jd._judge_engine)
+        captured = {}
+
+        def cmd(model, effort, outp):
+            captured["outp"] = outp
+            return ["codex-stub"]
+
+        def dead(*a, **k):
+            return types.SimpleNamespace(stdout="", stderr="", returncode=-14)
+
+        def served(*a, **k):
+            os.makedirs(os.path.dirname(captured["outp"]), exist_ok=True)
+            Path(captured["outp"]).write_text('{"done": [], "block": []}', encoding="utf-8")
+            return types.SimpleNamespace(stdout="", stderr="", returncode=0)
+        jd._judge_cmd_codex = cmd
+        jd._judge_engine = lambda: "codex"
+        jd._judge_ctx.fsid = "sid-cx2"
+        jd._judge_ctx.last_call_fail = None
+        with jd._health_lock:
+            jd._CALL_HEALTH["stats"].pop("gpt-5-test", None)
+            jd._CALL_HEALTH["degraded"].discard("gpt-5-test")
+        try:
+            jd.subprocess = types.SimpleNamespace(run=dead)
+            self.assertEqual(jd._judge_run("gpt-5-test", "S", "U", judge="closer"), "")
+            self.assertIsInstance(jd._judge_ctx.last_call_fail, dict, "the failure is stashed")
+            with jd._health_lock:
+                self.assertEqual(jd._CALL_HEALTH["stats"]["gpt-5-test"]["fails"], 1, "the failure latched")
+            jd.subprocess = types.SimpleNamespace(run=served)
+            out = jd._judge_run("gpt-5-test", "S", "U", judge="closer")
+        finally:
+            jd.subprocess, jd._judge_ctx.fsid, jd._judge_cmd_codex, jd._judge_engine = saved
+        self.assertEqual(out, '{"done": [], "block": []}', "the served reply reaches the caller")
+        self.assertIsNone(jd._judge_ctx.last_call_fail, "a served reply retires the stash on this engine too")
+        with jd._health_lock:
+            self.assertNotIn("gpt-5-test", jd._CALL_HEALTH["stats"], "the consecutive-failure count resets")
+            self.assertNotIn("gpt-5-test", jd._CALL_HEALTH["degraded"], "the model is not degraded for life")
+
     def test_dead_cli_call_row_carries_the_call_shape(self):
         # 2026-09-03: 192 consecutive alarm kills (exit -14) read as "the CLI is dying" until a reader
         # correlated the served calls' duration with their OUTPUT size — the kills were healthy-but-slow

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3663,6 +3663,8 @@ class SweepSession(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         jd.NAMES, jd.PROJECTS, jd.GOALDIR = names, proj, td / "goals"
+        self._saved_errors, jd.ERRORS = jd.ERRORS, td / "judge-errors.jsonl"   # the sweep's own rows, readable
+        self.cdir, self.pdir, self.names = cdir, pdir, names   # a test may add a second session beside SID
         # positive-only: always MINT a top, never DONE -> every top is left 'working'
         jd.plan_llm = lambda text, menu, human=False, **_kw: '{"ops":[{"why":"x","do":"mint","text":"Goal"}]}'
         jd.group_llm = lambda menu: '{"ops":[]}'   # planner now groups inline; keep the sweep's tops un-nested
@@ -3670,7 +3672,15 @@ class SweepSession(unittest.TestCase):
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.closer_llm, jd.group_llm) = self._saved
+        jd.ERRORS = self._saved_errors
+        jd._judge_ctx.paused, jd._judge_ctx.last_call_fail = False, None   # a stub's per-thread stash dies here
         self._td.cleanup()
+
+    def _errors(self):
+        try:
+            return [json.loads(l) for l in Path(jd.ERRORS).read_text().splitlines()]
+        except OSError:
+            return []
 
     def test_completes_and_settles_finished_tops_on_turn_end(self):
         jd.run_plan(now=self.now)
@@ -3783,18 +3793,129 @@ class SweepSession(unittest.TestCase):
         n = jd.run_close(now=self.now)
         self.assertGreaterEqual(n, 1, "the grown turn re-judged and completed the goal")
 
-    def test_transient_failures_never_tombstone(self):
-        # a 529/timeout recovers when the storm ends — those keep the plain retry-next-pass contract
+    # the dead-CLI stash byte-for-byte as _judge_run leaves it (its DEAD CLI branch): "" back to the
+    # caller, the per-thread dict naming the exit. -14 is SIGALRM — the CALL_ALARM_S kill, the shape of
+    # the 2026-09-03 incident (192 consecutive kills inside ONE session's walk, 6h22m of silence)
+    DEAD_CLI = {"note": "the model CLI died with no output (exit -14)", "model": "sonnet"}
+
+    def _dead_closer(self, calls):
+        return lambda tt, mt, *_a: (calls.append(1), setattr(
+            jd._judge_ctx, "last_call_fail", dict(self.DEAD_CLI)), "")[2]
+
+    def test_a_failed_call_cuts_this_sessions_sweep_for_the_pass(self):
+        # 2026-09-03: one session's closer calls were alarm-killed 192 times in a row inside ONE
+        # _close_session walk — every judge for every session silent for 6h22m, because the walk
+        # `continue`d to the next end-known turn after each kill and the next call died the same way
+        # (the same over-full menu rides every turn until a LANDED reply stamps it). A failed CALL is
+        # evidence about the session's calls, not about one turn: the first one ends this session's
+        # walk for the pass, loudly. The turn keeps the plain retry-next-pass contract — no strike, no
+        # tombstone — and the loop BREAKS rather than returns, so the store still saves and the
+        # death-marker epilogue still runs.
         jd.run_plan(now=self.now)
         calls = []
-        jd.closer_llm = lambda tt, mt, *_a: (calls.append(1), setattr(
-            jd._judge_ctx, "last_call_fail",
-            {"note": "API Error: Repeated 529 Overloaded errors.", "model": "fable"}), "")[2]
-        for _ in range(jd.DISTILL_FAIL_CAP + 2):
+        jd.closer_llm = self._dead_closer(calls)
+        jd.run_close(now=self.now)
+        self.assertEqual(len(calls), 1, "the first failed call ends this session's walk for the pass")
+        store = jd.load_goals(SID)
+        self.assertFalse(store.get("closedTurns"), "nothing swept while the calls fail")
+        self.assertFalse(store.get("closeFails"), "a call failure is never a strike against the turn")
+        self.assertIn("closedSig", store, "a break, not a return: the store was still saved")
+        rows = [r for r in self._errors() if r.get("err") == "sweep-cut"]
+        self.assertEqual(len(rows), 1, "one loud row per cut walk")
+        self.assertEqual((rows[0]["judge"], rows[0]["fsid"]), ("closer", SID))
+        self.assertIn("1 end-known turn(s)", rows[0]["note"], "the row counts the turns left behind")
+        self.assertIn("exit -14", rows[0]["note"], "…and carries the call failure it acted on")
+        for _ in range(jd.DISTILL_FAIL_CAP + 1):
             jd.run_close(now=self.now)
-        self.assertEqual(len(calls), 2 * (jd.DISTILL_FAIL_CAP + 2),
-                         "still retrying every pass — transient failures never adopt the turn")
-        self.assertFalse(jd.load_goals(SID).get("closedTurns"), "nothing swept while the calls fail")
+        self.assertEqual(len(calls), jd.DISTILL_FAIL_CAP + 2,
+                         "ONE call per pass: still retrying (no tombstone), never walking past the failure")
+        self.assertFalse(jd.load_goals(SID).get("closedTurns"), "transient failures never adopt the turn")
+
+    def test_a_cut_walk_leaves_a_death_marker_pending(self):
+        # review find (2026-09-03): a dead session is swept ONLY through the death drain, and the drain
+        # skips finalized markers — so finalizing off a CUT walk (turns left unswept behind the failed
+        # call) would strand those turns for good. The epilogue waits for a walk that reaches the end.
+        jd.run_plan(now=self.now)
+        marker = jd.GONEDIR / (SID + ".json")
+        jd.GONEDIR.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps({"t": self.now - 100, "by": "kill"}))
+        jd._gone_memo.pop(SID, None)
+        try:
+            calls = []
+            jd.closer_llm = self._dead_closer(calls)
+            jd.run_close(now=self.now)
+            self.assertEqual(len(calls), 1, "the walk was cut at the first failed call")
+            self.assertNotIn("endedAt", json.loads(marker.read_text()),
+                             "a cut walk does not finalize the marker: the session's turns are still owed")
+            jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'   # calls land again
+            jd.run_close(now=self.now)
+            self.assertEqual(len(jd.load_goals(SID).get("closedTurns") or []), 2, "the walk reached the end")
+            self.assertIn("endedAt", json.loads(marker.read_text()),
+                          "…and only then does the one-shot epilogue stamp the marker")
+        finally:
+            marker.unlink(missing_ok=True)
+            jd._gone_memo.pop(SID, None)
+
+    def test_a_parse_reject_still_walks_every_turn(self):
+        # the boundary: a served-but-unparseable reply is the MODEL's answer to THIS turn's prompt
+        # (last_call_fail stays None — a served reply retires it), so the next turn is still worth
+        # asking. `res is None` alone would cut here too; the discriminator is the call-failure stash.
+        jd.run_plan(now=self.now)
+        calls = []
+        jd.closer_llm = lambda tt, mt, *_a: (calls.append(1), "not json")[1]
+        jd.run_close(now=self.now)
+        self.assertEqual(len(calls), 2, "a parse reject walks on to the next turn")
+        store = jd.load_goals(SID)
+        self.assertEqual(len(store.get("closeFails") or {}), 2, "each turn took its own parse strike")
+        self.assertFalse(store.get("closedTurns"), "under the cap nothing is swept")
+        self.assertEqual([r for r in self._errors() if r.get("err") == "sweep-cut"], [],
+                         "a parse reject is not a cut")
+
+    def test_a_paused_skip_still_walks_every_turn(self):
+        # the other boundary: the rate gate / retry pause / scratch refusal return "" with paused=True
+        # and NO call was made — nothing failed, so the walk keeps visiting (and skipping) every turn
+        jd.run_plan(now=self.now)
+        calls = []
+        jd.closer_llm = lambda tt, mt, *_a: (calls.append(1), setattr(jd._judge_ctx, "paused", True), "")[2]
+        jd.run_close(now=self.now)
+        self.assertEqual(len(calls), 2, "a pause-skip is not a failed call: every turn is still visited")
+        store = jd.load_goals(SID)
+        self.assertFalse(store.get("closedTurns"), "nothing swept on a pause")
+        self.assertFalse(store.get("closeFails"), "nothing struck on a pause")
+        self.assertEqual([r for r in self._errors() if r.get("err") == "sweep-cut"], [],
+                         "a pause-skip is not a cut")
+
+    def test_other_sessions_close_while_one_is_cut(self):
+        # the incident's cost was not one session's stall but EVERY session's: run_close awaits one
+        # future per session, so the cut session's walk ending lets the pass finish and its peers close.
+        # Two sessions, the second under a PRIVATE synthetic sid (its override journal lives under this
+        # test's GOALDIR tempdir and dies with it in tearDown).
+        sid_b = "22222222-3333-4444-5555-666666666666"
+        records = [uline(T0, "task C", "u1", ps="typed"),
+                   aline(T0 + 30, "did C", "a1", "u1", stop="end_turn"),
+                   uline(T0 + 100, "task D", "u2", "a1", ps="typed"),
+                   aline(T0 + 130, "did D", "a2", "u2", stop="end_turn")]
+        (self.pdir / (sid_b + ".jsonl")).write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        (self.names / sid_b).write_text("testsess2\t%s\t#abcdef\n" % str(self.cdir))
+        jd.run_plan(now=self.now)
+        self.assertTrue(jd.load_goals(sid_b)["nodes"], "the second session planned goals too")
+        calls = []
+
+        def closer(tt, mt, *_a):
+            calls.append(jd._judge_ctx.fsid)
+            if jd._judge_ctx.fsid == SID:
+                jd._judge_ctx.last_call_fail = dict(self.DEAD_CLI)
+                return ""
+            return '{"done": [{"goal": 1, "why": "done"}], "block": []}'
+        jd.closer_llm = closer
+        jd.run_close(now=self.now)
+        self.assertEqual(calls.count(SID), 1, "the failing session made exactly one call")
+        self.assertEqual(calls.count(sid_b), 2, "the healthy session was judged turn by turn")
+        self.assertFalse(jd.load_goals(SID).get("closedTurns"), "the cut session swept nothing")
+        self.assertEqual(len(jd.load_goals(sid_b).get("closedTurns") or []), 2,
+                         "every end-known turn of the healthy session closed in the same pass")
+        rows = [r for r in self._errors() if r.get("err") == "sweep-cut"]
+        self.assertEqual([r["fsid"] for r in rows], [SID], "one cut row, naming the cut session")
 
 
 class CloserKeyMigration(unittest.TestCase):
@@ -7160,6 +7281,81 @@ class FailureContract(unittest.TestCase):
         self.assertIn("exit 134", row["note"], "the returncode is the evidence")
         self.assertIn("heap out of memory", row["note"], "…with the stderr tail")
         self.assertFalse(Path(jd.USAGE).exists(), "a dead CLI logs no usage row")
+
+    def test_codex_engine_dead_call_leaves_the_same_traces(self):
+        # 2026-09-03 review: the closer's sweep-cut keys on _judge_ctx.last_call_fail and the model-health
+        # latch on _mark_call_failed — both written only by the claude branch, so under `romp engine codex`
+        # an alarm-killed closer call walked on exactly as before the fix. The codex exits leave the same
+        # three traces now: the stash, the latch (a failed row), and the call shape on the row.
+        import types
+        saved = (jd.subprocess, getattr(jd._judge_ctx, "fsid", None), jd._judge_cmd_codex, jd._judge_engine)
+        jd.subprocess = types.SimpleNamespace(
+            run=lambda *a, **k: types.SimpleNamespace(stdout="", stderr="", returncode=-14))
+        jd._judge_cmd_codex = lambda model, effort, outp: ["codex-stub"]
+        jd._judge_engine = lambda: "codex"
+        jd._judge_ctx.fsid = "sid-cx"
+        jd._judge_ctx.last_call_fail = None
+        try:
+            out = jd._judge_run("gpt-5-test", "S", "U", judge="closer")
+        finally:
+            jd.subprocess, jd._judge_ctx.fsid, jd._judge_cmd_codex, jd._judge_engine = saved
+        self.assertEqual(out, "", "a dead codex call reads as an empty reply to every caller")
+        last = jd._judge_ctx.last_call_fail
+        self.assertIsInstance(last, dict, "the sweep-cut discriminator sees the failure on this engine too")
+        self.assertIn("codex empty reply (exit -14)", last["note"])
+        self.assertEqual(last["model"], "gpt-5-test")
+        row = self._errors()[-1]
+        self.assertEqual((row["judge"], row["err"], row["fsid"]), ("closer", "call", "sid-cx"))
+        for word in ("exit -14", "model=gpt-5-test", "chars=2", "ms="):
+            self.assertIn(word, row["note"], "the row carries the evidence and the call shape")
+
+    def test_dead_cli_call_row_carries_the_call_shape(self):
+        # 2026-09-03: 192 consecutive alarm kills (exit -14) read as "the CLI is dying" until a reader
+        # correlated the served calls' duration with their OUTPUT size — the kills were healthy-but-slow
+        # calls on an over-full menu. The row now carries the model, the prompt size in chars (no
+        # prompt text — privacy holds) and the wall-clock spent, so that diagnosis is a grep.
+        import re
+        import types
+        saved_sub, saved_fsid = jd.subprocess, getattr(jd._judge_ctx, "fsid", None)
+        jd.subprocess = types.SimpleNamespace(
+            run=lambda *a, **k: types.SimpleNamespace(stdout="", stderr="", returncode=-14))
+        jd._judge_ctx.fsid = "sid-slow"
+        try:
+            out = jd._judge_run("sonnet", "S", "U", judge="closer")
+        finally:
+            jd.subprocess = saved_sub
+            jd._judge_ctx.fsid = saved_fsid
+        self.assertEqual(out, "")
+        row = self._errors()[-1]
+        self.assertEqual((row["judge"], row["err"], row["fsid"]), ("closer", "call", "sid-slow"))
+        self.assertIn("exit -14", row["note"], "the returncode stays the headline evidence")
+        self.assertIn("model=sonnet", row["note"], "…with the model that was asked")
+        self.assertRegex(row["note"], r"\bchars=2\b", "…the size of what was sent (system + user), never its text")
+        self.assertRegex(row["note"], r"\bms=\d+\b", "…and the wall-clock the call took")
+        self.assertNotIn("S U", row["note"])
+
+    def test_subprocess_exception_call_row_carries_the_call_shape(self):
+        # the sibling branch: a subprocess that raised (a timeout past the alarm, an OSError) gets the
+        # same shape, so a grep over 'call' rows reads both kinds alike
+        import types
+
+        def boom(*a, **k):
+            raise OSError("no such binary")
+        saved_sub, saved_fsid = jd.subprocess, getattr(jd._judge_ctx, "fsid", None)
+        jd.subprocess = types.SimpleNamespace(run=boom)
+        jd._judge_ctx.fsid = "sid-boom"
+        try:
+            out = jd._judge_run("sonnet", "SYS", "U", judge="closer")
+        finally:
+            jd.subprocess = saved_sub
+            jd._judge_ctx.fsid = saved_fsid
+        self.assertEqual(out, "")
+        row = self._errors()[-1]
+        self.assertEqual((row["judge"], row["err"], row["fsid"]), ("closer", "call", "sid-boom"))
+        self.assertIn("OSError", row["note"], "the exception name stays the headline evidence")
+        self.assertIn("model=sonnet", row["note"])
+        self.assertRegex(row["note"], r"\bchars=4\b")
+        self.assertRegex(row["note"], r"\bms=\d+\b")
 
     # ── empty replies never count as parse rejects ──
     def test_empty_planner_reply_never_burns_retries_or_logs_parse(self):

--- a/tests/test_judge_close_riders.py
+++ b/tests/test_judge_close_riders.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""The closer caps its RIDERS per call (CLOSE_RIDER_CAP, 2026-09-03) — never the turn's own menu.
+
+The incident: one session's closer calls were alarm-killed 192 times in a row inside ONE
+_close_session walk (6h22m during which every judge for every session was silent). The kills were
+healthy-but-slow calls, not hangs: served closer duration tracks OUTPUT tokens, and the output size
+comes from the menu — _close_turn appended every rider (steps-finished + starved + status + lifted)
+with no count cap, 24 riders on most of the backlog, so every reply was a 24-entry JSON plus
+unbounded thinking, and did not fit under the alarm. Self-sustaining, because riders retire only
+through the closerLookT stamp a LANDED reply writes: a killed call stamps nothing, the identical
+menu rides the next turn's call, and dies identically.
+
+The cap is a DRAIN, not a fairness cap (the 2026-06-30 no-fairness-caps stance stands): lifted /
+steps-finished / starved riders re-nominate until stamped, so whatever is cut rides a later landed
+call (later, not always the next: a verdict a landed call files re-arms its earlier-stamped siblings)
+— a finite backlog, the same argument DEATH_DRAIN_PER_PASS makes. STATUS riders are never cut: they
+are turn-scoped and one-shot (no watermark), so a cut one would be lost from the very reply it was to
+be judged from, not deferred; they take their room off the cap first, and the re-nominating riders
+fill what is left.
+
+Synthetic fixtures only: a PRIVATE synthetic sid (goal-minting fixtures never share the placeholder
+sid — its override journal is replayed on every load), invented text, hostname TESTHOST."""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_close_riders", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "33333333-4444-5555-6666-777777777777"      # private synthetic sid — never the shared placeholder
+NOW = 1781100000
+T0 = NOW - 3600
+T1 = T0 + 100                                     # the sibling's filing: newer than every rider's mint
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def _aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _store():
+    return {"rompUuid": SID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+            "placements": {}, "status": {}}
+
+
+def _node(s, g, text, parent=None, t=T0, done=False, trail=(), log=None):
+    nd = {"id": SID + ":" + g, "text": text, "parentId": (SID + ":" + parent) if parent else None,
+          "nodeComplete": done, "blocked": False, "cleared": False, "trail": list(trail), "t": t,
+          "log": log if log is not None else
+                 ([{"ev_t": T1, "src": "closer", "kind": "done", "at": T1}] if done else [])}
+    s["nodes"][nd["id"]] = nd
+    return nd
+
+
+def _starved_leaves(s, parent, n, first):
+    """n starved-shaped open leaves under `parent` — mint-only trail, empty diary, distinct mints
+    (t = T0 + first + i, so oldest-first order is exact) — plus one DONE sibling filed at T1, the
+    'other work in the same effort settled' event that nominates them."""
+    ids = []
+    for i in range(n):
+        ids.append(_node(s, "%s-s%d" % (parent, i), "starved step %d of %s" % (i, parent),
+                         parent=parent, t=T0 + first + i)["id"])
+    _node(s, "%s-done" % parent, "shipped step of %s" % parent, parent=parent, done=True)
+    return ids
+
+
+class _Riders(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self.td))
+        jd._PARSE_CACHE.clear()
+        self._llm, self._menu_text = jd.closer_llm, jd._menu_text
+        self.menus = []                                  # [[node id, ...] per closer call], as sent
+        self.stamped_at_call = []                        # ids carrying closerLookT when each call was built
+        real = self._menu_text
+
+        def recording(store, menu):
+            self.menus.append([nd["id"] for nd in menu])
+            self.stamped_at_call.append({nid for nid, nd in store["nodes"].items() if nd.get("closerLookT")})
+            return real(store, menu)
+        jd._menu_text = recording
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'   # a LANDED empty verdict
+
+    def tearDown(self):
+        jd.closer_llm, jd._menu_text = self._llm, self._menu_text
+        try:
+            (jd._overrides_dir() / (SID + ".jsonl")).unlink()   # this sid's journal never outlives the test
+        except OSError:
+            pass
+        shutil.rmtree(self.td, ignore_errors=True)
+
+
+class RiderCap(_Riders):
+    def test_riders_are_capped_per_call_and_drain_across_landed_calls(self):
+        # 10 starved riders, a transcript with two ended turns touching no goal (n_touched = 0). The
+        # first call carries CLOSE_RIDER_CAP riders (the oldest mints); the landed reply stamps exactly
+        # those; the second turn's call carries the rest — the backlog drains across landed calls.
+        s = _store()
+        _node(s, "P", "Ship the notes-api search", trail=["seg-a", "seg-b"])   # reachable normally: not a rider
+        leaves = _starved_leaves(s, "P", 10, first=0)
+        jd.save_goals(SID, s)
+        path = os.path.join(self.td, SID + ".jsonl")
+        recs = [_uline(T0, "look at the search index", "u1"),
+                _aline(T0 + 30, "Looked; nothing to change.", "a1", "u1"),
+                _uline(T0 + 200, "and the tests?", "u2", "a1"),
+                _aline(T0 + 230, "Suite green.", "a2", "u2")]
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        cap = jd.CLOSE_RIDER_CAP
+        self.assertLess(cap, 10, "the fixture must exceed the cap or the test is vacuous")
+        jd._close_session(SID, path, T0 + 5000)
+        self.assertEqual(len(self.menus), 2, "one call per ended turn")
+        self.assertLessEqual(len(self.menus[0]), cap)
+        self.assertEqual(self.menus[0], leaves[:cap], "the first call carries the CAP oldest riders")
+        self.assertEqual(self.stamped_at_call[0], set(), "nothing looked at before the first call")
+        self.assertEqual(self.stamped_at_call[1], set(leaves[:cap]),
+                         "the landed reply stamped exactly the riders it carried")
+        self.assertEqual(self.menus[1], leaves[cap:],
+                         "the cut riders ride the next landed call (an empty verdict re-arms nothing)")
+        store = jd.load_goals(SID)
+        self.assertTrue(all(store["nodes"][i].get("closerLookT") for i in leaves),
+                        "two landed calls drained the whole backlog")
+        self.assertEqual(len(store.get("closedTurns") or []), 2)
+
+    def test_the_turns_own_menu_is_never_capped(self):
+        # the cap is on RIDERS: a turn whose own menu exceeds the cap (a segment placed on the deepest
+        # step of a long open chain — _turn_menu lists the node plus every open ancestor) still asks
+        # about every one of its goals; only the riders behind them are counted against the cap
+        s = _store()
+        n = jd.CLOSE_RIDER_CAP + 3
+        chain = [_node(s, "c%d" % i, "step %d of the chain" % i, parent=("c%d" % (i - 1)) if i else None,
+                       t=T0 + i, trail=["seg-x", "seg-y"])["id"] for i in range(n)]
+        leaves = _starved_leaves(s, "c0", 8, first=50)
+        path = os.path.join(self.td, SID + ".jsonl")
+        Path(path).write_text("\n".join(json.dumps(r) for r in [
+            _uline(T0 + 300, "finish the chain", "u1"),
+            _aline(T0 + 330, "Chain finished.", "a1", "u1")]) + "\n")
+        turn = jd.parsed_session(SID, [path], T0 + 5000)["turns"][0]
+        segs = jd._segs(turn, s)
+        self.assertTrue(segs)
+        s["placements"] = {segs[0]["id"]: chain[-1]}    # the segment landed on the deepest step
+        self.assertEqual(len(jd._turn_menu(turn, s)), n, "fixture: the turn's own menu exceeds the cap")
+        jd._close_turn(s, turn)
+        self.assertEqual(len(self.menus), 1)
+        menu = self.menus[0]
+        self.assertEqual(set(menu[:n]), set(chain), "every goal of the turn's own menu rides, first")
+        self.assertEqual(menu[n:], leaves[:jd.CLOSE_RIDER_CAP],
+                         "…and only the riders behind them are capped")
+
+
+class StatusPriority(_Riders):
+    def test_status_riders_take_priority_over_renominating_riders(self):
+        # a nudge-triggered turn (the status-report channel) on a board with two open working tops
+        # (each with 4 starved leaves + a done sibling) — 8 starved riders + 2 status riders. Status
+        # riders are one-shot per status turn; behind 8 re-nominating riders they would be silently
+        # starved every status turn, so they are kept first and the starved fill what is left.
+        s = _store()
+        _node(s, "A", "Ship the notes-api search", trail=["seg-a", "seg-b"])
+        _node(s, "B", "Fix the web login flow", t=T0 + 1, trail=["seg-c", "seg-d"])
+        la = _starved_leaves(s, "A", 4, first=10)
+        lb = _starved_leaves(s, "B", 4, first=20)
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / (SID + ".jsonl")
+            nudge = "<!-- romp-injected -->Where does each of these stand? <!-- romp-goal-id: %s -->" % (SID + ":A")
+            p.write_text("\n".join(json.dumps(r) for r in [
+                _uline(T0 + 300, nudge, "n1", ps="sdk"),
+                _aline(T0 + 330, "Search shipped; login still in progress.", "a1", "n1")]) + "\n")
+            sess = jd.em.parse_session(str(p), rompuuid=SID, candidate_files=[str(p)], now=T0 + 900)
+        turn = sess["turns"][0]
+        self.assertEqual({nd["id"] for nd in jd._status_report_candidates(s, turn)},
+                         {SID + ":A", SID + ":B"}, "fixture: both tops ride the status channel")
+        self.assertEqual(len(jd._starved_candidates(s)), 8, "fixture: eight starved riders")
+        cap = jd.CLOSE_RIDER_CAP
+        self.assertEqual(cap, 6, "the fixture's arithmetic (2 status + 4 starved) is written for cap 6")
+        jd._close_turn(s, turn)
+        self.assertEqual(len(self.menus), 1)
+        menu = self.menus[0]
+        self.assertEqual(len(menu), cap)
+        self.assertIn(SID + ":A", menu, "a status rider is never cut behind re-nominating riders")
+        self.assertIn(SID + ":B", menu)
+        self.assertEqual([i for i in menu if i not in (SID + ":A", SID + ":B")], la,
+                         "the starved fill the remaining slots, oldest mints first")
+        self.assertFalse(any(i in menu for i in lb), "the newer starved wait for a later landed call")
+        store = s["nodes"]
+        self.assertTrue(all(store[i].get("closerLookT") for i in la), "carried riders are stamped")
+        self.assertFalse(any(store[i].get("closerLookT") for i in lb), "cut riders stay armed")
+
+    def test_status_riders_ride_uncapped_and_take_the_room(self):
+        # a board with MORE open working tops than the cap: every top rides the status turn — a cut one
+        # would never be judged from THIS reply (the one the user asked for) and never deferred, since the
+        # channel has no watermark — and the re-nominating riders get no room at all on this call
+        s = _store()
+        n = jd.CLOSE_RIDER_CAP + 2
+        tops = [_node(s, "T%d" % i, "Top-level effort %d" % i, t=T0 + i, trail=["seg-a", "seg-b"])["id"]
+                for i in range(n)]
+        lt = _starved_leaves(s, "T0", 4, first=50)
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / (SID + ".jsonl")
+            nudge = "<!-- romp-injected -->Where does each of these stand? <!-- romp-goal-id: %s -->" % tops[0]
+            p.write_text("\n".join(json.dumps(r) for r in [
+                _uline(T0 + 300, nudge, "n1", ps="sdk"),
+                _aline(T0 + 330, "All of them are moving.", "a1", "n1")]) + "\n")
+            sess = jd.em.parse_session(str(p), rompuuid=SID, candidate_files=[str(p)], now=T0 + 900)
+        turn = sess["turns"][0]
+        self.assertEqual(len(jd._status_report_candidates(s, turn)), n, "fixture: every top rides the status channel")
+        self.assertEqual(len(jd._starved_candidates(s)), 4, "fixture: four starved riders behind them")
+        jd._close_turn(s, turn)
+        self.assertEqual(len(self.menus), 1)
+        menu = self.menus[0]
+        self.assertEqual(set(menu), set(tops), "every status rider rides, past the cap; no starved fits this call")
+        self.assertFalse(any(s["nodes"][i].get("closerLookT") for i in lt), "the cut riders stay armed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_close_riders.py
+++ b/tests/test_judge_close_riders.py
@@ -141,6 +141,51 @@ class RiderCap(_Riders):
                         "two landed calls drained the whole backlog")
         self.assertEqual(len(store.get("closedTurns") or []), 2)
 
+    def test_never_looked_riders_outrank_re_armed_ones_under_the_cap(self):
+        # review find 2026-09-03: every landed reply's own filing re-arms the riders an EARLIER call stamped
+        # (_filed_since), and those are older-minted — so under plain mint order a backlog past twice the
+        # room never drained while the top kept receiving filings: the same six rode every call, the rest
+        # never rode once. Here every landed call files one more done under the top (the wrapped
+        # apply_close); with 20 riders against a room of CLOSE_RIDER_CAP each call must still admit riders
+        # that have never been looked at, so the whole backlog rides within ceil(20 / room) landed calls.
+        s = _store()
+        _node(s, "P", "Ship the notes-api search", trail=["seg-a", "seg-b"])
+        leaves = _starved_leaves(s, "P", 20, first=0)
+        jd.save_goals(SID, s)
+        n_turns = 6
+        recs = []
+        for k in range(n_turns):
+            t = T0 + 200 * (k + 1)
+            recs.append(_uline(t, "step %d please" % k, "u%d" % k, ("a%d" % (k - 1)) if k else None))
+            recs.append(_aline(t + 30, "Done with step %d." % k, "a%d" % k, "u%d" % k))
+        path = os.path.join(self.td, SID + ".jsonl")
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        real_apply = jd.apply_close
+        filed = [0]
+
+        def apply_and_file(store, menu, verdicts, t=None, **kw):
+            out = real_apply(store, menu, verdicts, t=t, **kw)
+            filed[0] += 1                                  # the top receives one more filing per landed call
+            _node(store, "P-filed%d" % filed[0], "another shipped step", parent="P", done=True,
+                  log=[{"ev_t": (t or T0) + 1, "src": "planner", "kind": "done", "at": (t or T0) + 1}])
+            return out
+        jd.apply_close = apply_and_file
+        try:
+            jd._close_session(SID, path, T0 + 5000)
+        finally:
+            jd.apply_close = real_apply
+        room = jd.CLOSE_RIDER_CAP
+        self.assertEqual(len(self.menus), n_turns, "one landed call per ended turn")
+        need = -(-20 // room)                              # ceil(20 / room)
+        rode_by_need = set()
+        for m in self.menus[:need]:
+            rode_by_need |= set(m)
+        self.assertTrue(set(leaves) <= rode_by_need,
+                        "every rider must ride within %d calls; never rode: %s"
+                        % (need, sorted(set(leaves) - rode_by_need)))
+        for k in range(1, n_turns):
+            self.assertTrue(set(self.menus[k]) & set(leaves), "each call still carries riders (the drain never idles)")
+
     def test_the_turns_own_menu_is_never_capped(self):
         # the cap is on RIDERS: a turn whose own menu exceeds the cap (a segment placed on the deepest
         # step of a long open chain — _turn_menu lists the node plus every open ancestor) still asks
@@ -228,6 +273,40 @@ class StatusPriority(_Riders):
         menu = self.menus[0]
         self.assertEqual(set(menu), set(tops), "every status rider rides, past the cap; no starved fits this call")
         self.assertFalse(any(s["nodes"][i].get("closerLookT") for i in lt), "the cut riders stay armed")
+
+
+class SweepCutDrain(_Riders):
+    def test_a_cut_walk_rotates_a_dead_session_to_the_back_of_the_death_drain(self):
+        # review find 2026-09-03: a dead session's marker stays pending after a cut walk (its turns are
+        # reachable only through the death drain), and _death_pending drains the OLDEST marker first — so
+        # a turn whose call dies the same way every pass would hold the head of the queue for good, and
+        # DEATH_DRAIN_PER_PASS such sessions would starve every newer dead session. The cut now touches the
+        # marker: it waits at the back, one doomed call per pass, and is never finalized off the cut walk.
+        s = _store()
+        _node(s, "P", "Ship the notes-api search", trail=["seg-a", "seg-b"])
+        _starved_leaves(s, "P", 3, first=0)
+        jd.save_goals(SID, s)
+        path = os.path.join(self.td, SID + ".jsonl")
+        recs = [_uline(T0, "look at the search index", "u1"),
+                _aline(T0 + 30, "Looked; nothing to change.", "a1", "u1")]
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd.GONEDIR.mkdir(parents=True, exist_ok=True)
+        jd._write_death_marker(SID, {"t": T0 + 100})
+        marker = jd.GONEDIR / (SID + ".json")
+        os.utime(marker, (T0, T0))                         # the oldest marker in the queue
+        before = marker.stat().st_mtime_ns
+
+        def dead_call(*a, **k):                           # the call died: _judge_run's failure traces, no reply
+            jd._judge_ctx.last_call_fail = {"note": "exit -14", "model": "sonnet"}
+            return ""
+        jd.closer_llm = dead_call
+        jd._judge_ctx.paused = False
+        jd._close_session(SID, path, T0 + 5000)
+        self.assertGreater(marker.stat().st_mtime_ns, before, "the cut rotated the marker to the back of the queue")
+        m = json.loads(marker.read_text())
+        self.assertNotIn("endedAt", m, "a cut walk never finalizes the marker (its turns are still unswept)")
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertTrue(any(r.get("err") == "sweep-cut" for r in rows), "the cut is said loudly")
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_session_death.py
+++ b/tests/test_judge_session_death.py
@@ -189,8 +189,11 @@ class RunClosePins(unittest.TestCase):
         self.assertIn('discover(now, window=DEATH_BACKFILL_WINDOW)', src)
 
     def test_the_finalize_rides_every_close(self):
+        # …told NOT settled when the walk was CUT at a failed call (2026-09-03): a dead session is swept
+        # only through the death drain, so finalizing its marker off a walk that left turns unswept
+        # would strand them for good (the behavioral pin is test_judge.py SweepSession)
         import inspect
-        self.assertIn('_death_finalize(fsid, store, settled)', inspect.getsource(jd._close_session))
+        self.assertIn('_death_finalize(fsid, store, settled and not cut)', inspect.getsource(jd._close_session))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The closer caps its riders per call and a failed call ends the session's sweep for the pass

**The bug.** `_close_session` walks every end-known unclosed turn of a session and used to `continue` past a failed `_close_turn`; `run_close` awaits one such walk per session with no timeout. On 2026-09-03 one session's closer calls were alarm-killed 192 times in a row inside a single walk: 6h22m during which every judge for every session was silent. It recurred twice more the same day.

The kills were healthy but slow calls, not hangs. Served closer duration tracks output tokens (r≈0.99; input r≈0.07) at roughly 87 tok/s, so about 11.5k output tokens fits under `CALL_ALARM_S`; every served call with 10k+ output took 100 to 118 s, a distribution truncated at the alarm. The output came from the menu: `_close_turn` appended every rider with no cap, 24 riders on most of the backlog. It was self-sustaining because riders retire only through the `closerLookT` stamp a landed reply writes, so a killed call stamps nothing and the same menu rides the next turn.

**The fix.** `CLOSE_RIDER_CAP = 6` bounds the re-nominating riders per call (lifted, steps-finished, starved), never the turn's own menu and never the status riders (one-shot per status turn; a cut one would be lost, not deferred). Cut riders ride a later landed call, so the backlog drains one landed call at a time; this is a drain, not a fairness cap, and `CLOSE_FAIRNESS` stays `None`. `_close_session` ends the session's walk at the first failed call with a loud `sweep-cut` row carrying the menu's shape (counts only); a loop `break`, so the store still saves, and `_death_finalize` is told the session is not settled so a dead session's marker is never finalized off a walk that left turns unswept. The discriminator is `_judge_ctx.last_call_fail` being a dict, not `res is None`: parse rejects and pause-skips still walk on, and the safeguards tombstone keeps its arm. `_judge_run`'s failure exits leave the same traces on both engines (the stash, the model-health latch, and `model= chars= ms=` on the `call` row); the Codex branch previously wrote none of them.

**Unchanged on purpose.** `CALL_ALARM_S`, `CLOSE_FAIRNESS = None`, the safeguards tombstone. If a capped call still dies, the cost is one call per pass per such session, said loudly every pass; a degrade step for that case is a follow-up.

**Verification.** Full Python suite green (7034 passed, 0 failed on my head; 7048 on the maintainer's scratch merge with #904). Every behavioral test fails on the parent commit; the two boundary pins (a parse reject and a pause-skip still walk every turn) pass on the parent by design, since they fence the discriminator rather than exercise the fix. A four-lens adversarial review with two skeptics per finding confirmed six findings (status riders cut permanently, the Codex engine never engaging the cut, a cut walk finalizing a death marker, an overstated drain rate, a docs kinds list, a fixture leak), all fixed in the first commit.

**Review round.** The maintainer's commit on this branch gives the Codex served path the same recovery edge as the Claude one (`_mark_call_served`, cleared stash), lets never-looked riders take the room first so a top that keeps receiving filings cannot pin the same room-full every call, and rotates a cut dead session's marker to the back of the death drain. A docs bullet under "When a judge fails" now explains riders, the cap, and the cut. Left as a follow-up, as agreed: a give-up after repeated cuts on the same (turn, fingerprint), mirroring the safeguards tombstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
