### PR TITLE
The per-push transcript and states readers fold appends instead of re-reading whole files

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, copy
 from pathlib import Path
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -258,7 +258,40 @@ def _interrupt_cause(nxt_atom):
     return None
 
 
-_machine_cut_cache = {}   # str(path) -> ((mtime_ns, size), (t, cause))
+_machine_cut_cache = {}   # str(path) -> (records seen, last record, (t, cause)) — see _fold_records
+
+
+def _fold_records(cache, path, init, step):
+    """Fold a JSONL file's records into a carried state, APPEND-INCREMENTALLY (issue 903, 2026-09-03):
+    the states/transcript readers below re-read their whole file behind an (mtime,size) key that every
+    append invalidates — O(file) per push for every working session. em._read_jsonl_incremental already
+    serves the parsed records of a growing file incrementally (the parse reads the same list, so this adds
+    no I/O), and its contract — a grown file returns a NEW list whose prefix objects are the SAME — is the
+    identity gate here: when the cached prefix is intact, only the appended records run through `step`;
+    a rewrite (prefix identity lost, a shrink, a same-size-new-mtime) re-folds from record 0. `init()`
+    makes a fresh state; `step(state, record)` returns the next state (mutate-and-return is fine: the
+    cached state is deep-copied before folding onto it, so a state a caller was handed never changes
+    under it). Returns the state; [] records (a missing or unreadable file) fold to init()."""
+    recs = em._read_jsonl_incremental(path)
+    key = str(path)
+    hit = cache.get(key)
+    if hit is not None:
+        n0, last0, state0 = hit
+        if n0 == len(recs) and (n0 == 0 or recs[-1] is last0):
+            return state0
+        if 0 < n0 < len(recs) and recs[n0 - 1] is last0:
+            state, start = copy.deepcopy(state0), n0
+        else:
+            state, start = init(), 0
+    else:
+        state, start = init(), 0
+    for r in recs[start:]:
+        if isinstance(r, dict):
+            state = step(state, r)
+    if len(cache) > 256:                                  # bounded by the session count; never unbounded
+        cache.clear()
+    cache[key] = (len(recs), recs[-1] if recs else None, state)
+    return state
 
 
 def _last_machine_cut(sid):
@@ -271,29 +304,12 @@ def _last_machine_cut(sid):
     per session on EVERY push, and these files reach ~1MB / 4k lines on a long-lived session, so an
     uncached scan would add megabytes of reading per push cycle to a loop that is already CPU-bound."""
     p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    try:
-        st = p.stat(); key = (st.st_mtime_ns, st.st_size)
-    except OSError:
-        return 0.0, ""
-    hit = _machine_cut_cache.get(str(p))
-    if hit is not None and hit[0] == key:
-        return hit[1]
-    t, cause = 0.0, ""
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"machineCut"' not in line:
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                if isinstance(o, dict) and o.get("machineCut"):
-                    t, cause = float(o.get("t") or 0), str(o["machineCut"])
-    except OSError:
-        return 0.0, ""
-    _machine_cut_cache[str(p)] = (key, (t, cause))
-    return t, cause
+
+    def step(state, o):
+        if o.get("machineCut"):
+            return (float(o.get("t") or 0), str(o["machineCut"]))   # the NEWEST row decides
+        return state
+    return _fold_records(_machine_cut_cache, p, lambda: (0.0, ""), step)
 
 
 def _machine_cut_cause(users, i, cut_t=0.0, cut_cause=""):
@@ -16019,44 +16035,24 @@ def _pending_queued(path):
     DISPLAY — an unresolved entry is a bubble that never leaves, the bug this whole pass exists to end,
     while an over-resolved one self-heals at the next record — and the case is vanishingly rare besides
     (live corpus: one such remove in 305, and it is where a credited dequeue had already taken the entry)."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-    except OSError:
-        key = None
-    hit = _queued_parse_cache.get(path)
-    if hit is not None and key is not None and hit[0] == key:
-        return hit[1]
-    pending = []
-    try:
-        with open(path, errors="replace") as f:
-            for line in f:
-                if '"queue-operation"' not in line:          # fast skip: most lines aren't queue ops
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                if o.get("type") != "queue-operation":
-                    continue
-                op = o.get("operation")
-                content = o.get("content") if isinstance(o.get("content"), str) else None
-                if op == "enqueue":
-                    pending.append(content or "")
-                elif op == "popAll":                         # the whole queue recalled — nothing is left owed
-                    pending.clear()
-                elif op == "remove" and content is not None and content in pending:
-                    pending.remove(content)                  # that entry only; the rest keep their places
-                elif op in ("dequeue", "remove") and pending:
-                    del pending[0]                           # anonymous resolution: the oldest is the one taken
-    except OSError:
-        return []
-    out = [t.strip() for t in pending if _genuine_queued(t)]
-    if key is not None:
-        if len(_queued_parse_cache) > 256:                   # bounded by fleet size; never unbounded
-            _queued_parse_cache.clear()
-        _queued_parse_cache[path] = (key, out)
-    return out
+    # A queue LEDGER: a dequeue resolves the OLDEST entry, which can predate any window, so this folds
+    # append-incrementally over the whole record list (_fold_records) with the pending list carried.
+    def step(pending, o):
+        if o.get("type") != "queue-operation":
+            return pending
+        op = o.get("operation")
+        content = o.get("content") if isinstance(o.get("content"), str) else None
+        if op == "enqueue":
+            pending.append(content or "")
+        elif op == "popAll":                                 # the whole queue recalled — nothing is left owed
+            pending.clear()
+        elif op == "remove" and content is not None and content in pending:
+            pending.remove(content)                          # that entry only; the rest keep their places
+        elif op in ("dequeue", "remove") and pending:
+            del pending[0]                                   # anonymous resolution: the oldest is the one taken
+        return pending
+    pending = _fold_records(_queued_parse_cache, path, list, step)
+    return [t.strip() for t in pending if _genuine_queued(t)]
 
 
 # ── Idle-queue drive: wake signals stuck in an idle SDK CLI's queue (the user 2026-08-18) ──
@@ -16091,7 +16087,7 @@ _WAKE_DRIVE_FLOOR_S = 60.0    # ~400x the delivering regime's p90 (0.126s); a ro
 _AGENT_TASK_ID_RE = re.compile(r"<task-id>([^<]*)</task-id>")
 _AGENT_ID_SHAPE_RE = re.compile(r"a[0-9a-f]{16}")   # background-agent ids; monitor/cron/bash ids are
 #                                                     9-char base36, so the classes cannot collide
-_wake_tail_cache = {}         # path -> ((mtime, size), (entries, mark))
+_wake_tail_cache = {}         # path -> (records seen, last record, (tail, n)) — see _fold_records
 
 
 def _wake_ts_epoch(ts):
@@ -16136,87 +16132,65 @@ def _undelivered_wake_tail(path):
     otherwise-shaped id keeps wrapper=True — under-delivering is the original bug; the carve-out is
     only for the one class the CLI provably owns. Cached by (mtime, size) like _pending_queued,
     since the drive tick asks every push cycle."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-    except OSError:
-        return [], None
-    hit = _wake_tail_cache.get(path)
-    if hit is not None and hit[0] == key:
-        return hit[1]
-    tail = []
-    try:
-        with open(path, errors="replace") as f:
-            for pos, line in enumerate(f):
-                if '"queue-operation"' in line:              # cheap prefilter; the parse verifies
-                    try:
-                        o = json.loads(line)
-                    except Exception:
-                        continue
-                    if o.get("type") != "queue-operation":
-                        continue
-                    op = o.get("operation")
-                    if op == "enqueue":
-                        text = o.get("content") if isinstance(o.get("content"), str) else ""
-                        w = bool(em.SYSTEM_WRAPPER_RE.match(text))
-                        if w:
-                            m = _AGENT_TASK_ID_RE.search(text)
-                            if m and _AGENT_ID_SHAPE_RE.fullmatch(m.group(1)):
-                                w = False                    # an agent completion notice — the CLI's own
-                        #                                      to deliver, in every regime (see docstring)
-                        tail.append({"pos": pos, "ts": str(o.get("timestamp") or ""), "text": text,
-                                     "wrapper": w})
-                    elif op == "remove":
-                        c = o.get("content") if isinstance(o.get("content"), str) else None
-                        if c is not None:
-                            i = next((i for i, e in enumerate(tail) if e["text"] == c), None)
-                            if i is not None:                # content-addressed single-item discard —
-                                del tail[i]                  # the CLI's call on THAT entry only
-                        elif tail:
-                            del tail[0]                      # content-less: the oldest, as _pending_queued folds
-                    elif op == "popAll":                     # the whole queue recalled at once: every entry is
-                        tail.clear()                         # withdrawn, so nothing here is owed a turn any more
-                        #                                      (unhandled until 2026-08-26 — a recalled queue kept
-                        #                                      reading as undriven signals, one session holding 12)
-                    #      a `dequeue` clears nothing — its delivery evidence is the user record it produces
-                    continue
-                if not tail:
-                    continue                                 # nothing pending → nothing to resolve (fast path)
-                if '"user"' not in line:
-                    continue                                 # cheap prefilter for delivery-evidence records
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                if o.get("type") == "user" and not o.get("isMeta"):
-                    mc = (o.get("message") or {}).get("content")
-                    if isinstance(mc, str):
-                        utext = mc
-                    elif isinstance(mc, list):
-                        utext = "\n".join(str(b.get("text") or "") for b in mc
-                                          if isinstance(b, dict) and b.get("type") == "text")
-                    else:
-                        utext = ""
-                    if utext:                                # delivered = the record CARRIES the text
-                        budget = {}
-                        kept = []
-                        for e in tail:
-                            t = e["text"]
-                            if t and t in utext:
-                                if t not in budget:
-                                    budget[t] = utext.count(t)
-                                if budget[t] > 0:
-                                    budget[t] -= 1
-                                    continue                 # cleared: one entry per carried copy
-                            kept.append(e)
-                        tail = kept
-    except OSError:
-        return [], None
-    out = (tail, (tail[-1]["pos"], tail[-1]["ts"]) if tail else None)
-    if len(_wake_tail_cache) > 256:                          # bounded by the session count; never unbounded
-        _wake_tail_cache.clear()
-    _wake_tail_cache[path] = (key, out)
-    return out
+    # A per-entry LEDGER (an enqueue is resolved by a much later record), so it folds append-incrementally
+    # over the whole record list (_fold_records) with the pending tail carried. `pos` is the entry's
+    # RECORD index (was: line index) — the drive compares marks only against positions this same fold
+    # hands out later, and both are monotone within an unrewritten file.
+    def step(state, o):
+        tail, n = state
+        pos = n
+        n += 1
+        if o.get("type") == "queue-operation":
+            op = o.get("operation")
+            if op == "enqueue":
+                text = o.get("content") if isinstance(o.get("content"), str) else ""
+                w = bool(em.SYSTEM_WRAPPER_RE.match(text))
+                if w:
+                    m = _AGENT_TASK_ID_RE.search(text)
+                    if m and _AGENT_ID_SHAPE_RE.fullmatch(m.group(1)):
+                        w = False                            # an agent completion notice — the CLI's own
+                tail.append({"pos": pos, "ts": str(o.get("timestamp") or ""), "text": text,
+                             "wrapper": w})
+            elif op == "remove":
+                c = o.get("content") if isinstance(o.get("content"), str) else None
+                if c is not None:
+                    i = next((i for i, e in enumerate(tail) if e["text"] == c), None)
+                    if i is not None:                        # content-addressed single-item discard —
+                        del tail[i]                          # the CLI's call on THAT entry only
+                elif tail:
+                    del tail[0]                              # content-less: the oldest, as _pending_queued folds
+            elif op == "popAll":                             # the whole queue recalled at once: every entry is
+                tail.clear()                                 # withdrawn, so nothing here is owed a turn any more
+            #      a `dequeue` clears nothing — its delivery evidence is the user record it produces
+            return (tail, n)
+        if not tail:
+            return (tail, n)                                 # nothing pending → nothing to resolve (fast path)
+        if o.get("type") == "user" and not o.get("isMeta"):
+            mc = (o.get("message") or {}).get("content")
+            if isinstance(mc, str):
+                utext = mc
+            elif isinstance(mc, list):
+                utext = "\n".join(str(b.get("text") or "") for b in mc
+                                  if isinstance(b, dict) and b.get("type") == "text")
+            else:
+                utext = ""
+            if utext:                                        # delivered = the record CARRIES the text
+                budget = {}
+                kept = []
+                for e in tail:
+                    t = e["text"]
+                    if t and t in utext:
+                        if t not in budget:
+                            budget[t] = utext.count(t)
+                        if budget[t] > 0:
+                            budget[t] -= 1
+                            continue                         # cleared: one entry per carried copy
+                    kept.append(e)
+                tail = kept
+        return (tail, n)
+    tail, _n = _fold_records(_wake_tail_cache, path, lambda: ([], 0), step)
+    tail = [dict(e) for e in tail]                           # callers get their own copies of the carried entries
+    return (tail, (tail[-1]["pos"], tail[-1]["ts"]) if tail else None)
 
 
 _api_err_cache = {}           # path -> ((mtime, size), err|None)
@@ -17050,30 +17024,48 @@ def _session_retrying(sid, tm):
             "networkDown": info.get("networkDown"), "rateLimitType": info.get("rateLimitType")}
 
 
+_states_notes_cache = {}      # str(states path) -> (records seen, last record, the five note lists) — see _fold_records
+_NOTE_KEYS = ("recoveries", "gaveups", "orphans", "efforts", "gestures")
+
+
+def _states_notes(sid):
+    """The five durable-note lists build_session interleaves (retriesRecovered / retriesGaveUp /
+    orphanReply / effortApplied / cmdGesture rows of states/<sid>.jsonl), read in ONE append-incremental
+    fold (issue 903, 2026-09-03) instead of five uncached whole-file scans per build. Each reader below
+    hands out copies of its list; the shapes are unchanged."""
+    p = jd.STATE / "states" / ("%s.jsonl" % sid)
+
+    def step(state, o):
+        t = o.get("t")
+        if not t:
+            return state
+        n = o.get("retriesRecovered")
+        if isinstance(n, int) and n > 0:
+            state["recoveries"].append({"t": int(t), "retries": n})
+        n = o.get("retriesGaveUp")
+        if isinstance(n, int) and n > 0:
+            state["gaveups"].append({"t": int(t), "retries": n, "errorKind": str(o.get("errorKind") or "")})
+        orq = o.get("orphanReply")
+        if isinstance(orq, dict) and (orq.get("text") or "").strip():
+            state["orphans"].append({"t": int(t), "uuid": str(orq.get("uuid") or ""), "text": orq["text"]})
+        v = o.get("effortApplied")
+        if isinstance(v, str) and v:
+            state["efforts"].append({"t": int(t), "effort": v})
+        v = o.get("cmdGesture")
+        if isinstance(v, str) and v:
+            state["gestures"].append({"t": int(t), "cmd": v})
+        return state
+    return _fold_records(_states_notes_cache, p, lambda: {k: [] for k in _NOTE_KEYS}, step)
+
+
 def _retry_recoveries(sid):
     """Durable recovery markers from states/<sid>.jsonl — {"t":…,"retriesRecovered":N} lines the SDK backend
     writes when a stalled api_retry turn resumes real output (append_retry_recovered). Returns
     [{"t":epoch,"retries":N}, …] oldest first, so build_session can interleave a persistent "Recovered after N
     retries" note at the recovered turn. SDK-only — tmux has no api_retry signal, so its state files carry no
     such records and this is []."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    out = []
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"retriesRecovered"' not in line:       # cheap prefilter — most lines are plain state records
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                n = o.get("retriesRecovered")
-                if isinstance(n, int) and n > 0 and o.get("t"):
-                    out.append({"t": int(o["t"]), "retries": n})
-    except OSError:
-        return []
-    out.sort(key=lambda r: r["t"])
-    return out
+    return sorted((dict(r) for r in _states_notes(sid)["recoveries"]), key=lambda r: r["t"])   # one folded pass serves
+    #                                                                                  all five; oldest first
 
 
 def _retry_gaveups(sid):
@@ -17082,24 +17074,8 @@ def _retry_gaveups(sid):
     instead of output (append_retry_gave_up; the user 2026-07-25: the note used to read "Recovered after
     10 retries" over a turn that produced nothing). Twin of _retry_recoveries, so build_session can
     interleave a persistent "gave up after N retries" note right where the storm died."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    out = []
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"retriesGaveUp"' not in line:          # cheap prefilter — most lines are plain state records
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                n = o.get("retriesGaveUp")
-                if isinstance(n, int) and n > 0 and o.get("t"):
-                    out.append({"t": int(o["t"]), "retries": n, "errorKind": str(o.get("errorKind") or "")})
-    except OSError:
-        return []
-    out.sort(key=lambda r: r["t"])
-    return out
+    return sorted((dict(r) for r in _states_notes(sid)["gaveups"]), key=lambda r: r["t"])   # one folded pass serves
+    #                                                                                  all five; oldest first
 
 
 def _atom_md(a):
@@ -17119,24 +17095,8 @@ def _orphan_replies(sid):
     SDK backend writes (append_orphan_reply) when retire_live_work drops a live assistant reply the transcript
     never kept (a reply the user watched stream on an API-errored try). Returns [{"t","uuid","text"}, …] oldest
     first, so build_session can interleave the lost text back at its timestamp, DEDUP'd against the disk. SDK-only."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    out = []
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"orphanReply"' not in line:            # cheap prefilter — most lines are plain state records
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                orq = o.get("orphanReply")
-                if isinstance(orq, dict) and (orq.get("text") or "").strip() and o.get("t"):
-                    out.append({"t": int(o["t"]), "uuid": str(orq.get("uuid") or ""), "text": orq["text"]})
-    except OSError:
-        return []
-    out.sort(key=lambda r: r["t"])
-    return out
+    return sorted((dict(r) for r in _states_notes(sid)["orphans"]), key=lambda r: r["t"])   # one folded pass serves
+    #                                                                                  all five; oldest first
 
 
 def _effort_changes(sid):
@@ -17144,24 +17104,8 @@ def _effort_changes(sid):
     backend writes when an /effort reconnect lands (append_effort_applied). Returns [{"t":epoch,"effort":str}, …]
     oldest first, so build_session can interleave a persistent "effort set to X" note at the moment it took
     effect. SDK-only — tmux applies /effort in-band (a real command turn), so it needs no synthetic marker."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    out = []
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"effortApplied"' not in line:          # cheap prefilter — most lines are plain state records
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                v = o.get("effortApplied")
-                if isinstance(v, str) and v and o.get("t"):
-                    out.append({"t": int(o["t"]), "effort": v})
-    except OSError:
-        return []
-    out.sort(key=lambda r: r["t"])
-    return out
+    return sorted((dict(r) for r in _states_notes(sid)["efforts"]), key=lambda r: r["t"])   # one folded pass serves
+    #                                                                                  all five; oldest first
 
 
 def _cmd_gestures(sid):
@@ -17171,24 +17115,8 @@ def _cmd_gestures(sid):
     chip once prune_live retires the synthesized live one (the user 2026-08-14: the user's side of the history
     keeps what they did; the applied note keeps that it happened). SDK-only — tmux commands are real
     transcript turns already."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    out = []
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"cmdGesture"' not in line:             # cheap prefilter — most lines are plain state records
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                v = o.get("cmdGesture")
-                if isinstance(v, str) and v and o.get("t"):
-                    out.append({"t": int(o["t"]), "cmd": v})
-    except OSError:
-        return []
-    out.sort(key=lambda r: r["t"])
-    return out
+    return sorted((dict(r) for r in _states_notes(sid)["gestures"]), key=lambda r: r["t"])   # one folded pass serves
+    #                                                                                  all five; oldest first
 
 
 # ── background-task box (the user 2026-06-26) ───────────────────────────────────────────────────────

--- a/tests/test_scanner_folds.py
+++ b/tests/test_scanner_folds.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""The kernel's per-push transcript/states readers fold appends instead of re-reading whole files
+(issue 903): _pending_queued and _undelivered_wake_tail (queue ledgers over the transcript),
+_last_machine_cut and the five durable-note readers (states/<sid>.jsonl), all through _fold_records
+over em._read_jsonl_incremental's cached record list.
+
+The contract: the folded answer equals a from-scratch fold at EVERY appended record (the reference
+clears the fold caches first; the record list itself comes from the same incremental reader either
+way), a rewrite re-folds from record 0, an unchanged file is served without stepping a record, and the
+wake tail's positions stay stable across folds. Synthetic only: placeholder ids, invented text."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_scanfold", os.path.join(BIN, "romp-kernel")).load_module()
+jd, em = km.jd, km.em
+
+SID = "11111111-2222-3333-4444-555555555555"
+TASK = "<task-notification>\n<task-id>bash-1</task-id>\n<status>completed</status>\n</task-notification>"
+AGENT = "<task-notification>\n<task-id>a0123456789abcdef</task-id>\n<status>completed</status>\n</task-notification>"
+
+
+def qop(op, content=None, ts="2026-06-10T14:00:00.000Z"):
+    o = {"type": "queue-operation", "operation": op, "sessionId": SID, "timestamp": ts}
+    if content is not None:
+        o["content"] = content
+    return o
+
+
+def user(text, meta=False):
+    o = {"type": "user", "uuid": "u-%d" % abs(hash(text)) , "message": {"role": "user", "content": text}}
+    if meta:
+        o["isMeta"] = True
+    return o
+
+
+def asst(text):
+    return {"type": "assistant", "uuid": "a-%d" % abs(hash(text)),
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+def _clear_folds():
+    for c in (km._queued_parse_cache, km._wake_tail_cache, km._machine_cut_cache, km._states_notes_cache):
+        c.clear()
+
+
+class _Fold(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        (jd.STATE / "states").mkdir()
+        self.states = jd.STATE / "states" / (SID + ".jsonl")
+        self.tpath = Path(self.td.name) / (SID + ".jsonl")
+        self.tpath.write_text("")
+        self.states.write_text("")
+        _clear_folds()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        _clear_folds()
+        self.td.cleanup()
+
+    def append(self, path, recs):
+        with open(path, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        os.utime(path, None)
+
+    def rewrite(self, path, recs):
+        path.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        os.utime(path, None)
+
+    def differential(self, path, recs, folded, label):
+        """Append `recs` one at a time; after each, the folded answer must equal a fresh fold."""
+        for i, r in enumerate(recs):
+            self.append(path, [r])
+            inc = folded()
+            _clear_folds()
+            ref = folded()
+            self.assertEqual(json.dumps(inc, sort_keys=True), json.dumps(ref, sort_keys=True),
+                             "%s diverged at record %d (%s)" % (label, i + 1, r.get("operation") or r.get("type")))
+            folded()                                       # warm the fold cache again for the next step
+
+
+class PendingQueued(_Fold):
+    SEQ = [user("hello"), qop("enqueue", "first"), qop("enqueue", "second"), asst("working"),
+           qop("dequeue"), qop("enqueue", "third"), qop("remove"), qop("remove"), qop("enqueue", "fourth"),
+           user("[Request interrupted by user]"), qop("enqueue", "fifth"), qop("dequeue")]
+
+    def test_folded_equals_whole_file_at_every_append(self):
+        self.differential(self.tpath, self.SEQ, lambda: km._pending_queued(str(self.tpath)), "_pending_queued")
+        self.assertEqual(km._pending_queued(str(self.tpath)), ["fifth"])
+
+    def test_content_addressed_remove_and_popAll(self):
+        recs = [qop("enqueue", "a"), qop("enqueue", "b"), qop("enqueue", "c"), qop("remove", "b"),
+                qop("enqueue", "d"), qop("popAll"), qop("enqueue", "e"), qop("remove", "zzz")]
+        self.differential(self.tpath, recs, lambda: km._pending_queued(str(self.tpath)), "remove/popAll")
+        self.assertEqual(km._pending_queued(str(self.tpath)), [], "a remove naming nothing pending takes the oldest")
+        self.append(self.tpath, [qop("enqueue", "f"), qop("enqueue", "g"), qop("remove", "g")])
+        self.assertEqual(km._pending_queued(str(self.tpath)), ["f"], "a content-addressed remove takes that entry only")
+
+    def test_a_rewrite_refolds_from_zero(self):
+        self.append(self.tpath, self.SEQ)
+        self.assertEqual(km._pending_queued(str(self.tpath)), ["fifth"])
+        self.rewrite(self.tpath, self.SEQ[:3])            # a rewind: the file is a different prefix now
+        self.assertEqual(km._pending_queued(str(self.tpath)), ["first", "second"])
+        _clear_folds()
+        self.assertEqual(km._pending_queued(str(self.tpath)), ["first", "second"])
+
+    def test_missing_file_is_empty(self):
+        self.assertEqual(km._pending_queued(str(self.tpath) + ".nope"), [])
+
+
+class WakeTail(_Fold):
+    SEQ = [user("hi"), qop("enqueue", TASK, ts="2026-06-10T14:00:00.500Z"), qop("popAll"),   # recalled whole
+           qop("enqueue", TASK, ts="2026-06-10T14:00:01.000Z"), asst("busy"),
+           qop("enqueue", "plain text from a peer", ts="2026-06-10T14:00:02.000Z"),
+           qop("enqueue", AGENT, ts="2026-06-10T14:00:03.000Z"),
+           qop("dequeue"),                                  # clears NOTHING here
+           qop("remove", "plain text from a peer"),         # content-addressed: that entry only
+           user("<system-reminder>x</system-reminder>", meta=True),   # isMeta: no evidence
+           user("Delivered: " + TASK),                      # carries the wrapper → resolves it
+           qop("enqueue", TASK, ts="2026-06-10T14:00:09.000Z"),
+           qop("enqueue", TASK, ts="2026-06-10T14:00:10.000Z"),
+           user(TASK)]                                      # one copy carried → clears exactly one
+
+    def test_folded_equals_whole_file_at_every_append(self):
+        self.differential(self.tpath, self.SEQ, lambda: km._undelivered_wake_tail(str(self.tpath)), "_undelivered_wake_tail")
+        tail, mark = km._undelivered_wake_tail(str(self.tpath))
+        self.assertEqual([e["text"] for e in tail], [AGENT, TASK])
+        self.assertEqual([e["wrapper"] for e in tail], [False, True], "the agent notice is the CLI's own")
+        self.assertEqual(mark, (tail[-1]["pos"], tail[-1]["ts"]))
+
+    def test_positions_are_stable_across_folds(self):
+        self.append(self.tpath, self.SEQ[:7])
+        tail0, _ = km._undelivered_wake_tail(str(self.tpath))
+        pos_agent = next(e["pos"] for e in tail0 if e["text"] == AGENT)
+        self.append(self.tpath, self.SEQ[7:])
+        tail1, _ = km._undelivered_wake_tail(str(self.tpath))
+        self.assertEqual(next(e["pos"] for e in tail1 if e["text"] == AGENT), pos_agent,
+                         "an entry keeps its position while the file only grows")
+
+    def test_callers_cannot_mutate_the_carried_state(self):
+        self.append(self.tpath, self.SEQ[:4])
+        tail, _ = km._undelivered_wake_tail(str(self.tpath))
+        tail[0]["text"] = "clobbered"
+        tail2, _ = km._undelivered_wake_tail(str(self.tpath))
+        self.assertEqual(tail2[0]["text"], TASK)
+
+
+class MachineCut(_Fold):
+    SEQ = [{"t": 100, "state": "working"}, {"t": 110, "machineCut": "restart"}, {"t": 120, "state": "idle"},
+           {"t": 130, "machineCut": "crash"}, {"t": 140, "retriesRecovered": 2}]
+
+    def test_folded_equals_whole_file_and_newest_wins(self):
+        self.differential(self.states, self.SEQ, lambda: km._last_machine_cut(SID), "_last_machine_cut")
+        self.assertEqual(km._last_machine_cut(SID), (130.0, "crash"))
+
+    def test_no_marker_is_the_zero_answer(self):
+        self.append(self.states, self.SEQ[:1])
+        self.assertEqual(km._last_machine_cut(SID), (0.0, ""))
+        self.assertEqual(km._last_machine_cut("no-such-sid"), (0.0, ""))
+
+
+class Notes(_Fold):
+    SEQ = [{"t": 100, "state": "working"}, {"t": 105, "retriesRecovered": 3}, {"t": 110, "cmdGesture": "/effort high"},
+           {"t": 111, "effortApplied": "high"}, {"t": 120, "state": "idle"},
+           {"t": 130, "orphanReply": {"uuid": "o-1", "text": "the reply the disk lost"}},
+           {"t": 140, "retriesGaveUp": 5, "errorKind": "overloaded"}, {"t": 150, "retriesRecovered": 0},
+           {"no_t": True, "cmdGesture": "/model x"}, {"t": 160, "cmdGesture": "/model sonnet"}]
+
+    def _all(self):
+        return {"rec": km._retry_recoveries(SID), "gave": km._retry_gaveups(SID), "orph": km._orphan_replies(SID),
+                "eff": km._effort_changes(SID), "gest": km._cmd_gestures(SID)}
+
+    def test_folded_equals_whole_file_at_every_append(self):
+        self.differential(self.states, self.SEQ, self._all, "states notes")
+        a = self._all()
+        self.assertEqual(a["rec"], [{"t": 105, "retries": 3}])
+        self.assertEqual(a["gave"], [{"t": 140, "retries": 5, "errorKind": "overloaded"}])
+        self.assertEqual(a["orph"], [{"t": 130, "uuid": "o-1", "text": "the reply the disk lost"}])
+        self.assertEqual(a["eff"], [{"t": 111, "effort": "high"}])
+        self.assertEqual(a["gest"], [{"t": 110, "cmd": "/effort high"}, {"t": 160, "cmd": "/model sonnet"}])
+
+    def test_an_unchanged_file_is_served_without_refolding(self):
+        self.append(self.states, self.SEQ)
+        first = km._states_notes(SID)
+        self.assertIs(km._states_notes(SID), first, "same records → the cached state itself")
+        self.append(self.states, [{"t": 170, "effortApplied": "low"}])
+        second = km._states_notes(SID)
+        self.assertIsNot(second, first)
+        self.assertEqual(first["efforts"], [{"t": 111, "effort": "high"}], "the state a caller holds never changes under it")
+        self.assertEqual(second["efforts"], [{"t": 111, "effort": "high"}, {"t": 170, "effort": "low"}])
+
+
+class FoldRecords(_Fold):
+    def test_only_appended_records_are_stepped_and_a_rewrite_refolds(self):
+        cache, seen = {}, []
+
+        def step(state, r):
+            seen.append(r["n"])
+            return state + [r["n"]]
+        self.append(self.tpath, [{"n": i} for i in range(3)])
+        self.assertEqual(km._fold_records(cache, self.tpath, list, step), [0, 1, 2])
+        self.assertEqual(seen, [0, 1, 2])
+        self.append(self.tpath, [{"n": 3}, {"n": 4}])
+        self.assertEqual(km._fold_records(cache, self.tpath, list, step), [0, 1, 2, 3, 4])
+        self.assertEqual(seen, [0, 1, 2, 3, 4], "an append steps only the new records")
+        self.assertEqual(km._fold_records(cache, self.tpath, list, step), [0, 1, 2, 3, 4])
+        self.assertEqual(seen, [0, 1, 2, 3, 4], "an unchanged file steps nothing")
+        self.rewrite(self.tpath, [{"n": 7}, {"n": 8}])
+        self.assertEqual(km._fold_records(cache, self.tpath, list, step), [7, 8])
+        self.assertEqual(seen[-2:], [7, 8], "a rewrite folds from record 0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The rest of #903 (with #906 landed): the per-push readers that still re-read a whole file behind an `(mtime, size)` key every append invalidates.

## What

Eight readers ran on every push for every working session, each re-reading and re-parsing its whole file: `_pending_queued` and `_undelivered_wake_tail` (queue ledgers over the transcript, called by `build_session` and the idle-queue drive), `_last_machine_cut` (the interrupt tick), and the five durable-note readers `build_session` interleaves (`retriesRecovered`, `retriesGaveUp`, `orphanReply`, `effortApplied`, `cmdGesture` over `states/<sid>.jsonl`: five uncached scans per build). The issue named the first three as the incidental scanners beside `_api_error`, which #901 folded.

`_fold_records(cache, path, init, step)` folds a file's records into a carried state append-incrementally over `em._read_jsonl_incremental`'s cached record list, which the parse already reads, so no new I/O: when the cached prefix is intact **by identity** only the appended records step; a rewrite, a shrink or a same-size-new-mtime re-folds from record 0 (the reader's 64-byte prefix guard already handles the CLI's verbatim rewrites); an unchanged file is served without stepping a record; the carried state is deep-copied before folding, so a state a caller holds never changes under it.

The two ledgers keep their exact semantics (content-addressed `remove`, `popAll`, FIFO `dequeue`; per-entry delivery evidence for the wake tail). One deliberate change: the wake tail's `pos` is the entry's record index rather than its line index — the drive compares marks only against positions this same fold hands out later, and both are monotone within an unrewritten file. The five note readers share ONE folded pass and still return oldest-first copies. Cache names are unchanged for the tests that clear them.

## Numbers

Synthetic 20,000-record transcript (one queue enqueue, one delivery and one dequeue per ten records) and a 4,000-row states file, one call after one appended record, this machine:

| reader | before | after |
|---|---|---|
| `_pending_queued` | 12.1 ms | 0.1 ms |
| `_undelivered_wake_tail` | 17.9 ms | 0.0 ms |
| `_last_machine_cut` | 0.5 ms | 0.1 ms |
| the five note readers together | 1.9 ms | 0.4 ms |

Per working session per push that is about 32 ms → under 1 ms here; the reporter's transcripts are 5–25× longer, which is the "few seconds per cycle" the issue estimated. The cold call is higher after (the incremental reader parses every record once, not only the prefiltered lines) — a one-time cost the parse pays anyway on the same cached list.

## Tests

`tests/test_scanner_folds.py`: each reader replayed record by record against a fresh fold (caches cleared) at every appended record; rewrite, `popAll`, content-addressed remove, a remove naming nothing pending, position stability across folds, caller isolation from the carried state, the unchanged-file fast path (the cached state itself is returned), and `_fold_records` pinned to step only the appended records. The existing idle-queue-drive, machine-cut, gesture, effort-note, gave-up, orphan-reply and SDK-kernel suites pass unchanged. Full suite green locally.

## Still open on #903

The residual O(atoms) passes below the chat layer noted in #906 (the parse tail's `synthesize_orphans` / `segment_turns` re-sort per parse, `_scan_bg_tasks` per append), and the `_judge_gen` 3-second clock in `_chat_build_sig`.
