### PR TITLE
T234: an unresolved postal id warns once per (session, id) per kernel life

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -618,6 +618,9 @@ def _version_info():
             # the chat-payload fold's counters (issue 903) — the same shape as "parse", read by
             # `romp version` beside it: fold/full/bypass/fallback plus g:<reason> demotes
             "chatfold": dict(_CHAT_FOLD_STATS),
+            "postalUnresolved": {"ids": len(_POSTAL_UNRESOLVED["seen"]),   # T234: unresolved postal ids
+                                 "warned": _POSTAL_UNRESOLVED["warned"],    # (distinct pairs seen, lines
+                                 "suppressed": _POSTAL_UNRESOLVED["suppressed"]},   # written, repeats held)
             "drainRefused": dict(_DRAIN_REFUSED),   # T224: refused /busy?drain=1 arms — count (lifetime
             #                                          total), episodeCount (the current/last episode),
             #                                          open episode, last time; the silent degrade made visible
@@ -17844,6 +17847,23 @@ def _postal_addressed_to(rec, sid):
     return not to or not sid or to == sid
 
 
+# T234 (the user 2026-09-03): an unresolved postal id is a fact stated ONCE per (session, id) per kernel
+# life. The writer below used to fire on EVERY build - 20k to 116k journal lines per hour for 30+ hours,
+# the same pairs every pusher cycle - burying real signal (a kill event had to be filtered out of it).
+# Fail-loud stays: the FIRST sighting of a pair logs; repeats are counted, never printed; a NEW pair logs
+# again. `seen` is bounded (a wraparound re-warns each pair once - rare and still bounded); `warned` and
+# `suppressed` ride /version beside the other runtime counters, so the volume is visible without the log.
+_POSTAL_UNRESOLVED = {"seen": set(), "warned": 0, "suppressed": 0}
+_POSTAL_UNRESOLVED_CAP = 5000
+
+
+def _POSTAL_UNRESOLVED_RESET():
+    """Test seam: a fresh kernel life for the once-per-pair warning."""
+    _POSTAL_UNRESOLVED["seen"].clear()
+    _POSTAL_UNRESOLVED["warned"] = 0
+    _POSTAL_UNRESOLVED["suppressed"] = 0
+
+
 def _hydrate_postal(events, index, sid=None):
     """Replace postal traffic with clean cards: a send_message tool (or `romp mail send` Bash) → an
     OUTGOING card; a user event (or a MAIL READER's output — see _reads_mail) carrying romp-msg-id
@@ -17923,9 +17943,22 @@ def _hydrate_postal(events, index, sid=None):
                 ev["mids"] = _mids                       # every id, so any arc into this turn can match
                 # Fail LOUDLY (CLAUDE.md): a logged id that will not resolve is a real inconsistency
                 # between the message log and this session's view of it, and it used to pass in silence.
-                sys.stderr.write("postal hydrate: %d of %d message id(s) unresolved on %s (%s)\n"
-                                 % (len(ids) - len(cards), len(ids), ev.get("uuid") or "?",
-                                    ",".join(m for m in _mids if m not in {c["mid"] for c in cards})))
+                # ...but ONCE per (session, id) per kernel life (T234) - the same pairs recur on every
+                # build; a repeat is a count, a NEW pair is news.
+                _unres = [m for m in _mids if m not in {c["mid"] for c in cards}]
+                _skey = sid or ev.get("uuid") or "?"
+                _new = [m for m in _unres if (_skey, m) not in _POSTAL_UNRESOLVED["seen"]]
+                if _new:
+                    if len(_POSTAL_UNRESOLVED["seen"]) >= _POSTAL_UNRESOLVED_CAP:
+                        _POSTAL_UNRESOLVED["seen"].clear()           # bounded: wrap, re-warn once
+                    _POSTAL_UNRESOLVED["seen"].update((_skey, m) for m in _new)
+                    _POSTAL_UNRESOLVED["warned"] += 1
+                    sys.stderr.write("postal hydrate: %d of %d message id(s) unresolved on %s (%s) - said "
+                                     "once per id; repeats are counted on /version postalUnresolved\n"
+                                     % (len(ids) - len(cards), len(ids), ev.get("uuid") or "?",
+                                        ",".join(_unres)))
+                else:
+                    _POSTAL_UNRESOLVED["suppressed"] += 1
         out.append(ev)
     return out
 

--- a/tests/test_postal_hydrate_scope.py
+++ b/tests/test_postal_hydrate_scope.py
@@ -71,6 +71,11 @@ INBOX_TOOL = "mcp__romp-postal-service__check_inbox"
 
 
 class HydrateScope(unittest.TestCase):
+    def setUp(self):
+        km._POSTAL_UNRESOLVED_RESET()                   # T234: the warning is once per (session, id) per
+        #                                                kernel life - each test is its own life, so a pin
+        #                                                that expects the loud line never inherits an
+        #                                                earlier test's sighting of the same pair
     """Only a mail reader's output (and user text) is scanned for message ids."""
 
     def _run(self, events, index, sid=ME):
@@ -143,6 +148,11 @@ class HydrateScope(unittest.TestCase):
 
 
 class HydrateRecipient(unittest.TestCase):
+    def setUp(self):
+        km._POSTAL_UNRESOLVED_RESET()                   # T234: the warning is once per (session, id) per
+        #                                                kernel life - each test is its own life, so a pin
+        #                                                that expects the loud line never inherits an
+        #                                                earlier test's sighting of the same pair
     """Only mail addressed to THIS session is rendered in its chat."""
 
     def _run(self, events, index, sid=ME):

--- a/tests/test_postal_hydrate_unresolved.py
+++ b/tests/test_postal_hydrate_unresolved.py
@@ -44,6 +44,9 @@ def turn(*mids):
 
 
 class HydrateUnresolved(unittest.TestCase):
+    def setUp(self):
+        km._POSTAL_UNRESOLVED_RESET()                   # T234: each test is a fresh kernel life
+
     def _run(self, events, index):
         err = io.StringIO()
         real, km.sys.stderr = km.sys.stderr, err
@@ -80,6 +83,23 @@ class HydrateUnresolved(unittest.TestCase):
         out, warned = self._run([plain], {})
         self.assertEqual(out, [plain], "no mid keys invented on ordinary turns")
         self.assertEqual(warned, "")
+
+    # ── T234 (the user 2026-09-03): the warning is a fact stated ONCE per (session, id) per kernel life ──
+    # The same unresolved ids re-warned on EVERY build — 20k to 116k journal lines per hour for 30+ hours,
+    # the same pairs every pusher cycle — burying real signal. Fail-loud stays: the FIRST sighting of a
+    # pair logs; repeats are counted, not printed; a NEW pair logs again.
+    def test_the_same_unresolved_id_warns_once_across_builds_and_a_new_id_warns_again(self):
+        _, w1 = self._run([turn(UNKNOWN)], {})
+        _, w2 = self._run([turn(UNKNOWN)], {})           # the next build, same unresolved id
+        self.assertEqual(w1.count("unresolved"), 1, "the first sighting logs")
+        self.assertEqual(w2.count("unresolved"), 0,
+                         "the same (session, id) pair on the next build is a repeat, not news")
+        other = "22222222-3333-4444-5555-666666666666"
+        _, w3 = self._run([turn(other)], {})
+        self.assertEqual(w3.count("unresolved"), 1, "a NEW unresolved id is new information — it logs")
+        facts = km._POSTAL_UNRESOLVED
+        self.assertEqual(facts["warned"], 2, "two distinct pairs warned")
+        self.assertEqual(facts["suppressed"], 1, "one repeat suppressed — the counter is exact")
 
     def test_the_original_event_is_not_mutated_in_place(self):
         # build_session hands these dicts around; stamping the caller's object would leak the ids into


### PR DESCRIPTION
## Summary
The kernel journal carried `postal hydrate: N of M message id(s) unresolved` 20k–116k times per hour for 30+ hours — the same (session, id) pairs on every pusher cycle, ~40–900 lines per build. A long-standing once-per-build warning had become a per-cycle drumbeat that buried real signal and burned journal space. Not a regression of the fold; the writer had no memory.

It has one now: a bounded seen-set keyed on (sid — falling back to the event uuid — , message id). The **first** sighting of a pair still logs (fail-loud stands; the line says it is said once); a repeat is **counted**, never printed; a **new** pair logs again. The set is capped (a wraparound re-warns each pair once — rare, still bounded). `warned` and `suppressed` ride `/version` as `postalUnresolved` beside the other runtime counters.

## Test plan
- Red-first pin in `tests/test_postal_hydrate_unresolved.py`: two consecutive builds with the same unresolved id write one line — red on main (`1 != 0: the same (session, id) pair on the next build is a repeat, not news`); a new unresolved id writes another; `warned == 2`, `suppressed == 1` exactly. The harness resets the kernel-life state per test.
- Hydrate-touching modules (unresolved, longbody, delta-send, postal-ismeta): 25 pass. Full Python suite and webview node tests running (results in the ship report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)