### PR TITLE
T233: the close confirmation is an event — the "Couldn't close X" toast can no longer lie

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10533,7 +10533,9 @@ def _drive(msg, client):
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)
         be.kill(sid); _record_death(sid, int(time.time()), "kill")   # the one SDK event with no designed reviver
         _comment_kill_all(sid, be)   # its comment threads must not outlive it as unreachable running CLIs
-        _send_to_app("chat", {"type": "closed", "id": sid}); _push_soon()
+        _send_to_app("chat", {"type": "closed", "id": sid})
+        _confirm_close_now(sid)      # the kill IS the event: the fresh tab set rides it, not the next pusher cycle
+        _push_soon()
     elif t == "renameSession" and msg.get("name"):
         new = str(msg["name"]).strip()
         if not NAME_RE.match(new):
@@ -27857,7 +27859,7 @@ def _push(targets, connect=False, tmux=None):
     want_tl = any(c["app"] == "timeline" for c in targets)
     chat_clients = [c for c in targets if c["app"] == "chat"]
     try:
-        chat_list = _chat_tab_sessions(now, tmux)   # living + recently-died-while-shown, minus ×-hidden
+        chat_list = _chat_tab_sessions(now, tmux)   # live + explicitly kept-open (read-only reopened dead) — nothing else
         tab_order = [s["sid"] for s in chat_list]
         # order audit: a PERMUTED push (survivors swapped slots vs the previous push) is the reorder bug
         # leaving the kernel — log it with the stack. Set churn (a tab appearing/dying) is routine → skipped.
@@ -28187,6 +28189,37 @@ _pusher_wake = threading.Event()
 # an unchanged fleet sig — or the very push meant to show the change serves the stale pre-change payload
 # (the user 2026-07-05: a reply on a distilled card lagged its fly-to-Working by the 5s sig time-bucket).
 _views_dirty = [0.0]
+
+
+def _confirm_close_now(sid):
+    """The chat's CLOSE CONFIRMATION, sent off-cycle the moment a session is ended (T233, the user
+    2026-09-03: a false "Couldn't close X — romp still has it open" toast on a session this kernel had
+    killed within the same second). The client accepts exactly one confirmation — a tabOrder push that no
+    longer lists the id — and until now the only sender was the pusher's tabs-first send, whose cycle on a
+    loaded box runs 20-40s; past the client's 15s backstop, a still-listing order reads as a refused close.
+    The kill is the event, so the confirmation rides it: a fresh tab set computed off a FRESH liveness read
+    (the death is already recorded, so the ended session is gone from it), the same shape as the pusher's
+    tabs-first send, through the same per-client dedup slot — the next cycle's identical send is a no-op.
+    `_push_soon()` still follows for everything else the kill changed. Returns whether the fresh set is
+    indeed without the id (False = the end did not take; the client's own backstop then says so, honestly).
+    Off-cycle by design: `_tmux_sessions()` outside a pusher cycle is a live Sessions.live() read."""
+    try:
+        now = int(time.time())
+        chat_list = _chat_tab_sessions(now, _tmux_sessions())
+        tab_order = [s["sid"] for s in chat_list]
+        tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in chat_list]
+        frame = {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()}
+        with _clients_lock:
+            targets = [c for c in _clients if c["app"] == "chat"]
+        for c in targets:
+            try:
+                _send_client(c, ("taborder",), frame)
+            except Exception:
+                c["alive"] = False
+        return sid not in tab_order
+    except Exception:
+        sys.stderr.write("confirm-close %s: %s\n" % (sid, traceback.format_exc()))
+        return False
 
 
 def _push_soon():

--- a/tests/test_close_confirm.py
+++ b/tests/test_close_confirm.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""T233 (the user 2026-09-03): the chat's close confirmation is an EVENT, not the next pusher cycle.
+
+The false "Couldn't close X — romp still has it open" toast: the endSession WS op killed the session and
+recorded the death within the same second, yet the client toasted, because the ONLY confirmation it accepts
+is a tabOrder push that no longer lists the id — and until now the only sender of that was the pusher's
+periodic tabs-first send, whose cycle on a loaded box runs 20-40s, past the client's 15s backstop. Now the
+endSession handler sends a FRESH tab set to every chat client in the same handler, off-cycle, right after
+the kill — same shape as the pusher's tabs-first frame, through the same per-client dedup slot.
+
+Deterministic: the SDK backend, the liveness read, the tab builder and the pusher wake are stubbed; the
+frames each client receives are recorded in send order. Synthetic ids only, hermetic state.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_t233", os.path.join(BIN, "romp-kernel")).load_module()
+
+ENDED = "7a7a7a7a-1111-4222-8333-000000000233"   # the session the user ends
+KEPT = "7a7a7a7a-1111-4222-8333-000000000234"    # a session that stays
+
+
+class FakeBackend:
+    def __init__(self):
+        self.calls = []
+        self._owned = {ENDED, KEPT}
+        self.alive = {ENDED, KEPT}
+
+    def owns(self, sid):
+        return sid in self._owned
+
+    def kill(self, sid):
+        self.calls.append(("kill", sid)); self.alive.discard(sid); return True
+
+    def live_sessions(self):
+        return {s: {"state": "idle", "since": "100", "model": "m", "effort": "", "mode": "acceptEdits"} for s in self.alive}
+
+
+def _chat_client(app="chat"):
+    frames = []
+    c = {"app": app, "alive": True, "send": lambda s: frames.append(json.loads(s))}
+    return c, frames
+
+
+class CloseConfirmRidesTheKill(unittest.TestCase):
+    def setUp(self):
+        self.be = FakeBackend()
+        self.saved = (km._sdk, km._send_to_app, km._push_soon, km._chat_tab_sessions, km._tmux_sessions,
+                      km._comment_kill_all, km._record_death, list(km._clients))
+        km._sdk = lambda: self.be
+        self.events = []                                   # every side effect, in order
+        km._send_to_app = lambda app, msg: self.events.append(("app", app, msg))
+        km._push_soon = lambda: self.events.append(("push_soon",))
+        km._comment_kill_all = lambda sid, be: None
+        km._record_death = lambda sid, ts, why: self.events.append(("death", sid, why))
+        # the tab builder reads the backend's CURRENT liveness — so after the kill it lists only the survivor
+        km._tmux_sessions = lambda: {s: {} for s in self.be.alive}
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": s, "name": "web" if s == KEPT else "api", "path": "/nonexistent"}
+                                                   for s in (KEPT, ENDED) if s in tmux]
+        del km._clients[:]
+
+    def tearDown(self):
+        (km._sdk, km._send_to_app, km._push_soon, km._chat_tab_sessions, km._tmux_sessions,
+         km._comment_kill_all, km._record_death, clients) = self.saved
+        del km._clients[:]
+        km._clients.extend(clients)
+
+    def test_endSession_confirms_with_a_fresh_tab_set_in_the_same_handler(self):
+        chat, frames = _chat_client("chat")
+        feed, feed_frames = _chat_client("feed")
+        km._clients.extend([chat, feed])
+        # the frames land through the same recording send, so interleave them into the event log
+        chat["send"] = lambda s: (frames.append(json.loads(s)), self.events.append(("frame", json.loads(s)["type"])))
+        self.assertTrue(km._drive({"type": "endSession", "id": ENDED}, {"send": lambda s: None}))
+        self.assertIn(("kill", ENDED), self.be.calls)
+        kinds = [e[0] if e[0] != "frame" else "frame:" + e[1] for e in self.events]
+        self.assertEqual(kinds, ["death", "app", "frame:tabOrder", "push_soon"],
+                         "kill recorded → closed fan-out → the FRESH tabOrder → then the pusher wake; no cycle in between")
+        tab = frames[-1]
+        self.assertEqual(tab["type"], "tabOrder")
+        self.assertNotIn(ENDED, tab["order"], "the ended session is gone from the confirmation")
+        self.assertEqual(tab["order"], [KEPT])
+        self.assertEqual([t["id"] for t in tab["tabs"]], [KEPT], "tabs meta rides along, same shape as the pusher's")
+        self.assertIn("views", tab)
+        self.assertEqual(feed_frames, [], "only chat clients render the tab strip")
+
+    def test_the_confirmation_uses_the_pusher_dedup_slot_so_the_next_cycle_is_a_noop(self):
+        chat, frames = _chat_client()
+        km._clients.append(chat)
+        self.be.alive.discard(ENDED)
+        self.assertTrue(km._confirm_close_now(ENDED))
+        self.assertEqual(len(frames), 1)
+        self.assertIn(("taborder",), chat["sent"], "recorded under the pusher's own slot")
+        self.assertTrue(km._confirm_close_now(ENDED), "idempotent")
+        self.assertEqual(len(frames), 1, "an identical frame is deduped, exactly as the pusher's would be")
+
+    def test_an_end_that_did_not_take_still_sends_the_honest_order_and_says_so(self):
+        # the backend still lists the session → the fresh order still carries it. That frame is sent anyway
+        # (it is the kernel's true word), and the client's own 15s backstop is what turns it into the toast.
+        chat, frames = _chat_client()
+        km._clients.append(chat)
+        self.assertFalse(km._confirm_close_now(ENDED))
+        self.assertIn(ENDED, frames[-1]["order"])
+
+    def test_a_failing_builder_never_breaks_the_handler(self):
+        chat, frames = _chat_client()
+        km._clients.append(chat)
+        km._chat_tab_sessions = lambda now, tmux: (_ for _ in ()).throw(RuntimeError("boom"))
+        self.assertFalse(km._confirm_close_now(ENDED))
+        self.assertEqual(frames, [])
+
+    def test_the_call_site_comment_no_longer_claims_recently_died_tabs(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read() if not os.path.islink(os.path.join(BIN, "romp-kernel")) \
+            else open(os.path.realpath(os.path.join(BIN, "romp-kernel"))).read()
+        self.assertNotIn("living + recently-died-while-shown, minus ×-hidden", src)
+        self.assertIn("live + explicitly kept-open (read-only reopened dead) — nothing else", src)
+        self.assertIn("_confirm_close_now(sid)      # the kill IS the event", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/federation-closed-store.test.ts
+++ b/ui/webview/federation-closed-store.test.ts
@@ -1,0 +1,88 @@
+// T233 (the user 2026-09-03): a kernel's `closed` frame folds the session out of the federation manager's
+// STORED per-host slices, so no synthetic re-emit can resurrect it.
+//
+// The false "Couldn't close X — romp still has it open" toast: the kernel killed the session within the
+// same second and sent `closed`, but the manager's perHostOrder/perHostTabs for that host were updated
+// ONLY by the host's next inbound tabOrder push (one pusher cycle, 20-40s on a loaded box). In between,
+// every re-emit from the store — a view-order storage event, VIEW_ORDER_EVENT, a host attach or drop —
+// re-served the dead id; past the chat's 15s backstop that read as a refused close. Executed against
+// the real manager. Synthetic only (host TESTHOST, placeholder ids).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FederationManager } from "./federation";
+
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+
+function withManager(fn: (fm: any, emitted: any[]) => void): void {
+  const emitted: any[] = [];
+  const store = new Map<string, string>();
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  try { fn(new FederationManager(), emitted); } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+}
+const orders = (emitted: any[]) => emitted.filter((m) => m && m.type === "tabOrder");
+const last = (emitted: any[]) => orders(emitted).pop()!;
+
+test("closed(H, S) folds S out of H's stored slices; a storage-triggered re-emit no longer carries it", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: ["a"], tabs: [{ id: "a", name: "web" }] });
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [U, V], tabs: [{ id: U, name: "api" }, { id: V, name: "tests" }] });
+    assert.deepEqual(last(emitted).order, ["a", "TESTHOST:" + U, "TESTHOST:" + V]);
+    // the kill: TESTHOST's kernel sends `closed` for U (arrives bare, prefixed on the way in)
+    fm.inbound("TESTHOST", { type: "closed", id: U });
+    // BEFORE the fix the store still listed U here, and this re-emit resurrected it
+    fm.emitMergedOrder();                                           // what a view-order storage event / attach / drop does
+    assert.deepEqual(last(emitted).order, ["a", "TESTHOST:" + V], "the dead id is gone from every later re-emit");
+    assert.deepEqual(last(emitted).tabs.map((t: any) => t.id), ["a", "TESTHOST:" + V], "…and from the tabs meta");
+    assert.deepEqual(fm.perHostOrder["TESTHOST"], ["TESTHOST:" + V]);
+    assert.equal(fm.perHostSids["TESTHOST"]?.has("TESTHOST:" + U) ?? false, false);
+  });
+});
+
+test("the closed fold hands the pane its teardown frame first, then a merged order without the id — flagged synthetic", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: ["a"], tabs: [{ id: "a", name: "web" }] });
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "api" }] });
+    const n = emitted.length;
+    fm.inbound("TESTHOST", { type: "closed", id: U });
+    const after = emitted.slice(n);
+    assert.equal(after[0].type, "closed", "the pane's own teardown (dismissSession) runs first");
+    assert.equal(after[0].id, "TESTHOST:" + U);
+    assert.equal(after[1].type, "tabOrder");
+    assert.deepEqual(after[1].order, ["a"], "the merged order confirms the close by ABSENCE at once");
+    assert.equal(after[1].reemit, true, "…but it is a re-emit from the store, so it can never call a close refused");
+    assert.equal("freshHost" in after[1], false);
+  });
+});
+
+test("provenance: a host's own tabOrder push emits FRESH and names the host; every other emission says reemit", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: ["a"], tabs: [{ id: "a", name: "web" }] });
+    let o = last(emitted);
+    assert.equal(o.freshHost, "", "the LOCAL kernel's push: fresh, host ''");
+    assert.equal("reemit" in o, false);
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "api" }] });
+    o = last(emitted);
+    assert.equal(o.freshHost, "TESTHOST", "a remote host's push names ITSELF — only its ids are its current word");
+    fm.emitMergedOrder();                                           // storage / attach / drop path
+    o = last(emitted);
+    assert.equal(o.reemit, true);
+    assert.equal("freshHost" in o, false);
+  });
+});
+
+test("a `closed` for an id the store never held is harmless — passes through, re-emits unchanged", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: ["a"], tabs: [{ id: "a", name: "web" }] });
+    fm.inbound("", { type: "closed", id: "never-listed" });
+    assert.deepEqual(last(emitted).order, ["a"]);
+    assert.ok(emitted.some((m) => m.type === "closed" && m.id === "never-listed"), "the pane still hears it");
+  });
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -697,6 +697,24 @@ export class FederationManager {
     if (m && m.type === "session" && typeof m.id === "string") {
       (this.perHostSids[host] ||= new Set()).add(m.id);
     }
+    // A kernel's `closed` frame is ITS OWN report that the session is gone — the one other writer allowed
+    // to touch the per-host store (T233, the user 2026-09-03). The 2026-08-02 rule below forbids
+    // ARRANGEMENT writes on a re-emit (a stale pane pruning another pane's drag); a `closed` frame is new
+    // information about EXISTENCE from the owning host, exactly the evidence class absorbHostReport acts
+    // on. Without this, every synthetic re-emit between the kill and that host's next tabOrder push (a
+    // view-order storage event, a host attach or drop) re-served the stored slice WITH the dead id, and
+    // past the chat's 15s close backstop that read as a refused close — the false "Couldn't close X"
+    // toast. Fold it out of the slices, hand the pane its teardown frame, then re-emit a merged order
+    // without it: that re-emit CONFIRMS the close (absence) but, flagged synthetic, can never toast.
+    if (m && m.type === "closed" && typeof m.id === "string") {
+      const gone = m.id;
+      if (this.perHostOrder[host]) this.perHostOrder[host] = this.perHostOrder[host].filter((x) => x !== gone);
+      if (this.perHostTabs[host]) this.perHostTabs[host] = this.perHostTabs[host].filter((t: any) => !(t && t.id === gone));
+      this.perHostSids[host]?.delete(gone);
+      window.dispatchEvent(new MessageEvent("message", { data: m }));
+      this.emitMergedOrder();
+      return;
+    }
     if (m && m.type === "tabOrder") {
       const prevOrder = this.perHostOrder[host] || [];
       const prevTabs = this.perHostTabs[host] || [];
@@ -709,7 +727,7 @@ export class FederationManager {
       if (host === LOCAL && m.views && typeof m.views === "object") this.localViews = m.views;
       this.ensureHost(host);
       this.absorbHostReport(host, prevOrder, prevTabs);   // a host just reported its sessions → the one
-      this.emitMergedOrder();                             //   moment the stored arrangement may be touched
+      this.emitMergedOrder(true, host);                   //   moment the stored arrangement may be touched
       return;
     }
     if (m && m.type === "feed") {
@@ -822,11 +840,19 @@ export class FederationManager {
   // holding a stale session list pruned the very tab another pane had just moved). Only an inbound
   // tabOrder push mutates the store, in absorbHostReport below, because only a host's own report is
   // evidence about what exists.
-  private emitMergedOrder(): void {
+  private emitMergedOrder(fresh = false, freshHost: string = LOCAL): void {
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
     this.publishPending();
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs, views: this.localViews ?? undefined } }));
+    const data: any = { type: "tabOrder", order, tabs, views: this.localViews ?? undefined };
+    // Provenance for the chat's close backstop (T233): a FRESH emission is driven by one host's own
+    // tabOrder push and names that host (`freshHost`) — only ITS ids are that kernel's current word; the
+    // other hosts' slices ride along from the store. A SYNTHETIC re-emit (a view-order storage event, a
+    // host attach or drop, a `closed` fold) is re-served entirely from the store and says `reemit` — it
+    // confirms a close by absence like any order, but is never evidence that a kernel still has a tab.
+    if (fresh) data.freshHost = freshHost;
+    else data.reemit = true;
+    window.dispatchEvent(new MessageEvent("message", { data }));
   }
 
   // Fold a host's OWN report — the one moment with fresh evidence about what exists — into the stored

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4098,13 +4098,25 @@ function commitTabOrder() {
 // Settle the just-closed tabs against the kernel's authoritative list. Gone from it → the close landed, stop
 // suppressing. STILL in it past the backstop → it didn't land; say so plainly (a session left open while its
 // tab is hidden is exactly the silent-wrong-state we'd rather surface) and let the tab come back.
-function ackClosingTabs(kernelOrder: readonly string[]): void {
+// `report` is the frame's provenance under federation (federation.ts emitMergedOrder): `reemit` marks a
+// synthetic re-emission served from the manager's STORED per-host slices (a view-order storage event, a
+// host attach or drop), `freshHost` names the one host whose own push drove a fresh emission. A frame the
+// kernel sent directly (VS Code, a single-kernel page) carries neither.
+type OrderReport = { reemit?: boolean; freshHost?: string } | undefined;
+function ackClosingTabs(kernelOrder: readonly string[], report?: OrderReport): void {
   if (!closingTabs.size) return;
   const live = new Set(kernelOrder);
   const now = Date.now();
   for (const [id, ts] of Array.from(closingTabs)) {
     if (!live.has(id)) { closingTabs.delete(id); continue; }       // the kernel dropped it → confirmed
     if (now - ts < CLOSE_ACK_MS) continue;                         // still in flight; the shutdown runs behind us
+    // Past the backstop, only a FRESH report from the OWNING kernel may call the close refused (T233, the
+    // user 2026-09-03: a session the kernel had killed within the same second toasted "Couldn't close"
+    // because a federation re-emit re-served a stored slice still carrying the id 15s later). A re-emit
+    // is never new evidence, and another host's push says nothing about this id's kernel — both keep the
+    // suppression and wait for the owner's own word; the backstop stays the honest path for a close that
+    // genuinely did not take.
+    if (report && (report.reemit || (typeof report.freshHost === "string" && hostOf(id) !== report.freshHost))) continue;
     closingTabs.delete(id);
     warnToast(`Couldn't close “${tabMeta.get(id)?.name || id}” — romp still has it open.`);
   }
@@ -4121,7 +4133,7 @@ function ackClosingTabs(kernelOrder: readonly string[]): void {
 // looking alive). Add-only, never pruned: dropping an entry would hand a late stale `session` frame the
 // never-listed keep and re-mint the ghost. Client-minted ids (the create placeholder) never enter it.
 const kernelListed = new Set<string>();
-function applyTabOrder(o: any, tabs?: any) {
+function applyTabOrder(o: any, tabs?: any, report?: OrderReport) {
   // name+color per tab → renderTabs paints placeholders for tabs whose session hasn't arrived yet (tabs-first).
   // The payload is the kernel's AUTHORITATIVE current tab set, so REBUILD (not merge) — a closed tab drops out
   // and never lingers as a stale placeholder. Absent tabs (older kernel) → keep what we have.
@@ -4143,7 +4155,7 @@ function applyTabOrder(o: any, tabs?: any) {
   }
   // Adopt the kernel order verbatim, keeping any just-arrived tab the push doesn't carry yet (see tab-order.ts).
   const kernelOrder = Array.isArray(o) ? o.filter((x: any) => typeof x === "string") : [];
-  ackClosingTabs(kernelOrder);
+  ackClosingTabs(kernelOrder, report);
   // A kernel-owned tab the push no longer carries gets the SAME teardown the `closed` event runs — the
   // session map, its view, drafts and the active-tab reselect all go, not just the strip entry. Under
   // federation the merged order only omits an id when its OWNING host affirmatively reported it gone
@@ -12483,7 +12495,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "ledger") setLedger(m.id, m.ledger ?? null);
   else if (m.type === "working") { workingSet = new Set(Array.isArray(m.names) ? m.names : []); refreshPostalDots(); }
   else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null, typeof m.sid === "string" ? m.sid : null);
-  else if (m.type === "tabOrder") { captureViews(m.views || null); applyTabOrder(m.order, m.tabs); }
+  else if (m.type === "tabOrder") {
+    captureViews(m.views || null);
+    applyTabOrder(m.order, m.tabs, { reemit: m.reemit === true, freshHost: typeof m.freshHost === "string" ? m.freshHost : undefined });
+  }
   else if (m.type === "renamed" && m.id && typeof m.name === "string") {
     notePendingMeta(pendingTabMeta, m.id, { name: m.name });   // kernel truth — hold it against a push built pre-rename
     const s = sessions.get(m.id);

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -59,7 +59,8 @@ test("executed: the canonical key ignores list order AND which key the kernel us
 });
 
 test("the tabOrder frame carries the blob and the strip filters on it, composing with #only", () => {
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ captureViews\(m\.views \|\| null\); applyTabOrder\(m\.order, m\.tabs\); \}/,
+  // the frame's provenance rides along since T233 (captureViews still runs FIRST)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/,
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -13,6 +13,8 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import { hostOf } from "./host-prefix";
+
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 const CLOSE_ACK_MS = 15_000;
@@ -32,11 +34,15 @@ function model(now = 0) {
     session(id: string) { known.add(id); if (!kernelList.includes(id)) kernelList.push(id); },
     // the ✕: post closeTab, record it, drop the session locally (dismissSession)
     close(id: string) { closing.set(id, clock); known.delete(id); },
-    // a kernel tabOrder push — `list` is what the kernel currently believes is open
-    push(list: string[]) {
+    // a kernel tabOrder push — `list` is what the kernel currently believes is open. `report` is the
+    // frame's provenance under federation (T233): a synthetic re-emit (`reemit`) or the one host whose
+    // own push drove a fresh emission (`freshHost`); a frame straight from the kernel carries neither.
+    push(list: string[], report?: { reemit?: boolean; freshHost?: string }) {
       for (const [id, ts] of Array.from(closing)) {
         if (!list.includes(id)) { closing.delete(id); continue; }        // kernel agreed → confirmed
         if (clock - ts < CLOSE_ACK_MS) continue;                          // still in flight
+        // only a FRESH report from the OWNING kernel may call the close refused
+        if (report && (report.reemit || (typeof report.freshHost === "string" && hostOf(id) !== report.freshHost))) continue;
         closing.delete(id);
         warned.push(id);                                                  // the close plainly didn't take
       }
@@ -108,6 +114,53 @@ test("a session dying on its OWN is not recorded as a close of ours", () => {
   assert.deepEqual(m.warned, []);
 });
 
+// ---- T233 (the user 2026-09-03): the false "Couldn't close X" toast ------------------------------------
+// The kernel had killed the session within the same second; the toast fired anyway, because the ONLY
+// confirmation the client accepts is a tabOrder without the id, and a STALE order still listing it
+// reached the client past 15s: federation.ts re-emits a synthetic tabOrder from its STORED per-host
+// slices on any view-order storage event / host attach or drop, and nothing updated that store between
+// the kill and the host's next cycle push (20-40s on a loaded box). Now the kernel confirms off-cycle on
+// the kill itself, the `closed` frame folds the id out of the store, and a re-emit can confirm a close
+// (absence) but never call one refused.
+test("a synthetic re-emit still listing the id past the backstop does NOT toast and does NOT restore the tab", () => {
+  const m = model();
+  m.session("web"); m.session("api");
+  m.close("api");
+  m.tick(CLOSE_ACK_MS + 1000);
+  m.push(["web", "api"], { reemit: true });          // a stored slice re-served — not the kernel's word
+  assert.deepEqual(m.warned, [], "a re-emit is never evidence that the kernel still has the tab");
+  assert.deepEqual(m.tabs(), ["web"], "the suppression holds until the owner's own report");
+  // …and the honest failure path stays: the owning kernel's FRESH order still listing it past the backstop
+  m.push(["web", "api"], { freshHost: "" });
+  assert.deepEqual(m.warned, ["api"], "the kernel's own fresh word past the backstop = the close did not take");
+  assert.deepEqual(m.tabs(), ["web", "api"]);
+});
+
+test("another host's fresh push says nothing about this id's kernel; a re-emit still CONFIRMS by absence", () => {
+  const m = model();
+  m.session("web"); m.session("TESTHOST:api");
+  m.close("TESTHOST:api");
+  m.tick(CLOSE_ACK_MS + 1000);
+  m.push(["web", "TESTHOST:api"], { freshHost: "" });   // the LOCAL kernel's push, TESTHOST's slice riding along from the store
+  assert.deepEqual(m.warned, [], "not the owning host's report");
+  assert.deepEqual(m.tabs(), ["web"]);
+  m.push(["web"], { reemit: true });                    // the `closed` fold's re-emit: the id is gone from the store
+  assert.deepEqual(m.tabs(), ["web"]);
+  m.tick(CLOSE_ACK_MS * 10);
+  m.push(["web", "TESTHOST:api"], { freshHost: "TESTHOST" });   // a genuine revive on TESTHOST later shows again
+  assert.deepEqual(m.warned, [], "the suppression was retired by the absence, not by time — no false alarm");
+  assert.deepEqual(m.tabs(), ["web", "TESTHOST:api"]);
+});
+
+test("the wiring: applyTabOrder hands the frame's provenance to the backstop, which toasts only on the owner's fresh word", () => {
+  assert.match(RENDER, /type OrderReport = \{ reemit\?: boolean; freshHost\?: string \} \| undefined;/);
+  assert.match(RENDER, /function ackClosingTabs\(kernelOrder: readonly string\[\], report\?: OrderReport\): void/);
+  assert.match(RENDER, /if \(report && \(report\.reemit \|\| \(typeof report\.freshHost === "string" && hostOf\(id\) !== report\.freshHost\)\)\) continue;/);
+  assert.match(RENDER, /applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);/);
+  // confirm-on-absence is untouched: it acts BEFORE the provenance gate, on any order
+  assert.match(RENDER, /if \(!live\.has\(id\)\) \{ closingTabs\.delete\(id\); continue; \}[\s\S]{0,120}?if \(now - ts < CLOSE_ACK_MS\) continue;[\s\S]{0,900}?if \(report && /);
+});
+
 // ---- the wiring in render.ts -------------------------------------------------------------------------
 
 test("closeTabLocally drops the tab, THEN records the close — in that order", () => {
@@ -142,8 +195,8 @@ test("every close path is optimistic — the in-page ✕, a dead read-only tab, 
 });
 
 test("ackClosingTabs settles against the kernel's list on every tabOrder push", () => {
-  assert.match(RENDER, /ackClosingTabs\(kernelOrder\);/);
-  assert.match(RENDER, /function ackClosingTabs\(kernelOrder: readonly string\[\]\): void/);
+  assert.match(RENDER, /ackClosingTabs\(kernelOrder, report\);/);
+  assert.match(RENDER, /function ackClosingTabs\(kernelOrder: readonly string\[\], report\?: OrderReport\): void/);
   assert.match(RENDER, /if \(!live\.has\(id\)\) \{ closingTabs\.delete\(id\); continue; \}/, "gone from the kernel = confirmed");
   assert.match(RENDER, /if \(now - ts < CLOSE_ACK_MS\) continue;/, "inside the window a slow kernel is not a failure");
   assert.match(RENDER, /warnToast\(`Couldn't close/);

--- a/ui/webview/tab-ghost-heal.test.ts
+++ b/ui/webview/tab-ghost-heal.test.ts
@@ -114,7 +114,7 @@ test("a create placeholder the kernel has never listed still survives unrelated 
 test("applyTabOrder dismisses kernel-owned omissions BEFORE reconciling, then records add-only", () => {
   // the drop loop sits between ackClosingTabs and the reconcile, and dismissSession is the shared teardown
   assert.match(RENDER,
-    /ackClosingTabs\(kernelOrder\);[\s\S]{0,700}?for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(kernelListed\.has\(id\) && !inKernel\.has\(id\)\) dismissSession\(id\);\s*\n\s*\}/,
+    /ackClosingTabs\(kernelOrder, report\);[\s\S]{0,700}?for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(kernelListed\.has\(id\) && !inKernel\.has\(id\)\) dismissSession\(id\);\s*\n\s*\}/,
     "kernel-owned tabs the push stopped carrying get the closed-event teardown");
   // the reconcile passes the kernelListed predicate, so the pure model enforces the same rule
   assert.match(RENDER,

--- a/ui/webview/tab-meta.test.ts
+++ b/ui/webview/tab-meta.test.ts
@@ -115,6 +115,7 @@ test("both optimistic paths note their expectation: the color swatch and the ren
 test("the tabOrder frame's views land before the strip repaints — a CLI tag edit re-filters the tabs on the same push", () => {
   // captureViews (adopt the pushed views/tags blob) must run BEFORE applyTabOrder (whose renderTabs
   // re-filters via tabInView) in the tabOrder handler — the (c) leg of the live-update fix
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ captureViews\(m\.views \|\| null\); applyTabOrder\(m\.order, m\.tabs\); \}/);
+  // the frame's provenance rides along since T233 (captureViews still runs FIRST)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/);
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
 });

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -54,7 +54,9 @@ test("a pane answers another pane's drag by re-emitting, never by rewriting the 
   // about what exists; only a host's own report is, and that is the one caller allowed to touch the store.
   assert.match(FED, /this\.absorbHostReport\(host, prevOrder, prevTabs\);\s+\/\/ a host just reported/,
     "inbound tabOrder is the one store-mutating moment");
-  assert.match(FED, /private emitMergedOrder\(\): void \{\s*\n\s*const order = mergeHostOrder/,
+  // (the signature carries provenance since T233 — fresh/host-driven vs synthetic re-emit — but every
+  // caller still re-emits from the store, never rewrites it)
+  assert.match(FED, /private emitMergedOrder\(fresh = false, freshHost: string = LOCAL\): void \{\s*\n\s*const order = mergeHostOrder/,
     "every other caller — both drag paths included — re-emits without touching the stored order");
   assert.doesNotMatch(FED, /private gcView|this\.gcView/,
     "the old gc-on-emit hook is gone, folded into absorbHostReport");

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -15,9 +15,11 @@ test("a tabMeta map holds the kernel's name+color per tab", () => {
 });
 
 test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs don't linger)", () => {
-  assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any\)/);
+  // report = the frame's provenance for the close backstop (T233)
+  assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any, report\?: OrderReport\)/);
   assert.match(RENDER, /if \(Array\.isArray\(tabs\)\) \{\s*tabMeta\.clear\(\);/);
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ captureViews\(m\.views \|\| null\); applyTabOrder\(m\.order, m\.tabs\); \}/);
+  // the frame's provenance rides along since T233 (captureViews still runs FIRST)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/);
 });
 
 test("renderTabs renders the union of arrived sessions and tabMeta, placeholders for the rest", () => {


### PR DESCRIPTION
## T233: the close confirmation is an event, so the "Couldn't close X" toast can no longer lie

**User report (2026-09-03, 2:03 PM PT):** ending an SDK session from the chat tab raised "Couldn't close X — romp still has it open". The kernel log shows the endSession op killed the session and recorded the death within the same second. The close landed; the toast was a false interrupt.

### Mechanism
After End the client hides the tab and accepts exactly one confirmation: a tabOrder push that no longer lists the id. If an order still carrying the id arrives past the 15s backstop, it toasts and restores the tab. The only confirmation sender was the pusher's periodic tabs-first send, whose cycle on a loaded box runs 20-40s, and two paths could deliver a STALE order past 15s: a cycle whose liveness snapshot predates the kill but whose send lands late, and federation.ts re-emitting a synthetic tabOrder from its STORED per-host slices (view-order storage events, host attach or drop) — a store the kernel's `closed` frame never touched until that host's next cycle push.

### Change (event-based, no new timers)
1. **Kernel:** the endSession handler sends every chat client a FRESH tabOrder computed off-cycle right after the kill (`_confirm_close_now`: same shape as the pusher's tabs-first frame, through the same per-client dedup slot so the next cycle's identical send is a no-op). `_push_soon()` still follows. The stale comment at the pusher's `_chat_tab_sessions` call site now says what the function returns (live + explicitly kept-open).
2. **Federation:** an inbound `closed` frame from host H for id S is H's own report that S is gone — S is folded out of `perHostOrder[H]`, `perHostTabs[H]` and `perHostSids[H]` at that moment, the pane gets its teardown frame, and a merged order without S is re-emitted. Documented as the one other writer allowed to touch the store: the 2026-08-02 rule forbids arrangement writes on re-emit; a `closed` frame is new information about existence.
3. **Client:** every merged tabOrder now carries provenance — `freshHost` on an emission driven by one host's own push, `reemit: true` on a synthetic re-emission — and the backstop's toast branch acts only on a fresh report from the OWNING host. Confirm-on-absence still acts on any order; the 15s backstop stays as the honest path for a close that genuinely did not take.

### Tests (red-first pins, synthetic)
- `tests/test_close_confirm.py`: the endSession op emits the fresh tabOrder without the id to chat clients in the same handler, ordered kill → closed → tabOrder → pusher wake; dedup slot shared with the pusher; an end that did not take sends the honest order and reports False; a failing builder never breaks the handler; the call-site comment pin.
- `ui/webview/federation-closed-store.test.ts`: closed(H, S) then a storage-triggered re-emit → merged order lacks S; the fold hands the pane its teardown first then a `reemit` order; provenance flags per emission path.
- `ui/webview/tab-close-optimistic.test.ts`: a re-emitted stale order 16s after the close does NOT toast and does NOT restore the tab; another host's fresh push says nothing about this id's kernel; a fresh owning-host order still listing it past the backstop DOES toast; wiring pins.
- Pins moved with the wiring, each with the reason: `session-views`, `tab-meta`, `tabs-first` (the tabOrder handler now passes provenance; captureViews still runs first), `tab-ghost-heal`, `view-order-wiring` (emitMergedOrder's signature).

Boundary: kernel endSession handler + federation.ts store + render.ts ackClosingTabs. No pusher-cycle changes (issue 903's lane).

Residual, pre-existing and outside this lane: a tmux-backed session's stale cycle frame (snapshot before the kill, send after the fresh confirmation) can re-list the tab as a placeholder for one cycle without a toast; SDK sessions are read live from the registry, so the fresh order excludes them regardless of the snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
