### PR TITLE
Repeated kills on one turn give it up loudly, and the session's later turns get swept again

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -321,7 +321,11 @@ event).
 - **An empty reply never counts.** `parse` means the model's own text was
   rejected, and the row carries the reply tail so the log says why. Empty
   replies (the rate gate, a failed call) log nothing at the caller and
-  never burn a retry cap.
+  never burn a retry cap — with two exceptions, both the closer's, both
+  adopting a turn loudly on their own event: a safeguards refusal of the
+  turn's content, and a *killed* call (one the timer ended; never an API
+  error or a process that ended any other way), each counted against the
+  turn it happened on. The kill streak is described below.
 - **Every judge is capped.** Three genuine parse rejects on the same work
   item (`JUDGE_FAIL_CAP`) and the judge gives up loudly, one `give-up` row
   naming the re-arm event, instead of retrying every pass forever:
@@ -331,7 +335,7 @@ event).
 | opener, live re-plan | hard-places at card level immediately | (no retries needed) |
 | planner (work run) | 3 tries, then hard-place a user message / drop a non-user segment | on its next segment |
 | placer | files at the card immediately | (no retries needed) |
-| closer | 3 tries, then skips the turn | when the turn gains atoms |
+| closer | 3 parse rejects, or 3 killed calls, then skips the turn | when the turn gains atoms |
 | archiver | 3 tries, then keeps serving the old headline | when the session gains a turn |
 | grouper, consolidator | 3 tries, then leaves the board shape as is | when the top set changes |
 | courier | 3 tries, then resolves from the sender's declared kind | (terminal; never orphans a message) |
@@ -356,8 +360,13 @@ toward nothing.
   subprocess error, an API error envelope, on either engine) ends that
   session's sweep for the pass with one `sweep-cut` row naming the turns left
   behind and the shape of the menu that died; parse rejects and pause-skips
-  still walk on. A dead session cut this way keeps its marker pending and
-  waits at the back of the death drain, so it cannot starve the others.
+  still walk on. Three *killed* calls on the same turn at the same size (the
+  timer ending the call; an API error, or a process that ended any way other
+  than the timer, cuts the walk too but leaves no strike) give that turn up
+  loudly (one `give-up` row; the turn growing re-arms it) and the walk moves
+  on, so a session whose one turn always dies still gets its later turns
+  swept. A dead session cut this way keeps its marker pending and waits at
+  the back of the death drain, so it cannot starve the others.
 
 ## Billing, and when the credential itself is broken
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13,7 +13,7 @@ CLI:
   romp-judge --once               # one caption pass over the live fleet (writes captions/)
   romp-judge --test <transcript>  # caption one transcript's recent units, print them (no write)
 """
-import contextlib, json, os, re, secrets, shutil, stat, sys, time, subprocess, threading
+import contextlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -301,7 +301,11 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          3 genuine parse rejects on the SAME work item → a loud "give-up" row,
 #                                          then quiet until the item's own event re-arms it (a turn gaining atoms,
 #                                          a top set changing). Call-level failures never count — only replies the
-#                                          model actually wrote. Closer / grouper / consolidator / courier; the
+#                                          model actually wrote — with ONE exception: the closer strikes a KILLED
+#                                          call (the timer ending it; never an API error or a process that ended
+#                                          another way) against the turn it died on, _call_fail_kill /
+#                                          _close_strike. Closer / grouper /
+#                                          consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
 PLACEMENTS_V = 11                        # placements-identity schema version (plan P2, the user 2026-07-06).
@@ -387,7 +391,9 @@ JUDGE_JSON_CAP = 20000                    # cap a planner/closer reply BEFORE pa
 DISTILL_FAIL_CAP = 3                      # consecutive distill/brief CALL fails on ONE goal before we give up
                                          # and settle its card to the "" sentinel — so a persistently-failing
                                          # LLM call self-heals instead of looping "(generating…)" every pass
-                                         # forever (the user 2026-06-24). Mirrors PLAN_PARSE_RETRIES.
+                                         # forever (the user 2026-06-24). Mirrors PLAN_PARSE_RETRIES. Also
+                                         # bounds the closer's two no-reply streaks (_close_strike): the
+                                         # safeguards tombstone and, since 2026-09-03, the kill streak.
 DISTILL_WORK_CHARS = 24000               # cap the work history fed to a distill/brief call (keep the most
                                          # recent tail): an unbounded subtree could time out the Sonnet call
                                          # (logged "call"); the recent work is what the brief needs anyway.
@@ -406,7 +412,11 @@ CLOSE_FAIRNESS = None                    # per-session turn-close cap — REMOVE
                                          # That stance stands — successful closes are never capped. Two bounds
                                          # added 2026-09-03 are NOT fairness caps: CLOSE_RIDER_CAP (below) is a
                                          # queue drain across LANDED calls, and _close_session ends a session's
-                                         # walk at its first FAILED call (parse rejects and pause-skips walk on).
+                                         # walk at its first FAILED call (parse rejects and pause-skips walk on)
+                                         # UNTIL that turn's KILLED calls — the timer ending the call; never an
+                                         # API error or a process that ended another way, which leave no
+                                         # strike — reach DISTILL_FAIL_CAP at one size: then the turn is
+                                         # adopted loudly (a give-up row) and the walk goes on.
 CLOSE_RIDER_CAP = 6                      # RIDERS per closer call — the steps-finished / starved / status /
                                          # lifted nominations that ride BEHIND the turn's own menu (which is
                                          # never capped). 2026-09-03: one session's closer calls were
@@ -1264,6 +1274,18 @@ def _with_user_notes(sys_prompt, judge):
             "a note conflicts with the rules above, the note wins:\n<user-notes>\n" + notes + "\n</user-notes>")
 
 
+_KILL_EXC = subprocess.TimeoutExpired    # the CALL_ALARM_S + 5 backstop firing: the ONE subprocess exception that is a
+#                                          KILL (the call ran to the timer; _call_fail_kill). Bound at import so a test
+#                                          that swaps `subprocess` for a stub cannot unbind it. Every other exception is
+#                                          the OS answering (a missing binary, a broken pipe): transient.
+_KILL_RC = -signal.SIGALRM               # the other kill shape: the perl `alarm` wrapper's SIGALRM landing on the exec'd
+#                                          child, read as the returncode at the two empty-output exits. A clean exit of
+#                                          ANY code (0: exec failed under the wrapper — a missing binary; 1: a startup
+#                                          crash, or a codex refusal) or any other signal is the process answering:
+#                                          transient (second review, 2026-09-03 — stamped on every empty exit, a broken
+#                                          install would have tombstoned every turn it touched after three passes).
+
+
 def _call_shape(model, sys_prompt, user, sent):
     """The grep-able shape of a FAILED call for its 'call' row: the model, the prompt size in chars
     (system + user — the SIZE only, never the text) and the wall-clock ms since it was sent. 2026-09-03:
@@ -1381,7 +1403,8 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                     # the same three traces the claude branch leaves (2026-09-03): the stash the closer's
                     # sweep-cut keys on, the model-health latch, and the call shape for the grep — without
                     # them an alarm-killed closer call on this engine walked on exactly as before the fix
-                    _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
+                    _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model,
+                                                 "kill": isinstance(e, _KILL_EXC)}   # the backstop timer only
                     _mark_call_failed(model, type(e).__name__)
                     _log_judge_error(judge or tier, fsid, "call",
                                      note="%s %s" % (type(e).__name__, _call_shape(model, sys_prompt, user, sent)))
@@ -1396,7 +1419,11 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                     # dead/refused call — the -o file is the only success signal; record the evidence, and
                     # leave the same three traces the claude branch leaves (2026-09-03, see the except above)
                     fail = "codex empty reply (exit %s)" % getattr(p, "returncode", "?")
-                    _judge_ctx.last_call_fail = {"note": fail, "model": model}
+                    _judge_ctx.last_call_fail = {"note": fail, "model": model,
+                                                 "kill": getattr(p, "returncode", None) == _KILL_RC}
+                    # ^ a KILL only if the alarm's signal ended it. This engine has no error-envelope exit: a
+                    #   usage-limit refusal, an auth or network failure all end HERE as a clean nonzero exit with
+                    #   no -o file — the process answering, transient (second review, 2026-09-03)
                     _mark_call_failed(model, fail)
                     _log_judge_error(judge or tier, fsid, "call",
                                      note="%s: %s %s"
@@ -1441,7 +1468,8 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # _judge_run owns ALL call-level logging (this, the error envelope below, the rate gate above)
             # so callers never double-log: to a caller every failed call is just "", and "call" rows always
             # carry the judge's own name + fsid (pre-07-09 rows said "index"/"triage" with no session).
-            _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
+            _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model,
+                                         "kill": isinstance(e, _KILL_EXC)}   # the backstop timer only (_call_fail_kill)
             _mark_call_failed(model, type(e).__name__)
             _log_judge_error(judge or tier, fsid, "call",
                              note="%s %s" % (type(e).__name__, _call_shape(model, sys_prompt, user, sent)))
@@ -1512,7 +1540,11 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # fallback hides the very breakage we need to know about).
             _judge_ctx.last_call_fail = {
                 "note": "the model CLI died with no output (exit %s)" % getattr(p, "returncode", "?"),
-                "model": model}
+                "model": model,
+                "kill": getattr(p, "returncode", None) == _KILL_RC}   # the alarm's signal, and nothing else: a
+            #                                                          clean exit (0: exec failed under the
+            #                                                          wrapper; 1: a startup crash) or another
+            #                                                          signal is the process answering (transient)
             _mark_call_failed(model, _judge_ctx.last_call_fail["note"])
             _log_judge_error(judge or tier, fsid, "call",
                              note="empty stdout (exit %s): %s %s"
@@ -9751,17 +9783,23 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     out = _parse_close(raw, len(menu))
     if out is None:
         if not raw:
-            return None                                # the CALL failed (logged by _judge_run) → retry next
-            #                                            pass; never counts toward the give-up cap
+            return None                                # the CALL failed (logged by _judge_run): _close_session
+            #                                            cuts the session's walk, and strikes THIS turn only
+            #                                            for a KILL (_call_fail_kill) — any other failure
+            #                                            retries next pass with no strike
         _log_judge_error("closer", store.get("rompUuid"), "parse", note="reply tail: %r" % raw[-160:],
                          goal=[nd["id"] for nd in menu])
         fails = store.setdefault("closeFails", {})
-        fails[turn["id"]] = fails.get(turn["id"], 0) + 1
+        prev = fails.get(turn["id"])
+        # a parse streak of its own (an int): a dict here is a NO-REPLY streak — a kill or a safeguards
+        # refusal, see _close_strike — that this served reply just ended, so the parse count starts at 1
+        # (before kinds were kept apart this line did `dict + 1` on a safeguards record: a TypeError)
+        fails[turn["id"]] = (prev + 1) if isinstance(prev, int) else 1
         if fails[turn["id"]] >= JUDGE_FAIL_CAP:
             fails.pop(turn["id"], None)
             _log_judge_error("closer", store.get("rompUuid"), "give-up",
                              goal=[nd["id"] for nd in menu], note="%d parse rejects on turn %s; skipping it until the turn gains atoms"
-                                  % (JUDGE_FAIL_CAP, str(turn["id"])[:12]))
+                                  % (JUDGE_FAIL_CAP, _turn_tag(turn["id"])))
             return []                                  # give up on THIS turn: no verdicts, and the caller
             #                                            marks it closed at its current size — a new atom
             #                                            changes the size signature and re-judges (event re-arm)
@@ -9846,6 +9884,55 @@ def _turn_open(turn, turns):
             and not any(a["type"] == "idle" for a in turn["atoms"]))
 
 
+def _call_fail_kill(last):
+    """True when `last`, _judge_run's per-thread failure stash, records a KILL: the call RAN TO THE TIMER,
+    and nothing else (review finds, 2026-09-03, twice). Two shapes, both stamped by _judge_run as
+    `kill: True` and read here as that flag alone — never a match on note text: the perl `alarm`
+    wrapper's SIGALRM landing on the exec'd child, seen as returncode == -signal.SIGALRM (_KILL_RC) at the
+    two empty-output exits (the claude dead-CLI exit, the codex empty-reply exit); and
+    subprocess.TimeoutExpired (_KILL_EXC, the CALL_ALARM_S + 5 backstop) in either engine's exception
+    handler. Why the timer and only the timer: served duration tracks OUTPUT size (_call_shape), so a
+    call the timer ends is prompt-shaped — plausibly deterministic at one (turn, fp), the way a safeguards
+    refusal is at one prompt — and that is what justifies adopting a turn without verdicts. Everything
+    else is the API or the process ANSWERING, with an error in place of a reply, and says nothing about
+    the prompt: an error envelope (a 529, an auth error, a 429); a clean exit of any code with empty
+    output (0: exec failed under the wrapper — a missing binary; 1: a startup crash, or on codex — which
+    has no envelope exit — a usage-limit refusal, an auth or network failure); any other signal; any other
+    exception. Those stamp no flag and read transient here: they still cut the session's walk, loudly, and
+    leave no strike — their recovery is the storm ending or the install being fixed, and struck against a
+    turn, either would adopt a live turn for good after three passes (an end-known turn of a live session
+    never grows). Only kills are struck (_close_strike, the cut arm of _close_session). The producer knows
+    the class; this reader only asks."""
+    return isinstance(last, dict) and bool(last.get("kill"))
+
+
+def _close_strike(rec, fp, kind):
+    """The closer's strike count for one turn after one more NO-REPLY strike of `kind` — "safeguards" (the
+    filter refused this turn's content) or "kill" (the call ran to the timer: _call_fail_kill) — on a
+    turn of `fp` atoms, given the turn's current `closeFails` record. closeFails holds ONE record per
+    turn, so the rule is: the latest kind wins, and nothing adds up. The count continues only when the
+    record is the same kind at the same size; a record of another kind, or from another size (the turn
+    grew — a different prompt, new evidence), or no dict at all (the parse path's int) starts over at 1,
+    and the caller's new record replaces the old. Kinds never add up because they are different
+    evidence: a refusal is deterministic per prompt and a kill is only plausibly so, so two kills and a
+    refusal would tombstone a turn the filter refused once, and the row would say three refusals. A
+    parse reject is the third kind and lives outside this helper (an int, _close_turn): the model
+    ANSWERED that prompt, which ends any no-reply streak, and one no-reply never counts toward the parse
+    cap. A transient call failure is no strike of any kind and leaves the record as it stands (why: the
+    cut arm). A record with no kind predates kinds and was written by the safeguards arm, the only
+    writer then: it reads as safeguards and continues that count at the same fp."""
+    if not isinstance(rec, dict) or rec.get("fp") != fp or rec.get("kind", "safeguards") != kind:
+        return 1
+    return int(rec.get("fails") or 0) + 1
+
+
+def _turn_tag(tid):
+    """A turn id for a log row. Ids are `sid:t:hash` (event_model), so the first 12 chars name only the
+    session — the same for every turn of it. The tail tells turns apart; the row's fsid already has the sid."""
+    s = str(tid)
+    return s.split(":", 1)[1] if ":" in s else s[:12]
+
+
 def _closed_turns(store):
     """Turn ids the closer has already processed. Reads `closedTurns`, falling back to the pre-rename
     `sweptTurns` key so existing stores don't re-run the whole backlog after the rename."""
@@ -9894,8 +9981,25 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
     clears it) — NOT `res is None`, which a parse reject under the cap also returns. The safeguards
     tombstone keeps its own arm. A loop `break`, never a return: the store still saves below and
     _death_finalize still runs — told NOT settled, so a dead session's marker is never finalized off a
-    walk that left turns unswept (they are reachable only through the death drain). Returns the node ids
-    newly completed."""
+    walk that left turns unswept (they are reachable only through the death drain).
+
+    REPEATED KILLS ON ONE TURN GIVE IT UP (2026-09-03, the follow-up the sweep-cut row named): a cut by
+    a KILL — the call ran to the timer: the alarm's signal as its exit code, or TimeoutExpired
+    (_call_fail_kill) — is also struck against the turn it died on, at its current size, in a streak of
+    its own kind (_close_strike). The walk is cut at a failed call UNTIL that turn's kills reach
+    DISTILL_FAIL_CAP; then the turn is adopted exactly as the safeguards give-up adopts one — swept +
+    closedSig at fp, no verdicts — with one loud give-up row, and the walk CONTINUES to the next turn in
+    the same pass. Without it a live session whose head turn's call died the same way every pass (a menu
+    the timer cannot fit even capped, a prompt the model never finishes) cost one doomed call per pass
+    forever, and its later end-known turns were never reached, since every walk ended at the head; a dead
+    session at least rotated to the back of the death drain. A cut by any OTHER failure — an error
+    envelope (a 529, an auth error), a process that ended any way other than the timer (a crash, a
+    refusal, a missing binary), another exception — is the API or the process answering: it cuts the
+    walk just as loudly but is no strike, and leaves a kill streak exactly as it stands (a storm interleaved
+    with kills is evidence about the API, not about the prompt; erasing the streak would lose what the
+    kills said, and counting it would tombstone a live turn off a thirty-second storm). The re-arm event
+    is the turn GROWING (the closedSig growth check), new evidence, never a clock; a call for the turn
+    LANDING retires the record. Returns the node ids newly completed."""
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
     session = parsed_session(fsid, [path], now)
     store = load_goals(fsid)
@@ -9923,15 +10027,15 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
             # at the cap, adopt the turn exactly as a success would (swept + closedSig at fp), loudly —
             # the turn GROWING then re-judges it through the same closedSig growth check that re-judges
             # any closed turn, so the re-arm event is new evidence, never a clock. Transient failures
-            # (529s, timeouts) keep the plain retry: their recovery is the storm ending, and each pass
-            # costs one call, not a give-up.
+            # (an error envelope: a 529, an auth error) keep the plain retry: their recovery is the storm
+            # ending, and each pass costs one call, not a give-up. A KILL streak — the call running to
+            # the timer, prompt-shaped — takes the cut arm below and its own give-up.
             if not getattr(_judge_ctx, "paused", False):
                 last = getattr(_judge_ctx, "last_call_fail", None)
                 fail_note = str(last.get("note") or "") if isinstance(last, dict) else ""
                 if isinstance(last, dict) and "safeguards flagged" in fail_note:
                     fails = dict(store.get("closeFails") or {})
-                    rec = fails.get(tid) if isinstance(fails.get(tid), dict) else None
-                    k = (rec.get("fails", 0) + 1) if rec and rec.get("fp") == fp else 1
+                    k = _close_strike(fails.get(tid), fp, "safeguards")   # its own streak: a cut never counts here
                     if k >= DISTILL_FAIL_CAP:
                         swept.add(tid); sig[tid] = fp; did += 1
                         fails.pop(tid, None)
@@ -9939,7 +10043,7 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
                                          note="%d safeguards refusals on this turn's content; swept "
                                               "without verdicts; the turn growing re-judges it" % k)
                     else:
-                        fails[tid] = {"fp": fp, "fails": k}
+                        fails[tid] = {"fp": fp, "fails": k, "kind": "safeguards"}
                     store["closeFails"] = fails
                 elif isinstance(last, dict):
                     # SWEEP CUT (2026-09-03): the CALL failed — a dead CLI (the alarm kill), a subprocess
@@ -9948,24 +10052,61 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
                     # just died (its riders re-nominate until a LANDED reply stamps them, so the same
                     # menu rides every turn); one session's 192 consecutive kills held every judge for
                     # every session silent for 6h22m. End THIS session's walk for the pass, loudly, with
-                    # the shape of what was sent. The turn keeps the retry-next-pass contract (no strike,
-                    # no tombstone). A `break`, never a return: the store must still save and
-                    # _death_finalize must still run below.
-                    remaining = sum(1 for t in turns[ti + 1:]
-                                    if not _turn_open(t, turns)
-                                    and not (t["id"] in swept
-                                             and sig.get(t["id"], len(t["atoms"])) == len(t["atoms"])))
+                    # the shape of what was sent. A `break`, never a return: the store must still save
+                    # and _death_finalize must still run below.
+                    # …AND, FOR A KILL, STRIKE THE TURN (2026-09-03, the follow-up that row named): a
+                    # call that ran TO THE TIMER — the alarm's signal as its exit code, or TimeoutExpired
+                    # (_call_fail_kill) — is struck against this turn at its current size, the way
+                    # the arm above strikes a refusal, in its own streak (kind "kill" — a parse reject
+                    # means the model answered, a kill means it never did; _close_strike keeps the kinds
+                    # apart). Below the cap the walk is cut as above and the turn keeps the
+                    # retry-next-pass contract. AT the cap the turn is adopted exactly as the safeguards
+                    # give-up adopts one — swept + closedSig at fp, no verdicts — loudly, and the walk goes
+                    # ON to the next turn in this same pass: a live session whose head turn's call died
+                    # the same way every pass was cut at that turn every pass, so its later end-known
+                    # turns were never reached. The re-arm is the turn GROWING (the closedSig growth
+                    # check): new evidence, never a clock. A landed call for the turn retires the record
+                    # (below), as it does the parse strikes. Any OTHER failure — an error envelope, a
+                    # process that ended any other way (a crash, a refusal, a missing binary), another
+                    # exception: the API or the process answering — is TRANSIENT (review finds,
+                    # 2026-09-03: before them a thirty-second 529 storm, then a broken install, would have
+                    # adopted a live turn for good): it cuts the walk just as loudly, is no strike, and
+                    # leaves a kill streak as it stands — evidence about the API says nothing about the
+                    # prompt, so it neither adds to what the kills said nor erases it.
+                    kill = _call_fail_kill(last)
+                    fails = dict(store.get("closeFails") or {})
+                    k = _close_strike(fails.get(tid), fp, "kill") if kill else 0
                     shape = getattr(_judge_ctx, "close_menu", None)
                     shape_s = ("; menu %d own + %d steps-finished + %d starved + %d status + %d lifted, "
                                "%d rider(s) cut" % (shape["touched"], shape["cands"], shape["starved"],
                                                     shape["status"], shape["lifted"], shape["cut"])
                                if isinstance(shape, dict) else "")
-                    _log_judge_error("closer", fsid, "sweep-cut",
-                                     note="%d end-known turn(s) left unswept behind turn %s: %s (model %s%s)"
-                                          % (remaining, str(tid)[:12], fail_note[:160],
-                                             last.get("model"), shape_s))
-                    cut = True
-                    break
+                    if kill and k >= DISTILL_FAIL_CAP:
+                        swept.add(tid); sig[tid] = fp; did += 1
+                        fails.pop(tid, None)
+                        store["closeFails"] = fails
+                        _log_judge_error("closer", fsid, "give-up",
+                                         note="%d killed calls on turn %s at this size: %s (model %s%s); swept "
+                                              "without verdicts; the turn growing re-judges it, and the "
+                                              "walk goes on to the session's later turns"
+                                              % (k, _turn_tag(tid), fail_note[:160], last.get("model"), shape_s))
+                    else:
+                        if kill:
+                            fails[tid] = {"fp": fp, "fails": k, "kind": "kill"}
+                            store["closeFails"] = fails
+                            klass = "kill %d of %d on this turn at this size" % (k, DISTILL_FAIL_CAP)
+                        else:
+                            klass = "transient: no strike, retry next pass"
+                        remaining = sum(1 for t in turns[ti + 1:]
+                                        if not _turn_open(t, turns)
+                                        and not (t["id"] in swept
+                                                 and sig.get(t["id"], len(t["atoms"])) == len(t["atoms"])))
+                        _log_judge_error("closer", fsid, "sweep-cut",
+                                         note="%d end-known turn(s) left unswept behind turn %s: %s (model %s%s); %s"
+                                              % (remaining, _turn_tag(tid), fail_note[:160],
+                                                 last.get("model"), shape_s, klass))
+                        cut = True
+                        break
             continue                                   # LLM/parse failed → leave unswept, retry next pass
         newly += res
         if isinstance(store.get("closeFails"), dict):
@@ -10066,7 +10207,9 @@ def _death_rotate(fsid):
     each time — would hold the head of the queue for good, and DEATH_DRAIN_PER_PASS such sessions would
     starve every newer dead session of its sweep and its 'ended' settle (review find, 2026-09-03). Touch the
     marker so it takes its place at the BACK: one doomed call per pass, behind everyone else, and the
-    drain's bound stays honest. A give-up after repeated cuts is the follow-up the sweep-cut row names."""
+    drain's bound stays honest. Bounded for kills: DISTILL_FAIL_CAP killed calls on one turn give it up
+    and the walk goes on (_close_session), so a marker waits back here at most that many passes per
+    doomed turn; a transient storm rotates it for as long as the storm lasts — the storm's bound, not ours."""
     m = _death_marker(fsid)
     if not isinstance(m, dict) or "endedAt" in m:
         return

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3796,11 +3796,25 @@ class SweepSession(unittest.TestCase):
     # the dead-CLI stash byte-for-byte as _judge_run leaves it (its DEAD CLI branch): "" back to the
     # caller, the per-thread dict naming the exit. -14 is SIGALRM — the CALL_ALARM_S kill, the shape of
     # the 2026-09-03 incident (192 consecutive kills inside ONE session's walk, 6h22m of silence)
-    DEAD_CLI = {"note": "the model CLI died with no output (exit -14)", "model": "sonnet"}
+    DEAD_CLI = {"note": "the model CLI died with no output (exit -14)", "model": "sonnet", "kill": True}
+
+    # the other failure stashes _judge_run leaves, byte-for-byte: subprocess.TimeoutExpired (its except
+    # branches stash the exception's type name — the CALL_ALARM_S + 5 backstop firing), the codex engine's
+    # empty -o file, and an API error envelope (the CLI answering with an error string; the stash is that
+    # message). The first two are KILLS like the dead CLI — the call RAN TO THE TIMER: TimeoutExpired, or
+    # the alarm's SIGALRM as the exit code — and _judge_run stamps `kill: True` only then (a clean exit of
+    # any code is the process answering: no flag); the envelope is the API answering and carries no flag.
+    # _call_fail_kill reads the flag, never the note (the producer-side pins live in FailureContract).
+    TIMEOUT = {"note": "TimeoutExpired", "model": "sonnet", "kill": True}
+    CODEX_EMPTY = {"note": "codex empty reply (exit -14)", "model": "codex-default", "kill": True}
+    ENVELOPE_529 = {"note": "API Error: 529 overloaded_error", "model": "sonnet"}
+
+    def _failing_closer(self, calls, stash):
+        return lambda tt, mt, *_a: (calls.append(1), setattr(
+            jd._judge_ctx, "last_call_fail", dict(stash)), "")[2]
 
     def _dead_closer(self, calls):
-        return lambda tt, mt, *_a: (calls.append(1), setattr(
-            jd._judge_ctx, "last_call_fail", dict(self.DEAD_CLI)), "")[2]
+        return self._failing_closer(calls, self.DEAD_CLI)
 
     def test_a_failed_call_cuts_this_sessions_sweep_for_the_pass(self):
         # 2026-09-03: one session's closer calls were alarm-killed 192 times in a row inside ONE
@@ -3808,9 +3822,9 @@ class SweepSession(unittest.TestCase):
         # `continue`d to the next end-known turn after each kill and the next call died the same way
         # (the same over-full menu rides every turn until a LANDED reply stamps it). A failed CALL is
         # evidence about the session's calls, not about one turn: the first one ends this session's
-        # walk for the pass, loudly. The turn keeps the plain retry-next-pass contract — no strike, no
-        # tombstone — and the loop BREAKS rather than returns, so the store still saves and the
-        # death-marker epilogue still runs.
+        # walk for the pass, loudly. Below the cap the turn takes a strike — a KILL is prompt-shaped
+        # (_call_fail_kill) — but no tombstone, and the loop BREAKS rather than returns, so the store
+        # still saves and the death-marker epilogue still runs.
         jd.run_plan(now=self.now)
         calls = []
         jd.closer_llm = self._dead_closer(calls)
@@ -3818,18 +3832,19 @@ class SweepSession(unittest.TestCase):
         self.assertEqual(len(calls), 1, "the first failed call ends this session's walk for the pass")
         store = jd.load_goals(SID)
         self.assertFalse(store.get("closedTurns"), "nothing swept while the calls fail")
-        self.assertFalse(store.get("closeFails"), "a call failure is never a strike against the turn")
+        t1, t2 = self._turn_ids()
+        self.assertEqual(store.get("closeFails"), {t1: {"fp": 2, "fails": 1, "kind": "kill"}},
+                         "the cut is struck against the turn it died on, at its current size, in its own streak")
         self.assertIn("closedSig", store, "a break, not a return: the store was still saved")
         rows = [r for r in self._errors() if r.get("err") == "sweep-cut"]
         self.assertEqual(len(rows), 1, "one loud row per cut walk")
         self.assertEqual((rows[0]["judge"], rows[0]["fsid"]), ("closer", SID))
         self.assertIn("1 end-known turn(s)", rows[0]["note"], "the row counts the turns left behind")
         self.assertIn("exit -14", rows[0]["note"], "…and carries the call failure it acted on")
-        for _ in range(jd.DISTILL_FAIL_CAP + 1):
-            jd.run_close(now=self.now)
-        self.assertEqual(len(calls), jd.DISTILL_FAIL_CAP + 2,
-                         "ONE call per pass: still retrying (no tombstone), never walking past the failure")
-        self.assertFalse(jd.load_goals(SID).get("closedTurns"), "transient failures never adopt the turn")
+        self.assertIn("kill 1 of %d" % jd.DISTILL_FAIL_CAP, rows[0]["note"], "…and says how far the turn is from its give-up")
+        jd.run_close(now=self.now)
+        self.assertEqual(len(calls), 2, "ONE call per pass below the cap: retrying, never walking past the failure")
+        self.assertFalse(jd.load_goals(SID).get("closedTurns"), "below the cap a failed call never adopts the turn")
 
     def test_a_cut_walk_leaves_a_death_marker_pending(self):
         # review find (2026-09-03): a dead session is swept ONLY through the death drain, and the drain
@@ -3916,6 +3931,274 @@ class SweepSession(unittest.TestCase):
                          "every end-known turn of the healthy session closed in the same pass")
         rows = [r for r in self._errors() if r.get("err") == "sweep-cut"]
         self.assertEqual([r["fsid"] for r in rows], [SID], "one cut row, naming the cut session")
+
+    def _turn_ids(self):
+        path = next(p for f, p, a, n in jd.discover(self.now) if f == SID)
+        return [t["id"] for t in jd.parsed_session(SID, [path], self.now)["turns"]]
+
+    @staticmethod
+    def _turn_tag(tid):
+        return tid.split(":", 1)[1]                   # `t:hash` — the part of `sid:t:hash` that tells turns apart
+
+    def test_repeated_cuts_on_one_turn_give_it_up_and_the_walk_moves_on(self):
+        # the follow-up the sweep-cut row named (review of the cut, 2026-09-03): a LIVE session whose head
+        # turn's call dies the same way every pass (a menu the timer cannot fit even capped, a prompt the
+        # model never finishes) was cut at that turn every pass — one doomed call per pass forever, and
+        # every LATER end-known turn never reached, since the walk always ended at the head. A dead
+        # session at least rotated to the back of the death drain; a live one simply lost its later turns.
+        # Mirror the safeguards tombstone: strike-count the cuts per turn at its current size; at the cap
+        # adopt the turn (swept, no verdicts) LOUDLY, and walk ON in the same pass.
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        cap = jd.DISTILL_FAIL_CAP
+        calls = []
+        jd.closer_llm = self._dead_closer(calls)
+        for _ in range(cap - 1):
+            jd.run_close(now=self.now)
+        self.assertEqual(len(calls), cap - 1, "below the cap: one cut call per pass, always at the head turn")
+        store = jd.load_goals(SID)
+        self.assertFalse(store.get("closedTurns"), "nothing adopted below the cap")
+        self.assertEqual(store["closeFails"], {t1: {"fp": 2, "fails": cap - 1, "kind": "kill"}},
+                         "the head turn's cut streak, at its size; the second turn was never reached")
+        jd.run_close(now=self.now)                       # the capping pass
+        self.assertEqual(len(calls), cap + 1,
+                         "the capping pass adopted the head turn and went ON to the second turn's call")
+        store = jd.load_goals(SID)
+        self.assertEqual(store.get("closedTurns"), [t1], "the head turn is adopted at the cap…")
+        self.assertEqual(store["closedSig"][t1], 2, "…at the size it was struck at (growth re-judges it)")
+        self.assertTrue(all(not nd.get("nodeComplete") and not nd.get("blocked") for nd in store["nodes"].values()),
+                        "swept WITHOUT verdicts — no goal state was invented")
+        self.assertEqual(store["closeFails"], {t2: {"fp": 2, "fails": 1, "kind": "kill"}},
+                         "the give-up retired the head turn's record; the second turn took its own first cut")
+        give = [r for r in self._errors() if r.get("err") == "give-up"]
+        self.assertEqual(len(give), 1, "one loud give-up row")
+        self.assertEqual((give[0]["judge"], give[0]["fsid"]), ("closer", SID))
+        note = give[0]["note"]
+        self.assertIn(self._turn_tag(t1), note, "the row names the turn given up")
+        self.assertNotIn(self._turn_tag(t2), note)
+        self.assertIn("%d killed calls" % cap, note, "…the number of kills")
+        self.assertIn("exit -14", note, "…the failure class it acted on")
+        self.assertIn("turn growing", note, "…and the re-arm event: new evidence, never a clock")
+        cuts = [r for r in self._errors() if r.get("err") == "sweep-cut"]
+        self.assertEqual(len(cuts), cap, "each pass was still cut once: twice at the head turn, then at the second")
+        self.assertIn(self._turn_tag(t2), cuts[-1]["note"], "the capping pass's cut is at the SECOND turn")
+        self.assertIn("0 end-known turn(s)", cuts[-1]["note"])
+        for _ in range(cap - 1):                          # the second turn's own streak runs to the cap
+            jd.run_close(now=self.now)
+        store = jd.load_goals(SID)
+        self.assertEqual(sorted(store["closedTurns"]), sorted([t1, t2]), "the second turn is given up in turn")
+        self.assertFalse(store.get("closeFails"), "no record outlives its give-up")
+        n = len(calls)
+        jd.run_close(now=self.now)
+        self.assertEqual(len(calls), n, "a fully given-up session costs ZERO further calls")
+
+    def test_a_cut_strike_resets_when_the_turn_grows(self):
+        # the strike is per turn AT ITS CURRENT SIZE (the safeguards arm's rule): a turn that grew is a
+        # different prompt — new evidence — so its count starts over, and cuts on two sizes never add up
+        # to a give-up
+        path = next(p for f, p, a, n in jd.discover(self.now) if f == SID)
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        cap = jd.DISTILL_FAIL_CAP
+        calls = []
+        jd.closer_llm = self._dead_closer(calls)
+        for _ in range(cap - 1):
+            jd.run_close(now=self.now)
+        self.assertEqual(jd.load_goals(SID)["closeFails"][t1], {"fp": 2, "fails": cap - 1, "kind": "kill"},
+                         "one cut short of the give-up")
+        # the head turn GROWS: another assistant record on its chain, the second prompt re-parented onto it
+        recs = [uline(T0, "task A", "u1", ps="typed"),
+                aline(T0 + 30, "did A", "a1", "u1", stop="end_turn"),
+                aline(T0 + 60, "did more of A", "a1b", "a1", stop="end_turn"),
+                uline(T0 + 100, "task B", "u2", "a1b", ps="typed"),
+                aline(T0 + 130, "did B", "a2", "u2", stop="end_turn")]
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        self.assertEqual(self._turn_ids(), [t1, t2], "fixture: the same two turns, the first now larger")
+        jd.run_close(now=self.now)                       # the cut that would have capped, had the count carried
+        store = jd.load_goals(SID)
+        self.assertEqual(len(calls), cap, "one call: the walk is cut at the head turn again")
+        self.assertFalse(store.get("closedTurns"), "NOT adopted: this cut is the first at the new size")
+        self.assertEqual(store["closeFails"][t1], {"fp": 3, "fails": 1, "kind": "kill"},
+                         "the record restarted at the new size")
+        self.assertEqual([r for r in self._errors() if r.get("err") == "give-up"], [], "no give-up across sizes")
+
+    def test_cut_strikes_and_parse_strikes_do_not_add_up(self):
+        # two different streaks: a parse reject means the model ANSWERED this turn's prompt (the parser
+        # refused its text); a cut means it never did. closeFails holds the turn's CURRENT streak, and a
+        # strike of the other kind starts over — so a cut, a parse reject and a cut are never "3 in a row"
+        # toward either cap
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        calls = []
+        jd.closer_llm = self._dead_closer(calls)
+        jd.run_close(now=self.now)                                          # cut
+        self.assertEqual(jd.load_goals(SID)["closeFails"], {t1: {"fp": 2, "fails": 1, "kind": "kill"}})
+        jd.closer_llm = lambda tt, mt, *_a: (calls.append(1), "not json")[1]
+        jd.run_close(now=self.now)                                          # parse reject (walks both turns)
+        store = jd.load_goals(SID)
+        self.assertEqual(store["closeFails"], {t1: 1, t2: 1},
+                         "the parse strike starts its own count on the head turn: the model answered, the cut streak is over")
+        jd.closer_llm = self._dead_closer(calls)
+        jd.run_close(now=self.now)                                          # cut
+        store = jd.load_goals(SID)
+        self.assertEqual(store["closeFails"][t1], {"fp": 2, "fails": 1, "kind": "kill"},
+                         "the cut starts over too: three strikes of two kinds are not three in a row")
+        self.assertEqual(store["closeFails"][t2], 1, "the second turn's parse strike is untouched (the walk was cut before it)")
+        self.assertFalse(store.get("closedTurns"), "nothing adopted")
+        self.assertEqual([r for r in self._errors() if r.get("err") == "give-up"], [], "no give-up of either kind")
+
+    def test_a_landed_call_retires_the_cut_record(self):
+        # the record's own retire event is a call for that turn LANDING — the same pop a landed judgment
+        # has always done for the parse strikes — so a turn that dies twice and then answers carries no
+        # trace of the cuts
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        calls = []
+        jd.closer_llm = self._dead_closer(calls)
+        jd.run_close(now=self.now)
+        self.assertEqual(jd.load_goals(SID)["closeFails"], {t1: {"fp": 2, "fails": 1, "kind": "kill"}}, "the cut is on record")
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'
+        jd.run_close(now=self.now)
+        store = jd.load_goals(SID)
+        self.assertEqual(sorted(store["closedTurns"]), sorted([t1, t2]), "the landed calls swept both turns")
+        self.assertFalse(store.get("closeFails"), "…and the landed call retired the cut record")
+
+    def test_a_later_turn_lands_in_the_pass_that_gives_up_the_head(self):
+        # the whole point of the give-up, end to end: the pass that adopts the head turn goes on, and the
+        # session's later turn is judged from a REAL reply — a verdict lands, not merely a sweep
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        store = jd.load_goals(SID)
+        g1, g2 = [nd["id"] for nd in sorted((nd for nd in store["nodes"].values() if nd["parentId"] is None),
+                                            key=lambda nd: nd["t"])]
+        calls = []
+
+        def closer(tt, mt, *_a):
+            calls.append(1)
+            if "task A" in tt:                            # the head turn's call is alarm-killed every pass
+                jd._judge_ctx.last_call_fail = dict(self.DEAD_CLI)
+                return ""
+            return '{"done": [{"goal": 1, "why": "B shipped"}], "block": []}'
+        jd.closer_llm = closer
+        for _ in range(jd.DISTILL_FAIL_CAP - 1):
+            jd.run_close(now=self.now)
+        self.assertEqual(len(calls), jd.DISTILL_FAIL_CAP - 1, "cut at the head every pass: the second turn never asked")
+        n = jd.run_close(now=self.now)                    # the capping pass
+        store = jd.load_goals(SID)
+        self.assertEqual(sorted(store["closedTurns"]), sorted([t1, t2]), "both turns closed in the same pass")
+        self.assertFalse(store["nodes"][g1].get("nodeComplete"), "the head turn was adopted WITHOUT verdicts")
+        self.assertTrue(store["nodes"][g2].get("nodeComplete"), "the second turn was judged from a real reply: its top completed")
+        self.assertEqual(store["status"][g2], "completed")
+        self.assertGreaterEqual(n, 1, "the pass reported the completion")
+        self.assertEqual(len(calls), jd.DISTILL_FAIL_CAP + 1, "one landed call for the second turn, in the capping pass")
+        self.assertFalse(store.get("closeFails"), "the give-up retired the head's record; the landed call left none")
+        self.assertEqual(len([r for r in self._errors() if r.get("err") == "give-up"]), 1)
+        self.assertEqual(len([r for r in self._errors() if r.get("err") == "sweep-cut"]), jd.DISTILL_FAIL_CAP - 1,
+                         "no cut on the capping pass: the walk reached the end")
+
+    def test_a_transient_failure_cuts_the_walk_but_never_strikes_the_turn(self):
+        # review find on this change's first cut (2026-09-03): the strike counted EVERY failure class.
+        # Passes are event-driven with a seconds backstop and nothing but the retry pause holds judge
+        # calls, so a thirty-second 529 storm would have cut the same live turn three passes running
+        # and adopted it without verdicts — for good, since an end-known turn of a live session never
+        # grows. An error envelope is the API ANSWERING (with an error): evidence about the storm, not
+        # about this turn's prompt. It still cuts the walk, loudly, and leaves the plain retry.
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        calls = []
+        jd.closer_llm = self._failing_closer(calls, self.ENVELOPE_529)
+        for _ in range(jd.DISTILL_FAIL_CAP + 1):
+            jd.run_close(now=self.now)
+        self.assertEqual(len(calls), jd.DISTILL_FAIL_CAP + 1, "one cut call per pass, every pass")
+        store = jd.load_goals(SID)
+        self.assertFalse(store.get("closeFails"), "a transient failure is never a strike against the turn")
+        self.assertFalse(store.get("closedTurns"), "…and never adopts it: the storm ending is its recovery")
+        rows = [r for r in self._errors() if r.get("err") == "sweep-cut"]
+        self.assertEqual(len(rows), jd.DISTILL_FAIL_CAP + 1, "each pass was still cut, loudly")
+        self.assertTrue(all("529" in r["note"] and "transient" in r["note"] for r in rows),
+                        "the row carries the failure and its class")
+        self.assertEqual([r for r in self._errors() if r.get("err") == "give-up"], [], "no give-up on a storm")
+
+    def _kill_class_gives_up(self, stash, marker):
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        calls = []
+        jd.closer_llm = self._failing_closer(calls, stash)
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd.run_close(now=self.now)
+        store = jd.load_goals(SID)
+        self.assertEqual(store.get("closedTurns"), [t1], "a kill streak at the cap adopts the head turn")
+        self.assertEqual(store["closeFails"], {t2: {"fp": 2, "fails": 1, "kind": "kill"}},
+                         "…and the same pass went on to the second turn, which took its own first kill")
+        cuts = [r for r in self._errors() if r.get("err") == "sweep-cut"]
+        self.assertIn("kill 1 of %d" % jd.DISTILL_FAIL_CAP, cuts[0]["note"], "the cut row names the class")
+        give = [r for r in self._errors() if r.get("err") == "give-up"]
+        self.assertEqual(len(give), 1, "one loud give-up row")
+        self.assertIn(marker, give[0]["note"], "…carrying the failure it acted on")
+
+    def test_a_timeout_is_a_kill(self):
+        # subprocess.TimeoutExpired is the CALL_ALARM_S + 5 backstop firing: the call ran and never
+        # completed, prompt-shaped like the alarm kill, so it strikes and gives up the same way
+        self._kill_class_gives_up(self.TIMEOUT, "TimeoutExpired")
+
+    def test_a_codex_empty_reply_is_a_kill(self):
+        # the codex engine's only success signal is its -o file; an empty one is a call that never
+        # completed on that engine — the same class, the same strike
+        self._kill_class_gives_up(self.CODEX_EMPTY, "codex empty reply")
+
+    def test_a_transient_cut_leaves_a_kill_streak_untouched(self):
+        # the interleave decision: a storm between two kills is evidence about the API, not the prompt,
+        # so it neither adds to the kill streak nor erases it — only evidence about the prompt moves the
+        # record (a kill adds; a served reply, parsed or not, retires or restarts it)
+        jd.run_plan(now=self.now)
+        t1, t2 = self._turn_ids()
+        cap = jd.DISTILL_FAIL_CAP
+        calls = []
+        jd.closer_llm = self._dead_closer(calls)
+        for _ in range(cap - 1):
+            jd.run_close(now=self.now)
+        rec = {"fp": 2, "fails": cap - 1, "kind": "kill"}
+        self.assertEqual(jd.load_goals(SID)["closeFails"], {t1: rec}, "one kill short of the give-up")
+        jd.closer_llm = self._failing_closer(calls, self.ENVELOPE_529)
+        jd.run_close(now=self.now)                                          # the storm
+        store = jd.load_goals(SID)
+        self.assertEqual(store["closeFails"], {t1: rec}, "the storm neither added to the kill streak nor erased it")
+        self.assertFalse(store.get("closedTurns"), "…and did not cap it: not adopted")
+        self.assertEqual(len(calls), cap, "the storm pass was still cut at the head turn")
+        jd.closer_llm = self._dead_closer(calls)
+        jd.run_close(now=self.now)                                          # the capping kill
+        self.assertEqual(jd.load_goals(SID).get("closedTurns"), [t1],
+                         "the next kill caps the streak the storm left standing")
+
+
+class CloseStrike(unittest.TestCase):
+    """_close_strike, the closer's no-reply strike count: closeFails holds ONE record per turn, so the
+    latest kind wins and nothing adds up — the count continues only for the same kind at the same size."""
+
+    def test_kill_after_safeguards_restarts_at_one(self):
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 2, "kind": "safeguards"}, 2, "kill"), 1)
+
+    def test_safeguards_after_kill_restarts_at_one(self):
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 2, "kind": "kill"}, 2, "safeguards"), 1)
+
+    def test_the_same_kind_at_the_same_size_continues(self):
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 2, "kind": "kill"}, 2, "kill"), 3)
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 1, "kind": "safeguards"}, 2, "safeguards"), 2)
+
+    def test_a_legacy_record_reads_as_safeguards(self):
+        # written before kinds existed, by the safeguards arm — the only writer then
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 2}, 2, "safeguards"), 3, "its count continues")
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 2}, 2, "kill"), 1, "…and a kill does not continue it")
+
+    def test_a_size_change_restarts(self):
+        # the turn grew: a different prompt, new evidence
+        self.assertEqual(jd._close_strike({"fp": 2, "fails": 2, "kind": "kill"}, 3, "kill"), 1)
+        self.assertEqual(jd._close_strike({"fp": 3, "fails": 2, "kind": "kill"}, 2, "kill"), 1)
+
+    def test_a_non_dict_restarts_at_one(self):
+        # the parse path's int, or no record at all
+        self.assertEqual(jd._close_strike(2, 2, "kill"), 1)
+        self.assertEqual(jd._close_strike(None, 2, "safeguards"), 1)
 
 
 class CloserKeyMigration(unittest.TestCase):
@@ -7220,9 +7503,21 @@ class FailureContract(unittest.TestCase):
     def setUp(self):
         self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
+        # the model-health latch is process-global, keyed by model: the failing calls below push "model-x"
+        # and "gpt-5-test" past the degraded cap, so snapshot it here and restore it after — a later test
+        # must not inherit a degraded model (review nit, 2026-09-03)
+        with jd._health_lock:
+            self._health = (set(jd._CALL_HEALTH["degraded"]), jd._CALL_HEALTH["recovered"],
+                            {m: dict(st) for m, st in jd._CALL_HEALTH["stats"].items()})
 
     def tearDown(self):
         shutil.rmtree(self._td, ignore_errors=True)
+        with jd._health_lock:
+            jd._CALL_HEALTH["degraded"].clear()
+            jd._CALL_HEALTH["degraded"].update(self._health[0])
+            jd._CALL_HEALTH["recovered"] = self._health[1]
+            jd._CALL_HEALTH["stats"].clear()
+            jd._CALL_HEALTH["stats"].update(self._health[2])
 
     def _errors(self):
         try:
@@ -7253,6 +7548,9 @@ class FailureContract(unittest.TestCase):
             jd.subprocess = saved_sub
             jd._judge_ctx.fsid = saved_fsid
         self.assertEqual(out, "", "an error envelope reads as an empty reply to every caller")
+        last = jd._judge_ctx.last_call_fail
+        self.assertIsInstance(last, dict, "the failure is stashed for the closer's sweep-cut")
+        self.assertFalse(last.get("kill"), "the API ANSWERED, with an error: transient for the closer's strike, never a kill")
         row = self._errors()[-1]
         self.assertEqual((row["judge"], row["err"], row["fsid"]), ("closer", "call", "sid-env"))
         self.assertIn("API Error: 529 overloaded", row["note"], "the API's own message is the evidence")
@@ -7276,11 +7574,108 @@ class FailureContract(unittest.TestCase):
             jd.subprocess = saved_sub
             jd._judge_ctx.fsid = saved_fsid
         self.assertEqual(out, "", "a dead CLI reads as an empty reply to every caller")
+        self.assertFalse(jd._judge_ctx.last_call_fail.get("kill"),
+                         "a crash (exit 134) is the process ANSWERING, not the timer: transient for the closer's strike")
         row = self._errors()[-1]
         self.assertEqual((row["judge"], row["err"], row["fsid"]), ("briefer", "call", "sid-dead"))
         self.assertIn("exit 134", row["note"], "the returncode is the evidence")
         self.assertIn("heap out of memory", row["note"], "…with the stderr tail")
         self.assertFalse(Path(jd.USAGE).exists(), "a dead CLI logs no usage row")
+
+    def test_a_kill_is_the_alarm_signal_and_nothing_else(self):
+        # second review of the kill strike (2026-09-03): the flag was stamped at the empty-output exit
+        # however the process ended, so a broken install — exec failing under perl's alarm wrapper exits 0
+        # with empty stdout; a CLI dying at startup exits 1 — would have tombstoned every turn it touched
+        # after three passes. A kill is the call RUNNING TO THE TIMER and nothing else: the wrapper's
+        # SIGALRM landing on the child (returncode == -signal.SIGALRM) or TimeoutExpired. A clean exit of
+        # any code, or any other signal, is the process ANSWERING — a crash, a refusal, a missing binary —
+        # and stays transient.
+        import signal
+        import types
+        saved_sub, saved_fsid = jd.subprocess, getattr(jd._judge_ctx, "fsid", None)
+        jd._judge_ctx.fsid = "sid-rc"
+        cases = ((-signal.SIGALRM, True, "the alarm's signal: the call ran to the timer"),
+                 (1, False, "a clean nonzero exit is the process answering (a startup crash, a refusal)"),
+                 (0, False, "exit 0 with empty stdout is a failed exec under the wrapper, not a kill"),
+                 (-signal.SIGKILL, False, "another signal is not the timer"))
+        try:
+            for rc, kill, why in cases:
+                with self.subTest(rc=rc):
+                    res = types.SimpleNamespace(stdout="", stderr="", returncode=rc)
+                    jd.subprocess = types.SimpleNamespace(run=lambda *a, _r=res, **k: _r)
+                    jd._judge_ctx.last_call_fail = None
+                    self.assertEqual(jd._judge_run("model-x", "sys", "user", judge="closer"), "")
+                    last = jd._judge_ctx.last_call_fail
+                    self.assertIn("exit %d" % rc, last["note"], "the exit code stays the row's evidence")
+                    self.assertEqual(bool(last.get("kill")), kill, why)
+        finally:
+            jd.subprocess, jd._judge_ctx.fsid = saved_sub, saved_fsid
+            jd._judge_ctx.last_call_fail = None
+
+    def test_a_codex_kill_is_the_alarm_signal_and_nothing_else(self):
+        # the codex branch has NO error-envelope exit: a usage-limit refusal, an auth failure or a network
+        # error all end as `codex exec` exiting nonzero with no -o file — so stamping every empty -o file a
+        # kill was the 529-storm defect over again on this engine. Only the alarm's signal is a kill here too.
+        import signal
+        import types
+        saved = (jd.subprocess, getattr(jd._judge_ctx, "fsid", None), jd._judge_cmd_codex, jd._judge_engine)
+        jd._judge_cmd_codex = lambda model, effort, outp: ["codex-stub"]
+        jd._judge_engine = lambda: "codex"
+        jd._judge_ctx.fsid = "sid-cxrc"
+        cases = ((-signal.SIGALRM, True, "the alarm's signal: the call ran to the timer"),
+                 (1, False, "exit 1 with no -o file is codex answering: a refusal, an auth or network failure"),
+                 (0, False, "exit 0 with no -o file is not the timer either"),
+                 (-signal.SIGKILL, False, "another signal is not the timer"))
+        try:
+            for rc, kill, why in cases:
+                with self.subTest(rc=rc):
+                    res = types.SimpleNamespace(stdout="", stderr="", returncode=rc)
+                    jd.subprocess = types.SimpleNamespace(run=lambda *a, _r=res, **k: _r)
+                    jd._judge_ctx.last_call_fail = None
+                    self.assertEqual(jd._judge_run("gpt-5-test", "sys", "user", judge="closer"), "")
+                    last = jd._judge_ctx.last_call_fail
+                    self.assertIn("codex empty reply (exit %d)" % rc, last["note"])
+                    self.assertEqual(bool(last.get("kill")), kill, why)
+        finally:
+            jd.subprocess, jd._judge_ctx.fsid, jd._judge_cmd_codex, jd._judge_engine = saved
+            jd._judge_ctx.last_call_fail = None
+
+    def test_only_the_timeout_exception_is_stamped_a_kill(self):
+        # the closer's cut arm strikes a turn only for a KILL — a call that ran and never completed — and
+        # reads that off the stash's `kill` flag, which the producer stamps here (never matched on note
+        # text). Of the subprocess exceptions only TimeoutExpired (the CALL_ALARM_S + 5 backstop) is one;
+        # any other exception is the OS answering (a missing binary, a broken pipe) and stays transient.
+        # Both engines' handlers draw the same line.
+        import subprocess as sp
+        import types
+        saved = (jd.subprocess, getattr(jd._judge_ctx, "fsid", None), jd._judge_cmd_codex, jd._judge_engine)
+        jd._judge_ctx.fsid = "sid-exc"
+
+        def raising(exc):
+            def run(*a, **k):
+                raise exc
+            return types.SimpleNamespace(run=run)
+        try:
+            jd.subprocess = raising(sp.TimeoutExpired("claude", jd.CALL_ALARM_S + 5))
+            self.assertEqual(jd._judge_run("model-x", "sys", "user", judge="closer"), "")
+            last = jd._judge_ctx.last_call_fail
+            self.assertEqual((last["note"], last.get("kill")), ("TimeoutExpired", True), "the backstop timer is a kill")
+            jd.subprocess = raising(OSError("no such binary"))
+            self.assertEqual(jd._judge_run("model-x", "sys", "user", judge="closer"), "")
+            last = jd._judge_ctx.last_call_fail
+            self.assertEqual(last["note"], "OSError")
+            self.assertFalse(last.get("kill"), "any other exception is the OS answering: transient")
+            jd._judge_cmd_codex = lambda model, effort, outp: ["codex-stub"]
+            jd._judge_engine = lambda: "codex"
+            jd.subprocess = raising(sp.TimeoutExpired("codex", jd.CALL_ALARM_S + 5))
+            self.assertEqual(jd._judge_run("gpt-5-test", "sys", "user", judge="closer"), "")
+            self.assertIs(jd._judge_ctx.last_call_fail.get("kill"), True, "a timeout on the codex engine is a kill too")
+            jd.subprocess = raising(OSError("no such binary"))
+            self.assertEqual(jd._judge_run("gpt-5-test", "sys", "user", judge="closer"), "")
+            self.assertFalse(jd._judge_ctx.last_call_fail.get("kill"), "…and its other exceptions stay transient")
+        finally:
+            jd.subprocess, jd._judge_ctx.fsid, jd._judge_cmd_codex, jd._judge_engine = saved
+            jd._judge_ctx.last_call_fail = None
 
     def test_codex_engine_dead_call_leaves_the_same_traces(self):
         # 2026-09-03 review: the closer's sweep-cut keys on _judge_ctx.last_call_fail and the model-health
@@ -7304,6 +7699,7 @@ class FailureContract(unittest.TestCase):
         self.assertIsInstance(last, dict, "the sweep-cut discriminator sees the failure on this engine too")
         self.assertIn("codex empty reply (exit -14)", last["note"])
         self.assertEqual(last["model"], "gpt-5-test")
+        self.assertIs(last.get("kill"), True, "an empty -o file with the alarm's exit (-14 is SIGALRM): a KILL for the closer's strike")
         row = self._errors()[-1]
         self.assertEqual((row["judge"], row["err"], row["fsid"]), ("closer", "call", "sid-cx"))
         for word in ("exit -14", "model=gpt-5-test", "chars=2", "ms="):

--- a/tests/test_judge_close_riders.py
+++ b/tests/test_judge_close_riders.py
@@ -296,8 +296,9 @@ class SweepCutDrain(_Riders):
         os.utime(marker, (T0, T0))                         # the oldest marker in the queue
         before = marker.stat().st_mtime_ns
 
-        def dead_call(*a, **k):                           # the call died: _judge_run's failure traces, no reply
-            jd._judge_ctx.last_call_fail = {"note": "exit -14", "model": "sonnet"}
+        def dead_call(*a, **k):                           # the call was KILLED: the dead-CLI stash byte-for-byte
+            jd._judge_ctx.last_call_fail = {"note": "the model CLI died with no output (exit -14)",
+                                            "model": "sonnet", "kill": True}
             return ""
         jd.closer_llm = dead_call
         jd._judge_ctx.paused = False
@@ -306,7 +307,14 @@ class SweepCutDrain(_Riders):
         m = json.loads(marker.read_text())
         self.assertNotIn("endedAt", m, "a cut walk never finalizes the marker (its turns are still unswept)")
         rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
-        self.assertTrue(any(r.get("err") == "sweep-cut" for r in rows), "the cut is said loudly")
+        cuts = [r for r in rows if r.get("err") == "sweep-cut"]
+        self.assertEqual(len(cuts), 1, "the cut is said loudly")
+        # the KILL path, which a transient cut would not satisfy: the turn is struck at its size, and the
+        # row says so — DISTILL_FAIL_CAP such passes give the turn up and the marker stops rotating
+        tid = jd.parsed_session(SID, [path], T0 + 5000)["turns"][0]["id"]
+        self.assertEqual(jd.load_goals(SID).get("closeFails"), {tid: {"fp": 2, "fails": 1, "kind": "kill"}},
+                         "a killed call is struck against the turn it died on")
+        self.assertIn("kill 1 of %d" % jd.DISTILL_FAIL_CAP, cuts[0]["note"], "…and the row carries the class")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Repeated kills on one turn give it up loudly, and the session's later turns get swept again

Follow-up to #905, as requested in its review: "a give-up after repeated cuts on the same (turn, fingerprint), mirroring the safeguards tombstone, so a live session whose one turn always dies gets its later turns swept again."

**The problem.** After #905 a failed closer call ends the session's sweep for the pass and the turn keeps the retry-next-pass contract. If the same turn's call dies the same way every pass, that live session pays one doomed call per pass forever, and its later end-known turns are never reached because the walk is cut at the head turn every time. A dead session at least rotates to the back of the death drain; a live session's later turns simply stay unswept.

**The fix.** A KILL is struck against the turn it died on at its current atom count, in `closeFails[tid]` as `{"fp", "fails", "kind": "kill"}` under `DISTILL_FAIL_CAP`, the way the safeguards arm strikes refusals. At the cap the turn is adopted exactly as the safeguards give-up adopts one (swept, `closedSig` at fp, no verdicts), one `give-up` row names the turn, the kill count and the re-arm event (the turn growing re-judges it through the existing `closedSig` growth check), and the walk continues to the next turn in the same pass. A landed call retires the record.

**Only kills strike, and a kill is the timer.** The call runner stamps `"kill": True` on its failure record only when the call ran to the timer: the perl alarm wrapper's SIGALRM landing on the child (`returncode == -signal.SIGALRM` at the two empty-output exits, on either engine) or a `TimeoutExpired` from the subprocess backstop. Everything else is the API or the process answering with an error in place of a reply, and says nothing about the prompt: an error envelope (a 529, an auth error, a 429), a clean exit of any code with empty output (exit 0 is a failed exec under the wrapper, exit 1 a startup crash or, on Codex, which has no envelope exit, a usage-limit or auth refusal), any other signal, any other exception. Those still cut the sweep for the pass with a loud `sweep-cut` row, leave no strike, keep the plain retry, and leave an existing kill streak untouched. Without that line a short 529 storm or a broken install would have adopted live turns without verdicts, which the safeguards tombstone, justified by determinism per prompt, never does. The streak rule: `closeFails` holds one record per turn, so the latest kind wins and nothing adds up; the count continues only for the same kind at the same size, and a strike of another kind (a kill after a refusal, a refusal after a kill, a parse reject after either) or at another size starts over at 1. A parse reject means the model answered, a kill means it never did.

**Unchanged.** `CALL_ALARM_S`, `CLOSE_FAIRNESS = None`, the rider cap, the dead-session rotation, the safeguards arm's own behavior.

**Accepted trade-off, per review.** A kill streak cannot tell a doomed prompt from an API slow patch: three slow passes would adopt every live session's head turn without verdicts, permanently. That cost is bounded (one turn per session per three passes) and loud (a give-up row for each). A later gate could strike only while the model is otherwise serving, using the model-health latch, which would separate the two.

**Review round.** The six nits are folded: the streak rule stated precisely with direct `_close_strike` unit tests, the Codex flag test's other-signal case, the docs' two exceptions and re-wrap, `_CALL_HEALTH` restored after the failure-contract tests, and the `DISTILL_FAIL_CAP` comment.

**Verification.** Full Python suite green (7093 passed, 0 failed on top of today's main). Tests in `tests/test_judge.py`: repeated kills give the turn up and the walk goes on to the next turn in the same pass, including one where the later turn lands with a real verdict in that same pass; a kill strike resets when the turn grows; kill and parse strikes do not add up; a landed call retires the record; a transient failure cuts the walk but never strikes; a transient cut leaves a kill streak untouched; the flag is stamped for the alarm signal and a timeout and for nothing else (exit 0, exit 1, another signal, on both engines). `tests/test_judge_close_riders.py` drives the cut with the real alarm shape. Two adversarial review passes with two skeptics per finding ran on this change: the first caught that every failure class was striking, the second that the kill was still keyed on empty output rather than on the timer; both are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
