### PR TITLE
The chat fold holds an undecided seam at any depth, re-hydrates every sealed postal card, and re-stats task outputs

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18273,7 +18273,11 @@ _chat_fold_lock = threading.Lock()               # the dict ops only — builds 
 _CHAT_FOLD_MAX = 256
 _CHAT_FOLD_STATS = {"full": 0, "fold": 0, "bypass": 0, "fallback": 0}   # + g:<reason>; /version "chatfold"
 _chat_fold_warned = [False]
-_chat_fold_last = {}                             # the last build's {fold, k, n, prefix, tail} for the perf line
+_chat_fold_last = threading.local()              # per THREAD: the last build's {fold, k, n, prefix, why} for the perf line
+
+
+def _chat_fold_last_info():
+    return getattr(_chat_fold_last, "info", None) or {}
 
 
 def _chat_fold_get(sid):
@@ -18293,11 +18297,17 @@ def _chat_fold_put(sid, entry):
         _chat_fold[sid] = entry
 
 
+def _chat_fold_count(key):
+    """One counter increment under the cache lock — the pusher, the WS handlers and the backends all build."""
+    with _chat_fold_lock:
+        _CHAT_FOLD_STATS[key] = _CHAT_FOLD_STATS.get(key, 0) + 1
+        return _CHAT_FOLD_STATS[key]
+
+
 def _chat_fold_demote(reason):
     """Count WHY a build could not reuse its cached prefix (g:<reason>) — the hit-rate diagnosis
     this cache lives or dies by, mirroring event_model._asm_demote."""
-    k = "g:" + reason
-    _CHAT_FOLD_STATS[k] = _CHAT_FOLD_STATS.get(k, 0) + 1
+    _chat_fold_count("g:" + reason)
 
 
 def _chat_turn_fp(turn):
@@ -18341,6 +18351,15 @@ def _chat_postal_relevant(ev):
     if k == "user":
         return bool(em.POSTAL_RE.findall(ev.get("md") or ""))
     return False
+
+
+def _chat_stat_key(path):
+    """(mtime, size) of a file, or None when it is missing — the task-output gate's identity."""
+    try:
+        st = os.stat(path)
+        return (st.st_mtime, st.st_size)
+    except OSError:
+        return None
 
 
 def _chat_postal_key():
@@ -20996,7 +21015,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     _seams_sig = json.dumps((_bs_store or {}).get("seams") or [], sort_keys=True, default=str)
     _pk = _chat_postal_key()
     if path_override:
-        _CHAT_FOLD_STATS["bypass"] += 1
+        _chat_fold_count("bypass")
     elif _n_pref > 0:
         try:
             _fe = _chat_fold_get(sid)
@@ -21050,14 +21069,23 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                         if _ot in _tail_texts or any(dt.startswith(_ot) or _ot.startswith(dt) for dt in _tail_texts):
                             _fold_why = "orphan"      # a new reply retires an interleaved orphan in the prefix
                             break
-            if _fold_why is None and _fe["postal_pending"] and (_pk != _fe["postal_key"] or _judge_gen[0] != _fe["judge_gen"]):
-                # a card without its caption yet, or ids the log could not resolve: re-hydrate just those raw
-                # events against the current index; a different card means the prefix must be rebuilt
+            if _fold_why is None and _fe["postal_raw"] and (_pk != _fe["postal_key"] or _judge_gen[0] != _fe["judge_gen"]):
+                # re-hydrate just the sealed RAW postal events against the current index and captions; a
+                # different card means the prefix must be rebuilt. Every card, not only the pending ones
+                # (review find 2026-09-03): the judge writes a LIVE caption under an id it later overwrites
+                # with the final one, and a peer's colour can change — a card sealed complete was frozen
                 _cards = _hydrate_postal(list(_fe["postal_raw"]), _postal_index(), sid)
                 if _cards != _fe["postal_cards"]:
                     _fold_why = "postal"
                 else:
                     _fe["postal_key"], _fe["judge_gen"] = _pk, _judge_gen[0]
+            if _fold_why is None and _fe["task_outs"]:
+                # a sealed task-notification card carries its output file's tail: a file that grew, appeared
+                # or vanished since the seal renders differently (review find 2026-09-03), so re-stat each
+                for _of, _key in _fe["task_outs"]:
+                    if _chat_stat_key(_of) != _key:
+                        _fold_why = "task-output"
+                        break
             if _fold_why is None and _fe["pl_pending"]:
                 # unresolved path tokens are retried on every build BY DESIGN (a mention precedes the file):
                 # retry exactly those, and rebuild if one now resolves
@@ -21073,14 +21101,15 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             _fold_ok = _fold_why is None
         except Exception:
             _fold_ok, _fold_why = False, "fallback"
-            _CHAT_FOLD_STATS["fallback"] += 1
-            if not _chat_fold_warned[0] or _CHAT_FOLD_STATS["fallback"] in (10, 100, 1000):
+            with _chat_fold_lock:
+                _chat_fold.pop(sid, None)             # the entry the check choked on is not trusted again
+            if _chat_fold_count("fallback") in (1, 10, 100, 1000) or not _chat_fold_warned[0]:
                 _chat_fold_warned[0] = True
                 sys.stderr.write("chat fold: gate check failed (%s) — rebuilding in full (stats %r)\n"
                                  % (traceback.format_exc().strip().splitlines()[-1], dict(_CHAT_FOLD_STATS)))
     if _fold_ok:
         _fk = _fe["n"]
-        _CHAT_FOLD_STATS["fold"] += 1
+        _chat_fold_count("fold")
         events = list(_fe["events"])              # a NEW list of the SAME dicts — never written into (see above)
         _pref_len = len(events)
         uuid2seg, seg_anchors, seg_trig, seg_work = (dict(_fe["seg"][0]), dict(_fe["seg"][1]),
@@ -21089,13 +21118,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         last_t, last_model = _fe["last_t"], _fe["last_model"]
         _disk_texts = set(_fe["disk_texts"])
     elif not path_override:
-        _CHAT_FOLD_STATS["full"] += 1
-        if _fold_why not in (None, "cold"):
+        _chat_fold_count("full")
+        if _fold_why not in (None, "cold", "fallback"):     # fallback is its own counter, never also a g:
             _chat_fold_demote(_fold_why)
     for _i in range(_fk, len(_turns)):
         _disk_texts |= _texts_of_turn(_i)
-    _chat_fold_last.update({"fold": int(_fold_ok), "k": _fk, "n": len(_turns), "prefix": _pref_len,
-                            "why": _fold_why or ""})
+    _chat_fold_last.info = {"fold": int(_fold_ok), "k": _fk, "n": len(_turns), "prefix": _pref_len,
+                            "why": _fold_why or ""}
     # per-turn seg maps for the turns this build reshapes (the prefix's came with the entry)
     _seg_by_turn = {}                         # turn index → its (uuid2seg, seg_anchors, seg_trig, seg_work) items
     for _ti in range(_fk, len(_turns)):
@@ -21431,9 +21460,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                 _b = next((_i for _i in range(_pref_len, len(events)) if _turn_of(events[_i]) >= _np),
                           len(events))
                 _open = _chat_seam_open_at(events[:_b], _pref_len)   # an undecided seam holds the boundary
-                if _open is None or _turn_of(events[_open]) <= _fk:
+                if _open is None:
                     break
-                _np = _turn_of(events[_open])
+                _np = _turn_of(events[_open])   # may equal _fk: the next pass then finds _b == _pref_len and no
+                #                                 marker, and the entry is re-committed UNCHANGED. (Review find
+                #                                 2026-09-03: a `<= _fk: break` here sealed a marker whose turn had
+                #                                 just stopped being last — the common case, since the notice
+                #                                 that decides a kernel-restart seam lands after a nudge or a
+                #                                 peer's mail — and its cause was then never stamped.)
             if _np > _fk and _b > _pref_len or (_fold_ok and _np == _fk):
                 _newpart = events[_pref_len:_b]
                 _newids = {id(_e) for _e in _newpart}
@@ -21446,8 +21480,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                 _raw_new = [_e for _e in _raw_tail if _raw_turn.get(id(_e), _fk) < _np]
                 _praw = (list(_fe["postal_raw"]) if _fold_ok else []) + [_e for _e in _raw_new if _chat_postal_relevant(_e)]
                 _pcards = _hydrate_postal(list(_praw), _postal_index(), sid) if _praw else []
-                _ppend = any(not (_c.get("kind") == "postal-service" and _c.get("summary")) for _c in _pcards)
                 _plp = list(_fe["pl_pending"]) if _fold_ok else []
+                _touts = list(_fe["task_outs"]) if _fold_ok else []
+                for _e in _newpart:
+                    for _r in (_e.get("reminders") or []) if _e.get("kind") == "user" else ():
+                        _note = _parse_task_notification("<task-notification>%s</task-notification>" % _r)
+                        if _note and _note.get("tool_use_id") and _note.get("output_file"):
+                            _touts.append((_note["output_file"], _chat_stat_key(_note["output_file"])))
                 for _i in range(_pref_len, _b):
                     _e = events[_i]
                     if _e.get("kind") in ("user", "assistant") and _e.get("uuid") and _e.get("md"):
@@ -21478,14 +21517,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                     "orphan_uuids": {_o["uuid"] for _o in orphans[:_cur[3]] if _o.get("uuid")},
                     "orphan_texts": [_o["text"].strip() for _o in orphans[:_cur[3]] if (_o.get("text") or "").strip()],
                     "open_tools": _open_tools, "skill_unfilled": _skill_unf,
-                    "postal_raw": _praw, "postal_cards": _pcards, "postal_pending": _ppend,
-                    "postal_key": _pk, "judge_gen": _judge_gen[0], "pl_pending": _plp})
-            _chat_fold_last["prefix_next"] = _b
+                    "postal_raw": _praw, "postal_cards": _pcards,
+                    "postal_key": _pk, "judge_gen": _judge_gen[0], "pl_pending": _plp,
+                    "task_outs": _touts})
+            _chat_fold_last.info["prefix_next"] = _b
         except Exception:
-            _CHAT_FOLD_STATS["fallback"] += 1
             with _chat_fold_lock:
                 _chat_fold.pop(sid, None)
-            if not _chat_fold_warned[0] or _CHAT_FOLD_STATS["fallback"] in (10, 100, 1000):
+            if _chat_fold_count("fallback") in (1, 10, 100, 1000) or not _chat_fold_warned[0]:
                 _chat_fold_warned[0] = True
                 sys.stderr.write("chat fold: commit failed (%s) — this session rebuilds in full until it succeeds (stats %r)\n"
                                  % (traceback.format_exc().strip().splitlines()[-1], dict(_CHAT_FOLD_STATS)))
@@ -27949,9 +27988,9 @@ def _push(targets, connect=False, tmux=None):
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
                           ms=round((time.monotonic() - _t0) * 1000, 1),
                           events=(len(m.get("events") or []) if m else 0),
-                          fold=_chat_fold_last.get("fold", 0), k=_chat_fold_last.get("k", 0),
-                          prefix=_chat_fold_last.get("prefix", 0),   # events reused from the sealed prefix
-                          why=_chat_fold_last.get("why", ""))         # the demote reason on a full build
+                          fold=_chat_fold_last_info().get("fold", 0), k=_chat_fold_last_info().get("k", 0),
+                          prefix=_chat_fold_last_info().get("prefix", 0),   # events reused from the sealed prefix
+                          why=_chat_fold_last_info().get("why", ""))         # the demote reason on a full build
                 if not m:
                     continue
                 _note_chat_divergence(s["sid"], m.get("name") or "",
@@ -27991,7 +28030,9 @@ def _push(targets, connect=False, tmux=None):
                     _built_chat.pop(sid, None)
                     _prev_chat_events.pop(sid, None)
                     _prev_chat_ledger.pop(sid, None)
-                    with _chat_fold_lock:
+            with _chat_fold_lock:                        # …and every fold entry for a sid no longer shown,
+                for sid in list(_chat_fold):             # including ones _built_chat never held (thread sids,
+                    if sid not in shown_sids:            # loadOlder / connect-push builds)
                         _chat_fold.pop(sid, None)
             _retry_parked_creates()   # lag-parked comment creates ride every pusher cycle (T106)
             # COMMENT THREADS: one {type:"comments"} frame per session that has ever had one (its

--- a/tests/test_chat_fold.py
+++ b/tests/test_chat_fold.py
@@ -27,6 +27,10 @@ os.environ.pop("ROMP_STATE_DIR", None)
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_chatfold", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd                                      # the kernel's OWN judge module (a second load would rebind nothing)
+# a SECOND kernel instance for the deep replay: its fold cache is cleared before every build (always the
+# full path) while the first keeps folding fold on fold — the assembly replay's emi/emr arrangement
+kmr = SourceFileLoader("romp_kernel_chatfold_ref", os.path.join(BIN, "romp-kernel")).load_module()
+MODS = (km, kmr)
 
 SID = "11111111-2222-3333-4444-555555555555"
 
@@ -73,31 +77,34 @@ class Sess:
         self.tpath.write_text("")
         names = td / "names"; names.mkdir()
         (names / SID).write_text("web\t%s\t#abcdef\n" % str(self.cdir))
-        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
-        jd.NAMES, jd.PROJECTS = names, proj
-        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
-        jd.STATE = td
-        km.NAMES = names
-        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        self.saved = [(m.jd.NAMES, m.jd.PROJECTS, m.jd.CAPDIR, m.jd.ARCHDIR, m.jd.GOALDIR, m.jd.STATE,
+                       m.NAMES, m._tmux_sessions, m._GLOBAL_CLAUDE_MD, m._msg_summaries) for m in MODS]
         self.now = int(__import__("time").time())        # discovery keys on the real clock
         self.t = self.now - 3 * 86400
         state = "working" if working else "idle"
         self.tm = {SID: {"state": state, "since": self.now - 100, "model": "", "effort": "",
                          "context": None, "compactPct": None, "color": None}}
-        km._tmux_sessions = lambda: self.tm
-        km._chat_fold.clear()
-        km._parse_cache.clear()
-        km._PATH_LINK_CACHE.clear()                     # keyed (sid, uuid): fixtures reuse both across tests
-        km._SPACE_PATH_CACHE.clear()
-        jd._discover_cache.clear() if isinstance(jd._discover_cache, dict) else None
+        for m in MODS:                                   # both kernel instances see the same synthetic world
+            m.jd.NAMES, m.jd.PROJECTS = names, proj
+            m.jd.CAPDIR, m.jd.ARCHDIR, m.jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+            m.jd.STATE = td
+            m.NAMES = names
+            m._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+            m._tmux_sessions = lambda: self.tm
+            m._chat_fold.clear()
+            m._parse_cache.clear()
+            m._PATH_LINK_CACHE.clear()                  # keyed (sid, uuid): fixtures reuse both across tests
+            m._SPACE_PATH_CACHE.clear()
+            m._postal_index_memo[0] = None
+            m.jd._discover_cache.clear() if isinstance(m.jd._discover_cache, dict) else None
         self.n = 0
         self.last = None
 
     def close(self):
-        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved
-        km._chat_fold.clear()
+        for m, sv in zip(MODS, self.saved):
+            (m.jd.NAMES, m.jd.PROJECTS, m.jd.CAPDIR, m.jd.ARCHDIR, m.jd.GOALDIR, m.jd.STATE,
+             m.NAMES, m._tmux_sessions, m._GLOBAL_CLAUDE_MD, m._msg_summaries) = sv
+            m._chat_fold.clear()
         self.td.cleanup()
 
     def uid(self):
@@ -130,8 +137,8 @@ class Sess:
         self.tpath.write_text("".join(json.dumps(r) + "\n" for r in recs))
         os.utime(self.tpath, None)
 
-    def build(self):
-        return km.build_session(SID, self.now, self.tm)
+    def build(self, mod=None):
+        return (mod or km).build_session(SID, self.now, self.tm)
 
 
 def _dump(m):
@@ -288,6 +295,190 @@ class Gates(_Fold):
         self.assertEqual(km._chat_fold_get(SID)["n"], 3, "every ended turn before the last is sealed")
 
 
+ROMP_AUTO = "<!-- romp-injected --><!-- romp-auto -->Where does this stand? If nothing is blocking you, keep going."
+ROMP_RESTART = ("<!-- romp-injected --><!-- romp-system -->[romp] The romp kernel restarted and cut this "
+                "session's in-flight turn; the session has been resumed with its history intact.")
+
+
+class Seams(_Fold):
+    def _cut_turn(self, i):
+        """A turn cut by a kernel restart: prompt, a tool call in flight, the CLI's stop record, its
+        synthetic settle reply — the shape every restart mints."""
+        s = self.s
+        u = s.uid(); recs = [uline(s.tick(), "step %d: reindex the notes" % i, u, s.last)]
+        a = s.uid(); recs.append(aline(s.tick(), "Reindexing.", a, u, tools=("Bash",), stop="tool_use"))
+        m = s.uid(); recs.append(uline(s.tick(), "[Request interrupted by user]", m, a))
+        z = s.uid(); recs.append(aline(s.tick(), "No response requested.", z, m, model="<synthetic>"))
+        s.last = z
+        return recs
+
+    def test_an_undecided_seam_is_never_sealed_and_its_cause_lands_later(self):
+        # T0-T1 normal; T2 is cut; T3 opens with a romp auto-nudge (not a decider); the fold must hold the
+        # boundary BEFORE T2 through every build — including the one where T2 stops being the first tail
+        # turn — so that when the restart notice lands in T4 the marker is stamped and the settle dropped
+        s = self.s
+        self.grow(2)
+        s.append(self._cut_turn(2))
+        self.equiv("cut turn is last")
+        def romp_turn(text, reply):                       # a romp-injected prompt and the agent's reply: one ended turn
+            u_ = s.uid(); s.append([uline(s.tick(), text, u_, s.last)])
+            a_ = s.uid(); s.append([aline(s.tick(), reply, a_, u_)]); s.last = a_
+        romp_turn(ROMP_AUTO, "Still on the reindex.")
+        self.equiv("nudge turn after the cut")
+        self.assertLessEqual(km._chat_fold_get(SID)["n"], 2, "the undecided seam holds the boundary before its turn")
+        romp_turn(ROMP_AUTO, "Nothing new yet.")          # a second non-deciding turn: the seam stays undecided
+        self.equiv("a second nudge turn")
+        self.assertLessEqual(km._chat_fold_get(SID)["n"], 2, "…and keeps holding it while more non-deciding turns land")
+        romp_turn(ROMP_RESTART, "Resuming where I left off.")
+        inc = self.equiv("restart notice landed")
+        marker = next(ev for ev in inc["events"] if ev.get("interruptMarker"))
+        self.assertEqual(marker.get("interruptCause"), "restart")
+        self.assertTrue(marker.get("settleUuids"))
+        self.assertFalse(any(ev.get("interruptSettle") for ev in inc["events"]), "the machine cut's settle line is dropped")
+        s.append(s.turn(6))
+        self.equiv("decided seam seals with the next turn")
+        self.assertGreaterEqual(km._chat_fold_get(SID)["n"], 4, "once decided, the seam's turn seals like any other")
+
+
+class PostalCards(_Fold):
+    MID = "1788400000.100_1.TESTHOST"
+    PEER = "22222222-3333-4444-5555-666666666666"
+
+    def _log(self):
+        d = jd.STATE / "timeline"; d.mkdir(exist_ok=True)
+        (d / "messages.jsonl").write_text(json.dumps({"ev": "sent", "id": self.MID, "from": "api", "from_id": self.PEER,
+                                                      "to_id": SID, "body": "the api tests are green now",
+                                                      "kind": "coordinate", "t": self.s.t}) + "\n")
+
+    def test_a_caption_rewritten_after_the_seal_refreshes_the_card(self):
+        # the judge writes a LIVE caption under an id it later overwrites with the final one: a card
+        # sealed complete between the two must not keep the live gloss forever
+        s = self.s
+        self._log()
+        caps = {self.MID: "peer: tests green (live)"}
+        for m in MODS:
+            m._msg_summaries = lambda caps=caps: dict(caps)
+        self.grow(1)
+        u = s.uid(); s.append([uline(s.tick(), "<!-- romp-msg-id: %s -->\nthe api tests are green now" % self.MID, u, s.last)])
+        a = s.uid(); s.append([aline(s.tick(), "Noted, thanks.", a, u)]); s.last = a
+        s.append(s.turn(2))
+        inc = self.equiv("card sealed with the live caption")
+        card = next(ev for ev in inc["events"] if ev.get("kind") == "postal-service")
+        self.assertEqual(card.get("summary"), "peer: tests green (live)")
+        caps[self.MID] = "peer: api tests green"          # the FINAL caption lands
+        for m in MODS:
+            m._judge_gen[0] += 1
+        n0 = km._CHAT_FOLD_STATS.get("g:postal", 0)
+        inc2 = self.equiv("caption rewritten")
+        self.assertGreater(km._CHAT_FOLD_STATS.get("g:postal", 0), n0)
+        card2 = next(ev for ev in inc2["events"] if ev.get("kind") == "postal-service")
+        self.assertEqual(card2.get("summary"), "peer: api tests green")
+
+
+class TaskOutputs(_Fold):
+    def test_a_notification_whose_output_file_grows_after_the_seal_demotes(self):
+        s = self.s
+        out = s.cdir / "nightly.out"
+        out.write_text("line 1\n")
+        note = ("<task-notification>\n<status>completed</status>\n<summary>nightly check</summary>\n"
+                "<output-file>%s</output-file>\n<tool-use-id>toolu_bg_1</tool-use-id>\n</task-notification>" % out)
+        self.grow(1)
+        u = s.uid(); s.append([uline(s.tick(), note, u, s.last)])
+        a = s.uid(); s.append([aline(s.tick(), "The nightly check passed.", a, u)]); s.last = a
+        s.append(s.turn(2))
+        inc = self.equiv("notification sealed")
+        card = next(ev for ev in inc["events"] if ev.get("taskOutputs"))
+        self.assertIn("line 1", card["taskOutputs"]["toolu_bg_1"]["output"])
+        self.assertTrue(km._chat_fold_get(SID)["task_outs"], "the sealed card's output file is remembered")
+        with open(out, "a") as f:
+            f.write("line 2\n")
+        os.utime(out, None)
+        n0 = km._CHAT_FOLD_STATS.get("g:task-output", 0)
+        inc2 = self.equiv("output grew")
+        self.assertGreater(km._CHAT_FOLD_STATS.get("g:task-output", 0), n0)
+        card2 = next(ev for ev in inc2["events"] if ev.get("taskOutputs"))
+        self.assertIn("line 2", card2["taskOutputs"]["toolu_bg_1"]["output"])
+        out.unlink()                                     # …and a vanished file renders differently too
+        self.equiv("output vanished")
+
+
+class DeepReplay(_Fold):
+    def test_record_by_record_fold_on_fold_equals_a_full_build_at_every_step(self):
+        # the folding kernel is never reset (fold on fold, deep chains); the reference kernel clears its
+        # fold cache before every build — two module instances, one synthetic world
+        s = self.s
+        recs = []
+        for i in range(6):
+            recs += s.turn(i)
+        s.last = None
+        recs += self.__class__._interleave(self, recs)
+        f0 = km._CHAT_FOLD_STATS["fold"]
+        for i, r in enumerate(recs):
+            s.append([r])
+            inc = s.build(km)
+            kmr._chat_fold.clear()
+            ref = s.build(kmr)
+            self.assertEqual(_dump(ref), _dump(inc), "fold-on-fold diverged from full at record %d" % (i + 1))
+        self.assertGreater(km._CHAT_FOLD_STATS["fold"] - f0, len(recs) // 2, "the chain must actually fold")
+
+    @staticmethod
+    def _interleave(self, recs):
+        # a nudge, a cut turn and its late restart notice, in the same stream
+        s = self.s
+        s.last = recs[-1]["uuid"]
+        extra = []
+        n_ = s.uid(); extra.append(uline(s.tick(), ROMP_AUTO, n_, s.last)); s.last = n_
+        u = s.uid(); extra.append(uline(s.tick(), "step 6: reindex", u, s.last))
+        a = s.uid(); extra.append(aline(s.tick(), "Reindexing.", a, u, tools=("Bash",), stop="tool_use"))
+        m = s.uid(); extra.append(uline(s.tick(), "[Request interrupted by user]", m, a))
+        z = s.uid(); extra.append(aline(s.tick(), "No response requested.", z, m, model="<synthetic>"))
+        n2 = s.uid(); extra.append(uline(s.tick(), ROMP_AUTO, n2, z)); s.last = n2
+        r_ = s.uid(); extra.append(uline(s.tick(), ROMP_RESTART, r_, s.last)); s.last = r_   # decides the seam
+        extra += s.turn(7)
+        extra += s.turn(8)
+        return extra
+
+
+class Fallback(_Fold):
+    def test_a_gate_check_failure_counts_once_drops_the_entry_and_builds_in_full(self):
+        self.grow(3)
+        class Boom(dict):                             # read only by the gate check (the parse writes it)
+            def get(self, *a, **k):
+                raise RuntimeError("boom")
+        saved = km._parse_mode
+        km._parse_mode = Boom(saved)
+        try:
+            fb0, g0 = km._CHAT_FOLD_STATS["fallback"], km._CHAT_FOLD_STATS.get("g:fallback", 0)
+            self.s.append(self.s.turn(3))
+            inc = self.s.build()
+        finally:
+            km._parse_mode = saved
+        self.assertEqual(km._CHAT_FOLD_STATS["fallback"], fb0 + 1)
+        self.assertEqual(km._CHAT_FOLD_STATS.get("g:fallback", 0), g0, "a fallback is never also a demote")
+        km._chat_fold.clear()
+        self.assertEqual(_dump(self.s.build()), _dump(inc), "the fallback build is a correct full build")
+
+
+class DeltaSend(_Fold):
+    def test_a_fold_build_ships_as_a_tail_from_the_first_changed_index(self):
+        self.grow(2)
+        m1 = self.s.build()
+        sent = []
+        c = {"send": lambda body: sent.append(json.loads(body)), "sent": {}, "echat": {}}
+        km._send_chat(c, m1, None, 0, False)
+        self.assertEqual(sent[-1]["type"], "session")
+        self.s.append(self.s.turn(2))
+        m2 = self.s.build()                              # a fold: the prefix dicts are m1's
+        change_from = km._chat_diff(m1["events"], m2["events"])
+        self.assertGreater(change_from, 0)
+        km._send_chat(c, m2, None, change_from, False)
+        tail = sent[-1]
+        self.assertEqual(tail["type"], "chatTail")
+        self.assertEqual(tail["from"], change_from)
+        self.assertEqual(len(tail["events"]), len(m2["events"]) - change_from)
+        self.assertTrue(any(ev.get("md", "").startswith("step 2") for ev in tail["events"]))
+
+
 class Diff(unittest.TestCase):
     def test_chat_diff_takes_the_identity_path_before_comparing(self):
         class Bomb(dict):
@@ -338,7 +529,7 @@ class Wiring(unittest.TestCase):
 
     def test_perf_line_carries_the_fold_fields(self):
         src = inspect.getsource(km)
-        self.assertIn('fold=_chat_fold_last.get("fold", 0)', src)
+        self.assertIn('fold=_chat_fold_last_info().get("fold", 0)', src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #906 (issue #903): three fold/full divergences found by the manager session's adversarial review of the merged head, each reproduced there with a record sequence, plus the plumbing nits from the same review. All three were silent (fold counted, no `g:*`), the failure class the design forbids.

## Fixes

1. **The interrupt-seam hold sealed an undecided marker one build late.** The commit loop broke out without lowering the boundary when the undecided marker's turn was the first tail turn, which is exactly the state one build after the cut turn stops being last. A kernel restart's resume notice lands after nudges and peer mail, so the marker then sat in a sealed prefix that tail-only `_stamp_interrupt_causes` could never stamp: no cause, the settle bubble kept, until an unrelated gate happened to demote. The hold may now drop the boundary to the fold start; the next pass finds no marker and re-commits the unchanged prefix.
2. **A postal card sealed complete was never re-hydrated.** The gate re-hydrated the sealed raw postal events only while a card lacked its caption, but the judge writes a LIVE caption under an id it later overwrites with the final one, and a peer's colour can change. The sealed raw postal events are now re-hydrated on every postal-index or judge-pass move (a handful of raw events per session, cheap), and any card that differs demotes `g:postal`.
3. **Task-notification cards froze their output tail at the seal.** The entry now records each sealed notification's output file with its (mtime, size); a file that grew, appeared or vanished demotes `g:task-output`.

Plumbing: counters increment under the cache lock; a gate-check failure counts `fallback` once (no `g:fallback` double count) and drops the entry it choked on; the perf-line fields are per thread; the eviction sweep drops fold entries for every sid no longer shown, not only those `_built_chat` held.

## Tests (red-first: each scenario fails on #906's head)

`tests/test_chat_fold.py` gains a cut turn followed by nudges and a late restart notice (the boundary holds before the cut turn through every build; the notice then stamps the cause and drops the settle; the turn seals once decided), a peer card whose caption is rewritten after the seal, a notification whose output file grows and then vanishes, a record-by-record fold-on-fold replay against a second kernel instance that always builds in full (with the exact same scenario mix), a counted fallback that drops the entry and still builds correctly, and `_send_chat` shipping a fold build as a chatTail from the first changed index. Full suite green locally.
