### PR TITLE
TmuxBackend.busy() reads the hook-maintained session state, corroborated by the transcript's event order

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,7 +6,7 @@ fires on a Claude Code lifecycle event; none of them poll.
 
 | Hook | Event | What it does |
 |---|---|---|
-| `romp-wake.sh` | turn end / new work | Wakes the judges when an event creates new work for them (event-based over time heuristics, by design). |
+| `romp-wake.sh` | turn end / prompt / compaction end | Wakes the kernel — the judges and the parked-op drain — when an event creates new work for them (event-based over time heuristics, by design). |
 | `romp-summarize.sh` | turn events | The announcer: writes a short live phrase to the `@claude-summary` tmux var that status lines and dashboards render. Display-only. |
 | `tmux-status.sh` | status events | The passive status pipe serving both backends: membership, `working`/idle state, `@romp-session-id` re-anchoring after `/clear` forks. Never spawns or toasts. |
 | `romp-postal-ensure.sh` | SessionStart | Makes sure the postal bus is running (async, singleton). |

--- a/hooks/romp-wake.sh
+++ b/hooks/romp-wake.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 # romp-wake.sh — event-driven judge trigger (design: event-based over time heuristics).
 #
-# Fires on the Claude Code events that create NEW work for the judges — a turn
-# ended (Stop) or a prompt landed (UserPromptSubmit) — and pokes the kernel's
-# POST /tick so the producer runs a judge pass NOW instead of waiting out the
-# 20s backstop. Without this the feed can lag up to ~20s behind a completed turn.
+# Fires on the Claude Code events that create NEW work for the kernel — a turn
+# ended (Stop), a prompt landed (UserPromptSubmit), or a compaction ended
+# (PostCompact) — and pokes the kernel's POST /tick so the judge producer runs a
+# pass NOW instead of waiting out its 3 s backstop, and the pusher's parked-op
+# drain runs now instead of on its 0.5 s one. A tmux /compact ends at
+# PostCompact: the poke wakes the drain, and the op queued behind the compact
+# fires once the compaction is corroborated in the transcript (the boundary
+# record). Without this the feed lags a completed turn by a backstop.
 #
 # Fire-and-forget: it MUST never block or fail a turn. The curl is detached into
 # a subshell with a short timeout and every output/error is swallowed. If no
 # kernel is listening (none running, or a headless/non-romp session) the poke
-# fails silently — the producer's 20s backstop still covers it.
+# fails silently — the backstops still cover it.
 set -uo pipefail
 
 # Drain stdin (Claude Code sends the hook event as JSON) so we never SIGPIPE the
@@ -22,7 +26,7 @@ cat >/dev/null 2>&1 || true
 port="${ROMP_SERVE_PORT:-${ROMP_KERNEL_PORT:-29855}}"
 # The kernel gates every request on the serve token, loopback included (Jupyter's model) — read it
 # the way the kernel resolves it: env override, else the 0600 state file. Missing token → the poke
-# 403s silently, same posture as no kernel at all (the 20s backstop covers it).
+# 403s silently, same posture as no kernel at all (the backstops cover it).
 tok="${ROMP_SERVE_TOKEN:-}"
 [[ -n "$tok" ]] || tok="$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/serve-token" 2>/dev/null || true)"
 # The token goes in on STDIN as a curl config, never in argv: /proc/<pid>/cmdline is world-readable,

--- a/hooks/tmux-status.sh
+++ b/hooks/tmux-status.sh
@@ -46,6 +46,10 @@ input=$(cat)
 # mode's transient permission notifications (which the classifier allows moments
 # later) — an event-based replacement for the feed's old time-threshold debounce.
 [[ "$input" =~ \"permission_mode\":\"([^\"]+)\" ]] && PERM_MODE="${BASH_REMATCH[1]}" || PERM_MODE=""
+# PreCompact / PostCompact carry trigger = "manual" | "auto" (the CLI's own hook-input schema, verified on
+# 2.1.257; it is also the matcher those events filter on). An AUTO compaction runs INSIDE an open turn that
+# then continues; a MANUAL /compact is its own exchange and leaves the session idle.
+[[ "$input" =~ \"trigger\":\"([^\"]+)\" ]] && TRIGGER="${BASH_REMATCH[1]}" || TRIGGER=""
 
 case "$EVENT" in
     SessionStart)          state="waiting" ;;
@@ -53,7 +57,11 @@ case "$EVENT" in
     PostToolUse)           state="working" ;;
     Stop)                  state="waiting" ;;
     PreCompact)            state="compacting" ;;   # context compaction STARTED (manual /compact or auto)
-    PostCompact)           state="waiting" ;;      # compaction done → idle for next prompt (any real event re-corrects)
+    PostCompact)           # compaction done. MANUAL: the /compact was the whole exchange → idle for the next
+                           # prompt. AUTO: it ran inside an open turn that now goes on → still working (until
+                           # 2026-09-03 both wrote waiting, and the kernel read the continuing turn as quiet until
+                           # the next PostToolUse re-corrected it — a parked op could fire into it)
+        if [[ "$TRIGGER" == "auto" ]]; then state="working"; else state="waiting"; fi ;;
     Notification)
         case "$NOTIF_TYPE" in
             permission_prompt) state="permission" ;;

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,9 @@ WANT = {  # event -> [(hook script, timeout secs, async)]
 
     "Notification":     [("tmux-status.sh", 5, False)],
     "PreCompact":       [("tmux-status.sh", 5, False)],
-    "PostCompact":      [("tmux-status.sh", 5, False)],
+    "PostCompact":      [("tmux-status.sh", 5, False),
+                         ("romp-wake.sh", 5, True)],     # compaction ended → wake the drain; the op behind a /compact fires once
+                                                          # the compaction is corroborated in the transcript
 }
 
 try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10997,6 +10997,93 @@ class TmuxBackend(sb.SessionBackend):
                          "mode": p[9].strip() if len(p) > 9 else ""}   # @claude-permission-mode (shift+tab cycle)
         return out
 
+    # The @claude-state words this backend answers for, split by what a paste into the pane would do right
+    # now. Writers: hooks/tmux-status.sh (UserPromptSubmit / PostToolUse → working, Stop / SessionStart →
+    # waiting, PostCompact → waiting after a manual compaction and working after an auto one — that turn
+    # goes on —, the permission_prompt notification → permission, idle_prompt → idle) and record_state (the
+    # revive watcher's picker). compacting is deliberately in NEITHER tuple: busy() answers None for it, so
+    # _working_now falls to the cached parse and _compacting_now owns that gate, with the escape that
+    # disbelieves a stuck row (an open turn or a compact_boundary since the row's since). Any other word —
+    # "" before the first hook publish, an unknown spelling — is likewise no answer, never a hold.
+    BUSY_STATES = ("working", "permission", "picker")
+    QUIET_STATES = ("waiting", "idle")
+    corroborates_with_transcript = True   # busy() below may be overruled by the cached parse → the pusher keeps
+    #                                       it current for this backend's parked sids (_refresh_parked_parses)
+
+    def busy(self, sid):
+        """AUTHORITATIVE 'is a turn in flight' for a tmux session: the hook-maintained @claude-state,
+        corroborated against the cached transcript parse by EVENT ORDER (review finds on #904 and on this
+        change's first cut, 2026-09-03).
+
+        Why the row: before it this backend answered None and _working_now fell to the CACHED transcript
+        parse — which is None whenever the transcript's (mtime, size) moved since the last parse, and None
+        reads as idle. A tmux session MID-TURN therefore read as quiet the moment its transcript grew, and
+        the parked-op drain (every pusher cycle, ahead of the push that refreshes the cache) fired the op
+        behind into the open turn: a parked slash command landed as text. UserPromptSubmit flips the row to
+        working the instant the CLI accepts a prompt — no transcript write, no parse, no lag.
+
+        Why not the row alone: Claude Code fires NO hook on an Esc-interrupt (hooks/tmux-status.sh and
+        romp-idle-dots both say so), so an interrupted session's row reads working until romp-idle-dots
+        heals it — two minutes at the earliest, and only once the pane looks idle. Trusted alone, every send
+        typed after a Stop parked for minutes; the cached parse had corrected exactly this, because the
+        CLI's interrupt record (or the kernel's own idle record, _record_idle) ENDS the turn. So the two
+        sources are ordered by the events they record, the way _compacting disbelieves a compacting row: the
+        row carries `since` (@claude-state-since, rewritten on every hook write); when the cached parse
+        matches the file on disk (_parse_cached is not None — the transcript has NOT moved since it was
+        parsed) AND the last turn's newest record is NEWER than `since`, the transcript spoke after the
+        hook and its verdict wins (_session_working); otherwise the hook wins. "Newest record" is the
+        largest atom `t` of the last turn — never turn["end"], which for an idle span at the tail is the
+        PARSE time and would outrank every hook write; an idle atom's `t` is a real event (a states-file
+        record: the Stop hook's waiting, the kernel's interrupt idle, the idle-dots heal). The two shapes:
+          * a turn just STARTED — row working with a fresh since, the transcript not yet written (the cache
+            matches the file; the last turn ended BEFORE since) → the hook wins → True. The gap stays shut.
+          * an Esc-INTERRUPT — row working with an old since; the interrupt record (or the idle record)
+            ends the turn AFTER since → the parse wins → False. Sends deliver.
+        The same rule runs for permission and picker (a phantom or answered prompt strands those rows the
+        same way), and in the other direction for waiting / idle: a row older than an open turn's newer
+        records reads True — which also narrows the gap after an auto-compaction, whose PostCompact once
+        wrote waiting into a turn that went on. A parse that cannot be consulted — None (the file moved
+        since the last parse, or was never parsed) or a row without `since` — leaves the hook standing:
+        the transcript has not spoken since, or cannot be dated against the row. TIES (the same second)
+        go to the hook, deliberately: a hook fires after the record it reports on (Stop after the final
+        assistant record; the permission notification after the tool_use) or before any record exists
+        (UserPromptSubmit, before the prompt is written), so a same-second row is the later word. The one
+        sticky exception is accepted: a PostToolUse rewrite and an Esc in the same second leave working
+        standing until romp-idle-dots heals it or the next pane prompt.
+
+        This never parses — it also serves the WS handler, which must stay cheap — so headless (no chat or
+        timeline client, or every session after a kernel restart until one connects) nothing would fill
+        the cache and the row would stand verbatim; _refresh_parked_parses, at the head of every pusher
+        cycle, re-parses the moved transcripts of the sids that hold parked ops so the drain's gates read a
+        current transcript.
+
+        None when there is no answer: no tmux row for the sid (the hook is not installed, or the pane is
+        gone), a row another backend owns, a state no hook has published yet, an unknown word, or
+        compacting (see BUSY_STATES). Never "hold on unknown": a tmux session whose cache nobody refreshes
+        would otherwise never drain. The row is read through _tmux_sessions() — inside a pusher cycle the
+        cycle's one liveness snapshot, no fork; outside a cycle a fresh Sessions.live(), one tmux fork per
+        user gesture (tens of ms), accepted."""
+        row = _tmux_sessions().get(str(sid))
+        if not row or row.get("backend") != "tmux":
+            return None
+        st = (row.get("state") or "").strip()
+        if st in self.BUSY_STATES:
+            hook = True
+        elif st in self.QUIET_STATES:
+            hook = False
+        else:
+            return None
+        since = row.get("since")
+        path = _path_of(str(sid))
+        turns = ((_parse_cached(path) if path else None) or {}).get("turns") or []
+        if not since or not turns:
+            return hook                                   # the transcript has not spoken since, or cannot be dated
+        last = turns[-1]
+        newest = max([a.get("t") or 0 for a in (last.get("atoms") or [])] + [last.get("t") or 0])
+        if newest <= since:
+            return hook                                   # the row is the later word (a tie goes to the hook — see above)
+        return _session_working(turns)                    # the transcript spoke after the hook: its verdict
+
     # control — map sid→name, delegate to the existing injectors. send() does NOT echo: the kernel adds the
     # optimistic input echo for a composer send (see _optimistic_echo), matching today's split where the
     # command sends (/compact, /model, follow-ups) don't echo on tmux.
@@ -19470,8 +19557,10 @@ def _working_now(sid):
     """Is the session's turn OPEN right now. Prefer the backend's AUTHORITATIVE busy signal (SDK inflight)
     — the CACHED parse below LAGS a just-started turn (transcript-not-yet-written), which raced the drive-op
     gate: a /compact pressed while a turn was truly in flight saw 'not working', skipped the FIFO, and fired
-    immediately, out of press-order (the user 2026-07-14). tmux has no such signal (busy→None) → the cached
-    event-model parse, unchanged. Both are cheap enough for the WS handler + the pusher's drain."""
+    immediately, out of press-order (the user 2026-07-14). tmux answers from the hook-maintained
+    @claude-state, corroborated against the cached parse by event order (TmuxBackend.busy, 2026-09-03);
+    None — no row, no published state, compacting — falls to the cached event-model parse. Both are cheap
+    enough for the WS handler + the pusher's drain."""
     try:
         be = Sessions.backend_for(sid)
         b = be.busy(sid) if be is not None else None
@@ -19614,39 +19703,88 @@ _MOVE_BUSY_RETRIES = 3           # CLI-side `busy` answers retried without waiti
                                  # retry first waits out _MOVE_BUSY_RETRY_S (_hold_drain — see there for why).
 _MOVE_BUSY_RETRY_S = 3.0         # the spacing between those retries: the judge producer's pass cadence, which
                                  # spaced them by accident until the drain moved to the pusher (2026-09-03)
-_TMUX_PROMPT_HOLD_S = 3.0        # after the drain hands a turn-opening op to a backend with NO authoritative
-                                 # busy() (tmux), how long that sid's queue holds before the op behind may fire
-_drain_hold: dict = {}           # sid -> time.monotonic() deadline; _apply_pending_ops skips the sid until then
+_TMUX_PROMPT_HOLD_S = 3.0        # the prompt hold's clock FALLBACK: after the drain hands a session a turn-opening
+                                 # op and busy() did not read True inside send(), the sid holds until busy() is
+                                 # OBSERVED True (tmux: the UserPromptSubmit hook's flip) — or, if no flip ever comes
+                                 # (a paste tmux refused, a builtin that opens no prompt turn), until this many seconds
+_drain_hold: dict = {}           # sid -> (time.monotonic() deadline, until_busy); _apply_pending_ops skips the sid
+                                 # while the hold is open (_drain_hold_open)
 
 
-def _hold_drain(sid, seconds):
-    """Hold ONE sid's parked queue for `seconds` — the two places the drain must NOT run again at its own
-    cadence, made explicit (2026-09-03). The drain rides the pusher cycle, which any client push, any SDK
-    stream atom of any session, and the drain's own deliveries wake — so "the next cycle" can be
-    milliseconds away. Two consumers need more than that and have NO event to key on:
+def _hold_drain(sid, seconds, until_busy=False):
+    """Hold ONE sid's parked queue — the two places the drain must NOT run again at its own cadence, made
+    explicit (2026-09-03). The drain rides the pusher cycle, which any client push, any SDK stream atom of
+    any session, and the drain's own deliveries wake — so "the next cycle" can be milliseconds away. Two
+    consumers need more than that:
       * a move the CLI answered `busy` (_move_now): the CLI's post-result bookkeeping window is sub-second
         and emits nothing when it closes; the _MOVE_BUSY_RETRIES exist to outlast it, and back-to-back
-        cycles would burn all three inside it, leaving the op waiting on a turn_seq that never moves;
-      * a send / command / compact just handed to a tmux session (TmuxBackend has no busy(); _working_now
-        falls to the cached transcript parse): the keystrokes have landed but the transcript has not
-        recorded the prompt, so the gate reads idle for a moment and the op behind would fire into the
-        opening turn — the mis-delivery the SEND-ends-the-drain contract exists to prevent.
-    Both are the judge producer's old 3 s cadence made explicit, which spaced them by accident before. An
-    honest clock, named as one: the tmux half retires when TmuxBackend gains an authoritative busy() from
-    the hook-maintained session state; the SDK and Codex backends need neither hold (_after_turn_opening)."""
-    _drain_hold[str(sid)] = time.monotonic() + seconds
+        cycles would burn all three inside it, leaving the op waiting on a turn_seq that never moves. No
+        event to key on, so this one is a clock — `seconds` (_MOVE_BUSY_RETRY_S, the judge producer's old
+        3 s cadence, which spaced the retries by accident before), named as one;
+      * a send / command / compact just handed to a backend whose busy() did not read True inside send()
+        (_after_turn_opening). tmux: the paste is a daemon thread that clears the box, pastes and presses
+        Enter over ~0.3 s, and the row flips to working only when the CLI accepts the prompt and the
+        UserPromptSubmit hook runs — a cycle inside that window reads the row as still waiting, and the op
+        behind would fire into the opening turn, the mis-delivery the SEND-ends-the-drain contract exists
+        to prevent. Nothing in that path emits an event the kernel can see BEFORE the hook's flip, so the
+        hold is keyed on the flip itself: `until_busy` holds the sid until busy() has been OBSERVED True
+        once after the delivery (the flip, seen in a later cycle's snapshot), whereupon the working gate
+        owns the sid as for any open turn — the turn's Stop flip delivers the op behind; or until the sid
+        reads compacting (a delivered /compact: the compaction IS the event, and the compacting gate holds
+        the op behind until it is corroborated over — a compacting row gives no busy answer). `seconds`
+        (_TMUX_PROMPT_HOLD_S) is only the loud fallback for a flip that never comes — a paste tmux
+        refused, a builtin the CLI runs without a prompt turn — and its release is logged, so a queue that
+        drained on the clock is on the record.
+    The SDK and Codex backends need neither: their send() enqueues under the session lock, so busy() reads
+    True before it returns and _after_turn_opening arms nothing."""
+    _drain_hold[str(sid)] = (time.monotonic() + seconds, bool(until_busy))
 
 
-def _after_turn_opening(be, sid):
-    """The drain just handed `sid` an op that OPENS a turn (a send batch, a typed command, a /compact). A
-    backend with an authoritative busy() (SDK, Codex) closed the working gate synchronously inside send(),
-    so the op behind waits for the turn's end by itself; one without (tmux) gets the hold — _hold_drain."""
+def _drain_hold_open(sid, hold):
+    """Is this sid's hold still in force this cycle? A clock hold: until its deadline. An until_busy hold:
+    over the moment busy() reads True — the delivered prompt's turn is open, and the working gate takes it
+    from here — or the moment the sid reads compacting: a delivered /compact goes working → compacting
+    within a fraction of a second, a compacting row gives no busy answer, and without this arm the hold
+    rode the clock and logged the fallback line although the compaction IS the event it waited for; the
+    compacting gate holds the op behind from here. Else held until the fallback deadline, whose release
+    is logged: neither event came."""
+    deadline, until_busy = hold
+    if not until_busy:
+        return time.monotonic() < deadline
     try:
-        authoritative = be.busy(sid) is not None
+        be = Sessions.backend_for(sid)
+        b = be.busy(sid) if be is not None else None
     except Exception:
-        authoritative = False
-    if not authoritative:
-        _hold_drain(sid, _TMUX_PROMPT_HOLD_S)
+        b = None
+    if b is True:
+        return False                                  # the EVENT: the turn is open; the working gate owns the sid now
+    if _compacting_now(sid):
+        return False                                  # the EVENT for a /compact: it is compacting; that gate takes over
+    if time.monotonic() < deadline:
+        return True
+    sys.stderr.write("drain: %s — no busy state observed within the window after a delivered prompt; "
+                     "releasing the queue on the clock fallback\n" % sid)
+    return False
+
+
+def _after_turn_opening(be, sid, remaining):
+    """The drain just handed `sid` an op that OPENS a turn (a send batch, a typed command, a /compact), with
+    `remaining` still queued behind it. Nothing behind → nothing a hold could protect, and none is armed:
+    a hold armed after the queue's LAST op outlived the queue (the sid leaves _pending_ops, so no cycle
+    evaluated or removed it) and fired the fallback line when a later op parked for an unrelated reason.
+    A backend whose send() closed its own busy gate synchronously (SDK, Codex: the turn is pending under
+    the session lock before send() returns) reads busy() True right here, and the op behind waits for the
+    turn's end by itself. Any other answer — tmux's row still says waiting until the UserPromptSubmit hook
+    runs; a backend with no busy() at all — arms the until_busy hold: the sid waits until busy() has been
+    observed True, or the fallback clock runs out (_hold_drain)."""
+    if not remaining:
+        return
+    try:
+        closed = be.busy(sid) is True
+    except Exception:
+        closed = False
+    if not closed:
+        _hold_drain(sid, _TMUX_PROMPT_HOLD_S, until_busy=True)
 
 
 def _move_or_park(be, sid, path, client=None):
@@ -19755,6 +19893,7 @@ def _cancel_parked(sid, park, md):
     ops.pop(park)
     if not ops:
         _pending_ops.pop(sid, None)
+        _drain_hold.pop(sid, None)        # an emptied queue leaves no hold behind (nothing left for it to protect)
     _save_pending_ops()
     _mark_views_dirty()
     return None
@@ -20043,6 +20182,39 @@ def _deliver_send_batch(be, sid, run):
         _optimistic_echo(sid, merged, author=author)
 
 
+def _refresh_parked_parses(now):
+    """Before the drain: re-parse the transcript of every sid that HOLDS PARKED OPS and whose cached parse
+    has gone stale (second review of the tmux busy change, 2026-09-03). TmuxBackend.busy corroborates the
+    hook row against the CACHED parse and can overrule a stranded row (an Esc fires no hook) only when
+    _parse_cached returns a session — and _parse_cached never parses. The cache is filled by client builds
+    (build_session, build_timeline), the client-gated warmer, and a few gesture paths; headless — no chat or
+    timeline client, or every session after a kernel restart until one connects — every live tmux session's
+    cache is None from its first transcript write on, so busy() was the hook verbatim, and after a pane Esc
+    every `romp send` parked until romp-idle-dots healed the row, two minutes at the earliest: a regression
+    the parent did not have, whose stale-cache read was idle. A cache miss IS the event "the transcript
+    moved since we last read it", and this job answers it with the evidence the corroboration needs,
+    bounded four ways: only sids whose backend DECLARES that its busy() may be overruled by the transcript
+    (SessionBackend.corroborates_with_transcript — tmux; the SDK and Codex answer busy() and compacting()
+    authoritatively, so no drain gate reads their cache, and re-parsing an SDK transcript here would have
+    run on every cycle of a streaming turn, whose every atom moves the file AND wakes the pusher — load the
+    parent did not have), only sids with parked ops (the only sids the drain gates this cycle), once per
+    cycle, and only when the file moved (_parse_cached None). A sid with no backend is skipped too. busy()
+    itself stays parse-free — it also serves the WS handler, which must stay cheap. The consequence to
+    know: a headless `romp send` typed right after a pane Esc parks ONCE (at that instant the hook is all
+    busy() has), and the next cycle's refresh lets the drain deliver it — within the 0.5 s backstop instead
+    of ~2 minutes."""
+    for sid in list(_pending_ops):
+        try:
+            be = Sessions.backend_for(sid)
+        except Exception:
+            be = None
+        if be is None or not getattr(be, "corroborates_with_transcript", False):
+            continue                                  # its busy() is the whole truth: nothing here reads its cache
+        path = _path_of(sid)
+        if path and _parse_cached(path) is None:
+            _parse(path, sid, now)
+
+
 def _apply_pending_ops():
     """Pusher cycle: FIFO-deliver parked ops once the session is QUIET (neither compacting nor an open
     turn) — in exactly the order they were parked, which is exactly the order the chat rendered their
@@ -20068,17 +20240,22 @@ def _apply_pending_ops():
     and _fire_move claims _moving before its thread starts, so the sid is skipped until the relocation
     ends. Only a REAL mutation saves the mirror and wakes the pusher: a cycle that delivers nothing (a cwd
     op waiting on its turn_seq) must not re-wake the thread it runs on, or the backstop becomes a hot loop.
-    Two sids are skipped for a while even when quiet — a move the CLI answered busy, and a tmux session
-    just handed a turn-opening op — because their next step has no event to wait for (_hold_drain)."""
+    Two sids are skipped even when they read quiet — a move the CLI answered busy (a clock: its window
+    emits no event), and a session just handed a turn-opening op whose busy gate has not yet been SEEN
+    closed (until its backend reads busy — tmux's UserPromptSubmit flip — or the fallback clock passes) —
+    see _hold_drain."""
     for sid, ops in list(_pending_ops.items()):
         if not ops:
             _pending_ops.pop(sid, None)
+            _drain_hold.pop(sid, None)                # no queue, no hold
             continue
         if sid in _moving:
             continue                                  # a move is mid-flight: its relocation must finish first
-        if _drain_hold.get(sid, 0.0) > time.monotonic():
-            continue                                  # a CLI-side window is still open for this sid (_hold_drain)
-        _drain_hold.pop(sid, None)
+        hold = _drain_hold.get(sid)
+        if hold is not None:
+            if _drain_hold_open(sid, hold):
+                continue                              # this sid's window is still open (_hold_drain)
+            _drain_hold.pop(sid, None)
         if _compacting_now(sid) or _working_now(sid) or _limit_hold(sid):
             continue                                  # …or the account can't serve a request yet
         changed = False                               # a real mutation below → save the mirror + wake the pusher
@@ -20105,7 +20282,7 @@ def _apply_pending_ops():
                     while ops and ops[0][0] == "send":
                         run.append(ops.pop(0))
                     _deliver_send_batch(be, sid, run)
-                    _after_turn_opening(be, sid)
+                    _after_turn_opening(be, sid, ops)
                     break                             # the delivered turn must END before any op behind it fires
                 elif op[0] == "command":
                     # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
@@ -20118,13 +20295,13 @@ def _apply_pending_ops():
                     if op[1].strip().split()[0] == "/compact":
                         _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
                     ops.pop(0)
-                    _after_turn_opening(be, sid)
+                    _after_turn_opening(be, sid, ops)
                     break                             # its turn must end before anything behind it fires
                 elif op[0] == "compact":
                     be.send(sid, "/compact")
                     _mark_compacting(sid)
                     ops.pop(0)
-                    _after_turn_opening(be, sid)
+                    _after_turn_opening(be, sid, ops)
                     break                             # the compaction must finish first
                 elif op[0] == "model":
                     be.set_model(sid, op[1])
@@ -20146,6 +20323,7 @@ def _apply_pending_ops():
         except Exception:
             sys.stderr.write("pending ops apply: %s\n" % traceback.format_exc())
             _pending_ops.pop(sid, None)               # a dead session's queue is dropped, never retried
+            _drain_hold.pop(sid, None)                # …and its hold with it
             changed = True
         if not _pending_ops.get(sid):
             _pending_ops.pop(sid, None)
@@ -28986,6 +29164,10 @@ def _pusher_cycle():
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):
+    try:                                  # the drain's gates read the CACHED parse: re-parse the parked sids'
+        _refresh_parked_parses(now)       # moved transcripts first, so a stranded hook row can be overruled by
+    except Exception:                     # what the transcript says (headless, nobody else fills the cache)
+        sys.stderr.write("parked-parse refresh: %s\n" % traceback.format_exc())
     try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
         _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
     except Exception:                     # FIRST, so a delivered op's echo / retired chip rides this push;
@@ -33449,9 +33631,10 @@ class Handler(BaseHTTPRequestHandler):
                 now_ = _reveal_request(sid, wid)
                 return self._send(200, json.dumps({"ok": True, "delivered": now_}), "application/json")
             if u.path == "/tick":
-                # Event-driven wake: the Stop / UserPromptSubmit hooks (and the postal drain) poke this the
-                # instant a turn ends / a prompt lands / a message arrives, so the judges run NOW instead of
-                # on the next backstop tick. It ALSO wakes the chat PUSHER, so a tmux turn completing/landing
+                # Event-driven wake: the Stop / UserPromptSubmit / PostCompact hooks (and the postal drain) poke
+                # this the instant a turn ends / a prompt lands / a compaction ends / a message arrives, so the
+                # judges run NOW instead of on the next backstop tick — and the parked-op drain runs on the
+                # event it waits for. It ALSO wakes the chat PUSHER, so a tmux turn completing/landing
                 # appears in the chat immediately (the common 'why hasn't it shown up yet' moment) rather than
                 # waiting out the poll — tmux's per-message event-driven path, the SDK live-tail's analogue.
                 # Cheap + idempotent; the hook authorizes with X-Romp-Token read from the 0600 token file.

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -30,6 +30,11 @@ from abc import ABC, abstractmethod
 
 
 class SessionBackend(ABC):
+    # True when busy() may be overruled by the cached transcript parse, so the pusher must keep that parse
+    # current for the sids it holds parked ops for (_refresh_parked_parses); a backend whose busy() is the
+    # whole truth (SDK, Codex) leaves it False and its parked sids are never re-parsed on its account.
+    corroborates_with_transcript = False
+
     # ── liveness / identity ──────────────────────────────────────────────────────────────────────
     @abstractmethod
     def owns(self, sid: str) -> bool:
@@ -60,7 +65,11 @@ class SessionBackend(ABC):
         pressed in that window saw 'not working', bypassed the FIFO, and fired immediately — /compact jumped
         ahead of a model/message pressed right after it, and the parked ops then stalled (the user 2026-07-14,
         reproduced: compact→model→send pressed 150ms apart delivered out of order). The SDK knows its inflight
-        count exactly; tmux has no equivalent (returns None → cached-parse fallback, unchanged)."""
+        count exactly; tmux reads the hook-maintained @claude-state — working / permission / picker → True,
+        waiting / idle → False, compacting → None (the compacting gate owns it), and None for an unknown
+        word, no row, or a row another backend owns — an answer the transcript overrules when the cached
+        parse's newest record is newer than the row's since (an Esc fires no hook, so a stale row can say
+        working over an ended turn)."""
         return None
 
     def compacting(self, sid: str) -> "bool | None":

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -43,6 +43,9 @@ PY
     [ "$(count_cmd Stop romp-postal-drain.sh)" = "1" ]
     [ "$(count_cmd SessionStart romp-postal-ensure.sh)" = "1" ]
     [ "$(count_cmd PostToolUse tmux-status.sh)" = "1" ]
+    # a compaction's END wakes the kernel too: a parked op behind a tmux /compact delivers on this event
+    [ "$(count_cmd PostCompact tmux-status.sh)" = "1" ]
+    [ "$(count_cmd PostCompact romp-wake.sh)" = "1" ]
     [ -L "$HOME/.claude/romp-postal.mcp.json" ]
 }
 

--- a/tests/test_kernel_parked_ops_liveness.py
+++ b/tests/test_kernel_parked_ops_liveness.py
@@ -14,12 +14,14 @@ SYNTHETIC fixtures only: a placeholder uuid, invented texts.
 """
 import inspect
 import io
+import json
 import os
 import tempfile
 import threading
 import time
 import unittest
 from contextlib import redirect_stderr
+from datetime import datetime, timezone
 from unittest import mock
 from importlib.machinery import SourceFileLoader
 
@@ -36,8 +38,11 @@ km = SourceFileLoader("romp_kernel_parkedlive", os.path.join(BIN, "romp-kernel")
 # The ACCOUNT gate is a separate axis (tests/test_kernel_limit_queue.py); pinned off so the real
 # machine's usage.json can never make these tests park for a reason none of them is about.
 km._limit_hold = lambda sid: None
+REAL_PARSE_CACHED = km._parse_cached          # the never-parsing cache reader, before any test patches it
 
 SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "11111111-2222-3333-4444-666666666666"
+SID3 = "11111111-2222-3333-4444-777777777777"
 
 # Every pusher-cycle job except the drain, quieted so a cycle run here does exactly one thing.
 _OTHER_JOBS = ("_push_all", "_lift_spent_awaiting", "_death_sweep_tick", "_end_on_idle_sweep",
@@ -62,6 +67,7 @@ class _FakeBackend:
 
     def send(self, sid, text):
         self.calls.append(("send", text))
+        self.open = True                  # as SdkBackend.send: the turn is pending under the lock before send() returns
         return True
 
     def set_model(self, sid, value):
@@ -70,6 +76,13 @@ class _FakeBackend:
 
     def turn_seq(self, sid):
         return 0
+
+
+def _tmux_row(state):
+    """One romp tmux session's row, shaped as TmuxBackend.live_sessions builds it for the cycle snapshot
+    (the @claude-* vars: state/since/model/effort/context/compactPct/color/mode, tagged backend tmux)."""
+    return {"state": state, "since": int(time.time()) - 5, "model": "", "effort": "", "context": None,
+            "compactPct": None, "color": None, "mode": "", "backend": "tmux"}
 
 
 class DeliveryRidesTheSettle(unittest.TestCase):
@@ -157,7 +170,8 @@ class DeliveryRidesTheSettle(unittest.TestCase):
         km._pusher_cycle()
         self.assertEqual(self.be.calls, [("send", "one")], "the send fired; the compact waits for ITS turn to end")
         self.assertEqual([op[0] for op in km._pending_ops[SID]], ["compact"])
-        self.be.open = True                                                     # the delivered send's turn
+        self.assertNotIn(SID, km._drain_hold, "send() closed the busy gate before it returned: nothing to hold for")
+        self.assertTrue(self.be.open, "the delivered send's turn is in flight")
         km._pusher_cycle()
         self.assertEqual(self.be.calls, [("send", "one")], "nothing fires into an open turn")
         self.be.open = False                                                    # settle #2
@@ -166,27 +180,43 @@ class DeliveryRidesTheSettle(unittest.TestCase):
         self.assertNotIn(SID, km._pending_ops)
         self.assertNotIn(SID, km._drain_hold, "an authoritative busy() needs no hold between deliveries")
 
-    def test_a_tmux_shaped_delivery_holds_the_sid_until_the_prompt_can_have_landed(self):
-        # TmuxBackend has no busy(): _working_now falls to the cached transcript parse, which reads idle for a
-        # moment after the keystrokes land — and the drain's own delivery wakes the pusher, so without the hold
-        # the op behind would fire into the opening turn (the SEND-ends-the-drain contract, broken). The hold
-        # is the producer's old cadence made explicit; it retires when tmux gains an authoritative busy().
-        class _TmuxShaped(_FakeBackend):
+    def test_a_backend_that_cannot_say_busy_still_holds_for_the_fallback_window(self):
+        # a backend with NO busy() at all (a test fake, a future backend): nothing can ever observe its gate
+        # close, so the prompt hold arms and only its clock fallback (_TMUX_PROMPT_HOLD_S) releases it —
+        # the op behind never fires back-to-back into a turn that may be opening
+        class _Mute(_FakeBackend):
             def busy(self, sid):
                 return None
-        self.be = _TmuxShaped()
+        self.be = _Mute()
         with mock.patch.object(km, "_working_now", lambda sid: True):             # the turn is open: both park
             km._send_or_park(self.be, SID, "one", echo="human")
             km._compact_or_park(self.be, SID)
         self.assertEqual([op[0] for op in km._pending_ops[SID]], ["send", "compact"])
-        km._pusher_cycle()                                                        # the cached parse reads idle
-        self.assertEqual(self.be.calls, [("send", "one")], "the send fired")
-        self.assertIn(SID, km._drain_hold, "…and the sid is held while its prompt lands")
-        km._pusher_cycle()                                                        # back-to-back, as a wake would
-        self.assertEqual(self.be.calls, [("send", "one")], "the compact does NOT fire into the opening turn")
-        km._drain_hold.clear()                                                    # the window passed
-        km._pusher_cycle()
+        with mock.patch.object(km, "_TMUX_PROMPT_HOLD_S", 3600.0):
+            km._pusher_cycle()                                                    # the cached parse reads idle
+            self.assertEqual(self.be.calls, [("send", "one")], "the send fired")
+            self.assertIn(SID, km._drain_hold, "…and the sid is held while its prompt lands")
+            km._pusher_cycle()                                                    # back-to-back, as a wake would
+            self.assertEqual(self.be.calls, [("send", "one")], "the compact does NOT fire into the opening turn")
+        far = time.monotonic() + 7200.0                                           # the fallback window passed
+        with mock.patch.object(km.time, "monotonic", lambda: far), redirect_stderr(io.StringIO()):
+            km._pusher_cycle()
         self.assertEqual(self.be.calls, [("send", "one"), ("send", "/compact")])
+
+    def test_a_dead_sessions_queue_drop_takes_its_hold_with_it(self):
+        # the hold check precedes delivery, so a hold present when send() raises can only have been armed
+        # DURING the delivery (a concurrent writer — the move thread's re-park); the drop must not leave it behind
+        class _Dead(_FakeBackend):
+            def send(self, sid, text):
+                km._hold_drain(sid, 60.0)
+                raise RuntimeError("the session is gone")
+        self.be = _Dead()
+        self.be.open = False
+        km._pending_ops[SID] = [("send", "one", "human")]
+        with redirect_stderr(io.StringIO()):
+            km._apply_pending_ops()
+        self.assertNotIn(SID, km._pending_ops, "a dead session's queue is dropped")
+        self.assertNotIn(SID, km._drain_hold, "…and its hold with it")
 
     def test_wake_kernel_sets_both_events_and_is_the_backends_poke(self):
         km._producer_wake.clear()
@@ -248,6 +278,363 @@ class DeliveryRidesTheSettle(unittest.TestCase):
         self.assertIn("send", line)
         self.assertNotIn("a private sentence", line, "the body is user text — never logged")
         self.assertNotIn(SID, km._pending_ops)
+
+
+class TmuxBusyFromHookState(unittest.TestCase):
+    """TmuxBackend.busy() answers from the hook-maintained @claude-state the cycle snapshot already carries
+    (hooks/tmux-status.sh: UserPromptSubmit / PostToolUse → working, Stop / SessionStart → waiting,
+    PostCompact → waiting after a manual compaction and working after an auto one, PreCompact →
+    compacting, a permission_prompt notification → permission, an idle_prompt one → idle; the revive
+    watcher writes picker). Review find on #904: with busy() None, _working_now fell to the
+    cached transcript parse, which is None whenever the transcript's (mtime, size) moved since the last
+    parse — so a tmux session MID-TURN read as quiet the moment its transcript grew, and the drain fired a
+    parked op into the open turn (a parked slash command lands there as text). The drain runs every cycle
+    now and before _push_all refreshes the cache, so the stale read was the common case, not a corner.
+
+    The row is not trusted alone (review find on this change's first cut): Claude Code fires NO hook on an
+    Esc-interrupt, so an interrupted session's row reads working until romp-idle-dots heals it minutes later
+    — every send after a Stop would have parked. busy() corroborates by EVENT ORDER: when the cached parse
+    matches the file on disk and the last turn's newest record is NEWER than the row's since, the transcript
+    spoke after the hook and its verdict wins; otherwise the hook's does. compacting is no answer at all —
+    _compacting_now owns that gate.
+
+    These drive the REAL TmuxBackend (km._TMUX) with its paste stubbed: what it would have pasted, and
+    when, is the whole question."""
+
+    def setUp(self):
+        self.rows = {SID: _tmux_row("waiting")}
+        self.sent = []                                    # (tmux name, text) TmuxBackend.send handed to the paste
+        self._tmux_patch = mock.patch.object(km, "_tmux_sessions", lambda: self.rows)
+        self._patches = [
+            mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: km._TMUX)),
+            mock.patch.object(km, "_tmux_send", lambda name, text, **k: self.sent.append((name, text))),
+            mock.patch.object(km, "_compacting_now", lambda sid, **k: False),
+            mock.patch.object(km, "_optimistic_echo", lambda *a, **k: None),
+            mock.patch.object(km, "_mark_compacting", lambda sid: None),
+            mock.patch.object(km, "_names_snapshot", lambda: {}),
+            # the cached parse is STALE: the transcript moved since the last parse, so it answers None —
+            # which the fallback reads as idle. Every correct answer below has to come from the row.
+            mock.patch.object(km, "_parse_cached", lambda path: None),
+            mock.patch.object(km, "_path_of", lambda sid, now=None: "/nonexistent/" + str(sid) + ".jsonl"),
+            self._tmux_patch,
+        ] + [mock.patch.object(km, name, lambda *a, **k: None) for name in _OTHER_JOBS]
+        for p in self._patches:
+            p.start()
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._drain_hold.clear()
+        km._pusher_wake.clear()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._drain_hold.clear()
+
+    def test_busy_reads_the_hook_state_words(self):
+        # the class default: the cache is stale (None), so the transcript cannot be consulted and the row stands
+        for word in ("working", "permission", "picker"):
+            self.rows[SID] = _tmux_row(word)
+            self.assertIs(km._TMUX.busy(SID), True, word)
+        for word in ("waiting", "idle"):
+            self.rows[SID] = _tmux_row(word)
+            self.assertIs(km._TMUX.busy(SID), False, word)
+        self.rows[SID] = _tmux_row("compacting")
+        self.assertIsNone(km._TMUX.busy(SID), "compacting is no answer: _compacting_now owns that gate, with the "
+                                              "open-turn / compact_boundary escape that disbelieves a stuck row")
+        self.rows[SID] = _tmux_row("")                    # a fresh pane: no hook has published yet
+        self.assertIsNone(km._TMUX.busy(SID), "an unpublished state is no answer — never a hold")
+        self.rows[SID] = _tmux_row("frobnicating")
+        self.assertIsNone(km._TMUX.busy(SID), "an unknown word is no answer")
+        self.rows.clear()
+        self.assertIsNone(km._TMUX.busy(SID), "no tmux row → None → the cached parse decides")
+        self.rows[SID] = dict(_tmux_row("working"), backend="sdk")
+        self.assertIsNone(km._TMUX.busy(SID), "another backend's row is not tmux's to read")
+
+    def test_busy_inside_a_cycle_reads_the_snapshot_not_a_fork(self):
+        self._tmux_patch.stop()                           # the real delegator: snapshot inside a cycle, else live
+        try:
+            km._live_scope.snapshot = {SID: _tmux_row("working")}
+            with mock.patch.object(km.Sessions, "live", staticmethod(lambda: self.fail("forked tmux inside a cycle"))):
+                self.assertIs(km._TMUX.busy(SID), True)
+        finally:
+            km._live_scope.snapshot = None
+            self._tmux_patch.start()
+
+    def test_a_working_row_holds_a_parked_op_the_stale_cache_would_release(self):
+        # THE review find: the hook says mid-turn, the stale cache says idle. The row wins.
+        km._pending_ops[SID] = [("command", "/frobnicate now", None)]
+        self.rows[SID] = _tmux_row("working")             # UserPromptSubmit flipped it; the transcript grew since
+        self.assertTrue(km._working_now(SID))
+        km._pusher_cycle()
+        self.assertEqual(self.sent, [], "the slash command must not land as text in the open turn")
+        self.assertEqual(km._pending_ops[SID], [("command", "/frobnicate now", None)], "still parked")
+        self.rows[SID] = _tmux_row("waiting")             # Stop
+        km._pusher_cycle()
+        self.assertEqual(self.sent, [(SID, "/frobnicate now")], "the settle delivers it, alone")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_an_idle_row_delivers(self):
+        km._pending_ops[SID] = [("command", "/frobnicate now", None)]
+        self.rows[SID] = _tmux_row("idle")                # the idle_prompt notification
+        km._pusher_cycle()
+        self.assertEqual(self.sent, [(SID, "/frobnicate now")])
+
+    def test_no_row_falls_to_the_cached_parse(self):
+        # no tmux row for this sid (the hook never published, the pane is gone): busy() is None and the
+        # cached event-model parse decides, exactly as before — pinned in both directions
+        self.rows.clear()
+        km._pending_ops[SID] = [("command", "/frobnicate now", None)]
+        now = int(time.time())
+        open_turn = {"turns": [{"ended": False, "atoms": [{"type": "user"}], "t": now, "end": now}]}
+        with mock.patch.object(km, "_parse_cached", lambda path: open_turn), \
+             mock.patch.object(km, "_downtime", []):
+            self.assertIsNone(km._TMUX.busy(SID))
+            self.assertTrue(km._working_now(SID), "an open turn in the cached parse → working")
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [], "held on the parse")
+        km._pusher_cycle()                                # the class default: a stale cache reads idle
+        self.assertEqual(self.sent, [(SID, "/frobnicate now")])
+
+    def test_tmux_double_fire_closes_on_the_hook_flip_not_the_clock(self):
+        # SEND-ends-the-drain on tmux, through the EVENT. Two ops park mid-turn (a send, then a compact); the
+        # turn settles; the send is pasted. Between that paste and the CLI accepting the prompt the row still
+        # reads waiting — a back-to-back cycle (the delivery's own wake) would fire the compact into the
+        # opening turn, so the sid holds until the row has been SEEN working once after the delivery (the
+        # UserPromptSubmit hook's flip); from there the working gate owns it, and the Stop flip delivers the
+        # compact. The clock fallback is pinned out of reach: only the event can carry this test.
+        with mock.patch.object(km, "_TMUX_PROMPT_HOLD_S", 3600.0):
+            self.rows[SID] = _tmux_row("working")
+            self.assertTrue(km._send_or_park(km._TMUX, SID, "one", echo="human"), "mid-turn per the hook → parked")
+            self.assertTrue(km._compact_or_park(km._TMUX, SID), "…and the compact parks behind it")
+            self.assertEqual([op[0] for op in km._pending_ops[SID]], ["send", "compact"])
+            self.assertEqual(self.sent, [])
+            self.rows[SID] = _tmux_row("waiting")         # Stop: the turn settled
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "one")], "the send is pasted")
+            self.assertIn(SID, km._drain_hold, "…and the sid holds until the hook has seen the prompt")
+            km._pusher_cycle()                            # back-to-back: the paste is in flight, no hook yet
+            self.assertEqual(self.sent, [(SID, "one")], "the compact does NOT fire into the opening turn")
+            self.rows[SID] = _tmux_row("working")         # UserPromptSubmit: the CLI accepted the prompt
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "one")], "the turn is open: the working gate holds it now")
+            self.assertNotIn(SID, km._drain_hold, "the flip is the event that ends the hold")
+            self.rows[SID] = _tmux_row("waiting")         # Stop: the delivered turn ended
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "one"), (SID, "/compact")])
+            self.assertNotIn(SID, km._pending_ops)
+
+    def test_the_prompt_hold_falls_back_to_the_clock_loudly_when_no_flip_comes(self):
+        # a paste tmux refused (the input would not clear, the server died), or a builtin the CLI runs
+        # without opening a prompt turn: the row never reads busy, so the event cannot end the hold — the
+        # clock does, and says so on stderr (the sid, never the text)
+        km._pending_ops[SID] = [("send", "a private sentence", "human"), ("compact",)]
+        with mock.patch.object(km, "_TMUX_PROMPT_HOLD_S", 3600.0):
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "a private sentence")])
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "a private sentence")], "held: no flip, the clock not yet passed")
+        far = time.monotonic() + 7200.0                    # the fallback window passed, still no flip
+        buf = io.StringIO()
+        with mock.patch.object(km.time, "monotonic", lambda: far), redirect_stderr(buf):
+            km._pusher_cycle()
+        self.assertEqual(self.sent, [(SID, "a private sentence"), (SID, "/compact")], "the clock releases the queue")
+        self.assertIn(SID, buf.getvalue(), "loud: the release is on the record")
+        self.assertNotIn("a private sentence", buf.getvalue(), "the body is user text — never logged")
+        self.assertNotIn(SID, km._drain_hold, "the compact was the queue's LAST op: nothing behind it to hold for")
+
+    def test_the_hold_is_armed_and_the_docstrings_tell_the_final_truth(self):
+        src = inspect.getsource(km._hold_drain) + inspect.getsource(km._after_turn_opening)
+        self.assertNotIn("has no busy()", src, "tmux has an authoritative busy() now — the docstrings say so")
+        self.assertIn("until_busy", inspect.getsource(km._after_turn_opening),
+                      "a turn-opening delivery holds until busy() has been observed True, not for a clock")
+
+    # ── corroboration by event order ──
+    def _cached(self, turns):
+        """The cached parse MATCHES the file on disk: the transcript has not moved since it was parsed."""
+        return mock.patch.object(km, "_parse_cached", lambda path: {"turns": turns})
+
+    def test_a_turn_just_started_stays_busy_on_the_fresh_hook_row(self):
+        # shape 1 (the maintainer's gap): UserPromptSubmit flipped the row a moment ago; the transcript has not
+        # recorded the prompt yet, so the cache still matches the file and shows the previous turn ended
+        # BEFORE since → the hook wins
+        now = int(time.time())
+        self.rows[SID] = dict(_tmux_row("working"), since=now)
+        ended_before = [{"ended": True, "t": now - 40, "end": now - 30,
+                         "atoms": [{"type": "user", "t": now - 40}, {"type": "assistant", "t": now - 30}]}]
+        with self._cached(ended_before), mock.patch.object(km, "_downtime", []):
+            self.assertIs(km._TMUX.busy(SID), True)
+            km._pending_ops[SID] = [("command", "/frobnicate now", None)]
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [], "the slash command stays parked: the turn is opening")
+
+    def test_an_interrupted_turn_delivers_once_the_transcript_spoke_after_the_hook(self):
+        # shape 2: Esc fires no hook, so the row still says working from the last PostToolUse (an old since);
+        # the CLI's interrupt record ended the turn AFTER that → the transcript's verdict wins and a send
+        # typed after the Stop is handed over now, not parked for minutes
+        now = int(time.time())
+        self.rows[SID] = dict(_tmux_row("working"), since=now - 60)
+        interrupted = [{"ended": True, "t": now - 90, "end": now - 5,
+                        "atoms": [{"type": "user", "t": now - 90}, {"type": "assistant", "t": now - 70},
+                                  {"type": "user", "t": now - 5,
+                                   "message": {"role": "user", "content": "[Request interrupted by user]"}}]}]
+        with self._cached(interrupted), mock.patch.object(km, "_downtime", []):
+            self.assertIs(km._TMUX.busy(SID), False)
+            self.assertFalse(km._send_or_park(km._TMUX, SID, "a correction", echo="human"), "delivered, not parked")
+            self.assertEqual(self.sent, [(SID, "a correction")])
+        # the kernel's OWN Stop button writes no interrupt record but an idle record (_record_idle), which the
+        # parse turns into an idle span at the tail — same verdict, dated by the record's t, not the span's end
+        self.sent.clear()
+        kernel_stop = [{"ended": False, "t": now - 90, "end": now,
+                        "atoms": [{"type": "user", "t": now - 90}, {"type": "assistant", "t": now - 70},
+                                  {"type": "idle", "t": now - 6, "end": now}]}]
+        with self._cached(kernel_stop), mock.patch.object(km, "_downtime", []):
+            self.assertIs(km._TMUX.busy(SID), False)
+
+    def test_a_parse_time_idle_tail_never_outranks_the_hook(self):
+        # an idle span at the tail carries end = the PARSE time; only atom `t` (a real record) dates the
+        # transcript — else every fresh parse of an idle session would outrank a hook write that just landed
+        # and reopen shape 1
+        now = int(time.time())
+        self.rows[SID] = dict(_tmux_row("working"), since=now - 1)
+        idle_tail = [{"ended": True, "t": now - 40, "end": now,
+                      "atoms": [{"type": "user", "t": now - 40}, {"type": "assistant", "t": now - 30},
+                                {"type": "idle", "t": now - 30, "end": now}]}]
+        with self._cached(idle_tail), mock.patch.object(km, "_downtime", []):
+            self.assertIs(km._TMUX.busy(SID), True, "the newest RECORD (now-30) predates since (now-1): the hook wins")
+
+    def test_a_stale_waiting_row_yields_to_an_open_turn_the_transcript_shows(self):
+        # the other direction: a waiting row OLDER than an open turn's records reads busy (PostCompact once
+        # wrote waiting into an auto-compaction's continuing turn); a waiting row NEWER than the last record
+        # stands — the ordinary settle, where the Stop hook fires after the final assistant record
+        now = int(time.time())
+        open_turn = [{"ended": False, "t": now - 90, "end": now - 5,
+                      "atoms": [{"type": "user", "t": now - 90}, {"type": "assistant", "t": now - 5}]}]
+        with self._cached(open_turn), mock.patch.object(km, "_downtime", []):
+            self.rows[SID] = dict(_tmux_row("waiting"), since=now - 60)
+            self.assertIs(km._TMUX.busy(SID), True)
+            self.rows[SID] = dict(_tmux_row("waiting"), since=now)
+            self.assertIs(km._TMUX.busy(SID), False)
+
+    def test_a_row_without_since_stands(self):
+        now = int(time.time())
+        self.rows[SID] = dict(_tmux_row("working"), since=None)
+        interrupted = [{"ended": True, "t": now - 90, "end": now - 5,
+                        "atoms": [{"type": "user", "t": now - 90}, {"type": "user", "t": now - 5}]}]
+        with self._cached(interrupted), mock.patch.object(km, "_downtime", []):
+            self.assertIs(km._TMUX.busy(SID), True, "undated against the row, the transcript cannot overrule it")
+
+    # ── the hold and the queue's tail ──
+    def test_no_hold_outlives_the_queue(self):
+        # the queue's LAST op has nothing behind it for a hold to protect; a hold armed then outlived the queue
+        # (the sid leaves _pending_ops, so no cycle evaluated or removed it) and fired the fallback line when a
+        # later op parked for an unrelated reason
+        km._pending_ops[SID] = [("send", "one", "human")]
+        km._pusher_cycle()
+        self.assertEqual(self.sent, [(SID, "one")])
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertNotIn(SID, km._drain_hold, "no op behind → no hold")
+        self.rows[SID] = _tmux_row("working")             # later: a new op parks because a turn is open…
+        self.assertTrue(km._send_or_park(km._TMUX, SID, "two", echo="human"))
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._pusher_cycle()
+            self.rows[SID] = _tmux_row("waiting")         # …and delivers at the settle
+            km._pusher_cycle()
+        self.assertEqual(self.sent, [(SID, "one"), (SID, "two")])
+        self.assertNotIn("drain:", buf.getvalue(), "no stale hold, no spurious fallback line")
+
+    def test_a_delivered_compact_releases_its_hold_on_the_compacting_row_not_the_clock(self):
+        # a delivered /compact with an op behind arms an until_busy hold, but the row goes working →
+        # compacting within a fraction of a second and compacting is no busy answer — so the hold rode the
+        # clock and logged the fallback line although the compaction IS the event it waited for. The
+        # compacting gate is the release, and then holds the op behind until the compaction is over.
+        km._pending_ops[SID] = [("compact",), ("send", "after the compaction", "human")]
+        with mock.patch.object(km, "_TMUX_PROMPT_HOLD_S", 3600.0), \
+             mock.patch.object(km, "_compacting_now", lambda sid, **k: self.rows[SID]["state"] == "compacting"):
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "/compact")])
+            self.assertIn(SID, km._drain_hold, "the send behind the compact is held")
+            self.rows[SID] = _tmux_row("compacting")      # PreCompact
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "/compact")], "the compacting gate holds the send")
+            self.assertNotIn(SID, km._drain_hold, "the compaction is the event: the hold is over")
+            self.assertNotIn("drain:", buf.getvalue(), "no fallback line — the clock was never the release")
+            self.rows[SID] = _tmux_row("waiting")         # PostCompact (manual)
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "/compact"), (SID, "after the compaction")])
+
+    def test_the_cycle_refreshes_a_parked_sids_moved_transcript_before_the_drain(self):
+        # the headless defect (second review): busy() can overrule the hook only through _parse_cached, which
+        # NEVER parses — the cache is filled by client builds and the client-gated warmer. With no client, every
+        # live tmux session's cache is None from its first transcript write on, so busy() was the hook verbatim
+        # and a pane Esc parked every `romp send` for minutes. The cycle now re-parses the parked TMUX sids'
+        # moved transcripts before the drain — not a sid without parked ops, not a parked sid whose backend
+        # answers busy() authoritatively (SDK/Codex: re-parsing a streaming turn's transcript on every atom's
+        # wake was load the parent did not have — third review), and not again while the file is unmoved.
+        # REAL transcript files, the real cache reader and the real cache-filling parse; only the paths, the
+        # rows and the backend routing are stubbed.
+        now = int(time.time())
+        td = tempfile.mkdtemp()
+
+        def z(t):
+            return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+        def transcript(sid):
+            recs = [{"type": "user", "timestamp": z(now - 90), "uuid": "u1", "parentUuid": None,
+                     "promptSource": "typed", "message": {"role": "user", "content": "please frobnicate"}},
+                    {"type": "assistant", "timestamp": z(now - 70), "uuid": "a1", "parentUuid": "u1",
+                     "message": {"role": "assistant", "content": [{"type": "text", "text": "frobnicating"}],
+                                 "stop_reason": None}},
+                    {"type": "user", "timestamp": z(now - 5), "uuid": "u2", "parentUuid": "a1",
+                     "message": {"role": "user", "content": "[Request interrupted by user]"}}]   # the pane Esc
+            path = os.path.join(td, sid + ".jsonl")
+            with open(path, "w") as f:
+                f.write("".join(json.dumps(r) + "\n" for r in recs))
+            return path
+        paths = {SID: transcript(SID), SID2: transcript(SID2), SID3: transcript(SID3)}
+        self.rows[SID] = dict(_tmux_row("working"), since=now - 60)     # Esc fired no hook: the row is stale
+        self.rows[SID2] = dict(_tmux_row("working"), since=now - 60)    # …a second tmux session, same state, no ops
+        km._pending_ops[SID] = [("send", "a correction", "human"), ("compact",)]   # a headless `romp send`, parked
+        #                                                                              once, with an op behind it
+        sdk = _FakeBackend()                                            # an SDK-shaped backend mid-turn: busy() is
+        km._pending_ops[SID3] = [("send", "queued behind the stream", "human")]   # the whole truth, no cache read
+        self.assertFalse(getattr(sdk, "corroborates_with_transcript", False), "the ABC default")
+        self.assertTrue(km._TMUX.corroborates_with_transcript)
+        parsed = []
+        real_parse = km._parse
+        with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: sdk if str(sid) == SID3 else km._TMUX)), \
+             mock.patch.object(km, "_path_of", lambda sid, now=None: paths.get(str(sid))), \
+             mock.patch.object(km, "_parse_cached", REAL_PARSE_CACHED), \
+             mock.patch.object(km, "_parse", lambda path, sid, now: (parsed.append(path), real_parse(path, sid, now))[1]), \
+             mock.patch.object(km, "_downtime", []):
+            self.assertIsNone(REAL_PARSE_CACHED(paths[SID]), "never parsed: the cache is empty")
+            self.assertIs(km._TMUX.busy(SID), True, "at this instant the hook is all busy() has")
+            km._pusher_cycle()
+            self.assertIsNotNone(REAL_PARSE_CACHED(paths[SID]), "the cycle filled the cache")
+            self.assertEqual(parsed, [paths[SID]], "the parked tmux sid's moved transcript parsed once; not the idle "
+                                                    "tmux sid's, not the parked SDK sid's")
+            self.assertEqual(self.sent, [(SID, "a correction")], "the interrupt record overruled the stale row: delivered")
+            self.assertEqual([op[0] for op in km._pending_ops[SID]], ["compact"], "the op behind is held (until_busy)")
+            self.assertIn(SID, km._drain_hold)
+            km._pusher_cycle()                                          # the transcript is UNMOVED: the cache still matches
+            self.assertEqual(parsed, [paths[SID]], "no second parse while the file has not moved")
+            self.assertEqual(self.sent, [(SID, "a correction")])
+        self.assertEqual(sdk.calls, [], "the SDK-shaped sid stayed parked behind its turn — and was never parsed")
+
+    def test_cancelling_the_last_parked_op_drops_the_sids_hold(self):
+        km._pending_ops[SID] = [("send", "one", "human"), ("compact",)]
+        with mock.patch.object(km, "_TMUX_PROMPT_HOLD_S", 3600.0):
+            km._pusher_cycle()
+            self.assertEqual(self.sent, [(SID, "one")])
+            self.assertIn(SID, km._drain_hold, "the compact behind the send is what the hold protects")
+            with redirect_stderr(io.StringIO()):
+                self.assertIsNone(km._cancel_parked(SID, 0, "/compact"))
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertNotIn(SID, km._drain_hold, "an emptied queue leaves no hold behind")
 
 
 if __name__ == "__main__":

--- a/tests/tmux-status-hook.bats
+++ b/tests/tmux-status-hook.bats
@@ -120,6 +120,23 @@ run_hook() {
     grep -q 'tmux set -t test @claude-state waiting' "$MOCK_LOG"
 }
 
+@test "PostCompact trigger=manual sets waiting (the /compact was the whole exchange)" {
+    export MOCK_PREV_STATE=compacting
+    run run_hook '{"hook_event_name":"PostCompact","trigger":"manual","cwd":"/tmp/project"}'
+    [ "$status" -eq 0 ]
+    grep -q 'tmux set -t test @claude-state waiting' "$MOCK_LOG"
+    ! grep -q '@claude-state working' "$MOCK_LOG"
+}
+
+@test "PostCompact trigger=auto keeps working (the compaction ran inside a turn that goes on)" {
+    export MOCK_PREV_STATE=compacting
+    run run_hook '{"hook_event_name":"PostCompact","trigger":"auto","cwd":"/tmp/project"}'
+    [ "$status" -eq 0 ]
+    grep -q 'tmux set -t test @claude-state working' "$MOCK_LOG"
+    ! grep -q '@claude-state waiting' "$MOCK_LOG"
+    ! grep -q '@claude-state compacting' "$MOCK_LOG"
+}
+
 # ─── Notification mapping tests ───────────────────────────────────────
 
 @test "Notification permission_prompt sets state to permission" {


### PR DESCRIPTION
## TmuxBackend.busy() reads the hook-maintained session state, corroborated by the transcript's event order

Follow-up to #904, as requested in its review.

**The gap.** For a tmux session `_working_now` fell to the cached transcript parse, which reads idle whenever the transcript's (mtime, size) moved since the last parse or the cache is empty. A tmux session mid-turn whose transcript grew therefore read as quiet, and the drain could fire a parked op into the open turn, where a parked slash command lands as text. #904 polls that predicate every pusher cycle, so the window mattered more than on the producer's 3 s cadence.

**The fix.** `TmuxBackend.busy(sid)` answers from the hook-maintained tmux session state the cycle's liveness snapshot already carries (no extra tmux fork inside a cycle): `working`, `permission`, `picker` read busy; `waiting` and `idle` read quiet; `compacting` returns None so the compacting gate keeps owning it with its boundary escape; an unknown word, a missing row, or a row another backend owns return None so the cached parse decides, never a hold on an unknown.

**Corroboration by event order, not a clock.** Claude Code fires no hook on an Esc interrupt, so a `working` row can be stale. The hook row carries `since`; when the cached parse matches the file on disk and the transcript's newest record is newer than `since`, the transcript has spoken after the hook and its answer wins; otherwise the hook stands. Both directions: a turn that just started (transcript not yet written) stays busy on the fresh hook row, and an interrupted turn delivers once the interrupt record lands after the hook's write; a stale `waiting` yields to an open turn the transcript shows. Ties go to the hook. Headless, nothing else fills the parse cache, so the pusher's first job refreshes the parse for tmux sessions holding parked ops when their cache is stale, bounded to that declared backend, once per cycle, only when the file moved; SDK and Codex sessions are excluded because their `busy()` is the whole truth and a streaming turn would otherwise be re-parsed per stream event.

**The hook.** `hooks/tmux-status.sh` keeps `working` on PostCompact with `trigger=auto` (the turn continues) and writes `waiting` for manual; verified against the installed CLI's hook-input schema. `hooks/romp-wake.sh` is registered on PostCompact as `tmux-status.sh` already was.

**The hold, re-keyed.** The tmux half of `_hold_drain` cannot retire outright: `TmuxBackend.send` pastes on a thread and emits nothing the kernel can see until the CLI accepts the prompt and the hook flips the state, while the drain's own delivery wakes the pusher within milliseconds. So after a turn-opening delivery with ops still behind it, the sid holds until `busy()` is first observed True or the compacting gate closes; the 3 s clock remains only as a loud fallback with an observational log line. No hold is armed when nothing is behind; cancel, an emptied queue, and a dropped dead-session queue drop it. The move-retry half is unchanged.

**Verification.** Full Python suite green (7111 passed, 0 failed on today's main), hook and install bats 81 of 81. Tests in `tests/test_kernel_parked_ops_liveness.py` drive the real `TmuxBackend` with the paste stubbed: the state words, the snapshot read inside a cycle, a working row holding a parked op the stale cache would have released, an interrupted turn delivering once the transcript spoke after the hook, a turn just started staying busy, a stale waiting row yielding to an open turn, the double-fire closing on the hook flip with the clock pinned far out, the parse-time idle tail never outranking the hook, the headless refresh delivering in one cycle with the SDK-backed and unparked sids left alone and the file-moved bound pinned, the compact release, the hold's tail and cancel hygiene, and the fallback. `tests/tmux-status-hook.bats` pins both PostCompact triggers; `tests/install-sh.bats` pins the registration. Three adversarial review passes with two skeptics per finding ran on this change: the first caught that a stale `working` row after Esc would have parked every following send for minutes (the corroboration rule fixes it), the second the headless case (the refresh fixes it), the third the refresh's scope (the declaration fixes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
