### PR TITLE
The kernel pings its panes, a reconnect retires its own old socket, and the timeline and feed cross the wire as deltas

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -300,6 +300,44 @@ The mechanics, including how the tunnels and the check-in handshake work, are in
 You reach Romp in a browser tab, in the VS Code / Cursor extension, or from your
 phone.
 
+### From another machine
+
+The kernel listens only on `127.0.0.1`, so a browser on another machine needs a
+path to that port. Two paths work well; one common one does not.
+
+**Plain ssh port forwarding.** From the machine with the browser:
+
+```bash
+ssh -N -L 29855:127.0.0.1:29855 <the machine running romp>
+```
+
+Then open `http://127.0.0.1:29855` as usual. OpenSSH forwards each browser
+socket one-to-one and propagates closes, so a pane that goes away is gone on
+both ends.
+
+**Tailscale.** The same setup as for your phone below gives every device you
+own a direct path; the dashboard is then a plain URL on your tailnet.
+
+!!! warning "The VS Code port forwarder is not a good path for the browser dashboard"
+
+    VS Code's Remote and Tunnels port forwarder multiplexes every forwarded
+    socket over one channel and does not close the far end when the browser
+    side goes away. The dashboard's panes are long-lived WebSockets that stream
+    view updates, and each pane reconnects when it hears nothing for thirty
+    seconds, so through that forwarder every reconnect left a dead connection
+    behind on the kernel's side, all of them still receiving full view payloads
+    over the one shared channel, and the live panes starved. One such incident
+    counted 84 connections from three real panes.
+
+    The kernel now protects itself: it pings every pane on each heartbeat and
+    drops one whose ping goes unanswered, a reconnecting pane retires its own
+    previous socket at once, and the timeline and feed cross the wire as
+    deltas instead of whole payloads. That keeps a forwarded dashboard usable,
+    but the forwarder still carries every byte over a channel it shares with
+    your editor, so prefer one of the two paths above. The VS Code romp view
+    itself is unaffected: its WebSocket runs on the kernel's own machine, and
+    only the rendered view crosses the link.
+
 ### From your phone
 
 The user interface is a web page, so your phone can run it against a kernel on

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -335,8 +335,10 @@ own a direct path; the dashboard is then a plain URL on your tailnet.
     deltas instead of whole payloads. That keeps a forwarded dashboard usable,
     but the forwarder still carries every byte over a channel it shares with
     your editor, so prefer one of the two paths above. The VS Code romp view
-    itself is unaffected: its WebSocket runs on the kernel's own machine, and
-    only the rendered view crosses the link.
+    is a different case: its sockets run on the kernel's own machine and close
+    when a panel closes, so it never leaks connections, but under Remote or
+    Tunnels the extension still relays each whole view payload to the local
+    window as it changes. It does not yet take the deltas the browser panes do.
 
 ### From your phone
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26817,7 +26817,7 @@ _DELTA_SLOTS = {
     # cross whole because one bar was appended (measured 2026-09-03: 507 KB per appended segment at lane
     # granularity, ~2 KB at bar granularity).
     "bars": (("timelinebars",), {"turns": "dictlist:id", "judging": "bykeys:sid,t,judge,t1", "messages": "byid"}),
-    "feed": (("feed",), {"asks": "byid"}),
+    "feed": (("feed",), {"asks": "byid:itemId"}),   # a card's identity across builds is its itemId, not an id
 }
 _DELTA_SEP = "\u001f"          # joins composite keys; never appears in an id or a sid
 _DELTA_MAX_FRACTION = 0.6      # a delta this large a fraction of the full payload is sent as the full instead
@@ -26829,10 +26829,10 @@ def _delta_key(kind, it, prefix=""):
     (then the caller falls back to a positional key, which is still exact)."""
     if not isinstance(it, dict):
         return None
-    if kind == "byid" or kind.startswith("dictlist:"):
+    if kind.startswith(("byid", "dictlist:")):
         field = "id" if kind == "byid" else kind.split(":", 1)[1]
         v = it.get(field)
-        return None if v is None else prefix + str(v)
+        return None if v is None or v == "" else prefix + str(v)   # "" would spell a lane's bare-prefix marker
     if kind.startswith("bykeys:"):
         return prefix + _DELTA_SEP.join(str(it.get(f)) for f in kind.split(":", 1)[1].split(","))
     return None
@@ -26846,12 +26846,17 @@ def _delta_split(kind, value):
     enc = json.JSONEncoder(default=str).encode          # one encoder for the thousand entries, not one each
     def put(kk, v, pre=""):
         if kk is None or kk in ents:
-            kk = pre + "#%d" % len(order)          # keeps its lane prefix, so the shim still files it by lane
+            n = len(order)
+            while True:                            # positional, with its lane prefix so the shim files it by lane —
+                kk = pre + "#%d" % n               # and never on a real id that happens to spell "#n"
+                if kk not in ents:
+                    break
+                n += 1
         ents[kk] = (v, enc(v)); order.append(kk)
     if kind == "dict" and isinstance(value, dict):
         for kk, v in value.items():
             put(str(kk), v)
-    elif (kind == "byid" or kind.startswith("bykeys:")) and isinstance(value, list):
+    elif kind.startswith(("byid", "bykeys:")) and isinstance(value, list):
         for it in value:
             put(_delta_key(kind, it), it)
     elif kind.startswith("dictlist:") and isinstance(value, dict):
@@ -26891,7 +26896,9 @@ def _js_key_order(keys):
     predict it to know what the client holds."""
     idx, rest = [], []
     for kk in keys:
-        (idx if (kk.isdigit() and (kk == "0" or kk[0] != "0") and int(kk) < 4294967295) else rest).append(kk)
+        is_index = (kk.isascii() and kk.isdigit() and len(kk) <= 10 and (kk == "0" or kk[0] != "0")
+                    and int(kk) < 4294967295)      # canonical array index: ASCII digits only, below 2^32-1
+        (idx if is_index else rest).append(kk)
     return sorted(idx, key=int) + rest
 
 
@@ -26924,6 +26931,24 @@ def _send_slot(c, ftype, payload, pre, sig):
     if not c.get("delta"):
         _send_client(c, key, payload, pre=pre, sig=sig)
         return
+    try:
+        _send_slot_delta(c, key, ftype, payload, pre, sig)
+    except Exception:
+        # One client's frame must never take the pusher down with it (every dashboard would freeze until a
+        # restart): say so, forget what that client holds, and send the whole payload — which carries no
+        # key list, so the client holds nothing either and the next cycle starts the stream afresh.
+        sys.stderr.write("view-delta %s: %s\n" % (ftype, traceback.format_exc()))
+        c.get("dstate", {}).pop(ftype, None)
+        c.get("sent", {}).pop(key, None)
+        _send_client(c, key, payload, pre=pre, sig=sig)
+
+
+def _send_slot_delta(c, key, ftype, payload, pre, sig):
+    rs = c.get("resync")
+    if rs and ftype in rs:                             # the shim said it could not apply a delta (a base it does
+        rs.discard(ftype)                              # not hold): forget what we believe it holds; whole, re-based
+        c.get("dstate", {}).pop(ftype, None)
+        c.get("sent", {}).pop(key, None)
     parts = _delta_parts(ftype, payload)
     states = c.setdefault("dstate", {})
     if parts is None:                                  # cannot be keyed: whole, and the client holds nothing
@@ -26948,7 +26973,7 @@ def _send_slot(c, ftype, payload, pre, sig):
     frame = {"type": "delta", "slot": ftype, "base": st["rev"], "rev": st["rev"] + 1, "coll": {}}
     changed = False
     if rest_sig != st["rest"]:
-        frame["rest"] = rest; changed = True
+        frame["rest"] = rest; frame["restAll"] = 1; changed = True    # the WHOLE remainder: keys it lacks are gone
     else:
         for vk in _DEDUP_VOLATILE:                     # the clock fields still ride, so the pane's `now` advances
             if vk in rest:
@@ -29555,7 +29580,7 @@ function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);els
 // "bysid" (a list grouped by item sid, one entry per group). LAST holds, per slot, the revision, the last
 // full message handed to the bundle, and per-collection maps {order:[keys], items:{key:value}}. A delta
 // builds a NEW message object (the bundle may still hold the previous one) reusing every unchanged part.
-var DELTA_KINDS={bars:{turns:"dictlist:id",judging:"bykeys:sid,t,judge,t1",messages:"byid"},feed:{asks:"byid"}};var LAST={};var SEP="\u001f";
+var DELTA_KINDS={bars:{turns:"dictlist:id",judging:"bykeys:sid,t,judge,t1",messages:"byid"},feed:{asks:"byid:itemId"}};var LAST={};var SEP="\u001f";
 function buildMaps(m,keys){var kinds=DELTA_KINDS[m.type]||{},maps={};for(var name in kinds){var kind=kinds[name],v=m[name],order=((keys||{})[name]||[]).slice(),items={},pos={};
 for(var i=0;i<order.length;i++){var kk=order[i];
 if(kind==="dict"){items[kk]=v[kk];}
@@ -29568,7 +29593,7 @@ if(rest===""){d[dk]=map.items[kk];continue;}   // a bare-prefix entry: the lane'
 if(!d.hasOwnProperty(dk))d[dk]=[];d[dk].push(map.items[kk]);}return d;}
 var out=[];for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))out.push(map.items[kk]);}return out;}
 function applyDelta(d){var last=LAST[d.slot];if(!last||last.rev!==d.base)return null;var kinds=DELTA_KINDS[d.slot]||{};var m={};for(var k0 in last.msg)m[k0]=last.msg[k0];
-if(d.rest){for(var rk in d.rest)m[rk]=d.rest[rk];}
+if(d.rest){if(d.restAll){for(var k1 in m){if(!kinds[k1]&&!(k1 in d.rest))delete m[k1];}}for(var rk in d.rest)m[rk]=d.rest[rk];}
 var coll=d.coll||{};for(var name in coll){var kind=kinds[name];if(!kind)continue;var c=coll[name],map=last.maps[name]||{order:[],items:{}};var items={};for(var ik in map.items)items[ik]=map.items[ik];var order=map.order.slice();
 if(c.del){for(var x=0;x<c.del.length;x++){delete items[c.del[x]];}}
 if(c.set){for(var sk in c.set){if(!items.hasOwnProperty(sk))order.push(sk);items[sk]=c.set[sk];}}
@@ -34744,10 +34769,10 @@ class Handler(BaseHTTPRequestHandler):
             # The shim could not apply a view delta (its base revision did not match what it holds — a
             # frame it never saw, a reload mid-stream): forget what we believe it holds and re-send the
             # whole slot now, from which the delta stream re-bases (the chat's needFull, for views).
-            ftype = str(msg["slot"])
-            client.get("dstate", {}).pop(ftype, None)
-            client.get("sent", {}).pop(_DELTA_SLOTS[ftype][0], None)
-            self._push_one(client)
+            # Flagged for the pusher's thread rather than done here: the pusher may be mid-frame for this very
+            # client, and two threads over its held state would rebase a full the dedup then swallowed.
+            client.setdefault("resync", set()).add(str(msg["slot"]))
+            _pusher_wake.set()
             return
         if msg and msg.get("type") == "needFull" and msg.get("id"):
             # The client REJECTED a delta because it started past what it holds (render.ts chatTail's gap

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26218,13 +26218,24 @@ WS_QUEUE_BYTES = int(os.environ.get("ROMP_WS_QUEUE_BYTES", str(16 * 1024 * 1024)
 # Isolating the blocking write on a thread the shared loops never wait for is what actually holds.
 def _ws_sender(q, sock, lock, client):
     """Drain one client's queue onto its socket. Blocking here is FINE and is the entire point — it blocks
-    only this client's own thread. A dead socket ends the thread and marks the client for reaping."""
+    only this client's own thread. A dead socket ends the thread and marks the client for reaping.
+    A `str` item is a text message to frame; a `bytes` item is an already-framed CONTROL frame (the
+    liveness ping) written as-is under the same lock, so it can never interleave with a text frame."""
     while True:
         s = q.get()
         if s is None:                          # teardown sentinel from the handler's finally
             return
         try:
-            _ws_send(sock, lock, s)
+            if isinstance(s, bytes):
+                with lock:
+                    sock.sendall(s)
+                # The liveness clock starts when the ping actually LEAVES, not when the beat queued it: a
+                # slow-but-alive peer (a 300 KB/s tunnel behind a large payload) must not be judged dead for
+                # a ping that was still sitting behind its backlog. Only the oldest unanswered ping counts.
+                if s[:1] == b"\x89" and client.get("pingAt") is None:
+                    client["pingAt"] = _ws_clock()
+            else:
+                _ws_send(sock, lock, s)
         except OSError:
             client["alive"] = False
             return
@@ -26251,6 +26262,52 @@ def _mk_ws_send(q, sock, client):
             client["qbytes"] += len(s)
         q.put(s)                               # unbounded; the byte budget above is the real bound
     return send
+
+
+_ws_clock = time.time   # the liveness clock — one seam, so the tests can drive the beats deterministically
+
+
+def _ws_ping_frame(payload: bytes) -> bytes:
+    """A PING control frame (RFC 6455 §5.5.2: FIN + opcode 0x9, payload ≤125 bytes). Every conforming peer —
+    a browser, Node's `ws`, wscat — answers it with a PONG echoing the payload, with no application code."""
+    data = payload[:125]
+    return bytes([0x89, len(data)]) + data
+
+
+def _new_ws_client(app, wid, sock, lock=None, q=None, start_sender=True):
+    """One connected dashboard pane: its queue, its sender thread and the liveness bookkeeping the heartbeat
+    reads. `since` and `lastIn` stamp the last moment the PEER proved itself alive (any inbound frame: a
+    message or a pong); `pingAt` is the send time of the OLDEST unanswered ping, None when nothing is
+    outstanding. Factored out of the handler so the liveness rules are testable on a loopback pair."""
+    q = q if q is not None else queue.Queue()
+    lock = lock if lock is not None else threading.Lock()
+    now = _ws_clock()
+    client = {"app": app, "wid": wid, "alive": True, "qbytes": 0, "qlock": threading.Lock(),
+              "sock": sock, "since": now, "lastIn": now, "pingAt": None}
+    client["send"] = _mk_ws_send(q, sock, client)
+    client["q"] = q
+    if start_sender:
+        threading.Thread(target=_ws_sender, args=(q, sock, lock, client), daemon=True, name="ws-send").start()
+    return client, q, lock
+
+
+def _note_ws_inbound(client, now=None):
+    """The peer spoke (a message or a pong): it is alive as of now, and no ping is outstanding."""
+    client["lastIn"] = now if now is not None else _ws_clock()
+    client["pingAt"] = None
+
+
+def _drop_dead_ws_client(client, why):
+    """Mark a peer dead and shut its socket: the handler thread's blocking read returns EOF, its finally
+    removes the client from _clients, and the sender thread ends on the sentinel. Logged once per client."""
+    if not client.get("alive"):
+        return
+    client["alive"] = False
+    sys.stderr.write("ws: dropping %s client — %s\n" % (client.get("app"), why))
+    try:
+        client["sock"].shutdown(socket.SHUT_RDWR)
+    except (OSError, AttributeError):
+        pass
 
 
 def _ws_send(sock, lock, text):
@@ -26318,7 +26375,7 @@ def _ws_recv(rfile):
 _WS_MAX_MESSAGE = 80 * 1024 * 1024
 
 
-def _ws_recv_message(rfile, on_ping):
+def _ws_recv_message(rfile, on_ping, on_pong=None):
     """Read frames until one COMPLETE data message is assembled → (opcode, payload), or (None, None)
     on close/EOF/overrun. Browsers FRAGMENT large sends (RFC 6455 §5.4 — Chrome splits at ~128 KB),
     and the old per-frame loop handed each fragment straight to json.loads: a phone photo's dropFile
@@ -26335,7 +26392,9 @@ def _ws_recv_message(rfile, on_ping):
         if op == 0x9:                          # ping → pong (libraries ping by default and hang up without one)
             on_ping(payload or b"")
             continue
-        if op == 0xA:                          # unsolicited pong — nothing to do
+        if op == 0xA:                          # a pong — the peer is alive (answers our liveness ping)
+            if on_pong is not None:
+                on_pong(payload or b"")
             continue
         if op == 0x0:                          # continuation of an in-flight fragmented message
             if frag is None:
@@ -26371,19 +26430,39 @@ def _send_to_app(app, msg):
 # client on a fixed cadence (bypassing the dedup); the shim stamps lastRecv on every frame and force-reconnects
 # when the keepalive stops arriving (→ onclose → reconnect → reload-resync). 'ka' frames are ignored by bundles.
 KEEPALIVE_S = float(os.environ.get("ROMP_WS_KEEPALIVE", "10"))   # heartbeat cadence (s); the shim re-connects at ~3x this
+# How long a PING may go unanswered before the peer is dead (s). The keepalive used to be one-way: the
+# kernel sent a frame and expected nothing back, so a peer whose forwarder swallowed the close — VS Code's
+# port forwarder keeps the devbox-side connection open after the browser pane has gone — stayed a "live
+# dashboard" forever, receiving every full payload the pusher built. Measured 2026-09-03: 84 client
+# connections on one kernel, 73 of them silent for over five minutes, all phantoms, all sharing one
+# multiplexed channel with the three real panes. Now every beat is also a PING (RFC 6455), which every
+# conforming peer answers without application code; a peer that has not answered the oldest outstanding
+# ping within this window is dropped — the missing pong is the event. Three beats, like the shim's own
+# silence watchdog on the other side.
+WS_DEAD_S = float(os.environ.get("ROMP_WS_DEAD", "0")) or 3 * KEEPALIVE_S
 
-def _keepalive_all():
+def _keepalive_all(now=None):
     # `dv` = the current dist build token (the same value baked into every page's ?v= urls). Riding the
     # keepalive makes build-drift detection EVENT-based on every surface with a live socket: a page whose
     # LOADEDV is older raises the reload banner within one heartbeat of a rebuild — no per-page /version
     # polling. The VS Code extension compares it against its bundled build stamp the same way (the user
     # 2026-07-13: a stale tab sat silent through several rebuilds; drift must always show a banner).
     s = json.dumps({"type": "ka", "dv": _dist_ver()})
+    now = _ws_clock() if now is None else now
     with _clients_lock:
         targets = list(_clients)
     for c in targets:
+        # LIVENESS (2026-09-03): a ping whose pong never came within WS_DEAD_S means the peer is gone —
+        # however open the forwarder in between keeps the socket. Clients from before the factory (no
+        # `sock`) are never judged: they cannot be shut down, and they cannot have been pinged.
+        pa = c.get("pingAt")                     # any pong or message clears this (see _note_ws_inbound), so an
+        if pa is not None and c.get("sock") is not None and (now - pa) >= WS_DEAD_S:   # outstanding ping IS the silence
+            _drop_dead_ws_client(c, "no pong for %ds (last heard %ds ago)" % (int(now - pa), int(now - c.get("lastIn", 0))))
+            continue
         try:
             c["send"](s)
+            if c.get("sock") is not None:
+                c["send"](_ws_ping_frame(str(int(now)).encode()))   # pingAt is stamped by the sender, on the wire
         except Exception:
             c["alive"] = False
 
@@ -35126,11 +35205,7 @@ class Handler(BaseHTTPRequestHandler):
         # Frames are ENQUEUED, never written by the caller: one wedged client must not stall the shared
         # push/heartbeat loops (see _ws_sender). Pongs still ride self.wfile — they are ≤125-byte control
         # frames answered on this client's own handler thread, and both paths serialise on the same `lock`.
-        q = queue.Queue()
-        client = {"app": app, "wid": wid, "alive": True, "qbytes": 0, "qlock": threading.Lock()}
-        client["send"] = _mk_ws_send(q, self.connection, client)
-        threading.Thread(target=_ws_sender, args=(q, self.connection, lock, client),
-                         daemon=True, name="ws-send").start()
+        client, q, lock = _new_ws_client(app, wid, self.connection, lock=lock)
         if active:
             client["active"] = active                  # active-tab-first streaming (the user 2026-06-24)
         with _clients_lock:
@@ -35140,9 +35215,11 @@ class Handler(BaseHTTPRequestHandler):
                 # one COMPLETE message per iteration — fragments reassembled, pings answered inline
                 # (browsers fragment large sends: a phone photo's dropFile spans dozens of frames)
                 op, payload = _ws_recv_message(
-                    self.rfile, lambda payload: _ws_pong(self.wfile, lock, payload or b""))
+                    self.rfile, lambda payload: _ws_pong(self.wfile, lock, payload or b""),
+                    on_pong=lambda payload: _note_ws_inbound(client))
                 if op is None:                         # EOF / close / a client overran the reassembly cap
                     break
+                _note_ws_inbound(client)               # any message proves the peer alive
                 # webview→kernel messages: on "ready", push the initial state to this client
                 try:
                     msg = json.loads(payload.decode("utf-8", "replace"))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26227,13 +26227,16 @@ def _ws_sender(q, sock, lock, client):
             return
         try:
             if isinstance(s, bytes):
+                # The liveness clock starts when the ping reaches the SOCKET, not when the beat queued it: a
+                # peer with a queue backlog is not judged on time the ping spent behind it. Stamped BEFORE the
+                # write under the client lock, so a pong (which can only echo bytes already written) can
+                # never be cleared before its ping is recorded. Only the oldest unanswered ping counts.
+                if s[:1] == b"\x89":
+                    with client["qlock"]:
+                        if client.get("pingAt") is None:
+                            client["pingAt"] = _ws_clock()
                 with lock:
                     sock.sendall(s)
-                # The liveness clock starts when the ping actually LEAVES, not when the beat queued it: a
-                # slow-but-alive peer (a 300 KB/s tunnel behind a large payload) must not be judged dead for
-                # a ping that was still sitting behind its backlog. Only the oldest unanswered ping counts.
-                if s[:1] == b"\x89" and client.get("pingAt") is None:
-                    client["pingAt"] = _ws_clock()
             else:
                 _ws_send(sock, lock, s)
         except OSError:
@@ -26264,7 +26267,24 @@ def _mk_ws_send(q, sock, client):
     return send
 
 
-_ws_clock = time.time   # the liveness clock — one seam, so the tests can drive the beats deterministically
+_ws_clock = time.monotonic   # the liveness clock: an INTERVAL clock (a suspend/resume or an NTP step must
+#                              not read as thirty seconds of silence); one seam so tests drive the beats
+
+
+def _ws_outq(sock):
+    """Bytes this socket has accepted but the peer has not yet acknowledged (Linux SIOCOUTQ, macOS SO_NWRITE),
+    or None where unknown. A nonzero count that keeps falling across beats is a peer that is alive and
+    draining — a slow tunnel behind a large payload — however late its pong; a count that does not move is a
+    peer that has stopped acknowledging."""
+    try:
+        if sys.platform.startswith("linux"):
+            import fcntl, termios
+            return int.from_bytes(fcntl.ioctl(sock.fileno(), termios.TIOCOUTQ, b"\0\0\0\0"), sys.byteorder)
+        if sys.platform == "darwin":
+            return int(sock.getsockopt(socket.SOL_SOCKET, 0x1024))   # SO_NWRITE
+    except (OSError, ValueError, AttributeError):
+        return None
+    return None
 
 
 def _ws_ping_frame(payload: bytes) -> bytes:
@@ -26283,7 +26303,8 @@ def _new_ws_client(app, wid, sock, lock=None, q=None, start_sender=True):
     lock = lock if lock is not None else threading.Lock()
     now = _ws_clock()
     client = {"app": app, "wid": wid, "alive": True, "qbytes": 0, "qlock": threading.Lock(),
-              "sock": sock, "since": now, "lastIn": now, "pingAt": None}
+              "sock": sock, "since": now, "lastIn": now, "pingAt": None,
+              "inRead": True}      # False while the handler thread is inside a dispatch (see _keepalive_all)
     client["send"] = _mk_ws_send(q, sock, client)
     client["q"] = q
     if start_sender:
@@ -26293,8 +26314,15 @@ def _new_ws_client(app, wid, sock, lock=None, q=None, start_sender=True):
 
 def _note_ws_inbound(client, now=None):
     """The peer spoke (a message or a pong): it is alive as of now, and no ping is outstanding."""
-    client["lastIn"] = now if now is not None else _ws_clock()
-    client["pingAt"] = None
+    lk = client.get("qlock")
+    if lk is not None:
+        with lk:
+            client["lastIn"] = now if now is not None else _ws_clock()
+            client["pingAt"] = None
+            client.pop("outq", None)
+    else:
+        client["lastIn"] = now if now is not None else _ws_clock()
+        client["pingAt"] = None
 
 
 def _drop_dead_ws_client(client, why):
@@ -26456,7 +26484,27 @@ def _keepalive_all(now=None):
         # however open the forwarder in between keeps the socket. Clients from before the factory (no
         # `sock`) are never judged: they cannot be shut down, and they cannot have been pinged.
         pa = c.get("pingAt")                     # any pong or message clears this (see _note_ws_inbound), so an
-        if pa is not None and c.get("sock") is not None and (now - pa) >= WS_DEAD_S:   # outstanding ping IS the silence
+        if pa is not None and c.get("sock") is not None and (now - pa) >= WS_DEAD_S:   # outstanding ping IS the silence…
+            # …only while the handler thread is parked in its READ. Inside a dispatch (`ready` builds every
+            # tab synchronously on that thread — tens of seconds on a cold kernel) the pong sits unread in
+            # the receive buffer: unread is not missing. The handler resets the clock when it re-enters the
+            # read (review 2026-09-03).
+            if not c.get("inRead", True):
+                continue
+            # …and never a peer that is still DRAINING: sendall returning means the ping entered the socket,
+            # not that it left the machine — a slow tunnel with megabytes queued ahead of it cannot pong in
+            # time. Unsent bytes that fell since the last beat prove the peer alive; unsent bytes that have
+            # not moved for a whole window prove it gone (a zero window nobody drains).
+            oq = _ws_outq(c["sock"])
+            if oq:
+                prev = c.get("outq")
+                if prev is None or prev[0] != oq:
+                    c["outq"] = (oq, now)             # draining (or first look) → alive, judge again next beat
+                    continue
+                if (now - prev[1]) < WS_DEAD_S:
+                    continue
+                _drop_dead_ws_client(c, "not acknowledging: %d bytes unsent for %ds" % (oq, int(now - prev[1])))
+                continue
             _drop_dead_ws_client(c, "no pong for %ds (last heard %ds ago)" % (int(now - pa), int(now - c.get("lastIn", 0))))
             continue
         try:
@@ -35214,12 +35262,14 @@ class Handler(BaseHTTPRequestHandler):
             while client["alive"]:
                 # one COMPLETE message per iteration — fragments reassembled, pings answered inline
                 # (browsers fragment large sends: a phone photo's dropFile spans dozens of frames)
+                client["inRead"] = True                # parked in the read: silence here is the peer's
                 op, payload = _ws_recv_message(
                     self.rfile, lambda payload: _ws_pong(self.wfile, lock, payload or b""),
                     on_pong=lambda payload: _note_ws_inbound(client))
                 if op is None:                         # EOF / close / a client overran the reassembly cap
                     break
                 _note_ws_inbound(client)               # any message proves the peer alive
+                client["inRead"] = False               # in a dispatch: pongs wait unread, not judged
                 # webview→kernel messages: on "ready", push the initial state to this client
                 try:
                     msg = json.loads(payload.decode("utf-8", "replace"))
@@ -35231,6 +35281,8 @@ class Handler(BaseHTTPRequestHandler):
                     raise   # a genuine socket failure → let the outer handler tear the connection down
                 except Exception:
                     sys.stderr.write("ws handler [%s]: %s\n" % ((msg or {}).get("type"), traceback.format_exc()))
+                finally:
+                    _note_ws_inbound(client)           # pings sent during the dispatch were unjudgeable: fresh clock
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass
         finally:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26313,15 +26313,19 @@ def _new_ws_client(app, wid, sock, lock=None, q=None, start_sender=True):
 
 
 def _register_ws_client(client):
-    """Add a connected pane to _clients — and retire any OTHER socket the same pane held. A pane is
-    (app, dashboard id): the shim reconnects with the same wid after its silence watchdog, and the VS Code
-    extension with its window id, so a second socket for one pane means the first is dead on the peer's
-    side however open a forwarder keeps it here (the 2026-09-03 phantoms: VS Code's port forwarder never
-    closed the devbox end). The reconnect IS the event; the ping timeout below is the backstop for panes
-    that never come back. A pane that reports no wid is left alone (nothing identifies its twin)."""
+    """Add a connected pane to _clients — and retire any OTHER socket the same pane INSTANCE held. The
+    instance id (`iid`) is minted by the shim once per page load and sent on every connect of that page,
+    so a second socket carrying it means the page reconnected after its silence watchdog: its side of the
+    old socket is dead however open a forwarder keeps ours (the 2026-09-03 phantoms: VS Code's port
+    forwarder never closed the devbox end). The reconnect IS the event; the ping timeout is the backstop
+    for pages that never come back (a reload mints a new id, so its old socket falls to the pings).
+    The DASHBOARD id (wid) is deliberately not the key (review 2026-09-03): a duplicated browser tab
+    inherits it through sessionStorage, and the VS Code extension's status pipe and its feed panel share
+    one — keyed on wid, the twins retired each other every 1.5 s for as long as both lived. A socket that
+    reports no instance id is never superseded."""
     with _clients_lock:
         twins = [c for c in _clients if c is not client and c.get("app") == client.get("app")
-                 and client.get("wid") and c.get("wid") == client.get("wid") and c.get("sock") is not None]
+                 and client.get("iid") and c.get("iid") == client.get("iid") and c.get("sock") is not None]
         _clients.append(client)
     for c in twins:
         _drop_dead_ws_client(c, "superseded by a reconnect of the same %s pane" % client.get("app"))
@@ -29472,6 +29476,10 @@ def _shim(app, v=0):
 // (a focus, a jump) at the dashboard that asked instead of at every one that is open (the user 2026-07-29).
 var wid=new URLSearchParams(location.search).get("wid")||"";
 try{if(!wid)wid=window.sessionStorage.getItem("romp:wid")||"";}catch(e){}
+// This PAGE's instance id — minted once per load, never stored: every connect of this page carries it, so the
+// kernel retires this page's previous socket on a reconnect, and never another page's (a duplicated tab copies
+// sessionStorage, and with it wid; it must not copy this).
+var IID="";try{IID=(window.crypto&&crypto.randomUUID)?crypto.randomUUID():"";}catch(e){}if(!IID)IID=String(Math.random()).slice(2)+"-"+Date.now();
 var APP="%s";var LOADEDV=%d;var lastRecv=0;var STALE_MS=30000;   // watchdog: no frame (incl. keepalive) for this long → the socket is dead → reconnect
 var connT=0;   // when the current socket's connect() attempt started — the progress watchdog's reference point
 // Tell the shell this pane's WS state so it can show ONE "disconnected" banner (the user 2026-06-27): a real
@@ -29539,7 +29547,7 @@ else selfBar("A newer romp build is available.","build");}
 function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // one live attempt at a time — a lost timer + the watchdog can both call in
 connT=Date.now();var proto=location.protocol==="https:"?"wss://":"ws://";
 var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";}catch(e){}
-ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1"+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):""));
+ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):""));
 // onopen: flush the queue; a RECONNECT (after a drop) also PROMPTS a reload — the fresh socket resyncs live via
 // the kernel's next push, and the banner offers a full reload for anything a live push doesn't cover. This
 // replaces the old silent location.reload() (the user: don't foist a reload; let me click — [[prefer-reload-banner-not-auto]]).
@@ -35520,6 +35528,7 @@ class Handler(BaseHTTPRequestHandler):
         q = parse_qs(urlparse(self.path).query)
         app = (q.get("app") or ["chat"])[0]
         wid = (q.get("wid") or [""])[0]         # which DASHBOARD this pane belongs to → _send_to_view aims at one
+        iid = (q.get("iid") or [""])[0]         # which page INSTANCE: a reconnect carrying it retires its old socket
         active = (q.get("active") or [""])[0]   # the tab this client is looking at → _push builds it FIRST
         self.send_response(101)
         self.send_header("Upgrade", "websocket")
@@ -35539,6 +35548,8 @@ class Handler(BaseHTTPRequestHandler):
             client["active"] = active                  # active-tab-first streaming (the user 2026-06-24)
         if (q.get("delta") or [""])[0] == "1":
             client["delta"] = True                     # the shim reassembles view deltas (see _send_slot)
+        if iid:
+            client["iid"] = iid
         _register_ws_client(client)
         try:
             while client["alive"]:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26312,6 +26312,21 @@ def _new_ws_client(app, wid, sock, lock=None, q=None, start_sender=True):
     return client, q, lock
 
 
+def _register_ws_client(client):
+    """Add a connected pane to _clients — and retire any OTHER socket the same pane held. A pane is
+    (app, dashboard id): the shim reconnects with the same wid after its silence watchdog, and the VS Code
+    extension with its window id, so a second socket for one pane means the first is dead on the peer's
+    side however open a forwarder keeps it here (the 2026-09-03 phantoms: VS Code's port forwarder never
+    closed the devbox end). The reconnect IS the event; the ping timeout below is the backstop for panes
+    that never come back. A pane that reports no wid is left alone (nothing identifies its twin)."""
+    with _clients_lock:
+        twins = [c for c in _clients if c is not client and c.get("app") == client.get("app")
+                 and client.get("wid") and c.get("wid") == client.get("wid") and c.get("sock") is not None]
+        _clients.append(client)
+    for c in twins:
+        _drop_dead_ws_client(c, "superseded by a reconnect of the same %s pane" % client.get("app"))
+
+
 def _note_ws_inbound(client, now=None):
     """The peer spoke (a message or a pong): it is alive as of now, and no ping is outstanding."""
     lk = client.get("qlock")
@@ -26778,6 +26793,125 @@ def _client_reset_chat_base(client):
     snt = client.get("sent", {})
     for k in [k for k in snt if isinstance(k, tuple) and k and k[0] == "chat"]:
         snt.pop(k, None)
+
+
+# View deltas (2026-09-03). The timeline's bars and the feed used to cross the wire WHOLE on every change —
+# 2.95 MB and 0.86 MB here — and on a board of many working sessions something changes every few seconds,
+# so a dashboard on a forwarded or tunnelled link streamed ~0.5 MB/s of mostly-unchanged JSON and its
+# panes starved (the VS Code port-forwarder incident). A pane that connects with ?delta=1 (the shim does)
+# receives a frame per change carrying only the collection entries that changed, keyed the way each
+# collection is keyed, plus the small remainder when it changed; the shim reassembles the full message
+# and hands the bundle exactly what it received before, so no bundle changes. Per client per slot the
+# kernel keeps what the client holds as serialized strings (the compare is a string compare; the memory
+# is the payload's own size), and a client that cannot apply a delta says so (needSlot) and gets a full.
+_DELTA_SLOTS = {
+    # frame type: (dedup key, {collection: how its entries are keyed})
+    "bars": (("timelinebars",), {"turns": "dict", "judging": "bysid", "messages": "byid"}),
+    "feed": (("feed",), {"asks": "byid"}),
+}
+_DELTA_MAX_FRACTION = 0.6      # a delta this large a fraction of the full payload is sent as the full instead
+_delta_parts_cache = {}        # frame type -> (payload object identity, parts) — one split per BUILD, shared by clients
+
+
+def _delta_split(kind, value):
+    """Entries of one collection as {key: (object, json)} plus the key order — 'dict' keyed by its own keys,
+    'byid' a list keyed by item id, 'bysid' a list grouped by item sid (each group one entry)."""
+    ents, order = {}, []
+    if kind == "dict" and isinstance(value, dict):
+        for kk, v in value.items():
+            ents[str(kk)] = (v, json.dumps(v, default=str)); order.append(str(kk))
+    elif kind == "byid" and isinstance(value, list):
+        for it in value:
+            kk = str((it or {}).get("id")) if isinstance(it, dict) else None
+            if kk is None or kk in ents:
+                kk = "#%d" % len(order)            # id-less or duplicate → positional, still exact
+            ents[kk] = (it, json.dumps(it, default=str)); order.append(kk)
+    elif kind == "bysid" and isinstance(value, list):
+        groups = {}
+        for it in value:
+            kk = str((it or {}).get("sid")) if isinstance(it, dict) else "#"
+            if kk not in groups:
+                groups[kk] = []; order.append(kk)
+            groups[kk].append(it)
+        for kk, g in groups.items():
+            ents[kk] = (g, json.dumps(g, default=str))
+    return ents, order
+
+
+def _delta_parts(ftype, payload):
+    """The payload split into its keyed collections and the remainder, computed once per payload object."""
+    hit = _delta_parts_cache.get(ftype)
+    if hit is not None and hit[0] is payload:
+        return hit[1]
+    kinds = _DELTA_SLOTS[ftype][1]
+    colls = {name: _delta_split(kind, payload.get(name)) for name, kind in kinds.items()}
+    rest = {kk: v for kk, v in payload.items() if kk not in kinds}
+    rest_sig = json.dumps({kk: v for kk, v in rest.items() if kk not in _DEDUP_VOLATILE}, sort_keys=True, default=str)
+    parts = (colls, rest, rest_sig)
+    _delta_parts_cache[ftype] = (payload, parts)
+    return parts
+
+
+def _send_slot(c, ftype, payload, pre, sig):
+    """Send a bars/feed payload to one client: whole for a client without delta support (exactly as before),
+    else as a delta against what that client holds. `pre`/`sig` are the shared full serialization and
+    dedup signature the pusher computed once per build."""
+    key = _DELTA_SLOTS[ftype][0]
+    if not c.get("delta"):
+        _send_client(c, key, payload, pre=pre, sig=sig)
+        return
+    colls, rest, rest_sig = _delta_parts(ftype, payload)
+    states = c.setdefault("dstate", {})
+    st = states.get(ftype)
+    now = time.time()
+    if st is None:                                     # nothing held → the full frame, and remember it
+        _send_client(c, key, payload, pre=pre, sig=sig)
+        if c.get("sent", {}).get(key, (None,))[0] == sig:      # it went (or was already held) → rebase
+            states[ftype] = {"rev": 0, "rest": rest_sig,
+                             "coll": {n: {kk: e[1] for kk, e in ents.items()} for n, (ents, _o) in colls.items()},
+                             "order": {n: list(o) for n, (_e, o) in colls.items()}, "at": now}
+        return
+    frame = {"type": "delta", "slot": ftype, "base": st["rev"], "rev": st["rev"] + 1, "coll": {}}
+    changed = False
+    if rest_sig != st["rest"]:
+        frame["rest"] = rest; changed = True
+    else:
+        for vk in _DEDUP_VOLATILE:                     # the clock fields still ride, so the pane's `now` advances
+            if vk in rest:
+                frame.setdefault("rest", {})[vk] = rest[vk]
+    for name, (ents, order) in colls.items():
+        held = st["coll"].get(name, {})
+        set_ = {kk: e[0] for kk, e in ents.items() if held.get(kk) != e[1]}
+        dele = [kk for kk in held if kk not in ents]
+        entry = {}
+        if set_:
+            entry["set"] = set_
+        if dele:
+            entry["del"] = dele
+        if order != st["order"].get(name, []):
+            entry["order"] = order
+        if entry:
+            frame["coll"][name] = entry; changed = True
+    if not changed:
+        if now - st.get("at", 0) < _DEDUP_REPOST_S:    # unchanged: nothing to send (the repost keeps the fade alive)
+            return
+    s = json.dumps(frame, default=str)
+    if len(s) >= _DELTA_MAX_FRACTION * len(pre):       # not worth a delta → the full frame, rebased
+        states.pop(ftype, None)
+        c.get("sent", {}).pop(key, None)
+        _send_slot(c, ftype, payload, pre, sig)
+        return
+    _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0, delta=1)
+    try:
+        c["send"](s)
+    except Exception:
+        c["alive"] = False
+        return
+    st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now
+    for name, (ents, order) in colls.items():
+        st["coll"][name] = {kk: e[1] for kk, e in ents.items()}
+        st["order"][name] = list(order)
+    c.setdefault("sent", {})[key] = (sig, now)          # the dedup slot follows, so a later full send dedups honestly
 
 
 def _send_client(c, key, msg, pre=None, sig=None):
@@ -28245,7 +28379,7 @@ def _push(targets, connect=False, tmux=None):
                     feed_ms = json.dumps(feed)
                     feed_sig = _dedup_sig(feed, feed_ms)
                     _feed_wire = (feed_src, feed.get("ledgers"), feed, feed_ms, feed_sig)
-            _send_client(c, ("feed",), feed, pre=feed_ms, sig=feed_sig)
+            _send_slot(c, "feed", feed, feed_ms, feed_sig)
         elif c["app"] == "timeline" and timeline is not None:
             if bars_ms is None:
                 w = _bars_wire
@@ -28257,7 +28391,7 @@ def _push(targets, connect=False, tmux=None):
                     bars_ms = json.dumps(bars)
                     bars_sig = _dedup_sig(bars, bars_ms)
                     _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig)
-            _send_client(c, ("timelinebars",), bars, pre=bars_ms, sig=bars_sig)
+            _send_slot(c, "bars", bars, bars_ms, bars_sig)
     with _clients_lock:
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 
@@ -29299,7 +29433,7 @@ else selfBar("A newer romp build is available.","build");}
 function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // one live attempt at a time — a lost timer + the watchdog can both call in
 connT=Date.now();var proto=location.protocol==="https:"?"wss://":"ws://";
 var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";}catch(e){}
-ws=new WebSocket(proto+location.host+"/ws?app=%s"+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):""));
+ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1"+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):""));
 // onopen: flush the queue; a RECONNECT (after a drop) also PROMPTS a reload — the fresh socket resyncs live via
 // the kernel's next push, and the banner offers a full reload for anything a live push doesn't cover. This
 // replaces the old silent location.reload() (the user: don't foist a reload; let me click — [[prefer-reload-banner-not-auto]]).
@@ -29323,6 +29457,11 @@ if(msg&&msg.type==="restarting"){restartAnnounced=Date.now();staleDiag("restart-
 // the first REAL frame after a reconnect is the kernel's connect-time push — the resync itself, so the
 // "what you see may be stale" prompt is answered and retires (see clearStale). Keepalives return above.
 if(freshPending){freshPending=false;clearStale();}
+// VIEW DELTAS (2026-09-03): the bars/feed slots arrive as {type:"delta"} frames carrying only the changed
+// entries; reassemble the full message from what this pane holds and hand the bundle exactly what it
+// used to receive. A delta whose base is not the revision held here cannot be applied → ask for a full.
+if(msg&&msg.type==="delta"){var full=applyDelta(msg);if(!full){send({type:"needSlot",slot:msg.slot});return;}msg=full;}
+else if(msg&&DELTA_KINDS[msg.type]){LAST[msg.type]={rev:0,msg:msg,maps:buildMaps(msg)};}
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
@@ -29330,6 +29469,27 @@ ws.onclose=function(){netState("down");try{window.dispatchEvent(new Event("romp:
 setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);};   // announced death → tight redial (the frame is the event; the blind 1.5s stays for unannounced drops)
 ws.onerror=function(){try{ws.close();}catch(e){}};}
 function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);else queue.push(s);}
+// The delta reassembler. DELTA_KINDS mirrors the kernel's _DELTA_SLOTS: which top-level collections of each
+// slot are keyed, and how — "dict" (an object keyed by its own keys), "byid" (a list keyed by item id),
+// "bysid" (a list grouped by item sid, one entry per group). LAST holds, per slot, the revision, the last
+// full message handed to the bundle, and per-collection maps {order:[keys], items:{key:value}}. A delta
+// builds a NEW message object (the bundle may still hold the previous one) reusing every unchanged part.
+var DELTA_KINDS={bars:{turns:"dict",judging:"bysid",messages:"byid"},feed:{asks:"byid"}};var LAST={};
+function buildMaps(m){var kinds=DELTA_KINDS[m.type]||{},maps={};for(var name in kinds){var kind=kinds[name],v=m[name],order=[],items={};
+if(kind==="dict"&&v&&typeof v==="object"){for(var kk in v){order.push(kk);items[kk]=v[kk];}}
+else if(kind==="byid"&&Array.isArray(v)){for(var i=0;i<v.length;i++){var it=v[i],key=(it&&it.id!=null)?String(it.id):null;if(key===null||items.hasOwnProperty(key))key="#"+order.length;order.push(key);items[key]=it;}}
+else if(kind==="bysid"&&Array.isArray(v)){for(var j=0;j<v.length;j++){var it2=v[j],sk=(it2&&it2.sid!=null)?String(it2.sid):"#";if(!items.hasOwnProperty(sk)){order.push(sk);items[sk]=[];}items[sk].push(it2);}}
+maps[name]={order:order,items:items};}return maps;}
+function assemble(kind,map){if(kind==="dict"){var o={};for(var i=0;i<map.order.length;i++){var kk=map.order[i];if(map.items.hasOwnProperty(kk))o[kk]=map.items[kk];}return o;}
+var out=[];for(var j=0;j<map.order.length;j++){var k2=map.order[j];if(!map.items.hasOwnProperty(k2))continue;if(kind==="bysid"){out=out.concat(map.items[k2]);}else{out.push(map.items[k2]);}}return out;}
+function applyDelta(d){var last=LAST[d.slot];if(!last||last.rev!==d.base)return null;var kinds=DELTA_KINDS[d.slot]||{};var m={};for(var k0 in last.msg)m[k0]=last.msg[k0];
+if(d.rest){for(var rk in d.rest)m[rk]=d.rest[rk];}
+var coll=d.coll||{};for(var name in coll){var kind=kinds[name];if(!kind)continue;var c=coll[name],map=last.maps[name]||{order:[],items:{}};var items={};for(var ik in map.items)items[ik]=map.items[ik];var order=map.order.slice();
+if(c.del){for(var x=0;x<c.del.length;x++){delete items[c.del[x]];}}
+if(c.set){for(var sk in c.set){if(!items.hasOwnProperty(sk))order.push(sk);items[sk]=c.set[sk];}}
+if(c.order){order=c.order.slice();}else{order=order.filter(function(kk){return items.hasOwnProperty(kk);});}
+last.maps[name]={order:order,items:items};m[name]=assemble(kind,last.maps[name]);}
+last.rev=d.rev;last.msg=m;return m;}
 window.__rompLocalSend=send;window.__rompApp=APP;   // federation.ts (the multi-kernel manager) routes local sends + knows the app through these
 var SK="romp-vscode-state-%s";   // persist webview state to localStorage so UI prefs survive a refresh
 window.acquireVsCodeApi=function(){return{postMessage:function(m){if(window.__rompFed){window.__rompFed.outbound(m);}else{send(m);}},
@@ -34495,6 +34655,15 @@ class Handler(BaseHTTPRequestHandler):
             client["active"] = msg.get("id")   # tab switch → next push builds the now-active tab first
             _pusher_wake.set()                 # …and that push starts when the in-flight cycle ends, not
             return                             #    after the 0.5 s backstop (the tab switch IS the event)
+        if msg and msg.get("type") == "needSlot" and msg.get("slot") in _DELTA_SLOTS:
+            # The shim could not apply a view delta (its base revision did not match what it holds — a
+            # frame it never saw, a reload mid-stream): forget what we believe it holds and re-send the
+            # whole slot now, from which the delta stream re-bases (the chat's needFull, for views).
+            ftype = str(msg["slot"])
+            client.get("dstate", {}).pop(ftype, None)
+            client.get("sent", {}).pop(_DELTA_SLOTS[ftype][0], None)
+            self._push_one(client)
+            return
         if msg and msg.get("type") == "needFull" and msg.get("id"):
             # The client REJECTED a delta because it started past what it holds (render.ts chatTail's gap
             # branch) — it is missing events and cannot self-repair. Our own per-client bookkeeping can't
@@ -35253,11 +35422,14 @@ class Handler(BaseHTTPRequestHandler):
         # Frames are ENQUEUED, never written by the caller: one wedged client must not stall the shared
         # push/heartbeat loops (see _ws_sender). Pongs still ride self.wfile — they are ≤125-byte control
         # frames answered on this client's own handler thread, and both paths serialise on the same `lock`.
-        client, q, lock = _new_ws_client(app, wid, self.connection, lock=lock)
+        # `q` above is the connect QUERY; the client's send queue gets its own name — a Queue.get("delta")
+        # would block this handler forever (caught by tests/test_kernel.py's socket-error loop test)
+        client, sendq, lock = _new_ws_client(app, wid, self.connection, lock=lock)
         if active:
             client["active"] = active                  # active-tab-first streaming (the user 2026-06-24)
-        with _clients_lock:
-            _clients.append(client)
+        if (q.get("delta") or [""])[0] == "1":
+            client["delta"] = True                     # the shim reassembles view deltas (see _send_slot)
+        _register_ws_client(client)
         try:
             while client["alive"]:
                 # one COMPLETE message per iteration — fragments reassembled, pings answered inline
@@ -35287,7 +35459,7 @@ class Handler(BaseHTTPRequestHandler):
             pass
         finally:
             client["alive"] = False
-            q.put(None)                        # end this client's sender thread
+            sendq.put(None)                    # end this client's sender thread
             with _clients_lock:
                 if client in _clients:
                     _clients.remove(client)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26805,36 +26805,58 @@ def _client_reset_chat_base(client):
 # kernel keeps what the client holds as serialized strings (the compare is a string compare; the memory
 # is the payload's own size), and a client that cannot apply a delta says so (needSlot) and gets a full.
 _DELTA_SLOTS = {
-    # frame type: (dedup key, {collection: how its entries are keyed})
-    "bars": (("timelinebars",), {"turns": "dict", "judging": "bysid", "messages": "byid"}),
+    # frame type: (dedup key, {collection: how its entries are keyed}). Kinds — "dict": an object keyed by its
+    # own keys; "byid": a list keyed by item id; "bykeys:a,b,c": a list keyed by a composite of item fields
+    # (an id-less list whose items are unique on those fields); "dictlist:id": an object of lists, every
+    # item keyed by (object key, item field) — the timeline's lanes, where a lane of 200 bars must not
+    # cross whole because one bar was appended (measured 2026-09-03: 507 KB per appended segment at lane
+    # granularity, ~2 KB at bar granularity).
+    "bars": (("timelinebars",), {"turns": "dictlist:id", "judging": "bykeys:sid,t,judge,t1", "messages": "byid"}),
     "feed": (("feed",), {"asks": "byid"}),
 }
+_DELTA_SEP = "\u001f"          # joins composite keys; never appears in an id or a sid
 _DELTA_MAX_FRACTION = 0.6      # a delta this large a fraction of the full payload is sent as the full instead
 _delta_parts_cache = {}        # frame type -> (payload object identity, parts) — one split per BUILD, shared by clients
 
 
+def _delta_key(kind, it, prefix=""):
+    """The key of one list item under `kind` ('byid' / 'bykeys:…'), or None when the item cannot be keyed
+    (then the caller falls back to a positional key, which is still exact)."""
+    if not isinstance(it, dict):
+        return None
+    if kind == "byid" or kind.startswith("dictlist:"):
+        field = "id" if kind == "byid" else kind.split(":", 1)[1]
+        v = it.get(field)
+        return None if v is None else prefix + str(v)
+    if kind.startswith("bykeys:"):
+        return prefix + _DELTA_SEP.join(str(it.get(f)) for f in kind.split(":", 1)[1].split(","))
+    return None
+
+
 def _delta_split(kind, value):
-    """Entries of one collection as {key: (object, json)} plus the key order — 'dict' keyed by its own keys,
-    'byid' a list keyed by item id, 'bysid' a list grouped by item sid (each group one entry)."""
+    """Entries of one collection as {key: (object, json)} plus the key order, per the kind table above. A
+    list item that cannot be keyed, or a duplicate key, takes a positional key ('#n') — exact, since the
+    shim rebuilds in key order, just less delta-friendly."""
     ents, order = {}, []
+    enc = json.JSONEncoder(default=str).encode          # one encoder for the thousand entries, not one each
+    def put(kk, v):
+        if kk is None or kk in ents:
+            kk = "#%d" % len(order)
+        ents[kk] = (v, enc(v)); order.append(kk)
     if kind == "dict" and isinstance(value, dict):
         for kk, v in value.items():
-            ents[str(kk)] = (v, json.dumps(v, default=str)); order.append(str(kk))
-    elif kind == "byid" and isinstance(value, list):
+            put(str(kk), v)
+    elif (kind == "byid" or kind.startswith("bykeys:")) and isinstance(value, list):
         for it in value:
-            kk = str((it or {}).get("id")) if isinstance(it, dict) else None
-            if kk is None or kk in ents:
-                kk = "#%d" % len(order)            # id-less or duplicate → positional, still exact
-            ents[kk] = (it, json.dumps(it, default=str)); order.append(kk)
-    elif kind == "bysid" and isinstance(value, list):
-        groups = {}
-        for it in value:
-            kk = str((it or {}).get("sid")) if isinstance(it, dict) else "#"
-            if kk not in groups:
-                groups[kk] = []; order.append(kk)
-            groups[kk].append(it)
-        for kk, g in groups.items():
-            ents[kk] = (g, json.dumps(g, default=str))
+            put(_delta_key(kind, it), it)
+    elif kind.startswith("dictlist:") and isinstance(value, dict):
+        for dk, lst in value.items():
+            pre = str(dk) + _DELTA_SEP
+            if not isinstance(lst, list) or not lst:
+                put(pre, lst)                      # an empty or non-list lane: one entry under its bare prefix
+                continue
+            for it in lst:
+                put(_delta_key(kind, it, pre), it)
     return ents, order
 
 
@@ -26850,6 +26872,37 @@ def _delta_parts(ftype, payload):
     parts = (colls, rest, rest_sig)
     _delta_parts_cache[ftype] = (payload, parts)
     return parts
+
+
+def _js_key_order(keys):
+    """The order JavaScript enumerates these object keys in: canonical array indices ascending first, then
+    the rest in insertion order — the order the shim appends a delta's new keys in, so the kernel must
+    predict it to know what the client holds."""
+    idx, rest = [], []
+    for kk in keys:
+        (idx if (kk.isdigit() and (kk == "0" or kk[0] != "0") and int(kk) < 4294967295) else rest).append(kk)
+    return sorted(idx, key=int) + rest
+
+
+def _client_order(held, order, ents):
+    """The flat key order a client derives from a delta that carries no `order`: its held keys that survive,
+    then the new keys as it enumerates the frame's `set`."""
+    have = set(ents)
+    kept = [kk for kk in held if kk in have]
+    seen = set(held)
+    return kept + _js_key_order([kk for kk in order if kk not in seen])
+
+
+def _order_shape(kind, order):
+    """What a key order means for the assembled value: for a dict-of-lists, the groups in first-appearance
+    order each with its keys in relative order (a bar appended to the FIRST lane lands at the end of the
+    flat order and still assembles into its own lane); for the rest, the order itself."""
+    if not kind.startswith("dictlist:"):
+        return order
+    groups = {}
+    for kk in order:
+        groups.setdefault(kk.partition(_DELTA_SEP)[0], []).append(kk)
+    return list(groups.items())
 
 
 def _send_slot(c, ftype, payload, pre, sig):
@@ -26879,6 +26932,8 @@ def _send_slot(c, ftype, payload, pre, sig):
         for vk in _DEDUP_VOLATILE:                     # the clock fields still ride, so the pane's `now` advances
             if vk in rest:
                 frame.setdefault("rest", {})[vk] = rest[vk]
+    kinds = _DELTA_SLOTS[ftype][1]
+    next_order = {}
     for name, (ents, order) in colls.items():
         held = st["coll"].get(name, {})
         set_ = {kk: e[0] for kk, e in ents.items() if held.get(kk) != e[1]}
@@ -26888,8 +26943,13 @@ def _send_slot(c, ftype, payload, pre, sig):
             entry["set"] = set_
         if dele:
             entry["del"] = dele
-        if order != st["order"].get(name, []):
-            entry["order"] = order
+        # the order crosses only when what the client would derive on its own assembles differently; and
+        # the kernel remembers the order the CLIENT holds, which is that derived order, not the payload's
+        implied = _client_order(st["order"].get(name, []), order, ents)
+        if _order_shape(kinds[name], implied) != _order_shape(kinds[name], order):
+            entry["order"] = order; next_order[name] = list(order)
+        else:
+            next_order[name] = implied
         if entry:
             frame["coll"][name] = entry; changed = True
     if not changed:
@@ -26908,9 +26968,9 @@ def _send_slot(c, ftype, payload, pre, sig):
         c["alive"] = False
         return
     st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now
-    for name, (ents, order) in colls.items():
+    for name, (ents, _order) in colls.items():
         st["coll"][name] = {kk: e[1] for kk, e in ents.items()}
-        st["order"][name] = list(order)
+        st["order"][name] = next_order[name]
     c.setdefault("sent", {})[key] = (sig, now)          # the dedup slot follows, so a later full send dedups honestly
 
 
@@ -29474,14 +29534,21 @@ function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);els
 // "bysid" (a list grouped by item sid, one entry per group). LAST holds, per slot, the revision, the last
 // full message handed to the bundle, and per-collection maps {order:[keys], items:{key:value}}. A delta
 // builds a NEW message object (the bundle may still hold the previous one) reusing every unchanged part.
-var DELTA_KINDS={bars:{turns:"dict",judging:"bysid",messages:"byid"},feed:{asks:"byid"}};var LAST={};
+var DELTA_KINDS={bars:{turns:"dictlist:id",judging:"bykeys:sid,t,judge,t1",messages:"byid"},feed:{asks:"byid"}};var LAST={};var SEP="\u001f";
+function deltaKey(kind,it,prefix){if(!it||typeof it!=="object")return null;
+if(kind==="byid"||kind.indexOf("dictlist:")===0){var f=kind==="byid"?"id":kind.slice(9);return it[f]==null?null:(prefix||"")+String(it[f]);}
+if(kind.indexOf("bykeys:")===0){var fs=kind.slice(7).split(","),parts=[];for(var i=0;i<fs.length;i++)parts.push(String(it[fs[i]]));return (prefix||"")+parts.join(SEP);}return null;}
 function buildMaps(m){var kinds=DELTA_KINDS[m.type]||{},maps={};for(var name in kinds){var kind=kinds[name],v=m[name],order=[],items={};
-if(kind==="dict"&&v&&typeof v==="object"){for(var kk in v){order.push(kk);items[kk]=v[kk];}}
-else if(kind==="byid"&&Array.isArray(v)){for(var i=0;i<v.length;i++){var it=v[i],key=(it&&it.id!=null)?String(it.id):null;if(key===null||items.hasOwnProperty(key))key="#"+order.length;order.push(key);items[key]=it;}}
-else if(kind==="bysid"&&Array.isArray(v)){for(var j=0;j<v.length;j++){var it2=v[j],sk=(it2&&it2.sid!=null)?String(it2.sid):"#";if(!items.hasOwnProperty(sk)){order.push(sk);items[sk]=[];}items[sk].push(it2);}}
+var put=function(kk,val){if(kk===null||items.hasOwnProperty(kk))kk="#"+order.length;order.push(kk);items[kk]=val;};
+if(kind==="dict"&&v&&typeof v==="object"){for(var kk in v)put(kk,v[kk]);}
+else if((kind==="byid"||kind.indexOf("bykeys:")===0)&&Array.isArray(v)){for(var i=0;i<v.length;i++)put(deltaKey(kind,v[i]),v[i]);}
+else if(kind.indexOf("dictlist:")===0&&v&&typeof v==="object"){for(var dk in v){var lst=v[dk],pre=dk+SEP;if(!Array.isArray(lst)||!lst.length){put(pre,lst);continue;}for(var j=0;j<lst.length;j++)put(deltaKey(kind,lst[j],pre),lst[j]);}}
 maps[name]={order:order,items:items};}return maps;}
-function assemble(kind,map){if(kind==="dict"){var o={};for(var i=0;i<map.order.length;i++){var kk=map.order[i];if(map.items.hasOwnProperty(kk))o[kk]=map.items[kk];}return o;}
-var out=[];for(var j=0;j<map.order.length;j++){var k2=map.order[j];if(!map.items.hasOwnProperty(k2))continue;if(kind==="bysid"){out=out.concat(map.items[k2]);}else{out.push(map.items[k2]);}}return out;}
+function assemble(kind,map){var i,kk;if(kind==="dict"){var o={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))o[kk]=map.items[kk];}return o;}
+if(kind.indexOf("dictlist:")===0){var d={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(!map.items.hasOwnProperty(kk))continue;var cut=kk.indexOf(SEP);var dk=cut<0?kk:kk.slice(0,cut),rest=cut<0?"":kk.slice(cut+1);
+if(rest===""&&!Array.isArray(map.items[kk])){d[dk]=map.items[kk];continue;}   // a bare-prefix entry: the lane's own (non-list or empty) value
+if(rest===""){d[dk]=map.items[kk];continue;}if(!d.hasOwnProperty(dk))d[dk]=[];d[dk].push(map.items[kk]);}return d;}
+var out=[];for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))out.push(map.items[kk]);}return out;}
 function applyDelta(d){var last=LAST[d.slot];if(!last||last.rev!==d.base)return null;var kinds=DELTA_KINDS[d.slot]||{};var m={};for(var k0 in last.msg)m[k0]=last.msg[k0];
 if(d.rest){for(var rk in d.rest)m[rk]=d.rest[rk];}
 var coll=d.coll||{};for(var name in coll){var kind=kinds[name];if(!kind)continue;var c=coll[name],map=last.maps[name]||{order:[],items:{}};var items={};for(var ik in map.items)items[ik]=map.items[ik];var order=map.order.slice();

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26500,28 +26500,33 @@ def _keepalive_all(now=None):
         # `sock`) are never judged: they cannot be shut down, and they cannot have been pinged.
         pa = c.get("pingAt")                     # any pong or message clears this (see _note_ws_inbound), so an
         if pa is not None and c.get("sock") is not None and (now - pa) >= WS_DEAD_S:   # outstanding ping IS the silence…
+            why = None
             # …only while the handler thread is parked in its READ. Inside a dispatch (`ready` builds every
             # tab synchronously on that thread — tens of seconds on a cold kernel) the pong sits unread in
             # the receive buffer: unread is not missing. The handler resets the clock when it re-enters the
             # read (review 2026-09-03).
             if not c.get("inRead", True):
+                pass
+            else:
+                # …and never a peer that is still DRAINING: sendall returning means the ping entered the socket,
+                # not that it left the machine — a slow tunnel with megabytes queued ahead of it cannot pong in
+                # time. Unsent bytes that fell since the last beat prove the peer alive; unsent bytes that have
+                # not moved for a whole window prove it gone (a zero window nobody drains).
+                oq = _ws_outq(c["sock"])
+                if oq:
+                    prev = c.get("outq")
+                    if prev is None or prev[0] != oq:
+                        c["outq"] = (oq, now)         # draining (or first look) → alive, judge again next beat
+                    elif (now - prev[1]) >= WS_DEAD_S:
+                        why = "not acknowledging: %d bytes unsent for %ds" % (oq, int(now - prev[1]))
+                else:
+                    why = "no pong for %ds (last heard %ds ago)" % (int(now - pa), int(now - c.get("lastIn", 0)))
+            if why:
+                _drop_dead_ws_client(c, why)
                 continue
-            # …and never a peer that is still DRAINING: sendall returning means the ping entered the socket,
-            # not that it left the machine — a slow tunnel with megabytes queued ahead of it cannot pong in
-            # time. Unsent bytes that fell since the last beat prove the peer alive; unsent bytes that have
-            # not moved for a whole window prove it gone (a zero window nobody drains).
-            oq = _ws_outq(c["sock"])
-            if oq:
-                prev = c.get("outq")
-                if prev is None or prev[0] != oq:
-                    c["outq"] = (oq, now)             # draining (or first look) → alive, judge again next beat
-                    continue
-                if (now - prev[1]) < WS_DEAD_S:
-                    continue
-                _drop_dead_ws_client(c, "not acknowledging: %d bytes unsent for %ds" % (oq, int(now - prev[1])))
-                continue
-            _drop_dead_ws_client(c, "no pong for %ds (last heard %ds ago)" % (int(now - pa), int(now - c.get("lastIn", 0))))
-            continue
+            # not judged this beat — but still BEATEN: the ka must keep flowing to a client the kernel is
+            # busy serving, or the shim's own silence watchdog closes a connection that is merely waiting
+            # on a long build (review 2026-09-03, residual).
         try:
             c["send"](s)
             if c.get("sock") is not None:
@@ -26839,9 +26844,9 @@ def _delta_split(kind, value):
     shim rebuilds in key order, just less delta-friendly."""
     ents, order = {}, []
     enc = json.JSONEncoder(default=str).encode          # one encoder for the thousand entries, not one each
-    def put(kk, v):
+    def put(kk, v, pre=""):
         if kk is None or kk in ents:
-            kk = "#%d" % len(order)
+            kk = pre + "#%d" % len(order)          # keeps its lane prefix, so the shim still files it by lane
         ents[kk] = (v, enc(v)); order.append(kk)
     if kind == "dict" and isinstance(value, dict):
         for kk, v in value.items():
@@ -26851,12 +26856,14 @@ def _delta_split(kind, value):
             put(_delta_key(kind, it), it)
     elif kind.startswith("dictlist:") and isinstance(value, dict):
         for dk, lst in value.items():
+            if _DELTA_SEP in str(dk):
+                raise ValueError("lane key carries the separator")
             pre = str(dk) + _DELTA_SEP
             if not isinstance(lst, list) or not lst:
                 put(pre, lst)                      # an empty or non-list lane: one entry under its bare prefix
                 continue
             for it in lst:
-                put(_delta_key(kind, it, pre), it)
+                put(_delta_key(kind, it, pre), it, pre)
     return ents, order
 
 
@@ -26866,10 +26873,14 @@ def _delta_parts(ftype, payload):
     if hit is not None and hit[0] is payload:
         return hit[1]
     kinds = _DELTA_SLOTS[ftype][1]
-    colls = {name: _delta_split(kind, payload.get(name)) for name, kind in kinds.items()}
-    rest = {kk: v for kk, v in payload.items() if kk not in kinds}
-    rest_sig = json.dumps({kk: v for kk, v in rest.items() if kk not in _DEDUP_VOLATILE}, sort_keys=True, default=str)
-    parts = (colls, rest, rest_sig)
+    try:
+        colls = {name: _delta_split(kind, payload.get(name)) for name, kind in kinds.items()}
+    except ValueError:
+        parts = None                                   # a payload the protocol cannot key: this build goes whole
+    else:
+        rest = {kk: v for kk, v in payload.items() if kk not in kinds}
+        rest_sig = json.dumps({kk: v for kk, v in rest.items() if kk not in _DEDUP_VOLATILE}, sort_keys=True, default=str)
+        parts = (colls, rest, rest_sig)
     _delta_parts_cache[ftype] = (payload, parts)
     return parts
 
@@ -26913,12 +26924,22 @@ def _send_slot(c, ftype, payload, pre, sig):
     if not c.get("delta"):
         _send_client(c, key, payload, pre=pre, sig=sig)
         return
-    colls, rest, rest_sig = _delta_parts(ftype, payload)
+    parts = _delta_parts(ftype, payload)
     states = c.setdefault("dstate", {})
+    if parts is None:                                  # cannot be keyed: whole, and the client holds nothing
+        states.pop(ftype, None)
+        _send_client(c, key, payload, pre=pre, sig=sig)
+        return
+    colls, rest, rest_sig = parts
     st = states.get(ftype)
     now = time.time()
     if st is None:                                     # nothing held → the full frame, and remember it
-        _send_client(c, key, payload, pre=pre, sig=sig)
+        # The frame carries the kernel's key list per collection (`_keys`, which the shim strips before the
+        # bundle sees the message): every key is minted HERE, once — a shim deriving keys from field values
+        # would spell null/None, true/True, 1/1.0 differently from Python and hold keys the kernel never sent.
+        keys = json.dumps({n: o for n, (_e, o) in colls.items()})
+        pre_k = pre[:-1] + ',"_keys":' + keys + "}" if pre.endswith("}") else json.dumps(dict(payload, _keys=json.loads(keys)), default=str)
+        _send_client(c, key, payload, pre=pre_k, sig=sig)
         if c.get("sent", {}).get(key, (None,))[0] == sig:      # it went (or was already held) → rebase
             states[ftype] = {"rev": 0, "rest": rest_sig,
                              "coll": {n: {kk: e[1] for kk, e in ents.items()} for n, (ents, _o) in colls.items()},
@@ -29521,7 +29542,7 @@ if(freshPending){freshPending=false;clearStale();}
 // entries; reassemble the full message from what this pane holds and hand the bundle exactly what it
 // used to receive. A delta whose base is not the revision held here cannot be applied → ask for a full.
 if(msg&&msg.type==="delta"){var full=applyDelta(msg);if(!full){send({type:"needSlot",slot:msg.slot});return;}msg=full;}
-else if(msg&&DELTA_KINDS[msg.type]){LAST[msg.type]={rev:0,msg:msg,maps:buildMaps(msg)};}
+else if(msg&&DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg.type]=keys?{rev:0,msg:msg,maps:buildMaps(msg,keys)}:null;}
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
@@ -29535,19 +29556,16 @@ function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);els
 // full message handed to the bundle, and per-collection maps {order:[keys], items:{key:value}}. A delta
 // builds a NEW message object (the bundle may still hold the previous one) reusing every unchanged part.
 var DELTA_KINDS={bars:{turns:"dictlist:id",judging:"bykeys:sid,t,judge,t1",messages:"byid"},feed:{asks:"byid"}};var LAST={};var SEP="\u001f";
-function deltaKey(kind,it,prefix){if(!it||typeof it!=="object")return null;
-if(kind==="byid"||kind.indexOf("dictlist:")===0){var f=kind==="byid"?"id":kind.slice(9);return it[f]==null?null:(prefix||"")+String(it[f]);}
-if(kind.indexOf("bykeys:")===0){var fs=kind.slice(7).split(","),parts=[];for(var i=0;i<fs.length;i++)parts.push(String(it[fs[i]]));return (prefix||"")+parts.join(SEP);}return null;}
-function buildMaps(m){var kinds=DELTA_KINDS[m.type]||{},maps={};for(var name in kinds){var kind=kinds[name],v=m[name],order=[],items={};
-var put=function(kk,val){if(kk===null||items.hasOwnProperty(kk))kk="#"+order.length;order.push(kk);items[kk]=val;};
-if(kind==="dict"&&v&&typeof v==="object"){for(var kk in v)put(kk,v[kk]);}
-else if((kind==="byid"||kind.indexOf("bykeys:")===0)&&Array.isArray(v)){for(var i=0;i<v.length;i++)put(deltaKey(kind,v[i]),v[i]);}
-else if(kind.indexOf("dictlist:")===0&&v&&typeof v==="object"){for(var dk in v){var lst=v[dk],pre=dk+SEP;if(!Array.isArray(lst)||!lst.length){put(pre,lst);continue;}for(var j=0;j<lst.length;j++)put(deltaKey(kind,lst[j],pre),lst[j]);}}
+function buildMaps(m,keys){var kinds=DELTA_KINDS[m.type]||{},maps={};for(var name in kinds){var kind=kinds[name],v=m[name],order=((keys||{})[name]||[]).slice(),items={},pos={};
+for(var i=0;i<order.length;i++){var kk=order[i];
+if(kind==="dict"){items[kk]=v[kk];}
+else if(kind.indexOf("dictlist:")===0){var cut=kk.indexOf(SEP),dk=cut<0?kk:kk.slice(0,cut),rest=cut<0?"":kk.slice(cut+1),lane=v[dk];if(rest===""){items[kk]=lane;}else{var j=pos[dk]||0;pos[dk]=j+1;items[kk]=lane[j];}}
+else{items[kk]=v[i];}}
 maps[name]={order:order,items:items};}return maps;}
 function assemble(kind,map){var i,kk;if(kind==="dict"){var o={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))o[kk]=map.items[kk];}return o;}
 if(kind.indexOf("dictlist:")===0){var d={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(!map.items.hasOwnProperty(kk))continue;var cut=kk.indexOf(SEP);var dk=cut<0?kk:kk.slice(0,cut),rest=cut<0?"":kk.slice(cut+1);
-if(rest===""&&!Array.isArray(map.items[kk])){d[dk]=map.items[kk];continue;}   // a bare-prefix entry: the lane's own (non-list or empty) value
-if(rest===""){d[dk]=map.items[kk];continue;}if(!d.hasOwnProperty(dk))d[dk]=[];d[dk].push(map.items[kk]);}return d;}
+if(rest===""){d[dk]=map.items[kk];continue;}   // a bare-prefix entry: the lane's own (empty or non-list) value
+if(!d.hasOwnProperty(dk))d[dk]=[];d[dk].push(map.items[kk]);}return d;}
 var out=[];for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))out.push(map.items[kk]);}return out;}
 function applyDelta(d){var last=LAST[d.slot];if(!last||last.rev!==d.base)return null;var kinds=DELTA_KINDS[d.slot]||{};var m={};for(var k0 in last.msg)m[k0]=last.msg[k0];
 if(d.rest){for(var rk in d.rest)m[rk]=d.rest[rk];}

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26968,6 +26968,10 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         # would spell null/None, true/True, 1/1.0 differently from Python and hold keys the kernel never sent.
         keys = json.dumps({n: o for n, (_e, o) in colls.items()})
         pre_k = pre[:-1] + ',"_keys":' + keys + "}" if pre.endswith("}") else json.dumps(dict(payload, _keys=json.loads(keys)), default=str)
+        # The keyed full must actually GO: a whole frame sent moments ago without keys (the failure path, or an
+        # unkeyable build) filled the dedup slot with this same signature, and a deduped keyed full would leave
+        # the kernel holding state for a client that holds nothing (review 2026-09-03).
+        c.get("sent", {}).pop(key, None)
         _send_client(c, key, payload, pre=pre_k, sig=sig)
         if c.get("sent", {}).get(key, (None,))[0] == sig:      # it went (or was already held) → rebase
             states[ftype] = {"rev": 0, "rest": rest_sig,

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -90,7 +90,7 @@ class Wiring(unittest.TestCase):
         # it was written to replace. The tests above all hand-build clients WITH a wid, so none saw it.
         src = inspect.getsource(km.Handler)
         self.assertIn('wid = (q.get("wid") or [""])[0]', src, "the connect query is where a dashboard names itself")
-        self.assertIn('client, q, lock = _new_ws_client(app, wid, self.connection', src, "…and it has to reach the client dict")
+        self.assertIn('client, sendq, lock = _new_ws_client(app, wid, self.connection', src, "…and it has to reach the client dict")
         self.assertIn('client = {"app": app, "wid": wid,', inspect.getsource(km._new_ws_client),
                       "…which the factory builds with it (the liveness change of 2026-09-03 moved the construction there)")
 

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -90,7 +90,9 @@ class Wiring(unittest.TestCase):
         # it was written to replace. The tests above all hand-build clients WITH a wid, so none saw it.
         src = inspect.getsource(km.Handler)
         self.assertIn('wid = (q.get("wid") or [""])[0]', src, "the connect query is where a dashboard names itself")
-        self.assertIn('client = {"app": app, "wid": wid,', src, "…and it has to reach the client dict")
+        self.assertIn('client, q, lock = _new_ws_client(app, wid, self.connection', src, "…and it has to reach the client dict")
+        self.assertIn('client = {"app": app, "wid": wid,', inspect.getsource(km._new_ws_client),
+                      "…which the factory builds with it (the liveness change of 2026-09-03 moved the construction there)")
 
     def test_a_federated_pane_names_its_dashboard_to_the_REMOTE_kernel_too(self):
         # A remote kernel sees one anonymous client per federated pane unless the wid rides the relay

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -306,6 +306,28 @@ class BarsDeltas(unittest.TestCase):
         fr = st.push(_bars({S1: self._turn(S1, 2)}, [], [], now=1005))
         self.assertEqual([f["type"] for f in fr], ["bars"]); self.assertIn("_keys", fr[0], "the stream starts afresh")
 
+    def test_m_after_a_keyless_whole_frame_the_keyed_full_still_goes_even_for_an_unchanged_payload(self):
+        """The failure path sends the whole payload without keys, filling the dedup slot with its signature. If
+        the next cycle's keyed full were deduped, the kernel would hold state for a client holding nothing, and
+        its next delta would be refused (review 2026-09-03). The keyed full always goes once."""
+        import io, contextlib
+        st = _Stream("bars")
+        p1 = _bars({S1: self._turn(S1, 1)}, [], [])
+        real = km._delta_parts
+        km._delta_parts = lambda ftype, payload: (_ for _ in ()).throw(RuntimeError("synthetic"))
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                st.push(p1)
+        finally:
+            km._delta_parts = real
+        self.assertIsNone(st.last)
+        fr = st.push(dict(p1, now=1001))                            # the same payload, only the clock moved
+        self.assertEqual([f["type"] for f in fr], ["bars"]); self.assertIn("_keys", fr[0], "keyed full not deduped away")
+        self.assertEqual(st.held, dict(p1, now=1001))
+        self.assertEqual(st.c["dstate"]["bars"]["rev"], 0)
+        fr = st.push(_bars({S1: self._turn(S1, 2)}, [], [], now=1005))
+        self.assertEqual([f["type"] for f in fr], ["delta"], "…and the stream continues as deltas the client can apply")
+
 
     def test_g_a_bar_appended_to_an_earlier_lane_crosses_alone_and_lands_in_its_lane(self):
         """The flat key order changes (the new bar sits before the later lanes' bars) but the assembled

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -52,7 +52,7 @@ class _Client(dict):
         self["send"] = lambda s: self.frames.append(json.loads(s))
 
 
-KINDS = {"bars": {"turns": "dictlist:id", "judging": "bykeys:sid,t,judge,t1", "messages": "byid"}, "feed": {"asks": "byid"}}
+KINDS = {"bars": {"turns": "dictlist:id", "judging": "bykeys:sid,t,judge,t1", "messages": "byid"}, "feed": {"asks": "byid:itemId"}}
 SEP = "\u001f"
 
 
@@ -79,6 +79,9 @@ def _py_apply(last, d):
     if last is None or last["rev"] != d["base"]:
         return None
     m = dict(last["msg"])
+    if d.get("rest") is not None and d.get("restAll"):
+        for k in [k for k in m if k not in KINDS[d["slot"]] and k not in d["rest"]]:
+            del m[k]                                    # a full remainder retires the keys it no longer carries
     for k, v in (d.get("rest") or {}).items():
         m[k] = v
     for name, c in (d.get("coll") or {}).items():
@@ -244,11 +247,64 @@ class BarsDeltas(unittest.TestCase):
         p1 = _bars({S1: self._turn(S1, 1)}, [], []); st.push(p1)
         p2 = _bars({S1: self._turn(S1, 2)}, [], [], now=1005); st.push(p2)
         self.assertEqual(st.c["dstate"]["bars"]["rev"], 1)
-        # the shim could not apply a delta → the kernel forgets what the client holds
-        st.c["dstate"].pop("bars"); st.c["sent"].pop(("timelinebars",), None)
+        # the shim could not apply a delta → the socket handler flags the slot for the PUSHER (not its own
+        # thread: two threads over one client's held state would rebase a full the dedup then swallowed)
+        st.c.setdefault("resync", set()).add("bars")
         p3 = _bars({S1: self._turn(S1, 3)}, [], [], now=1010)
-        self.assertEqual([f["type"] for f in st.push(p3)], ["bars"])
-        self.assertEqual(st.held, p3)
+        fr = st.push(p3)
+        self.assertEqual([f["type"] for f in fr], ["bars"]); self.assertIn("_keys", fr[0])
+        self.assertEqual(st.held, p3); self.assertEqual(st.c["resync"], set())
+        src = open(km.__file__, encoding="utf-8").read()
+        h = src[src.index('msg.get("type") == "needSlot"'):]
+        h = h[:h.index("return")]
+        self.assertIn('client.setdefault("resync", set()).add(', h, "the handler flags the slot…")
+        self.assertIn("_pusher_wake.set()", h, "…and wakes the pusher, which sends on its own thread")
+        self.assertNotIn("_push_one", h)
+
+    def test_i_a_top_level_key_that_leaves_the_payload_leaves_the_client(self):
+        st = _Stream("bars")
+        st.push(_bars({S1: self._turn(S1, 1)}, [], [], warming=True))
+        p2 = _bars({S1: self._turn(S1, 1)}, [], [], now=1005); del p2["warming"]
+        fr = st.push(p2)
+        self.assertEqual(fr[0].get("restAll"), 1); self.assertNotIn("warming", fr[0]["rest"])
+        self.assertEqual(st.held, p2, "the remainder is replaced, not merged: a dropped key is gone")
+
+    def test_j_an_empty_id_and_a_positional_key_spelling_a_real_id_stay_exact(self):
+        st = _Stream("bars")
+        lane = [{"id": "", "t": 1}, {"id": "b2", "t": 2}]
+        msgs = [{"id": "#2", "x": 0}, {"x": 1}, {"x": 2}]
+        p1 = _bars({S1: lane}, [], msgs); st.push(p1)
+        self.assertEqual(st.held, p1)
+        keys = st.c["dstate"]["bars"]["order"]
+        self.assertEqual(keys["turns"], [S1 + SEP + "#0", S1 + SEP + "b2"], "an empty id is positional, in its lane")
+        self.assertEqual(keys["messages"], ["#2", "#1", "#3"], "the positional key steps past the real '#2'")
+        p2 = _bars({S1: [{"id": "", "t": 1}, {"id": "b2", "t": 3}]}, [], [{"id": "#2", "x": 0}, {"x": 1}, {"x": 5}], now=1005)
+        st.push(p2)
+        self.assertEqual(st.held, p2)
+
+    def test_k_javascript_index_keys_are_ascii_and_bounded(self):
+        odd = ["\u00b2", "\u0661", "\uff11\uff12", "9" * 5000, "10", "9", "x", "4294967295", "4294967294"]
+        self.assertEqual(km._js_key_order(odd), ["9", "10", "4294967294", "\u00b2", "\u0661", "\uff11\uff12", "9" * 5000, "x", "4294967295"])
+
+    def test_l_a_failing_delta_never_takes_the_pusher_down(self):
+        import io, contextlib
+        st = _Stream("bars")
+        p1 = _bars({S1: self._turn(S1, 1)}, [], [])
+        real = km._delta_parts
+        def boom(ftype, payload): raise RuntimeError("synthetic")
+        km._delta_parts = boom
+        try:
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                fr = st.push(p1)
+        finally:
+            km._delta_parts = real
+        self.assertEqual([f["type"] for f in fr], ["bars"]); self.assertNotIn("_keys", fr[0])
+        self.assertIn("view-delta bars", err.getvalue()); self.assertIn("synthetic", err.getvalue())
+        self.assertNotIn("bars", st.c.get("dstate", {}))
+        self.assertIsNone(st.last, "a full frame without keys leaves the client holding nothing")
+        fr = st.push(_bars({S1: self._turn(S1, 2)}, [], [], now=1005))
+        self.assertEqual([f["type"] for f in fr], ["bars"]); self.assertIn("_keys", fr[0], "the stream starts afresh")
 
 
     def test_g_a_bar_appended_to_an_earlier_lane_crosses_alone_and_lands_in_its_lane(self):
@@ -295,7 +351,7 @@ class FeedDeltas(unittest.TestCase):
         km._DELTA_MAX_FRACTION = self._frac
 
     def _ask(self, i, column="working", text="do the thing"):
-        return {"id": "g%d" % i, "sid": S1, "column": column, "text": text, "color": None, "trail": [1, 2, 3]}
+        return {"itemId": "awaiting:g%d" % i, "sid": S1, "column": column, "text": text, "color": None, "trail": [1, 2, 3]}
 
     def test_a_only_the_card_that_moved_crosses(self):
         st = _Stream("feed")
@@ -304,7 +360,7 @@ class FeedDeltas(unittest.TestCase):
         p2 = _feed([self._ask(1), self._ask(2, column="done"), self._ask(3)], now=1005)
         frames = st.push(p2)
         self.assertEqual(frames[0]["type"], "delta")
-        self.assertEqual(set(frames[0]["coll"]["asks"]["set"]), {"g2"})
+        self.assertEqual(set(frames[0]["coll"]["asks"]["set"]), {"awaiting:g2"})
         self.assertEqual(st.held, p2)
 
     def test_b_the_remainder_rides_only_when_it_changed(self):
@@ -314,6 +370,19 @@ class FeedDeltas(unittest.TestCase):
         fr = st.push(p2)
         self.assertEqual(fr[0]["type"], "delta")
         self.assertIn("showDismissed", fr[0]["rest"]); self.assertEqual(fr[0]["coll"], {})
+        self.assertEqual(st.held, p2)
+
+
+    def test_c_a_card_inserted_at_the_top_costs_one_card_and_the_order(self):
+        """Cards are keyed by itemId, so an insert anywhere ships that card plus the key order — never the feed."""
+        km._DELTA_MAX_FRACTION = self._frac                    # the real threshold
+        st = _Stream("feed")
+        st.push(_feed([self._ask(i, text="x" * 300) for i in range(30)]))
+        p2 = _feed([self._ask(99, text="y" * 300)] + [self._ask(i, text="x" * 300) for i in range(30)], now=1005)
+        fr = st.push(p2)
+        self.assertEqual(fr[0]["type"], "delta")
+        self.assertEqual(set(fr[0]["coll"]["asks"]["set"]), {"awaiting:g99"})
+        self.assertEqual(fr[0]["coll"]["asks"]["order"][0], "awaiting:g99")
         self.assertEqual(st.held, p2)
 
 
@@ -349,6 +418,9 @@ class ShimDecoderMatchesTheKernel(unittest.TestCase):
             _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [], [msg("10", 1), msg("11", 2), msg("30", 3), msg("9", 4)], now=1025),
             # the first lane empties to a bare value, the last lane grows: bare-prefix entry + append
             _bars({S1: [], S3: turn(S3, 2)}, [], [msg("9", 4)], now=1030),
+            # an empty id and a real id spelling a positional key; then the `warming` key leaves the payload
+            _bars({S1: [{"id": "", "t": 1}, {"id": "b2", "t": 2}], S3: turn(S3, 2)}, [], [{"id": "#1", "x": 0}, {"x": 1}], now=1035, warming=True),
+            dict((kk, v) for kk, v in _bars({S1: [{"id": "", "t": 1}, {"id": "b2", "t": 3}], S3: turn(S3, 2)}, [], [{"id": "#1", "x": 0}, {"x": 5}], now=1040).items() if kk != "warming"),
         ]
         frames = []
         for p in payloads:

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -52,56 +52,84 @@ class _Client(dict):
         self["send"] = lambda s: self.frames.append(json.loads(s))
 
 
+KINDS = {"bars": {"turns": "dictlist:id", "judging": "bykeys:sid,t,judge,t1", "messages": "byid"}, "feed": {"asks": "byid"}}
+SEP = "\u001f"
+
+
+def _key(kind, it, prefix=""):
+    if not isinstance(it, dict):
+        return None
+    if kind == "byid" or kind.startswith("dictlist:"):
+        f = "id" if kind == "byid" else kind.split(":", 1)[1]
+        return None if it.get(f) is None else prefix + str(it[f])
+    if kind.startswith("bykeys:"):
+        return prefix + SEP.join(str(it.get(f)) for f in kind.split(":", 1)[1].split(","))
+    return None
+
+
+def _assemble(kind, order, items):
+    if kind == "dict":
+        return {kk: items[kk] for kk in order if kk in items}
+    if kind.startswith("dictlist:"):
+        d = {}
+        for kk in order:
+            if kk not in items:
+                continue
+            dk, _, rest = kk.partition(SEP)
+            if rest == "" and not isinstance(items[kk], list):
+                d[dk] = items[kk]; continue
+            if rest == "":
+                d[dk] = items[kk]; continue
+            d.setdefault(dk, []).append(items[kk])
+        return d
+    return [items[kk] for kk in order if kk in items]
+
+
 def _py_apply(last, d):
     """A faithful Python mirror of the shim's applyDelta/buildMaps/assemble — the reference the JS is held to."""
-    kinds = {"bars": {"turns": "dict", "judging": "bysid", "messages": "byid"}, "feed": {"asks": "byid"}}
     if last is None or last["rev"] != d["base"]:
         return None
     m = dict(last["msg"])
     for k, v in (d.get("rest") or {}).items():
         m[k] = v
     for name, c in (d.get("coll") or {}).items():
-        kind = kinds[d["slot"]].get(name)
+        kind = KINDS[d["slot"]].get(name)
         mp = last["maps"].get(name) or {"order": [], "items": {}}
         items = dict(mp["items"]); order = list(mp["order"])
         for kk in c.get("del") or []:
             items.pop(kk, None)
+        new = [kk for kk in (c.get("set") or {}) if kk not in items]
         for kk, v in (c.get("set") or {}).items():
-            if kk not in items:
-                order.append(kk)
             items[kk] = v
+        order += km._js_key_order(new)                  # JS enumerates integer-like keys first, ascending
         order = list(c["order"]) if c.get("order") else [kk for kk in order if kk in items]
         last["maps"][name] = {"order": order, "items": items}
-        if kind == "dict":
-            m[name] = {kk: items[kk] for kk in order if kk in items}
-        elif kind == "bysid":
-            m[name] = [it for kk in order if kk in items for it in items[kk]]
-        else:
-            m[name] = [items[kk] for kk in order if kk in items]
+        m[name] = _assemble(kind, order, items)
     last["rev"] = d["rev"]; last["msg"] = m
     return m
 
 
 def _py_maps(msg):
-    kinds = {"bars": {"turns": "dict", "judging": "bysid", "messages": "byid"}, "feed": {"asks": "byid"}}
     maps = {}
-    for name, kind in kinds[msg["type"]].items():
+    for name, kind in KINDS[msg["type"]].items():
         v = msg.get(name); order, items = [], {}
+        def put(kk, val):
+            if kk is None or kk in items:
+                kk = "#%d" % len(order)
+            order.append(kk); items[kk] = val
         if kind == "dict":
             for kk, vv in (v or {}).items():
-                order.append(kk); items[kk] = vv
-        elif kind == "byid":
+                put(str(kk), vv)
+        elif kind == "byid" or kind.startswith("bykeys:"):
             for it in v or []:
-                kk = str(it.get("id")) if isinstance(it, dict) and it.get("id") is not None else None
-                if kk is None or kk in items:
-                    kk = "#%d" % len(order)
-                order.append(kk); items[kk] = it
-        else:
-            for it in v or []:
-                kk = str(it.get("sid")) if isinstance(it, dict) and it.get("sid") is not None else "#"
-                if kk not in items:
-                    order.append(kk); items[kk] = []
-                items[kk].append(it)
+                put(_key(kind, it), it)
+        elif kind.startswith("dictlist:"):
+            for dk, lst in (v or {}).items():
+                pre = str(dk) + SEP
+                if not isinstance(lst, list) or not lst:
+                    put(pre, lst); continue
+                for it in lst:
+                    put(_key(kind, it, pre), it)
         maps[name] = {"order": order, "items": items}
     return maps
 
@@ -144,7 +172,7 @@ class BarsDeltas(unittest.TestCase):
         km._DELTA_MAX_FRACTION = self._frac
 
     def _turn(self, sid, n):
-        return {"segs": [[self.t0 - 60 * i, self.t0 - 60 * i + 30, "seg-%s-%d" % (sid[-1], i)] for i in range(n)]}
+        return [{"id": "seg-%s-%d" % (sid[-1], i), "t": self.t0 - 60 * i, "end": self.t0 - 60 * i + 30, "open": False} for i in range(n)]
 
     def test_a_first_send_is_full_then_only_the_changed_lane_crosses(self):
         st = _Stream("bars")
@@ -159,8 +187,8 @@ class BarsDeltas(unittest.TestCase):
         self.assertEqual([f["type"] for f in frames], ["delta"])
         d = frames[0]
         self.assertEqual(set(d["coll"]), {"turns"}, "only the lane that moved is in the frame")
-        self.assertEqual(set(d["coll"]["turns"]["set"]), {S2})
-        self.assertNotIn("del", d["coll"]["turns"]); self.assertNotIn("order", d["coll"]["turns"])
+        self.assertEqual(set(d["coll"]["turns"]["set"]), {S2 + SEP + "seg-2-2"}, "one BAR crosses, not the lane")
+        self.assertNotIn("del", d["coll"]["turns"]); self.assertNotIn("order", d["coll"]["turns"], "an appended bar needs no order")
         self.assertEqual(d.get("rest"), {"now": 1005}, "the clock rides, the unchanged remainder does not")
         self.assertEqual(st.held, p2, "the reassembled message is the new payload, exactly")
         self.assertLess(len(json.dumps(d)), len(json.dumps(p2)) / 2)
@@ -181,9 +209,9 @@ class BarsDeltas(unittest.TestCase):
         frames = st.push(p2)
         self.assertEqual(frames[0]["type"], "delta")
         d = frames[0]
-        self.assertEqual(d["coll"]["turns"].get("del"), [S2])
-        self.assertEqual(set(d["coll"]["turns"]["set"]), {S3})
-        self.assertEqual(set(d["coll"]["judging"]["set"]), {S3}, "a grouped collection replaces the group that changed")
+        self.assertEqual(d["coll"]["turns"].get("del"), [S2 + SEP + "seg-2-0"], "a removed lane deletes its bars")
+        self.assertEqual(set(d["coll"]["turns"]["set"]), {S3 + SEP + "seg-3-1"}, "a grown lane adds only its new bar")
+        self.assertEqual(set(d["coll"]["judging"]["set"]), {SEP.join([S3, "9", "courier", "10"])}, "a judge call is one keyed item")
         self.assertEqual(d["coll"]["messages"]["order"], ["m3", "m2", "m1"], "a reorder ships the key order")
         self.assertEqual(st.held, p2)
         # and a delta stream keeps going: a third push changes nothing but the clock
@@ -237,6 +265,40 @@ class BarsDeltas(unittest.TestCase):
         self.assertEqual(st.held, p3)
 
 
+    def test_g_a_bar_appended_to_an_earlier_lane_crosses_alone_and_lands_in_its_lane(self):
+        """The flat key order changes (the new bar sits before the later lanes' bars) but the assembled
+        lanes do not — so no order crosses, and the client's derived order must still assemble right."""
+        st = _Stream("bars")
+        st.push(_bars({S1: self._turn(S1, 2), S2: self._turn(S2, 2), S3: self._turn(S3, 1)}, [], []))
+        p2 = _bars({S1: self._turn(S1, 3), S2: self._turn(S2, 2), S3: self._turn(S3, 1)}, [], [], now=1001)
+        fr = st.push(p2)
+        self.assertEqual(len(fr), 1); d = fr[0]
+        self.assertEqual(set(d["coll"]["turns"]["set"]), {S1 + SEP + "seg-1-2"})
+        self.assertNotIn("order", d["coll"]["turns"], "same lanes, same relative order: nothing to say")
+        self.assertEqual(st.held, p2, "…and the client's own derived order assembles the exact payload")
+        self.assertEqual(list(st.held["turns"]), [S1, S2, S3], "lane order kept")
+        # a lane whose bars all go, then a bar in a lane that never existed: deletes and a fresh group
+        p3 = _bars({S1: self._turn(S1, 3), S3: self._turn(S3, 1), "11111111-2222-3333-4444-aaaaaaaaaaa4": self._turn("x4", 1)}, [], [], now=1002)
+        st.push(p3)
+        self.assertEqual(st.held, p3)
+
+    def test_h_numeric_ids_enumerate_ascending_in_javascript_so_the_order_crosses_when_that_would_misplace_them(self):
+        """JS enumerates integer-like object keys ascending before the rest — the shim appends a delta's new
+        keys in THAT order. Two new messages with ids "10" then "9" would land as "9","10"; the kernel must
+        predict the misplacement and send the order. Numeric ids that arrive ascending need none."""
+        def msg(i, when): return {"id": i, "sent": when, "text": "m"}
+        st = _Stream("bars")
+        st.push(_bars({S1: self._turn(S1, 1)}, [], [msg("10", 1)]))
+        p2 = _bars({S1: self._turn(S1, 1)}, [], [msg("10", 1), msg("11", 2)], now=1001)
+        d = st.push(p2)[0]
+        self.assertNotIn("order", d["coll"]["messages"], "an ascending numeric id appends where JS puts it anyway")
+        self.assertEqual(st.held, p2)
+        p3 = _bars({S1: self._turn(S1, 1)}, [], [msg("10", 1), msg("11", 2), msg("30", 3), msg("9", 4)], now=1002)
+        d = st.push(p3)[0]
+        self.assertEqual(d["coll"]["messages"].get("order"), ["10", "11", "30", "9"], "JS would put 9 first: the order must cross")
+        self.assertEqual(st.held, p3)
+        self.assertEqual([m["id"] for m in st.held["messages"]], ["10", "11", "30", "9"])
+
 class FeedDeltas(unittest.TestCase):
     def setUp(self):
         km._delta_parts_cache.clear()
@@ -288,18 +350,26 @@ class ShimDecoderMatchesTheKernel(unittest.TestCase):
         self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
         st = _Stream("bars")
         t0 = 1000
-        def turn(sid, n): return {"segs": [[t0 - 60 * i, t0 - 60 * i + 30, "s%d" % i] for i in range(n)]}
+        def turn(sid, n): return [{"id": "s%s-%d" % (sid[-1], i), "t": t0 - 60 * i, "end": t0 - 60 * i + 30} for i in range(n)]
+        def msg(i, when): return {"id": i, "sent": when, "text": "m"}
         payloads = [
             _bars({S1: turn(S1, 2), S2: turn(S2, 1)}, [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}], [{"id": "m1", "to": "x"}]),
             _bars({S1: turn(S1, 3), S2: turn(S2, 1)}, [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}], [{"id": "m1", "to": "x"}], now=1005),
             _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [{"sid": S3, "judge": "planner", "t": 3, "t1": 4}, {"sid": S1, "judge": "closer", "t": 1, "t1": 2}],
                   [{"id": "m2", "to": "y"}, {"id": "m1", "to": "x"}], now=1010, warming=True),
             _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [], [{"id": "m2", "to": "y"}], now=1015),
+            # numeric ids: "11" appends where JS puts it; then "30" followed by "9" needs the order to cross
+            _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [], [msg("10", 1), msg("11", 2)], now=1020),
+            _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [], [msg("10", 1), msg("11", 2), msg("30", 3), msg("9", 4)], now=1025),
+            # the first lane empties to a bare value, the last lane grows: bare-prefix entry + append
+            _bars({S1: [], S3: turn(S3, 2)}, [], [msg("9", 4)], now=1030),
         ]
         frames = []
         for p in payloads:
             frames += st.push(p)
-        self.assertGreaterEqual(sum(1 for f in frames if f["type"] == "delta"), 3)
+        self.assertGreaterEqual(sum(1 for f in frames if f["type"] == "delta"), 5)
+        self.assertTrue(any("order" in (f.get("coll") or {}).get("messages", {}) for f in frames if f["type"] == "delta"),
+                        "the numeric-id step must have shipped an order for the shim to be tested on it")
         fx = tempfile.mkdtemp()
         with open(os.path.join(fx, "frames.json"), "w") as f:
             json.dump(frames, f)
@@ -320,6 +390,7 @@ process.stdout.write(JSON.stringify(out));"""
         self.assertEqual(out[0], payloads[0])
         for i in range(1, len(payloads)):
             self.assertEqual(out[i], payloads[i], "frame %d reassembled differently in the shim than the kernel built" % i)
+        self.assertTrue(any("dictlist" in f.get("coll", {}).get("turns", {}).__class__.__name__ or True for f in frames))
 
     def test_b_a_delta_whose_base_is_not_held_is_refused(self):
         node = shutil.which("node")

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -468,3 +468,59 @@ process.stdout.write(JSON.stringify({refused:r===null,rev:LAST.bars.rev}));"""
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class HandlerWiring(unittest.TestCase):
+    """The handshake end to end, with the real handler: the shim asks for deltas and carries its page id, the
+    connect handler records both, a needSlot is flagged for the pusher, and the shim reacts to a refused delta.
+    A mutation review (2026-09-03) turned each of these off with every test still green."""
+
+    def _fake_self(self, path):
+        import io
+        class FakeSelf:
+            headers = {"Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ=="}
+            rfile = io.BytesIO(); wfile = io.BytesIO()
+            connection = type("FakeSock", (), {"sendall": lambda self, b: None, "shutdown": lambda self, how: None})()
+            close_connection = False
+            def send_response(self, *a): pass
+            def send_header(self, *a): pass
+            def end_headers(self): pass
+        FakeSelf.path = path
+        return FakeSelf()
+
+    def test_a_the_connect_handler_records_the_delta_flag_and_the_page_id(self):
+        import contextlib, io
+        got = []
+        real_reg, real_recv = km._register_ws_client, km._ws_recv
+        km._register_ws_client = lambda c: (got.append(c), km._clients.append(c))
+        km._ws_recv = lambda rfile: (0x8, b"", True)              # the peer closes at once
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                km.Handler._ws(self._fake_self("/ws?app=feed&delta=1&iid=page-9&wid=w1"))
+        finally:
+            km._register_ws_client, km._ws_recv = real_reg, real_recv
+            for c in got:
+                if c in km._clients:
+                    km._clients.remove(c)
+        self.assertEqual(len(got), 1)
+        c = got[0]
+        self.assertTrue(c.get("delta")); self.assertEqual(c.get("iid"), "page-9"); self.assertEqual(c.get("wid"), "w1")
+        self.assertEqual(c.get("app"), "feed")
+
+    def test_b_a_needslot_is_flagged_for_the_pusher_and_wakes_it(self):
+        client = _Client(); client["dstate"] = {"bars": {"rev": 3}}
+        km._pusher_wake.clear()
+        km.Handler._dispatch_ws(self._fake_self("/ws?app=timeline"), {"type": "needSlot", "slot": "bars"}, client)
+        self.assertEqual(client.get("resync"), {"bars"})
+        self.assertTrue(km._pusher_wake.is_set(), "the pusher is woken to re-base on its own thread")
+        self.assertEqual(client["dstate"], {"bars": {"rev": 3}}, "the handler itself touches no held state")
+        km.Handler._dispatch_ws(self._fake_self("/ws?app=timeline"), {"type": "needSlot", "slot": "nope"}, client)
+        self.assertEqual(client.get("resync"), {"bars"}, "an unknown slot is ignored")
+
+    def test_c_the_shim_asks_for_deltas_carries_its_page_id_and_asks_again_when_refused(self):
+        js = km._shim("timeline", 1)
+        self.assertIn('/ws?app=timeline&delta=1&iid="+encodeURIComponent(IID)', js)
+        self.assertIn('send({type:"needSlot",slot:msg.slot})', js)
+        self.assertIn("var IID=", js)
+        self.assertNotIn('sessionStorage.setItem("romp:iid"', js, "the page id is never stored: a duplicated tab must not inherit it")
+

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""The timeline's bars and the feed cross the wire as DELTAS (2026-09-03).
+
+Both slots used to be sent whole on every change — 2.95 MB and 0.86 MB on a seventeen-session board,
+where something changes every few seconds — so a dashboard on a forwarded or tunnelled link streamed
+about half a megabyte a second of mostly-unchanged JSON and its panes starved. A pane that connects with
+?delta=1 (the shim does) now receives, per change, only the collection entries that changed, keyed the
+way each collection is keyed; the shim reassembles the full message and hands the bundle exactly what it
+received before. These tests drive the kernel encoder against a fake client and check the reassembly two
+ways: with a Python mirror of the shim's decoder, and — when node is installed — with the shim's own
+JavaScript, lifted verbatim from the served page. Synthetic payloads only.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_viewdelta", os.path.join(BIN, "romp-kernel")).load_module()
+
+S1 = "11111111-2222-3333-4444-aaaaaaaaaaa1"
+S2 = "11111111-2222-3333-4444-aaaaaaaaaaa2"
+S3 = "11111111-2222-3333-4444-aaaaaaaaaaa3"
+
+
+def _bars(turns, judging, messages, now=1000, warming=False):
+    return {"type": "bars", "turns": turns, "judging": judging, "messages": messages, "now": now, "warming": warming}
+
+
+def _feed(asks, now=1000, **rest):
+    d = {"type": "feed", "asks": asks, "now": now, "sessions": [{"sid": S1, "name": "web", "color": None}],
+         "order": [S1], "working": [], "awaiting": []}
+    d.update(rest)
+    return d
+
+
+class _Client(dict):
+    """A delta-capable client whose frames are captured rather than written."""
+
+    def __init__(self):
+        super().__init__(app="timeline", wid="w1", alive=True, delta=True, sock=object())
+        self.frames = []
+        self["send"] = lambda s: self.frames.append(json.loads(s))
+
+
+def _py_apply(last, d):
+    """A faithful Python mirror of the shim's applyDelta/buildMaps/assemble — the reference the JS is held to."""
+    kinds = {"bars": {"turns": "dict", "judging": "bysid", "messages": "byid"}, "feed": {"asks": "byid"}}
+    if last is None or last["rev"] != d["base"]:
+        return None
+    m = dict(last["msg"])
+    for k, v in (d.get("rest") or {}).items():
+        m[k] = v
+    for name, c in (d.get("coll") or {}).items():
+        kind = kinds[d["slot"]].get(name)
+        mp = last["maps"].get(name) or {"order": [], "items": {}}
+        items = dict(mp["items"]); order = list(mp["order"])
+        for kk in c.get("del") or []:
+            items.pop(kk, None)
+        for kk, v in (c.get("set") or {}).items():
+            if kk not in items:
+                order.append(kk)
+            items[kk] = v
+        order = list(c["order"]) if c.get("order") else [kk for kk in order if kk in items]
+        last["maps"][name] = {"order": order, "items": items}
+        if kind == "dict":
+            m[name] = {kk: items[kk] for kk in order if kk in items}
+        elif kind == "bysid":
+            m[name] = [it for kk in order if kk in items for it in items[kk]]
+        else:
+            m[name] = [items[kk] for kk in order if kk in items]
+    last["rev"] = d["rev"]; last["msg"] = m
+    return m
+
+
+def _py_maps(msg):
+    kinds = {"bars": {"turns": "dict", "judging": "bysid", "messages": "byid"}, "feed": {"asks": "byid"}}
+    maps = {}
+    for name, kind in kinds[msg["type"]].items():
+        v = msg.get(name); order, items = [], {}
+        if kind == "dict":
+            for kk, vv in (v or {}).items():
+                order.append(kk); items[kk] = vv
+        elif kind == "byid":
+            for it in v or []:
+                kk = str(it.get("id")) if isinstance(it, dict) and it.get("id") is not None else None
+                if kk is None or kk in items:
+                    kk = "#%d" % len(order)
+                order.append(kk); items[kk] = it
+        else:
+            for it in v or []:
+                kk = str(it.get("sid")) if isinstance(it, dict) and it.get("sid") is not None else "#"
+                if kk not in items:
+                    order.append(kk); items[kk] = []
+                items[kk].append(it)
+        maps[name] = {"order": order, "items": items}
+    return maps
+
+
+class _Stream:
+    """Drive the kernel encoder for one client and mirror the shim: every captured frame is applied."""
+
+    def __init__(self, ftype):
+        self.ftype, self.c, self.last, self.fulls, self.deltas = ftype, _Client(), None, 0, 0
+
+    def push(self, payload):
+        pre = json.dumps(payload); sig = km._dedup_sig(payload, pre)
+        n0 = len(self.c.frames)
+        km._send_slot(self.c, self.ftype, payload, pre, sig)
+        for fr in self.c.frames[n0:]:
+            if fr.get("type") == "delta":
+                self.deltas += 1
+                out = _py_apply(self.last, fr)
+                assert out is not None, "the mirror rejected a delta the kernel sent: %r" % fr
+            else:
+                self.fulls += 1
+                self.last = {"rev": 0, "msg": fr, "maps": _py_maps(fr)}
+        return self.c.frames[n0:]
+
+    @property
+    def held(self):
+        return self.last["msg"] if self.last else None
+
+
+class BarsDeltas(unittest.TestCase):
+    def setUp(self):
+        km._delta_parts_cache.clear()
+        self.t0 = time.time()
+        # the size guard sends a delta that is not smaller than the whole as the whole; these synthetic payloads are
+        # tiny, so the structural tests switch it off — test_d covers the guard with the real threshold
+        self._frac = km._DELTA_MAX_FRACTION
+        km._DELTA_MAX_FRACTION = 10.0
+
+    def tearDown(self):
+        km._DELTA_MAX_FRACTION = self._frac
+
+    def _turn(self, sid, n):
+        return {"segs": [[self.t0 - 60 * i, self.t0 - 60 * i + 30, "seg-%s-%d" % (sid[-1], i)] for i in range(n)]}
+
+    def test_a_first_send_is_full_then_only_the_changed_lane_crosses(self):
+        st = _Stream("bars")
+        p1 = _bars({S1: self._turn(S1, 3), S2: self._turn(S2, 2)},
+                   [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}, {"sid": S2, "judge": "planner", "t": 3, "t1": 4}],
+                   [{"id": "m1", "from": "web", "to": "api", "sent": 1}])
+        frames = st.push(p1)
+        self.assertEqual([f["type"] for f in frames], ["bars"], "a client holding nothing gets the whole slot")
+        self.assertEqual(st.held, p1)
+        p2 = json.loads(json.dumps(p1)); p2["turns"][S2] = self._turn(S2, 3); p2["now"] = 1005
+        frames = st.push(p2)
+        self.assertEqual([f["type"] for f in frames], ["delta"])
+        d = frames[0]
+        self.assertEqual(set(d["coll"]), {"turns"}, "only the lane that moved is in the frame")
+        self.assertEqual(set(d["coll"]["turns"]["set"]), {S2})
+        self.assertNotIn("del", d["coll"]["turns"]); self.assertNotIn("order", d["coll"]["turns"])
+        self.assertEqual(d.get("rest"), {"now": 1005}, "the clock rides, the unchanged remainder does not")
+        self.assertEqual(st.held, p2, "the reassembled message is the new payload, exactly")
+        self.assertLess(len(json.dumps(d)), len(json.dumps(p2)) / 2)
+
+    def test_b_removed_added_and_reordered_entries(self):
+        st = _Stream("bars")
+        p1 = _bars({S1: self._turn(S1, 1), S2: self._turn(S2, 1), S3: self._turn(S3, 1)},
+                   [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}, {"sid": S1, "judge": "planner", "t": 5, "t1": 6},
+                    {"sid": S3, "judge": "closer", "t": 7, "t1": 8}],
+                   [{"id": "m1", "from": "a", "to": "b", "sent": 1}, {"id": "m2", "from": "b", "to": "a", "sent": 2}])
+        st.push(p1)
+        # S2 gone, a new session S3 judging group grows, messages reversed and one added
+        p2 = _bars({S1: self._turn(S1, 1), S3: self._turn(S3, 2)},
+                   [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}, {"sid": S1, "judge": "planner", "t": 5, "t1": 6},
+                    {"sid": S3, "judge": "closer", "t": 7, "t1": 8}, {"sid": S3, "judge": "courier", "t": 9, "t1": 10}],
+                   [{"id": "m3", "from": "c", "to": "a", "sent": 3}, {"id": "m2", "from": "b", "to": "a", "sent": 2},
+                    {"id": "m1", "from": "a", "to": "b", "sent": 1}], now=1010)
+        frames = st.push(p2)
+        self.assertEqual(frames[0]["type"], "delta")
+        d = frames[0]
+        self.assertEqual(d["coll"]["turns"].get("del"), [S2])
+        self.assertEqual(set(d["coll"]["turns"]["set"]), {S3})
+        self.assertEqual(set(d["coll"]["judging"]["set"]), {S3}, "a grouped collection replaces the group that changed")
+        self.assertEqual(d["coll"]["messages"]["order"], ["m3", "m2", "m1"], "a reorder ships the key order")
+        self.assertEqual(st.held, p2)
+        # and a delta stream keeps going: a third push changes nothing but the clock
+        p3 = json.loads(json.dumps(p2)); p3["now"] = 1011
+        st.c.setdefault("dstate", {})["bars"]["at"] = time.time() - km._DEDUP_REPOST_S - 1   # the repost is due
+        frames = st.push(p3)
+        self.assertEqual(frames[0]["type"], "delta"); self.assertEqual(frames[0]["coll"], {})
+        self.assertEqual(frames[0]["rest"], {"now": 1011})
+        self.assertEqual(st.held, p3)
+
+    def test_c_an_unchanged_payload_sends_nothing_until_the_repost_is_due(self):
+        st = _Stream("bars")
+        p = _bars({S1: self._turn(S1, 2)}, [], [])
+        st.push(p)
+        self.assertEqual(st.push(p), [], "nothing moved, nothing sent")
+        self.assertEqual(st.push(dict(p, now=1002)), [], "…and the clock alone is not a change inside the repost window")
+        st.c["dstate"]["bars"]["at"] -= km._DEDUP_REPOST_S + 1
+        fr = st.push(dict(p, now=1003))
+        self.assertEqual(len(fr), 1); self.assertEqual(fr[0]["type"], "delta"); self.assertEqual(fr[0]["coll"], {})
+
+    def test_d_a_delta_not_worth_its_bytes_is_sent_whole_and_rebases(self):
+        km._DELTA_MAX_FRACTION = self._frac                    # the real threshold, for this test alone
+        st = _Stream("bars")
+        st.push(_bars({S1: self._turn(S1, 1)}, [], []))
+        big = _bars({S1: self._turn(S1, 40), S2: self._turn(S2, 40), S3: self._turn(S3, 40)}, [], [], now=1020)
+        frames = st.push(big)
+        self.assertEqual([f["type"] for f in frames], ["bars"], "a near-total change crosses whole")
+        self.assertEqual(st.held, big)
+        self.assertEqual(st.c["dstate"]["bars"]["rev"], 0, "…and the stream re-bases from it")
+        small = json.loads(json.dumps(big)); small["turns"][S1] = self._turn(S1, 41); small["now"] = 1021
+        self.assertEqual(st.push(small)[0]["type"], "delta")
+
+    def test_e_a_client_without_delta_support_gets_whole_payloads_exactly_as_before(self):
+        c = _Client(); c.pop("delta")
+        p1 = _bars({S1: self._turn(S1, 1)}, [], []); pre = json.dumps(p1); sig = km._dedup_sig(p1, pre)
+        km._send_slot(c, "bars", p1, pre, sig)
+        p2 = _bars({S1: self._turn(S1, 2)}, [], [], now=1005); pre2 = json.dumps(p2); sig2 = km._dedup_sig(p2, pre2)
+        km._send_slot(c, "bars", p2, pre2, sig2)
+        self.assertEqual([f["type"] for f in c.frames], ["bars", "bars"])
+        self.assertEqual(c.frames[1], p2)
+
+    def test_f_needslot_resets_the_stream_to_a_full_frame(self):
+        st = _Stream("bars")
+        p1 = _bars({S1: self._turn(S1, 1)}, [], []); st.push(p1)
+        p2 = _bars({S1: self._turn(S1, 2)}, [], [], now=1005); st.push(p2)
+        self.assertEqual(st.c["dstate"]["bars"]["rev"], 1)
+        # the shim could not apply a delta → the kernel forgets what the client holds
+        st.c["dstate"].pop("bars"); st.c["sent"].pop(("timelinebars",), None)
+        p3 = _bars({S1: self._turn(S1, 3)}, [], [], now=1010)
+        self.assertEqual([f["type"] for f in st.push(p3)], ["bars"])
+        self.assertEqual(st.held, p3)
+
+
+class FeedDeltas(unittest.TestCase):
+    def setUp(self):
+        km._delta_parts_cache.clear()
+        self._frac = km._DELTA_MAX_FRACTION
+        km._DELTA_MAX_FRACTION = 10.0
+
+    def tearDown(self):
+        km._DELTA_MAX_FRACTION = self._frac
+
+    def _ask(self, i, column="working", text="do the thing"):
+        return {"id": "g%d" % i, "sid": S1, "column": column, "text": text, "color": None, "trail": [1, 2, 3]}
+
+    def test_a_only_the_card_that_moved_crosses(self):
+        st = _Stream("feed")
+        p1 = _feed([self._ask(1), self._ask(2), self._ask(3)])
+        self.assertEqual([f["type"] for f in st.push(p1)], ["feed"])
+        p2 = _feed([self._ask(1), self._ask(2, column="done"), self._ask(3)], now=1005)
+        frames = st.push(p2)
+        self.assertEqual(frames[0]["type"], "delta")
+        self.assertEqual(set(frames[0]["coll"]["asks"]["set"]), {"g2"})
+        self.assertEqual(st.held, p2)
+
+    def test_b_the_remainder_rides_only_when_it_changed(self):
+        st = _Stream("feed")
+        st.push(_feed([self._ask(1)]))
+        p2 = _feed([self._ask(1)], now=1005, showDismissed=True)
+        fr = st.push(p2)
+        self.assertEqual(fr[0]["type"], "delta")
+        self.assertIn("showDismissed", fr[0]["rest"]); self.assertEqual(fr[0]["coll"], {})
+        self.assertEqual(st.held, p2)
+
+
+class ShimDecoderMatchesTheKernel(unittest.TestCase):
+    """The shim's own JavaScript, lifted verbatim from the served page, reassembles the kernel's frames to the
+    exact new payload — the property the whole scheme rests on."""
+
+    def _shim_functions(self):
+        js = km._shim("timeline", 1)
+        m = re.search(r"var DELTA_KINDS=.*?last\.rev=d\.rev;last\.msg=m;return m;\}", js, re.S)
+        self.assertIsNotNone(m, "the delta functions must be present in the shim")
+        return m.group(0)
+
+    def test_a_node_reassembles_every_frame_of_a_stream_to_the_new_payload(self):
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        km._delta_parts_cache.clear()
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        st = _Stream("bars")
+        t0 = 1000
+        def turn(sid, n): return {"segs": [[t0 - 60 * i, t0 - 60 * i + 30, "s%d" % i] for i in range(n)]}
+        payloads = [
+            _bars({S1: turn(S1, 2), S2: turn(S2, 1)}, [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}], [{"id": "m1", "to": "x"}]),
+            _bars({S1: turn(S1, 3), S2: turn(S2, 1)}, [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}], [{"id": "m1", "to": "x"}], now=1005),
+            _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [{"sid": S3, "judge": "planner", "t": 3, "t1": 4}, {"sid": S1, "judge": "closer", "t": 1, "t1": 2}],
+                  [{"id": "m2", "to": "y"}, {"id": "m1", "to": "x"}], now=1010, warming=True),
+            _bars({S1: turn(S1, 3), S3: turn(S3, 1)}, [], [{"id": "m2", "to": "y"}], now=1015),
+        ]
+        frames = []
+        for p in payloads:
+            frames += st.push(p)
+        self.assertGreaterEqual(sum(1 for f in frames if f["type"] == "delta"), 3)
+        fx = tempfile.mkdtemp()
+        with open(os.path.join(fx, "frames.json"), "w") as f:
+            json.dump(frames, f)
+        script = self._shim_functions() + r"""
+var frames=JSON.parse(require("fs").readFileSync(process.argv[2],"utf8"));var out=[];
+for(var i=0;i<frames.length;i++){var msg=frames[i];
+if(msg.type==="delta"){var full=applyDelta(msg);if(!full){out.push({error:"rejected",at:i});break;}msg=full;}
+else if(DELTA_KINDS[msg.type]){LAST[msg.type]={rev:0,msg:msg,maps:buildMaps(msg)};}
+out.push(msg);}
+process.stdout.write(JSON.stringify(out));"""
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(script)
+        r = subprocess.run([node, os.path.join(fx, "run.js"), os.path.join(fx, "frames.json")], capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        out = json.loads(r.stdout)
+        self.assertEqual(len(out), len(frames))
+        # every frame reassembles to the payload the kernel had at that moment
+        self.assertEqual(out[0], payloads[0])
+        for i in range(1, len(payloads)):
+            self.assertEqual(out[i], payloads[i], "frame %d reassembled differently in the shim than the kernel built" % i)
+
+    def test_b_a_delta_whose_base_is_not_held_is_refused(self):
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        fx = tempfile.mkdtemp()
+        script = self._shim_functions() + r"""
+LAST.bars={rev:0,msg:{type:"bars",turns:{},judging:[],messages:[],now:1},maps:buildMaps({type:"bars",turns:{},judging:[],messages:[]})};
+var r=applyDelta({type:"delta",slot:"bars",base:3,rev:4,coll:{}});
+process.stdout.write(JSON.stringify({refused:r===null,rev:LAST.bars.rev}));"""
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(script)
+        r = subprocess.run([node, os.path.join(fx, "run.js")], capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(json.loads(r.stdout), {"refused": True, "rev": 0}, "a base mismatch is refused and nothing moves")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -56,17 +56,6 @@ KINDS = {"bars": {"turns": "dictlist:id", "judging": "bykeys:sid,t,judge,t1", "m
 SEP = "\u001f"
 
 
-def _key(kind, it, prefix=""):
-    if not isinstance(it, dict):
-        return None
-    if kind == "byid" or kind.startswith("dictlist:"):
-        f = "id" if kind == "byid" else kind.split(":", 1)[1]
-        return None if it.get(f) is None else prefix + str(it[f])
-    if kind.startswith("bykeys:"):
-        return prefix + SEP.join(str(it.get(f)) for f in kind.split(":", 1)[1].split(","))
-    return None
-
-
 def _assemble(kind, order, items):
     if kind == "dict":
         return {kk: items[kk] for kk in order if kk in items}
@@ -109,27 +98,22 @@ def _py_apply(last, d):
     return m
 
 
-def _py_maps(msg):
+def _py_maps(msg, keys):
+    """The shim's buildMaps: the kernel's key list zipped onto the payload positionally, per kind."""
     maps = {}
     for name, kind in KINDS[msg["type"]].items():
-        v = msg.get(name); order, items = [], {}
-        def put(kk, val):
-            if kk is None or kk in items:
-                kk = "#%d" % len(order)
-            order.append(kk); items[kk] = val
-        if kind == "dict":
-            for kk, vv in (v or {}).items():
-                put(str(kk), vv)
-        elif kind == "byid" or kind.startswith("bykeys:"):
-            for it in v or []:
-                put(_key(kind, it), it)
-        elif kind.startswith("dictlist:"):
-            for dk, lst in (v or {}).items():
-                pre = str(dk) + SEP
-                if not isinstance(lst, list) or not lst:
-                    put(pre, lst); continue
-                for it in lst:
-                    put(_key(kind, it, pre), it)
+        v = msg.get(name); order = list((keys or {}).get(name) or []); items = {}; pos = {}
+        for i, kk in enumerate(order):
+            if kind == "dict":
+                items[kk] = v[kk]
+            elif kind.startswith("dictlist:"):
+                dk, _, rest = kk.partition(SEP); lane = v[dk]
+                if rest == "":
+                    items[kk] = lane
+                else:
+                    j = pos.get(dk, 0); pos[dk] = j + 1; items[kk] = lane[j]
+            else:
+                items[kk] = v[i]
         maps[name] = {"order": order, "items": items}
     return maps
 
@@ -151,7 +135,9 @@ class _Stream:
                 assert out is not None, "the mirror rejected a delta the kernel sent: %r" % fr
             else:
                 self.fulls += 1
-                self.last = {"rev": 0, "msg": fr, "maps": _py_maps(fr)}
+                keys = fr.get("_keys")                       # the frame itself stays as the wire carried it
+                msg = {kk: v for kk, v in fr.items() if kk != "_keys"}
+                self.last = {"rev": 0, "msg": msg, "maps": _py_maps(msg, keys)} if keys is not None else None
         return self.c.frames[n0:]
 
     @property
@@ -377,7 +363,7 @@ class ShimDecoderMatchesTheKernel(unittest.TestCase):
 var frames=JSON.parse(require("fs").readFileSync(process.argv[2],"utf8"));var out=[];
 for(var i=0;i<frames.length;i++){var msg=frames[i];
 if(msg.type==="delta"){var full=applyDelta(msg);if(!full){out.push({error:"rejected",at:i});break;}msg=full;}
-else if(DELTA_KINDS[msg.type]){LAST[msg.type]={rev:0,msg:msg,maps:buildMaps(msg)};}
+else if(DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg.type]=keys?{rev:0,msg:msg,maps:buildMaps(msg,keys)}:null;}
 out.push(msg);}
 process.stdout.write(JSON.stringify(out));"""
         with open(os.path.join(fx, "run.js"), "w") as f:
@@ -398,7 +384,7 @@ process.stdout.write(JSON.stringify(out));"""
             self.skipTest("node not installed")
         fx = tempfile.mkdtemp()
         script = self._shim_functions() + r"""
-LAST.bars={rev:0,msg:{type:"bars",turns:{},judging:[],messages:[],now:1},maps:buildMaps({type:"bars",turns:{},judging:[],messages:[]})};
+LAST.bars={rev:0,msg:{type:"bars",turns:{},judging:[],messages:[],now:1},maps:buildMaps({type:"bars",turns:{},judging:[],messages:[]},{turns:[],judging:[],messages:[]})};
 var r=applyDelta({type:"delta",slot:"bars",base:3,rev:4,coll:{}});
 process.stdout.write(JSON.stringify({refused:r===null,rev:LAST.bars.rev}));"""
         with open(os.path.join(fx, "run.js"), "w") as f:

--- a/tests/test_ws_liveness.py
+++ b/tests/test_ws_liveness.py
@@ -53,7 +53,10 @@ class _Peer(threading.Thread):
     def run(self):
         rf = self.sock.makefile("rb")
         while not self.stop:
-            op, payload, fin = km._ws_recv(rf)      # server frames are unmasked; the reader tolerates that
+            try:
+                op, payload, fin = km._ws_recv(rf)  # server frames are unmasked; the reader tolerates that
+            except OSError:
+                return                              # the kernel side shut the pair down under us (teardown)
             if op is None:
                 return
             if op == 0x9:

--- a/tests/test_ws_liveness.py
+++ b/tests/test_ws_liveness.py
@@ -251,22 +251,35 @@ class PhantomPanesAreDropped(unittest.TestCase):
     def test_c5_the_liveness_clock_is_monotonic(self):
         self.assertIs(self._saved_clock, time.monotonic, "a suspend or an NTP step must not read as silence")
 
-    def test_c6_a_reconnect_of_the_same_pane_retires_its_previous_socket_at_once(self):
-        """The exact event behind the leak: a pane reconnects (same app, same dashboard id) because its side
-        of the old socket is dead, however open a forwarder keeps our side. The old socket goes now, not
-        after a ping window; a pane with another id, or no id, is untouched (review + user 2026-09-03)."""
-        old, peer_old, h_old = self._connect(pongs=True)
-        other_kern, other_peer = self._pair()
-        other, oq, _ = km._new_ws_client("timeline", "w2", other_kern); km._clients.append(other); self.queues.append(oq)
-        anon_kern, anon_peer = self._pair()
-        anon, aq, _ = km._new_ws_client("timeline", "", anon_kern); km._clients.append(anon); self.queues.append(aq)
-        new_kern, new_peer = self._pair()
-        new, nq, _ = km._new_ws_client("timeline", "w1", new_kern); self.queues.append(nq)
-        km._register_ws_client(new)                                  # the same pane again
-        self.assertFalse(old["alive"], "the pane's previous socket is retired on the reconnect itself")
-        self.assertTrue(new["alive"] and other["alive"] and anon["alive"], "the reconnected pane, another pane and an id-less pane stand")
+    def test_c6_a_reconnect_of_the_same_page_retires_its_previous_socket_at_once(self):
+        """The exact event behind the leak: a page reconnects (same app, same page-instance id) because its
+        side of the old socket is dead, however open a forwarder keeps our side. The old socket goes now, not
+        after a ping window. Keyed on the INSTANCE id, not the dashboard id: two sockets that share a
+        dashboard id without an instance id (the VS Code extension's status pipe beside its feed panel), or
+        with different instance ids (a duplicated browser tab, which inherits sessionStorage), are twins that
+        must BOTH live — keyed on wid they retired each other every 1.5 s (review 2026-09-03)."""
+        old, peer_old, h_old = self._connect(pongs=True); old["iid"] = "page-1"
+        def pane(wid, iid):
+            kern, _peer = self._pair()
+            c, q, _ = km._new_ws_client("timeline", wid, kern); self.queues.append(q)
+            if iid:
+                c["iid"] = iid
+            km._clients.append(c)
+            return c
+        dup_tab = pane("w1", "page-2")                                # same dashboard id, another page
+        twin_pipe_a, twin_pipe_b = pane("w1", ""), pane("w1", "")      # the extension's shape: no instance id
+        other_dash = pane("w2", "page-3")
+        new_kern, _np = self._pair()
+        new, nq, _ = km._new_ws_client("timeline", "w1", new_kern); self.queues.append(nq); new["iid"] = "page-1"
+        km._register_ws_client(new)                                  # the same page again
+        self.assertFalse(old["alive"], "the page's previous socket is retired on the reconnect itself")
+        for c in (new, dup_tab, twin_pipe_a, twin_pipe_b, other_dash):
+            self.assertTrue(c["alive"], "every other socket stands")
         self.assertIn(new, km._clients)
         h_old.join(3.0); self.assertFalse(h_old.is_alive(), "the old handler's read ended")
+        # and the extension's shape from the other side: a second id-less socket retires nothing
+        km._register_ws_client(pane("w1", ""))
+        self.assertTrue(twin_pipe_a["alive"] and twin_pipe_b["alive"] and new["alive"])
 
     def test_d_the_ping_frame_is_well_formed(self):
         f = km._ws_ping_frame(b"1700000000")

--- a/tests/test_ws_liveness.py
+++ b/tests/test_ws_liveness.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""The kernel notices a dead dashboard pane (2026-09-03).
+
+The keepalive was one-way: the kernel sent a small frame every KEEPALIVE_S and expected nothing back. A
+peer whose forwarder kept the devbox-side socket open after the browser pane was gone — VS Code's port
+forwarder does exactly that — therefore stayed a "live dashboard" forever, and the pusher kept building
+and streaming every full payload to it. Measured live: 84 client connections on one kernel, 73 silent for
+over five minutes, all phantoms sharing one multiplexed channel with three real panes.
+
+Now every beat is also a WebSocket PING (RFC 6455), which every conforming peer answers with a PONG
+without application code; a peer that has not answered the oldest outstanding ping within WS_DEAD_S is
+dropped — the missing pong is the event. Any inbound message counts as life too. Real TCP loopback
+pairs, matching the kernel's transport. Synthetic only.
+"""
+import json
+import os
+import socket
+import struct
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_wslive", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _mask(payload):
+    """A client-side (masked) frame body for `payload` with a fixed mask — what a browser's pong looks like."""
+    mask = b"\x11\x22\x33\x44"
+    return mask + bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+
+
+def _client_frame(opcode, payload):
+    n = len(payload)
+    hdr = bytes([0x80 | opcode, 0x80 | n]) if n < 126 else bytes([0x80 | opcode, 0x80 | 126]) + struct.pack(">H", n)
+    return hdr + _mask(payload)
+
+
+class _Peer(threading.Thread):
+    """The far end of a pane's socket. `pongs=True` behaves like a browser (answers every ping with a pong
+    echoing its payload); `pongs=False` is the phantom: it reads what arrives and never answers."""
+
+    def __init__(self, sock, pongs):
+        super().__init__(daemon=True)
+        self.sock, self.pongs, self.pings, self.texts, self.stop = sock, pongs, [], [], False
+
+    def run(self):
+        rf = self.sock.makefile("rb")
+        while not self.stop:
+            op, payload, fin = km._ws_recv(rf)      # server frames are unmasked; the reader tolerates that
+            if op is None:
+                return
+            if op == 0x9:
+                self.pings.append(payload)
+                if self.pongs:
+                    try:
+                        self.sock.sendall(_client_frame(0xA, payload))
+                    except OSError:
+                        return
+            elif op == 0x1:
+                self.texts.append(payload)
+
+
+class _Handler(threading.Thread):
+    """The kernel side's read loop, as the connection handler runs it: pongs and messages stamp liveness."""
+
+    def __init__(self, client, sock):
+        super().__init__(daemon=True)
+        self.client, self.sock, self.msgs = client, sock, []
+
+    def run(self):
+        rf = self.sock.makefile("rb")
+        while self.client["alive"]:
+            op, payload = km._ws_recv_message(rf, lambda p: None, on_pong=lambda p: km._note_ws_inbound(self.client))
+            if op is None:
+                break
+            km._note_ws_inbound(self.client)
+            self.msgs.append(payload)
+        self.client["alive"] = False
+
+
+class PhantomPanesAreDropped(unittest.TestCase):
+    def setUp(self):
+        self.closeables = []
+        self._saved_clients = list(km._clients)
+        km._clients[:] = []
+        self.clock = [1_800_000_000.0]
+        self._saved_clock = km._ws_clock
+        km._ws_clock = lambda: self.clock[0]
+
+    def tearDown(self):
+        km._ws_clock = self._saved_clock
+        km._clients[:] = self._saved_clients
+        for s in self.closeables:
+            try:
+                s.close()
+            except OSError:
+                pass
+
+    def _pair(self):
+        srv = socket.socket(); srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0)); srv.listen(1)
+        peer = socket.create_connection(srv.getsockname())
+        kern, _ = srv.accept()
+        srv.close()
+        self.closeables += [peer, kern]
+        return kern, peer
+
+    def _connect(self, pongs, app="timeline"):
+        kern, peer_sock = self._pair()
+        client, q, lock = km._new_ws_client(app, "w1", kern)
+        km._clients.append(client)
+        peer = _Peer(peer_sock, pongs); peer.start()
+        handler = _Handler(client, kern); handler.start()
+        return client, peer, handler
+
+    def _settle(self, pred, timeout=3.0):
+        t0 = time.time()
+        while time.time() - t0 < timeout:
+            if pred():
+                return True
+            time.sleep(0.02)
+        return pred()
+
+    def test_a_the_beat_carries_a_ping_and_a_browser_answers_it(self):
+        client, peer, _ = self._connect(pongs=True)
+        t0 = 1_800_000_000.0
+        km._keepalive_all(now=t0)
+        self.assertTrue(self._settle(lambda: len(peer.pings) == 1 and len(peer.texts) == 1), "one ka text + one ping per beat")
+        self.assertEqual(json.loads(peer.texts[0])["type"], "ka")
+        self.assertEqual(peer.pings[0], str(int(t0)).encode(), "the ping carries the beat's stamp")
+        self.assertTrue(self._settle(lambda: client["pingAt"] is None), "the pong cleared the outstanding ping")
+        self.assertTrue(client["alive"])
+
+    def test_b_a_peer_that_never_answers_is_dropped_after_the_window_and_only_then(self):
+        client, peer, handler = self._connect(pongs=False)
+        t0 = self.clock[0]
+        km._keepalive_all(now=t0)
+        self.assertTrue(self._settle(lambda: len(peer.pings) == 1))
+        self.assertTrue(self._settle(lambda: client["pingAt"] == t0), "the clock runs from the first unanswered ping, stamped as it left")
+        self.clock[0] = t0 + km.KEEPALIVE_S
+        km._keepalive_all(now=self.clock[0])                        # second beat: still inside the window
+        self.assertTrue(self._settle(lambda: len(peer.pings) == 2))
+        self.assertTrue(client["alive"], "one missed pong is not death")
+        self.assertEqual(client["pingAt"], t0, "…and the oldest unanswered ping keeps the clock")
+        self.clock[0] = t0 + km.WS_DEAD_S
+        km._keepalive_all(now=self.clock[0])                        # the window has run out
+        self.assertFalse(client["alive"], "no pong within WS_DEAD_S → dropped")
+        handler.join(3.0)
+        self.assertFalse(handler.is_alive(), "the shutdown ended the handler's blocking read")
+        self.assertTrue(self._settle(lambda: not peer.is_alive()), "…and the peer saw the close")
+
+    def test_c_any_inbound_message_is_life(self):
+        client, peer, handler = self._connect(pongs=False)          # never pongs, but talks
+        t0 = self.clock[0]
+        km._keepalive_all(now=t0)
+        self.assertTrue(self._settle(lambda: len(peer.pings) == 1 and client["pingAt"] == t0))
+        peer.sock.sendall(_client_frame(0x1, json.dumps({"type": "activeTab", "id": "x"}).encode()))
+        self.assertTrue(self._settle(lambda: client["pingAt"] is None), "a message cleared the outstanding ping")
+        self.clock[0] = t0 + km.WS_DEAD_S + 1
+        km._keepalive_all(now=self.clock[0])
+        self.assertTrue(client["alive"], "a talking peer is never dropped for a missing pong")
+
+    def test_c2_the_clock_starts_when_the_ping_leaves_not_when_the_beat_queued_it(self):
+        """A slow-but-alive peer with a backlog ahead of the ping must not be judged on time the ping spent in
+        the queue — the diagnosis this change answers found a 300 KB/s tunnel client rightly kept alive."""
+        kern, peer_sock = self._pair()
+        client, q, lock = km._new_ws_client("timeline", "w1", kern, start_sender=False)   # sender held back = backlog
+        km._clients.append(client)
+        t0 = self.clock[0]
+        km._keepalive_all(now=t0)
+        self.assertIsNone(client["pingAt"], "queued, not on the wire → no clock yet")
+        self.clock[0] = t0 + 10 * km.WS_DEAD_S                       # a long backlog later…
+        km._keepalive_all(now=self.clock[0])
+        self.assertTrue(client["alive"], "…still not judged: no ping has reached the peer")
+        threading.Thread(target=km._ws_sender, args=(q, kern, lock, client), daemon=True).start()   # backlog drains
+        self.assertTrue(self._settle(lambda: client["pingAt"] == self.clock[0]), "stamped as the first ping left")
+        q.put(None)
+
+    def test_d_the_ping_frame_is_well_formed(self):
+        f = km._ws_ping_frame(b"1700000000")
+        self.assertEqual(f[0], 0x89, "FIN + ping opcode")
+        self.assertEqual(f[1], len(b"1700000000"))
+        self.assertEqual(f[2:], b"1700000000")
+        self.assertEqual(len(km._ws_ping_frame(b"x" * 300)), 2 + 125, "control payloads are capped at 125 bytes")
+
+    def test_e_a_legacy_client_without_a_socket_is_never_judged(self):
+        sent = []
+        legacy = {"app": "feed", "wid": "", "alive": True, "send": sent.append}
+        km._clients.append(legacy)
+        km._keepalive_all(now=1_800_000_000.0)
+        km._keepalive_all(now=1_800_000_000.0 + 10 * km.WS_DEAD_S)
+        self.assertTrue(legacy["alive"])
+        self.assertEqual(len(sent), 2, "it still gets the ka text and never a ping")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ws_liveness.py
+++ b/tests/test_ws_liveness.py
@@ -213,6 +213,20 @@ class PhantomPanesAreDropped(unittest.TestCase):
         km._keepalive_all(now=self.clock[0])                        # …judged on its own fresh window
         self.assertFalse(client["alive"], "back in the read and still silent for a whole window → dropped")
 
+    def test_c3b_a_peer_the_kernel_declines_to_judge_still_gets_its_beat(self):
+        """Not judging a client mid-dispatch must not also starve it: the ka is what the shim's own silence
+        watchdog listens for, and a long build sends nothing else for tens of seconds (review 2026-09-03)."""
+        client, peer, handler = self._connect(pongs=False)
+        t0 = self.clock[0]
+        client["inRead"] = False
+        km._keepalive_all(now=t0)
+        self.assertTrue(self._settle(lambda: len(peer.texts) >= 1 and client["pingAt"] == t0))
+        self.clock[0] = t0 + 3 * km.WS_DEAD_S
+        km._keepalive_all(now=self.clock[0])                        # ancient stamp, but the handler is busy
+        self.assertTrue(client["alive"])
+        self.assertTrue(self._settle(lambda: len(peer.texts) >= 2), "the beat still crossed to the peer")
+        self.assertEqual(json.loads(peer.texts[-1])["type"], "ka")
+
     def test_c4_a_peer_still_draining_its_backlog_is_alive_and_one_that_stopped_acknowledging_is_not(self):
         client, peer, handler = self._connect(pongs=False)
         t0 = self.clock[0]

--- a/tests/test_ws_liveness.py
+++ b/tests/test_ws_liveness.py
@@ -87,21 +87,31 @@ class _Handler(threading.Thread):
 
 class PhantomPanesAreDropped(unittest.TestCase):
     def setUp(self):
-        self.closeables = []
+        self.closeables, self.threads, self.queues = [], [], []
         self._saved_clients = list(km._clients)
         km._clients[:] = []
         self.clock = [1_800_000_000.0]
-        self._saved_clock = km._ws_clock
+        self._saved_clock, self._saved_outq = km._ws_clock, km._ws_outq
         km._ws_clock = lambda: self.clock[0]
+        km._ws_outq = lambda sock: 0                  # loopback drains instantly; the drain probe has its own test
 
     def tearDown(self):
-        km._ws_clock = self._saved_clock
+        km._ws_clock, km._ws_outq = self._saved_clock, self._saved_outq
         km._clients[:] = self._saved_clients
+        for q in self.queues:
+            q.put(None)                               # end every sender thread the test started
         for s in self.closeables:
+            try:
+                s.shutdown(socket.SHUT_RDWR)          # a thread parked in a read returns EOF (close alone would
+            except OSError:                           # not: the reader's file object keeps the descriptor)
+                pass
             try:
                 s.close()
             except OSError:
                 pass
+        for t in self.threads:
+            t.join(3.0)
+            self.assertFalse(t.is_alive(), "a test thread outlived its test: %r" % t)
 
     def _pair(self):
         srv = socket.socket(); srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -115,9 +125,10 @@ class PhantomPanesAreDropped(unittest.TestCase):
     def _connect(self, pongs, app="timeline"):
         kern, peer_sock = self._pair()
         client, q, lock = km._new_ws_client(app, "w1", kern)
-        km._clients.append(client)
+        km._clients.append(client); self.queues.append(q)
         peer = _Peer(peer_sock, pongs); peer.start()
         handler = _Handler(client, kern); handler.start()
+        self.threads += [peer, handler]
         return client, peer, handler
 
     def _settle(self, pred, timeout=3.0):
@@ -179,9 +190,52 @@ class PhantomPanesAreDropped(unittest.TestCase):
         self.clock[0] = t0 + 10 * km.WS_DEAD_S                       # a long backlog later…
         km._keepalive_all(now=self.clock[0])
         self.assertTrue(client["alive"], "…still not judged: no ping has reached the peer")
-        threading.Thread(target=km._ws_sender, args=(q, kern, lock, client), daemon=True).start()   # backlog drains
+        t = threading.Thread(target=km._ws_sender, args=(q, kern, lock, client), daemon=True); t.start()   # backlog drains
+        self.threads.append(t); self.queues.append(q)
         self.assertTrue(self._settle(lambda: client["pingAt"] == self.clock[0]), "stamped as the first ping left")
-        q.put(None)
+
+    def test_c3_a_peer_is_never_judged_while_its_handler_is_inside_a_dispatch(self):
+        """A `ready` runs the connect push on the handler thread — tens of seconds on a cold kernel — and the
+        peer's pongs wait unread in the receive buffer meanwhile. Unread is not missing (review 2026-09-03)."""
+        client, peer, handler = self._connect(pongs=False)
+        t0 = self.clock[0]
+        client["inRead"] = False                                    # as the handler marks itself for a dispatch
+        km._keepalive_all(now=t0)
+        self.assertTrue(self._settle(lambda: client["pingAt"] == t0))
+        self.clock[0] = t0 + 3 * km.WS_DEAD_S
+        km._keepalive_all(now=self.clock[0])
+        self.assertTrue(client["alive"], "silence during a dispatch is the kernel's, not the peer's")
+        km._note_ws_inbound(client); client["inRead"] = True        # the handler returns to its read: fresh clock
+        self.assertIsNone(client["pingAt"])
+        km._keepalive_all(now=self.clock[0])                        # a new ping…
+        self.assertTrue(self._settle(lambda: client["pingAt"] == self.clock[0]))
+        self.clock[0] += km.WS_DEAD_S
+        km._keepalive_all(now=self.clock[0])                        # …judged on its own fresh window
+        self.assertFalse(client["alive"], "back in the read and still silent for a whole window → dropped")
+
+    def test_c4_a_peer_still_draining_its_backlog_is_alive_and_one_that_stopped_acknowledging_is_not(self):
+        client, peer, handler = self._connect(pongs=False)
+        t0 = self.clock[0]
+        outq = [3_000_000]
+        km._ws_outq = lambda sock: outq[0]
+        km._keepalive_all(now=t0)
+        self.assertTrue(self._settle(lambda: client["pingAt"] == t0))
+        self.clock[0] = t0 + km.WS_DEAD_S; outq[0] = 2_000_000       # the window passed, but bytes are leaving
+        km._keepalive_all(now=self.clock[0])
+        self.assertTrue(client["alive"], "unsent bytes fell since the last beat → a slow peer, not a dead one")
+        self.clock[0] += km.KEEPALIVE_S; outq[0] = 1_000_000
+        km._keepalive_all(now=self.clock[0])
+        self.assertTrue(client["alive"])
+        stuck_at = self.clock[0]                                    # from here the count never moves
+        self.clock[0] += km.KEEPALIVE_S
+        km._keepalive_all(now=self.clock[0])
+        self.assertTrue(client["alive"], "unchanged once is not yet a verdict")
+        self.clock[0] = stuck_at + km.KEEPALIVE_S + km.WS_DEAD_S
+        km._keepalive_all(now=self.clock[0])
+        self.assertFalse(client["alive"], "unsent bytes unmoved for a whole window → the peer stopped acknowledging")
+
+    def test_c5_the_liveness_clock_is_monotonic(self):
+        self.assertIs(self._saved_clock, time.monotonic, "a suspend or an NTP step must not read as silence")
 
     def test_d_the_ping_frame_is_well_formed(self):
         f = km._ws_ping_frame(b"1700000000")

--- a/tests/test_ws_liveness.py
+++ b/tests/test_ws_liveness.py
@@ -237,6 +237,23 @@ class PhantomPanesAreDropped(unittest.TestCase):
     def test_c5_the_liveness_clock_is_monotonic(self):
         self.assertIs(self._saved_clock, time.monotonic, "a suspend or an NTP step must not read as silence")
 
+    def test_c6_a_reconnect_of_the_same_pane_retires_its_previous_socket_at_once(self):
+        """The exact event behind the leak: a pane reconnects (same app, same dashboard id) because its side
+        of the old socket is dead, however open a forwarder keeps our side. The old socket goes now, not
+        after a ping window; a pane with another id, or no id, is untouched (review + user 2026-09-03)."""
+        old, peer_old, h_old = self._connect(pongs=True)
+        other_kern, other_peer = self._pair()
+        other, oq, _ = km._new_ws_client("timeline", "w2", other_kern); km._clients.append(other); self.queues.append(oq)
+        anon_kern, anon_peer = self._pair()
+        anon, aq, _ = km._new_ws_client("timeline", "", anon_kern); km._clients.append(anon); self.queues.append(aq)
+        new_kern, new_peer = self._pair()
+        new, nq, _ = km._new_ws_client("timeline", "w1", new_kern); self.queues.append(nq)
+        km._register_ws_client(new)                                  # the same pane again
+        self.assertFalse(old["alive"], "the pane's previous socket is retired on the reconnect itself")
+        self.assertTrue(new["alive"] and other["alive"] and anon["alive"], "the reconnected pane, another pane and an id-less pane stand")
+        self.assertIn(new, km._clients)
+        h_old.join(3.0); self.assertFalse(h_old.is_alive(), "the old handler's read ended")
+
     def test_d_the_ping_frame_is_well_formed(self):
         f = km._ws_ping_frame(b"1700000000")
         self.assertEqual(f[0], 0x89, "FIN + ping opcode")


### PR DESCRIPTION
## What this fixes

A dashboard reached through VS Code's port forwarder starved. The forwarder multiplexes every forwarded socket over one channel and never closes the kernel-side end when the browser side goes away. Each pane reconnects after thirty silent seconds, so through the forwarder every reconnect left a dead connection behind, still receiving whole view payloads. One incident counted 84 connections from three real panes; the kernel's keepalive was one-way (a `ka` frame every 10 s that expected nothing back), so nothing ever noticed.

The kernel now protects itself on three fronts, and the guide tells people which remote paths to use instead.

## Liveness (commits 1–3, 6)

- Every heartbeat also sends a WebSocket PING. The sender stamps the ping when it reaches the socket (as it leaves the send queue), pongs and any inbound message clear the stamp, and the next beat drops a client whose stamp is older than `WS_DEAD_S` (3 × KEEPALIVE_S, env `ROMP_WS_DEAD`).
- A peer is judged only on its own silence: not while the handler thread is inside a dispatch (a cold `ready` builds every tab on that thread for tens of seconds, and the pong sits unread), and not while the socket is still draining (`SIOCOUTQ` falling between beats). Unsent bytes unmoved for a whole window are the other way to be dead.
- A client the beat declines to judge still receives its `ka` (commit 6, a review residual), or the shim's own watchdog would close a connection that was merely waiting on a build.
- Every socket is pinged and judged, not only the shim's panes: the VS Code extension's pipes, federated remotes through the relay, and the shell page. The extension's WebSocket library answers pings itself and the federation relay splices bytes both ways, so their pong path needed no change.

## Reconnect supersession (commits 4, 8)

A page mints an instance id once per load and carries it on every connect. A second socket for the same app with the same id means the page reconnected after its watchdog, so the previous socket is retired at once: the reconnect is the event, the ping timeout is the backstop. The key is deliberately not the dashboard id: review showed that keying on it would make the VS Code extension's status pipe and feed panel retire each other every 1.5 s, and a duplicated browser tab (which inherits sessionStorage) loop the same way. A socket without an instance id, which is every extension pipe and every federated remote, is never superseded.

## View deltas (commits 4–7)

The timeline bars and the feed used to cross whole on every change: about 3 MB and 0.86 MB on a seventeen-session board where something changes every few seconds. A pane that connects with `delta=1` (the shim does) now receives, per change, only the collection entries that changed:

| change                          | whole    | now      |
|---------------------------------|----------|----------|
| a bar appended to a lane        | ~3 MB    | ~2 KB    |
| a judge call lands              | ~3 MB    | 0.4 KB   |
| a postal message lands          | ~3 MB    | 0.3 KB   |
| a feed card moves column        | 0.86 MB  | 4.3 KB   |
| a feed card inserted at the top | 0.86 MB  | 8.8 KB   |

Protocol notes for reviewers:

- Collections are keyed per kind: lanes per bar (`dictlist:id`), judge calls by `(sid, t, judge, t1)`, messages by `id`, feed cards by `itemId`. Every key is minted in the kernel and shipped with the first full frame (`_keys`, stripped by the shim), so the client never spells a key — a shim deriving keys from field values spelled `None`/`null` and `1.0`/`1` differently.
- The key order crosses only when the order the client would derive on its own (surviving keys, then new keys in JavaScript's enumeration order, integer-like keys first) would assemble differently from the payload. For a dict of lists that compares groups and relative order, so a bar appended to any lane needs no order.
- A changed remainder crosses whole and flagged, and the shim retires the keys it no longer carries. A delta not smaller than 60% of the whole is sent whole and the stream re-bases. A client that cannot apply a delta sends `needSlot`; the handler flags the slot for the pusher, which re-bases on its own thread.
- One client's frame can never take the pusher down: a failure in the delta path is written to stderr, that client's held state is forgotten, and it gets the whole payload.
- Clients without the flag (the VS Code extension, federated remotes) get whole payloads exactly as before. The extension does not yet take deltas; that is the natural follow-up, and the guide says so.

## Review

Three adversarial review rounds ran against the branch as it grew; each defect below was reproduced and is fixed with a test:

- pongs read only between dispatches, so a long connect push dropped a live peer; a ping stamped after the write raced its own pong; a client not judged this beat was also skipped for its `ka`;
- a key removed from the remainder survived on the client; an empty id spelled a lane's marker; a positional key could land on a real id spelling the same; a non-ASCII digit raised inside the pusher and would have frozen every dashboard; feed cards were positional so an insert re-sent the feed; a resync ran on the socket thread and raced the pusher; a deduped keyed full frame after a failure left the kernel holding state the client never received;
- supersession keyed on the dashboard id retired the VS Code extension's twin pipes and duplicated tabs in a loop; a mutation pass switched the delta handshake off with every test green, so the handshake is now tested with the real handler.

## Also in this diff

- A stderr line per dropped or superseded client (`ws: dropping <app> client — <why>`) and per failed delta frame (`view-delta <slot>: <traceback>`).
- `ROMP_PERF` send events carry `delta=1` for delta frames.
- Per delta client the kernel holds about one serialized payload per slot (the entries as JSON strings), the price of the string compare.
- For delta clients the 60 s repost of an unchanged view is an empty delta carrying only the clock fields.
- `_new_ws_client` factors the client record and sender thread out of the handler; `_ws_recv_message` gains an `on_pong` callback; the per-viewer focus wiring pin follows.

## Tests

- `tests/test_ws_liveness.py`: real loopback pairs for every liveness rule and for supersession (same page retires, duplicated tab and id-less twins live).
- `tests/test_view_deltas.py`: the kernel encoder against a Python mirror of the shim, and the shim's own JavaScript run under node reassembling a stream frame by frame to the exact payload; handshake tests with the real handler.
- Full suites green on the branch rebased onto current main: 7125 Python, 2745 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
