### PR TITLE
"1 month" means a rolling month — the bill figure gets its own honest row

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24717,18 +24717,35 @@ def _spend_windows(keyed_only=False):
         keys = {time.strftime("%Y-%m-%dT%H", time.localtime(now - i * 3600)) for i in range(hrs + 1)}
         return _sum(v for k, v in hours.items() if k in keys)
 
-    month = time.strftime("%Y-%m")
+    def _rolling_days(n):
+        # the recorder keys day buckets by LOCAL strftime date — build the key set the same way, so
+        # the window is "the last n local dates through today" on this host regardless of its zone
+        keys = {time.strftime("%Y-%m-%d", time.localtime(now - i * 86400)) for i in range(n + 1)}
+        return _sum(v for k, v in days.items() if k in keys), keys
+
+    month = time.strftime("%Y-%m", time.localtime(now))   # explicit clock: the frozen-clock tests govern it
     # day/week are the API-key cell's windows (the user 2026-08-13: pay-per-token has no reset windows,
     # so "one day / one week / one month" is the honest read; the hour ledger holds 192h = 8 days, so
     # both fit). fiveHour/sevenDay stay emitted for ONE release: a remote host on an older kernel still
-    # sums its cell from them (version skew), and the strip reads day||fiveHour meanwhile. month stays
-    # calendar month-to-date — it matches the bill.
+    # sums its cell from them (version skew), and the strip reads day||fiveHour meanwhile.
+    # `month` is a ROLLING 30 local days (T235, the user 2026-09-03: "1 month" beside "1 hour / 1 day /
+    # 1 week" promises a rolling window, and on the 3rd the old calendar month-to-date read LOWER than
+    # the week — a superset window that reads lower is the label lying). The bill-tracking figure keeps
+    # its own honest key, `monthToDate` (calendar month so far; the month BUDGET, a bill-cycle cap,
+    # attaches HERE and never to the rolling window). The days ledger keeps 90 days, so the rolling
+    # month is exact once the ledger is old enough; a younger ledger says so (`since`) rather than
+    # reading as a silently short window.
+    rolling_month, month_keys = _rolling_days(30)
     win = {"fiveHour": _rolling(5), "sevenDay": _rolling(7 * 24),
            "hour": _rolling(1),   # the last hour, same rolling bucket math as day (the user 2026-08-15)
            "day": _rolling(24), "week": _rolling(7 * 24),
-           "month": _sum(v for k, v in days.items() if isinstance(k, str) and k.startswith(month))}
+           "month": rolling_month,
+           "monthToDate": _sum(v for k, v in days.items() if isinstance(k, str) and k.startswith(month))}
+    oldest = min((k for k in days if isinstance(k, str) and len(k) == 10), default=None)
+    if oldest and oldest > min(month_keys):
+        win["month"]["since"] = oldest          # the ledger is younger than the window — say how far it reaches
     for k, v in _spend_budgets().items():
-        win[k]["budget"] = v
+        win["monthToDate" if k == "month" else k]["budget"] = v
     return win
 
 
@@ -30099,15 +30116,26 @@ function fmtUsd(v){return '$'+String(Math.round(v));}   // whole dollars everywh
 // pay-per-token has no reset windows (the user 2026-08-13): the key's story is 1 hour (the user
 // 2026-08-15) / 1 day / 1 week / 1 month.
 // fiveHour/sevenDay fallbacks remain readable from older remote kernels (version skew) via day||fiveHour.
-var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 month']];
+// 'month' is a ROLLING 30 days (T235, 2026-09-03: a superset window must never read lower than the
+// week — it did, three days into a month, while month meant calendar-to-date); the bill figure sits
+// on its own row directly under it so it is still one glance away.
+var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 month'],['monthToDate','this month']];
 // The per-host SPEND detail for the rich hover: plain NUMBERS per window (dollars, tokens, turns).
 // No bars anywhere for spend (the user 2026-08-08: the spend bar graphs told you nothing. The old
 // hover scaled each window's bar to the largest window, a shape with no meaning, and the budget-fill
 // tracks die with it): the numbers are the information, so the numbers are the rendering.
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
 if(typeof u.spendAt==='number')det._spendAt=u.spendAt;   // the spend's OWN last-record moment
-SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
-(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});
+// VERSION SKEW (one release, T235): an older kernel ships only a CALENDAR 'month' and no monthToDate.
+// Summing that into the rolling "1 month" would mix two different windows in one number, so that
+// host's calendar figure is filed under "this month" (which is what it IS) and its share is LEFT OUT
+// of the rolling row, which then says how many machines it does not count — the honest option.
+var legacy=(sp.month&&typeof sp.month.usd==='number'&&!sp.monthToDate);
+if(legacy){det._spendLegacyMonth=true;}
+SPEND_WINS.forEach(function(w){var k=w[0];if(legacy&&k==='monthToDate')k='month';else if(legacy&&k==='month')return;
+var seg=sp[k];if(!seg||typeof seg.usd!=='number')return;
+var row=(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};
+if(w[0]==='month'&&typeof seg.since==='string')row.since=seg.since;});   // a ledger younger than the window says so
 if(u.spendSeries&&u.spendSeries.usd)det._spendSeries=u.spendSeries;}   // $/hour, for the hover graph (the user 2026-08-13)
 // One payload's WINDOW detail for the hover (used/elapsed/reset per window). Detail only, no markup:
 // the rail no longer draws each account's own bars (they aggregate, below), but the tip still tells
@@ -30292,12 +30320,14 @@ return h;}
 // The ONE API-spend section for the whole hover (the user 2026-08-13): every host's windows summed —
 // one shared key is one number — plus the summed $/hour over the last 7 days as an area graph. A host
 // that ships no series (an older kernel) still joins the window sums; the graph adds only contributors.
-function fleetSpendHTML(sets){var sum={},series=null,hosts=0,per=[];
+function fleetSpendHTML(sets){var sum={},series=null,hosts=0,per=[],legacyN=0;
 sets.forEach(function(e){var sp=e.det&&e.det._spend;if(!sp)return;hosts++;
 if(sp.week&&typeof sp.week.usd==='number')per.push({host:e.host,usd:sp.week.usd});
 SPEND_WINS.forEach(function(w){var v=sp[w[0]];if(!v)return;
 var t=(sum[w[0]]=sum[w[0]]||{label:w[1],usd:0,tok:0,turns:0});
-t.usd+=v.usd;t.tok+=v.tok;t.turns+=v.turns;});
+t.usd+=v.usd;t.tok+=v.tok;t.turns+=v.turns;
+if(v.since&&(!t.since||v.since<t.since))t.since=v.since;});   // the OLDEST reach among hosts caveats the sum
+if(e.det._spendLegacyMonth)legacyN++;
 var ss=e.det._spendSeries;
 if(ss&&ss.usd){if(!series){series={h0:ss.h0,usd:ss.usd.slice()};}
 else{var off=ss.h0-series.h0;   // align on the base hour — hosts' polls may straddle an hour edge
@@ -30310,7 +30340,12 @@ if(!ks.length)return '';
 var sAt=0;sets.forEach(function(e){var a=e.det&&e.det._spendAt;if(typeof a==='number'&&a>sAt)sAt=a;});
 var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>API spend'+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
 +ks.map(function(k){var v=sum[k];
-return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
+// the rolling month's caveats ride its label: a ledger younger than 30 days ("since <date>"), and
+// the machines whose older build could contribute only a calendar month (left out, counted)
+var lab=v.label;
+if(k==='month'&&v.since)lab+=' \u00b7 since '+esc(v.since);
+if(k==='month'&&legacyN)lab+=' \u00b7 '+legacyN+' machine'+(legacyN>1?'s':'')+' not counted (older build)';
+return '<div class=ru-tip-row><span class=ru-tip-k>'+lab+'</span>'
 +'<span class=ru-tip-v>'+fmtUsd(v.usd)+' \u00b7 '+fmtTok(v.tok)+' tok \u00b7 '+(v.turns||0)+' turns</span></div>';}).join('');
 // every machine in the sum, BY NAME (the user 2026-08-13: a host with no login \u2014 the devbox \u2014 vanished
 // from the hover entirely when the per-host spend rows collapsed into this one section; '3 machines'

--- a/tests/test_spend_windows.py
+++ b/tests/test_spend_windows.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""T235 (the user's spend hover, 2026-09-03): the "1 month" row read LOWER than "1 week" — because
+hour/day/week were ROLLING sums while month was CALENDAR month-to-date, three days into September.
+A label beside "1 hour / 1 day / 1 week" promises a rolling window, and a superset window can never
+read lower. Now `month` is a rolling 30 local days over the days ledger, and the bill-tracking figure
+lives under its own honest key, `monthToDate`, which carries the month budget. A ledger younger than
+30 days marks the rolling window with its `since` date rather than reading as a silently short window.
+Frozen clock, synthetic ledger, local-time bucket keys built the recorder's own way."""
+import json
+import os
+import tempfile
+import time
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_spendwin", os.path.join(BIN, "romp-kernel")).load_module()
+
+# the 3rd of a month, midday local — the exact shape of the user's screenshot
+FROZEN = time.mktime((2026, 9, 3, 12, 0, 0, 0, 0, -1))
+
+
+def _day(n):
+    return time.strftime("%Y-%m-%d", time.localtime(FROZEN - n * 86400))
+
+
+def _hour(n):
+    return time.strftime("%Y-%m-%dT%H", time.localtime(FROZEN - n * 3600))
+
+
+class SpendWindows(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.jd.STATE, km.time)
+        km.jd.STATE = Path(self.td.name)
+        # freeze the module's clock: time() answers FROZEN; every formatter stays the real one, fed
+        # explicit struct_times by the implementation (a bare strftime() would read the wall clock)
+        frozen = types.SimpleNamespace(time=lambda: FROZEN, strftime=time.strftime, localtime=time.localtime,
+                                       gmtime=time.gmtime, mktime=time.mktime, sleep=time.sleep,
+                                       monotonic=time.monotonic, time_ns=time.time_ns)
+        km.time = frozen
+
+    def tearDown(self):
+        km.jd.STATE, km.time = self._saved
+        self.td.cleanup()
+
+    def _ledger(self, days=None, hours=None, budgets=None):
+        (km.jd.STATE / "spend.json").write_text(json.dumps({"days": days or {}, "hours": hours or {}}))
+        if budgets is not None:
+            (km.jd.STATE / "spend-budgets.json").write_text(json.dumps(budgets))
+
+    def _bucket(self, usd, turns=1, tok=10):
+        return {"usd": usd, "turns": turns, "tokIn": tok}
+
+    def test_windows_are_monotone_hour_day_week_month(self):
+        # 40 days of $24/day (one $1 turn per hour for the last 7 days mirrors the days ledger)
+        days = {_day(n): self._bucket(24.0, turns=24, tok=240) for n in range(40)}
+        hours = {_hour(n): self._bucket(1.0) for n in range(7 * 24 + 1)}
+        self._ledger(days, hours)
+        w = km._spend_windows()
+        for metric in ("usd", "tok", "turns"):
+            chain = [w[k][metric] for k in ("hour", "day", "week", "month")]
+            self.assertEqual(chain, sorted(chain), "%s: hour ≤ day ≤ week ≤ month — the invariant the screenshot broke: %r" % (metric, chain))
+        self.assertGreater(w["month"]["usd"], w["week"]["usd"], "a rolling month is a strict superset of a week here")
+
+    def test_month_to_date_is_the_calendar_sum_and_carries_the_budget(self):
+        days = {_day(n): self._bucket(10.0) for n in range(40)}   # Sep 1,2,3 = 3 buckets in the calendar month
+        self._ledger(days, {}, budgets={"month": 150})
+        w = km._spend_windows()
+        self.assertEqual(w["monthToDate"]["usd"], 30.0, "Sep 1–3 only — what the bill accrues")
+        self.assertEqual(w["monthToDate"]["budget"], 150.0, "the bill-cycle budget rides the bill figure")
+        self.assertNotIn("budget", w["month"], "…never the rolling window — a cycle cap is not a 30-day cap")
+
+    def test_rolling_month_spans_exactly_the_last_30_local_days_across_a_boundary(self):
+        days = {_day(30): self._bucket(100.0), _day(29): self._bucket(1.0), _day(0): self._bucket(1.0),
+                _day(31): self._bucket(1000.0)}
+        self._ledger(days, {})
+        w = km._spend_windows()
+        self.assertEqual(w["month"]["usd"], 102.0, "today back through 30 days ago inclusive (31 local dates) — 31 days ago is out")
+
+    def test_a_ledger_younger_than_30_days_marks_its_since_date(self):
+        days = {_day(n): self._bucket(1.0) for n in range(5)}
+        self._ledger(days, {})
+        w = km._spend_windows()
+        self.assertEqual(w["month"]["since"], _day(4), "a short ledger says how far back it truly reaches")
+        self._ledger({_day(n): self._bucket(1.0) for n in range(35)}, {})
+        self.assertNotIn("since", km._spend_windows()["month"], "a full window carries no caveat")
+
+    def test_empty_ledger_stays_honest_zero_everywhere(self):
+        self._ledger({}, {})
+        w = km._spend_windows()
+        self.assertEqual(w["month"], {"usd": 0.0, "tok": 0, "turns": 0})
+        self.assertEqual(w["monthToDate"], {"usd": 0.0, "tok": 0, "turns": 0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -25,7 +25,8 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   assert.ok(KERNEL.includes('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):'));
   assert.ok(KERNEL.includes('out = {"apiKey": True, "spend": _spend_windows(),'));
   // the hover's spend rows lead with the rolling hour (the user 2026-08-15); the collapsed cell keeps day+month
-  assert.ok(KERNEL.includes("var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 month']];"));
+  // …'1 month' is ROLLING 30 days and 'this month' the calendar bill figure beneath it (T235, 2026-09-03)
+  assert.ok(KERNEL.includes("var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 month'],['monthToDate','this month']];"));
   assert.ok(KERNEL.includes('"hour": _rolling(1),'));
   // …and the $/hour series rides beside the windows for the hover graph (the user 2026-08-13)
   assert.ok(KERNEL.includes('out["spendSeries"] = ss'));

--- a/ui/webview/spend-windows-hover.test.ts
+++ b/ui/webview/spend-windows-hover.test.ts
@@ -1,0 +1,38 @@
+// T235's display half: the rail's spend hover reads "1 month" as a ROLLING 30 days (a superset window
+// can never read lower than "1 week" again) with "this month" — the calendar figure the bill accrues —
+// directly under it; a ledger younger than 30 days says "since <date>"; and a host on an older build
+// (calendar `month`, no monthToDate) files its figure under "this month" and is LEFT OUT of the rolling
+// row, which then says how many machines it does not count. The strip's cell title carries both rows.
+// The kernel half (window math, budget attachment) executes in tests/test_spend_windows.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const STRIP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "strip.ts"), "utf8");
+
+test("the hover renders both rows: rolling '1 month' and calendar 'this month'", () => {
+  assert.match(KERNEL, /var SPEND_WINS=\[\['hour','1 hour'\],\['day','1 day'\],\['week','1 week'\],\['month','1 month'\],\['monthToDate','this month'\]\];/);
+  assert.match(KERNEL, /"month": rolling_month,\s*\n\s*"monthToDate": _sum\(v for k, v in days\.items\(\) if isinstance\(k, str\) and k\.startswith\(month\)\)/,
+    "the kernel ships both keys — rolling under the old name, the bill figure under its own");
+  assert.match(KERNEL, /win\["monthToDate" if k == "month" else k\]\["budget"\] = v/, "the bill-cycle budget rides the bill figure, never the rolling window");
+});
+
+test("the version-skew arm: an older host's calendar month is filed honestly and never mixed into the rolling sum", () => {
+  assert.match(KERNEL, /var legacy=\(sp\.month&&typeof sp\.month\.usd==='number'&&!sp\.monthToDate\);/);
+  assert.match(KERNEL, /if\(legacy&&k==='monthToDate'\)k='month';else if\(legacy&&k==='month'\)return;/,
+    "calendar → 'this month'; its rolling share is left out rather than summed as a different window");
+  assert.match(KERNEL, /' \\u00b7 '\+legacyN\+' machine'\+\(legacyN>1\?'s':''\)\+' not counted \(older build\)'/,
+    "…and the rolling row says how many it does not count");
+});
+
+test("a ledger younger than 30 days marks the rolling row with its reach", () => {
+  assert.match(KERNEL, /win\["month"\]\["since"\] = oldest/, "the kernel states how far back the ledger truly goes");
+  assert.match(KERNEL, /if\(k==='month'&&v\.since\)lab\+=' \\u00b7 since '\+esc\(v\.since\);/, "…and the hover shows it on the row");
+  assert.match(KERNEL, /if\(v\.since&&\(!t\.since\|\|v\.since<t\.since\)\)t\.since=v\.since;/, "across hosts, the OLDEST reach caveats the sum");
+});
+
+test("the strip's cell title carries both rows too", () => {
+  assert.match(STRIP, /\["month", "1 month"\], \["monthToDate", "this month"\]\] as const/);
+});

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -129,7 +129,9 @@ export function apiCell(usage: any): ApiCell | null {
   }
   if (!segs.length) return null;
   const lines = ["API-key spend"];
-  for (const [key, label] of [["day", "1 day"], ["week", "1 week"], ["month", "1 month"]] as const) {
+  // '1 month' is ROLLING 30 days (T235); 'this month' is the calendar figure the bill accrues — an older
+  // kernel ships only a calendar `month`, which the hover files under "this month" (the same skew rule)
+  for (const [key, label] of [["day", "1 day"], ["week", "1 week"], ["month", "1 month"], ["monthToDate", "this month"]] as const) {
     const seg = sp[key];
     if (!seg || typeof seg.usd !== "number") continue;
     const turns = seg.turns || 0;


### PR DESCRIPTION
The user's spend hover (2026-09-03, three machines): the **'1 month' row read lower than '1 week'** at every metric. Cause, verified in `_spend_windows`: hour/day/week were rolling sums over the hour ledger while `month` was **calendar month-to-date** — three days of September. A label beside '1 hour / 1 day / 1 week' promises a rolling window, and a superset window can never read lower.

`month` is now a **rolling 30 local days** over the days ledger, its key set built the way the recorder keys buckets (local strftime, `_rolling`'s shape), so the window is 'the last 30 local dates through today' on every host regardless of zone. The bill-tracking figure keeps its own honest key, **`monthToDate`** (calendar month so far), and the month **budget** — a bill-cycle cap — attaches there, never to the rolling window. A ledger younger than 30 days marks the rolling window with its **`since`** date rather than reading as a silently short window (the days ledger already keeps 90 days — no retention change; the devbox's short history is recording age, not pruning).

The hover shows **both rows** — '1 month' then 'this month' directly under it — and carries the caveats on the rolling row: 'since <date>' for a young ledger (the oldest reach among hosts), and the **version-skew arm** for one release: an older host ships only a calendar `month`, which is filed under 'this month' (what it is) and left out of the rolling row, which then says how many machines it does not count — never two windows summed into one number. The strip's cell title carries both rows too.

Red-first pins (frozen clock on the 3rd, synthetic ledgers): monotonicity hour ≤ day ≤ week ≤ month across usd/tok/turns (red on main), monthToDate = calendar sum carrying the budget, the rolling month spanning exactly the last 30 local days across a boundary, the young-ledger mark, honest zeros; source pins for both hover rows, the skew arm, the since caveat, and the strip title; one stale hover-array pin retargeted. Python 7121 passed / extension 2749 passed on the pushed head; served-page hover screenshot (both rows, monotone chain) in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)