### PR TITLE
The background-task pairing, state intervals and postal log fold appends; last_state reads the tail

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -26,7 +26,7 @@ Auxiliary inputs the file adapter may read (same category as the transcript):
                                transcript lost to an API-errored try; judge parse only)
   timeline/messages.jsonl   -> peer rompUuid for a postal atom (join on the msg id)
 """
-import json, os, re, sys, time, hashlib, threading
+import copy, json, os, re, sys, time, hashlib, threading
 from datetime import datetime
 from pathlib import Path
 
@@ -262,8 +262,39 @@ def _scan_bg_tasks(path, want_all=False):
     Returns [{id,status,summary,command,outputFile}] (+ type on agent/workflow rows; + endT — the
     transcript time its result LANDED — on rows a notification has terminal-marked, so the awaiting-stamp
     lift can tell a return that ENDED a stamped wait from one the stamping judge had already seen)."""
-    tasks, order = {}, []
-    dispatch = {}   # tool_use id -> the launching Agent/Task/Workflow block's own words (see docstring)
+    state = _bg_fresh(want_all)
+    for o in _read_jsonl(path):
+        if isinstance(o, dict):
+            _bg_step(state, o)
+    return _bg_finish(state, want_all)
+
+
+def _bg_fresh(want_all=False):
+    """A fresh pairing state. `all`: keep every task's row (the launch-ordered history view); otherwise a
+    task that reaches a terminal status is dropped from the state at once — the running-only view can
+    never show it again (no branch below ever returns an existing task to "running"), so a long-lived
+    transcript's fold state stays the size of its in-flight work, not its history. `done` is that view's
+    tombstone set: transcripts DO replay records — a duplicate async ack (same tool-use id, even the same
+    uuid) can land after the terminal notification — and with the row gone such a replay would pass the
+    `tid not in tasks` creation guards and resurrect the task as running, where a retained row ignored it.
+    The tombstone keeps that answer while releasing the row and its prompt text."""
+    return {"tasks": {}, "order": [], "dispatch": {}, "all": bool(want_all), "done": set()}
+
+
+def _bg_forget_terminal(state, tid):
+    if not state["all"] and state["tasks"].get(tid, {}).get("status") != "running":
+        state["done"].add(tid)
+        state["tasks"].pop(tid, None)
+        try:
+            state["order"].remove(tid)
+        except ValueError:
+            pass
+
+
+def _bg_step(state, o):
+    """One transcript record of the pairing — see _scan_bg_tasks. Returns the state (the fold_records
+    contract)."""
+    tasks, order, dispatch, done = state["tasks"], state["order"], state["dispatch"], state["done"]
 
     def _mark(note, end_t=None):
         # a notification keyed by its INNER <tool-use-id> (the string/queue shapes have no wrapper block)
@@ -275,137 +306,156 @@ def _scan_bg_tasks(path, want_all=False):
                               summary=note["summary"] or tasks[tid]["summary"])
             if end_t:                      # WHEN the result landed — the awaiting-stamp lift keys the
                 tasks[tid]["endT"] = end_t  # "returned after the stamp was written" test on it (2026-08-16)
+            _bg_forget_terminal(state, tid)
 
-    try:
-        with open(path, errors="replace") as f:
-            for line in f:
-                if '"type"' not in line:
+    t = o.get("type")
+    c = (o.get("message") or {}).get("content")
+    if t == "assistant" and isinstance(c, list):
+        for b in c:
+            if not (isinstance(b, dict) and b.get("type") == "tool_use"):
+                continue
+            inp = b.get("input") or {}
+            if b.get("name") in ("Agent", "Task", "Workflow") and b.get("id") \
+                    and b["id"] not in tasks and b["id"] not in done:
+                # remember the dispatch's own words — consumed by its async ack below, or
+                # right here when an explicit run_in_background rides the input (the dominant
+                # real Agent shape, which registers via the launch branch below instead). A
+                # replayed launch record for a task already registered or already returned can
+                # never be consumed (both creation paths refuse the id), so it is not captured.
+                dispatch[b["id"]] = {
+                    "desc": str(inp.get("description") or "").strip(),
+                    "detail": _clip_detail(inp.get("prompt") or inp.get("script")
+                                           or ("script: " + str(inp["scriptPath"])
+                                               if inp.get("scriptPath") else "")),
+                    "type": "local_workflow" if b.get("name") == "Workflow" else "local_agent"}
+            # The THIRD durable launch shape: a Monitor tool_use. A non-persistent monitor is
+            # dispatched background work exactly like a backgrounded Bash — a session idle
+            # behind one read as plain 'ready', its goal stamps could lift only by the 6h
+            # backstop, and the nudge gates couldn't see the wait. A PERSISTENT monitor is
+            # skipped: a session-length subscription (a log tail) never returns, so counting it
+            # would hold "awaiting" forever — it is furniture, not awaited work.
+            is_mon = b.get("name") == "Monitor"
+            if is_mon and inp.get("persistent"):
+                continue
+            if not (inp.get("run_in_background") or is_mon):
+                continue
+            tid = b.get("id")
+            if tid and tid not in tasks and tid not in done:
+                tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
+                              "summary": (inp.get("description") or b.get("name") or "Background task"),
+                              "command": inp.get("command") or (inp.get("ws") or {}).get("url", ""),
+                              "outputFile": ""}
+                d = dispatch.pop(tid, None)
+                if d:   # an Agent/Task/Workflow with an explicit run_in_background lands
+                        # HERE, not at its ack (tid already registered) — same enrichment
+                    tasks[tid]["command"] = tasks[tid]["command"] or d["detail"]
+                    tasks[tid]["type"] = d["type"]
+                if is_mon:
+                    tasks[tid]["monitor"] = True
+                    # its recorded lifetime ceiling → the deadline consumers expire on
+                    # (see _bg_expired); the harness clamps timeout_ms to [1s, 1h]
+                    tmo = inp.get("timeout_ms")
+                    tmo = float(tmo) if isinstance(tmo, (int, float)) else 300000.0
+                    if tasks[tid]["t"]:
+                        tasks[tid]["deadline"] = tasks[tid]["t"] + min(max(tmo, 1000.0), 3600000.0) / 1000.0
+                order.append(tid)
+    elif t == "user" and isinstance(c, list):
+        tur = o.get("toolUseResult")
+        tur = tur if isinstance(tur, dict) else {}
+        async_launch = bool(tur.get("isAsync")) or tur.get("status") == "async_launched"
+        for b in c:
+            if isinstance(b, dict) and b.get("type") == "tool_result":
+                tid = b.get("tool_use_id")
+                if not async_launch:
+                    # the tool_use's ONE result has landed synchronously — a remembered Agent/Task/Workflow
+                    # dispatch can no longer be acked async, so its words are dead weight in the state
+                    dispatch.pop(tid, None)
+                if async_launch and tid and tid not in tasks and tid not in done:
+                    # an async Agent/Workflow dispatch ack — the durable "this work is now
+                    # running" record; the gist prefers the ack's own words, the launching
+                    # tool_use fills what the ack omits (see docstring). Acks carry the ask
+                    # too (prompt / scriptPath) — the fallback when the launch predates the
+                    # transcript tail or the block went unseen.
+                    d = dispatch.pop(tid, {})
+                    wf = tur.get("workflowName")
+                    tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
+                                  "summary": (tur.get("description") or tur.get("summary")
+                                              or d.get("desc")
+                                              or ("workflow " + str(wf) if wf else "Background agent")),
+                                  "command": d.get("detail")
+                                             or _clip_detail(tur.get("prompt")
+                                                             or ("script: " + str(tur["scriptPath"])
+                                                                 if tur.get("scriptPath") else "")),
+                                  "outputFile": tur.get("outputFile") or ""}
+                    if tur.get("taskType") or d.get("type"):
+                        tasks[tid]["type"] = tur.get("taskType") or d["type"]
+                    order.append(tid)
                     continue
-                try:
-                    o = json.loads(line)
-                except Exception:
+                if async_launch and tid in tasks and not b.get("is_error") \
+                        and tasks[tid]["status"] == "running":
+                    # the ack of a launch the assistant branch already registered (explicit
+                    # run_in_background): the ack still owns outputFile/taskType — fill what
+                    # the launch row lacks, never overwrite what it has
+                    tk = tasks[tid]
+                    tk["outputFile"] = tk["outputFile"] or tur.get("outputFile") or ""
+                    if tur.get("taskType"):
+                        tk["type"] = tur["taskType"]
+                    if not tk["command"]:
+                        tk["command"] = _clip_detail(tur.get("prompt") or "")
                     continue
-                t = o.get("type")
-                c = (o.get("message") or {}).get("content")
-                if t == "assistant" and isinstance(c, list):
-                    for b in c:
-                        if not (isinstance(b, dict) and b.get("type") == "tool_use"):
-                            continue
-                        inp = b.get("input") or {}
-                        if b.get("name") in ("Agent", "Task", "Workflow") and b.get("id"):
-                            # remember the dispatch's own words — consumed by its async ack below, or
-                            # right here when an explicit run_in_background rides the input (the dominant
-                            # real Agent shape, which registers via the launch branch below instead)
-                            dispatch[b["id"]] = {
-                                "desc": str(inp.get("description") or "").strip(),
-                                "detail": _clip_detail(inp.get("prompt") or inp.get("script")
-                                                       or ("script: " + str(inp["scriptPath"])
-                                                           if inp.get("scriptPath") else "")),
-                                "type": "local_workflow" if b.get("name") == "Workflow" else "local_agent"}
-                        # The THIRD durable launch shape: a Monitor tool_use. A non-persistent monitor is
-                        # dispatched background work exactly like a backgrounded Bash — a session idle
-                        # behind one read as plain 'ready', its goal stamps could lift only by the 6h
-                        # backstop, and the nudge gates couldn't see the wait. A PERSISTENT monitor is
-                        # skipped: a session-length subscription (a log tail) never returns, so counting it
-                        # would hold "awaiting" forever — it is furniture, not awaited work.
-                        is_mon = b.get("name") == "Monitor"
-                        if is_mon and inp.get("persistent"):
-                            continue
-                        if not (inp.get("run_in_background") or is_mon):
-                            continue
-                        tid = b.get("id")
-                        if tid and tid not in tasks:
-                            tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
-                                          "summary": (inp.get("description") or b.get("name") or "Background task"),
-                                          "command": inp.get("command") or (inp.get("ws") or {}).get("url", ""),
-                                          "outputFile": ""}
-                            d = dispatch.pop(tid, None)
-                            if d:   # an Agent/Task/Workflow with an explicit run_in_background lands
-                                    # HERE, not at its ack (tid already registered) — same enrichment
-                                tasks[tid]["command"] = tasks[tid]["command"] or d["detail"]
-                                tasks[tid]["type"] = d["type"]
-                            if is_mon:
-                                tasks[tid]["monitor"] = True
-                                # its recorded lifetime ceiling → the deadline consumers expire on
-                                # (see _bg_expired); the harness clamps timeout_ms to [1s, 1h]
-                                tmo = inp.get("timeout_ms")
-                                tmo = float(tmo) if isinstance(tmo, (int, float)) else 300000.0
-                                if tasks[tid]["t"]:
-                                    tasks[tid]["deadline"] = tasks[tid]["t"] + min(max(tmo, 1000.0), 3600000.0) / 1000.0
-                            order.append(tid)
-                elif t == "user" and isinstance(c, list):
-                    tur = o.get("toolUseResult")
-                    tur = tur if isinstance(tur, dict) else {}
-                    async_launch = bool(tur.get("isAsync")) or tur.get("status") == "async_launched"
-                    for b in c:
-                        if isinstance(b, dict) and b.get("type") == "tool_result":
-                            tid = b.get("tool_use_id")
-                            if async_launch and tid and tid not in tasks:
-                                # an async Agent/Workflow dispatch ack — the durable "this work is now
-                                # running" record; the gist prefers the ack's own words, the launching
-                                # tool_use fills what the ack omits (see docstring). Acks carry the ask
-                                # too (prompt / scriptPath) — the fallback when the launch predates the
-                                # transcript tail or the block went unseen.
-                                d = dispatch.pop(tid, {})
-                                wf = tur.get("workflowName")
-                                tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
-                                              "summary": (tur.get("description") or tur.get("summary")
-                                                          or d.get("desc")
-                                                          or ("workflow " + str(wf) if wf else "Background agent")),
-                                              "command": d.get("detail")
-                                                         or _clip_detail(tur.get("prompt")
-                                                                         or ("script: " + str(tur["scriptPath"])
-                                                                             if tur.get("scriptPath") else "")),
-                                              "outputFile": tur.get("outputFile") or ""}
-                                if tur.get("taskType") or d.get("type"):
-                                    tasks[tid]["type"] = tur.get("taskType") or d["type"]
-                                order.append(tid)
-                                continue
-                            if async_launch and tid in tasks and not b.get("is_error") \
-                                    and tasks[tid]["status"] == "running":
-                                # the ack of a launch the assistant branch already registered (explicit
-                                # run_in_background): the ack still owns outputFile/taskType — fill what
-                                # the launch row lacks, never overwrite what it has
-                                tk = tasks[tid]
-                                tk["outputFile"] = tk["outputFile"] or tur.get("outputFile") or ""
-                                if tur.get("taskType"):
-                                    tk["type"] = tur["taskType"]
-                                if not tk["command"]:
-                                    tk["command"] = _clip_detail(tur.get("prompt") or "")
-                                continue
-                            note = _parse_task_notification(_result_text(b.get("content")))
-                            if tid in tasks and note:      # its result landed → mark it done; the keep-filter drops it
-                                if tasks[tid].get("monitor") and not note.get("has_status"):
-                                    continue               # a wrapped monitor EVENT — not a terminal (see _mark)
-                                tasks[tid].update(status=note["status"], outputFile=note["output_file"],
-                                                  summary=note["summary"] or tasks[tid]["summary"])
-                                et = parse_z(o.get("timestamp"))
-                                if et:                     # the return's moment (see _mark)
-                                    tasks[tid]["endT"] = et
-                            elif tid in tasks and note is None and b.get("is_error") \
-                                    and tasks[tid]["status"] == "running":
-                                # the LAUNCH's own ack errored (refused permission, bad input) → nothing ever
-                                # started, and no notification will ever come. Without this, the phantom
-                                # reads "running" forever and holds awaiting/nudge gates open on nothing.
-                                tasks[tid]["status"] = "failed"
-                                et = parse_z(o.get("timestamp"))
-                                if et:
-                                    tasks[tid]["endT"] = et
-                elif t == "user" and isinstance(c, str):
-                    _mark(_parse_task_notification(c), parse_z(o.get("timestamp")))
-                elif t == "queue-operation" and o.get("operation") == "enqueue":
-                    _mark(_parse_task_notification(o.get("content") or ""), parse_z(o.get("timestamp")))
-    except OSError:
-        return []
+                note = _parse_task_notification(_result_text(b.get("content")))
+                if tid in tasks and note:      # its result landed → mark it done; the keep-filter drops it
+                    if tasks[tid].get("monitor") and not note.get("has_status"):
+                        continue               # a wrapped monitor EVENT — not a terminal (see _mark)
+                    tasks[tid].update(status=note["status"], outputFile=note["output_file"],
+                                      summary=note["summary"] or tasks[tid]["summary"])
+                    et = parse_z(o.get("timestamp"))
+                    if et:                     # the return's moment (see _mark)
+                        tasks[tid]["endT"] = et
+                    _bg_forget_terminal(state, tid)
+                elif tid in tasks and note is None and b.get("is_error") \
+                        and tasks[tid]["status"] == "running":
+                    # the LAUNCH's own ack errored (refused permission, bad input) → nothing ever
+                    # started, and no notification will ever come. Without this, the phantom
+                    # reads "running" forever and holds awaiting/nudge gates open on nothing.
+                    tasks[tid]["status"] = "failed"
+                    et = parse_z(o.get("timestamp"))
+                    if et:
+                        tasks[tid]["endT"] = et
+                    _bg_forget_terminal(state, tid)
+    elif t == "user" and isinstance(c, str):
+        _mark(_parse_task_notification(c), parse_z(o.get("timestamp")))
+    elif t == "queue-operation" and o.get("operation") == "enqueue":
+        _mark(_parse_task_notification(o.get("content") or ""), parse_z(o.get("timestamp")))
+    return state
+
+
+def _bg_finish(state, want_all=False):
+    """The scan's answer from a pairing state — row COPIES, so a holder of one answer is never changed by
+    the next fold step (fold_records deep-copies the cached state before folding, and a caller scribbling
+    on its rows must not reach the cache either)."""
+    tasks, order = state["tasks"], state["order"]
     if want_all:
         # EVERY task the transcript knows, launch-ordered, each carrying its launch `t` and its CURRENT
         # status (still "running", or the terminal status its notification reported). The awaiting-stamp
         # lift (_lift_spent_awaiting) needs the RETURNED ones too: "this goal's dispatches have all come
         # back" is precisely the event that ends a wait, and the running-only view cannot express it.
-        return [tasks[tid] for tid in order]
-    keep = [tasks[tid] for tid in order if tasks[tid]["status"] == "running"]
+        return [dict(tasks[tid]) for tid in order]
+    keep = [dict(tasks[tid]) for tid in order if tasks[tid]["status"] == "running"]
     keep.reverse()
     return keep[:60]
+
+
+def scan_bg_tasks_cached(path, cache, want_all=False):
+    """_scan_bg_tasks folded append-incrementally through `cache` (fold_records): a changed transcript
+    steps only its appended records instead of re-pairing the whole file — the kernel's chat box, awaiting
+    source and awaiting-stamp lift, and the judge's settled gate, all asked per push per session, and
+    each re-walked a working session's entire transcript on every streamed record (measured live
+    2026-09-02: four such readers over one 180 MB transcript held the push loop at a full core). `cache`
+    is the caller's dict (the kernel keeps a running-only and an every-task cache; the judge its own), so
+    the two views never invalidate each other and a test's `.clear()` still forces a re-fold."""
+    state = fold_records(cache, path, lambda: _bg_fresh(want_all), _bg_step)
+    return _bg_finish(state, want_all)
 
 
 def _read_jsonl(path):
@@ -518,6 +568,74 @@ def _read_jsonl_incremental(path):
             _JSONL_CACHE.pop(next(iter(_JSONL_CACHE)))   # oldest-used first; hot entries survive any cold flood
         _JSONL_CACHE[path] = (st.st_mtime, st.st_size, offset, tail, records)
     return records
+
+
+def fold_records(cache, path, init, step):
+    """Fold a JSONL file's records into a carried state, APPEND-INCREMENTALLY (issue 903, 2026-09-03):
+    the states/transcript readers re-read their whole file behind an (mtime,size) key that every append
+    invalidates — O(file) per push for every working session. _read_jsonl_incremental already serves the
+    parsed records of a growing file incrementally (the parse reads the same list, so this adds no I/O),
+    and its contract — a grown file returns a NEW list whose prefix objects are the SAME — is the
+    identity gate here: when the cached prefix is intact, only the appended records run through `step`;
+    a rewrite (prefix identity lost, a shrink, a same-size-new-mtime) re-folds from record 0. `init()`
+    makes a fresh state; `step(state, record)` returns the next state (mutate-and-return is fine: the
+    cached state is deep-copied before folding onto it, so a state a caller was handed never changes
+    under it). Returns the state; [] records (a missing or unreadable file) fold to init().
+
+    Lives here (moved from the kernel, 2026-09-03) so the judge's readers can fold too — the
+    background-task pairing below is shared by both."""
+    recs = _read_jsonl_incremental(path)
+    key = str(path)
+    hit = cache.get(key)
+    if hit is not None:
+        n0, last0, state0 = hit
+        if n0 == len(recs) and (n0 == 0 or recs[-1] is last0):
+            return _fold_eof_fragment(key, state0, step)   # unchanged records; a newline-less tail may still sit past them
+        if 0 < n0 < len(recs) and recs[n0 - 1] is last0:
+            state, start = copy.deepcopy(state0), n0
+        else:
+            state, start = init(), 0
+    else:
+        state, start = init(), 0
+    for r in recs[start:]:
+        if isinstance(r, dict):
+            state = step(state, r)
+    if len(cache) > 256:                                  # bounded by the session count; never unbounded
+        cache.clear()
+    cache[key] = (len(recs), recs[-1] if recs else None, state)
+    return _fold_eof_fragment(key, state, step)
+
+
+def _trailing_record(path):
+    """The complete JSON record sitting past _read_jsonl_incremental's consumed offset WITHOUT its newline
+    yet, or None. The incremental reader leaves such a line unconsumed by design (a writer caught
+    mid-append must not enter the cache torn); the readers folded here used to walk the text to EOF and
+    saw a final newline-less record — so the fold reads it provisionally (see _fold_eof_fragment)."""
+    with _JSONL_CACHE_LOCK:
+        hit = _JSONL_CACHE.get(path)
+    if hit is None or hit[1] <= hit[2]:                   # nothing past the consumed offset (the common case)
+        return None
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(hit[2])
+            frag = fh.read(hit[1] - hit[2]).strip()
+        if not frag or b"\n" in frag:
+            return None
+        o = json.loads(frag.decode("utf-8", "replace"))
+    except (OSError, ValueError):
+        return None
+    return o if isinstance(o, dict) else None
+
+
+def _fold_eof_fragment(key, state, step):
+    """fold_records' answer with a newline-less final record folded in PROVISIONALLY: applied to a copy,
+    never to the cached state, so the record is folded for good exactly once — when its newline lands and
+    the incremental reader serves it as a record. Keeps the old whole-file readers' answer (they saw that
+    final line) without giving up the cache's torn-write safety."""
+    frag = _trailing_record(key)
+    if frag is None:
+        return state
+    return step(copy.deepcopy(state), frag)
 
 
 def _is_tool_result(r):

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -5919,26 +5919,15 @@ def _session_closed(session):
     return bool(last.get("ended")) or any(a["type"] == "idle" for a in last["atoms"])
 
 
-_BG_SCAN_CACHE = {}                       # path -> ((mtime, size), running tasks) — mirrors the kernel's _bg_scan_cached
+_BG_SCAN_CACHE = {}                       # path -> em.fold_records entry (running tasks) — mirrors the kernel's _bg_scan_cached
 
 
 def _bg_unresolved(path):
     """The transcript's still-RUNNING background launches (em._scan_bg_tasks pairing), mtime+size-cached.
     The DURABLE awaited-work source: the pairing lives in the transcript, so unlike any live backend
     snapshot it survives a kernel restart and covers tmux CLIs whose tasks outlive the kernel."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-    except OSError:
-        return []
-    hit = _BG_SCAN_CACHE.get(path)
-    if hit and hit[0] == key:
-        tasks = hit[1]
-    else:
-        tasks = em._scan_bg_tasks(path)
-        if len(_BG_SCAN_CACHE) > 256:     # bounded by fleet size; a wholesale clear on overflow is fine
-            _BG_SCAN_CACHE.clear()
-        _BG_SCAN_CACHE[path] = (key, tasks)
+    # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records
+    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
     # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
     # terminal record, and an idle transcript never busts the mtime key — a cached verdict would say
     # "running" forever (see em._bg_expired)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -261,37 +261,8 @@ def _interrupt_cause(nxt_atom):
 _machine_cut_cache = {}   # str(path) -> (records seen, last record, (t, cause)) — see _fold_records
 
 
-def _fold_records(cache, path, init, step):
-    """Fold a JSONL file's records into a carried state, APPEND-INCREMENTALLY (issue 903, 2026-09-03):
-    the states/transcript readers below re-read their whole file behind an (mtime,size) key that every
-    append invalidates — O(file) per push for every working session. em._read_jsonl_incremental already
-    serves the parsed records of a growing file incrementally (the parse reads the same list, so this adds
-    no I/O), and its contract — a grown file returns a NEW list whose prefix objects are the SAME — is the
-    identity gate here: when the cached prefix is intact, only the appended records run through `step`;
-    a rewrite (prefix identity lost, a shrink, a same-size-new-mtime) re-folds from record 0. `init()`
-    makes a fresh state; `step(state, record)` returns the next state (mutate-and-return is fine: the
-    cached state is deep-copied before folding onto it, so a state a caller was handed never changes
-    under it). Returns the state; [] records (a missing or unreadable file) fold to init()."""
-    recs = em._read_jsonl_incremental(path)
-    key = str(path)
-    hit = cache.get(key)
-    if hit is not None:
-        n0, last0, state0 = hit
-        if n0 == len(recs) and (n0 == 0 or recs[-1] is last0):
-            return state0
-        if 0 < n0 < len(recs) and recs[n0 - 1] is last0:
-            state, start = copy.deepcopy(state0), n0
-        else:
-            state, start = init(), 0
-    else:
-        state, start = init(), 0
-    for r in recs[start:]:
-        if isinstance(r, dict):
-            state = step(state, r)
-    if len(cache) > 256:                                  # bounded by the session count; never unbounded
-        cache.clear()
-    cache[key] = (len(recs), recs[-1] if recs else None, state)
-    return state
+_fold_records = em.fold_records   # moved to event_model (2026-09-03) so the judge folds the same way;
+#                                   the kernel's readers below are unchanged callers
 
 
 def _last_machine_cut(sid):
@@ -17216,21 +17187,10 @@ def _sdk_spawned_at(sid):
 def _bg_scan_cached(path):
     """The mtime+size-cached _scan_bg_tasks result for a transcript — the task META only (no output tails;
     callers that show output read it fresh, a running task's log grows independently of the transcript).
-    Shared by the chat box (_bg_tasks) and the awaiting source (_session_awaiting source 0.75)."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-    except OSError:
-        key = None
-    hit = _bgtasks_cache.get(path)
-    if hit is not None and key is not None and hit[0] == key:
-        return hit[1]
-    scan = _scan_bg_tasks(path)
-    if key is not None:
-        if len(_bgtasks_cache) > 256:
-            _bgtasks_cache.clear()
-        _bgtasks_cache[path] = (key, scan)
-    return scan
+    Shared by the chat box (_bg_tasks) and the awaiting source (_session_awaiting source 0.75).
+    Folds append-incrementally since 2026-09-03 (em.fold_records): a streaming session no longer re-
+    pairs its whole transcript per record."""
+    return em.scan_bg_tasks_cached(path, _bgtasks_cache, want_all=False)
 
 
 _bgall_cache = {}             # path -> ((mtime,size), [every task, launch-ordered])
@@ -17240,21 +17200,9 @@ def _bg_scan_all_cached(path):
     """Every background task the transcript records (launch-ordered, each with its launch `t` and current
     status), mtime+size cached like _bg_scan_cached. Its own cache: the running-only view is read on every
     push, this one only by the awaiting-stamp lift, and sharing one entry would make each invalidate the
-    other's shape."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-    except OSError:
-        key = None
-    hit = _bgall_cache.get(path)
-    if hit is not None and key is not None and hit[0] == key:
-        return hit[1]
-    scan = _scan_bg_tasks(path, want_all=True)
-    if key is not None:
-        if len(_bgall_cache) > 256:
-            _bgall_cache.clear()
-        _bgall_cache[path] = (key, scan)
-    return scan
+    other's shape.
+    Folds append-incrementally since 2026-09-03 (em.fold_records), like _bg_scan_cached."""
+    return em.scan_bg_tasks_cached(path, _bgall_cache, want_all=True)
 
 
 def _bg_tasks(path, spawned_at=None, live=None):
@@ -24211,23 +24159,12 @@ def _state_intervals(sid, want, now):
     'compacting' → cross-hatch), from states/<sid>.jsonl: an entry runs until the next transition
     (or `now` if still in it). `want` is a single state or any collection of them (the awaiting band
     passes both needs-input states). Forward-only — periods predating the log don't appear. File-based
-    port of the obsidian timeline's stateIntervals (the kernel reads states/, never tmux)."""
+    port of the obsidian timeline's stateIntervals (the kernel reads states/, never tmux).
+    Folds the states log append-incrementally since 2026-09-03 (_fold_records): every timeline
+    rebuild used to re-read and re-parse the whole file, twice per session (once per `want`); the
+    intervals themselves are cheap."""
     want = {want} if isinstance(want, str) else set(want)
-    try:
-        text = (jd.STATE / "states" / (sid + ".jsonl")).read_text(errors="replace")
-    except OSError:
-        return []
-    ev = []
-    for line in text.splitlines():
-        if not line:
-            continue
-        try:
-            o = json.loads(line)
-        except Exception:
-            continue
-        if o.get("t") and o.get("state"):
-            ev.append((o["t"], o["state"]))
-    ev.sort()
+    ev = sorted(_fold_records(_state_ev_cache, jd.STATE / "states" / (sid + ".jsonl"), list, _state_ev_step))
     cutoff, out = now - TL_HORIZON, []
     for i, (t, st) in enumerate(ev):
         if st not in want:
@@ -24237,6 +24174,15 @@ def _state_intervals(sid, want, now):
             continue
         out.append([max(t, cutoff), end])
     return out
+
+
+_state_ev_cache = {}          # states path -> _fold_records entry over its (t, state) transitions
+
+
+def _state_ev_step(ev, o):
+    if o.get("t") and o.get("state"):
+        ev.append((o["t"], o["state"]))
+    return ev
 
 
 _ACCT_CACHE = {"mtime": -1.0, "val": "", "label": ""}
@@ -24826,6 +24772,28 @@ def _msg_summaries():
     return _msg_sum_cache["map"]
 
 
+_postal_log_cache = {}        # messages.jsonl -> _fold_records entry; every timeline rebuild used to re-parse the whole log
+
+
+def _postal_log_fresh():
+    return {"sent": {}, "execd": {}, "ended": set()}
+
+
+def _postal_log_step(state, o):
+    """One messages.jsonl row of _postal_messages' fold: sent rows by id, exec receipts, ended ids."""
+    sent, execd, ended = state["sent"], state["execd"], state["ended"]
+    if o.get("ev") == "sent" and o.get("id"):
+        sent[o["id"]] = o
+    elif o.get("ev") == "exec" and o.get("id"):
+        execd[o["id"]] = (o.get("t"), o.get("dmid"))   # dmid: the recipient-side delivery mid (relayed mail)
+    elif o.get("ev") == "unexec" and o.get("id"):    # a drain that CLAIMED the mail then rolled back
+        execd.pop(o["id"], None)                     # (postal restore) — it never reached the recipient
+    elif o.get("ev") in ("recall", "bounced") and o.get("id"):
+        ended.add(o["id"])                           # terminally ended: recalled by the sender, or the
+        #                                              bus refused/destroyed it — it can never land now
+    return state
+
+
 def _postal_messages(now, alive_sids, id2name, live_sids=None):
     """Inter-session connectors for the timeline, from the postal log (timeline/messages.jsonl): each
     'sent' row joined to its 'exec' by id → a [sent,exec] arrow between two lanes. File-based (the old
@@ -24835,25 +24803,10 @@ def _postal_messages(now, alive_sids, id2name, live_sids=None):
     host's lane by bare sid, and a connector whose far end matches nothing is dropped by the view's
     lane lookup, exactly like before. `live_sids` = the TRUE live set for the pending flag's
     recipient-liveness leg (alive_sids is the broader LANE set); None skips that leg."""
-    try:
-        lines = (jd.STATE / "timeline" / "messages.jsonl").read_text(errors="replace").splitlines()
-    except OSError:
+    log = _fold_records(_postal_log_cache, jd.STATE / "timeline" / "messages.jsonl", _postal_log_fresh, _postal_log_step)
+    sent, execd, ended = log["sent"], log["execd"], log["ended"]
+    if not sent:
         return []
-    sent, execd, ended = {}, {}, set()
-    for ln in lines:
-        try:
-            o = json.loads(ln)
-        except Exception:
-            continue
-        if o.get("ev") == "sent" and o.get("id"):
-            sent[o["id"]] = o
-        elif o.get("ev") == "exec" and o.get("id"):
-            execd[o["id"]] = (o.get("t"), o.get("dmid"))   # dmid: the recipient-side delivery mid (relayed mail)
-        elif o.get("ev") == "unexec" and o.get("id"):    # a drain that CLAIMED the mail then rolled back
-            execd.pop(o["id"], None)                     # (postal restore) — it never reached the recipient
-        elif o.get("ev") in ("recall", "bounced") and o.get("id"):
-            ended.add(o["id"])                           # terminally ended: recalled by the sender, or the
-            #                                              bus refused/destroyed it — it can never land now
     cutoff, out = now - TL_HORIZON, []
     msgsum = _msg_summaries()                           # {id: Haiku caption} → the timeline shows it over the raw body
     tanchors = _thread_anchors(alive_sids)              # {tid: (parent sid, anchorT, name)} — thread mail's home

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -897,13 +897,39 @@ def _same_window(a, b) -> bool:
     return abs(a - b) <= WINDOW_SLACK
 
 
+def _lines_from_end(p: Path, block: int = 65536):
+    """The file's lines LAST to first, newline-stripped, read backwards in blocks — so a reader that
+    wants the newest record touches the tail of the file, not all of it. Exactly the lines forward
+    iteration would yield: a trailing newline closes the last line rather than opening an empty one."""
+    with open(p, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        pos = f.tell()
+        rest = b""
+        first = True
+        while pos > 0:
+            n = min(block, pos)
+            pos -= n
+            f.seek(pos)
+            data = f.read(n) + rest
+            parts = data.split(b"\n")
+            rest = parts[0]
+            for raw in reversed(parts[1:]):
+                if first:
+                    first = False
+                    if raw == b"" and data.endswith(b"\n"):
+                        continue                      # the newline that closed the last line
+                yield raw.decode("utf-8", "replace")
+        yield rest.decode("utf-8", "replace")
+
+
 def last_state(state_dir: Path, sid: str) -> dict:
+    """The literal last line of states/<sid>.jsonl as a record ({} when absent, blank, or unparseable).
+    Reads the file's tail only (2026-09-03): every caller wanted the newest record and paid a full
+    forward walk of a log that only ever grows — megabytes per call for a long-lived session, on the
+    kernel's push path."""
     p = Path(state_dir) / "states" / (sid + ".jsonl")
     try:
-        line = ""
-        with open(p) as f:
-            for line in f:
-                pass
+        line = next(_lines_from_end(p), "")
         return json.loads(line) if line.strip() else {}
     except (OSError, ValueError):
         return {}
@@ -915,22 +941,20 @@ def last_state_value(state_dir: Path, sid: str) -> str:
     overlay (the boot heal itself appends awaiting:false) — so anything keying on the state tail
     (the boot reconcile's cut-turn detector) must read through the overlays, not the last line."""
     p = Path(state_dir) / "states" / (sid + ".jsonl")
-    val = ""
     try:
-        with open(p) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except ValueError:
-                    continue
-                if isinstance(rec, dict) and "state" in rec:
-                    val = str(rec["state"])
+        for line in _lines_from_end(p):              # newest first; the first STATE record wins
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and "state" in rec:
+                return str(rec["state"])
     except OSError:
         pass
-    return val
+    return ""
 
 
 def last_awaiting(state_dir: Path, sid: str) -> bool | None:

--- a/tests/test_bg_scan_fold.py
+++ b/tests/test_bg_scan_fold.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""The background-task pairing, the timeline's state intervals and postal connectors, and the
+last-state readers stop re-walking whole files (2026-09-03). Profiled live with ~10 sessions, the
+kernel's push loop held a full core, a third of it json-decoding bytes it had already decoded: the
+bg-scan caches (kernel ×2, judge ×1) re-paired a working session's ENTIRE transcript on every appended
+record (one was 180 MB), `_state_intervals` re-read and re-parsed every states log twice per 2 s
+timeline rebuild, `_postal_messages` re-parsed the whole message log per rebuild, and `last_state`
+read a whole log to find its last line. The scan is now a fold over em.fold_records (moved from the
+kernel so the judge shares it); the running-only view forgets terminal tasks behind a tombstone; the
+last-state readers read the tail backwards. Contract: every answer equals the old from-scratch walk.
+Synthetic fixtures only: placeholder ids, invented text."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_bgfold", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_bgfold", os.path.join(BIN, "..", "kernel", "sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+PEER = "11111111-2222-3333-4444-666666666666"
+
+
+def _bump(path):
+    """Make the next write land under a DIFFERENT mtime even on a coarse-clock filesystem."""
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 2))
+
+
+def _append(path, *recs):
+    with open(path, "a") as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+    _bump(path)
+
+
+def _user(text, **kw):
+    r = {"type": "user", "uuid": kw.pop("uuid", "u"), "timestamp": kw.pop("ts", "2026-09-02T10:00:00.000Z"),
+         "message": {"role": "user", "content": text}}
+    r.update(kw)
+    return r
+
+
+def _assistant(blocks, **kw):
+    r = {"type": "assistant", "uuid": kw.pop("uuid", "a"), "timestamp": kw.pop("ts", "2026-09-02T10:00:01.000Z"),
+         "message": {"role": "assistant", "content": blocks}}
+    r.update(kw)
+    return r
+
+
+def _launch(tid, desc):
+    return _assistant([{"type": "tool_use", "id": tid, "name": "Bash",
+                        "input": {"command": "sleep 1", "run_in_background": True, "description": desc}}])
+
+
+def _result(tid, status="completed"):
+    note = ("<task-notification>\n<task-id>%s</task-id>\n<tool-use-id>%s</tool-use-id>\n"
+            "<status>%s</status>\n<summary>%s</summary>\n</task-notification>" % ("b1", tid, status, status))
+    return _user(note, ts="2026-09-02T10:00:05.000Z")
+
+
+class BackgroundTasks(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.p = os.path.join(self.td.name, SID + ".jsonl")
+        for c in (km._bgtasks_cache, km._bgall_cache, jd._BG_SCAN_CACHE):
+            c.clear()
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _steps(self, cache):
+        """Records folded so far, per the fold_records entry (n, last record, state)."""
+        return cache[self.p][0]
+
+    def test_caches_fold_appends_and_keep_their_two_views_apart(self):
+        _append(self.p, _launch("toolu_1", "first job"))
+        self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_1"])
+        self.assertEqual([t["status"] for t in km._bg_scan_all_cached(self.p)], ["running"])
+        _append(self.p, _launch("toolu_2", "second job"), _result("toolu_1"))
+        self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_2"],
+                         "toolu_1 returned → only toolu_2 still runs")
+        every = km._bg_scan_all_cached(self.p)
+        self.assertEqual([(t["id"], t["status"]) for t in every],
+                         [("toolu_1", "completed"), ("toolu_2", "running")])
+        self.assertTrue(every[0].get("endT"), "the return's moment rides the row")
+        self.assertEqual(self._steps(km._bgtasks_cache), 3)
+        self.assertEqual(self._steps(km._bgall_cache), 3)
+
+    def test_only_the_appended_records_are_stepped(self):
+        _append(self.p, _launch("toolu_1", "a"), _launch("toolu_2", "b"))
+        km._bg_scan_cached(self.p)
+        seen = []
+        real = em._bg_step
+
+        def spy(state, o):
+            seen.append(o.get("uuid"))
+            return real(state, o)
+        em._bg_step = spy
+        try:
+            _append(self.p, _result("toolu_2"))
+            self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_1"])
+        finally:
+            em._bg_step = real
+        self.assertEqual(seen, ["u"], "one appended record → one step; the prefix was not re-paired")
+
+    def test_answers_are_snapshots_of_the_fold_state(self):
+        _append(self.p, _launch("toolu_1", "a"))
+        row = km._bg_scan_all_cached(self.p)[0]
+        row["status"] = "tampered"                   # a caller scribbling on its answer...
+        _append(self.p, _launch("toolu_2", "b"))
+        self.assertEqual([t["status"] for t in km._bg_scan_all_cached(self.p)], ["running", "running"],
+                         "...never reaches the fold state the next incremental answer is built from")
+
+    def test_running_only_state_forgets_terminal_tasks_and_dead_dispatches(self):
+        _append(self.p, _launch("toolu_1", "a"),
+                _assistant([{"type": "tool_use", "id": "toolu_sync", "name": "Agent",
+                             "input": {"description": "sync agent", "prompt": "x" * 500}}]),
+                _user([{"type": "tool_result", "tool_use_id": "toolu_sync", "content": "done"}]),
+                _result("toolu_1"))
+        self.assertEqual(km._bg_scan_cached(self.p), [])
+        st = km._bgtasks_cache[self.p][2]
+        self.assertEqual((st["tasks"], st["order"], st["dispatch"], st["done"]), ({}, [], {}, {"toolu_1"}),
+                         "a returned task leaves a tombstone, not a row; a synchronously-acked dispatch leaves nothing")
+        every = km._bg_scan_all_cached(self.p)
+        self.assertEqual([(t["id"], t["status"]) for t in every], [("toolu_1", "completed")],
+                         "the history view keeps the returned task")
+        self.assertEqual(km._bgall_cache[self.p][2]["dispatch"], {})
+
+    def test_a_replayed_ack_after_the_terminal_does_not_resurrect_the_task(self):
+        # a real transcript shape: launch → async ack → terminal notification → the SAME ack again
+        launch = _assistant([{"type": "tool_use", "id": "toolu_ag", "name": "Agent",
+                              "input": {"description": "explore", "prompt": "look around"}}])
+        ack = _user([{"type": "tool_result", "tool_use_id": "toolu_ag", "content": "launched"}],
+                    toolUseResult={"isAsync": True, "status": "async_launched", "description": "explore",
+                                   "taskType": "local_agent"}, uuid="ack-1")
+        _append(self.p, launch, ack)
+        self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_ag"])
+        _append(self.p, _result("toolu_ag"))
+        self.assertEqual(km._bg_scan_cached(self.p), [])
+        _append(self.p, ack)                          # the replay lands AFTER the row was dropped
+        self.assertEqual(km._bg_scan_cached(self.p), [], "a tombstoned id cannot come back as running")
+        self.assertEqual(km._bg_scan_cached(self.p), em._scan_bg_tasks(self.p),
+                         "…and the incremental answer still equals the full walk")
+        self.assertEqual([(t["id"], t["status"]) for t in km._bg_scan_all_cached(self.p)],
+                         [("toolu_ag", "completed")])
+        _append(self.p, launch)                       # a replayed LAUNCH record is ignored the same way
+        self.assertEqual(km._bg_scan_cached(self.p), [])
+        for cache in (km._bgtasks_cache, km._bgall_cache):
+            self.assertEqual(cache[self.p][2]["dispatch"], {},
+                             "neither replay left a dispatch entry behind in either view's state")
+
+    def test_uncached_scan_and_cached_scans_agree(self):
+        _append(self.p, _launch("toolu_1", "a"), _launch("toolu_2", "b"), _result("toolu_2", "failed"))
+        self.assertEqual(em._scan_bg_tasks(self.p), km._bg_scan_cached(self.p))
+        self.assertEqual(em._scan_bg_tasks(self.p, want_all=True), km._bg_scan_all_cached(self.p))
+        self.assertEqual(em._scan_bg_tasks(self.p), em.scan_bg_tasks_cached(self.p, jd._BG_SCAN_CACHE))
+        self.assertEqual(jd._bg_unresolved(self.p), em._scan_bg_tasks(self.p), "the judge's gate reads the same fold")
+
+    def test_rewrite_refolds_from_the_top(self):
+        _append(self.p, _launch("toolu_1", "a"), _launch("toolu_2", "b"))
+        self.assertEqual(len(km._bg_scan_cached(self.p)), 2)
+        with open(self.p, "w") as f:
+            f.write(json.dumps(_launch("toolu_9", "z")) + "\n")
+        _bump(self.p)
+        self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_9"])
+
+    def test_missing_file(self):
+        self.assertEqual(km._bg_scan_cached("/no/such/transcript.jsonl"), [])
+        self.assertEqual(km._bg_scan_all_cached("/no/such/transcript.jsonl"), [])
+
+    def test_a_final_record_without_its_newline_still_counts(self):
+        # the old whole-file walk saw a complete final line with no "\n"; the incremental reader leaves it
+        # unconsumed (torn-write safety), so the fold applies it provisionally — and permanently once the
+        # newline lands, exactly once
+        _append(self.p, _launch("toolu_1", "a"))
+        self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_1"])
+        with open(self.p, "a") as f:
+            f.write(json.dumps(_result("toolu_1")))   # complete record, no newline yet
+        _bump(self.p)
+        self.assertEqual(km._bg_scan_cached(self.p), [], "the terminal record counts even without its newline")
+        self.assertEqual(km._bg_scan_cached(self.p), em._scan_bg_tasks(self.p))
+        self.assertEqual(km._bgtasks_cache[self.p][0], 1, "…but it is not in the cached fold yet")
+        with open(self.p, "a") as f:
+            f.write("\n")
+        _bump(self.p)
+        self.assertEqual(km._bg_scan_cached(self.p), [])
+        self.assertEqual(km._bgtasks_cache[self.p][0], 2, "the newline lands → folded for good, once")
+        self.assertEqual([(t["id"], t["status"]) for t in km._bg_scan_all_cached(self.p)], [("toolu_1", "completed")])
+
+    def test_a_torn_final_record_is_ignored_until_complete(self):
+        _append(self.p, _launch("toolu_1", "a"))
+        km._bg_scan_cached(self.p)
+        with open(self.p, "a") as f:
+            f.write(json.dumps(_result("toolu_1"))[:-20])   # a writer caught mid-append
+        _bump(self.p)
+        self.assertEqual([t["id"] for t in km._bg_scan_cached(self.p)], ["toolu_1"])
+
+
+class TimelineReaders(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd._rebind_state(Path(self.td.name))
+        (jd.STATE / "states").mkdir(parents=True)
+        (jd.STATE / "timeline").mkdir(parents=True)
+        km._state_ev_cache.clear()
+        km._postal_log_cache.clear()
+
+    def tearDown(self):
+        jd._rebind_state(self.saved)
+        self.td.cleanup()
+
+    def test_state_intervals_fold_appended_transitions(self):
+        now = 1_000_000
+        p = jd.STATE / "states" / (SID + ".jsonl")
+        _append(str(p), {"t": now - 300, "state": "working"}, {"t": now - 200, "state": "permission"})
+        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now]],
+                         "an open awaiting interval runs to now")
+        _append(str(p), {"t": now - 100, "state": "working"}, {"awaiting": False})
+        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now - 100]])
+        self.assertEqual(km._state_intervals(SID, "compacting", now), [])
+        self.assertEqual(km._state_ev_cache[str(p)][0], 4, "one fold serves every `want`")
+
+    def test_state_transition_without_its_newline_still_counts(self):
+        now = 1_000_000
+        p = jd.STATE / "states" / (SID + ".jsonl")
+        _append(str(p), {"t": now - 300, "state": "working"})
+        with open(p, "a") as f:
+            f.write(json.dumps({"t": now - 200, "state": "permission"}))
+        _bump(str(p))
+        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now]])
+        self.assertEqual(km._state_ev_cache[str(p)][0], 1, "provisional: not folded into the cache")
+
+    def test_postal_event_without_its_newline_still_counts(self):
+        now = int(time.time())
+        log = jd.STATE / "timeline" / "messages.jsonl"
+        _append(str(log), {"ev": "sent", "id": "m1", "from_id": SID, "to_id": PEER, "t": now - 60, "body": "ping"})
+        with open(log, "a") as f:
+            f.write(json.dumps({"ev": "exec", "id": "m1", "t": now - 30}))
+        _bump(str(log))
+        rows = km._postal_messages(now, {SID, PEER}, {SID: "web", PEER: "api"}, live_sids={SID, PEER})
+        self.assertEqual([(r["id"], r["hasExec"]) for r in rows], [("m1", True)])
+
+    def test_state_intervals_missing_file(self):
+        self.assertEqual(km._state_intervals(SID, "permission", 5), [])
+
+    def test_postal_connectors_fold_the_message_log(self):
+        now = int(time.time())
+        log = jd.STATE / "timeline" / "messages.jsonl"
+        _append(str(log), {"ev": "sent", "id": "m1", "from_id": SID, "to_id": PEER, "t": now - 60, "body": "ping"})
+        names = {SID: "web", PEER: "api"}
+        rows = km._postal_messages(now, {SID, PEER}, names, live_sids={SID, PEER})
+        self.assertEqual([(r["id"], r["hasExec"], r["pending"]) for r in rows], [("m1", False, True)])
+        _append(str(log), {"ev": "exec", "id": "m1", "t": now - 30},
+                {"ev": "sent", "id": "m2", "from_id": PEER, "to_id": SID, "t": now - 20, "body": "pong"},
+                {"ev": "recall", "id": "m2", "t": now - 10})
+        rows = km._postal_messages(now, {SID, PEER}, names, live_sids={SID, PEER})
+        self.assertEqual([(r["id"], r["hasExec"], r["pending"]) for r in rows],
+                         [("m1", True, False), ("m2", False, False)])
+        self.assertEqual(km._postal_log_cache[str(log)][0], 4)
+
+    def test_postal_connectors_missing_log(self):
+        self.assertEqual(km._postal_messages(5, {SID}, {SID: "web"}), [])
+
+
+class LastState(unittest.TestCase):
+    """last_state / last_state_value read the file's TAIL backwards; they must answer exactly what the
+    forward walk did, on every file shape — including lines longer than the read block."""
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        (Path(self.td.name) / "states").mkdir()
+        self.p = Path(self.td.name) / "states" / (SID + ".jsonl")
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    @staticmethod
+    def _forward_last(p):
+        try:
+            line = ""
+            with open(p) as f:
+                for line in f:
+                    pass
+            return json.loads(line) if line.strip() else {}
+        except (OSError, ValueError):
+            return {}
+
+    @staticmethod
+    def _forward_value(p):
+        val = ""
+        try:
+            with open(p) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except ValueError:
+                        continue
+                    if isinstance(rec, dict) and "state" in rec:
+                        val = str(rec["state"])
+        except OSError:
+            pass
+        return val
+
+    def _check(self, text):
+        self.p.write_text(text)
+        self.assertEqual(sb.last_state(self.td.name, SID), self._forward_last(self.p), repr(text[-40:]))
+        self.assertEqual(sb.last_state_value(self.td.name, SID), self._forward_value(self.p), repr(text[-40:]))
+
+    def test_shapes(self):
+        a = json.dumps({"t": 1, "state": "working"})
+        b = json.dumps({"t": 2, "state": "ready"})
+        ov = json.dumps({"awaiting": False})
+        for text in ("", "\n", a, a + "\n", a + "\n" + b, a + "\n" + b + "\n", a + "\n" + b + "\n\n",
+                     a + "\n" + b + "\n" + ov + "\n", a + "\n" + ov + "\n" + ov + "\n",
+                     a + "\n" + "not json\n", "\n\n" + a + "\n", a + "\r\n" + b + "\r\n"):
+            self._check(text)
+
+    def test_lines_longer_than_a_read_block(self):
+        big = json.dumps({"t": 1, "state": "working", "pad": "x" * 200_000})
+        self._check(big + "\n" + json.dumps({"awaiting": True}) + "\n")
+        self._check(json.dumps({"awaiting": True}) + "\n" + big + "\n")
+        self._check(big)
+
+    def test_multibyte_text_across_a_block_boundary(self):
+        rec = json.dumps({"t": 1, "state": "working", "pad": "é" * 70_000}, ensure_ascii=False)
+        self._check(rec + "\n" + json.dumps({"awaiting": True}) + "\n")
+
+    def test_missing_file(self):
+        self.assertEqual(sb.last_state(self.td.name, "nope"), {})
+        self.assertEqual(sb.last_state_value(self.td.name, "nope"), "")
+
+    def test_reads_the_tail_only(self):
+        many = "".join(json.dumps({"t": i, "state": "working", "pad": "y" * 100}) + "\n" for i in range(5000))
+        self.p.write_text(many + json.dumps({"t": 5000, "state": "ready"}) + "\n")
+        real_open = open
+        sizes = []
+
+        class Spy:
+            def __init__(self, f):
+                self.f = f
+
+            def read(self, n=-1):
+                sizes.append(n)
+                return self.f.read(n)
+
+            def __getattr__(self, k):
+                return getattr(self.f, k)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return self.f.__exit__(*a)
+
+        sb.open = lambda *a, **k: Spy(real_open(*a, **k))
+        try:
+            self.assertEqual(sb.last_state(self.td.name, SID)["state"], "ready")
+        finally:
+            del sb.open
+        self.assertLess(sum(sizes), self.p.stat().st_size // 4, "one block from the end, not the file")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Profiled the live kernel with a nonblocking py-spy sample (2026-09-02, ~10 SDK sessions, 4 browsers): the process held one full core, and **96% of GIL time was the `_pusher` thread**, a third of it `json.loads` re-decoding files it had already decoded. Issue 903's `_read_jsonl_incremental` + `_fold_records` (landed since) already retired most of that for the queue ledgers, `_session_meta`, the states/ note readers, and made `_api_error` tail-window. This finishes the set that was still walking whole files on every push:

- **The background-task pairing** (`em._scan_bg_tasks`), behind three `(mtime, size)` caches — the kernel's running-only and history views and the judge's settled gate — each of which re-paired a working session's *entire* transcript on every appended record. One live transcript was 180 MB, so a single streamed line cost three full re-walks.
- **`_state_intervals`** re-read and re-parsed every session's `states/<sid>.jsonl` twice per 2 s timeline rebuild (54 files, 14 MB on the profiled box).
- **`_postal_messages`** re-parsed the whole `timeline/messages.jsonl` per rebuild.
- **`last_state` / `last_state_value`** (15 call sites) read an entire states log to find its last line.

## What

- `_fold_records` **moves to `em.fold_records`** (the kernel keeps `_fold_records = em.fold_records`) so the judge can fold the same way. It also now folds a complete final record that lacks its newline **provisionally** (applied to a copy, never to the cached state, so it is folded for good exactly once when the newline lands): `_read_jsonl_incremental` leaves such a line unconsumed by design, but the whole-file readers being replaced saw it, and without this a terminal notification written without its newline would read as still running. Torn fragments stay ignored.
- `em._scan_bg_tasks` becomes `_bg_fresh` / `_bg_step(state, record)` / `_bg_finish`, and **`em.scan_bg_tasks_cached(path, cache, want_all)`** folds it through the caller's cache. The kernel's two caches and the judge's `_BG_SCAN_CACHE` call it; the uncached `_scan_bg_tasks` is the same fold run from scratch.
  - The running-only state stays the size of the in-flight work: a task that reaches a terminal status is dropped and its id **tombstoned**, and both creation paths (launch record, async ack) and the Agent/Task/Workflow dispatch capture refuse tombstoned ids. That matters: real transcripts replay async acks (same tool-use id, same uuid) *after* the terminal notification, and without the tombstone a dropped row would let the replay resurrect the task as running. A synchronous tool_result also releases its dispatch entry, which used to be retained forever.
  - The history view keeps every row, as its cache already did.
- `_state_intervals` folds the states log into a `(t, state)` list (`_state_ev_cache`); `_postal_messages` folds the message log into `{sent, execd, ended}` (`_postal_log_cache`). Both were the last `read_text()`-per-rebuild readers on the timeline path.
- `last_state` / `last_state_value` read the file's tail backwards in 64 KiB blocks (`_lines_from_end`), answering exactly what the forward walk did on every file shape.

Behavior is unchanged by design; only cost changes.

## Measured

- Across **6,242 real transcripts (1.1 GB)** on the machine that motivated this, the incremental running-only and history answers equal the old full walk's in every file.
- On a live-shaped 60 MB synthetic transcript, the three bg readers' cost for a one-record append went from 0.87 s (three full re-walks) to 5.8 ms.

## Tests

`tests/test_bg_scan_fold.py` (21 tests): the two bg views fold appends and stay independent; only the appended records are stepped (spy on `_bg_step`); answers are snapshots of the fold state; the running-only state forgets terminal tasks and dead dispatches while the history view keeps them; **launch → async ack → terminal → replayed ack, then a replayed launch, resurrects nothing and leaves no dispatch behind**, and the incremental answer equals the full walk; cached and uncached scans and the judge's gate agree; a rewrite re-folds from the top; a complete final record without its newline counts (for the bg pairing, a state transition, and a postal event) and is cached exactly once when the newline lands, while a torn fragment is ignored; `_state_intervals` and `_postal_messages` fold appends; `last_state` / `last_state_value` equal the forward walk on twelve file shapes including CRLF, a 200 KB line, multibyte text across a block boundary, and a spy proving only the tail is read.

Full suite green locally on Python 3.12; the new tests plus the 47 test modules touching these readers also green on 3.10. Reviewed adversarially by GPT-5.6 Sol across several rounds; the tombstone, dispatch-release and newline-less-EOF rules above are its catches, each with a test.

## Not in this PR

`load_goals` stays uncached: callers mutate and CAS-save the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
