### PR TITLE
T237: the comment mark turns yellow only when the reply has landed — the kernel is the one truth

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8737,29 +8737,77 @@ def _comment_thread_row_created(tsid):
     return _comment_created_memo.get(tsid)
 
 
-def _thread_turn_open(tsid, reg, state):
-    """Is the thread's reply still being WORKED ON? The transcript decides, with the chat's own working
-    predicate (_session_working over the event model's turns: the last turn has not ENDED — no end_turn
-    stop, no interrupt, not idle at its tail). The backend's live `state` is only the fallback when the
-    transcript cannot be read (pre-fork, unreadable): it can flap to ""/waiting between the records of
-    one turn and linger "working" for a push after the final record — neither is the landing event
-    (T237, the user 2026-09-03: the mark went yellow while the thread had only started responding)."""
+_thread_parse_warned = set()                        # (tsid, error) pairs already shouted — once per cause
+
+
+def _turn_is_meta(turn):
+    """A turn with nothing of the exchange in it: a compaction boundary the CLI wrote (mid-reply, before
+    the assistant resumed) or a slash-command-only turn. _finalize_turn marks these ENDED, but neither is
+    a reply landing — skip them when reading whether the thread's reply is done."""
+    atoms = turn.get("atoms") or []
+    if any(a.get("type") == "assistant" for a in atoms):
+        return False
+    first = atoms[0] if atoms else {}
+    return bool((first.get("type") == "system" and first.get("subtype") == "compact_boundary")
+                or (atoms and all(a.get("command") for a in atoms)))
+
+
+def _turn_landed(turn):
+    """(landed, interrupted): the reply RECORD is in — an assistant atom stopped with end_turn — or the
+    CLI's own interrupt record closed the turn (the user stopped it; nothing more is coming)."""
+    atoms = turn.get("atoms") or []
+    tail = next((a for a in reversed(atoms) if not a.get("command") and a.get("type") != "idle"), None)
+    if tail is not None and em.is_interrupt_record(tail):
+        return True, True
+    last_sr = None
+    for a in atoms:
+        if a.get("type") == "assistant":
+            last_sr = (a.get("message") or {}).get("stop_reason")
+    return last_sr in em.END_STOPS, False
+
+
+def _thread_turn_read(tsid, reg, state):
+    """(turn_open, interrupted) for the thread — is its reply still being WORKED ON, and did the user's
+    interrupt close it? The transcript decides: the newest turn that carries the exchange (compaction
+    boundaries and slash-command turns skipped) has LANDED iff its assistant stopped with end_turn or the
+    CLI's interrupt record closed it — whatever the backend's state still says. An unlanded turn is open
+    while the backend is busy, else per the chat's own working read (_session_working: idle-terminated or
+    suspended → dead, not owed). The backend's live `state` alone decides only when there is nothing to
+    read yet (pre-fork, no turns): it flaps to ""/waiting between the records of one turn and lingers
+    "working" for a push after the final record — neither is the landing event (T237, the user
+    2026-09-03: the mark went yellow while the thread had only started responding)."""
     if reg.get("forkOf"):
-        return True                                 # the fork hasn't landed: the first reply is ahead
+        return True, False                          # the fork hasn't landed: the first reply is ahead
     busy_state = state in ("working", "retrying", "compacting")
     try:
         path = _thread_transcript_path(reg, tsid)
         session = _parse(path, tsid, int(time.time())) if path else None   # the real (mtime-cached) parse — _parse_cached never parses
-    except Exception:
+    except Exception as e:                          # LOUD, then the backend's word: a silent fallback would re-create the very symptom
+        key = (tsid, repr(e)[:200])
+        if key not in _thread_parse_warned:
+            _thread_parse_warned.add(key)
+            print("[comments] thread %s: transcript parse failed (%r) — reading the reply state from the backend instead"
+                  % (tsid[:8], e), file=sys.stderr)
         session = None
     turns = (session or {}).get("turns") or []
     if not turns:
-        return busy_state                           # nothing to read yet: the backend's word is all there is
-    if turns[-1].get("ended"):
-        return False                                # the end_turn / interrupt record IS the landing, whatever the backend still says
+        return busy_state, False                    # nothing to read yet: the backend's word is all there is
+    at = next((i for i in range(len(turns) - 1, -1, -1) if not _turn_is_meta(turns[i])), None)
+    if at is None:
+        return busy_state, False                    # only boundaries / commands so far
+    landed, interrupted = _turn_landed(turns[at])
+    if landed:
+        return False, interrupted                   # the reply RECORD is in (or the user stopped it), whatever the backend still says
     if busy_state:
-        return True                                 # mid-turn: tool calls, intermediate text — the reply is still coming
-    return bool(_session_working(turns))            # backend quiet on an unended turn: the chat's own read (idle-terminated / suspended → dead, not owed)
+        return True, False                          # mid-turn: tool calls, intermediate text, a compaction — the reply is still coming
+    # backend quiet on an unlanded turn: the chat's own working read, over the turns up to the exchange
+    # turn — a trailing compaction boundary is bookkeeping, not an ended reply
+    return bool(_session_working(turns[:at + 1])), False
+
+
+def _thread_turn_open(tsid, reg, state):
+    """Is the thread's reply still being worked on? (_thread_turn_read's first half.)"""
+    return _thread_turn_read(tsid, reg, state)[0]
 
 
 def _agent_landed_after(events, msgs, seen):
@@ -8826,9 +8874,11 @@ def _comments_frame(sid, tmux=None):
         seen = int(th.get("lastSeenT") or 0)
         events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
         reg = _thread_reg(tsid)
-        turn_open = status == "open" and _thread_turn_open(tsid, reg, state)
+        turn_open, interrupted = _thread_turn_read(tsid, reg, state) if status == "open" else (False, False)
         unread = (not turn_open) and _agent_landed_after(events, msgs, seen)
-        reply_owed = status == "open" and (turn_open or not msgs or msgs[-1]["who"] == "you")
+        # owed: the turn is in progress, nothing has landed yet, or the user's message is the newest — unless
+        # that newest "message" is the CLI's own interrupt record (the user stopped it: nothing more is owed)
+        reply_owed = status == "open" and (turn_open or not msgs or (msgs[-1]["who"] == "you" and not interrupted))
         # (T102: the push-count settle — settledPushes — is RETIRED. The client's pulse is exchange-
         # scoped now: latched at the send gesture, cleared by the reply RECORD arriving in msgs; the
         # frame's msgs already carry that event, so no per-push counter rides here anymore.)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8737,10 +8737,55 @@ def _comment_thread_row_created(tsid):
     return _comment_created_memo.get(tsid)
 
 
+def _thread_turn_open(tsid, reg, state):
+    """Is the thread's reply still being WORKED ON? The transcript decides, with the chat's own working
+    predicate (_session_working over the event model's turns: the last turn has not ENDED — no end_turn
+    stop, no interrupt, not idle at its tail). The backend's live `state` is only the fallback when the
+    transcript cannot be read (pre-fork, unreadable): it can flap to ""/waiting between the records of
+    one turn and linger "working" for a push after the final record — neither is the landing event
+    (T237, the user 2026-09-03: the mark went yellow while the thread had only started responding)."""
+    if reg.get("forkOf"):
+        return True                                 # the fork hasn't landed: the first reply is ahead
+    busy_state = state in ("working", "retrying", "compacting")
+    try:
+        path = _thread_transcript_path(reg, tsid)
+        session = _parse(path, tsid, int(time.time())) if path else None   # the real (mtime-cached) parse — _parse_cached never parses
+    except Exception:
+        session = None
+    turns = (session or {}).get("turns") or []
+    if not turns:
+        return busy_state                           # nothing to read yet: the backend's word is all there is
+    if turns[-1].get("ended"):
+        return False                                # the end_turn / interrupt record IS the landing, whatever the backend still says
+    if busy_state:
+        return True                                 # mid-turn: tool calls, intermediate text — the reply is still coming
+    return bool(_session_working(turns))            # backend quiet on an unended turn: the chat's own read (idle-terminated / suspended → dead, not owed)
+
+
+def _agent_landed_after(events, msgs, seen):
+    """Agent content newer than the read watermark, read from the projection the popover RENDERS: the
+    events when it has them (assistant/tool events after the cut), else the msgs projection; both
+    empty (the popover holds its loader) → nothing is unread."""
+    if events:
+        for e in events:
+            if e.get("kind") in ("assistant", "tool") and int(em.parse_z(e.get("ts")) or 0) > seen:
+                return True
+        return False
+    return any(m["who"] == "agent" and m["t"] > seen for m in msgs)
+
+
 def _comments_frame(sid, tmux=None):
     """The chat pane's {type:"comments"} frame for parent session `sid`, or None when it has never
     had a thread. Built per push for sessions WITH a store (few) — _send_client's dedup keeps an
-    unchanged frame off the wire."""
+    unchanged frame off the wire.
+
+    Two per-thread bits carry the mark's colour, and the kernel is their ONE truth (T237, the user
+    2026-09-03, twice): `unread` — yellow — means "a FINISHED reply you have not seen": the thread's
+    turn has ended (_thread_turn_open false) AND agent content newer than lastSeenT exists in the
+    projection the popover renders. `replyOwed` — the green in-flight wash — means a reply is still
+    owed: the thread has no exchange yet, the user's message is the newest, or the turn is in progress.
+    Neither is a client-side latch or a timer: an intermediate record of a multi-record turn flips
+    nothing; the end_turn record flips both in the same frame the popover can show the reply."""
     p = _comments_path(sid)
     if not p.exists():
         return None
@@ -8779,9 +8824,11 @@ def _comments_frame(sid, tmux=None):
         msgs = [] if status == "promoted" else _thread_messages(
             tsid, str(th.get("cutUuid") or ""), floor_t=(0 if th.get("cutUuid") else int(th.get("createdT") or 0)))
         seen = int(th.get("lastSeenT") or 0)
-        unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
         reg = _thread_reg(tsid)
+        turn_open = status == "open" and _thread_turn_open(tsid, reg, state)
+        unread = (not turn_open) and _agent_landed_after(events, msgs, seen)
+        reply_owed = status == "open" and (turn_open or not msgs or msgs[-1]["who"] == "you")
         # (T102: the push-count settle — settledPushes — is RETIRED. The client's pulse is exchange-
         # scoped now: latched at the send gesture, cleared by the reply RECORD arriving in msgs; the
         # frame's msgs already carry that event, so no per-push counter rides here anymore.)
@@ -8806,7 +8853,8 @@ def _comments_frame(sid, tmux=None):
                         "name": th.get("name") or "", "color": th.get("color") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
-                        "unread": unread, "promotedName": th.get("promotedName") or "",
+                        "unread": unread, "replyOwed": reply_owed,   # yellow / green — see the docstring (T237)
+                        "promotedName": th.get("promotedName") or "",
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
                         "sinceEpoch": since_ms,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8681,12 +8681,12 @@ def _thread_messages(tsid, cut_uuid, floor_t=0):
             txt = _comment_msg_text(r)
             if r.get("type") == "user" and txt.lstrip().startswith("<task-notification>"):
                 txt = ""                            # harness bookkeeping for the AGENT (a parent bg task died
-            if r.get("type") == "user" and (em.COMMAND_NAME_ANY_RE.search(txt) or em.LOCAL_STDOUT_RE.match(txt)
-                                            or txt.lstrip().startswith("<local-command-caveat>")):
-                txt = ""                            # a slash command's invocation/output wrapper: the CLI's own
-                                                    # bookkeeping, not something the user SAID — it must not read as
-                                                    # "the user's message is newest" and owe a reply (T237 review)
                 #                                     with the fork) — never the user's own words (2026-08-17)
+            if r.get("type") == "user" and em.CMD_WRAP_RE.match(txt):
+                txt = ""                            # a slash command's invocation/output wrapper (the record BEGINS
+                                                    # with one — the event model's own anchored test; prose that merely
+                                                    # quotes a tag is the user's message): the CLI's bookkeeping, not
+                                                    # something the user SAID — it must not owe a reply (T237 review)
             if txt and txt != boot_nudge and not (r.get("type") == "user" and "<!-- romp-" in txt):
                 rows.append({"who": "you" if r.get("type") == "user" else "agent",
                              "text": txt[:4000],
@@ -8757,12 +8757,17 @@ def _turn_is_meta(turn):
                 or (atoms and all(a.get("command") for a in atoms)))
 
 
-def _turn_landed(turn):
+def _turn_landed(turn, cut_t=0.0):
     """(landed, interrupted): the reply RECORD is in — an assistant atom stopped with end_turn — or the
-    CLI's own interrupt record closed the turn (the user stopped it; nothing more is coming)."""
+    CLI's own interrupt record closed the turn (the user stopped it; nothing more is coming). `cut_t` is
+    the backend's newest machineCut stamp (_last_machine_cut): an interrupt record at or before it is a
+    cut ROMP made and is resuming (crash / restart), not the user's stop — the turn stays in progress
+    (T237 review: otherwise the mark flapped yellow → green → yellow across every resume)."""
     atoms = turn.get("atoms") or []
     tail = next((a for a in reversed(atoms) if not a.get("command") and a.get("type") != "idle"), None)
     if tail is not None and em.is_interrupt_record(tail):
+        if cut_t and cut_t >= float(tail.get("t") or 0):
+            return False, False                     # romp's own cut, being resumed — nothing landed, nobody stopped it
         return True, True
     last_sr = None
     for a in atoms:
@@ -8802,7 +8807,7 @@ def _thread_turn_read(tsid, reg, state):
     at = next((i for i in range(len(turns) - 1, -1, -1) if not _turn_is_meta(turns[i])), None)
     if at is None:
         return busy_state, False, turns             # only boundaries / commands so far
-    landed, interrupted = _turn_landed(turns[at])
+    landed, interrupted = _turn_landed(turns[at], _last_machine_cut(tsid)[0])
     if landed:
         return False, interrupted, turns            # the reply RECORD is in (or the user stopped it), whatever the backend still says
     if busy_state:
@@ -8849,6 +8854,8 @@ def _agent_landed_after(events, msgs, seen):
     empty (the popover holds its loader) → nothing is unread."""
     if events:
         for e in events:
+            if e.get("command") or e.get("interruptSettle"):
+                continue                            # a slash command's confirmation / the interrupt's null settle: not a reply
             if e.get("kind") in ("assistant", "tool") and int(em.parse_z(e.get("ts")) or 0) > seen:
                 return True
         return False
@@ -8909,10 +8916,17 @@ def _comments_frame(sid, tmux=None):
         reg = _thread_reg(tsid)
         turn_open, interrupted, turns = _thread_turn_read(tsid, reg, state) if status == "open" else (False, False, [])
         unread = (not turn_open) and _agent_landed_after(events, msgs, seen)
-        # owed: the turn is in progress, the FRESH thread has no exchange yet, or the user's message is the
-        # newest — unless that newest "message" is the CLI's own interrupt record (the user stopped it)
-        reply_owed = status == "open" and (turn_open
-                                           or (not msgs and _thread_owes_first_reply(tsid, reg, th, turns))
+        queued = 0                                  # sends the backend HOLDS (a follow-up typed mid-turn waits for the
+        if be and status == "open" and hasattr(be, "pending_queued"):   # turn to end before it is even written) —
+            try:                                    # owed, and not yet in any projection (T237 review)
+                queued = len(be.pending_queued(tsid) or [])
+            except Exception:
+                queued = 0
+        owes_first = status == "open" and not msgs and _thread_owes_first_reply(tsid, reg, th, turns)
+        unreachable = status == "open" and not msgs and not owes_first and not reg.get("forkOf")
+        # owed: the turn is in progress, a send is held, the FRESH thread has no exchange yet, or the user's
+        # message is the newest — unless that newest "message" is the CLI's own interrupt record
+        reply_owed = status == "open" and (turn_open or queued > 0 or owes_first
                                            or (bool(msgs) and msgs[-1]["who"] == "you" and not interrupted))
         # (T102: the push-count settle — settledPushes — is RETIRED. The client's pulse is exchange-
         # scoped now: latched at the send gesture, cleared by the reply RECORD arriving in msgs; the
@@ -8939,6 +8953,8 @@ def _comments_frame(sid, tmux=None):
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
                         "unread": unread, "replyOwed": reply_owed,   # yellow / green — see the docstring (T237)
+                        "queued": queued,                              # sends the backend holds, not yet in any projection
+                        "unreachable": unreachable or None,            # a broken thread (missing transcript / lost cut): owes nothing
                         "promotedName": th.get("promotedName") or "",
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
@@ -21652,6 +21668,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                                            "uuid": a.get("uuid"), "ts": ts})
                             continue
                         ev = {"kind": "assistant", "md": txt, "uuid": a.get("uuid"), "ts": ts}
+                        if a.get("command"):
+                            ev["command"] = True    # a slash command's own output (<local-command-stdout>), not a reply (T237)
                         sp = _space_paths(txt, sid, a.get("uuid"))
                         if sp:
                             ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8943,10 +8943,19 @@ def _comments_frame(sid, tmux=None):
             except Exception:
                 live = []
             if live:
-                tx_user = {t for tr in turns for a in (tr.get("atoms") or []) for t in _atom_user_texts(a)}
+                # an echo has LANDED when a user record written at or after its own send carries its text —
+                # never any earlier record: a fork copies the parent's history, and "ok" / "go ahead" / a
+                # deliberate re-send repeat earlier texts, which read as "already in the transcript" and hid a
+                # send the CLI still held (round-5 review). A `dropped` echo (the backend adjudicated the send
+                # LOST — a reconnect with it in flight; the popover shows "never delivered") owes nothing.
+                user_atoms = [a for tr in turns for a in (tr.get("atoms") or []) if a.get("type") == "user"]
+                def _landed(e):
+                    et = (e.get("_echo_text") or "").strip()
+                    since = float(e.get("t") or 0) - 2                 # the send's own time, a little skew allowed
+                    return any(et in _atom_user_texts(a) for a in user_atoms if float(a.get("t") or 0) >= since)
                 floor = _human_turn_floor({"turns": turns}) if turns else 0
                 held = [a for a in live if (a.get("_echo_text") or "").strip() and not a.get("command")
-                        and (a.get("_echo_text") or "").strip() not in tx_user and not _echo_overtaken(a, floor)]
+                        and not a.get("dropped") and not _landed(a) and not _echo_overtaken(a, floor)]
                 queued = max(queued, len(held))
         # the newest record the projection shows (or the transcript holds): the client's "did the transcript
         # move?" datum, independent of the 80-event / 40-message caps on the shipped projections

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8764,14 +8764,23 @@ def _turn_landed(turn, cut_t=0.0):
     cut ROMP made and is resuming (crash / restart), not the user's stop — the turn stays in progress
     (T237 review: otherwise the mark flapped yellow → green → yellow across every resume)."""
     atoms = turn.get("atoms") or []
-    tail = next((a for a in reversed(atoms) if not a.get("command") and a.get("type") != "idle"), None)
+    # the CLI's null settle ("No response requested.", model "<synthetic>") follows every stop record it
+    # writes — the same signals _interrupt_settle reads; it is part of the stop, never the reply, so the tail
+    # and the stop reason look past it (round-4 review: with the settle as tail the machineCut guard was
+    # never reached and the settle's own end_turn read as a landing)
+    def _settle(a):
+        if a.get("type") != "assistant":
+            return False
+        m = a.get("message") or {}
+        return m.get("model") == "<synthetic>" or (a.get("text") or "").strip() == "No response requested."
+    tail = next((a for a in reversed(atoms) if not a.get("command") and a.get("type") != "idle" and not _settle(a)), None)
     if tail is not None and em.is_interrupt_record(tail):
         if cut_t and cut_t >= float(tail.get("t") or 0):
             return False, False                     # romp's own cut, being resumed — nothing landed, nobody stopped it
         return True, True
     last_sr = None
     for a in atoms:
-        if a.get("type") == "assistant":
+        if a.get("type") == "assistant" and not _settle(a):
             last_sr = (a.get("message") or {}).get("stop_reason")
     return last_sr in em.END_STOPS, False
 
@@ -8916,12 +8925,34 @@ def _comments_frame(sid, tmux=None):
         reg = _thread_reg(tsid)
         turn_open, interrupted, turns = _thread_turn_read(tsid, reg, state) if status == "open" else (False, False, [])
         unread = (not turn_open) and _agent_landed_after(events, msgs, seen)
-        queued = 0                                  # sends the backend HOLDS (a follow-up typed mid-turn waits for the
-        if be and status == "open" and hasattr(be, "pending_queued"):   # turn to end before it is even written) —
-            try:                                    # owed, and not yet in any projection (T237 review)
-                queued = len(be.pending_queued(tsid) or [])
+        # sends the backend has taken but the transcript does not hold yet — owed, and in no projection.
+        # Two windows, one number: the backend's queue (a follow-up typed mid-turn waits there until the
+        # turn ends) and the fed-but-unwritten send (popped to the CLI, which writes its record at its next
+        # boundary). The backend's own INPUT ECHO atom spans both — it lives from the send until the record
+        # lands (prune_live) — so count echoes the way the chat's queued indicator does (build_session:
+        # not already in the transcript's user texts, not overtaken by a later human turn, never a slash
+        # command's echo, which is consumed without a reply) — the same fold, not a twin (round-3/4 review).
+        queued = 0
+        if be and status == "open":
+            try:
+                queued = len(be.pending_queued(tsid) or []) if hasattr(be, "pending_queued") else 0
             except Exception:
                 queued = 0
+            try:
+                live = be.live_atoms(tsid) if hasattr(be, "live_atoms") else []
+            except Exception:
+                live = []
+            if live:
+                tx_user = {t for tr in turns for a in (tr.get("atoms") or []) for t in _atom_user_texts(a)}
+                floor = _human_turn_floor({"turns": turns}) if turns else 0
+                held = [a for a in live if (a.get("_echo_text") or "").strip() and not a.get("command")
+                        and (a.get("_echo_text") or "").strip() not in tx_user and not _echo_overtaken(a, floor)]
+                queued = max(queued, len(held))
+        # the newest record the projection shows (or the transcript holds): the client's "did the transcript
+        # move?" datum, independent of the 80-event / 40-message caps on the shipped projections
+        last_uuid = ((events[-1].get("uuid") if events else None)
+                     or next((a.get("uuid") for tr in reversed(turns) for a in reversed(tr.get("atoms") or []) if a.get("uuid")), None)
+                     or "")
         owes_first = status == "open" and not msgs and _thread_owes_first_reply(tsid, reg, th, turns)
         unreachable = status == "open" and not msgs and not owes_first and not reg.get("forkOf")
         # owed: the turn is in progress, a send is held, the FRESH thread has no exchange yet, or the user's
@@ -8953,7 +8984,8 @@ def _comments_frame(sid, tmux=None):
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
                         "unread": unread, "replyOwed": reply_owed,   # yellow / green — see the docstring (T237)
-                        "queued": queued,                              # sends the backend holds, not yet in any projection
+                        "queued": queued,                              # sends the backend holds or has fed, not yet in the transcript
+                        "lastUuid": last_uuid,                         # the newest record shown/held — the client's cap-proof "transcript moved" datum
                         "unreachable": unreachable or None,            # a broken thread (missing transcript / lost cut): owes nothing
                         "promotedName": th.get("promotedName") or "",
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8681,6 +8681,11 @@ def _thread_messages(tsid, cut_uuid, floor_t=0):
             txt = _comment_msg_text(r)
             if r.get("type") == "user" and txt.lstrip().startswith("<task-notification>"):
                 txt = ""                            # harness bookkeeping for the AGENT (a parent bg task died
+            if r.get("type") == "user" and (em.COMMAND_NAME_ANY_RE.search(txt) or em.LOCAL_STDOUT_RE.match(txt)
+                                            or txt.lstrip().startswith("<local-command-caveat>")):
+                txt = ""                            # a slash command's invocation/output wrapper: the CLI's own
+                                                    # bookkeeping, not something the user SAID — it must not read as
+                                                    # "the user's message is newest" and owe a reply (T237 review)
                 #                                     with the fork) — never the user's own words (2026-08-17)
             if txt and txt != boot_nudge and not (r.get("type") == "user" and "<!-- romp-" in txt):
                 rows.append({"who": "you" if r.get("type") == "user" else "agent",
@@ -8767,17 +8772,19 @@ def _turn_landed(turn):
 
 
 def _thread_turn_read(tsid, reg, state):
-    """(turn_open, interrupted) for the thread — is its reply still being WORKED ON, and did the user's
-    interrupt close it? The transcript decides: the newest turn that carries the exchange (compaction
-    boundaries and slash-command turns skipped) has LANDED iff its assistant stopped with end_turn or the
-    CLI's interrupt record closed it — whatever the backend's state still says. An unlanded turn is open
-    while the backend is busy, else per the chat's own working read (_session_working: idle-terminated or
-    suspended → dead, not owed). The backend's live `state` alone decides only when there is nothing to
-    read yet (pre-fork, no turns): it flaps to ""/waiting between the records of one turn and lingers
-    "working" for a push after the final record — neither is the landing event (T237, the user
-    2026-09-03: the mark went yellow while the thread had only started responding)."""
+    """(turn_open, interrupted, turns) for the thread — is its reply still being WORKED ON, did the user's
+    interrupt close it, and what the transcript held (the parsed turns; [] when nothing could be read).
+    The transcript decides: the newest turn that carries the exchange (compaction boundaries and
+    slash-command turns skipped) has LANDED iff its assistant stopped with end_turn or the CLI's
+    interrupt record closed it — whatever the backend's state still says. An unlanded turn is open while
+    the backend is busy, else per the chat's own working read (_session_working: idle-terminated or
+    suspended → dead, not owed — the idle atoms a stop mints after a trailing compaction boundary fold
+    into THAT turn, so the read looks there too). The backend's live `state` alone decides only when
+    there is nothing to read yet (pre-fork, no turns): it flaps to ""/waiting between the records of one
+    turn and lingers "working" for a push after the final record — neither is the landing event (T237,
+    the user 2026-09-03: the mark went yellow while the thread had only started responding)."""
     if reg.get("forkOf"):
-        return True, False                          # the fork hasn't landed: the first reply is ahead
+        return True, False, []                      # the fork hasn't landed: the first reply is ahead
     busy_state = state in ("working", "retrying", "compacting")
     try:
         path = _thread_transcript_path(reg, tsid)
@@ -8791,23 +8798,49 @@ def _thread_turn_read(tsid, reg, state):
         session = None
     turns = (session or {}).get("turns") or []
     if not turns:
-        return busy_state, False                    # nothing to read yet: the backend's word is all there is
+        return busy_state, False, []                # nothing to read yet: the backend's word is all there is
     at = next((i for i in range(len(turns) - 1, -1, -1) if not _turn_is_meta(turns[i])), None)
     if at is None:
-        return busy_state, False                    # only boundaries / commands so far
+        return busy_state, False, turns             # only boundaries / commands so far
     landed, interrupted = _turn_landed(turns[at])
     if landed:
-        return False, interrupted                   # the reply RECORD is in (or the user stopped it), whatever the backend still says
+        return False, interrupted, turns            # the reply RECORD is in (or the user stopped it), whatever the backend still says
     if busy_state:
-        return True, False                          # mid-turn: tool calls, intermediate text, a compaction — the reply is still coming
-    # backend quiet on an unlanded turn: the chat's own working read, over the turns up to the exchange
-    # turn — a trailing compaction boundary is bookkeeping, not an ended reply
-    return bool(_session_working(turns[:at + 1])), False
+        return True, False, turns                   # mid-turn: tool calls, intermediate text, a compaction — the reply is still coming
+    # backend quiet on an unlanded turn: the chat's own working read. A trailing compaction boundary is
+    # bookkeeping, not an ended reply — but the idle atoms a stop mints AFTER it fold into that boundary
+    # turn, so an idle tail there means the turn died idle-terminated: dead, not owed (T237 review)
+    tail = [a for t in turns[at + 1:] for a in (t.get("atoms") or []) if not a.get("command")]
+    if tail and tail[-1].get("type") == "idle":
+        return False, False, turns
+    return bool(_session_working(turns[:at + 1])), False, turns
 
 
 def _thread_turn_open(tsid, reg, state):
-    """Is the thread's reply still being worked on? (_thread_turn_read's first half.)"""
+    """Is the thread's reply still being worked on? (_thread_turn_read's first value.)"""
     return _thread_turn_read(tsid, reg, state)[0]
+
+
+_thread_unreadable_warned = set()
+
+
+def _thread_owes_first_reply(tsid, reg, th, turns):
+    """An open thread with NO exchange yet owes its first reply only while that is the fresh state — the
+    fork pending (forkOf), or a transcript that reads and holds the cut with nothing after it. A MISSING
+    or unreadable transcript, or one the cut is not in, is a broken thread: shout once, owe nothing —
+    a green wash promising a reply that will never come is the lie this change exists to end."""
+    if reg.get("forkOf"):
+        return True
+    cut = str(th.get("cutUuid") or "")
+    if turns and (not cut or any(a.get("uuid") == cut for t in turns for a in (t.get("atoms") or []))):
+        return True
+    key = (tsid, "missing" if not turns else "cut-missing")
+    if key not in _thread_unreadable_warned:
+        _thread_unreadable_warned.add(key)
+        print("[comments] thread %s: %s — its mark owes no reply (open, but nothing can land)"
+              % (tsid[:8], "transcript missing or unreadable" if not turns else "cut record %s not in its transcript" % cut[:8]),
+              file=sys.stderr)
+    return False
 
 
 def _agent_landed_after(events, msgs, seen):
@@ -8874,11 +8907,13 @@ def _comments_frame(sid, tmux=None):
         seen = int(th.get("lastSeenT") or 0)
         events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
         reg = _thread_reg(tsid)
-        turn_open, interrupted = _thread_turn_read(tsid, reg, state) if status == "open" else (False, False)
+        turn_open, interrupted, turns = _thread_turn_read(tsid, reg, state) if status == "open" else (False, False, [])
         unread = (not turn_open) and _agent_landed_after(events, msgs, seen)
-        # owed: the turn is in progress, nothing has landed yet, or the user's message is the newest — unless
-        # that newest "message" is the CLI's own interrupt record (the user stopped it: nothing more is owed)
-        reply_owed = status == "open" and (turn_open or not msgs or (msgs[-1]["who"] == "you" and not interrupted))
+        # owed: the turn is in progress, the FRESH thread has no exchange yet, or the user's message is the
+        # newest — unless that newest "message" is the CLI's own interrupt record (the user stopped it)
+        reply_owed = status == "open" and (turn_open
+                                           or (not msgs and _thread_owes_first_reply(tsid, reg, th, turns))
+                                           or (bool(msgs) and msgs[-1]["who"] == "you" and not interrupted))
         # (T102: the push-count settle — settledPushes — is RETIRED. The client's pulse is exchange-
         # scoped now: latched at the send gesture, cleared by the reply RECORD arriving in msgs; the
         # frame's msgs already carry that event, so no per-push counter rides here anymore.)

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -372,6 +372,146 @@ class ThreadProjection(CommentBase):
         fr = km._comments_frame(PARENT)
         self.assertFalse(fr["threads"][0]["unread"])
 
+    # ── T237 (the user 2026-09-03, twice): the mark turns yellow only when the reply has LANDED ────────
+    # yellow = a FINISHED reply you have not seen. The kernel is the one truth: `unread` keys on the
+    # thread's turn having ENDED (the event model's own turn-end — the chat's working predicate, never
+    # the backend's flapping state alone) plus agent content newer than the watermark in whichever
+    # projection the popover renders (events, else msgs); `replyOwed` says a reply is still owed (the
+    # user's message is newest, the turn is in progress, or the thread has no exchange yet) — the
+    # client's green wash keys on that, not on a gesture latch it can lose.
+    class _State:
+        """A backend stub reporting one live state — with the reads the frame's parse path makes
+        (pending_cut / session_since / session_meta), so the transcript is genuinely parsed."""
+        def __init__(self, st):
+            self.st = st
+        def session_state(self, sid):
+            return self.st
+        def launch_error(self, sid):
+            return None
+        def pending_cut(self, sid):
+            return ""
+        def owns(self, sid):
+            return False
+        def session_since(self, sid):
+            return 0
+        def session_meta(self, sid):
+            return {}
+        def __getattr__(self, name):              # any other backend read the parse path grows: neutral, never a crash
+            return lambda *a, **k: None
+
+    def _thread_side(self, *tail):
+        t = self.now - 500
+        return [uline(t, "how should the retry loop back off?", "u1"),
+                aline(t + 5, "Use exponential backoff with a jitter of ten percent.", "a1", parent="u1"),
+                uline(t + 100, km._comment_first_message("exponential backoff", "Why jitter at all?"),
+                      "cu1", parent="a1")] + list(tail)
+
+    def _frame_thread(self, records, state=""):
+        self._write(THREAD, records)
+        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear()
+        km._sdk = lambda: self._State(state)
+        return km._comments_frame(PARENT)["threads"][0]
+
+    def _tool_result(self, t, uuid, parent, tool_uuid):
+        return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+                "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_" + tool_uuid,
+                                                          "content": "the file's contents"}]}}
+
+    def _partial_text(self, t, text, uuid, parent):
+        """An intermediate prose block of a turn that goes on to call a tool — stop_reason tool_use."""
+        return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+                "message": {"role": "assistant", "stop_reason": "tool_use",
+                            "content": [{"type": "text", "text": text},
+                                        {"type": "tool_use", "id": "tu_" + uuid, "name": "Read", "input": {}}]}}
+
+    def test_a_partial_turn_is_not_unread_and_a_reply_is_still_owed(self):
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        # (i) an assistant record lands while the turn is in progress — an intermediate text block that
+        # goes on to a tool call: NOT a landed reply, whatever the backend's state says
+        th = self._frame_thread(self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1")),
+                                state="working")
+        self.assertFalse(th["unread"], "an intermediate record is not a finished reply")
+        self.assertTrue(th["replyOwed"], "the reply is still being worked on")
+        # (vi) the backend's state flaps to "" between records — the transcript's open turn still holds busy
+        th = self._frame_thread(self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
+                                                  self._tool_result(t + 112, "cr1", "cp1", "cp1")), state="")
+        self.assertFalse(th["unread"])
+        self.assertTrue(th["replyOwed"], "a state flap between records must not drop the in-flight wash")
+        # the turn ENDS (end_turn) — the reply has landed: yellow now, owed no more
+        th = self._frame_thread(self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
+                                                  self._tool_result(t + 112, "cr1", "cp1", "cp1"),
+                                                  aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cr1")),
+                                state="")
+        self.assertTrue(th["unread"], "the finished reply is newer than the watermark")
+        self.assertFalse(th["replyOwed"])
+
+    def test_a_multi_record_turn_flips_unread_exactly_once_at_its_end(self):
+        # (iii) tool_use → tool_result → final text: unread stays False through the partials, True at the end
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        steps = [tline(t + 110, "ct1", "cu1"),
+                 self._tool_result(t + 112, "cr1", "ct1", "ct1"),
+                 aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cr1")]
+        flips = []
+        for i in range(1, len(steps) + 1):
+            th = self._frame_thread(self._thread_side(*steps[:i]), state="working" if i < len(steps) else "waiting")
+            flips.append(th["unread"])
+        self.assertEqual(flips, [False, False, True])
+
+    def test_the_transcripts_turn_end_is_the_landing_not_the_backends_state(self):
+        # the chat's own working predicate decides: an end_turn record IS the landing even while the
+        # backend still reports the turn in flight for a push; an open turn stays busy even when the
+        # backend already says waiting
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        th = self._frame_thread(self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1")),
+                                state="working")
+        self.assertTrue(th["unread"]); self.assertFalse(th["replyOwed"])
+        th = self._frame_thread(self._thread_side(tline(t + 110, "ct1", "cu1")), state="waiting")
+        self.assertFalse(th["unread"]); self.assertTrue(th["replyOwed"])
+
+    def test_unread_follows_what_the_popover_can_render(self):
+        # (ii) the popover renders events when it has them, else the msgs projection; unread reads the same
+        # source — and with BOTH empty (the popover holds its loader) nothing is unread
+        self._seed_thread(seen=self.now - 450)
+        saved = km._thread_events
+        try:
+            km._thread_events = lambda *a, **k: []
+            th = self._frame_thread(self._thread_records(), state="")
+            self.assertEqual(th["events"], [])
+            self.assertTrue(th["unread"], "the msgs projection shows the finished reply — so does the mark")
+            saved_m = km._thread_messages
+            km._thread_messages = lambda *a, **k: []
+            try:
+                th = self._frame_thread(self._thread_records(), state="")
+                self.assertFalse(th["unread"], "nothing renderable → nothing unread")
+                self.assertTrue(th["replyOwed"], "an open thread with no exchange yet still owes its first reply")
+            finally:
+                km._thread_messages = saved_m
+        finally:
+            km._thread_events = saved
+
+    def test_a_fresh_thread_owes_a_reply_from_its_first_frame(self):
+        # (vii)'s kernel half: pre-fork (reg still carries forkOf) the projections are empty by design —
+        # the comment exists, no reply has landed: owed, not unread
+        self._seed_thread()
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "thread-x", "cwd": self.cdir, "lastSid": PARENT,
+             "alive": True, "threadOf": PARENT, "forkOf": PARENT}))
+        th = self._frame_thread(self._thread_records(), state="")
+        self.assertEqual((th["msgs"], th["events"]), ([], []))
+        self.assertTrue(th["replyOwed"])
+        self.assertFalse(th["unread"])
+
+    def test_a_users_follow_up_owes_a_reply_again(self):
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        th = self._frame_thread(self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"),
+                                                  uline(t + 200, "and the cap?", "cu2", parent="ca1")), state="")
+        self.assertTrue(th["replyOwed"], "the user's message is the newest — a reply is owed")
+        self.assertFalse(th["unread"], "nothing new from the agent since the last look")
+
     def test_no_store_no_frame(self):
         self.assertIsNone(km._comments_frame(PARENT))
 

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -396,8 +396,6 @@ class ThreadProjection(CommentBase):
             return 0
         def session_meta(self, sid):
             return {}
-        def __getattr__(self, name):              # any other backend read the parse path grows: neutral, never a crash
-            return lambda *a, **k: None
 
     def _thread_side(self, *tail):
         t = self.now - 500
@@ -503,6 +501,47 @@ class ThreadProjection(CommentBase):
         self.assertEqual((th["msgs"], th["events"]), ([], []))
         self.assertTrue(th["replyOwed"])
         self.assertFalse(th["unread"])
+
+    def test_a_compaction_boundary_mid_reply_is_not_a_landing(self):
+        # the CLI writes a compact_boundary system record mid-reply; the event model files it as its own
+        # ENDED turn (no assistant atoms) — that is bookkeeping, not the reply: still owed, not unread,
+        # whether the backend reads compacting or has flapped to ""
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        recs = self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
+                                 self._tool_result(t + 112, "cr1", "cp1", "cp1"),
+                                 boundary(t + 113, "cb1", "cr1"))
+        for state in ("compacting", ""):
+            th = self._frame_thread(recs, state=state)
+            self.assertFalse(th["unread"], "state=%r" % state)
+            self.assertTrue(th["replyOwed"], "a compaction mid-reply is not the reply — state=%r" % state)
+        # …and the reply landing after the boundary flips both
+        th = self._frame_thread(recs + [aline(t + 130, "Jitter prevents thundering herds.", "ca1", parent="cb1")], state="")
+        self.assertTrue(th["unread"]); self.assertFalse(th["replyOwed"])
+
+    def test_the_users_interrupt_closes_the_turn_and_owes_nothing(self):
+        # the CLI's own "[Request interrupted by user]" record ends the turn: nothing more is coming, so
+        # no reply is owed (the mark must not stay green), and what did land is simply there to read
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        stop = uline(t + 115, "[Request interrupted by user]", "ci1", parent="cp1")
+        th = self._frame_thread(self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"), stop),
+                                state="waiting")
+        self.assertFalse(th["replyOwed"], "an interrupted send owes nothing until the next send")
+        self.assertTrue(th["unread"], "the partial reply that did land is newer than the watermark")
+
+    def test_agent_landed_after_reads_the_events_arm_when_events_exist(self):
+        # the projection the popover renders decides: assistant/tool events newer than the watermark
+        ev = lambda kind, t: {"kind": kind, "ts": iso(t), "uuid": "e-%d" % t}
+        seen = self.now - 450
+        self.assertTrue(km._agent_landed_after([ev("user", seen - 10), ev("assistant", seen + 5)], [], seen))
+        self.assertTrue(km._agent_landed_after([ev("tool", seen + 5)], [], seen), "a tool event is agent content")
+        self.assertFalse(km._agent_landed_after([ev("assistant", seen - 5)], [{"who": "agent", "t": seen + 9, "text": "x"}], seen),
+                         "with events present, msgs are not consulted — the popover shows the events")
+        self.assertFalse(km._agent_landed_after([ev("user", seen + 5), {"kind": "branch"}], [], seen),
+                         "user events and ts-less inserts are not agent content")
+        self.assertTrue(km._agent_landed_after([], [{"who": "agent", "t": seen + 1, "text": "x"}], seen), "no events → the msgs projection")
+        self.assertFalse(km._agent_landed_after([], [{"who": "agent", "t": seen, "text": "x"}], seen), "t == seen is already seen")
 
     def test_a_users_follow_up_owes_a_reply_again(self):
         t = self.now - 500

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -673,6 +673,32 @@ class ThreadProjection(CommentBase):
         finally:
             self._State.live = []
 
+    def test_a_dropped_echo_and_a_repeat_text_send_are_read_right(self):
+        # round-5 review, two faults in the echo fold: (1) an echo the backend flagged `dropped` (the send was
+        # LOST on a reconnect; the popover shows "never delivered") counted as held → green forever; (2) an
+        # echo whose text repeats ANY earlier user text (copied history, "ok", a re-send) read as landed
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"))
+        try:
+            self._State.live = [{"type": "user", "author": "human", "t": t + 130, "uuid": "echo:1",
+                                 "_echo_text": "and the cap?", "dropped": True}]
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 0, "a dropped send is not held")
+            self.assertFalse(th["replyOwed"], "the kernel adjudicated it lost — no green promise")
+            # a re-send of the thread's opening question (its text is already in the copied history)
+            repeat = "how should the retry loop back off?"
+            self._State.live = [{"type": "user", "author": "human", "t": t + 130, "uuid": "echo:2", "_echo_text": repeat}]
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 1, "the earlier identical text is not THIS send's landing")
+            self.assertTrue(th["replyOwed"])
+            # …until a record written at/after the send carries it
+            th = self._frame_thread(recs + [uline(t + 131, repeat, "cu2", parent="ca1")], state="")
+            self.assertEqual(th["queued"], 0, "landed by its own record")
+            self.assertTrue(th["replyOwed"], "the user's message is newest — owed by the transcript now")
+        finally:
+            self._State.live = []
+
     def test_the_frame_ships_the_newest_record_uuid_beyond_the_projection_caps(self):
         t = self.now - 500
         self._seed_thread(seen=self.now)

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -391,7 +391,11 @@ class ThreadProjection(CommentBase):
         def pending_cut(self, sid):
             return ""
         def owns(self, sid):
-            return False
+            return True                           # the thread is a live SDK session: build_session runs, events are REAL
+        def pending_queued(self, sid):
+            return []
+        def live_atoms(self, sid):
+            return []
         def session_since(self, sid):
             return 0
         def session_meta(self, sid):
@@ -542,6 +546,79 @@ class ThreadProjection(CommentBase):
                          "user events and ts-less inserts are not agent content")
         self.assertTrue(km._agent_landed_after([], [{"who": "agent", "t": seen + 1, "text": "x"}], seen), "no events → the msgs projection")
         self.assertFalse(km._agent_landed_after([], [{"who": "agent", "t": seen, "text": "x"}], seen), "t == seen is already seen")
+
+    def test_the_frame_tests_read_unread_from_real_events(self):
+        # the events projection is populated in this harness (the stub OWNS the thread), so the frame-level
+        # unread verdicts above are decided by the arm the popover renders in production — not msgs alone
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        th = self._frame_thread(self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1")), state="")
+        self.assertTrue(th["events"], "build_session's events reach the frame")
+        self.assertIn("assistant", [e.get("kind") for e in th["events"]])
+        saved = km._thread_messages
+        km._thread_messages = lambda *a, **k: [{"who": "you", "text": "Why jitter at all?", "t": t + 100}]
+        try:
+            th = self._frame_thread(self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1")), state="")
+            self.assertTrue(th["unread"], "with events present, unread reads the EVENTS — a blinded msgs projection changes nothing")
+        finally:
+            km._thread_messages = saved
+
+    def test_a_stop_after_a_mid_reply_compaction_reads_dead_not_owed(self):
+        # round-2 review: the idle atoms a stop mints AFTER a trailing compaction boundary fold into the
+        # boundary turn; skipping that turn dropped the evidence and left the mark green for good
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        recs = self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
+                                 self._tool_result(t + 112, "cr1", "cp1", "cp1"),
+                                 boundary(t + 113, "cb1", "cr1"))
+        states = jd.STATE / "states" / (THREAD + ".jsonl")
+        states.parent.mkdir(parents=True, exist_ok=True)
+        states.write_text("".join(json.dumps(r) + "\n" for r in (
+            {"t": t + 100, "state": "working"}, {"t": t + 114, "state": "waiting"}, {"t": t + 116, "state": "idle"})))
+        try:
+            for state in ("waiting", ""):
+                th = self._frame_thread(recs, state=state)
+                self.assertFalse(th["replyOwed"], "a thread that stopped after compacting owes nothing — state=%r" % state)
+        finally:
+            states.unlink()
+
+    def test_a_slash_command_after_a_landed_reply_owes_nothing(self):
+        # the CLI's <command-name>/<local-command-stdout> wrapper records are bookkeeping, not the user's
+        # message: they neither show as "you" rows nor re-owe a reply
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"),
+                                 uline(t + 130, "<command-name>/model</command-name>\n<command-message>model</command-message>\n<command-args>sonnet</command-args>", "cc1", parent="ca1"),
+                                 uline(t + 131, "<local-command-stdout>Set model to sonnet</local-command-stdout>", "cc2", parent="cc1"))
+        th = self._frame_thread(recs, state="")
+        self.assertEqual([m["who"] for m in th["msgs"]], ["you", "agent"], "the command wrappers are not conversation")
+        self.assertFalse(th["replyOwed"])
+        self.assertFalse(th["unread"])
+
+    def test_a_missing_transcript_owes_nothing_and_is_shouted(self):
+        # round-2 review: `not msgs` used to owe a reply forever over a MISSING transcript, in silence
+        import contextlib, io
+        self._seed_thread()
+        (self.proj / (THREAD + ".jsonl")).unlink()
+        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear()
+        km._thread_unreadable_warned.clear()
+        km._sdk = lambda: self._State("")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            th = km._comments_frame(PARENT)["threads"][0]
+            th2 = km._comments_frame(PARENT)["threads"][0]
+        self.assertEqual(th["msgs"], [])
+        self.assertFalse(th["replyOwed"], "nothing can land: no green promise")
+        self.assertFalse(th2["replyOwed"])
+        self.assertEqual(err.getvalue().count("transcript missing or unreadable"), 1, "shouted once, not per push")
+        # …while a genuinely fresh thread (fork pending) still owes its first reply, quietly
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "thread-x", "cwd": self.cdir, "lastSid": PARENT,
+             "alive": True, "threadOf": PARENT, "forkOf": PARENT}))
+        err2 = io.StringIO()
+        with contextlib.redirect_stderr(err2):
+            th = km._comments_frame(PARENT)["threads"][0]
+        self.assertTrue(th["replyOwed"]); self.assertEqual(err2.getvalue(), "")
 
     def test_a_users_follow_up_owes_a_reply_again(self):
         t = self.now - 500

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -393,10 +393,13 @@ class ThreadProjection(CommentBase):
         def owns(self, sid):
             return True                           # the thread is a live SDK session: build_session runs, events are REAL
         queued = []
+        live = []
         def pending_queued(self, sid):
             return list(self.queued)
         def live_atoms(self, sid):
-            return []
+            return list(self.live)
+        def live_sessions(self):
+            return {}
         def session_since(self, sid):
             return 0
         def session_meta(self, sid):
@@ -620,22 +623,64 @@ class ThreadProjection(CommentBase):
         # the backend's machineCut stamp says whose stop it was — romp's cut keeps the reply in progress
         t = self.now - 500
         self._seed_thread(seen=self.now - 450)
-        recs = self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
+        settle = lambda sr: {"type": "assistant", "timestamp": iso(t + 115), "uuid": "cs1", "parentUuid": "ci1",
+                             "message": {"role": "assistant", "model": "<synthetic>", "stop_reason": sr,
+                                         "content": [{"type": "text", "text": "No response requested."}]}}
+        base = self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
                                  uline(t + 115, "[Request interrupted by user]", "ci1", parent="cp1"))
         states = jd.STATE / "states" / (THREAD + ".jsonl")
         states.parent.mkdir(parents=True, exist_ok=True)
-        states.write_text(json.dumps({"t": t + 116, "machineCut": "crash"}) + "\n")
+        states.write_text(json.dumps({"t": t + 120, "machineCut": "restart"}) + "\n")
         try:
-            km._machine_cut_cache.clear() if hasattr(km, "_machine_cut_cache") and hasattr(km._machine_cut_cache, "clear") else None
-            th = self._frame_thread(recs, state="working")
-            self.assertTrue(th["replyOwed"], "romp cut it and is resuming — still owed")
-            self.assertFalse(th["unread"], "nothing landed yet")
+            # the shape every restart cut writes: stop record THEN the CLI's null settle (round-4 review: with
+            # the settle as the turn's tail the stamp was never consulted and its end_turn read as a landing)
+            for recs in (base, base + [settle("end_turn")], base + [settle("stop_sequence")]):
+                km._machine_cut_cache.clear() if hasattr(km, "_machine_cut_cache") and hasattr(km._machine_cut_cache, "clear") else None
+                th = self._frame_thread(recs, state="working")
+                self.assertTrue(th["replyOwed"], "romp cut it and is resuming — still owed (%d records)" % len(recs))
+                self.assertFalse(th["unread"], "nothing landed yet (%d records)" % len(recs))
         finally:
             states.unlink()
+        recs = base
         # a genuine stop (no machine-cut stamp at or after it) still closes the turn
         km._machine_cut_cache.clear() if hasattr(km, "_machine_cut_cache") and hasattr(km._machine_cut_cache, "clear") else None
         th = self._frame_thread(recs, state="waiting")
         self.assertFalse(th["replyOwed"]); self.assertTrue(th["unread"])
+
+    def test_a_send_fed_to_the_cli_but_unwritten_is_owed_via_its_echo(self):
+        # round-4 review: the backend pops a queued send to the CLI within milliseconds, so `_pending` is
+        # empty while the CLI still holds it unwritten; the backend's own INPUT ECHO atom spans that window
+        # (it lives until the record lands) — counted exactly as the chat's queued indicator counts it
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"))
+        echo = {"type": "user", "author": "human", "t": t + 130, "uuid": "echo:1", "_echo_text": "and the cap?"}
+        self._State.live = [echo]
+        try:
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 1, "the echo is a held send")
+            self.assertTrue(th["replyOwed"], "owed while the CLI holds it")
+            # a slash command's echo is consumed without a reply — never owed
+            self._State.live = [dict(echo, _echo_text="/model sonnet", command=True)]
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 0); self.assertFalse(th["replyOwed"])
+            # an echo the transcript has caught up on is retired by the same text rule the chat uses
+            self._State.live = [echo]
+            th = self._frame_thread(recs + [uline(t + 130, "and the cap?", "cu2", parent="ca1"),
+                                            aline(t + 140, "Cap it at two minutes.", "ca2", parent="cu2")], state="")
+            self.assertEqual(th["queued"], 0, "landed → not held")
+            self.assertFalse(th["replyOwed"])
+        finally:
+            self._State.live = []
+
+    def test_the_frame_ships_the_newest_record_uuid_beyond_the_projection_caps(self):
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"))
+        a = self._frame_thread(recs, state="")["lastUuid"]
+        b = self._frame_thread(recs + [uline(t + 130, "<command-name>/model</command-name>", "cc1", parent="ca1"),
+                                       uline(t + 131, "<local-command-stdout>Set model to sonnet</local-command-stdout>", "cc2", parent="cc1")], state="")["lastUuid"]
+        self.assertTrue(a and b and a != b, "a consumed slash command moves the newest record though msgs does not change")
 
     def test_a_send_the_backend_holds_is_owed_before_any_projection_sees_it(self):
         # round-3 review: a follow-up typed mid-turn waits in the backend until the turn ends; the frame

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -392,8 +392,9 @@ class ThreadProjection(CommentBase):
             return ""
         def owns(self, sid):
             return True                           # the thread is a live SDK session: build_session runs, events are REAL
+        queued = []
         def pending_queued(self, sid):
-            return []
+            return list(self.queued)
         def live_atoms(self, sid):
             return []
         def session_since(self, sid):
@@ -582,6 +583,76 @@ class ThreadProjection(CommentBase):
         finally:
             states.unlink()
 
+    def test_prose_that_merely_quotes_a_command_tag_is_the_users_message(self):
+        # round-3 review: the wrapper test is ANCHORED (the event model's CMD_WRAP_RE) — a comment or follow-up
+        # that quotes <command-name>…</command-name> in prose is what the user said, kept as a "you" row
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        quoting = "the CLI writes a <command-name>/model</command-name> record first — why is that a command?"
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"),
+                                 uline(t + 130, quoting, "cq1", parent="ca1"))
+        th = self._frame_thread(recs, state="")
+        self.assertEqual([m["who"] for m in th["msgs"]], ["you", "agent", "you"])
+        self.assertTrue(th["replyOwed"], "the user asked again — a reply is owed")
+
+    def test_a_command_confirmation_or_settle_event_is_not_a_landed_reply(self):
+        # round-3 review: the events arm skips a slash command's own output (an assistant atom flagged
+        # `command`) and the interrupt's null settle — neither is a reply to read
+        seen = self.now - 450
+        ev = lambda t, **k: dict({"kind": "assistant", "ts": iso(t), "uuid": "e-%d" % t}, **k)
+        self.assertFalse(km._agent_landed_after([ev(seen + 5, command=True)], [], seen))
+        self.assertFalse(km._agent_landed_after([ev(seen + 5, interruptSettle=True)], [], seen))
+        self.assertTrue(km._agent_landed_after([ev(seen + 5)], [], seen))
+        # …and through the frame: the reply was READ, then /model ran — no yellow for its confirmation
+        t = self.now - 500
+        self._seed_thread(seen=t + 125)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"),
+                                 uline(t + 130, "<command-name>/model</command-name>\n<command-message>model</command-message>\n<command-args>sonnet</command-args>", "cc1", parent="ca1"),
+                                 uline(t + 131, "<local-command-stdout>Set model to sonnet</local-command-stdout>", "cc2", parent="cc1"))
+        th = self._frame_thread(recs, state="")
+        self.assertTrue(th["events"], "the events projection is live in this harness")
+        self.assertTrue(any(e.get("command") for e in th["events"]), "the command's output rides the events flagged")
+        self.assertFalse(th["unread"], "a command confirmation is not a reply to read")
+        self.assertFalse(th["replyOwed"])
+
+    def test_a_machine_cut_interrupt_record_is_not_the_users_stop(self):
+        # round-3 review: a crash/restart resume mints the same "[Request interrupted by user]" record;
+        # the backend's machineCut stamp says whose stop it was — romp's cut keeps the reply in progress
+        t = self.now - 500
+        self._seed_thread(seen=self.now - 450)
+        recs = self._thread_side(self._partial_text(t + 110, "Let me check the code.", "cp1", "cu1"),
+                                 uline(t + 115, "[Request interrupted by user]", "ci1", parent="cp1"))
+        states = jd.STATE / "states" / (THREAD + ".jsonl")
+        states.parent.mkdir(parents=True, exist_ok=True)
+        states.write_text(json.dumps({"t": t + 116, "machineCut": "crash"}) + "\n")
+        try:
+            km._machine_cut_cache.clear() if hasattr(km, "_machine_cut_cache") and hasattr(km._machine_cut_cache, "clear") else None
+            th = self._frame_thread(recs, state="working")
+            self.assertTrue(th["replyOwed"], "romp cut it and is resuming — still owed")
+            self.assertFalse(th["unread"], "nothing landed yet")
+        finally:
+            states.unlink()
+        # a genuine stop (no machine-cut stamp at or after it) still closes the turn
+        km._machine_cut_cache.clear() if hasattr(km, "_machine_cut_cache") and hasattr(km._machine_cut_cache, "clear") else None
+        th = self._frame_thread(recs, state="waiting")
+        self.assertFalse(th["replyOwed"]); self.assertTrue(th["unread"])
+
+    def test_a_send_the_backend_holds_is_owed_before_any_projection_sees_it(self):
+        # round-3 review: a follow-up typed mid-turn waits in the backend until the turn ends; the frame
+        # ships `queued` and counts it as owed, so the green never drops between the landing and the write
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"))
+        th = self._frame_thread(recs, state="")
+        self.assertEqual(th["queued"], 0); self.assertFalse(th["replyOwed"])
+        self._State.queued = ["and the cap?"]
+        try:
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 1)
+            self.assertTrue(th["replyOwed"], "a held send is owed")
+        finally:
+            self._State.queued = []
+
     def test_a_slash_command_after_a_landed_reply_owes_nothing(self):
         # the CLI's <command-name>/<local-command-stdout> wrapper records are bookkeeping, not the user's
         # message: they neither show as "you" rows nor re-owe a reply
@@ -609,6 +680,7 @@ class ThreadProjection(CommentBase):
             th2 = km._comments_frame(PARENT)["threads"][0]
         self.assertEqual(th["msgs"], [])
         self.assertFalse(th["replyOwed"], "nothing can land: no green promise")
+        self.assertTrue(th["unreachable"], "…and the frame says so, for the client's latch")
         self.assertFalse(th2["replyOwed"])
         self.assertEqual(err.getvalue().count("transcript missing or unreadable"), 1, "shouted once, not per push")
         # …while a genuinely fresh thread (fork pending) still owes its first reply, quietly

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -90,7 +90,8 @@ test("the pulse is exchange-scoped (T102): send-gesture latch, reply-record clea
   assert.doesNotMatch(RENDER, /settleConfirmed|commentBusyLatch/);
   assert.match(RENDER, /const cmtAwaitBase = new Map<string, number>\(\);/);
   // the frame handler already repaints marks AND the open popover per frame — the live wire
-  assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) \{/);
+  // T237: the open popover's seen-stamp now runs BEFORE the paint, so the paint is followed by the re-render only
+  assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) renderCommentPopover\(\);/);
 });
 test("a family click sends the kernel's alias default; a version the seed table lacks renders LOUDLY as new", () => {
   // the family row's label is the family's OWN label — never a version-table lookup — so an alias

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -88,7 +88,7 @@ test("the pulse is exchange-scoped (T102): send-gesture latch, reply-record clea
   // (comments.test.ts carries the full lifecycle pins; this guards the retirement on this surface).
   assert.doesNotMatch(KERNEL, /_comment_settle/);
   assert.doesNotMatch(RENDER, /settleConfirmed|commentBusyLatch/);
-  assert.match(RENDER, /const cmtAwaitBase = new Map<string, number>\(\);/);
+  assert.match(RENDER, /const cmtAwaitBase = new Map<string, CmtLatch>\(\);/);   // T237: the latch remembers the click's counts
   // the frame handler already repaints marks AND the open popover per frame — the live wire
   // T237: the open popover's seen-stamp now runs BEFORE the paint, so the paint is followed by the re-render only
   assert.match(RENDER, /applyCommentMarks\(sid\);\s*\n\s*if \(openCommentKey && openCommentKey\.sid === sid\) renderCommentPopover\(\);/);

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -26,14 +26,15 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("the kernel ships replyOwed beside unread, both from the thread's own turn-end", () => {
   assert.match(KERNEL, /def _thread_turn_read\(tsid, reg, state\):/);
-  assert.match(KERNEL, /def _turn_landed\(turn\):/);
+  assert.match(KERNEL, /def _turn_landed\(turn, cut_t=0\.0\):/, "an interrupt at or before the backend's machineCut stamp is romp's cut, not the user's stop");
   assert.match(KERNEL, /def _turn_is_meta\(turn\):/, "compaction boundaries and command-only turns are not landings");
   assert.match(KERNEL, /if landed:\s*\n\s*return False, interrupted/, "the end_turn / interrupt record IS the landing");
   assert.match(KERNEL, /print\("\[comments\] thread %s: transcript parse failed/, "a parse failure is shouted, never swallowed");
   assert.match(KERNEL, /def _agent_landed_after\(events, msgs, seen\):/);
   assert.match(KERNEL, /turn_open, interrupted, turns = _thread_turn_read\(tsid, reg, state\) if status == "open" else \(False, False, \[\]\)/);
   assert.match(KERNEL, /unread = \(not turn_open\) and _agent_landed_after\(events, msgs, seen\)/);
-  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open\s*\n\s*or \(not msgs and _thread_owes_first_reply\(tsid, reg, th, turns\)\)\s*\n\s*or \(bool\(msgs\) and msgs\[-1\]\["who"\] == "you" and not interrupted\)\)/);
+  assert.match(KERNEL, /owes_first = status == "open" and not msgs and _thread_owes_first_reply\(tsid, reg, th, turns\)/);
+  assert.match(KERNEL, /or \(bool\(msgs\) and msgs\[-1\]\["who"\] == "you" and not interrupted\)\)/);
   assert.match(KERNEL, /def _thread_owes_first_reply\(tsid, reg, th, turns\):/, "a missing transcript owes nothing, loudly");
   assert.match(KERNEL, /if tail and tail\[-1\]\.get\("type"\) == "idle":\s*\n\s*return False, False, turns/, "an idle tail after a trailing boundary reads dead, not owed");
   assert.match(KERNEL, /"unread": unread, "replyOwed": reply_owed,/);
@@ -52,7 +53,10 @@ test("the client keys the green wash on the kernel's replyOwed; the gesture latc
   // an OLDER kernel (no replyOwed bit) keeps the T102 agent-count-with-settled-state clear
   assert.match(RENDER, /if \(base !== undefined && cmtLatchReleased\(t, base\)\) cmtAwaitBase\.delete\(t\.tid\);/);
   assert.match(RENDER, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/, "a follow-up latches on its thread's counts at the click");
-  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ you: 0, youT: 0, agents: 0 \}\);/, "the create gesture latches its synthetic thread");
+  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ \.\.\.CMT_LATCH_ZERO \}\);/, "the create gesture latches its synthetic thread");
+  assert.match(COMMENTS, /queued\?: number;/); assert.match(COMMENTS, /unreachable\?: boolean \| null;/);
+  assert.match(KERNEL, /"queued": queued,/); assert.match(KERNEL, /"unreachable": unreachable or None,/);
+  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or queued > 0 or owes_first/);
   assert.match(RENDER, /else if \(m\.type === "commentSendFailed" && m\.tid\) \{\s*\n\s*cmtAwaitBase\.delete\(String\(m\.tid\)\);/, "a refused send releases its latch");
   assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\], name: nm \|\| "comment"/,
     "the synthetic thread owes its reply from the click");
@@ -88,7 +92,7 @@ function markFor(th: CommentThread, latched = false): Set<string> {
   const inflightSrc = "const commentInFlight = (th) => {" + RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0] + "\n};";
   const styleSrc = "function styleCommentMark(m, th) {" + RENDER.split("function styleCommentMark(m: HTMLElement, th: CommentThread): void {")[1].split("\n}")[0] + "\n}";
   const prelude = `
-    const cmtAwaitBase = new Map(${latched ? '[["t1", { you: 0, youT: 0, agents: 0 }]]' : ""});
+    const cmtAwaitBase = new Map(${latched ? '[["t1", { you: 0, youT: 0, agents: 0, queued: 0, events: 0 }]]' : ""});
     const cmtInterrupted = new Set();
     const threadStuck = (st) => st === "permission" || st === "picker";
     const replyOwed = (th) => { const l = th.msgs.length ? th.msgs[th.msgs.length - 1] : null; return !!l && l.who === "you"; };
@@ -140,8 +144,11 @@ test("the CSS intent stands: green wash while busy, yellow tiers for base/unread
 });
 
 // ── executed: the latch RELEASE rule (cmtLatchReleased) over the frame sequences the review named ──────────
-function latchReleased(t: CommentThread, base: { you: number; youT: number; agents: number }): boolean {
-  const src = "function cmtLatchReleased(t, base) {" + RENDER.split("function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {")[1].split("\n}")[0] + "\n}";
+type LatchBase = { you: number; youT: number; agents: number; queued?: number; events?: number };
+function latchReleased(t: CommentThread, base0: LatchBase): boolean {
+  const base = { queued: 0, events: 0, ...base0 };
+  const src = ("function cmtLatchReleased(t, base) {" + RENDER.split("function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {")[1].split("\n}")[0] + "\n}")
+    .replace(/ as unknown\[\]/g, "");   // the one TypeScript cast in the body — plain JS for new Function
   const prelude = `
     const cmtYouRows = (th) => (th.msgs || []).filter((m) => m.who === "you");
     const agentCount = (th) => (th.msgs || []).filter((m) => m.who === "agent").length;
@@ -180,4 +187,19 @@ test("leaving open, or a launch error, releases either way", () => {
   assert.equal(latchReleased(base({ replyOwed: true, status: "resolved", msgs: [] }), b), true);
   assert.equal(latchReleased(base({ replyOwed: true, error: "could not start", msgs: [] }), b), true);
   assert.equal(latchReleased(base({ replyOwed: true, msgs: [] }), b), false, "a fresh thread holds until its send lands");
+});
+
+test("the kernel's other acknowledgements release the latch: a held send, a consumed slash command, an unreachable thread", () => {
+  const b = { you: 1, youT: 50, agents: 1, queued: 0, events: 2 };
+  // the follow-up typed mid-turn is HELD: queued grew — the kernel owes it now
+  assert.equal(latchReleased(base({ replyOwed: true, queued: 1, msgs: [you(50), agent(100)] }), b), true);
+  // the reply lands while the send is still queued: kernel says owed (queued) — released to the kernel is fine, and
+  // the kernel keeps the green; with NO queue seen and no new "you" row the latch still holds
+  assert.equal(latchReleased(base({ replyOwed: false, unread: true, msgs: [you(50), agent(105)], events: [1, 2] as unknown[] }), b), false);
+  // a slash command typed in the popover: no "you" row ever, the transcript grew, the kernel owes nothing
+  assert.equal(latchReleased(base({ replyOwed: false, msgs: [you(50), agent(100)], events: [1, 2, 3, 4] as unknown[] }), b), true);
+  // …but a grown transcript while the kernel still owes (agent partials) does not release
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: [you(50), agent(104)], events: [1, 2, 3] as unknown[] }), b), false);
+  // a broken thread: nothing can land
+  assert.equal(latchReleased(base({ replyOwed: false, unreachable: true, msgs: [] }), { ...b, you: 0, youT: 0, events: 0 }), true);
 });

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -1,0 +1,133 @@
+// T237 (the user 2026-09-03, twice, ~4:25 PM PT): the marked passage must not turn YELLOW until the reply
+// has LANDED. Two sightings, one design: the mark wears a faded AWAIT-GREEN `.busy` wash while the thread
+// is mid-reply and settles into the yellow `.unread` the moment the reply lands — and both times the green
+// failed to apply. Convicted at the source:
+//   * `.busy` keyed on a CLIENT gesture latch (cmtAwaitBase) that any session's comments frame could prune
+//     (the prune ran against ONE session's thread list) and that cleared on a reply-arrived heuristic
+//     (agentCount rising + !threadBusy(state)) — the first agent record of a multi-record turn with the
+//     backend's state read as ""/waiting dropped the wash while the thread was still responding; the
+//     msgs-derived replyOwed() fallback flips false at that same first record.
+//   * `unread` keyed in the kernel on ANY agent record newer than the watermark — an intermediate text
+//     block or tool call of a turn in progress painted yellow before the turn ended.
+// Fix: the kernel is the one truth (tests/test_comment_threads.py pins the rule): `replyOwed` (green) and
+// `unread` = a FINISHED reply newer than the watermark (yellow), both from the thread's transcript with the
+// event model's own turn-end. The client keys `.busy` on th.replyOwed and keeps the gesture latch only for
+// the pre-round-trip instant (from the send click until a frame carries the send); no timers anywhere.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { CommentThread } from "./comments";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const COMMENTS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "comments.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the kernel ships replyOwed beside unread, both from the thread's own turn-end", () => {
+  assert.match(KERNEL, /def _thread_turn_open\(tsid, reg, state\):/);
+  assert.match(KERNEL, /if turns\[-1\]\.get\("ended"\):\s*\n\s*return False/, "the end_turn / interrupt record IS the landing");
+  assert.match(KERNEL, /def _agent_landed_after\(events, msgs, seen\):/);
+  assert.match(KERNEL, /turn_open = status == "open" and _thread_turn_open\(tsid, reg, state\)/);
+  assert.match(KERNEL, /unread = \(not turn_open\) and _agent_landed_after\(events, msgs, seen\)/);
+  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or not msgs or msgs\[-1\]\["who"\] == "you"\)/);
+  assert.match(KERNEL, /"unread": unread, "replyOwed": reply_owed,/);
+  assert.match(KERNEL, /yellow — means "a FINISHED reply you have not seen"/, "the rule is stated in the docstring");
+});
+
+test("the client keys the green wash on the kernel's replyOwed; the gesture latch covers only the pre-round-trip instant", () => {
+  const inflight = RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0];
+  assert.match(inflight, /if \(cmtAwaitBase\.has\(th\.tid\)\) return true;/);
+  assert.match(inflight, /const owed = typeof th\.replyOwed === "boolean" \? th\.replyOwed : replyOwed\(th\);/,
+    "kernel truth when present; the msgs-derived fallback only for an older kernel");
+  assert.match(inflight, /return owed && !cmtInterrupted\.has\(th\.tid\);/);
+  assert.doesNotMatch(inflight, /agentCount|threadBusy/, "no reply-arrived heuristic in the wash");
+  // the latch clears when a frame carries the SEND (its projected message count grew) — never on an
+  // agent-count-vs-state heuristic
+  assert.match(RENDER, /if \(base !== undefined && \(t\.msgs\.length > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/);
+  assert.doesNotMatch(RENDER, /agentCount\(t\) > base && !threadBusy\(t\.state\)/);
+  assert.match(RENDER, /cmtAwaitBase\.set\(cur\.th\.tid, cur\.th\.msgs\.length\);/, "a follow-up latches on the message count at its click");
+  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, 0\);/, "the create gesture latches its synthetic thread");
+  assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\], name: nm \|\| "comment"/,
+    "the synthetic thread owes its reply from the click");
+  assert.match(COMMENTS, /replyOwed\?: boolean;/);
+});
+
+test("latches are pruned only against EVERY session's known threads — never one frame's list", () => {
+  assert.match(RENDER, /const knownTids = new Set<string>\(\);\s*\n\s*commentThreads\.forEach\(\(list\) => list\.forEach\(\(t\) => knownTids\.add\(t\.tid\)\)\);/);
+  assert.match(RENDER, /if \(!k\.startsWith\("pending:"\) && !knownTids\.has\(k\)\) cmtAwaitBase\.delete\(k\);/);
+  assert.doesNotMatch(RENDER, /!threads\.some\(\(t\) => t\.tid === k\)\) cmtAwaitBase\.delete\(k\)/,
+    "the one-frame prune that dropped other sessions' latches is gone");
+  // the "pending:" → real tid carry on adoption stays
+  assert.match(RENDER, /if \(k\.startsWith\("pending:"\)\) \{ cmtAwaitBase\.set\(tid, cmtAwaitBase\.get\(k\)!\); cmtAwaitBase\.delete\(k\); \}/);
+});
+
+test("a reply landing while its popover is open advances the watermark BEFORE the marks paint", () => {
+  const handler = RENDER.split('else if (m.type === "comments" && m.id) {')[1].split("\n  }\n")[0];
+  const seen = handler.indexOf('vscodeApi?.postMessage({ type: "commentSeen", id: sid, tid: th.tid });');
+  const paint = handler.indexOf("applyCommentMarks(sid);");
+  assert.ok(seen > 0 && paint > 0 && seen < paint, "seen-stamp first, paint after — the mark never wears yellow for a reply read as it lands");
+  assert.match(handler, /if \(openCommentKey && openCommentKey\.sid === sid\) renderCommentPopover\(\);/);
+});
+
+test("no timer anywhere in the colour path", () => {
+  const inflight = RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0];
+  const style = RENDER.split("function styleCommentMark(")[1].split("\n}")[0];
+  for (const src of [inflight, style]) assert.doesNotMatch(src, /setTimeout|Date\.now|setInterval/);
+});
+
+// ── executed: the mark's classes for the kernel's frames (no jsdom dependency here — a minimal element shim) ──
+function markFor(th: CommentThread, latched = false): Set<string> {
+  const inflightSrc = "const commentInFlight = (th) => {" + RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0] + "\n};";
+  const styleSrc = "function styleCommentMark(m, th) {" + RENDER.split("function styleCommentMark(m: HTMLElement, th: CommentThread): void {")[1].split("\n}")[0] + "\n}";
+  const prelude = `
+    const cmtAwaitBase = new Map(${latched ? '[["t1", 0]]' : ""});
+    const cmtInterrupted = new Set();
+    const threadStuck = (st) => st === "permission" || st === "picker";
+    const replyOwed = (th) => { const l = th.msgs.length ? th.msgs[th.msgs.length - 1] : null; return !!l && l.who === "you"; };
+    const commentInFlight_ = null;`;
+  const classes = new Set<string>();
+  const m = { classList: { toggle(c: string, on: boolean) { if (on) classes.add(c); else classes.delete(c); } }, title: "" };
+  new Function("m", "th", prelude + "\n" + inflightSrc + "\n" + styleSrc + "\nstyleCommentMark(m, th);")(m, th);
+  return classes;
+}
+const base = (over: Partial<CommentThread>): CommentThread => ({
+  tid: "t1", anchorUuid: "a1", exact: "the passage", status: "open", createdT: 0,
+  state: "", unread: false, promotedName: "", msgs: [], ...over,
+});
+
+test("(v)/(vii) while the popover would show its loader — no exchange yet — the mark is busy, never unread", () => {
+  const c = markFor(base({ replyOwed: true, unread: false, msgs: [], events: [] } as Partial<CommentThread>));
+  assert.ok(c.has("busy") && !c.has("unread"));
+});
+
+test("(vi) a partial reply (the kernel still owes it, whatever the state reads) keeps the wash", () => {
+  for (const state of ["working", "", "waiting"]) {
+    const c = markFor(base({ state, replyOwed: true, unread: false,
+      msgs: [{ who: "you", text: "why jitter?", t: 1 }, { who: "agent", text: "Let me check.", t: 2 }] }));
+    assert.ok(c.has("busy") && !c.has("unread"), "state=" + JSON.stringify(state));
+  }
+});
+
+test("(viii) the finished reply: yellow in the same frame the kernel says it landed, green gone", () => {
+  const c = markFor(base({ replyOwed: false, unread: true,
+    msgs: [{ who: "you", text: "why jitter?", t: 1 }, { who: "agent", text: "Jitter prevents thundering herds.", t: 2 }] }));
+  assert.ok(c.has("unread") && !c.has("busy"));
+});
+
+test("the pre-round-trip latch alone keeps a fresh mark busy before any frame carries the send", () => {
+  const c = markFor(base({ msgs: [], unread: false }), true);
+  assert.ok(c.has("busy") && !c.has("unread"));
+});
+
+test("an older kernel (no replyOwed bit) falls back to the msgs-derived read", () => {
+  const owed = markFor(base({ msgs: [{ who: "you", text: "why?", t: 1 }] }));
+  assert.ok(owed.has("busy"));
+  const answered = markFor(base({ msgs: [{ who: "you", text: "why?", t: 1 }, { who: "agent", text: "because", t: 2 }] }));
+  assert.ok(!answered.has("busy"));
+});
+
+test("the CSS intent stands: green wash while busy, yellow tiers for base/unread", () => {
+  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);/);
+  assert.match(CSS, /mark\.cmt-hl\.unread \{ background: color-mix\(in srgb, var\(--cmt-hl\) 45%, transparent\); \}/);
+});

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -25,12 +25,15 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("the kernel ships replyOwed beside unread, both from the thread's own turn-end", () => {
-  assert.match(KERNEL, /def _thread_turn_open\(tsid, reg, state\):/);
-  assert.match(KERNEL, /if turns\[-1\]\.get\("ended"\):\s*\n\s*return False/, "the end_turn / interrupt record IS the landing");
+  assert.match(KERNEL, /def _thread_turn_read\(tsid, reg, state\):/);
+  assert.match(KERNEL, /def _turn_landed\(turn\):/);
+  assert.match(KERNEL, /def _turn_is_meta\(turn\):/, "compaction boundaries and command-only turns are not landings");
+  assert.match(KERNEL, /if landed:\s*\n\s*return False, interrupted/, "the end_turn / interrupt record IS the landing");
+  assert.match(KERNEL, /print\("\[comments\] thread %s: transcript parse failed/, "a parse failure is shouted, never swallowed");
   assert.match(KERNEL, /def _agent_landed_after\(events, msgs, seen\):/);
-  assert.match(KERNEL, /turn_open = status == "open" and _thread_turn_open\(tsid, reg, state\)/);
+  assert.match(KERNEL, /turn_open, interrupted = _thread_turn_read\(tsid, reg, state\) if status == "open" else \(False, False\)/);
   assert.match(KERNEL, /unread = \(not turn_open\) and _agent_landed_after\(events, msgs, seen\)/);
-  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or not msgs or msgs\[-1\]\["who"\] == "you"\)/);
+  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or not msgs or \(msgs\[-1\]\["who"\] == "you" and not interrupted\)\)/);
   assert.match(KERNEL, /"unread": unread, "replyOwed": reply_owed,/);
   assert.match(KERNEL, /yellow — means "a FINISHED reply you have not seen"/, "the rule is stated in the docstring");
 });
@@ -42,12 +45,14 @@ test("the client keys the green wash on the kernel's replyOwed; the gesture latc
     "kernel truth when present; the msgs-derived fallback only for an older kernel");
   assert.match(inflight, /return owed && !cmtInterrupted\.has\(th\.tid\);/);
   assert.doesNotMatch(inflight, /agentCount|threadBusy/, "no reply-arrived heuristic in the wash");
-  // the latch clears when a frame carries the SEND (its projected message count grew) — never on an
-  // agent-count-vs-state heuristic
-  assert.match(RENDER, /if \(base !== undefined && \(t\.msgs\.length > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/);
-  assert.doesNotMatch(RENDER, /agentCount\(t\) > base && !threadBusy\(t\.state\)/);
-  assert.match(RENDER, /cmtAwaitBase\.set\(cur\.th\.tid, cur\.th\.msgs\.length\);/, "a follow-up latches on the message count at its click");
-  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, 0\);/, "the create gesture latches its synthetic thread");
+  // the latch clears when a frame carries the SEND — a message newer than the click's newest, or more
+  // messages than then (the count alone misses a thread at the projection's 40-message cap) — and only
+  // an OLDER kernel (no replyOwed bit) keeps the T102 agent-count-with-settled-state clear
+  assert.match(RENDER, /const sendLanded = t\.msgs\.length > base\.n \|\| newestT > base\.t;/);
+  assert.match(RENDER, /const legacyReplyArrived = agentCount\(t\) > base\.agents && !threadBusy\(t\.state\);/);
+  assert.match(RENDER, /const clear = \(typeof t\.replyOwed === "boolean" \? sendLanded : legacyReplyArrived\) \|\| t\.status !== "open" \|\| !!t\.error;/);
+  assert.match(RENDER, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/, "a follow-up latches on its thread's counts at the click");
+  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ n: 0, t: 0, agents: 0 \}\);/, "the create gesture latches its synthetic thread");
   assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\], name: nm \|\| "comment"/,
     "the synthetic thread owes its reply from the click");
   assert.match(COMMENTS, /replyOwed\?: boolean;/);
@@ -78,10 +83,11 @@ test("no timer anywhere in the colour path", () => {
 
 // ── executed: the mark's classes for the kernel's frames (no jsdom dependency here — a minimal element shim) ──
 function markFor(th: CommentThread, latched = false): Set<string> {
+  // the latch map's VALUE shape is irrelevant to the wash (has() alone is read) — a zeroed latch stands in
   const inflightSrc = "const commentInFlight = (th) => {" + RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0] + "\n};";
   const styleSrc = "function styleCommentMark(m, th) {" + RENDER.split("function styleCommentMark(m: HTMLElement, th: CommentThread): void {")[1].split("\n}")[0] + "\n}";
   const prelude = `
-    const cmtAwaitBase = new Map(${latched ? '[["t1", 0]]' : ""});
+    const cmtAwaitBase = new Map(${latched ? '[["t1", { n: 0, t: 0, agents: 0 }]]' : ""});
     const cmtInterrupted = new Set();
     const threadStuck = (st) => st === "permission" || st === "picker";
     const replyOwed = (th) => { const l = th.msgs.length ? th.msgs[th.msgs.length - 1] : null; return !!l && l.who === "you"; };

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -54,8 +54,10 @@ test("the client keys the green wash on the kernel's replyOwed; the gesture latc
   assert.match(RENDER, /if \(base !== undefined && cmtLatchReleased\(t, base\)\) cmtAwaitBase\.delete\(t\.tid\);/);
   assert.match(RENDER, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/, "a follow-up latches on its thread's counts at the click");
   assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ \.\.\.CMT_LATCH_ZERO \}\);/, "the create gesture latches its synthetic thread");
-  assert.match(COMMENTS, /queued\?: number;/); assert.match(COMMENTS, /unreachable\?: boolean \| null;/);
-  assert.match(KERNEL, /"queued": queued,/); assert.match(KERNEL, /"unreachable": unreachable or None,/);
+  assert.match(COMMENTS, /queued\?: number;/); assert.match(COMMENTS, /unreachable\?: boolean \| null;/); assert.match(COMMENTS, /lastUuid\?: string;/);
+  assert.match(KERNEL, /"queued": queued,/); assert.match(KERNEL, /"unreachable": unreachable or None,/); assert.match(KERNEL, /"lastUuid": last_uuid,/);
+  assert.match(KERNEL, /held = \[a for a in live if \(a\.get\("_echo_text"\) or ""\)\.strip\(\) and not a\.get\("command"\)/, "echo-held sends count as owed, the chat's own fold");
+  assert.match(KERNEL, /def _settle\(a\):/, "the stop's settle record is skipped when reading the landing");
   assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or queued > 0 or owes_first/);
   assert.match(RENDER, /else if \(m\.type === "commentSendFailed" && m\.tid\) \{\s*\n\s*cmtAwaitBase\.delete\(String\(m\.tid\)\);/, "a refused send releases its latch");
   assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\], name: nm \|\| "comment"/,
@@ -92,7 +94,7 @@ function markFor(th: CommentThread, latched = false): Set<string> {
   const inflightSrc = "const commentInFlight = (th) => {" + RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0] + "\n};";
   const styleSrc = "function styleCommentMark(m, th) {" + RENDER.split("function styleCommentMark(m: HTMLElement, th: CommentThread): void {")[1].split("\n}")[0] + "\n}";
   const prelude = `
-    const cmtAwaitBase = new Map(${latched ? '[["t1", { you: 0, youT: 0, agents: 0, queued: 0, events: 0 }]]' : ""});
+    const cmtAwaitBase = new Map(${latched ? '[["t1", { you: 0, youT: 0, agents: 0, queued: 0, last: "" }]]' : ""});
     const cmtInterrupted = new Set();
     const threadStuck = (st) => st === "permission" || st === "picker";
     const replyOwed = (th) => { const l = th.msgs.length ? th.msgs[th.msgs.length - 1] : null; return !!l && l.who === "you"; };
@@ -144,9 +146,9 @@ test("the CSS intent stands: green wash while busy, yellow tiers for base/unread
 });
 
 // ── executed: the latch RELEASE rule (cmtLatchReleased) over the frame sequences the review named ──────────
-type LatchBase = { you: number; youT: number; agents: number; queued?: number; events?: number };
+type LatchBase = { you: number; youT: number; agents: number; queued?: number; last?: string };
 function latchReleased(t: CommentThread, base0: LatchBase): boolean {
-  const base = { queued: 0, events: 0, ...base0 };
+  const base = { queued: 0, last: "", ...base0 };
   const src = ("function cmtLatchReleased(t, base) {" + RENDER.split("function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {")[1].split("\n}")[0] + "\n}")
     .replace(/ as unknown\[\]/g, "");   // the one TypeScript cast in the body — plain JS for new Function
   const prelude = `
@@ -189,17 +191,19 @@ test("leaving open, or a launch error, releases either way", () => {
   assert.equal(latchReleased(base({ replyOwed: true, msgs: [] }), b), false, "a fresh thread holds until its send lands");
 });
 
-test("the kernel's other acknowledgements release the latch: a held send, a consumed slash command, an unreachable thread", () => {
-  const b = { you: 1, youT: 50, agents: 1, queued: 0, events: 2 };
-  // the follow-up typed mid-turn is HELD: queued grew — the kernel owes it now
-  assert.equal(latchReleased(base({ replyOwed: true, queued: 1, msgs: [you(50), agent(100)] }), b), true);
-  // the reply lands while the send is still queued: kernel says owed (queued) — released to the kernel is fine, and
-  // the kernel keeps the green; with NO queue seen and no new "you" row the latch still holds
-  assert.equal(latchReleased(base({ replyOwed: false, unread: true, msgs: [you(50), agent(105)], events: [1, 2] as unknown[] }), b), false);
-  // a slash command typed in the popover: no "you" row ever, the transcript grew, the kernel owes nothing
-  assert.equal(latchReleased(base({ replyOwed: false, msgs: [you(50), agent(100)], events: [1, 2, 3, 4] as unknown[] }), b), true);
-  // …but a grown transcript while the kernel still owes (agent partials) does not release
-  assert.equal(latchReleased(base({ replyOwed: true, msgs: [you(50), agent(104)], events: [1, 2, 3] as unknown[] }), b), false);
+test("the kernel's other acknowledgements release the latch: a held/fed send, a consumed slash command, an unreachable thread", () => {
+  const b = { you: 1, youT: 50, agents: 1, queued: 0, last: "a-100" };
+  // the follow-up typed mid-turn is held or fed (its echo lives until the record lands): queued grew — the kernel owes it now
+  assert.equal(latchReleased(base({ replyOwed: true, queued: 1, msgs: [you(50), agent(100)], lastUuid: "a-100" }), b), true);
+  // the reply lands while the send is still unwritten but the kernel has not acknowledged it (no echo seen, no queue,
+  // no "you" row): the latch HOLDS even though the newest record moved — "moved" alone is never the send
+  assert.equal(latchReleased(base({ replyOwed: true, unread: false, msgs: [you(50), agent(105)], lastUuid: "a-105" }), b), false);
+  // a slash command typed in the popover: no "you" row ever, the newest record moved (its wrapper records), nothing owed
+  assert.equal(latchReleased(base({ replyOwed: false, msgs: [you(50), agent(100)], lastUuid: "cc-2" }), b), true);
+  // …an unchanged newest record with nothing owed (the click's own frame) does not release
+  assert.equal(latchReleased(base({ replyOwed: false, msgs: [you(50), agent(100)], lastUuid: "a-100" }), b), false);
+  // …and a moved record while the kernel still owes (agent partials) does not release
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: [you(50), agent(104)], lastUuid: "a-104" }), b), false);
   // a broken thread: nothing can land
-  assert.equal(latchReleased(base({ replyOwed: false, unreachable: true, msgs: [] }), { ...b, you: 0, youT: 0, events: 0 }), true);
+  assert.equal(latchReleased(base({ replyOwed: false, unreachable: true, msgs: [] }), { ...b, you: 0, youT: 0, last: "" }), true);
 });

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -31,9 +31,11 @@ test("the kernel ships replyOwed beside unread, both from the thread's own turn-
   assert.match(KERNEL, /if landed:\s*\n\s*return False, interrupted/, "the end_turn / interrupt record IS the landing");
   assert.match(KERNEL, /print\("\[comments\] thread %s: transcript parse failed/, "a parse failure is shouted, never swallowed");
   assert.match(KERNEL, /def _agent_landed_after\(events, msgs, seen\):/);
-  assert.match(KERNEL, /turn_open, interrupted = _thread_turn_read\(tsid, reg, state\) if status == "open" else \(False, False\)/);
+  assert.match(KERNEL, /turn_open, interrupted, turns = _thread_turn_read\(tsid, reg, state\) if status == "open" else \(False, False, \[\]\)/);
   assert.match(KERNEL, /unread = \(not turn_open\) and _agent_landed_after\(events, msgs, seen\)/);
-  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or not msgs or \(msgs\[-1\]\["who"\] == "you" and not interrupted\)\)/);
+  assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open\s*\n\s*or \(not msgs and _thread_owes_first_reply\(tsid, reg, th, turns\)\)\s*\n\s*or \(bool\(msgs\) and msgs\[-1\]\["who"\] == "you" and not interrupted\)\)/);
+  assert.match(KERNEL, /def _thread_owes_first_reply\(tsid, reg, th, turns\):/, "a missing transcript owes nothing, loudly");
+  assert.match(KERNEL, /if tail and tail\[-1\]\.get\("type"\) == "idle":\s*\n\s*return False, False, turns/, "an idle tail after a trailing boundary reads dead, not owed");
   assert.match(KERNEL, /"unread": unread, "replyOwed": reply_owed,/);
   assert.match(KERNEL, /yellow — means "a FINISHED reply you have not seen"/, "the rule is stated in the docstring");
 });
@@ -48,11 +50,10 @@ test("the client keys the green wash on the kernel's replyOwed; the gesture latc
   // the latch clears when a frame carries the SEND — a message newer than the click's newest, or more
   // messages than then (the count alone misses a thread at the projection's 40-message cap) — and only
   // an OLDER kernel (no replyOwed bit) keeps the T102 agent-count-with-settled-state clear
-  assert.match(RENDER, /const sendLanded = t\.msgs\.length > base\.n \|\| newestT > base\.t;/);
-  assert.match(RENDER, /const legacyReplyArrived = agentCount\(t\) > base\.agents && !threadBusy\(t\.state\);/);
-  assert.match(RENDER, /const clear = \(typeof t\.replyOwed === "boolean" \? sendLanded : legacyReplyArrived\) \|\| t\.status !== "open" \|\| !!t\.error;/);
+  assert.match(RENDER, /if \(base !== undefined && cmtLatchReleased\(t, base\)\) cmtAwaitBase\.delete\(t\.tid\);/);
   assert.match(RENDER, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/, "a follow-up latches on its thread's counts at the click");
-  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ n: 0, t: 0, agents: 0 \}\);/, "the create gesture latches its synthetic thread");
+  assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ you: 0, youT: 0, agents: 0 \}\);/, "the create gesture latches its synthetic thread");
+  assert.match(RENDER, /else if \(m\.type === "commentSendFailed" && m\.tid\) \{\s*\n\s*cmtAwaitBase\.delete\(String\(m\.tid\)\);/, "a refused send releases its latch");
   assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\], name: nm \|\| "comment"/,
     "the synthetic thread owes its reply from the click");
   assert.match(COMMENTS, /replyOwed\?: boolean;/);
@@ -87,7 +88,7 @@ function markFor(th: CommentThread, latched = false): Set<string> {
   const inflightSrc = "const commentInFlight = (th) => {" + RENDER.split("const commentInFlight = (th: CommentThread): boolean => {")[1].split("\n};")[0] + "\n};";
   const styleSrc = "function styleCommentMark(m, th) {" + RENDER.split("function styleCommentMark(m: HTMLElement, th: CommentThread): void {")[1].split("\n}")[0] + "\n}";
   const prelude = `
-    const cmtAwaitBase = new Map(${latched ? '[["t1", { n: 0, t: 0, agents: 0 }]]' : ""});
+    const cmtAwaitBase = new Map(${latched ? '[["t1", { you: 0, youT: 0, agents: 0 }]]' : ""});
     const cmtInterrupted = new Set();
     const threadStuck = (st) => st === "permission" || st === "picker";
     const replyOwed = (th) => { const l = th.msgs.length ? th.msgs[th.msgs.length - 1] : null; return !!l && l.who === "you"; };
@@ -136,4 +137,47 @@ test("an older kernel (no replyOwed bit) falls back to the msgs-derived read", (
 test("the CSS intent stands: green wash while busy, yellow tiers for base/unread", () => {
   assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);/);
   assert.match(CSS, /mark\.cmt-hl\.unread \{ background: color-mix\(in srgb, var\(--cmt-hl\) 45%, transparent\); \}/);
+});
+
+// ── executed: the latch RELEASE rule (cmtLatchReleased) over the frame sequences the review named ──────────
+function latchReleased(t: CommentThread, base: { you: number; youT: number; agents: number }): boolean {
+  const src = "function cmtLatchReleased(t, base) {" + RENDER.split("function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {")[1].split("\n}")[0] + "\n}";
+  const prelude = `
+    const cmtYouRows = (th) => (th.msgs || []).filter((m) => m.who === "you");
+    const agentCount = (th) => (th.msgs || []).filter((m) => m.who === "agent").length;
+    const threadBusy = (st) => st === "working" || st === "retrying" || st === "compacting";`;
+  return new Function("t", "base", prelude + "\n" + src + "\nreturn cmtLatchReleased(t, base);")(t, base) as boolean;
+}
+const you = (t: number) => ({ who: "you" as const, text: "q", t });
+const agent = (t: number) => ({ who: "agent" as const, text: "a", t });
+
+test("a follow-up sent MID-turn keeps its latch while the backend holds the send: agent rows never release it", () => {
+  const b = { you: 1, youT: 50, agents: 1 };   // clicked with msgs [you@50, agent partial@100]
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: [you(50), agent(100)] }), b), false, "the click's own frame");
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: [you(50), agent(104)] }), b), false, "the partial's merged row advances — still the agent");
+  assert.equal(latchReleased(base({ replyOwed: false, unread: true, msgs: [you(50), agent(105)] }), b), false,
+    "the current reply LANDS while the send is still queued — green must hold for the queued send");
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: [you(50), agent(105), you(106)] }), b), true, "the send is written: released to the kernel");
+});
+
+test("a thread at the projection cap releases on the newer 'you' time, not the row count", () => {
+  const capped = Array.from({ length: 40 }, (_, i) => (i % 2 ? agent(i + 1) : you(i + 1)));
+  const b = { you: 20, youT: 39, agents: 20 };
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: capped }), b), false);
+  const rolled = [...capped.slice(2), agent(41), you(42)];   // still 40 rows, the send is the newest you
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: rolled }), b), true);
+});
+
+test("an older kernel (no replyOwed) keeps the T102 reply-arrived release: agent count up AND the thread settled", () => {
+  const b = { you: 1, youT: 50, agents: 0 };
+  assert.equal(latchReleased(base({ state: "working", msgs: [you(50), agent(100)] }), b), false, "mid-turn: not yet");
+  assert.equal(latchReleased(base({ state: "", msgs: [you(50), agent(100)] }), b), true, "settled with a new agent row");
+  assert.equal(latchReleased(base({ state: "", msgs: [you(50)] }), b), false, "no reply yet");
+});
+
+test("leaving open, or a launch error, releases either way", () => {
+  const b = { you: 0, youT: 0, agents: 0 };
+  assert.equal(latchReleased(base({ replyOwed: true, status: "resolved", msgs: [] }), b), true);
+  assert.equal(latchReleased(base({ replyOwed: true, error: "could not start", msgs: [] }), b), true);
+  assert.equal(latchReleased(base({ replyOwed: true, msgs: [] }), b), false, "a fresh thread holds until its send lands");
 });

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -530,19 +530,21 @@ test("agentCount is the reply-arrived detector's datum — records of the exchan
 test("busy latches at the SEND gesture and clears exactly on the reply-arrived record (source pins)", () => {
   // create: the gesture latches under the synth tid, before any kernel round-trip
   assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, 0\);\s+\/\/ the SEND gesture latches the pulse/);
-  // follow-up: re-latches at ITS send, with the agent count at that moment as the base
-  assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, agentCount\(cur\.th\)\);/);
+  // follow-up: re-latches at ITS send, with the projected message count at that moment as the base (T237)
+  assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, cur\.th\.msgs\.length\);/);
   // the create's latch carries onto the real thread at adopt (the synth tid retires)
   assert.match(UI, /if \(k\.startsWith\("pending:"\)\) \{ cmtAwaitBase\.set\(tid, cmtAwaitBase\.get\(k\)!\); cmtAwaitBase\.delete\(k\); \}/);
-  // the ONE clearing site: the comments frame whose msgs carry MORE agent records than the base —
-  // or the thread leaving "open"/erroring (green would lie about a reply no longer on the way)
-  assert.match(UI, /if \(base !== undefined && \(\(agentCount\(t\) > base && !threadBusy\(t\.state\)\) \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/,
-    "T112: the clear is the reply-COMPLETED event — a new agent record AND the turn settled; a "
-    + "mid-turn interim (the specimen's 'checking…' text) must never clear the pulse early. "
-    + "threadBusy on the CLEAR side only delays; the latch side never re-derives from state.");
-  // the mark's predicate: the latch, or (post-reload) the records' own owed reading; never state
+  // the ONE clearing site (T237): the comments frame whose projection carries the SEND (more messages
+  // than at the click) — or the thread leaving "open"/erroring. From that frame the KERNEL's replyOwed
+  // owns the wash: it reads the thread's transcript with the event model's own turn-end, so a mid-turn
+  // interim (the specimen's 'checking…' text) or a backend state flap can never clear the pulse early.
+  assert.match(UI, /if \(base !== undefined && \(t\.msgs\.length > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/,
+    "the latch covers only the pre-round-trip instant; no agent-count-vs-state heuristic on the clear side");
+  // the mark's predicate: the latch, then the kernel's owed bit (an older kernel: the records' own owed
+  // reading); never a timer, never the client's state read
   assert.match(UI, /if \(cmtAwaitBase\.has\(th\.tid\)\) return true;/);
-  assert.match(UI, /return replyOwed\(th\) && !cmtInterrupted\.has\(th\.tid\);/,
+  assert.match(UI, /const owed = typeof th\.replyOwed === "boolean" \? th\.replyOwed : replyOwed\(th\);/);
+  assert.match(UI, /return owed && !cmtInterrupted\.has\(th\.tid\);/,
     "the owed arm carries the T138 stop tombstone — an interrupted send owes nothing until the NEXT send");
   assert.match(UI, /if \(th\.status !== "open" \|\| !!th\.error \|\| threadStuck\(th\.state\)\) return false;/);
   // the push-count proxy is GONE root and branch
@@ -672,7 +674,7 @@ test("the popover interrupt posts the THREAD sid, clears the send-latch on the g
   // the mark green forever after a stop). The tombstone is record-count-keyed, never a clock, and a
   // fresh send retires it (re-owed).
   assert.match(body, /cmtInterrupted\.add\(sid\);/);
-  assert.match(UI, /return replyOwed\(th\) && !cmtInterrupted\.has\(th\.tid\);/,
+  assert.match(UI, /return owed && !cmtInterrupted\.has\(th\.tid\);/,   // owed = the kernel's replyOwed, else the msgs read (T237)
     "gesture-pair tombstone: stop sets it, ONLY the next send clears it — the CLI files the interrupt "
     + "as a trailing user-kind record, so any record-shape re-derivation would re-fire (lab-caught)");
   assert.match(UI, /cmtInterrupted\.delete\(cur\.th\.tid\);/);

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -529,7 +529,7 @@ test("agentCount is the reply-arrived detector's datum — records of the exchan
 
 test("busy latches at the SEND gesture and clears exactly on the reply-arrived record (source pins)", () => {
   // create: the gesture latches under the synth tid, before any kernel round-trip
-  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, \{ n: 0, t: 0, agents: 0 \}\);\s+\/\/ the SEND gesture latches the pulse/);
+  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, \{ you: 0, youT: 0, agents: 0 \}\);\s+\/\/ the SEND gesture latches the pulse/);
   // follow-up: re-latches at ITS send, with the thread's projected counts at that moment as the base (T237)
   assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/);
   // the create's latch carries onto the real thread at adopt (the synth tid retires)
@@ -538,8 +538,8 @@ test("busy latches at the SEND gesture and clears exactly on the reply-arrived r
   // than at the click) — or the thread leaving "open"/erroring. From that frame the KERNEL's replyOwed
   // owns the wash: it reads the thread's transcript with the event model's own turn-end, so a mid-turn
   // interim (the specimen's 'checking…' text) or a backend state flap can never clear the pulse early.
-  assert.match(UI, /const clear = \(typeof t\.replyOwed === "boolean" \? sendLanded : legacyReplyArrived\) \|\| t\.status !== "open" \|\| !!t\.error;/,
-    "against a T237 kernel the latch covers only the pre-round-trip instant; an older kernel keeps the T102 reply-arrived clear");
+  assert.match(UI, /if \(base !== undefined && cmtLatchReleased\(t, base\)\) cmtAwaitBase\.delete\(t\.tid\);/,
+    "against a T237 kernel the latch covers only the pre-round-trip instant (released by the user's own send); an older kernel keeps the T102 reply-arrived clear");
   // the mark's predicate: the latch, then the kernel's owed bit (an older kernel: the records' own owed
   // reading); never a timer, never the client's state read
   assert.match(UI, /if \(cmtAwaitBase\.has\(th\.tid\)\) return true;/);

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -529,7 +529,7 @@ test("agentCount is the reply-arrived detector's datum — records of the exchan
 
 test("busy latches at the SEND gesture and clears exactly on the reply-arrived record (source pins)", () => {
   // create: the gesture latches under the synth tid, before any kernel round-trip
-  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, \{ you: 0, youT: 0, agents: 0 \}\);\s+\/\/ the SEND gesture latches the pulse/);
+  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, \{ \.\.\.CMT_LATCH_ZERO \}\);\s+\/\/ the SEND gesture latches the pulse/);
   // follow-up: re-latches at ITS send, with the thread's projected counts at that moment as the base (T237)
   assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/);
   // the create's latch carries onto the real thread at adopt (the synth tid retires)

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -529,17 +529,17 @@ test("agentCount is the reply-arrived detector's datum — records of the exchan
 
 test("busy latches at the SEND gesture and clears exactly on the reply-arrived record (source pins)", () => {
   // create: the gesture latches under the synth tid, before any kernel round-trip
-  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, 0\);\s+\/\/ the SEND gesture latches the pulse/);
-  // follow-up: re-latches at ITS send, with the projected message count at that moment as the base (T237)
-  assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, cur\.th\.msgs\.length\);/);
+  assert.match(UI, /cmtAwaitBase\.set\(synth\.tid, \{ n: 0, t: 0, agents: 0 \}\);\s+\/\/ the SEND gesture latches the pulse/);
+  // follow-up: re-latches at ITS send, with the thread's projected counts at that moment as the base (T237)
+  assert.match(UI, /cmtAwaitBase\.set\(cur\.th\.tid, cmtLatchOf\(cur\.th\)\);/);
   // the create's latch carries onto the real thread at adopt (the synth tid retires)
   assert.match(UI, /if \(k\.startsWith\("pending:"\)\) \{ cmtAwaitBase\.set\(tid, cmtAwaitBase\.get\(k\)!\); cmtAwaitBase\.delete\(k\); \}/);
   // the ONE clearing site (T237): the comments frame whose projection carries the SEND (more messages
   // than at the click) — or the thread leaving "open"/erroring. From that frame the KERNEL's replyOwed
   // owns the wash: it reads the thread's transcript with the event model's own turn-end, so a mid-turn
   // interim (the specimen's 'checking…' text) or a backend state flap can never clear the pulse early.
-  assert.match(UI, /if \(base !== undefined && \(t\.msgs\.length > base \|\| t\.status !== "open" \|\| !!t\.error\)\) cmtAwaitBase\.delete\(t\.tid\);/,
-    "the latch covers only the pre-round-trip instant; no agent-count-vs-state heuristic on the clear side");
+  assert.match(UI, /const clear = \(typeof t\.replyOwed === "boolean" \? sendLanded : legacyReplyArrived\) \|\| t\.status !== "open" \|\| !!t\.error;/,
+    "against a T237 kernel the latch covers only the pre-round-trip instant; an older kernel keeps the T102 reply-arrived clear");
   // the mark's predicate: the latch, then the kernel's owed bit (an older kernel: the records' own owed
   // reading); never a timer, never the client's state read
   assert.match(UI, /if \(cmtAwaitBase\.has\(th\.tid\)\) return true;/);

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -18,7 +18,9 @@ export type CommentThread = {
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
   error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // a FINISHED agent reply newer than the read watermark — yellow (kernel truth, T237)
-  replyOwed?: boolean;        // a reply is still owed (no exchange yet / user's message newest / turn in progress) — the green wash (kernel truth, T237; absent on an older kernel)
+  replyOwed?: boolean;        // a reply is still owed (no exchange yet / user's message newest / turn in progress / a send held) — the green wash (kernel truth, T237; absent on an older kernel)
+  queued?: number;            // sends the backend holds for this thread, not yet in any projection (T237)
+  unreachable?: boolean | null;   // a broken thread (missing transcript / lost cut): the kernel owes nothing and says so (T237)
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   mode?: string;              // the thread's permission mode — the popover statusline's Auto badge
   fast?: string;              // fast-mode state ("on"/"off"/"cooldown"; "" = unknown → no badge)

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -69,7 +69,10 @@ export function replyOwed(th: CommentThread): boolean {
 // the exchange's own records: never wall clocks (cross-host transcripts skew) and never push counts
 // (the banned proxy — the old two-quiet-pushes settle counter killed the create-window green
 // while the fork booted, and any stall in its 0→1→2 stepping parked green forever with no event to
-// clear it). agentCount is the reply-arrived detector's datum; render.ts holds the per-send base.
+// clear it). agentCount is that reply-arrived detector's datum; render.ts holds the per-send base.
+// Since T237 the KERNEL ships replyOwed (read from the thread's transcript with the event model's own
+// turn-end), and the latch covers only the pre-round-trip instant against such a kernel; the
+// agentCount clear stays the contract for an older kernel that ships no bit.
 export function agentCount(th: CommentThread): number {
   return (th.msgs || []).filter((m) => m.who === "agent").length;
 }

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -17,7 +17,8 @@ export type CommentThread = {
   createdT: number;
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
   error?: string;             // the thread CLI's launch error, when it could not start
-  unread: boolean;            // an agent reply newer than the read watermark
+  unread: boolean;            // a FINISHED agent reply newer than the read watermark — yellow (kernel truth, T237)
+  replyOwed?: boolean;        // a reply is still owed (no exchange yet / user's message newest / turn in progress) — the green wash (kernel truth, T237; absent on an older kernel)
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   mode?: string;              // the thread's permission mode — the popover statusline's Auto badge
   fast?: string;              // fast-mode state ("on"/"off"/"cooldown"; "" = unknown → no badge)

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -19,7 +19,8 @@ export type CommentThread = {
   error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // a FINISHED agent reply newer than the read watermark — yellow (kernel truth, T237)
   replyOwed?: boolean;        // a reply is still owed (no exchange yet / user's message newest / turn in progress / a send held) — the green wash (kernel truth, T237; absent on an older kernel)
-  queued?: number;            // sends the backend holds for this thread, not yet in any projection (T237)
+  queued?: number;            // sends the backend holds or has fed for this thread, not yet in the transcript (T237)
+  lastUuid?: string;          // the newest record shown/held — "did the transcript move?" without the projection caps (T237)
   unreachable?: boolean | null;   // a broken thread (missing transcript / lost cut): the kernel owes nothing and says so (T237)
   sinceEpoch?: number;        // ms epoch the thread's current state began — the popover chip's timer
   mode?: string;              // the thread's permission mode — the popover statusline's Auto badge

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -50,7 +50,7 @@ import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
 import { setTip, pruneTip } from "./tip";
-import { replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 import { dragSlotIndex } from "./dragslot";
 
 for (const [name, lang] of Object.entries({
@@ -6560,14 +6560,19 @@ const commentPending = new Map<string, { text: string; t: number; imgPaths?: str
 // image paths shipped into the OPEN popover's box (the droppedPath ack) and not yet sent — the next
 // send attaches them to its pending entry so the echo renders the same thumbnails the chat's does
 let cmtShippedImgs: string[] = [];
-// THE EXCHANGE LATCH (T102, the user 2026-08-26): tid → the agent-message count at the newest SEND.
-// Set at the send GESTURE (create seeds 0 under the synth tid, transferred on adopt; a reply stamps
-// the count at its send), cleared ONLY by the reply-arrived event — the agent's reply record landing
-// in th.msgs (agentCount rising past the base; see the comments frame handler). Follow-ups re-latch
-// identically, each until ITS reply arrives. No push counting, no thread-state proxy: the old
-// push-count settle killed the create-window green while the fork booted (its frames read
-// all-quiet) and any stall in its stepping parked green forever — both ends of the reported bug.
-const cmtAwaitBase = new Map<string, number>();
+// THE SEND LATCH (T102, the user 2026-08-26; rescoped T237): tid → what the thread's projection held at
+// the newest SEND gesture — its message count, its newest message's time, its agent-message count. Set
+// at the gesture (create seeds zeros under the synth tid, transferred on adopt; a follow-up stamps its
+// thread's counts), BEFORE any kernel round-trip. Against a kernel that ships replyOwed (T237) the latch
+// covers ONLY the pre-round-trip instant: it clears once a frame's projection carries the send (a message
+// newer than the click's newest, or more messages than then — the count alone misses a thread already at
+// the projection's 40-message cap) and the kernel's owed bit owns the wash from there. Against an OLDER
+// kernel (no bit) it keeps the T102 contract: cleared by the reply-arrived event — the agent's reply record
+// landing (agentCount rising past the base) with the thread settled. No push counting, no timers.
+type CmtLatch = { n: number; t: number; agents: number };
+const cmtAwaitBase = new Map<string, CmtLatch>();
+const cmtLatchOf = (th: CommentThread): CmtLatch => ({
+  n: th.msgs.length, t: th.msgs.length ? (th.msgs[th.msgs.length - 1].t || 0) : 0, agents: agentCount(th) });
 // Creates in flight (T106 lab find, 2026-08-26): a comment made seconds after a reply lands can be
 // refused by the kernel's parse lag ("isn't in the transcript yet"). The payload holds here from the
 // send; a TRANSIENT nack keeps the optimistic mark + latch alive and the create RE-POSTS when the
@@ -7328,7 +7333,7 @@ function commentSendFromPop(pop: HTMLElement): void {
       unread: false, replyOwed: true, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
-    cmtAwaitBase.set(synth.tid, 0);   // the SEND gesture latches the pulse — before any kernel round-trip (T102); cleared once a frame carries the send (T237)
+    cmtAwaitBase.set(synth.tid, { n: 0, t: 0, agents: 0 });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); cleared once a frame carries the send (T237)
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
@@ -7341,7 +7346,7 @@ function commentSendFromPop(pop: HTMLElement): void {
   const cur = openCommentThread();
   if (!cur) return;
   vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
-  cmtAwaitBase.set(cur.th.tid, cur.th.msgs.length);   // a follow-up RE-LATCHES at its own send — until a frame carries that send; then the kernel's replyOwed owns it (T102 → T237)
+  cmtAwaitBase.set(cur.th.tid, cmtLatchOf(cur.th));   // a follow-up RE-LATCHES at its own send — until a frame carries that send; then the kernel's replyOwed owns it (T102 → T237)
   cmtInterrupted.delete(cur.th.tid);                  // a fresh send re-owes a reply — the stop tombstone retires (T138)
   cur.th.state = "working";                     // optimistic: the pulse rides the SEND, not the
   applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
@@ -12720,10 +12725,17 @@ window.addEventListener("message", (e: MessageEvent) => {
     // clear (the latch side never re-derives from state), so the boot-flap class T102 removed
     // cannot re-green anything. Leaving "open" (or erroring) still clears immediately.
     for (const t of threads) {
-      // the gesture latch covers ONLY the pre-round-trip instant (T237): once a frame's projection carries
-      // the send (its message count grew past the count at the click), the kernel's replyOwed owns the wash
       const base = cmtAwaitBase.get(t.tid);
-      if (base !== undefined && (t.msgs.length > base || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
+      if (base === undefined) continue;
+      // T237: against a kernel that ships replyOwed the latch covers ONLY the pre-round-trip instant — it
+      // clears once a frame's projection carries the SEND (a message newer than the click's newest, or more
+      // messages than at the click; the count alone never grows on a thread at the 40-message cap) and the
+      // kernel's owed bit owns the wash from there. An older kernel keeps the T102 reply-arrived clear.
+      const newestT = t.msgs.length ? (t.msgs[t.msgs.length - 1].t || 0) : 0;
+      const sendLanded = t.msgs.length > base.n || newestT > base.t;
+      const legacyReplyArrived = agentCount(t) > base.agents && !threadBusy(t.state);
+      const clear = (typeof t.replyOwed === "boolean" ? sendLanded : legacyReplyArrived) || t.status !== "open" || !!t.error;
+      if (clear) cmtAwaitBase.delete(t.tid);
     }
     // prune latches only for tids NO session's thread list knows (T237): this frame lists ONE session's
     // threads, and pruning against it dropped every other session's latch — and any tid a frame

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6569,34 +6569,35 @@ let cmtShippedImgs: string[] = [];
 // the projection's 40-message cap) and the kernel's owed bit owns the wash from there. Against an OLDER
 // kernel (no bit) it keeps the T102 contract: cleared by the reply-arrived event — the agent's reply record
 // landing (agentCount rising past the base) with the thread settled. No push counting, no timers.
-type CmtLatch = { you: number; youT: number; agents: number; queued: number; events: number };
+type CmtLatch = { you: number; youT: number; agents: number; queued: number; last: string };
 const cmtAwaitBase = new Map<string, CmtLatch>();
 const cmtYouRows = (th: CommentThread) => (th.msgs || []).filter((m) => m.who === "you");
 const cmtLatchOf = (th: CommentThread): CmtLatch => {
   const you = cmtYouRows(th);
   return { you: you.length, youT: you.length ? (you[you.length - 1].t || 0) : 0, agents: agentCount(th),
-           queued: th.queued || 0, events: ((th.events || []) as unknown[]).length };
+           queued: th.queued || 0, last: th.lastUuid || "" };
 };
-const CMT_LATCH_ZERO: CmtLatch = { you: 0, youT: 0, agents: 0, queued: 0, events: 0 };
+const CMT_LATCH_ZERO: CmtLatch = { you: 0, youT: 0, agents: 0, queued: 0, last: "" };
 /** Does this frame's thread release the send latch? Against a kernel that ships replyOwed (T237), the
  *  KERNEL'S ACKNOWLEDGEMENT of the send does — any of: the user's own "you" row newer than the click's
  *  newest (or more "you" rows than then; the count alone never grows on a thread at the projection's
- *  40-message cap); the backend now HOLDING the send (queued grew — a follow-up typed mid-turn waits there
- *  until the turn ends, owed but in no projection yet); the send consumed as a slash command (the
- *  transcript grew — new events — while the kernel says nothing is owed); or the kernel marking the thread
- *  unreachable (a broken thread owes nothing). Never an agent row alone: the agent's partials and the
- *  reply itself land BEFORE a held send is written, and clearing on them dropped the green while the send
- *  was still queued (round-2 review). Against an older kernel (no bit) the T102 reply-arrived clear
- *  stands. A thread leaving "open" or erroring releases either way. */
+ *  40-message cap); the backend now holding or having fed the send (queued grew — its input echo lives from
+ *  the send until the record lands, so this covers the mid-turn follow-up the backend queues AND the send
+ *  the CLI has but has not written); the send consumed as a slash command (the newest record moved —
+ *  lastUuid, cap-proof — while the kernel says nothing is owed); or the kernel marking the thread
+ *  unreachable (a broken thread owes nothing). Never an agent row alone, and never "the transcript grew"
+ *  alone: the agent's partials and the reply itself land BEFORE a held send is written, and clearing on
+ *  them dropped the green while the send was still owed (round-2/4 review). Against an older kernel (no
+ *  bit) the T102 reply-arrived clear stands. A thread leaving "open" or erroring releases either way. */
 function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {
   if (t.status !== "open" || !!t.error) return true;
   if (typeof t.replyOwed === "boolean") {
     const you = cmtYouRows(t);
     const newestYouT = you.length ? (you[you.length - 1].t || 0) : 0;
     if (you.length > base.you || newestYouT > base.youT) return true;   // written
-    if ((t.queued || 0) > base.queued) return true;                       // held by the backend — the kernel owes it now
+    if ((t.queued || 0) > base.queued) return true;                       // held or fed by the backend — the kernel owes it now
     if (t.unreachable) return true;                                       // nothing can land — no green promise
-    return ((t.events || []) as unknown[]).length > base.events && t.replyOwed === false;   // consumed as a command
+    return !!t.lastUuid && t.lastUuid !== base.last && t.replyOwed === false;   // consumed as a command: moved, nothing owed
   }
   return agentCount(t) > base.agents && !threadBusy(t.state);
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6569,26 +6569,34 @@ let cmtShippedImgs: string[] = [];
 // the projection's 40-message cap) and the kernel's owed bit owns the wash from there. Against an OLDER
 // kernel (no bit) it keeps the T102 contract: cleared by the reply-arrived event — the agent's reply record
 // landing (agentCount rising past the base) with the thread settled. No push counting, no timers.
-type CmtLatch = { you: number; youT: number; agents: number };
+type CmtLatch = { you: number; youT: number; agents: number; queued: number; events: number };
 const cmtAwaitBase = new Map<string, CmtLatch>();
 const cmtYouRows = (th: CommentThread) => (th.msgs || []).filter((m) => m.who === "you");
 const cmtLatchOf = (th: CommentThread): CmtLatch => {
   const you = cmtYouRows(th);
-  return { you: you.length, youT: you.length ? (you[you.length - 1].t || 0) : 0, agents: agentCount(th) };
+  return { you: you.length, youT: you.length ? (you[you.length - 1].t || 0) : 0, agents: agentCount(th),
+           queued: th.queued || 0, events: ((th.events || []) as unknown[]).length };
 };
-/** Does this frame's thread release the send latch? Against a kernel that ships replyOwed (T237), only the
- *  USER'S OWN send landing does — a "you" row newer than the click's newest, or more "you" rows than then
- *  (the count alone never grows on a thread at the projection's 40-message cap). Never an agent row: the
- *  backend HOLDS a follow-up sent mid-turn until the turn ends, so the agent's partials (whose merged row's
- *  time advances) and the reply itself land BEFORE the send is written — clearing on them dropped the
- *  green while the send was still queued (round-2 review). Against an older kernel (no bit) the T102
- *  reply-arrived clear stands. A thread leaving "open" or erroring releases either way. */
+const CMT_LATCH_ZERO: CmtLatch = { you: 0, youT: 0, agents: 0, queued: 0, events: 0 };
+/** Does this frame's thread release the send latch? Against a kernel that ships replyOwed (T237), the
+ *  KERNEL'S ACKNOWLEDGEMENT of the send does — any of: the user's own "you" row newer than the click's
+ *  newest (or more "you" rows than then; the count alone never grows on a thread at the projection's
+ *  40-message cap); the backend now HOLDING the send (queued grew — a follow-up typed mid-turn waits there
+ *  until the turn ends, owed but in no projection yet); the send consumed as a slash command (the
+ *  transcript grew — new events — while the kernel says nothing is owed); or the kernel marking the thread
+ *  unreachable (a broken thread owes nothing). Never an agent row alone: the agent's partials and the
+ *  reply itself land BEFORE a held send is written, and clearing on them dropped the green while the send
+ *  was still queued (round-2 review). Against an older kernel (no bit) the T102 reply-arrived clear
+ *  stands. A thread leaving "open" or erroring releases either way. */
 function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {
   if (t.status !== "open" || !!t.error) return true;
   if (typeof t.replyOwed === "boolean") {
     const you = cmtYouRows(t);
     const newestYouT = you.length ? (you[you.length - 1].t || 0) : 0;
-    return you.length > base.you || newestYouT > base.youT;
+    if (you.length > base.you || newestYouT > base.youT) return true;   // written
+    if ((t.queued || 0) > base.queued) return true;                       // held by the backend — the kernel owes it now
+    if (t.unreachable) return true;                                       // nothing can land — no green promise
+    return ((t.events || []) as unknown[]).length > base.events && t.replyOwed === false;   // consumed as a command
   }
   return agentCount(t) > base.agents && !threadBusy(t.state);
 }
@@ -7352,7 +7360,7 @@ function commentSendFromPop(pop: HTMLElement): void {
       unread: false, replyOwed: true, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
-    cmtAwaitBase.set(synth.tid, { you: 0, youT: 0, agents: 0 });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); released once a frame carries the send (T237)
+    cmtAwaitBase.set(synth.tid, { ...CMT_LATCH_ZERO });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); released once a frame acknowledges the send (T237)
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -50,7 +50,7 @@ import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
 import { setTip, pruneTip } from "./tip";
-import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 import { dragSlotIndex } from "./dragslot";
 
 for (const [name, lang] of Object.entries({
@@ -6614,8 +6614,13 @@ function dropSynthThread(sid: string, uuid: string): void {
 const cmtInterrupted = new Set<string>();
 const commentInFlight = (th: CommentThread): boolean => {
   if (th.status !== "open" || !!th.error || threadStuck(th.state)) return false;
-  if (cmtAwaitBase.has(th.tid)) return true;
-  return replyOwed(th) && !cmtInterrupted.has(th.tid);
+  if (cmtAwaitBase.has(th.tid)) return true;    // the pre-round-trip instant only: from the send click until a frame carries it
+  // the kernel is the one truth for "a reply is still owed" (T237): it reads the thread's transcript with
+  // the chat's own turn-end, so an intermediate record of a multi-record turn, a state flap between
+  // records, or a frame that lost a client latch can no longer drop the green wash to yellow while the
+  // thread is still responding. An older kernel ships no bit → the msgs-derived fallback.
+  const owed = typeof th.replyOwed === "boolean" ? th.replyOwed : replyOwed(th);
+  return owed && !cmtInterrupted.has(th.tid);
 };
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 // The popover-boot hold (fillCommentMsgs): tid → when the loader first held the list. Held until the
@@ -7320,10 +7325,10 @@ function commentSendFromPop(pop: HTMLElement): void {
     // so its never-listed tid unwraps through the standard sweep the moment the real thread lands
     const synth: CommentThread = { tid: "pending:" + create.uuid, anchorUuid: create.uuid,
       exact: create.exact, status: "open", createdT: Date.now() / 1000, state: "working",
-      unread: false, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
+      unread: false, replyOwed: true, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
-    cmtAwaitBase.set(synth.tid, 0);   // the SEND gesture latches the pulse — before any kernel round-trip (T102)
+    cmtAwaitBase.set(synth.tid, 0);   // the SEND gesture latches the pulse — before any kernel round-trip (T102); cleared once a frame carries the send (T237)
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
@@ -7336,7 +7341,7 @@ function commentSendFromPop(pop: HTMLElement): void {
   const cur = openCommentThread();
   if (!cur) return;
   vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
-  cmtAwaitBase.set(cur.th.tid, agentCount(cur.th));   // a follow-up RE-LATCHES at its own send, until ITS reply (T102)
+  cmtAwaitBase.set(cur.th.tid, cur.th.msgs.length);   // a follow-up RE-LATCHES at its own send — until a frame carries that send; then the kernel's replyOwed owns it (T102 → T237)
   cmtInterrupted.delete(cur.th.tid);                  // a fresh send re-owes a reply — the stop tombstone retires (T138)
   cur.th.state = "working";                     // optimistic: the pulse rides the SEND, not the
   applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
@@ -12715,26 +12720,33 @@ window.addEventListener("message", (e: MessageEvent) => {
     // clear (the latch side never re-derives from state), so the boot-flap class T102 removed
     // cannot re-green anything. Leaving "open" (or erroring) still clears immediately.
     for (const t of threads) {
+      // the gesture latch covers ONLY the pre-round-trip instant (T237): once a frame's projection carries
+      // the send (its message count grew past the count at the click), the kernel's replyOwed owns the wash
       const base = cmtAwaitBase.get(t.tid);
-      if (base !== undefined && ((agentCount(t) > base && !threadBusy(t.state)) || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
+      if (base !== undefined && (t.msgs.length > base || t.status !== "open" || !!t.error)) cmtAwaitBase.delete(t.tid);
     }
+    // prune latches only for tids NO session's thread list knows (T237): this frame lists ONE session's
+    // threads, and pruning against it dropped every other session's latch — and any tid a frame
+    // momentarily lacked — leaving a fresh comment's mark plain yellow while it was still "opening"
+    const knownTids = new Set<string>();
+    commentThreads.forEach((list) => list.forEach((t) => knownTids.add(t.tid)));
     for (const k of Array.from(cmtAwaitBase.keys()))
-      if (!k.startsWith("pending:") && !threads.some((t) => t.tid === k)) cmtAwaitBase.delete(k);
+      if (!k.startsWith("pending:") && !knownTids.has(k)) cmtAwaitBase.delete(k);
     const live = new Set(threads.filter((t) => t.status !== "promoted").map((t) => t.tid));
     for (const k of Array.from(commentPending.keys())) if (!live.has(k)) commentPending.delete(k);
     for (const k of Array.from(commentDrafts.keys())) if (!k.startsWith("new:") && !live.has(k)) commentDrafts.delete(k);
     if (pendingAdoptTid && threads.some((t) => t.tid === pendingAdoptTid)) adoptCommentThread(sid, pendingAdoptTid);
-    applyCommentMarks(sid);
     if (openCommentKey && openCommentKey.sid === sid) {
-      // reading IS seeing: a reply that lands while its popover is open must not dot the mark
+      // reading IS seeing: a reply that lands while its popover is open must not dot the mark — the
+      // watermark advances BEFORE the marks paint (T237), so it never wears yellow for it, not even one tick
       const th = threads.find((t) => t.tid === openCommentKey!.tid);
       if (th && th.unread) {
         th.unread = false;
         vscodeApi?.postMessage({ type: "commentSeen", id: sid, tid: th.tid });
-        applyCommentMarks(sid);
       }
-      renderCommentPopover();
     }
+    applyCommentMarks(sid);
+    if (openCommentKey && openCommentKey.sid === sid) renderCommentPopover();
   }
   // the create ack names the new thread: adopt exactly it (never a guess). The kernel sends the
   // frame first; if this ack somehow beat it, park the tid and the next frame adopts. The draft is

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6569,10 +6569,29 @@ let cmtShippedImgs: string[] = [];
 // the projection's 40-message cap) and the kernel's owed bit owns the wash from there. Against an OLDER
 // kernel (no bit) it keeps the T102 contract: cleared by the reply-arrived event — the agent's reply record
 // landing (agentCount rising past the base) with the thread settled. No push counting, no timers.
-type CmtLatch = { n: number; t: number; agents: number };
+type CmtLatch = { you: number; youT: number; agents: number };
 const cmtAwaitBase = new Map<string, CmtLatch>();
-const cmtLatchOf = (th: CommentThread): CmtLatch => ({
-  n: th.msgs.length, t: th.msgs.length ? (th.msgs[th.msgs.length - 1].t || 0) : 0, agents: agentCount(th) });
+const cmtYouRows = (th: CommentThread) => (th.msgs || []).filter((m) => m.who === "you");
+const cmtLatchOf = (th: CommentThread): CmtLatch => {
+  const you = cmtYouRows(th);
+  return { you: you.length, youT: you.length ? (you[you.length - 1].t || 0) : 0, agents: agentCount(th) };
+};
+/** Does this frame's thread release the send latch? Against a kernel that ships replyOwed (T237), only the
+ *  USER'S OWN send landing does — a "you" row newer than the click's newest, or more "you" rows than then
+ *  (the count alone never grows on a thread at the projection's 40-message cap). Never an agent row: the
+ *  backend HOLDS a follow-up sent mid-turn until the turn ends, so the agent's partials (whose merged row's
+ *  time advances) and the reply itself land BEFORE the send is written — clearing on them dropped the
+ *  green while the send was still queued (round-2 review). Against an older kernel (no bit) the T102
+ *  reply-arrived clear stands. A thread leaving "open" or erroring releases either way. */
+function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {
+  if (t.status !== "open" || !!t.error) return true;
+  if (typeof t.replyOwed === "boolean") {
+    const you = cmtYouRows(t);
+    const newestYouT = you.length ? (you[you.length - 1].t || 0) : 0;
+    return you.length > base.you || newestYouT > base.youT;
+  }
+  return agentCount(t) > base.agents && !threadBusy(t.state);
+}
 // Creates in flight (T106 lab find, 2026-08-26): a comment made seconds after a reply lands can be
 // refused by the kernel's parse lag ("isn't in the transcript yet"). The payload holds here from the
 // send; a TRANSIENT nack keeps the optimistic mark + latch alive and the create RE-POSTS when the
@@ -7333,7 +7352,7 @@ function commentSendFromPop(pop: HTMLElement): void {
       unread: false, replyOwed: true, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
-    cmtAwaitBase.set(synth.tid, { n: 0, t: 0, agents: 0 });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); cleared once a frame carries the send (T237)
+    cmtAwaitBase.set(synth.tid, { you: 0, youT: 0, agents: 0 });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); released once a frame carries the send (T237)
     applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
@@ -12725,17 +12744,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     // clear (the latch side never re-derives from state), so the boot-flap class T102 removed
     // cannot re-green anything. Leaving "open" (or erroring) still clears immediately.
     for (const t of threads) {
+      // T237: the latch covers ONLY the pre-round-trip instant — released once a frame's projection carries
+      // the user's own send (see cmtLatchReleased); the kernel's owed bit owns the wash from there
       const base = cmtAwaitBase.get(t.tid);
-      if (base === undefined) continue;
-      // T237: against a kernel that ships replyOwed the latch covers ONLY the pre-round-trip instant — it
-      // clears once a frame's projection carries the SEND (a message newer than the click's newest, or more
-      // messages than at the click; the count alone never grows on a thread at the 40-message cap) and the
-      // kernel's owed bit owns the wash from there. An older kernel keeps the T102 reply-arrived clear.
-      const newestT = t.msgs.length ? (t.msgs[t.msgs.length - 1].t || 0) : 0;
-      const sendLanded = t.msgs.length > base.n || newestT > base.t;
-      const legacyReplyArrived = agentCount(t) > base.agents && !threadBusy(t.state);
-      const clear = (typeof t.replyOwed === "boolean" ? sendLanded : legacyReplyArrived) || t.status !== "open" || !!t.error;
-      if (clear) cmtAwaitBase.delete(t.tid);
+      if (base !== undefined && cmtLatchReleased(t, base)) cmtAwaitBase.delete(t.tid);
     }
     // prune latches only for tids NO session's thread list knows (T237): this frame lists ONE session's
     // threads, and pruning against it dropped every other session's latch — and any tid a frame
@@ -12787,6 +12799,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   // a reply the kernel refused: drop its optimistic bubble (it must not read as 'still thinking'
   // forever) and hand the words back for review-and-resend — the toast says why it failed
   else if (m.type === "commentSendFailed" && m.tid) {
+    cmtAwaitBase.delete(String(m.tid));           // a refused send owes nothing — the latch it armed goes with it (T237 review)
     const pl = commentPending.get(String(m.tid));
     if (pl && pl.length) {
       const lost = pl.pop()!;


### PR DESCRIPTION
## Summary
The marked passage turned **yellow** (unread) while the popover still said "opening the thread…", and earlier while the thread had only started responding. The design is a faded await-green `.busy` wash mid-reply that settles into yellow the moment the reply lands. Two faults, both convicted in code:

- **`.busy` hung on a client gesture latch** (`cmtAwaitBase`) that any session's comments frame pruned (the prune ran against one session's thread list) and that cleared on a reply-arrived heuristic; the msgs-derived `replyOwed()` fallback flips false at the first agent record of a turn.
- **`unread` keyed on any agent record** newer than the watermark, so an intermediate text block or tool call painted yellow before the turn ended.

## Fix
- **Kernel is the one truth.** `_comments_frame` ships `replyOwed` (green) and `unread` = a *finished* reply newer than `lastSeenT` (yellow). Turn-in-progress is read from the thread's transcript with the event model's own turn-end (`_thread_turn_open`); agent content from the projection the popover renders (events, else msgs). Rule stated in the docstring.
- **Client keys `.busy` on `replyOwed`**; the gesture latch covers only the pre-round-trip instant (send click → first frame carrying the send) and is pruned only against every session's known threads; a reply landing while its popover is open advances the watermark before the marks paint. No timers.

## Tests
- `tests/test_comment_threads.py` — red first (`KeyError: 'replyOwed'`, yellow on a partial record): partial record, state flap, multi-record turn flips once, transcript end beats lingering state, open turn beats early "waiting", rendered-projection rule, fresh thread owes, follow-up owes, watermark pin intact
- `ui/webview/comment-reply-landed.test.ts` — source pins + executed mark-class checks over the kernel's frames (opening / partial / finished / latch-only / older kernel)
- old latch pins in `comments.test.ts` and `comment-popover-parity.test.ts` retargeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
