### PR TITLE
An unsent draft survives a host drop, and the composer never changes hands silently (T236)

### DIFF
--- a/ui/webview/click-safe.test.ts
+++ b/ui/webview/click-safe.test.ts
@@ -54,8 +54,9 @@ test("chat tab bar: select + ✕ (Close / End session) are DELEGATED to the stab
   // and the tab is dropped + a new one reselected OPTIMISTICALLY (don't wait for the kernel's closed event →
   // no stale content from the just-closed session — the user 2026-06-24)
   assert.match(RENDER, /closeTab", id \}\);\s*\n\s*closeTabLocally\(id\);/);   // …and it STAYS gone: tab-close-optimistic.test.ts
-  assert.match(RENDER, /function dismissSession\(id: string\): void/);
-  assert.match(RENDER, /m\.type === "closed"\) dismissSession\(m\.id\)/);   // the kernel's own death event reuses it
+  assert.match(RENDER, /function dismissSession\(id: string, why: DismissWhy, doomed\?: ReadonlySet<string>\): void/);
+  // the kernel's own death event reuses it — naming its reason (T236: federation's stand-in for a dropped host is stamped, not an end)
+  assert.match(RENDER, /m\.type === "closed"\) dismissSession\(m\.id, m\.hostDrop === true \? "hostDrop" : "end"\)/);
 });
 
 test("Fleet: header / row open + caret fold are DELEGATED to the stable #fleet-list, not per-node", () => {

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -186,7 +186,8 @@ test("Enter with a live transcript selection drops into the message box with the
   // and re-seeding at Enter makes the chip exactly what's selected at that moment
   assert.match(RENDER, /const q = transcriptSelection\(\);\s*\n\s*if \(q && activeId\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*seedTranscriptQuote\(activeId, q\.text, q\.uuid\);\s*\n\s*focusComposer\(\);\s*\n\s*return;/);
   // the bare-area fallback (Enter with no selection — the user 2026-06-26) survives untouched below it
-  assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(focusComposerOrAsk\(\)\) e\.preventDefault\(\);/);
+  // (T236: while the hand-over note holds the box, this default stands down — see draft-teardown.test.ts)
+  assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(composerNoteHolds\(\)\) return;[^\n]*\n\s*if \(focusComposerOrAsk\(\)\) e\.preventDefault\(\);/);
 });
 
 test("closing a session clears its composer reply context — chip, draft, and edit pill (the user 2026-08-04)", () => {

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -190,15 +190,16 @@ test("Enter with a live transcript selection drops into the message box with the
 });
 
 test("closing a session clears its composer reply context — chip, draft, and edit pill (the user 2026-08-04)", () => {
-  const body = RENDER.match(/function dismissSession\(id: string\): void \{[\s\S]*?\n\}/);
+  const body = RENDER.match(/function dismissSession\(id: string, why: DismissWhy, doomed\?: ReadonlySet<string>\): void \{[\s\S]*?\n\}/);
   assert.ok(body, "dismissSession not found");
   // the maps: the draft, the citation chip, and any pending edit mode all die with the session
   assert.match(body![0], /drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\); composerFiles\.delete\(id\); persistDrafts\(\);/);
   // …and when the CLOSED session was the active one, the shared chip strip is repainted for the newly
   // selected tab. Without this the dead session's chip lingered in the strip — and its ✕, bound to the
   // dead id whose map entry is already gone, early-returned in removeCitation, so the stale chip could
-  // not even be dismissed by hand.
-  assert.match(body![0], /renderComposerChips\(activeId\);[\s\S]*?showActive\(\);/);
+  // not even be dismissed by hand. (The repaint rides loadComposerFor since T236 — chips, thumbnails,
+  // staged stack and draft in one loader, shared with the only-tab adoption.)
+  assert.match(body![0], /loadComposerFor\(activeId\);[\s\S]*?showActive\(\);/);
 });
 
 test("quote chips send a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -90,5 +90,7 @@ test("attachments live the DRAFT lifecycle: switch, reload, close", () => {
   assert.match(RENDER, /renderComposerFiles\(activeId\);   \/\/ attachments persisted across the reload/);
   // closing a session drops its attachments with its draft, and repaints for the new active tab
   assert.match(RENDER, /drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\); composerFiles\.delete\(id\); persistDrafts\(\);/);
-  assert.match(RENDER, /renderComposerFiles\(activeId\);   \/\/ same for its attachment thumbnails/);
+  // …through the shared loader (T236): loadComposerFor paints thumbnails with the chips, staged stack and draft
+  assert.match(RENDER, /loadComposerFor\(activeId\);   \/\/ the strip was showing the CLOSED session/);
+  assert.match(RENDER, /function loadComposerFor\(id: string \| null, keepTyped = false\): void \{[\s\S]*?renderComposerFiles\(id\);/);
 });

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -39,6 +39,7 @@ function model() {
   let composer = "";                        // #composer-input's value
   let focused = false;                      // document.activeElement === the textarea
   let note: { sid: string; why: Why } | null = null;   // the line above the box (#composer-note)
+  let flashes = 0;                          // swallowed keystrokes that pulsed the note
   const touchMru = (id: string) => { const i = mru.indexOf(id); if (i >= 0) mru.splice(i, 1); mru.unshift(id); };
   // setActive's composer half: stash the leaving tab's text, show the entering tab's own
   const activate = (id: string) => {
@@ -83,6 +84,17 @@ function model() {
     },
     activate,
     focus() { focused = true; },
+    // a CLICK into the box: focus, and the deliberate re-bind that retires the note (its pointerdown)
+    clickBox() { focused = true; note = null; },
+    // the "type from anywhere" default: a printable key with no owner drops the cursor into the box and
+    // inserts — unless the hand-over note holds the box, when the key is swallowed and the note flashes
+    typeAnywhere(text: string) {
+      if (focused) { this.type(text); return; }
+      if (note) { flashes++; return; }
+      focused = true;
+      this.type(text);
+    },
+    get flashes() { return flashes; },
     // a keystroke: only a focused textarea receives one; the input handler files under the ACTIVE id
     type(text: string) {
       if (!focused) return;
@@ -126,14 +138,19 @@ test("(ii) typing after an active-tab teardown never lands under another session
   m.type(" …and more");                                   // keystrokes with no focus go nowhere
   assert.equal(m.hasDraft("hostB:api"), false, "nothing was filed under the survivor");
   assert.equal(m.draft("hostA:web"), "dear hostA", "the original text is intact under its own id");
-  // clicking INTO the blurred box is a deliberate act: the note above it names whose box went away, the
-  // active tab is the survivor's — typing now is the survivor's own draft, and the note stays (still true)
-  m.focus(); m.type("for api");
-  assert.equal(m.draft("hostB:api"), "for api");
-  assert.ok(m.note && m.note.sid === "hostA:web");
-  // an explicit switch to another tab is the event that retires it
-  m.activate("hostB:tests");
+  // the harness caught the leak the blur alone left open: a printable key "nobody claimed" re-focused the
+  // box and inserted. While the note holds, that default stands down — swallowed, the note flashes.
+  m.typeAnywhere("c");
+  assert.equal(m.flashes, 1);
+  assert.equal(m.focused, false);
+  assert.equal(m.hasDraft("hostB:api"), false, "still nothing under the survivor");
+  assert.ok(m.note && m.note.sid === "hostA:web", "the note stays up until a deliberate act");
+  // clicking INTO the box IS that act: the note retires and typing is the survivor's own draft
+  m.clickBox(); m.type("for api");
   assert.equal(m.note, null);
+  assert.equal(m.draft("hostB:api"), "for api");
+  // an explicit switch to another tab binds the box there
+  m.activate("hostB:tests");
   m.type("for tests");
   assert.equal(m.draft("hostB:tests"), "for tests", "typed AFTER an explicit switch → that tab's own draft");
   assert.equal(m.draft("hostA:web"), "dear hostA");
@@ -268,6 +285,18 @@ test("an active tab torn down under the user: stash first, prune the fallback, b
   assert.match(fn, /const home = hostOf\(id\);[^\n]*\n\s*const goingToo = \(x: string\) => \(doomed\?\.has\(x\) \?\? false\) \|\| \(why === "hostDrop" && !!home && hostOf\(x\) === home\);[\s\S]*?activeId = mru\.find\(\(x\) => order\.includes\(x\) && !goingToo\(x\)\) \|\| order\.find\(\(x\) => !goingToo\(x\)\) \|\| null;[\s\S]*?loadComposerFor\(activeId\);/);
   // …and, unless the user themself clicked ✕, the box is blurred and the note names what went away
   assert.match(fn, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/);
+});
+
+test("while the note holds the box, the type-from-anywhere defaults stand down; a click into the box ends the hold", () => {
+  // the printable-key default: no focus steal into the survivor's box + flash (the handler stays preventDefault-free, as pinned by composer-citation.test.ts)
+  assert.match(RENDER, /if \(composerNoteHolds\(\)\) return;[^\n]*\n\s*ta\.focus\(\{ preventScroll: true \}\);/);
+  // bare-area Enter: stands down before focusComposerOrAsk
+  assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(composerNoteHolds\(\)\) return;/);
+  assert.match(RENDER, /function composerNoteHolds\(\): boolean \{\s*\n\s*if \(!composerNoteSid\) return false;\s*\n\s*flashComposerNote\(\);\s*\n\s*return true;/);
+  // the deliberate act: a pointerdown in the box
+  assert.match(RENDER, /ta\.addEventListener\("pointerdown", \(\) => \{ if \(composerNoteSid\) clearComposerNote\(\); \}\);/);
+  // the note says so
+  assert.match(RENDER, /hint\.textContent = " Click the box to type here\.";/);
 });
 
 test("the note retires on the exact events: an explicit switch, the session's return, or its ✕", () => {

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -80,12 +80,13 @@ function model() {
       sessions.add(id);
       if (!order.includes(id)) order.push(id);
       if (!activeId) { activeId = id; if (!composer) composer = drafts.get(id) ?? ""; touchMru(id); }   // the adoption goes through the draft load
-      if (note && note.sid === id) note = null;   // it is back, draft and all
+      if (note && note.sid === id) activate(id);  // back while the note still holds → the user did nothing since → back on it, draft and all
     },
     activate,
-    focus() { focused = true; },
-    // a CLICK into the box: focus, and the deliberate re-bind that retires the note (its pointerdown)
-    clickBox() { focused = true; note = null; },
+    // the box gaining focus — by a click, Tab, Enter over a selection, a slash pick… — is the deliberate re-bind
+    // that retires the note (render.ts: the composer's focus listener)
+    focus() { focused = true; note = null; },
+    clickBox() { this.focus(); },
     // the "type from anywhere" default: a printable key with no owner drops the cursor into the box and
     // inserts — unless the hand-over note holds the box, when the key is swallowed and the note flashes
     typeAnywhere(text: string) {
@@ -120,10 +121,17 @@ test("(i) a draft under a remote session survives its host dropping, and is back
   assert.equal(m.hasDraft("hostA:web"), true, "a host drop is not a close — the draft is stashed, not deleted");
   assert.equal(m.draft("hostA:web"), "half a thought");
   assert.deepEqual(m.tabs(), ["hostB:tests"]);
-  // the host comes back: its session frame re-adds the tab, and activating it shows the draft again
+  // the host comes back: its session frame re-adds the tab — and, the note still holding, re-activates it
   m.arrive("hostA:web");
-  m.activate("hostA:web");
+  assert.equal(m.activeId, "hostA:web");
   assert.equal(m.composer, "half a thought", "the returning session's box holds what was typed into it");
+  // …whereas a return AFTER the user moved on (they clicked into the survivor's box → the note is gone)
+  // stays where they are; the draft waits on its tab
+  m.hostDrop(["hostA:web"]); m.clickBox();
+  m.arrive("hostA:web");
+  assert.equal(m.activeId, "hostB:tests");
+  m.activate("hostA:web");
+  assert.equal(m.composer, "half a thought");
 });
 
 test("(ii) typing after an active-tab teardown never lands under another session without an explicit switch", () => {
@@ -145,15 +153,28 @@ test("(ii) typing after an active-tab teardown never lands under another session
   assert.equal(m.focused, false);
   assert.equal(m.hasDraft("hostB:api"), false, "still nothing under the survivor");
   assert.ok(m.note && m.note.sid === "hostA:web", "the note stays up until a deliberate act");
-  // clicking INTO the box IS that act: the note retires and typing is the survivor's own draft
-  m.clickBox(); m.type("for api");
-  assert.equal(m.note, null);
-  assert.equal(m.draft("hostB:api"), "for api");
-  // an explicit switch to another tab binds the box there
+  // an explicit switch to another tab IS a deliberate act: the note retires and the box is that tab's
   m.activate("hostB:tests");
-  m.type("for tests");
+  assert.equal(m.note, null, "the switch retires the note");
+  m.focus(); m.type("for tests");
   assert.equal(m.draft("hostB:tests"), "for tests", "typed AFTER an explicit switch → that tab's own draft");
   assert.equal(m.draft("hostA:web"), "dear hostA");
+});
+
+test("(ii-c) a click into the box — or any other route into it — ends the hold, and typing is the survivor's own", () => {
+  const m = model();
+  m.arrive("hostB:tests"); m.arrive("hostA:web");
+  m.activate("hostA:web"); m.focus(); m.type("dear hostA");
+  m.hostDrop(["hostA:web"]);
+  m.typeAnywhere("x");
+  assert.equal(m.flashes, 1);
+  m.clickBox();
+  assert.equal(m.note, null, "focus by the user's own hand retires the note");
+  m.type("for tests");
+  assert.equal(m.draft("hostB:tests"), "for tests");
+  assert.equal(m.draft("hostA:web"), "dear hostA");
+  m.typeAnywhere("!");                                    // no hold any more — the default is back
+  assert.equal(m.draft("hostB:tests"), "for tests!");
 });
 
 test("(ii-b) an omission teardown of the active tab gets the same blur + note, and keeps the draft", () => {
@@ -168,9 +189,12 @@ test("(ii-b) an omission teardown of the active tab gets the same blur + note, a
   assert.ok(m.note && m.note.sid === "api" && m.note.why === "omitted");
   assert.equal(m.draft("api"), "typed into api", "an omission is not the user's close — stash, don't delete");
   m.arrive("api");                                        // it is listed again (a boot-partial push caught up)
-  assert.equal(m.note, null, "the note retires when the session is back");
-  m.activate("api");
-  assert.equal(m.composer, "typed into api");
+  assert.equal(m.note, null, "the note retires when the session is back…");
+  assert.equal(m.activeId, "api", "…by putting the user back on it: nothing happened in between");
+  assert.equal(m.composer, "typed into api", "with the kept draft in the box");
+  m.typeAnywhere("!");                                    // the blind keystroke the harness typed → into ITS box
+  assert.equal(m.draft("api"), "typed into api!");
+  assert.equal(m.hasDraft("web"), false);
 });
 
 test("(iii) a genuine end still clears the draft — the user's ✕ and the owning kernel's closed frame alike", () => {
@@ -293,8 +317,13 @@ test("while the note holds the box, the type-from-anywhere defaults stand down; 
   // bare-area Enter: stands down before focusComposerOrAsk
   assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(composerNoteHolds\(\)\) return;/);
   assert.match(RENDER, /function composerNoteHolds\(\): boolean \{\s*\n\s*if \(!composerNoteSid\) return false;\s*\n\s*flashComposerNote\(\);\s*\n\s*return true;/);
-  // the deliberate act: a pointerdown in the box
-  assert.match(RENDER, /ta\.addEventListener\("pointerdown", \(\) => \{ if \(composerNoteSid\) clearComposerNote\(\); \}\);/);
+  // the deliberate act: the box gaining focus, by any route
+  assert.match(RENDER, /ta\.addEventListener\("focus", \(\) => \{ if \(composerNoteSid\) clearComposerNote\(\); \}\);/);
+  // the flash is one-shot in every mode: the class leaves on animationend, and the sheet has no reduced-motion freeze
+  assert.match(RENDER, /n\.addEventListener\("animationend", \(\) => n\.classList\.remove\("composer-note-flash"\), \{ once: true \}\);/);
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.composer-note-flash \{ animation: composer-note-flash 0\.7s ease-out; \}/);
+  assert.doesNotMatch(CSS, /prefers-reduced-motion: reduce\) \{ \.composer-note-flash/);
   // the note says so
   assert.match(RENDER, /hint\.textContent = " Click the box to type here\.";/);
 });
@@ -302,8 +331,8 @@ test("while the note holds the box, the type-from-anywhere defaults stand down; 
 test("the note retires on the exact events: an explicit switch, the session's return, or its ✕", () => {
   // setActive: a real switch re-binds the box → the note is stale
   assert.match(RENDER, /function setActive\(id: string[\s\S]*?if \(ta && activeId !== id\) \{[\s\S]*?clearComposerNote\(\);/);
-  // the session frame: the torn-down session is back
-  assert.match(RENDER, /if \(composerNoteSid === msg\.id\) clearComposerNote\(\);/);
+  // the session frame: the torn-down session is back while the note still holds → back on it (setActive retires the note)
+  assert.match(RENDER, /if \(composerNoteSid === msg\.id\) setActive\(msg\.id\);/);
   // its own ✕
   assert.match(RENDER, /function renderComposerNote\(sid: string, why: DismissWhy, name: string\): void \{[\s\S]*?x\.addEventListener\("click", \(\) => clearComposerNote\(\)\);/);
 });

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -1,0 +1,288 @@
+// A composer draft belongs to the session it was typed in, and a teardown that is NOT that session's end
+// must not destroy it or hand the keyboard to another session unannounced (T236, the user 2026-09-03: an
+// unsent draft typed into one session's box "ended up in a different session's box" after a remote host
+// dropped off and the session list changed).
+//
+// The mechanism: federation's closeRemote dispatches a synthetic `closed` per session of a dropped host,
+// and applyTabOrder dismisses any kernel-listed id a push omits — both ran dismissSession exactly like the
+// user's own ✕: the draft was DELETED, and when the torn-down tab was the active one the composer silently
+// re-bound to the most-recently-used survivor while focus stayed in the textarea. The user kept typing into
+// what they believed was session A's box; the input handler filed it under the new active id. A's text was
+// gone, and the continuation surfaced in B.
+//
+// The rule now: only a GENUINE end (the user's ✕/End, or the owning kernel's `closed` for a session that
+// actually ended) clears a session's composer state. A host drop (`hostDrop: true` on the synthetic frame)
+// or a kernel-order omission STASHES it under the session's stable id and it comes back with the session.
+// And whenever the ACTIVE tab is torn down under the user, the composer is blurred and says so above the
+// box — the next keystroke cannot land in another session unnoticed; an explicit tab switch is what binds
+// the box to a new session.
+//
+// The executed model below mirrors render.ts's dismissSession / setActive / session-adoption / input paths;
+// the source pins hold the wiring (no jsdom harness for this renderer — the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+
+type Why = "close" | "end" | "hostDrop" | "omitted";
+
+function model() {
+  const sessions = new Set<string>();
+  const order: string[] = [];
+  const mru: string[] = [];                 // front = most-recently-active
+  const drafts = new Map<string, string>();
+  const kernelListed = new Set<string>();
+  let activeId: string | null = null;
+  let composer = "";                        // #composer-input's value
+  let focused = false;                      // document.activeElement === the textarea
+  let note: { sid: string; why: Why } | null = null;   // the line above the box (#composer-note)
+  const touchMru = (id: string) => { const i = mru.indexOf(id); if (i >= 0) mru.splice(i, 1); mru.unshift(id); };
+  // setActive's composer half: stash the leaving tab's text, show the entering tab's own
+  const activate = (id: string) => {
+    if (activeId === id) return;
+    if (activeId) { if (composer) drafts.set(activeId, composer); else drafts.delete(activeId); }
+    composer = drafts.get(id) ?? "";
+    note = null;                            // an explicit switch is the event that re-binds the box
+    activeId = id;
+    touchMru(id);
+  };
+  const hostOf = (x: string) => { const i = x.indexOf(":"); return i > 0 ? x.slice(0, i) : ""; };
+  // dismissSession(id, why, doomed)
+  const dismiss = (id: string, why: Why, doomed?: ReadonlySet<string>) => {
+    const wasActive = activeId === id;
+    if (wasActive) { if (composer) drafts.set(id, composer); else drafts.delete(id); }   // stash FIRST
+    sessions.delete(id);
+    if (why === "close" || why === "end") drafts.delete(id);                          // a genuine end clears
+    const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
+    const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);                       // never the fallback
+    if (wasActive) {
+      const home = hostOf(id);
+      const goingToo = (x: string) => (doomed?.has(x) ?? false) || (why === "hostDrop" && !!home && hostOf(x) === home);
+      activeId = mru.find((x) => order.includes(x) && !goingToo(x)) || order.find((x) => !goingToo(x)) || null;   // recency first, then the strip — staying either way
+      composer = (activeId && drafts.get(activeId)) || "";
+      if (why !== "close") { focused = false; note = { sid: id, why }; }             // blur + say so
+    }
+  };
+  return {
+    get activeId() { return activeId; },
+    get composer() { return composer; },
+    get focused() { return focused; },
+    get note() { return note; },
+    tabs() { return order.slice(); },
+    hasDraft(id: string) { return drafts.has(id); },
+    draft(id: string) { return drafts.get(id); },
+    // a session frame arriving (render.ts's session handler)
+    arrive(id: string) {
+      sessions.add(id);
+      if (!order.includes(id)) order.push(id);
+      if (!activeId) { activeId = id; if (!composer) composer = drafts.get(id) ?? ""; touchMru(id); }   // the adoption goes through the draft load
+      if (note && note.sid === id) note = null;   // it is back, draft and all
+    },
+    activate,
+    focus() { focused = true; },
+    // a keystroke: only a focused textarea receives one; the input handler files under the ACTIVE id
+    type(text: string) {
+      if (!focused) return;
+      composer += text;
+      if (activeId) { if (composer) drafts.set(activeId, composer); else drafts.delete(activeId); }
+    },
+    closeX(id: string) { dismiss(id, "close"); },                                        // the user's own ✕ / End
+    closedFrame(id: string, hostDrop = false) { dismiss(id, hostDrop ? "hostDrop" : "end"); },
+    hostDrop(ids: string[]) { for (const id of ids) dismiss(id, "hostDrop"); },        // federation closeRemote
+    push(list: string[]) {                                                              // a kernel tabOrder push
+      const omitted = new Set(order.filter((id) => kernelListed.has(id) && !list.includes(id)));
+      for (const id of order.slice()) if (omitted.has(id)) dismiss(id, "omitted", omitted);
+      for (const id of list) kernelListed.add(id);
+    },
+  };
+}
+
+test("(i) a draft under a remote session survives its host dropping, and is back when the session returns", () => {
+  const m = model();
+  m.arrive("hostA:web"); m.arrive("hostA:api"); m.arrive("hostB:tests");
+  m.activate("hostA:web"); m.focus(); m.type("half a thought");
+  m.hostDrop(["hostA:web", "hostA:api"]);
+  assert.equal(m.hasDraft("hostA:web"), true, "a host drop is not a close — the draft is stashed, not deleted");
+  assert.equal(m.draft("hostA:web"), "half a thought");
+  assert.deepEqual(m.tabs(), ["hostB:tests"]);
+  // the host comes back: its session frame re-adds the tab, and activating it shows the draft again
+  m.arrive("hostA:web");
+  m.activate("hostA:web");
+  assert.equal(m.composer, "half a thought", "the returning session's box holds what was typed into it");
+});
+
+test("(ii) typing after an active-tab teardown never lands under another session without an explicit switch", () => {
+  const m = model();
+  m.arrive("hostB:tests"); m.arrive("hostB:api"); m.arrive("hostA:web");
+  m.activate("hostB:api"); m.activate("hostA:web");      // mru: web, api, tests
+  m.focus(); m.type("dear hostA");
+  m.hostDrop(["hostA:web"]);
+  assert.equal(m.activeId, "hostB:api", "the strip falls back to the previously-active tab");
+  assert.equal(m.focused, false, "the box is BLURRED — the next keystroke cannot land anywhere unnoticed");
+  assert.ok(m.note && m.note.sid === "hostA:web" && m.note.why === "hostDrop", "and the composer says whose box went away");
+  m.type(" …and more");                                   // keystrokes with no focus go nowhere
+  assert.equal(m.hasDraft("hostB:api"), false, "nothing was filed under the survivor");
+  assert.equal(m.draft("hostA:web"), "dear hostA", "the original text is intact under its own id");
+  // clicking INTO the blurred box is a deliberate act: the note above it names whose box went away, the
+  // active tab is the survivor's — typing now is the survivor's own draft, and the note stays (still true)
+  m.focus(); m.type("for api");
+  assert.equal(m.draft("hostB:api"), "for api");
+  assert.ok(m.note && m.note.sid === "hostA:web");
+  // an explicit switch to another tab is the event that retires it
+  m.activate("hostB:tests");
+  assert.equal(m.note, null);
+  m.type("for tests");
+  assert.equal(m.draft("hostB:tests"), "for tests", "typed AFTER an explicit switch → that tab's own draft");
+  assert.equal(m.draft("hostA:web"), "dear hostA");
+});
+
+test("(ii-b) an omission teardown of the active tab gets the same blur + note, and keeps the draft", () => {
+  const m = model();
+  m.arrive("web"); m.arrive("api");
+  m.push(["web", "api"]);
+  m.activate("web"); m.activate("api");
+  m.focus(); m.type("typed into api");
+  m.push(["web"]);                                        // the kernel's push stops carrying api
+  assert.equal(m.activeId, "web");
+  assert.equal(m.focused, false);
+  assert.ok(m.note && m.note.sid === "api" && m.note.why === "omitted");
+  assert.equal(m.draft("api"), "typed into api", "an omission is not the user's close — stash, don't delete");
+  m.arrive("api");                                        // it is listed again (a boot-partial push caught up)
+  assert.equal(m.note, null, "the note retires when the session is back");
+  m.activate("api");
+  assert.equal(m.composer, "typed into api");
+});
+
+test("(iii) a genuine end still clears the draft — the user's ✕ and the owning kernel's closed frame alike", () => {
+  const m = model();
+  m.arrive("web"); m.arrive("api");
+  m.activate("web"); m.focus(); m.type("web draft");
+  m.activate("api"); m.type("api draft");
+  m.closeX("web");                                        // End session / Close tab
+  assert.equal(m.hasDraft("web"), false, "the ✕ drops the draft (the user 2026-08-04)");
+  m.closedFrame("api");                                   // the session died on its own — the kernel's own word
+  assert.equal(m.hasDraft("api"), false, "a real end clears it too");
+  assert.equal(m.activeId, null);
+  // …and a synthetic closed from a host drop is NOT that
+  m.arrive("hostA:web"); m.activate("hostA:web"); m.focus(); m.type("kept");
+  m.closedFrame("hostA:web", true);
+  assert.equal(m.draft("hostA:web"), "kept");
+});
+
+test("(iii-b) the kernel's closed frame that CONFIRMS our own ✕ neither notes nor blurs (the tab is already gone)", () => {
+  const m = model();
+  m.arrive("web"); m.arrive("api");
+  m.activate("web"); m.activate("api");
+  m.closeX("api");
+  assert.equal(m.activeId, "web");
+  m.focus();
+  m.closedFrame("api");                                   // the confirm lands a moment later
+  assert.equal(m.focused, true, "not the active tab any more → no retarget happened → nothing to announce");
+  assert.equal(m.note, null);
+});
+
+test("(iv) the fallback never selects the dismissed id, wherever it sat in the recency stack", () => {
+  const m = model();
+  m.arrive("web"); m.arrive("api"); m.arrive("tests");
+  m.activate("tests"); m.activate("api"); m.activate("web");   // mru: web, api, tests
+  m.activate("api");                                           // mru: api, web, tests — api active AND most recent
+  m.closedFrame("api");
+  assert.equal(m.activeId, "web", "the dismissed id is pruned before the fallback is read");
+  m.hostDrop(["web"]);
+  assert.equal(m.activeId, "tests");
+  m.closedFrame("tests");
+  assert.equal(m.activeId, null, "no survivor → no active tab, never the dead id");
+  // no RECENCY left but tabs still on the strip → the first of them, not null (a strip with no active tab
+  // read "No session open" and handed the box to the next arriving frame — the harness caught it)
+  const n = model();
+  n.arrive("hostA:web"); n.arrive("hostB:tests");        // only ever looked at web (adopted at arrival)
+  n.hostDrop(["hostA:web"]);
+  assert.equal(n.activeId, "hostB:tests");
+});
+
+test("(iv-b) the fallback skips what the same teardown takes next, so the note names the box the user was in", () => {
+  const m = model();
+  m.arrive("hostB:tests"); m.arrive("hostA:api"); m.arrive("hostA:web");
+  m.activate("hostA:api"); m.activate("hostA:web");      // mru: web, api, tests — the sibling is the recency neighbor
+  m.focus(); m.type("dear hostA");
+  m.hostDrop(["hostA:web", "hostA:api"]);                // closeRemote runs the host's sids in a burst
+  assert.equal(m.activeId, "hostB:tests", "straight to a survivor on another host, never via the doomed sibling");
+  assert.ok(m.note && m.note.sid === "hostA:web", "ONE note, for the box the user was typing in");
+  assert.equal(m.draft("hostA:web"), "dear hostA");
+  // same rule for a push that omits several at once
+  const k = model();
+  k.arrive("web"); k.arrive("api"); k.arrive("tests");
+  k.push(["web", "api", "tests"]);
+  k.activate("api"); k.activate("web"); k.focus(); k.type("typed into web");
+  k.push(["tests"]);                                     // web and api both dropped from the list
+  assert.equal(k.activeId, "tests");
+  assert.ok(k.note && k.note.sid === "web");
+  assert.equal(k.draft("web"), "typed into web");
+  assert.equal(k.hasDraft("api"), false, "api had no draft to keep; nothing invented");
+});
+
+test("a returning session adopted as the ONLY tab gets its stashed draft back in the box", () => {
+  const m = model();
+  m.arrive("hostA:web");
+  m.activate("hostA:web"); m.focus(); m.type("only tab, half typed");
+  m.hostDrop(["hostA:web"]);
+  assert.equal(m.activeId, null);
+  assert.equal(m.composer, "");
+  m.arrive("hostA:web");                                  // the host is back; nothing else is open → adopted
+  assert.equal(m.activeId, "hostA:web");
+  assert.equal(m.composer, "only tab, half typed", "the `!activeId` adoption loads the draft like setActive does");
+});
+
+// ── source pins: the wiring in render.ts / federation.ts ─────────────────────────────────────────────────
+
+test("federation stamps its synthetic closed frames as a host drop, not an end", () => {
+  assert.match(FED, /private closeRemote\(host: string\): void \{[\s\S]*?data: \{ type: "closed", id: sid, hostDrop: true \}/);
+  // the owning kernel's own closed frame (the T233 fold) is passed through UNSTAMPED — a genuine end
+  assert.match(FED, /if \(m && m\.type === "closed" && typeof m\.id === "string"\) \{[\s\S]*?window\.dispatchEvent\(new MessageEvent\("message", \{ data: m \}\)\);/);
+});
+
+test("every teardown names its reason, and only a genuine end clears the composer state", () => {
+  assert.match(RENDER, /type DismissWhy = "close" \| "end" \| "hostDrop" \| "omitted";/);
+  assert.match(RENDER, /function dismissSession\(id: string, why: DismissWhy, doomed\?: ReadonlySet<string>\): void \{/);
+  // the user's ✕ / End
+  assert.match(RENDER, /function closeTabLocally\(id: string\): void \{[\s\S]*?dismissSession\(id, "close"\);\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);/);
+  // the kernel's closed frame — or federation's stamped stand-in for a dropped host
+  assert.match(RENDER, /else if \(m\.type === "closed"\) dismissSession\(m\.id, m\.hostDrop === true \? "hostDrop" : "end"\);/);
+  // applyTabOrder's kernel-order omission
+  assert.match(RENDER, /const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\)\)\);[^\n]*\n\s*for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(omitted\.has\(id\)\) dismissSession\(id, "omitted", omitted\);/);
+  // the clear is gated: the existing one-liner (composer-draft-persist.test.ts pins it) now runs for an end only
+  assert.match(RENDER, /if \(why === "close" \|\| why === "end"\) \{[\s\S]*?drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\); composerFiles\.delete\(id\); persistDrafts\(\);\s*\n\s*\} else \{\s*\n\s*persistDrafts\(\);/);
+});
+
+test("an active tab torn down under the user: stash first, prune the fallback, blur, and say so above the box", () => {
+  const body = RENDER.slice(RENDER.indexOf("function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string>)"));
+  const fn = body.slice(0, body.indexOf("\n}\n") + 3);
+  // the live text is stashed under ITS id before anything is cleared or re-bound
+  assert.ok(fn.indexOf("stashActiveDraft(id)") >= 0 && fn.indexOf("stashActiveDraft(id)") < fn.indexOf("sessions.delete(id)"), "stash precedes the teardown");
+  // the dismissed id leaves the recency stack BEFORE the fallback is read
+  assert.ok(fn.indexOf("mru.splice(mi, 1)") < fn.indexOf("activeId = mru.find("), "pin (iv): fallback never the dismissed id");
+  // …and never an id the strip no longer shows: the re-bound box loads the fallback's own draft through the shared loader
+  assert.match(fn, /const home = hostOf\(id\);[^\n]*\n\s*const goingToo = \(x: string\) => \(doomed\?\.has\(x\) \?\? false\) \|\| \(why === "hostDrop" && !!home && hostOf\(x\) === home\);[\s\S]*?activeId = mru\.find\(\(x\) => order\.includes\(x\) && !goingToo\(x\)\) \|\| order\.find\(\(x\) => !goingToo\(x\)\) \|\| null;[\s\S]*?loadComposerFor\(activeId\);/);
+  // …and, unless the user themself clicked ✕, the box is blurred and the note names what went away
+  assert.match(fn, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/);
+});
+
+test("the note retires on the exact events: an explicit switch, the session's return, or its ✕", () => {
+  // setActive: a real switch re-binds the box → the note is stale
+  assert.match(RENDER, /function setActive\(id: string[\s\S]*?if \(ta && activeId !== id\) \{[\s\S]*?clearComposerNote\(\);/);
+  // the session frame: the torn-down session is back
+  assert.match(RENDER, /if \(composerNoteSid === msg\.id\) clearComposerNote\(\);/);
+  // its own ✕
+  assert.match(RENDER, /function renderComposerNote\(sid: string, why: DismissWhy, name: string\): void \{[\s\S]*?x\.addEventListener\("click", \(\) => clearComposerNote\(\)\);/);
+});
+
+test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
+  assert.match(RENDER, /const adopted = !activeId;\s*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); \}/);
+  // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
+  assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
+  // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints
+  assert.match(RENDER, /function loadComposerFor\(id: string \| null, keepTyped = false\): void \{[\s\S]*?ta\.value = \(id && drafts\.get\(id\)\) \|\| "";[\s\S]*?renderComposerChips\(id\);[\s\S]*?renderComposerFiles\(id\);/);
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -1118,7 +1118,9 @@ export class FederationManager {
     this.hostSeq = this.hostSeq.filter((h) => h !== host);
     // drop that host's tabs from the panes (else they linger stale), then re-emit the merged order.
     for (const sid of this.perHostSids[host] || []) {
-      window.dispatchEvent(new MessageEvent("message", { data: { type: "closed", id: sid } }));
+      // Stamped `hostDrop`: this is NOT the session's end — its kernel is simply out of reach — so the pane
+      // keeps the session's unsent draft for its return instead of clearing it like a close (T236).
+      window.dispatchEvent(new MessageEvent("message", { data: { type: "closed", id: sid, hostDrop: true } }));
     }
     delete this.perHostOrder[host];
     delete this.perHostTabs[host];

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -114,7 +114,7 @@ test("the silent-failure backstop is long, because it is no longer what you wait
 });
 
 test("closing a provisional tab aborts the pending spawn; a FAILED one is a plain local discard", () => {
-  assert.match(RENDER, /if \(id === provisionalId\) cancelProvisional\(\);\s*\n\s*else \{ failedProvisionals\.delete\(id\); dismissSession\(id\); \}/);
+  assert.match(RENDER, /if \(id === provisionalId\) cancelProvisional\(\);\s*\n\s*else \{ failedProvisionals\.delete\(id\); dismissSession\(id, "close"\); \}/);
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "cancelCreate", name \}\)/);
   // the kernel never knew a provisional id — the dead-tab ✕ must not post closeTab for one
   assert.match(RENDER, /if \(!isProvisionalId\(id\)\) vscodeApi\.postMessage\(\{ type: "closeTab", id \}\);/);

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -22,7 +22,7 @@ test("upsert tells append from fork by transcript OVERLAP, not the first uuid (s
 test("a content refresh appends (preserves scroll); only a fork drops the DOM", () => {
   assert.match(RENDER, /if \(forked\) \{[\s\S]{0,120}?v\.el\.remove\(\)/,
     "the cached DOM is dropped only on a fork, not on every push");
-  assert.match(RENDER, /if \(existed && !forked && !firstBuild\) \{\s*appendActive\(\);/,
+  assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*appendActive\(\);/,   // !adopted: T236 — an adoption is a first show
     "a refresh of the active tab appends instead of snapping to the bottom");
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4161,8 +4161,9 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport) {
   // federation the merged order only omits an id when its OWNING host affirmatively reported it gone
   // (per-host slices persist across down/detached hosts), so this never fires on a tunnel blip.
   const inKernel = new Set<string>(kernelOrder);
+  const omitted = new Set(order.filter((id) => kernelListed.has(id) && !inKernel.has(id)));   // all of them first: no fallback onto one going in the same breath
   for (const id of order.slice()) {
-    if (kernelListed.has(id) && !inKernel.has(id)) dismissSession(id);
+    if (omitted.has(id)) dismissSession(id, "omitted", omitted);
   }
   const next = reconcileTabOrder(kernelOrder, order, (id) => sessions.has(id) || tabMeta.has(id),
                                  (id) => kernelListed.has(id));
@@ -4639,7 +4640,7 @@ function renderTabs() {
     const label = el("span", "tab-label");
     label.replaceChildren(...hostNameNodes(s.name, id));   // remote "host:" prefix renders as quiet metadata
     // ...and the whole tab dims when that host is unreachable, so a disconnected session reads as one at
-    // a glance rather than only on inspection (the user 2026-07-29). The struck "host:" carries the why.
+    // a glance rather than only on inspection (the user 2026-07-29). The marked "host:" carries the why.
     if (hostIsDown(id)) { tab.classList.add("host-off"); tab.title = hostDownNote(id); }
     if (s.status.faded && id !== activeId && s.color) {
       const full = s.color.bg;
@@ -5563,7 +5564,7 @@ function dropProvisional(): { queued: string[]; draft: string } {
     const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
     draft = (activeId === id && ta) ? ta.value : (drafts.get(id) ?? "");
     pendingSent.delete(id);                // the optimistic bubbles belong to a tab that is going away
-    dismissSession(id);                    // drops it from sessions/order/views and reselects
+    dismissSession(id, "close");           // drops it from sessions/order/views and reselects
   }
   return { queued, draft };
 }
@@ -11791,6 +11792,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
   // Stash the leaving tab's draft; show the entering tab's own (usually empty).
   const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   if (ta && activeId !== id) {
+    clearComposerNote();   // a real switch binds the box to `id` — a note about the last hand-over is stale (T236)
     if (activeId) {
       if (ta.value) drafts.set(activeId, ta.value); else drafts.delete(activeId);
       // A citation chip is a "reply to this card right now" intent — switching tabs abandons it, so drop the
@@ -11910,13 +11912,17 @@ function upsert(msg: any) {
   }
   if ("ledger" in msg) ledgers.set(msg.id, msg.ledger ?? null);
   if (!existed) order.push(msg.id);
-  if (!activeId) activeId = msg.id;
+  if (composerNoteSid === msg.id) clearComposerNote();   // the torn-down session is back — tab and kept draft with it (T236)
+  const adopted = !activeId;
+  if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); }   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork
   // lands at the bottom/anchor (showActive). This is what keeps new pushes from snapping to bottom.
   if (msg.id === activeId) {
-    if (existed && !forked && !firstBuild) {
+    // an ADOPTION is a first show even for a payload this page already held: the no-active-tab state hid
+    // every view, and appendActive never re-reveals one (T236 harness: a tab active over "No session open")
+    if (existed && !forked && !firstBuild && !adopted) {
       appendActive();
     } else {
       showActive();
@@ -12181,10 +12187,10 @@ function closeTabLocally(id: string): void {
   // (and the kernel never knew the id): its ✕ is a plain local discard — tab, draft, and all.
   if (isProvisionalId(id)) {
     if (id === provisionalId) cancelProvisional();
-    else { failedProvisionals.delete(id); dismissSession(id); }
+    else { failedProvisionals.delete(id); dismissSession(id, "close"); }
     return;
   }
-  dismissSession(id);
+  dismissSession(id, "close");
   closingTabs.set(id, Date.now());
 }
 
@@ -12198,28 +12204,127 @@ function closeTabLocally(id: string): void {
 // event — is both the regression above (the ✕ path runs through here microseconds after recording the
 // close) and wrong under federation, where a `closed` ack can predate stale merged frames that still list
 // the id: the moment nothing suppresses it, the strip re-draws the swirl placeholder.
-function dismissSession(id: string): void {
+// WHY a session is leaving the panel — the one fact that decides what happens to its composer state
+// (T236, the user 2026-09-03: an unsent draft typed into one session's box turned up in another's after
+// a remote host dropped off). "close" is the user's own ✕ / End; "end" is the owning kernel's `closed`
+// frame — the session actually ended. Both are GENUINE ends and clear the draft (the user 2026-08-04).
+// "hostDrop" is federation's synthetic `closed` for every session of a host that left the mesh — the
+// session still exists on its kernel; "omitted" is a kernel tabOrder push that stopped carrying an id it
+// used to (applyTabOrder's teardown) — an absence, not a report of an end. Neither is the user's close,
+// so the draft (and citations, edit pill, attachments) is STASHED under the session's stable id and comes
+// back with the session. Deleting it here, as every teardown once did, is what lost the user's text.
+type DismissWhy = "close" | "end" | "hostDrop" | "omitted";
+
+// The active box's live text, filed under ITS OWN id. The input handler keeps `drafts` current on every
+// keystroke, but a box filled programmatically (a slash pick, a history recall) can be ahead of it — so
+// a teardown stashes explicitly before anything is cleared or the box changes hands.
+function stashActiveDraft(id: string): void {
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!ta || activeId !== id) return;
+  if (ta.value) drafts.set(id, ta.value); else drafts.delete(id);
+}
+
+// Bind the composer to `id`: its draft into the box (unless `keepTyped` and the box already holds live
+// typing — the never-clobber rule restoreActiveDraftOnce follows), then its citation chips, attachment
+// thumbnails and staged stack. setActive paints the same set inline (pinned there); this is the loader
+// for the two OTHER ways the box changes hands — the active tab's teardown and the `!activeId` adoption
+// of an arriving session — which used to load less (on adoption, no draft at all: a session that LEFT
+// and came back as the only tab showed an empty box over a kept draft).
+function loadComposerFor(id: string | null, keepTyped = false): void {
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (ta) {
+    if (!(keepTyped && ta.value)) ta.value = (id && drafts.get(id)) || "";
+    growComposer(ta);
+  }
+  renderComposerChips(id);
+  renderComposerFiles(id);
+  renderStagedStrip(id);
+}
+
+// The line above the box after the ACTIVE tab was torn down under the user (T236): whose box went away,
+// why, and — for a host drop or an omission — that the unsent draft is kept. The tab strip alone did not
+// carry this (the report proves it: the user kept typing). One note at a time; it retires on the exact
+// events that make it stale — an explicit tab switch (setActive re-binds the box), the session's own
+// return (its next session frame), or its ✕ — never a timer.
+let composerNoteSid: string | null = null;
+function renderComposerNote(sid: string, why: DismissWhy, name: string): void {
+  const box = document.getElementById("composer");
+  if (!box) return;
+  clearComposerNote();
+  const note = el("div", "composer-note");
+  note.id = "composer-note";
+  const msg = el("span", "composer-note-msg");
+  const who = el("span", "composer-note-name");
+  who.replaceChildren(...hostNameNodes(name, sid));   // the same "host:" + name the tab wore
+  let tail: string;
+  if (why === "hostDrop") tail = "’s host disconnected — your unsent draft is kept and comes back with it.";
+  else if (why === "omitted") tail = " is no longer listed by romp — your unsent draft is kept and comes back with it.";
+  else {
+    const next = activeId ? (sessions.get(activeId)?.name || tabMeta.get(activeId)?.name || "") : "";
+    tail = next ? ` ended — the box below is “${next}”’s now.` : " ended.";
+  }
+  msg.append(who, document.createTextNode(tail));
+  const x = el("button", "composer-chip-x");
+  x.setAttribute("aria-label", "Dismiss");
+  x.title = "dismiss";
+  x.textContent = "✕";
+  x.addEventListener("click", () => clearComposerNote());
+  note.append(msg, x);
+  box.insertBefore(note, box.firstChild);
+  composerNoteSid = sid;
+}
+function clearComposerNote(): void {
+  document.getElementById("composer-note")?.remove();
+  composerNoteSid = null;
+}
+
+// `doomed`: the other ids the same teardown is about to run through (applyTabOrder hands over every id its
+// push omitted); a host drop needs no list — every session on that host is going. The fallback must skip
+// them: landing on a sibling that is dismissed a moment later re-binds the box twice and leaves the note
+// naming the sibling, not the box the user was typing in.
+function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string>): void {
   if (peekId === id) peekId = null;   // its tab is going — the peek goes with it
+  const wasActive = activeId === id;
+  const name = sessions.get(id)?.name || tabMeta.get(id)?.name || id;   // read before the maps forget it
+  if (wasActive) stashActiveDraft(id);   // FIRST: what is on screen belongs to this id, whatever happens next
   sessions.delete(id);
   liveAsks.delete(id);
   ledgers.delete(id);
-  // ALL of the closed session's composer context goes with it — the draft, the reply-context citation
-  // chip, and any pending edit pill (the user 2026-08-04). Deleting from the maps is not enough when the
-  // closed session was ACTIVE: the shared chip strip above the composer still shows its chip until
-  // someone repaints it, and that stale chip's ✕ targets the dead id (whose map entry is gone), so the
-  // click early-returns and the chip can't even be dismissed — hence the repaint below.
-  drafts.delete(id); composerCitations.delete(id); composerEdits.delete(id); composerFiles.delete(id); persistDrafts();
+  if (why === "close" || why === "end") {
+    // ALL of the closed session's composer context goes with it — the draft, the reply-context citation
+    // chip, and any pending edit pill (the user 2026-08-04). Deleting from the maps is not enough when the
+    // closed session was ACTIVE: the shared chip strip above the composer still shows its chip until
+    // someone repaints it, and that stale chip's ✕ targets the dead id (whose map entry is gone), so the
+    // click early-returns and the chip can't even be dismissed — hence the repaint below.
+    drafts.delete(id); composerCitations.delete(id); composerEdits.delete(id); composerFiles.delete(id); persistDrafts();
+  } else {
+    persistDrafts();   // a host drop / omission KEEPS it all (see DismissWhy) — the stash above may have updated the copy
+  }
   const v = views.get(id);
   if (v) { v.el.remove(); views.delete(id); }
   const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
-  const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);
+  const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);   // before the fallback read below — never the dead id
   renderTabs();                          // tab removed from `order` above → repaint without it
-  if (activeId === id) {
-    activeId = mru[0] || null; // MRU: return to the previously-active tab, not the positional neighbor
-    const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-    if (ta) { ta.value = (activeId && drafts.get(activeId)) || ""; growComposer(ta); }
-    renderComposerChips(activeId);   // the strip was showing the CLOSED session's chip — swap in the new active tab's (usually none)
-    renderComposerFiles(activeId);   // same for its attachment thumbnails
+  if (wasActive) {
+    // MRU: return to the previously-active tab, not the positional neighbor — one still on the strip (the
+    // dead id left `mru` above; an id `order` no longer carries would bind the box to a tab nobody can see,
+    // and the next keystroke would file under it) and not one this same teardown takes next.
+    const home = hostOf(id);   // "" for a local id, and then no sibling rule: every local tab would "share" it
+    const goingToo = (x: string) => (doomed?.has(x) ?? false) || (why === "hostDrop" && !!home && hostOf(x) === home);
+    // …and with no recency left (the user only ever looked at this one tab), the first tab still on the
+    // strip: leaving activeId null with tabs showing read "No session open" under a visible strip, and
+    // handed the box to whichever session frame happened to arrive next (the harness caught both, T236).
+    activeId = mru.find((x) => order.includes(x) && !goingToo(x)) || order.find((x) => !goingToo(x)) || null;
+    loadComposerFor(activeId);   // the strip was showing the CLOSED session's chip/thumbnails/draft — swap in the new active tab's (usually none)
+    // The box just changed hands under the user. Their own ✕ is the one case they already know; for every
+    // other reason BLUR it — a keystroke a moment later must not land in the survivor's session unnoticed
+    // (the T236 report: the continuation of A's draft surfaced in B's box) — and say above it whose box
+    // went away. An explicit tab click is what binds the box to a session again.
+    if (why !== "close") {
+      const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+      if (ta) ta.blur();
+      renderComposerNote(id, why, name);
+    }
     showActive();
   }
 }
@@ -12637,7 +12742,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       }
     }
   }
-  else if (m.type === "closed") dismissSession(m.id);   // a session died on its own (or the kernel confirms our close)
+  else if (m.type === "closed") dismissSession(m.id, m.hostDrop === true ? "hostDrop" : "end");   // a session died on its own (or the kernel confirms our close) — or its HOST dropped (federation's stand-in, stamped: not an end)
   // any payload that rebuilt transcript DOM must get its highlights re-applied (marks live IN that DOM)
   if (m && m.id && (m.type === "session" || m.type === "chatTail" || m.type === "chatHead" || m.type === "chatEpisode"))
     applyCommentMarks(String(m.id));

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11914,7 +11914,12 @@ function upsert(msg: any) {
   }
   if ("ledger" in msg) ledgers.set(msg.id, msg.ledger ?? null);
   if (!existed) order.push(msg.id);
-  if (composerNoteSid === msg.id) clearComposerNote();   // the torn-down session is back — tab and kept draft with it (T236)
+  // The torn-down session is BACK while its hand-over note still holds the box: the user has done nothing
+  // since (a click into the box, a tab switch or the ✕ would have retired it), so put them back exactly
+  // where they were — its tab active, its kept draft in the box. Merely retiring the note here left the
+  // fallback tab active with the box unheld, and the next blind keystroke landed there after all (the
+  // T236 harness, omission path: the tab is re-listed within seconds). setActive clears the note.
+  if (composerNoteSid === msg.id) setActive(msg.id);
   const adopted = !activeId;
   if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); }   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
@@ -12288,8 +12293,9 @@ function clearComposerNote(): void {
 // printable keystroke nobody claimed, Enter from the bare area) stand down instead of dropping the cursor
 // into the survivor's box — the harness showed the blur alone was not enough: the first printable key
 // re-focused the box and the continuation of A's draft landed in B's anyway (T236). The keystroke is
-// swallowed and the note flashes: the eye goes to the line that explains it. A CLICK into the box (its
-// pointerdown), a tab switch or the note's ✕ ends the hold — every one a deliberate act.
+// swallowed and the note flashes: the eye goes to the line that explains it. The box gaining focus (a click,
+// Tab, any other route the user takes into it), a tab switch or the note's ✕ ends the hold — every one a
+// deliberate act.
 function composerNoteHolds(): boolean {
   if (!composerNoteSid) return false;
   flashComposerNote();
@@ -12301,6 +12307,7 @@ function flashComposerNote(): void {
   n.classList.remove("composer-note-flash");
   void n.offsetWidth;   // restart the one-shot animation
   n.classList.add("composer-note-flash");
+  n.addEventListener("animationend", () => n.classList.remove("composer-note-flash"), { once: true });   // one-shot: the class leaves on the animation's own end
 }
 
 // `doomed`: the other ids the same teardown is about to run through (applyTabOrder hands over every id its
@@ -13234,7 +13241,11 @@ function setupComposer() {
     return false;
   };
   ta.addEventListener("focus", () => { if (slashSid !== (activeId || "")) loadCmds(activeId || ""); });   // pre-warm the cache before "/"
-  ta.addEventListener("pointerdown", () => { if (composerNoteSid) clearComposerNote(); });   // a CLICK into the box is the deliberate re-bind the note asked for (T236)
+  // The box GAINING FOCUS is the deliberate re-bind the note asked for (T236): the teardown blurred it, showActive
+  // never focuses it, and the two type-from-anywhere defaults stand down while the note holds — so any focus now
+  // is the user's own act (a click, Tab, Enter over a selection, Quote, a citation seed, a slash pick, an edit
+  // recall). Retiring on pointerdown alone left the note over a box they were typing in by any other route.
+  ta.addEventListener("focus", () => { if (composerNoteSid) clearComposerNote(); });
   ta.addEventListener("blur", () => window.setTimeout(closeSlash, 120));   // close when leaving (a row's mousedown keeps focus, so it fires only on a real leave)
   window.addEventListener("resize", positionSlash);
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5408,6 +5408,7 @@ window.addEventListener("keydown", (e) => {
     // default: Enter always lands you in the box unless you're already on a tab or in the box.
     const ae = document.activeElement;
     if (ae && ae !== document.body) return;
+    if (composerNoteHolds()) return;               // the box just changed hands under the user — a click re-binds it, not a key (T236)
     if (focusComposerOrAsk()) e.preventDefault();   // the picker card if one's up, else the message box
   }
 });
@@ -5432,6 +5433,7 @@ window.addEventListener("keydown", (e) => {
   if (document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse")
       || document.getElementById("romp-lightbox")) return;   // full-pane surfaces own their keys
   if (document.querySelector("#rsettings:not([hidden]), #ra-back:not([hidden]), #rkeys-back, .meta-menu")) return;   // the pane's own modals + meta menus own their keys (a letter typed there must never land in the draft)
+  if (composerNoteHolds()) return;   // the box just changed hands under the user — no focus steal, the note flashes; a click re-binds (T236). Nothing to cancel either: a key on the bare body has nothing to insert into.
   ta.focus({ preventScroll: true });   // the native keystroke lands in the box; the chip survives (a collapse never clears it)
 });
 // Cmd/Ctrl+O and Cmd/Ctrl+Shift+O — the in-PAGE fallback, from anywhere including the composer, the
@@ -12264,6 +12266,11 @@ function renderComposerNote(sid: string, why: DismissWhy, name: string): void {
     tail = next ? ` ended — the box below is “${next}”’s now.` : " ended.";
   }
   msg.append(who, document.createTextNode(tail));
+  if (activeId) {   // a survivor owns the box now — say what re-binds typing to it (the keys alone will not, see composerNoteHolds)
+    const hint = el("span", "composer-note-hint");
+    hint.textContent = " Click the box to type here.";
+    msg.appendChild(hint);
+  }
   const x = el("button", "composer-chip-x");
   x.setAttribute("aria-label", "Dismiss");
   x.title = "dismiss";
@@ -12276,6 +12283,24 @@ function renderComposerNote(sid: string, why: DismissWhy, name: string): void {
 function clearComposerNote(): void {
   document.getElementById("composer-note")?.remove();
   composerNoteSid = null;
+}
+// While the note is up, the box has NO keyboard owner: the two "type from anywhere" defaults below (a
+// printable keystroke nobody claimed, Enter from the bare area) stand down instead of dropping the cursor
+// into the survivor's box — the harness showed the blur alone was not enough: the first printable key
+// re-focused the box and the continuation of A's draft landed in B's anyway (T236). The keystroke is
+// swallowed and the note flashes: the eye goes to the line that explains it. A CLICK into the box (its
+// pointerdown), a tab switch or the note's ✕ ends the hold — every one a deliberate act.
+function composerNoteHolds(): boolean {
+  if (!composerNoteSid) return false;
+  flashComposerNote();
+  return true;
+}
+function flashComposerNote(): void {
+  const n = document.getElementById("composer-note");
+  if (!n) return;
+  n.classList.remove("composer-note-flash");
+  void n.offsetWidth;   // restart the one-shot animation
+  n.classList.add("composer-note-flash");
 }
 
 // `doomed`: the other ids the same teardown is about to run through (applyTabOrder hands over every id its
@@ -13209,6 +13234,7 @@ function setupComposer() {
     return false;
   };
   ta.addEventListener("focus", () => { if (slashSid !== (activeId || "")) loadCmds(activeId || ""); });   // pre-warm the cache before "/"
+  ta.addEventListener("pointerdown", () => { if (composerNoteSid) clearComposerNote(); });   // a CLICK into the box is the deliberate re-bind the note asked for (T236)
   ta.addEventListener("blur", () => window.setTimeout(closeSlash, 120));   // close when leaving (a row's mousedown keeps focus, so it fires only on a real leave)
   window.addEventListener("resize", positionSlash);
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -898,6 +898,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 #composer-note { flex: 1 1 100%; display: flex; align-items: center; gap: 6px; padding: 0 0 6px 2px; font-size: 12px; line-height: 1.4; color: var(--dim, #9a9a9a); }
 .composer-note-msg { flex: 1 1 auto; min-width: 0; }
 .composer-note-name { color: var(--fg); }
+.composer-note-hint { opacity: 0.75; }
+/* a keystroke swallowed while the note holds the box (render.ts composerNoteHolds) — one accent wash, fading */
+.composer-note-flash { animation: composer-note-flash 0.7s ease-out; }
+@keyframes composer-note-flash { from { background: color-mix(in srgb, var(--accent) 30%, transparent); } to { background: transparent; } }
+@media (prefers-reduced-motion: reduce) { .composer-note-flash { animation: none; background: color-mix(in srgb, var(--accent) 18%, transparent); } }
 .composer-file { position: relative; display: inline-flex; align-items: center; cursor: pointer; }
 .composer-file-img { display: block; height: 46px; max-width: 96px; object-fit: cover; border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent); background: color-mix(in srgb, var(--accent) 8%, transparent); }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -900,9 +900,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .composer-note-name { color: var(--fg); }
 .composer-note-hint { opacity: 0.75; }
 /* a keystroke swallowed while the note holds the box (render.ts composerNoteHolds) — one accent wash, fading */
-.composer-note-flash { animation: composer-note-flash 0.7s ease-out; }
+.composer-note-flash { animation: composer-note-flash 0.7s ease-out; }   /* a colour fade, not motion — no reduced-motion override (render.ts removes the class on animationend) */
 @keyframes composer-note-flash { from { background: color-mix(in srgb, var(--accent) 30%, transparent); } to { background: transparent; } }
-@media (prefers-reduced-motion: reduce) { .composer-note-flash { animation: none; background: color-mix(in srgb, var(--accent) 18%, transparent); } }
 .composer-file { position: relative; display: inline-flex; align-items: center; cursor: pointer; }
 .composer-file-img { display: block; height: 46px; max-width: 96px; object-fit: cover; border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent); background: color-mix(in srgb, var(--accent) 8%, transparent); }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -892,6 +892,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* attachment thumbnails (the user 2026-08-04): dropped/pasted/picked files sit as little previews above
    the box until send — a row that wraps, unlike the stacked context chips below it */
 #composer-files { flex: 1 1 100%; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 0 0 6px 2px; }
+/* The line above the box after the ACTIVE tab was torn down under the user (T236, render.ts renderComposerNote):
+   whose box went away and that the unsent draft is kept. Chip-strip geometry and the chips' 12px; the ✕ is the
+   chip ✕. Dim by default, the session name in the normal fg — it is the one thing to read. */
+#composer-note { flex: 1 1 100%; display: flex; align-items: center; gap: 6px; padding: 0 0 6px 2px; font-size: 12px; line-height: 1.4; color: var(--dim, #9a9a9a); }
+.composer-note-msg { flex: 1 1 auto; min-width: 0; }
+.composer-note-name { color: var(--fg); }
 .composer-file { position: relative; display: inline-flex; align-items: center; cursor: pointer; }
 .composer-file-img { display: block; height: 46px; max-width: 96px; object-fit: cover; border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent); background: color-mix(in srgb, var(--accent) 8%, transparent); }

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -171,7 +171,7 @@ test("closeTabLocally drops the tab, THEN records the close — in that order", 
   // this shipped as set-then-dismiss while dismissSession opened with closingTabs.delete(id), so the
   // record was erased the instant it was written — the executed model above passed while the composed
   // wiring was a no-op. Hence these pins hold the ORDER, and the next test holds dismissSession's hands.
-  assert.match(RENDER, /return;\s*\n\s*\}\s*\n\s*dismissSession\(id\);\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);/,
+  assert.match(RENDER, /return;\s*\n\s*\}\s*\n\s*dismissSession\(id, "close"\);\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);/,
     "the provisional short-circuit returns above; a real tab still dismisses THEN records");
   // declared beside tabMeta, NOT down by dismissSession: renderTabs reads it and can run before the module
   // finishes evaluating, which would make a `const` down there a temporal-dead-zone throw.
@@ -206,7 +206,7 @@ test("dismissSession never touches the suppression — retiring belongs to ack, 
   // dismissSession is the shared drop path: the ✕ runs through it microseconds after recording the close,
   // and under federation the kernel's `closed` event can predate stale merged frames that still list the
   // id. A closingTabs.delete in its body is what disarmed the whole optimistic close (see above).
-  const body = RENDER.match(/function dismissSession\(id: string\): void \{[\s\S]*?\n\}/);
+  const body = RENDER.match(/function dismissSession\(id: string, why: DismissWhy, doomed\?: ReadonlySet<string>\): void \{[\s\S]*?\n\}/);
   assert.ok(body, "dismissSession not found");
   assert.doesNotMatch(body![0], /closingTabs\./, "dismissSession must not read or write closingTabs");
   // …and the one legitimate early retire: an explicit reveal (reopen from the picker inside the ack

--- a/ui/webview/tab-ghost-heal.test.ts
+++ b/ui/webview/tab-ghost-heal.test.ts
@@ -10,6 +10,11 @@
 // kernel-owned (`kernelListed`), and a later push omitting it dismisses the tab with the same teardown the
 // `closed` event runs. `closed` stays as the fast path.
 //
+// One difference since T236 (the user 2026-09-03): an OMISSION is an absence, not a report of an end — the
+// same push shape also follows a boot-partial list or a collapsed liveness read — so the teardown it runs
+// keeps the session's unsent composer draft stashed under its id (back with the session if it returns);
+// only a genuine end (the user's ✕, the kernel's own `closed`) clears it. See draft-teardown.test.ts.
+//
 // The executed model below runs the real reconcileTabOrder through the whole miss-and-heal cycle with
 // applyTabOrder's bookkeeping; the source pins hold that wiring in render.ts.
 import { test } from "node:test";
@@ -21,27 +26,29 @@ import { reconcileTabOrder } from "./tab-order";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 // A stand-in for the client around a session death: the sessions map, the render order, and applyTabOrder's
-// kernelListed bookkeeping. dismiss() mirrors dismissSession's teardown surface (session + view + draft go).
+// kernelListed bookkeeping. dismiss() mirrors dismissSession's teardown surface (session + view go; the draft
+// goes only for a genuine end, never for an omission).
 function model() {
   let order: string[] = [];
   const sessions = new Map<string, { state: string }>();
   const drafts = new Map<string, string>();
   const kernelListed = new Set<string>();
   const dismissed: string[] = [];
-  const dismiss = (id: string) => {
+  const dismiss = (id: string, why: "end" | "omitted") => {
     dismissed.push(id);
-    sessions.delete(id); drafts.delete(id);
+    sessions.delete(id);
+    if (why === "end") drafts.delete(id);      // a genuine end clears; an omission stashes (T236)
     order = order.filter((x) => x !== id);
   };
   return {
     dismissed,
     session(id: string, state = "working") { sessions.set(id, { state }); if (!order.includes(id)) order.push(id); },
     draft(id: string, text: string) { drafts.set(id, text); },
-    closedEvent(id: string) { dismiss(id); },     // the kernel's one-shot frame, when it DOES arrive
+    closedEvent(id: string) { dismiss(id, "end"); },     // the kernel's one-shot frame, when it DOES arrive
     // a kernel tabOrder push, with applyTabOrder's new bookkeeping: kernel-owned omissions dismiss first,
     // then the reconcile (whose keep no longer applies to kernel-owned ids), then the add-only record.
     push(kernel: string[]) {
-      for (const id of order.slice()) if (kernelListed.has(id) && !kernel.includes(id)) dismiss(id);
+      for (const id of order.slice()) if (kernelListed.has(id) && !kernel.includes(id)) dismiss(id, "omitted");
       order = reconcileTabOrder(kernel, order, (id) => sessions.has(id), (id) => kernelListed.has(id));
       for (const id of kernel) kernelListed.add(id);
     },
@@ -68,13 +75,18 @@ test("a session ended while the socket was down leaves the strip on the reconnec
   assert.deepEqual(m.tabs(), ["web"]);
 });
 
-test("the teardown clears the dead session's composer leftovers too", () => {
+test("the omission teardown KEEPS the session's composer draft — an absence is not the user's close (T236)", () => {
   const m = model();
   m.session("web"); m.session("api");
   m.push(["web", "api"]);
   m.draft("api", "half-typed message");
   m.push(["web"]);
-  assert.equal(m.hasDraft("api"), false, "kernel-driven drop runs the full dismissSession surface");
+  assert.deepEqual(m.tabs(), ["web"], "the tab still goes");
+  assert.equal(m.hasDraft("api"), true, "…but the draft is stashed under its id, back with the session if it returns");
+  // the kernel's own closed frame — the session actually ended — is what clears it
+  m.session("api"); m.push(["web", "api"]);
+  m.closedEvent("api");
+  assert.equal(m.hasDraft("api"), false, "a genuine end clears the draft (the user 2026-08-04)");
 });
 
 test("the closed event remains the fast path; the push after it has nothing left to do", () => {
@@ -114,7 +126,7 @@ test("a create placeholder the kernel has never listed still survives unrelated 
 test("applyTabOrder dismisses kernel-owned omissions BEFORE reconciling, then records add-only", () => {
   // the drop loop sits between ackClosingTabs and the reconcile, and dismissSession is the shared teardown
   assert.match(RENDER,
-    /ackClosingTabs\(kernelOrder, report\);[\s\S]{0,700}?for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(kernelListed\.has\(id\) && !inKernel\.has\(id\)\) dismissSession\(id\);\s*\n\s*\}/,
+    /ackClosingTabs\(kernelOrder, report\);[\s\S]{0,900}?const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\)\)\);[^\n]*\n\s*for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(omitted\.has\(id\)\) dismissSession\(id, "omitted", omitted\);\s*\n\s*\}/,
     "kernel-owned tabs the push stopped carrying get the closed-event teardown");
   // the reconcile passes the kernelListed predicate, so the pure model enforces the same rule
   assert.match(RENDER,
@@ -122,7 +134,7 @@ test("applyTabOrder dismisses kernel-owned omissions BEFORE reconciling, then re
   // add-only, recorded AFTER the reconcile: dropping entries would hand a late stale `session` frame the
   // never-listed keep and re-mint the ghost
   assert.match(RENDER, /for \(const id of next\) order\.push\(id\);\s*\n\s*for \(const id of kernelOrder\) kernelListed\.add\(id\);/);
-  const body = RENDER.match(/function dismissSession\(id: string\): void \{[\s\S]*?\n\}/);
+  const body = RENDER.match(/function dismissSession\(id: string, why: DismissWhy, doomed\?: ReadonlySet<string>\): void \{[\s\S]*?\n\}/);
   assert.ok(body, "dismissSession not found");
   assert.doesNotMatch(body![0], /kernelListed/, "the record outlives the dismiss (add-only set)");
 });

--- a/vscode-extension/src/chat-focus-model.test.ts
+++ b/vscode-extension/src/chat-focus-model.test.ts
@@ -43,7 +43,7 @@ test("Enter from the bare chat area (no focused control) drops into the message 
   // gated on activeElement === body so it never steals Enter from a control/tab/the live-ask card, and it
   // hooks no clicks → highlighting + expanding folds are unaffected
   const i = SRC.indexOf('window.addEventListener("keydown"', SRC.indexOf("NAV_SCROLL_STEP"));
-  const block = SRC.slice(i, i + 2600);
+  const block = SRC.slice(i, i + 2800);   // the tail grew a hold line (T236: the hand-over note stands the default down)
   assert.match(block, /e\.key === "Enter"/);
   assert.match(block, /const ae = document\.activeElement;\s*if \(ae && ae !== document\.body\) return;/);
   assert.match(block, /if \(focusComposerOrAsk\(\)\) e\.preventDefault\(\);/);


### PR DESCRIPTION
## An unsent draft survives a host drop, and the box never changes hands silently (T236)

**The report** (relayed, unverified by the user): a draft typed into one session's chat box turned up in a *different* session's box after a remote host dropped off and the session list changed. Reproduced on a hermetic federated harness (two fake hosts, no ssh) on the unfixed build, on every path below.

**Root cause.** Every teardown of a chat tab ran `dismissSession` exactly like the user's own ✕: it deleted the session's draft, citations, edit pill and attachments, and when the torn-down tab was the active one it silently re-bound the composer to the most-recently-used survivor (or to `null`, then to whichever session frame arrived next) while keyboard focus stayed in the textarea. Federation's `closeRemote` dispatches a synthetic `closed` for every session of a host that left `/tunnels` (a detach, a check-in row replaced or stopped), and `applyTabOrder` runs the same teardown for any kernel-listed id a push omits. Neither is the session's end, but the pane could not tell. The user kept typing into what they believed was session A's box; the input handler filed it under B. A's text was gone.

**The change.**
- `dismissSession(id, why, doomed?)` names its reason: `close` (the user's ✕/End), `end` (the owning kernel's own `closed` frame), `hostDrop` (federation's synthetic frame, now stamped `hostDrop: true` in `closeRemote`), `omitted` (applyTabOrder's kernel-order omission). Only `close` and `end` clear the composer state (the existing behavior, the user 2026-08-04). A host drop or an omission **stashes** it under the session's stable host-prefixed id; it is back in the box when the session returns and is clicked, and `persistDrafts` keeps the persisted copy in sync.
- When the ACTIVE tab is torn down for any reason but the user's own ✕: the live text is stashed under its own id *first*, the fallback skips the dismissed id and anything the same teardown takes next (a dropped host's siblings, a push's other omissions), recency first then the strip itself (never `null` while tabs remain), the composer is **blurred**, and a note above the box says whose box went away, that the draft is kept, and that a click into the box is what binds typing to the survivor. While that note is up the two type-from-anywhere defaults (a printable key nobody claimed, Enter from the bare area) stand down: the key is swallowed and the note flashes. The harness showed the blur alone was not enough: the first printable key re-focused the box and the continuation still landed in the survivor's draft. The note retires on exact events only: a click into the box (its pointerdown), an explicit tab switch, its ✕, or the session's RETURN (its next session frame) — which, the note still holding, puts the user back on that tab with the kept draft in the box: they did nothing in between, so the blip should read as a blip. (Merely retiring the note on return left the fallback tab active and unheld; the independent harness re-run caught a blind keystroke landing there once the omitted tab was re-listed.)
- The `!activeId` adoption of an arriving session loads that session's draft (through the same `loadComposerFor` the teardown uses) and takes the first-show path even for a payload the page already held (the no-active-tab state had hidden every view; the append path never re-revealed one, so a tab sat active over "No session open").
- `federation.ts`: the synthetic frames carry `hostDrop: true`; the owning kernel's own `closed` (the T233 fold) passes through unstamped.

**Deliberately unchanged.** The 15s close-confirm backstop and `closingTabs` suppression; the kernel's pusher and its tabOrder writers (see caveats); a genuine end still clears the draft; setActive's own stash/load block (pinned by composer-draft-persist.test.ts) is untouched beyond retiring the note.

**Evidence.**
- Executed model + source pins: `ui/webview/draft-teardown.test.ts` — (i) a remote draft survives a host drop and is back on return; (ii) typing after an active-tab teardown never lands under another session without an explicit switch (blur + note; keystrokes with no focus go nowhere); (ii-b) the omission path gets the same treatment; (iii) a genuine end (✕ and the kernel's closed) still clears; (iii-b) the closed frame confirming our own ✕ neither notes nor blurs; (iv) the fallback never selects the dismissed id, nor one the same teardown takes next, nor `null` while tabs remain; the only-tab adoption loads the stashed draft. Pins in tab-ghost-heal (an omission now KEEPS the draft), composer-citation, composer-files, tab-close-optimistic, provisional, click-safe, render-scroll updated to the new literals.
- Hermetic federated harness (kernel + two fake check-in hosts + playwright), unfixed build vs this branch, scenarios: S1 detach of hostA while typing in hostA:web; S2 a push omitting the active session once; S3 the remote's socket re-accepted with a partial first list; S4 a local kernel restart with the page alive. Unfixed build: S1, S2, S3 reproduced (draft deleted, box emptied with focus kept, blind keystrokes filed under the survivor, original not back after re-attach); S4 not reproduced (remote tabs and draft intact through the restart). This branch, same scenarios: the draft is kept under its id, the box is blurred and the note shows above it, the blind keystroke is swallowed and nothing is filed anywhere, and when the dropped/omitted session returns the user is put back on its tab with the draft in the box (S2/S3: the keystroke typed after the return lands in the returned session's own draft). An independent agent re-ran the unfixed scenarios from the same scripts and confirmed each verdict, plus S1 with a script of its own. Harness scripts, logs and screenshots live outside the repo under a scratch dir (synthetic hosts and sids only).
- Suites on the pushed head: webview `npm test` 2764 pass / 0 fail, `npm run typecheck` clean; full Python suite 7121 passed / 0 failed (run at the first commit; `kernel/` has no diff on this branch). The 29 Python tests that read the UI sources: 748 passed, plus two `test_kernel.py::ViewBuilder` nudge tests that fail only inside that partial selection and pass alone (an ordering artifact of tests this branch does not touch).

**Caveats / what this does not touch.** Side observation from the harness, pre-existing and untouched here: a tab omitted by one push and re-listed by the next returns at the END of the strip (federation's arrival adoption appends an id the viewer arrangement no longer holds). A genuine natural death (`_record_death "gone"`) emits no `closed` frame and reaches the pane only as an omission, so its draft is now kept rather than cleared (it returns with a revive of the same sid; a read-only reopen shows it in a disabled box). Two kernel-side omission sources the trace found are left for the pusher lane, not fixed here: a `tmux list-sessions` timeout collapses the live set to `[]` for one push (every tmux-backed tab is torn down and re-added), and the `ready` handler's second tabOrder (`_ordered_alive`, live-only) omits dead kept-open tabs the tabs-first frame just listed (a 60s flap under the dedup slot); `_kept_open` is in-memory so a kernel restart drops kept-open dead tabs. With this change all three keep their drafts instead of destroying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
