### PR TITLE
A p2p update restarts the far kernel through its manager's quiet window, and the dialing side expects the gap

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12709,6 +12709,10 @@ def _demand_redial(host, kind):
         if not r or r.get("checkin_peer"):
             return
         alive = _tunnel_proc_alive(r)
+        if kind == "refused" and alive and isinstance(r.get("restartExpected"), dict):
+            return                                   # the far kernel is restarting because WE updated it
+            #                                          (T238): the ssh is healthy — never terminate it. A
+            #                                          DEAD ssh is a real demand and falls through (review)
         if alive and r.get("status") in ("starting", "authorizing"):
             return                                   # a dial is mid-flight — the demand is already served
         r["fails"], r["next_try"] = 0, 0
@@ -12736,6 +12740,65 @@ def _tunnel_status(proc_alive, port_up, remote_answered):
     if port_up:
         return "no-kernel"
     return "starting"
+
+
+RESTART_EXPECT_GAP_S = 120.0      # cap on an expected restart's UNANSWERED stretch — a kernel boot is ~2s; this
+#                                   can never trap a row: past it the ordinary no-kernel path resumes, loudly
+RESTART_EXPECT_MAX_S = 20 * 60.0  # a restart that never comes: the far manager's quiet window is capped at 15
+#                                   min (QUIET_MAX_DEFER_MS), so an expectation older than this is stale
+
+
+def _expected_restart_status(r, st, rsha, now):
+    """Reinterpret a tunnel row's polled status while a restart WE caused is expected (T238). After a
+    p2p update or an explicit remote restart the far kernel goes away for ~2s; the supervisor used to
+    read that gap as a dead far kernel — 'no-kernel' (red), a data-path hit terminating the healthy
+    ssh, a backoff step — so a 2s restart the puller itself caused showed as 15-60s of "unreachable"
+    on a merge day, nine times in three hours. With r["restartExpected"] = {sha, t} stamped by the
+    apply, an unanswered poll reads 'restarting' instead, and the row's ladder/misses are left alone.
+    Event-keyed ends: the far kernel ANSWERS again after the gap, or reports the pushed sha (a
+    quiet-window restart may land minutes later). Two can-never-trap caps, both loud on the dial log:
+    RESTART_EXPECT_GAP_S from the first unanswered poll, and RESTART_EXPECT_MAX_S for an expectation
+    whose restart never comes. Pure on (row, status, polled sha, now); mutates only the row."""
+    exp = r.get("restartExpected")
+    if not isinstance(exp, dict):
+        return st
+    aged = now - float(exp.get("t") or now) > RESTART_EXPECT_MAX_S
+    if st == "up":
+        gap0 = exp.get("gapT")
+        want = str(exp.get("sha") or "")
+        if gap0 is not None or (want and rsha and _shas_agree(rsha, want)):
+            # the far kernel answered after its gap, or already reports the pushed sha (a quiet-window
+            # restart may land minutes later). An EXPLICIT restart carries no sha — only the gap ends it,
+            # since the old kernel answers the very sha it already ran (review find)
+            r.pop("restartExpected", None)
+            _tunnel_log(r.get("host") or "?", "restart-expected-ended", sha=want[:12],
+                        gapS=(round(now - gap0, 1) if gap0 is not None else 0), sawNewSha=bool(want and rsha))
+        elif aged:
+            r.pop("restartExpected", None)
+            _tunnel_log(r.get("host") or "?", "restart-expected-expired", sha=want[:12],
+                        note="the far kernel kept answering the old build past the quiet-window cap")
+            if want:
+                # SAY it on the row, not just the dial log: the update landed on disk but that kernel never
+                # restarted into it (a manager that owns no kernel, a quiet window that never came)
+                r["detail"] = ("pushed %s there, but that kernel never restarted into it — restart it from "
+                               "its popover" % want[:8])
+        return st
+    if st in ("down", "starting") and aged:
+        r.pop("restartExpected", None)   # never a permanent latch, whatever the row is doing (review find)
+        _tunnel_log(r.get("host") or "?", "restart-expected-expired", sha=str(exp.get("sha") or "")[:12],
+                    note="aged out while the tunnel itself was %s" % st)
+        return st
+    if st == "no-kernel":
+        gap0 = exp.get("gapT")
+        if gap0 is None:
+            exp["gapT"] = gap0 = now             # the restart began: count the cap from here
+        if now - gap0 <= RESTART_EXPECT_GAP_S:
+            return "restarting"
+        r.pop("restartExpected", None)
+        _tunnel_log(r.get("host") or "?", "restart-expected-expired", sha=str(exp.get("sha") or "")[:12],
+                    gapS=round(now - gap0, 1), cap=RESTART_EXPECT_GAP_S,
+                    note="the far kernel did not come back — treating it as a dead far kernel again")
+    return st
 
 
 def _remote_public(r):
@@ -14198,6 +14261,16 @@ def _update_remote(host):
     if rdirty:
         return False, "remote %s has uncommitted changes — commit or discard them there first (won't clobber)" % host
     if rhead and rhead == lfull:
+        with _remotes_lock:
+            rr = _remotes.get(host)
+            if rr is not None and rr.get("kernel_sha") and not _shas_agree(rr["kernel_sha"], lfull) \
+                    and not isinstance(rr.get("restartExpected"), dict):
+                # the checkout already holds our build but the KERNEL still answers the old one: a
+                # restart is pending there (a quiet window we asked for and then forgot across our own
+                # restart, or one nobody asked for) — expect it again rather than read its gap as death
+                rr["restartExpected"] = {"sha": lfull, "t": time.time(), "quiet": None}
+                return True, ("already up to date (%s) — that kernel has not restarted into it yet"
+                              % (_local_head(short=True) or lfull[:8]))
         return True, "already up to date (%s)" % (_local_head(short=True) or lfull[:8])
     # (2) push local HEAD to a scratch ref on the remote (non-checked-out → no denyCurrentBranch issue)
     env = dict(os.environ, GIT_SSH_COMMAND="%s %s" % (SSH_BIN, " ".join(_SSH_OPTS)))
@@ -14227,6 +14300,29 @@ def _update_remote(host):
         # can't run (or the port never returns) we relaunch romp-serve bare as a last resort so the host isn't
         # left dead. The port poll confirms whichever path brought it back.
         'if [ ! -x "$R/bin/romp-serve" ]; then echo "NOLAUNCH:$NEW"; exit 0; fi; '
+        # NEVER AN ANONYMOUS SIGTERM (T238, the T121 rule): a restart-audit row lands BEFORE whichever
+        # restart happens, so the far kernel's cut row carries WHO and WHY (the p2p update, from this
+        # machine, to this sha) — nine restarts in three hours had no reason on record. The restart
+        # goes THROUGH THE FAR MANAGER'S QUIET WINDOW (restart-all --quiet: no in-flight turn is cut,
+        # the 15-minute backstop still lands the deploy, a second apply arriving while one is pending
+        # coalesces into the same bounce) — but ONLY when that manager actually OWNS the kernel on the
+        # polled port (its /status lists it): a manager owning nothing, or a bare kernel beside a
+        # crash-looping managed one, answers 202 and restarts nothing, which would have turned this
+        # into a silent never-restart (review find). SYNCED:<sha>:QUIET = deferred; SYNCED:<sha>:FALLBACK
+        # = the immediate path below ran (no owning manager reachable — node absent, no manager, or
+        # the polled kernel is bare). The quiet audit row says when=quiet; the fallback writes its own
+        # row without it, so the cut row joins the right request with the right window.
+        'OWNED=0; if command -v node >/dev/null 2>&1 && [ -x "$R/bin/romp-manager" ]; then '
+        'OWNED="$("$R/bin/romp-manager" status 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); '
+        'print(1 if any(int(k.get(\'port\') or 0)==%d for k in (d.get(\'kernels\') or [])) else 0)" 2>/dev/null || echo 0)"; fi; '
+        'if [ "$OWNED" = 1 ]; then '
+        'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
+        '\'reason\':\'from %s to %s\',\'when\':\'quiet\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
+        'if "$R/bin/romp-manager" restart-all --quiet >>"$LOGDIR/update.log" 2>&1; then echo "SYNCED:$NEW:QUIET"; exit 0; fi; fi; '
+        # LAST RESORT (no owning manager answering on this host): the immediate path below — audit row,
+        # kill, then `ensure` upgrades the host to a supervised kernel.
+        'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
+        '\'reason\':\'from %s to %s (immediate: no owning manager)\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
         # SELF-MATCH GUARD. `pkill -f` matches its pattern against every process's FULL COMMAND LINE —
         # including this apply script's own, because the pattern text sits literally inside it. The plain
         # spelling therefore killed the apply shell AT THIS LINE, before it could restart the kernel or
@@ -14239,8 +14335,10 @@ def _update_remote(host):
         'if command -v node >/dev/null 2>&1 && [ -x "$R/bin/romp-manager" ]; then "$R/bin/romp-manager" ensure >>"$LOGDIR/update.log" 2>&1 || true; fi; '
         'UP=0; for i in 1 2 3 4 5 6 7 8; do sleep 1; if bash -c "exec 3<>/dev/tcp/127.0.0.1/%d" 2>/dev/null; then UP=1; break; fi; done; '
         'if [ "$UP" = 0 ]; then nohup "$R/bin/romp-serve" >>"$LOGDIR/kernel.log" 2>&1 </dev/null &  sleep 1; fi; '
-        'echo "SYNCED:$NEW"'
-    ) % (shlex.quote(rdir), _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, kport)
+        'echo "SYNCED:$NEW:FALLBACK"'
+    ) % (shlex.quote(rdir), _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF,
+         kport, _local_machine_label(), (_local_head(short=True) or lfull[:8]),
+         _local_machine_label(), (_local_head(short=True) or lfull[:8]), kport)
     # The apply KILLS the running kernel before booting its replacement, so it must be immune to the
     # ssh dying between the two halves — exactly what a flaky link does (the user 2026-07-11:
     # every drop mid-apply left the host kernel-LESS, and each banner Retry re-killed whatever a
@@ -14251,18 +14349,46 @@ def _update_remote(host):
     # AFTER the boot has been launched. Falls back to plain bash where setsid doesn't exist (macOS).
     guarded_apply = ('APPLY=%s; if command -v setsid >/dev/null 2>&1; then exec setsid bash -c "$APPLY"; '
                      'else exec bash -c "$APPLY"; fi' % shlex.quote(apply_cmd))
+    # The dialing side EXPECTS the restart it is about to cause (T238) — stamped BEFORE the apply runs:
+    # an idle far kernel is SIGTERMed within milliseconds of the manager's 202, and the fallback path
+    # kills it mid-ssh, so a stamp after the ssh returned arrived after the gap it was meant to explain
+    # (review find). The expected sha is the NEW build, which the old kernel cannot report, so the
+    # sha-agreement end cannot fire early. Popped again below if the apply did not restart anything.
+    def _expect(quiet):
+        with _remotes_lock:
+            rr = _remotes.get(host)
+            if rr is not None:
+                rr["restartExpected"] = {"sha": lfull, "t": time.time(), "quiet": quiet}
+    def _unexpect():
+        with _remotes_lock:
+            rr = _remotes.get(host)
+            if rr is not None:
+                rr.pop("restartExpected", None)
+    _expect(None)
     try:
         a = subprocess.run([SSH_BIN] + _SSH_OPTS + ["--", host, guarded_apply], capture_output=True, text=True, timeout=60)
     except subprocess.TimeoutExpired:
+        # the detached apply keeps running there — the restart may still come, so the expectation stays
         return False, ("pushed, but confirming the restart timed out — the detached restart keeps "
                        "running on %s; check the popover in a minute" % host)
     except Exception as e:
+        _unexpect()
         return False, "pushed, but the remote reset/restart failed: " + str(e)[:150]
     aout = (a.stdout or "").strip()
     tag, _, rest = aout.partition(":")
     tag, rest = tag.strip(), rest.strip()
     if tag == "SYNCED":
-        return True, "synced to %s + restarting" % (rest or _local_head(short=True) or "HEAD")
+        short, _, mode = rest.partition(":")
+        mode = mode.strip()
+        _expect(mode == "QUIET")
+        short = short.strip() or _local_head(short=True) or "HEAD"
+        if mode == "QUIET":
+            return True, "synced to %s — restarting at its next quiet window" % short
+        if mode == "FALLBACK":
+            return True, ("synced to %s + restarting now (no manager owns that kernel there — an "
+                          "immediate restart)" % short)
+        return True, "synced to %s + restarting" % short
+    _unexpect()                                   # nothing restarted: DIVERGED / RESETFAIL / NOLAUNCH / error
     if tag == "DIVERGED":
         # Two very different causes land here, and the old wording only described the first, which is
         # why a rewritten local history read as an unexplained refusal (the user 2026-07-22): either the
@@ -14492,12 +14618,22 @@ def _restart_remote_kernel(host):
     apply_cmd = (
         'LOGDIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"; mkdir -p "$LOGDIR"; R=%s; '
         'if [ ! -x "$R/bin/romp-serve" ]; then echo NOLAUNCH; exit 0; fi; '
+        # never an anonymous SIGTERM (T238): the far kernel's cut row names this explicit restart
+        'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'remote-restart\','
+        '\'reason\':\'requested from %s\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
         'pkill -f "bin/romp-kern[e]l" 2>/dev/null; '
         'if command -v node >/dev/null 2>&1 && [ -x "$R/bin/romp-manager" ]; then "$R/bin/romp-manager" ensure >>"$LOGDIR/update.log" 2>&1 || true; fi; '
         'UP=0; for i in 1 2 3 4 5 6 7 8; do sleep 1; if bash -c "exec 3<>/dev/tcp/127.0.0.1/%d" 2>/dev/null; then UP=1; break; fi; done; '
         'if [ "$UP" = 0 ]; then nohup "$R/bin/romp-serve" >>"$LOGDIR/kernel.log" 2>&1 </dev/null &  sleep 1; fi; '
         'echo "RESTARTED:$UP"'
-    ) % (shlex.quote(rdir), kport)
+    ) % (shlex.quote(rdir), _local_machine_label(), kport)
+    with _remotes_lock:
+        rr = _remotes.get(host)
+        if rr is not None:
+            # the supervisor expects the gap this restart is about to cause — stamped BEFORE the ssh,
+            # with NO sha: a same-build restart brings back the sha the old kernel already answers, so
+            # a sha-agreement end would fire before the kill; only the observed gap ends it (review)
+            rr["restartExpected"] = {"sha": "", "t": time.time(), "quiet": False}
     guarded = ('APPLY=%s; if command -v setsid >/dev/null 2>&1; then exec setsid bash -c "$APPLY"; '
                'else exec bash -c "$APPLY"; fi' % shlex.quote(apply_cmd))
     try:
@@ -14509,6 +14645,10 @@ def _restart_remote_kernel(host):
     out = (a.stdout or "").strip()
     if out.startswith("RESTARTED"):
         return True, "restarted (same build)"
+    with _remotes_lock:                           # nothing restarted — stop expecting a gap
+        rr = _remotes.get(host)
+        if rr is not None:
+            rr.pop("restartExpected", None)
     if out == "NOLAUNCH":
         return False, "found no romp/romp-serve launcher to restart the kernel"
     return False, (_ssh_err(a.stderr) or out or "remote restart failed").strip()[:180]
@@ -14703,11 +14843,27 @@ def _recent_restart_reason(window=90, now=None):
             return ""
         rec = json.loads(tail[-1])
         t0 = int(now if now is not None else time.time())
+        if isinstance(rec, dict) and rec.get("when") == "quiet":
+            # a QUIET-WINDOW request is pending until the restart it asked for lands — up to the far
+            # manager's 15-minute backstop — so it names the cut well past the immediate window (T238)
+            window = max(window, RESTART_EXPECT_MAX_S)
         if isinstance(rec, dict) and isinstance(rec.get("t"), int) and t0 - rec["t"] <= window:
             return str(rec.get("action") or "") + (": " + str(rec["reason"]) if rec.get("reason") else "")
     except Exception:
         pass
     return ""
+
+
+def _local_machine_label():
+    """This machine's name as the far side's audit row should carry it — the hostname, SANITIZED to
+    [A-Za-z0-9._-]: it is interpolated into a shell script the far host runs, so a quote, $ or
+    backtick in a hostname must never break the apply or silently drop the audit row (review find)."""
+    try:
+        raw = socket.gethostname() or ""
+    except Exception:
+        raw = ""
+    clean = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-")[:64]
+    return clean or "this-machine"
 
 
 def _restart_this_kernel(reason="", manager_port=_PORT_FROM_ENV):
@@ -14931,6 +15087,8 @@ def _tunnel_supervisor():
                         _note_poll(r, st == "up")
                     else:
                         st = _tunnel_status(_tunnel_proc_alive(r), up, sids is not None)
+                        st = _expected_restart_status(r, st, rsha, now)   # our own p2p restart is not a
+                        #                                                    dead far kernel (T238)
                         # A LIVE ssh is not proof of a live tunnel (the user 2026-07-29). ssh answers the
                         # local connect from its own listener, so a proc whose transport is gone looks
                         # exactly like a healthy tunnel with no romp behind it — and this branch only
@@ -14943,7 +15101,10 @@ def _tunnel_supervisor():
                         # answered at all means the path is gone. Kill it and let the branch above re-dial —
                         # once, on the transition, never on a timer.
                         silent = (st == "no-kernel" and r.get("_probe") == "timeout")
-                        if _note_poll(r, not silent):
+                        if st == "restarting":
+                            pass                    # the gap of a restart WE caused: no miss, no teardown,
+                            #                         no ladder step — the expectation's own caps bound it
+                        elif _note_poll(r, not silent):
                             _tunnel_log(r["host"], "stale-tunnel",
                                         pid=(r["proc"].pid if r.get("proc") else 0),
                                         misses=int(r.get("misses") or 0),
@@ -14984,6 +15145,9 @@ def _tunnel_supervisor():
                         #                                    so a later down row can date what it remembers
                         if r.get("detail"):
                             r["detail"] = ""               # any parked error/hint is moot once it answers
+                    elif st == "restarting":
+                        r["detail"] = ("restarting after an update pushed from this machine — back in a "
+                                       "moment; nothing to do")
                     elif st == "no-kernel" and not r.get("booting"):
                         cur = r.get("detail") or ""
                         if not cur or cur.startswith("no kernel answering"):
@@ -30621,12 +30785,13 @@ function fillHosts(){if(!dl)return;var hs=[];
 dl.innerHTML=hs.map(function(h){return '<option value=\"'+h+'\"></option>';}).join('');}
 function loadHosts(){fetch('/ssh-hosts',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
 _cfg=(d&&d.hosts)||[];fillHosts();}).catch(function(){});}
-var LBL={up:'connected',authorizing:'authorizing\\u2026',connecting:'connecting\\u2026',starting:'connecting\\u2026','no-kernel':'kernel not answering',down:'reconnecting\\u2026',error:'error'};
+var LBL={up:'connected',authorizing:'authorizing\\u2026',connecting:'connecting\\u2026',starting:'connecting\\u2026','no-kernel':'kernel not answering',restarting:'restarting after update\\u2026',down:'reconnecting\\u2026',error:'error'};
 // Every status explains itself on hover (the user 2026-07-22: learn it from tooltips, not the CLI).
 var TIP={up:'Connected: the ssh tunnel is open and that machine\\u2019s romp kernel is answering through it. Its sessions appear in your tabs and timeline.',
 authorizing:'Opening an ssh connection and reading that machine\\u2019s access token. Needs `ssh <host>` to work without a prompt.',
 connecting:'The ssh tunnel is up; waiting for the remote kernel to answer on its port.',
 starting:'The ssh tunnel is up; waiting for the remote kernel to answer on its port.',
+restarting:'This machine just pushed its build there; that kernel is restarting into it and will answer again in a moment. Nothing to do.',
 'no-kernel':'The tunnel is open but no romp kernel is answering on that machine. Re-dial re-opens the link in case it is only wedged; Start pushes this machine\\u2019s romp there and boots it.',
 down:'The ssh tunnel is not up. romp keeps retrying on its own, waiting longer between tries the longer it stays down, so a machine that comes back is picked up without you doing anything. Try now dials immediately.',
 error:'The connection failed. Hover the status text for the reason romp got back. romp keeps retrying in the background.'};

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -115,6 +115,143 @@ class UpdateRemote(unittest.TestCase):
         self.assertIn("TESTHOST:/home/u/romp", push)
         self.assertTrue(any(str(x).startswith("HEAD:refs/heads/") for x in push), "pushes HEAD to a scratch ref")
 
+    def test_the_apply_restarts_through_the_manager_quiet_window_with_an_audit_row(self):
+        # T238: the remote apply used to `pkill` the far kernel outright — an anonymous, immediate
+        # SIGTERM (no restart-audit row, no quiet window: nine in-flight-turn cuts in three hours on a
+        # merge day, each read by the dialing side as "unreachable"). The apply now writes the audit
+        # row first and asks the far MANAGER for a quiet-window restart; pkill survives only as the
+        # last-resort branch for a host with no manager.
+        calls = self._wire(apply_out="SYNCED:abcdef0:QUIET")
+        km._remotes["TESTHOST"] = {"host": "TESTHOST"}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        ok, detail = km._update_remote("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertIn("quiet window", detail)
+        apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
+        self.assertIn("restart-audit.jsonl", apply, "the restart is never anonymous")
+        self.assertIn("p2p-update", apply)
+        self.assertIn("restart-all --quiet", apply, "the manager's quiet-window gate, not a kill")
+        self.assertLess(apply.index("restart-all --quiet"), apply.index('pkill -f "bin/romp-kern[e]l"'),
+                        "pkill is the fallback AFTER the manager path, never the first move")
+        exp = km._remotes["TESTHOST"].get("restartExpected")
+        self.assertTrue(exp and exp.get("sha") == self.LFULL and exp.get("t") and exp.get("quiet") is True,
+                        "the dialing side is told to expect the restart it just caused")
+
+    def test_a_host_with_no_owning_manager_restarts_the_old_way_and_says_so(self):
+        calls = self._wire(apply_out="SYNCED:abcdef0:FALLBACK")
+        km._remotes["TESTHOST"] = {"host": "TESTHOST"}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        ok, detail = km._update_remote("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertIn("immediate", detail)
+        self.assertNotIn("quiet window", detail)
+        self.assertIs(km._remotes["TESTHOST"]["restartExpected"]["quiet"], False)
+
+    def test_the_quiet_path_requires_the_manager_to_own_the_polled_kernel(self):
+        # a manager owning nothing (or a bare kernel beside a crash-looping managed one) answers 202
+        # and restarts nothing — trusting it turned the update into a silent never-restart (review)
+        calls = self._wire(apply_out="SYNCED:abcdef0:QUIET")
+        km._update_remote("TESTHOST")
+        apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
+        self.assertIn('romp-manager" status', apply, "ownership is read from the manager's own registry")
+        self.assertLess(apply.index('romp-manager" status'), apply.index("restart-all --quiet"))
+        self.assertIn('if [ "$OWNED" = 1 ]', apply)
+        # per-branch audit rows: the quiet row precedes the quiet call; the fallback writes its own
+        # row (no when=quiet) right before pkill, so the cut row joins the request that happened
+        self.assertEqual(apply.count("restart-audit.jsonl"), 2)
+        self.assertLess(apply.index("p2p-update"), apply.index("restart-all --quiet"),
+                        "the quiet row lands before the quiet request")
+        self.assertLess(apply.index("restart-all --quiet"), apply.index("immediate: no owning manager"),
+                        "the fallback writes its own row after the quiet branch was skipped")
+        self.assertLess(apply.index("immediate: no owning manager"), apply.index('pkill -f "bin/romp-kern[e]l"'))
+        self.assertIn('SYNCED:$NEW:FALLBACK', apply)
+
+    def test_both_generated_apply_scripts_parse_as_bash(self):
+        import shlex, subprocess as sp
+        calls = self._wire(apply_out="SYNCED:abcdef0:QUIET")
+        km._update_remote("TESTHOST")
+        wrapper = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
+        inner = shlex.split(wrapper.split("; if command -v setsid")[0][len("APPLY="):])[0]
+        r = sp.run(["bash", "-n"], input=inner, capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        calls2 = []
+        real = km.subprocess.run
+        def fake2(argv, **kw):
+            calls2.append(argv)
+            if argv[0] == "git":
+                return _R(out=self.LFULL)
+            cmd = argv[-1]
+            if "for d in" in cmd:
+                return _R(out="DIR:/home/u/romp\nHEAD:%s\nDIRTY:" % self.RHEAD)
+            return _R(out="RESTARTED:1")
+        km.subprocess.run = fake2
+        try:
+            ok, _ = km._restart_remote_kernel("TESTHOST")
+        finally:
+            km.subprocess.run = real
+        self.assertTrue(ok)
+        wrapper2 = next(a[-1] for a in calls2 if isinstance(a[-1], str) and "RESTARTED" in a[-1])
+        inner2 = shlex.split(wrapper2.split("; if command -v setsid")[0][len("APPLY="):])[0]
+        r2 = sp.run(["bash", "-n"], input=inner2, capture_output=True, text=True)
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+
+    def test_the_expectation_is_stamped_before_the_apply_runs_and_popped_when_nothing_restarted(self):
+        # an idle far kernel is SIGTERMed within milliseconds of the manager's 202, and the fallback
+        # kills it mid-ssh: a stamp AFTER the ssh returned arrived after the gap it explains (review)
+        km._remotes["TESTHOST"] = {"host": "TESTHOST"}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        seen = []
+        calls = self._wire(apply_out="SYNCED:abcdef0")
+        real = km.subprocess.run
+        def spy(argv, **kw):
+            if isinstance(argv[-1], str) and "reset --hard" in argv[-1]:
+                seen.append(dict(km._remotes["TESTHOST"].get("restartExpected") or {}))
+            return real(argv, **kw)
+        km.subprocess.run = spy
+        km._update_remote("TESTHOST")
+        km.subprocess.run = real
+        self.assertTrue(seen and seen[0].get("sha") == self.LFULL, "expected BEFORE the apply ssh ran: %r" % seen)
+        # a DIVERGED apply restarts nothing → the expectation is withdrawn
+        self._wire(apply_out="DIVERGED")
+        ok, _ = km._update_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertNotIn("restartExpected", km._remotes["TESTHOST"])
+
+    def test_already_up_to_date_re_arms_the_expectation_while_the_far_kernel_lags(self):
+        # the checkout holds our build but the KERNEL still answers the old sha: a restart is pending
+        # (a quiet window forgotten across our own restart) — expect its gap instead of reading death
+        self._wire(rhead=self.LFULL)
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_sha": "2222222"}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        ok, detail = km._update_remote("TESTHOST")
+        self.assertTrue(ok)
+        self.assertIn("has not restarted into it yet", detail)
+        self.assertEqual(km._remotes["TESTHOST"]["restartExpected"]["sha"], self.LFULL)
+
+    def test_an_explicit_restart_expects_a_gap_with_no_sha_and_withdraws_on_failure(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_sha": "2" * 40, "kernel_port": 29855}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        seen = []
+        real = km.subprocess.run
+        def fake(argv, **kw):
+            if argv[0] == "git":
+                return _R(out=self.LFULL)
+            cmd = argv[-1]
+            if "for d in" in cmd:
+                return _R(out="DIR:/home/u/romp\nHEAD:%s\nDIRTY:" % self.RHEAD)
+            seen.append(dict(km._remotes["TESTHOST"].get("restartExpected") or {}))
+            return _R(out="NOLAUNCH")
+        km.subprocess.run = fake
+        try:
+            ok, _ = km._restart_remote_kernel("TESTHOST")
+        finally:
+            km.subprocess.run = real
+        self.assertFalse(ok)
+        self.assertEqual(seen[0].get("sha"), "", "same build: no new sha to wait for — only the gap ends it")
+        self.assertNotIn("restartExpected", km._remotes["TESTHOST"], "nothing restarted → withdrawn")
+
     def test_already_up_to_date_short_circuits(self):
         self._wire(rhead=self.LFULL)          # remote already at local HEAD
         ok, detail = km._update_remote("TESTHOST")

--- a/tests/test_kernel_tunnel_truth.py
+++ b/tests/test_kernel_tunnel_truth.py
@@ -6,8 +6,10 @@ and the /sessions + /version polls failing left no mark. _tunnel_status derives 
 actually crossed the tunnel; an alive tunnel with nobody answering is 'no-kernel', surfaced in the
 popover with the next step. The /send remote forward reports a dead far kernel instead of ok:true.
 Synthetic fixtures only."""
+import json
 import os
 import unittest
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 import tempfile
 
@@ -40,6 +42,109 @@ class TunnelStatus(unittest.TestCase):
         self.assertEqual(km._tunnel_status(False, False, False), "down")
 
 
+class ExpectedRestart(unittest.TestCase):
+    """T238: a restart the DIALING side caused (its p2p update) must read as 'restarting after update',
+    never as a dead far kernel — no red no-kernel, no terminated ssh, no backoff step — until the event
+    that ends it (the far kernel answers again, or reports the new sha) or a can-never-trap cap."""
+
+    def _row(self, **kw):
+        r = {"host": "TESTHOST", "status": "up", "fails": 2, "next_try": 50.0, "misses": 0,
+             "restartExpected": {"sha": "1" * 40, "t": 1000.0}}
+        r.update(kw)
+        return r
+
+    def test_an_unanswered_poll_during_an_expected_restart_reads_restarting(self):
+        r = self._row()
+        st = km._expected_restart_status(r, "no-kernel", None, now=1005.0)
+        self.assertEqual(st, "restarting")
+        self.assertEqual(r["misses"], 0, "a restart gap is not a miss — nothing tears the ssh down")
+        self.assertEqual((r["fails"], r["next_try"]), (2, 50.0), "no backoff step")
+        self.assertIn("gapT", r["restartExpected"], "the gap's start is recorded — the cap counts from here")
+
+    def test_the_far_kernel_answering_again_ends_it(self):
+        r = self._row()
+        km._expected_restart_status(r, "no-kernel", None, now=1005.0)
+        st = km._expected_restart_status(r, "up", "2" * 40, now=1008.0)
+        self.assertEqual(st, "up")
+        self.assertNotIn("restartExpected", r, "the answer after the gap is the event that ends it")
+
+    def test_the_new_sha_showing_up_ends_it_even_without_a_gap(self):
+        # a quiet-window restart may land minutes later; a poll that already reports the pushed sha
+        # proves the restart happened whether or not we saw the gap
+        r = self._row()
+        st = km._expected_restart_status(r, "up", "1" * 40, now=1300.0)
+        self.assertEqual(st, "up")
+        self.assertNotIn("restartExpected", r)
+
+    def test_the_cap_ends_it_loudly_and_the_ordinary_path_resumes(self):
+        r = self._row()
+        km._expected_restart_status(r, "no-kernel", None, now=1005.0)
+        before = len(km.TUNNEL_LOG.read_text().splitlines()) if km.TUNNEL_LOG.exists() else 0
+        st = km._expected_restart_status(r, "no-kernel", None, now=1005.0 + km.RESTART_EXPECT_GAP_S + 1)
+        self.assertEqual(st, "no-kernel", "past the cap the row is honestly a dead far kernel")
+        self.assertNotIn("restartExpected", r)
+        appended = [json.loads(x) for x in km.TUNNEL_LOG.read_text().splitlines()[before:] if x.strip()]
+        self.assertTrue(any(x.get("event") == "restart-expected-expired" for x in appended), appended)
+
+    def test_a_restart_that_never_comes_expires_too(self):
+        # the far kernel keeps answering the OLD sha long past any quiet window: stop expecting
+        r = self._row()
+        st = km._expected_restart_status(r, "up", "2" * 40, now=1000.0 + km.RESTART_EXPECT_MAX_S + 1)
+        self.assertEqual(st, "up")
+        self.assertNotIn("restartExpected", r)
+
+    def test_an_explicit_restart_with_no_sha_ends_only_by_its_gap(self):
+        r = self._row(restartExpected={"sha": "", "t": 1000.0})
+        km._expected_restart_status(r, "up", "2" * 40, now=1002.0)
+        self.assertIn("restartExpected", r, "the old kernel answers the same sha — that is not the end")
+        km._expected_restart_status(r, "no-kernel", None, now=1004.0)
+        self.assertEqual(km._expected_restart_status(r, "up", "2" * 40, now=1008.0), "up")
+        self.assertNotIn("restartExpected", r)
+
+    def test_a_never_coming_restart_is_said_on_the_row(self):
+        r = self._row()
+        km._expected_restart_status(r, "up", "2" * 40, now=1000.0 + km.RESTART_EXPECT_MAX_S + 1)
+        self.assertIn("never restarted", r.get("detail") or "", "not just a dial-log line")
+
+    def test_the_expectation_ages_out_while_the_tunnel_is_down_too(self):
+        r = self._row()
+        km._expected_restart_status(r, "down", None, now=1000.0 + km.RESTART_EXPECT_MAX_S + 1)
+        self.assertNotIn("restartExpected", r, "never a permanent latch, whatever the row is doing")
+
+    def test_a_refused_demand_redial_with_a_dead_ssh_is_a_real_demand(self):
+        proc = mock.Mock()
+        proc.poll = lambda: 1                    # the ssh itself died
+        km._remotes["TESTHOST"] = self._row(proc=proc)
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        km._demand_redial("TESTHOST", "refused")
+        self.assertEqual((km._remotes["TESTHOST"]["fails"], km._remotes["TESTHOST"]["next_try"]), (0, 0),
+                         "a dead ssh during the expectation still earns the redial")
+
+    def test_no_expectation_changes_nothing(self):
+        r = self._row()
+        r.pop("restartExpected")
+        self.assertEqual(km._expected_restart_status(r, "no-kernel", None, now=1005.0), "no-kernel")
+
+    def test_a_refused_demand_redial_is_a_no_op_while_the_restart_is_expected(self):
+        terminated = []
+        proc = mock.Mock()
+        proc.poll = lambda: None
+        proc.terminate = lambda: terminated.append(1)
+        km._remotes["TESTHOST"] = self._row(proc=proc)
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        km._demand_redial("TESTHOST", "refused")
+        self.assertEqual(terminated, [], "a data-path hit during our own restart must not kill a healthy ssh")
+        self.assertEqual((km._remotes["TESTHOST"]["fails"], km._remotes["TESTHOST"]["next_try"]), (2, 50.0))
+
+    def test_a_quiet_pending_audit_row_names_the_cut_beyond_the_usual_window(self):
+        # the quiet window can defer the restart for minutes; the cut row must still carry the reason
+        km._audit_restart_request("p2p-update", reason="from TESTHOST to 1111111", when="quiet",
+                                  t=int(2000 - 600))
+        self.assertIn("p2p-update", km._recent_restart_reason(now=2000))
+        km._audit_restart_request("rail-button", t=int(3000 - 600))
+        self.assertEqual(km._recent_restart_reason(now=3000), "", "an immediate request keeps the 90s window")
+
+
 class SourcePins(unittest.TestCase):
     def setUp(self):
         self.src = open(os.path.join(BIN, "romp-kernel")).read()
@@ -53,6 +158,15 @@ class SourcePins(unittest.TestCase):
     def test_popover_labels_and_colors_the_new_status(self):
         self.assertIn("'no-kernel':'kernel not answering'", self.src)
         self.assertIn("t.status==='no-kernel'", self.src)
+
+    def test_the_strip_labels_an_expected_restart_and_never_paints_it_red(self):
+        self.assertTrue("restarting:'restarting after update" in self.src, "strip label for the expected restart")
+        self.assertTrue("t.status==='no-kernel'||t.status==='error')return 'warn'" in self.src,
+                        "the warn (red) line names no-kernel and error only — restarting is a wait")
+
+    def test_the_supervisor_consults_the_expectation_before_it_judges_the_far_kernel(self):
+        self.assertTrue("_expected_restart_status(r, st, rsha, now)" in self.src,
+                        "the supervisor consults the expectation before judging the far kernel")
 
     def test_send_remote_forward_reports_a_dead_far_kernel(self):
         self.assertIn("isn't answering — message not delivered", self.src)

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -403,7 +403,8 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
 
   const LBL: Record<string, string> = {
     up: "connected", authorizing: "authorizing…", connecting: "connecting…", starting: "connecting…",
-    "no-kernel": "kernel not answering", down: "reconnecting…", error: "error",   // a row exists = intent stands; romp never stops dialing (the user 2026-08-24)
+    "no-kernel": "kernel not answering", restarting: "restarting after update…",
+    down: "reconnecting…", error: "error",   // a row exists = intent stands; romp never stops dialing (the user 2026-08-24)
   };
   // Every status explains itself on hover (the user 2026-07-22: learn it from tooltips, not the CLI).
   // Mirrors the web popover's TIP map — the two copies must say the same thing.
@@ -413,6 +414,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
     connecting: "The ssh tunnel is up; waiting for the remote kernel to answer on its port.",
     starting: "The ssh tunnel is up; waiting for the remote kernel to answer on its port.",
     "no-kernel": "The tunnel is open but no romp kernel is answering on that machine. Start pushes this machine's romp there and boots it.",
+    restarting: "This machine just pushed its build there; that kernel is restarting into it and will answer again in a moment. Nothing to do.",
     down: "The ssh tunnel is not up. romp keeps retrying on its own, waiting longer between tries the longer it stays down, so a machine that comes back is picked up without you doing anything. Try now dials immediately.",
     error: "The connection failed. Hover the status text for the reason romp got back. romp keeps retrying in the background.",
   };


### PR DESCRIPTION
## What (T238)

The devbox "keeps dropping / unreachable" while ssh works fine. Verified on the box: 22 kernel boots in the day, 16 with no reason on record; the shared checkout's reflog shows `reset: moving to romp-p2p-sync` seconds before twelve of them, each right after a PR merged to main. That is `_update_remote` — the peer-to-peer update driven by `_maybe_auto_sync`: the other machine converges to main, force-pushes its HEAD to the devbox's scratch ref, and over ssh runs `git reset --hard` then `pkill -f bin/romp-kern[e]l` — an **anonymous, immediate SIGTERM** (no restart-audit row, no quiet window). Each is a 1.2–2.5 s outage, and the **dialing** side reads that gap as a dead far kernel: `no-kernel` (red), a data-path hit terminating the healthy ssh via `_demand_redial("refused")`, then the backoff ladder. A 2 s restart the puller itself caused showed as 15–60 s of "unreachable" — nine times in three hours. Not the network.

## Two halves, both event-keyed (the auto-push *policy* is untouched — the user's call)

1. **The apply is never an anonymous kill.** It first checks that the far **manager owns the kernel on the polled port** (its `/status` lists it — a manager owning nothing, or a bare kernel beside a crash-looping managed one, answers 202 and restarts nothing). If so: audit row (`p2p-update`, `from <machine> to <sha>`, `when: quiet`) then `romp-manager restart-all --quiet` — no in-flight turn cut, the 15-minute backstop still lands the deploy, and a second apply arriving while one is pending coalesces into the same bounce (verified in the manager's `pendingQuiet`). `SYNCED:<sha>:QUIET` = deferred. Otherwise the old immediate path runs with its **own** audit row and echoes `SYNCED:<sha>:FALLBACK`, so the caller says so. `_recent_restart_reason` honors a quiet-pending row past the 90 s window, so the cut row names the update whenever the restart lands. The explicit remote restart writes its audit row too (kept immediate — a click never waits). The hostname in the row is sanitized to `[A-Za-z0-9._-]`.
2. **The dialing side expects the restart it caused — stamped *before* the apply runs** (an idle far kernel is SIGTERMed within milliseconds of the 202; the fallback kills it mid-ssh), with the *new* sha so the sha-agreement end cannot fire early, and withdrawn if nothing restarted. `_expected_restart_status` reads an unanswered poll as `restarting` — the strip labels it "restarting after update…" (a wait, never red), no miss is counted, no healthy ssh is terminated (`_demand_redial("refused")` is a no-op only while the ssh is alive), no ladder step — until the event that ends it: the far kernel answers again, or reports the pushed sha. The explicit restart expects a gap with no sha (only the gap ends it). Two can-never-trap caps, loud on the dial log and aged out on every status branch: 120 s from the first unanswered poll, 20 min for a restart that never comes — which is also said on the row ("pushed … but that kernel never restarted into it"). An already-up-to-date checkout whose kernel still answers the old sha re-arms the expectation. A checked-in peer announces no restart of its own — noted, out of scope.

## Review (3 lenses, 21 findings, all real, all folded)

Manager-ownership check before trusting the quiet 202 (a regression otherwise); stamp ordering on both restart paths; the explicit restart's sha-agreement race; re-arm on the already-up-to-date short-circuit; age-out on down/starting; the refused guard swallowing a dead-ssh demand; per-branch audit rows (the immediate kill no longer gets a 20-minute attribution window); the hostname quoting hazard; the tagged fallback (node absent / no owning manager is no longer silent); the strip.ts mirror; script-parses and explicit-restart pins.

## Pins, red-first, synthetic

Apply-script shape (ownership check → quiet row → quiet call → fallback row → pkill, `FALLBACK` tag); `QUIET`/`FALLBACK` parsing and stamping; stamp-before-ssh and withdrawal on DIVERGED; already-up-to-date re-arm; both generated scripts run through `bash -n`; explicit restart's sha-less expectation and withdrawal; the helper's restarting / answered-after-gap / new-sha / no-sha / cap / never-came (with detail) / down-age-out arms; refused-redial no-op with a live ssh vs a real demand with a dead one; the quiet-pending audit window; strip label and supervisor call by source. 11 original pins red on main → green.

Figure for the record: 12 p2p applies → 12 restarts on the devbox in one day; the quiet-window path makes each land only when no turn is in flight and coalesces back-to-back merges into one bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)