### PR TITLE
The rolling month holds up under skew, DST, and mixed ledgers — three fixes

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13,7 +13,7 @@ Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
 import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, copy
 from pathlib import Path
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from importlib.machinery import SourceFileLoader
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, quote, unquote, urlencode
@@ -24718,9 +24718,13 @@ def _spend_windows(keyed_only=False):
         return _sum(v for k, v in hours.items() if k in keys)
 
     def _rolling_days(n):
-        # the recorder keys day buckets by LOCAL strftime date — build the key set the same way, so
-        # the window is "the last n local dates through today" on this host regardless of its zone
-        keys = {time.strftime("%Y-%m-%d", time.localtime(now - i * 86400)) for i in range(n + 1)}
+        # the recorder keys day buckets by LOCAL date — build the key set as DATES, not seconds (T235b,
+        # romp_ui's adversarial pass): `now - i*86400` crossed a DST shift one hour short, so every
+        # early-morning reading for weeks after spring-forward skipped the transition date and shifted
+        # the window a day older — month could read below week again in that hour. Date arithmetic
+        # keeps "the last n local dates through today" exact on every host regardless of its zone.
+        today = datetime.fromtimestamp(now).date()
+        keys = {(today - timedelta(days=i)).isoformat() for i in range(n + 1)}
         return _sum(v for k, v in days.items() if k in keys), keys
 
     month = time.strftime("%Y-%m", time.localtime(now))   # explicit clock: the frozen-clock tests govern it
@@ -30187,19 +30191,27 @@ return html;}
 // constant 'API' \u2014 no fragment of any key, not even a last-4 tail, reaches a surface (2026-08-08,
 // evening: a tail is still key material, and the hover's HOST names already tell whose spend is
 // whose). The full per-window, per-host breakdown is the hover's job.
-function apiCellHTML(live){var sum={day:{usd:0,tok:0},month:{usd:0,tok:0}},any=false;
+function apiCellHTML(live){var sum={day:{usd:0,tok:0},month:{usd:0,tok:0}},any=false,legacyN=0;
 live.forEach(function(e){var sp=e.det._spend;if(!sp)return;any=true;
+// VERSION SKEW, the hover's rule (T235b): a host on the previous build ships a CALENDAR month and no
+// monthToDate — spendDet filed it under 'this month' and left no rolling 'month' here, so it never
+// joins this rolling segment (two windows summed into one number is the lie T235 removed). Its DAY
+// still counts, so day can exceed month in the cell for that host — the caveat on the segment says why.
+if(e.det._spendLegacyMonth)legacyN++;
 // day||fiveHour: an older remote kernel ships no 'day' window yet (version skew) \u2014 its 5h burn is the
 // closest honest stand-in until it updates, and dropping it entirely would blank that host's spend
-var d=sp.day||sp.fiveHour,m=sp.month;
+var d=sp.day||sp.fiveHour,m=sp.month;   // m: the ROLLING month only (a legacy host has none here)
 if(d){sum.day.usd+=d.usd;sum.day.tok+=d.tok||0;}
 if(m){sum.month.usd+=m.usd;sum.month.tok+=m.tok||0;}});
 if(!any)return '';
-var seg=function(k,lbl){return '<div class=ru-name>'+lbl+'</div>'
+// the caveat is a GLYPH here, never a native title (the rail's one hover surface is the rich tip, which
+// already reads "N machines not counted (older build)" on its rolling-month row — one explanation, one place)
+var seg=function(k,lbl,cav){return '<div class=ru-name>'+lbl+(cav?' \u26a0':'')+'</div>'
 +'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \u00b7 '+fmtTok(sum[k].tok)+' tok</div>';};
+var monthCav=legacyN>0;   // some machine's calendar month was left out of this rolling segment (T235b)
 return '<div class="ru-w ru-api">'
 +'<div class=ru-name>API</div>'
-+seg('day','1 day')+seg('month','1 month')
++seg('day','1 day')+seg('month','1 month',monthCav)
 +'</div>';}
 // The collapsed rail is the AGGREGATE story (the user 2026-08-08; supersedes the one-set-per-account
 // rendering of 2026-07-30): one set of window bars for the whole fleet plus one API cell, never a
@@ -30326,7 +30338,7 @@ if(sp.week&&typeof sp.week.usd==='number')per.push({host:e.host,usd:sp.week.usd}
 SPEND_WINS.forEach(function(w){var v=sp[w[0]];if(!v)return;
 var t=(sum[w[0]]=sum[w[0]]||{label:w[1],usd:0,tok:0,turns:0});
 t.usd+=v.usd;t.tok+=v.tok;t.turns+=v.turns;
-if(v.since&&(!t.since||v.since<t.since))t.since=v.since;});   // the OLDEST reach among hosts caveats the sum
+if(v.since&&(!t.since||v.since>t.since))t.since=v.since;});   // the YOUNGEST ledger bounds the sum (T235b): it is complete only from there
 if(e.det._spendLegacyMonth)legacyN++;
 var ss=e.det._spendSeries;
 if(ss&&ss.usd){if(!series){series={h0:ss.h0,usd:ss.usd.slice()};}
@@ -30343,7 +30355,7 @@ var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>AP
 // the rolling month's caveats ride its label: a ledger younger than 30 days ("since <date>"), and
 // the machines whose older build could contribute only a calendar month (left out, counted)
 var lab=v.label;
-if(k==='month'&&v.since)lab+=' \u00b7 since '+esc(v.since);
+if(k==='month'&&v.since)lab+=' \u00b7 complete since '+esc(v.since);
 if(k==='month'&&legacyN)lab+=' \u00b7 '+legacyN+' machine'+(legacyN>1?'s':'')+' not counted (older build)';
 return '<div class=ru-tip-row><span class=ru-tip-k>'+lab+'</span>'
 +'<span class=ru-tip-v>'+fmtUsd(v.usd)+' \u00b7 '+fmtTok(v.tok)+' tok \u00b7 '+(v.turns||0)+' turns</span></div>';}).join('');

--- a/tests/test_spend_windows.py
+++ b/tests/test_spend_windows.py
@@ -99,5 +99,62 @@ class SpendWindows(unittest.TestCase):
         self.assertEqual(w["monthToDate"], {"usd": 0.0, "tok": 0, "turns": 0})
 
 
+
+class RollingMonthAcrossDst(SpendWindows):
+    """T235b (romp_ui's adversarial pass): `now - i*86400` skips a LOCAL date across a DST shift —
+    every 00:00-01:00 reading in the weeks after spring-forward omitted the transition date, so the
+    30-day set held 29 dates and month could read below week again in that hour. Date arithmetic
+    keeps the recorder's local-date keying without the skip."""
+
+    def _with_tz(self, tz, fn):
+        old = os.environ.get("TZ")
+        os.environ["TZ"] = tz
+        time.tzset()
+        try:
+            return fn()
+        finally:
+            if old is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old
+            time.tzset()
+
+    def test_the_window_holds_31_consecutive_local_dates_inside_a_dst_hour(self):
+        def run():
+            frozen = time.mktime((2026, 3, 9, 0, 30, 0, 0, 0, -1))   # 00:30 the day after spring-forward
+            km.time.time = lambda: frozen
+            # $1 on each of the 31 dates the window should hold (today back through 30 days ago),
+            # $1000 on the dates just beyond — a skipped transition date shifts the set one day OLDER,
+            # so the seconds-arithmetic bug reads 30 + 1000, never 31 (built by DATE, not seconds)
+            import datetime as _dt
+            today = _dt.date.fromtimestamp(frozen)
+            days = {(today - _dt.timedelta(days=n)).isoformat(): self._bucket(1.0 if n <= 30 else 1000.0)
+                    for n in range(40)}
+            self._ledger(days, {})
+            w = km._spend_windows()
+            return w["month"]["usd"], "2026-03-08" in days
+        usd, has_dst_date = self._with_tz("America/Los_Angeles", run)
+        self.assertTrue(has_dst_date)
+        self.assertEqual(usd, 31.0, "exactly today plus the 30 dates before it — the transition date 2026-03-08 must not be skipped for an older one")
+
+
+class DisplayCaveatsFollowTheData(unittest.TestCase):
+    """T235b, source pins on the kernel-served rail JS: the summed rolling month is complete only
+    from the YOUNGEST ledger (fold `since` with MAX, and say so), and the collapsed API cell follows
+    the hover's version-skew rule instead of silently dropping or mixing a legacy host's month."""
+    JS = Path(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read_text()
+
+    def test_since_folds_to_the_youngest_ledger_and_says_complete_since(self):
+        self.assertIn("if(v.since&&(!t.since||v.since>t.since))t.since=v.since;", self.JS,
+                      "MAX: the sum is complete only from the youngest host's reach")
+        self.assertIn("' \\u00b7 complete since '+esc(v.since)", self.JS)
+        self.assertNotIn("v.since<t.since", self.JS, "the MIN fold overstated coverage")
+
+    def test_the_collapsed_cell_carries_the_legacy_caveat(self):
+        cell = self.JS[self.JS.index("function apiCellHTML"):self.JS.index("// The collapsed rail is the AGGREGATE story")]
+        self.assertIn("_spendLegacyMonth", cell, "the cell counts the hosts whose month it cannot fold in")
+        self.assertIn("var monthCav=legacyN>0;", cell, "…and the month segment wears the caveat glyph (no native title — the rich tip explains)")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -182,8 +182,10 @@ class RailRendering(unittest.TestCase):
         self.assertNotIn("_tail", self.js)
         # pay-per-token wears calendar-ish windows (the user 2026-08-13): 1 day + 1 month on the cell
         # (1 week rides the hover); day||fiveHour keeps an older remote's spend visible (version skew)
-        self.assertIn("seg('day','1 day')+seg('month','1 month')", self.js)
-        self.assertIn("var d=sp.day||sp.fiveHour,m=sp.month;", self.js)
+        # …the month segment carries the version-skew caveat (T235b): a legacy host's CALENDAR month is
+        # left out of this rolling segment and the title says how many machines were not counted
+        self.assertIn("seg('day','1 day')+seg('month','1 month',monthCav)", self.js)
+        self.assertIn("var d=sp.day||sp.fiveHour,m=sp.month;   // m: the ROLLING month only (a legacy host has none here)", self.js)
         self.assertIn("'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' · '+fmtTok(sum[k].tok)+' tok</div>'", self.js)
         self.assertNotIn("spendColor", self.js)
         self.assertNotIn("spendWinsHTML", self.js)

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -85,9 +85,12 @@ test("the web rail's API cell is numbers under a constant label — no spend bar
   assert.ok(usageJS.includes("function apiCellHTML(live)"));
   assert.ok(usageJS.includes("'<div class=ru-name>API</div>'"));
   assert.ok(!usageJS.includes("_tail"), "no tail plumbing survives in the rail JS");
-  assert.ok(usageJS.includes("seg('day','1 day')+seg('month','1 month')"));
-  assert.ok(usageJS.includes("var d=sp.day||sp.fiveHour,m=sp.month;"), "older remote kernels stay visible");
-  assert.ok(usageJS.includes("var seg=function(k,lbl){return '<div class=ru-name>'+lbl+'</div>'"));
+  // the month segment carries the version-skew caveat (T235b): a legacy host's calendar month is left
+  // out of the rolling segment, and the segment's title says how many machines were not counted
+  assert.ok(usageJS.includes("seg('day','1 day')+seg('month','1 month',monthCav)"));
+  assert.ok(usageJS.includes("var d=sp.day||sp.fiveHour,m=sp.month;   // m: the ROLLING month only (a legacy host has none here)"), "older remote kernels stay visible on the day segment");
+  assert.ok(usageJS.includes("var seg=function(k,lbl,cav){return '<div class=ru-name>'+lbl+(cav?' \\u26a0':'')+'</div>'"),
+    "the caveat is a glyph on the segment — no native title (the rich tip is the ONE hover surface and carries the words)");
   assert.ok(usageJS.includes("'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \\u00b7 '+fmtTok(sum[k].tok)+' tok</div>'"));
   // the graph and the budget fills are gone: no spend track, no spend color ramp, no shared scale
   assert.ok(!usageJS.includes("spendColor"), "the budget-fill ramp died with the spend bars");

--- a/ui/webview/spend-windows-hover.test.ts
+++ b/ui/webview/spend-windows-hover.test.ts
@@ -29,10 +29,19 @@ test("the version-skew arm: an older host's calendar month is filed honestly and
 
 test("a ledger younger than 30 days marks the rolling row with its reach", () => {
   assert.match(KERNEL, /win\["month"\]\["since"\] = oldest/, "the kernel states how far back the ledger truly goes");
-  assert.match(KERNEL, /if\(k==='month'&&v\.since\)lab\+=' \\u00b7 since '\+esc\(v\.since\);/, "…and the hover shows it on the row");
-  assert.match(KERNEL, /if\(v\.since&&\(!t\.since\|\|v\.since<t\.since\)\)t\.since=v\.since;/, "across hosts, the OLDEST reach caveats the sum");
+  assert.match(KERNEL, /if\(k==='month'&&v\.since\)lab\+=' \\u00b7 complete since '\+esc\(v\.since\);/, "…and the hover shows it on the row");
+  // T235b: folded to the YOUNGEST ledger — the summed window is complete only from there (MIN overstated coverage)
+  assert.match(KERNEL, /if\(v\.since&&\(!t\.since\|\|v\.since>t\.since\)\)t\.since=v\.since;/, "across hosts, the youngest reach bounds the sum");
 });
 
 test("the strip's cell title carries both rows too", () => {
   assert.match(STRIP, /\["month", "1 month"\], \["monthToDate", "this month"\]\] as const/);
+});
+
+test("T235b: the collapsed API cell follows the hover's skew rule, and the since caveat folds to the youngest ledger", () => {
+  const cell = KERNEL.slice(KERNEL.indexOf("function apiCellHTML"), KERNEL.indexOf("// The collapsed rail is the AGGREGATE story"));
+  assert.match(cell, /_spendLegacyMonth/, "a legacy host's calendar month is never folded into the rolling segment");
+  assert.match(cell, /var monthCav=legacyN>0;/, "…and the month segment wears the ⚠ glyph — the words live on the rich tip's rolling row, the ONE hover surface");
+  assert.match(KERNEL, /if\(v\.since&&\(!t\.since\|\|v\.since>t\.since\)\)t\.since=v\.since;/, "MAX — complete only from the youngest reach");
+  assert.match(KERNEL, /' \\u00b7 complete since '\+esc\(v\.since\)/);
 });


### PR DESCRIPTION
Follow-up to the rolling-month change (romp_ui's adversarial pass, spot-checked by the manager), **red-first for all three**:

1. **The collapsed API cell follows the hover's version-skew rule.** A host on the previous build ships a calendar `month` and no `monthToDate`; the hover already filed that figure under 'this month' and left it out of the rolling row, but the compact cell summed whatever `month` it saw — a calendar month folded into a rolling one, the exact lie the change removed — or rendered a silent $0. The cell now counts those hosts and wears a ⚠ glyph on the month segment; the words stay on the rich tip's rolling row, the rail's **one hover surface** (no native title — the standing rule the suite enforces). A legacy host's day still counts, so day can exceed month in the cell for that host; the glyph says why.
2. **The rolling-day key set is built by date arithmetic, not seconds.** `now - i*86400` crossed a DST shift one hour short: every early-morning reading for weeks after spring-forward skipped the transition date and shifted the window a day older, so month could read below week again in that hour. `datetime.date` arithmetic keeps the recorder's local-date keying exact on every host.
3. **The `since` caveat folds to the youngest ledger and reads 'complete since'**: the summed rolling month is complete only from the newest host's reach, so the MIN fold overstated coverage.

Pins: a frozen clock at 00:30 the day after spring-forward under America/Los_Angeles holds exactly today plus the 30 dates before it ($1 each, $1000 on the dates beyond — the skip reads 1030, never 31); the MAX fold and its label; the cell's legacy count and glyph. Two pins that locked the old cell line moved with reasons. Python 7129 passed / extension 2750 passed on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)